### PR TITLE
Pick up server address from --address option

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -97,7 +97,7 @@ func splitNetPath(networkPath string) (netAddr, netPath string, err error) {
 // `host:port` format.
 func getLocalAddress(srvCmdConfig serverCmdConfig) string {
 	if !srvCmdConfig.isDistXL {
-		return fmt.Sprintf(":%d", globalMinioPort)
+		return srvCmdConfig.serverAddr
 	}
 	for _, export := range srvCmdConfig.disks {
 		// Validates if remote disk is local.

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -245,7 +245,8 @@ func TestLocalAddress(t *testing.T) {
 		// Test 2 - local address is everything.
 		{
 			srvCmdConfig: serverCmdConfig{
-				isDistXL: false,
+				serverAddr: fmt.Sprintf(":%d", globalMinioPort),
+				isDistXL:   false,
 				disks: []string{
 					"/mnt/disk1",
 					"/mnt/disk2",
@@ -267,6 +268,22 @@ func TestLocalAddress(t *testing.T) {
 				},
 			},
 			localAddr: "",
+		},
+		// Test 4 - in case of FS mode, with SSL, the host
+		// name is specified in the --address option on the
+		// server command line.
+		{
+			srvCmdConfig: serverCmdConfig{
+				serverAddr: "play.minio.io:9000",
+				isDistXL:   false,
+				disks: []string{
+					"/mnt/disk1",
+					"/mnt/disk2",
+					"/mnt/disk3",
+					"/mnt/disk4",
+				},
+			},
+			localAddr: "play.minio.io:9000",
 		},
 	}
 


### PR DESCRIPTION
This makes sure that when SSL is enabled (for FS/single node mode),
the server address is picked up from the --address option (that needs
to include the hostname for SSL verification, and has to be input
appropriately by user), instead of just using ":<port>".

Fixes #3002 
