### PR TITLE
Avoid path-cleaning policy resources for a better compliance with S3

### DIFF
--- a/cmd/bucket-policy-parser.go
+++ b/cmd/bucket-policy-parser.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
 	"sort"
 	"strings"
 
@@ -224,7 +223,7 @@ func resourcePrefix(resource string) string {
 	if strings.HasSuffix(resource, "*") {
 		resource = strings.TrimSuffix(resource, "*")
 	}
-	return path.Clean(resource)
+	return resource
 }
 
 // checkBucketPolicyResources validates Resources in unmarshalled bucket policy structure.


### PR DESCRIPTION
Below is the get bucket policy response against AWS S3, which supports resources with `..`, `//` and `/` at the end. So we need to disable policy resources cleaning in the code.

```
[
  {
    "Version": "2012-10-17",
    "Statement": [
      {
        "Sid": "",
        "Effect": "Allow",
        "Principal": {
          "AWS": "*"
        },
        "Action": "s3:GetBucketLocation",
        "Resource": "arn:aws:s3:::vadmeste"
      },
      {
        "Sid": "",
        "Effect": "Allow",
        "Principal": {
          "AWS": "*"
        },
        "Action": "s3:ListBucket",
        "Resource": "arn:aws:s3:::vadmeste",
        "Condition": {
          "StringEquals": {
            "s3:prefix": [
              "inexistent/",
              "inexistentdir/../inexistent",
              "inexistentdir//inexistent",
              "inexistentdir/inexistent"
            ]
          }
        }
      },
      {
        "Sid": "",
        "Effect": "Allow",
        "Principal": {
          "AWS": "*"
        },
        "Action": "s3:GetObject",
        "Resource": [
          "arn:aws:s3:::vadmeste/inexistent/*",
          "arn:aws:s3:::vadmeste/inexistentdir/../inexistent*",
          "arn:aws:s3:::vadmeste/inexistentdir//inexistent*",
          "arn:aws:s3:::vadmeste/inexistentdir/inexistent*"
        ]
      }
    ]
  }
]
```

This fixes #2822 
