### PR TITLE
Allow Travis builds from GitHub forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+go_import_path: github.com/minio/minio
 sudo: required
 
 dist: trusty


### PR DESCRIPTION
Set the go_import_path explicitly. See
https://docs.travis-ci.com/user/languages/go#Go-Import-Path
