### PR TITLE
Store and retrieve user-defined object metadata in a .metadata bucket

### DIFF
--- a/fs-v1-multipart.go
+++ b/fs-v1-multipart.go
@@ -240,6 +240,12 @@ func (fs fsObjects) newMultipartUpload(bucket string, object string, meta map[st
 		}
 		return "", toObjectErr(err, minioMetaBucket, uploadIDPath)
 	}
+
+	err = PutObjectMetadata(fs.storage, bucket, object, meta)
+	if err != nil {
+		return "", toObjectErr(err, bucket, object)
+	}
+
 	// Return success.
 	return uploadID, nil
 }
@@ -250,7 +256,6 @@ func (fs fsObjects) newMultipartUpload(bucket string, object string, meta map[st
 //
 // Implements S3 compatible initiate multipart API.
 func (fs fsObjects) NewMultipartUpload(bucket, object string, meta map[string]string) (string, error) {
-	meta = make(map[string]string) // Reset the meta value, we are not going to save headers for fs.
 	// Verify if bucket name is valid.
 	if !IsValidBucketName(bucket) {
 		return "", BucketNameInvalid{Bucket: bucket}

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,94 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+var (
+	metadataBucket = ".metadata"
+)
+
+// PutObjectMetadata saved object's metadata
+func PutObjectMetadata(storage StorageAPI, bucket, object string, metadata map[string]string) error {
+	name := metadataFilename(bucket, object)
+	bytes, err := json.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+	storage.DeleteFile(metadataBucket, name)
+	err = storage.AppendFile(metadataBucket, name, bytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetObjectMetadata returns object's metadata
+func GetObjectMetadata(storage StorageAPI, bucket, object string) (map[string]string, error) {
+	name := metadataFilename(bucket, object)
+	bytes, err := storage.ReadAll(metadataBucket, name)
+	if err != nil {
+		return nil, err
+	}
+	metadata := make(map[string]string)
+	json.Unmarshal(bytes, &metadata)
+	return metadata, nil
+}
+
+// ExtractMetadata extracts metadata from an HTTP request
+func ExtractMetadata(r *http.Request) map[string]string {
+	metadata := make(map[string]string)
+	// Save other metadata if available.
+	metadata["Content-Type"] = r.Header.Get("Content-Type")
+	metadata["Content-Encoding"] = r.Header.Get("Content-Encoding")
+	for key, value := range r.Header {
+		for _, val := range value {
+			k, v := handleMetadataHeader(metadata, key, val)
+			if v != "" {
+				metadata[k] = v
+			}
+		}
+	}
+	return metadata
+}
+
+func handleMetadataHeader(metadata map[string]string, key, value string) (k, v string) {
+	k = http.CanonicalHeaderKey(key)
+	if strings.HasPrefix(k, "X-Amz-Meta-") {
+		v = metadataKeyMerge(metadata, k, value)
+	} else if strings.HasPrefix(k, "X-Minio-Meta-") {
+		v = metadataKeyMerge(metadata, k, value)
+	} else {
+		v = ""
+	}
+	return
+}
+
+func metadataKeyMerge(metadata map[string]string, key, value string) string {
+	if val, ok := metadata[key]; ok {
+		return val + "," + value
+	}
+	return value
+}
+
+func metadataFilename(bucket, object string) string {
+	return pathJoin(bucket, object)
+}

--- a/object-common.go
+++ b/object-common.go
@@ -104,6 +104,16 @@ func initMetaVolume(storageDisks []StorageAPI) error {
 					errs[index] = err
 				}
 			}
+			// Attempt to create `.metdata`.
+			err = disk.MakeVol(metadataBucket)
+			if err != nil {
+				switch err {
+				// Ignored errors.
+				case errVolumeExists, errDiskNotFound, errFaultyDisk:
+				default:
+					errs[index] = err
+				}
+			}
 		}(index, disk)
 	}
 

--- a/object-interface.go
+++ b/object-interface.go
@@ -35,6 +35,7 @@ type ObjectLayer interface {
 	GetObjectInfo(bucket, object string) (objInfo ObjectInfo, err error)
 	PutObject(bucket, object string, size int64, data io.Reader, metadata map[string]string) (md5 string, err error)
 	DeleteObject(bucket, object string) error
+	GetObjectMetadata(bucket, object string) (metadata map[string]string, err error)
 
 	// Multipart operations.
 	ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (result ListMultipartsInfo, err error)

--- a/xl-v1-multipart.go
+++ b/xl-v1-multipart.go
@@ -287,6 +287,15 @@ func (xl xlObjects) newMultipartUpload(bucket string, object string, meta map[st
 	}
 	rErr := xl.renameObject(minioMetaBucket, tempUploadIDPath, minioMetaBucket, uploadIDPath)
 	if rErr == nil {
+		for _, storage := range xl.storageDisks {
+			if storage == nil {
+				continue
+			}
+			err = PutObjectMetadata(storage, bucket, object, meta)
+			if err != nil && err != errDiskNotFound {
+				return "", toObjectErr(err, bucket, object)
+			}
+		}
 		// Return success.
 		return uploadID, nil
 	}

--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -542,6 +542,16 @@ func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.
 		newBuffer.Close()
 	}
 
+	for _, storage := range xl.storageDisks {
+		if storage == nil {
+			continue
+		}
+		err = PutObjectMetadata(storage, bucket, object, metadata)
+		if err != nil && err != errDiskNotFound {
+			return "", toObjectErr(err, bucket, object)
+		}
+	}
+
 	// Return md5sum, successfully wrote object.
 	return newMD5Hex, nil
 }
@@ -613,4 +623,14 @@ func (xl xlObjects) DeleteObject(bucket, object string) (err error) {
 
 	// Success.
 	return nil
+}
+
+func (xl xlObjects) GetObjectMetadata(bucket, object string) (map[string]string, error) {
+	for _, storage := range xl.storageDisks {
+		if storage == nil {
+			continue
+		}
+		return GetObjectMetadata(storage, bucket, object)
+	}
+	return make(map[string]string), nil
 }


### PR DESCRIPTION
Also fixes a problem with a non-canonical header naming validation

P.S. I wasn't quite sure where to write an actual HTTP PUT/GET test (where are these tests in the test suite, a cursory glance didn't reveal them?), but if you can advise me on this, I will happily amend this PR.
