### PR TITLE
routers: Move API and Web routers into their own files.

### DIFF
--- a/api-router.go
+++ b/api-router.go
@@ -1,0 +1,90 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	router "github.com/gorilla/mux"
+	"github.com/minio/minio/pkg/fs"
+)
+
+// storageAPI container for S3 compatible API.
+type storageAPI struct {
+	// Filesystem instance.
+	Filesystem fs.Filesystem
+}
+
+// registerAPIRouter - registers S3 compatible APIs.
+func registerAPIRouter(mux *router.Router, api storageAPI) {
+	// API Router
+	apiRouter := mux.NewRoute().PathPrefix("/").Subrouter()
+
+	// Bucket router
+	bucket := apiRouter.PathPrefix("/{bucket}").Subrouter()
+
+	/// Object operations
+
+	// HeadObject
+	bucket.Methods("HEAD").Path("/{object:.+}").HandlerFunc(api.HeadObjectHandler)
+	// PutObjectPart
+	bucket.Methods("PUT").Path("/{object:.+}").HandlerFunc(api.PutObjectPartHandler).Queries("partNumber", "{partNumber:[0-9]+}", "uploadId", "{uploadId:.*}")
+	// ListObjectPxarts
+	bucket.Methods("GET").Path("/{object:.+}").HandlerFunc(api.ListObjectPartsHandler).Queries("uploadId", "{uploadId:.*}")
+	// CompleteMultipartUpload
+	bucket.Methods("POST").Path("/{object:.+}").HandlerFunc(api.CompleteMultipartUploadHandler).Queries("uploadId", "{uploadId:.*}")
+	// NewMultipartUpload
+	bucket.Methods("POST").Path("/{object:.+}").HandlerFunc(api.NewMultipartUploadHandler).Queries("uploads", "")
+	// AbortMultipartUpload
+	bucket.Methods("DELETE").Path("/{object:.+}").HandlerFunc(api.AbortMultipartUploadHandler).Queries("uploadId", "{uploadId:.*}")
+	// GetObject
+	bucket.Methods("GET").Path("/{object:.+}").HandlerFunc(api.GetObjectHandler)
+	// CopyObject
+	bucket.Methods("PUT").Path("/{object:.+}").HeadersRegexp("X-Amz-Copy-Source", ".*?(\\/).*?").HandlerFunc(api.CopyObjectHandler)
+	// PutObject
+	bucket.Methods("PUT").Path("/{object:.+}").HandlerFunc(api.PutObjectHandler)
+	// DeleteObject
+	bucket.Methods("DELETE").Path("/{object:.+}").HandlerFunc(api.DeleteObjectHandler)
+
+	/// Bucket operations
+
+	// GetBucketLocation
+	bucket.Methods("GET").HandlerFunc(api.GetBucketLocationHandler).Queries("location", "")
+	// GetBucketPolicy
+	bucket.Methods("GET").HandlerFunc(api.GetBucketPolicyHandler).Queries("policy", "")
+	// ListMultipartUploads
+	bucket.Methods("GET").HandlerFunc(api.ListMultipartUploadsHandler).Queries("uploads", "")
+	// ListObjects
+	bucket.Methods("GET").HandlerFunc(api.ListObjectsHandler)
+	// PutBucketPolicy
+	bucket.Methods("PUT").HandlerFunc(api.PutBucketPolicyHandler).Queries("policy", "")
+	// PutBucket
+	bucket.Methods("PUT").HandlerFunc(api.PutBucketHandler)
+	// HeadBucket
+	bucket.Methods("HEAD").HandlerFunc(api.HeadBucketHandler)
+	// PostPolicy
+	bucket.Methods("POST").HeadersRegexp("Content-Type", "multipart/form-data*").HandlerFunc(api.PostPolicyBucketHandler)
+	// DeleteMultipleObjects
+	bucket.Methods("POST").HandlerFunc(api.DeleteMultipleObjectsHandler)
+	// DeleteBucketPolicy
+	bucket.Methods("DELETE").HandlerFunc(api.DeleteBucketPolicyHandler).Queries("policy", "")
+	// DeleteBucket
+	bucket.Methods("DELETE").HandlerFunc(api.DeleteBucketHandler)
+
+	/// Root operation
+
+	// ListBuckets
+	apiRouter.Methods("GET").HandlerFunc(api.ListBucketsHandler)
+}

