### PR TITLE
POST Policy, multiple fixes: AccessDenied with unmet conditions, ${filename} in Key, missing filename in multipart

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -347,7 +347,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		return
 	}
 
-	fileBody, formValues, err := extractHTTPFormValues(reader)
+	fileBody, fileName, formValues, err := extractHTTPFormValues(reader)
 	if err != nil {
 		errorIf(err, "Unable to parse form values.")
 		writeErrorResponse(w, r, ErrMalformedPOSTRequest, r.URL.Path)
@@ -356,6 +356,12 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	bucket := mux.Vars(r)["bucket"]
 	formValues["Bucket"] = bucket
 	object := formValues["Key"]
+
+	if fileName != "" && strings.Contains(object, "${filename}") {
+		// S3 feature to replace ${filename} found in Key form field
+		// by the filename attribute passed in multipart
+		object = strings.Replace(object, "${filename}", fileName, -1)
+	}
 
 	// Verify policy signature.
 	apiErr := doesPolicySignatureMatch(formValues)

--- a/handler-utils.go
+++ b/handler-utils.go
@@ -99,10 +99,11 @@ func extractMetadataFromHeader(header http.Header) map[string]string {
 	return metadata
 }
 
-func extractHTTPFormValues(reader *multipart.Reader) (io.Reader, map[string]string, error) {
+func extractHTTPFormValues(reader *multipart.Reader) (io.Reader, string, map[string]string, error) {
 	/// HTML Form values
 	formValues := make(map[string]string)
 	filePart := new(bytes.Buffer)
+	fileName := ""
 	var err error
 	for err == nil {
 		var part *multipart.Part
@@ -113,16 +114,17 @@ func extractHTTPFormValues(reader *multipart.Reader) (io.Reader, map[string]stri
 				var buffer []byte
 				buffer, err = ioutil.ReadAll(part)
 				if err != nil {
-					return nil, nil, err
+					return nil, "", nil, err
 				}
 				formValues[canonicalFormName] = string(buffer)
 			} else {
 				if _, err = io.Copy(filePart, part); err != nil {
-					return nil, nil, err
+					return nil, "", nil, err
 				}
+				fileName = part.FileName()
 			}
 		}
 	}
-	return filePart, formValues, nil
+	return filePart, fileName, formValues, nil
 
 }

--- a/handler-utils.go
+++ b/handler-utils.go
@@ -108,13 +108,14 @@ func extractHTTPFormValues(reader *multipart.Reader) (io.Reader, map[string]stri
 		var part *multipart.Part
 		part, err = reader.NextPart()
 		if part != nil {
-			if part.FileName() == "" {
+			canonicalFormName := http.CanonicalHeaderKey(part.FormName())
+			if canonicalFormName != "File" {
 				var buffer []byte
 				buffer, err = ioutil.ReadAll(part)
 				if err != nil {
 					return nil, nil, err
 				}
-				formValues[http.CanonicalHeaderKey(part.FormName())] = string(buffer)
+				formValues[canonicalFormName] = string(buffer)
 			} else {
 				if _, err = io.Copy(filePart, part); err != nil {
 					return nil, nil, err

--- a/signature-v4-postpolicyform.go
+++ b/signature-v4-postpolicyform.go
@@ -170,32 +170,32 @@ func checkPostPolicy(formValues map[string]string) APIErrorCode {
 	}
 	if postPolicyForm.Conditions.Policies["$bucket"].Operator == "eq" {
 		if formValues["Bucket"] != postPolicyForm.Conditions.Policies["$bucket"].Value {
-			return ErrMissingFields
+			return ErrAccessDenied
 		}
 	}
 	if postPolicyForm.Conditions.Policies["$x-amz-date"].Operator == "eq" {
 		if formValues["X-Amz-Date"] != postPolicyForm.Conditions.Policies["$x-amz-date"].Value {
-			return ErrMissingFields
+			return ErrAccessDenied
 		}
 	}
 	if postPolicyForm.Conditions.Policies["$Content-Type"].Operator == "starts-with" {
 		if !strings.HasPrefix(formValues["Content-Type"], postPolicyForm.Conditions.Policies["$Content-Type"].Value) {
-			return ErrMissingFields
+			return ErrAccessDenied
 		}
 	}
 	if postPolicyForm.Conditions.Policies["$Content-Type"].Operator == "eq" {
 		if formValues["Content-Type"] != postPolicyForm.Conditions.Policies["$Content-Type"].Value {
-			return ErrMissingFields
+			return ErrAccessDenied
 		}
 	}
 	if postPolicyForm.Conditions.Policies["$key"].Operator == "starts-with" {
 		if !strings.HasPrefix(formValues["Key"], postPolicyForm.Conditions.Policies["$key"].Value) {
-			return ErrMissingFields
+			return ErrAccessDenied
 		}
 	}
 	if postPolicyForm.Conditions.Policies["$key"].Operator == "eq" {
 		if formValues["Key"] != postPolicyForm.Conditions.Policies["$key"].Value {
-			return ErrMissingFields
+			return ErrAccessDenied
 		}
 	}
 	return ErrNone


### PR DESCRIPTION
Fixes #2294 
Fixes #2302 
Fixes #2303 
-   Unsatisfied conditions will return AccessDenied instead of MissingFields
-   Require form-field `file` in POST policy and make `filename` an optional attribute
-   S3 feature: Replace in Key by filename attribute passed in multipart
