### PR TITLE
ObjectLayer/GetObject: Should return the right error value. Fix done in FS and XL.

### DIFF
--- a/fs-v1.go
+++ b/fs-v1.go
@@ -248,7 +248,7 @@ func (fs fsObjects) GetObject(bucket, object string, offset int64, length int64,
 	}
 	// Allocate a staging buffer.
 	buf := make([]byte, int(bufSize))
-	for totalLeft > 0 {
+	for {
 		// Figure out the right size for the buffer.
 		curLeft := bufSize
 		if totalLeft < bufSize {
@@ -280,6 +280,9 @@ func (fs fsObjects) GetObject(bucket, object string, offset int64, length int64,
 		}
 		if er != nil {
 			err = er
+			break
+		}
+		if totalLeft == 0 {
 			break
 		}
 	}

--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -67,6 +67,11 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 		return toObjectErr(errXLReadQuorum, bucket, object)
 	}
 
+	// If all the disks returned error, we return error.
+	if err := reduceErrs(errs); err != nil {
+		return toObjectErr(err, bucket, object)
+	}
+
 	// List all online disks.
 	onlineDisks, highestVersion, err := xl.listOnlineDisks(metaArr, errs)
 	if err != nil {

--- a/xl-v1-utils_test.go
+++ b/xl-v1-utils_test.go
@@ -1,0 +1,43 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import "testing"
+import "syscall"
+
+// Test for reduceErrs.
+func TestReduceErrs(t *testing.T) {
+	testCases := []struct {
+		errs []error
+		err  error
+	}{
+		{[]error{errDiskNotFound, errDiskNotFound, errDiskFull}, errDiskNotFound},
+		{[]error{errDiskNotFound, errDiskFull, errDiskFull}, errDiskFull},
+		{[]error{errDiskFull, errDiskNotFound, errDiskFull}, errDiskFull},
+		// A case for error not in the known errors list (refer to func reduceErrs)
+		{[]error{errDiskFull, syscall.EEXIST, syscall.EEXIST}, syscall.EEXIST},
+		{[]error{errDiskNotFound, errDiskNotFound, nil}, nil},
+		{[]error{nil, nil, nil}, nil},
+	}
+	for i, testCase := range testCases {
+		expected := testCase.err
+		got := reduceErrs(testCase.errs)
+		if expected != got {
+			t.Errorf("Test %d : expected %s, got %s", i+1, expected, got)
+		}
+	}
+}


### PR DESCRIPTION
fixes #2117

@harshavardhana, recudeErrs() was the easiest solution I could think of, not sure if it's the cleanest.

Also this behavior is not observed in an actual setup as GetObjectInfo is done in GetObjectHandler() which returned the right error.
