### PR TITLE
Validation: Reject object names with trailing "/".

### DIFF
--- a/object-utils.go
+++ b/object-utils.go
@@ -73,27 +73,35 @@ func IsValidBucketName(bucket string) bool {
 // - Caret ("^")
 // - Grave accent / back tick ("`")
 // - Vertical bar / pipe ("|")
+//
+// Minio does not support object names with trailing "/".
 func IsValidObjectName(object string) bool {
-	if len(object) > 1024 || len(object) == 0 {
+	if len(object) == 0 {
+		return false
+	}
+	if strings.HasSuffix(object, slashSeparator) {
+		return false
+	}
+	if strings.HasPrefix(object, slashSeparator) {
+		return false
+	}
+	return IsValidObjectPrefix(object)
+}
+
+// IsValidObjectPrefix verifies whether the prefix is a valid object name.
+// Its valid to have a empty prefix.
+func IsValidObjectPrefix(object string) bool {
+	if len(object) > 1024 {
 		return false
 	}
 	if !utf8.ValidString(object) {
 		return false
 	}
 	// Reject unsupported characters in object name.
-	return !strings.ContainsAny(object, "`^*|\\\"")
-}
-
-// IsValidObjectPrefix verifies whether the prefix is a valid object name.
-// Its valid to have a empty prefix.
-func IsValidObjectPrefix(object string) bool {
-	// Prefix can be empty or "/".
-	if object == "" || object == "/" {
-		return true
+	if strings.ContainsAny(object, "`^*|\\\"") {
+		return false
 	}
-	// Verify if prefix is a valid object name.
-	return IsValidObjectName(object)
-
+	return true
 }
 
 // Slash separator.

--- a/object-utils_test.go
+++ b/object-utils_test.go
@@ -90,6 +90,8 @@ func TestIsValidObjectName(t *testing.T) {
 		// cases for which test should fail.
 		// passing invalid object names.
 		{"", false},
+		{"a/b/c/", false},
+		{"/a/b/c", false},
 		{string([]byte{0xff, 0xfe, 0xfd}), false},
 	}
 

--- a/object_api_suite_test.go
+++ b/object_api_suite_test.go
@@ -417,7 +417,7 @@ func testGetDirectoryReturnsObjectNotFound(c *check.C, create func() ObjectLayer
 
 	_, err = obj.GetObject("bucket", "dir1/", 0)
 	switch err := err.(type) {
-	case ObjectNotFound:
+	case ObjectNameInvalid:
 		c.Assert(err.Bucket, check.Equals, "bucket")
 		c.Assert(err.Object, check.Equals, "dir1/")
 	default:


### PR DESCRIPTION
Fixes #1616
