### PR TITLE
getCertsPath should use getConfigPath instead of defaulting to users homedir.

### DIFF
--- a/certs.go
+++ b/certs.go
@@ -19,7 +19,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"fmt"
 )
 
 // createCertsPath create certs path.
@@ -39,7 +38,6 @@ func getCertsPath() (string, error) {
 		return "", err
 	}
 	certsPath = filepath.Join(configDir, globalMinioCertsDirname)
-	fmt.Printf("%s", certsPath)
 	return certsPath, nil
 }
 

--- a/certs.go
+++ b/certs.go
@@ -19,8 +19,7 @@ package main
 import (
 	"os"
 	"path/filepath"
-
-	"github.com/minio/go-homedir"
+	"fmt"
 )
 
 // createCertsPath create certs path.
@@ -34,11 +33,13 @@ func createCertsPath() error {
 
 // getCertsPath get certs path.
 func getCertsPath() (string, error) {
-	homeDir, err := homedir.Dir()
+	var certsPath string
+	configDir, err := getConfigPath()
 	if err != nil {
 		return "", err
 	}
-	certsPath := filepath.Join(homeDir, globalMinioCertsDir)
+	certsPath = filepath.Join(configDir, globalMinioCertsDirname)
+	fmt.Printf("%s", certsPath)
 	return certsPath, nil
 }
 

--- a/certs.go
+++ b/certs.go
@@ -37,7 +37,7 @@ func getCertsPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	certsPath = filepath.Join(configDir, globalMinioCertsDirname)
+	certsPath = filepath.Join(configDir, globalMinioCertsDir)
 	return certsPath, nil
 }
 

--- a/globals.go
+++ b/globals.go
@@ -33,6 +33,7 @@ const (
 	globalMinioConfigFile    = "config.json"
 	globalMinioProfilePath   = "profile"
 	// Add new global values here.
+	globalMinioCertsDirname = "certs"
 )
 
 var (

--- a/globals.go
+++ b/globals.go
@@ -27,13 +27,12 @@ const (
 const (
 	globalMinioConfigVersion = "4"
 	globalMinioConfigDir     = ".minio"
-	globalMinioCertsDir      = ".minio/certs"
+	globalMinioCertsDir      = "certs"
 	globalMinioCertFile      = "public.crt"
 	globalMinioKeyFile       = "private.key"
 	globalMinioConfigFile    = "config.json"
 	globalMinioProfilePath   = "profile"
 	// Add new global values here.
-	globalMinioCertsDirname = "certs"
 )
 
 var (


### PR DESCRIPTION
Considering that "-certs-path' is not a flag, I assume that it is always a subpath from '-config-dir', so I changed getCertsPath to call getConfigPath instead of homeDir directly.
