### PR TITLE
Read/write quorum algo with uploads.json in xl (Fixes #3123)

### DIFF
--- a/cmd/fs-v1-multipart-common_test.go
+++ b/cmd/fs-v1-multipart-common_test.go
@@ -122,7 +122,7 @@ func TestFSWriteUploadJSON(t *testing.T) {
 		t.Fatal("Unexpected err: ", err)
 	}
 
-	if err := fs.writeUploadJSON(bucketName, objectName, uploadID, time.Now().UTC()); err != nil {
+	if err := fs.updateUploadJSON(bucketName, objectName, uploadIDChange{uploadID, time.Now().UTC(), false}); err != nil {
 		t.Fatal("Unexpected err: ", err)
 	}
 
@@ -131,36 +131,8 @@ func TestFSWriteUploadJSON(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		naughty := newNaughtyDisk(fsStorage, map[int]error{i: errFaultyDisk}, nil)
 		fs.storage = naughty
-		if err := fs.writeUploadJSON(bucketName, objectName, uploadID, time.Now().UTC()); errorCause(err) != errFaultyDisk {
-			t.Fatal("Unexpected err: ", err)
-		}
-	}
-}
-
-// TestFSUpdateUploadsJSON - tests for updateUploadsJSON for FS
-func TestFSUpdateUploadsJSON(t *testing.T) {
-	// Prepare for tests
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
-	defer removeAll(disk)
-
-	obj := initFSObjects(disk, t)
-	fs := obj.(fsObjects)
-
-	bucketName := "bucket"
-	objectName := "object"
-
-	obj.MakeBucket(bucketName)
-
-	if err := fs.updateUploadsJSON(bucketName, objectName, uploadsV1{}); err != nil {
-		t.Fatal("Unexpected err: ", err)
-	}
-
-	// isUploadIdExists with a faulty disk should return false
-	fsStorage := fs.storage.(*posix)
-	for i := 1; i <= 2; i++ {
-		naughty := newNaughtyDisk(fsStorage, map[int]error{i: errFaultyDisk}, nil)
-		fs.storage = naughty
-		if err := fs.updateUploadsJSON(bucketName, objectName, uploadsV1{}); errorCause(err) != errFaultyDisk {
+		if err := fs.updateUploadJSON(bucketName, objectName,
+			uploadIDChange{uploadID, time.Now().UTC(), false}); errorCause(err) != errFaultyDisk {
 			t.Fatal("Unexpected err: ", err)
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->
- Reads and writes of uploads.json in XL now uses quorum for
  newMultipart, completeMultipart and abortMultipart operations.
- Each disk's `uploads.json` file is read and updated independently for
  adding or removing an upload id from the file. Quorum is used to
  decide if the high-level operation actually succeeded.
- Refactor FS code to simplify the flow, and fix a bug while reading
  uploads.json.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #3123 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

All existing unit-tests pass.

Manual testing is underway.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
