### PR TITLE
XL: Change ReadFile() to ensure returning 'length' bytes.

### DIFF
--- a/fs-v1.go
+++ b/fs-v1.go
@@ -188,25 +188,8 @@ func (fs fsObjects) GetObject(bucket, object string, startOffset int64, length i
 		return ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
 	var totalLeft = length
-	for totalLeft > 0 {
-		// Figure out the right blockSize as it was encoded before.
-		var curBlockSize int64
-		if blockSizeV1 < totalLeft {
-			curBlockSize = blockSizeV1
-		} else {
-			curBlockSize = totalLeft
-		}
-		buf := make([]byte, curBlockSize)
-		n, err := fs.storage.ReadFile(bucket, object, startOffset, buf)
-		if err != nil {
-			return toObjectErr(err, bucket, object)
-		}
-		_, err = writer.Write(buf[:n])
-		if err != nil {
-			return toObjectErr(err, bucket, object)
-		}
-		totalLeft -= n
-		startOffset += n
+	if err := writeN(fs.storage, bucket, object, startOffset, totalLeft, writer); err != nil {
+		return toObjectErr(err, bucket, object)
 	}
 	return nil
 }

--- a/rpc-client.go
+++ b/rpc-client.go
@@ -169,16 +169,16 @@ func (n networkStorage) StatFile(volume, path string) (fileInfo FileInfo, err er
 }
 
 // ReadFile - reads a file.
-func (n networkStorage) ReadFile(volume string, path string, offset int64, buffer []byte) (m int64, err error) {
+func (n networkStorage) ReadFile(volume string, path string, offset int64, length int64) (buf []byte, err error) {
 	if err = n.rpcClient.Call("Storage.ReadFileHandler", ReadFileArgs{
 		Vol:    volume,
 		Path:   path,
 		Offset: offset,
-		Buffer: buffer,
-	}, &m); err != nil {
-		return 0, toStorageErr(err)
+		Length: length,
+	}, &buf); err != nil {
+		return nil, toStorageErr(err)
 	}
-	return m, nil
+	return buf, nil
 }
 
 // ListDir - list all entries at prefix.

--- a/rpc-server-datatypes.go
+++ b/rpc-server-datatypes.go
@@ -39,8 +39,8 @@ type ReadFileArgs struct {
 	// Starting offset to start reading into Buffer.
 	Offset int64
 
-	// Data buffer read from the path at offset.
-	Buffer []byte
+	// Length of the data read from the path at offset.
+	Length int64
 }
 
 // AppendFileArgs represents append file RPC arguments.

--- a/rpc-server.go
+++ b/rpc-server.go
@@ -76,12 +76,12 @@ func (s *storageServer) ListDirHandler(arg *ListDirArgs, reply *[]string) error 
 }
 
 // ReadFileHandler - read file handler is rpc wrapper to read file.
-func (s *storageServer) ReadFileHandler(arg *ReadFileArgs, reply *int64) error {
-	n, err := s.storage.ReadFile(arg.Vol, arg.Path, arg.Offset, arg.Buffer)
+func (s *storageServer) ReadFileHandler(arg *ReadFileArgs, reply *[]byte) error {
+	buf, err := s.storage.ReadFile(arg.Vol, arg.Path, arg.Offset, arg.Length)
 	if err != nil {
 		return err
 	}
-	reply = &n
+	reply = &buf
 	return nil
 }
 

--- a/storage-interface.go
+++ b/storage-interface.go
@@ -26,7 +26,7 @@ type StorageAPI interface {
 
 	// File operations.
 	ListDir(volume, dirPath string) ([]string, error)
-	ReadFile(volume string, path string, offset int64, buf []byte) (n int64, err error)
+	ReadFile(volume string, path string, offset int64, length int64) (buf []byte, err error)
 	AppendFile(volume string, path string, buf []byte) (err error)
 	RenameFile(srcVolume, srcPath, dstVolume, dstPath string) error
 	StatFile(volume string, path string) (file FileInfo, err error)

--- a/storage-utils.go
+++ b/storage-utils.go
@@ -1,0 +1,61 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import "io"
+
+// writeN - writes the all contents from path to aforementioned
+// writer until the size. Additionally you can also provide a starting
+// to read at.
+func writeN(disk StorageAPI, volume string, path string, startOffset int64, size int64, writer io.Writer) error {
+	var totalLeft = size
+	for totalLeft > 0 {
+		// Figure out the right blockSize to read.
+		var curBlockSize int64
+		if blockSizeV1 < totalLeft {
+			curBlockSize = blockSizeV1
+		} else {
+			curBlockSize = totalLeft
+		}
+		buf, err := disk.ReadFile(volume, path, startOffset, curBlockSize)
+		if err != nil {
+			return err
+		}
+		n, err := writer.Write(buf)
+		if err != nil {
+			return err
+		}
+		totalLeft -= int64(n)
+		startOffset += int64(n)
+	}
+	return nil
+}
+
+// readAll - returns contents from volume/path as byte array.
+// Be careful on using this function to read large files, this is
+// only meant to be used on case to case basis. Predominantly used
+// in case of reading metadata json files.
+func readAll(disk StorageAPI, volume string, path string) ([]byte, error) {
+	fi, err := disk.StatFile(volume, path)
+	if err != nil {
+		return nil, err
+	}
+	var startOffset = int64(0)
+	var totalLeft = fi.Size
+	// Read the entire file.
+	return disk.ReadFile(volume, path, startOffset, totalLeft)
+}

--- a/xl-v1-metadata.go
+++ b/xl-v1-metadata.go
@@ -201,17 +201,12 @@ func (xl xlObjects) readXLMetadata(bucket, object string) (xlMeta xlMetaV1, err 
 		if disk == nil {
 			continue
 		}
-		var buf []byte
-		buf, err = readAll(disk, bucket, path.Join(object, xlMetaJSONFile))
+		xlMeta, err = readXLMeta(disk, bucket, object)
 		if err != nil {
 			// For any reason disk is not available continue and read from other disks.
 			if err == errDiskNotFound || err == errFaultyDisk {
 				continue
 			}
-			return xlMetaV1{}, err
-		}
-		err = json.Unmarshal(buf, &xlMeta)
-		if err != nil {
 			return xlMetaV1{}, err
 		}
 		break


### PR DESCRIPTION
ReadFile() returns a buffer of 'length' bytes as requested.
If length bytes are not available it returns ' < length ' bytes
but never more than what was requested.

Error of io.EOF is returned if no bytes were read, returns any
other errors as well.

Fixes #1893
