### PR TITLE
XL/fs: Change minioMetaBucket different than '.minio' config dir.

### DIFF
--- a/object-utils.go
+++ b/object-utils.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// Minio meta bucket.
-	minioMetaBucket = ".minio"
+	minioMetaBucket = ".minio.sys"
 	// Multipart meta prefix.
 	mpartMetaPrefix = "multipart"
 	// Tmp meta prefix.


### PR DESCRIPTION
This fixes corruption of config directory seen when minio server
exports 'home' directory.

```
minio server ~
```
