### PR TITLE
bug-fix: fix for tests failure when cache is disabled

### DIFF
--- a/erasure-readfile.go
+++ b/erasure-readfile.go
@@ -43,8 +43,8 @@ func isSuccessDecodeBlocks(enBlocks [][]byte, dataBlocks int) bool {
 		} // else { // update parity block count.
 		successParityBlocksCount++
 	}
-	// Returns true if we have atleast dataBlocks + 1 parity.
-	return successDataBlocksCount == dataBlocks || successDataBlocksCount+successParityBlocksCount >= dataBlocks+1
+	// Returns true if we have atleast dataBlocks parity.
+	return successDataBlocksCount == dataBlocks || successDataBlocksCount+successParityBlocksCount >= dataBlocks
 }
 
 // isSuccessDataBlocks - do we have all the data blocks?
@@ -86,7 +86,7 @@ func getReadDisks(orderedDisks []StorageAPI, index int, dataBlocks int) (readDis
 	if dataDisks == dataBlocks {
 		return nil, 0, errUnexpected
 	}
-	if dataDisks+parityDisks >= dataBlocks+1 {
+	if dataDisks+parityDisks >= dataBlocks {
 		return nil, 0, errUnexpected
 	}
 
@@ -103,8 +103,7 @@ func getReadDisks(orderedDisks []StorageAPI, index int, dataBlocks int) (readDis
 		readDisks[i] = orderedDisks[i]
 		if dataDisks == dataBlocks {
 			return readDisks, i + 1, nil
-		}
-		if dataDisks+parityDisks == dataBlocks+1 {
+		} else if dataDisks+parityDisks == dataBlocks {
 			return readDisks, i + 1, nil
 		}
 	}


### PR DESCRIPTION
When cache is disabled and tests are run, it was failiong with following we error, 

```
OK: 102 passed
--- FAIL: TestGetObjectDiskNotFound (0.03s)
        object-api-getobject_test.go:318: Test 6: XL: Expected to fail with error "EOF", but instead failed with error "Storage resources are insufficient for the read operation." instead.
        object-api-getobject_test.go:310: Test 7: XL:  Expected to pass, but failed with: <ERROR> Storage resources are insufficient for the read operation.
        object-api-getobject_test.go:310: Test 8: XL:  Expected to pass, but failed with: <ERROR> Storage resources are insufficient for the read operation.
        object-api-getobject_test.go:310: Test 9: XL:  Expected to pass, but failed with: <ERROR> Storage resources are insufficient for the read operation.
FAIL
```

The test had 8 out 16 disks down. 

Fix relaxes the checks which were not necessary. 
