### PR TITLE
object: Allow '[' and ']' as part of object names.

### DIFF
--- a/object-utils.go
+++ b/object-utils.go
@@ -58,8 +58,6 @@ func IsValidBucketName(bucket string) bool {
 // - Caret ("^")
 // - Right curly brace ("}")
 // - Grave accent / back tick ("`")
-// - Right square bracket ("]")
-// - Left square bracket ("[")
 // - Tilde ("~")
 // - 'Greater Than' symbol (">")
 // - 'Less Than' symbol ("<")
@@ -72,7 +70,7 @@ func IsValidObjectName(object string) bool {
 		return false
 	}
 	// Reject unsupported characters in object name.
-	return !strings.ContainsAny(object, "`^*{}[]|\\\"'")
+	return !strings.ContainsAny(object, "`^*{}|\\\"'")
 }
 
 // IsValidObjectPrefix verifies whether the prefix is a valid object name.


### PR DESCRIPTION
One of the bash commands "[" is a valid file name. 
