### PR TITLE
server: We shouldn't exit the server in lazy init.

### DIFF
--- a/cmd/bucket-policy.go
+++ b/cmd/bucket-policy.go
@@ -100,10 +100,13 @@ func initBucketPolicies(objAPI ObjectLayer) error {
 		return err
 	}
 
+	// Populate global bucket collection.
 	globalBucketPolicies = &bucketPolicies{
 		rwMutex:             &sync.RWMutex{},
 		bucketPolicyConfigs: policies,
 	}
+
+	// Success.
 	return nil
 }
 

--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -21,6 +21,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"path"
 	"sync"
@@ -306,6 +307,14 @@ func loadAllQueueTargets() (map[string]*logrus.Logger, error) {
 		// Using accountID we can now initialize a new AMQP logrus instance.
 		amqpLog, err := newAMQPNotify(accountID)
 		if err != nil {
+			// Encapsulate network error to be more informative.
+			if _, ok := err.(net.Error); ok {
+				return nil, &net.OpError{
+					Op:  "Connecting to " + queueARN,
+					Net: "tcp",
+					Err: err,
+				}
+			}
 			return nil, err
 		}
 		queueTargets[queueARN] = amqpLog
@@ -325,6 +334,14 @@ func loadAllQueueTargets() (map[string]*logrus.Logger, error) {
 		// Using accountID we can now initialize a new Redis logrus instance.
 		redisLog, err := newRedisNotify(accountID)
 		if err != nil {
+			// Encapsulate network error to be more informative.
+			if _, ok := err.(net.Error); ok {
+				return nil, &net.OpError{
+					Op:  "Connecting to " + queueARN,
+					Net: "tcp",
+					Err: err,
+				}
+			}
 			return nil, err
 		}
 		queueTargets[queueARN] = redisLog
@@ -343,6 +360,13 @@ func loadAllQueueTargets() (map[string]*logrus.Logger, error) {
 		// Using accountID we can now initialize a new ElasticSearch logrus instance.
 		elasticLog, err := newElasticNotify(accountID)
 		if err != nil {
+			// Encapsulate network error to be more informative.
+			if _, ok := err.(net.Error); ok {
+				return nil, &net.OpError{
+					Op: "Connecting to " + queueARN, Net: "tcp",
+					Err: err,
+				}
+			}
 			return nil, err
 		}
 		queueTargets[queueARN] = elasticLog

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -61,10 +61,10 @@ func newObjectLayerFactory(disks, ignoredDisks []string) func() ObjectLayer {
 		}
 		// Migrate bucket policy from configDir to .minio.sys/buckets/
 		err = migrateBucketPolicyConfig(objAPI)
-		fatalIf(err, "Unable to migrate bucket policy from config directory")
+		errorIf(err, "Unable to migrate bucket policy from config directory")
 
 		err = cleanupOldBucketPolicyConfigs()
-		fatalIf(err, "Unable to clean up bucket policy from config directory.")
+		errorIf(err, "Unable to clean up bucket policy from config directory.")
 
 		// Register the callback that should be called when the process shuts down.
 		globalShutdownCBs.AddObjectLayerCB(func() errCode {
@@ -76,11 +76,11 @@ func newObjectLayerFactory(disks, ignoredDisks []string) func() ObjectLayer {
 
 		// Initialize a new event notifier.
 		err = initEventNotifier(objAPI)
-		fatalIf(err, "Unable to initialize event notification queue")
+		errorIf(err, "Unable to initialize event notification.")
 
 		// Initialize and load bucket policies.
 		err = initBucketPolicies(objAPI)
-		fatalIf(err, "Unable to load all bucket policies")
+		errorIf(err, "Unable to load all bucket policies.")
 
 		// Success.
 		return objAPI


### PR DESCRIPTION
Avoid fatalIf instead these are non-critical errors,
continue running the server.
- initializing bucket notifications
- initializing bucket policies.
- migrating bucket policies failure.

Fixes #2547
