### PR TITLE
Add Dockerfile to build a docker image with embarked minio server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+
+FROM ubuntu:14.04
+
+MAINTAINER Minio Community
+
+ENV GOLANG_TARBALL go1.4.2.linux-amd64.tar.gz
+
+ENV GOROOT /usr/local/go/
+ENV GOPATH /go-workspace 
+ENV PATH ${GOROOT}/bin:${GOPATH}/bin/:$PATH
+
+RUN apt-get update -y && apt-get install -y -q \
+		curl \
+		git \
+		build-essential \
+		ca-certificates \
+		yasm \
+		python-pip
+
+RUN curl -O -s https://storage.googleapis.com/golang/${GOLANG_TARBALL} && \
+		tar -xzf ${GOLANG_TARBALL} -C ${GOROOT%*go*} && \
+		rm ${GOLANG_TARBALL} && \
+		pip install mkdocs
+
+ADD . ${GOPATH}/src/github.com/minio-io/minio
+
+RUN cd ${GOPATH}/src/github.com/minio-io/minio && \
+		make
+
+RUN apt-get remove -y build-essential curl git python-pip && \
+        apt-get -y autoremove && \
+        rm -rf /var/lib/apt/lists/*
+
+EXPOSE 9000 9001
+
+CMD ["sh", "-c", "${GOPATH}/bin/minio"]
+


### PR DESCRIPTION
The generated image is little big for now. I think we have two options to reduce image size :
1. Build minio binaries in the host system and embark them directly into the docker image
2. Wait until someone creates minio package for Ubuntu or another distro 
