### PR TITLE
fs: Break fs package to top-level and introduce ObjectAPI interface.

### DIFF
--- a/api-headers.go
+++ b/api-headers.go
@@ -23,8 +23,6 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
-
-	"github.com/minio/minio/pkg/fs"
 )
 
 //// helpers
@@ -60,7 +58,7 @@ func encodeResponse(response interface{}) []byte {
 }
 
 // Write object header
-func setObjectHeaders(w http.ResponseWriter, objectInfo fs.ObjectInfo, contentRange *httpRange) {
+func setObjectHeaders(w http.ResponseWriter, objectInfo ObjectInfo, contentRange *httpRange) {
 	// set common headers
 	setCommonHeaders(w)
 

--- a/api-resources.go
+++ b/api-resources.go
@@ -19,8 +19,6 @@ package main
 import (
 	"net/url"
 	"strconv"
-
-	"github.com/minio/minio/pkg/fs"
 )
 
 // parse bucket url queries
@@ -34,7 +32,7 @@ func getBucketResources(values url.Values) (prefix, marker, delimiter string, ma
 }
 
 // part bucket url queries for ?uploads
-func getBucketMultipartResources(values url.Values) (v fs.BucketMultipartResourcesMetadata) {
+func getBucketMultipartResources(values url.Values) (v BucketMultipartResourcesMetadata) {
 	v.Prefix = values.Get("prefix")
 	v.KeyMarker = values.Get("key-marker")
 	v.MaxUploads, _ = strconv.Atoi(values.Get("max-uploads"))
@@ -45,10 +43,15 @@ func getBucketMultipartResources(values url.Values) (v fs.BucketMultipartResourc
 }
 
 // parse object url queries
-func getObjectResources(values url.Values) (v fs.ObjectResourcesMetadata) {
+func getObjectResources(values url.Values) (v ObjectResourcesMetadata) {
 	v.UploadID = values.Get("uploadId")
 	v.PartNumberMarker, _ = strconv.Atoi(values.Get("part-number-marker"))
 	v.MaxParts, _ = strconv.Atoi(values.Get("max-parts"))
 	v.EncodingType = values.Get("encoding-type")
 	return
+}
+
+// get upload id.
+func getUploadID(values url.Values) (uploadID string) {
+	return getObjectResources(values).UploadID
 }

--- a/api-response.go
+++ b/api-response.go
@@ -20,8 +20,6 @@ import (
 	"encoding/xml"
 	"net/http"
 	"time"
-
-	"github.com/minio/minio/pkg/fs"
 )
 
 const (
@@ -225,7 +223,7 @@ func getLocation(r *http.Request) string {
 //
 // output:
 // populated struct that can be serialized to match xml and json api spec output
-func generateListBucketsResponse(buckets []fs.BucketInfo) ListBucketsResponse {
+func generateListBucketsResponse(buckets []BucketInfo) ListBucketsResponse {
 	var listbuckets []Bucket
 	var data = ListBucketsResponse{}
 	var owner = Owner{}
@@ -247,7 +245,7 @@ func generateListBucketsResponse(buckets []fs.BucketInfo) ListBucketsResponse {
 }
 
 // generates an ListObjects response for the said bucket with other enumerated options.
-func generateListObjectsResponse(bucket, prefix, marker, delimiter string, maxKeys int, resp fs.ListObjectsResult) ListObjectsResponse {
+func generateListObjectsResponse(bucket, prefix, marker, delimiter string, maxKeys int, resp ListObjectsResult) ListObjectsResponse {
 	var contents []Object
 	var prefixes []CommonPrefix
 	var owner = Owner{}
@@ -319,7 +317,7 @@ func generateCompleteMultpartUploadResponse(bucket, key, location, etag string) 
 }
 
 // generateListPartsResult
-func generateListPartsResponse(objectMetadata fs.ObjectResourcesMetadata) ListPartsResponse {
+func generateListPartsResponse(objectMetadata ObjectResourcesMetadata) ListPartsResponse {
 	// TODO - support EncodingType in xml decoding
 	listPartsResponse := ListPartsResponse{}
 	listPartsResponse.Bucket = objectMetadata.Bucket
@@ -349,7 +347,7 @@ func generateListPartsResponse(objectMetadata fs.ObjectResourcesMetadata) ListPa
 }
 
 // generateListMultipartUploadsResponse
-func generateListMultipartUploadsResponse(bucket string, metadata fs.BucketMultipartResourcesMetadata) ListMultipartUploadsResponse {
+func generateListMultipartUploadsResponse(bucket string, metadata BucketMultipartResourcesMetadata) ListMultipartUploadsResponse {
 	listMultipartUploadsResponse := ListMultipartUploadsResponse{}
 	listMultipartUploadsResponse.Bucket = bucket
 	listMultipartUploadsResponse.Delimiter = metadata.Delimiter

--- a/api-router.go
+++ b/api-router.go
@@ -16,19 +16,15 @@
 
 package main
 
-import (
-	router "github.com/gorilla/mux"
-	"github.com/minio/minio/pkg/fs"
-)
+import router "github.com/gorilla/mux"
 
-// storageAPI container for S3 compatible API.
-type storageAPI struct {
-	// Filesystem instance.
-	Filesystem fs.Filesystem
+// objectStorageAPI container for S3 compatible API.
+type objectStorageAPI struct {
+	ObjectAPI ObjectAPI
 }
 
 // registerAPIRouter - registers S3 compatible APIs.
-func registerAPIRouter(mux *router.Router, api storageAPI) {
+func registerAPIRouter(mux *router.Router, api objectStorageAPI) {
 	// API Router
 	apiRouter := mux.NewRoute().PathPrefix("/").Subrouter()
 

--- a/bucket-policy-handlers.go
+++ b/bucket-policy-handlers.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	mux "github.com/gorilla/mux"
-	"github.com/minio/minio/pkg/fs"
 	"github.com/minio/minio/pkg/probe"
 )
 
@@ -128,7 +127,7 @@ func bucketPolicyConditionMatch(conditions map[string]string, statement policySt
 // -----------------
 // This implementation of the PUT operation uses the policy
 // subresource to add to or replace a policy on a bucket
-func (api storageAPI) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
+func (api objectStorageAPI) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 
@@ -188,7 +187,7 @@ func (api storageAPI) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		errorIf(err.Trace(bucket, string(bucketPolicyBuf)), "SaveBucketPolicy failed.", nil)
 		switch err.ToGoError().(type) {
-		case fs.BucketNameInvalid:
+		case BucketNameInvalid:
 			writeErrorResponse(w, r, ErrInvalidBucketName, r.URL.Path)
 		default:
 			writeErrorResponse(w, r, ErrInternalError, r.URL.Path)
@@ -202,7 +201,7 @@ func (api storageAPI) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Requ
 // -----------------
 // This implementation of the DELETE operation uses the policy
 // subresource to add to remove a policy on a bucket.
-func (api storageAPI) DeleteBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
+func (api objectStorageAPI) DeleteBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 
@@ -223,9 +222,9 @@ func (api storageAPI) DeleteBucketPolicyHandler(w http.ResponseWriter, r *http.R
 	if err != nil {
 		errorIf(err.Trace(bucket), "DeleteBucketPolicy failed.", nil)
 		switch err.ToGoError().(type) {
-		case fs.BucketNameInvalid:
+		case BucketNameInvalid:
 			writeErrorResponse(w, r, ErrInvalidBucketName, r.URL.Path)
-		case fs.BucketPolicyNotFound:
+		case BucketPolicyNotFound:
 			writeErrorResponse(w, r, ErrNoSuchBucketPolicy, r.URL.Path)
 		default:
 			writeErrorResponse(w, r, ErrInternalError, r.URL.Path)
@@ -239,7 +238,7 @@ func (api storageAPI) DeleteBucketPolicyHandler(w http.ResponseWriter, r *http.R
 // -----------------
 // This operation uses the policy
 // subresource to return the policy of a specified bucket.
-func (api storageAPI) GetBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
+func (api objectStorageAPI) GetBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 
@@ -260,9 +259,9 @@ func (api storageAPI) GetBucketPolicyHandler(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		errorIf(err.Trace(bucket), "GetBucketPolicy failed.", nil)
 		switch err.ToGoError().(type) {
-		case fs.BucketNameInvalid:
+		case BucketNameInvalid:
 			writeErrorResponse(w, r, ErrInvalidBucketName, r.URL.Path)
-		case fs.BucketPolicyNotFound:
+		case BucketPolicyNotFound:
 			writeErrorResponse(w, r, ErrNoSuchBucketPolicy, r.URL.Path)
 		default:
 			writeErrorResponse(w, r, ErrInternalError, r.URL.Path)

--- a/bucket-policy.go
+++ b/bucket-policy.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/minio/minio/pkg/fs"
 	"github.com/minio/minio/pkg/probe"
 )
 
@@ -70,8 +69,8 @@ func createBucketConfigPath(bucket string) *probe.Error {
 // readBucketPolicy - read bucket policy.
 func readBucketPolicy(bucket string) ([]byte, *probe.Error) {
 	// Verify bucket is valid.
-	if !fs.IsValidBucketName(bucket) {
-		return nil, probe.NewError(fs.BucketNameInvalid{Bucket: bucket})
+	if !IsValidBucketName(bucket) {
+		return nil, probe.NewError(BucketNameInvalid{Bucket: bucket})
 	}
 
 	bucketConfigPath, err := getBucketConfigPath(bucket)
@@ -83,7 +82,7 @@ func readBucketPolicy(bucket string) ([]byte, *probe.Error) {
 	bucketPolicyFile := filepath.Join(bucketConfigPath, "access-policy.json")
 	if _, e := os.Stat(bucketPolicyFile); e != nil {
 		if os.IsNotExist(e) {
-			return nil, probe.NewError(fs.BucketPolicyNotFound{Bucket: bucket})
+			return nil, probe.NewError(BucketPolicyNotFound{Bucket: bucket})
 		}
 		return nil, probe.NewError(e)
 	}
@@ -98,8 +97,8 @@ func readBucketPolicy(bucket string) ([]byte, *probe.Error) {
 // removeBucketPolicy - remove bucket policy.
 func removeBucketPolicy(bucket string) *probe.Error {
 	// Verify bucket is valid.
-	if !fs.IsValidBucketName(bucket) {
-		return probe.NewError(fs.BucketNameInvalid{Bucket: bucket})
+	if !IsValidBucketName(bucket) {
+		return probe.NewError(BucketNameInvalid{Bucket: bucket})
 	}
 
 	bucketConfigPath, err := getBucketConfigPath(bucket)
@@ -111,7 +110,7 @@ func removeBucketPolicy(bucket string) *probe.Error {
 	bucketPolicyFile := filepath.Join(bucketConfigPath, "access-policy.json")
 	if _, e := os.Stat(bucketPolicyFile); e != nil {
 		if os.IsNotExist(e) {
-			return probe.NewError(fs.BucketPolicyNotFound{Bucket: bucket})
+			return probe.NewError(BucketPolicyNotFound{Bucket: bucket})
 		}
 		return probe.NewError(e)
 	}
@@ -121,8 +120,8 @@ func removeBucketPolicy(bucket string) *probe.Error {
 // writeBucketPolicy - save bucket policy.
 func writeBucketPolicy(bucket string, accessPolicyBytes []byte) *probe.Error {
 	// Verify if bucket path legal
-	if !fs.IsValidBucketName(bucket) {
-		return probe.NewError(fs.BucketNameInvalid{Bucket: bucket})
+	if !IsValidBucketName(bucket) {
+		return probe.NewError(BucketNameInvalid{Bucket: bucket})
 	}
 
 	// Create bucket config path.

--- a/fs-backend-metadata.go
+++ b/fs-backend-metadata.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import (
 	"github.com/minio/minio/pkg/probe"

--- a/fs-bucket-listobjects.go
+++ b/fs-bucket-listobjects.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import (
 	"fmt"
@@ -38,7 +38,7 @@ func (fs Filesystem) ListObjects(bucket, prefix, marker, delimiter string, maxKe
 		return result, probe.NewError(BucketNameInvalid{Bucket: bucket})
 	}
 
-	bucket = fs.denormalizeBucket(bucket)
+	bucket = getActualBucketname(fs.path, bucket) // Get the right bucket name.
 	bucketDir := filepath.Join(fs.path, bucket)
 	// Verify if bucket exists.
 	if status, err := isDirExist(bucketDir); !status {

--- a/fs-bucket-listobjects_test.go
+++ b/fs-bucket-listobjects_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import (
 	"bytes"
@@ -27,15 +27,15 @@ import (
 )
 
 func TestListObjects(t *testing.T) {
-	// Make a temporary directory to use as the filesystem.
+	// Make a temporary directory to use as the fs.
 	directory, e := ioutil.TempDir("", "minio-list-object-test")
 	if e != nil {
 		t.Fatal(e)
 	}
 	defer os.RemoveAll(directory)
 
-	// Create the filesystem.
-	fs, err := New(directory)
+	// Create the fs.
+	fs, err := newFS(directory)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,36 +57,36 @@ func TestListObjects(t *testing.T) {
 	}
 	defer os.Remove(tmpfile.Name()) // clean up
 
-	_, err = fs.CreateObject("test-bucket-list-object", "Asia-maps", int64(len("asia-maps")), bytes.NewBufferString("asia-maps"), nil)
+	_, err = fs.PutObject("test-bucket-list-object", "Asia-maps", int64(len("asia-maps")), bytes.NewBufferString("asia-maps"), nil)
 	if err != nil {
 		t.Fatal(e)
 	}
 
-	_, err = fs.CreateObject("test-bucket-list-object", "Asia/India/India-summer-photos-1", int64(len("contentstring")), bytes.NewBufferString("contentstring"), nil)
+	_, err = fs.PutObject("test-bucket-list-object", "Asia/India/India-summer-photos-1", int64(len("contentstring")), bytes.NewBufferString("contentstring"), nil)
 	if err != nil {
 		t.Fatal(e)
 	}
 
-	_, err = fs.CreateObject("test-bucket-list-object", "Asia/India/Karnataka/Bangalore/Koramangala/pics", int64(len("contentstring")), bytes.NewBufferString("contentstring"), nil)
+	_, err = fs.PutObject("test-bucket-list-object", "Asia/India/Karnataka/Bangalore/Koramangala/pics", int64(len("contentstring")), bytes.NewBufferString("contentstring"), nil)
 	if err != nil {
 		t.Fatal(e)
 	}
 
 	for i := 0; i < 2; i++ {
 		key := "newPrefix" + strconv.Itoa(i)
-		_, err = fs.CreateObject("test-bucket-list-object", key, int64(len(key)), bytes.NewBufferString(key), nil)
+		_, err = fs.PutObject("test-bucket-list-object", key, int64(len(key)), bytes.NewBufferString(key), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
-	_, err = fs.CreateObject("test-bucket-list-object", "newzen/zen/recurse/again/again/again/pics", int64(len("recurse")), bytes.NewBufferString("recurse"), nil)
+	_, err = fs.PutObject("test-bucket-list-object", "newzen/zen/recurse/again/again/again/pics", int64(len("recurse")), bytes.NewBufferString("recurse"), nil)
 	if err != nil {
 		t.Fatal(e)
 	}
 
 	for i := 0; i < 3; i++ {
 		key := "obj" + strconv.Itoa(i)
-		_, err = fs.CreateObject("test-bucket-list-object", key, int64(len(key)), bytes.NewBufferString(key), nil)
+		_, err = fs.PutObject("test-bucket-list-object", key, int64(len(key)), bytes.NewBufferString(key), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -570,28 +570,28 @@ func TestListObjects(t *testing.T) {
 }
 
 func BenchmarkListObjects(b *testing.B) {
-	// Make a temporary directory to use as the filesystem.
+	// Make a temporary directory to use as the fs.
 	directory, e := ioutil.TempDir("", "minio-list-benchmark")
 	if e != nil {
 		b.Fatal(e)
 	}
 	defer os.RemoveAll(directory)
 
-	// Create the filesystem.
-	filesystem, err := New(directory)
+	// Create the fs.
+	fs, err := newFS(directory)
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	// Create a bucket.
-	err = filesystem.MakeBucket("ls-benchmark-bucket")
+	err = fs.MakeBucket("ls-benchmark-bucket")
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	for i := 0; i < 20000; i++ {
 		key := "obj" + strconv.Itoa(i)
-		_, err = filesystem.CreateObject("ls-benchmark-bucket", key, int64(len(key)), bytes.NewBufferString(key), nil)
+		_, err = fs.PutObject("ls-benchmark-bucket", key, int64(len(key)), bytes.NewBufferString(key), nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -601,7 +601,7 @@ func BenchmarkListObjects(b *testing.B) {
 
 	// List the buckets over and over and over.
 	for i := 0; i < b.N; i++ {
-		_, err = filesystem.ListObjects("ls-benchmark-bucket", "", "obj9000", "", -1)
+		_, err = fs.ListObjects("ls-benchmark-bucket", "", "obj9000", "", -1)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/fs-datatypes.go
+++ b/fs-datatypes.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import "time"
 
@@ -87,5 +87,5 @@ func (a completedParts) Less(i, j int) bool { return a[i].PartNumber < a[j].Part
 
 // CompleteMultipartUpload container for completing multipart upload
 type CompleteMultipartUpload struct {
-	Part []CompletePart
+	Parts []CompletePart `xml:"Part"`
 }

--- a/fs-dir.go
+++ b/fs-dir.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import (
 	"io"

--- a/fs-errors.go
+++ b/fs-errors.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import "fmt"
 

--- a/fs-utils.go
+++ b/fs-utils.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import (
 	"regexp"

--- a/fs-utils_test.go
+++ b/fs-utils_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import (
 	"testing"

--- a/fs.go
+++ b/fs.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import (
 	"os"
@@ -95,8 +95,8 @@ type Multiparts struct {
 	ActiveSession map[string]*MultipartSession `json:"activeSessions"`
 }
 
-// New instantiate a new donut
-func New(rootPath string) (Filesystem, *probe.Error) {
+// newFS instantiate a new filesystem.
+func newFS(rootPath string) (ObjectAPI, *probe.Error) {
 	setFSMultipartsMetadataPath(filepath.Join(rootPath, "$multiparts-session.json"))
 
 	var err *probe.Error
@@ -117,7 +117,7 @@ func New(rootPath string) (Filesystem, *probe.Error) {
 		}
 	}
 
-	fs := Filesystem{
+	fs := &Filesystem{
 		rwLock: &sync.RWMutex{},
 	}
 	fs.path = rootPath
@@ -125,7 +125,7 @@ func New(rootPath string) (Filesystem, *probe.Error) {
 
 	/// Defaults
 
-	// minium free disk required for i/o operations to succeed.
+	// Minium free disk required for i/o operations to succeed.
 	fs.minFreeDisk = 5
 
 	fs.listObjectMap = make(map[ListObjectParams][]ObjectInfoChannel)

--- a/fs_test.go
+++ b/fs_test.go
@@ -14,29 +14,22 @@
  * limitations under the License.
  */
 
-package fs
+package main
 
 import (
 	"io/ioutil"
 	"os"
-	"testing"
 
 	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-type MySuite struct{}
-
-var _ = Suite(&MySuite{})
-
-func (s *MySuite) TestAPISuite(c *C) {
+func (s *MyAPISuite) TestAPISuite(c *C) {
 	var storageList []string
-	create := func() Filesystem {
+	create := func() ObjectAPI {
 		path, e := ioutil.TempDir(os.TempDir(), "minio-")
 		c.Check(e, IsNil)
 		storageList = append(storageList, path)
-		store, err := New(path)
+		store, err := newFS(path)
 		c.Check(err, IsNil)
 		return store
 	}
@@ -46,7 +39,6 @@ func (s *MySuite) TestAPISuite(c *C) {
 
 func removeRoots(c *C, roots []string) {
 	for _, root := range roots {
-		err := os.RemoveAll(root)
-		c.Check(err, IsNil)
+		os.RemoveAll(root)
 	}
 }

--- a/httprange.go
+++ b/httprange.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/minio/minio/pkg/fs"
 	"github.com/minio/minio/pkg/probe"
 )
 
@@ -60,7 +59,7 @@ func getRequestedRange(hrange string, size int64) (*httpRange, *probe.Error) {
 func (r *httpRange) parse(ra string) *probe.Error {
 	i := strings.Index(ra, "-")
 	if i < 0 {
-		return probe.NewError(fs.InvalidRange{})
+		return probe.NewError(InvalidRange{})
 	}
 	start, end := strings.TrimSpace(ra[:i]), strings.TrimSpace(ra[i+1:])
 	if start == "" {
@@ -68,7 +67,7 @@ func (r *httpRange) parse(ra string) *probe.Error {
 		// range start relative to the end of the file.
 		i, err := strconv.ParseInt(end, 10, 64)
 		if err != nil {
-			return probe.NewError(fs.InvalidRange{})
+			return probe.NewError(InvalidRange{})
 		}
 		if i > r.size {
 			i = r.size
@@ -78,7 +77,7 @@ func (r *httpRange) parse(ra string) *probe.Error {
 	} else {
 		i, err := strconv.ParseInt(start, 10, 64)
 		if err != nil || i > r.size || i < 0 {
-			return probe.NewError(fs.InvalidRange{})
+			return probe.NewError(InvalidRange{})
 		}
 		r.start = i
 		if end == "" {
@@ -87,7 +86,7 @@ func (r *httpRange) parse(ra string) *probe.Error {
 		} else {
 			i, err := strconv.ParseInt(end, 10, 64)
 			if err != nil || r.start > i {
-				return probe.NewError(fs.InvalidRange{})
+				return probe.NewError(InvalidRange{})
 			}
 			if i >= r.size {
 				i = r.size - 1
@@ -104,7 +103,7 @@ func (r *httpRange) parseRange(s string) *probe.Error {
 		return probe.NewError(errors.New("header not present"))
 	}
 	if !strings.HasPrefix(s, b) {
-		return probe.NewError(fs.InvalidRange{})
+		return probe.NewError(InvalidRange{})
 	}
 
 	ras := strings.Split(s[len(b):], ",")
@@ -118,7 +117,7 @@ func (r *httpRange) parseRange(s string) *probe.Error {
 
 	ra := strings.TrimSpace(ras[0])
 	if ra == "" {
-		return probe.NewError(fs.InvalidRange{})
+		return probe.NewError(InvalidRange{})
 	}
 	return r.parse(ra)
 }

--- a/object-api-interface.go
+++ b/object-api-interface.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io"
+
+	"github.com/minio/minio/pkg/probe"
+)
+
+// ObjectAPI interface.
+type ObjectAPI interface {
+	// Bucket resource API.
+	DeleteBucket(bucket string) *probe.Error
+	ListBuckets() ([]BucketInfo, *probe.Error)
+	MakeBucket(bucket string) *probe.Error
+	GetBucketInfo(bucket string) (BucketInfo, *probe.Error)
+
+	// Bucket query API.
+	ListObjects(bucket, prefix, marker, delimiter string, maxKeys int) (ListObjectsResult, *probe.Error)
+	ListMultipartUploads(bucket string, resources BucketMultipartResourcesMetadata) (BucketMultipartResourcesMetadata, *probe.Error)
+
+	// Object resource API.
+	GetObject(bucket, object string, startOffset int64) (io.ReadCloser, *probe.Error)
+	GetObjectInfo(bucket, object string) (ObjectInfo, *probe.Error)
+	PutObject(bucket string, object string, size int64, data io.Reader, metadata map[string]string) (ObjectInfo, *probe.Error)
+	DeleteObject(bucket, object string) *probe.Error
+
+	// Object query API.
+	NewMultipartUpload(bucket, object string) (string, *probe.Error)
+	PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Hex string) (string, *probe.Error)
+	ListObjectParts(bucket, object string, resources ObjectResourcesMetadata) (ObjectResourcesMetadata, *probe.Error)
+	CompleteMultipartUpload(bucket string, object string, uploadID string, parts []CompletePart) (ObjectInfo, *probe.Error)
+	AbortMultipartUpload(bucket, object, uploadID string) *probe.Error
+}

--- a/object-interface.go
+++ b/object-interface.go
@@ -1,0 +1,1 @@
+package main

--- a/routers.go
+++ b/routers.go
@@ -20,18 +20,18 @@ import (
 	"net/http"
 
 	router "github.com/gorilla/mux"
-	"github.com/minio/minio/pkg/fs"
 )
 
 // configureServer handler returns final handler for the http server.
-func configureServerHandler(filesystem fs.Filesystem) http.Handler {
+func configureServerHandler(objectAPI ObjectAPI) http.Handler {
 	// Initialize API.
-	api := storageAPI{
-		Filesystem: filesystem,
+	api := objectStorageAPI{
+		ObjectAPI: objectAPI,
 	}
+
 	// Initialize Web.
 	web := &webAPI{
-		Filesystem: filesystem,
+		ObjectAPI: objectAPI,
 	}
 
 	// Initialize router.

--- a/web-router.go
+++ b/web-router.go
@@ -25,13 +25,12 @@ import (
 	router "github.com/gorilla/mux"
 	jsonrpc "github.com/gorilla/rpc/v2"
 	"github.com/gorilla/rpc/v2/json2"
-	"github.com/minio/minio/pkg/fs"
 	"github.com/minio/miniobrowser"
 )
 
 // webAPI container for Web API.
 type webAPI struct {
-	Filesystem fs.Filesystem
+	ObjectAPI ObjectAPI
 }
 
 // indexHandler - Handler to serve index.html


### PR DESCRIPTION
ObjectAPI interface brings in changes needed for XL ObjectAPI layer.

The new interface for any ObjectAPI layer is as below

```
// ObjectAPI interface.
type ObjectAPI interface {
        // Bucket resource API.
        DeleteBucket(bucket string) *probe.Error
        ListBuckets() ([]BucketInfo, *probe.Error)
        MakeBucket(bucket string) *probe.Error
        GetBucketInfo(bucket string) (BucketInfo, *probe.Error)

        // Bucket query API.
        ListObjects(bucket, prefix, marker, delimiter string, maxKeys int) (ListObjectsResult, *probe.Error)
        ListMultipartUploads(bucket string, resources BucketMultipartResourcesMetadata) (BucketMultipartResourcesMetadata, *probe.Error)

        // Object resource API.
        GetObject(bucket, object string, startOffset int64) (io.ReadCloser, *probe.Error)
        GetObjectInfo(bucket, object string) (ObjectInfo, *probe.Error)
        PutObject(bucket string, object string, size int64, data io.Reader, metadata map[string]string) (ObjectInfo, *probe.Error)
        DeleteObject(bucket, object string) *probe.Error

        // Object query API.
        NewMultipartUpload(bucket, object string) (string, *probe.Error)
        PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Hex string) (string, *probe.Error)
        ListObjectParts(bucket, object string, resources ObjectResourcesMetadata) (ObjectResourcesMetadata, *probe.Error)
        CompleteMultipartUpload(bucket string, object string, uploadID string, parts []CompletePart) (ObjectInfo, *probe.Error)
        AbortMultipartUpload(bucket, object, uploadID string) *probe.Error
}
```
