### PR TITLE
XL: Implement ignore errors.

### DIFF
--- a/fs-v1-multipart.go
+++ b/fs-v1-multipart.go
@@ -85,7 +85,7 @@ func (fs fsObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 			// For any walk error return right away.
 			if walkResult.err != nil {
 				// File not found or Disk not found is a valid case.
-				if walkResult.err == errFileNotFound || walkResult.err == errDiskNotFound || walkResult.err == errFaultyDisk {
+				if isErrIgnored(walkResult.err, walkResultIgnoredErrs) {
 					eof = true
 					break
 				}

--- a/object-common.go
+++ b/object-common.go
@@ -43,6 +43,16 @@ func registerShutdown(callback func()) {
 	}()
 }
 
+// isErrIgnored should we ignore this error?, takes a list of errors which can be ignored.
+func isErrIgnored(err error, ignoredErrs []error) bool {
+	for _, ignoredErr := range ignoredErrs {
+		if ignoredErr == err {
+			return true
+		}
+	}
+	return false
+}
+
 // House keeping code needed for FS.
 func fsHouseKeeping(storageDisk StorageAPI) error {
 	// Cleanup all temp entries upon start.

--- a/xl-v1-common.go
+++ b/xl-v1-common.go
@@ -67,7 +67,7 @@ func (xl xlObjects) isObject(bucket, prefix string) (ok bool) {
 			return true
 		}
 		// Ignore for file not found,  disk not found or faulty disk.
-		if err == errFileNotFound || err == errDiskNotFound || err == errFaultyDisk {
+		if isErrIgnored(err, walkResultIgnoredErrs) {
 			continue
 		}
 		errorIf(err, "Unable to stat a file %s/%s/%s", bucket, prefix, xlMetaJSONFile)

--- a/xl-v1-multipart.go
+++ b/xl-v1-multipart.go
@@ -68,7 +68,10 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 				continue
 			}
 			uploads, _, err = listMultipartUploadIDs(bucket, keyMarker, uploadIDMarker, maxUploads, disk)
-			if err == errDiskNotFound || err == errFaultyDisk {
+			if err == nil {
+				break
+			}
+			if isErrIgnored(err, objMetadataOpIgnoredErrs) {
 				continue
 			}
 			break
@@ -100,7 +103,7 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 			// For any walk error return right away.
 			if walkResult.err != nil {
 				// File not found or Disk not found is a valid case.
-				if walkResult.err == errFileNotFound || walkResult.err == errDiskNotFound || walkResult.err == errFaultyDisk {
+				if isErrIgnored(walkResult.err, walkResultIgnoredErrs) {
 					continue
 				}
 				return ListMultipartsInfo{}, err
@@ -130,14 +133,17 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 					continue
 				}
 				newUploads, end, err = listMultipartUploadIDs(bucket, entry, uploadIDMarker, maxUploads, disk)
-				if err == errDiskNotFound || err == errFaultyDisk {
+				if err == nil {
+					break
+				}
+				if isErrIgnored(err, objMetadataOpIgnoredErrs) {
 					continue
 				}
 				break
 			}
 			nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry))
 			if err != nil {
-				if err == errFileNotFound || walkResult.err == errDiskNotFound || walkResult.err == errFaultyDisk {
+				if isErrIgnored(err, walkResultIgnoredErrs) {
 					continue
 				}
 				return ListMultipartsInfo{}, err
@@ -723,7 +729,10 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 			continue
 		}
 		uploadsJSON, err = readUploadsJSON(bucket, object, disk)
-		if err == errDiskNotFound || err == errFaultyDisk {
+		if err == nil {
+			break
+		}
+		if isErrIgnored(err, objMetadataOpIgnoredErrs) {
 			continue
 		}
 		break
@@ -774,7 +783,10 @@ func (xl xlObjects) abortMultipartUpload(bucket, object, uploadID string) (err e
 			continue
 		}
 		uploadsJSON, err = readUploadsJSON(bucket, object, disk)
-		if err == errDiskNotFound || err == errFaultyDisk {
+		if err == nil {
+			break
+		}
+		if isErrIgnored(err, objMetadataOpIgnoredErrs) {
 			continue
 		}
 		break


### PR DESCRIPTION
Each metadata ops have a list of errors which can be
ignored, this is essentially needed when
- disks are not found
- disks are found but cannot be accessed (permission denied)
- disks found but fauly (I/O error)
- disks are fresh disks.

This is needed since we don't have healing code in place where
it would have healed the fresh disks added.

Fixes #2072
