### PR TITLE
events: ElasticSearch doesnt support objects with '/' in them.

### DIFF
--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -204,7 +204,7 @@ func eventNotify(event eventData) {
 			targetLog := globalEventNotifier.GetQueueTarget(qConfig.QueueARN)
 			if targetLog != nil {
 				targetLog.WithFields(logrus.Fields{
-					"Key":       objectName,
+					"Key":       path.Join(event.Bucket, objectName),
 					"EventType": eventType,
 					"Records":   notificationEvent,
 				}).Info()


### PR DESCRIPTION
Fix this by using a unique sha256 generated for each unique key.
