### PR TITLE
remove duplicate checks for yasm

### DIFF
--- a/checkdeps.sh
+++ b/checkdeps.sh
@@ -36,11 +36,6 @@ if [ $? -ne 0 ]; then
     MISSING="${MISSING} build-essential"
 fi
 
-env yasm --version > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    MISSING="${MISSING} yasm"
-fi
-
 if ! yasm -f elf64 pkg/storage/erasure/gf-vect-dot-prod-avx2.asm -o /dev/null 2>/dev/null ; then
     MISSING="${MISSING} yasm(1.2.0)"
 fi


### PR DESCRIPTION
Sufficient to perform the second check. If not, it will report missing yasm twice.
