### PR TITLE
Heal corrupted formats of disks already containing objects

### DIFF
--- a/format-config-v1_test.go
+++ b/format-config-v1_test.go
@@ -16,7 +16,10 @@
 
 package main
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 // generates a valid format.json for XL backend.
 func genFormatXLValid() []*formatConfigV1 {
@@ -140,6 +143,141 @@ func genFormatXLInvalidDisksOrder() []*formatConfigV1 {
 	jbod1[1], jbod1[2] = jbod[2], jbod[1]
 	formatConfigs[2].XL.JBOD = jbod1
 	return formatConfigs
+}
+
+// Simulate XL disks creation, delete some format.json and remove the content of
+// a given disk to test healing a corrupted disk
+func TestFormatXLHeal(t *testing.T) {
+	// Create an instance of xl backend.
+	obj, fsDirs, err := getXLObjectLayer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xl := obj.(xlObjects)
+
+	err = obj.MakeBucket("bucket")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bucket := "bucket"
+	object := "object"
+
+	_, err = obj.PutObject(bucket, object, int64(len("abcd")), bytes.NewReader([]byte("abcd")), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, remove two format files.. Load them and reorder
+	if err = xl.storageDisks[3].DeleteFile(".minio.sys", "format.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err = xl.storageDisks[11].DeleteFile(".minio.sys", "format.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove the content of export dir 10 but preserve .minio.sys because it is automatically
+	// created when minio starts
+	if err = xl.storageDisks[10].DeleteFile(".minio.sys", "format.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err = xl.storageDisks[10].DeleteFile(".minio.sys", "tmp"); err != nil {
+		t.Fatal(err)
+	}
+	if err = xl.storageDisks[10].DeleteFile(bucket, object+"/xl.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err = xl.storageDisks[10].DeleteFile(bucket, object+"/part.1"); err != nil {
+		t.Fatal(err)
+	}
+	if err = xl.storageDisks[10].DeleteVol(bucket); err != nil {
+		t.Fatal(err)
+	}
+
+	permutedStorageDisks := []StorageAPI{xl.storageDisks[1], xl.storageDisks[4],
+		xl.storageDisks[2], xl.storageDisks[8], xl.storageDisks[6], xl.storageDisks[7],
+		xl.storageDisks[0], xl.storageDisks[15], xl.storageDisks[13], xl.storageDisks[14],
+		xl.storageDisks[3], xl.storageDisks[10], xl.storageDisks[12], xl.storageDisks[9],
+		xl.storageDisks[5], xl.storageDisks[11]}
+
+	// Start healing disks
+	err = healFormatXLCorruptedDisks(permutedStorageDisks)
+	if err != nil {
+		t.Fatal("healing corrupted disk failed: ", err)
+	}
+
+	// Load again XL format.json to validate it
+	_, err = loadFormatXL(permutedStorageDisks)
+	if err != nil {
+		t.Fatal("loading healed disk failed: ", err)
+	}
+
+	// Clean all
+	removeRoots(fsDirs)
+}
+
+// Test on ReorderByInspection by simulating creating disks and removing
+// some of format.json
+func TestFormatXLReorderByInspection(t *testing.T) {
+	// Create an instance of xl backend.
+	obj, fsDirs, err := getXLObjectLayer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xl := obj.(xlObjects)
+
+	err = obj.MakeBucket("bucket")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bucket := "bucket"
+	object := "object"
+
+	_, err = obj.PutObject(bucket, object, int64(len("abcd")), bytes.NewReader([]byte("abcd")), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, remove two format files.. Load them and reorder
+	if err = xl.storageDisks[3].DeleteFile(".minio.sys", "format.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err = xl.storageDisks[5].DeleteFile(".minio.sys", "format.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	permutedStorageDisks := []StorageAPI{xl.storageDisks[1], xl.storageDisks[4],
+		xl.storageDisks[2], xl.storageDisks[8], xl.storageDisks[6], xl.storageDisks[7],
+		xl.storageDisks[0], xl.storageDisks[15], xl.storageDisks[13], xl.storageDisks[14],
+		xl.storageDisks[3], xl.storageDisks[10], xl.storageDisks[12], xl.storageDisks[9],
+		xl.storageDisks[5], xl.storageDisks[11]}
+
+	permutedFormatConfigs, _ := loadAllFormats(permutedStorageDisks)
+
+	orderedDisks, err := reorderDisks(permutedStorageDisks, permutedFormatConfigs)
+	if err != nil {
+		t.Fatal("error reordering disks\n")
+	}
+
+	orderedDisks, err = reorderDisksByInspection(orderedDisks, permutedStorageDisks, permutedFormatConfigs)
+	if err != nil {
+		t.Fatal("failed to reorder disk by inspection")
+	}
+
+	// Check disks reordering
+	for i := 0; i <= 15; i++ {
+		if orderedDisks[i] == nil && i != 3 && i != 5 {
+			t.Fatal("should not be nil")
+		}
+		if orderedDisks[i] != nil && orderedDisks[i] != xl.storageDisks[i] {
+			t.Fatal("Disks were not ordered correctly.")
+		}
+	}
+
+	removeRoots(fsDirs)
 }
 
 // Wrapper for calling FormatXL tests - currently validates

--- a/xl-v1.go
+++ b/xl-v1.go
@@ -145,6 +145,10 @@ func newXLObjects(disks, ignoredDisks []string) (ObjectLayer, error) {
 
 	// Handles different cases properly.
 	switch reduceFormatErrs(sErrs, len(storageDisks)) {
+	case errCorruptedFormat:
+		if err := healFormatXLCorruptedDisks(storageDisks); err != nil {
+			return nil, fmt.Errorf("Unable to repair corrupted format, %s", err)
+		}
 	case errUnformattedDisk:
 		// All drives online but fresh, initialize format.
 		if err := initFormatXL(storageDisks); err != nil {


### PR DESCRIPTION
- reduceFormatErrs return multiple errors because we can have different disks with different erros
- Add healFormatXLCorruptedDisks()

Fixes #2182 
