### PR TITLE
XL/fs: Optimize calling isBucketExist()

### DIFF
--- a/fs-objects.go
+++ b/fs-objects.go
@@ -94,9 +94,6 @@ func (fs fsObjects) GetObject(bucket, object string, startOffset int64) (io.Read
 	if !IsValidBucketName(bucket) {
 		return nil, BucketNameInvalid{Bucket: bucket}
 	}
-	if !isBucketExist(fs.storage, bucket) {
-		return nil, BucketNotFound{Bucket: bucket}
-	}
 	// Verify if object is valid.
 	if !IsValidObjectName(object) {
 		return nil, ObjectNameInvalid{Bucket: bucket, Object: object}
@@ -113,9 +110,6 @@ func (fs fsObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
 	// Verify if bucket is valid.
 	if !IsValidBucketName(bucket) {
 		return ObjectInfo{}, (BucketNameInvalid{Bucket: bucket})
-	}
-	if !isBucketExist(fs.storage, bucket) {
-		return ObjectInfo{}, BucketNotFound{Bucket: bucket}
 	}
 	// Verify if object is valid.
 	if !IsValidObjectName(object) {
@@ -148,10 +142,6 @@ func (fs fsObjects) PutObject(bucket string, object string, size int64, data io.
 	// Verify if bucket is valid.
 	if !IsValidBucketName(bucket) {
 		return "", BucketNameInvalid{Bucket: bucket}
-	}
-	// Check whether the bucket exists.
-	if !isBucketExist(fs.storage, bucket) {
-		return "", BucketNotFound{Bucket: bucket}
 	}
 	if !IsValidObjectName(object) {
 		return "", ObjectNameInvalid{
@@ -218,9 +208,6 @@ func (fs fsObjects) DeleteObject(bucket, object string) error {
 	// Verify if bucket is valid.
 	if !IsValidBucketName(bucket) {
 		return BucketNameInvalid{Bucket: bucket}
-	}
-	if !isBucketExist(fs.storage, bucket) {
-		return BucketNotFound{Bucket: bucket}
 	}
 	if !IsValidObjectName(object) {
 		return ObjectNameInvalid{Bucket: bucket, Object: object}

--- a/object-common-multipart.go
+++ b/object-common-multipart.go
@@ -80,7 +80,6 @@ func newMultipartUploadCommon(storage StorageAPI, bucket string, object string) 
 	if !isBucketExist(storage, bucket) {
 		return "", BucketNotFound{Bucket: bucket}
 	}
-
 	// Verify if object name is valid.
 	if !IsValidObjectName(object) {
 		return "", ObjectNameInvalid{Bucket: bucket, Object: object}
@@ -229,7 +228,6 @@ func abortMultipartUploadCommon(storage StorageAPI, bucket, object, uploadID str
 	if !IsValidBucketName(bucket) {
 		return BucketNameInvalid{Bucket: bucket}
 	}
-	// Verify whether the bucket exists.
 	if !isBucketExist(storage, bucket) {
 		return BucketNotFound{Bucket: bucket}
 	}
@@ -371,7 +369,6 @@ func listMultipartUploadsCommon(layer ObjectLayer, bucket, prefix, keyMarker, up
 	case fsObjects:
 		storage = l.storage
 	}
-
 	result := ListMultipartsInfo{}
 	// Verify if bucket is valid.
 	if !IsValidBucketName(bucket) {

--- a/object-common.go
+++ b/object-common.go
@@ -144,17 +144,14 @@ func listObjectsCommon(layer ObjectLayer, bucket, prefix, marker, delimiter stri
 	case fsObjects:
 		storage = l.storage
 	}
-
 	// Verify if bucket is valid.
 	if !IsValidBucketName(bucket) {
 		return ListObjectsInfo{}, BucketNameInvalid{Bucket: bucket}
 	}
-
-	// Verify whether the bucket exists.
+	// Verify if bucket exists.
 	if !isBucketExist(storage, bucket) {
 		return ListObjectsInfo{}, BucketNotFound{Bucket: bucket}
 	}
-
 	if !IsValidObjectPrefix(prefix) {
 		return ListObjectsInfo{}, ObjectNameInvalid{Bucket: bucket, Object: prefix}
 	}
@@ -174,6 +171,7 @@ func listObjectsCommon(layer ObjectLayer, bucket, prefix, marker, delimiter stri
 		}
 	}
 
+	// With max keys of zero we have reached eof, return right here.
 	if maxKeys == 0 {
 		return ListObjectsInfo{}, nil
 	}

--- a/posix.go
+++ b/posix.go
@@ -128,28 +128,8 @@ func checkDiskFree(diskPath string, minFreeDisk int64) (err error) {
 	return nil
 }
 
-func removeDuplicateVols(volsInfo []VolInfo) []VolInfo {
-	// Use map to record duplicates as we find them.
-	result := []VolInfo{}
-
-	m := make(map[string]VolInfo)
-	for _, v := range volsInfo {
-		if _, found := m[v.Name]; !found {
-			m[v.Name] = v
-		}
-	}
-
-	result = make([]VolInfo, 0, len(m))
-	for _, v := range m {
-		result = append(result, v)
-	}
-
-	// Return the new slice.
-	return result
-}
-
-// gets all the unique directories from diskPath.
-func getAllUniqueVols(dirPath string) ([]VolInfo, error) {
+// List all the volumes from diskPath.
+func listVols(dirPath string) ([]VolInfo, error) {
 	if err := checkPathLength(dirPath); err != nil {
 		return nil, err
 	}
@@ -179,14 +159,14 @@ func getAllUniqueVols(dirPath string) ([]VolInfo, error) {
 			Created: fi.ModTime(),
 		})
 	}
-	return removeDuplicateVols(volsInfo), nil
+	return volsInfo, nil
 }
 
-// getVolumeDir - will convert incoming volume names to
+// getVolDir - will convert incoming volume names to
 // corresponding valid volume names on the backend in a platform
 // compatible way for all operating systems. If volume is not found
 // an error is generated.
-func (s fsStorage) getVolumeDir(volume string) (string, error) {
+func (s fsStorage) getVolDir(volume string) (string, error) {
 	if !isValidVolname(volume) {
 		return "", errInvalidArgument
 	}
@@ -204,7 +184,7 @@ func (s fsStorage) MakeVol(volume string) (err error) {
 		return err
 	}
 
-	volumeDir, err := s.getVolumeDir(volume)
+	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return err
 	}
@@ -225,7 +205,7 @@ func (s fsStorage) ListVols() (volsInfo []VolInfo, err error) {
 	if err != nil {
 		return nil, err
 	}
-	volsInfo, err = getAllUniqueVols(s.diskPath)
+	volsInfo, err = listVols(s.diskPath)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +229,7 @@ func (s fsStorage) ListVols() (volsInfo []VolInfo, err error) {
 // StatVol - get volume info.
 func (s fsStorage) StatVol(volume string) (volInfo VolInfo, err error) {
 	// Verify if volume is valid and it exists.
-	volumeDir, err := s.getVolumeDir(volume)
+	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return VolInfo{}, err
 	}
@@ -283,7 +263,7 @@ func (s fsStorage) StatVol(volume string) (volInfo VolInfo, err error) {
 // DeleteVol - delete a volume.
 func (s fsStorage) DeleteVol(volume string) error {
 	// Verify if volume is valid and it exists.
-	volumeDir, err := s.getVolumeDir(volume)
+	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return err
 	}
@@ -308,7 +288,7 @@ func (s fsStorage) DeleteVol(volume string) error {
 // If an entry is a directory it will be returned with a trailing "/".
 func (s fsStorage) ListDir(volume, dirPath string) ([]string, error) {
 	// Verify if volume is valid and it exists.
-	volumeDir, err := s.getVolumeDir(volume)
+	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +305,7 @@ func (s fsStorage) ListDir(volume, dirPath string) ([]string, error) {
 
 // ReadFile - read a file at a given offset.
 func (s fsStorage) ReadFile(volume string, path string, offset int64) (readCloser io.ReadCloser, err error) {
-	volumeDir, err := s.getVolumeDir(volume)
+	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +349,7 @@ func (s fsStorage) ReadFile(volume string, path string, offset int64) (readClose
 
 // CreateFile - create a file at path.
 func (s fsStorage) CreateFile(volume, path string) (writeCloser io.WriteCloser, err error) {
-	volumeDir, err := s.getVolumeDir(volume)
+	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +388,7 @@ func (s fsStorage) CreateFile(volume, path string) (writeCloser io.WriteCloser, 
 
 // StatFile - get file info.
 func (s fsStorage) StatFile(volume, path string) (file FileInfo, err error) {
-	volumeDir, err := s.getVolumeDir(volume)
+	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return FileInfo{}, err
 	}
@@ -486,7 +466,7 @@ func deleteFile(basePath, deletePath string) error {
 
 // DeleteFile - delete a file at path.
 func (s fsStorage) DeleteFile(volume, path string) error {
-	volumeDir, err := s.getVolumeDir(volume)
+	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return err
 	}
@@ -512,14 +492,29 @@ func (s fsStorage) DeleteFile(volume, path string) error {
 
 // RenameFile - rename file.
 func (s fsStorage) RenameFile(srcVolume, srcPath, dstVolume, dstPath string) error {
-	srcVolumeDir, err := s.getVolumeDir(srcVolume)
+	srcVolumeDir, err := s.getVolDir(srcVolume)
 	if err != nil {
 		return err
 	}
-	dstVolumeDir, err := s.getVolumeDir(dstVolume)
+	dstVolumeDir, err := s.getVolDir(dstVolume)
 	if err != nil {
 		return err
 	}
+	// Stat a volume entry.
+	_, err = os.Stat(srcVolumeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errVolumeNotFound
+		}
+		return err
+	}
+	_, err = os.Stat(dstVolumeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errVolumeNotFound
+		}
+	}
+
 	srcIsDir := strings.HasSuffix(srcPath, slashSeparator)
 	dstIsDir := strings.HasSuffix(dstPath, slashSeparator)
 	// Either src and dst have to be directories or files, else return error.

--- a/xl-objects.go
+++ b/xl-objects.go
@@ -146,9 +146,6 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64) (io.Read
 	if !IsValidBucketName(bucket) {
 		return nil, BucketNameInvalid{Bucket: bucket}
 	}
-	if !isBucketExist(xl.storage, bucket) {
-		return nil, BucketNotFound{Bucket: bucket}
-	}
 	// Verify if object is valid.
 	if !IsValidObjectName(object) {
 		return nil, ObjectNameInvalid{Bucket: bucket, Object: object}
@@ -261,10 +258,6 @@ func (xl xlObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
 	if !IsValidBucketName(bucket) {
 		return ObjectInfo{}, BucketNameInvalid{Bucket: bucket}
 	}
-	// Check whether the bucket exists.
-	if !isBucketExist(xl.storage, bucket) {
-		return ObjectInfo{}, BucketNotFound{Bucket: bucket}
-	}
 	// Verify if object is valid.
 	if !IsValidObjectName(object) {
 		return ObjectInfo{}, ObjectNameInvalid{Bucket: bucket, Object: object}
@@ -282,7 +275,7 @@ func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.
 	if !IsValidBucketName(bucket) {
 		return "", BucketNameInvalid{Bucket: bucket}
 	}
-	// Check whether the bucket exists.
+	// Verify bucket exists.
 	if !isBucketExist(xl.storage, bucket) {
 		return "", BucketNotFound{Bucket: bucket}
 	}
@@ -432,9 +425,6 @@ func (xl xlObjects) DeleteObject(bucket, object string) error {
 	// Verify if bucket is valid.
 	if !IsValidBucketName(bucket) {
 		return BucketNameInvalid{Bucket: bucket}
-	}
-	if !isBucketExist(xl.storage, bucket) {
-		return BucketNotFound{Bucket: bucket}
 	}
 	if !IsValidObjectName(object) {
 		return ObjectNameInvalid{Bucket: bucket, Object: object}


### PR DESCRIPTION
This is necessary compromise to avoid significant slowness this
causes under load. The compromise is also substantial in a way
so that to avoid penalizing common cases v/s special cases.

For buckets with Caps on Unixes, we filter buckets based on the
latest anyways, so this is completely acceptable.
