### PR TITLE
[Proposed] XL: No need to filter out multipart v/s regular objects properly

### DIFF
--- a/xl-objects-multipart.go
+++ b/xl-objects-multipart.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"strings"
 	"sync"
 	"time"
 )
@@ -45,16 +44,6 @@ type MultipartObjectInfo struct {
 	ContentEncoding string
 	// Add more fields here.
 }
-
-type byMultipartFiles []string
-
-func (files byMultipartFiles) Len() int { return len(files) }
-func (files byMultipartFiles) Less(i, j int) bool {
-	first := strings.TrimSuffix(files[i], multipartSuffix)
-	second := strings.TrimSuffix(files[j], multipartSuffix)
-	return first < second
-}
-func (files byMultipartFiles) Swap(i, j int) { files[i], files[j] = files[j], files[i] }
 
 // GetPartNumberOffset - given an offset for the whole object, return the part and offset in that part.
 func (m MultipartObjectInfo) GetPartNumberOffset(offset int64) (partIndex int, partOffset int64, err error) {


### PR DESCRIPTION
We should avoid using special keywords to filter out later in loops.
Either this leads to confusion or bugs like these.

We will still be able to support many different types of prefixes
and we do not really have to worry about special files.

Ref #1691
