### PR TITLE
logrus based logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,66 @@
+/*
+ * Minio Cloud Storage, (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/minio/minio/pkg/probe"
+	"github.com/weekface/mgorus"
+)
+
+type fields map[string]interface{}
+
+var log = logrus.New() // Default console logger.
+
+// log2Mongo enables logging to mongodb. Use capped collection to
+func log2Mongo(url, db, collection string) *probe.Error {
+	hooker, e := mgorus.NewHooker(url, db, collection)
+	if e != nil {
+		return probe.NewError(e)
+	}
+
+	log.Hooks.Add(hooker)                   // Add mongodb hook.
+	log.Formatter = &logrus.JSONFormatter{} // JSON formatted log.
+	log.Level = logrus.InfoLevel            // Minimum log level.
+	return nil
+}
+
+func errorIf(err *probe.Error, msg string, fields map[string]interface{}) {
+	if err == nil {
+		return
+	}
+	if fields == nil {
+		fields = make(map[string]interface{})
+	}
+
+	fields["error"] = err.ToGoError()
+	if jsonErr, e := json.Marshal(err); e == nil {
+		fields["probe"] = string(jsonErr)
+	}
+	log.WithFields(fields).Error(msg)
+
+}
+
+func audit(msg string, fields logrus.Fields) {
+	if fields == nil {
+		fields = make(map[string]interface{})
+	}
+
+	log.WithFields(fields).Info(msg)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,23 @@
+/*
+ * Minio Cloud Storage (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import . "gopkg.in/check.v1"
+
+func (s *CmdTestSuite) TestLogger(c *C) {
+
+}

--- a/server-main.go
+++ b/server-main.go
@@ -17,14 +17,17 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/minio/cli"
+	"github.com/minio/minio/pkg/probe"
 	"github.com/minio/minio/pkg/server"
 	"github.com/minio/minio/pkg/server/api"
 )
 
 var serverCmd = cli.Command{
 	Name:   "server",
-	Usage:  "Start minio server",
+	Usage:  "Start minio server.",
 	Action: serverMain,
 	CustomHelpTemplate: `NAME:
   minio {{.Name}} - {{.Description}}
@@ -60,7 +63,9 @@ func serverMain(c *cli.Context) {
 		cli.ShowCommandHelpAndExit(c, "server", 1)
 	}
 	apiServerConfig := getServerConfig(c)
-	if err := server.Start(apiServerConfig); err != nil {
-		Fatalln(err.Trace())
-	}
+
+	err := server.Start(apiServerConfig)
+	err = probe.NewError(fmt.Errorf("Fake error."))
+	errorIf(err.Trace(), "Failed to start the server.", nil)
+
 }

--- a/vendor.json
+++ b/vendor.json
@@ -87,6 +87,13 @@
 			"revisionTime": "2015-08-29T22:34:20-07:00"
 		},
 		{
+			"canonical": "github.com/weekface/mgorus",
+			"comment": "",
+			"local": "vendor/github.com/weekface/mgorus",
+			"revision": "9a3ff865bf11d949ab7084198479139d9746c68f",
+			"revisionTime": "2015-09-01T11:57:24+08:00"
+		},
+		{
 			"canonical": "gopkg.in/check.v1",
 			"comment": "",
 			"local": "vendor/gopkg.in/check.v1",

--- a/vendor/github.com/weekface/mgorus/LICENSE
+++ b/vendor/github.com/weekface/mgorus/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/weekface/mgorus/README.md
+++ b/vendor/github.com/weekface/mgorus/README.md
@@ -1,0 +1,34 @@
+# Mongodb Hooks for [Logrus](https://github.com/Sirupsen/logrus) <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
+
+## Install
+
+```shell
+$ go get github.com/weekface/mgorus
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/weekface/mgorus"
+)
+
+func main() {
+	log := logrus.New()
+	hooker, err := mgorus.NewHooker("localhost:27017", "db", "collection")
+	if err == nil {
+	    log.Hooks.Add(hooker)
+	}
+
+	log.WithFields(logrus.Fields{
+		"name": "zhangsan",
+		"age":  28,
+	}).Error("Hello world!")
+}
+```
+
+## License
+*MIT*

--- a/vendor/github.com/weekface/mgorus/mgorus.go
+++ b/vendor/github.com/weekface/mgorus/mgorus.go
@@ -1,0 +1,47 @@
+package mgorus
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type hooker struct {
+	c *mgo.Collection
+}
+
+type M bson.M
+
+func NewHooker(mgoUrl, db, collection string) (*hooker, error) {
+	session, err := mgo.Dial(mgoUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &hooker{c: session.DB(db).C(collection)}, nil
+}
+
+func (h *hooker) Fire(entry *logrus.Entry) error {
+	entry.Data["Level"] = entry.Level.String()
+	entry.Data["Time"] = entry.Time
+	entry.Data["Message"] = entry.Message
+	mgoErr := h.c.Insert(M(entry.Data))
+	if mgoErr != nil {
+		return fmt.Errorf("Failed to send log entry to mongodb: %s", mgoErr)
+	}
+
+	return nil
+}
+
+func (h *hooker) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+		logrus.InfoLevel,
+		logrus.DebugLevel,
+	}
+}


### PR DESCRIPTION
If the user enables logging option from controller UI, controller will call server RPC (on each server) to activate logging to mongodb (log2mongo function). Until then, logging goes to stdout and forgotten.

Requiring a documentdb for logging allows the controller UI to query logs and perform useful analysis.
Controller will also have options to log to fluentd, elastic-search, other services as an additional method.
