### PR TITLE
browser: Object upload should save metadata and notify.

### DIFF
--- a/bucket-handlers.go
+++ b/bucket-handlers.go
@@ -397,7 +397,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	writeSuccessResponse(w, encodedSuccessResponse)
 
 	// Load notification config if any.
-	nConfig, err := api.loadNotificationConfig(bucket)
+	nConfig, err := loadNotificationConfig(api.ObjectAPI, bucket)
 	// Notifications not set, return.
 	if err == errNoSuchNotifications {
 		return

--- a/bucket-notification-handlers.go
+++ b/bucket-notification-handlers.go
@@ -32,10 +32,10 @@ const (
 )
 
 // loads notifcation config if any for a given bucket, returns back structured notification config.
-func (api objectAPIHandlers) loadNotificationConfig(bucket string) (nConfig notificationConfig, err error) {
+func loadNotificationConfig(objAPI ObjectLayer, bucket string) (nConfig notificationConfig, err error) {
 	notificationConfigPath := path.Join(bucketConfigPrefix, bucket, bucketNotificationConfig)
 	var objInfo ObjectInfo
-	objInfo, err = api.ObjectAPI.GetObjectInfo(minioMetaBucket, notificationConfigPath)
+	objInfo, err = objAPI.GetObjectInfo(minioMetaBucket, notificationConfigPath)
 	if err != nil {
 		switch err.(type) {
 		case ObjectNotFound:
@@ -44,7 +44,7 @@ func (api objectAPIHandlers) loadNotificationConfig(bucket string) (nConfig noti
 		return notificationConfig{}, err
 	}
 	var buffer bytes.Buffer
-	err = api.ObjectAPI.GetObject(minioMetaBucket, notificationConfigPath, 0, objInfo.Size, &buffer)
+	err = objAPI.GetObject(minioMetaBucket, notificationConfigPath, 0, objInfo.Size, &buffer)
 	if err != nil {
 		switch err.(type) {
 		case ObjectNotFound:

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -357,7 +357,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	pipeReader.Close()
 
 	// Load notification config if any.
-	nConfig, err := api.loadNotificationConfig(bucket)
+	nConfig, err := loadNotificationConfig(api.ObjectAPI, bucket)
 	// Notifications not set, return.
 	if err == errNoSuchNotifications {
 		return
@@ -441,7 +441,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	writeSuccessResponse(w, nil)
 
 	// Load notification config if any.
-	nConfig, err := api.loadNotificationConfig(bucket)
+	nConfig, err := loadNotificationConfig(api.ObjectAPI, bucket)
 	// Notifications not set, return.
 	if err == errNoSuchNotifications {
 		return
@@ -778,7 +778,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 	w.(http.Flusher).Flush()
 
 	// Load notification config if any.
-	nConfig, err := api.loadNotificationConfig(bucket)
+	nConfig, err := loadNotificationConfig(api.ObjectAPI, bucket)
 	// Notifications not set, return.
 	if err == errNoSuchNotifications {
 		return
@@ -835,7 +835,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 	writeSuccessNoContent(w)
 
 	// Load notification config if any.
-	nConfig, err := api.loadNotificationConfig(bucket)
+	nConfig, err := loadNotificationConfig(api.ObjectAPI, bucket)
 	// Notifications not set, return.
 	if err == errNoSuchNotifications {
 		return


### PR DESCRIPTION
Object upload from browser should save additional
incoming metadata. Additionally should also notify
through bucket notifications once they are set.

Fixes #2292
