### PR TITLE
XL: set write quorum (no. of disk / 2) + 2

### DIFF
--- a/xl-v1.go
+++ b/xl-v1.go
@@ -169,9 +169,9 @@ func newXLObjects(disks []string) (ObjectLayer, error) {
 	// erasure requirements)
 	xl.readQuorum = len(xl.storageDisks)/2 + 1
 
-	// Write quorum is assumed if we have total disks + 3
-	// parity. (Need to discuss this again)
-	xl.writeQuorum = len(xl.storageDisks)/2 + 3
+	// Write quorum is assumed if we have total disks + 2
+	// parity.
+	xl.writeQuorum = len(xl.storageDisks)/2 + 2
 	if xl.writeQuorum > len(xl.storageDisks) {
 		xl.writeQuorum = len(xl.storageDisks)
 	}


### PR DESCRIPTION
Previously write quorum was set to (no. of disk / 2) + 3.  As per new
change, the write quorum is set to (no. of disk / 2) + 2.
