### PR TITLE
api: Fix verification of checkLeafDirectory.

### DIFF
--- a/object-api.go
+++ b/object-api.go
@@ -294,7 +294,7 @@ func (o objectAPI) ListObjects(bucket, prefix, marker, delimiter string, maxKeys
 		return ListObjectsInfo{}, probe.NewError(ObjectNameInvalid{Bucket: bucket, Object: prefix})
 	}
 	// Verify if delimiter is anything other than '/', which we do not support.
-	if delimiter != "" && delimiter != slashPathSeparator {
+	if delimiter != "" && delimiter != slashSeparator {
 		return ListObjectsInfo{}, probe.NewError(UnsupportedDelimiter{
 			Delimiter: delimiter,
 		})
@@ -309,7 +309,7 @@ func (o objectAPI) ListObjects(bucket, prefix, marker, delimiter string, maxKeys
 		}
 	}
 	recursive := true
-	if delimiter == slashPathSeparator {
+	if delimiter == slashSeparator {
 		recursive = false
 	}
 	fileInfos, eof, e := o.storage.ListFiles(bucket, prefix, marker, recursive, maxKeys)
@@ -325,7 +325,7 @@ func (o objectAPI) ListObjects(bucket, prefix, marker, delimiter string, maxKeys
 	result := ListObjectsInfo{IsTruncated: !eof}
 	for _, fileInfo := range fileInfos {
 		// With delimiter set we fill in NextMarker and Prefixes.
-		if delimiter == slashPathSeparator {
+		if delimiter == slashSeparator {
 			result.NextMarker = fileInfo.Name
 			if fileInfo.Mode.IsDir() {
 				result.Prefixes = append(result.Prefixes, fileInfo.Name)

--- a/object-utils.go
+++ b/object-utils.go
@@ -23,10 +23,6 @@ import (
 	"unicode/utf8"
 )
 
-const (
-	slashPathSeparator = "/"
-)
-
 // validBucket regexp.
 var validBucket = regexp.MustCompile(`^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$`)
 
@@ -91,8 +87,17 @@ func IsValidObjectPrefix(object string) bool {
 
 }
 
-func pathJoin(path1 string, path2 string) string {
-	return strings.TrimSuffix(path1, slashPathSeparator) + slashPathSeparator + path2
+// Slash separator.
+const slashSeparator = "/"
+
+// retainSlash - retains slash from a path.
+func retainSlash(s string) string {
+	return strings.TrimSuffix(s, slashSeparator) + slashSeparator
+}
+
+// pathJoin - path join.
+func pathJoin(s1 string, s2 string) string {
+	return retainSlash(s1) + s2
 }
 
 // validates location constraint from the request body.


### PR DESCRIPTION
This fixes a problem where leaf directory has more than 1000
entries, also resulting in listing issues, leading to an infinite
loop.

Fixes #1334 
