### PR TITLE
Fix a crash when service shutdown is signaled and object API is not ready yet

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -113,8 +113,9 @@ func (m *ServerMux) handleServiceSignals() error {
 				if objAPI == nil {
 					// Server not initialized yet, exit happily.
 					runExitFn(nil)
+				} else {
+					runExitFn(objAPI.Shutdown())
 				}
-				runExitFn(objAPI.Shutdown())
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #2933 
