### PR TITLE
pkg/fs: optimize GetObject, add benchmark

### DIFF
--- a/pkg/fs/fs-object_test.go
+++ b/pkg/fs/fs-object_test.go
@@ -1,0 +1,73 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/base64"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkGetObject(b *testing.B) {
+	// Make a temporary directory to use as the filesystem.
+	directory, e := ioutil.TempDir("", "minio-benchmark-getobject")
+	if e != nil {
+		b.Fatal(e)
+	}
+	defer os.RemoveAll(directory)
+
+	// Create the filesystem.
+	filesystem, err := New(directory, 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Make a bucket and put in a few objects.
+	err = filesystem.MakeBucket("bucket")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	text := "Jack and Jill went up the hill / To fetch a pail of water."
+	hasher := md5.New()
+	hasher.Write([]byte(text))
+	sum := base64.StdEncoding.EncodeToString(hasher.Sum(nil))
+	for i := 0; i < 10; i++ {
+		_, err = filesystem.CreateObject("bucket", "object"+strconv.Itoa(i), sum, int64(len(text)), bytes.NewBufferString(text), nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	var w bytes.Buffer
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		n, err := filesystem.GetObject(&w, "bucket", "object"+strconv.Itoa(i%10), 0, 0)
+		if err != nil {
+			b.Error(err)
+		}
+		if n != int64(len(text)) {
+			b.Errorf("GetObject returned incorrect length %d (should be %d)\n", n, int64(len(text)))
+		}
+	}
+}


### PR DESCRIPTION
This PR optimizes `GetObject` by delaying the excess system calls unless they are actually necessary. They're used to give the correct error message back to the user, but the common case is that the correct object is retrieved, and not the bucket is not found. This optimizes for the common case. This should not penalize the uncommon case, as no system calls are added, it just restructures them so as to avoid them when unnecessary.

It also adds a benchmark so you can see the improvement (on my OSX laptop, drops ~500 ns/op):

```
# With patch
BenchmarkGetObject-4           30000         48197 ns/op
BenchmarkGetObject-4           30000         47472 ns/op
BenchmarkGetObject-4           30000         44748 ns/op
# Without patch
BenchmarkGetObject-4           30000         52736 ns/op
BenchmarkGetObject-4           30000         52875 ns/op
BenchmarkGetObject-4           30000         53476 ns/op
```
