### PR TITLE
Don't set empty ETag values

### DIFF
--- a/api-headers.go
+++ b/api-headers.go
@@ -79,7 +79,9 @@ func setObjectHeaders(w http.ResponseWriter, metadata fs.ObjectMetadata, content
 	lastModified := metadata.Created.Format(http.TimeFormat)
 	// object related headers
 	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("ETag", "\""+metadata.Md5+"\"")
+	if metadata.Md5 != "" {
+		w.Header().Set("ETag", "\""+metadata.Md5+"\"")
+	}
 	w.Header().Set("Last-Modified", lastModified)
 
 	// set content range


### PR DESCRIPTION
Currently, `metadata.Md5` value isn't populated, yet the `ETag` is set to
`""`, causing AWS Java SDK to fail integrity checks with GetObject
api calls.

This avoids requiring setting the `com.amazonaws.services.s3.disableGetObjectMD5Validation` property to `true`.
