### PR TITLE
XL/Healing: errDiskNotFound is the only pardonable error in xlShouldH…

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -135,10 +135,10 @@ func xlShouldHeal(partsMetadata []xlMetaV1, errs []error) bool {
 	modTime := commonTime(listObjectModtimes(partsMetadata, errs))
 	for index := range partsMetadata {
 		if errs[index] == errDiskNotFound {
-			return true
+			continue
 		}
 		if errs[index] != nil {
-			continue
+			return true
 		}
 		if modTime != partsMetadata[index].Stat.ModTime {
 			return true


### PR DESCRIPTION
…eal.

This is so that we try to heal a file for all the "bad" cases except when the disk is down.
