### PR TITLE
XL: Format heal should re-allocate new UUIDs not reuse.

### DIFF
--- a/xl-v1.go
+++ b/xl-v1.go
@@ -28,8 +28,13 @@ import (
 const (
 	// Format config file carries backend format specific details.
 	formatConfigFile = "format.json"
+
+	// Format config tmp file carries backend format.
+	formatConfigFileTmp = "format.json.tmp"
+
 	// XL metadata file carries per object metadata.
 	xlMetaJSONFile = "xl.json"
+
 	// Uploads metadata file carries per multipart object metadata.
 	uploadsJSONFile = "uploads.json"
 )


### PR DESCRIPTION
 This patch also supports writing to a temporary file and renaming 
 rather than appending to an existing file. This helps in avoiding
 inconsistent files.
