### PR TITLE
getObject: Add support for special response headers.

### DIFF
--- a/pkg/fs/signature.go
+++ b/pkg/fs/signature.go
@@ -308,6 +308,14 @@ func (r *Signature) DoesPresignedSignatureMatch() (bool, *probe.Error) {
 	query.Set("X-Amz-Expires", strconv.Itoa(expireSeconds))
 	query.Set("X-Amz-SignedHeaders", r.getSignedHeaders(r.extractSignedHeaders()))
 	query.Set("X-Amz-Credential", r.AccessKeyID+"/"+r.getScope(t))
+
+	// Save other headers available in the request parameters.
+	for k, v := range r.Request.URL.Query() {
+		if strings.HasPrefix(strings.ToLower(k), "x-amz") {
+			continue
+		}
+		query[k] = v
+	}
 	encodedQuery := query.Encode()
 
 	// Verify if date query is same.

--- a/vendor/github.com/minio/minio-go/CONTRIBUTING.md
+++ b/vendor/github.com/minio/minio-go/CONTRIBUTING.md
@@ -14,7 +14,7 @@
     - Have test cases for the new code. If you have questions about how to do it, please ask in your pull request.
     - Run `go fmt`
     - Squash your commits into a single commit. `git rebase -i`. It's okay to force update your pull request.
-    - Make sure `go test -race ./...` and `go build` completes.
+    - Make sure `go test -short -race ./...` and `go build` completes.
 
 * Read [Effective Go](https://github.com/golang/go/wiki/CodeReviewComments) article from Golang project
     - `minio-go` project is strictly conformant with Golang style

--- a/vendor/github.com/minio/minio-go/README.md
+++ b/vendor/github.com/minio/minio-go/README.md
@@ -83,7 +83,7 @@ func main() {
 * [FGetObject(bucketName, objectName, filePath) error](examples/s3/fgetobject.go)
 
 ### Presigned Operations.
-* [PresignedGetObject(bucketName, objectName, time.Duration) (string, error)](examples/s3/presignedgetobject.go)
+* [PresignedGetObject(bucketName, objectName, time.Duration, url.Values) (string, error)](examples/s3/presignedgetobject.go)
 * [PresignedPutObject(bucketName, objectName, time.Duration) (string, error)](examples/s3/presignedputobject.go)
 * [PresignedPostPolicy(NewPostPolicy()) (map[string]string, error)](examples/s3/presignedpostpolicy.go)
 

--- a/vendor/github.com/minio/minio-go/api-put-object-common.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-common.go
@@ -55,7 +55,7 @@ func shouldUploadPart(objPart objectPart, objectParts map[int]objectPart) bool {
 		return true
 	}
 	// if md5sum mismatches should upload the part.
-	if objPart.ETag == uploadedPart.ETag {
+	if objPart.ETag != uploadedPart.ETag {
 		return true
 	}
 	return false

--- a/vendor/github.com/minio/minio-go/api_functional_v2_test.go
+++ b/vendor/github.com/minio/minio-go/api_functional_v2_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -954,11 +955,12 @@ func TestFunctionalV2(t *testing.T) {
 		t.Fatal("Error: ", err)
 	}
 
-	presignedGetURL, err := c.PresignedGetObject(bucketName, objectName, 3600*time.Second)
+	// Generate presigned GET object url.
+	presignedGetURL, err := c.PresignedGetObject(bucketName, objectName, 3600*time.Second, nil)
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-
+	// Verify if presigned url works.
 	resp, err := http.Get(presignedGetURL)
 	if err != nil {
 		t.Fatal("Error: ", err)
@@ -972,6 +974,34 @@ func TestFunctionalV2(t *testing.T) {
 	}
 	if !bytes.Equal(newPresignedBytes, buf) {
 		t.Fatal("Error: bytes mismatch.")
+	}
+
+	// Set request parameters.
+	reqParams := make(url.Values)
+	reqParams.Set("response-content-disposition", "attachment; filename=\"test.txt\"")
+	// Generate presigned GET object url.
+	presignedGetURL, err = c.PresignedGetObject(bucketName, objectName, 3600*time.Second, reqParams)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+	// Verify if presigned url works.
+	resp, err = http.Get(presignedGetURL)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("Error: ", resp.Status)
+	}
+	newPresignedBytes, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+	if !bytes.Equal(newPresignedBytes, buf) {
+		t.Fatal("Error: bytes mismatch for presigned GET url.")
+	}
+	// Verify content disposition.
+	if resp.Header.Get("Content-Disposition") != "attachment; filename=\"test.txt\"" {
+		t.Fatalf("Error: wrong Content-Disposition received %s", resp.Header.Get("Content-Disposition"))
 	}
 
 	presignedPutURL, err := c.PresignedPutObject(bucketName, objectName+"-presigned", 3600*time.Second)

--- a/vendor/github.com/minio/minio-go/api_functional_v4_test.go
+++ b/vendor/github.com/minio/minio-go/api_functional_v4_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -983,11 +984,13 @@ func TestFunctional(t *testing.T) {
 		t.Fatal("Error: ", err)
 	}
 
-	presignedGetURL, err := c.PresignedGetObject(bucketName, objectName, 3600*time.Second)
+	// Generate presigned GET object url.
+	presignedGetURL, err := c.PresignedGetObject(bucketName, objectName, 3600*time.Second, nil)
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
 
+	// Verify if presigned url works.
 	resp, err := http.Get(presignedGetURL)
 	if err != nil {
 		t.Fatal("Error: ", err)
@@ -1001,6 +1004,32 @@ func TestFunctional(t *testing.T) {
 	}
 	if !bytes.Equal(newPresignedBytes, buf) {
 		t.Fatal("Error: bytes mismatch.")
+	}
+
+	// Set request parameters.
+	reqParams := make(url.Values)
+	reqParams.Set("response-content-disposition", "attachment; filename=\"test.txt\"")
+	presignedGetURL, err = c.PresignedGetObject(bucketName, objectName, 3600*time.Second, reqParams)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+	// Verify if presigned url works.
+	resp, err = http.Get(presignedGetURL)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("Error: ", resp.Status)
+	}
+	newPresignedBytes, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+	if !bytes.Equal(newPresignedBytes, buf) {
+		t.Fatal("Error: bytes mismatch for presigned GET URL.")
+	}
+	if resp.Header.Get("Content-Disposition") != "attachment; filename=\"test.txt\"" {
+		t.Fatalf("Error: wrong Content-Disposition received %s", resp.Header.Get("Content-Disposition"))
 	}
 
 	presignedPutURL, err := c.PresignedPutObject(bucketName, objectName+"-presigned", 3600*time.Second)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -59,8 +59,8 @@
 		},
 		{
 			"path": "github.com/minio/minio-go",
-			"revision": "c5884ce9ce3ac73b025d0bc58c4d3d72870edc0b",
-			"revisionTime": "2016-02-02T13:13:10+05:30"
+			"revision": "280f16a52008d3ebba1bd64398b9b082e6738386",
+			"revisionTime": "2016-02-07T03:45:25-08:00"
 		},
 		{
 			"path": "github.com/minio/minio-xl/pkg/atomic",

--- a/web-handlers.go
+++ b/web-handlers.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -206,7 +208,10 @@ func (web *WebAPI) GetObjectURL(r *http.Request, args *GetObjectURLArgs, reply *
 	if e != nil {
 		return e
 	}
-	signedURLStr, e := client.PresignedGetObject(args.BucketName, args.ObjectName, time.Duration(60*60)*time.Second)
+	reqParams := make(url.Values)
+	// Set content disposition for browser to download the file.
+	reqParams.Set("response-content-disposition", fmt.Sprintf(`attachment; filename="%s"`, filepath.Base(args.ObjectName)))
+	signedURLStr, e := client.PresignedGetObject(args.BucketName, args.ObjectName, time.Duration(60*60)*time.Second, reqParams)
 	if e != nil {
 		return e
 	}


### PR DESCRIPTION
Supports now response-content-type, response-content-disposition,
response-cache-control, response-expires.
