### PR TITLE
server: set globalCacheSize honoring system limits for max memory.

### DIFF
--- a/server-main.go
+++ b/server-main.go
@@ -203,6 +203,11 @@ func initServerConfig(c *cli.Context) {
 	// Set maxOpenFiles, This is necessary since default operating
 	// system limits of 1024, 2048 are not enough for Minio server.
 	setMaxOpenFiles()
+	// Set maxMemory, This is necessary since default operating
+	// system limits might be changed and we need to make sure we
+	// do not crash the server so the set the maxCacheSize appropriately.
+	setMaxMemory()
+
 	// Do not fail if this is not allowed, lower limits are fine as well.
 }
 

--- a/server-rlimit-win.go
+++ b/server-rlimit-win.go
@@ -24,3 +24,8 @@ func setMaxOpenFiles() error {
 	// (well, you do but it is based on your resources like memory).
 	return nil
 }
+
+func setMaxMemory() error {
+	// TODO: explore if Win32 API's provide anything special here.
+	return nil
+}


### PR DESCRIPTION
On unix systems it is possible to set max memory used by
running processes using 'ulimit -m' or 'syscall.RLIMIT_AS'.

A process whence exceeds this limit, kernel would pro-actively
kill such a server with OOM. To avoid this problem of defaulting
our cache size to 8GB we should look for if the current system
limits are lower and set the cache size appropriately. So that
we do not crash minio server by over allocating that what
is allowed.
