### PR TITLE
Adding return error value to checkPortAvailability to enable testing …

### DIFF
--- a/checkport_test.go
+++ b/checkport_test.go
@@ -1,0 +1,54 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+	"testing"
+)
+
+func TestCheckPortAvailability(t *testing.T) {
+	tests := []struct {
+		port int
+	}{
+		{9000},
+		{10000},
+	}
+	for _, test := range tests {
+		// This test should pass if the ports are available
+		err := checkPortAvailability(test.port)
+		if err != nil {
+			t.Fatalf("checkPortAvailability test failed for port: %d. Error: %v", test.port, err)
+		}
+
+		// Now use the ports and check again
+		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", test.port))
+		if err != nil {
+			t.Fail()
+		}
+		defer ln.Close()
+
+		err = checkPortAvailability(test.port)
+
+		// Skip if the os is windows due to https://github.com/golang/go/issues/7598
+		if err == nil && runtime.GOOS != "windows" {
+			t.Fatalf("checkPortAvailability should fail for port: %d. Error: %v", test.port, err)
+		}
+	}
+}

--- a/server-main.go
+++ b/server-main.go
@@ -246,7 +246,9 @@ func serverMain(c *cli.Context) {
 	serverAddress := c.String("address")
 
 	// Check if requested port is available.
-	checkPortAvailability(getPort(serverAddress))
+	port := getPort(serverAddress)
+	err := checkPortAvailability(port)
+	fatalIf(err, "Port unavailable %d", port)
 
 	// Disks to be ignored in server init, to skip format healing.
 	ignoredDisks := strings.Split(c.String("ignore-disks"), ",")
@@ -268,7 +270,6 @@ func serverMain(c *cli.Context) {
 	printStartupMessage(endPoints)
 
 	// Start server.
-	var err error
 	// Configure TLS if certs are available.
 	if tls {
 		err = apiServer.ListenAndServeTLS(mustGetCertFile(), mustGetKeyFile())


### PR DESCRIPTION
Adding checkport_test.go to test checkPortAvailability. Updated server-main.go to use error value from checkPortAvailability and calls fatalIf if an error is returned. 
