### PR TITLE
objectAPI: Fix object API interface, remove unnecessary structs.

### DIFF
--- a/api-headers.go
+++ b/api-headers.go
@@ -58,20 +58,20 @@ func encodeResponse(response interface{}) []byte {
 }
 
 // Write object header
-func setObjectHeaders(w http.ResponseWriter, objectInfo ObjectInfo, contentRange *httpRange) {
+func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, contentRange *httpRange) {
 	// set common headers
 	setCommonHeaders(w)
 
 	// set object-related metadata headers
-	lastModified := objectInfo.ModifiedTime.UTC().Format(http.TimeFormat)
+	lastModified := objInfo.ModifiedTime.UTC().Format(http.TimeFormat)
 	w.Header().Set("Last-Modified", lastModified)
 
-	w.Header().Set("Content-Type", objectInfo.ContentType)
-	if objectInfo.MD5Sum != "" {
-		w.Header().Set("ETag", "\""+objectInfo.MD5Sum+"\"")
+	w.Header().Set("Content-Type", objInfo.ContentType)
+	if objInfo.MD5Sum != "" {
+		w.Header().Set("ETag", "\""+objInfo.MD5Sum+"\"")
 	}
 
-	w.Header().Set("Content-Length", strconv.FormatInt(objectInfo.Size, 10))
+	w.Header().Set("Content-Length", strconv.FormatInt(objInfo.Size, 10))
 
 	// for providing ranged content
 	if contentRange != nil {

--- a/api-resources.go
+++ b/api-resources.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 )
 
-// parse bucket url queries
+// Parse bucket url queries
 func getBucketResources(values url.Values) (prefix, marker, delimiter string, maxkeys int, encodingType string) {
 	prefix = values.Get("prefix")
 	marker = values.Get("marker")
@@ -31,27 +31,29 @@ func getBucketResources(values url.Values) (prefix, marker, delimiter string, ma
 	return
 }
 
-// part bucket url queries for ?uploads
-func getBucketMultipartResources(values url.Values) (v BucketMultipartResourcesMetadata) {
-	v.Prefix = values.Get("prefix")
-	v.KeyMarker = values.Get("key-marker")
-	v.MaxUploads, _ = strconv.Atoi(values.Get("max-uploads"))
-	v.Delimiter = values.Get("delimiter")
-	v.EncodingType = values.Get("encoding-type")
-	v.UploadIDMarker = values.Get("upload-id-marker")
+// Parse bucket url queries for ?uploads
+func getBucketMultipartResources(values url.Values) (prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int, encodingType string) {
+
+	prefix = values.Get("prefix")
+	keyMarker = values.Get("key-marker")
+	uploadIDMarker = values.Get("upload-id-marker")
+	delimiter = values.Get("delimiter")
+	maxUploads, _ = strconv.Atoi(values.Get("max-uploads"))
+	encodingType = values.Get("encoding-type")
 	return
 }
 
-// parse object url queries
-func getObjectResources(values url.Values) (v ObjectResourcesMetadata) {
-	v.UploadID = values.Get("uploadId")
-	v.PartNumberMarker, _ = strconv.Atoi(values.Get("part-number-marker"))
-	v.MaxParts, _ = strconv.Atoi(values.Get("max-parts"))
-	v.EncodingType = values.Get("encoding-type")
+// Parse object url queries
+func getObjectResources(values url.Values) (uploadID string, partNumberMarker, maxParts int, encodingType string) {
+	uploadID = values.Get("uploadId")
+	partNumberMarker, _ = strconv.Atoi(values.Get("part-number-marker"))
+	maxParts, _ = strconv.Atoi(values.Get("max-parts"))
+	encodingType = values.Get("encoding-type")
 	return
 }
 
-// get upload id.
+// Get upload id.
 func getUploadID(values url.Values) (uploadID string) {
-	return getObjectResources(values).UploadID
+	uploadID, _, _, _ = getObjectResources(values)
+	return
 }

--- a/api-response.go
+++ b/api-response.go
@@ -245,7 +245,7 @@ func generateListBucketsResponse(buckets []BucketInfo) ListBucketsResponse {
 }
 
 // generates an ListObjects response for the said bucket with other enumerated options.
-func generateListObjectsResponse(bucket, prefix, marker, delimiter string, maxKeys int, resp ListObjectsResult) ListObjectsResponse {
+func generateListObjectsResponse(bucket, prefix, marker, delimiter string, maxKeys int, resp ListObjectsInfo) ListObjectsResponse {
 	var contents []Object
 	var prefixes []CommonPrefix
 	var owner = Owner{}
@@ -317,25 +317,25 @@ func generateCompleteMultpartUploadResponse(bucket, key, location, etag string) 
 }
 
 // generateListPartsResult
-func generateListPartsResponse(objectMetadata ObjectResourcesMetadata) ListPartsResponse {
+func generateListPartsResponse(partsInfo ListPartsInfo) ListPartsResponse {
 	// TODO - support EncodingType in xml decoding
 	listPartsResponse := ListPartsResponse{}
-	listPartsResponse.Bucket = objectMetadata.Bucket
-	listPartsResponse.Key = objectMetadata.Object
-	listPartsResponse.UploadID = objectMetadata.UploadID
+	listPartsResponse.Bucket = partsInfo.Bucket
+	listPartsResponse.Key = partsInfo.Object
+	listPartsResponse.UploadID = partsInfo.UploadID
 	listPartsResponse.StorageClass = "STANDARD"
 	listPartsResponse.Initiator.ID = "minio"
 	listPartsResponse.Initiator.DisplayName = "minio"
 	listPartsResponse.Owner.ID = "minio"
 	listPartsResponse.Owner.DisplayName = "minio"
 
-	listPartsResponse.MaxParts = objectMetadata.MaxParts
-	listPartsResponse.PartNumberMarker = objectMetadata.PartNumberMarker
-	listPartsResponse.IsTruncated = objectMetadata.IsTruncated
-	listPartsResponse.NextPartNumberMarker = objectMetadata.NextPartNumberMarker
+	listPartsResponse.MaxParts = partsInfo.MaxParts
+	listPartsResponse.PartNumberMarker = partsInfo.PartNumberMarker
+	listPartsResponse.IsTruncated = partsInfo.IsTruncated
+	listPartsResponse.NextPartNumberMarker = partsInfo.NextPartNumberMarker
 
-	listPartsResponse.Parts = make([]Part, len(objectMetadata.Part))
-	for index, part := range objectMetadata.Part {
+	listPartsResponse.Parts = make([]Part, len(partsInfo.Parts))
+	for index, part := range partsInfo.Parts {
 		newPart := Part{}
 		newPart.PartNumber = part.PartNumber
 		newPart.ETag = "\"" + part.ETag + "\""
@@ -347,21 +347,21 @@ func generateListPartsResponse(objectMetadata ObjectResourcesMetadata) ListParts
 }
 
 // generateListMultipartUploadsResponse
-func generateListMultipartUploadsResponse(bucket string, metadata BucketMultipartResourcesMetadata) ListMultipartUploadsResponse {
+func generateListMultipartUploadsResponse(bucket string, multipartsInfo ListMultipartsInfo) ListMultipartUploadsResponse {
 	listMultipartUploadsResponse := ListMultipartUploadsResponse{}
 	listMultipartUploadsResponse.Bucket = bucket
-	listMultipartUploadsResponse.Delimiter = metadata.Delimiter
-	listMultipartUploadsResponse.IsTruncated = metadata.IsTruncated
-	listMultipartUploadsResponse.EncodingType = metadata.EncodingType
-	listMultipartUploadsResponse.Prefix = metadata.Prefix
-	listMultipartUploadsResponse.KeyMarker = metadata.KeyMarker
-	listMultipartUploadsResponse.NextKeyMarker = metadata.NextKeyMarker
-	listMultipartUploadsResponse.MaxUploads = metadata.MaxUploads
-	listMultipartUploadsResponse.NextUploadIDMarker = metadata.NextUploadIDMarker
-	listMultipartUploadsResponse.UploadIDMarker = metadata.UploadIDMarker
+	listMultipartUploadsResponse.Delimiter = multipartsInfo.Delimiter
+	listMultipartUploadsResponse.IsTruncated = multipartsInfo.IsTruncated
+	listMultipartUploadsResponse.EncodingType = multipartsInfo.EncodingType
+	listMultipartUploadsResponse.Prefix = multipartsInfo.Prefix
+	listMultipartUploadsResponse.KeyMarker = multipartsInfo.KeyMarker
+	listMultipartUploadsResponse.NextKeyMarker = multipartsInfo.NextKeyMarker
+	listMultipartUploadsResponse.MaxUploads = multipartsInfo.MaxUploads
+	listMultipartUploadsResponse.NextUploadIDMarker = multipartsInfo.NextUploadIDMarker
+	listMultipartUploadsResponse.UploadIDMarker = multipartsInfo.UploadIDMarker
 
-	listMultipartUploadsResponse.Uploads = make([]Upload, len(metadata.Upload))
-	for index, upload := range metadata.Upload {
+	listMultipartUploadsResponse.Uploads = make([]Upload, len(multipartsInfo.Uploads))
+	for index, upload := range multipartsInfo.Uploads {
 		newUpload := Upload{}
 		newUpload.UploadID = upload.UploadID
 		newUpload.Key = upload.Object

--- a/fs-backend-metadata.go
+++ b/fs-backend-metadata.go
@@ -23,15 +23,14 @@ import (
 
 var multipartsMetadataPath string
 
-// SetFSMultipartsMetadataPath - set custom multiparts session
-// metadata path.
+// SetFSMultipartsMetadataPath - set custom multiparts session metadata path.
 func setFSMultipartsMetadataPath(metadataPath string) {
 	multipartsMetadataPath = metadataPath
 }
 
-// saveMultipartsSession - save multiparts
-func saveMultipartsSession(multiparts Multiparts) *probe.Error {
-	qc, err := quick.New(multiparts)
+// saveMultipartsSession - save multiparts.
+func saveMultipartsSession(mparts multiparts) *probe.Error {
+	qc, err := quick.New(mparts)
 	if err != nil {
 		return err.Trace()
 	}
@@ -41,17 +40,17 @@ func saveMultipartsSession(multiparts Multiparts) *probe.Error {
 	return nil
 }
 
-// loadMultipartsSession load multipart session file
-func loadMultipartsSession() (*Multiparts, *probe.Error) {
-	multiparts := &Multiparts{}
-	multiparts.Version = "1"
-	multiparts.ActiveSession = make(map[string]*MultipartSession)
-	qc, err := quick.New(multiparts)
+// loadMultipartsSession load multipart session file.
+func loadMultipartsSession() (*multiparts, *probe.Error) {
+	mparts := &multiparts{}
+	mparts.Version = "1"
+	mparts.ActiveSession = make(map[string]*multipartSession)
+	qc, err := quick.New(mparts)
 	if err != nil {
 		return nil, err.Trace()
 	}
 	if err := qc.Load(multipartsMetadataPath); err != nil {
 		return nil, err.Trace()
 	}
-	return qc.Data().(*Multiparts), nil
+	return qc.Data().(*multiparts), nil
 }

--- a/fs-bucket-listobjects_test.go
+++ b/fs-bucket-listobjects_test.go
@@ -95,7 +95,7 @@ func TestListObjects(t *testing.T) {
 	// Formualting the result data set to be expected from ListObjects call inside the tests,
 	// This will be used in testCases and used for asserting the correctness of ListObjects output in the tests.
 
-	resultCases := []ListObjectsResult{
+	resultCases := []ListObjectsInfo{
 		// ListObjectsResult-0.
 		// Testing for listing all objects in the bucket, (testCase 20,21,22).
 		{
@@ -428,44 +428,44 @@ func TestListObjects(t *testing.T) {
 		delimeter  string
 		maxKeys    int
 		// Expected output of ListObjects.
-		result ListObjectsResult
+		result ListObjectsInfo
 		err    error
 		// Flag indicating whether the test is expected to pass or not.
 		shouldPass bool
 	}{
 		// Test cases with invalid bucket names ( Test number 1-4 ).
-		{".test", "", "", "", 0, ListObjectsResult{}, BucketNameInvalid{Bucket: ".test"}, false},
-		{"Test", "", "", "", 0, ListObjectsResult{}, BucketNameInvalid{Bucket: "Test"}, false},
-		{"---", "", "", "", 0, ListObjectsResult{}, BucketNameInvalid{Bucket: "---"}, false},
-		{"ad", "", "", "", 0, ListObjectsResult{}, BucketNameInvalid{Bucket: "ad"}, false},
+		{".test", "", "", "", 0, ListObjectsInfo{}, BucketNameInvalid{Bucket: ".test"}, false},
+		{"Test", "", "", "", 0, ListObjectsInfo{}, BucketNameInvalid{Bucket: "Test"}, false},
+		{"---", "", "", "", 0, ListObjectsInfo{}, BucketNameInvalid{Bucket: "---"}, false},
+		{"ad", "", "", "", 0, ListObjectsInfo{}, BucketNameInvalid{Bucket: "ad"}, false},
 		// Using an existing file for bucket name, but its not a directory (5).
-		{"simple-file.txt", "", "", "", 0, ListObjectsResult{}, BucketNotFound{Bucket: "simple-file.txt"}, false},
+		{"simple-file.txt", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "simple-file.txt"}, false},
 		// Valid bucket names, but they donot exist (6-8).
-		{"volatile-bucket-1", "", "", "", 0, ListObjectsResult{}, BucketNotFound{Bucket: "volatile-bucket-1"}, false},
-		{"volatile-bucket-2", "", "", "", 0, ListObjectsResult{}, BucketNotFound{Bucket: "volatile-bucket-2"}, false},
-		{"volatile-bucket-3", "", "", "", 0, ListObjectsResult{}, BucketNotFound{Bucket: "volatile-bucket-3"}, false},
+		{"volatile-bucket-1", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-1"}, false},
+		{"volatile-bucket-2", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-2"}, false},
+		{"volatile-bucket-3", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-3"}, false},
 		// Valid, existing bucket, but sending invalid delimeter values (9-10).
 		// Empty string < "" > and forward slash < / > are the ony two valid arguments for delimeter.
-		{"test-bucket-list-object", "", "", "*", 0, ListObjectsResult{}, fmt.Errorf("delimiter '%s' is not supported", "*"), false},
-		{"test-bucket-list-object", "", "", "-", 0, ListObjectsResult{}, fmt.Errorf("delimiter '%s' is not supported", "-"), false},
+		{"test-bucket-list-object", "", "", "*", 0, ListObjectsInfo{}, fmt.Errorf("delimiter '%s' is not supported", "*"), false},
+		{"test-bucket-list-object", "", "", "-", 0, ListObjectsInfo{}, fmt.Errorf("delimiter '%s' is not supported", "-"), false},
 		// Marker goes through url QueryUnescape, sending inputs for which QueryUnescape would fail (11-12).
 		// Here is how QueryUnescape behaves https://golang.org/pkg/net/url/#QueryUnescape.
 		// QueryUnescape is necessasry since marker is provided as URL query parameter.
-		{"test-bucket-list-object", "", "test%", "", 0, ListObjectsResult{}, fmt.Errorf("invalid URL escape"), false},
-		{"test-bucket-list-object", "", "test%A", "", 0, ListObjectsResult{}, fmt.Errorf("invalid URL escape"), false},
+		{"test-bucket-list-object", "", "test%", "", 0, ListObjectsInfo{}, fmt.Errorf("invalid URL escape"), false},
+		{"test-bucket-list-object", "", "test%A", "", 0, ListObjectsInfo{}, fmt.Errorf("invalid URL escape"), false},
 		// Testing for failure cases with both perfix and marker (13).
 		// The prefix and marker combination to be valid it should satisy strings.HasPrefix(marker, prefix).
-		{"test-bucket-list-object", "asia", "europe-object", "", 0, ListObjectsResult{}, fmt.Errorf("Invalid combination of marker '%s' and prefix '%s'", "europe-object", "asia"), false},
+		{"test-bucket-list-object", "asia", "europe-object", "", 0, ListObjectsInfo{}, fmt.Errorf("Invalid combination of marker '%s' and prefix '%s'", "europe-object", "asia"), false},
 		// Setting a non-existing directory to be prefix (14-15).
-		{"empty-bucket", "europe/france/", "", "", 1, ListObjectsResult{}, nil, true},
-		{"empty-bucket", "europe/tunisia/", "", "", 1, ListObjectsResult{}, nil, true},
+		{"empty-bucket", "europe/france/", "", "", 1, ListObjectsInfo{}, nil, true},
+		{"empty-bucket", "europe/tunisia/", "", "", 1, ListObjectsInfo{}, nil, true},
 		// Testing on empty bucket, that is, bucket without any objects in it (16).
-		{"empty-bucket", "", "", "", 0, ListObjectsResult{}, nil, true},
+		{"empty-bucket", "", "", "", 0, ListObjectsInfo{}, nil, true},
 		// Setting maxKeys to negative value (17-18).
-		{"empty-bucket", "", "", "", -1, ListObjectsResult{}, nil, true},
-		{"empty-bucket", "", "", "", 1, ListObjectsResult{}, nil, true},
+		{"empty-bucket", "", "", "", -1, ListObjectsInfo{}, nil, true},
+		{"empty-bucket", "", "", "", 1, ListObjectsInfo{}, nil, true},
 		// Setting maxKeys to a very large value (19).
-		{"empty-bucket", "", "", "", 1111000000000000, ListObjectsResult{}, nil, true},
+		{"empty-bucket", "", "", "", 1111000000000000, ListObjectsInfo{}, nil, true},
 		// Testing for all 7 objects in the bucket (20).
 		{"test-bucket-list-object", "", "", "", 9, resultCases[0], nil, true},
 		//Testing for negative value of maxKey, this should set maxKeys to listObjectsLimit (21).
@@ -493,7 +493,7 @@ func TestListObjects(t *testing.T) {
 		{"test-bucket-list-object", "", "man", "", 10, resultCases[13], nil, true},
 		// Marker being set to a value which is greater than and all object names when sorted (38).
 		// Expected to send an empty response in this case.
-		{"test-bucket-list-object", "", "zen", "", 10, ListObjectsResult{}, nil, true},
+		{"test-bucket-list-object", "", "zen", "", 10, ListObjectsInfo{}, nil, true},
 		// Marker being set to a value which is lesser than and all object names when sorted (39).
 		// Expected to send all the objects in the bucket in this case.
 		{"test-bucket-list-object", "", "Abc", "", 10, resultCases[14], nil, true},
@@ -511,13 +511,13 @@ func TestListObjects(t *testing.T) {
 		{"test-bucket-list-object", "new", "newPrefix0", "", 2, resultCases[22], nil, true},
 		// Testing with maxKeys set to 0 (48-54).
 		// The parameters have to valid.
-		{"test-bucket-list-object", "", "obj1", "", 0, ListObjectsResult{}, nil, true},
-		{"test-bucket-list-object", "", "obj0", "", 0, ListObjectsResult{}, nil, true},
-		{"test-bucket-list-object", "new", "", "", 0, ListObjectsResult{}, nil, true},
-		{"test-bucket-list-object", "obj", "", "", 0, ListObjectsResult{}, nil, true},
-		{"test-bucket-list-object", "obj", "obj0", "", 0, ListObjectsResult{}, nil, true},
-		{"test-bucket-list-object", "obj", "obj1", "", 0, ListObjectsResult{}, nil, true},
-		{"test-bucket-list-object", "new", "newPrefix0", "", 0, ListObjectsResult{}, nil, true},
+		{"test-bucket-list-object", "", "obj1", "", 0, ListObjectsInfo{}, nil, true},
+		{"test-bucket-list-object", "", "obj0", "", 0, ListObjectsInfo{}, nil, true},
+		{"test-bucket-list-object", "new", "", "", 0, ListObjectsInfo{}, nil, true},
+		{"test-bucket-list-object", "obj", "", "", 0, ListObjectsInfo{}, nil, true},
+		{"test-bucket-list-object", "obj", "obj0", "", 0, ListObjectsInfo{}, nil, true},
+		{"test-bucket-list-object", "obj", "obj1", "", 0, ListObjectsInfo{}, nil, true},
+		{"test-bucket-list-object", "new", "newPrefix0", "", 0, ListObjectsInfo{}, nil, true},
 		// Tests on hierarchical key names as prefix.
 		// Without delimteter the code should recurse into the prefix Dir.
 		// Tests with prefix, but without delimiter (55-56).

--- a/fs-bucket.go
+++ b/fs-bucket.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/minio/minio/pkg/disk"
 	"github.com/minio/minio/pkg/probe"
@@ -56,19 +55,13 @@ func (fs Filesystem) DeleteBucket(bucket string) *probe.Error {
 	return nil
 }
 
-// BucketInfo - name and create date
-type BucketInfo struct {
-	Name    string
-	Created time.Time
-}
-
 // ListBuckets - Get service.
 func (fs Filesystem) ListBuckets() ([]BucketInfo, *probe.Error) {
 	files, e := ioutil.ReadDir(fs.path)
 	if e != nil {
 		return []BucketInfo{}, probe.NewError(e)
 	}
-	var metadataList []BucketInfo
+	var buckets []BucketInfo
 	for _, file := range files {
 		if !file.IsDir() {
 			// If not directory, ignore all file types.
@@ -79,15 +72,15 @@ func (fs Filesystem) ListBuckets() ([]BucketInfo, *probe.Error) {
 		if !IsValidBucketName(dirName) {
 			continue
 		}
-		metadata := BucketInfo{
+		bucket := BucketInfo{
 			Name:    dirName,
 			Created: file.ModTime(),
 		}
-		metadataList = append(metadataList, metadata)
+		buckets = append(buckets, bucket)
 	}
 	// Remove duplicated entries.
-	metadataList = removeDuplicateBuckets(metadataList)
-	return metadataList, nil
+	buckets = removeDuplicateBuckets(buckets)
+	return buckets, nil
 }
 
 // removeDuplicateBuckets - remove duplicate buckets.

--- a/fs-multipart.go
+++ b/fs-multipart.go
@@ -50,55 +50,57 @@ func (fs Filesystem) isValidUploadID(object, uploadID string) (ok bool) {
 }
 
 // byObjectInfoKey is a sortable interface for UploadMetadata slice
-type byUploadMetadataKey []*UploadMetadata
+type byUploadMetadataKey []uploadMetadata
 
 func (b byUploadMetadataKey) Len() int           { return len(b) }
 func (b byUploadMetadataKey) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b byUploadMetadataKey) Less(i, j int) bool { return b[i].Object < b[j].Object }
 
 // ListMultipartUploads - list incomplete multipart sessions for a given BucketMultipartResourcesMetadata
-func (fs Filesystem) ListMultipartUploads(bucket string, resources BucketMultipartResourcesMetadata) (BucketMultipartResourcesMetadata, *probe.Error) {
+func (fs Filesystem) ListMultipartUploads(bucket, objectPrefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (ListMultipartsInfo, *probe.Error) {
 	// Input validation.
 	if !IsValidBucketName(bucket) {
-		return BucketMultipartResourcesMetadata{}, probe.NewError(BucketNameInvalid{Bucket: bucket})
+		return ListMultipartsInfo{}, probe.NewError(BucketNameInvalid{Bucket: bucket})
 	}
 	bucket = getActualBucketname(fs.path, bucket)
 	bucketPath := filepath.Join(fs.path, bucket)
 	if _, e := os.Stat(bucketPath); e != nil {
 		// Check bucket exists.
 		if os.IsNotExist(e) {
-			return BucketMultipartResourcesMetadata{}, probe.NewError(BucketNotFound{Bucket: bucket})
+			return ListMultipartsInfo{}, probe.NewError(BucketNotFound{Bucket: bucket})
 		}
-		return BucketMultipartResourcesMetadata{}, probe.NewError(e)
+		return ListMultipartsInfo{}, probe.NewError(e)
 	}
-	var uploads []*UploadMetadata
+	var uploads []uploadMetadata
+	multipartsInfo := ListMultipartsInfo{}
+
 	fs.rwLock.RLock()
 	defer fs.rwLock.RUnlock()
 	for uploadID, session := range fs.multiparts.ActiveSession {
 		objectName := session.ObjectName
-		if strings.HasPrefix(objectName, resources.Prefix) {
-			if len(uploads) > resources.MaxUploads {
+		if strings.HasPrefix(objectName, objectPrefix) {
+			if len(uploads) > maxUploads {
 				sort.Sort(byUploadMetadataKey(uploads))
-				resources.Upload = uploads
-				resources.NextKeyMarker = session.ObjectName
-				resources.NextUploadIDMarker = uploadID
-				resources.IsTruncated = true
-				return resources, nil
+				multipartsInfo.Uploads = uploads
+				multipartsInfo.NextKeyMarker = session.ObjectName
+				multipartsInfo.NextUploadIDMarker = uploadID
+				multipartsInfo.IsTruncated = true
+				return multipartsInfo, nil
 			}
-			// UploadIDMarker is ignored if KeyMarker is empty.
+			// uploadIDMarker is ignored if KeyMarker is empty.
 			switch {
-			case resources.KeyMarker != "" && resources.UploadIDMarker == "":
-				if objectName > resources.KeyMarker {
-					upload := new(UploadMetadata)
+			case keyMarker != "" && uploadIDMarker == "":
+				if objectName > keyMarker {
+					upload := uploadMetadata{}
 					upload.Object = objectName
 					upload.UploadID = uploadID
 					upload.Initiated = session.Initiated
 					uploads = append(uploads, upload)
 				}
-			case resources.KeyMarker != "" && resources.UploadIDMarker != "":
-				if session.UploadID > resources.UploadIDMarker {
-					if objectName >= resources.KeyMarker {
-						upload := new(UploadMetadata)
+			case keyMarker != "" && uploadIDMarker != "":
+				if session.UploadID > uploadIDMarker {
+					if objectName >= keyMarker {
+						upload := uploadMetadata{}
 						upload.Object = objectName
 						upload.UploadID = uploadID
 						upload.Initiated = session.Initiated
@@ -106,7 +108,7 @@ func (fs Filesystem) ListMultipartUploads(bucket string, resources BucketMultipa
 					}
 				}
 			default:
-				upload := new(UploadMetadata)
+				upload := uploadMetadata{}
 				upload.Object = objectName
 				upload.UploadID = uploadID
 				upload.Initiated = session.Initiated
@@ -115,13 +117,13 @@ func (fs Filesystem) ListMultipartUploads(bucket string, resources BucketMultipa
 		}
 	}
 	sort.Sort(byUploadMetadataKey(uploads))
-	resources.Upload = uploads
-	return resources, nil
+	multipartsInfo.Uploads = uploads
+	return multipartsInfo, nil
 }
 
 // verify if parts sent over the network do really match with what we
 // have for the session.
-func doPartsMatch(parts []CompletePart, savedParts []PartMetadata) bool {
+func doPartsMatch(parts []completePart, savedParts []partInfo) bool {
 	if parts == nil || savedParts == nil {
 		return false
 	}
@@ -175,7 +177,7 @@ func MultiCloser(closers ...io.Closer) io.Closer {
 }
 
 // removeParts - remove all parts.
-func removeParts(partPathPrefix string, parts []PartMetadata) *probe.Error {
+func removeParts(partPathPrefix string, parts []partInfo) *probe.Error {
 	for _, part := range parts {
 		// We are on purpose ignoring the return values here, since
 		// another thread would have purged these entries.
@@ -185,7 +187,7 @@ func removeParts(partPathPrefix string, parts []PartMetadata) *probe.Error {
 }
 
 // saveParts - concantenate and save all parts.
-func saveParts(partPathPrefix string, mw io.Writer, parts []CompletePart) *probe.Error {
+func saveParts(partPathPrefix string, mw io.Writer, parts []completePart) *probe.Error {
 	var partReaders []io.Reader
 	var partClosers []io.Closer
 	for _, part := range parts {
@@ -274,13 +276,13 @@ func (fs Filesystem) NewMultipartUpload(bucket, object string) (string, *probe.E
 	fs.rwLock.Lock()
 	defer fs.rwLock.Unlock()
 	// Initialize multipart session.
-	mpartSession := &MultipartSession{}
+	mpartSession := &multipartSession{}
 	mpartSession.TotalParts = 0
 	mpartSession.ObjectName = object
 	mpartSession.UploadID = uploadID
 	mpartSession.Initiated = time.Now().UTC()
 	// Multipart has maximum of 10000 parts.
-	var parts []PartMetadata
+	var parts []partInfo
 	mpartSession.Parts = parts
 
 	fs.multiparts.ActiveSession[uploadID] = mpartSession
@@ -291,7 +293,7 @@ func (fs Filesystem) NewMultipartUpload(bucket, object string) (string, *probe.E
 }
 
 // Remove all duplicated parts based on the latest time of their upload.
-func removeDuplicateParts(parts []PartMetadata) []PartMetadata {
+func removeDuplicateParts(parts []partInfo) []partInfo {
 	length := len(parts) - 1
 	for i := 0; i < length; i++ {
 		for j := i + 1; j <= length; j++ {
@@ -311,7 +313,7 @@ func removeDuplicateParts(parts []PartMetadata) []PartMetadata {
 }
 
 // partNumber is a sortable interface for Part slice.
-type partNumber []PartMetadata
+type partNumber []partInfo
 
 func (a partNumber) Len() int           { return len(a) }
 func (a partNumber) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
@@ -324,16 +326,10 @@ func (fs Filesystem) PutObjectPart(bucket, object, uploadID string, partID int, 
 		return "", probe.NewError(err)
 	}
 
-	// Remove 5% from total space for cumulative disk space used for
-	// journalling, inodes etc.
+	// Remove 5% from total space for cumulative disk space used for journalling, inodes etc.
 	availableDiskSpace := (float64(di.Free) / (float64(di.Total) - (0.05 * float64(di.Total)))) * 100
 	if int64(availableDiskSpace) <= fs.minFreeDisk {
 		return "", probe.NewError(RootPathFull{Path: fs.path})
-	}
-
-	// Part id cannot be negative.
-	if partID <= 0 {
-		return "", probe.NewError(errors.New("invalid part id, cannot be zero or less than zero"))
 	}
 
 	// Check bucket name valid.
@@ -344,6 +340,11 @@ func (fs Filesystem) PutObjectPart(bucket, object, uploadID string, partID int, 
 	// Verify object path legal.
 	if !IsValidObjectName(object) {
 		return "", probe.NewError(ObjectNameInvalid{Bucket: bucket, Object: object})
+	}
+
+	// Part id cannot be negative.
+	if partID <= 0 {
+		return "", probe.NewError(errors.New("invalid part id, cannot be zero or less than zero"))
 	}
 
 	// Verify upload is valid for the incoming object.
@@ -394,11 +395,11 @@ func (fs Filesystem) PutObjectPart(bucket, object, uploadID string, partID int, 
 	if e != nil {
 		return "", probe.NewError(e)
 	}
-	partMetadata := PartMetadata{}
-	partMetadata.PartNumber = partID
-	partMetadata.ETag = newMD5Hex
-	partMetadata.Size = fi.Size()
-	partMetadata.LastModified = fi.ModTime()
+	prtInfo := partInfo{}
+	prtInfo.PartNumber = partID
+	prtInfo.ETag = newMD5Hex
+	prtInfo.Size = fi.Size()
+	prtInfo.LastModified = fi.ModTime()
 
 	// Critical region requiring read lock.
 	fs.rwLock.RLock()
@@ -409,10 +410,11 @@ func (fs Filesystem) PutObjectPart(bucket, object, uploadID string, partID int, 
 	}
 
 	// Add all incoming parts.
-	deserializedMultipartSession.Parts = append(deserializedMultipartSession.Parts, partMetadata)
+	deserializedMultipartSession.Parts = append(deserializedMultipartSession.Parts, prtInfo)
 
 	// Remove duplicate parts based on the most recent uploaded.
 	deserializedMultipartSession.Parts = removeDuplicateParts(deserializedMultipartSession.Parts)
+
 	// Save total parts uploaded.
 	deserializedMultipartSession.TotalParts = len(deserializedMultipartSession.Parts)
 
@@ -431,7 +433,7 @@ func (fs Filesystem) PutObjectPart(bucket, object, uploadID string, partID int, 
 }
 
 // CompleteMultipartUpload - complete a multipart upload and persist the data
-func (fs Filesystem) CompleteMultipartUpload(bucket string, object string, uploadID string, parts []CompletePart) (ObjectInfo, *probe.Error) {
+func (fs Filesystem) CompleteMultipartUpload(bucket string, object string, uploadID string, parts []completePart) (ObjectInfo, *probe.Error) {
 	// Check bucket name is valid.
 	if !IsValidBucketName(bucket) {
 		return ObjectInfo{}, probe.NewError(BucketNameInvalid{Bucket: bucket})
@@ -531,35 +533,32 @@ func (fs Filesystem) CompleteMultipartUpload(bucket string, object string, uploa
 	return newObject, nil
 }
 
-// ListObjectParts - list parts from incomplete multipart session for a given ObjectResourcesMetadata
-func (fs Filesystem) ListObjectParts(bucket, object string, resources ObjectResourcesMetadata) (ObjectResourcesMetadata, *probe.Error) {
+// ListObjectParts - list parts from incomplete multipart session.
+func (fs Filesystem) ListObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (ListPartsInfo, *probe.Error) {
 	// Check bucket name is valid.
 	if !IsValidBucketName(bucket) {
-		return ObjectResourcesMetadata{}, probe.NewError(BucketNameInvalid{Bucket: bucket})
+		return ListPartsInfo{}, probe.NewError(BucketNameInvalid{Bucket: bucket})
 	}
 
 	// Verify object path legal.
 	if !IsValidObjectName(object) {
-		return ObjectResourcesMetadata{}, probe.NewError(ObjectNameInvalid{Bucket: bucket, Object: object})
+		return ListPartsInfo{}, probe.NewError(ObjectNameInvalid{Bucket: bucket, Object: object})
 	}
-
-	// Save upload id.
-	uploadID := resources.UploadID
 
 	// Verify if upload id is valid for incoming object.
 	if !fs.isValidUploadID(object, uploadID) {
-		return ObjectResourcesMetadata{}, probe.NewError(InvalidUploadID{UploadID: uploadID})
+		return ListPartsInfo{}, probe.NewError(InvalidUploadID{UploadID: uploadID})
 	}
 
-	objectResourcesMetadata := resources
-	objectResourcesMetadata.Bucket = bucket
-	objectResourcesMetadata.Object = object
+	prtsInfo := ListPartsInfo{}
+	prtsInfo.Bucket = bucket
+	prtsInfo.Object = object
 	var startPartNumber int
 	switch {
-	case objectResourcesMetadata.PartNumberMarker == 0:
+	case partNumberMarker == 0:
 		startPartNumber = 1
 	default:
-		startPartNumber = objectResourcesMetadata.PartNumberMarker
+		startPartNumber = partNumberMarker
 	}
 
 	bucket = getActualBucketname(fs.path, bucket)
@@ -567,9 +566,9 @@ func (fs Filesystem) ListObjectParts(bucket, object string, resources ObjectReso
 	if _, e := os.Stat(bucketPath); e != nil {
 		// Check bucket exists.
 		if os.IsNotExist(e) {
-			return ObjectResourcesMetadata{}, probe.NewError(BucketNotFound{Bucket: bucket})
+			return ListPartsInfo{}, probe.NewError(BucketNotFound{Bucket: bucket})
 		}
-		return ObjectResourcesMetadata{}, probe.NewError(e)
+		return ListPartsInfo{}, probe.NewError(e)
 	}
 
 	// Critical region requiring read lock.
@@ -577,22 +576,22 @@ func (fs Filesystem) ListObjectParts(bucket, object string, resources ObjectReso
 	deserializedMultipartSession, ok := fs.multiparts.ActiveSession[uploadID]
 	fs.rwLock.RUnlock()
 	if !ok {
-		return ObjectResourcesMetadata{}, probe.NewError(InvalidUploadID{UploadID: resources.UploadID})
+		return ListPartsInfo{}, probe.NewError(InvalidUploadID{UploadID: uploadID})
 	}
-	var parts []PartMetadata
+	var parts []partInfo
 	for i := startPartNumber; i <= deserializedMultipartSession.TotalParts; i++ {
-		if len(parts) > objectResourcesMetadata.MaxParts {
+		if len(parts) > maxParts {
 			sort.Sort(partNumber(parts))
-			objectResourcesMetadata.IsTruncated = true
-			objectResourcesMetadata.Part = parts
-			objectResourcesMetadata.NextPartNumberMarker = i
-			return objectResourcesMetadata, nil
+			prtsInfo.IsTruncated = true
+			prtsInfo.Parts = parts
+			prtsInfo.NextPartNumberMarker = i
+			return prtsInfo, nil
 		}
 		parts = append(parts, deserializedMultipartSession.Parts[i-1])
 	}
 	sort.Sort(partNumber(parts))
-	objectResourcesMetadata.Part = parts
-	return objectResourcesMetadata, nil
+	prtsInfo.Parts = parts
+	return prtsInfo, nil
 }
 
 // AbortMultipartUpload - abort an incomplete multipart session

--- a/fs-object.go
+++ b/fs-object.go
@@ -58,7 +58,6 @@ func (fs Filesystem) GetObject(bucket, object string, startOffset int64) (io.Rea
 			if os.IsNotExist(e) {
 				return nil, probe.NewError(BucketNotFound{Bucket: bucket})
 			}
-
 			return nil, probe.NewError(ObjectNotFound{Bucket: bucket, Object: object})
 		}
 		return nil, probe.NewError(e)
@@ -73,7 +72,7 @@ func (fs Filesystem) GetObject(bucket, object string, startOffset int64) (io.Rea
 		return nil, probe.NewError(ObjectNotFound{Bucket: bucket, Object: object})
 	}
 
-	// Seet to a starting offset.
+	// Seek to a starting offset.
 	_, e = file.Seek(startOffset, os.SEEK_SET)
 	if e != nil {
 		// When the "handle is invalid", the file might be a directory on Windows.
@@ -82,8 +81,6 @@ func (fs Filesystem) GetObject(bucket, object string, startOffset int64) (io.Rea
 		}
 		return nil, probe.NewError(e)
 	}
-
-	// Return successfully seeked file handler.
 	return file, nil
 }
 

--- a/fs-object_test.go
+++ b/fs-object_test.go
@@ -238,19 +238,17 @@ func BenchmarkGetObject(b *testing.B) {
 	}
 
 	b.ResetTimer()
-
 	for i := 0; i < b.N; i++ {
-		var w bytes.Buffer
+		var buffer = new(bytes.Buffer)
 		r, err := fs.GetObject("bucket", "object"+strconv.Itoa(i%10), 0)
 		if err != nil {
 			b.Error(err)
 		}
-		n, e := io.Copy(&w, r)
-		if e != nil {
+		if _, e := io.Copy(buffer, r); e != nil {
 			b.Error(e)
 		}
-		if n != int64(len(text)) {
-			b.Errorf("GetObject returned incorrect length %d (should be %d)\n", n, int64(len(text)))
+		if buffer.Len() != len(text) {
+			b.Errorf("GetObject returned incorrect length %d (should be %d)\n", buffer.Len(), len(text))
 		}
 		r.Close()
 	}

--- a/fs.go
+++ b/fs.go
@@ -25,8 +25,8 @@ import (
 	"github.com/minio/minio/pkg/probe"
 )
 
-// ListObjectParams - list object params used for list object map
-type ListObjectParams struct {
+// listObjectParams - list object params used for list object map
+type listObjectParams struct {
 	bucket    string
 	delimiter string
 	marker    string
@@ -38,16 +38,31 @@ type Filesystem struct {
 	path               string
 	minFreeDisk        int64
 	rwLock             *sync.RWMutex
-	multiparts         *Multiparts
-	listObjectMap      map[ListObjectParams][]ObjectInfoChannel
+	multiparts         *multiparts
+	listObjectMap      map[listObjectParams][]objectInfoChannel
 	listObjectMapMutex *sync.Mutex
 }
 
-func (fs *Filesystem) pushListObjectCh(params ListObjectParams, ch ObjectInfoChannel) {
+// MultipartSession holds active session information
+type multipartSession struct {
+	TotalParts int
+	ObjectName string
+	UploadID   string
+	Initiated  time.Time
+	Parts      []partInfo
+}
+
+// multiparts collection of many parts
+type multiparts struct {
+	Version       string                       `json:"version"`
+	ActiveSession map[string]*multipartSession `json:"activeSessions"`
+}
+
+func (fs *Filesystem) pushListObjectCh(params listObjectParams, ch objectInfoChannel) {
 	fs.listObjectMapMutex.Lock()
 	defer fs.listObjectMapMutex.Unlock()
 
-	channels := []ObjectInfoChannel{ch}
+	channels := []objectInfoChannel{ch}
 	if _, ok := fs.listObjectMap[params]; ok {
 		channels = append(fs.listObjectMap[params], ch)
 	}
@@ -55,7 +70,7 @@ func (fs *Filesystem) pushListObjectCh(params ListObjectParams, ch ObjectInfoCha
 	fs.listObjectMap[params] = channels
 }
 
-func (fs *Filesystem) popListObjectCh(params ListObjectParams) *ObjectInfoChannel {
+func (fs *Filesystem) popListObjectCh(params listObjectParams) *objectInfoChannel {
 	fs.listObjectMapMutex.Lock()
 	defer fs.listObjectMapMutex.Unlock()
 
@@ -80,40 +95,25 @@ func (fs *Filesystem) popListObjectCh(params ListObjectParams) *ObjectInfoChanne
 	return nil
 }
 
-// MultipartSession holds active session information
-type MultipartSession struct {
-	TotalParts int
-	ObjectName string
-	UploadID   string
-	Initiated  time.Time
-	Parts      []PartMetadata
-}
-
-// Multiparts collection of many parts
-type Multiparts struct {
-	Version       string                       `json:"version"`
-	ActiveSession map[string]*MultipartSession `json:"activeSessions"`
-}
-
 // newFS instantiate a new filesystem.
 func newFS(rootPath string) (ObjectAPI, *probe.Error) {
 	setFSMultipartsMetadataPath(filepath.Join(rootPath, "$multiparts-session.json"))
 
 	var err *probe.Error
 	// load multiparts session from disk
-	var multiparts *Multiparts
-	multiparts, err = loadMultipartsSession()
+	var mparts *multiparts
+	mparts, err = loadMultipartsSession()
 	if err != nil {
 		if os.IsNotExist(err.ToGoError()) {
-			multiparts = &Multiparts{
+			mparts = &multiparts{
 				Version:       "1",
-				ActiveSession: make(map[string]*MultipartSession),
+				ActiveSession: make(map[string]*multipartSession),
 			}
-			if err = saveMultipartsSession(*multiparts); err != nil {
-				return Filesystem{}, err.Trace()
+			if err = saveMultipartsSession(*mparts); err != nil {
+				return nil, err.Trace()
 			}
 		} else {
-			return Filesystem{}, err.Trace()
+			return nil, err.Trace()
 		}
 	}
 
@@ -121,14 +121,14 @@ func newFS(rootPath string) (ObjectAPI, *probe.Error) {
 		rwLock: &sync.RWMutex{},
 	}
 	fs.path = rootPath
-	fs.multiparts = multiparts
+	fs.multiparts = mparts
 
 	/// Defaults
 
 	// Minium free disk required for i/o operations to succeed.
 	fs.minFreeDisk = 5
 
-	fs.listObjectMap = make(map[ListObjectParams][]ObjectInfoChannel)
+	fs.listObjectMap = make(map[listObjectParams][]objectInfoChannel)
 	fs.listObjectMapMutex = &sync.Mutex{}
 
 	// Return here.

--- a/object-api-interface.go
+++ b/object-api-interface.go
@@ -15,8 +15,8 @@ type ObjectAPI interface {
 	GetBucketInfo(bucket string) (BucketInfo, *probe.Error)
 
 	// Bucket query API.
-	ListObjects(bucket, prefix, marker, delimiter string, maxKeys int) (ListObjectsResult, *probe.Error)
-	ListMultipartUploads(bucket string, resources BucketMultipartResourcesMetadata) (BucketMultipartResourcesMetadata, *probe.Error)
+	ListObjects(bucket, prefix, marker, delimiter string, maxKeys int) (ListObjectsInfo, *probe.Error)
+	ListMultipartUploads(bucket, objectPrefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (ListMultipartsInfo, *probe.Error)
 
 	// Object resource API.
 	GetObject(bucket, object string, startOffset int64) (io.ReadCloser, *probe.Error)
@@ -27,7 +27,7 @@ type ObjectAPI interface {
 	// Object query API.
 	NewMultipartUpload(bucket, object string) (string, *probe.Error)
 	PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Hex string) (string, *probe.Error)
-	ListObjectParts(bucket, object string, resources ObjectResourcesMetadata) (ObjectResourcesMetadata, *probe.Error)
-	CompleteMultipartUpload(bucket string, object string, uploadID string, parts []CompletePart) (ObjectInfo, *probe.Error)
+	ListObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (ListPartsInfo, *probe.Error)
+	CompleteMultipartUpload(bucket string, object string, uploadID string, parts []completePart) (ObjectInfo, *probe.Error)
 	AbortMultipartUpload(bucket, object, uploadID string) *probe.Error
 }

--- a/object-datatypes.go
+++ b/object-datatypes.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,26 @@ package main
 
 import "time"
 
-// PartMetadata - various types of individual part resources
-type PartMetadata struct {
-	PartNumber   int
-	LastModified time.Time
-	ETag         string
-	Size         int64
+// BucketInfo - bucket name and create date
+type BucketInfo struct {
+	Name    string
+	Created time.Time
 }
 
-// ObjectResourcesMetadata - various types of object resources
-type ObjectResourcesMetadata struct {
+// ObjectInfo - object info.
+type ObjectInfo struct {
+	Bucket       string
+	Name         string
+	ModifiedTime time.Time
+	ContentType  string
+	MD5Sum       string
+	Size         int64
+	IsDir        bool
+	Err          error
+}
+
+// ListPartsInfo - various types of object resources.
+type ListPartsInfo struct {
 	Bucket               string
 	Object               string
 	UploadID             string
@@ -37,20 +47,12 @@ type ObjectResourcesMetadata struct {
 	MaxParts             int
 	IsTruncated          bool
 
-	Part         []PartMetadata
+	Parts        []partInfo
 	EncodingType string
 }
 
-// UploadMetadata container capturing metadata on in progress multipart upload in a given bucket
-type UploadMetadata struct {
-	Object       string
-	UploadID     string
-	StorageClass string
-	Initiated    time.Time
-}
-
-// BucketMultipartResourcesMetadata - various types of bucket resources for inprogress multipart uploads
-type BucketMultipartResourcesMetadata struct {
+// ListMultipartsInfo - various types of bucket resources for inprogress multipart uploads.
+type ListMultipartsInfo struct {
 	KeyMarker          string
 	UploadIDMarker     string
 	NextKeyMarker      string
@@ -58,34 +60,50 @@ type BucketMultipartResourcesMetadata struct {
 	EncodingType       string
 	MaxUploads         int
 	IsTruncated        bool
-	Upload             []*UploadMetadata
+	Uploads            []uploadMetadata
 	Prefix             string
 	Delimiter          string
 	CommonPrefixes     []string
 }
 
-// ListObjectsResult - container for list object request results.
-type ListObjectsResult struct {
+// ListObjectsInfo - container for list objects.
+type ListObjectsInfo struct {
 	IsTruncated bool
 	NextMarker  string
 	Objects     []ObjectInfo
 	Prefixes    []string
 }
 
-// CompletePart - completed part container
-type CompletePart struct {
+// partInfo - various types of individual part resources.
+type partInfo struct {
+	PartNumber   int
+	LastModified time.Time
+	ETag         string
+	Size         int64
+}
+
+// uploadMetadata container capturing metadata on in progress multipart upload in a given bucket
+type uploadMetadata struct {
+	Object       string
+	UploadID     string
+	StorageClass string
+	Initiated    time.Time
+}
+
+// completePart - completed part container.
+type completePart struct {
 	PartNumber int
 	ETag       string
 }
 
 // completedParts is a sortable interface for Part slice
-type completedParts []CompletePart
+type completedParts []completePart
 
 func (a completedParts) Len() int           { return len(a) }
 func (a completedParts) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a completedParts) Less(i, j int) bool { return a[i].PartNumber < a[j].PartNumber }
 
-// CompleteMultipartUpload container for completing multipart upload
-type CompleteMultipartUpload struct {
-	Parts []CompletePart `xml:"Part"`
+// completeMultipartUpload container for completing multipart upload
+type completeMultipartUpload struct {
+	Parts []completePart `xml:"Part"`
 }

--- a/server-main.go
+++ b/server-main.go
@@ -293,7 +293,6 @@ func serverMain(c *cli.Context) {
 	printListenIPs(apiServer)
 
 	console.Println("\nTo configure Minio Client:")
-
 	// Download 'mc' links.
 	if runtime.GOOS == "windows" {
 		console.Println("    Download 'mc' from https://dl.minio.io/client/mc/release/" + runtime.GOOS + "-" + runtime.GOARCH + "/mc.exe")

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -881,7 +881,7 @@ func (s *MyAPISuite) TestPartialContent(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
-	// prepare request
+	// Prepare request
 	request, err = s.newRequest("GET", testAPIFSCacheServer.URL+"/partial-content/bar", 0, nil)
 	c.Assert(err, IsNil)
 	request.Header.Add("Range", "bytes=6-7")
@@ -1288,8 +1288,8 @@ func (s *MyAPISuite) TestObjectMultipart(c *C) {
 	c.Assert(response2.StatusCode, Equals, http.StatusOK)
 
 	// Complete multipart upload
-	completeUploads := &CompleteMultipartUpload{
-		Parts: []CompletePart{
+	completeUploads := &completeMultipartUpload{
+		Parts: []completePart{
 			{
 				PartNumber: 1,
 				ETag:       response1.Header.Get("ETag"),

--- a/web-handlers.go
+++ b/web-handlers.go
@@ -139,12 +139,12 @@ func (web *webAPI) MakeBucket(r *http.Request, args *MakeBucketArgs, reply *Gene
 
 // ListBucketsRep - list buckets response
 type ListBucketsRep struct {
-	Buckets   []BketInfo `json:"buckets"`
-	UIVersion string     `json:"uiVersion"`
+	Buckets   []WebBucketInfo `json:"buckets"`
+	UIVersion string          `json:"uiVersion"`
 }
 
-// BketInfo container for list buckets.
-type BketInfo struct {
+// WebBucketInfo container for list buckets metadata.
+type WebBucketInfo struct {
 	// The name of the bucket.
 	Name string `json:"name"`
 	// Date the bucket was created.
@@ -163,7 +163,7 @@ func (web *webAPI) ListBuckets(r *http.Request, args *GenericArgs, reply *ListBu
 	for _, bucket := range buckets {
 		// List all buckets which are not private.
 		if bucket.Name != path.Base(reservedBucket) {
-			reply.Buckets = append(reply.Buckets, BketInfo{
+			reply.Buckets = append(reply.Buckets, WebBucketInfo{
 				Name:         bucket.Name,
 				CreationDate: bucket.Created,
 			})
@@ -181,12 +181,12 @@ type ListObjectsArgs struct {
 
 // ListObjectsRep - list objects response.
 type ListObjectsRep struct {
-	Objects   []ObjInfo `json:"objects"`
-	UIVersion string    `json:"uiVersion"`
+	Objects   []WebObjectInfo `json:"objects"`
+	UIVersion string          `json:"uiVersion"`
 }
 
-// ObjInfo container for list objects.
-type ObjInfo struct {
+// WebObjectInfo container for list objects metadata.
+type WebObjectInfo struct {
 	// Name of the object
 	Key string `json:"name"`
 	// Date and time the object was last modified.
@@ -210,14 +210,14 @@ func (web *webAPI) ListObjects(r *http.Request, args *ListObjectsArgs, reply *Li
 		}
 		marker = lo.NextMarker
 		for _, obj := range lo.Objects {
-			reply.Objects = append(reply.Objects, ObjInfo{
+			reply.Objects = append(reply.Objects, WebObjectInfo{
 				Key:          obj.Name,
 				LastModified: obj.ModifiedTime,
 				Size:         obj.Size,
 			})
 		}
 		for _, prefix := range lo.Prefixes {
-			reply.Objects = append(reply.Objects, ObjInfo{
+			reply.Objects = append(reply.Objects, WebObjectInfo{
 				Key: prefix,
 			})
 		}


### PR DESCRIPTION
ObjectAPI changes.

```
ListObjects(bucket, prefix, marker, delimiter string, maxKeys int) (ListObjectsInfo, *probe.Error)
ListMultipartUploads(bucket, objectPrefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (ListMultipartsInfo, *probe.Error)
ListObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (ListPartsInfo, *probe.Error)
CompleteMultipartUpload(bucket string, object string, uploadID string, parts []completePart) (ObjectInfo, *probe.Error)
```
