### PR TITLE
Alpine & CA-Certs for SSL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # use "make dockerimage" to build
-FROM scratch
+FROM alpine:3.3
+RUN apk add --no-cache ca-certificates
 ADD minio.dockerimage /minio
 ADD export /export
 EXPOSE 9000


### PR DESCRIPTION
Switch to alpine as a base image and install the ca certifcates to enable the minio docker container to run behind a SSL proxy, which will fix #1146
