### PR TITLE
web: Handle private bucket match from prefix to exact match.

### DIFF
--- a/web-handlers.go
+++ b/web-handlers.go
@@ -174,10 +174,13 @@ func (web *webAPI) ListBuckets(r *http.Request, args *ListBucketsArgs, reply *Li
 		return &json2.Error{Message: e.Error()}
 	}
 	for _, bucket := range buckets {
-		reply.Buckets = append(reply.Buckets, BucketInfo{
-			Name:         bucket.Name,
-			CreationDate: bucket.CreationDate,
-		})
+		// List all buckets which are not private.
+		if bucket.Name != privateBucket {
+			reply.Buckets = append(reply.Buckets, BucketInfo{
+				Name:         bucket.Name,
+				CreationDate: bucket.CreationDate,
+			})
+		}
 	}
 	reply.UIVersion = uiVersion
 	return nil


### PR DESCRIPTION
additionally filter out 'privateBucket' from listBuckets output.
