### PR TITLE
Add 5% cumulative reduction in total size of the disk

### DIFF
--- a/api-errors.go
+++ b/api-errors.go
@@ -228,7 +228,7 @@ var errorCodeResponse = map[int]APIError{
 	},
 	RootPathFull: {
 		Code:           "RootPathFull",
-		Description:    "Root path has reached its minimum free disk threshold. Please clear few objects to proceed.",
+		Description:    "Root path has reached its minimum free disk threshold. Please delete few objects to proceed.",
 		HTTPStatusCode: http.StatusInternalServerError,
 	},
 }

--- a/pkg/fs/fs-bucket.go
+++ b/pkg/fs/fs-bucket.go
@@ -98,7 +98,9 @@ func (fs Filesystem) MakeBucket(bucket, acl string) *probe.Error {
 		return probe.NewError(err)
 	}
 
-	if int64((float64(stfs.Free)/float64(stfs.Total))*100) <= fs.minFreeDisk {
+	// Remove 5% from total space for cumulative disk space used for journalling, inodes etc.
+	availableDiskSpace := (float64(stfs.Free) / (float64(stfs.Total) - (0.05 * float64(stfs.Total)))) * 100
+	if int64(availableDiskSpace) <= fs.minFreeDisk {
 		return probe.NewError(RootPathFull{Path: fs.path})
 	}
 

--- a/pkg/fs/fs-multipart.go
+++ b/pkg/fs/fs-multipart.go
@@ -153,7 +153,9 @@ func (fs Filesystem) NewMultipartUpload(bucket, object string) (string, *probe.E
 		return "", probe.NewError(err)
 	}
 
-	if int64((float64(stfs.Free)/float64(stfs.Total))*100) <= fs.minFreeDisk {
+	// Remove 5% from total space for cumulative disk space used for journalling, inodes etc.
+	availableDiskSpace := (float64(stfs.Free) / (float64(stfs.Total) - (0.05 * float64(stfs.Total)))) * 100
+	if int64(availableDiskSpace) <= fs.minFreeDisk {
 		return "", probe.NewError(RootPathFull{Path: fs.path})
 	}
 
@@ -228,7 +230,9 @@ func (fs Filesystem) CreateObjectPart(bucket, object, uploadID, expectedMD5Sum s
 		return "", probe.NewError(err)
 	}
 
-	if int64((float64(stfs.Free)/float64(stfs.Total))*100) <= fs.minFreeDisk {
+	// Remove 5% from total space for cumulative disk space used for journalling, inodes etc.
+	availableDiskSpace := (float64(stfs.Free) / (float64(stfs.Total) - (0.05 * float64(stfs.Total)))) * 100
+	if int64(availableDiskSpace) <= fs.minFreeDisk {
 		return "", probe.NewError(RootPathFull{Path: fs.path})
 	}
 

--- a/pkg/fs/fs-object.go
+++ b/pkg/fs/fs-object.go
@@ -171,7 +171,9 @@ func (fs Filesystem) CreateObject(bucket, object, expectedMD5Sum string, size in
 		return ObjectMetadata{}, probe.NewError(err)
 	}
 
-	if int64((float64(stfs.Free)/float64(stfs.Total))*100) <= fs.minFreeDisk {
+	// Remove 5% from total space for cumulative disk space used for journalling, inodes etc.
+	availableDiskSpace := (float64(stfs.Free) / (float64(stfs.Total) - (0.05 * float64(stfs.Total)))) * 100
+	if int64(availableDiskSpace) <= fs.minFreeDisk {
 		return ObjectMetadata{}, probe.NewError(RootPathFull{Path: fs.path})
 	}
 

--- a/server-main.go
+++ b/server-main.go
@@ -247,6 +247,8 @@ func serverMain(c *cli.Context) {
 
 	var minFreeDisk int64
 	minFreeDiskSet := false
+	// Default
+	minFreeDisk = 10
 
 	var expiration time.Duration
 	expirationSet := false


### PR DESCRIPTION
This is done due to filesystem holding additional metadata and inode space
which is unaccounted for during min-free-disk calculation.
