### PR TITLE
Problem: AWS documentation defines event timestamp as ISO-8601

### DIFF
--- a/event-notifier.go
+++ b/event-notifier.go
@@ -60,7 +60,7 @@ func newNotificationEvent(event eventData) NotificationEvent {
 		EventVersion:      "2.0",
 		EventSource:       "aws:s3",
 		AwsRegion:         region,
-		EventTime:         tnow.Format(iso8601Format),
+		EventTime:         tnow.Format(timeFormatAMZ),
 		EventName:         event.Type.String(),
 		UserIdentity:      defaultIdentity(),
 		RequestParameters: event.ReqParams,


### PR DESCRIPTION
It specifies the following format: 1970-01-01T00:00:00.000Z

While the one Minio is using 20160814T124605Z

(See http://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html)

Solution: adhere to AWS documentation
