### PR TITLE
Add missing dependency on minio/cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ getdeps: checkdeps checkgopath
 	@go get github.com/golang/lint/golint && echo "Installed golint:"
 	@go get golang.org/x/tools/cmd/vet && echo "Installed vet:"
 	@go get github.com/fzipp/gocyclo && echo "Installed gocyclo:"
+	@go get github.com/minio/cli && echo "Installed cli:"
 
 verifiers: getdeps vet fmt lint cyclo
 


### PR DESCRIPTION
When building following the instructions in CONTRIBUTING.md, the build stops when the minio/cli fork cannot be found. This patch adds the missing dependency. LMK if I've just misunderstood something.
