### PR TITLE
presignV4:  fix errors response and tests.

### DIFF
--- a/signature-v4.go
+++ b/signature-v4.go
@@ -234,8 +234,10 @@ func doesPresignedSignatureMatch(hashedPayload string, r *http.Request, validate
 	}
 
 	// Extract all the signed headers along with its values.
-	extractedSignedHeaders := extractSignedHeaders(preSignValues.SignedHeaders, req.Header)
-
+	extractedSignedHeaders, errCode := extractSignedHeaders(preSignValues.SignedHeaders, req.Header)
+	if errCode != ErrNone {
+		return errCode
+	}
 	// Construct new query.
 	query := make(url.Values)
 	if contentSha256 != "" {
@@ -341,7 +343,10 @@ func doesSignatureMatch(hashedPayload string, r *http.Request, validateRegion bo
 	}
 
 	// Extract all the signed headers along with its values.
-	extractedSignedHeaders := extractSignedHeaders(signV4Values.SignedHeaders, req.Header)
+	extractedSignedHeaders, errCode := extractSignedHeaders(signV4Values.SignedHeaders, req.Header)
+	if errCode != ErrNone {
+		return errCode
+	}
 
 	// Verify if the access key id matches.
 	if signV4Values.Credential.accessKey != cred.AccessKeyID {

--- a/streaming-signature-v4.go
+++ b/streaming-signature-v4.go
@@ -95,8 +95,10 @@ func calculateSeedSignature(r *http.Request) (signature string, date time.Time, 
 	}
 
 	// Extract all the signed headers along with its values.
-	extractedSignedHeaders := extractSignedHeaders(signV4Values.SignedHeaders, req.Header)
-
+	extractedSignedHeaders, errCode := extractSignedHeaders(signV4Values.SignedHeaders, req.Header)
+	if errCode != ErrNone {
+		return "", time.Time{}, errCode
+	}
 	// Verify if the access key id matches.
 	if signV4Values.Credential.accessKey != cred.AccessKeyID {
 		return "", time.Time{}, ErrInvalidAccessKeyID

--- a/test-utils_test.go
+++ b/test-utils_test.go
@@ -312,7 +312,6 @@ func newTestRequest(method, urlStr string, contentLength int64, body io.ReadSeek
 		req.Header.Set("Content-Md5", md5Base64)
 	}
 	req.Header.Set("x-amz-content-sha256", hashedPayload)
-
 	// Seek back to beginning.
 	if body != nil {
 		body.Seek(0, 0)


### PR DESCRIPTION
- Fix error response when one of the query params in the presign URL is
  missing.
- Exhasutive test coverage for presignv4 parser. 
- Fixes https://github.com/minio/minio/issues/2372 . 
