### PR TITLE
XL: Change minimum disks supported to 6 now.

### DIFF
--- a/erasure_test.go
+++ b/erasure_test.go
@@ -34,7 +34,7 @@ func mustEncodeData(data []byte, dataBlocks, parityBlocks int) [][]byte {
 // Generates good encoded data with one parity block and data block missing.
 func getGoodEncodedData(data []byte, dataBlocks, parityBlocks int) [][]byte {
 	encodedData := mustEncodeData(data, dataBlocks, parityBlocks)
-	encodedData[7] = nil
+	encodedData[3] = nil
 	encodedData[1] = nil
 	return encodedData
 }
@@ -42,7 +42,7 @@ func getGoodEncodedData(data []byte, dataBlocks, parityBlocks int) [][]byte {
 // Generates bad encoded data with one parity block and data block with garbage data.
 func getBadEncodedData(data []byte, dataBlocks, parityBlocks int) [][]byte {
 	encodedData := mustEncodeData(data, dataBlocks, parityBlocks)
-	encodedData[7] = []byte("garbage")
+	encodedData[3] = []byte("garbage")
 	encodedData[1] = []byte("garbage")
 	return encodedData
 }
@@ -71,6 +71,7 @@ type encodingMatrix struct {
 
 // List of encoding matrices the tests will run on.
 var encodingMatrices = []encodingMatrix{
+	{3, 3}, // 3 data, 3 parity blocks.
 	{4, 4}, // 4 data, 4 parity blocks.
 	{5, 5}, // 5 data, 5 parity blocks.
 	{6, 6}, // 6 data, 6 parity blocks.

--- a/xl-v1.go
+++ b/xl-v1.go
@@ -74,7 +74,7 @@ const (
 	// Maximum erasure blocks.
 	maxErasureBlocks = 16
 	// Minimum erasure blocks.
-	minErasureBlocks = 8
+	minErasureBlocks = 6
 )
 
 // Validate if input disks are sufficient for initializing XL.
@@ -94,7 +94,7 @@ func checkSufficientDisks(disks []string) error {
 	}
 
 	// Verify if we have even number of disks.
-	// only combination of 8, 12, 16 are supported.
+	// only combination of 6, 8, 10, 12, 14, 16 are supported.
 	if !isEven(totalDisks) {
 		return errXLNumDisks
 	}

--- a/xl-v1_test.go
+++ b/xl-v1_test.go
@@ -45,9 +45,9 @@ func TestCheckSufficientDisks(t *testing.T) {
 		disks       []string
 		expectedErr error
 	}{
-		// Even number of disks '8'.
+		// Even number of disks '6'.
 		{
-			disks[0:8],
+			disks[0:6],
 			nil,
 		},
 		// Even number of disks '12'.
@@ -66,9 +66,9 @@ func TestCheckSufficientDisks(t *testing.T) {
 			append(disks[0:16], "/mnt/unsupported"),
 			errXLMaxDisks,
 		},
-		// Lesser than minimum number of disks < 8.
+		// Lesser than minimum number of disks < 6.
 		{
-			disks[0:7],
+			disks[0:5],
 			errXLMinDisks,
 		},
 		// Odd number of disks, not divisible by '2'.


### PR DESCRIPTION
This change co-incides with another patch set https://github.com/minio/minio/pull/2018 which
reduces the writeQuorum requirement. With the
write quorum change it is now possible to support
6 disk configuration.
