### PR TITLE
Fix all the golint complaints about newly added changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ fmt:
 
 lint:
 	@echo "Running $@:"
-	@GO15VENDOREXPERIMENT=1 golint .
-	@GO15VENDOREXPERIMENT=1 golint pkg
+	@GO15VENDOREXPERIMENT=1 golint *.go
+	@GO15VENDOREXPERIMENT=1 golint github.com/minio/minio/pkg...
 
 cyclo:
 	@echo "Running $@:"

--- a/genversion.go
+++ b/genversion.go
@@ -26,6 +26,7 @@ import (
 	"time"
 )
 
+// Version version string
 type Version struct {
 	Date string
 }

--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -29,7 +29,7 @@ func getRPCHandler() http.Handler {
 	s.RegisterService(new(rpc.VersionService), "Version")
 	s.RegisterService(new(rpc.DonutService), "Donut")
 	s.RegisterService(new(rpc.AuthService), "Auth")
-	s.RegisterService(rpc.NewServerService(), "Server")
+	s.RegisterService(new(rpc.ServerService), "Server")
 	// Add new RPC services here
 	return registerRPC(router.NewRouter(), s)
 }

--- a/pkg/controller/rpc/rpc.go
+++ b/pkg/controller/rpc/rpc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gorilla/rpc/v2/json"
 )
 
+// Server new rpc server container
 type Server struct {
 	*rpc.Server
 }

--- a/pkg/controller/rpc/server.go
+++ b/pkg/controller/rpc/server.go
@@ -25,26 +25,35 @@ import (
 	"github.com/minio/minio/pkg/probe"
 )
 
+// MinioServer - container for minio server data
 type MinioServer struct {
 	Name string `json:"name"`
 	IP   string `json:"ip"`
 	ID   string `json:"id"`
 }
 
+// ServerArg - server arg
 type ServerArg struct {
 	MinioServer
 }
 
-type DummyReply struct{}
+// ServerAddReply - server add reply
+type ServerAddReply struct {
+	Server MinioServer `json:"server"`
+	Status string      `json:"status"`
+}
 
+// MemStatsReply memory statistics
 type MemStatsReply struct {
 	runtime.MemStats `json:"memstats"`
 }
 
+// DiskStatsReply disk statistics
 type DiskStatsReply struct {
 	DiskStats syscall.Statfs_t `json:"diskstats"`
 }
 
+// SysInfoReply system info
 type SysInfoReply struct {
 	Hostname  string `json:"hostname"`
 	SysARCH   string `json:"sys.arch"`
@@ -54,30 +63,38 @@ type SysInfoReply struct {
 	GOVersion string `json:"goversion"`
 }
 
-type ListReply struct {
-	List []MinioServer `json:"list"`
+// ServerListReply list of minio servers
+type ServerListReply struct {
+	ServerList []MinioServer `json:"servers"`
 }
 
+// ServerService server json rpc service
 type ServerService struct {
-	list []MinioServer
+	serverList []MinioServer
 }
 
-func (this *ServerService) Add(r *http.Request, arg *ServerArg, reply *DummyReply) error {
-	this.list = append(this.list, MinioServer{arg.Name, arg.IP, arg.ID})
+// Add - add new server
+func (s *ServerService) Add(r *http.Request, arg *ServerArg, reply *ServerAddReply) error {
+	reply.Server = MinioServer{arg.Name, arg.IP, arg.ID}
+	reply.Status = "connected"
+	s.serverList = append(s.serverList, reply.Server)
 	return nil
 }
 
-func (this *ServerService) MemStats(r *http.Request, arg *ServerArg, reply *MemStatsReply) error {
+// MemStats - memory statistics on the server
+func (s *ServerService) MemStats(r *http.Request, arg *ServerArg, reply *MemStatsReply) error {
 	runtime.ReadMemStats(&reply.MemStats)
 	return nil
 }
 
-func (this *ServerService) DiskStats(r *http.Request, arg *ServerArg, reply *DiskStatsReply) error {
+// DiskStats - disk statistics on the server
+func (s *ServerService) DiskStats(r *http.Request, arg *ServerArg, reply *DiskStatsReply) error {
 	syscall.Statfs("/", &reply.DiskStats)
 	return nil
 }
 
-func (this *ServerService) SysInfo(r *http.Request, arg *ServerArg, reply *SysInfoReply) error {
+// SysInfo - system info for the server
+func (s *ServerService) SysInfo(r *http.Request, arg *ServerArg, reply *SysInfoReply) error {
 	reply.SysARCH = runtime.GOARCH
 	reply.SysOS = runtime.GOOS
 	reply.SysCPUS = runtime.NumCPU()
@@ -91,17 +108,12 @@ func (this *ServerService) SysInfo(r *http.Request, arg *ServerArg, reply *SysIn
 	return nil
 }
 
-func (this *ServerService) List(r *http.Request, arg *ServerArg, reply *ListReply) error {
-	reply.List = this.list
-	return nil
-}
-
-func NewServerService() *ServerService {
-	s := &ServerService{}
-	s.list = []MinioServer{
+// List of servers in the cluster
+func (s *ServerService) List(r *http.Request, arg *ServerArg, reply *ServerListReply) error {
+	reply.ServerList = []MinioServer{
 		{"server.one", "192.168.1.1", "192.168.1.1"},
 		{"server.two", "192.168.1.2", "192.168.1.2"},
 		{"server.three", "192.168.1.3", "192.168.1.3"},
 	}
-	return s
+	return nil
 }

--- a/pkg/server/api/generic-handlers.go
+++ b/pkg/server/api/generic-handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rs/cors"
 )
 
+// MiddlewareHandler - useful to chain different middleware http.Handler
 type MiddlewareHandler func(http.Handler) http.Handler
 
 type contentTypeHandler struct {
@@ -153,6 +154,7 @@ func (h validateAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// CorsHandler handler for CORS (Cross Origin Resource Sharing)
 func CorsHandler(h http.Handler) http.Handler {
 	return cors.Default().Handler(h)
 }


### PR DESCRIPTION
Do not use `func(this *server)`, such generic names should not be used for writing struct methods.

struct methods instead should have 

```
func (s *Server) or better func (server *Server) 
```
