### PR TITLE
signature: No need to validate region for getBucketLocation and listBuckets

### DIFF
--- a/auth-handler.go
+++ b/auth-handler.go
@@ -129,10 +129,11 @@ func isReqAuthenticated(r *http.Request) (s3Error APIErrorCode) {
 	}
 	// Populate back the payload.
 	r.Body = ioutil.NopCloser(bytes.NewReader(payload))
+	validateRegion := true // Validate region.
 	if isRequestSignatureV4(r) {
-		return doesSignatureMatch(hex.EncodeToString(sum256(payload)), r)
+		return doesSignatureMatch(hex.EncodeToString(sum256(payload)), r, validateRegion)
 	} else if isRequestPresignedSignatureV4(r) {
-		return doesPresignedSignatureMatch(r)
+		return doesPresignedSignatureMatch(r, validateRegion)
 	}
 	return ErrAccessDenied
 }

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -601,8 +601,9 @@ func (api objectStorageAPI) PutObjectHandler(w http.ResponseWriter, r *http.Requ
 		// Create anonymous object.
 		objectInfo, err = api.ObjectAPI.PutObject(bucket, object, size, r.Body, nil)
 	case authTypePresigned:
+		validateRegion := true // Validate region.
 		// For presigned requests verify them right here.
-		if apiErr := doesPresignedSignatureMatch(r); apiErr != ErrNone {
+		if apiErr := doesPresignedSignatureMatch(r, validateRegion); apiErr != ErrNone {
 			writeErrorResponse(w, r, apiErr, r.URL.Path)
 			return
 		}
@@ -622,7 +623,8 @@ func (api objectStorageAPI) PutObjectHandler(w http.ResponseWriter, r *http.Requ
 				return
 			}
 			shaPayload := shaWriter.Sum(nil)
-			if apiErr := doesSignatureMatch(hex.EncodeToString(shaPayload), r); apiErr != ErrNone {
+			validateRegion := true // Validate region.
+			if apiErr := doesSignatureMatch(hex.EncodeToString(shaPayload), r, validateRegion); apiErr != ErrNone {
 				if apiErr == ErrSignatureDoesNotMatch {
 					writer.CloseWithError(errSignatureMismatch)
 					return
@@ -779,8 +781,9 @@ func (api objectStorageAPI) PutObjectPartHandler(w http.ResponseWriter, r *http.
 		// already allowed.
 		partMD5, err = api.ObjectAPI.PutObjectPart(bucket, object, uploadID, partID, size, r.Body, hex.EncodeToString(md5Bytes))
 	case authTypePresigned:
+		validateRegion := true // Validate region.
 		// For presigned requests verify right here.
-		apiErr := doesPresignedSignatureMatch(r)
+		apiErr := doesPresignedSignatureMatch(r, validateRegion)
 		if apiErr != ErrNone {
 			writeErrorResponse(w, r, apiErr, r.URL.Path)
 			return
@@ -800,7 +803,8 @@ func (api objectStorageAPI) PutObjectPartHandler(w http.ResponseWriter, r *http.
 				return
 			}
 			shaPayload := shaWriter.Sum(nil)
-			if apiErr := doesSignatureMatch(hex.EncodeToString(shaPayload), r); apiErr != ErrNone {
+			validateRegion := true // Validate region.
+			if apiErr := doesSignatureMatch(hex.EncodeToString(shaPayload), r, validateRegion); apiErr != ErrNone {
 				if apiErr == ErrSignatureDoesNotMatch {
 					writer.CloseWithError(errSignatureMismatch)
 					return


### PR DESCRIPTION
This type of check is added for making sure that we can support
custom regions.

ListBuckets and GetBucketLocation are always "us-east-1" rest
should look for the configured region.

Fixes #1278
