### PR TITLE
fs: Fix GetObject failure to read large blocks.

### DIFF
--- a/object-common.go
+++ b/object-common.go
@@ -27,6 +27,9 @@ import (
 const (
 	// Block size used for all internal operations version 1.
 	blockSizeV1 = 10 * 1024 * 1024 // 10MiB.
+
+	// Staging buffer read size for all internal operations version 1.
+	readSizeV1 = 128 * 1024 // 128KiB.
 )
 
 // Register callback functions that needs to be called when process shutsdown.


### PR DESCRIPTION
Add relevant test cases as well for verifying this
part of the codebase.

Fixes #1979
