### PR TITLE
boot: getPath() should take care of simple directory exports.

### DIFF
--- a/cmd/object-common.go
+++ b/cmd/object-common.go
@@ -165,12 +165,16 @@ func getPath(ep *url.URL) string {
 	var diskPath string
 	// For windows ep.Path is usually empty
 	if runtime.GOOS == "windows" {
-		// For full URLs windows drive is part of URL path.
-		// Eg: http://ip:port/C:\mydrive
-		if ep.Scheme == "http" || ep.Scheme == "https" {
+		switch ep.Scheme {
+		case "":
+			// Eg. "minio server .\export"
+			diskPath = ep.Path
+		case "http", "https":
+			// For full URLs windows drive is part of URL path.
+			// Eg: http://ip:port/C:\mydrive
 			// For windows trim off the preceding "/".
 			diskPath = ep.Path[1:]
-		} else {
+		default:
 			// For the rest url splits drive letter into
 			// Scheme contruct the disk path back.
 			diskPath = ep.Scheme + ":" + ep.Opaque

--- a/cmd/object-common_test.go
+++ b/cmd/object-common_test.go
@@ -111,10 +111,12 @@ func TestGetPath(t *testing.T) {
 			path  string
 		}{
 			{"\\export", "\\export"},
-			{"D:\\export", "D:\\export"},
-			{"D:\\", "D:\\"},
-			{"D:", "D:"},
+			{"D:\\export", "d:\\export"},
+			{"D:\\", "d:\\"},
+			{"D:", "d:"},
 			{"\\", "\\"},
+			{"http://localhost/d:/export", "d:/export"},
+			{"https://localhost/d:/export", "d:/export"},
 		}
 	} else {
 		testCases = []struct {
@@ -122,6 +124,8 @@ func TestGetPath(t *testing.T) {
 			path  string
 		}{
 			{"/export", "/export"},
+			{"http://localhost/export", "/export"},
+			{"https://localhost/export", "/export"},
 		}
 	}
 	testCasesCommon := []struct {
@@ -129,19 +133,17 @@ func TestGetPath(t *testing.T) {
 		path  string
 	}{
 		{"export", "export"},
-		{"http://localhost/export", "/export"},
-		{"https://localhost/export", "/export"},
 	}
 	testCases = append(testCases, testCasesCommon...)
-	for _, test := range testCases {
+	for i, test := range testCases {
 		eps, err := parseStorageEndpoints([]string{test.epStr})
 		if err != nil {
-			t.Error(test.epStr, err)
+			t.Errorf("Test %d: %s - %s", i+1, test.epStr, err)
 			continue
 		}
 		path := getPath(eps[0])
 		if path != test.path {
-			t.Errorf("For endpoing %s, getPath() failed, got: %s, expected: %s,", test.epStr, path, test.path)
+			t.Errorf("Test %d: For endpoing %s, getPath() failed, got: %s, expected: %s,", i+1, test.epStr, path, test.path)
 		}
 	}
 }

--- a/cmd/object-common_test.go
+++ b/cmd/object-common_test.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"net/url"
 	"runtime"
 	"sync"
 	"testing"
@@ -100,51 +99,49 @@ func TestHouseKeeping(t *testing.T) {
 	}
 }
 
-// Test constructing the final path.
+// Test getPath() - the path that needs to be passed to newPosix()
 func TestGetPath(t *testing.T) {
 	var testCases []struct {
-		ep   *url.URL
-		path string
+		epStr string
+		path  string
 	}
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS == "windows" {
 		testCases = []struct {
-			ep   *url.URL
-			path string
+			epStr string
+			path  string
 		}{
-			{
-				ep:   nil,
-				path: "",
-			},
-			{
-				ep:   &url.URL{Path: "/test1"},
-				path: "/test1",
-			},
+			{"\\export", "\\export"},
+			{"D:\\export", "D:\\export"},
+			{"D:\\", "D:\\"},
+			{"D:", "D:"},
+			{"\\", "\\"},
 		}
 	} else {
 		testCases = []struct {
-			ep   *url.URL
-			path string
+			epStr string
+			path  string
 		}{
-			{
-				ep:   nil,
-				path: "",
-			},
-			{
-				ep:   &url.URL{Opaque: "\\test1", Scheme: "C"},
-				path: "C:\\test1",
-			},
-			{
-				ep:   &url.URL{Scheme: "http", Path: "/C:\\test1"},
-				path: "C:\\test1",
-			},
+			{"/export", "/export"},
 		}
 	}
-
-	// Validate all the test cases.
-	for i, testCase := range testCases {
-		path := getPath(testCase.ep)
-		if path != testCase.path {
-			t.Fatalf("Test: %d Expected path %s, got %s", i+1, testCase.path, path)
+	testCasesCommon := []struct {
+		epStr string
+		path  string
+	}{
+		{"export", "export"},
+		{"http://localhost/export", "/export"},
+		{"https://localhost/export", "/export"},
+	}
+	testCases = append(testCases, testCasesCommon...)
+	for _, test := range testCases {
+		eps, err := parseStorageEndpoints([]string{test.epStr})
+		if err != nil {
+			t.Error(test.epStr, err)
+			continue
+		}
+		path := getPath(eps[0])
+		if path != test.path {
+			t.Errorf("For endpoing %s, getPath() failed, got: %s, expected: %s,", test.epStr, path, test.path)
 		}
 	}
 }


### PR DESCRIPTION
## Description

in Windows "minio server export" the ep.Scheme and ep.Opaque both will be "" but ep.Path will be "export".
This case should be handled.
## Motivation and Context

Details available here https://github.com/minio/minio/issues/3120
## How Has This Been Tested?

Manual testing, added unit test cases.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  fixes #3120
