### PR TITLE
optimize memory allocation during erasure-read by using temporary buffer pool.

### DIFF
--- a/erasure-readfile_test.go
+++ b/erasure-readfile_test.go
@@ -21,6 +21,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/minio/minio/pkg/bpool"
 )
 import "reflect"
 
@@ -249,13 +251,13 @@ func TestErasureReadFileDiskFail(t *testing.T) {
 		t.Errorf("erasureCreateFile returned %d, expected %d", size, length)
 	}
 
-	// create scratch pool buffer which will be used by erasureReadFile as scratch space for
+	// create byte pool which will be used by erasureReadFile for
 	// reading from disks and erasure decoding.
 	chunkSize := getChunkSize(blockSize, dataBlocks)
-	scratch := newScratchPool(chunkSize, len(disks))
+	pool := bpool.NewBytePool(chunkSize, len(disks))
 
 	buf := &bytes.Buffer{}
-	size, err = erasureReadFile(buf, disks, "testbucket", "testobject", 0, length, length, blockSize, dataBlocks, parityBlocks, checkSums, scratch)
+	size, err = erasureReadFile(buf, disks, "testbucket", "testobject", 0, length, length, blockSize, dataBlocks, parityBlocks, checkSums, pool)
 	if err != nil {
 		t.Error(err)
 	}
