### PR TITLE
FS: Place defer file.Close() right after opening it. 

### DIFF
--- a/posix.go
+++ b/posix.go
@@ -492,6 +492,10 @@ func (s *posix) ReadFile(volume string, path string, offset int64, buf []byte) (
 		}
 		return 0, err
 	}
+
+	// Close the file descriptor.
+	defer file.Close()
+
 	st, err := file.Stat()
 	if err != nil {
 		return 0, err
@@ -505,9 +509,6 @@ func (s *posix) ReadFile(volume string, path string, offset int64, buf []byte) (
 	if err != nil {
 		return 0, err
 	}
-
-	// Close the reader.
-	defer file.Close()
 
 	// Read full until buffer.
 	m, err := io.ReadFull(file, buf)


### PR DESCRIPTION
Here is the current code posix.ReadFile 

```
// Open the file for reading.
    file, err := os.Open(preparePath(filePath))
    if err != nil {
        if os.IsNotExist(err) {
            return 0, errFileNotFound
        } else if os.IsPermission(err) {
            return 0, errFileAccessDenied
        } else if strings.Contains(err.Error(), "not a directory") {
            return 0, errFileNotFound
        }
        return 0, err
    }
    st, err := file.Stat()
    if err != nil {
        return 0, err
    }
    // Verify if its not a regular file, since subsequent Seek is undefined.
    if !st.Mode().IsRegular() {
        return 0, errFileNotFound
    }
    // Seek to requested offset.
    _, err = file.Seek(offset, os.SEEK_SET)
    if err != nil {
return 0, err
    }

    // Close the reader.
    defer file.Close()

    // Read full until buffer.


```

if Seek or stat fails the descriptor wont be closed since its registered after Seek and Stat, just registering `defer Close()` right after opening the descriptor. 
