### PR TITLE
API: add writePartTooSmallErrorResponse to extend standard error responses.

### DIFF
--- a/api-response-multipart.go
+++ b/api-response-multipart.go
@@ -1,0 +1,54 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// File carries any specific responses constructed/necessary in
+// multipart operations.
+package main
+
+import "net/http"
+
+// writeErrorResponsePartTooSmall - function is used specifically to
+// construct a proper error response during CompleteMultipartUpload
+// when one of the parts is < 5MB.
+// The requirement comes due to the fact that generic ErrorResponse
+// XML doesn't carry the additional fields required to send this
+// error. So we construct a new type which lies well within the scope
+// of this function.
+func writePartSmallErrorResponse(w http.ResponseWriter, r *http.Request, err PartTooSmall) {
+	// Represents additional fields necessary for ErrPartTooSmall S3 error.
+	type completeMultipartAPIError struct {
+		// Proposed size represents uploaded size of the part.
+		ProposedSize int64
+		// Minimum size allowed epresents the minimum size allowed per
+		// part. Defaults to 5MB.
+		MinSizeAllowed int64
+		// Part number of the part which is incorrect.
+		PartNumber int
+		// ETag of the part which is incorrect.
+		PartETag string
+		// Other default XML error responses.
+		APIErrorResponse
+	}
+	// Generate complete multipart error response.
+	errorResponse := getAPIErrorResponse(getAPIError(toAPIErrorCode(err)), r.URL.Path)
+	cmpErrResp := completeMultipartAPIError{err.PartSize, int64(5242880), err.PartNumber, err.PartETag, errorResponse}
+	encodedErrorResponse := encodeResponse(cmpErrResp)
+	// Write error body
+	w.Write(encodedErrorResponse)
+	w.(http.Flusher).Flush()
+}
+
+// Add any other multipart specific responses here.

--- a/api-response.go
+++ b/api-response.go
@@ -506,7 +506,7 @@ func writeErrorResponse(w http.ResponseWriter, req *http.Request, errorCode APIE
 }
 
 func writeErrorResponseNoHeader(w http.ResponseWriter, req *http.Request, error APIError, resource string) {
-	// generate error response
+	// Generate error response.
 	errorResponse := getAPIErrorResponse(error, resource)
 	encodedErrorResponse := encodeResponse(errorResponse)
 	// HEAD should have no body, do not attempt to write to it

--- a/fs-v1-multipart.go
+++ b/fs-v1-multipart.go
@@ -504,7 +504,11 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 		}
 		// All parts except the last part has to be atleast 5MB.
 		if (i < len(parts)-1) && !isMinAllowedPartSize(fsMeta.Parts[partIdx].Size) {
-			return "", PartTooSmall{}
+			return "", PartTooSmall{
+				PartNumber: part.PartNumber,
+				PartSize:   fsMeta.Parts[partIdx].Size,
+				PartETag:   part.ETag,
+			}
 		}
 		// Construct part suffix.
 		partSuffix := fmt.Sprintf("object%d", part.PartNumber)

--- a/object-api-multipart_test.go
+++ b/object-api-multipart_test.go
@@ -1841,7 +1841,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t *
 		// Test case with non existent object name (Test number 14).
 		{bucketNames[0], "my-object", uploadIDs[0], []completePart{{ETag: "abcd", PartNumber: 1}}, "", InvalidUploadID{UploadID: uploadIDs[0]}, false},
 		// Testing for Part being too small (Test number 15).
-		{bucketNames[0], objectNames[0], uploadIDs[0], inputParts[1].parts, "", PartTooSmall{}, false},
+		{bucketNames[0], objectNames[0], uploadIDs[0], inputParts[1].parts, "", PartTooSmall{PartNumber: 1}, false},
 		// TestCase with invalid Part Number (Test number 16).
 		// Should error with Invalid Part .
 		{bucketNames[0], objectNames[0], uploadIDs[0], inputParts[2].parts, "", InvalidPart{}, false},

--- a/object-errors.go
+++ b/object-errors.go
@@ -251,8 +251,12 @@ func (e InvalidPartOrder) Error() string {
 }
 
 // PartTooSmall - error if part size is less than 5MB.
-type PartTooSmall struct{}
+type PartTooSmall struct {
+	PartSize   int64
+	PartNumber int
+	PartETag   string
+}
 
 func (e PartTooSmall) Error() string {
-	return "Part size should be atleast 5MB"
+	return fmt.Sprintf("Part size for %d should be atleast 5MB", e.PartNumber)
 }

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -986,7 +986,14 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 
 	if err != nil {
 		errorIf(err, "Unable to complete multipart upload.")
-		writeErrorResponseNoHeader(w, r, getAPIError(toAPIErrorCode(err)), r.URL.Path)
+		switch oErr := err.(type) {
+		case PartTooSmall:
+			// Write part too small error.
+			writePartSmallErrorResponse(w, r, oErr)
+		default:
+			// Handle all other generic issues.
+			writeErrorResponseNoHeader(w, r, getAPIError(toAPIErrorCode(err)), r.URL.Path)
+		}
 		return
 	}
 

--- a/xl-v1-multipart.go
+++ b/xl-v1-multipart.go
@@ -594,7 +594,11 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 
 		// All parts except the last part has to be atleast 5MB.
 		if (i < len(parts)-1) && !isMinAllowedPartSize(currentXLMeta.Parts[partIdx].Size) {
-			return "", PartTooSmall{}
+			return "", PartTooSmall{
+				PartNumber: part.PartNumber,
+				PartSize:   currentXLMeta.Parts[partIdx].Size,
+				PartETag:   part.ETag,
+			}
 		}
 
 		// Last part could have been uploaded as 0bytes, do not need


### PR DESCRIPTION
This function is added to extend the standard error responses.
Which is needed in some cases for example CompleteMultipartUpload
should respond with ErrPartTooSmall error when parts uploaded are
lesser than 5MB (i.e minimum allowed size per part).

Fixes #1536
