### PR TITLE
routers: Fix order of PostPolicyHandlers and headers.

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -518,8 +518,7 @@ func extractHTTPFormValues(reader *multipart.Reader) (io.Reader, map[string]stri
 // signature policy in multipart/form-data
 func (api storageAPI) PostPolicyBucketHandler(w http.ResponseWriter, r *http.Request) {
 	// Here the parameter is the size of the form data that should
-	// be loaded in memory, the remaining being put in temporary
-	// files
+	// be loaded in memory, the remaining being put in temporary files.
 	reader, e := r.MultipartReader()
 	if e != nil {
 		errorIf(probe.NewError(e), "Unable to initialize multipart reader.", nil)

--- a/routers.go
+++ b/routers.go
@@ -149,10 +149,10 @@ func registerAPIHandlers(mux *router.Router, a storageAPI, w *webAPI) {
 	bucket.Methods("PUT").HandlerFunc(a.PutBucketHandler)
 	// HeadBucket
 	bucket.Methods("HEAD").HandlerFunc(a.HeadBucketHandler)
+	// PostPolicy
+	bucket.Methods("POST").HeadersRegexp("Content-Type", "multipart/form-data*").HandlerFunc(a.PostPolicyBucketHandler)
 	// DeleteMultipleObjects
 	bucket.Methods("POST").HandlerFunc(a.DeleteMultipleObjectsHandler)
-	// PostPolicy
-	bucket.Methods("POST").Headers("Content-Type", "multipart/form-data").HandlerFunc(a.PostPolicyBucketHandler)
 	// DeleteBucketPolicy
 	bucket.Methods("DELETE").HandlerFunc(a.DeleteBucketPolicyHandler).Queries("policy", "")
 	// DeleteBucket


### PR DESCRIPTION
This fixes a bug where a POST request is treated as DeleteObjects request. Validate "multipart/form-data" first if present then use PostPolicyHandlers.
