### PR TITLE
api: Add diskInfo as part of StatVol and ListVols.

### DIFF
--- a/Browser.md
+++ b/Browser.md
@@ -35,5 +35,3 @@ JSON RPC namespace is `Web`.
 * PutObjectURL - generates a URL for upload access, requies a valid token.
   (generated URL is valid for 1hr)
 
-#### Server Operations. 
-* DiskInfo - get backend disk statistics.

--- a/fs.go
+++ b/fs.go
@@ -226,6 +226,12 @@ func (s fsStorage) MakeVol(volume string) (err error) {
 
 // ListVols - list volumes.
 func (s fsStorage) ListVols() (volsInfo []VolInfo, err error) {
+	// Get disk info to be populated for VolInfo.
+	var diskInfo disk.Info
+	diskInfo, err = disk.GetInfo(s.diskPath)
+	if err != nil {
+		return nil, err
+	}
 	volsInfo, err = getAllUniqueVols(s.diskPath)
 	if err != nil {
 		return nil, err
@@ -238,6 +244,9 @@ func (s fsStorage) ListVols() (volsInfo []VolInfo, err error) {
 		volInfo := VolInfo{
 			Name:    volName,
 			Created: vol.Created,
+			Total:   diskInfo.Total,
+			Free:    diskInfo.Free,
+			FSType:  diskInfo.FSType,
 		}
 		volsInfo[i] = volInfo
 	}
@@ -260,12 +269,21 @@ func (s fsStorage) StatVol(volume string) (volInfo VolInfo, err error) {
 		}
 		return VolInfo{}, err
 	}
+	// Get disk info, to be returned back along with volume info.
+	var diskInfo disk.Info
+	diskInfo, err = disk.GetInfo(s.diskPath)
+	if err != nil {
+		return VolInfo{}, err
+	}
 	// As os.Stat() doesn't carry other than ModTime(), use ModTime()
 	// as CreatedTime.
 	createdTime := st.ModTime()
 	return VolInfo{
 		Name:    volume,
 		Created: createdTime,
+		Free:    diskInfo.Free,
+		Total:   diskInfo.Total,
+		FSType:  diskInfo.FSType,
 	}, nil
 }
 

--- a/object-api.go
+++ b/object-api.go
@@ -72,6 +72,8 @@ func (o objectAPI) GetBucketInfo(bucket string) (BucketInfo, *probe.Error) {
 	return BucketInfo{
 		Name:    bucket,
 		Created: vi.Created,
+		Total:   vi.Total,
+		Free:    vi.Free,
 	}, nil
 }
 
@@ -91,6 +93,8 @@ func (o objectAPI) ListBuckets() ([]BucketInfo, *probe.Error) {
 		bucketInfos = append(bucketInfos, BucketInfo{
 			Name:    vol.Name,
 			Created: vol.Created,
+			Total:   vol.Total,
+			Free:    vol.Free,
 		})
 	}
 	return bucketInfos, nil

--- a/object-datatypes.go
+++ b/object-datatypes.go
@@ -22,6 +22,8 @@ import "time"
 type BucketInfo struct {
 	Name    string
 	Created time.Time
+	Total   int64
+	Free    int64
 }
 
 // ObjectInfo - object info.

--- a/storage-datatypes.go
+++ b/storage-datatypes.go
@@ -1,3 +1,19 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (
@@ -9,6 +25,9 @@ import (
 type VolInfo struct {
 	Name    string
 	Created time.Time
+	Total   int64
+	Free    int64
+	FSType  string
 }
 
 // FileInfo - file stat information.

--- a/web-handlers.go
+++ b/web-handlers.go
@@ -31,7 +31,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/rpc/v2/json2"
-	"github.com/minio/minio/pkg/disk"
 	"github.com/minio/miniobrowser"
 )
 
@@ -99,27 +98,6 @@ func (web *webAPIHandlers) ServerInfo(r *http.Request, args *WebGenericArgs, rep
 	return nil
 }
 
-// DiskInfoRep - disk info reply.
-type DiskInfoRep struct {
-	DiskInfo  disk.Info `json:"diskInfo"`
-	UIVersion string    `json:"uiVersion"`
-}
-
-// DiskInfo - get disk statistics.
-func (web *webAPIHandlers) DiskInfo(r *http.Request, args *WebGenericArgs, reply *DiskInfoRep) error {
-	// FIXME: bring in StatFS in StorageAPI interface and uncomment the below lines.
-	// if !isJWTReqAuthenticated(r) {
-	// 	return &json2.Error{Message: "Unauthorized request"}
-	// }
-	// info, e := disk.GetInfo(web.ObjectAPI.(*Filesystem).GetRootPath())
-	// if e != nil {
-	// 	return &json2.Error{Message: e.Error()}
-	// }
-	// reply.DiskInfo = info
-	// reply.UIVersion = miniobrowser.UIVersion
-	return nil
-}
-
 // MakeBucketArgs - make bucket args.
 type MakeBucketArgs struct {
 	BucketName string `json:"bucketName"`
@@ -150,6 +128,10 @@ type WebBucketInfo struct {
 	Name string `json:"name"`
 	// Date the bucket was created.
 	CreationDate time.Time `json:"creationDate"`
+	// Total storage space where the bucket resides.
+	Total int64 `json:"total"`
+	// Free storage space where the bucket resides.
+	Free int64 `json:"free"`
 }
 
 // ListBuckets - list buckets api.
@@ -167,6 +149,8 @@ func (web *webAPIHandlers) ListBuckets(r *http.Request, args *WebGenericArgs, re
 			reply.Buckets = append(reply.Buckets, WebBucketInfo{
 				Name:         bucket.Name,
 				CreationDate: bucket.Created,
+				Total:        bucket.Total,
+				Free:         bucket.Free,
 			})
 		}
 	}


### PR DESCRIPTION
It is the bucket and volumes which needs to have this
value rather than the DiskInfo API itself. Eventually
this can be extended to show disk usage per
Buckets/Volumes whenever we have that functionality.

For now since buckets/volumes are thinly provisioned
this is the right approach.
