### PR TITLE
signature: Fix signature handling of parallel requests.

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -242,6 +242,7 @@ func (api storageAPI) PutBucketHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Set http request for signature.
 	auth := api.Signature.SetHTTPRequestToVerify(r)
+
 	if isRequestPresignedSignatureV4(r) {
 		ok, err := auth.DoesPresignedSignatureMatch()
 		if err != nil {
@@ -355,10 +356,10 @@ func (api storageAPI) PostPolicyBucketHandler(w http.ResponseWriter, r *http.Req
 	var ok bool
 
 	// Set http request for signature.
-	api.Signature.SetHTTPRequestToVerify(r)
+	auth := api.Signature.SetHTTPRequestToVerify(r)
 
 	// Verify policy signature.
-	ok, err = api.Signature.DoesPolicySignatureMatch(formValues)
+	ok, err = auth.DoesPolicySignatureMatch(formValues)
 	if err != nil {
 		errorIf(err.Trace(), "Unable to verify signature.", nil)
 		writeErrorResponse(w, r, SignatureDoesNotMatch, r.URL.Path)

--- a/pkg/s3/signature4/v4-signature.go
+++ b/pkg/s3/signature4/v4-signature.go
@@ -74,13 +74,13 @@ func New(accessKeyID, secretAccessKey, region string) (*Sign, *probe.Error) {
 }
 
 // SetHTTPRequestToVerify - sets the http request which needs to be verified.
-func (s *Sign) SetHTTPRequestToVerify(r *http.Request) *Sign {
+func (s *Sign) SetHTTPRequestToVerify(r *http.Request) Sign {
 	// Do not set http request if its 'nil'.
 	if r == nil {
-		return s
+		return *s
 	}
 	s.httpRequest = r
-	return s
+	return *s
 }
 
 // getCanonicalHeaders generate a list of request headers with their values


### PR DESCRIPTION
Signature struct should be immutable, this fixes an issue with AWS cli not being able to do multipart put operations.
