### PR TITLE
Allow asterisk character in key names

### DIFF
--- a/api-errors.go
+++ b/api-errors.go
@@ -118,7 +118,7 @@ const (
 	ErrFilterNameInvalid
 	ErrFilterNamePrefix
 	ErrFilterNameSuffix
-	ErrFilterPrefixValueInvalid
+	ErrFilterValueInvalid
 
 	// S3 extended errors.
 	ErrContentSHA256Mismatch
@@ -500,9 +500,9 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Description:    "Cannot specify more than one suffix rule in a filter.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrFilterPrefixValueInvalid: {
+	ErrFilterValueInvalid: {
 		Code:           "InvalidArgument",
-		Description:    "prefix rule value cannot exceed 1024 characters",
+		Description:    "Size of filter rule value cannot exceed 1024 bytes in UTF-8 representation",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 

--- a/bucket-notification-utils.go
+++ b/bucket-notification-utils.go
@@ -88,9 +88,8 @@ func checkFilterRules(filterRules []filterRule) APIErrorCode {
 			}
 		}
 
-		// Maximum prefix length can be up to 1,024 characters, validate.
 		if !IsValidObjectPrefix(filterRule.Value) {
-			return ErrFilterPrefixValueInvalid
+			return ErrFilterValueInvalid
 		}
 
 		// Set the new rule name to keep track of duplicates.

--- a/object-utils.go
+++ b/object-utils.go
@@ -103,7 +103,7 @@ func IsValidObjectPrefix(object string) bool {
 		return false
 	}
 	// Reject unsupported characters in object name.
-	if strings.ContainsAny(object, "`^*|\\\"") {
+	if strings.ContainsAny(object, "`^|\\\"") {
 		return false
 	}
 	return true

--- a/object-utils_test.go
+++ b/object-utils_test.go
@@ -88,6 +88,7 @@ func TestIsValidObjectName(t *testing.T) {
 		{"Cost Benefit Analysis (2009-2010).pptx", true},
 		{"117Gn8rfHL2ACARPAhaFd0AGzic9pUbIA/5OCn5A", true},
 		{"SHØRT", true},
+		{"f*le", true},
 		{"There are far too many object names, and far too few bucket names!", true},
 		// cases for which test should fail.
 		// passing invalid object names.


### PR DESCRIPTION
http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys, in section `Safe Characters`, asterisk is listed.

I successfully tested simple mc commands (ls, cp, cat) with keys that contain asterisks. Otherwise, I don't know if there is a wise reason to do not allow asterisk, drop the patch if any.

Refer #2483 
