### PR TITLE
change root check to info from fatal

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func init() {
 	// It is an unsafe practice to run network services as
 	// root. Containers are an exception.
 	if !isContainerized() && os.Geteuid() == 0 {
-		console.Fatalln("Please run ‘minio’ as a non-root user.")
+		console.Infoln("Please run ‘minio’ as a non-root user.")
 	}
 }
 


### PR DESCRIPTION
I'm not sure that it's the responsibility of an application to ensure it's execution context is "responsible".  The warning/instruction to not run as root is definitely good advice, but enforcing it by exiting causes some issues:
- If I want to be irresponsible and just run as root, I should be able to.
- Containers often run the processes "root". The isContainerized() check in place doesn't work -- (at least with docker 1.11).  Also, Docker is not the only containerization tool, so maintaining this check over time is probably going to be a maintenance headache.

I've left the console output in place, but completely removing it and the check code might make sense.
