### PR TITLE
objects: Save all the incoming metadata properly.

### DIFF
--- a/fs-objects-multipart.go
+++ b/fs-objects-multipart.go
@@ -28,8 +28,9 @@ func (fs fsObjects) ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 }
 
 // NewMultipartUpload - initialize a new multipart upload, returns a unique id.
-func (fs fsObjects) NewMultipartUpload(bucket, object string) (string, error) {
-	return newMultipartUploadCommon(fs.storage, bucket, object)
+func (fs fsObjects) NewMultipartUpload(bucket, object string, meta map[string]string) (string, error) {
+	meta = make(map[string]string) // Reset the meta value, we are not going to save headers for fs.
+	return newMultipartUploadCommon(fs.storage, bucket, object, meta)
 }
 
 // PutObjectPart - writes the multipart upload chunks.

--- a/object-api-multipart_test.go
+++ b/object-api-multipart_test.go
@@ -35,7 +35,7 @@ func testObjectNewMultipartUpload(obj ObjectLayer, instanceType string, t *testi
 
 	errMsg := "Bucket not found: minio-bucket"
 	// opearation expected to fail since the bucket on which NewMultipartUpload is being initiated doesn't exist.
-	uploadID, err := obj.NewMultipartUpload(bucket, object)
+	uploadID, err := obj.NewMultipartUpload(bucket, object, nil)
 	if err == nil {
 		t.Fatalf("%s: Expected to fail since the NewMultipartUpload is intialized on a non-existant bucket.", instanceType)
 	}
@@ -50,7 +50,7 @@ func testObjectNewMultipartUpload(obj ObjectLayer, instanceType string, t *testi
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}
 
-	uploadID, err = obj.NewMultipartUpload(bucket, object)
+	uploadID, err = obj.NewMultipartUpload(bucket, object, nil)
 	if err != nil {
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}
@@ -83,7 +83,7 @@ func testObjectAPIIsUploadIDExists(obj ObjectLayer, instanceType string, t *test
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}
 
-	_, err = obj.NewMultipartUpload(bucket, object)
+	_, err = obj.NewMultipartUpload(bucket, object, nil)
 	if err != nil {
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}
@@ -114,7 +114,7 @@ func testObjectAPIPutObjectPart(obj ObjectLayer, instanceType string, t *testing
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}
 	// Initiate Multipart Upload on the above created bucket.
-	uploadID, err := obj.NewMultipartUpload(bucket, object)
+	uploadID, err := obj.NewMultipartUpload(bucket, object, nil)
 	if err != nil {
 		// Failed to create NewMultipartUpload, abort.
 		t.Fatalf("%s : %s", instanceType, err.Error())

--- a/object-interface.go
+++ b/object-interface.go
@@ -35,7 +35,7 @@ type ObjectLayer interface {
 
 	// Multipart operations.
 	ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (result ListMultipartsInfo, err error)
-	NewMultipartUpload(bucket, object string) (uploadID string, err error)
+	NewMultipartUpload(bucket, object string, metadata map[string]string) (uploadID string, err error)
 	PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Hex string) (md5 string, err error)
 	ListObjectParts(bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error)
 	AbortMultipartUpload(bucket, object, uploadID string) error

--- a/object_api_suite_test.go
+++ b/object_api_suite_test.go
@@ -61,7 +61,7 @@ func testMultipartObjectCreation(c *check.C, create func() ObjectLayer) {
 	obj := create()
 	err := obj.MakeBucket("bucket")
 	c.Assert(err, check.IsNil)
-	uploadID, err := obj.NewMultipartUpload("bucket", "key")
+	uploadID, err := obj.NewMultipartUpload("bucket", "key", nil)
 	c.Assert(err, check.IsNil)
 	// Create a byte array of 5MB.
 	data := bytes.Repeat([]byte("0123456789abcdef"), 5*1024*1024/16)
@@ -87,7 +87,7 @@ func testMultipartObjectAbort(c *check.C, create func() ObjectLayer) {
 	obj := create()
 	err := obj.MakeBucket("bucket")
 	c.Assert(err, check.IsNil)
-	uploadID, err := obj.NewMultipartUpload("bucket", "key")
+	uploadID, err := obj.NewMultipartUpload("bucket", "key", nil)
 	c.Assert(err, check.IsNil)
 
 	parts := make(map[int]string)


### PR DESCRIPTION
For both multipart and single put operation
