### PR TITLE
api: Implement support for additional request headers.

### DIFF
--- a/api-headers.go
+++ b/api-headers.go
@@ -76,7 +76,7 @@ func setObjectHeaders(w http.ResponseWriter, metadata fs.ObjectMetadata, content
 		setCommonHeaders(w)
 	}
 	// set object headers
-	lastModified := metadata.LastModified.Format(http.TimeFormat)
+	lastModified := metadata.LastModified.UTC().Format(http.TimeFormat)
 	// object related headers
 	w.Header().Set("Content-Type", metadata.ContentType)
 	if metadata.MD5 != "" {

--- a/api-response.go
+++ b/api-response.go
@@ -298,7 +298,7 @@ func generateListObjectsResponse(bucket, prefix, marker, delimiter string, maxKe
 			continue
 		}
 		content.Key = object.Object
-		content.LastModified = object.LastModified.Format(timeFormatAMZ)
+		content.LastModified = object.LastModified.UTC().Format(timeFormatAMZ)
 		if object.MD5 != "" {
 			content.ETag = "\"" + object.MD5 + "\""
 		}
@@ -331,7 +331,7 @@ func generateListObjectsResponse(bucket, prefix, marker, delimiter string, maxKe
 func generateCopyObjectResponse(etag string, lastModified time.Time) CopyObjectResponse {
 	return CopyObjectResponse{
 		ETag:         "\"" + etag + "\"",
-		LastModified: lastModified.Format(timeFormatAMZ),
+		LastModified: lastModified.UTC().Format(timeFormatAMZ),
 	}
 }
 
@@ -378,7 +378,7 @@ func generateListPartsResponse(objectMetadata fs.ObjectResourcesMetadata) ListPa
 		newPart.PartNumber = part.PartNumber
 		newPart.ETag = "\"" + part.ETag + "\""
 		newPart.Size = part.Size
-		newPart.LastModified = part.LastModified.Format(timeFormatAMZ)
+		newPart.LastModified = part.LastModified.UTC().Format(timeFormatAMZ)
 		listPartsResponse.Parts = append(listPartsResponse.Parts, newPart)
 	}
 	return listPartsResponse

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -648,6 +648,24 @@ func (s *MyAPIFSCacheSuite) TestHeadOnObject(c *C) {
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	lastModified := response.Header.Get("Last-Modified")
+	t, err := time.Parse(http.TimeFormat, lastModified)
+	c.Assert(err, IsNil)
+
+	request, err = s.newRequest("HEAD", testAPIFSCacheServer.URL+"/headonobject/object1", 0, nil)
+	c.Assert(err, IsNil)
+	request.Header.Set("If-Modified-Since", t.Add(1*time.Minute).UTC().Format(http.TimeFormat))
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusNotModified)
+
+	request, err = s.newRequest("HEAD", testAPIFSCacheServer.URL+"/headonobject/object1", 0, nil)
+	c.Assert(err, IsNil)
+	request.Header.Set("If-Unmodified-Since", t.Add(-1*time.Minute).UTC().Format(http.TimeFormat))
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusPreconditionFailed)
 }
 
 func (s *MyAPIFSCacheSuite) TestHeadOnBucket(c *C) {


### PR DESCRIPTION
Now GetObject and HeadObject both support
- If-Modified-Since, If-Unmodified-Since
- If-Match, If-None-Match

request headers.

These headers are used to further fine grain the responses for GetObject
and HeadObject API.

Fixes #1098
