### PR TITLE
api: Implement multiple objects Delete api - fixes #956

### DIFF
--- a/api-datatypes.go
+++ b/api-datatypes.go
@@ -1,0 +1,30 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+// ObjectIdentifier carries key name for the object to delete.
+type ObjectIdentifier struct {
+	ObjectName string `xml:"Key"`
+}
+
+// DeleteObjectsRequest - xml carrying the object key names which needs to be deleted.
+type DeleteObjectsRequest struct {
+	// Element to enable quiet mode for the request
+	Quiet bool
+	// List of objects to be deleted
+	Objects []ObjectIdentifier `xml:"Object"`
+}

--- a/api-errors.go
+++ b/api-errors.go
@@ -62,6 +62,7 @@ const (
 	InvalidCopyDest
 	MalformedXML
 	MissingContentLength
+	MissingContentMD5
 	MissingRequestBodyError
 	NoSuchBucket
 	NoSuchKey
@@ -125,7 +126,7 @@ var errorCodeResponse = map[int]APIError{
 	},
 	BadDigest: {
 		Code:           "BadDigest",
-		Description:    "The Content-MD5 you specified did not match what we received.",
+		Description:    "The Content-Md5 you specified did not match what we received.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	BucketAlreadyExists: {
@@ -165,7 +166,7 @@ var errorCodeResponse = map[int]APIError{
 	},
 	InvalidDigest: {
 		Code:           "InvalidDigest",
-		Description:    "The Content-MD5 you specified is not valid.",
+		Description:    "The Content-Md5 you specified is not valid.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	InvalidRange: {
@@ -182,6 +183,11 @@ var errorCodeResponse = map[int]APIError{
 		Code:           "MissingContentLength",
 		Description:    "You must provide the Content-Length HTTP header.",
 		HTTPStatusCode: http.StatusLengthRequired,
+	},
+	MissingContentMD5: {
+		Code:           "MissingContentMD5",
+		Description:    "Missing required header for this request: Content-Md5.",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	MissingRequestBodyError: {
 		Code:           "MissingRequestBodyError",

--- a/api-response.go
+++ b/api-response.go
@@ -218,6 +218,24 @@ type CompleteMultipartUploadResponse struct {
 	ETag     string
 }
 
+// DeleteError structure.
+type DeleteError struct {
+	Code    string
+	Message string
+	Key     string
+}
+
+// DeleteObjectsResponse container for multiple object deletes.
+type DeleteObjectsResponse struct {
+	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ DeleteResult" json:"-"`
+
+	// Collection of all deleted objects
+	DeletedObjects []ObjectIdentifier `xml:"Deleted,omitempty"`
+
+	// Collection of errors deleting certain objects.
+	Errors []DeleteError `xml:"Error,omitempty"`
+}
+
 // getLocation get URL location.
 func getLocation(r *http.Request) string {
 	return r.URL.Path
@@ -412,6 +430,16 @@ func generateListMultipartUploadsResponse(bucket string, metadata fs.BucketMulti
 		listMultipartUploadsResponse.Uploads = append(listMultipartUploadsResponse.Uploads, newUpload)
 	}
 	return listMultipartUploadsResponse
+}
+
+// generate multi objects delete response.
+func generateMultiDeleteResponse(quiet bool, deletedObjects []ObjectIdentifier, errs []DeleteError) DeleteObjectsResponse {
+	deleteResp := DeleteObjectsResponse{}
+	if !quiet {
+		deleteResp.DeletedObjects = deletedObjects
+	}
+	deleteResp.Errors = errs
+	return deleteResp
 }
 
 // writeSuccessResponse write success headers and response if any.

--- a/generic-handlers.go
+++ b/generic-handlers.go
@@ -289,7 +289,6 @@ var notimplementedBucketResourceNames = map[string]bool{
 	"requestPayment": true,
 	"versioning":     true,
 	"website":        true,
-	"delete":         true,
 }
 
 // List of not implemented object queries

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -420,8 +420,8 @@ func (api storageAPI) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// get Content-MD5 sent by client and verify if valid
-	md5 := r.Header.Get("Content-MD5")
+	// get Content-Md5 sent by client and verify if valid
+	md5 := r.Header.Get("Content-Md5")
 	if !isValidMD5(md5) {
 		writeErrorResponse(w, r, InvalidDigest, r.URL.Path)
 		return
@@ -554,8 +554,8 @@ func (api storageAPI) PutObjectPartHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	// get Content-MD5 sent by client and verify if valid
-	md5 := r.Header.Get("Content-MD5")
+	// get Content-Md5 sent by client and verify if valid
+	md5 := r.Header.Get("Content-Md5")
 	if !isValidMD5(md5) {
 		writeErrorResponse(w, r, InvalidDigest, r.URL.Path)
 		return
@@ -811,7 +811,7 @@ func (api storageAPI) CompleteMultipartUploadHandler(w http.ResponseWriter, r *h
 
 /// Delete storageAPI
 
-// DeleteObjectHandler - Delete object
+// DeleteObjectHandler - delete an object
 func (api storageAPI) DeleteObjectHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]

--- a/pkg/fs/fs-multipart.go
+++ b/pkg/fs/fs-multipart.go
@@ -202,7 +202,7 @@ func saveParts(partPathPrefix string, mw io.Writer, parts []CompletePart) *probe
 			if !os.IsNotExist(e) {
 				return probe.NewError(e)
 			}
-			// Some clients do not set Content-MD5, so we would have
+			// Some clients do not set Content-Md5, so we would have
 			// created part files without 'ETag' in them.
 			partFile, e = os.OpenFile(partPathPrefix+fmt.Sprintf("$%d-$multiparts", part.PartNumber), os.O_RDONLY, 0600)
 			if e != nil {

--- a/routers.go
+++ b/routers.go
@@ -149,6 +149,8 @@ func registerAPIHandlers(mux *router.Router, a storageAPI, w *webAPI) {
 	bucket.Methods("PUT").HandlerFunc(a.PutBucketHandler)
 	// HeadBucket
 	bucket.Methods("HEAD").HandlerFunc(a.HeadBucketHandler)
+	// DeleteMultipleObjects
+	bucket.Methods("POST").HandlerFunc(a.DeleteMultipleObjectsHandler)
 	// PostPolicy
 	bucket.Methods("POST").HandlerFunc(a.PostPolicyBucketHandler)
 	// DeleteBucket

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -1158,7 +1158,7 @@ func (s *MyAPIFSCacheSuite) TestObjectMultipart(c *C) {
 
 	buffer1 := bytes.NewReader([]byte("hello world"))
 	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/objectmultiparts/object?uploadId="+uploadID+"&partNumber=1", int64(buffer1.Len()), buffer1)
-	request.Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(md5Sum))
+	request.Header.Set("Content-Md5", base64.StdEncoding.EncodeToString(md5Sum))
 	c.Assert(err, IsNil)
 
 	client = http.Client{}
@@ -1168,7 +1168,7 @@ func (s *MyAPIFSCacheSuite) TestObjectMultipart(c *C) {
 
 	buffer2 := bytes.NewReader([]byte("hello world"))
 	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/objectmultiparts/object?uploadId="+uploadID+"&partNumber=2", int64(buffer2.Len()), buffer2)
-	request.Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(md5Sum))
+	request.Header.Set("Content-Md5", base64.StdEncoding.EncodeToString(md5Sum))
 	c.Assert(err, IsNil)
 
 	client = http.Client{}


### PR DESCRIPTION
This API takes input XML input in following form.

```
<?xml version="1.0" encoding="UTF-8"?>
<Delete>
    <Quiet>true</Quiet>
    <Object>
         <Key>Key</Key>
    </Object>
    <Object>
         <Key>Key</Key>
    </Object>
    ...
</Delete>
```

and responds the list of successful deletes, list of errors
for all the deleted objects.

```
<?xml version="1.0" encoding="UTF-8"?>
<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <Deleted>
    <Key>sample1.txt</Key>
  </Deleted>
  <Error>
    <Key>sample2.txt</Key>
    <Code>AccessDenied</Code>
    <Message>Access Denied</Message>
  </Error>
</DeleteResult>
```
