### PR TITLE
api: ListObject - Changing to empty response when prefixDir doesn't exist

### DIFF
--- a/pkg/fs/fs-bucket-listobjects_test.go
+++ b/pkg/fs/fs-bucket-listobjects_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -459,8 +458,8 @@ func TestListObjects(t *testing.T) {
 		// The prefix and marker combination to be valid it should satisy strings.HasPrefix(marker, prefix).
 		{"test-bucket-list-object", "asia", "europe-object", "", 0, ListObjectsResult{}, fmt.Errorf("Invalid combination of marker '%s' and prefix '%s'", "europe-object", "asia"), false},
 		// Setting a non-existing directory to be prefix (14-15).
-		{"empty-bucket", "europe/france/", "", "", 1, ListObjectsResult{}, fmt.Errorf("%s", filepath.FromSlash("/empty-bucket/europe/france")), false},
-		{"empty-bucket", "europe/tunisia/", "", "", 1, ListObjectsResult{}, fmt.Errorf("%s", filepath.FromSlash("/empty-bucket/europe/tunisia")), false},
+		{"empty-bucket", "europe/france/", "", "", 1, ListObjectsResult{}, nil, true},
+		{"empty-bucket", "europe/tunisia/", "", "", 1, ListObjectsResult{}, nil, true},
 		// Testing on empty bucket, that is, bucket without any objects in it (16).
 		{"empty-bucket", "", "", "", 0, ListObjectsResult{}, nil, true},
 		// Setting maxKeys to negative value (17-18).

--- a/pkg/fs/fs-utils.go
+++ b/pkg/fs/fs-utils.go
@@ -51,3 +51,15 @@ func IsValidObjectName(object string) bool {
 	}
 	return true
 }
+
+// IsValidObjectPrefix verifies whether the prefix is a valid object name.
+// Its valid to have a empty prefix.
+func IsValidObjectPrefix(object string) bool {
+	// Prefix can be empty.
+	if object == "" {
+		return true
+	}
+	// Verify if prefix is a valid object name.
+	return IsValidObjectName(object)
+
+}


### PR DESCRIPTION
ListObjects would return an error for non-existent prefixes which is incompatible with 'S3' response where non-existent prefix requests respond back with empty response. 
