### PR TITLE
event: Notifications don't need double caching.

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -330,20 +330,18 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 	// Write success response.
 	writeSuccessResponse(w, encodedSuccessResponse)
 
-	if globalEventNotifier.IsBucketNotificationSet(bucket) {
-		// Notify deleted event for objects.
-		for _, dobj := range deletedObjects {
-			eventNotify(eventData{
-				Type:   ObjectRemovedDelete,
-				Bucket: bucket,
-				ObjInfo: ObjectInfo{
-					Name: dobj.ObjectName,
-				},
-				ReqParams: map[string]string{
-					"sourceIPAddress": r.RemoteAddr,
-				},
-			})
-		}
+	// Notify deleted event for objects.
+	for _, dobj := range deletedObjects {
+		eventNotify(eventData{
+			Type:   ObjectRemovedDelete,
+			Bucket: bucket,
+			ObjInfo: ObjectInfo{
+				Name: dobj.ObjectName,
+			},
+			ReqParams: map[string]string{
+				"sourceIPAddress": r.RemoteAddr,
+			},
+		})
 	}
 }
 
@@ -452,17 +450,15 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	// Write successful response.
 	writeSuccessNoContent(w)
 
-	if globalEventNotifier.IsBucketNotificationSet(bucket) {
-		// Notify object created event.
-		eventNotify(eventData{
-			Type:    ObjectCreatedPost,
-			Bucket:  bucket,
-			ObjInfo: objInfo,
-			ReqParams: map[string]string{
-				"sourceIPAddress": r.RemoteAddr,
-			},
-		})
-	}
+	// Notify object created event.
+	eventNotify(eventData{
+		Type:    ObjectCreatedPost,
+		Bucket:  bucket,
+		ObjInfo: objInfo,
+		ReqParams: map[string]string{
+			"sourceIPAddress": r.RemoteAddr,
+		},
+	})
 }
 
 // HeadBucketHandler - HEAD Bucket

--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -152,9 +152,6 @@ func (api objectAPIHandlers) PutBucketNotificationHandler(w http.ResponseWriter,
 		return
 	}
 
-	// Set bucket notification config.
-	globalEventNotifier.SetBucketNotificationConfig(bucket, &notificationCfg)
-
 	// Success.
 	writeSuccessResponse(w, nil)
 }
@@ -245,6 +242,7 @@ func (api objectAPIHandlers) ListenBucketNotificationHandler(w http.ResponseWrit
 		return
 	}
 
+	// Fetch bucket notification config.
 	notificationCfg := globalEventNotifier.GetBucketNotificationConfig(bucket)
 	if notificationCfg == nil {
 		writeErrorResponse(w, r, ErrARNNotification, r.URL.Path)

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -17,8 +17,9 @@
 package cmd
 
 import (
-	"github.com/minio/minio/pkg/disk"
 	"sync"
+
+	"github.com/minio/minio/pkg/disk"
 )
 
 // naughtyDisk wraps a POSIX disk and returns programmed errors
@@ -56,48 +57,48 @@ func (d *naughtyDisk) calcError() (err error) {
 }
 
 func (d *naughtyDisk) DiskInfo() (info disk.Info, err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return info, err
 	}
 	return d.disk.DiskInfo()
 }
 
 func (d *naughtyDisk) MakeVol(volume string) (err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return err
 	}
 	return d.disk.MakeVol(volume)
 }
 
 func (d *naughtyDisk) ListVols() (vols []VolInfo, err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return nil, err
 	}
 	return d.disk.ListVols()
 }
 
 func (d *naughtyDisk) StatVol(volume string) (volInfo VolInfo, err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return VolInfo{}, err
 	}
 	return d.disk.StatVol(volume)
 }
 func (d *naughtyDisk) DeleteVol(volume string) (err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return err
 	}
 	return d.disk.DeleteVol(volume)
 }
 
 func (d *naughtyDisk) ListDir(volume, path string) (entries []string, err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return []string{}, err
 	}
 	return d.disk.ListDir(volume, path)
 }
 
 func (d *naughtyDisk) ReadFile(volume string, path string, offset int64, buf []byte) (n int64, err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return 0, err
 	}
 	return d.disk.ReadFile(volume, path, offset, buf)
