### PR TITLE
Test: Better structuring of fs-utils test

### DIFF
--- a/pkg/fs/fs-utils_test.go
+++ b/pkg/fs/fs-utils_test.go
@@ -20,53 +20,95 @@ import (
 	"testing"
 )
 
-func ensureBucketName(name string, t *testing.T, pass bool) {
-	if pass && IsValidBucketName(name) {
-		return
+//Validating bucket name.
+func ensureBucketName(t *testing.T, name string, testNum int, pass bool) {
+	isValidBucketName := IsValidBucketName(name)
+	if pass && !isValidBucketName {
+		t.Errorf("Test case %d: Expected \"%s\" to be a valid bucket name", testNum, name)
 	}
-	if !pass && !IsValidBucketName(name) {
-		return
+	if !pass && isValidBucketName {
+		t.Errorf("Test case %d: Expected bucket name \"%s\" to be invalid", testNum, name)
 	}
-
-	t.Errorf("\"%s\" should have passed [%t]\n", name, pass)
 }
 
 func TestIsValidBucketName(t *testing.T) {
-	ensureBucketName("lol", t, true)
-	ensureBucketName("s3-eu-west-1.amazonaws.com", t, true)
-	ensureBucketName("ideas-are-more-powerful-than-guns", t, true)
-	ensureBucketName("testbucket", t, true)
-	ensureBucketName("1bucket", t, true)
-	ensureBucketName("bucket1", t, true)
+	testCases := []struct {
+		bucketName string
+		shouldPass bool
+	}{
+		//cases which should pass the test
+		//passing in valid bucket names
+		{"lol", true},
+		{"1-this-is-valid", true},
+		{"1-this-too-is-valid-1", true},
+		{"this.works.too.1", true},
+		{"1234567", true},
+		{"123", true},
+		{"s3-eu-west-1.amazonaws.com", true},
+		{"ideas-are-more-powerful-than-guns", true},
+		{"testbucket", true},
+		{"1bucket", true},
+		{"bucket1", true},
+		//cases for which test should fail
+		//passing invalid bucket names
+		{"------", false},
+		{"$this-is-not-valid-too", false},
+		{"contains-$-dollar", false},
+		{"contains-^-carrot", false},
+		{"contains-$-dollar", false},
+		{"contains-$-dollar", false},
+		{"......", false},
+		{"", false},
+		{"a", false},
+		{"ab", false},
+		{".starts-with-a-dot", false},
+		{"ends-with-a-dot.", false},
+		{"ends-with-a-dash-", false},
+		{"-starts-with-a-dash", false},
+		{"THIS-BEINGS-WITH-UPPERCASe", false},
+		{"tHIS-ENDS-WITH-UPPERCASE", false},
+		{"ThisBeginsAndEndsWithUpperCase", false},
+		{"una ñina", false},
+		{"lalalallalallalalalallalallalala-theString-size-is-greater-than-64", false},
+	}
 
-	ensureBucketName("testing.", t, false)
-	ensureBucketName("", t, false)
-	ensureBucketName("......", t, false)
-	ensureBucketName("THIS-IS-UPPERCASE", t, false)
-	ensureBucketName("una ñina", t, false)
-	ensureBucketName("lalalallalallalalalallalallalallalallalallalallalallalallallalala", t, false)
+	for i, testCase := range testCases {
+		ensureBucketName(t, testCase.bucketName, i+1, testCase.shouldPass)
+	}
 }
 
-func ensureObjectName(name string, t *testing.T, pass bool) {
-	if pass && IsValidObjectName(name) {
-		return
+//Test for validating object name.
+func ensureObjectName(t *testing.T, name string, testNum int, pass bool) {
+	isValidObjectName := IsValidObjectName(name)
+	if pass && !isValidObjectName {
+		t.Errorf("Test case %d: Expected \"%s\" to be a valid object name", testNum, name)
 	}
-	if !pass && !IsValidObjectName(name) {
-		return
+	if !pass && isValidObjectName {
+		t.Errorf("Test case %d: Expected object name \"%s\" to be invalid", testNum, name)
 	}
 
-	t.Errorf("\"%s\" should have passed [%t]\n", name, pass)
 }
 
 func TestIsValidObjectName(t *testing.T) {
-	ensureObjectName("object", t, true)
-	ensureObjectName("The Shining Script <v1>.pdf", t, true)
-	ensureObjectName("Cost Benefit Analysis (2009-2010).pptx", t, true)
-	ensureObjectName("117Gn8rfHL2ACARPAhaFd0AGzic9pUbIA/5OCn5A", t, true)
-	ensureObjectName("SHØRT", t, true)
-	ensureObjectName("There are far too many object names, and far too few bucket names!", t, true)
+	testCases := []struct {
+		objectName string
+		shouldPass bool
+	}{
+		//cases which should pass the test
+		//passing in valid object name
+		{"object", true},
+		{"The Shining Script <v1>.pdf", true},
+		{"Cost Benefit Analysis (2009-2010).pptx", true},
+		{"117Gn8rfHL2ACARPAhaFd0AGzic9pUbIA/5OCn5A", true},
+		{"SHØRT", true},
+		{"There are far too many object names, and far too few bucket names!", true},
+		//cases for which test should fail
+		//passing invalid object names
+		{"", false},
+		{string([]byte{0xff, 0xfe, 0xfd}), false},
+	}
 
-	ensureObjectName("", t, false)
-	// Bad UTF8 strings should not pass.
-	ensureObjectName(string([]byte{0xff, 0xfe, 0xfd}), t, false)
+	for i, testCase := range testCases {
+		ensureObjectName(t, testCase.objectName, i+1, testCase.shouldPass)
+	}
 }


### PR DESCRIPTION
1. Structuring fs-utils_tests in a better way
2. This format makes the code more readable
3. Easy to add new cases 
4. More readable error status 
