### PR TITLE
xl/metadata: Keep the json erasure tag consistent.

### DIFF
--- a/xl-erasure-v1-metadata.go
+++ b/xl-erasure-v1-metadata.go
@@ -35,7 +35,7 @@ type xlMetaV1 struct {
 		DataBlocks   int   `json:"data"`
 		ParityBlocks int   `json:"parity"`
 		BlockSize    int64 `json:"blockSize"`
-	}
+	} `json:"erasure"`
 	Minio struct {
 		Release string `json:"release"`
 	} `json:"minio"`


### PR DESCRIPTION
Currently the on-disk json has "Erasure" we should
keep it consistent name and move to lower case instead.