--- a/web-handlers.go
+++ b/web-handlers.go
@@ -168,7 +168,7 @@ func (web *webAPI) ListBuckets(r *http.Request, args *ListBucketsArgs, reply *Li
 	}
 	for _, bucket := range buckets {
 		// List all buckets which are not private.
-		if bucket.Name != path.Base(privateBucket) {
+		if bucket.Name != path.Base(reservedBucket) {
 			reply.Buckets = append(reply.Buckets, BucketInfo{
 				Name:         bucket.Name,
 				CreationDate: bucket.CreationDate,

--- a/web-router.go
+++ b/web-router.go
@@ -1,0 +1,95 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/elazarl/go-bindata-assetfs"
+	"github.com/gorilla/handlers"
+	router "github.com/gorilla/mux"
+	jsonrpc "github.com/gorilla/rpc/v2"
+	"github.com/gorilla/rpc/v2/json2"
+	"github.com/minio/minio-go"
+	"github.com/minio/miniobrowser"
+)
+
+// webAPI container for Web API.
+type webAPI struct {
+	// FSPath filesystem path.
+	FSPath string
+	// Minio client instance.
+	Client *minio.Client
+
+	// private params.
+	apiAddress string // api destination address.
+	// credential kept to be used internally.
+	accessKeyID     string
+	secretAccessKey string
+}
+
+// indexHandler - Handler to serve index.html
+type indexHandler struct {
+	handler http.Handler
+}
+
+func (h indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.URL.Path = reservedBucket + "/"
+	h.handler.ServeHTTP(w, r)
+}
+
+const assetPrefix = "production"
+
+func assetFS() *assetfs.AssetFS {
+	return &assetfs.AssetFS{
+		Asset:     miniobrowser.Asset,
+		AssetDir:  miniobrowser.AssetDir,
+		AssetInfo: miniobrowser.AssetInfo,
+		Prefix:    assetPrefix,
+	}
+}
+
+// specialAssets are files which are unique files not embedded inside index_bundle.js.
+const specialAssets = "loader.css|logo.svg|firefox.png|safari.png|chrome.png|favicon.ico"
+
+// registerWebRouter - registers web router for serving minio browser.
+func registerWebRouter(mux *router.Router, web *webAPI) {
+	// Initialize a new json2 codec.
+	codec := json2.NewCodec()
+
+	// Minio rpc router
+	webBrowserRouter := mux.NewRoute().PathPrefix(reservedBucket).Subrouter()
+
+	// Initialize json rpc handlers.
+	webRPC := jsonrpc.NewServer()
+	webRPC.RegisterCodec(codec, "application/json")
+	webRPC.RegisterCodec(codec, "application/json; charset=UTF-8")
+	webRPC.RegisterService(web, "Web")
+
+	// RPC handler at URI - /minio/rpc
+	webBrowserRouter.Path("/rpc").Handler(webRPC)
+
+	// Add compression for assets.
+	compressedAssets := handlers.CompressHandler(http.StripPrefix(reservedBucket, http.FileServer(assetFS())))
+
+	// Serve javascript files and favicon from assets.
+	webBrowserRouter.Path(fmt.Sprintf("/{assets:[^/]+.js|%s}", specialAssets)).Handler(compressedAssets)
+
+	// Serve index.html for rest of the requests.
+	webBrowserRouter.Path("/{index:.*}").Handler(indexHandler{http.StripPrefix(reservedBucket, http.FileServer(assetFS()))})
+}


### PR DESCRIPTION
This is done to ensure we have a clean way to add new routers such as
- diskRouter
- configRouter
- lockRouter
