### PR TITLE
fs: Fail createObject with appropriate message.

### DIFF
--- a/api-errors.go
+++ b/api-errors.go
@@ -74,6 +74,7 @@ const (
 	SignatureVersionNotSupported
 	BucketNotEmpty
 	RootPathFull
+	ObjectExistsAsPrefix
 )
 
 // APIError code to Error structure map
@@ -237,6 +238,11 @@ var errorCodeResponse = map[int]APIError{
 		Code:           "RootPathFull",
 		Description:    "Root path has reached its minimum free disk threshold. Please delete few objects to proceed.",
 		HTTPStatusCode: http.StatusInternalServerError,
+	},
+	ObjectExistsAsPrefix: {
+		Code:           "ObjectExistsAsPrefix",
+		Description:    "An object already exists as your prefix, choose a different prefix to proceed.",
+		HTTPStatusCode: http.StatusConflict,
 	},
 }
 

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -170,6 +170,8 @@ func (api CloudStorageAPI) PutObjectHandler(w http.ResponseWriter, req *http.Req
 			writeErrorResponse(w, req, EntityTooLarge, req.URL.Path)
 		case fs.InvalidDigest:
 			writeErrorResponse(w, req, InvalidDigest, req.URL.Path)
+		case fs.ObjectExistsAsPrefix:
+			writeErrorResponse(w, req, ObjectExistsAsPrefix, req.URL.Path)
 		default:
 			writeErrorResponse(w, req, InternalError, req.URL.Path)
 		}

--- a/pkg/fs/errors.go
+++ b/pkg/fs/errors.go
@@ -102,6 +102,16 @@ func (e ObjectNotFound) Error() string {
 	return "Object not found: " + e.Bucket + "#" + e.Object
 }
 
+// ObjectExistsAsPrefix object already exists with a requested prefix.
+type ObjectExistsAsPrefix struct {
+	Bucket string
+	Prefix string
+}
+
+func (e ObjectExistsAsPrefix) Error() string {
+	return "Object exists on : " + e.Bucket + " as prefix " + e.Prefix
+}
+
 // ObjectCorrupted object found to be corrupted
 type ObjectCorrupted struct {
 	Object string


### PR DESCRIPTION
Fail createObject() if a file already exists and one attempts
to create a prefix/directory by same name.

Send an approriate error back to the client as 409 Conflict.
