### PR TITLE
[WIP] Intrumentation: Instrumentation for locks. 

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/json"
 	"encoding/xml"
 	"net/http"
 	"runtime"
@@ -54,6 +55,17 @@ func encodeResponse(response interface{}) []byte {
 	bytesBuffer.WriteString(xml.Header)
 	e := xml.NewEncoder(&bytesBuffer)
 	e.Encode(response)
+	return bytesBuffer.Bytes()
+}
+
+// Encodes response into json format.
+func mustEncodeJSON(response interface{}) []byte {
+	var bytesBuffer bytes.Buffer
+	e := json.NewEncoder(&bytesBuffer)
+	err := e.Encode(response)
+	if err != nil {
+		panic(err)
+	}
 	return bytesBuffer.Bytes()
 }
 

--- a/cmd/control-heal-main.go
+++ b/cmd/control-heal-main.go
@@ -36,7 +36,7 @@ var healCmd = cli.Command{
 USAGE:
   minio control {{.Name}}
 
-EAMPLES:
+EXAMPLES:
   1. Heal an object.
      $ minio control {{.Name}} http://localhost:9000/songs/classical/western/piano.mp3
 

--- a/cmd/control-main.go
+++ b/cmd/control-main.go
@@ -25,6 +25,7 @@ var controlCmd = cli.Command{
 	Action: mainControl,
 	Subcommands: []cli.Command{
 		healCmd,
+		lockCmd,
 		shutdownCmd,
 	},
 	CustomHelpTemplate: `NAME:

--- a/cmd/controller-handlers.go
+++ b/cmd/controller-handlers.go
@@ -86,3 +86,13 @@ func (c *controllerAPIHandlers) Shutdown(arg *ShutdownArgs, reply *ShutdownReply
 	}
 	return nil
 }
+
+//
+func (c *controllerAPIHandlers) LockInfo(arg *struct{}, reply *SystemLockState) error {
+	lockInfo, err := generateSystemLockResponse()
+	if err != nil {
+		return err
+	}
+	reply = &lockInfo
+	return nil
+}

--- a/cmd/controller_test.go
+++ b/cmd/controller_test.go
@@ -1,0 +1,95 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/rpc"
+	"path"
+	"strconv"
+
+	. "gopkg.in/check.v1"
+)
+
+// API suite container common to both FS and XL.
+type TestRPCControllerSuite struct {
+	serverType string
+	testServer TestServer
+	endPoint   string
+	accessKey  string
+	secretKey  string
+}
+
+// Init and run test on FS backend.
+var _ = Suite(&TestRPCControllerSuite{serverType: "FS"})
+
+// Init and run test on XL backend.
+var _ = Suite(&TestRPCControllerSuite{serverType: "XL"})
+
+// Setting up the test suite.
+// Starting the Test server with temporary FS backend.
+func (s *TestRPCControllerSuite) SetUpSuite(c *C) {
+	s.testServer = StartTestRPCServer(c, s.serverType)
+	s.endPoint = s.testServer.Server.Listener.Addr().String()
+	s.accessKey = s.testServer.AccessKey
+	s.secretKey = s.testServer.SecretKey
+}
+
+// Called implicitly by "gopkg.in/check.v1" after all tests are run.
+func (s *TestRPCControllerSuite) TearDownSuite(c *C) {
+	s.testServer.Stop()
+}
+
+// Tests to validate the correctness of lock instrumentation control RPC end point.
+func (s *TestRPCControllerSuite) TestRPCControlLock(c *C) {
+	// enabling lock instrumentation.
+	globalDebugLock = true
+	// initializing the locks.
+	initNSLock()
+	// set debug lock info  to `nil` so that the next tests have to initialize them again.
+	defer func() {
+		globalDebugLock = false
+		nsMutex.debugLockMap = nil
+	}()
+
+	var client *rpc.Client
+	var err error
+	client, err = rpc.DialHTTPPath("tcp", s.endPoint, path.Join(reservedBucket, controlPath))
+	if err != nil {
+		c.Fatal("dialing", err)
+	}
+
+	defer client.Close()
+
+	for i := 0; i < 5; i++ {
+		nsMutex.RUnlock("my-bucket", "my-object", strconv.Itoa(i))
+	}
+	// Synchronous calls
+	args := &struct{}{}
+	reply := &SystemLockState{}
+	err = client.Call("Control.LockInfo", args, reply)
+	if err != nil {
+		c.Errorf("Add: expected no error but got string %q", err.Error())
+	}
+	fmt.Println("RPC test log")
+	b, err := json.MarshalIndent(*reply, "", "  ")
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Print(string(b))
+}

--- a/cmd/debug-handlers.go
+++ b/cmd/debug-handlers.go
@@ -1,0 +1,96 @@
+/*
+ * Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// SystemLockState - Structure to fill the lock state of entire object storage.
+// That is the total locks held, total calls blocked on locks and state of all the locks for the entire system.
+type SystemLockState struct {
+	TotalLocks         int64            `json:"totalLocks"`
+	TotalBlockedLocks  int64            `json:"totalBlockedLocks"`  // count of operations which are blocked waiting for the lock to be released.
+	TotalAcquiredLocks int64            `json:"totalAcquiredLocks"` // count of operations which has successfully acquired the lock but hasn't unlocked yet( operation in progress).
+	LocksInfoPerObject []VolumeLockInfo `json:"locksInfoPerObject"`
+}
+
+// VolumeLockInfo - Structure to contain the lock state info for volume, path pair.
+type VolumeLockInfo struct {
+	Bucket                string         `json:"bucket"`
+	Object                string         `json:"object"`
+	LocksOnObject         int64          `json:"locksOnObject"`         // All locks blocked + running for given <volume,path> pair.
+	LocksAcquiredOnObject int64          `json:"locksAcquiredOnObject"` // count of operations which has successfully acquired the lock but hasn't unlocked yet( operation in progress).
+	TotalBlockedLocks     int64          `json:"locksBlockedOnObject"`  // count of operations which are blocked waiting for the lock to be released.
+	LockDetailsOnObject   []OpsLockState `json:"lockDetailsOnObject"`   // state information containing state of the locks for all operations on given <volume,path> pair.
+}
+
+// OpsLockState - structure to fill in state information of the lock.
+// structure to fill in status information for each operation with given operation ID.
+type OpsLockState struct {
+	OperationID string `json:"opsID"`      // string containing operation ID.
+	LockOrigin  string `json:"lockOrigin"` // contant which mentions the operation type (Get Obejct, PutObject...)
+	LockType    string `json:"lockType"`
+	Status      string `json:"status"`      // status can be running/ready/blocked.
+	StatusSince string `json:"statusSince"` // time info of the since how long the status holds true, value in seconds.
+}
+
+// Read entire state of the locks in the system and return.
+func generateSystemLockResponse() (SystemLockState, error) {
+	nsMutex.mutex.Lock()
+	defer nsMutex.mutex.Unlock()
+
+	if nsMutex.debugLockMap == nil {
+		return SystemLockState{}, LockInfoNil{}
+	}
+
+	lockState := SystemLockState{}
+
+	lockState.TotalBlockedLocks = nsMutex.blockedCounter
+	lockState.TotalLocks = nsMutex.globalLockCounter
+	lockState.TotalAcquiredLocks = nsMutex.runningLockCounter
+
+	for param := range nsMutex.debugLockMap {
+		volLockInfo := VolumeLockInfo{}
+		volLockInfo.Bucket = param.volume
+		volLockInfo.Object = param.path
+		volLockInfo.TotalBlockedLocks = nsMutex.debugLockMap[param].blocked
+		volLockInfo.LocksAcquiredOnObject = nsMutex.debugLockMap[param].running
+		volLockInfo.LocksOnObject = nsMutex.debugLockMap[param].ref
+		for opsID := range nsMutex.debugLockMap[param].lockInfo {
+			opsState := OpsLockState{}
+			opsState.OperationID = opsID
+			opsState.LockOrigin = nsMutex.debugLockMap[param].lockInfo[opsID].lockOrigin
+			opsState.LockType = nsMutex.debugLockMap[param].lockInfo[opsID].lockType
+			opsState.Status = nsMutex.debugLockMap[param].lockInfo[opsID].status
+			opsState.StatusSince = time.Now().Sub(nsMutex.debugLockMap[param].lockInfo[opsID].since).String()
+
+			volLockInfo.LockDetailsOnObject = append(volLockInfo.LockDetailsOnObject, opsState)
+		}
+		lockState.LocksInfoPerObject = append(lockState.LocksInfoPerObject, volLockInfo)
+	}
+	fmt.Printf("Inside lock state")
+	b, err := json.MarshalIndent(lockState, "", "  ")
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Print(string(b))
+
+	return lockState, nil
+}

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -58,9 +58,13 @@ func (fs fsObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 	var err error
 	var eof bool
 	if uploadIDMarker != "" {
-		nsMutex.RLock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, keyMarker))
+		// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+		// used for instrumentation on locks.
+		opsID := getOpsID()
+
+		nsMutex.RLock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, keyMarker), opsID)
 		uploads, _, err = listMultipartUploadIDs(bucket, keyMarker, uploadIDMarker, maxUploads, fs.storage)
-		nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, keyMarker))
+		nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, keyMarker), opsID)
 		if err != nil {
 			return ListMultipartsInfo{}, err
 		}
@@ -110,9 +114,14 @@ func (fs fsObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 			var tmpUploads []uploadMetadata
 			var end bool
 			uploadIDMarker = ""
-			nsMutex.RLock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry))
+
+			// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+			// used for instrumentation on locks.
+			opsID := getOpsID()
+
+			nsMutex.RLock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry), opsID)
 			tmpUploads, end, err = listMultipartUploadIDs(bucket, entry, uploadIDMarker, maxUploads, fs.storage)
-			nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry))
+			nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry), opsID)
 			if err != nil {
 				return ListMultipartsInfo{}, err
 			}
@@ -225,9 +234,13 @@ func (fs fsObjects) newMultipartUpload(bucket string, object string, meta map[st
 		fsMeta.Meta = meta
 	}
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
 	// This lock needs to be held for any changes to the directory contents of ".minio/multipart/object/"
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
 
 	uploadID = getUUID()
 	initiated := time.Now().UTC()
@@ -291,17 +304,23 @@ func (fs fsObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 
 	uploadIDPath := path.Join(mpartMetaPrefix, bucket, object, uploadID)
 
-	nsMutex.RLock(minioMetaBucket, uploadIDPath)
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
+	nsMutex.RLock(minioMetaBucket, uploadIDPath, opsID)
 	// Just check if the uploadID exists to avoid copy if it doesn't.
 	uploadIDExists := fs.isUploadIDExists(bucket, object, uploadID)
-	nsMutex.RUnlock(minioMetaBucket, uploadIDPath)
+	nsMutex.RUnlock(minioMetaBucket, uploadIDPath, opsID)
 	if !uploadIDExists {
 		return "", InvalidUploadID{UploadID: uploadID}
 	}
-
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID = getOpsID()
 	// Hold write lock on the part so that there is no parallel upload on the part.
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID, strconv.Itoa(partID)))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID, strconv.Itoa(partID)))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID, strconv.Itoa(partID)), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID, strconv.Itoa(partID)), opsID)
 
 	partSuffix := fmt.Sprintf("object%d", partID)
 	tmpPartPath := path.Join(tmpMetaPrefix, uploadID+"-"+partSuffix)
@@ -357,9 +376,13 @@ func (fs fsObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 		}
 	}
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID = getOpsID()
+
 	// Hold write lock as we are updating fs.json
-	nsMutex.Lock(minioMetaBucket, uploadIDPath)
-	defer nsMutex.Unlock(minioMetaBucket, uploadIDPath)
+	nsMutex.Lock(minioMetaBucket, uploadIDPath, opsID)
+	defer nsMutex.Unlock(minioMetaBucket, uploadIDPath, opsID)
 
 	// Just check if the uploadID exists to avoid copy if it doesn't.
 	if !fs.isUploadIDExists(bucket, object, uploadID) {
@@ -465,9 +488,14 @@ func (fs fsObjects) ListObjectParts(bucket, object, uploadID string, partNumberM
 	if !IsValidObjectName(object) {
 		return ListPartsInfo{}, ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
+
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
 	// Hold lock so that there is no competing abort-multipart-upload or complete-multipart-upload.
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
 	if !fs.isUploadIDExists(bucket, object, uploadID) {
 		return ListPartsInfo{}, InvalidUploadID{UploadID: uploadID}
@@ -498,12 +526,17 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 	}
 
 	uploadIDPath := path.Join(mpartMetaPrefix, bucket, object, uploadID)
+
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
 	// Hold lock so that
 	// 1) no one aborts this multipart upload
 	// 2) no one does a parallel complete-multipart-upload on this
 	// multipart upload
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
 	if !fs.isUploadIDExists(bucket, object, uploadID) {
 		return "", InvalidUploadID{UploadID: uploadID}
@@ -609,10 +642,14 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 		return "", toObjectErr(err, bucket, object)
 	}
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID = getOpsID()
+
 	// Hold the lock so that two parallel complete-multipart-uploads do not
 	// leave a stale uploads.json behind.
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
 
 	// Validate if there are other incomplete upload-id's present for
 	// the object, if yes do not attempt to delete 'uploads.json'.
@@ -701,9 +738,13 @@ func (fs fsObjects) AbortMultipartUpload(bucket, object, uploadID string) error 
 		return ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
 	// Hold lock so that there is no competing complete-multipart-upload or put-object-part.
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
 	if !fs.isUploadIDExists(bucket, object, uploadID) {
 		return InvalidUploadID{UploadID: uploadID}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"github.com/fatih/color"
 	"github.com/minio/minio/pkg/objcache"
+	"os"
 )
 
 // Global constants for Minio.
@@ -38,8 +39,11 @@ const (
 )
 
 var (
-	globalQuiet = false // Quiet flag set via command line
-	globalTrace = false // Trace flag set via environment setting.
+	globalQuiet       = false // Quiet flag set via command line
+	globalTrace       = false // Trace flag set via environment setting.
+	globalDebug       = false // Debug flag set to print debug info.
+	globalDebugLock   = false // Lock debug info set via environment variable MINIO_DEBUG=lock .
+	globalDebugMemory = false // Memory debug info set via environment variable MINIO_DEBUG=mem
 	// Add new global flags here.
 
 	// Maximum connections handled per
@@ -63,3 +67,15 @@ var (
 	colorBlue = color.New(color.FgBlue).SprintfFunc()
 	colorBold = color.New(color.Bold).SprintFunc()
 )
+
+// fetch from environment variables and set the global values related to locks.
+func setGlobalsDebugFromEnv() {
+	debugEnv := os.Getenv("MINIO_DEBUG")
+	switch debugEnv {
+	case "lock":
+		globalDebugLock = true
+	case "mem":
+		globalDebugMemory = true
+	}
+	globalDebug = globalDebugLock || globalDebugMemory
+}

--- a/cmd/lock-instrument.go
+++ b/cmd/lock-instrument.go
@@ -1,0 +1,283 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	debugRLockStr = "RLock"
+	debugWLockStr = "WLock"
+)
+
+// struct containing information of status (ready/running/blocked) of an operation with given operation ID.
+type debugLockInfo struct {
+	lockType   string    // "Rlock" or "WLock".
+	lockOrigin string    // contains the trace of the function which invoked the lock, obtained from runtime.
+	status     string    // status can be running/ready/blocked.
+	since      time.Time // time info of the since how long the status holds true.
+}
+
+// debugLockInfo - container for storing locking information for unique copy (volume,path) pair.
+// ref variable holds the reference count for locks held for.
+// `ref` values helps us understand the n locks held for given <volume, path> pair.
+// `running` value helps us understand the total successful locks held (not blocked) for given <volume, path> pair and the operation is under execution.
+// `blocked` value helps us understand the total number of operations blocked waiting on locks for given <volume,path> pair.
+type debugLockInfoPerVolumePath struct {
+	ref      int64                      // running + blocked operations.
+	running  int64                      // count of successful lock acquire and running operations.
+	blocked  int64                      // count of number of operations blocked waiting on lock.
+	lockInfo (map[string]debugLockInfo) // map of [operationID] debugLockInfo{operation, status, since} .
+}
+
+// returns an instance of debugLockInfo.
+// need to create this for every unique pair of {volume,path}.
+// total locks, number of calls blocked on locks, and number of successful locks held but not unlocked yet.
+func newDebugLockInfoPerVolumePath() *debugLockInfoPerVolumePath {
+	return &debugLockInfoPerVolumePath{
+		lockInfo: make(map[string]debugLockInfo),
+		ref:      0,
+		blocked:  0,
+		running:  0,
+	}
+}
+
+// LockInfoNil - Returned if the lock info map is not initialized.
+type LockInfoNil struct {
+}
+
+func (l LockInfoNil) Error() string {
+	return fmt.Sprintf("Debug Lock Map not initialized:\n1. Enable Lock Debugging using right ENV settings \n2. Make sure initNSLock() is called.")
+}
+
+// LockInfoOriginNotFound - While changing the state of the lock info its important that the entry for
+// lock at a given origin exists, if not `LockInfoOriginNotFound` is returned.
+type LockInfoOriginNotFound struct {
+	volume      string
+	path        string
+	operationID string
+	lockOrigin  string
+}
+
+func (l LockInfoOriginNotFound) Error() string {
+	return fmt.Sprintf("No lock state stored for the lock origined at \"%s\", for <volume> %s, <path> %s, <operationID> %s.",
+		l.lockOrigin, l.volume, l.path, l.operationID)
+}
+
+// LockInfoVolPathMssing - Error interface. Returned when the info the
+type LockInfoVolPathMssing struct {
+	volume string
+	path   string
+}
+
+func (l LockInfoVolPathMssing) Error() string {
+	return fmt.Sprintf("No entry in debug Lock Map for Volume: %s, path: %s.", l.volume, l.path)
+}
+
+// LockInfoOpsIDNotFound - Returned when the lock state info exists, but the entry for
+// given operation ID doesn't exist.
+type LockInfoOpsIDNotFound struct {
+	volume      string
+	path        string
+	operationID string
+}
+
+func (l LockInfoOpsIDNotFound) Error() string {
+	return fmt.Sprintf("No entry in lock info for <Operation ID> %s, <volume> %s, <path> %s.", l.operationID, l.volume, l.path)
+}
+
+// LockInfoStateNotBlocked - When an attempt to change the state of the lock form `blocked` to `running` is done,
+// its necessary that the state before the transsition is "blocked", otherwise LockInfoStateNotBlocked returned.
+type LockInfoStateNotBlocked struct {
+	volume      string
+	path        string
+	operationID string
+}
+
+func (l LockInfoStateNotBlocked) Error() string {
+	return fmt.Sprintf("Lock state should be \"Blocked\" for <volume> %s, <path> %s, <operationID> %s.", l.volume, l.path, l.operationID)
+}
+
+// change the state of the lock from Blocked to Running.
+func (n *nsLockMap) statusBlockedToRunning(param nsParam, lockOrigin, operationID string, readLock bool) error {
+	// This operation is not executed under the scope nsLockMap.mutex.Lock(), lock has to be explicitly held here.
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	if n.debugLockMap == nil {
+		return LockInfoNil{}
+	}
+	// new state info to be set for the lock.
+	newLockInfo := debugLockInfo{
+		lockOrigin: lockOrigin,
+		status:     "Running",
+		since:      time.Now().UTC(),
+	}
+
+	// set lock type.
+	if readLock {
+		newLockInfo.lockType = debugRLockStr
+	} else {
+		newLockInfo.lockType = debugWLockStr
+	}
+
+	// check whether the lock info entry for <volume, path> pair already exists and its not `nil`.
+	if debugLockMap, ok := n.debugLockMap[param]; ok {
+		//  ``*debugLockInfoPerVolumePath` entry containing lock info for `param <volume, path>` is `nil`.
+		if debugLockMap == nil {
+			return LockInfoNil{}
+		}
+	} else {
+		// The lock state info foe given <volume, path> pair should already exist.
+		// If not return `LockInfoVolPathMssing`.
+		return LockInfoVolPathMssing{param.volume, param.path}
+	}
+
+	// Lock info the for the given operation ID shouldn't be `nil`.
+	if n.debugLockMap[param].lockInfo == nil {
+		return LockInfoOpsIDNotFound{param.volume, param.path, operationID}
+	}
+
+	if lockInfo, ok := n.debugLockMap[param].lockInfo[operationID]; ok {
+		// The entry for the lock origined at `lockOrigin` should already exist.
+		// If not return `LockInfoOriginNotFound`.
+		if lockInfo.lockOrigin != lockOrigin {
+			return LockInfoOriginNotFound{param.volume, param.path, operationID, lockOrigin}
+		}
+		// Status of the lock should already be set to "Blocked".
+		// If not return `LockInfoStateNotBlocked`.
+		if lockInfo.status != "Blocked" {
+			return LockInfoStateNotBlocked{param.volume, param.path, operationID}
+		}
+	} else {
+		// The lock info entry for given `opsID` should already exist for given <volume, path> pair.
+		// If not return `LockInfoOpsIDNotFound`.
+		return LockInfoOpsIDNotFound{param.volume, param.path, operationID}
+	}
+
+	// All checks finished.
+	// changing the status of the operation from blocked to running and updating the time.
+	n.debugLockMap[param].lockInfo[operationID] = newLockInfo
+
+	// After locking unblocks decrease the blocked counter.
+	n.blockedCounter--
+	// Increase the running counter.
+	n.runningLockCounter++
+	n.debugLockMap[param].blocked--
+	n.debugLockMap[param].running++
+	return nil
+}
+
+// change the state of the lock from Ready to Blocked.
+func (n *nsLockMap) statusNoneToBlocked(param nsParam, lockOrigin, operationID string, readLock bool) error {
+	if n.debugLockMap == nil {
+		return LockInfoNil{}
+	}
+
+	newLockInfo := debugLockInfo{
+		lockOrigin: lockOrigin,
+		status:     "Blocked",
+		since:      time.Now().UTC(),
+	}
+	if readLock {
+		newLockInfo.lockType = debugRLockStr
+	} else {
+		newLockInfo.lockType = debugWLockStr
+	}
+
+	if lockInfo, ok := n.debugLockMap[param]; ok {
+		if lockInfo == nil {
+			//  *debugLockInfoPerVolumePath entry is nil, initialize here to avoid any case of `nil` pointer access.
+			n.initLockInfoForVolumePath(param)
+		}
+	} else {
+		// State info entry for the given <volume, pair> doesn't exist, initializing it.
+		n.initLockInfoForVolumePath(param)
+	}
+
+	// lockInfo is a map[string]debugLockInfo, which holds map[OperationID]{status,time, origin} of the lock.
+	if n.debugLockMap[param].lockInfo == nil {
+		n.debugLockMap[param].lockInfo = make(map[string]debugLockInfo)
+	}
+	// The status of the operation with the given operation ID is marked blocked till its gets unblocked from the lock.
+	n.debugLockMap[param].lockInfo[operationID] = newLockInfo
+	// Increment the Global lock counter.
+	n.globalLockCounter++
+	// Increment the counter for number of blocked opertions, decrement it after the locking unblocks.
+	n.blockedCounter++
+	// increment the reference of the lock for the given <volume,path> pair.
+	n.debugLockMap[param].ref++
+	// increment the blocked counter for the given <volume, path> pair.
+	n.debugLockMap[param].blocked++
+	return nil
+}
+
+// deleteLockInfoEntry - Deletes the lock state information for given <volume, path> pair. Called when nsLk.ref count is 0.
+func (n *nsLockMap) deleteLockInfoEntryForVolumePath(param nsParam) error {
+	if n.debugLockMap == nil {
+		return LockInfoNil{}
+	}
+	// delete the lock info for the given operation.
+	if _, found := n.debugLockMap[param]; found {
+		// Remove from the map if there are no more references for the given (volume,path) pair.
+		delete(n.debugLockMap, param)
+	} else {
+		return LockInfoVolPathMssing{param.volume, param.path}
+	}
+	return nil
+}
+
+// deleteLockInfoEntry - Deletes the entry for given opsID in the lock state information of given <volume, path> pair.
+// called when the nsLk ref count for the given <volume, path> pair is not 0.
+func (n *nsLockMap) deleteLockInfoEntryForOps(param nsParam, operationID string) error {
+	if n.debugLockMap == nil {
+		return LockInfoNil{}
+	}
+	// delete the lock info for the given operation.
+	if infoMap, found := n.debugLockMap[param]; found {
+		// the opertion finished holding the lock on the resource, remove the entry for the given operation with the operation ID.
+		if _, foundInfo := infoMap.lockInfo[operationID]; foundInfo {
+			// decrease the global running and lock reference counter.
+			n.runningLockCounter--
+			n.globalLockCounter--
+			// decrease the lock referene counter for the lock info for given <volume,path> pair.
+			// decrease the running operation number. Its assumed that the operation is over once an attempt to release the lock is made.
+			infoMap.running--
+			// decrease the total reference count of locks jeld on <volume,path> pair.
+			infoMap.ref--
+			delete(infoMap.lockInfo, operationID)
+		} else {
+			// Unlock request with invalid opertion ID not accepted.
+			return LockInfoOpsIDNotFound{param.volume, param.path, operationID}
+		}
+	} else {
+		return LockInfoVolPathMssing{param.volume, param.path}
+	}
+	return nil
+}
+
+// return randomly generated string ID if lock debug is enabled,
+// else returns empty string
+func getOpsID() (opsID string) {
+	// check if lock debug is enabled.
+	if globalDebugLock {
+		// generated random ID.
+		opsID = string(generateRequestID())
+	}
+	return opsID
+}

