### PR TITLE
modify registerCloudStorageAPI for improving compatibility with S3.

### DIFF
--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -524,6 +524,15 @@ func (s *MyAPIFSCacheSuite) TestPutBucket(c *C) {
 	response, err := client.Do(request)
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/put-bucket-slash/", 0, nil)
+	c.Assert(err, IsNil)
+	request.Header.Add("x-amz-acl", "private")
+
+	client = http.Client{}
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
 }
 
 func (s *MyAPIFSCacheSuite) TestPutObject(c *C) {


### PR DESCRIPTION
I have modified `registerCloudStorageAPI` in `routers.go` as it can process trailing-slash properly.
With this modification, [S3cmd(S3 client)](http://s3tools.org/s3cmd) can work with Minio.
