### PR TITLE
XL/DeleteObject: delete call on a prefix should not delete the entire…

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -362,7 +362,7 @@ func (s *MyAPISuite) TestDeleteObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
-	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/deletebucketobject/myobject", 0, nil)
+	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/deletebucketobject/prefix/myobject", 0, nil)
 	c.Assert(err, IsNil)
 
 	client = http.Client{}
@@ -370,7 +370,15 @@ func (s *MyAPISuite) TestDeleteObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
-	request, err = s.newRequest("DELETE", testAPIFSCacheServer.URL+"/deletebucketobject/myobject", 0, nil)
+	// Should not delete "prefix/myobject"
+	request, err = s.newRequest("DELETE", testAPIFSCacheServer.URL+"/deletebucketobject/prefix", 0, nil)
+	c.Assert(err, IsNil)
+	client = http.Client{}
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusNoContent)
+
+	request, err = s.newRequest("DELETE", testAPIFSCacheServer.URL+"/deletebucketobject/prefix/myobject", 0, nil)
 	c.Assert(err, IsNil)
 	client = http.Client{}
 	response, err = client.Do(request)
@@ -378,7 +386,7 @@ func (s *MyAPISuite) TestDeleteObject(c *C) {
 	c.Assert(response.StatusCode, Equals, http.StatusNoContent)
 
 	// Delete non existent object should return http.StatusNoContent.
-	request, err = s.newRequest("DELETE", testAPIFSCacheServer.URL+"/deletebucketobject/myobject1", 0, nil)
+	request, err = s.newRequest("DELETE", testAPIFSCacheServer.URL+"/deletebucketobject/prefix/myobject1", 0, nil)
 	c.Assert(err, IsNil)
 	client = http.Client{}
 	response, err = client.Do(request)

--- a/server_xl_test.go
+++ b/server_xl_test.go
@@ -369,7 +369,7 @@ func (s *MyAPIXLSuite) TestDeleteObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
-	request, err = s.newRequest("PUT", testAPIXLServer.URL+"/deletebucketobject/myobject", 0, nil)
+	request, err = s.newRequest("PUT", testAPIXLServer.URL+"/deletebucketobject/prefix/myobject", 0, nil)
 	c.Assert(err, IsNil)
 
 	client = http.Client{}
@@ -377,7 +377,15 @@ func (s *MyAPIXLSuite) TestDeleteObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
-	request, err = s.newRequest("HEAD", testAPIXLServer.URL+"/deletebucketobject/myobject", 0, nil)
+	// Should not delete "prefix/myobject"
+	request, err = s.newRequest("DELETE", testAPIXLServer.URL+"/deletebucketobject/prefix", 0, nil)
+	c.Assert(err, IsNil)
+	client = http.Client{}
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusNoContent)
+
+	request, err = s.newRequest("HEAD", testAPIXLServer.URL+"/deletebucketobject/prefix/myobject", 0, nil)
 	c.Assert(err, IsNil)
 
 	client = http.Client{}
@@ -385,7 +393,15 @@ func (s *MyAPIXLSuite) TestDeleteObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
-	request, err = s.newRequest("DELETE", testAPIXLServer.URL+"/deletebucketobject/myobject", 0, nil)
+	request, err = s.newRequest("DELETE", testAPIXLServer.URL+"/deletebucketobject/prefix/myobject", 0, nil)
+	c.Assert(err, IsNil)
+	client = http.Client{}
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusNoContent)
+
+	// Delete of non-existant data should return success.
+	request, err = s.newRequest("DELETE", testAPIXLServer.URL+"/deletebucketobject/prefix/myobject1", 0, nil)
 	c.Assert(err, IsNil)
 	client = http.Client{}
 	response, err = client.Do(request)

--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -446,6 +446,10 @@ func (xl xlObjects) DeleteObject(bucket, object string) (err error) {
 	nsMutex.Lock(bucket, object)
 	defer nsMutex.Unlock(bucket, object)
 
+	if !xl.isObject(bucket, object) {
+		return ObjectNotFound{bucket, object}
+	}
+
 	if err = xl.deleteObject(bucket, object); err == errFileNotFound {
 		// Its valid to return success if given object is not found.
 		err = nil


### PR DESCRIPTION
… tree structure.

fixes #1915
