### PR TITLE
logging: Log only for unhandled errors, remove all the verbose logging.

### DIFF
--- a/access-key.go
+++ b/access-key.go
@@ -50,7 +50,7 @@ var isValidAccessKey = regexp.MustCompile(`^[a-zA-Z0-9\\-\\.\\_\\~]{5,20}$`)
 // mustGenAccessKeys - must generate access credentials.
 func mustGenAccessKeys() (creds credential) {
 	creds, err := genAccessKeys()
-	fatalIf(err, "Unable to generate access keys.", nil)
+	fatalIf(err, "Unable to generate access keys.")
 	return creds
 }
 

--- a/accesslog-handler.go
+++ b/accesslog-handler.go
@@ -58,9 +58,9 @@ type LogMessage struct {
 
 func (h *accessLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	message, err := getLogMessage(w, req)
-	fatalIf(err, "Unable to extract http message.", nil)
+	fatalIf(err, "Unable to parse HTTP request and response fields.")
 	_, err = h.accessLogFile.Write(message)
-	fatalIf(err, "Writing to log file failed.", nil)
+	fatalIf(err, "Unable to log HTTP access.")
 
 	h.Handler.ServeHTTP(w, req)
 }
@@ -112,7 +112,7 @@ func getLogMessage(w http.ResponseWriter, req *http.Request) ([]byte, error) {
 // setAccessLogHandler logs requests
 func setAccessLogHandler(h http.Handler) http.Handler {
 	file, err := os.OpenFile("access.log", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
-	fatalIf(err, "Unable to open access log.", nil)
+	fatalIf(err, "Failed top open access log.")
 
 	return &accessLogHandler{Handler: h, accessLogFile: file}
 }

--- a/auth-handler.go
+++ b/auth-handler.go
@@ -111,12 +111,10 @@ func sumMD5(data []byte) []byte {
 // Verify if request has valid AWS Signature Version '4'.
 func isReqAuthenticated(r *http.Request) (s3Error APIErrorCode) {
 	if r == nil {
-		errorIf(errInvalidArgument, "HTTP request cannot be empty.", nil)
 		return ErrInternalError
 	}
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		errorIf(err, "Unable to read HTTP body.", nil)
 		return ErrInternalError
 	}
 	// Verify Content-Md5, if payload is set.

--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -36,7 +36,7 @@ func enforceBucketPolicy(action string, bucket string, reqURL *url.URL) (s3Error
 	// Read saved bucket policy.
 	policy, err := readBucketPolicy(bucket)
 	if err != nil {
-		errorIf(err, "GetBucketPolicy failed.", nil)
+		errorIf(err, "Unable read bucket policy.")
 		switch err.(type) {
 		case BucketNotFound:
 			return ErrNoSuchBucket
@@ -50,7 +50,7 @@ func enforceBucketPolicy(action string, bucket string, reqURL *url.URL) (s3Error
 	// Parse the saved policy.
 	bucketPolicy, err := parseBucketPolicy(policy)
 	if err != nil {
-		errorIf(err, "Parse policy failed.", nil)
+		errorIf(err, "Unable to parse bucket policy.")
 		return ErrAccessDenied
 	}
 
@@ -117,7 +117,7 @@ func (api objectAPIHandlers) GetBucketLocationHandler(w http.ResponseWriter, r *
 	}
 
 	if _, err := api.ObjectAPI.GetBucketInfo(bucket); err != nil {
-		errorIf(err, "GetBucketInfo failed.", nil)
+		errorIf(err, "Unable to fetch bucket info.")
 		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
 		return
 	}
@@ -180,7 +180,7 @@ func (api objectAPIHandlers) ListMultipartUploadsHandler(w http.ResponseWriter, 
 
 	listMultipartsInfo, err := api.ObjectAPI.ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
 	if err != nil {
-		errorIf(err, "ListMultipartUploads failed.", nil)
+		errorIf(err, "Unable to list multipart uploads.")
 		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
 		return
 	}
@@ -252,7 +252,7 @@ func (api objectAPIHandlers) ListObjectsHandler(w http.ResponseWriter, r *http.R
 		writeSuccessResponse(w, encodedSuccessResponse)
 		return
 	}
-	errorIf(err, "ListObjects failed.", nil)
+	errorIf(err, "Unable to list objects.")
 	writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
 }
 
@@ -306,7 +306,7 @@ func (api objectAPIHandlers) ListBucketsHandler(w http.ResponseWriter, r *http.R
 		writeSuccessResponse(w, encodedSuccessResponse)
 		return
 	}
-	errorIf(err, "ListBuckets failed.", nil)
+	errorIf(err, "Unable to list buckets.")
 	writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
 }
 
@@ -352,7 +352,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 
 	// Read incoming body XML bytes.
 	if _, err := io.ReadFull(r.Body, deleteXMLBytes); err != nil {
-		errorIf(err, "DeleteMultipleObjects failed.", nil)
+		errorIf(err, "Unable to read HTTP body.")
 		writeErrorResponse(w, r, ErrInternalError, r.URL.Path)
 		return
 	}
@@ -360,7 +360,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 	// Unmarshal list of keys to be deleted.
 	deleteObjects := &DeleteObjectsRequest{}
 	if err := xml.Unmarshal(deleteXMLBytes, deleteObjects); err != nil {
-		errorIf(err, "DeleteMultipartObjects xml decoding failed.", nil)
+		errorIf(err, "Unable to unmarshal delete objects request XML.")
 		writeErrorResponse(w, r, ErrMalformedXML, r.URL.Path)
 		return
 	}
@@ -375,7 +375,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 				ObjectName: object.ObjectName,
 			})
 		} else {
-			errorIf(err, "DeleteObject failed.", nil)
+			errorIf(err, "Unable to delete object.")
 			deleteErrors = append(deleteErrors, DeleteError{
 				Code:    errorCodeResponse[toAPIErrorCode(err)].Code,
 				Message: errorCodeResponse[toAPIErrorCode(err)].Description,
@@ -423,7 +423,7 @@ func (api objectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 	// Make bucket.
 	err := api.ObjectAPI.MakeBucket(bucket)
 	if err != nil {
-		errorIf(err, "MakeBucket failed.", nil)
+		errorIf(err, "Unable to create a bucket.")
 		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
 		return
 	}
@@ -467,14 +467,14 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	// be loaded in memory, the remaining being put in temporary files.
 	reader, err := r.MultipartReader()
 	if err != nil {
-		errorIf(err, "Unable to initialize multipart reader.", nil)
+		errorIf(err, "Unable to initialize multipart reader.")
 		writeErrorResponse(w, r, ErrMalformedPOSTRequest, r.URL.Path)
 		return
 	}
 
 	fileBody, formValues, err := extractHTTPFormValues(reader)
 	if err != nil {
-		errorIf(err, "Unable to parse form values.", nil)
+		errorIf(err, "Unable to parse form values.")
 		writeErrorResponse(w, r, ErrMalformedPOSTRequest, r.URL.Path)
 		return
 	}
@@ -494,7 +494,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	}
 	md5Sum, err := api.ObjectAPI.PutObject(bucket, object, -1, fileBody, nil)
 	if err != nil {
-		errorIf(err, "PutObject failed.", nil)
+		errorIf(err, "Unable to create object.")
 		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
 		return
 	}
@@ -540,7 +540,7 @@ func (api objectAPIHandlers) HeadBucketHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	if _, err := api.ObjectAPI.GetBucketInfo(bucket); err != nil {
-		errorIf(err, "GetBucketInfo failed.", nil)
+		errorIf(err, "Unable to fetch bucket info.")
 		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
 		return
 	}
@@ -565,7 +565,7 @@ func (api objectAPIHandlers) DeleteBucketHandler(w http.ResponseWriter, r *http.
 	}
 
 	if err := api.ObjectAPI.DeleteBucket(bucket); err != nil {
-		errorIf(err, "DeleteBucket failed.", nil)
+		errorIf(err, "Unable to delete a bucket.")
 		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
 		return
 	}

--- a/bucket-policy-handlers.go
+++ b/bucket-policy-handlers.go
@@ -67,7 +67,7 @@ func bucketPolicyActionMatch(action string, statement policyStatement) bool {
 	for _, policyAction := range statement.Actions {
 		// Policy action can be a regex, validate the action with matching string.
 		matched, err := regexp.MatchString(policyAction, action)
-		fatalIf(err, "Invalid pattern, please verify the pattern string.", nil)
+		fatalIf(err, "Invalid action \"%s\" in bucket policy.", action)
 		if matched {
 			return true
 		}
@@ -190,7 +190,7 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 	// bucket policies are limited to 20KB in size, using a limit reader.
 	bucketPolicyBuf, err := ioutil.ReadAll(io.LimitReader(r.Body, maxAccessPolicySize))
 	if err != nil {
-		errorIf(err, "Reading policy failed.", nil)
+		errorIf(err, "Unable to read bucket policy.")
 		writeErrorResponse(w, r, ErrInternalError, r.URL.Path)
 		return
 	}
@@ -198,7 +198,7 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 	// Parse bucket policy.
 	bucketPolicy, err := parseBucketPolicy(bucketPolicyBuf)
 	if err != nil {
-		errorIf(err, "Unable to parse bucket policy.", nil)
+		errorIf(err, "Unable to parse bucket policy.")
 		writeErrorResponse(w, r, ErrInvalidPolicyDocument, r.URL.Path)
 		return
 	}
@@ -211,7 +211,7 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 
 	// Save bucket policy.
 	if err := writeBucketPolicy(bucket, bucketPolicyBuf); err != nil {
-		errorIf(err, "SaveBucketPolicy failed.", nil)
+		errorIf(err, "Unable to write bucket policy.")
 		switch err.(type) {
 		case BucketNameInvalid:
 			writeErrorResponse(w, r, ErrInvalidBucketName, r.URL.Path)
@@ -245,7 +245,7 @@ func (api objectAPIHandlers) DeleteBucketPolicyHandler(w http.ResponseWriter, r 
 
 	// Delete bucket access policy.
 	if err := removeBucketPolicy(bucket); err != nil {
-		errorIf(err, "DeleteBucketPolicy failed.", nil)
+		errorIf(err, "Unable to remove bucket policy.")
 		switch err.(type) {
 		case BucketNameInvalid:
 			writeErrorResponse(w, r, ErrInvalidBucketName, r.URL.Path)
@@ -282,7 +282,7 @@ func (api objectAPIHandlers) GetBucketPolicyHandler(w http.ResponseWriter, r *ht
 	// Read bucket access policy.
 	p, err := readBucketPolicy(bucket)
 	if err != nil {
-		errorIf(err, "GetBucketPolicy failed.", nil)
+		errorIf(err, "Unable to read bucket policy.")
 		switch err.(type) {
 		case BucketNameInvalid:
 			writeErrorResponse(w, r, ErrInvalidBucketName, r.URL.Path)

--- a/certs.go
+++ b/certs.go
@@ -45,7 +45,7 @@ func getCertsPath() (string, error) {
 // mustGetCertsPath must get certs path.
 func mustGetCertsPath() string {
 	certsPath, err := getCertsPath()
-	fatalIf(err, "Unable to retrieve certs path.", nil)
+	fatalIf(err, "Failed to get certificate path.")
 	return certsPath
 }
 

--- a/commands.go
+++ b/commands.go
@@ -31,6 +31,10 @@ var globalFlags = []cli.Flag{
 		Value: mustGetConfigPath(),
 		Usage: "Path to configuration folder.",
 	},
+	cli.BoolFlag{
+		Name:  "quiet",
+		Usage: "Suppress chatty output.",
+	},
 }
 
 // registerCommand registers a cli command.

--- a/config-migrate.go
+++ b/config-migrate.go
@@ -40,18 +40,18 @@ func purgeV1() {
 	if err != nil && os.IsNotExist(err) {
 		return
 	}
-	fatalIf(err, "Unable to load config version ‘1’.", nil)
+	fatalIf(err, "Unable to load config version ‘1’.")
 
 	if cv1.Version == "1" {
-		console.Println("Unsupported config version ‘1’ found, removed successfully.")
+		console.Println("Removed unsupported config version ‘1’.")
 		/// Purge old fsUsers.json file
 		configPath, err := getConfigPath()
-		fatalIf(err, "Unable to retrieve config path.", nil)
+		fatalIf(err, "Unable to retrieve config path.")
 
 		configFile := filepath.Join(configPath, "fsUsers.json")
 		os.RemoveAll(configFile)
 	}
-	fatalIf(errors.New(""), "Unexpected version found ‘"+cv1.Version+"’, cannot migrate.", nil)
+	fatalIf(errors.New(""), "Failed to migrate unrecognized config version ‘"+cv1.Version+"’.")
 }
 
 // Version '2' to '3' config migration adds new fields and re-orders
@@ -61,7 +61,7 @@ func migrateV2ToV3() {
 	if err != nil && os.IsNotExist(err) {
 		return
 	}
-	fatalIf(err, "Unable to load config version ‘2’.", nil)
+	fatalIf(err, "Unable to load config version ‘2’.")
 	if cv2.Version != "2" {
 		return
 	}
@@ -98,14 +98,14 @@ func migrateV2ToV3() {
 	srvConfig.Logger.Syslog = slogger
 
 	qc, err := quick.New(srvConfig)
-	fatalIf(err, "Unable to initialize config.", nil)
+	fatalIf(err, "Unable to initialize config.")
 
 	configFile, err := getConfigFile()
-	fatalIf(err, "Unable to get config file.", nil)
+	fatalIf(err, "Unable to get config file.")
 
 	// Migrate the config.
 	err = qc.Save(configFile)
-	fatalIf(err, "Migrating from version ‘"+cv2.Version+"’ to ‘"+srvConfig.Version+"’ failed.", nil)
+	fatalIf(err, "Failed to migrate config from ‘"+cv2.Version+"’ to ‘"+srvConfig.Version+"’ failed.")
 
 	console.Println("Migration from version ‘" + cv2.Version + "’ to ‘" + srvConfig.Version + "’ completed successfully.")
 }
@@ -118,7 +118,7 @@ func migrateV3ToV4() {
 	if err != nil && os.IsNotExist(err) {
 		return
 	}
-	fatalIf(err, "Unable to load config version ‘3’.", nil)
+	fatalIf(err, "Unable to load config version ‘3’.")
 	if cv3.Version != "3" {
 		return
 	}
@@ -137,12 +137,12 @@ func migrateV3ToV4() {
 	srvConfig.Logger.Syslog = cv3.Logger.Syslog
 
 	qc, err := quick.New(srvConfig)
-	fatalIf(err, "Unable to initialize the quick config.", nil)
+	fatalIf(err, "Unable to initialize the quick config.")
 	configFile, err := getConfigFile()
-	fatalIf(err, "Unable to get config file.", nil)
+	fatalIf(err, "Unable to get config file.")
 
 	err = qc.Save(configFile)
-	fatalIf(err, "Migrating from version ‘"+cv3.Version+"’ to ‘"+srvConfig.Version+"’ failed.", nil)
+	fatalIf(err, "Failed to migrate config from ‘"+cv3.Version+"’ to ‘"+srvConfig.Version+"’ failed.")
 
 	console.Println("Migration from version ‘" + cv3.Version + "’ to ‘" + srvConfig.Version + "’ completed successfully.")
 }

--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ func getConfigPath() (string, error) {
 // mustGetConfigPath must get server config path.
 func mustGetConfigPath() string {
 	configPath, err := getConfigPath()
-	fatalIf(err, "Unable to get config path.", nil)
+	fatalIf(err, "Unable to get config path.")
 	return configPath
 }
 
@@ -73,7 +73,7 @@ func isConfigFileExists() bool {
 // mustGetConfigFile must get server config file.
 func mustGetConfigFile() string {
 	configFile, err := getConfigFile()
-	fatalIf(err, "Unable to get config file.", nil)
+	fatalIf(err, "Unable to get config file.")
 
 	return configFile
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,11 +1,9 @@
 ### Logging.
 
-- `log.Fatalf`
-- `log.Errorf`
-- `log.Warnf`
-- `log.Infof`
+- `fatalIf` - wrapper function which takes error and prints jsonic error messages.
+- `errorIf` - similar to fatalIf but doesn't exit on err != nil.
 
-Logging is enabled across the codebase. There are three types of logging supported.
+Supported logging targets.
 
 - console
 - file
@@ -20,11 +18,11 @@ Sample logger section from `~/.minio/config.json`
 		"file": {
 			"enable": false,
 			"fileName": "",
-			"level": "trace"
+			"level": "error"
 		},
 		"syslog": {
 			"enable": false,
 			"address": "",
-			"level": "info"
+			"level": "error"
 		}
 ```

--- a/globals.go
+++ b/globals.go
@@ -16,11 +16,7 @@
 
 package main
 
-import (
-	"github.com/fatih/color"
-	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
-)
+import "github.com/fatih/color"
 
 // Global constants for Minio.
 const (
@@ -41,7 +37,7 @@ const (
 
 var (
 	globalQuiet = false // Quiet flag set via command line
-	globalDebug = false // Debug flag set via command line
+	globalTrace = false // Trace flag set via environment setting.
 	// Add new global flags here.
 )
 
@@ -51,22 +47,3 @@ var (
 	colorWhite   = color.New(color.FgWhite, color.Bold).SprintfFunc()
 	colorGreen   = color.New(color.FgGreen, color.Bold).SprintfFunc()
 )
-
-// Set global states. NOTE: It is deliberately kept monolithic to
-// ensure we dont miss out any flags.
-func setGlobals(quiet, debug bool) {
-	globalQuiet = quiet
-	globalDebug = debug
-	// Enable debug messages if requested.
-	if globalDebug {
-		console.DebugPrint = true
-	}
-}
-
-// Set global states. NOTE: It is deliberately kept monolithic to
-// ensure we dont miss out any flags.
-func setGlobalsFromContext(ctx *cli.Context) {
-	quiet := ctx.Bool("quiet") || ctx.GlobalBool("quiet")
-	debug := ctx.Bool("debug") || ctx.GlobalBool("debug")
-	setGlobals(quiet, debug)
-}

--- a/logger-console-hook.go
+++ b/logger-console-hook.go
@@ -36,10 +36,11 @@ func enableConsoleLogger() {
 		log.Out = ioutil.Discard
 		return
 	}
+
 	// log.Out and log.Formatter use the default versions.
 	// Only set specific log level.
 	lvl, err := logrus.ParseLevel(clogger.Level)
-	fatalIf(err, "Unknown log level detected, please fix your console logger configuration.", nil)
+	fatalIf(err, "Unknown log level found in the config file.")
 
 	log.Level = lvl
 }

--- a/logger-file-hook.go
+++ b/logger-file-hook.go
@@ -40,13 +40,13 @@ func enableFileLogger() {
 	}
 
 	file, err := os.OpenFile(flogger.Filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
-	fatalIf(err, "Unable to open log file.", nil)
+	fatalIf(err, "Unable to open log file.")
 
 	// Add a local file hook.
 	log.Hooks.Add(&localFile{file})
 
 	lvl, err := logrus.ParseLevel(flogger.Level)
-	fatalIf(err, "Unknown log level detected, please fix your console logger configuration.", nil)
+	fatalIf(err, "Unknown log level found in the config file.")
 
 	// Set default JSON formatter.
 	log.Formatter = new(logrus.JSONFormatter)
@@ -64,14 +64,11 @@ func (l *localFile) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
-// Levels -
+// Levels - indicate log levels supported.
 func (l *localFile) Levels() []logrus.Level {
 	return []logrus.Level{
 		logrus.PanicLevel,
 		logrus.FatalLevel,
 		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
 	}
 }

--- a/logger-syslog-hook_nix.go
+++ b/logger-syslog-hook_nix.go
@@ -41,11 +41,11 @@ type syslogHook struct {
 // enableSyslogLogger - enable logger at raddr.
 func enableSyslogLogger(raddr string) {
 	syslogHook, err := newSyslog("udp", raddr, syslog.LOG_ERR, "MINIO")
-	fatalIf(err, "Unable to instantiate syslog.", nil)
+	fatalIf(err, "Unable to initialize syslog logger.")
 
 	log.Hooks.Add(syslogHook)               // Add syslog hook.
 	log.Formatter = &logrus.JSONFormatter{} // JSON formatted log.
-	log.Level = logrus.InfoLevel            // Minimum log level.
+	log.Level = logrus.ErrorLevel           // Minimum log level.
 }
 
 // newSyslog - Creates a hook to be added to an instance of logger.
@@ -67,12 +67,6 @@ func (hook *syslogHook) Fire(entry *logrus.Entry) error {
 		return hook.writer.Crit(line)
 	case logrus.ErrorLevel:
 		return hook.writer.Err(line)
-	case logrus.WarnLevel:
-		return hook.writer.Warning(line)
-	case logrus.InfoLevel:
-		return hook.writer.Info(line)
-	case logrus.DebugLevel:
-		return hook.writer.Debug(line)
 	default:
 		return nil
 	}
@@ -84,8 +78,5 @@ func (hook *syslogHook) Levels() []logrus.Level {
 		logrus.PanicLevel,
 		logrus.FatalLevel,
 		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
 	}
 }

--- a/logger-syslog-hook_windows.go
+++ b/logger-syslog-hook_windows.go
@@ -26,5 +26,5 @@ type syslogLogger struct {
 
 // enableSyslogLogger - unsupported on windows.
 func enableSyslogLogger(raddr string) {
-	fatalIf(errSyslogNotSupported, "Unable to enable syslog.", nil)
+	fatalIf(errSyslogNotSupported, "Unable to enable syslog.")
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -36,12 +36,12 @@ func (s *LoggerSuite) TestLogger(c *C) {
 	log.Out = &buffer
 	log.Formatter = new(logrus.JSONFormatter)
 
-	errorIf(errors.New("Fake error"), "Failed with error.", nil)
+	errorIf(errors.New("Fake error"), "Failed with error.")
 	err := json.Unmarshal(buffer.Bytes(), &fields)
 	c.Assert(err, IsNil)
 	c.Assert(fields["level"], Equals, "error")
 
-	msg, ok := fields["Error"]
+	msg, ok := fields["cause"]
 	c.Assert(ok, Equals, true)
-	c.Assert(msg.(map[string]interface{})["cause"], Equals, "Fake error")
+	c.Assert(msg, Equals, "Fake error")
 }

--- a/namespace-lock.go
+++ b/namespace-lock.go
@@ -17,9 +17,8 @@
 package main
 
 import (
+	"errors"
 	"sync"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // nsParam - carries name space resource.
@@ -91,10 +90,7 @@ func (n *nsLockMap) unlock(volume, path string, readLock bool) {
 			nsLk.Unlock()
 		}
 		if nsLk.ref == 0 {
-			log.WithFields(logrus.Fields{
-				"volume": volume,
-				"path":   path,
-			}).Error("ref count in NS lock can not be 0.")
+			errorIf(errors.New("Namespace reference count cannot be 0."), "Invalid reference count detected.")
 		}
 		if nsLk.ref != 0 {
 			nsLk.ref--

--- a/posix-list-dir-nix.go
+++ b/posix-list-dir-nix.go
@@ -25,8 +25,6 @@ import (
 	"strings"
 	"syscall"
 	"unsafe"
-
-	"github.com/Sirupsen/logrus"
 )
 
 const (
@@ -114,10 +112,6 @@ func readDir(dirPath string) (entries []string, err error) {
 	buf := make([]byte, readDirentBufSize)
 	d, err := os.Open(dirPath)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"dirPath": dirPath,
-		}).Debugf("Open failed with %s", err)
-
 		// File is really not found.
 		if os.IsNotExist(err) {
 			return nil, errFileNotFound

--- a/posix-list-dir-others.go
+++ b/posix-list-dir-others.go
@@ -22,18 +22,12 @@ import (
 	"io"
 	"os"
 	"strings"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // Return all the entries at the directory dirPath.
 func readDir(dirPath string) (entries []string, err error) {
 	d, err := os.Open(dirPath)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"dirPath": dirPath,
-		}).Debugf("Open failed with %s", err)
-
 		// File is really not found.
 		if os.IsNotExist(err) {
 			return nil, errFileNotFound

--- a/routers.go
+++ b/routers.go
@@ -42,11 +42,11 @@ func newObjectLayer(exportPaths ...string) (ObjectLayer, error) {
 // configureServer handler returns final handler for the http server.
 func configureServerHandler(srvCmdConfig serverCmdConfig) http.Handler {
 	objAPI, err := newObjectLayer(srvCmdConfig.exportPaths...)
-	fatalIf(err, "Initializing object layer failed.", nil)
+	fatalIf(err, "Unable to intialize object layer.")
 
 	// Initialize storage rpc server.
 	storageRPC, err := newRPCServer(srvCmdConfig.exportPaths[0]) // FIXME: should only have one path.
-	fatalIf(err, "Initializing storage rpc server failed.", nil)
+	fatalIf(err, "Unable to initialize storage RPC server.")
 
 	// Initialize API.
 	apiHandlers := objectAPIHandlers{

--- a/tree-walk.go
+++ b/tree-walk.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // listParams - list object params used for list object map
@@ -258,18 +256,10 @@ func saveTreeWalk(layer ObjectLayer, params listParams, walker *treeWalker) {
 	listObjectMapMutex.Lock()
 	defer listObjectMapMutex.Unlock()
 
-	log.WithFields(logrus.Fields{
-		"bucket":    params.bucket,
-		"recursive": params.recursive,
-		"marker":    params.marker,
-		"prefix":    params.prefix,
-	}).Debugf("saveTreeWalk has been invoked.")
-
 	walkers, _ := listObjectMap[params]
 	walkers = append(walkers, walker)
 
 	listObjectMap[params] = walkers
-	log.Debugf("Successfully saved in listObjectMap.")
 }
 
 // Lookup the goroutine reference from map
@@ -287,12 +277,6 @@ func lookupTreeWalk(layer ObjectLayer, params listParams) *treeWalker {
 	listObjectMapMutex.Lock()
 	defer listObjectMapMutex.Unlock()
 
-	log.WithFields(logrus.Fields{
-		"bucket":    params.bucket,
-		"recursive": params.recursive,
-		"marker":    params.marker,
-		"prefix":    params.prefix,
-	}).Debugf("lookupTreeWalk has been invoked.")
 	if walkChs, ok := listObjectMap[params]; ok {
 		for i, walkCh := range walkChs {
 			if !walkCh.timedOut {
@@ -302,12 +286,6 @@ func lookupTreeWalk(layer ObjectLayer, params listParams) *treeWalker {
 				} else {
 					delete(listObjectMap, params)
 				}
-				log.WithFields(logrus.Fields{
-					"bucket":    params.bucket,
-					"recursive": params.recursive,
-					"marker":    params.marker,
-					"prefix":    params.prefix,
-				}).Debugf("Found the previous saved listsObjects params.")
 				return walkCh
 			}
 		}

--- a/update-main.go
+++ b/update-main.go
@@ -89,7 +89,7 @@ func (u updateMessage) String() string {
 		return updateMessage("You are already running the most recent version of ‘minio’.")
 	}
 	msg, err := colorizeUpdateMessage(u.Download)
-	fatalIf(err, "Unable to colorize experimental update notification string ‘"+msg+"’.", nil)
+	fatalIf(err, "Unable to colorize update notice ‘"+msg+"’.")
 	return msg
 }
 
@@ -97,7 +97,7 @@ func (u updateMessage) String() string {
 func (u updateMessage) JSON() string {
 	u.Status = "success"
 	updateMessageJSONBytes, err := json.Marshal(u)
-	fatalIf((err), "Unable to marshal into JSON.", nil)
+	fatalIf((err), "Unable to marshal into JSON.")
 
 	return string(updateMessageJSONBytes)
 }
@@ -166,12 +166,12 @@ func getReleaseUpdate(updateURL string, noError bool) updateMessage {
 	if err != nil && noError {
 		return updateMsg
 	}
-	fatalIf((err), "Unable to read from update URL ‘"+newUpdateURL+"’.", nil)
+	fatalIf((err), "Unable to read from update URL ‘"+newUpdateURL+"’.")
 
 	// Error out if 'update' command is issued for development based builds.
 	if minioVersion == "DEVELOPMENT.GOGET" && !noError {
 		fatalIf((errors.New("")),
-			"Update mechanism is not supported for ‘go get’ based binary builds. Please download official releases from https://minio.io/#minio", nil)
+			"Update mechanism is not supported for ‘go get’ based binary builds. Please download official releases from https://minio.io/#minio")
 	}
 
 	// Parse current minio version into RFC3339.
@@ -179,12 +179,12 @@ func getReleaseUpdate(updateURL string, noError bool) updateMessage {
 	if err != nil && noError {
 		return updateMsg
 	}
-	fatalIf((err), "Unable to parse version string as time.", nil)
+	fatalIf((err), "Unable to parse version string as time.")
 
 	// Verify if current minio version is zero.
 	if current.IsZero() && !noError {
 		fatalIf((errors.New("")),
-			"Updates not supported for custom builds. Version field is empty. Please download official releases from https://minio.io/#minio", nil)
+			"Updates mechanism is not supported for custom builds. Please download official releases from https://minio.io/#minio")
 	}
 
 	// Verify if we have a valid http response i.e http.StatusOK.
@@ -194,7 +194,7 @@ func getReleaseUpdate(updateURL string, noError bool) updateMessage {
 			if noError {
 				return updateMsg
 			}
-			fatalIf((errors.New("")), "Update server responsed with "+data.Status, nil)
+			fatalIf((errors.New("")), "Failed to retrieve update notice. "+data.Status)
 		}
 	}
 
@@ -203,19 +203,19 @@ func getReleaseUpdate(updateURL string, noError bool) updateMessage {
 	if err != nil && noError {
 		return updateMsg
 	}
-	fatalIf((err), "Fetching updates failed. Please try again.", nil)
+	fatalIf((err), "Failed to retrieve update notice. Please try again later.")
 
 	// Parse the date if its valid.
 	latest, err := parseReleaseData(string(updateBody))
 	if err != nil && noError {
 		return updateMsg
 	}
-	fatalIf(err, "Please report this issue at https://github.com/minio/minio/issues.", nil)
+	errMsg := "Failed to retrieve update notice. Please try again later. Please report this issue at https://github.com/minio/minio/issues"
+	fatalIf(err, errMsg)
 
 	// Verify if the date is not zero.
 	if latest.IsZero() && !noError {
-		fatalIf((errors.New("")),
-			"Unable to validate any update available at this time. Please open an issue at https://github.com/minio/minio/issues", nil)
+		fatalIf((errors.New("")), errMsg)
 	}
 
 	// Is the update latest?.

--- a/xl-erasure-v1-common.go
+++ b/xl-erasure-v1-common.go
@@ -20,8 +20,6 @@ import (
 	"errors"
 	slashpath "path"
 	"sync"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // Get the highest integer from a given integer slice.
@@ -125,12 +123,6 @@ func (xl XL) listOnlineDisks(volume, path string) (onlineDisks []StorageAPI, mda
 		// Verify if online disks count are lesser than readQuorum
 		// threshold, return an error if yes.
 		if onlineDiskCount < xl.readQuorum {
-			log.WithFields(logrus.Fields{
-				"volume":          volume,
-				"path":            path,
-				"onlineDiskCount": onlineDiskCount,
-				"readQuorumCount": xl.readQuorum,
-			}).Errorf("%s", errReadQuorum)
 			return nil, xlMetaV1{}, false, errReadQuorum
 		}
 	}


### PR DESCRIPTION
This patch brings in the removal of debug logging altogether, instead
we bring in the functionality of being able to trace the errors properly
pointing back to the origination of the problem.

To enable tracing you need to enable "MINIO_TRACE" set to "1" or "true"
environment variable which would print back traces whenever there is an
error which is unhandled or at the handler layer.

By default this tracing is turned off and only user level logging is provided.
