### PR TITLE
erasure: Fix block index matching.

### DIFF
--- a/format-config-v1.go
+++ b/format-config-v1.go
@@ -231,6 +231,7 @@ func checkDisksConsistency(formatConfigs []*formatConfigV1) error {
 	// Collect currently available disk uuids.
 	for index, formatConfig := range formatConfigs {
 		if formatConfig == nil {
+			disks[index] = ""
 			continue
 		}
 		disks[index] = formatConfig.XL.Disk


### PR DESCRIPTION
This patch fixes an important issue of block reconstruction upon block corruption. 
