### PR TITLE
Encoder now directly reads from the object stream. Using split.Stream…

### DIFF
--- a/pkg/donut/donut-v1.go
+++ b/pkg/donut/donut-v1.go
@@ -134,7 +134,7 @@ func (donut API) listObjects(bucket, prefix, marker, delimiter string, maxkeys i
 }
 
 // putObject - put object
-func (donut API) putObject(bucket, object, expectedMD5Sum string, reader io.Reader, metadata map[string]string, signature *Signature) (ObjectMetadata, error) {
+func (donut API) putObject(bucket, object, expectedMD5Sum string, reader io.Reader, size int64, metadata map[string]string, signature *Signature) (ObjectMetadata, error) {
 	errParams := map[string]string{
 		"bucket": bucket,
 		"object": object,
@@ -158,7 +158,7 @@ func (donut API) putObject(bucket, object, expectedMD5Sum string, reader io.Read
 	if _, ok := bucketMeta.Buckets[bucket].BucketObjects[object]; ok {
 		return ObjectMetadata{}, iodine.New(ObjectExists{Object: object}, errParams)
 	}
-	objMetadata, err := donut.buckets[bucket].WriteObject(object, reader, expectedMD5Sum, metadata, signature)
+	objMetadata, err := donut.buckets[bucket].WriteObject(object, reader, size, expectedMD5Sum, metadata, signature)
 	if err != nil {
 		return ObjectMetadata{}, iodine.New(err, errParams)
 	}
@@ -170,7 +170,7 @@ func (donut API) putObject(bucket, object, expectedMD5Sum string, reader io.Read
 }
 
 // putObject - put object
-func (donut API) putObjectPart(bucket, object, expectedMD5Sum, uploadID string, partID int, reader io.Reader, metadata map[string]string, signature *Signature) (PartMetadata, error) {
+func (donut API) putObjectPart(bucket, object, expectedMD5Sum, uploadID string, partID int, reader io.Reader, size int64, metadata map[string]string, signature *Signature) (PartMetadata, error) {
 	errParams := map[string]string{
 		"bucket": bucket,
 		"object": object,
@@ -198,7 +198,7 @@ func (donut API) putObjectPart(bucket, object, expectedMD5Sum, uploadID string, 
 		return PartMetadata{}, iodine.New(ObjectExists{Object: object}, errParams)
 	}
 	objectPart := object + "/" + "multipart" + "/" + strconv.Itoa(partID)
-	objmetadata, err := donut.buckets[bucket].WriteObject(objectPart, reader, expectedMD5Sum, metadata, signature)
+	objmetadata, err := donut.buckets[bucket].WriteObject(objectPart, reader, size, expectedMD5Sum, metadata, signature)
 	if err != nil {
 		return PartMetadata{}, iodine.New(err, errParams)
 	}

--- a/pkg/donut/donut-v2.go
+++ b/pkg/donut/donut-v2.go
@@ -373,6 +373,7 @@ func (donut API) createObject(bucket, key, contentType, expectedMD5Sum string, s
 			key,
 			expectedMD5Sum,
 			data,
+			size,
 			map[string]string{
 				"contentType":   contentType,
 				"contentLength": strconv.FormatInt(size, 10),

--- a/pkg/donut/encoder.go
+++ b/pkg/donut/encoder.go
@@ -17,6 +17,7 @@
 package donut
 
 import (
+	"io"
 	"strconv"
 
 	encoding "github.com/minio/minio/pkg/erasure"
@@ -84,6 +85,14 @@ func (e encoder) Encode(data []byte) (encodedData [][]byte, err error) {
 		return nil, iodine.New(err, nil)
 	}
 	return encodedData, nil
+}
+
+func (e encoder) EncodeStream(data io.Reader, size int64) (encodedData [][]byte, inputData []byte, err error) {
+	encodedData, inputData, err = e.encoder.EncodeStream(data, size)
+	if err != nil {
+		return nil, nil, iodine.New(err, nil)
+	}
+	return encodedData, inputData, nil
 }
 
 // Decode - erasure decode input encoded bytes

--- a/pkg/donut/multipart.go
+++ b/pkg/donut/multipart.go
@@ -155,7 +155,7 @@ func (donut API) createObjectPart(bucket, key, uploadID string, partID int, cont
 			}
 			expectedMD5Sum = hex.EncodeToString(expectedMD5SumBytes)
 		}
-		partMetadata, err := donut.putObjectPart(bucket, key, expectedMD5Sum, uploadID, partID, data, metadata, signature)
+		partMetadata, err := donut.putObjectPart(bucket, key, expectedMD5Sum, uploadID, partID, data, size, metadata, signature)
 		if err != nil {
 			return "", iodine.New(err, nil)
 		}


### PR DESCRIPTION
…() was causing lot of redundant memory operations.

RSS usage during a 2GB file PUT came down from 180 MB to 65MB
