### PR TITLE
xl: ReedSolomon code fix small file erasure bug.

### DIFF
--- a/vendor/github.com/klauspost/reedsolomon/reedsolomon.go
+++ b/vendor/github.com/klauspost/reedsolomon/reedsolomon.go
@@ -57,8 +57,8 @@ type Encoder interface {
 	// If the data size isn't dividable by the number of shards,
 	// the last shard will contain extra zeros.
 	//
-	// There must be at least the same number of bytes as there are data shards,
-	// otherwise ErrShortData will be returned.
+	// There must be at least 1 byte otherwise ErrShortData will be
+	// returned.
 	//
 	// The data will not be copied, except for the last shard, so you
 	// should not modify the data of the input slice afterwards.
@@ -457,16 +457,15 @@ var ErrShortData = errors.New("not enough data to fill the number of requested s
 // If the data size isn't divisible by the number of shards,
 // the last shard will contain extra zeros.
 //
-// There must be at least the same number of bytes as there are data shards,
-// otherwise ErrShortData will be returned.
+// There must be at least 1 byte otherwise ErrShortData will be
+// returned.
 //
 // The data will not be copied, except for the last shard, so you
 // should not modify the data of the input slice afterwards.
 func (r reedSolomon) Split(data []byte) ([][]byte, error) {
-	if len(data) < r.DataShards {
+	if len(data) == 0 {
 		return nil, ErrShortData
 	}
-
 	// Calculate number of bytes per shard.
 	perShard := (len(data) + r.DataShards - 1) / r.DataShards
 

--- a/vendor/github.com/klauspost/reedsolomon/streaming.go
+++ b/vendor/github.com/klauspost/reedsolomon/streaming.go
@@ -77,8 +77,8 @@ type StreamEncoder interface {
 	// the last shard will contain extra zeros.
 	//
 	// You must supply the total size of your input.
-	// 'ErrShortData' will be returned if it is unable to retrieve the number of bytes
-	// indicated.
+	// 'ErrShortData' will be returned if it is unable to retrieve the
+	// number of bytes indicated.
 	Split(data io.Reader, dst []io.Writer, size int64) (err error)
 
 	// Join the shards and write the data segment to dst.
@@ -537,13 +537,12 @@ func (r rsStream) Join(dst io.Writer, shards []io.Reader, outSize int64) error {
 // the last shard will contain extra zeros.
 //
 // You must supply the total size of your input.
-// 'ErrShortData' will be returned if it is unable to retrieve the number of bytes
-// indicated.
+// 'ErrShortData' will be returned if it is unable to retrieve the
+// number of bytes indicated.
 func (r rsStream) Split(data io.Reader, dst []io.Writer, size int64) error {
-	if size < int64(r.r.DataShards) {
+	if size == 0 {
 		return ErrShortData
 	}
-
 	if len(dst) != r.r.DataShards {
 		return ErrInvShardNum
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -64,8 +64,8 @@
 		},
 		{
 			"path": "github.com/klauspost/reedsolomon",
-			"revision": "0b630aea2793158b43d0e18f2f50280bfb27c4b4",
-			"revisionTime": "2016-04-29T14:00:48-07:00"
+			"revision": "4fadad856421f3f13883bd681de8a9283809076e",
+			"revisionTime": "2016-05-01T12:00:51+02:00"
 		},
 		{
 			"path": "github.com/mattn/go-colorable",


### PR DESCRIPTION
For files less than 'dataBlocks', erasure encoding would fail
with short data due to a bug in the implementation itself.

Relax the error return, even a single byte can be properly
erasure coded without issues.

Fixes #1413
