### PR TITLE
Add missing asm instruction to correct sha256 calculation in avx mode

### DIFF
--- a/pkg/utils/crypto/sha256/sha256-avx-asm.S
+++ b/pkg/utils/crypto/sha256/sha256-avx-asm.S
@@ -451,6 +451,7 @@ a = TMP_
 	or      y2, y0                  # y0 = MAJ = (a|c)&b)|(a&c)
 	add     y0, h                   # h = h + S1 + CH + k + w + S0 + MAJ
 	ROTATE_ARGS
+	mov     e, y0                   # y0 = e 
 	mov     a, y1                   # y1 = a
 	MY_ROR  (25-11), y0             # y0 = e >> (25-11)
 	xor     e, y0                   # y0 = e ^ (e >> (25-11))


### PR DESCRIPTION
The error is not noticed by people using a CPU with avx2 enabled, I found the missing instruction by comparing this assembler file to the similar one present in the linux tree
