### PR TITLE
use environment variables to set and override access and secret keys

### DIFF
--- a/api-auth-utils.go
+++ b/api-auth-utils.go
@@ -38,6 +38,12 @@ func isValidAccessKey(accessKeyID string) bool {
 	return regex.MatchString(accessKeyID)
 }
 
+ // isValidSecretKey - validate secret key
+ func isValidSecretKey(secretKeyID string) bool {
+ 	regex := regexp.MustCompile("^[a-zA-Z0-9\\-\\.\\_\\~]{40}$")
+ 	return regex.MatchString(secretKeyID)
+ }
+
 // generateAccessKeyID - generate random alpha numeric value using only uppercase characters
 // takes input as size in integer
 func generateAccessKeyID() ([]byte, *probe.Error) {

--- a/server-main.go
+++ b/server-main.go
@@ -53,7 +53,7 @@ OPTIONS:
   {{range .Flags}}{{.}}
   {{end}}
 
-ENVIRONMENT VARIABLES
+ENVIRONMENT VARIABLES:
   MINIO_ACCESS_KEY, MINIO_SECRET_KEY: Access and secret key to use.
 
 EXAMPLES:
@@ -263,21 +263,22 @@ func serverMain(c *cli.Context) {
 		fatalIf(probe.NewError(errInvalidArgument), "Both certificate and key are required to enable https.", nil)
 	}
 
-
 	accessKey := os.Getenv("MINIO_ACCESS_KEY")
 	secretKey := os.Getenv("MINIO_SECRET_KEY")
-	if (accessKey != "" && secretKey != "") {
-		if (! isValidAccessKey(accessKey)) {
-	 			fatalIf(probe.NewError(errInvalidArgument), "Access key does not have required length", nil)
-	 	}
-	 	if (! isValidSecretKey(secretKey)) {
-	 			fatalIf(probe.NewError(errInvalidArgument), "Secret key does not have required length", nil)
-	 	}
+	if accessKey != "" && secretKey != "" {
+		if !isValidAccessKey(accessKey) {
+			fatalIf(probe.NewError(errInvalidArgument), "Access key does not have required length", nil)
+		}
+		if !isValidSecretKey(secretKey) {
+			fatalIf(probe.NewError(errInvalidArgument), "Secret key does not have required length", nil)
+		}
 
-	 		conf.Credentials.AccessKeyID = accessKey
-	 		conf.Credentials.SecretAccessKey = secretKey
-	 		saveConfig(conf)
-	 }
+		conf.Credentials.AccessKeyID = accessKey
+		conf.Credentials.SecretAccessKey = secretKey
+
+		err = saveConfig(conf)
+		fatalIf(err.Trace(), "Unable to save credentials to config.", nil)
+	}
 
 	minFreeDisk, err := parsePercentToInt(c.String("min-free-disk"), 64)
 	fatalIf(err.Trace(c.String("min-free-disk")), "Invalid minium free disk size "+c.String("min-free-disk")+" passed.", nil)

--- a/server-main.go
+++ b/server-main.go
@@ -52,6 +52,10 @@ USAGE:
 OPTIONS:
   {{range .Flags}}{{.}}
   {{end}}
+
+ENVIRONMENT VARIABLES
+  MINIO_ACCESS_KEY, MINIO_SECRET_KEY: Access and secret key to use.
+
 EXAMPLES:
   1. Start minio server on Linux.
       $ minio {{.Name}} /home/shared
@@ -258,6 +262,22 @@ func serverMain(c *cli.Context) {
 	if (certFile != "" && keyFile == "") || (certFile == "" && keyFile != "") {
 		fatalIf(probe.NewError(errInvalidArgument), "Both certificate and key are required to enable https.", nil)
 	}
+
+
+	accessKey := os.Getenv("MINIO_ACCESS_KEY")
+	secretKey := os.Getenv("MINIO_SECRET_KEY")
+	if (accessKey != "" && secretKey != "") {
+		if (! isValidAccessKey(accessKey)) {
+	 			fatalIf(probe.NewError(errInvalidArgument), "Access key does not have required length", nil)
+	 	}
+	 	if (! isValidSecretKey(secretKey)) {
+	 			fatalIf(probe.NewError(errInvalidArgument), "Secret key does not have required length", nil)
+	 	}
+
+	 		conf.Credentials.AccessKeyID = accessKey
+	 		conf.Credentials.SecretAccessKey = secretKey
+	 		saveConfig(conf)
+	 }
 
 	minFreeDisk, err := parsePercentToInt(c.String("min-free-disk"), 64)
 	fatalIf(err.Trace(c.String("min-free-disk")), "Invalid minium free disk size "+c.String("min-free-disk")+" passed.", nil)


### PR DESCRIPTION
Replaces #1143 and makes use of environment variables to setup keys at server startup, allowing to override automatic generation of keys.
