### PR TITLE
xl: Introduce new blocking writer to make CreateFile atomic.

### DIFF
--- a/object-api-multipart.go
+++ b/object-api-multipart.go
@@ -255,10 +255,6 @@ func (o objectAPI) NewMultipartUpload(bucket, object string) (string, *probe.Err
 			// uploadIDPath doesn't exist, so create empty file to reserve the name
 			var w io.WriteCloser
 			if w, e = o.storage.CreateFile(minioMetaVolume, uploadIDPath); e == nil {
-				// Just write some data for erasure code, rather than zero bytes.
-				if _, e = w.Write([]byte(uploadID)); e != nil {
-					return "", probe.NewError(toObjectErr(e, minioMetaVolume, uploadIDPath))
-				}
 				// Close the writer.
 				if e = w.Close(); e != nil {
 					return "", probe.NewError(e)

--- a/object-api.go
+++ b/object-api.go
@@ -287,6 +287,8 @@ func (o objectAPI) ListObjects(bucket, prefix, marker, delimiter string, maxKeys
 			})
 		}
 	}
+
+	// Default is recursive, if delimiter is set then list non recursive.
 	recursive := true
 	if delimiter == slashSeparator {
 		recursive = false
@@ -298,6 +300,7 @@ func (o objectAPI) ListObjects(bucket, prefix, marker, delimiter string, maxKeys
 	if maxKeys == 0 {
 		return ListObjectsInfo{}, nil
 	}
+
 	result := ListObjectsInfo{IsTruncated: !eof}
 	for _, fileInfo := range fileInfos {
 		// With delimiter set we fill in NextMarker and Prefixes.

--- a/routers.go
+++ b/routers.go
@@ -17,8 +17,10 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"os"
+	"runtime"
 
 	router "github.com/gorilla/mux"
 	"github.com/minio/minio/pkg/probe"
@@ -42,6 +44,9 @@ func configureServerHandler(srvCmdConfig serverCmdConfig) http.Handler {
 			fatalIf(probe.NewError(e), "Initializing network fs failed.", nil)
 		}
 	} else {
+		if runtime.GOOS == "windows" {
+			fatalIf(probe.NewError(errors.New("")), "Initializing XL failed, not supported on windows yet.", nil)
+		}
 		// Initialize XL storage API.
 		storageAPI, e = newXL(srvCmdConfig.exportPaths...)
 		fatalIf(probe.NewError(e), "Initializing XL failed.", nil)

--- a/xl-v1-blockingwriter.go
+++ b/xl-v1-blockingwriter.go
@@ -1,0 +1,80 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"io"
+	"sync"
+)
+
+// blockingWriteCloser is a WriteCloser that blocks until released.
+type blockingWriteCloser struct {
+	writer  io.WriteCloser  // Embedded writer.
+	release *sync.WaitGroup // Waitgroup for atomicity.
+	mutex   *sync.Mutex     // Mutex for thread safety.
+	err     error
+}
+
+// Write to the underlying writer.
+func (b *blockingWriteCloser) Write(data []byte) (int, error) {
+	n, err := b.writer.Write(data)
+	if err != nil {
+		b.mutex.Lock()
+		b.err = err
+		b.mutex.Unlock()
+	}
+	return n, b.err
+}
+
+// Close blocks until another goroutine calls Release(error). Returns
+// error code if either writer fails or Release is called with an error.
+func (b *blockingWriteCloser) Close() error {
+	err := b.writer.Close()
+	if err != nil {
+		b.mutex.Lock()
+		b.err = err
+		b.mutex.Unlock()
+	}
+	b.release.Wait()
+	return b.err
+}
+
+// Release the Close, causing it to unblock. Only call this
+// once. Calling it multiple times results in a panic.
+func (b *blockingWriteCloser) Release(err error) {
+	b.release.Done()
+	if err != nil {
+		b.mutex.Lock()
+		b.err = err
+		b.mutex.Unlock()
+	}
+	return
+}
+
+// newBlockingWriteCloser Creates a new write closer that must be
+// released by the read consumer.
+func newBlockingWriteCloser(writer io.WriteCloser) *blockingWriteCloser {
+	// Wait group for the go-routine.
+	wg := &sync.WaitGroup{}
+	// Add to the wait group to wait for.
+	wg.Add(1)
+	return &blockingWriteCloser{
+		writer:  writer,
+		mutex:   &sync.Mutex{},
+		release: wg,
+	}
+}


### PR DESCRIPTION
Creates a new write closer that must be released
by the read consumer. This is necessary so that
while commiting the underlying writers in erasure
coding we need to make sure we reply success only if
we have committed to disk.

This in turn also fixes plethora of bugs related to
subsequent PutObject() races with namespace locking.

This patch also enables most of the tests, other than
ListObjects paging which has some issues still.

Fixes #1358, #1360
