### PR TITLE
server: Attempt to increase max open files.

### DIFF
--- a/server-main.go
+++ b/server-main.go
@@ -149,6 +149,11 @@ func initServerConfig(c *cli.Context) {
 			SecretAccessKey: secretKey,
 		})
 	}
+
+	// Set maxOpenFiles, This is necessary since default operating
+	// system limits of 1024, 2048 are not enough for Minio server.
+	setMaxOpenFiles()
+	// Do not fail if this is not allowed, lower limits are fine as well.
 }
 
 // Check server arguments.

--- a/server-rlimit-nix.go
+++ b/server-rlimit-nix.go
@@ -1,0 +1,44 @@
+//  +build !windows,!plan9
+
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import "syscall"
+
+// For all unixes we need to bump allowed number of open files to a
+// higher value than its usual default of '1024'. The reasoning is
+// that this value is too small for a server.
+func setMaxOpenFiles() error {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return err
+	}
+	// Safe limit to be set on all platforms.
+	rLimit.Max = 4000
+	rLimit.Cur = 4000
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return err
+	}
+	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/server-rlimit-win.go
+++ b/server-rlimit-win.go
@@ -1,0 +1,26 @@
+// +build windows
+
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+func setMaxOpenFiles() error {
+	// Golang uses Win32 file API (CreateFile, WriteFile, ReadFile,
+	// CloseHandle, etc.), then you don't have a limit on open files
+	// (well, you do but it is based on your resources like memory).
+	return nil
+}


### PR DESCRIPTION
Set maxOpenFiles, This is necessary since default operating
system limits of 1024, 2048 are not enough for Minio server.
