### PR TITLE
utils: Take monitorShutdownSignal to take an exitFunc which would exe…

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func main() {
 
 	// Initialize and monitor shutdown signal
 	shutdownSignal = make(chan bool, 1)
-	monitorShutdownSignal()
+	monitorShutdownSignal(os.Exit)
 
 	// Run the app - exit on error.
 	app.RunAndExitOnError()

--- a/utils_test.go
+++ b/utils_test.go
@@ -16,13 +16,10 @@
 
 package main
 
-import (
-	"testing"
-)
+import "testing"
 
-// ShutdownCallback simulates a successful exit here, all registered
-// shutdown callbacks need to return exitSuccess for this test to succeed
-func TestShutdownCallback(t *testing.T) {
+// ShutdownCallback simulates a successful and failure exit here.
+func TestShutdownCallbackSuccess(t *testing.T) {
 	// Register two callbacks that return success
 	registerObjectStorageShutdown(func() errCode {
 		return exitSuccess
@@ -33,10 +30,11 @@ func TestShutdownCallback(t *testing.T) {
 
 	shutdownSignal = make(chan bool, 1)
 	shutdownSignal <- true
-	// Start executing callbacks and quit if everything is fine
-	monitorShutdownSignal()
-
-	// Infinite loop here simulates an infinite running program
-	for {
+	// Start executing callbacks and exitFunc receives a success.
+	dummySuccess := func(code int) {
+		if code != int(exitSuccess) {
+			t.Fatalf("Expected %d, got %d instead.", code, exitSuccess)
+		}
 	}
+	monitorShutdownSignal(dummySuccess)
 }


### PR DESCRIPTION
…cuted upon error.

This hook approach allows program to keep running but being able to handle exiting
of the program in the dynamic way.

Fixes #2377
