### PR TITLE
multipart: NewMultipartUpload shouldn't return empty UploadID

### DIFF
--- a/pkg/fs/fs-multipart.go
+++ b/pkg/fs/fs-multipart.go
@@ -173,13 +173,13 @@ func (fs Filesystem) NewMultipartUpload(bucket, object string) (string, *probe.E
 	objectPath := filepath.Join(bucketPath, object)
 	objectDir := filepath.Dir(objectPath)
 	if _, e := os.Stat(objectDir); e != nil {
-		if os.IsNotExist(e) {
-			e = os.MkdirAll(objectDir, 0700)
-			if e != nil {
-				return "", probe.NewError(e)
-			}
+		if !os.IsNotExist(e) {
+			return "", probe.NewError(e)
 		}
-		return "", probe.NewError(e)
+		e = os.MkdirAll(objectDir, 0700)
+		if e != nil {
+			return "", probe.NewError(e)
+		}
 	}
 
 	id := []byte(strconv.FormatInt(rand.Int63(), 10) + bucket + object + time.Now().String())
@@ -192,7 +192,7 @@ func (fs Filesystem) NewMultipartUpload(bucket, object string) (string, *probe.E
 	}
 	defer multiPartfile.Close()
 
-	mpartSession := new(MultipartSession)
+	mpartSession := &MultipartSession{}
 	mpartSession.TotalParts = 0
 	mpartSession.UploadID = uploadID
 	mpartSession.Initiated = time.Now().UTC()

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -974,6 +974,29 @@ func (s *MyAPIFSCacheSuite) TestBucketMultipartList(c *C) {
 	c.Assert(newResponse3.Bucket, Equals, "bucketmultipartlist")
 }
 
+func (s *MyAPIFSCacheSuite) TestValidateObjectMultipartUploadID(c *C) {
+	request, err := s.newRequest("PUT", testAPIFSCacheServer.URL+"/objectmultipartlist-uploadid", 0, nil)
+	c.Assert(err, IsNil)
+
+	client := http.Client{}
+	response, err := client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, 200)
+
+	request, err = s.newRequest("POST", testAPIFSCacheServer.URL+"/objectmultipartlist-uploadid/directory1/directory2/object?uploads", 0, nil)
+	c.Assert(err, IsNil)
+
+	response, err = client.Do(request)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	decoder := xml.NewDecoder(response.Body)
+	newResponse := &InitiateMultipartUploadResponse{}
+
+	err = decoder.Decode(newResponse)
+	c.Assert(err, IsNil)
+	c.Assert(len(newResponse.UploadID) > 0, Equals, true)
+}
+
 func (s *MyAPIFSCacheSuite) TestObjectMultipartList(c *C) {
 	request, err := s.newRequest("PUT", testAPIFSCacheServer.URL+"/objectmultipartlist", 0, nil)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Existing code

```
{
  if os.IsNotExist(e) {
       e = os.MkdirAll(objectDir, 0700)
       if e != nil {
            return "", probe.NewError(e)
       }
  }
  return "", probe.NewError(e)  ---> Error was here.
}
```

For a successful 'MkdirAll' it would still return an empty uploadID,
but the 'error' would be nil. This would succeed the request but
client would fail.

Fix is to re-arrange the logic. Thanks to Alexander Neumann @fd0, for
reporting this problem.
