### PR TITLE
routers: Fix a crash while initializing network fs.

### DIFF
--- a/network-fs.go
+++ b/network-fs.go
@@ -79,7 +79,7 @@ func toStorageErr(err error) error {
 // Initialize new network file system.
 func newNetworkFS(networkPath string) (StorageAPI, error) {
 	// Input validation.
-	if networkPath == "" && strings.LastIndex(networkPath, ":") != -1 {
+	if networkPath == "" || strings.LastIndex(networkPath, ":") == -1 {
 		log.WithFields(logrus.Fields{
 			"networkPath": networkPath,
 		}).Debugf("Network path is malformed, should be of form <ip>:<port>:<export_dir>")

--- a/object-api_test.go
+++ b/object-api_test.go
@@ -32,7 +32,8 @@ func (s *MySuite) TestFSAPISuite(c *C) {
 	create := func() objectAPI {
 		path, err := ioutil.TempDir(os.TempDir(), "minio-")
 		c.Check(err, IsNil)
-		storageAPI, err := newFS(path)
+		storageAPI, err := newStorageAPI(path)
+		c.Check(err, IsNil)
 		objAPI := newObjectLayer(storageAPI)
 		storageList = append(storageList, path)
 		return objAPI
@@ -52,7 +53,7 @@ func (s *MySuite) TestXLAPISuite(c *C) {
 			erasureDisks = append(erasureDisks, path)
 		}
 		storageList = append(storageList, erasureDisks...)
-		storageAPI, err := newXL(erasureDisks...)
+		storageAPI, err := newStorageAPI(erasureDisks...)
 		c.Check(err, IsNil)
 		objAPI := newObjectLayer(storageAPI)
 		return objAPI

--- a/server-main.go
+++ b/server-main.go
@@ -162,7 +162,7 @@ func initServerConfig(c *cli.Context) {
 
 // Check server arguments.
 func checkServerSyntax(c *cli.Context) {
-	if !c.Args().Present() && c.Args().First() == "help" {
+	if !c.Args().Present() || c.Args().First() == "help" {
 		cli.ShowCommandHelpAndExit(c, "server", 1)
 	}
 }


### PR DESCRIPTION
Crash happens when 'minio server filename' a file name is
provided instead of a directory on command line argument.

```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
panic(0x5eb460, 0xc82000e0b0)
    /usr/local/opt/go/libexec/src/runtime/panic.go:464 +0x3e6
main.splitNetPath(0x7fff5fbff9bd, 0x7, 0x0, 0x0, 0x0, 0x0)
    /Users/harsha/mygo/src/github.com/minio/minio/network-fs.go:49 +0xb7
main.newNetworkFS(0x7fff5fbff9bd, 0x7, 0x0, 0x0, 0x0, 0x0)
    /Users/harsha/mygo/src/github.com/minio/minio/network-fs.go:90 +0x20a
main.configureServerHandler(0xc82024e1c8, 0x5, 0xc8200640e0, 0x1, 0x1, 0x0, 0x0)
    /Users/harsha/mygo/src/github.com/minio/minio/routers.go:43 +0x6ce
main.configureServer(0xc82024e1c8, 0x5, 0xc8200640e0, 0x1, 0x1, 0x5)
    /Users/harsha/mygo/src/github.com/minio/minio/server-main.go:86 +0x67
```
