### PR TITLE
api: Return NotImplemented for MultiDelete and CopyObject APIs

### DIFF
--- a/generic-handlers.go
+++ b/generic-handlers.go
@@ -238,6 +238,11 @@ func (h resourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeErrorResponse(w, r, NotImplemented, r.URL.Path)
 		return
 	}
+	// X-Amz-Copy-Source should be ignored as NotImplemented.
+	if _, ok := r.Header[http.CanonicalHeaderKey("x-amz-copy-source")]; ok {
+		writeErrorResponse(w, r, NotImplemented, r.URL.Path)
+		return
+	}
 	h.handler.ServeHTTP(w, r)
 }
 
@@ -276,6 +281,7 @@ var notimplementedBucketResourceNames = map[string]bool{
 	"requestPayment": true,
 	"versioning":     true,
 	"website":        true,
+	"delete":         true,
 }
 
 // List of not implemented object queries

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -508,6 +508,15 @@ func (s *MyAPIFSCacheSuite) TestNotImplemented(c *C) {
 	response, err := client.Do(request)
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusNotImplemented)
+
+	request, err = s.newRequest("POST", testAPIFSCacheServer.URL+"/bucket/object", 0, nil)
+	request.Header.Set("X-Amz-Copy-Source", "/bucket/object-old")
+	c.Assert(err, IsNil)
+
+	client = http.Client{}
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusNotImplemented)
 }
 
 func (s *MyAPIFSCacheSuite) TestHeader(c *C) {


### PR DESCRIPTION
This patch is added to make sure that certain s3Clients receive proper error on what is not implemented, rather than end up creating zero byte files. 

Interim reply for #1172 
