### PR TITLE
xl: Fix how we deal with read offsets at erasure layer.

### DIFF
--- a/xl-erasure-v1-utils.go
+++ b/xl-erasure-v1-utils.go
@@ -16,6 +16,16 @@
 
 package main
 
+// getDataBlocks - fetches the data block only part of the input encoded blocks.
+func getDataBlocks(enBlocks [][]byte, dataBlocks int, curBlockSize int) []byte {
+	var data []byte
+	for _, block := range enBlocks[:dataBlocks] {
+		data = append(data, block...)
+	}
+	data = data[:curBlockSize]
+	return data
+}
+
 // checkBlockSize return the size of a single block.
 // The first non-zero size is returned,
 // or 0 if all blocks are size 0.


### PR DESCRIPTION
Requires skipping necessary parts of dataBlocks during
decoding phase and requires us to properly skip the
entries as needed.

Thanks to Karthic for reproducing this important issue.

Fixes #1503
