### PR TITLE
erasure: waitCloser should implement CloseWithError.

### DIFF
--- a/object-utils.go
+++ b/object-utils.go
@@ -144,9 +144,9 @@ func safeCloseAndRemove(writer io.WriteCloser) error {
 	if ok {
 		return safeWriter.CloseAndRemove()
 	}
-	pipeWriter, ok := writer.(*io.PipeWriter)
+	wCloser, ok := writer.(*waitCloser)
 	if ok {
-		return pipeWriter.CloseWithError(errors.New("Close and error out."))
+		return wCloser.CloseWithError(errors.New("Close and error out."))
 	}
 	return nil
 }

--- a/xl-erasure-v1-waitcloser.go
+++ b/xl-erasure-v1-waitcloser.go
@@ -43,6 +43,16 @@ func (b *waitCloser) Close() error {
 	return err
 }
 
+// CloseWithError closes the writer; subsequent read to the read
+// half of the pipe will return the error err.
+func (b *waitCloser) CloseWithError(err error) error {
+	w, ok := b.writer.(*io.PipeWriter)
+	if ok {
+		return w.CloseWithError(err)
+	}
+	return err
+}
+
 // release the Close, causing it to unblock. Only call this
 // once. Calling it multiple times results in a panic.
 func (b *waitCloser) release() {


### PR DESCRIPTION
This is needed so that the other end of the pipe receives
and error, cleanups temporary files.