--- a/cmd/lock-instrument_test.go
+++ b/cmd/lock-instrument_test.go
@@ -1,0 +1,660 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+type lockStateCase struct {
+	volume      string
+	path        string
+	lockOrigin  string
+	opsID       string
+	readLock    bool // lock type.
+	setBlocked  bool // initialize the initial state to blocked.
+	expectedErr error
+	// expected global lock stats.
+	expectedLockStatus string // Status of the lock Blocked/Running.
+
+	expectedGlobalLockCount  int // Total number of locks held across the system, includes blocked + held locks.
+	expectedBlockedLockCount int // Total blocked lock across the system.
+	expectedRunningLockCount int // Total succesfully held locks (non-blocking).
+	// expected lock statu for given <volume, path> pair.
+	expectedVolPathLockCount    int // Total locks held for given <volume,path> pair, includes blocked locks.
+	expectedVolPathRunningCount int // Total succcesfully held locks for given <volume, path> pair.
+	expectedVolPathBlockCount   int // Total locks blocked on the given <volume, path> pair.
+}
+
+func verifyGlobalLockStats(l lockStateCase, t *testing.T, testNum int) {
+	nsMutex.mutex.Lock()
+
+	// Verifying the lock stats.
+	if nsMutex.globalLockCounter != int64(l.expectedGlobalLockCount) {
+		t.Errorf("Test %d: Expected the global lock counter to be %v, but got %v", testNum, int64(l.expectedGlobalLockCount),
+			nsMutex.globalLockCounter)
+	}
+	// verify the count for total blocked locks.
+	if nsMutex.blockedCounter != int64(l.expectedBlockedLockCount) {
+		t.Errorf("Test %d: Expected the total blocked lock counter to be %v, but got %v", testNum, int64(l.expectedBlockedLockCount),
+			nsMutex.blockedCounter)
+	}
+	// verify the count for total running locks.
+	if nsMutex.runningLockCounter != int64(l.expectedRunningLockCount) {
+		t.Errorf("Test %d: Expected the total running lock counter to be %v, but got %v", testNum, int64(l.expectedRunningLockCount),
+			nsMutex.runningLockCounter)
+	}
+	nsMutex.mutex.Unlock()
+	// Verifying again with the JSON response of the lock info.
+	// Verifying the lock stats.
+	sysLockState, err := generateSystemLockResponse()
+	if err != nil {
+		t.Fatalf("Obtaining lock info failed with <ERROR> %s", err)
+
+	}
+	if sysLockState.TotalLocks != int64(l.expectedGlobalLockCount) {
+		t.Errorf("Test %d: Expected the global lock counter to be %v, but got %v", testNum, int64(l.expectedGlobalLockCount),
+			sysLockState.TotalLocks)
+	}
+	// verify the count for total blocked locks.
+	if sysLockState.TotalBlockedLocks != int64(l.expectedBlockedLockCount) {
+		t.Errorf("Test %d: Expected the total blocked lock counter to be %v, but got %v", testNum, int64(l.expectedBlockedLockCount),
+			sysLockState.TotalBlockedLocks)
+	}
+	// verify the count for total running locks.
+	if sysLockState.TotalAcquiredLocks != int64(l.expectedRunningLockCount) {
+		t.Errorf("Test %d: Expected the total running lock counter to be %v, but got %v", testNum, int64(l.expectedRunningLockCount),
+			sysLockState.TotalAcquiredLocks)
+	}
+}
+
+func verifyLockStats(l lockStateCase, t *testing.T, testNum int) {
+	nsMutex.mutex.Lock()
+	defer nsMutex.mutex.Unlock()
+	param := nsParam{l.volume, l.path}
+
+	// Verify the total locks (blocked+running) for given <vol,path> pair.
+	if nsMutex.debugLockMap[param].ref != int64(l.expectedVolPathLockCount) {
+		t.Errorf("Test %d: Expected the total lock count for volume: \"%s\", path: \"%s\" to be %v, but got %v", testNum,
+			param.volume, param.path, int64(l.expectedVolPathLockCount), nsMutex.debugLockMap[param].ref)
+	}
+	// Verify the total running locks for given <volume, path> pair.
+	if nsMutex.debugLockMap[param].running != int64(l.expectedVolPathRunningCount) {
+		t.Errorf("Test %d: Expected the total running locks for volume: \"%s\", path: \"%s\" to be %v, but got %v", testNum, param.volume, param.path,
+			int64(l.expectedVolPathRunningCount), nsMutex.debugLockMap[param].running)
+	}
+	// Verify the total blocked locks for givne <volume, path> pair.
+	if nsMutex.debugLockMap[param].blocked != int64(l.expectedVolPathBlockCount) {
+		t.Errorf("Test %d:  Expected the total blocked locks for volume: \"%s\", path: \"%s\"  to be %v, but got %v", testNum, param.volume, param.path,
+			int64(l.expectedVolPathBlockCount), nsMutex.debugLockMap[param].blocked)
+	}
+}
+
+func verifyLockState(l lockStateCase, t *testing.T, testNum int) {
+
+	param := nsParam{l.volume, l.path}
+
+	verifyGlobalLockStats(l, t, testNum)
+	nsMutex.mutex.Lock()
+	// Verifying the lock statuS fields.
+	if debugLockMap, ok := nsMutex.debugLockMap[param]; ok {
+		if lockInfo, ok := debugLockMap.lockInfo[l.opsID]; ok {
+			// Validating the lock type filed in the debug lock information.
+			if l.readLock {
+				if lockInfo.lockType != debugRLockStr {
+					t.Fatalf("Test case %d: Expected the lock type in the lock debug info to be \"%s\"", testNum, debugRLockStr)
+				}
+			} else {
+				if lockInfo.lockType != debugWLockStr {
+					t.Fatalf("Test case %d: Expected the lock type in the lock debug info to be \"%s\"", testNum, debugWLockStr)
+				}
+			}
+
+			// validating the lock origin.
+			if l.lockOrigin != lockInfo.lockOrigin {
+				t.Fatalf("Test %d: Expected the lock origin info to be \"%s\", but got \"%s\"", testNum, l.lockOrigin, lockInfo.lockOrigin)
+			}
+			// validating the status of the lock.
+			if lockInfo.status != l.expectedLockStatus {
+				t.Fatalf("Test %d: Expected the status of the lock to be \"%s\", but got \"%s\"", testNum, l.expectedLockStatus, lockInfo.status)
+			}
+		} else {
+			// Stop the tests if lock debug entry for given <volume, path> pair is not found.
+			t.Fatalf("Test case %d: Expected an debug lock entry for opsID \"%s\"", testNum, l.opsID)
+		}
+	} else {
+		// To change the status the entry for given <volume, path> should exist in the lock info struct.
+		t.Fatalf("Test case %d: Debug lock entry for volume: %s, path: %s doesn't exist", testNum, param.volume, param.path)
+	}
+	// verifyLockStats holds its own lock.
+	nsMutex.mutex.Unlock()
+
+	// verify the lock count.
+	verifyLockStats(l, t, testNum)
+}
+
+// TestNewDebugLockInfoPerVolumePath -  Validates the values initialized by newDebugLockInfoPerVolumePath().
+func TestNewDebugLockInfoPerVolumePath(t *testing.T) {
+	lockInfo := newDebugLockInfoPerVolumePath()
+
+	if lockInfo.ref != 0 {
+		t.Errorf("Expected initial reference value of total locks to be 0, got %d", lockInfo.ref)
+	}
+	if lockInfo.blocked != 0 {
+		t.Errorf("Expected initial reference of blocked locks to be 0, got %d", lockInfo.blocked)
+	}
+	if lockInfo.running != 0 {
+		t.Errorf("Expected initial reference value of held locks to be 0, got %d", lockInfo.running)
+	}
+}
+
+// TestNsLockMapStatusBlockedToRunning - Validates the function for changing the lock state from blocked to running.
+func TestNsLockMapStatusBlockedToRunning(t *testing.T) {
+
+	testCases := []struct {
+		volume      string
+		path        string
+		lockOrigin  string
+		opsID       string
+		readLock    bool // lock type.
+		setBlocked  bool // initialize the initial state to blocked.
+		expectedErr error
+	}{
+		// Test case - 1.
+		{
+
+			volume:     "my-bucket",
+			path:       "my-object",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "abcd1234",
+			readLock:   true,
+			setBlocked: true,
+			// expected metrics.
+			expectedErr: nil,
+		},
+		// Test case - 2.
+		// No entry for <volume, path> pair.
+		// So an attempt to change the state of the lock from `Blocked`->`Running` should fail.
+		{
+
+			volume:     "my-bucket",
+			path:       "my-object-2",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "abcd1234",
+			readLock:   false,
+			setBlocked: false,
+			// expected metrics.
+			expectedErr: LockInfoVolPathMssing{"my-bucket", "my-object-2"},
+		},
+		// Test case - 3.
+		// Entry for the given operationID doesn't exist in the lock state info.
+		{
+			volume:     "my-bucket",
+			path:       "my-object",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "ops-Id-not-registered",
+			readLock:   true,
+			setBlocked: false,
+			// expected metrics.
+			expectedErr: LockInfoOpsIDNotFound{"my-bucket", "my-object", "ops-Id-not-registered"},
+		},
+		// Test case - 4.
+		// Test case with non-existent lock origin.
+		{
+			volume:     "my-bucket",
+			path:       "my-object",
+			lockOrigin: "Bad Origin",
+			opsID:      "abcd1234",
+			readLock:   true,
+			setBlocked: false,
+			// expected metrics.
+			expectedErr: LockInfoOriginNotFound{"my-bucket", "my-object", "abcd1234", "Bad Origin"},
+		},
+		// Test case - 5.
+		// Test case with write lock.
+		{
+
+			volume:     "my-bucket",
+			path:       "my-object",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "abcd1234",
+			readLock:   false,
+			setBlocked: true,
+			// expected metrics.
+			expectedErr: nil,
+		},
+	}
+
+	param := nsParam{testCases[0].volume, testCases[0].path}
+	// Testing before the initialization done.
+	// Since the data structures for
+	actualErr := nsMutex.statusBlockedToRunning(param, testCases[0].lockOrigin,
+		testCases[0].opsID, testCases[0].readLock)
+
+	expectedNilErr := LockInfoNil{}
+	if actualErr != expectedNilErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedNilErr, actualErr)
+	}
+
+	nsMutex = &nsLockMap{
+		// entries of <volume,path> -> stateInfo of locks, for instrumentation purpose.
+		debugLockMap: make(map[nsParam]*debugLockInfoPerVolumePath),
+		lockMap:      make(map[nsParam]*nsLock),
+	}
+	// Entry for <volume, path> pair is set to nil.
+	// Should fail with `LockInfoNil{}`.
+	nsMutex.debugLockMap[param] = nil
+	actualErr = nsMutex.statusBlockedToRunning(param, testCases[0].lockOrigin,
+		testCases[0].opsID, testCases[0].readLock)
+
+	expectedNilErr = LockInfoNil{}
+	if actualErr != expectedNilErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedNilErr, actualErr)
+	}
+
+	// Setting the lock info the be `nil`.
+	nsMutex.debugLockMap[param] = &debugLockInfoPerVolumePath{
+		lockInfo: nil, // setting the lockinfo to nil.
+		ref:      0,
+		blocked:  0,
+		running:  0,
+	}
+
+	actualErr = nsMutex.statusBlockedToRunning(param, testCases[0].lockOrigin,
+		testCases[0].opsID, testCases[0].readLock)
+
+	expectedOpsErr := LockInfoOpsIDNotFound{testCases[0].volume, testCases[0].path, testCases[0].opsID}
+	if actualErr != expectedOpsErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedOpsErr, actualErr)
+	}
+
+	// Next case: ase whether an attempt to change the state of the lock to "Running" done,
+	// but the initial state if already "Running". Such an attempt should fail
+	nsMutex.debugLockMap[param] = &debugLockInfoPerVolumePath{
+		lockInfo: make(map[string]debugLockInfo),
+		ref:      0,
+		blocked:  0,
+		running:  0,
+	}
+
+	// Setting the status of the lock to be "Running".
+	// The initial state of the lock should set to "Blocked", otherwise its not possible to change the state from "Blocked" -> "Running".
+	nsMutex.debugLockMap[param].lockInfo[testCases[0].opsID] = debugLockInfo{
+		lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+		status:     "Running", // State set to "Running". Should fail with `LockInfoStateNotBlocked`.
+		since:      time.Now().UTC(),
+	}
+
+	actualErr = nsMutex.statusBlockedToRunning(param, testCases[0].lockOrigin,
+		testCases[0].opsID, testCases[0].readLock)
+
+	expectedBlockErr := LockInfoStateNotBlocked{testCases[0].volume, testCases[0].path, testCases[0].opsID}
+	if actualErr != expectedBlockErr {
+		t.Fatalf("Errors mismatch: Expected: \"%s\", got: \"%s\"", expectedBlockErr, actualErr)
+	}
+
+	// enabling lock instrumentation.
+	globalDebugLock = true
+	// initializing the locks.
+	initNSLock()
+	// set debug lock info  to `nil` so that the next tests have to initialize them again.
+	defer func() {
+		globalDebugLock = false
+		nsMutex.debugLockMap = nil
+	}()
+	// Iterate over the cases and assert the result.
+	for i, testCase := range testCases {
+		param := nsParam{testCase.volume, testCase.path}
+		// status of the lock to be set to "Blocked", before setting Blocked->Running.
+		if testCase.setBlocked {
+			nsMutex.mutex.Lock()
+			err := nsMutex.statusNoneToBlocked(param, testCase.lockOrigin, testCase.opsID, testCase.readLock)
+			if err != nil {
+				t.Fatalf("Test %d: Initializing the initial state to Blocked failed <ERROR> %s", i+1, err)
+			}
+			nsMutex.mutex.Unlock()
+		}
+		// invoking the method under test.
+		actualErr = nsMutex.statusBlockedToRunning(param, testCase.lockOrigin, testCase.opsID, testCase.readLock)
+		if actualErr != testCase.expectedErr {
+			t.Fatalf("Test %d: Errors mismatch: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, actualErr)
+		}
+		// In case of no error proceed with validating the lock state information.
+		if actualErr == nil {
+			// debug entry for given <volume, path> pair should exist.
+			if debugLockMap, ok := nsMutex.debugLockMap[param]; ok {
+				if lockInfo, ok := debugLockMap.lockInfo[testCase.opsID]; ok {
+					// Validating the lock type filed in the debug lock information.
+					if testCase.readLock {
+						if lockInfo.lockType != debugRLockStr {
+							t.Errorf("Test case %d: Expected the lock type in the lock debug info to be \"%s\"", i+1, debugRLockStr)
+						}
+					} else {
+						if lockInfo.lockType != debugWLockStr {
+							t.Errorf("Test case %d: Expected the lock type in the lock debug info to be \"%s\"", i+1, debugWLockStr)
+						}
+					}
+
+					// validating the lock origin.
+					if testCase.lockOrigin != lockInfo.lockOrigin {
+						t.Errorf("Test %d: Expected the lock origin info to be \"%s\", but got \"%s\"", i+1, testCase.lockOrigin, lockInfo.lockOrigin)
+					}
+					// validating the status of the lock.
+					if lockInfo.status != "Running" {
+						t.Errorf("Test %d: Expected the status of the lock to be \"%s\", but got \"%s\"", i+1, "Running", lockInfo.status)
+					}
+				} else {
+					// Stop the tests if lock debug entry for given <volume, path> pair is not found.
+					t.Fatalf("Test case %d: Expected an debug lock entry for opsID \"%s\"", i+1, testCase.opsID)
+				}
+			} else {
+				// To change the status the entry for given <volume, path> should exist in the lock info struct.
+				t.Fatalf("Test case %d: Debug lock entry for  volume: %s, path: %s doesn't exist", i+1, param.volume, param.path)
+			}
+		}
+	}
+
+}
+
+// TestNsLockMapStatusNoneToBlocked - Validates the function for changing the lock state to blocked
+func TestNsLockMapStatusNoneToBlocked(t *testing.T) {
+
+	testCases := []lockStateCase{
+		// Test case - 1.
+		{
+
+			volume:     "my-bucket",
+			path:       "my-object",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "abcd1234",
+			readLock:   true,
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  1,
+			expectedRunningLockCount: 0,
+			expectedBlockedLockCount: 1,
+
+			expectedVolPathLockCount:    1,
+			expectedVolPathRunningCount: 0,
+			expectedVolPathBlockCount:   1,
+		},
+		// Test case - 2.
+		// No entry for <volume, path> pair.
+		// So an attempt to change the state of the lock from `Blocked`->`Running` should fail.
+		{
+
+			volume:     "my-bucket",
+			path:       "my-object-2",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "abcd1234",
+			readLock:   false,
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  2,
+			expectedRunningLockCount: 0,
+			expectedBlockedLockCount: 2,
+
+			expectedVolPathLockCount:    1,
+			expectedVolPathRunningCount: 0,
+			expectedVolPathBlockCount:   1,
+		},
+		// Test case - 3.
+		// Entry for the given operationID doesn't exist in the lock state info.
+		// The entry should be created and relevant counters should be set.
+		{
+			volume:     "my-bucket",
+			path:       "my-object",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "ops-Id-not-registered",
+			readLock:   true,
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  3,
+			expectedRunningLockCount: 0,
+			expectedBlockedLockCount: 3,
+
+			expectedVolPathLockCount:    2,
+			expectedVolPathRunningCount: 0,
+			expectedVolPathBlockCount:   2,
+		},
+	}
+
+	param := nsParam{testCases[0].volume, testCases[0].path}
+	// Testing before the initialization done.
+	// Since the data structures for
+	actualErr := nsMutex.statusBlockedToRunning(param, testCases[0].lockOrigin,
+		testCases[0].opsID, testCases[0].readLock)
+
+	expectedNilErr := LockInfoNil{}
+	if actualErr != expectedNilErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedNilErr, actualErr)
+	}
+	// enabling lock instrumentation.
+	globalDebugLock = true
+	// initializing the locks.
+	initNSLock()
+	// set debug lock info  to `nil` so that the next tests have to initialize them again.
+	defer func() {
+		nsMutex.debugLockMap = nil
+	}()
+	// Iterate over the cases and assert the result.
+	for i, testCase := range testCases {
+		nsMutex.mutex.Lock()
+		param := nsParam{testCase.volume, testCase.path}
+		actualErr := nsMutex.statusNoneToBlocked(param, testCase.lockOrigin, testCase.opsID, testCase.readLock)
+		if actualErr != testCase.expectedErr {
+			t.Fatalf("Test %d: Errors mismatch: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, actualErr)
+		}
+		nsMutex.mutex.Unlock()
+		if actualErr == nil {
+			verifyLockState(testCase, t, i+1)
+		}
+	}
+}
+
+// TestNsLockMapDeleteLockInfoEntryForOps - Validates the removal of entry for given Operational ID from the lock info.
+func TestNsLockMapDeleteLockInfoEntryForOps(t *testing.T) {
+	testCases := []lockStateCase{
+		// Test case - 1.
+		{
+			volume:     "my-bucket",
+			path:       "my-object",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "abcd1234",
+			readLock:   true,
+			// expected metrics.
+		},
+	}
+	// case  - 1.
+	// Testing the case where delete lock info is attempted even before the lock is initialized.
+	param := nsParam{testCases[0].volume, testCases[0].path}
+	// Testing before the initialization done.
+
+	actualErr := nsMutex.deleteLockInfoEntryForOps(param, testCases[0].opsID)
+
+	expectedNilErr := LockInfoNil{}
+	if actualErr != expectedNilErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedNilErr, actualErr)
+	}
+
+	// enabling lock instrumentation.
+	globalDebugLock = true
+	// initializing the locks.
+	initNSLock()
+	// set debug lock info  to `nil` so that the next tests have to initialize them again.
+	defer func() {
+		nsMutex.debugLockMap = nil
+	}()
+	// case - 2.
+	// Case where an attempt to delete the entry for non-existent <volume, path> pair is done.
+	// Set the status of the lock to blocked and then to running.
+	nonExistParam := nsParam{volume: "non-exist-volume", path: "non-exist-path"}
+	actualErr = nsMutex.deleteLockInfoEntryForOps(nonExistParam, testCases[0].opsID)
+
+	expectedVolPathErr := LockInfoVolPathMssing{nonExistParam.volume, nonExistParam.path}
+	if actualErr != expectedVolPathErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedVolPathErr, actualErr)
+	}
+
+	// Case - 3.
+	// Lock state is set to Running and then an attempt to delete the info for non-existant opsID done.
+	nsMutex.mutex.Lock()
+	err := nsMutex.statusNoneToBlocked(param, testCases[0].lockOrigin, testCases[0].opsID, testCases[0].readLock)
+	if err != nil {
+		t.Fatalf("Setting lock status to Blocked failed: <ERROR> %s", err)
+	}
+	nsMutex.mutex.Unlock()
+	err = nsMutex.statusBlockedToRunning(param, testCases[0].lockOrigin, testCases[0].opsID, testCases[0].readLock)
+	if err != nil {
+		t.Fatalf("Setting lock status to Running failed: <ERROR> %s", err)
+	}
+	actualErr = nsMutex.deleteLockInfoEntryForOps(param, "non-existant-OpsID")
+
+	expectedOpsIDErr := LockInfoOpsIDNotFound{param.volume, param.path, "non-existant-OpsID"}
+	if actualErr != expectedOpsIDErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedOpsIDErr, actualErr)
+	}
+	// case - 4.
+	// Attempt to delete an registered entry is done.
+	// All metrics should be 0 after deleting the entry.
+
+	// Verify that the entry the opsID exists.
+	if debugLockMap, ok := nsMutex.debugLockMap[param]; ok {
+		if _, ok := debugLockMap.lockInfo[testCases[0].opsID]; !ok {
+			t.Fatalf("Entry for OpsID \"%s\" in <volume> %s, <path> %s should have existed. ", testCases[0].opsID, param.volume, param.path)
+		}
+	} else {
+		t.Fatalf("Entry for <volume> %s, <path> %s should have existed. ", param.volume, param.path)
+	}
+
+	actualErr = nsMutex.deleteLockInfoEntryForOps(param, testCases[0].opsID)
+	if actualErr != nil {
+		t.Fatalf("Expected the error to be <nil>, but got <ERROR> %s", actualErr)
+	}
+
+	// Verify that the entry for the opsId doesn't exists.
+	if debugLockMap, ok := nsMutex.debugLockMap[param]; ok {
+		if _, ok := debugLockMap.lockInfo[testCases[0].opsID]; ok {
+			t.Fatalf("The entry for opsID \"%s\" should have been deleted", testCases[0].opsID)
+		}
+	} else {
+		t.Fatalf("Entry for <volume> %s, <path> %s should have existed. ", param.volume, param.path)
+	}
+	if nsMutex.runningLockCounter != int64(0) {
+		t.Errorf("Expected the count of total running locks to be %v, but got %v", int64(0), nsMutex.runningLockCounter)
+	}
+	if nsMutex.blockedCounter != int64(0) {
+		t.Errorf("Expected the count of total blocked locks to be %v, but got %v", int64(0), nsMutex.blockedCounter)
+	}
+	if nsMutex.globalLockCounter != int64(0) {
+		t.Errorf("Expected the count of all locks to be %v, but got %v", int64(0), nsMutex.globalLockCounter)
+	}
+}
+
+// TestNsLockMapDeleteLockInfoEntryForVolumePath - Tests validate the logic for removal
+// of entry for given <volume, path> pair from lock info.
+func TestNsLockMapDeleteLockInfoEntryForVolumePath(t *testing.T) {
+	testCases := []lockStateCase{
+		// Test case - 1.
+		{
+			volume:     "my-bucket",
+			path:       "my-object",
+			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
+			opsID:      "abcd1234",
+			readLock:   true,
+			// expected metrics.
+		},
+	}
+	// case  - 1.
+	// Testing the case where delete lock info is attempted even before the lock is initialized.
+	param := nsParam{testCases[0].volume, testCases[0].path}
+	// Testing before the initialization done.
+
+	actualErr := nsMutex.deleteLockInfoEntryForVolumePath(param)
+
+	expectedNilErr := LockInfoNil{}
+	if actualErr != expectedNilErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedNilErr, actualErr)
+	}
+
+	// enabling lock instrumentation.
+	globalDebugLock = true
+	// initializing the locks.
+	initNSLock()
+	// set debug lock info  to `nil` so that the next tests have to initialize them again.
+	defer func() {
+		nsMutex.debugLockMap = nil
+	}()
+	// case - 2.
+	// Case where an attempt to delete the entry for non-existent <volume, path> pair is done.
+	// Set the status of the lock to blocked and then to running.
+	nonExistParam := nsParam{volume: "non-exist-volume", path: "non-exist-path"}
+	actualErr = nsMutex.deleteLockInfoEntryForVolumePath(nonExistParam)
+
+	expectedVolPathErr := LockInfoVolPathMssing{nonExistParam.volume, nonExistParam.path}
+	if actualErr != expectedVolPathErr {
+		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedVolPathErr, actualErr)
+	}
+
+	// case - 3.
+	// Attempt to delete an registered entry is done.
+	// All metrics should be 0 after deleting the entry.
+
+	// Registering the entry first.
+	nsMutex.mutex.Lock()
+	err := nsMutex.statusNoneToBlocked(param, testCases[0].lockOrigin, testCases[0].opsID, testCases[0].readLock)
+	if err != nil {
+		t.Fatalf("Setting lock status to Blocked failed: <ERROR> %s", err)
+	}
+	nsMutex.mutex.Unlock()
+	err = nsMutex.statusBlockedToRunning(param, testCases[0].lockOrigin, testCases[0].opsID, testCases[0].readLock)
+	if err != nil {
+		t.Fatalf("Setting lock status to Running failed: <ERROR> %s", err)
+	}
+	// Verify that the entry the for given <volume, path> exists.
+	if _, ok := nsMutex.debugLockMap[param]; !ok {
+		t.Fatalf("Entry for <volume> %s, <path> %s should have existed.", param.volume, param.path)
+	}
+	// first delete the entry for the operation ID.
+	err = nsMutex.deleteLockInfoEntryForOps(param, testCases[0].opsID)
+	actualErr = nsMutex.deleteLockInfoEntryForVolumePath(param)
+	if actualErr != nil {
+		t.Fatalf("Expected the error to be <nil>, but got <ERROR> %s", actualErr)
+	}
+
+	// Verify that the entry for the opsId doesn't exists.
+	if _, ok := nsMutex.debugLockMap[param]; ok {
+		t.Fatalf("Entry for <volume> %s, <path> %s should have been deleted. ", param.volume, param.path)
+	}
+	// The lock count values should be 0.
+	if nsMutex.runningLockCounter != int64(0) {
+		t.Errorf("Expected the count of total running locks to be %v, but got %v", int64(0), nsMutex.runningLockCounter)
+	}
+	if nsMutex.blockedCounter != int64(0) {
+		t.Errorf("Expected the count of total blocked locks to be %v, but got %v", int64(0), nsMutex.blockedCounter)
+	}
+	if nsMutex.globalLockCounter != int64(0) {
+		t.Errorf("Expected the count of all locks to be %v, but got %v", int64(0), nsMutex.globalLockCounter)
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,6 +63,8 @@ func init() {
 
 	// Set global trace flag.
 	globalTrace = os.Getenv("MINIO_TRACE") == "1"
+	// Set all the debug flags from ENV if any.
+	setGlobalsDebugFromEnv()
 }
 
 func migrate() {

--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"runtime"
 	"sync"
 )
 
@@ -36,8 +38,13 @@ type nsLock struct {
 // nsLockMap - namespace lock map, provides primitives to Lock,
 // Unlock, RLock and RUnlock.
 type nsLockMap struct {
-	lockMap map[nsParam]*nsLock
-	mutex   sync.Mutex
+	// lock counter using for lock debugging.
+	globalLockCounter  int64                                   //total locks held.
+	blockedCounter     int64                                   // total operations blocked waiting for locks.
+	runningLockCounter int64                                   // total locks held but not released yet.
+	debugLockMap       map[nsParam]*debugLockInfoPerVolumePath // info for instrumentation on locks.
+	lockMap            map[nsParam]*nsLock                     // RLock, WLock locks used for operations.
+	mutex              sync.Mutex
 }
 
 // Global name space lock.
@@ -45,16 +52,31 @@ var nsMutex *nsLockMap
 
 // initNSLock - initialize name space lock map.
 func initNSLock() {
-	nsMutex = &nsLockMap{
-		lockMap: make(map[nsParam]*nsLock),
+	if globalDebugLock {
+		// lock Debugging enabed, initialize nsLockMap with entry for debugging information.
+		nsMutex = &nsLockMap{
+			// entries of <volume,path> -> stateInfo of locks, for instrumentation purpose.
+			debugLockMap: make(map[nsParam]*debugLockInfoPerVolumePath),
+			lockMap:      make(map[nsParam]*nsLock),
+		}
+	} else {
+		nsMutex = &nsLockMap{
+			lockMap: make(map[nsParam]*nsLock),
+		}
 	}
 }
 
+func (n *nsLockMap) initLockInfoForVolumePath(param nsParam) {
+	n.debugLockMap[param] = newDebugLockInfoPerVolumePath()
+}
+
 // Lock the namespace resource.
-func (n *nsLockMap) lock(volume, path string, readLock bool) {
+func (n *nsLockMap) lock(volume, path string, lockOrigin, opsID string, readLock bool) {
 	n.mutex.Lock()
 
+	// <volume, path> pair. This is the key for storing locks and state info of locks.
 	param := nsParam{volume, path}
+	// checking if any locks for givne <volume, pair> already held.
 	nsLk, found := n.lockMap[param]
 	if !found {
 		nsLk = &nsLock{
@@ -62,65 +84,130 @@ func (n *nsLockMap) lock(volume, path string, readLock bool) {
 		}
 		n.lockMap[param] = nsLk
 	}
+
 	nsLk.ref++ // Update ref count here to avoid multiple races.
 	// Unlock map before Locking NS which might block.
-	n.mutex.Unlock()
 
+	if globalDebugLock {
+		// change the state of the lock to be  blocked for the given pair of <volume, path> and <OperationID> till the lock unblocks.
+		// The lock for accessing `nsMutex` is held inside the function itself.
+		err := n.statusNoneToBlocked(param, lockOrigin, opsID, readLock)
+		if err != nil {
+			errorIf(err, "Failed to set lock state to blocked.")
+		}
+	}
+
+	n.mutex.Unlock()
 	// Locking here can block.
 	if readLock {
+		// read lock blocks if write lock is held by other routines.
 		nsLk.RLock()
 	} else {
+		// write lock blocks if read/write lock for the resource is held by other routines.
 		nsLk.Lock()
+	}
+
+	// check if lock debugging enabled.
+	if globalDebugLock {
+		// Changing the status of the operation from blocked to running.
+		// change the state of the lock to be  running (from blocked) for the given pair of <volume, path> and <OperationID>.
+		err := n.statusBlockedToRunning(param, lockOrigin, opsID, readLock)
+		if err != nil {
+			errorIf(err, "Failed to set the lock state to running.")
+		}
 	}
 }
 
 // Unlock the namespace resource.
-func (n *nsLockMap) unlock(volume, path string, readLock bool) {
+func (n *nsLockMap) unlock(volume, path string, opsID string, readLock bool) {
 	// nsLk.Unlock() will not block, hence locking the map for the entire function is fine.
 	n.mutex.Lock()
+	// locking the lock information structure for udpating.
 	defer n.mutex.Unlock()
 
 	param := nsParam{volume, path}
+	// check if the volume, path pair exists in the entry.
 	if nsLk, found := n.lockMap[param]; found {
+		// if the lock held was readlock, then unlock the read lock.
 		if readLock {
 			nsLk.RUnlock()
 		} else {
+			// if the lock held was write lock, unlock the write lock.
 			nsLk.Unlock()
 		}
+		// the reference count cannot be zero when unlock is requseted.
 		if nsLk.ref == 0 {
 			errorIf(errors.New("Namespace reference count cannot be 0."), "Invalid reference count detected.")
 		}
+
 		if nsLk.ref != 0 {
 			nsLk.ref--
+			// locking debug enabled, delete the lock state entry for given operation ID.
+			if globalDebugLock {
+				err := n.deleteLockInfoEntryForOps(param, opsID)
+				if err != nil {
+					errorIf(err, "Failed to delete lock info entry.")
+				}
+			}
 		}
+
 		if nsLk.ref == 0 {
 			// Remove from the map if there are no more references.
 			delete(n.lockMap, param)
+			// locking debug enabled, delete the lock state entry for given <volume, path> pair.
+			if globalDebugLock {
+				err := n.deleteLockInfoEntryForVolumePath(param)
+				if err != nil {
+					errorIf(err, "Failed to delete lock info entry.")
+				}
+			}
 		}
 	}
 }
 
 // Lock - locks the given resource for writes, using a previously
 // allocated name space lock or initializing a new one.
-func (n *nsLockMap) Lock(volume, path string) {
+func (n *nsLockMap) Lock(volume, path string, opsID string) {
+	var lockOrigin string
+	// lock debugging enabled. The caller information of the lock held has be obtained here before calling any other function.
+	if globalDebugLock {
+		// fetching the package, function name and the line number of the caller from the runtime.
+		// here is an example https://play.golang.org/p/perrmNRI9_ .
+		pc, fn, line, success := runtime.Caller(1)
+		if !success {
+			errorIf(errors.New("Couldn't get caller info."), "Fetching caller info form runtime failed.")
+		}
+		lockOrigin = fmt.Sprintf("[lock held] in %s[%s:%d]", runtime.FuncForPC(pc).Name(), fn, line)
+	}
 	readLock := false
-	n.lock(volume, path, readLock)
+	n.lock(volume, path, lockOrigin, opsID, readLock)
 }
 
 // Unlock - unlocks any previously acquired write locks.
-func (n *nsLockMap) Unlock(volume, path string) {
+func (n *nsLockMap) Unlock(volume, path string, opsID string) {
 	readLock := false
-	n.unlock(volume, path, readLock)
+	n.unlock(volume, path, opsID, readLock)
 }
 
 // RLock - locks any previously acquired read locks.
-func (n *nsLockMap) RLock(volume, path string) {
+func (n *nsLockMap) RLock(volume, path, opsID string) {
+	var lockOrigin string
+	// lock debugging enabled. The caller information of the lock held has be obtained here before calling any other function.
+	if globalDebugLock {
+		// fetching the package, function name and the line number of the caller from the runtime.
+		// here is an example https://play.golang.org/p/perrmNRI9_ .
+		pc, fn, line, success := runtime.Caller(1)
+		if !success {
+			errorIf(errors.New("Couldn't get caller info."), "Fetching caller info form runtime failed.")
+		}
+		lockOrigin = fmt.Sprintf("[lock held] in %s[%s:%d]", runtime.FuncForPC(pc).Name(), fn, line)
+	}
 	readLock := true
-	n.lock(volume, path, readLock)
+	n.lock(volume, path, lockOrigin, opsID, readLock)
 }
 
 // RUnlock - unlocks any previously acquired read locks.
-func (n *nsLockMap) RUnlock(volume, path string) {
+func (n *nsLockMap) RUnlock(volume, path string, opsID string) {
 	readLock := true
-	n.unlock(volume, path, readLock)
+	n.unlock(volume, path, opsID, readLock)
 }

--- a/cmd/namespace-lock_test.go
+++ b/cmd/namespace-lock_test.go
@@ -16,16 +16,21 @@
 
 package cmd
 
-import "testing"
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
 
 // Tests functionality provided by namespace lock.
 func TestNamespaceLockTest(t *testing.T) {
 	// List of test cases.
 	testCases := []struct {
-		lk               func(s1, s2 string)
-		unlk             func(s1, s2 string)
-		rlk              func(s1, s2 string)
-		runlk            func(s1, s2 string)
+		lk               func(s1, s2, s3 string)
+		unlk             func(s1, s2, s3 string)
+		rlk              func(s1, s2, s3 string)
+		runlk            func(s1, s2, s3 string)
 		lkCount          int
 		lockedRefCount   uint
 		unlockedRefCount uint
@@ -58,7 +63,7 @@ func TestNamespaceLockTest(t *testing.T) {
 
 	// Write lock tests.
 	testCase := testCases[0]
-	testCase.lk("a", "b") // lock once.
+	testCase.lk("a", "b", "c") // lock once.
 	nsLk, ok := nsMutex.lockMap[nsParam{"a", "b"}]
 	if !ok && testCase.shouldPass {
 		t.Errorf("Lock in map missing.")
@@ -67,7 +72,7 @@ func TestNamespaceLockTest(t *testing.T) {
 	if testCase.lockedRefCount != nsLk.ref && testCase.shouldPass {
 		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 1, testCase.lockedRefCount, nsLk.ref)
 	}
-	testCase.unlk("a", "b") // unlock once.
+	testCase.unlk("a", "b", "c") // unlock once.
 	if testCase.unlockedRefCount != nsLk.ref && testCase.shouldPass {
 		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 1, testCase.unlockedRefCount, nsLk.ref)
 	}
@@ -78,10 +83,10 @@ func TestNamespaceLockTest(t *testing.T) {
 
 	// Read lock tests.
 	testCase = testCases[1]
-	testCase.rlk("a", "b") // lock once.
-	testCase.rlk("a", "b") // lock second time.
-	testCase.rlk("a", "b") // lock third time.
-	testCase.rlk("a", "b") // lock fourth time.
+	testCase.rlk("a", "b", "c") // lock once.
+	testCase.rlk("a", "b", "c") // lock second time.
+	testCase.rlk("a", "b", "c") // lock third time.
+	testCase.rlk("a", "b", "c") // lock fourth time.
 	nsLk, ok = nsMutex.lockMap[nsParam{"a", "b"}]
 	if !ok && testCase.shouldPass {
 		t.Errorf("Lock in map missing.")
@@ -90,8 +95,9 @@ func TestNamespaceLockTest(t *testing.T) {
 	if testCase.lockedRefCount != nsLk.ref && testCase.shouldPass {
 		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 1, testCase.lockedRefCount, nsLk.ref)
 	}
-	testCase.runlk("a", "b") // unlock once.
-	testCase.runlk("a", "b") // unlock second time.
+
+	testCase.runlk("a", "b", "c") // unlock once.
+	testCase.runlk("a", "b", "c") // unlock second time.
 	if testCase.unlockedRefCount != nsLk.ref && testCase.shouldPass {
 		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 2, testCase.unlockedRefCount, nsLk.ref)
 	}
@@ -102,7 +108,7 @@ func TestNamespaceLockTest(t *testing.T) {
 
 	// Read lock 0 ref count.
 	testCase = testCases[2]
-	testCase.rlk("a", "c") // lock once.
+	testCase.rlk("a", "c", "d") // lock once.
 
 	nsLk, ok = nsMutex.lockMap[nsParam{"a", "c"}]
 	if !ok && testCase.shouldPass {
@@ -112,7 +118,7 @@ func TestNamespaceLockTest(t *testing.T) {
 	if testCase.lockedRefCount != nsLk.ref && testCase.shouldPass {
 		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 3, testCase.lockedRefCount, nsLk.ref)
 	}
-	testCase.runlk("a", "c") // unlock once.
+	testCase.runlk("a", "c", "d") // unlock once.
 	if testCase.unlockedRefCount != nsLk.ref && testCase.shouldPass {
 		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 3, testCase.unlockedRefCount, nsLk.ref)
 	}
@@ -120,4 +126,215 @@ func TestNamespaceLockTest(t *testing.T) {
 	if ok && !testCase.shouldPass {
 		t.Errorf("Lock map not found.")
 	}
+}
+
+func TestLockStats(t *testing.T) {
+
+	expectedResult := []lockStateCase{
+		{
+
+			volume: "my-bucket",
+			path:   "my-object",
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  10,
+			expectedRunningLockCount: 10,
+			expectedBlockedLockCount: 0,
+
+			expectedVolPathLockCount:    10,
+			expectedVolPathRunningCount: 10,
+			expectedVolPathBlockCount:   0,
+		},
+		{
+
+			volume: "my-bucket",
+			path:   "my-object",
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  5,
+			expectedRunningLockCount: 5,
+			expectedBlockedLockCount: 0,
+
+			expectedVolPathLockCount:    5,
+			expectedVolPathRunningCount: 5,
+			expectedVolPathBlockCount:   0,
+		},
+		{
+
+			volume: "my-bucket",
+			path:   "my-object",
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  2,
+			expectedRunningLockCount: 1,
+			expectedBlockedLockCount: 1,
+
+			expectedVolPathLockCount:    2,
+			expectedVolPathRunningCount: 1,
+			expectedVolPathBlockCount:   1,
+		},
+		{
+
+			volume: "my-bucket",
+			path:   "my-object",
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  1,
+			expectedRunningLockCount: 0,
+			expectedBlockedLockCount: 1,
+
+			expectedVolPathLockCount:    1,
+			expectedVolPathRunningCount: 0,
+			expectedVolPathBlockCount:   1,
+		},
+		{
+
+			volume: "my-bucket",
+			path:   "my-object",
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  1,
+			expectedRunningLockCount: 1,
+			expectedBlockedLockCount: 0,
+
+			expectedVolPathLockCount:    1,
+			expectedVolPathRunningCount: 1,
+			expectedVolPathBlockCount:   0,
+		},
+		{
+
+			volume: "my-bucket",
+			path:   "my-object",
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  7,
+			expectedRunningLockCount: 5,
+			expectedBlockedLockCount: 2,
+
+			expectedVolPathLockCount:    7,
+			expectedVolPathRunningCount: 5,
+			expectedVolPathBlockCount:   2,
+		},
+		{
+			volume: "my-bucket",
+			path:   "my-object",
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  2,
+			expectedRunningLockCount: 0,
+			expectedBlockedLockCount: 2,
+
+			expectedVolPathLockCount:    2,
+			expectedVolPathRunningCount: 0,
+			expectedVolPathBlockCount:   2,
+		},
+		{
+
+			volume: "my-bucket",
+			path:   "my-object",
+			// expected metrics.
+			expectedErr:        nil,
+			expectedLockStatus: "Blocked",
+
+			expectedGlobalLockCount:  0,
+			expectedRunningLockCount: 0,
+			expectedBlockedLockCount: 0,
+		},
+	}
+	var wg sync.WaitGroup
+	// enabling lock instrumentation.
+	globalDebugLock = true
+	// initializing the locks.
+	initNSLock()
+	// hold 10 read locks.
+	for i := 0; i < 10; i++ {
+		nsMutex.RLock("my-bucket", "my-object", strconv.Itoa(i))
+	}
+	// expected lock info.
+	expectedLockStats := expectedResult[0]
+	// verify the actual lock info with the expected one.
+	verifyLockStats(expectedLockStats, t, 1)
+	// unlock 5 readlock.
+	for i := 0; i < 5; i++ {
+		nsMutex.RUnlock("my-bucket", "my-object", strconv.Itoa(i))
+	}
+
+	expectedLockStats = expectedResult[1]
+	// verify the actual lock info with the expected one.
+	verifyLockStats(expectedLockStats, t, 1)
+
+	syncChan := make(chan struct{}, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// blocks till all read locks are released.
+		nsMutex.Lock("my-bucket", "my-object", strconv.Itoa(10))
+		// Once the above attempt to lock is unblocked/acquired, we verify the stats and release the lock.
+		expectedWLockStats := expectedResult[2]
+		// Since the write lock acquired here, the number of blocked locks should reduce by 1 and
+		// count of running locks should increase by 1.
+		verifyLockStats(expectedWLockStats, t, 4)
+		// release the write lock.
+		nsMutex.Unlock("my-bucket", "my-object", strconv.Itoa(10))
+		// The number of running locks should decrease by 1.
+		expectedWLockStats = expectedResult[3]
+		verifyLockStats(expectedWLockStats, t, 4)
+		// Take the lock stats after the first write lock is unlocked.
+		// Only then unlock then second write lock.
+		syncChan <- struct{}{}
+	}()
+	// waiting so that the write locks in the above go routines are held.
+	// sleeping so that we can predict the order of the write locks held.
+	time.Sleep(100 * time.Millisecond)
+
+	// since there are 5 more readlocks still held on <"my-bucket","my-object">,
+	// an attempt to hold write locks blocks. So its run in a new go routine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// blocks till all read locks are released.
+		nsMutex.Lock("my-bucket", "my-object", strconv.Itoa(11))
+		// Once the above attempt to lock is unblocked/acquired, we release the lock.
+		// Unlock the second write lock only after lock stats for first write lock release is taken.
+		<-syncChan
+		// The number of running locks should decrease by 1.
+		expectedWLockStats := expectedResult[4]
+		verifyLockStats(expectedWLockStats, t, 5)
+		nsMutex.Unlock("my-bucket", "my-object", strconv.Itoa(11))
+	}()
+
+	expectedLockStats = expectedResult[5]
+
+	time.Sleep(1 * time.Second)
+	// verify the actual lock info with the expected one.
+	verifyLockStats(expectedLockStats, t, 2)
+
+	// unlock 5 readlock.
+	for i := 0; i < 5; i++ {
+		nsMutex.RUnlock("my-bucket", "my-object", strconv.Itoa(i+5))
+	}
+
+	expectedLockStats = expectedResult[6]
+	// verify the actual lock info with the expected one.
+	verifyLockStats(expectedLockStats, t, 3)
+	wg.Wait()
+
+	expectedLockStats = expectedResult[7]
+	// verify the actual lock info with the expected one.
+	verifyGlobalLockStats(expectedLockStats, t, 6)
+
 }

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -35,8 +35,12 @@ func (xl xlObjects) MakeBucket(bucket string) error {
 		return toObjectErr(errVolumeExists, bucket)
 	}
 
-	nsMutex.Lock(bucket, "")
-	defer nsMutex.Unlock(bucket, "")
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
+	nsMutex.Lock(bucket, "", opsID)
+	defer nsMutex.Unlock(bucket, "", opsID)
 
 	// Initialize sync waitgroup.
 	var wg = &sync.WaitGroup{}
@@ -157,8 +161,12 @@ func (xl xlObjects) getBucketInfo(bucketName string) (bucketInfo BucketInfo, err
 
 // Checks whether bucket exists.
 func (xl xlObjects) isBucketExist(bucket string) bool {
-	nsMutex.RLock(bucket, "")
-	defer nsMutex.RUnlock(bucket, "")
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
+	nsMutex.RLock(bucket, "", opsID)
+	defer nsMutex.RUnlock(bucket, "", opsID)
 
 	// Check whether bucket exists.
 	_, err := xl.getBucketInfo(bucket)
@@ -178,8 +186,13 @@ func (xl xlObjects) GetBucketInfo(bucket string) (BucketInfo, error) {
 	if !IsValidBucketName(bucket) {
 		return BucketInfo{}, BucketNameInvalid{Bucket: bucket}
 	}
-	nsMutex.RLock(bucket, "")
-	defer nsMutex.RUnlock(bucket, "")
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
+	nsMutex.RLock(bucket, "", opsID)
+	defer nsMutex.RUnlock(bucket, "", opsID)
+
 	bucketInfo, err := xl.getBucketInfo(bucket)
 	if err != nil {
 		return BucketInfo{}, toObjectErr(err, bucket)
@@ -253,9 +266,12 @@ func (xl xlObjects) DeleteBucket(bucket string) error {
 	if !xl.isBucketExist(bucket) {
 		return BucketNotFound{Bucket: bucket}
 	}
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
 
-	nsMutex.Lock(bucket, "")
-	defer nsMutex.Unlock(bucket, "")
+	nsMutex.Lock(bucket, "", opsID)
+	defer nsMutex.Unlock(bucket, "", opsID)
 
 	// Collect if all disks report volume not found.
 	var wg = &sync.WaitGroup{}

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -62,7 +62,10 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 	// List all upload ids for the keyMarker starting from
 	// uploadIDMarker first.
 	if uploadIDMarker != "" {
-		nsMutex.RLock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, keyMarker))
+		// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+		// used for instrumentation on locks.
+		opsID := getOpsID()
+		nsMutex.RLock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, keyMarker), opsID)
 		for _, disk := range xl.getLoadBalancedDisks() {
 			if disk == nil {
 				continue
@@ -76,7 +79,7 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 			}
 			break
 		}
-		nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, keyMarker))
+		nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, keyMarker), opsID)
 		if err != nil {
 			return ListMultipartsInfo{}, err
 		}
@@ -128,7 +131,11 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 			var end bool
 			uploadIDMarker = ""
 			// For the new object entry we get all its pending uploadIDs.
-			nsMutex.RLock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry))
+
+			// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+			// used for instrumentation on locks.
+			opsID := getOpsID()
+			nsMutex.RLock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry), opsID)
 			var disk StorageAPI
 			for _, disk = range xl.getLoadBalancedDisks() {
 				if disk == nil {
@@ -143,7 +150,7 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 				}
 				break
 			}
-			nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry))
+			nsMutex.RUnlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, entry), opsID)
 			if err != nil {
 				if isErrIgnored(err, walkResultIgnoredErrs) {
 					continue
@@ -269,9 +276,12 @@ func (xl xlObjects) newMultipartUpload(bucket string, object string, meta map[st
 	xlMeta.Stat.ModTime = time.Now().UTC()
 	xlMeta.Meta = meta
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
 	// This lock needs to be held for any changes to the directory contents of ".minio/multipart/object/"
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
 
 	uploadID = getUUID()
 	initiated := time.Now().UTC()
@@ -339,20 +349,24 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	var partsMetadata []xlMetaV1
 	var errs []error
 	uploadIDPath := pathJoin(mpartMetaPrefix, bucket, object, uploadID)
-	nsMutex.RLock(minioMetaBucket, uploadIDPath)
+
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+	nsMutex.RLock(minioMetaBucket, uploadIDPath, opsID)
 	// Validates if upload ID exists.
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
-		nsMutex.RUnlock(minioMetaBucket, uploadIDPath)
+		nsMutex.RUnlock(minioMetaBucket, uploadIDPath, opsID)
 		return "", InvalidUploadID{UploadID: uploadID}
 	}
 	// Read metadata associated with the object from all disks.
 	partsMetadata, errs = readAllXLMetadata(xl.storageDisks, minioMetaBucket,
 		uploadIDPath)
 	if !isDiskQuorum(errs, xl.writeQuorum) {
-		nsMutex.RUnlock(minioMetaBucket, uploadIDPath)
+		nsMutex.RUnlock(minioMetaBucket, uploadIDPath, opsID)
 		return "", toObjectErr(errXLWriteQuorum, bucket, object)
 	}
-	nsMutex.RUnlock(minioMetaBucket, uploadIDPath)
+	nsMutex.RUnlock(minioMetaBucket, uploadIDPath, opsID)
 
 	// List all online disks.
 	onlineDisks, modTime := listOnlineDisks(xl.storageDisks, partsMetadata, errs)
@@ -421,8 +435,12 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 		}
 	}
 
-	nsMutex.Lock(minioMetaBucket, uploadIDPath)
-	defer nsMutex.Unlock(minioMetaBucket, uploadIDPath)
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID = getOpsID()
+
+	nsMutex.Lock(minioMetaBucket, uploadIDPath, opsID)
+	defer nsMutex.Unlock(minioMetaBucket, uploadIDPath, opsID)
 
 	// Validate again if upload ID still exists.
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
@@ -565,9 +583,13 @@ func (xl xlObjects) ListObjectParts(bucket, object, uploadID string, partNumberM
 	if !IsValidObjectName(object) {
 		return ListPartsInfo{}, ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
+
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
 	// Hold lock so that there is no competing abort-multipart-upload or complete-multipart-upload.
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
 		return ListPartsInfo{}, InvalidUploadID{UploadID: uploadID}
@@ -600,8 +622,12 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	// Hold lock so that
 	// 1) no one aborts this multipart upload
 	// 2) no one does a parallel complete-multipart-upload on this multipart upload
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
+
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), getOpsID())
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
 		return "", InvalidUploadID{UploadID: uploadID}
@@ -712,15 +738,18 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	if rErr != nil {
 		return "", toObjectErr(rErr, minioMetaBucket, uploadIDPath)
 	}
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID = getOpsID()
 	// Hold write lock on the destination before rename.
-	nsMutex.Lock(bucket, object)
+	nsMutex.Lock(bucket, object, opsID)
 	defer func() {
 		// A new complete multipart upload invalidates any
 		// previously cached object in memory.
 		xl.objCache.Delete(path.Join(bucket, object))
 
 		// This lock also protects the cache namespace.
-		nsMutex.Unlock(bucket, object)
+		nsMutex.Unlock(bucket, object, opsID)
 
 		// Prefetch the object from disk by triggering a fake GetObject call
 		// Unlike a regular single PutObject,  multipart PutObject is comes in
@@ -761,10 +790,13 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	// Delete the previously successfully renamed object.
 	xl.deleteObject(minioMetaBucket, path.Join(tmpMetaPrefix, uniqueID))
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID = getOpsID()
 	// Hold the lock so that two parallel complete-multipart-uploads do not
 	// leave a stale uploads.json behind.
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
 
 	// Validate if there are other incomplete upload-id's present for
 	// the object, if yes do not attempt to delete 'uploads.json'.
@@ -804,8 +836,12 @@ func (xl xlObjects) abortMultipartUpload(bucket, object, uploadID string) (err e
 		return toObjectErr(err, bucket, object)
 	}
 
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object))
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object), opsID)
 	// Validate if there are other incomplete upload-id's present for
 	// the object, if yes do not attempt to delete 'uploads.json'.
 	uploadsJSON, err := xl.readUploadsJSON(bucket, object)
@@ -857,9 +893,13 @@ func (xl xlObjects) AbortMultipartUpload(bucket, object, uploadID string) error 
 		return ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
 	// Hold lock so that there is no competing complete-multipart-upload or put-object-part.
-	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
-	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID))
+	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
+	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
 		return InvalidUploadID{UploadID: uploadID}

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -56,9 +56,13 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 	if writer == nil {
 		return toObjectErr(errUnexpected, bucket, object)
 	}
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
 	// Lock the object before reading.
