### PR TITLE
rpc: Fix json rpc to handle array and object request params.

### DIFF
--- a/vendor/github.com/gorilla/rpc/v2/json2/server.go
+++ b/vendor/github.com/gorilla/rpc/v2/json2/server.go
@@ -125,21 +125,20 @@ func (c *CodecRequest) Method() (string, error) {
 
 // ReadRe<quest fills the request object for the RPC method.
 func (c *CodecRequest) ReadRequest(args interface{}) error {
-	if c.err == nil {
-		if c.request.Params != nil {
-			// JSON params structured object. Unmarshal to the args object.
-			err := json.Unmarshal(*c.request.Params, args)
-			if err != nil {
+	if c.err == nil && c.request.Params != nil {
+		// Note: if c.request.Params is nil it's not an error, it's an optional member.
+		// JSON params structured object. Unmarshal to the args object.
+		if err := json.Unmarshal(*c.request.Params, args); err != nil {
+			// Structed unmarshalling failed, attempt JSON params as
+			// array value. Unmarshal into array containing the
+			// request struct.
+			params := [1]interface{}{args}
+			if err = json.Unmarshal(*c.request.Params, &params); err != nil {
 				c.err = &Error{
 					Code:    E_INVALID_REQ,
 					Message: err.Error(),
 					Data:    c.request.Params,
 				}
-			}
-		} else {
-			c.err = &Error{
-				Code:    E_INVALID_REQ,
-				Message: "rpc: method request ill-formed: missing params field",
 			}
 		}
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -44,8 +44,8 @@
 		},
 		{
 			"path": "github.com/gorilla/rpc/v2/json2",
-			"revision": "839c4c31c6bb12c15f41802cf89325aa89439ac3",
-			"revisionTime": "2015-07-14T15:53:15-07:00"
+			"revision": "64e20900b8aa38bb0771dec71ba3bcc2b07fc8ec",
+			"revisionTime": "2015-11-05T07:45:51+08:00"
 		},
 		{
 			"path": "github.com/mattn/go-isatty",


### PR DESCRIPTION
rpc/v2/json2 code has a bug where it treats all jsonrpc 2.0
request params like an 'object'. In accordance with the spec
it could be both 'object' or an 'array'.

Handle both cases.
