### PR TITLE
multipart: remove proper MD5, rather create MD5 based on parts to be s3 compatible.

### DIFF
--- a/api-response.go
+++ b/api-response.go
@@ -218,6 +218,11 @@ type CompleteMultipartUploadResponse struct {
 	ETag     string
 }
 
+// getLocation get URL location.
+func getLocation(r *http.Request) string {
+	return r.URL.Path
+}
+
 // takes an array of Bucketmetadata information for serialization
 // input:
 // array of bucket metadata

--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -291,7 +291,7 @@ func (api storageAPI) PutBucketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Make sure to add Location information here only for bucket
-	w.Header().Set("Location", "/"+bucket)
+	w.Header().Set("Location", getLocation(r))
 	writeSuccessResponse(w, nil)
 }
 

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -798,7 +798,10 @@ func (api storageAPI) CompleteMultipartUploadHandler(w http.ResponseWriter, r *h
 		}
 		return
 	}
-	response := generateCompleteMultpartUploadResponse(bucket, object, r.URL.String(), metadata.MD5)
+	// get object location.
+	location := getLocation(r)
+	// Generate complete multipart response.
+	response := generateCompleteMultpartUploadResponse(bucket, object, location, metadata.MD5)
 	encodedSuccessResponse := encodeSuccessResponse(response)
 	// write headers
 	setCommonHeaders(w)

--- a/pkg/fs/api_suite_nix_test.go
+++ b/pkg/fs/api_suite_nix_test.go
@@ -66,7 +66,6 @@ func testMultipartObjectCreation(c *check.C, create func() Filesystem) {
 
 	completedParts := CompleteMultipartUpload{}
 	completedParts.Part = make([]CompletePart, 0)
-	finalHasher := md5.New()
 	for i := 1; i <= 10; i++ {
 		randomPerm := rand.Perm(10)
 		randomString := ""
@@ -75,7 +74,6 @@ func testMultipartObjectCreation(c *check.C, create func() Filesystem) {
 		}
 
 		hasher := md5.New()
-		finalHasher.Write([]byte(randomString))
 		hasher.Write([]byte(randomString))
 		expectedmd5Sum := base64.StdEncoding.EncodeToString(hasher.Sum(nil))
 		expectedmd5Sumhex := hex.EncodeToString(hasher.Sum(nil))
@@ -87,12 +85,11 @@ func testMultipartObjectCreation(c *check.C, create func() Filesystem) {
 		c.Assert(calculatedmd5sum, check.Equals, expectedmd5Sumhex)
 		completedParts.Part = append(completedParts.Part, CompletePart{PartNumber: i, ETag: calculatedmd5sum})
 	}
-	finalExpectedmd5SumHex := hex.EncodeToString(finalHasher.Sum(nil))
 	completedPartsBytes, e := xml.Marshal(completedParts)
 	c.Assert(e, check.IsNil)
 	objectMetadata, err := fs.CompleteMultipartUpload("bucket", "key", uploadID, bytes.NewReader(completedPartsBytes), nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(objectMetadata.MD5, check.Equals, finalExpectedmd5SumHex)
+	c.Assert(objectMetadata.MD5, check.Equals, "9b7d6f13ba00e24d0b02de92e814891b-10")
 }
 
 func testMultipartObjectAbort(c *check.C, create func() Filesystem) {

--- a/pkg/fs/api_suite_windows_test.go
+++ b/pkg/fs/api_suite_windows_test.go
@@ -65,7 +65,6 @@ func testMultipartObjectCreation(c *check.C, create func() Filesystem) {
 
 	completedParts := CompleteMultipartUpload{}
 	completedParts.Part = make([]CompletePart, 0)
-	finalHasher := md5.New()
 	for i := 1; i <= 10; i++ {
 		randomPerm := rand.Perm(10)
 		randomString := ""
@@ -74,7 +73,6 @@ func testMultipartObjectCreation(c *check.C, create func() Filesystem) {
 		}
 
 		hasher := md5.New()
-		finalHasher.Write([]byte(randomString))
 		hasher.Write([]byte(randomString))
 		expectedmd5Sum := base64.StdEncoding.EncodeToString(hasher.Sum(nil))
 		expectedmd5Sumhex := hex.EncodeToString(hasher.Sum(nil))
@@ -86,12 +84,11 @@ func testMultipartObjectCreation(c *check.C, create func() Filesystem) {
 		c.Assert(calculatedmd5sum, check.Equals, expectedmd5Sumhex)
 		completedParts.Part = append(completedParts.Part, CompletePart{PartNumber: i, ETag: calculatedmd5sum})
 	}
-	finalExpectedmd5SumHex := hex.EncodeToString(finalHasher.Sum(nil))
 	completedPartsBytes, e := xml.Marshal(completedParts)
 	c.Assert(e, check.IsNil)
 	objectMetadata, err := fs.CompleteMultipartUpload("bucket", "key", uploadID, bytes.NewReader(completedPartsBytes), nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(objectMetadata.MD5, check.Equals, finalExpectedmd5SumHex)
+	c.Assert(objectMetadata.MD5, check.Equals, "9b7d6f13ba00e24d0b02de92e814891b-10")
 }
 
 func testMultipartObjectAbort(c *check.C, create func() Filesystem) {


### PR DESCRIPTION
This increases the performance phenominally.
