### PR TITLE
Do not guess content-type for objects with no file extension

### DIFF
--- a/fs-v1.go
+++ b/fs-v1.go
@@ -225,13 +225,15 @@ func (fs fsObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
 	if err != nil {
 		return ObjectInfo{}, toObjectErr(err, bucket, object)
 	}
-	contentType := "application/octet-stream"
+
+	// Guess content-type from the extension if possible.
+	contentType := ""
 	if objectExt := filepath.Ext(object); objectExt != "" {
-		content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]
-		if ok {
+		if content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]; ok {
 			contentType = content.ContentType
 		}
 	}
+
 	return ObjectInfo{
 		Bucket:      bucket,
 		Name:        object,

--- a/object_api_suite_test.go
+++ b/object_api_suite_test.go
@@ -83,7 +83,7 @@ func APITestSuite(c *check.C, create func() ObjectLayer) {
 	testListObjectsTestsForNonExistantBucket(c, create)
 	testNonExistantObjectInBucket(c, create)
 	testGetDirectoryReturnsObjectNotFound(c, create)
-	testDefaultContentType(c, create)
+	testContentType(c, create)
 	testMultipartObjectCreation(c, create)
 	testMultipartObjectAbort(c, create)
 }
@@ -485,16 +485,16 @@ func testGetDirectoryReturnsObjectNotFound(c *check.C, create func() ObjectLayer
 	}
 }
 
-// Tests valdiate the default ContentType.
-func testDefaultContentType(c *check.C, create func() ObjectLayer) {
+// Test content-type
+func testContentType(c *check.C, create func() ObjectLayer) {
 	obj := create()
 	err := obj.MakeBucket("bucket")
 	c.Assert(err, check.IsNil)
 
 	// Test empty.
-	_, err = obj.PutObject("bucket", "one", int64(len("The specified multipart upload does not exist. The upload ID might be invalid, or the multipart upload might have been aborted or completed.")), bytes.NewBufferString("The specified multipart upload does not exist. The upload ID might be invalid, or the multipart upload might have been aborted or completed."), nil)
+	_, err = obj.PutObject("bucket", "minio.png", int64(len("The specified multipart upload does not exist. The upload ID might be invalid, or the multipart upload might have been aborted or completed.")), bytes.NewBufferString("The specified multipart upload does not exist. The upload ID might be invalid, or the multipart upload might have been aborted or completed."), nil)
 	c.Assert(err, check.IsNil)
-	objInfo, err := obj.GetObjectInfo("bucket", "one")
+	objInfo, err := obj.GetObjectInfo("bucket", "minio.png")
 	c.Assert(err, check.IsNil)
-	c.Assert(objInfo.ContentType, check.Equals, "application/octet-stream")
+	c.Assert(objInfo.ContentType, check.Equals, "image/png")
 }

--- a/server_test.go
+++ b/server_test.go
@@ -835,7 +835,7 @@ func (s *MyAPISuite) TestContentTypePersists(c *C) {
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
 	buffer1 := bytes.NewReader([]byte("hello world"))
-	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/contenttype-persists/one", int64(buffer1.Len()), buffer1)
+	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/contenttype-persists/minio.png", int64(buffer1.Len()), buffer1)
 	delete(request.Header, "Content-Type")
 	c.Assert(err, IsNil)
 
@@ -844,24 +844,24 @@ func (s *MyAPISuite) TestContentTypePersists(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
-	request, err = s.newRequest("HEAD", testAPIFSCacheServer.URL+"/contenttype-persists/one", 0, nil)
+	request, err = s.newRequest("HEAD", testAPIFSCacheServer.URL+"/contenttype-persists/minio.png", 0, nil)
 	c.Assert(err, IsNil)
 
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
-	c.Assert(response.Header.Get("Content-Type"), Equals, "application/octet-stream")
+	c.Assert(response.Header.Get("Content-Type"), Equals, "image/png")
 
-	request, err = s.newRequest("GET", testAPIFSCacheServer.URL+"/contenttype-persists/one", 0, nil)
+	request, err = s.newRequest("GET", testAPIFSCacheServer.URL+"/contenttype-persists/minio.png", 0, nil)
 	c.Assert(err, IsNil)
 
 	client = http.Client{}
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
-	c.Assert(response.Header.Get("Content-Type"), Equals, "application/octet-stream")
+	c.Assert(response.Header.Get("Content-Type"), Equals, "image/png")
 
 	buffer2 := bytes.NewReader([]byte("hello world"))
-	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/contenttype-persists/two", int64(buffer2.Len()), buffer2)
+	request, err = s.newRequest("PUT", testAPIFSCacheServer.URL+"/contenttype-persists/minio.json", int64(buffer2.Len()), buffer2)
 	delete(request.Header, "Content-Type")
 	request.Header.Add("Content-Type", "application/json")
 	c.Assert(err, IsNil)
@@ -870,19 +870,19 @@ func (s *MyAPISuite) TestContentTypePersists(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
-	request, err = s.newRequest("HEAD", testAPIFSCacheServer.URL+"/contenttype-persists/two", 0, nil)
+	request, err = s.newRequest("HEAD", testAPIFSCacheServer.URL+"/contenttype-persists/minio.json", 0, nil)
 	c.Assert(err, IsNil)
 
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
-	c.Assert(response.Header.Get("Content-Type"), Equals, "application/octet-stream")
+	c.Assert(response.Header.Get("Content-Type"), Equals, "application/json")
 
-	request, err = s.newRequest("GET", testAPIFSCacheServer.URL+"/contenttype-persists/two", 0, nil)
+	request, err = s.newRequest("GET", testAPIFSCacheServer.URL+"/contenttype-persists/minio.json", 0, nil)
 	c.Assert(err, IsNil)
 
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
-	c.Assert(response.Header.Get("Content-Type"), Equals, "application/octet-stream")
+	c.Assert(response.Header.Get("Content-Type"), Equals, "application/json")
 }
 
 func (s *MyAPISuite) TestPartialContent(c *C) {

--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -312,16 +312,13 @@ func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.
 		metadata["md5Sum"] = newMD5Hex
 	}
 
-	// If not set default to "application/octet-stream"
+	// Guess content-type from the extension if possible.
 	if metadata["content-type"] == "" {
-		contentType := "application/octet-stream"
 		if objectExt := filepath.Ext(object); objectExt != "" {
-			content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]
-			if ok {
-				contentType = content.ContentType
+			if content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]; ok {
+				metadata["content-type"] = content.ContentType
 			}
 		}
-		metadata["content-type"] = contentType
 	}
 
 	// md5Hex representation.


### PR DESCRIPTION
Thanks to @diresi for catching this bug #1902. 
