### PR TITLE
s3: Fix compliance bugs reported by s3verify.

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -263,7 +263,7 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	},
 	ErrNoSuchBucketPolicy: {
 		Code:           "NoSuchBucketPolicy",
-		Description:    "The specified bucket does not have a bucket policy.",
+		Description:    "The bucket policy does not exist",
 		HTTPStatusCode: http.StatusNotFound,
 	},
 	ErrNoSuchKey: {
@@ -328,7 +328,7 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	},
 	ErrBucketNotEmpty: {
 		Code:           "BucketNotEmpty",
-		Description:    "The bucket you tried to delete is not empty.",
+		Description:    "The bucket you tried to delete is not empty",
 		HTTPStatusCode: http.StatusConflict,
 	},
 	ErrAllAccessDisabled: {
@@ -446,7 +446,7 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	ErrExpiredPresignRequest: {
 		Code:           "AccessDenied",
 		Description:    "Request has expired",
-		HTTPStatusCode: http.StatusBadRequest,
+		HTTPStatusCode: http.StatusForbidden,
 	},
 	// FIXME: Actual XML error response also contains the header which missed in lsit of signed header parameters.
 	ErrUnsignedHeaders: {

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -226,16 +226,6 @@ type CompleteMultipartUploadResponse struct {
 	ETag     string
 }
 
-// PostResponse container for completed post upload response
-type PostResponse struct {
-	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ PostResponse" json:"-"`
-
-	Location string
-	Bucket   string
-	Key      string
-	ETag     string
-}
-
 // DeleteError structure.
 type DeleteError struct {
 	Code    string

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -387,18 +387,15 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	if md5Sum != "" {
 		w.Header().Set("ETag", "\""+md5Sum+"\"")
 	}
-	encodedSuccessResponse := encodeResponse(PostResponse{
-		Location: getObjectLocation(bucket, object), // TODO Full URL is preferred
-		Bucket:   bucket,
-		Key:      object,
-		ETag:     md5Sum,
-	})
+
+	// TODO full URL is preferred.
+	w.Header().Set("Location", getObjectLocation(bucket, object))
 
 	// Set common headers.
 	setCommonHeaders(w)
 
 	// Write successful response.
-	writeSuccessResponse(w, encodedSuccessResponse)
+	writeSuccessNoContent(w)
 
 	if eventN.IsBucketNotificationSet(bucket) {
 		// Fetch object info for notifications.


### PR DESCRIPTION
- Fixes couple of error strings reported are mismatching.
- Fixes a error HTTP status which was wrong fixed.
- Remove usage of an deprecated PostResponse, au contraire
  to their documentation there is no response body in
  PostPolicy.
