### PR TITLE
server: Implement --ignore-disks for ignoring disks from healing.

### DIFF
--- a/fs-v1_test.go
+++ b/fs-v1_test.go
@@ -40,7 +40,7 @@ func TestNewFS(t *testing.T) {
 	}
 
 	// Initializes all disks with XL
-	_, err := newXLObjects(disks)
+	_, err := newXLObjects(disks, nil)
 	if err != nil {
 		t.Fatalf("Unable to initialize XL object, %s", err)
 	}

--- a/object-common.go
+++ b/object-common.go
@@ -86,7 +86,7 @@ func initMetaVolume(storageDisks []StorageAPI) error {
 	// Initialize all disks in parallel.
 	for index, disk := range storageDisks {
 		if disk == nil {
-			errs[index] = errDiskNotFound
+			// Ignore create meta volume on disks which are not found.
 			continue
 		}
 		wg.Add(1)
@@ -135,7 +135,6 @@ func xlHouseKeeping(storageDisks []StorageAPI) error {
 	// Initialize all disks in parallel.
 	for index, disk := range storageDisks {
 		if disk == nil {
-			errs[index] = errDiskNotFound
 			continue
 		}
 		wg.Add(1)

--- a/routers.go
+++ b/routers.go
@@ -23,16 +23,15 @@ import (
 	router "github.com/gorilla/mux"
 )
 
-// newObjectLayer - initialize any object layer depending on the
-// number of export paths.
-func newObjectLayer(exportPaths []string) (ObjectLayer, error) {
-	if len(exportPaths) == 1 {
-		exportPath := exportPaths[0]
+// newObjectLayer - initialize any object layer depending on the number of disks.
+func newObjectLayer(disks, ignoredDisks []string) (ObjectLayer, error) {
+	if len(disks) == 1 {
+		exportPath := disks[0]
 		// Initialize FS object layer.
 		return newFSObjects(exportPath)
 	}
 	// Initialize XL object layer.
-	objAPI, err := newXLObjects(exportPaths)
+	objAPI, err := newXLObjects(disks, ignoredDisks)
 	if err == errXLWriteQuorum {
 		return objAPI, errors.New("Disks are different with last minio server run.")
 	}
@@ -41,11 +40,11 @@ func newObjectLayer(exportPaths []string) (ObjectLayer, error) {
 
 // configureServer handler returns final handler for the http server.
 func configureServerHandler(srvCmdConfig serverCmdConfig) http.Handler {
-	objAPI, err := newObjectLayer(srvCmdConfig.exportPaths)
+	objAPI, err := newObjectLayer(srvCmdConfig.disks, srvCmdConfig.ignoredDisks)
 	fatalIf(err, "Unable to intialize object layer.")
 
 	// Initialize storage rpc server.
-	storageRPC, err := newRPCServer(srvCmdConfig.exportPaths[0]) // FIXME: should only have one path.
+	storageRPC, err := newRPCServer(srvCmdConfig.disks[0]) // FIXME: should only have one path.
 	fatalIf(err, "Unable to initialize storage RPC server.")
 
 	// Initialize API.

--- a/test-utils_test.go
+++ b/test-utils_test.go
@@ -129,7 +129,7 @@ func StartTestServer(t TestErrHandler, instanceType string) TestServer {
 	testServer.AccessKey = credentials.AccessKeyID
 	testServer.SecretKey = credentials.SecretAccessKey
 	// Run TestServer.
-	testServer.Server = httptest.NewServer(configureServerHandler(serverCmdConfig{exportPaths: erasureDisks}))
+	testServer.Server = httptest.NewServer(configureServerHandler(serverCmdConfig{disks: erasureDisks}))
 
 	return testServer
 }
@@ -632,7 +632,7 @@ func getXLObjectLayer() (ObjectLayer, []string, error) {
 		erasureDisks = append(erasureDisks, path)
 	}
 
-	objLayer, err := newXLObjects(erasureDisks)
+	objLayer, err := newXLObjects(erasureDisks, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/xl-v1_test.go
+++ b/xl-v1_test.go
@@ -132,7 +132,7 @@ func TestNewXL(t *testing.T) {
 		defer removeAll(disk)
 	}
 	// Initializes all erasure disks
-	_, err := newXLObjects(erasureDisks)
+	_, err := newXLObjects(erasureDisks, nil)
 	if err != nil {
 		t.Fatalf("Unable to initialize erasure, %s", err)
 	}


### PR DESCRIPTION
By default server heals/creates missing directories and re-populates `format.json`, in some scenarios when disk is down for maintenance it would be beneficial for users to ignore such disks rather than
mistakenly using `root` partition.

Fixes #2128
