### PR TITLE
[GH-1237] api: Handling maxKeys=0 case with a empty response

### DIFF
--- a/pkg/fs/fs-bucket-listobjects.go
+++ b/pkg/fs/fs-bucket-listobjects.go
@@ -64,7 +64,12 @@ func (fs Filesystem) ListObjects(bucket, prefix, marker, delimiter string, maxKe
 		}
 	}
 
-	if maxKeys <= 0 || maxKeys > listObjectsLimit {
+	// Return empty response for a valid request when maxKeys is 0.
+	if maxKeys == 0 {
+		return result, nil
+	}
+
+	if maxKeys < 0 || maxKeys > listObjectsLimit {
 		maxKeys = listObjectsLimit
 	}
 


### PR DESCRIPTION
Fixes #1237 . 
