### PR TITLE
tests: Remove racey failedDisks behavior in RenameObject tests.

### DIFF
--- a/namespace-lock_test.go
+++ b/namespace-lock_test.go
@@ -20,9 +20,6 @@ import "testing"
 
 // Tests functionality provided by namespace lock.
 func TestNamespaceLockTest(t *testing.T) {
-	// Initialize name space lock.
-	initNSLock()
-
 	// List of test cases.
 	testCases := []struct {
 		lk               func(s1, s2 string)

--- a/test-utils_test.go
+++ b/test-utils_test.go
@@ -40,6 +40,12 @@ import (
 	router "github.com/gorilla/mux"
 )
 
+// Tests should initNSLock only once.
+func init() {
+	// Initialize name space lock.
+	initNSLock()
+}
+
 // The Argument to TestServer should satidy the interface.
 // Golang Testing.T and Testing.B, and gocheck.C satisfy the interface.
 // This makes it easy to run the TestServer from any of the tests.
@@ -554,9 +560,6 @@ func getXLObjectLayer() (ObjectLayer, []string, error) {
 		erasureDisks = append(erasureDisks, path)
 	}
 
-	// Initialize name space lock.
-	initNSLock()
-
 	objLayer, err := newXLObjects(erasureDisks)
 	if err != nil {
 		return nil, nil, err
@@ -571,9 +574,6 @@ func getSingleNodeObjectLayer() (ObjectLayer, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-
-	// Initialize name space lock.
-	initNSLock()
 
 	// Create the obj.
 	objLayer, err := newFSObjects(fsDir)


### PR DESCRIPTION
Additionally also initialize namespace lock only once per test
run, there is no reason to initialize it multiple times to avoid
races.

Fixes #2137
