### PR TITLE
Require go 1.7.1 to build Minio server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ after_success:
 - bash <(curl -s https://codecov.io/bash)
 
 go:
-- 1.6.2
+- 1.7.1

--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -21,7 +21,7 @@ _init() {
 
     ## Minimum required versions for build dependencies
     GIT_VERSION="1.0"
-    GO_VERSION="1.6"
+    GO_VERSION="1.7.1"
     OSX_VERSION="10.8"
     UNAME=$(uname -sm)
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -26,7 +26,7 @@ import (
 
 // Global constants for Minio.
 const (
-	minGoVersion = ">= 1.6" // Minio requires at least Go v1.6
+	minGoVersion = ">= 1.7.1" // minimum Go runtime version
 )
 
 // minio configuration related constants.


### PR DESCRIPTION
Fixes #2674 
