### PR TITLE
isContainerized should look for /.dockerenv not /.dockerinit

### DIFF
--- a/runtime-checks.go
+++ b/runtime-checks.go
@@ -29,8 +29,8 @@ import (
 
 // isContainerized returns true if we are inside a containerized environment.
 func isContainerized() bool {
-	// Docker containers contain ".dockerinit" at its root path.
-	if _, e := os.Stat("/.dockerinit"); e == nil {
+	// Docker containers contain ".dockerenv" at their root path.
+	if _, e := os.Stat("/.dockerenv"); e == nil {
 		return true
 	}
 


### PR DESCRIPTION
The file `/.dockerenv` has been present in docker containers since at least version 0.6.6, whereas `/.dockerinit` was removed in 1.11.0 (docker/docker#19490).

I'm not sure how _official_ `/.dockerenv` is -- it's pretty much undocumented, but https://github.com/docker/libnetwork/pull/815 seems to imply that it'll be longer-lived :wink:

Fixes #1329 

Signed-off-by: Dave Henderson dhenderson@gmail.com
