### PR TITLE
XL/heal: Should skip healing if CreateFile() failed on the part which needed healing.

### DIFF
--- a/xl-erasure-v1-createfile.go
+++ b/xl-erasure-v1-createfile.go
@@ -89,10 +89,6 @@ func (xl XL) writeErasure(volume, path string, reader *io.PipeReader, wcloser *w
 				xl.cleanupCreateFileOps(volume, path, append(writers, metadataWriters...)...)
 				reader.CloseWithError(err)
 				return
-			} else if err == errVolumeNotFound {
-				xl.cleanupCreateFileOps(volume, path, append(writers, metadataWriters...)...)
-				reader.CloseWithError(err)
-				return
 			}
 
 			createFileError++

--- a/xl-erasure-v1-healfile.go
+++ b/xl-erasure-v1-healfile.go
@@ -55,19 +55,6 @@ func (xl XL) healFile(volume string, path string) error {
 		}
 	}
 
-	// Check if there is atleast one part that needs to be healed.
-	atleastOneHeal := false
-	for _, healNeeded := range needsHeal {
-		if healNeeded {
-			atleastOneHeal = true
-			break
-		}
-	}
-	if !atleastOneHeal {
-		// Return if healing not needed anywhere.
-		return nil
-	}
-
 	// create writers for parts where healing is needed.
 	for index, healNeeded := range needsHeal {
 		if !healNeeded {
@@ -81,6 +68,20 @@ func (xl XL) healFile(volume string, path string) error {
 			continue
 		}
 	}
+
+	// Check if there is atleast one part that needs to be healed.
+	atleastOneHeal := false
+	for _, healNeeded := range needsHeal {
+		if healNeeded {
+			atleastOneHeal = true
+			break
+		}
+	}
+	if !atleastOneHeal {
+		// Return if healing not needed anywhere.
+		return nil
+	}
+
 	var totalLeft = metadata.Stat.Size
 	for totalLeft > 0 {
 		// Figure out the right blockSize.


### PR DESCRIPTION
Fixes #1684
