### PR TITLE
Minor changes to Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ fmt:
 
 lint:
 	@echo "Running $@:"
-	@GO15VENDOREXPERIMENT=1 golint *.go
-	@GO15VENDOREXPERIMENT=1 golint github.com/minio/minio/pkg...
+	@GO15VENDOREXPERIMENT=1 ${GOPATH}/bin/golint *.go
+	@GO15VENDOREXPERIMENT=1 ${GOPATH}/bin/golint github.com/minio/minio/pkg...
 
 cyclo:
 	@echo "Running $@:"
-	@GO15VENDOREXPERIMENT=1 gocyclo -over 65 *.go
-	@GO15VENDOREXPERIMENT=1 gocyclo -over 65 pkg
+	@GO15VENDOREXPERIMENT=1 ${GOPATH}/bin/gocyclo -over 65 *.go
+	@GO15VENDOREXPERIMENT=1 ${GOPATH}/bin/gocyclo -over 65 pkg
 
 build: getdeps verifiers
 	@echo "Installing minio:"


### PR DESCRIPTION
Minor changes to Makefile to avoid the make failure when $GOPATH/bin is not part of $PATH . I encountered this issue while building from source and its not necessary for someone to have $GOPATH/bin in $PATH . 
