### PR TITLE
api: Add new bucket policy nesting error

### DIFF
--- a/api-errors.go
+++ b/api-errors.go
@@ -109,6 +109,7 @@ const (
 	ErrWriteQuorum
 	ErrStorageFull
 	ErrObjectExistsAsDirectory
+	ErrPolicyNesting
 )
 
 // error code to APIError structure, these fields carry respective
@@ -414,6 +415,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Code:           "XMinioWriteQuorum",
 		Description:    "Multiple disks failures, unable to write data.",
 		HTTPStatusCode: http.StatusServiceUnavailable,
+	},
+	ErrPolicyNesting: {
+		Code:           "XMinioPolicyNesting",
+		Description:    "Policy nesting conflict has occurred.",
+		HTTPStatusCode: http.StatusConflict,
 	},
 	// Add your error structure here.
 }

--- a/bucket-policy-parser.go
+++ b/bucket-policy-parser.go
@@ -255,7 +255,7 @@ func checkBucketPolicyResources(bucket string, bucketPolicy BucketPolicy) APIErr
 		for _, otherResource := range resources {
 			// Common prefix reject such rules.
 			if strings.HasPrefix(otherResource, resource) {
-				return ErrMalformedPolicy
+				return ErrPolicyNesting
 			}
 		}
 	}

--- a/bucket-policy-parser_test.go
+++ b/bucket-policy-parser_test.go
@@ -514,8 +514,8 @@ func TestCheckBucketPolicyResources(t *testing.T) {
 		{bucketAccessPolicies[4], ErrMalformedPolicy, false},
 		// Test case - 6.
 		// contructing policy statement with recursive resources.
-		// should result in ErrMalformedPolicy.
-		{bucketAccessPolicies[5], ErrMalformedPolicy, false},
+		// should result in ErrPolicyNesting.
+		{bucketAccessPolicies[5], ErrPolicyNesting, false},
 		// Test case - 7.
 		// constructing policy statement with lexically close
 		// characters.


### PR DESCRIPTION
Fixes https://github.com/minio/mc/issues/1706
- Added ErrPolicyNesting which is returned when nesting of policies has occured
- Replaces ErrMalformedPolicy in the case of nesting
