### PR TITLE
Make export directory an exposed volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ RUN \
 
 EXPOSE 9000
 ENTRYPOINT ["go-wrapper", "run", "server"]
+VOLUME ["/export"]
 CMD ["/export"]


### PR DESCRIPTION
This exposes the /export directory, making it possible to mount it from other
containers. It also makes it possible to bind a local folder to the internal /export
mount point using the native Docker for Mac/Windows and Kinematic.
