### PR TITLE
config: Migrate to the new version. Remove backend details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,10 @@ $ make
 
 ### How to use Minio?
 
-Initialize minio server at `~/Photos`
-~~~
-$ minio init fs ~/Photos
-~~~
-
-After successfully initializing, start minio server.
+Start minio server.
 
 ~~~
-$ minio server
+$ minio server ~/Photos
 
 AccessKey: WLGDGYAQYIGI833EV05A  SecretKey: BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF  Region: us-east-1
 

--- a/config-old.go
+++ b/config-old.go
@@ -79,3 +79,70 @@ func loadConfigV2() (*configV2, *probe.Error) {
 	}
 	return qc.Data().(*configV2), nil
 }
+
+/////////////////// Config V3 ///////////////////
+
+// backendV3 type.
+type backendV3 struct {
+	Type  string   `json:"type"`
+	Disk  string   `json:"disk,omitempty"`
+	Disks []string `json:"disks,omitempty"`
+}
+
+// loggerV3 type.
+type loggerV3 struct {
+	Console struct {
+		Enable bool   `json:"enable"`
+		Level  string `json:"level"`
+	}
+	File struct {
+		Enable   bool   `json:"enable"`
+		Filename string `json:"fileName"`
+		Level    string `json:"level"`
+	}
+	Syslog struct {
+		Enable bool   `json:"enable"`
+		Addr   string `json:"address"`
+		Level  string `json:"level"`
+	} `json:"syslog"`
+	// Add new loggers here.
+}
+
+// configV3 server configuration version '3'.
+type configV3 struct {
+	Version string `json:"version"`
+
+	// Backend configuration.
+	Backend backendV3 `json:"backend"`
+
+	// http Server configuration.
+	Addr string `json:"address"`
+
+	// S3 API configuration.
+	Credential credential `json:"credential"`
+	Region     string     `json:"region"`
+
+	// Additional error logging configuration.
+	Logger loggerV3 `json:"logger"`
+}
+
+// loadConfigV3 load config version '3'.
+func loadConfigV3() (*configV3, *probe.Error) {
+	configFile, err := getConfigFile()
+	if err != nil {
+		return nil, err.Trace()
+	}
+	if _, err := os.Stat(configFile); err != nil {
+		return nil, probe.NewError(err)
+	}
+	a := &configV3{}
+	a.Version = "3"
+	qc, err := quick.New(a)
+	if err != nil {
+		return nil, err.Trace()
+	}
+	if err := qc.Load(configFile); err != nil {
+		return nil, err.Trace()
+	}
+	return qc.Data().(*configV3), nil
+}

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
-if [ "$1" = 'fs' ]; then
-    if [ -z "$2" ]; then
-        echo "Invalid arguments"
-        echo "Usage: fs <export_dir>"
-        exit 1
-    else
-        /bin/mkdir -p "$2" && /minio init fs "$2" && /minio server
-    fi
+## Fix this check when we arrive at XL.
+if [ -z "$1" ]; then
+    echo "Invalid arguments"
+    echo "Usage: <export_dir>"
+    exit 1
 else
-    echo "Usage: fs <export_dir>"
-    exit 0
+    /bin/mkdir -p "$2" && /minio server "$2"
 fi

