### PR TITLE
Added clear subcommand for control lock

### DIFF
--- a/cmd/control-handlers.go
+++ b/cmd/control-handlers.go
@@ -261,7 +261,7 @@ func (c *controlAPIHandlers) ServiceHandler(args *ServiceArgs, reply *ServiceRep
 	return nil
 }
 
-// LockInfo - RPC control handler for `minio control lock`. Returns the info of the locks held in the system.
+// TryInitHandler - generic RPC control handler
 func (c *controlAPIHandlers) TryInitHandler(args *GenericArgs, reply *GenericReply) error {
 	if !isRPCTokenValid(args.Token) {
 		return errInvalidToken

--- a/cmd/control-lock-main_test.go
+++ b/cmd/control-lock-main_test.go
@@ -44,3 +44,134 @@ func TestPrintLockState(t *testing.T) {
 	// Does not print any lock state in debug print mode.
 	printLockStateVerbose(sysLockStateMap, 10*time.Second)
 }
+
+// Helper function to test equality of locks (without taking timing info into account)
+func testLockStateEquality(vliLeft, vliRight VolumeLockInfo) bool {
+
+	if vliLeft.Bucket != vliRight.Bucket ||
+	vliLeft.Object != vliRight.Object ||
+	vliLeft.LocksOnObject != vliRight.LocksOnObject ||
+	vliLeft.LocksAcquiredOnObject != vliRight.LocksAcquiredOnObject ||
+	vliLeft.TotalBlockedLocks != vliRight.TotalBlockedLocks {
+		return false
+	}
+	return true
+}
+
+// Test clearing of locks.
+func TestLockStateClear(t *testing.T) {
+
+	// Helper function to circumvent RPC call to LockClear and call msMutex.ForceUnlock immediately.
+	f := func(bucket, object string) {
+		nsMutex.ForceUnlock(bucket, object)
+	}
+
+	nsMutex.Lock("testbucket", "1.txt", "11-11")
+
+	sysLockState, err := getSystemLockState()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedVli := VolumeLockInfo{
+		Bucket:                "testbucket",
+		Object:                "1.txt",
+		LocksOnObject:         1,
+		LocksAcquiredOnObject: 1,
+		TotalBlockedLocks:     0,
+	}
+
+	// Test initial condition.
+	if !testLockStateEquality(expectedVli, sysLockState.LocksInfoPerObject[0]) {
+		t.Errorf("Expected %#v, got %#v", expectedVli, sysLockState.LocksInfoPerObject[0])
+	}
+
+	sysLockStateMap := map[string]SystemLockState{}
+	sysLockStateMap["testnode1"] = sysLockState
+
+	// Clear locks that are 10 seconds old (which is a no-op in this case)
+	clearLockState(f, sysLockStateMap, 10*time.Second, "", false)
+
+	if sysLockState, err = getSystemLockState(); err != nil {
+		t.Fatal(err)
+	}
+	if !testLockStateEquality(expectedVli, sysLockState.LocksInfoPerObject[0]) {
+		t.Errorf("Expected %#v, got %#v", expectedVli, sysLockState.LocksInfoPerObject[0])
+	}
+
+	// Clear all locks (older than 0 seconds)
+	clearLockState(f, sysLockStateMap, 0, "", false)
+
+	// Verify that there are no locks
+	if sysLockState, err = getSystemLockState(); err != nil {
+		t.Fatal(err)
+	}
+	if len(sysLockState.LocksInfoPerObject) != 0 {
+		t.Errorf("Expected no locks, got %#v", sysLockState.LocksInfoPerObject)
+	}
+
+	// Create another lock
+	nsMutex.RLock("testbucket", "blob.txt", "22-22")
+
+	if sysLockState, err = getSystemLockState(); err != nil {
+		t.Fatal(err)
+	}
+	sysLockStateMap["testnode1"] = sysLockState
+
+	// Correct wildcard match but bad age.
+	clearLockState(f, sysLockStateMap, 10*time.Second, "testbucket/blob", true)
+
+	// Ensure lock is still there.
+	if sysLockState, err = getSystemLockState(); err != nil {
+		t.Fatal(err)
+	}
+	expectedVli.Object = "blob.txt"
+	if !testLockStateEquality(expectedVli, sysLockState.LocksInfoPerObject[0]) {
+		t.Errorf("Expected %#v, got %#v", expectedVli, sysLockState.LocksInfoPerObject[0])
+	}
+
+	// Clear lock based on wildcard match.
+	clearLockState(f, sysLockStateMap, 0, "testbucket/blob", true)
+
+	// Verify that there are no locks
+	if sysLockState, err = getSystemLockState(); err != nil {
+		t.Fatal(err)
+	}
+	if len(sysLockState.LocksInfoPerObject) != 0 {
+		t.Errorf("Expected no locks, got %#v", sysLockState.LocksInfoPerObject)
+	}
+
+	// Create yet another lock
+	nsMutex.RLock("testbucket", "exact.txt", "33-33")
+
+	if sysLockState, err = getSystemLockState(); err != nil {
+		t.Fatal(err)
+	}
+	sysLockStateMap["testnode1"] = sysLockState
+
+	// Make sure that exact match can fail.
+	clearLockState(f, sysLockStateMap, 0, "testbucket/exact.txT", false)
+
+	// Ensure lock is still there.
+	if sysLockState, err = getSystemLockState(); err != nil {
+		t.Fatal(err)
+	}
+	expectedVli.Object = "exact.txt"
+	if !testLockStateEquality(expectedVli, sysLockState.LocksInfoPerObject[0]) {
+		t.Errorf("Expected %#v, got %#v", expectedVli, sysLockState.LocksInfoPerObject[0])
+	}
+
+	// Clear lock based on exact match.
+	clearLockState(f, sysLockStateMap, 0, "testbucket/exact.txt", false)
+
+	// Verify that there are no locks
+	if sysLockState, err = getSystemLockState(); err != nil {
+		t.Fatal(err)
+	}
+	if len(sysLockState.LocksInfoPerObject) != 0 {
+		t.Errorf("Expected no locks, got %#v", sysLockState.LocksInfoPerObject)
+	}
+
+	// reset lock states for further tests
+	initNSLock(false)
+}

--- a/cmd/lockinfo-handlers.go
+++ b/cmd/lockinfo-handlers.go
@@ -99,7 +99,7 @@ func getSystemLockState() (SystemLockState, error) {
 func (c *controlAPIHandlers) remoteLockInfoCall(args *GenericArgs, replies []SystemLockState) error {
 	var wg sync.WaitGroup
 	var errs = make([]error, len(c.RemoteControls))
-	// Send remote call to all neighboring peers to restart minio servers.
+	// Send remote call to all neighboring peers fetch control lock info.
 	for index, clnt := range c.RemoteControls {
 		wg.Add(1)
 		go func(index int, client *AuthRPCClient) {
@@ -133,7 +133,7 @@ func (c *controlAPIHandlers) RemoteLockInfo(args *GenericArgs, reply *SystemLock
 	return nil
 }
 
-// LockInfo - RPC control handler for `minio control lock`. Returns the info of the locks held in the cluster.
+// LockInfo - RPC control handler for `minio control lock list`. Returns the info of the locks held in the cluster.
 func (c *controlAPIHandlers) LockInfo(args *GenericArgs, reply *map[string]SystemLockState) error {
 	if !isRPCTokenValid(args.Token) {
 		return errInvalidToken

--- a/cmd/lockinfo-handlers.go
+++ b/cmd/lockinfo-handlers.go
@@ -167,3 +167,20 @@ func (c *controlAPIHandlers) LockInfo(args *GenericArgs, reply *map[string]Syste
 	// Success.
 	return nil
 }
+
+// LockClearArgs - arguments for LockClear handler
+type LockClearArgs struct {
+	GenericArgs
+	Bucket string
+	Object string
+}
+
+// LockClear - RPC control handler for `minio control lock clear`.
+func (c *controlAPIHandlers) LockClear(args *LockClearArgs, reply *GenericReply) error {
+	if !isRPCTokenValid(args.Token) {
+		return errInvalidToken
+	}
+	nsMutex.ForceUnlock(args.Bucket, args.Object)
+	*reply = GenericReply{}
+	return nil
+}


### PR DESCRIPTION
Added clear subcommand for control lock with following options:

```
  3. Clear lock named 'bucket/object' (exact match).
    $ minio control lock clear http://localhost:9000/bucket/object

  4. Clear all locks with names that start with 'bucket/prefix' (wildcard match).
    $ minio control lock --recursive clear http://localhost:9000/bucket/prefix

  5. Clear all locks older than 10minutes.
    $ minio control lock --older-than=10m clear http://localhost:9000/

  6. Clear all locks with names that start with 'bucket/a' and that are older than 1hour.
    $ minio control lock --recursive --older-than=1h clear http://localhost:9000/bucket/a
```
