### PR TITLE
bucket-handlers: fix missing return statement

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -284,6 +284,7 @@ func (api objectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 	// requests which do not follow valid region requirements.
 	if s3Error := isValidLocationConstraint(r); s3Error != ErrNone {
 		writeErrorResponse(w, r, s3Error, r.URL.Path)
+		return
 	}
 
 	// Proceed to creating a bucket.


### PR DESCRIPTION
If the location was invalid, it would write an error response but then
continue to attempt to make the bucket. Whether or not it would succeed,
it would attempt to call `response.WriteHeaders` twice in a row, which
would cause a message to be logged to the server console (bad).

[Here](https://github.com/golang/go/blob/c80e0d374ba3caf8ee32c6fe4a5474fa33928086/src/net/http/server.go#L878-L881) is the relevant Go code.
