### PR TITLE
URL Encode X-Amz-Copy-Source as per the spec

### DIFF
--- a/api-errors.go
+++ b/api-errors.go
@@ -62,6 +62,7 @@ const (
 	ErrInvalidMaxParts
 	ErrInvalidPartNumberMarker
 	ErrInvalidRequestBody
+	ErrCouldntDecodeCopySource
 	ErrInvalidCopySource
 	ErrInvalidCopyDest
 	ErrInvalidPolicyDocument
@@ -126,6 +127,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	ErrInvalidCopyDest: {
 		Code:           "InvalidRequest",
 		Description:    "This copy request is illegal because it is trying to copy an object to itself.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrCouldntDecodeCopySource: {
+		Code:           "InvalidArgument",
+		Description:    "Couldn't URL decode the copy source.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidCopySource: {

--- a/api-router.go
+++ b/api-router.go
@@ -48,7 +48,7 @@ func registerAPIRouter(mux *router.Router, api objectAPIHandlers) {
 	// GetObject
 	bucket.Methods("GET").Path("/{object:.+}").HandlerFunc(api.GetObjectHandler)
 	// CopyObject
-	bucket.Methods("PUT").Path("/{object:.+}").HeadersRegexp("X-Amz-Copy-Source", ".*?(\\/).*?").HandlerFunc(api.CopyObjectHandler)
+	bucket.Methods("PUT").Path("/{object:.+}").HeadersRegexp("X-Amz-Copy-Source", ".*?(\\/|%2F).*?").HandlerFunc(api.CopyObjectHandler)
 	// PutObject
 	bucket.Methods("PUT").Path("/{object:.+}").HandlerFunc(api.PutObjectHandler)
 	// DeleteObject

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -341,7 +341,12 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	// don't even read it.
 
 	// objectSource
-	objectSource := r.Header.Get("X-Amz-Copy-Source")
+	objectSource, err := url.QueryUnescape(r.Header.Get("X-Amz-Copy-Source"))
+	if err != nil {
+		writeErrorResponse(w, r, ErrCouldntDecodeCopySource, r.URL.Path)
+		return
+	}
+	log.Errorf("source %q\n", objectSource)
 
 	// Skip the first element if it is '/', split the rest.
 	if strings.HasPrefix(objectSource, "/") {

--- a/server_test.go
+++ b/server_test.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -689,7 +690,7 @@ func (s *TestSuiteCommon) TestCopyObject(c *C) {
 	request, err = newTestRequest("PUT", getPutObjectURL(s.endPoint, bucketName, objectName2),
 		0, nil, s.accessKey, s.secretKey)
 	// setting the "X-Amz-Copy-Source" to allow copying the content of previously uploaded object.
-	request.Header.Set("X-Amz-Copy-Source", "/"+bucketName+"/"+objectName)
+	request.Header.Set("X-Amz-Copy-Source", url.QueryEscape("/"+bucketName+"/"+objectName))
 	c.Assert(err, IsNil)
 	// execute the HTTP request.
 	// the content is expected to have the content of previous disk.


### PR DESCRIPTION
The documents for COPY state that the X-Amz-Copy-Source must be URL encoded.

http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html

I discovered this while experimenting with [rclone](http://github.com/ncw/rclone) and minio.
