### PR TITLE
New Dockerfile for building & running minio inside Docker (#1473)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.6
+
+RUN mkdir -p /go/src/app
+WORKDIR /go/src/app
+
+COPY . /go/src/app
+RUN go-wrapper download
+RUN go-wrapper install
+
+ENV ALLOW_CONTAINER_ROOT=1
+RUN mkdir -p /export/docker && cp /go/src/app/Docker.md /export/docker/
+
+EXPOSE 9000
+ENTRYPOINT ["go-wrapper", "run", "server"]
+CMD ["/export"]


### PR DESCRIPTION
See my sample repo that is working: https://hub.docker.com/r/soxhub/minio/

Unfortunately to use the same Docker repo, you'll have to delete and re-create as an automated build repo, but I have tested it in Dockerhub and the configuration is below:

![screenshot 2016-05-04 15 55 21](https://cloud.githubusercontent.com/assets/182605/15031986/028ea68a-1212-11e6-8f2f-3dbd8d260eb0.png)
