### PR TITLE
Bug: Adding return statement after error response 

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -487,6 +487,7 @@ func (api objectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 	errCode := isValidLocationContraint(r.Body, serverConfig.GetRegion())
 	if errCode != ErrNone {
 		writeErrorResponse(w, r, errCode, r.URL.Path)
+		return
 	}
 	// Make bucket.
 	err := api.ObjectAPI.MakeBucket(bucket)


### PR DESCRIPTION
Adding return statement after error response in the latest commit to verify location constraint
