### PR TITLE
bucketPolicy: Do not use regexes, just do prefix matches.

### DIFF
--- a/bucket-policy-handlers.go
+++ b/bucket-policy-handlers.go
@@ -75,41 +75,41 @@ func bucketPolicyActionMatch(action string, statement policyStatement) bool {
 	return false
 }
 
-// Verify if given resource matches with policy statement.
-func bucketPolicyResourceMatch(resource string, statement policyStatement) bool {
-
-	match := func(pattern, subj string) bool {
-		if pattern == "" {
-			return subj == pattern
-		}
-		if pattern == "*" {
-			return true
-		}
-		parts := strings.Split(pattern, "*")
-		if len(parts) == 1 {
-			return subj == pattern
-		}
-		tGlob := strings.HasSuffix(pattern, "*")
-		end := len(parts) - 1
-		if !strings.HasPrefix(subj, parts[0]) {
+// Match function matches wild cards in 'pattern' for resource.
+func resourceMatch(pattern, resource string) bool {
+	if pattern == "" {
+		return resource == pattern
+	}
+	if pattern == "*" {
+		return true
+	}
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return resource == pattern
+	}
+	tGlob := strings.HasSuffix(pattern, "*")
+	end := len(parts) - 1
+	if !strings.HasPrefix(resource, parts[0]) {
+		return false
+	}
+	for i := 1; i < end; i++ {
+		if !strings.Contains(resource, parts[i]) {
 			return false
 		}
-		for i := 1; i < end; i++ {
-			if !strings.Contains(subj, parts[i]) {
-				return false
-			}
-			idx := strings.Index(subj, parts[i]) + len(parts[i])
-			subj = subj[idx:]
-		}
-		return tGlob || strings.HasSuffix(subj, parts[end])
+		idx := strings.Index(resource, parts[i]) + len(parts[i])
+		resource = resource[idx:]
 	}
+	return tGlob || strings.HasSuffix(resource, parts[end])
+}
 
-	for _, presource := range statement.Resources {
+// Verify if given resource matches with policy statement.
+func bucketPolicyResourceMatch(resource string, statement policyStatement) bool {
+	for _, resourcep := range statement.Resources {
 		// the resource rule for object could contain "*" wild card.
 		// the requested object can be given access based on the already set bucket policy if
 		// the match is successful.
 		// More info: http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-arn-format.html .
-		if matched := match(presource, resource); !matched {
+		if matched := resourceMatch(resourcep, resource); !matched {
 			return false
 		}
 	}


### PR DESCRIPTION
AWS arn supports wildcards and this is flat namespace, simple
prefix matching is fine.

Fixes #1481
Fixes #1482