@@ -268,7 +270,7 @@ func TestErasureReadFileDiskFail(t *testing.T) {
 	disks[5] = ReadDiskDown{disks[5].(*posix)}
 
 	buf.Reset()
-	size, err = erasureReadFile(buf, disks, "testbucket", "testobject", 0, length, length, blockSize, dataBlocks, parityBlocks, checkSums, scratch)
+	size, err = erasureReadFile(buf, disks, "testbucket", "testobject", 0, length, length, blockSize, dataBlocks, parityBlocks, checkSums, pool)
 	if err != nil {
 		t.Error(err)
 	}
@@ -283,7 +285,7 @@ func TestErasureReadFileDiskFail(t *testing.T) {
 	disks[11] = ReadDiskDown{disks[11].(*posix)}
 
 	buf.Reset()
-	size, err = erasureReadFile(buf, disks, "testbucket", "testobject", 0, length, length, blockSize, dataBlocks, parityBlocks, checkSums, scratch)
+	size, err = erasureReadFile(buf, disks, "testbucket", "testobject", 0, length, length, blockSize, dataBlocks, parityBlocks, checkSums, pool)
 	if err != nil {
 		t.Error(err)
 	}
@@ -294,7 +296,7 @@ func TestErasureReadFileDiskFail(t *testing.T) {
 	// 1 more disk down. 7 disks down in total. Read should fail.
 	disks[12] = ReadDiskDown{disks[12].(*posix)}
 	buf.Reset()
-	size, err = erasureReadFile(buf, disks, "testbucket", "testobject", 0, length, length, blockSize, dataBlocks, parityBlocks, checkSums, scratch)
+	size, err = erasureReadFile(buf, disks, "testbucket", "testobject", 0, length, length, blockSize, dataBlocks, parityBlocks, checkSums, pool)
 	if err != errXLReadQuorum {
 		t.Fatal("expected errXLReadQuorum error")
 	}
@@ -353,12 +355,13 @@ func TestErasureReadFileOffsetLength(t *testing.T) {
 		{length - blockSize - 1, blockSize + 1},
 	}
 	chunkSize := getChunkSize(blockSize, dataBlocks)
-	scratch := newScratchPool(chunkSize, len(disks))
+	pool := bpool.NewBytePool(chunkSize, len(disks))
+
 	// Compare the data read from file with "data" byte array.
 	for i, testCase := range testCases {
 		expected := data[testCase.offset:(testCase.offset + testCase.length)]
 		buf := &bytes.Buffer{}
-		size, err = erasureReadFile(buf, disks, "testbucket", "testobject", testCase.offset, testCase.length, length, blockSize, dataBlocks, parityBlocks, checkSums, scratch)
+		size, err = erasureReadFile(buf, disks, "testbucket", "testobject", testCase.offset, testCase.length, length, blockSize, dataBlocks, parityBlocks, checkSums, pool)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -412,10 +415,10 @@ func TestErasureReadFileRandomOffsetLength(t *testing.T) {
 	// To generate random offset/length.
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	// create scratch pool buffer which will be used by erasureReadFile as scratch space for
+	// create pool buffer which will be used by erasureReadFile for
 	// reading from disks and erasure decoding.
 	chunkSize := getChunkSize(blockSize, dataBlocks)
-	scratch := newScratchPool(chunkSize, len(disks))
+	pool := bpool.NewBytePool(chunkSize, len(disks))
 
 	buf := &bytes.Buffer{}
 
@@ -426,7 +429,7 @@ func TestErasureReadFileRandomOffsetLength(t *testing.T) {
 
 		expected := data[offset : offset+readLen]
 
-		size, err = erasureReadFile(buf, disks, "testbucket", "testobject", offset, readLen, length, blockSize, dataBlocks, parityBlocks, checkSums, scratch)
+		size, err = erasureReadFile(buf, disks, "testbucket", "testobject", offset, readLen, length, blockSize, dataBlocks, parityBlocks, checkSums, pool)
 		if err != nil {
 			t.Fatal(err, offset, readLen)
 		}

--- a/erasure-utils.go
+++ b/erasure-utils.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"hash"
 	"io"
-	"sync"
 
 	"github.com/klauspost/reedsolomon"
 	"github.com/minio/blake2b-simd"
@@ -235,49 +234,4 @@ func copyBuffer(writer io.Writer, disk StorageAPI, volume string, path string, b
 
 	// Success.
 	return nil
-}
-
-// Error returned when there are no more free buffers in the scratch pool.
-// Normally this error should never be returned as scratch pool should always be
-// initialized with dataBlocks+parityBlocks number of buffers.
-var errScratchNoBuf = errors.New("no free buffer")
-
-// Temporary pool of buffers that can be used for scratch space.
-type scratchPool struct {
-	buf  [][]byte
-	used []bool
-	sync.Mutex
-}
-
-// Returns an unused buffer.
-func (s *scratchPool) get() (buf []byte, err error) {
-	s.Lock()
-	defer s.Unlock()
-	for i := 0; i < len(s.used); i++ {
-		if !s.used[i] {
-			s.used[i] = true
-			return s.buf[i], nil
-		}
-	}
-	return nil, errScratchNoBuf
-}
-
-// Marks all buffers as unused.
-func (s *scratchPool) reset() {
-	s.Lock()
-	defer s.Unlock()
-	for i := 0; i < len(s.used); i++ {
-		s.used[i] = false
-		s.buf[i] = s.buf[i][:0]
-	}
-}
-
-// Returns new scratch pool with n number of buffers each with size specified as arguemnt.
-func newScratchPool(size int64, n int) *scratchPool {
-	used := make([]bool, n)
-	buf := make([][]byte, n)
-	for i := 0; i < n; i++ {
-		buf[i] = make([]byte, size)
-	}
-	return &scratchPool{buf, used, sync.Mutex{}}
 }

--- a/pkg/bpool/bpool.go
+++ b/pkg/bpool/bpool.go
@@ -1,0 +1,69 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package bpool implements a fixed size pool of byte slices.
+package bpool
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrBpoolNoFree - Normally this error should never be returned, this error
+// indicates a bug in the package consumer.
+var ErrBpoolNoFree = errors.New("no free byte slice in pool")
+
+// BytePool - temporary pool of byte slices.
+type BytePool struct {
+	buf  [][]byte // array of byte slices
+	used []bool   // indicates if a buf[i] is in use
+	size int64    // size of buf[i]
+	mu   sync.Mutex
+}
+
+// Get - Returns an unused byte slice.
+func (b *BytePool) Get() (buf []byte, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := 0; i < len(b.used); i++ {
+		if !b.used[i] {
+			b.used[i] = true
+			if b.buf[i] == nil {
+				b.buf[i] = make([]byte, b.size)
+			}
+			return b.buf[i], nil
+		}
+	}
+	return nil, ErrBpoolNoFree
+}
+
+// Reset - Marks all slices as unused.
+func (b *BytePool) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := 0; i < len(b.used); i++ {
+		b.used[i] = false
+	}
+}
+
+// NewBytePool - Returns new pool.
+// size - length of each slice.
+// n - number of slices in the pool.
+func NewBytePool(size int64, n int) *BytePool {
+	used := make([]bool, n)
+	buf := make([][]byte, n)
+	return &BytePool{buf, used, size, sync.Mutex{}}
+}

--- a/pkg/bpool/bpool_test.go
+++ b/pkg/bpool/bpool_test.go
@@ -1,0 +1,53 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bpool
+
+import "testing"
+
+func TestBytePool(t *testing.T) {
+	size := int64(10)
+	n := 16
+	pool := NewBytePool(size, n)
+	enBlocks := make([][]byte, n)
+
+	// Allocates all the 16 byte slices in the pool.
+	alloc := func() {
+		for i := range enBlocks {
+			var err error
+			enBlocks[i], err = pool.Get()
+			if err != nil {
+				t.Fatal("expected nil, got", err)
+			}
+			// Make sure the slice length is as expected.
+			if len(enBlocks[i]) != int(size) {
+				t.Fatalf("expected size %d, got %d", len(enBlocks[i]), size)
+			}
+		}
+	}
+
+	// Allocate everything in the pool.
+	alloc()
+	// Any Get() will fail when the pool does not have any free buffer.
+	_, err := pool.Get()
+	if err == nil {
+		t.Fatalf("expected %s, got nil", err)
+	}
+	// Reset - so that all the buffers are marked as unused.
+	pool.Reset()
+	// Allocation of all the buffers in the pool should succeed now.
+	alloc()
+}

--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -153,6 +153,10 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 	}
 
 	totalBytesRead := int64(0)
+
+	chunkSize := getChunkSize(xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks)
+	scratch := newScratchPool(chunkSize, len(onlineDisks))
+
 	// Read from all parts.
 	for ; partIndex <= lastPartIndex; partIndex++ {
 		if length == totalBytesRead {
@@ -183,7 +187,7 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 		}
 
 		// Start reading the part name.
-		n, err := erasureReadFile(mw, onlineDisks, bucket, pathJoin(object, partName), partOffset, readSize, partSize, xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, checkSums)
+		n, err := erasureReadFile(mw, onlineDisks, bucket, pathJoin(object, partName), partOffset, readSize, partSize, xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, checkSums, scratch)
 		if err != nil {
 			return toObjectErr(err, bucket, object)
 		}

--- a/xl-v1-object.go
+++ b/xl-v1-object.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/minio/minio/pkg/bpool"
 	"github.com/minio/minio/pkg/mimedb"
 	"github.com/minio/minio/pkg/objcache"
 )
@@ -155,7 +156,7 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 	totalBytesRead := int64(0)
 
 	chunkSize := getChunkSize(xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks)
-	scratch := newScratchPool(chunkSize, len(onlineDisks))
+	pool := bpool.NewBytePool(chunkSize, len(onlineDisks))
 
 	// Read from all parts.
 	for ; partIndex <= lastPartIndex; partIndex++ {
@@ -187,7 +188,7 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 		}
 
 		// Start reading the part name.
-		n, err := erasureReadFile(mw, onlineDisks, bucket, pathJoin(object, partName), partOffset, readSize, partSize, xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, checkSums, scratch)
+		n, err := erasureReadFile(mw, onlineDisks, bucket, pathJoin(object, partName), partOffset, readSize, partSize, xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, checkSums, pool)
 		if err != nil {
 			return toObjectErr(err, bucket, object)
 		}


### PR DESCRIPTION
With the change the buffer needed during GetObject by erasureReadFile is allocated only once.
