### PR TITLE
Let user specify access and secret key via command line

### DIFF
--- a/api-auth-utils.go
+++ b/api-auth-utils.go
@@ -38,6 +38,15 @@ func isValidAccessKey(accessKeyID string) bool {
 	return regex.MatchString(accessKeyID)
 }
 
+// isValidAccessKey - validate access key
+func isValidSecretKey(secretKeyID string) bool {
+	if secretKeyID == "" {
+		return true
+	}
+	regex := regexp.MustCompile("^[a-zA-Z0-9\\-\\.\\_\\~]{40}$")
+	return regex.MatchString(secretKeyID)
+}
+
 // generateAccessKeyID - generate random alpha numeric value using only uppercase characters
 // takes input as size in integer
 func generateAccessKeyID() ([]byte, *probe.Error) {

--- a/api-auth-utils.go
+++ b/api-auth-utils.go
@@ -38,7 +38,7 @@ func isValidAccessKey(accessKeyID string) bool {
 	return regex.MatchString(accessKeyID)
 }
 
-// isValidAccessKey - validate access key
+// isValidSecretKey - validate secret key
 func isValidSecretKey(secretKeyID string) bool {
 	if secretKeyID == "" {
 		return true

--- a/flags.go
+++ b/flags.go
@@ -49,6 +49,16 @@ var (
 		Name:  "key",
 		Usage: "Provide your domain private key.",
 	}
+
+	accessKeyID = cli.StringFlag{
+		Name:  "accessKeyID",
+		Usage: "AccessKey identifier.",
+	}
+
+	secretAccessKey = cli.StringFlag{
+		Name:  "secretAccessKey",
+		Usage: "Secret key identifier.",
+	}
 )
 
 // registerFlag registers a cli flag

--- a/main.go
+++ b/main.go
@@ -129,6 +129,8 @@ func registerApp() *cli.App {
 	registerFlag(accessLogFlag)
 	registerFlag(certFlag)
 	registerFlag(keyFlag)
+	registerFlag(accessKeyID)
+	registerFlag(secretAccessKey)
 
 	// set up app
 	app := cli.NewApp()

--- a/server-main.go
+++ b/server-main.go
@@ -263,6 +263,13 @@ func serverMain(c *cli.Context) {
 	secretKey := c.GlobalString("secretAccessKey")
 
 	if (accessKey != "" && secretKey != "") {
+		if (! isValidAccessKey(accessKey)) {
+			fatalIf(probe.NewError(errInvalidArgument), "Access key does not have required length", nil)
+		}
+		if (! isValidSecretKey(secretKey)) {
+			fatalIf(probe.NewError(errInvalidArgument), "Secret key does not have required length", nil)
+		}
+		
 		conf.Credentials.AccessKeyID = accessKey
 		conf.Credentials.SecretAccessKey = secretKey
 		saveConfig(conf)

--- a/server-main.go
+++ b/server-main.go
@@ -259,6 +259,16 @@ func serverMain(c *cli.Context) {
 		fatalIf(probe.NewError(errInvalidArgument), "Both certificate and key are required to enable https.", nil)
 	}
 
+	accessKey := c.GlobalString("accessKeyID")
+	secretKey := c.GlobalString("secretAccessKey")
+
+	if (accessKey != "" && secretKey != "") {
+		conf.Credentials.AccessKeyID = accessKey
+		conf.Credentials.SecretAccessKey = secretKey
+		saveConfig(conf)
+	}
+
+
 	minFreeDisk, err := parsePercentToInt(c.String("min-free-disk"), 64)
 	fatalIf(err.Trace(c.String("min-free-disk")), "Invalid minium free disk size "+c.String("min-free-disk")+" passed.", nil)
 


### PR DESCRIPTION
This patch allow to specify both access and secret key via command line instead of generating them at startup. This eases the integration with other apps that could provide them (see issue #1142).
