### PR TITLE
tests: Fix a bug in TestObjectAPIIsUploadIDExists.

### DIFF
--- a/object-api-multipart_test.go
+++ b/object-api-multipart_test.go
@@ -106,10 +106,7 @@ func TestObjectAPIIsUploadIDExists(t *testing.T) {
 
 	// UploadID file shouldn't exist.
 	isExists, e := obj.isUploadIDExists(bucket, object, "abc")
-	if e == nil {
-		t.Fatal(e.Error())
-	}
-	if isExists {
+	if e == nil && isExists {
 		t.Fatal("Expected uploadIDPath to not to exist.")
 	}
 


### PR DESCRIPTION
The following code crashes when upload ID does not
exist, since we are setting err == nil when we find
err == errFileNotFound.

```
if e == nil {
   t.Fatal(e.Error())
```

Fix it.
