### PR TITLE
events: Change event notifiers to delete and update keys.

### DIFF
--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -204,7 +204,9 @@ func eventNotify(event eventData) {
 			targetLog := globalEventNotifier.GetQueueTarget(qConfig.QueueARN)
 			if targetLog != nil {
 				targetLog.WithFields(logrus.Fields{
-					"Records": notificationEvent,
+					"Key":       objectName,
+					"EventType": eventType,
+					"Records":   notificationEvent,
 				}).Info()
 			}
 		}


### PR DESCRIPTION
ElasticSearch and Redis are both treated like a database.
Each indexs are based on the object names uniquely indentifying
the event. Each code upon delete of the named object deletes
the index also on elasticsearch and redis respectively.

Fixes #2738 
