### PR TITLE
XL: Refactor usage of reduceErrs and consistent behavior.

### DIFF
--- a/object-api-multipart_test.go
+++ b/object-api-multipart_test.go
@@ -129,7 +129,7 @@ func testPutObjectPartDiskNotFound(obj ObjectLayer, instanceType string, disks [
 	}
 
 	// Remove some random disk.
-	for _, disk := range disks[:7] {
+	for _, disk := range disks[:6] {
 		removeAll(disk)
 	}
 
@@ -165,7 +165,10 @@ func testPutObjectPartDiskNotFound(obj ObjectLayer, instanceType string, disks [
 	}
 
 	// This causes quorum failure verify.
-	removeAll(disks[len(disks)-1])
+	disks = disks[len(disks)-3:]
+	for _, disk := range disks {
+		removeAll(disk)
+	}
 
 	// Object part upload should fail with quorum not available.
 	testCase := createPartCases[len(createPartCases)-1]

--- a/xl-v1-common.go
+++ b/xl-v1-common.go
@@ -25,7 +25,7 @@ import (
 // randomized quorum disk slice.
 func (xl xlObjects) getLoadBalancedQuorumDisks() (disks []StorageAPI) {
 	// It is okay to have readQuorum disks.
-	return xl.getLoadBalancedDisks()[:xl.readQuorum-1]
+	return xl.getLoadBalancedDisks()[0 : xl.readQuorum-1]
 }
 
 // getLoadBalancedDisks - fetches load balanced (sufficiently

--- a/xl-v1-multipart.go
+++ b/xl-v1-multipart.go
@@ -285,7 +285,7 @@ func (xl xlObjects) newMultipartUpload(bucket string, object string, meta map[st
 	if err = writeSameXLMetadata(xl.storageDisks, minioMetaBucket, tempUploadIDPath, xlMeta, xl.writeQuorum, xl.readQuorum); err != nil {
 		return "", toObjectErr(err, minioMetaBucket, tempUploadIDPath)
 	}
-	rErr := renameObject(xl.storageDisks, minioMetaBucket, tempUploadIDPath, minioMetaBucket, uploadIDPath, xl.writeQuorum, xl.readQuorum)
+	rErr := renameObject(xl.storageDisks, minioMetaBucket, tempUploadIDPath, minioMetaBucket, uploadIDPath, xl.writeQuorum)
 	if rErr == nil {
 		// Return success.
 		return uploadID, nil
@@ -431,7 +431,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 
 	// Rename temporary part file to its final location.
 	partPath := path.Join(uploadIDPath, partSuffix)
-	err = renamePart(onlineDisks, minioMetaBucket, tmpPartPath, minioMetaBucket, partPath, xl.writeQuorum, xl.readQuorum)
+	err = renamePart(onlineDisks, minioMetaBucket, tmpPartPath, minioMetaBucket, partPath, xl.writeQuorum)
 	if err != nil {
 		return "", toObjectErr(err, minioMetaBucket, partPath)
 	}
@@ -466,12 +466,11 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	newUUID := getUUID()
 	tempXLMetaPath := path.Join(tmpMetaPrefix, newUUID)
 
-	// Writes a unique `xl.json` each disk carrying new checksum
-	// related information.
-	if err = writeUniqueXLMetadata(onlineDisks, minioMetaBucket, tempXLMetaPath, partsMetadata, xl.writeQuorum, xl.readQuorum); err != nil {
+	// Writes a unique `xl.json` each disk carrying new checksum related information.
+	if err = writeUniqueXLMetadata(onlineDisks, minioMetaBucket, tempXLMetaPath, partsMetadata, xl.writeQuorum); err != nil {
 		return "", toObjectErr(err, minioMetaBucket, tempXLMetaPath)
 	}
-	rErr := commitXLMetadata(onlineDisks, tempXLMetaPath, uploadIDPath, xl.writeQuorum, xl.readQuorum)
+	rErr := commitXLMetadata(onlineDisks, tempXLMetaPath, uploadIDPath, xl.writeQuorum)
 	if rErr != nil {
 		return "", toObjectErr(rErr, minioMetaBucket, uploadIDPath)
 	}
@@ -696,10 +695,10 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	}
 
 	// Write unique `xl.json` for each disk.
-	if err = writeUniqueXLMetadata(xl.storageDisks, minioMetaBucket, tempUploadIDPath, partsMetadata, xl.writeQuorum, xl.readQuorum); err != nil {
+	if err = writeUniqueXLMetadata(xl.storageDisks, minioMetaBucket, tempUploadIDPath, partsMetadata, xl.writeQuorum); err != nil {
 		return "", toObjectErr(err, minioMetaBucket, tempUploadIDPath)
 	}
-	rErr := commitXLMetadata(xl.storageDisks, tempUploadIDPath, uploadIDPath, xl.writeQuorum, xl.readQuorum)
+	rErr := commitXLMetadata(xl.storageDisks, tempUploadIDPath, uploadIDPath, xl.writeQuorum)
 	if rErr != nil {
 		return "", toObjectErr(rErr, minioMetaBucket, uploadIDPath)
 	}
@@ -722,7 +721,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	// Rename if an object already exists to temporary location.
 	uniqueID := getUUID()
 	if xl.isObject(bucket, object) {
-		err = renameObject(xl.storageDisks, bucket, object, minioMetaBucket, path.Join(tmpMetaPrefix, uniqueID), xl.writeQuorum, xl.readQuorum)
+		err = renameObject(xl.storageDisks, bucket, object, minioMetaBucket, path.Join(tmpMetaPrefix, uniqueID), xl.writeQuorum)
 		if err != nil {
 			return "", toObjectErr(err, bucket, object)
 		}
@@ -742,7 +741,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	}
 
 	// Rename the multipart object to final location.
-	if err = renameObject(xl.storageDisks, minioMetaBucket, uploadIDPath, bucket, object, xl.writeQuorum, xl.readQuorum); err != nil {
+	if err = renameObject(xl.storageDisks, minioMetaBucket, uploadIDPath, bucket, object, xl.writeQuorum); err != nil {
 		return "", toObjectErr(err, bucket, object)
 	}
 

--- a/xl-v1-utils.go
+++ b/xl-v1-utils.go
@@ -30,9 +30,12 @@ import (
 // value is greater than or equal to simple majority, since none of the equally
 // maximal values would occur quorum or more number of times.
 
-func reduceErrs(errs []error) (int, error) {
+func reduceErrs(errs []error, ignoredErrs []error) error {
 	errorCounts := make(map[error]int)
 	for _, err := range errs {
+		if isErrIgnored(err, ignoredErrs) {
+			continue
+		}
 		errorCounts[err]++
 	}
 	max := 0
@@ -43,7 +46,7 @@ func reduceErrs(errs []error) (int, error) {
 			errMax = err
 		}
 	}
-	return max, errMax
+	return errMax
 }
 
 // Validates if we have quorum based on the errors related to disk only.

--- a/xl-v1-utils_test.go
+++ b/xl-v1-utils_test.go
@@ -20,22 +20,39 @@ import "testing"
 
 // Test for reduceErrs.
 func TestReduceErrs(t *testing.T) {
+	// List all of all test cases to validate various cases of reduce errors.
 	testCases := []struct {
-		errs  []error
-		err   error
-		count int
+		errs        []error
+		ignoredErrs []error
+		err         error
 	}{
-		{[]error{errDiskNotFound, errDiskNotFound, errDiskFull}, errDiskNotFound, 2},
-		{[]error{errDiskFull, errDiskNotFound, nil, nil}, nil, 2},
-		{[]error{}, nil, 0},
+		// Validate if have reduced properly.
+		{[]error{
+			errDiskNotFound,
+			errDiskNotFound,
+			errDiskFull,
+		}, []error{}, errDiskNotFound},
+		// Validate if have no consensus.
+		{[]error{
+			errDiskFull,
+			errDiskNotFound,
+			nil, nil,
+		}, []error{}, nil},
+		// Validate if have consensus and errors ignored.
+		{[]error{
+			errVolumeNotFound,
+			errVolumeNotFound,
+			errVolumeNotFound,
+			errDiskNotFound,
+			errDiskNotFound,
+		}, []error{errDiskNotFound}, errVolumeNotFound},
+		{[]error{}, []error{}, nil},
 	}
+	// Validates list of all the testcases for returning valid errors.
 	for i, testCase := range testCases {
-		gotMax, gotErr := reduceErrs(testCase.errs)
+		gotErr := reduceErrs(testCase.errs, testCase.ignoredErrs)
 		if testCase.err != gotErr {
 			t.Errorf("Test %d : expected %s, got %s", i+1, testCase.err, gotErr)
-		}
-		if testCase.count != gotMax {
-			t.Errorf("Test %d : expected %d, got %d", i+1, testCase.count, gotMax)
 		}
 	}
 }

--- a/xl-v1.go
+++ b/xl-v1.go
@@ -45,7 +45,7 @@ const (
 	maxErasureBlocks = 16
 
 	// Minimum erasure blocks.
-	minErasureBlocks = 6
+	minErasureBlocks = 4
 )
 
 // xlObjects - Implements XL object layer.
@@ -84,7 +84,7 @@ func checkSufficientDisks(disks []string) error {
 	}
 
 	// Verify if we have even number of disks.
-	// only combination of 6, 8, 10, 12, 14, 16 are supported.
+	// only combination of 4, 6, 8, 10, 12, 14, 16 are supported.
 	if !isEven(totalDisks) {
 		return errXLNumDisks
 	}
@@ -194,9 +194,9 @@ func newXLObjects(disks, ignoredDisks []string) (ObjectLayer, error) {
 	}
 
 	// Figure out read and write quorum based on number of storage disks.
-	// READ and WRITE quorum is always set to (N/2 + 1) number of disks.
-	xl.readQuorum = len(xl.storageDisks)/2 + 1
-	xl.writeQuorum = len(xl.storageDisks)/2 + 1
+	// READ and WRITE quorum is always set to (N/2) number of disks.
+	xl.readQuorum = len(xl.storageDisks) / 2
+	xl.writeQuorum = len(xl.storageDisks) / 2
 
 	// Return successfully initialized object layer.
 	return xl, nil

--- a/xl-v1_test.go
+++ b/xl-v1_test.go
@@ -73,7 +73,7 @@ func TestCheckSufficientDisks(t *testing.T) {
 		},
 		// Lesser than minimum number of disks < 6.
 		{
-			disks[0:5],
+			disks[0:3],
 			errXLMinDisks,
 		},
 		// Odd number of disks, not divisible by '2'.


### PR DESCRIPTION
This refactor is also needed in lieu of our quorum
requirement change for the newly understood logic behind
klauspost/reedsolom implementation.
