### PR TITLE
multipart: Multipart session map now is based on uploadID.

### DIFF
--- a/pkg/fs/fs-bucket-listobjects.go
+++ b/pkg/fs/fs-bucket-listobjects.go
@@ -82,7 +82,8 @@ func (fs Filesystem) listObjects(bucket, prefix, marker, delimiter string, maxKe
 			if e != nil {
 				return e
 			}
-			if strings.HasSuffix(path, "$multiparts") {
+			// Skip special temporary files, kept for multipart transaction.
+			if strings.Contains(path, "$multiparts") || strings.Contains(path, "$tmpobject") {
 				return nil
 			}
 			// We don't need to list the walk path.

--- a/pkg/fs/fs-object.go
+++ b/pkg/fs/fs-object.go
@@ -237,7 +237,7 @@ func (fs Filesystem) CreateObject(bucket, object, expectedMD5Sum string, size in
 	}
 
 	// Write object.
-	file, e := atomic.FileCreateWithPrefix(objectPath, "")
+	file, e := atomic.FileCreateWithPrefix(objectPath, "$tmpobject")
 	if e != nil {
 		switch e := e.(type) {
 		case *os.PathError:

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -46,6 +46,7 @@ type Buckets struct {
 // MultipartSession holds active session information
 type MultipartSession struct {
 	TotalParts int
+	ObjectName string
 	UploadID   string
 	Initiated  time.Time
 	Parts      []PartMetadata


### PR DESCRIPTION
- Fixes initiating parallel uploads, and configs being quickly
  re-written by another incoming request.
- Parallel uploads work smoothly now and return expected behavior.
