### PR TITLE
Fix user-agent prefix to have docker instead of suffix.

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -25,7 +25,7 @@ import (
 
 // Global constants for Minio.
 const (
-	minGoVersion = ">= 1.7.1" // minimum Go runtime version
+	minGoVersion = ">= 1.7" // Minio requires at least Go v1.7
 )
 
 // minio configuration related constants.

--- a/cmd/update-main_nix_test.go
+++ b/cmd/update-main_nix_test.go
@@ -37,8 +37,6 @@ func TestReleaseUpdateVersion(t *testing.T) {
 		fmt.Fprintln(w, "fbe246edbd382902db9a4035df7dce8cb441357d minio.RELEASE.2016-10-07T01-16-39Z")
 	}))
 	userAgentSuffix = "Minio/" + Version + " " + "Minio/" + ReleaseTag + " " + "Minio/" + CommitID
-	userAgentPrefix = "Minio (" + runtime.GOOS + "; " + runtime.GOARCH + ") "
-	userAgent = userAgentPrefix + userAgentSuffix
 	defer ts.Close()
 	testCases := []struct {
 		updateURL  string

--- a/cmd/update-main_windows_test.go
+++ b/cmd/update-main_windows_test.go
@@ -37,8 +37,6 @@ func TestReleaseUpdateVersion(t *testing.T) {
 		fmt.Fprintln(w, "fbe246edbd382902db9a4035df7dce8cb441357d minio.RELEASE.2016-10-07T01-16-39Z")
 	}))
 	userAgentSuffix = "Minio/" + Version + " " + "Minio/" + ReleaseTag + " " + "Minio/" + CommitID
-	userAgentPrefix = "Minio (" + runtime.GOOS + "; " + runtime.GOARCH + ") "
-	userAgent = userAgentPrefix + userAgentSuffix
 	defer ts.Close()
 	testCases := []struct {
 		updateURL  string


### PR DESCRIPTION
## Description

Modifies user-agent to add docker variable as part of user agent prefix.
## Motivation and Context

Updates custom user-agent sent to the download server when release update is verified.
## How Has This Been Tested?

By performing `minio update` command.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
