### PR TITLE
api: Set content-encoding properly if set.

### DIFF
--- a/api-errors.go
+++ b/api-errors.go
@@ -107,6 +107,7 @@ const (
 
 	// S3 extended errors.
 	ErrContentSHA256Mismatch
+
 	// Add new extended error codes here.
 
 	// Minio extended errors.

--- a/api-headers.go
+++ b/api-headers.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
-	"strings"
 )
 
 //// helpers
@@ -67,16 +66,18 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, contentRange *h
 	lastModified := objInfo.ModTime.UTC().Format(http.TimeFormat)
 	w.Header().Set("Last-Modified", lastModified)
 
-	w.Header().Set("Content-Type", objInfo.ContentType)
+	if objInfo.ContentType != "" {
+		w.Header().Set("Content-Type", objInfo.ContentType)
+	}
 	if objInfo.MD5Sum != "" {
 		w.Header().Set("ETag", "\""+objInfo.MD5Sum+"\"")
 	}
-
+	if objInfo.ContentEncoding != "" {
+		w.Header().Set("Content-Encoding", objInfo.ContentEncoding)
+	}
 	w.Header().Set("Content-Length", strconv.FormatInt(objInfo.Size, 10))
 	for k, v := range objInfo.UserDefined {
-		if strings.HasPrefix(k, "X-Amz-Meta-") {
-			w.Header().Set(k, v)
-		}
+		w.Header().Set(k, v)
 	}
 
 	// for providing ranged content

--- a/fs-v1.go
+++ b/fs-v1.go
@@ -584,6 +584,7 @@ func (fs fsObjects) listObjects(bucket, prefix, marker, delimiter string, maxKey
 			Name:    fileInfo.Name,
 			ModTime: fileInfo.ModTime,
 			Size:    fileInfo.Size,
+			MD5Sum:  fileInfo.MD5Sum,
 			IsDir:   false,
 		})
 	}

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -325,8 +325,12 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	// Save metadata.
 	metadata := make(map[string]string)
 	// Save other metadata if available.
-	metadata["content-type"] = objInfo.ContentType
-	metadata["content-encoding"] = objInfo.ContentEncoding
+	if objInfo.ContentType != "" {
+		metadata["content-type"] = objInfo.ContentType
+	}
+	if objInfo.ContentEncoding != "" {
+		metadata["content-encoding"] = objInfo.ContentEncoding
+	}
 	// Do not set `md5sum` as CopyObject will not keep the
 	// same md5sum as the source.
 
@@ -393,8 +397,14 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	// Make sure we hex encode md5sum here.
 	metadata["md5Sum"] = hex.EncodeToString(md5Bytes)
 	// Save other metadata if available.
-	metadata["content-type"] = r.Header.Get("Content-Type")
-	metadata["content-encoding"] = r.Header.Get("Content-Encoding")
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "" {
+		metadata["content-type"] = contentType
+	}
+	contentEncoding := r.Header.Get("Content-Encoding")
+	if contentEncoding != "" {
+		metadata["content-encoding"] = contentEncoding
+	}
 	for key := range r.Header {
 		cKey := http.CanonicalHeaderKey(key)
 		if strings.HasPrefix(cKey, "X-Amz-Meta-") {
@@ -465,13 +475,19 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 	// Save metadata.
 	metadata := make(map[string]string)
 	// Save other metadata if available.
-	metadata["content-type"] = r.Header.Get("Content-Type")
-	metadata["content-encoding"] = r.Header.Get("Content-Encoding")
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "" {
+		metadata["content-type"] = contentType
+	}
+	contentEncoding := r.Header.Get("Content-Encoding")
+	if contentEncoding != "" {
+		metadata["content-encoding"] = contentEncoding
+	}
 	for key := range r.Header {
 		cKey := http.CanonicalHeaderKey(key)
-		if strings.HasPrefix(cKey, "x-amz-meta-") {
+		if strings.HasPrefix(cKey, "X-Amz-Meta-") {
 			metadata[cKey] = r.Header.Get(cKey)
-		} else if strings.HasPrefix(key, "x-minio-meta-") {
+		} else if strings.HasPrefix(key, "X-Minio-Meta-") {
 			metadata[cKey] = r.Header.Get(cKey)
 		}
 	}

--- a/xl-v1-list-objects.go
+++ b/xl-v1-list-objects.go
@@ -97,6 +97,7 @@ func (xl xlObjects) listObjects(bucket, prefix, marker, delimiter string, maxKey
 			Name:    objInfo.Name,
 			ModTime: objInfo.ModTime,
 			Size:    objInfo.Size,
+			MD5Sum:  objInfo.MD5Sum,
 			IsDir:   false,
 		})
 	}


### PR DESCRIPTION
Additionally don't set content-type if not present, golang http
server automaticaly handles this and sets it automatically.
