### PR TITLE
[WIP] Reduce the amount of buffer allocations in FS codepath.

### DIFF
--- a/cmd/benchmark-utils_test.go
+++ b/cmd/benchmark-utils_test.go
@@ -43,6 +43,7 @@ func prepareBenchmarkBackend(instanceType string) (ObjectLayer, []string, error)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return obj, disks, nil
 }
 
@@ -151,6 +152,12 @@ func runPutObjectPartBenchmark(b *testing.B, obj ObjectLayer, partSize int) {
 
 // creates XL/FS backend setup, obtains the object layer and calls the runPutObjectPartBenchmark function.
 func benchmarkPutObjectPart(b *testing.B, instanceType string, objSize int) {
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		b.Fatalf("Unable to initialize config. %s", err)
+	}
+	defer removeAll(rootPath)
+
 	// create a temp XL/FS backend.
 	objLayer, disks, err := prepareBenchmarkBackend(instanceType)
 	if err != nil {
@@ -164,6 +171,12 @@ func benchmarkPutObjectPart(b *testing.B, instanceType string, objSize int) {
 
 // creates XL/FS backend setup, obtains the object layer and calls the runPutObjectBenchmark function.
 func benchmarkPutObject(b *testing.B, instanceType string, objSize int) {
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		b.Fatalf("Unable to initialize config. %s", err)
+	}
+	defer removeAll(rootPath)
+
 	// create a temp XL/FS backend.
 	objLayer, disks, err := prepareBenchmarkBackend(instanceType)
 	if err != nil {
@@ -177,6 +190,12 @@ func benchmarkPutObject(b *testing.B, instanceType string, objSize int) {
 
 // creates XL/FS backend setup, obtains the object layer and runs parallel benchmark for put object.
 func benchmarkPutObjectParallel(b *testing.B, instanceType string, objSize int) {
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		b.Fatalf("Unable to initialize config. %s", err)
+	}
+	defer removeAll(rootPath)
+
 	// create a temp XL/FS backend.
 	objLayer, disks, err := prepareBenchmarkBackend(instanceType)
 	if err != nil {
@@ -191,7 +210,12 @@ func benchmarkPutObjectParallel(b *testing.B, instanceType string, objSize int) 
 // Benchmark utility functions for ObjectLayer.GetObject().
 // Creates Object layer setup ( MakeBucket, PutObject) and then runs the benchmark.
 func runGetObjectBenchmark(b *testing.B, obj ObjectLayer, objSize int) {
-	var err error
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		b.Fatalf("Unable to initialize config. %s", err)
+	}
+	defer removeAll(rootPath)
+
 	// obtains random bucket name.
 	bucket := getRandomBucketName()
 	// create bucket.
@@ -257,6 +281,12 @@ func generateBytesData(size int) []byte {
 
 // creates XL/FS backend setup, obtains the object layer and calls the runGetObjectBenchmark function.
 func benchmarkGetObject(b *testing.B, instanceType string, objSize int) {
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		b.Fatalf("Unable to initialize config. %s", err)
+	}
+	defer removeAll(rootPath)
+
 	// create a temp XL/FS backend.
 	objLayer, disks, err := prepareBenchmarkBackend(instanceType)
 	if err != nil {
@@ -270,6 +300,12 @@ func benchmarkGetObject(b *testing.B, instanceType string, objSize int) {
 
 // creates XL/FS backend setup, obtains the object layer and runs parallel benchmark for ObjectLayer.GetObject() .
 func benchmarkGetObjectParallel(b *testing.B, instanceType string, objSize int) {
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		b.Fatalf("Unable to initialize config. %s", err)
+	}
+	defer removeAll(rootPath)
+
 	// create a temp XL/FS backend.
 	objLayer, disks, err := prepareBenchmarkBackend(instanceType)
 	if err != nil {
@@ -284,7 +320,12 @@ func benchmarkGetObjectParallel(b *testing.B, instanceType string, objSize int) 
 // Parallel benchmark utility functions for ObjectLayer.PutObject().
 // Creates Object layer setup ( MakeBucket ) and then runs the PutObject benchmark.
 func runPutObjectBenchmarkParallel(b *testing.B, obj ObjectLayer, objSize int) {
-	var err error
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		b.Fatalf("Unable to initialize config. %s", err)
+	}
+	defer removeAll(rootPath)
+
 	// obtains random bucket name.
 	bucket := getRandomBucketName()
 	// create bucket.
@@ -329,7 +370,12 @@ func runPutObjectBenchmarkParallel(b *testing.B, obj ObjectLayer, objSize int) {
 // Parallel benchmark utility functions for ObjectLayer.GetObject().
 // Creates Object layer setup ( MakeBucket, PutObject) and then runs the benchmark.
 func runGetObjectBenchmarkParallel(b *testing.B, obj ObjectLayer, objSize int) {
-	var err error
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		b.Fatalf("Unable to initialize config. %s", err)
+	}
+	defer removeAll(rootPath)
+
 	// obtains random bucket name.
 	bucket := getRandomBucketName()
 	// create bucket.

--- a/cmd/object-common.go
+++ b/cmd/object-common.go
@@ -27,7 +27,7 @@ const (
 	blockSizeV1 = 10 * 1024 * 1024 // 10MiB.
 
 	// Staging buffer read size for all internal operations version 1.
-	readSizeV1 = 128 * 1024 // 128KiB.
+	readSizeV1 = 2 * 1024 * 1024 // 2MiB.
 
 	// Buckets meta prefix.
 	bucketMetaPrefix = "buckets"

--- a/cmd/object-utils.go
+++ b/cmd/object-utils.go
@@ -77,7 +77,7 @@ func IsValidBucketName(bucket string) bool {
 //
 // - Backslash ("\")
 //
-// additionally minio does not support object names with trailing "/".
+// Additionally minio does not support object names with trailing "/".
 func IsValidObjectName(object string) bool {
 	if len(object) == 0 {
 		return false
@@ -101,7 +101,7 @@ func IsValidObjectPrefix(object string) bool {
 		return false
 	}
 	// Reject unsupported characters in object name.
-	if strings.ContainsAny(object, "\\") {
+	if strings.ContainsAny(object, `\`) {
 		return false
 	}
 	return true

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -679,7 +679,7 @@ func TestPosixListDir(t *testing.T) {
 		}
 
 		if err = posixStorage.DeleteFile("bin", "yes"); err != errFileAccessDenied {
-			t.Errorf("expected: %s, got: %s", errFileAccessDenied, err)
+			t.Errorf("expected: %s error, got: %s", errFileAccessDenied, err)
 		}
 	}
 
@@ -793,7 +793,7 @@ func TestDeleteFile(t *testing.T) {
 		}
 
 		if err = posixStorage.DeleteFile("bin", "yes"); err != errFileAccessDenied {
-			t.Errorf("expected: %s, got: %s", errFileAccessDenied, err)
+			t.Errorf("expected: %s error, got: %s", errFileAccessDenied, err)
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This patch is to efficiently utilize making lot of "make([]byte)" operations. This is needed for a long term stability of the server, to reduce overall gc pressure. 
## Motivation and Context

Context behind this to alleviate GC pressure and allowing higher throughput i/o.  Previously we used to perform 32K i/o with significant allocation overahead. This patch fixes that by bringing usage of sync.Pool at various places. 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
