### PR TITLE
removed HomeDir

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"log"
+	"os/user"
 	"path"
 	"reflect"
 
@@ -27,7 +28,6 @@ import (
 	mstorage "github.com/minio-io/minio/pkg/storage"
 	"github.com/minio-io/minio/pkg/storage/fs"
 	"github.com/minio-io/minio/pkg/storage/inmemory"
-	"github.com/minio-io/minio/pkg/utils/helpers"
 )
 
 type ServerConfig struct {
@@ -128,8 +128,11 @@ func getStorageChannels(storageType StorageType) (ctrlChans []chan<- string, sta
 		}
 	case storageType == FileStorage:
 		{
-			homeDir := helpers.HomeDir()
-			root := path.Join(homeDir, "minio-storage")
+			u, err := user.Current()
+			if err != nil {
+				return nil, nil, nil
+			}
+			root := path.Join(u.HomeDir, "minio-storage")
 			ctrlChan, statusChan, storage = fs.Start(root)
 			ctrlChans = append(ctrlChans, ctrlChan)
 			statusChans = append(statusChans, statusChan)

--- a/pkg/utils/config/config.go
+++ b/pkg/utils/config/config.go
@@ -20,10 +20,9 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"os/user"
 	"path"
 	"sync"
-
-	"github.com/minio-io/minio/pkg/utils/helpers"
 )
 
 type Config struct {
@@ -41,7 +40,12 @@ type User struct {
 
 // Initialize config directory and template config
 func (c *Config) SetupConfig() error {
-	confPath := path.Join(helpers.HomeDir(), ".minio")
+	u, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	confPath := path.Join(u.HomeDir, ".minio")
 	if err := os.MkdirAll(confPath, os.ModeDir); err != nil {
 		return err
 	}

--- a/pkg/utils/helpers/common.go
+++ b/pkg/utils/helpers/common.go
@@ -19,22 +19,8 @@ package helpers
 import (
 	"io/ioutil"
 	"log"
-	"os"
-	"runtime"
 	"strings"
 )
-
-// Get current user home directory
-func HomeDir() string {
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-		return home
-	}
-	return os.Getenv("HOME")
-}
 
 // Create a new temp directory
 func MakeTempTestDir() (string, error) {


### PR DESCRIPTION
Use os/user.Current().HomeDir instead. Go's package will ensure more portability than our own variant. user.Current is will not work for cross-compiling which we are OK with.
