### PR TITLE
XL/GetObject: If the offset does not fall in the first "dataBlock" it gives incorrect data.

### DIFF
--- a/xl-erasure-v1-readfile.go
+++ b/xl-erasure-v1-readfile.go
@@ -179,6 +179,7 @@ func (xl XL) ReadFile(volume, path string, startOffset int64) (io.ReadCloser, er
 				startOffset = startOffset - int64(len(dataBlocks))
 				// Start offset is greater than or equal to zero, skip the dataBlocks.
 				if startOffset >= 0 {
+					totalLeft = totalLeft - metadata.Erasure.BlockSize
 					continue
 				}
 				// Now get back the remaining offset if startOffset is negative.


### PR DESCRIPTION
Fixes #1582
