### PR TITLE
minio: Replace 'BucketAlreadyExists' error by 'BucketAlreadyOwnedByYou'.

### DIFF
--- a/api-errors.go
+++ b/api-errors.go
@@ -104,6 +104,7 @@ const (
 	ErrMissingDateHeader
 	ErrInvalidQuerySignatureAlgo
 	ErrInvalidQueryParams
+	ErrBucketAlreadyOwnedByYou
 	// Add new error codes here.
 
 	// Extended errors.
@@ -408,6 +409,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Code:           "AuthorizationQueryParametersError",
 		Description:    "Query-string authentication version 4 requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, X-Amz-SignedHeaders, and X-Amz-Expires parameters.",
 		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrBucketAlreadyOwnedByYou: {
+		Code:           "BucketAlreadyOwnedByYou",
+		Description:    "Your previous request to create the named bucket succeeded and you already own it.",
+		HTTPStatusCode: http.StatusConflict,
 	},
 	// Add your error structure here.
 }

--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -499,7 +499,7 @@ func (api objectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 		case BucketNameInvalid:
 			writeErrorResponse(w, r, ErrInvalidBucketName, r.URL.Path)
 		case BucketExists:
-			writeErrorResponse(w, r, ErrBucketAlreadyExists, r.URL.Path)
+			writeErrorResponse(w, r, ErrBucketAlreadyOwnedByYou, r.URL.Path)
 		default:
 			writeErrorResponse(w, r, ErrInternalError, r.URL.Path)
 		}

--- a/server_test.go
+++ b/server_test.go
@@ -954,7 +954,7 @@ func (s *MyAPISuite) TestPutBucketErrors(c *C) {
 
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
-	verifyError(c, response, "BucketAlreadyExists", "The requested bucket name is not available.", http.StatusConflict)
+	verifyError(c, response, "BucketAlreadyOwnedByYou", "Your previous request to create the named bucket succeeded and you already own it.", http.StatusConflict)
 
 	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/putbucket?acl", 0, nil)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
S3 API returns BucketAlreadyExists error when some another user has such bucket.
If user that creates the bucket already has it, s3 returns BucketAlreadyOwnedByYou.
As minio has only one user, it should behave accordingly.
Otherwise it causes failures in the applications that ignore creation of already existing bucket in the account, but fail when bucket name is used by someone else.