--- a/globals.go
+++ b/globals.go
@@ -29,7 +29,7 @@ const (
 
 // minio configuration related constants.
 const (
-	globalMinioConfigVersion = "3"
+	globalMinioConfigVersion = "4"
 	globalMinioConfigDir     = ".minio"
 	globalMinioCertsDir      = ".minio/certs"
 	globalMinioCertFile      = "public.crt"

--- a/main.go
+++ b/main.go
@@ -73,10 +73,6 @@ func init() {
 	if !isContainerized() && os.Geteuid() == 0 {
 		console.Fatalln("Please run ‘minio’ as a non-root user.")
 	}
-
-	// Initialize config.
-	err := initConfig()
-	fatalIf(err.Trace(), "Unable to initialize minio config.", nil)
 }
 
 func migrate() {
@@ -142,7 +138,6 @@ func findClosestCommands(command string) []string {
 
 func registerApp() *cli.App {
 	// Register all commands.
-	registerCommand(initCmd)
 	registerCommand(serverCmd)
 	registerCommand(versionCmd)
 	registerCommand(updateCmd)
@@ -198,6 +193,10 @@ func main() {
 
 		// Migrate any old version of config / state files to newer format.
 		migrate()
+
+		// Initialize config.
+		err := initConfig()
+		fatalIf(err.Trace(), "Unable to initialize minio config.", nil)
 
 		// Enable all loggers by now.
 		enableLoggers()

--- a/minio.md
+++ b/minio.md
@@ -1,32 +1,40 @@
-# Server command line SPEC. - Tue Mar 22 06:04:42 UTC 2016
+# Server command line SPEC - Fri Apr  1 19:49:56 PDT 2016
 
-Minio initialize filesystem backend.
-~~~
-$ minio init fs <path>
-~~~
+## Single disk
+Regular single server, single disk mode.
+```
+$ minio server <disk>
+```
 
-Minio initialize XL backend.
-~~~
-$ minio init xl <url1>...<url16>
-~~~
+##  Multi disk
+```
+$ minio controller start - Start minio controller.
+```
+Prints a secret token to be used by all parties.
 
-For 'fs' backend it starts the server.
-~~~
-$ minio server
-~~~
+Start all servers without disk with `MINIO_CONTROLLER` env set, start in cluster mode.
+```
+$ MINIO_CONTROLLER=<host>:<token> minio server
+```
 
-For 'xl' backend it waits for servers to join.
-~~~
-$ minio server
-... [PROGRESS BAR] of servers connecting
-~~~
+## Minio Controller cli.
 
-Now on other servers execute 'join' and they connect.
-~~~
-....
-minio join <url1> -- from <url2> && minio server
-minio join <url1> -- from <url3> && minio server
-...
-...
-minio join <url1> -- from <url16> && minio server
-~~~
+Set controller host and token.
+```
+$ export MINIO_CONTROLLER=<host>:<token>
+```
+
+Create a cluster from the pool of nodes.
+```
+$ minioctl new <clustername> <ip1>:/mnt/disk1 .. <ip16>:/mnt/disk1
+```
+
+Start the cluster.
+```
+$ minioctl start <clustername>
+```
+
+Stop the cluster
+```
+$ minioctl stop <clustername>
+```

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -81,14 +81,14 @@ func (s *MyAPISuite) SetUpSuite(c *C) {
 	// Initialize server config.
 	initConfig()
 
+	// Set port.
+	addr := ":" + strconv.Itoa(getFreePort())
+
 	// Get credential.
 	s.credential = serverConfig.GetCredential()
 
 	// Set a default region.
 	serverConfig.SetRegion("us-east-1")
-
-	// Set a new address.
-	serverConfig.SetAddr(":" + strconv.Itoa(getFreePort()))
 
 	// Do this only once here
 	setGlobalConfigPath(root)
@@ -99,8 +99,8 @@ func (s *MyAPISuite) SetUpSuite(c *C) {
 	fs, err := newFS(fsroot)
 	c.Assert(err, IsNil)
 
-	httpHandler := configureServerHandler(fs)
-	testAPIFSCacheServer = httptest.NewServer(httpHandler)
+	apiServer := configureServer(addr, fs)
+	testAPIFSCacheServer = httptest.NewServer(apiServer.Handler)
 }
 
 func (s *MyAPISuite) TearDownSuite(c *C) {


### PR DESCRIPTION
Migrate to new config format v4.

```
{
    "version": "4",
    "credential": {
        "accessKey": "WLGDGYAQYIGI833EV05A",
        "secretKey": "BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF"
    },
    "region": "us-east-1",
    "logger": {
        "console": {
            "enable": true,
            "level": "fatal"
        },
        "file": {
            "enable": false,
            "fileName": "",
            "level": "error"
        },
        "syslog": {
            "enable": false,
            "address": "",
            "level": "debug"
        }
    }
}
```

This patch also updates [minio cli spec](./minio.md)
