### PR TITLE
XL: Ignore errDiskNotFound in certain situations

### DIFF
--- a/object-common-multipart.go
+++ b/object-common-multipart.go
@@ -312,8 +312,8 @@ func listMetaBucketMultipartFiles(layer ObjectLayer, prefixPath string, markerPa
 				"marker":    markerPath,
 				"recursive": recursive,
 			}).Debugf("Walk resulted in an error %s", walkResult.err)
-			// File not found is a valid case.
-			if walkResult.err == errFileNotFound {
+			// 'File not found' or 'Disk not found' is a valid case.
+			if walkResult.err == errFileNotFound || walkResult.err == errDiskNotFound {
 				return nil, true, nil
 			}
 			return nil, false, toObjectErr(walkResult.err, minioMetaBucket, prefixPath)

--- a/xl-erasure-v1-common.go
+++ b/xl-erasure-v1-common.go
@@ -58,9 +58,9 @@ func (xl XL) listOnlineDisks(volume, path string) (onlineDisks []StorageAPI, mda
 	notFoundCount := 0
 	diskNotFoundCount := 0
 	for _, err := range errs {
-		if err == errFileNotFound {
+		if err == errFileNotFound || err == errDiskNotFound {
 			notFoundCount++
-			// If we have errors with file not found greater than
+			// If we have errors with 'file not found' or 'disk not found' greater than
 			// writeQuroum, return as errFileNotFound.
 			if notFoundCount > len(xl.storageDisks)-xl.readQuorum {
 				return nil, xlMetaV1{}, false, errFileNotFound

--- a/xl-erasure-v1.go
+++ b/xl-erasure-v1.go
@@ -243,8 +243,8 @@ func (xl XL) DeleteVol(volume string) error {
 			log.WithFields(logrus.Fields{
 				"volume": volume,
 			}).Errorf("DeleteVol failed with %s", err)
-			// We ignore error if errVolumeNotFound.
-			if err == errVolumeNotFound {
+			// We ignore error if errVolumeNotFound or errDiskNotFound
+			if err == errVolumeNotFound || err == errDiskNotFound {
 				volumeNotFoundErrCnt++
 				continue
 			}


### PR DESCRIPTION
When a disk is removed while an operation is going on
(eg. single/multipart put object, list/multipart list objects etc),
its required to ignore errDiskNotFound error and continue the
operation.

Fixes #1552
