### PR TITLE
Implemented stacktrace support for errors: #1827

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"runtime"
+)
+
+func ErrorWithStack(err error) errorWithStack {
+	buf := make([]byte, 1024)
+	for {
+		n := runtime.Stack(buf, false)
+		if n < len(buf) {
+			buf = buf[:n]
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+
+	return errorWithStack{
+		error: err,
+		buf:   buf,
+	}
+}
+
+type errorWithStack struct {
+	error
+	buf []byte
+}
+
+func (s *errorWithStack) Stack() string {
+	return string(s.buf)
+}
+
+func (s *errorWithStack) Print() {
+	os.Stderr.Write(s.buf)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestErrorWithStack(t *testing.T) {
+	e := ErrorWithStack(fmt.Errorf("test"))
+	if !strings.Contains(e.Stack(), "TestErrorWithStack") {
+		t.Errorf("Stack doesn't contain current test function")
+	}
+}


### PR DESCRIPTION
Added an ErrorWithStack function, which will create stacktrace for current function and returns an error. This allows us to implement everywhere where necessary enriched errors with stacktrace. #1827 
