### PR TITLE
backend/fs: remove timer channel from scanMultipartDir()

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -49,7 +49,7 @@ type Filesystem struct {
 	rwLock                      *sync.RWMutex
 	listObjectMap               map[listObjectParams][]*treeWalker
 	listObjectMapMutex          *sync.Mutex
-	listMultipartObjectMap      map[listMultipartObjectParams][]multipartObjectInfoChannel
+	listMultipartObjectMap      map[listMultipartObjectParams][]<-chan multipartObjectInfo
 	listMultipartObjectMapMutex *sync.Mutex
 }
 
@@ -69,7 +69,7 @@ func newFS(diskPath string) (ObjectAPI, *probe.Error) {
 	fs.listObjectMapMutex = &sync.Mutex{}
 
 	// Initialize list multipart map.
-	fs.listMultipartObjectMap = make(map[listMultipartObjectParams][]multipartObjectInfoChannel)
+	fs.listMultipartObjectMap = make(map[listMultipartObjectParams][]<-chan multipartObjectInfo)
 	fs.listMultipartObjectMapMutex = &sync.Mutex{}
 
 	// Return here.


### PR DESCRIPTION
Previously scanMultipartDir() returns object info channel and timer
channel where timer channel is used to check whether object info
channel is alive or not.  This causes a race condition that timeout
may occur while object info channel in use.

This patch fixes the issue by removing timer channel and uses object
info channel directly where each object info has End bool field
indicates whether received object info is end or not.
