### PR TITLE
signature: Use the client sent region if region is properly validated.

### DIFF
--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -361,9 +361,8 @@ func doesSignatureMatch(hashedPayload string, r *http.Request, validateRegion bo
 		if !isValidRegion(sRegion, region) {
 			return ErrInvalidRegion
 		}
-	} else {
-		region = sRegion
 	}
+	region = sRegion
 
 	// Extract date, if not present throw error.
 	var date string


### PR DESCRIPTION
A properly validated region string from the client should be once
validated properly.

Fixes #2521
