### PR TITLE
Fix metadata storage for compatibility with S3

### DIFF
--- a/api-headers.go
+++ b/api-headers.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
+	"strings"
 )
 
 //// helpers
@@ -72,6 +73,11 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, contentRange *h
 	}
 
 	w.Header().Set("Content-Length", strconv.FormatInt(objInfo.Size, 10))
+	for k, v := range objInfo.UserDefined {
+		if strings.HasPrefix(k, "X-Amz-Meta-") {
+			w.Header().Set(k, v)
+		}
+	}
 
 	// for providing ranged content
 	if contentRange != nil && contentRange.offsetBegin > -1 {

--- a/object-datatypes.go
+++ b/object-datatypes.go
@@ -62,6 +62,9 @@ type ObjectInfo struct {
 	// what decoding mechanisms must be applied to obtain the object referenced
 	// by the Content-Type header field.
 	ContentEncoding string
+
+	// User-Defined metadata
+	UserDefined map[string]string
 }
 
 // ListPartsInfo - represents list of all parts.

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -397,9 +397,9 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	metadata["content-encoding"] = r.Header.Get("Content-Encoding")
 	for key := range r.Header {
 		cKey := http.CanonicalHeaderKey(key)
-		if strings.HasPrefix(cKey, "x-amz-meta-") {
+		if strings.HasPrefix(cKey, "X-Amz-Meta-") {
 			metadata[cKey] = r.Header.Get(cKey)
-		} else if strings.HasPrefix(key, "x-minio-meta-") {
+		} else if strings.HasPrefix(key, "X-Minio-Meta-") {
 			metadata[cKey] = r.Header.Get(cKey)
 		}
 	}

--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -226,6 +226,7 @@ func (xl xlObjects) getObjectInfo(bucket, object string) (objInfo ObjectInfo, er
 		MD5Sum:          xlMeta.Meta["md5Sum"],
 		ContentType:     xlMeta.Meta["content-type"],
 		ContentEncoding: xlMeta.Meta["content-encoding"],
+		UserDefined:     xlMeta.Meta,
 	}
 	return objInfo, nil
 }


### PR DESCRIPTION
This fixes a bug in PutObjectHandler that keeps it from saving metadata headers, and enables returning them back through ObjectInfo.
