### PR TITLE
posix: ReadAll should handle the case when parent is not a dir.

### DIFF
--- a/posix_test.go
+++ b/posix_test.go
@@ -73,6 +73,9 @@ func TestReadAll(t *testing.T) {
 	if err = posix.AppendFile("exists", "as-file", []byte("Hello, World")); err != nil {
 		t.Fatalf("Unable to create a file \"as-file\", %s", err)
 	}
+	if err = posix.AppendFile("exists", "as-file-parent", []byte("Hello, World")); err != nil {
+		t.Fatalf("Unable to create a file \"as-file-parent\", %s", err)
+	}
 
 	// Testcases to validate different conditions for ReadAll API.
 	testCases := []struct {
@@ -99,8 +102,12 @@ func TestReadAll(t *testing.T) {
 			"as-directory",
 			errFileNotFound,
 		},
-		// Validate the good condition file exists and we are able to
-		// read it.
+		{
+			"exists",
+			"as-file-parent/as-file",
+			errFileNotFound,
+		},
+		// Validate the good condition file exists and we are able to read it.
 		{
 			"exists",
 			"as-file",

--- a/xl-v1-metadata.go
+++ b/xl-v1-metadata.go
@@ -203,6 +203,7 @@ var objMetadataOpIgnoredErrs = []error{
 	errDiskAccessDenied,
 	errFaultyDisk,
 	errVolumeNotFound,
+	errFileAccessDenied,
 }
 
 // readXLMetadata - returns the object metadata `xl.json` content from


### PR DESCRIPTION
It can happen so that a read request can come for a file which
already has a parent i.e a file.

This fix handles this scenario - fixes #2047
