### PR TITLE
server: http.Server do not add deadlines causes issues.

### DIFF
--- a/cmd/server-mux.go
+++ b/cmd/server-mux.go
@@ -188,9 +188,9 @@ func NewMuxServer(addr string, handler http.Handler) *MuxServer {
 	m := &MuxServer{
 		Server: http.Server{
 			Addr: addr,
-			// Adding timeout of 10 minutes for unresponsive client connections.
-			ReadTimeout:    10 * time.Minute,
-			WriteTimeout:   10 * time.Minute,
+			// Do not add any timeouts Golang net.Conn
+			// closes connections right after 10mins even
+			// if they are not idle.
 			Handler:        handler,
 			MaxHeaderBytes: 1 << 20,
 		},


### PR DESCRIPTION
Adding deadlines is a no go since Golang doesn't back off
the timers if there is an active i/o in progress.

It is meant to be for applications to handle this themselves
and manually progress the deadlines.

Fixes #2561
