### PR TITLE
Forbid requests generated at least 15 min in the past or in the future

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -198,9 +198,10 @@ func (h timeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeErrorResponse(w, r, apiErr, r.URL.Path)
 			return
 		}
-		// Verify if the request date header is more than 5minutes
-		// late, reject such clients.
-		if time.Now().UTC().Sub(amzDate)/time.Minute > time.Duration(5)*time.Minute {
+		// Verify if the request date header is shifted by less than maxSkewTime parameter in the past
+		// or in the future, reject request otherwise.
+		curTime := time.Now().UTC()
+		if curTime.Sub(amzDate) > maxSkewTime || amzDate.Sub(curTime) > maxSkewTime {
 			writeErrorResponse(w, r, ErrRequestTimeTooSkewed, r.URL.Path)
 			return
 		}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -17,6 +17,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/fatih/color"
 	"github.com/minio/minio/pkg/objcache"
 )
@@ -56,6 +58,11 @@ var (
 	// Limit fields size (except file) to 1Mib since Policy document
 	// can reach that size according to https://aws.amazon.com/articles/1434
 	maxFormFieldSize = int64(1024 * 1024)
+)
+
+var (
+	// The maximum allowed difference between the request generation time and the server processing time
+	maxSkewTime = 15 * time.Minute
 )
 
 // global colors.


### PR DESCRIPTION
Time skew detection wasn't really working. Fix it and allow skew in the future too
