### PR TITLE
Refactoring checkPortAvailability to check each tcp network (tcp, tcp…

### DIFF
--- a/checkport.go
+++ b/checkport.go
@@ -17,11 +17,8 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net"
-	"os"
-	"syscall"
 )
 
 // Make sure that none of the other processes are listening on the
@@ -32,69 +29,18 @@ import (
 // However on Mac OSX Listen() on ":9000" falls back to the IPv6 address.
 // This causes confusion on Mac OSX that minio server is not reachable
 // on 127.0.0.1 even though minio server is running. So before we start
-// the minio server we make sure that the port is free on all the IPs.
+// the minio server we make sure that the port is free on each tcp network.
 func checkPortAvailability(port int) error {
-	isAddrInUse := func(err error) bool {
-		// Check if the syscall error is EADDRINUSE.
-		// EADDRINUSE is the system call error if another process is
-		// already listening at the specified port.
-		neterr, ok := err.(*net.OpError)
-		if !ok {
-			return false
-		}
-		osErr, ok := neterr.Err.(*os.SyscallError)
-		if !ok {
-			return false
-		}
-		sysErr, ok := osErr.Err.(syscall.Errno)
-		if !ok {
-			return false
-		}
-		if sysErr != syscall.EADDRINUSE {
-			return false
-		}
-		return true
-	}
-
-	ifcs, err := net.Interfaces()
-	if err != nil {
-		return err
-	}
-
-	for _, ifc := range ifcs {
-		addrs, err := ifc.Addrs()
+	network := [3]string{"tcp", "tcp4", "tcp6"}
+	for _, n := range network {
+		l, err := net.Listen(n, fmt.Sprintf(":%d", port))
 		if err != nil {
 			return err
 		}
 
-		for _, addr := range addrs {
-			ipnet, ok := addr.(*net.IPNet)
-			if !ok {
-				errorIf(errors.New(""), "Failed to assert type on (*net.IPNet) interface.")
-				continue
-			}
-
-			ip := ipnet.IP
-			network := "tcp4"
-			if ip.To4() == nil {
-				network = "tcp6"
-			}
-
-			l, err := net.Listen(network, fmt.Sprintf(":%d", port))
-			if err != nil {
-				if isAddrInUse(err) {
-					// Fail if port is already in use.
-					return err
-				}
-
-				// Ignore other errors.
-				continue
-
-			}
-
-			if err = l.Close(); err != nil {
-				return err
-			}
+		// look for error so we don't have dangling connection
+		if err = l.Close(); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
After reading through https://github.com/golang/go/issues/7598 it gave me the idea to check each network rather than each address. 
