### PR TITLE
handlers: read ContentLength directly from http.Request

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -226,8 +226,8 @@ func (api CloudStorageAPI) PutBucketHandler(w http.ResponseWriter, req *http.Req
 
 	// if body of request is non-nil then check for validity of Content-Length
 	if req.Body != nil {
-		/// if Content-Length missing, deny the request
-		if req.Header.Get("Content-Length") == "" {
+		/// if Content-Length is unknown/missing, deny the request
+		if req.ContentLength == -1 {
 			writeErrorResponse(w, req, MissingContentLength, req.URL.Path)
 			return
 		}
@@ -275,9 +275,8 @@ func (api CloudStorageAPI) PutBucketHandler(w http.ResponseWriter, req *http.Req
 func (api CloudStorageAPI) PostPolicyBucketHandler(w http.ResponseWriter, req *http.Request) {
 	// if body of request is non-nil then check for validity of Content-Length
 	if req.Body != nil {
-		/// if Content-Length missing, deny the request
-		size := req.Header.Get("Content-Length")
-		if size == "" {
+		/// if Content-Length is unknown/missing, deny the request
+		if req.ContentLength == -1 {
 			writeErrorResponse(w, req, MissingContentLength, req.URL.Path)
 			return
 		}

--- a/utils.go
+++ b/utils.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"encoding/base64"
-	"strconv"
 	"strings"
 )
 
@@ -36,17 +35,13 @@ func isValidMD5(md5 string) bool {
 
 /// http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html
 const (
-	// maximum object size per PUT request is 5GB
+	// maximum object size per PUT request is 5GiB
 	maxObjectSize = 1024 * 1024 * 1024 * 5
 )
 
 // isMaxObjectSize - verify if max object size
-func isMaxObjectSize(size string) bool {
-	i, err := strconv.ParseInt(size, 10, 64)
-	if err != nil {
-		return true
-	}
-	if i > maxObjectSize {
+func isMaxObjectSize(size int64) bool {
+	if size > maxObjectSize {
 		return true
 	}
 	return false


### PR DESCRIPTION
Do not look for Content-Length in headers and try to convert them into
integer representations use ContentLength field from _http.Request_.

If Content-Length is understood to be as '-1' then treat it as an error
condition, since it could be a malformed body to crash the server.

Fixes #1011
