### PR TITLE
posix: Use sync.Pool buffers to copy in large buffers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ language: go
 
 os:
 - linux
-- osx
-
-osx_image: xcode7.2
 
 env:
 - ARCH=x86_64

--- a/cmd/object-common.go
+++ b/cmd/object-common.go
@@ -27,7 +27,7 @@ const (
 	blockSizeV1 = 10 * 1024 * 1024 // 10MiB.
 
 	// Staging buffer read size for all internal operations version 1.
-	readSizeV1 = 128 * 1024 // 128KiB.
+	readSizeV1 = 1 * 1024 * 1024 // 1MiB.
 
 	// Buckets meta prefix.
 	bucketMetaPrefix = "buckets"

--- a/cmd/posix-utils_windows_test.go
+++ b/cmd/posix-utils_windows_test.go
@@ -36,7 +36,7 @@ func TestUNCPaths(t *testing.T) {
 		{string(bytes.Repeat([]byte("界"), 85)), true},
 		// Each path component must be <= 255 bytes long.
 		{string(bytes.Repeat([]byte("界"), 100)), false},
-		{`\\p\q\r\s\t`, true},
+		{`/p/q/r/s/t`, true},
 	}
 	// Instantiate posix object to manage a disk
 	var err error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This problem was reproduced while running GlusterFS 3x replication we had to increase the buffer size for all the copy operations to complete.

<!--- Describe your changes in detail -->
## Motivation and Context

GlusterFS requires large block i/o using io.Copy results in 32K writes which are significantly slower on GlusterFS. 

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

You would need a 3 node setup of GlusterFS replication factor of 3 with 10Gige bandwidth. 

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  These fixes are borrowed from the fixes required for GlusterFS i/o throughput.
