### PR TITLE
Symlink fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ checkdeps:
 	@./checkdeps.sh
 
 createsymlink:
-	@if test ! -e $(GOPATH)/src/github.com/minio-io/minio; then echo "Creating symlink to $(GOPATH)/src/github.com/minio-io/minio" && ln -s $(PWD) $(GOPATH)/src/github.com/minio-io/minio; fi
+	@if test ! -e $(GOPATH)/src/github.com/minio-io/minio; then echo "Creating symlink to $(GOPATH)/src/github.com/minio-io/minio" && mkdir -p $(GOPATH)/src/github.com/minio-io && ln -s $(PWD) $(GOPATH)/src/github.com/minio-io/minio; fi
 
 getdeps: checkdeps
 	@go get github.com/tools/godep && echo "Installed godep"

--- a/checkdeps.sh
+++ b/checkdeps.sh
@@ -36,11 +36,6 @@ if [ $? -ne 0 ]; then
     MISSING="${MISSING} build-essential"
 fi
 
-env yasm --version > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    MISSING="${MISSING} yasm"
-fi
-
 if ! yasm -f elf64 pkg/storage/erasure/gf-vect-dot-prod-avx2.asm -o /dev/null 2>/dev/null ; then
     MISSING="${MISSING} yasm(1.2.0)"
 fi


### PR DESCRIPTION
Create top level Minio-io dir before creating a symlink. Build fails otherwise.
