### PR TITLE
Updated 'aws s3 ls' example in README.md to include s3://

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $ aws --endpoint-url http://localhost:9000 s3 ls
 
 To list contents inside bucket.
 ```
-$ aws --endpoint-url http://localhost:9000 s3 ls testbucket
+$ aws --endpoint-url http://localhost:9000 s3 ls s3://testbucket
                            PRE test/
 2015-12-17 08:46:41   12232928 vim
 2016-01-07 16:38:23   32232928 emacs


### PR DESCRIPTION
Apparently this is needed for other 'aws s3' commands such as 'cp' or 'rm'
