### PR TITLE
Use runtime/debug.Stack() in leak detect test.

### DIFF
--- a/cmd/leak-detect_test.go
+++ b/cmd/leak-detect_test.go
@@ -8,7 +8,7 @@
 package cmd
 
 import (
-	"runtime"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"time"
@@ -126,9 +126,8 @@ func isIgnoredStackFn(stack string) (ok bool) {
 // pickRelevantGoroutines returns all goroutines we care about for the purpose
 // of leak checking. It excludes testing or runtime ones.
 func pickRelevantGoroutines() (gs []string) {
-	// make a large buffer to hold the runtime stack info.
-	buf := make([]byte, 2<<20)
-	buf = buf[:runtime.Stack(buf, true)]
+	// get runtime stack buffer.
+	buf := debug.Stack()
 	// runtime stack of go routines will be listed with 2 blank spaces between each of them, so split on "\n\n" .
 	for _, g := range strings.Split(string(buf), "\n\n") {
 		// Again split on a new line, the first line of the second half contaisn the info about the go routine.


### PR DESCRIPTION
- [runtime/debug.Stack()](https://golang.org/src/runtime/debug/stack.go?s=587:606#L11) is cleaner way of getting stack trace, replacing `runtime.Stack` .
