### PR TITLE
posix: checkDiskFree() also checks free inodes.

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -23,5 +23,7 @@ package disk
 type Info struct {
 	Total  int64
 	Free   int64
+	Files  int64
+	Ffree  int64
 	FSType string
 }

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -41,5 +41,7 @@ func (s *MySuite) TestFree(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(di.Total, Not(Equals), 0)
 	c.Assert(di.Free, Not(Equals), 0)
+	c.Assert(di.Files, Not(Equals), 0)
+	c.Assert(di.Ffree, Not(Equals), 0)
 	c.Assert(di.FSType, Not(Equals), "UNKNOWN")
 }

--- a/pkg/disk/stat_nix.go
+++ b/pkg/disk/stat_nix.go
@@ -32,6 +32,8 @@ func GetInfo(path string) (info Info, err error) {
 	info = Info{}
 	info.Total = int64(s.Bsize) * int64(s.Blocks)
 	info.Free = int64(s.Bsize) * int64(s.Bfree)
+	info.Files = int64(s.Files)
+	info.Ffree = int64(s.Ffree)
 	info.FSType, err = getFSType(path)
 	if err != nil {
 		return Info{}, err

--- a/posix.go
+++ b/posix.go
@@ -133,7 +133,7 @@ func getDiskInfo(diskPath string) (di disk.Info, err error) {
 	return di, err
 }
 
-// checkDiskFree verifies if disk path has sufficient minimum free disk space.
+// checkDiskFree verifies if disk path has sufficient minimum free disk space and files.
 func checkDiskFree(diskPath string, minFreeDisk int64) (err error) {
 	di, err := getDiskInfo(diskPath)
 	if err != nil {
@@ -143,7 +143,8 @@ func checkDiskFree(diskPath string, minFreeDisk int64) (err error) {
 	// Remove 5% from total space for cumulative disk
 	// space used for journalling, inodes etc.
 	availableDiskSpace := (float64(di.Free) / (float64(di.Total) - (0.05 * float64(di.Total)))) * 100
-	if int64(availableDiskSpace) <= minFreeDisk {
+	availableFiles := (float64(di.Ffree) / (float64(di.Files) - (0.05 * float64(di.Files)))) * 100
+	if int64(availableDiskSpace) <= minFreeDisk || int64(availableFiles) <= minFreeDisk {
 		return errDiskFull
 	}
 


### PR DESCRIPTION
Previously checkDiskFree() checks for free available space.  This
patch enables checkDiskFree() also checks for free inodes in linux and
free clusters in windows.

Fixes #2075
