### PR TITLE
Signature-V4: Include content-length for signature calculation.

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -21,6 +21,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -29,6 +30,18 @@ import (
 
 	"github.com/pkg/profile"
 )
+
+// make a copy of http.Header
+func cloneHeader(h http.Header) http.Header {
+	h2 := make(http.Header, len(h))
+	for k, vv := range h {
+		vv2 := make([]string, len(vv))
+		copy(vv2, vv)
+		h2[k] = vv2
+
+	}
+	return h2
+}
 
 // xmlDecoder provide decoded value in xml.
 func xmlDecoder(body io.Reader, v interface{}, size int64) error {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -16,7 +16,35 @@
 
 package cmd
 
-import "testing"
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+// Tests http.Header clone.
+func TestCloneHeader(t *testing.T) {
+	headers := []http.Header{
+		http.Header{
+			"Content-Type":   {"text/html; charset=UTF-8"},
+			"Content-Length": {"0"},
+		},
+		http.Header{
+			"Content-Length": {"0", "1", "2"},
+		},
+		http.Header{
+			"Expires":          {"-1"},
+			"Content-Length":   {"0"},
+			"Content-Encoding": {"gzip"},
+		},
+	}
+	for i, header := range headers {
+		clonedHeader := cloneHeader(header)
+		if !reflect.DeepEqual(header, clonedHeader) {
+			t.Errorf("Test %d failed", i+1)
+		}
+	}
+}
 
 // Tests maximum object size.
 func TestMaxObjectSize(t *testing.T) {


### PR DESCRIPTION
This is to be compatible with clients which includes content-length for signature calculation
(and hence deviating from AWS Signature-v4 spec)
