### PR TITLE
Use net.ParseCIDR instead of custom-built parsers

### DIFF
--- a/cmd/host-to-ip.go
+++ b/cmd/host-to-ip.go
@@ -36,14 +36,18 @@ func (n byLastOctet) Less(i, j int) bool {
 func sortIPsByOctet(ips []string) error {
 	var nips []net.IP
 	for _, ip := range ips {
-		nip := net.ParseIP(ip)
-		if nip == nil {
+		nip, _, err := net.ParseCIDR(ip)
+		if err != nil {
 			return fmt.Errorf("Unable to parse invalid ip %s", ip)
+		}
+		if nip.To4() == nil {
+			continue
 		}
 		nips = append(nips, nip)
 	}
 	// Reverse sort ips by their last octet.
 	sort.Sort(sort.Reverse(byLastOctet(nips)))
+	ips = ips[:len(nips)]
 	for i, nip := range nips {
 		ips[i] = nip.String()
 	}

--- a/cmd/host-to-ip.go
+++ b/cmd/host-to-ip.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"fmt"
 	"net"
 	"sort"
 )
@@ -33,19 +32,7 @@ func (n byLastOctet) Less(i, j int) bool {
 }
 
 // sortIPsByOctet - returns a reverse sorted list of hosts based on the last octet value.
-func sortIPsByOctet(ips []string) error {
-	var nips []net.IP
-	for _, ip := range ips {
-		nip := net.ParseIP(ip)
-		if nip == nil {
-			return fmt.Errorf("Unable to parse invalid ip %s", ip)
-		}
-		nips = append(nips, nip)
-	}
+func sortIPsByOctet(ips []net.IP) {
 	// Reverse sort ips by their last octet.
-	sort.Sort(sort.Reverse(byLastOctet(nips)))
-	for i, nip := range nips {
-		ips[i] = nip.String()
-	}
-	return nil
+	sort.Sort(sort.Reverse(byLastOctet(ips)))
 }

--- a/cmd/host-to-ip.go
+++ b/cmd/host-to-ip.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net"
 	"sort"
 )
@@ -32,7 +33,19 @@ func (n byLastOctet) Less(i, j int) bool {
 }
 
 // sortIPsByOctet - returns a reverse sorted list of hosts based on the last octet value.
-func sortIPsByOctet(ips []net.IP) {
+func sortIPsByOctet(ips []string) error {
+	var nips []net.IP
+	for _, ip := range ips {
+		nip := net.ParseIP(ip)
+		if nip == nil {
+			return fmt.Errorf("Unable to parse invalid ip %s", ip)
+		}
+		nips = append(nips, nip)
+	}
 	// Reverse sort ips by their last octet.
-	sort.Sort(sort.Reverse(byLastOctet(ips)))
+	sort.Sort(sort.Reverse(byLastOctet(nips)))
+	for i, nip := range nips {
+		ips[i] = nip.String()
+	}
+	return nil
 }

--- a/cmd/host-to-ip_test.go
+++ b/cmd/host-to-ip_test.go
@@ -33,13 +33,13 @@ func TestHostToIP(t *testing.T) {
 		{
 			// List of ip addresses that need to be sorted.
 			ips: []string{
-				"129.95.30.40",
-				"5.24.69.2",
-				"19.20.203.5",
-				"1.2.3.4",
-				"127.0.0.1",
-				"19.20.21.22",
-				"5.220.100.50",
+				"129.95.30.40/24",
+				"5.24.69.2/24",
+				"19.20.203.5/24",
+				"1.2.3.4/24",
+				"127.0.0.1/24",
+				"19.20.21.22/24",
+				"5.220.100.50/24",
 			},
 			// Numerical sorting result based on the last octet.
 			sortedIPs: []string{

--- a/cmd/host-to-ip_test.go
+++ b/cmd/host-to-ip_test.go
@@ -17,7 +17,7 @@
 package cmd
 
 import (
-	"fmt"
+	"net"
 	"testing"
 )
 
@@ -25,10 +25,8 @@ import (
 func TestHostToIP(t *testing.T) {
 	// Collection of test cases to validate last octet sorting.
 	testCases := []struct {
-		ips        []string
-		sortedIPs  []string
-		err        error
-		shouldPass bool
+		ips       []string
+		sortedIPs []string
 	}{
 		{
 			// List of ip addresses that need to be sorted.
@@ -51,35 +49,24 @@ func TestHostToIP(t *testing.T) {
 				"5.24.69.2",
 				"127.0.0.1",
 			},
-			err:        nil,
-			shouldPass: true,
-		},
-		{
-			ips: []string{
-				"localhost",
-			},
-			sortedIPs:  []string{},
-			err:        fmt.Errorf("Unable to parse invalid ip localhost"),
-			shouldPass: false,
 		},
 	}
 
 	// Tests the correct sorting behavior of getIPsFromHosts.
 	for j, testCase := range testCases {
-		err := sortIPsByOctet(testCase.ips)
-		if !testCase.shouldPass && testCase.err.Error() != err.Error() {
-			t.Fatalf("Test %d: Expected error %s, got %s", j+1, testCase.err, err)
-		}
-		if testCase.shouldPass && err != nil {
-			t.Fatalf("Test %d: Expected error %s", j+1, err)
-		}
-		if testCase.shouldPass {
-			for i, ip := range testCase.ips {
-				if ip == testCase.sortedIPs[i] {
-					continue
-				}
-				t.Errorf("Test %d expected to pass but failed. Wanted ip %s, but got %s", j+1, testCase.sortedIPs[i], ip)
+		ips := []net.IP{}
+		for _, ipStr := range testCase.ips {
+			if ip := net.ParseIP(ipStr); ip != nil {
+				ips = append(ips, ip)
 			}
+		}
+		sortIPsByOctet(ips)
+
+		for i, ip := range ips {
+			if ip.String() == testCase.sortedIPs[i] {
+				continue
+			}
+			t.Errorf("Test %d expected to pass but failed. Wanted ip %s, but got %s", j+1, testCase.sortedIPs[i], ip)
 		}
 	}
 }

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -228,12 +228,7 @@ func getListenIPs(httpServerConf *http.Server) (hosts []string, port string, err
 			return nil, port, fmt.Errorf("Unable to determine network interface address. %s", err)
 		}
 		for _, addr := range addrs {
-			if addr.Network() == "ip+net" {
-				hostname := strings.Split(addr.String(), "/")[0]
-				if ip := net.ParseIP(hostname); ip.To4() != nil {
-					hosts = append(hosts, hostname)
-				}
-			}
+			hosts = append(hosts, addr.String())
 		}
 		err = sortIPsByOctet(hosts)
 		if err != nil {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/minio/cli"
 )
 
+var errNoAddr = errors.New("Unable to find any valid network address.")
 var serverFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "address",
@@ -223,21 +224,29 @@ func getListenIPs(httpServerConf *http.Server) (hosts []string, port string, err
 	}
 	if host == "" {
 		var addrs []net.Addr
+		var ips []net.IP
 		addrs, err = net.InterfaceAddrs()
 		if err != nil {
 			return nil, port, fmt.Errorf("Unable to determine network interface address. %s", err)
 		}
 		for _, addr := range addrs {
 			if addr.Network() == "ip+net" {
-				hostname := strings.Split(addr.String(), "/")[0]
-				if ip := net.ParseIP(hostname); ip.To4() != nil {
-					hosts = append(hosts, hostname)
+				ip, _, err := net.ParseCIDR(addr.String())
+				if err != nil {
+					return nil, port, fmt.Errorf("Unable to parse IP from network interface address. %s", err)
+				}
+				// FIXME: For now, we support only IPv4 addresses. This is mainly due to our sortIPsByOctet.
+				if ip.To4() != nil {
+					ips = append(ips, ip)
 				}
 			}
 		}
-		err = sortIPsByOctet(hosts)
-		if err != nil {
-			return nil, port, fmt.Errorf("Unable reverse sorted ips from hosts %s", err)
+		if len(ips) == 0 {
+			return nil, port, errNoAddr
+		}
+		sortIPsByOctet(ips)
+		for _, ip := range ips {
+			hosts = append(hosts, ip.String())
 		}
 		return hosts, port, nil
 	} // if host != "" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->

During server initialization we parse endpoint network addresses by parsing their string representation directly. This PR uses standard `net` package function, `ParseCIDR` instead.
- Remove avoidable conversion to and from net.IP to string.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

This change makes parsing of network addresses provided as part of server endpoint address more reliable by depending on standard packages.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

Existing unit tests cover this change.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
