### PR TITLE
XL: format.json healing should cater for mismatching order.

### DIFF
--- a/xl-v1.go
+++ b/xl-v1.go
@@ -152,7 +152,7 @@ func newXLObjects(disks, ignoredDisks []string) (ObjectLayer, error) {
 		}
 	case errSomeDiskUnformatted:
 		// All drives online but some report missing format.json.
-		if err := healFormatXL(storageDisks); err != nil {
+		if err := healFormatXLFreshDisks(storageDisks); err != nil {
 			// There was an unexpected unrecoverable error during healing.
 			return nil, fmt.Errorf("Unable to heal backend %s", err)
 		}


### PR DESCRIPTION
Fresh disks can be provided in any order, we need to make sure
to preserve existing disk order and populate the fresh disks
in new positions.

Thanks for Anis Elleuch vadmeste@gmail.com for finding this issue.
