### PR TITLE
Exit with error code if minio server fails to start

### DIFF
--- a/server-main.go
+++ b/server-main.go
@@ -316,5 +316,5 @@ func serverMain(c *cli.Context) {
 		// Fallback to http.
 		err = apiServer.ListenAndServe()
 	}
-	errorIf(err, "Failed to start minio server.")
+	fatalIf(err, "Failed to start minio server.")
 }


### PR DESCRIPTION
This commit replaces the call to `errorIf` with `fatalIf`, so that the
minio server exits with an non-zero exit status if something fails, e.g.
the port was already openend by another process.

``` sh
$ minio server --address 127.0.0.1:9000 $(mktemp -d) &
$ minio server --address 127.0.0.1:9000 $(mktemp -d)
$ echo $?
$ 1
```
