### PR TITLE
api: xmlDecoder should honor contentLength.

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -322,10 +322,9 @@ func (api objectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	// the location value in the request body should match the Region in serverConfig.
-	// other values of location are not accepted.
-	// make bucket fails in such cases.
-	errCode := isValidLocationContraint(r.Body, serverConfig.GetRegion())
+	// Validate if incoming location constraint is valid, reject
+	// requests which do not follow valid region requirements.
+	errCode := isValidLocationConstraint(r)
 	if errCode != ErrNone {
 		writeErrorResponse(w, r, errCode, r.URL.Path)
 		return

--- a/utils.go
+++ b/utils.go
@@ -24,8 +24,14 @@ import (
 )
 
 // xmlDecoder provide decoded value in xml.
-func xmlDecoder(body io.Reader, v interface{}) error {
-	d := xml.NewDecoder(body)
+func xmlDecoder(body io.Reader, v interface{}, size int64) error {
+	var lbody io.Reader
+	if size > 0 {
+		lbody = io.LimitReader(body, size)
+	} else {
+		lbody = body
+	}
+	d := xml.NewDecoder(lbody)
 	return d.Decode(v)
 }
 


### PR DESCRIPTION
This is needed so that we avoid reading large amounts
of data from compromised clients.
