### PR TITLE
S3-layer: Multiple-delete should return success for non-existent objects.

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -267,6 +267,12 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 			deletedObjects = append(deletedObjects, object)
 			continue
 		}
+		if _, ok := err.(ObjectNotFound); ok {
+			// If the object is not found it should be
+			// accounted as deleted as per S3 spec.
+			deletedObjects = append(deletedObjects, object)
+			continue
+		}
 		errorIf(err, "Unable to delete object. %s", object.ObjectName)
 		// Error during delete should be collected separately.
 		deleteErrors = append(deleteErrors, DeleteError{

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -347,6 +347,11 @@ func (s *TestSuiteCommon) TestDeleteMultipleObjects(c *C) {
 			ObjectName: objName,
 		})
 	}
+	// Append a non-existent object for which the response should be marked
+	// as deleted.
+	delObjReq.Objects = append(delObjReq.Objects, ObjectIdentifier{
+		ObjectName: fmt.Sprintf("%d/%s", 10, objectName),
+	})
 
 	// Marshal delete request.
 	deleteReqBytes, err := xml.Marshal(delObjReq)
@@ -367,7 +372,8 @@ func (s *TestSuiteCommon) TestDeleteMultipleObjects(c *C) {
 	c.Assert(err, IsNil)
 	err = xml.Unmarshal(delRespBytes, &deleteResp)
 	c.Assert(err, IsNil)
-	for i := 0; i < 10; i++ {
+	for i := 0; i <= 10; i++ {
+		// All the objects should be under deleted list (including non-existent object)
 		c.Assert(deleteResp.DeletedObjects[i], DeepEquals, delObjReq.Objects[i])
 	}
 	c.Assert(len(deleteResp.Errors), Equals, 0)


### PR DESCRIPTION
Fixes #2630
