### PR TITLE
Use new algorithm to get fixed random order of disks

### DIFF
--- a/xl-v1-common.go
+++ b/xl-v1-common.go
@@ -16,7 +16,10 @@
 
 package main
 
-import "path"
+import (
+	"path"
+	"time"
+)
 
 // getLoadBalancedQuorumDisks - fetches load balanced sufficiently
 // randomized quorum disk slice.
@@ -29,7 +32,7 @@ func (xl xlObjects) getLoadBalancedQuorumDisks() (disks []StorageAPI) {
 // randomized) disk slice.
 func (xl xlObjects) getLoadBalancedDisks() (disks []StorageAPI) {
 	// Based on the random shuffling return back randomized disks.
-	for _, i := range randInts(len(xl.storageDisks)) {
+	for _, i := range hashOrder(time.Now().UTC().String(), len(xl.storageDisks)) {
 		disks = append(disks, xl.storageDisks[i-1])
 	}
 	return disks

--- a/xl-v1-metadata.go
+++ b/xl-v1-metadata.go
@@ -119,7 +119,7 @@ func newXLMetaV1(dataBlocks, parityBlocks int) (xlMeta xlMetaV1) {
 		DataBlocks:   dataBlocks,
 		ParityBlocks: parityBlocks,
 		BlockSize:    blockSizeV1,
-		Distribution: randInts(dataBlocks + parityBlocks),
+		Distribution: hashOrder(time.Now().UTC().String(), dataBlocks+parityBlocks),
 	}
 	return xlMeta
 }

--- a/xl-v1-utils.go
+++ b/xl-v1-utils.go
@@ -18,9 +18,8 @@ package main
 
 import (
 	"encoding/json"
-	"math/rand"
+	"hash/crc32"
 	"path"
-	"time"
 )
 
 // Validates if we have quorum based on the errors with errDiskNotFound.
@@ -48,19 +47,16 @@ func diskCount(disks []StorageAPI) int {
 	return diskCount
 }
 
-// randInts - uses Knuth Fisher-Yates shuffle algorithm for generating uniform shuffling.
-func randInts(count int) []int {
-	rand.Seed(time.Now().UTC().UnixNano()) // Seed with current time.
-	ints := make([]int, count)
-	for i := 0; i < count; i++ {
-		ints[i] = i + 1
+// hashOrder returns hashed integers.
+func hashOrder(token string, count int) []int {
+	hTok := crc32.Checksum([]byte(token), crc32.IEEETable)
+	nums := make([]int, count)
+
+	start := int(uint32(hTok)%uint32(count)) | 1
+	for i := 1; i <= count; i++ {
+		nums[i-1] = 1 + ((start + i) % count)
 	}
-	for i := 0; i < count; i++ {
-		// Choose index uniformly in [i, count-1]
-		r := i + rand.Intn(count-i)
-		ints[r], ints[i] = ints[i], ints[r]
-	}
-	return ints
+	return nums
 }
 
 // readXLMeta reads `xl.json` and returns back XL metadata structure.

--- a/xl-v1_test.go
+++ b/xl-v1_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -134,5 +135,30 @@ func TestNewXL(t *testing.T) {
 	_, err := newXLObjects(erasureDisks)
 	if err != nil {
 		t.Fatalf("Unable to initialize erasure, %s", err)
+	}
+}
+
+// TestHashOrder - test order of ints in array
+func TestHashOrder(t *testing.T) {
+
+	v12 := "[7 8 9 10 11 12 1 2 3 4 5 6]"
+	t12 := hashOrder("minio", 12)
+
+	if v12 != fmt.Sprintf("%v", t12) {
+		t.Errorf(": \nexpected %s\ngot      %v", v12, t12)
+	}
+
+	v16 := "[5 6 7 8 9 10 11 12 13 14 15 16 1 2 3 4]"
+	t16 := hashOrder("xl", 16)
+
+	if v16 != fmt.Sprintf("%v", t16) {
+		t.Errorf(": \nexpected %s\ngot      %v", v16, t16)
+	}
+
+	v6 := "[5 6 1 2 3 4]"
+	t6 := hashOrder("minio-fs", 6)
+
+	if v6 != fmt.Sprintf("%v", t6) {
+		t.Errorf(": \nexpected %s\ngot      %v", v6, t6)
 	}
 }


### PR DESCRIPTION
As discussed with AB, different algorithm to get "fixed random" order of disks.

Passing in proper object name is going to require a bit more work, also code is called in e.g. listMultipartUploads() where no object key name is available, so changing to this seems to be a bit too much at current moment.
