### PR TITLE
api: ListMultipartUploads and ListParts responded more entries.

### DIFF
--- a/api-response.go
+++ b/api-response.go
@@ -359,13 +359,13 @@ func generateListPartsResponse(objectMetadata fs.ObjectResourcesMetadata) ListPa
 	listPartsResponse.NextPartNumberMarker = objectMetadata.NextPartNumberMarker
 
 	listPartsResponse.Parts = make([]Part, len(objectMetadata.Part))
-	for _, part := range objectMetadata.Part {
+	for index, part := range objectMetadata.Part {
 		newPart := Part{}
 		newPart.PartNumber = part.PartNumber
 		newPart.ETag = "\"" + part.ETag + "\""
 		newPart.Size = part.Size
 		newPart.LastModified = part.LastModified.UTC().Format(timeFormatAMZ)
-		listPartsResponse.Parts = append(listPartsResponse.Parts, newPart)
+		listPartsResponse.Parts[index] = newPart
 	}
 	return listPartsResponse
 }
@@ -385,12 +385,12 @@ func generateListMultipartUploadsResponse(bucket string, metadata fs.BucketMulti
 	listMultipartUploadsResponse.UploadIDMarker = metadata.UploadIDMarker
 
 	listMultipartUploadsResponse.Uploads = make([]Upload, len(metadata.Upload))
-	for _, upload := range metadata.Upload {
+	for index, upload := range metadata.Upload {
 		newUpload := Upload{}
 		newUpload.UploadID = upload.UploadID
 		newUpload.Key = upload.Object
-		newUpload.Initiated = upload.Initiated.Format(timeFormatAMZ)
-		listMultipartUploadsResponse.Uploads = append(listMultipartUploadsResponse.Uploads, newUpload)
+		newUpload.Initiated = upload.Initiated.UTC().Format(timeFormatAMZ)
+		listMultipartUploadsResponse.Uploads[index] = newUpload
 	}
 	return listMultipartUploadsResponse
 }

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -1103,8 +1103,34 @@ func (s *MyAPIFSCacheSuite) TestBucketMultipartList(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response3.StatusCode, Equals, http.StatusOK)
 
+	// listMultipartUploadsResponse - format for list multipart uploads response.
+	type listMultipartUploadsResponse struct {
+		XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ListMultipartUploadsResult" json:"-"`
+
+		Bucket             string
+		KeyMarker          string
+		UploadIDMarker     string `xml:"UploadIdMarker"`
+		NextKeyMarker      string
+		NextUploadIDMarker string `xml:"NextUploadIdMarker"`
+		EncodingType       string
+		MaxUploads         int
+		IsTruncated        bool
+		// All the in progress multipart uploads.
+		Uploads []struct {
+			Key          string
+			UploadID     string `xml:"UploadId"`
+			Initiator    Initiator
+			Owner        Owner
+			StorageClass string
+			Initiated    time.Time // Keep this native to be able to parse properly.
+		}
+		Prefix         string
+		Delimiter      string
+		CommonPrefixes []CommonPrefix
+	}
+
 	decoder = xml.NewDecoder(response3.Body)
-	newResponse3 := &ListMultipartUploadsResponse{}
+	newResponse3 := &listMultipartUploadsResponse{}
 	err = decoder.Decode(newResponse3)
 	c.Assert(err, IsNil)
 	c.Assert(newResponse3.Bucket, Equals, "bucketmultipartlist")


### PR DESCRIPTION
Issue is empty entries were added since allocating an array was
followed by an append. Keep the index and copy the right entries
precisely.

Fixes an issue reported at - https://github.com/minio/mc/issues/1642