-	nsMutex.RLock(bucket, object)
-	defer nsMutex.RUnlock(bucket, object)
+	nsMutex.RLock(bucket, object, opsID)
+	defer nsMutex.RUnlock(bucket, object, opsID)
 
 	// Read metadata associated with the object from all disks.
 	metaArr, errs := readAllXLMetadata(xl.storageDisks, bucket, object)
@@ -226,9 +230,13 @@ func (xl xlObjects) HealObject(bucket, object string) error {
 		return ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
 	// Lock the object before healing.
-	nsMutex.RLock(bucket, object)
-	defer nsMutex.RUnlock(bucket, object)
+	nsMutex.RLock(bucket, object, opsID)
+	defer nsMutex.RUnlock(bucket, object, opsID)
 
 	partsMetadata, errs := readAllXLMetadata(xl.storageDisks, bucket, object)
 	if err := reduceErrs(errs, nil); err != nil {
@@ -350,8 +358,13 @@ func (xl xlObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
 	if !IsValidObjectName(object) {
 		return ObjectInfo{}, ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
-	nsMutex.RLock(bucket, object)
-	defer nsMutex.RUnlock(bucket, object)
+
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
+	nsMutex.RLock(bucket, object, opsID)
+	defer nsMutex.RUnlock(bucket, object, opsID)
 	info, err := xl.getObjectInfo(bucket, object)
 	if err != nil {
 		return ObjectInfo{}, toObjectErr(err, bucket, object)
@@ -609,9 +622,13 @@ func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.
 		}
 	}
 
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
 	// Lock the object.
-	nsMutex.Lock(bucket, object)
-	defer nsMutex.Unlock(bucket, object)
+	nsMutex.Lock(bucket, object, opsID)
+	defer nsMutex.Unlock(bucket, object, opsID)
 
 	// Check if an object is present as one of the parent dir.
 	// -- FIXME. (needs a new kind of lock).
@@ -724,8 +741,12 @@ func (xl xlObjects) DeleteObject(bucket, object string) (err error) {
 	if !IsValidObjectName(object) {
 		return ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
-	nsMutex.Lock(bucket, object)
-	defer nsMutex.Unlock(bucket, object)
+	// generates random string on setting MINIO_DEBUG=lock, else returns empty string.
+	// used for instrumentation on locks.
+	opsID := getOpsID()
+
+	nsMutex.Lock(bucket, object, opsID)
+	defer nsMutex.Unlock(bucket, object, opsID)
 
 	// Validate object exists.
 	if !xl.isObject(bucket, object) {


### PR DESCRIPTION
- Enabled by setting MINIO_DEBUG=lock. 
- Info avaialbe via endpoint, currently active on `/minio/debug/locks`
- Here is the current format

```
{
    "totalLocks": 1,
    "totalBlockedLocks": 0,
    "totalAcquiredLocks": 1,
    "locksInfoPerObject": [{
        "bucket": "testbucket",
        "object": "1gb",
        "locksOnObject": 1,
        "locksAcquiredOnObject": 1,
        "locksBlockedOnObject": 0,
        "LockDetailsOnObject": [{
            "opsID": "MCPNVX9ULMV16Q5S",
            "lockOrigin": "[lock held] in main.xlObjects.GetObject[/home/minio/gopath/src/github.com/minio/minio/xl-v1-object.go:64]",
            "lockType": "RLock",
            "status": "Running",
            "statusSince": "403.022271ms"
        }]
    }]
}
```
