### PR TITLE
Set content-length header instead of Add

### DIFF
--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -354,7 +354,7 @@ func doesSignatureMatch(hashedPayload string, r *http.Request, validateRegion bo
 	for _, h := range signV4Values.SignedHeaders {
 		if h == "content-length" {
 			header = cloneHeader(req.Header)
-			header.Add("content-length", strconv.FormatInt(r.ContentLength, 10))
+			header.Set("content-length", strconv.FormatInt(r.ContentLength, 10))
 			break
 		}
 	}


### PR DESCRIPTION
Adding the header results in duplicated headers if the requester had already set content-length since Add simply appends: https://golang.org/pkg/net/http/#Header.Add . This results in an invalid request because the string to sign generated by minio will be different than the one from the requester.

Setting the header should alleviate this problem since it will overwrite instead of appending. 
