### PR TITLE
xl-v1-metadata.go, xl-v1-multipart-common.go

### DIFF
--- a/fs-v1-multipart-common.go
+++ b/fs-v1-multipart-common.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"path"
-	"strings"
 	"time"
 )
 
@@ -27,20 +26,6 @@ import (
 func (fs fsObjects) isMultipartUpload(bucket, prefix string) bool {
 	_, err := fs.storage.StatFile(bucket, pathJoin(prefix, uploadsJSONFile))
 	return err == nil
-}
-
-// listUploadsInfo - list all uploads info.
-func (fs fsObjects) listUploadsInfo(prefixPath string) (uploads []uploadInfo, err error) {
-	splitPrefixes := strings.SplitN(prefixPath, "/", 3)
-	uploadIDs, err := readUploadsJSON(splitPrefixes[1], splitPrefixes[2], fs.storage)
-	if err != nil {
-		if err == errFileNotFound {
-			return []uploadInfo{}, nil
-		}
-		return nil, err
-	}
-	uploads = uploadIDs.Uploads
-	return uploads, nil
 }
 
 // Checks whether bucket exists.

--- a/server_test.go
+++ b/server_test.go
@@ -1686,6 +1686,14 @@ func (s *TestSuiteCommon) TestObjectMultipartAbort(c *C) {
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
 	objectName := "test-multipart-object"
+
+	// 1. Initiate 2 uploads for the same object
+	// 2. Upload 2 parts for the second upload
+	// 3. Abort the second upload.
+	// 4. Abort the first upload.
+	// This will test abort upload when there are more than one upload IDs
+	// and the case where there is only one upload ID.
+
 	// construct HTTP request to initiate a NewMultipart upload.
 	request, err = newTestSignedRequest("POST", getNewMultipartURL(s.endPoint, bucketName, objectName),
 		0, nil, s.accessKey, s.secretKey)
@@ -1698,6 +1706,23 @@ func (s *TestSuiteCommon) TestObjectMultipartAbort(c *C) {
 	// parse the response body and obtain the new upload ID.
 	decoder := xml.NewDecoder(response.Body)
 	newResponse := &InitiateMultipartUploadResponse{}
+
+	err = decoder.Decode(newResponse)
+	c.Assert(err, IsNil)
+	c.Assert(len(newResponse.UploadID) > 0, Equals, true)
+
+	// construct HTTP request to initiate a NewMultipart upload.
+	request, err = newTestSignedRequest("POST", getNewMultipartURL(s.endPoint, bucketName, objectName),
+		0, nil, s.accessKey, s.secretKey)
+	c.Assert(err, IsNil)
+
+	// execute the HTTP request initiating the new multipart upload.
+	response, err = client.Do(request)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	// parse the response body and obtain the new upload ID.
+	decoder = xml.NewDecoder(response.Body)
+	newResponse = &InitiateMultipartUploadResponse{}
 
 	err = decoder.Decode(newResponse)
 	c.Assert(err, IsNil)

--- a/xl-v1-multipart-common.go
+++ b/xl-v1-multipart-common.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"path"
-	"strings"
 	"sync"
 	"time"
 )
@@ -196,31 +195,6 @@ func (xl xlObjects) isMultipartUpload(bucket, prefix string) bool {
 		break
 	}
 	return false
-}
-
-// listUploadsInfo - list all uploads info.
-func (xl xlObjects) listUploadsInfo(prefixPath string) (uploadsInfo []uploadInfo, err error) {
-	for _, disk := range xl.getLoadBalancedDisks() {
-		if disk == nil {
-			continue
-		}
-		splitPrefixes := strings.SplitN(prefixPath, "/", 3)
-		var uploadsJSON uploadsV1
-		uploadsJSON, err = readUploadsJSON(splitPrefixes[1], splitPrefixes[2], disk)
-		if err == nil {
-			uploadsInfo = uploadsJSON.Uploads
-			return uploadsInfo, nil
-		}
-		if err == errFileNotFound {
-			return []uploadInfo{}, nil
-		}
-		// For any reason disk was deleted or goes offline, continue
-		if isErrIgnored(err, objMetadataOpIgnoredErrs) {
-			continue
-		}
-		break
-	}
-	return []uploadInfo{}, err
 }
 
 // isUploadIDExists - verify if a given uploadID exists and is valid.


### PR DESCRIPTION
remaining code will be covered when we do testing with simulation of quorum error.
Need to implement tests by simulating disk failures similar to how it is done
in erasure-readfile_test.go and erasure-createfile_test.go This should fix coverage
in other files too which has code path for quorum error.
