### PR TITLE
handlers: Remove 'notification.xml' when bucket is deleted.

### DIFF
--- a/bucket-handlers-listobjects.go
+++ b/bucket-handlers-listobjects.go
@@ -71,7 +71,7 @@ func (api objectAPIHandlers) ListObjectsV2Handler(w http.ResponseWriter, r *http
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
-		if s3Error := enforceBucketPolicy(api, "s3:ListBucket", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:ListBucket", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -130,7 +130,7 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
-		if s3Error := enforceBucketPolicy(api, "s3:ListBucket", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:ListBucket", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}

--- a/bucket-notification-handlers.go
+++ b/bucket-notification-handlers.go
@@ -272,3 +272,14 @@ func (api objectAPIHandlers) ListenBucketNotificationHandler(w http.ResponseWrit
 	// Start sending bucket notifications.
 	sendBucketNotification(w, nEventCh)
 }
+
+// Removes notification.xml for a given bucket, only used during DeleteBucket.
+func removeNotificationConfig(bucket string, objAPI ObjectLayer) error {
+	// Verify bucket is valid.
+	if !IsValidBucketName(bucket) {
+		return BucketNameInvalid{Bucket: bucket}
+	}
+
+	notificationConfigPath := path.Join(bucketConfigPrefix, bucket, bucketNotificationConfig)
+	return objAPI.DeleteObject(minioMetaBucket, notificationConfigPath)
+}

--- a/bucket-policy-handlers.go
+++ b/bucket-policy-handlers.go
@@ -188,7 +188,7 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 	}
 
 	// Save bucket policy.
-	if err := writeBucketPolicy(api, bucket, bucketPolicyBuf); err != nil {
+	if err := writeBucketPolicy(bucket, api.ObjectAPI, bucketPolicyBuf); err != nil {
 		errorIf(err, "Unable to write bucket policy.")
 		switch err.(type) {
 		case BucketNameInvalid:
@@ -222,7 +222,7 @@ func (api objectAPIHandlers) DeleteBucketPolicyHandler(w http.ResponseWriter, r 
 	}
 
 	// Delete bucket access policy.
-	if err := removeBucketPolicy(api, bucket); err != nil {
+	if err := removeBucketPolicy(bucket, api.ObjectAPI); err != nil {
 		errorIf(err, "Unable to remove bucket policy.")
 		switch err.(type) {
 		case BucketNameInvalid:
@@ -258,7 +258,7 @@ func (api objectAPIHandlers) GetBucketPolicyHandler(w http.ResponseWriter, r *ht
 	}
 
 	// Read bucket access policy.
-	p, err := readBucketPolicy(api, bucket)
+	p, err := readBucketPolicy(bucket, api.ObjectAPI)
 	if err != nil {
 		errorIf(err, "Unable to read bucket policy.")
 		switch err.(type) {

--- a/bucket-policy.go
+++ b/bucket-policy.go
@@ -31,14 +31,14 @@ func getOldBucketsConfigPath() (string, error) {
 }
 
 // readBucketPolicy - read bucket policy.
-func readBucketPolicy(api objectAPIHandlers, bucket string) ([]byte, error) {
+func readBucketPolicy(bucket string, objAPI ObjectLayer) ([]byte, error) {
 	// Verify bucket is valid.
 	if !IsValidBucketName(bucket) {
 		return nil, BucketNameInvalid{Bucket: bucket}
 	}
 
 	policyPath := pathJoin(bucketConfigPrefix, bucket, policyJSON)
-	objInfo, err := api.ObjectAPI.GetObjectInfo(minioMetaBucket, policyPath)
+	objInfo, err := objAPI.GetObjectInfo(minioMetaBucket, policyPath)
 	if err != nil {
 		if _, ok := err.(ObjectNotFound); ok {
 			return nil, BucketPolicyNotFound{Bucket: bucket}
@@ -46,7 +46,7 @@ func readBucketPolicy(api objectAPIHandlers, bucket string) ([]byte, error) {
 		return nil, err
 	}
 	var buffer bytes.Buffer
-	err = api.ObjectAPI.GetObject(minioMetaBucket, policyPath, 0, objInfo.Size, &buffer)
+	err = objAPI.GetObject(minioMetaBucket, policyPath, 0, objInfo.Size, &buffer)
 	if err != nil {
 		if _, ok := err.(ObjectNotFound); ok {
 			return nil, BucketPolicyNotFound{Bucket: bucket}
@@ -57,14 +57,14 @@ func readBucketPolicy(api objectAPIHandlers, bucket string) ([]byte, error) {
 }
 
 // removeBucketPolicy - remove bucket policy.
-func removeBucketPolicy(api objectAPIHandlers, bucket string) error {
+func removeBucketPolicy(bucket string, objAPI ObjectLayer) error {
 	// Verify bucket is valid.
 	if !IsValidBucketName(bucket) {
 		return BucketNameInvalid{Bucket: bucket}
 	}
 
 	policyPath := pathJoin(bucketConfigPrefix, bucket, policyJSON)
-	if err := api.ObjectAPI.DeleteObject(minioMetaBucket, policyPath); err != nil {
+	if err := objAPI.DeleteObject(minioMetaBucket, policyPath); err != nil {
 		if _, ok := err.(ObjectNotFound); ok {
 			return BucketPolicyNotFound{Bucket: bucket}
 		}
@@ -74,13 +74,13 @@ func removeBucketPolicy(api objectAPIHandlers, bucket string) error {
 }
 
 // writeBucketPolicy - save bucket policy.
-func writeBucketPolicy(api objectAPIHandlers, bucket string, accessPolicyBytes []byte) error {
+func writeBucketPolicy(bucket string, objAPI ObjectLayer, accessPolicyBytes []byte) error {
 	// Verify if bucket path legal
 	if !IsValidBucketName(bucket) {
 		return BucketNameInvalid{Bucket: bucket}
 	}
 
 	policyPath := pathJoin(bucketConfigPrefix, bucket, policyJSON)
-	_, err := api.ObjectAPI.PutObject(minioMetaBucket, policyPath, int64(len(accessPolicyBytes)), bytes.NewReader(accessPolicyBytes), nil)
+	_, err := objAPI.PutObject(minioMetaBucket, policyPath, int64(len(accessPolicyBytes)), bytes.NewReader(accessPolicyBytes), nil)
 	return err
 }

--- a/object-handlers.go
+++ b/object-handlers.go
@@ -52,13 +52,13 @@ func setGetRespHeaders(w http.ResponseWriter, reqParams url.Values) {
 // this is in keeping with the permissions sections of the docs of both:
 //   HEAD Object: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html
 //   GET Object: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
-func errAllowableObjectNotFound(api objectAPIHandlers, bucket string, r *http.Request) APIErrorCode {
+func errAllowableObjectNotFound(objAPI ObjectLayer, bucket string, r *http.Request) APIErrorCode {
 	if getRequestAuthType(r) == authTypeAnonymous {
 		//we care about the bucket as a whole, not a particular resource
 		url := *r.URL
 		url.Path = "/" + bucket
 
-		if s3Error := enforceBucketPolicy(api, "s3:ListBucket", bucket, &url); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(objAPI, "s3:ListBucket", bucket, &url); s3Error != ErrNone {
 			return ErrAccessDenied
 		}
 	}
@@ -89,7 +89,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
-		if s3Error := enforceBucketPolicy(api, "s3:GetObject", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:GetObject", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -105,7 +105,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 		errorIf(err, "Unable to fetch object info.")
 		apiErr := toAPIErrorCode(err)
 		if apiErr == ErrNoSuchKey {
-			apiErr = errAllowableObjectNotFound(api, bucket, r)
+			apiErr = errAllowableObjectNotFound(api.ObjectAPI, bucket, r)
 		}
 		writeErrorResponse(w, r, apiErr, r.URL.Path)
 		return
@@ -195,7 +195,7 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
-		if s3Error := enforceBucketPolicy(api, "s3:GetObject", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:GetObject", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -211,7 +211,7 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 		errorIf(err, "Unable to fetch object info.")
 		apiErr := toAPIErrorCode(err)
 		if apiErr == ErrNoSuchKey {
-			apiErr = errAllowableObjectNotFound(api, bucket, r)
+			apiErr = errAllowableObjectNotFound(api.ObjectAPI, bucket, r)
 		}
 		writeErrorResponse(w, r, apiErr, r.URL.Path)
 		return
@@ -245,7 +245,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
-		if s3Error := enforceBucketPolicy(api, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -424,7 +424,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
-		if s3Error := enforceBucketPolicy(api, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -490,7 +490,7 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html
-		if s3Error := enforceBucketPolicy(api, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -581,7 +581,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html
-		if s3Error := enforceBucketPolicy(api, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -625,7 +625,7 @@ func (api objectAPIHandlers) AbortMultipartUploadHandler(w http.ResponseWriter, 
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html
-		if s3Error := enforceBucketPolicy(api, "s3:AbortMultipartUpload", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:AbortMultipartUpload", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -658,7 +658,7 @@ func (api objectAPIHandlers) ListObjectPartsHandler(w http.ResponseWriter, r *ht
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html
-		if s3Error := enforceBucketPolicy(api, "s3:ListMultipartUploadParts", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:ListMultipartUploadParts", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -709,7 +709,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html
-		if s3Error := enforceBucketPolicy(api, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:PutObject", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}
@@ -830,7 +830,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
-		if s3Error := enforceBucketPolicy(api, "s3:DeleteObject", bucket, r.URL); s3Error != ErrNone {
+		if s3Error := enforceBucketPolicy(api.ObjectAPI, "s3:DeleteObject", bucket, r.URL); s3Error != ErrNone {
 			writeErrorResponse(w, r, s3Error, r.URL.Path)
 			return
 		}


### PR DESCRIPTION
Do not pass around objectHandlers object, input argument
should comply to a type for only that would be used inside
the function body.
