### PR TITLE
Add link explaining bucket name restrictions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+go_import_path: github.com/minio/minio
 sudo: required
 
 dist: trusty

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -155,6 +156,7 @@ func (fs fsObjects) ListBuckets() ([]BucketInfo, error) {
 		// StorageAPI can send volume names which are incompatible
 		// with buckets, handle it and skip them.
 		if !IsValidBucketName(vol.Name) {
+			err = errors.New("One or more invalid bucket names found, skipping them")
 			continue
 		}
 		// Ignore the volume special bucket.
@@ -167,7 +169,7 @@ func (fs fsObjects) ListBuckets() ([]BucketInfo, error) {
 		})
 	}
 	sort.Sort(byBucketName(bucketInfos))
-	return bucketInfos, nil
+	return bucketInfos, err
 }
 
 // DeleteBucket - delete a bucket.


### PR DESCRIPTION
Does this count as friendlier? Or is the intention to explain the actual rule the bucket-name has failed to validate against? Ref #2832
