### PR TITLE
XL/ObjectCache: DeleteObject() should delete the object from the object cache.

### DIFF
--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -554,6 +554,9 @@ func (xl xlObjects) DeleteObject(bucket, object string) (err error) {
 		return toObjectErr(err, bucket, object)
 	}
 
+	// Delete from the cache.
+	xl.objCache.Delete(pathJoin(bucket, object))
+
 	// Success.
 	return nil
 }


### PR DESCRIPTION
fixes #2103
