### PR TITLE
certs: Bring back '--cert' and '--key' flags.

### DIFF
--- a/certs.go
+++ b/certs.go
@@ -65,8 +65,8 @@ func mustGetKeyFile() string {
 
 // isCertFileExists verifies if cert file exists, returns true if
 // found, false otherwise.
-func isCertFileExists() bool {
-	st, e := os.Stat(filepath.Join(mustGetCertsPath(), globalMinioCertFile))
+func isCertFileExists(certFile string) bool {
+	st, e := os.Stat(certFile)
 	// If file exists and is regular return true.
 	if e == nil && st.Mode().IsRegular() {
 		return true
@@ -76,8 +76,8 @@ func isCertFileExists() bool {
 
 // isKeyFileExists verifies if key file exists, returns true if found,
 // false otherwise.
-func isKeyFileExists() bool {
-	st, e := os.Stat(filepath.Join(mustGetCertsPath(), globalMinioKeyFile))
+func isKeyFileExists(keyFile string) bool {
+	st, e := os.Stat(keyFile)
 	// If file exists and is regular return true.
 	if e == nil && st.Mode().IsRegular() {
 		return true
@@ -86,8 +86,8 @@ func isKeyFileExists() bool {
 }
 
 // isSSL - returns true with both cert and key exists.
-func isSSL() bool {
-	if isCertFileExists() && isKeyFileExists() {
+func isSSL(certFile, keyFile string) bool {
+	if isCertFileExists(certFile) && isKeyFileExists(keyFile) {
 		return true
 	}
 	return false

--- a/server_fs_test.go
+++ b/server_fs_test.go
@@ -99,7 +99,7 @@ func (s *MyAPISuite) SetUpSuite(c *C) {
 	fs, err := newFS(fsroot)
 	c.Assert(err, IsNil)
 
-	apiServer := configureServer(addr, fs)
+	apiServer := configureServer(addr, mustGetCertFile(), mustGetKeyFile(), fs)
 	testAPIFSCacheServer = httptest.NewServer(apiServer.Handler)
 }
 


### PR DESCRIPTION
This is generally just for ease of usage of SSL.
We still default to `${HOME}/.minio/certs` to
look for certs.
