### PR TITLE
server/config: Create 'certs' directory in initServerConfig().

### DIFF
--- a/config-v5.go
+++ b/config-v5.go
@@ -41,24 +41,21 @@ type serverConfigV5 struct {
 // initConfig - initialize server config. config version (called only once).
 func initConfig() error {
 	if !isConfigFileExists() {
+		// Initialize server config.
 		srvCfg := &serverConfigV5{}
 		srvCfg.Version = globalMinioConfigVersion
 		srvCfg.Region = "us-east-1"
 		srvCfg.Credential = mustGenAccessKeys()
+
 		// Enable console logger by default on a fresh run.
 		srvCfg.Logger.Console = consoleLogger{
 			Enable: true,
 			Level:  "fatal",
 		}
 		srvCfg.rwMutex = &sync.RWMutex{}
+
 		// Create config path.
 		err := createConfigPath()
-		if err != nil {
-			return err
-		}
-
-		// Create certs path.
-		err = createCertsPath()
 		if err != nil {
 			return err
 		}

--- a/server-main.go
+++ b/server-main.go
@@ -154,8 +154,12 @@ func finalizeEndpoints(tls bool, apiServer *http.Server) (endPoints []string) {
 
 // initServerConfig initialize server config.
 func initServerConfig(c *cli.Context) {
+	// Create certs path.
+	err := createCertsPath()
+	fatalIf(err, "Unable to create \"certs\" directory.")
+
 	// Save new config.
-	err := serverConfig.Save()
+	err = serverConfig.Save()
 	fatalIf(err, "Unable to save config.")
 
 	// Fetch max conn limit from environment variable.


### PR DESCRIPTION
certs directory was created only if config was not present, our
expectancy is we need 'certs' directory to be present all the
time making it easier to be documented.
