### PR TITLE
Refactor of xl.PutObjectPart and erasureCreateFile.

### DIFF
--- a/erasure-readfile_test.go
+++ b/erasure-readfile_test.go
@@ -109,9 +109,8 @@ func testGetReadDisks(t *testing.T, xl xlObjects) {
 // actual distribution.
 func testGetOrderedDisks(t *testing.T, xl xlObjects) {
 	disks := xl.storageDisks
-	blockCheckSums := make([]checkSumInfo, len(disks))
 	distribution := []int{16, 14, 12, 10, 8, 6, 4, 2, 1, 3, 5, 7, 9, 11, 13, 15}
-	orderedDisks, _ := getOrderedDisks(distribution, disks, blockCheckSums)
+	orderedDisks := getOrderedDisks(distribution, disks)
 	// From the "distribution" above you can notice that:
 	// 1st data block is in the 9th disk (i.e distribution index 8)
 	// 2nd data block is in the 8th disk (i.e distribution index 7) and so on.

--- a/xl-v1-healing.go
+++ b/xl-v1-healing.go
@@ -131,10 +131,9 @@ func (xl xlObjects) shouldHeal(onlineDisks []StorageAPI) (heal bool) {
 
 // Returns slice of online disks needed.
 // - slice returing readable disks.
-// - xlMetaV1
-// - bool value indicating if healing is needed.
-func (xl xlObjects) listOnlineDisks(partsMetadata []xlMetaV1, errs []error) (onlineDisks []StorageAPI, modTime time.Time) {
-	onlineDisks = make([]StorageAPI, len(xl.storageDisks))
+// - modTime of the Object
+func listOnlineDisks(disks []StorageAPI, partsMetadata []xlMetaV1, errs []error) (onlineDisks []StorageAPI, modTime time.Time) {
+	onlineDisks = make([]StorageAPI, len(disks))
 
 	// List all the file commit ids from parts metadata.
 	modTimes := listObjectModtimes(partsMetadata, errs)
@@ -145,7 +144,7 @@ func (xl xlObjects) listOnlineDisks(partsMetadata []xlMetaV1, errs []error) (onl
 	// Create a new online disks slice, which have common uuid.
 	for index, t := range modTimes {
 		if t == modTime {
-			onlineDisks[index] = xl.storageDisks[index]
+			onlineDisks[index] = disks[index]
 		} else {
 			onlineDisks[index] = nil
 		}

--- a/xl-v1-metadata.go
+++ b/xl-v1-metadata.go
@@ -163,6 +163,27 @@ func (m *xlMetaV1) AddObjectPart(partNumber int, partName string, partETag strin
 	sort.Sort(byObjectPartNumber(m.Parts))
 }
 
+// AddCheckSum - add checksum of a part.
+func (m *xlMetaV1) AddCheckSum(partName, algorithm, checkSum string) {
+	for i, sum := range m.Erasure.Checksum {
+		if sum.Name == partName {
+			m.Erasure.Checksum[i] = checkSumInfo{partName, "blake2b", checkSum}
+			return
+		}
+	}
+	m.Erasure.Checksum = append(m.Erasure.Checksum, checkSumInfo{partName, "blake2b", checkSum})
+}
+
+// GetCheckSum - get checksum of a part.
+func (m *xlMetaV1) GetCheckSum(partName string) (checkSum, algorithm string, err error) {
+	for _, sum := range m.Erasure.Checksum {
+		if sum.Name == partName {
+			return sum.Hash, sum.Algorithm, nil
+		}
+	}
+	return "", "", errUnexpected
+}
+
 // ObjectToPartOffset - translate offset of an object to offset of its individual part.
 func (m xlMetaV1) ObjectToPartOffset(offset int64) (partIndex int, partOffset int64, err error) {
 	if offset == 0 {

--- a/xl-v1-metadata.go
+++ b/xl-v1-metadata.go
@@ -187,10 +187,11 @@ func (m xlMetaV1) ObjectToPartOffset(offset int64) (partIndex int, partOffset in
 // pickValidXLMeta - picks one valid xlMeta content and returns from a
 // slice of xlmeta content. If no value is found this function panics
 // and dies.
-func pickValidXLMeta(xlMetas []xlMetaV1) xlMetaV1 {
-	for _, xlMeta := range xlMetas {
-		if xlMeta.IsValid() {
-			return xlMeta
+func pickValidXLMeta(metaArr []xlMetaV1, modTime time.Time) xlMetaV1 {
+	// Pick latest valid metadata.
+	for _, meta := range metaArr {
+		if meta.IsValid() && meta.Stat.ModTime == modTime {
+			return meta
 		}
 	}
 	panic("Unable to look for valid XL metadata content")

--- a/xl-v1-multipart.go
+++ b/xl-v1-multipart.go
@@ -450,20 +450,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 			continue
 		}
 		partsMetadata[index].Parts = xlMeta.Parts
-		for i, sum := range partsMetadata[index].Erasure.Checksum {
-			if sum.Name == partSuffix {
-				// If the part was previously uploaded, remove entry.
-				Checksum := partsMetadata[index].Erasure.Checksum
-				Checksum = append(Checksum[:i], Checksum[i+1:]...)
-				partsMetadata[index].Erasure.Checksum = Checksum
-				break
-			}
-		}
-		partsMetadata[index].Erasure.Checksum = append(partsMetadata[index].Erasure.Checksum, checkSumInfo{
-			partSuffix,
-			"blake2b",
-			checkSums[index],
-		})
+		partsMetadata[index].AddCheckSum(partSuffix, "blake2b", checkSums[index])
 	}
 
 	// Write all the checksum metadata.

--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -509,7 +509,7 @@ func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.
 	// Update `xl.json` content on each disks.
 	for index := range partsMetadata {
 		partsMetadata[index] = xlMeta
-		partsMetadata[index].Erasure.Checksum = []checkSumInfo{{"part.1", "blake2b", checkSums[index]}}
+		partsMetadata[index].AddCheckSum("part.1", "blake2b", checkSums[index])
 	}
 
 	// Write unique `xl.json` for each disk.


### PR DESCRIPTION
Needs review and testing.

erasureCreateFile is much simpler -
- it does not worry about disk ordering
- knowledge of XL's data structures is taken out

PutObjectPart refactored -
- works on orderedDisks which makes reading code easier.
- simplified code.
