### PR TITLE
Change Dockerfile to use smaller distro, non-root user, and Go 1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-
-FROM ubuntu:14.04
+FROM ubuntu-debootstrap:14.04
 
 MAINTAINER Minio Community
 
-ENV GOLANG_TARBALL go1.5.linux-amd64.tar.gz
+ENV GOLANG_TARBALL go1.5.1.linux-amd64.tar.gz
 
 ENV GOROOT /usr/local/go/
 ENV GOPATH /go-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV GOROOT /usr/local/go/
 ENV GOPATH /go-workspace
 ENV PATH ${GOROOT}/bin:${GOPATH}/bin/:$PATH
 
+ENV MINIOHOME /home/minio
+ENV MINIOUSER minio
+RUN useradd -m -d $MINIOHOME $MINIOUSER
+
 RUN apt-get update -y && apt-get install -y -q \
 		curl \
 		git \
@@ -27,6 +31,8 @@ RUN cd ${GOPATH}/src/github.com/minio/minio && \
 RUN apt-get remove -y build-essential curl git && \
         apt-get -y autoremove && \
         rm -rf /var/lib/apt/lists/*
+
+USER minio
 
 EXPOSE 9000 9001
 


### PR DESCRIPTION
This pull request does the following:
- Switch from the `ubuntu:14.04` image to `ubuntu-debootstrap:14.04` (a minimal packaging of Ubuntu). This shaves off about 70M from the image size.
- Change the Go download from 1.5 to 1.5.1, in order to meet the minimum dependencies.
- Create a `minio` user account and start `minio` as that user instead of as root.
