### PR TITLE
When updating the meta file, write to temp file first and then rename to the actual location.

### DIFF
--- a/fs-v1.go
+++ b/fs-v1.go
@@ -461,8 +461,13 @@ func (fs fsObjects) PutObject(bucket string, object string, size int64, data io.
 		fsMeta := newFSMetaV1()
 		fsMeta.Meta = metadata
 
+		// Write the metadata to a temp file and rename it to the actual location.
+		tmpMetaPath := path.Join(tmpMetaPrefix, getUUID())
 		fsMetaPath := path.Join(bucketMetaPrefix, bucket, object, fsMetaJSONFile)
-		if err = writeFSMetadata(fs.storage, minioMetaBucket, fsMetaPath, fsMeta); err != nil {
+		if err = writeFSMetadata(fs.storage, minioMetaBucket, tmpMetaPath, fsMeta); err != nil {
+			return "", toObjectErr(err, bucket, object)
+		}
+		if err = fs.storage.RenameFile(minioMetaBucket, tmpMetaPath, minioMetaBucket, fsMetaPath); err != nil {
 			return "", toObjectErr(err, bucket, object)
 		}
 	}


### PR DESCRIPTION
This prevents appending the metadata to the metadata-file when a file is reuploaded.
