### PR TITLE
Add quick.CheckVersion() to verify config version quickly before unma…

### DIFF
--- a/pkg/quick/quick_test.go
+++ b/pkg/quick/quick_test.go
@@ -57,6 +57,29 @@ func (s *MySuite) TestCheckData(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *MySuite) TestVersion(c *C) {
+	defer os.RemoveAll("test.json")
+	type myStruct struct {
+		Version  string
+		User     string
+		Password string
+		Folders  []string
+	}
+	saveMe := myStruct{"1", "guest", "nopassword", []string{"Work", "Documents", "Music"}}
+	config, err := quick.New(&saveMe)
+	c.Assert(err, IsNil)
+	c.Assert(config, Not(IsNil))
+	config.Save("test.json")
+
+	valid, err := quick.CheckVersion("test.json", "1")
+	c.Assert(err, IsNil)
+	c.Assert(valid, Equals, true)
+
+	valid, err = quick.CheckVersion("test.json", "2")
+	c.Assert(err, IsNil)
+	c.Assert(valid, Equals, false)
+}
+
 func (s *MySuite) TestSaveLoad(c *C) {
 	defer os.RemoveAll("test.json")
 	type myStruct struct {


### PR DESCRIPTION
…rshalling the full struct

This is needed during migration where we would need to verify the underlying version number
in a quick way.
