### PR TITLE
listObjects: Cleanup and naming conventions.

### DIFF
--- a/api-resources.go
+++ b/api-resources.go
@@ -26,19 +26,26 @@ func getBucketResources(values url.Values) (prefix, marker, delimiter string, ma
 	prefix = values.Get("prefix")
 	marker = values.Get("marker")
 	delimiter = values.Get("delimiter")
-	maxkeys, _ = strconv.Atoi(values.Get("max-keys"))
+	if values.Get("max-keys") != "" {
+		maxkeys, _ = strconv.Atoi(values.Get("max-keys"))
+	} else {
+		maxkeys = maxObjectList
+	}
 	encodingType = values.Get("encoding-type")
 	return
 }
 
 // Parse bucket url queries for ?uploads
 func getBucketMultipartResources(values url.Values) (prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int, encodingType string) {
-
 	prefix = values.Get("prefix")
 	keyMarker = values.Get("key-marker")
 	uploadIDMarker = values.Get("upload-id-marker")
 	delimiter = values.Get("delimiter")
-	maxUploads, _ = strconv.Atoi(values.Get("max-uploads"))
+	if values.Get("max-uploads") != "" {
+		maxUploads, _ = strconv.Atoi(values.Get("max-uploads"))
+	} else {
+		maxUploads = maxUploadsList
+	}
 	encodingType = values.Get("encoding-type")
 	return
 }
@@ -47,7 +54,11 @@ func getBucketMultipartResources(values url.Values) (prefix, keyMarker, uploadID
 func getObjectResources(values url.Values) (uploadID string, partNumberMarker, maxParts int, encodingType string) {
 	uploadID = values.Get("uploadId")
 	partNumberMarker, _ = strconv.Atoi(values.Get("part-number-marker"))
-	maxParts, _ = strconv.Atoi(values.Get("max-parts"))
+	if values.Get("max-parts") != "" {
+		maxParts, _ = strconv.Atoi(values.Get("max-parts"))
+	} else {
+		maxParts = maxPartsList
+	}
 	encodingType = values.Get("encoding-type")
 	return
 }

--- a/api-response.go
+++ b/api-response.go
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	// Reply date format
-	timeFormatAMZ = "2006-01-02T15:04:05.000Z"
-	// Limit number of objects in a given response.
-	maxObjectList = 1000
+	timeFormatAMZ  = "2006-01-02T15:04:05.000Z" // Reply date format
+	maxObjectList  = 1000                       // Limit number of objects in a listObjectsResponse.
+	maxUploadsList = 1000                       // Limit number of uploads in a listUploadsResponse.
+	maxPartsList   = 1000                       // Limit number of parts in a listPartsResponse.
 )
 
 // LocationResponse - format for location response.

--- a/fs-bucket-listobjects_test.go
+++ b/fs-bucket-listobjects_test.go
@@ -448,11 +448,6 @@ func TestListObjects(t *testing.T) {
 		// Empty string < "" > and forward slash < / > are the ony two valid arguments for delimeter.
 		{"test-bucket-list-object", "", "", "*", 0, ListObjectsInfo{}, fmt.Errorf("delimiter '%s' is not supported", "*"), false},
 		{"test-bucket-list-object", "", "", "-", 0, ListObjectsInfo{}, fmt.Errorf("delimiter '%s' is not supported", "-"), false},
-		// Marker goes through url QueryUnescape, sending inputs for which QueryUnescape would fail (11-12).
-		// Here is how QueryUnescape behaves https://golang.org/pkg/net/url/#QueryUnescape.
-		// QueryUnescape is necessasry since marker is provided as URL query parameter.
-		{"test-bucket-list-object", "", "test%", "", 0, ListObjectsInfo{}, fmt.Errorf("invalid URL escape"), false},
-		{"test-bucket-list-object", "", "test%A", "", 0, ListObjectsInfo{}, fmt.Errorf("invalid URL escape"), false},
 		// Testing for failure cases with both perfix and marker (13).
 		// The prefix and marker combination to be valid it should satisy strings.HasPrefix(marker, prefix).
 		{"test-bucket-list-object", "asia", "europe-object", "", 0, ListObjectsInfo{}, fmt.Errorf("Invalid combination of marker '%s' and prefix '%s'", "europe-object", "asia"), false},

--- a/fs-dir-others.go
+++ b/fs-dir-others.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 )
 
+// Read all directory entries, returns a list of lexically sorted entries.
 func readDirAll(readDirPath, entryPrefixMatch string) ([]fsDirent, error) {
 	f, err := os.Open(readDirPath)
 	if err != nil {
@@ -57,6 +58,6 @@ func readDirAll(readDirPath, entryPrefixMatch string) ([]fsDirent, error) {
 		}
 	}
 	// Sort dirents.
-	sort.Sort(fsDirents(dirents))
+	sort.Sort(byDirentNames(dirents))
 	return dirents, nil
 }

--- a/fs-dirent-fileno.go
+++ b/fs-dirent-fileno.go
@@ -20,6 +20,7 @@ package main
 
 import "syscall"
 
-func skipDirent(dirent *syscall.Dirent) bool {
+// True if dirent is absent in directory.
+func isEmptyDirent(dirent *syscall.Dirent) bool {
 	return dirent.Fileno == 0
 }

--- a/fs-dirent-ino.go
+++ b/fs-dirent-ino.go
@@ -20,6 +20,7 @@ package main
 
 import "syscall"
 
-func skipDirent(dirent *syscall.Dirent) bool {
+// True if dirent is absent in directory.
+func isEmptyDirent(dirent *syscall.Dirent) bool {
 	return dirent.Ino == 0
 }

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -34,12 +34,7 @@ import (
 	"github.com/minio/minio/pkg/probe"
 )
 
-const (
-	maxPartsList = 1000
-)
-
-// supportedGetReqParams - supported request parameters for GET
-// presigned request.
+// supportedGetReqParams - supported request parameters for GET presigned request.
 var supportedGetReqParams = map[string]string{
 	"response-expires":             "Expires",
 	"response-content-type":        "Content-Type",


### PR DESCRIPTION
```
- Marker should be escaped outside in handlers.
- Delimiter should be handled outside in handlers.
- Add missing comments and change the function names.
- Handle case of 'maxKeys' when its set to '0', its a valid
  case and should be treated as such.
```
