### PR TITLE
Remove MINIO_DEBUG environment variable

### DIFF
--- a/cmd/control-mains_test.go
+++ b/cmd/control-mains_test.go
@@ -59,14 +59,11 @@ func TestControlLockMain(t *testing.T) {
 	// schedule cleanup at the end
 	defer testServer.Stop()
 
-	// enabling lock instrumentation.
-	globalDebugLock = true
 	// initializing the locks.
 	initNSLock(false)
 	// set debug lock info to `nil` so that other tests do not see
 	// such modified env settings.
 	defer func() {
-		globalDebugLock = false
 		nsMutex.debugLockMap = nil
 	}()
 

--- a/cmd/controller_test.go
+++ b/cmd/controller_test.go
@@ -66,14 +66,11 @@ func TestRPCControlLock(t *testing.T) {
 
 // Tests to validate the correctness of lock instrumentation control RPC end point.
 func (s *TestRPCControllerSuite) testRPCControlLock(c *testing.T) {
-	// enabling lock instrumentation.
-	globalDebugLock = true
 	// initializing the locks.
 	initNSLock(false)
 	// set debug lock info to `nil` so that the next tests have to
 	// initialize them again.
 	defer func() {
-		globalDebugLock = false
 		nsMutex.debugLockMap = nil
 	}()
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/minio/pkg/objcache"
-	"os"
 )
 
 // Global constants for Minio.
@@ -44,9 +43,6 @@ var (
 	globalQuiet = false // Quiet flag set via command line
 	globalTrace = false // Trace flag set via environment setting.
 
-	globalDebug       = false // Debug flag set to print debug info.
-	globalDebugLock   = false // Lock debug info set via environment variable MINIO_DEBUG=lock .
-	globalDebugMemory = false // Memory debug info set via environment variable MINIO_DEBUG=mem
 	// Add new global flags here.
 
 	// Maximum connections handled per
@@ -75,15 +71,3 @@ var (
 	colorBlue = color.New(color.FgBlue).SprintfFunc()
 	colorBold = color.New(color.Bold).SprintFunc()
 )
-
-// fetch from environment variables and set the global values related to locks.
-func setGlobalsDebugFromEnv() {
-	debugEnv := os.Getenv("MINIO_DEBUG")
-	switch debugEnv {
-	case "lock":
-		globalDebugLock = true
-	case "mem":
-		globalDebugMemory = true
-	}
-	globalDebug = globalDebugLock || globalDebugMemory
-}

--- a/cmd/lock-instrument.go
+++ b/cmd/lock-instrument.go
@@ -271,13 +271,7 @@ func (n *nsLockMap) deleteLockInfoEntryForOps(param nsParam, operationID string)
 	return nil
 }
 
-// return randomly generated string ID if lock debug is enabled,
-// else returns empty string
-func getOpsID() (opsID string) {
-	// check if lock debug is enabled.
-	if globalDebugLock {
-		// generated random ID.
-		opsID = string(generateRequestID())
-	}
-	return opsID
+// return randomly generated string ID
+func getOpsID() string {
+	return string(generateRequestID())
 }

--- a/cmd/lock-instrument_test.go
+++ b/cmd/lock-instrument_test.go
@@ -389,13 +389,10 @@ func TestNsLockMapStatusBlockedToRunning(t *testing.T) {
 		t.Fatalf("Errors mismatch: Expected: \"%s\", got: \"%s\"", expectedBlockErr, actualErr)
 	}
 
-	// enabling lock instrumentation.
-	globalDebugLock = true
 	// initializing the locks.
 	initNSLock(false)
 	// set debug lock info  to `nil` so that the next tests have to initialize them again.
 	defer func() {
-		globalDebugLock = false
 		nsMutex.debugLockMap = nil
 	}()
 	// Iterate over the cases and assert the result.
@@ -531,13 +528,10 @@ func TestNsLockMapStatusNoneToBlocked(t *testing.T) {
 	if actualErr != expectedNilErr {
 		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedNilErr, actualErr)
 	}
-	// enabling lock instrumentation.
-	globalDebugLock = true
 	// initializing the locks.
 	initNSLock(false)
 	// set debug lock info  to `nil` so that the next tests have to initialize them again.
 	defer func() {
-		globalDebugLock = false
 		nsMutex.debugLockMap = nil
 	}()
 	// Iterate over the cases and assert the result.
@@ -580,13 +574,10 @@ func TestNsLockMapDeleteLockInfoEntryForOps(t *testing.T) {
 		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedNilErr, actualErr)
 	}
 
-	// enabling lock instrumentation.
-	globalDebugLock = true
 	// initializing the locks.
 	initNSLock(false)
 	// set debug lock info  to `nil` so that the next tests have to initialize them again.
 	defer func() {
-		globalDebugLock = false
 		nsMutex.debugLockMap = nil
 	}()
 	// case - 2.
@@ -681,13 +672,10 @@ func TestNsLockMapDeleteLockInfoEntryForVolumePath(t *testing.T) {
 		t.Fatalf("Errors mismatch: Expected \"%s\", got \"%s\"", expectedNilErr, actualErr)
 	}
 
-	// enabling lock instrumentation.
-	globalDebugLock = true
 	// initializing the locks.
 	initNSLock(false)
 	// set debug lock info  to `nil` so that the next tests have to initialize them again.
 	defer func() {
-		globalDebugLock = false
 		nsMutex.debugLockMap = nil
 	}()
 	// case - 2.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,9 +73,6 @@ func init() {
 
 	// Set global trace flag.
 	globalTrace = os.Getenv("MINIO_TRACE") == "1"
-
-	// Set all the debug flags from ENV if any.
-	setGlobalsDebugFromEnv()
 }
 
 func migrate() {

--- a/cmd/namespace-lock_test.go
+++ b/cmd/namespace-lock_test.go
@@ -298,14 +298,11 @@ func TestLockStats(t *testing.T) {
 		},
 	}
 	var wg sync.WaitGroup
-	// enabling lock instrumentation.
-	globalDebugLock = true
 	// initializing the locks.
 	initNSLock(false)
 
 	// set debug lock info  to `nil` so that the next tests have to initialize them again.
 	defer func() {
-		globalDebugLock = false
 		nsMutex.debugLockMap = nil
 	}()
 


### PR DESCRIPTION
Removes the unimplemented settings of MINIO_DEBUG=mem and makes
MINIO_DEBUG=lock the default behaviour.
