### PR TITLE
handler: CopyObject should save metadata.

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -492,7 +492,12 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		writeErrorResponse(w, r, apiErr, r.URL.Path)
 		return
 	}
-	md5Sum, err := api.ObjectAPI.PutObject(bucket, object, -1, fileBody, nil)
+
+	// Save metadata.
+	metadata := make(map[string]string)
+	// Nothing to store right now.
+
+	md5Sum, err := api.ObjectAPI.PutObject(bucket, object, -1, fileBody, metadata)
 	if err != nil {
 		errorIf(err, "Unable to create object.")
 		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)

--- a/object-common-multipart.go
+++ b/object-common-multipart.go
@@ -85,6 +85,10 @@ func newMultipartUploadCommon(storage StorageAPI, bucket string, object string, 
 	if !IsValidObjectName(object) {
 		return "", ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
+	// No metadata is set, allocate a new one.
+	if meta == nil {
+		meta = make(map[string]string)
+	}
 	// This lock needs to be held for any changes to the directory contents of ".minio/multipart/object/"
 	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
 	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))

--- a/object-datatypes.go
+++ b/object-datatypes.go
@@ -28,13 +28,14 @@ type BucketInfo struct {
 
 // ObjectInfo - object info.
 type ObjectInfo struct {
-	Bucket      string
-	Name        string
-	ModTime     time.Time
-	ContentType string
-	MD5Sum      string
-	Size        int64
-	IsDir       bool
+	Bucket          string
+	Name            string
+	ModTime         time.Time
+	Size            int64
+	IsDir           bool
+	MD5Sum          string
+	ContentType     string
+	ContentEncoding string
 }
 
 // ListPartsInfo - various types of object resources.

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -404,8 +404,16 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	// Size of object.
 	size := objInfo.Size
 
+	// Save metadata.
+	metadata := make(map[string]string)
+	// Save other metadata if available.
+	metadata["content-type"] = objInfo.ContentType
+	metadata["content-encoding"] = objInfo.ContentEncoding
+	// Do not set `md5sum` as CopyObject will not keep the
+	// same md5sum as the source.
+
 	// Create the object.
-	md5Sum, err := api.ObjectAPI.PutObject(bucket, object, size, readCloser, nil)
+	md5Sum, err := api.ObjectAPI.PutObject(bucket, object, size, readCloser, metadata)
 	if err != nil {
 		errorIf(err, "Unable to create an object.")
 		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)

--- a/server_xl_test.go
+++ b/server_xl_test.go
@@ -624,6 +624,7 @@ func (s *MyAPIXLSuite) TestPutBucket(c *C) {
 
 }
 
+// Tests copy object.
 func (s *MyAPIXLSuite) TestCopyObject(c *C) {
 	request, err := s.newRequest("PUT", testAPIXLServer.URL+"/put-object-copy", 0, nil)
 	c.Assert(err, IsNil)
@@ -635,6 +636,7 @@ func (s *MyAPIXLSuite) TestCopyObject(c *C) {
 
 	buffer1 := bytes.NewReader([]byte("hello world"))
 	request, err = s.newRequest("PUT", testAPIXLServer.URL+"/put-object-copy/object", int64(buffer1.Len()), buffer1)
+	request.Header.Set("Content-Type", "application/json")
 	c.Assert(err, IsNil)
 
 	response, err = client.Do(request)
@@ -657,8 +659,8 @@ func (s *MyAPIXLSuite) TestCopyObject(c *C) {
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 	object, err := ioutil.ReadAll(response.Body)
 	c.Assert(err, IsNil)
-
 	c.Assert(string(object), Equals, "hello world")
+	c.Assert(response.Header.Get("Content-Type"), Equals, "application/json")
 }
 
 func (s *MyAPIXLSuite) TestPutObject(c *C) {

--- a/xl-objects-multipart.go
+++ b/xl-objects-multipart.go
@@ -37,11 +37,12 @@ type MultipartPartInfo struct {
 // MultipartObjectInfo - contents of the multipart metadata file after
 // CompleteMultipartUpload() is called.
 type MultipartObjectInfo struct {
-	Parts       []MultipartPartInfo
-	ModTime     time.Time
-	Size        int64
-	MD5Sum      string
-	ContentType string
+	Parts           []MultipartPartInfo
+	ModTime         time.Time
+	Size            int64
+	MD5Sum          string
+	ContentType     string
+	ContentEncoding string
 	// Add more fields here.
 }
 
@@ -212,6 +213,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	// Save successfully calculated md5sum.
 	metadata.MD5Sum = s3MD5
 	metadata.ContentType = objMeta["content-type"]
+	metadata.ContentEncoding = objMeta["content-encoding"]
 
 	// Save modTime as well as the current time.
 	metadata.ModTime = time.Now().UTC()


### PR DESCRIPTION
- Content-Type
- Content-Encoding
- ETag

Fixes #1682
