### PR TITLE
Minor changes to CONTIRBUTING.md instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 If you do not have a working Golang environment setup please follow [Golang Installation Guide](./INSTALLGO.md).
 
 ### Setup your Minio Github Repository
-Fork [Minio upstream](https://github.com/minio/minio/fork) source repository to your own personal repository. Copy the URL and pass it to ``go get`` command. Go uses git to clone a copy into your project workspace folder.
+Fork [Minio upstream](https://github.com/minio/minio/fork) source repository to your own personal repository. Copy the URL for minio from your personal github repo (you will need it for the `git clone` command below).
 ```sh
 $ mkdir -p $GOPATH/src/github.com/minio
 $ cd $GOPATH/src/github.com/minio
-$ git clone https://github.com/$USER_ID/minio
+$ git clone <paste saved URL for personal forked minio repo>
 $ cd minio
 ```
 


### PR DESCRIPTION
Made some changes to the instructions for contributors. The old instructions reference a go get command in the text but the actual instructions use git clone instead. Also the instructions around copy and pasting the URL (from the user's personal github repo) were misleading. 
