### PR TITLE
signature-v2 fix.

### DIFF
--- a/cmd/signature-v2_test.go
+++ b/cmd/signature-v2_test.go
@@ -104,3 +104,79 @@ func TestDoesPresignedV2SignatureMatch(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateV2AuthHeader - Tests validate the logic of V2 Authorization header validator.
+func TestValidateV2AuthHeader(t *testing.T) {
+	// Initialize server config.
+	if err := initConfig(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save config.
+	if err := serverConfig.Save(); err != nil {
+		t.Fatal(err)
+	}
+	accessID := serverConfig.GetCredential().AccessKeyID
+
+	testCases := []struct {
+		authString    string
+		expectedError APIErrorCode
+	}{
+		// Test case - 1.
+		// Case with empty V2AuthString.
+		{
+
+			authString:    "",
+			expectedError: ErrAuthHeaderEmpty,
+		},
+		// Test case - 2.
+		// Test case with `signV2Algorithm` ("AWS") not being the prefix.
+		{
+
+			authString:    "NoV2Prefix",
+			expectedError: ErrSignatureVersionNotSupported,
+		},
+		// Test case - 3.
+		// Test case with missing parts in the Auth string.
+		// below is the correct format of V2 Authorization header.
+		// Authorization = "AWS" + " " + AWSAccessKeyId + ":" + Signature
+		{
+
+			authString:    signV2Algorithm,
+			expectedError: ErrMissingFields,
+		},
+		// Test case - 4.
+		// Test case with signature part missing.
+		{
+
+			authString:    fmt.Sprintf("%s %s", signV2Algorithm, accessID),
+			expectedError: ErrMissingFields,
+		},
+		// Test case - 5.
+		// Test case with wrong accessID.
+		{
+
+			authString:    fmt.Sprintf("%s %s:%s", signV2Algorithm, "InvalidAccessID", "signature"),
+			expectedError: ErrInvalidAccessKeyID,
+		},
+		// Test case - 6.
+		// Case with right accessID and format.
+		{
+
+			authString:    fmt.Sprintf("%s %s:%s", signV2Algorithm, accessID, "signature"),
+			expectedError: ErrNone,
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("Case %d AuthStr \"%s\".", i+1, testCase.authString), func(t *testing.T) {
+
+			actualErrCode := validateV2AuthHeader(testCase.authString)
+
+			if testCase.expectedError != actualErrCode {
+				t.Errorf("Expected the error code to be %v, got %v.", testCase.expectedError, actualErrCode)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
- Return errors similar to V4 Sign processsing.
- Return ErrMissing fields when Auth Header fields are missing.
- Return InvalidAccessID when accessID doesn't match.
- V2 signature test cases for bucket handlers. 
- Fixes https://github.com/minio/minio/issues/2909 . 
