### PR TITLE
api: Notify events only if bucket notifications are set.

### DIFF
--- a/bucket-notification-datatypes.go
+++ b/bucket-notification-datatypes.go
@@ -16,7 +16,10 @@
 
 package main
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"errors"
+)
 
 // Represents the criteria for the filter rule.
 type filterRule struct {
@@ -67,6 +70,9 @@ type notificationConfig struct {
 	TopicConfigurations  []topicConfig      `xml:"TopicConfiguration"`
 	LambdaConfigurations []lambdaFuncConfig `xml:"CloudFunctionConfiguration"`
 }
+
+// Internal error used to signal notifications not set.
+var errNoSuchNotifications = errors.New("The specified bucket does not have bucket notifications")
 
 // EventName is AWS S3 event type:
 // http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html

--- a/bucket-notification-handlers.go
+++ b/bucket-notification-handlers.go
@@ -39,7 +39,7 @@ func (api objectAPIHandlers) loadNotificationConfig(bucket string) (nConfig noti
 	if err != nil {
 		switch err.(type) {
 		case ObjectNotFound:
-			return notificationConfig{}, nil
+			return notificationConfig{}, errNoSuchNotifications
 		}
 		return notificationConfig{}, err
 	}
@@ -48,7 +48,7 @@ func (api objectAPIHandlers) loadNotificationConfig(bucket string) (nConfig noti
 	if err != nil {
 		switch err.(type) {
 		case ObjectNotFound:
-			return notificationConfig{}, nil
+			return notificationConfig{}, errNoSuchNotifications
 		}
 		return notificationConfig{}, err
 	}


### PR DESCRIPTION
While the existing code worked, it went to an entire cycle
of constructing event structure and end up not sending it.

Avoid this in the first place, but returning quickly if
notifications are not set on the bucket.
