### PR TITLE
Fix error message when wrong set of disks are passed

### DIFF
--- a/routers.go
+++ b/routers.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 
 	router "github.com/gorilla/mux"
@@ -31,7 +32,11 @@ func newObjectLayer(exportPaths ...string) (ObjectLayer, error) {
 		return newFSObjects(exportPath)
 	}
 	// Initialize XL object layer.
-	return newXLObjects(exportPaths...)
+	objAPI, err := newXLObjects(exportPaths...)
+	if err == errWriteQuorum {
+		return objAPI, errors.New("Disks are different with last minio server run.")
+	}
+	return objAPI, err
 }
 
 // configureServer handler returns final handler for the http server.


### PR DESCRIPTION
Previously when wrong set of disks are given with last minio server
run, it throws unclear error message.  This is fixed by returning
appropriate errors.

Fixes #1591
