### PR TITLE
Lower quorum minimum to 2

### DIFF
--- a/cmd/server-main_test.go
+++ b/cmd/server-main_test.go
@@ -153,9 +153,9 @@ func TestCheckSufficientDisks(t *testing.T) {
 			xlDisks,
 			errXLMaxDisks,
 		},
-		// Lesser than minimum number of disks < 6.
+		// Lesser than minimum number of disks < 2.
 		{
-			xlDisks[0:3],
+			xlDisks[0:1],
 			errXLMinDisks,
 		},
 		// Odd number of disks, not divisible by '2'.

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -45,7 +45,7 @@ const (
 	maxErasureBlocks = 16
 
 	// Minimum erasure blocks.
-	minErasureBlocks = 4
+	minErasureBlocks = 2
 )
 
 // xlObjects - Implements XL object layer.

--- a/vendor/github.com/minio/dsync/README.md
+++ b/vendor/github.com/minio/dsync/README.md
@@ -16,7 +16,7 @@ This package was developed for the distributed server version of [Minio Object S
 For [minio](https://minio.io/) the distributed version is started as follows (for a 6-server system):
 
 ```
-$ minio server server1/disk server2/disk server3/disk server4/disk server5/disk server6/disk 
+$ minio server server1:/disk server2:/disk server3:/disk server4:/disk server5:/disk server6:/disk 
 ```
  
 _(note that the same identical command should be run on servers `server1` through to `server6`)_

--- a/vendor/github.com/minio/dsync/dsync.go
+++ b/vendor/github.com/minio/dsync/dsync.go
@@ -45,8 +45,8 @@ func SetNodesWithClients(rpcClnts []RPC, rpcOwnNode int) (err error) {
 	// Validate if number of nodes is within allowable range.
 	if dnodeCount != 0 {
 		return errors.New("Cannot reinitialize dsync package")
-	} else if len(rpcClnts) < 4 {
-		return errors.New("Dsync not designed for less than 4 nodes")
+	} else if len(rpcClnts) < 2 {
+		return errors.New("Dsync not designed for less than 2 nodes")
 	} else if len(rpcClnts) > 16 {
 		return errors.New("Dsync not designed for more than 16 nodes")
 	} else if len(rpcClnts)&1 == 1 {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -111,10 +111,10 @@
 			"revisionTime": "2015-11-18T20:00:48-08:00"
 		},
 		{
-			"checksumSHA1": "UWpLeW+oLfe/MiphMckp1HqKrW0=",
+			"checksumSHA1": "zls+RD0QVJbOwHpc1hPP2VM4PfE=",
 			"path": "github.com/minio/dsync",
-			"revision": "fcea3bf5533c1b8a5af3cb377d30363782d2532d",
-			"revisionTime": "2016-10-15T15:40:54Z"
+			"revision": "9c7a452d3ceb9ac24894452aa184147930343e6f",
+			"revisionTime": "2016-10-26T09:50:03Z"
 		},
 		{
 			"path": "github.com/minio/go-homedir",


### PR DESCRIPTION
With both read quorum for erasure coding determined at N/2 and read lock (in dsync) adjusted to N/2, we can lower the minimum number of nodes for Distributed from 4 to 2.

Fixes https://github.com/minio/minio/issues/3071
