### PR TITLE
accessPolicy: allow anonymous HEAD for Getable objects

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -600,6 +600,12 @@ func (api objectStorageAPI) HeadBucketHandler(w http.ResponseWriter, r *http.Req
 		// For all unknown auth types return error.
 		writeErrorResponse(w, r, ErrAccessDenied, r.URL.Path)
 		return
+	case authTypeAnonymous:
+		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
+		if s3Error := enforceBucketPolicy("s3:ListBucket", bucket, r.URL); s3Error != ErrNone {
+			writeErrorResponse(w, r, s3Error, r.URL.Path)
+			return
+		}
 	case authTypePresigned, authTypeSigned:
 		if s3Error := isReqAuthenticated(r); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -253,6 +253,12 @@ func (api objectStorageAPI) HeadObjectHandler(w http.ResponseWriter, r *http.Req
 		// For all unknown auth types return error.
 		writeErrorResponse(w, r, ErrAccessDenied, r.URL.Path)
 		return
+	case authTypeAnonymous:
+		// http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html
+		if s3Error := enforceBucketPolicy("s3:GetObject", bucket, r.URL); s3Error != ErrNone {
+			writeErrorResponse(w, r, s3Error, r.URL.Path)
+			return
+		}
 	case authTypePresigned, authTypeSigned:
 		if s3Error := isReqAuthenticated(r); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)


### PR DESCRIPTION
This seems to be how S3 works, and generally, when an object you can GET, 403s on a HEAD its pretty confusing 

It is likely a similar change could happen in `bucket-handlers.go` as well, but that one didn't bite me personally today :(

EDIT: did it, since I had to update branch anwyay

EDIT 2: actually a renege on the bucket change, as what the specific permission to require will require some experimentation, but in support of the Head object change, I point the permissions section of http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html 

> Permissions
> 
> You need the s3:GetObject permission for this operation.  For more information, go to Specifying Permissions in a Policy in the Amazon Simple Storage Service Developer Guide. If the object you request does not exist, the error Amazon S3 returns depends on whether you also have the ?s3:ListBucket permission.
> 
> If you have the s3:ListBucket permission on the bucket, Amazon S3 will return a HTTP status code 404 ("no such key") error.
> if you don’t have the s3:ListBucket permission, Amazon S3 will return a HTTP status code 403 ("access denied") error.

I'll check whether this does that 404 / 403 trade off correctly```

EDIT 3: yeah the table here http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html shows that HeadBucket is tied to the ListBucket permission. I'll change that
