### PR TITLE
Show offline nodes after a fixed number of init retry

### DIFF
--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -58,8 +58,8 @@ var globalRandomSource = rand.New(&lockedRandSource{
 
 // newRetryTimer creates a timer with exponentially increasing delays
 // until the maximum retry attempts are reached.
-func newRetryTimer(unit time.Duration, cap time.Duration, jitter float64, doneCh chan struct{}) <-chan struct{} {
-	attemptCh := make(chan struct{})
+func newRetryTimer(unit time.Duration, cap time.Duration, jitter float64, doneCh chan struct{}) <-chan int {
+	attemptCh := make(chan int)
 
 	// computes the exponential backoff duration according to
 	// https://www.awsarchitectureblog.com/2015/03/backoff.html
@@ -89,7 +89,7 @@ func newRetryTimer(unit time.Duration, cap time.Duration, jitter float64, doneCh
 		for {
 			select {
 			// Attempts starts.
-			case attemptCh <- struct{}{}:
+			case attemptCh <- nextBackoff:
 				nextBackoff++
 			case <-globalWakeupCh:
 				// Reset nextBackoff to reduce the subsequent wait and re-read


### PR DESCRIPTION
## Description

After 5 format retries, show which nodes are offline
## Motivation and Context

The user needs a better information about what's wrong when nodes fail to init after some moments
## How Has This Been Tested?

Manually
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
