### PR TITLE
screenshot: Use the full path to the screenshot when embedding images

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Object API (Amazon S3 compatible):
 ## 3. Test Minio Server using Minio Browser
 Open a web browser and navigate to http://127.0.0.1:9000 to view your buckets on minio server.
 
-![Screenshot](./Minio_Browser.png)
+![Screenshot](https://raw.githubusercontent.com/minio/minio/master/Minio_Browser.png)
 
 ## 4. Test Minio Server using `mc`
 


### PR DESCRIPTION
Use full URLs to embed images so that the markdown files are self contained.
