### PR TITLE
server: Startup sequence should be more idempotent.

### DIFF
--- a/cmd/lock-rpc-server_test.go
+++ b/cmd/lock-rpc-server_test.go
@@ -339,7 +339,7 @@ func TestLockRpcServerForceUnlock(t *testing.T) {
 		Timestamp: timestamp,
 		Node:      "node",
 		RPCPath:   "rpc-path",
-		UID:	   "1234-5678",
+		UID:       "1234-5678",
 	}
 
 	// First test that UID should be empty

--- a/cmd/net-rpc-client.go
+++ b/cmd/net-rpc-client.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/rpc"
 	"sync"
+	"time"
 )
 
 // RPCClient is a wrapper type for rpc.Client which provides reconnect on first failure.
@@ -78,7 +79,8 @@ func (rpcClient *RPCClient) dialRPCClient() (*rpc.Client, error) {
 	if rpcClient.secureConn {
 		conn, err = tls.Dial("tcp", rpcClient.node, &tls.Config{})
 	} else {
-		conn, err = net.Dial("tcp", rpcClient.node)
+		// Have a dial timeout with 3 secs.
+		conn, err = net.DialTimeout("tcp", rpcClient.node, 3*time.Second)
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/object-common.go
+++ b/cmd/object-common.go
@@ -194,7 +194,7 @@ func xlHouseKeeping(storageDisks []StorageAPI) error {
 			err := cleanupDir(disk, minioMetaBucket, tmpMetaPrefix)
 			if err != nil {
 				switch errorCause(err) {
-				case errDiskNotFound, errVolumeNotFound:
+				case errDiskNotFound, errVolumeNotFound, errFileNotFound:
 				default:
 					errs[index] = err
 				}

--- a/cmd/prepare-storage-msg.go
+++ b/cmd/prepare-storage-msg.go
@@ -65,6 +65,9 @@ func getHealMsg(firstEndpoint string, storageDisks []StorageAPI) string {
 	msg = fmt.Sprintf(msg, creds.AccessKeyID, creds.SecretAccessKey, firstEndpoint)
 	disksInfo, _, _ := getDisksInfo(storageDisks)
 	for i, info := range disksInfo {
+		if storageDisks[i] == nil {
+			continue
+		}
 		msg += fmt.Sprintf(
 			"\n[%s] %s - %s %s",
 			int2Str(i+1, len(storageDisks)),
@@ -92,6 +95,9 @@ func getRegularMsg(storageDisks []StorageAPI) string {
 	msg := colorBlue("\nInitializing data volume.")
 	disksInfo, _, _ := getDisksInfo(storageDisks)
 	for i, info := range disksInfo {
+		if storageDisks[i] == nil {
+			continue
+		}
 		msg += fmt.Sprintf(
 			"\n[%s] %s - %s %s",
 			int2Str(i+1, len(storageDisks)),
@@ -119,6 +125,9 @@ func getFormatMsg(storageDisks []StorageAPI) string {
 	msg := colorBlue("\nInitializing data volume for the first time.")
 	disksInfo, _, _ := getDisksInfo(storageDisks)
 	for i, info := range disksInfo {
+		if storageDisks[i] == nil {
+			continue
+		}
 		msg += fmt.Sprintf(
 			"\n[%s] %s - %s %s",
 			int2Str(i+1, len(storageDisks)),


### PR DESCRIPTION
Fixes #2971 - honors ignore-disks option properly.
Fixes #2969 - change the net.Dial to have a timeout of 3secs.
