### PR TITLE
Add simple FreeBSD support, make the minio project compilable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,12 @@ endif
 ifeq ($(CPU), x86_64)
   HOST := $(HOST)64
 else
+ifeq ($(CPU), amd64)
+  HOST := $(HOST)64
+else
 ifeq ($(CPU), i686)
   HOST := $(HOST)32
+endif
 endif
 endif
 
@@ -41,6 +45,10 @@ ifndef (OS)
   else
   ifeq ($(HOST), Darwin32)
     arch = clang
+  else
+  ifeq ($(HOST), FreeBSD64)
+    arch = gcc
+  endif
   endif
   endif
   endif
@@ -84,7 +92,7 @@ isa-l:
 
 	@echo "Configuring $@:"
 	@git clone -q https://github.com/minio/isa-l.git
-	@cd isa-l; make -f Makefile.unx arch=$(arch) >/dev/null; mv include isa-l;
+	@cd isa-l; ${MAKE} -f Makefile.unx arch=$(arch) >/dev/null; mv include isa-l;
 
 lint:
 	@echo "Running $@:"

--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -141,6 +141,9 @@ is_supported_os() {
         "Linux")
             os="linux"
             ;;
+        "FreeBSD")
+            os="freebsd"
+            ;;
         "Darwin")
             osx_host_version=$(env sw_vers -productVersion)
             check_version "${osx_host_version}" "${OSX_VERSION}"
@@ -155,7 +158,7 @@ is_supported_os() {
 is_supported_arch() {
     local supported
     case ${UNAME##* } in
-        "x86_64")
+        "x86_64" | "amd64")
             supported=1
             ;;
         "arm"*)

--- a/buildscripts/checkgopath.sh
+++ b/buildscripts/checkgopath.sh
@@ -19,8 +19,8 @@ _init() {
 
     shopt -s extglob
 
-    PWD=$(pwd)
-    GOPATH=$(go env GOPATH)
+    PWD=$(pwd -P)
+    GOPATH=$(cd "$(go env GOPATH)" ; env pwd -P)
 }
 
 main() {

--- a/pkg/crypto/sha256/sha256.go
+++ b/pkg/crypto/sha256/sha256.go
@@ -1,4 +1,4 @@
-// +build darwin windows 386 arm !cgo
+// +build freebsd darwin windows 386 arm !cgo
 
 /*
  * Minio Cloud Storage, (C) 2014-2016 Minio, Inc.

--- a/pkg/crypto/sha512/sha512.go
+++ b/pkg/crypto/sha512/sha512.go
@@ -1,4 +1,4 @@
-// +build darwin windows 386 arm !cgo
+// +build freebsd darwin windows 386 arm !cgo
 
 /*
  * Minio Cloud Storage, (C) 2014-2016 Minio, Inc.

--- a/pkg/disk/type_unix.go
+++ b/pkg/disk/type_unix.go
@@ -1,0 +1,44 @@
+// +build freebsd
+
+/*
+ * Minio Cloud Storage, (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package disk
+
+import (
+	"strconv"
+	"syscall"
+)
+
+// fsType2StringMap - list of filesystems supported by donut on linux
+var fsType2StringMap = map[string]string{
+	"35": "UFS",
+}
+
+// getFSType returns the filesystem type of the underlying mounted filesystem
+func getFSType(path string) (string, error) {
+	s := syscall.Statfs_t{}
+	err := syscall.Statfs(path, &s)
+	if err != nil {
+		return "", err
+	}
+	fsTypeHex := strconv.FormatInt(int64(s.Type), 16)
+	fsTypeString, ok := fsType2StringMap[fsTypeHex]
+	if ok == false {
+		return "UNKNOWN", nil
+	}
+	return fsTypeString, nil
+}


### PR DESCRIPTION
Just a simple change which makes the project compilable under FreeBSD, however:
1. gmake should be used instead of make, otherwise autotools will be needed
2. isa-l package is compiled but it is still not used, the golang standard sha256/512 are used instead
3. The function getFSType is copied in a new file for freebsd target, since it is kind of strange to have a wrong filesystem magic number of UFS (the standard one of freeBSD), it seems to be a golang bug, I will investigate about that