@@ -118,21 +119,21 @@ func (d *naughtyDisk) RenameFile(srcVolume, srcPath, dstVolume, dstPath string) 
 }
 
 func (d *naughtyDisk) StatFile(volume string, path string) (file FileInfo, err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return FileInfo{}, err
 	}
 	return d.disk.StatFile(volume, path)
 }
 
 func (d *naughtyDisk) DeleteFile(volume string, path string) (err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return err
 	}
 	return d.disk.DeleteFile(volume, path)
 }
 
 func (d *naughtyDisk) ReadAll(volume string, path string) (buf []byte, err error) {
-	if err := d.calcError(); err != nil {
+	if err = d.calcError(); err != nil {
 		return nil, err
 	}
 	return d.disk.ReadAll(volume, path)

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1925,9 +1925,8 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 		}
 		// Passes as expected, but asserting the results.
 		if actualErr == nil && testCase.shouldPass {
-
-			// Asserting IsTruncated.
-			if actualResult != testCase.expectedS3MD5 {
+			// Asserting md5sum.
+			if actualResult.MD5Sum != testCase.expectedS3MD5 {
 				t.Errorf("Test %d: %s: Expected the result to be \"%v\", but found it to \"%v\"", i+1, instanceType, testCase.expectedS3MD5, actualResult)
 			}
 		}

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -728,6 +728,10 @@ func testAPICompleteMultipartHandler(obj ObjectLayer, instanceType, bucketName s
 	successResponse := generateCompleteMultpartUploadResponse(bucketName, objectName, getGetObjectURL("", bucketName, objectName), s3MD5)
 	encodedSuccessResponse := encodeResponse(successResponse)
 
+	if err = initEventNotifier(obj); err != nil {
+		t.Fatal("Initializing event notifier failed.", err)
+	}
+
 	testCases := []struct {
 		bucket   string
 		object   string

--- a/cmd/object-interface.go
+++ b/cmd/object-interface.go
@@ -36,7 +36,7 @@ type ObjectLayer interface {
 	// Object operations.
 	GetObject(bucket, object string, startOffset int64, length int64, writer io.Writer) (err error)
 	GetObjectInfo(bucket, object string) (objInfo ObjectInfo, err error)
-	PutObject(bucket, object string, size int64, data io.Reader, metadata map[string]string) (objInto ObjectInfo, err error)
+	PutObject(bucket, object string, size int64, data io.Reader, metadata map[string]string) (objInfo ObjectInfo, err error)
 	DeleteObject(bucket, object string) error
 	HealObject(bucket, object string) error
 
@@ -46,5 +46,5 @@ type ObjectLayer interface {
 	PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Hex string) (md5 string, err error)
 	ListObjectParts(bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error)
 	AbortMultipartUpload(bucket, object, uploadID string) error
-	CompleteMultipartUpload(bucket, object, uploadID string, uploadedParts []completePart) (md5 string, err error)
+	CompleteMultipartUpload(bucket, object, uploadID string, uploadedParts []completePart) (objInfo ObjectInfo, err error)
 }

--- a/cmd/object_api_suite_test.go
+++ b/cmd/object_api_suite_test.go
@@ -118,11 +118,11 @@ func testMultipartObjectCreation(obj ObjectLayer, instanceType string, c TestErr
 		}
 		completedParts.Parts = append(completedParts.Parts, completePart{PartNumber: i, ETag: calculatedMD5sum})
 	}
-	md5Sum, err := obj.CompleteMultipartUpload("bucket", "key", uploadID, completedParts.Parts)
+	objInfo, err := obj.CompleteMultipartUpload("bucket", "key", uploadID, completedParts.Parts)
 	if err != nil {
 		c.Fatalf("%s: <ERROR> %s", instanceType, err)
 	}
-	if md5Sum != "7d364cb728ce42a74a96d22949beefb2-10" {
+	if objInfo.MD5Sum != "7d364cb728ce42a74a96d22949beefb2-10" {
 		c.Errorf("Md5 mismtch")
 	}
 }

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -416,29 +416,21 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 		writeWebErrorResponse(w, errors.New("Server not initialized, please try again."))
 		return
 	}
-	if _, err := objectAPI.PutObject(bucket, object, -1, r.Body, metadata); err != nil {
+	objInfo, err := objectAPI.PutObject(bucket, object, -1, r.Body, metadata)
+	if err != nil {
 		writeWebErrorResponse(w, err)
 		return
 	}
 
-	// Fetch object info for notifications.
-	objInfo, err := objectAPI.GetObjectInfo(bucket, object)
-	if err != nil {
-		errorIf(err, "Unable to fetch object info for \"%s\"", path.Join(bucket, object))
-		return
-	}
-
-	if globalEventNotifier.IsBucketNotificationSet(bucket) {
-		// Notify object created event.
-		eventNotify(eventData{
-			Type:    ObjectCreatedPut,
-			Bucket:  bucket,
-			ObjInfo: objInfo,
-			ReqParams: map[string]string{
-				"sourceIPAddress": r.RemoteAddr,
-			},
-		})
-	}
+	// Notify object created event.
+	eventNotify(eventData{
+		Type:    ObjectCreatedPut,
+		Bucket:  bucket,
+		ObjInfo: objInfo,
+		ReqParams: map[string]string{
+			"sourceIPAddress": r.RemoteAddr,
+		},
+	})
 }
 
 // Download - file download handler.


### PR DESCRIPTION
This is also resolves the problem of dist notification
problem when notification is being set and reset across
many nodes in distributed XL mode.

This patch on the other hand penalizes FS backend
to read the 'notification.xml' for each requests.
