### PR TITLE
XL: Regexp removal from isValidVolname

### DIFF
--- a/posix-utils.go
+++ b/posix-utils.go
@@ -17,19 +17,15 @@
 package main
 
 import (
-	"regexp"
 	"runtime"
 	"strings"
 	"unicode/utf8"
 )
 
-// validVolname regexp.
-var validVolname = regexp.MustCompile(`^.{3,63}$`)
-
 // isValidVolname verifies a volname name in accordance with object
 // layer requirements.
 func isValidVolname(volname string) bool {
-	if !validVolname.MatchString(volname) {
+	if len(volname) < 3 || len(volname) > 63 {
 		return false
 	}
 	switch runtime.GOOS {


### PR DESCRIPTION
Removing regexp check and adding string based check, regexp check was not necessary. 

Fixes #1626 . 

The profile with the code changes doesn't contain regexp block as seen in #1626. 
[150block-2.pdf](https://github.com/minio/minio/files/262884/150block-2.pdf)
