### PR TITLE
fs: Cleanup Golang errors to be called 'e' and probe to be called as …

### DIFF
--- a/accesslog-handler.go
+++ b/accesslog-handler.go
@@ -59,10 +59,10 @@ type LogMessage struct {
 }
 
 func (h *accessLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	message, perr := getLogMessage(w, req)
-	fatalIf(perr.Trace(), "Unable to extract http message.", nil)
-	_, err := h.accessLogFile.Write(message)
-	fatalIf(probe.NewError(err), "Writing to log file failed.", nil)
+	message, err := getLogMessage(w, req)
+	fatalIf(err.Trace(), "Unable to extract http message.", nil)
+	_, e := h.accessLogFile.Write(message)
+	fatalIf(probe.NewError(e), "Writing to log file failed.", nil)
 
 	h.Handler.ServeHTTP(w, req)
 }
@@ -103,9 +103,9 @@ func getLogMessage(w http.ResponseWriter, req *http.Request) ([]byte, *probe.Err
 
 	// logMessage.HTTP.Request = req
 	logMessage.Duration = time.Now().UTC().Sub(logMessage.StartTime)
-	js, err := json.Marshal(logMessage)
-	if err != nil {
-		return nil, probe.NewError(err)
+	js, e := json.Marshal(logMessage)
+	if e != nil {
+		return nil, probe.NewError(e)
 	}
 	js = append(js, byte('\n')) // append a new line
 	return js, nil
@@ -113,8 +113,8 @@ func getLogMessage(w http.ResponseWriter, req *http.Request) ([]byte, *probe.Err
 
 // AccessLogHandler logs requests
 func AccessLogHandler(h http.Handler) http.Handler {
-	file, err := os.OpenFile("access.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
-	fatalIf(probe.NewError(err), "Unable to open access log.", nil)
+	file, e := os.OpenFile("access.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	fatalIf(probe.NewError(e), "Unable to open access log.", nil)
 
 	return &accessLogHandler{Handler: h, accessLogFile: file}
 }

--- a/api-auth-utils.go
+++ b/api-auth-utils.go
@@ -42,9 +42,8 @@ func isValidAccessKey(accessKeyID string) bool {
 // takes input as size in integer
 func generateAccessKeyID() ([]byte, *probe.Error) {
 	alpha := make([]byte, minioAccessID)
-	_, err := rand.Read(alpha)
-	if err != nil {
-		return nil, probe.NewError(err)
+	if _, e := rand.Read(alpha); e != nil {
+		return nil, probe.NewError(e)
 	}
 	for i := 0; i < minioAccessID; i++ {
 		alpha[i] = alphaNumericTable[alpha[i]%byte(len(alphaNumericTable))]
@@ -55,9 +54,8 @@ func generateAccessKeyID() ([]byte, *probe.Error) {
 // generateSecretAccessKey - generate random base64 numeric value from a random seed.
 func generateSecretAccessKey() ([]byte, *probe.Error) {
 	rb := make([]byte, minioSecretID)
-	_, err := rand.Read(rb)
-	if err != nil {
-		return nil, probe.NewError(err)
+	if _, e := rand.Read(rb); e != nil {
+		return nil, probe.NewError(e)
 	}
 	return []byte(base64.StdEncoding.EncodeToString(rb))[:minioSecretID], nil
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"runtime"
 	"strconv"
 
@@ -54,12 +53,6 @@ VERSION:
 func init() {
 	// Check if minio was compiled using a supported version of Golang.
 	checkGolangRuntimeVersion()
-
-	// Check for the environment early on and gracefuly report.
-	_, err := user.Current()
-	if err != nil {
-
-	}
 
 	if os.Getenv("DOCKERIMAGE") == "1" {
 		// the further checks are ignored for docker image

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -39,6 +39,13 @@ func (api CloudStorageAPI) GetObjectHandler(w http.ResponseWriter, req *http.Req
 	bucket = vars["bucket"]
 	object = vars["object"]
 
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
+
 	metadata, err := api.Filesystem.GetObjectMetadata(bucket, object)
 	if err != nil {
 		errorIf(err.Trace(), "GetObject failed.", nil)
@@ -78,6 +85,13 @@ func (api CloudStorageAPI) HeadObjectHandler(w http.ResponseWriter, req *http.Re
 	bucket = vars["bucket"]
 	object = vars["object"]
 
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
+
 	metadata, err := api.Filesystem.GetObjectMetadata(bucket, object)
 	if err != nil {
 		switch err.ToGoError().(type) {
@@ -106,6 +120,13 @@ func (api CloudStorageAPI) PutObjectHandler(w http.ResponseWriter, req *http.Req
 	vars := mux.Vars(req)
 	bucket = vars["bucket"]
 	object = vars["object"]
+
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) || api.Filesystem.IsReadOnlyBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
 
 	// get Content-MD5 sent by client and verify if valid
 	md5 := req.Header.Get("Content-MD5")
@@ -192,6 +213,13 @@ func (api CloudStorageAPI) NewMultipartUploadHandler(w http.ResponseWriter, req 
 	bucket = vars["bucket"]
 	object = vars["object"]
 
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) || api.Filesystem.IsReadOnlyBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
+
 	uploadID, err := api.Filesystem.NewMultipartUpload(bucket, object)
 	if err != nil {
 		errorIf(err.Trace(), "NewMultipartUpload failed.", nil)
@@ -225,6 +253,13 @@ func (api CloudStorageAPI) PutObjectPartHandler(w http.ResponseWriter, req *http
 	vars := mux.Vars(req)
 	bucket := vars["bucket"]
 	object := vars["object"]
+
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) || api.Filesystem.IsReadOnlyBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
 
 	// get Content-MD5 sent by client and verify if valid
 	md5 := req.Header.Get("Content-MD5")
@@ -317,6 +352,13 @@ func (api CloudStorageAPI) AbortMultipartUploadHandler(w http.ResponseWriter, re
 	bucket := vars["bucket"]
 	object := vars["object"]
 
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) || api.Filesystem.IsReadOnlyBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
+
 	objectResourcesMetadata := getObjectResources(req.URL.Query())
 	err := api.Filesystem.AbortMultipartUpload(bucket, object, objectResourcesMetadata.UploadID)
 	if err != nil {
@@ -345,6 +387,13 @@ func (api CloudStorageAPI) ListObjectPartsHandler(w http.ResponseWriter, req *ht
 	vars := mux.Vars(req)
 	bucket := vars["bucket"]
 	object := vars["object"]
+
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) || api.Filesystem.IsReadOnlyBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
 
 	objectResourcesMetadata := getObjectResources(req.URL.Query())
 	if objectResourcesMetadata.PartNumberMarker < 0 {
@@ -391,6 +440,13 @@ func (api CloudStorageAPI) CompleteMultipartUploadHandler(w http.ResponseWriter,
 	vars := mux.Vars(req)
 	bucket := vars["bucket"]
 	object := vars["object"]
+
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) || api.Filesystem.IsReadOnlyBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
 
 	objectResourcesMetadata := getObjectResources(req.URL.Query())
 	var signature *fs.Signature
@@ -460,6 +516,13 @@ func (api CloudStorageAPI) DeleteObjectHandler(w http.ResponseWriter, req *http.
 	vars := mux.Vars(req)
 	bucket := vars["bucket"]
 	object := vars["object"]
+
+	if isRequestRequiresACLCheck(req) {
+		if api.Filesystem.IsPrivateBucket(bucket) || api.Filesystem.IsReadOnlyBucket(bucket) {
+			writeErrorResponse(w, req, AccessDenied, req.URL.Path)
+			return
+		}
+	}
 
 	err := api.Filesystem.DeleteObject(bucket, object)
 	if err != nil {

--- a/pkg/fs/fs-bucket-listobjects.go
+++ b/pkg/fs/fs-bucket-listobjects.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/minio/minio-xl/pkg/probe"
+	"github.com/minio/minio/pkg/ioutils"
 )
 
 // listObjectsParams - list objects input parameters.
@@ -77,7 +78,7 @@ func (fs Filesystem) listObjects(bucket, prefix, marker, delimiter string, maxKe
 				walkPath = prefixPath
 			}
 		}
-		Walk(walkPath, func(path string, info os.FileInfo, err error) error {
+		ioutils.FTW(walkPath, func(path string, info os.FileInfo, err error) error {
 			// We don't need to list the walk path.
 			if path == walkPath {
 				return nil
@@ -108,7 +109,7 @@ func (fs Filesystem) listObjects(bucket, prefix, marker, delimiter string, maxKe
 				// If delimiter is set, we stop if current path is a
 				// directory.
 				if delimiter != "" && info.IsDir() {
-					return ErrSkipDir
+					return ioutils.ErrSkipDir
 				}
 			}
 			return nil

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -33,12 +33,12 @@ var _ = Suite(&MySuite{})
 func (s *MySuite) TestAPISuite(c *C) {
 	var storageList []string
 	create := func() Filesystem {
-		path, err := ioutil.TempDir(os.TempDir(), "minio-")
-		c.Check(err, IsNil)
+		path, e := ioutil.TempDir(os.TempDir(), "minio-")
+		c.Check(e, IsNil)
 		storageList = append(storageList, path)
-		store, perr := New(path)
+		store, err := New(path)
 		store.SetMinFreeDisk(0)
-		c.Check(perr, IsNil)
+		c.Check(err, IsNil)
 		return store
 	}
 	APITestSuite(c, create)

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -51,17 +51,17 @@ var _ = Suite(&MyAPIFSCacheSuite{})
 var testAPIFSCacheServer *httptest.Server
 
 func (s *MyAPIFSCacheSuite) SetUpSuite(c *C) {
-	root, err := ioutil.TempDir(os.TempDir(), "api-")
-	c.Assert(err, IsNil)
+	root, e := ioutil.TempDir(os.TempDir(), "api-")
+	c.Assert(e, IsNil)
 	s.root = root
 
-	fsroot, err := ioutil.TempDir(os.TempDir(), "api-")
-	c.Assert(err, IsNil)
+	fsroot, e := ioutil.TempDir(os.TempDir(), "api-")
+	c.Assert(e, IsNil)
 
-	accessKeyID, perr := generateAccessKeyID()
-	c.Assert(perr, IsNil)
-	secretAccessKey, perr := generateSecretAccessKey()
-	c.Assert(perr, IsNil)
+	accessKeyID, err := generateAccessKeyID()
+	c.Assert(err, IsNil)
+	secretAccessKey, err := generateSecretAccessKey()
+	c.Assert(err, IsNil)
 
 	conf := newConfigV2()
 	conf.Credentials.AccessKeyID = string(accessKeyID)
@@ -72,8 +72,7 @@ func (s *MyAPIFSCacheSuite) SetUpSuite(c *C) {
 	// do this only once here
 	setGlobalConfigPath(root)
 
-	perr = saveConfig(conf)
-	c.Assert(perr, IsNil)
+	c.Assert(saveConfig(conf), IsNil)
 
 	cloudServer := cloudServerConfig{
 		Path:        fsroot,

--- a/signature-handler.go
+++ b/signature-handler.go
@@ -44,6 +44,13 @@ func isRequestSignatureV4(req *http.Request) bool {
 	return false
 }
 
+func isRequestRequiresACLCheck(req *http.Request) bool {
+	if isRequestSignatureV4(req) || isRequestPresignedSignatureV4(req) || isRequestPostPolicySignatureV4(req) {
+		return false
+	}
+	return true
+}
+
 func isRequestPresignedSignatureV4(req *http.Request) bool {
 	if _, ok := req.URL.Query()["X-Amz-Credential"]; ok {
 		return ok


### PR DESCRIPTION
…'err'
- Replace the ACL checks back, remove them when bucket
  policy is implemented.
- Move FTW (File Tree Walk) into ioutils package.
