### PR TITLE
posix: Split on ":" in path d:\export makes minio use wrong disk.

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -103,9 +103,6 @@ func newPosix(diskPath string) (StorageAPI, error) {
 		return nil, errInvalidArgument
 	}
 	suppliedDiskPath := diskPath
-	if idx := strings.LastIndex(diskPath, ":"); idx != -1 {
-		diskPath = diskPath[idx+1:]
-	}
 	var err error
 	// Disallow relative paths, figure out absolute paths.
 	diskPath, err = filepath.Abs(diskPath)


### PR DESCRIPTION
As the host/path split happens at a higher layer now, split at posix is not needed.
fixes part of #2987
