### PR TITLE
No `listener.json` for single-node mode (Fixes #3052)

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -379,11 +379,13 @@ func AddBucketListenerConfig(bucket string, lcfg *listenerConfig, objAPI ObjectL
 	// Release lock after notifying peers
 	defer nsMutex.Unlock(bucket, "", opsID)
 
-	// update persistent config
-	err := persistListenerConfig(bucket, listenerCfgs, objAPI)
-	if err != nil {
-		errorIf(err, "Error persisting listener config when adding a listener.")
-		return err
+	// update persistent config if dist XL
+	if globalS3Peers.isDistXL {
+		err := persistListenerConfig(bucket, listenerCfgs, objAPI)
+		if err != nil {
+			errorIf(err, "Error persisting listener config when adding a listener.")
+			return err
+		}
 	}
 
 	// persistence success - now update in-memory globals on all
@@ -419,11 +421,13 @@ func RemoveBucketListenerConfig(bucket string, lcfg *listenerConfig, objAPI Obje
 	// Release lock after notifying peers
 	defer nsMutex.Unlock(bucket, "", opsID)
 
-	// update persistent config
-	err := persistListenerConfig(bucket, updatedLcfgs, objAPI)
-	if err != nil {
-		errorIf(err, "Error persisting listener config when removing a listener.")
-		return
+	// update persistent config if dist XL
+	if globalS3Peers.isDistXL {
+		err := persistListenerConfig(bucket, updatedLcfgs, objAPI)
+		if err != nil {
+			errorIf(err, "Error persisting listener config when removing a listener.")
+			return
+		}
 	}
 
 	// persistence success - now update in-memory globals on all

--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -347,6 +347,13 @@ func loadNotificationConfig(bucket string, objAPI ObjectLayer) (*notificationCon
 // loads notification config if any for a given bucket, returns
 // structured notification config.
 func loadListenerConfig(bucket string, objAPI ObjectLayer) ([]listenerConfig, error) {
+	// in single node mode, there are no peers, so in this case
+	// there is no configuration to load, as any previously
+	// connected listen clients have been disconnected
+	if !globalS3Peers.isDistXL {
+		return nil, nil
+	}
+
 	// Construct the notification config path.
 	listenerConfigPath := path.Join(bucketConfigPrefix, bucket, bucketListenerConfig)
 	objInfo, err := objAPI.GetObjectInfo(minioMetaBucket, listenerConfigPath)

--- a/cmd/event-notifier_test.go
+++ b/cmd/event-notifier_test.go
@@ -291,6 +291,11 @@ func TestInitEventNotifier(t *testing.T) {
 		t.Fatal("Unexpected error:", err)
 	}
 
+	// needed to load listener config from disk for testing (in
+	// single peer mode, the listener config is ingored, but here
+	// we want to test the loading from disk too.)
+	globalS3Peers.isDistXL = true
+
 	// test event notifier init
 	if err := initEventNotifier(obj); err != nil {
 		t.Fatal("Unexpected error:", err)
@@ -360,6 +365,11 @@ func TestListenBucketNotification(t *testing.T) {
 	if err := persistListenerConfig(bucketName, lcfgs, obj); err != nil {
 		t.Fatalf("Test Setup error: %v", err)
 	}
+
+	// needed to load listener config from disk for testing (in
+	// single peer mode, the listener config is ingored, but here
+	// we want to test the loading from disk too.)
+	globalS3Peers.isDistXL = true
 
 	// Init event notifier
 	if err := initEventNotifier(obj); err != nil {

--- a/cmd/s3-peer-client.go
+++ b/cmd/s3-peer-client.go
@@ -32,6 +32,9 @@ type s3Peers struct {
 
 	mutex *sync.RWMutex
 
+	// Is single-node?
+	isDistXL bool
+
 	// Slice of all peer addresses (in `host:port` format).
 	peers []string
 }
@@ -53,6 +56,9 @@ func initGlobalS3Peers(eps []storageEndPoint) {
 
 	// Save new peers
 	globalS3Peers.peers = peers
+
+	// store if this is a distributed setup or not.
+	globalS3Peers.isDistXL = len(globalS3Peers.peers) > 1
 }
 
 func (s3p *s3Peers) GetPeers() []string {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->

In FS or single-node XL mode, there is no need to save listener
configuration to persistent storage. As there is only one server, if it
is restarted, any connected listenBucketAPI clients were disconnected
and will have to reconnect - so there is nothing to actually store.

This incidentally solves #3052 by avoiding the problem.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

In distributed mode, persisting listener configuration is required, otherwise, when nodes are coming up, they will be unaware of listenBucketAPI clients that are connected to other cluster members. However, in single mode, this is not necessary, because when a single node minio cluster is rebooted, the node will be disconnect from the listenBucketAPI client.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
- Tested manually that FS mode works as expected. 
- Tested that the bug does not arise in FS mode.
- In distributed mode, had `mc watch` on server 1, checked that events are sent for upload to server 2; then restarted server 2 and checked that uploads to server 2 again generated events for the watch.
- Tests pass locally.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
