### PR TITLE
INSTALLGO.md mentions Go 1.5+ for OS X

### DIFF
--- a/INSTALLGO.md
+++ b/INSTALLGO.md
@@ -53,7 +53,7 @@ $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/maste
 $ brew install git python
 ```
 
-##### Install Go 1.5+
+##### Install Go 1.6+
 
 Install golang binaries using `brew`
 


### PR DESCRIPTION
However, current requirement is 1.6, so the file has been updated to reflect that.
