### PR TITLE
Object-cache: enforce cache size to be less than RAM.

### DIFF
--- a/pkg/sys/stats.go
+++ b/pkg/sys/stats.go
@@ -1,0 +1,27 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+import "errors"
+
+// ErrNotImplemented - GetStats() is implemented only on linux. On other OSes return this error.
+var ErrNotImplemented = errors.New("not implemented")
+
+// Stats - system statistics.
+type Stats struct {
+	TotalRAM uint64 // RAM size
+}

--- a/pkg/sys/stats.go
+++ b/pkg/sys/stats.go
@@ -18,10 +18,10 @@ package sys
 
 import "errors"
 
-// ErrNotImplemented - GetStats() is implemented only on linux. On other OSes return this error.
+// ErrNotImplemented - GetStats() is not implemented on bsds.
 var ErrNotImplemented = errors.New("not implemented")
 
 // Stats - system statistics.
 type Stats struct {
-	TotalRAM uint64 // RAM size
+	TotalRAM uint64 // Physical RAM size in bytes,
 }

--- a/pkg/sys/stats_bsd.go
+++ b/pkg/sys/stats_bsd.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!windows,!darwin
 
 /*
  * Minio Cloud Storage, (C) 2016 Minio, Inc.
@@ -18,8 +18,7 @@
 
 package sys
 
-// GetStats - return system statistics.
-// Note: not implemented on non-linux OSes.
+// GetStats - return system statistics for windows.
 func GetStats() (stats Stats, err error) {
 	return Stats{}, ErrNotImplemented
 }

--- a/pkg/sys/stats_linux.go
+++ b/pkg/sys/stats_linux.go
@@ -1,0 +1,32 @@
+// +build linux
+
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+import "syscall"
+
+// GetStats - return system statistics.
+func GetStats() (stats Stats, err error) {
+	si := syscall.Sysinfo_t{}
+	err = syscall.Sysinfo(&si)
+	if err != nil {
+		return
+	}
+	stats.TotalRAM = si.Totalram
+	return stats, nil
+}

--- a/pkg/sys/stats_others.go
+++ b/pkg/sys/stats_others.go
@@ -1,0 +1,25 @@
+// +build !linux
+
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+// GetStats - return system statistics.
+// Note: not implemented on non-linux OSes.
+func GetStats() (stats Stats, err error) {
+	return Stats{}, ErrNotImplemented
+}

--- a/pkg/sys/stats_windows.go
+++ b/pkg/sys/stats_windows.go
@@ -1,0 +1,55 @@
+// +build windows
+
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32              = syscall.NewLazyDLL("kernel32.dll")
+	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
+)
+
+type memoryStatusEx struct {
+	cbSize                  uint32
+	dwMemoryLoad            uint32
+	ullTotalPhys            uint64 // in bytes
+	ullAvailPhys            uint64
+	ullTotalPageFile        uint64
+	ullAvailPageFile        uint64
+	ullTotalVirtual         uint64
+	ullAvailVirtual         uint64
+	ullAvailExtendedVirtual uint64
+}
+
+// GetStats - return system statistics for windows.
+func GetStats() (stats Stats, err error) {
+	var memInfo memoryStatusEx
+	memInfo.cbSize = uint32(unsafe.Sizeof(memInfo))
+	mem, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(&memInfo)))
+	if mem == 0 {
+		return Stats{}, syscall.GetLastError()
+	}
+	stats = Stats{
+		TotalRAM: memInfo.ullTotalPhys,
+	}
+	return stats, nil
+}

--- a/server-rlimit-nix.go
+++ b/server-rlimit-nix.go
@@ -18,7 +18,12 @@
 
 package main
 
-import "syscall"
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/minio/minio/pkg/sys"
+)
 
 // For all unixes we need to bump allowed number of open files to a
 // higher value than its usual default of '1024'. The reasoning is
@@ -59,6 +64,7 @@ func setMaxMemory() error {
 	// TO decrease this limit further user has to manually edit
 	// `/etc/security/limits.conf`
 	rLimit.Cur = rLimit.Max
+	fmt.Println(rLimit.Max)
 	err = syscall.Setrlimit(syscall.RLIMIT_AS, &rLimit)
 	if err != nil {
 		return err
@@ -71,6 +77,17 @@ func setMaxMemory() error {
 	// than max cache size. Then we should use such value.
 	if rLimit.Cur < globalMaxCacheSize {
 		globalMaxCacheSize = (80 / 100) * rLimit.Cur
+	}
+
+	// Make sure globalMaxCacheSize is less than RAM size.
+	stats, err := sys.GetStats()
+	if err != nil && err != sys.ErrNotImplemented {
+		// sys.GetStats() is implemented only on linux. Ignore errors
+		// from other OSes.
+		return err
+	}
+	if err == nil && stats.TotalRAM < globalMaxCacheSize {
+		globalMaxCacheSize = (80 / 100) * stats.TotalRAM
 	}
 	return nil
 }

--- a/server-rlimit-nix.go
+++ b/server-rlimit-nix.go
@@ -19,7 +19,6 @@
 package main
 
 import (
-	"fmt"
 	"syscall"
 
 	"github.com/minio/minio/pkg/sys"
@@ -64,7 +63,6 @@ func setMaxMemory() error {
 	// TO decrease this limit further user has to manually edit
 	// `/etc/security/limits.conf`
 	rLimit.Cur = rLimit.Max
-	fmt.Println(rLimit.Max)
 	err = syscall.Setrlimit(syscall.RLIMIT_AS, &rLimit)
 	if err != nil {
 		return err


### PR DESCRIPTION
Implemented on linux because of availability of syscall.SysInfo()
fixes #2337

For other OSes there seemed to be no way of doing this other than reading /proc/
