### PR TITLE
Logging: errorIf fatalIf print in the format [file.go:82:funcName()]

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -42,7 +42,6 @@ const (
 
 var (
 	globalQuiet = false // Quiet flag set via command line
-	globalTrace = false // Trace flag set via environment setting.
 
 	// Add new global flags here.
 

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -17,13 +17,9 @@
 package cmd
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"path"
-	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -44,37 +40,6 @@ type logger struct {
 	File    fileLogger    `json:"file"`
 	Syslog  syslogLogger  `json:"syslog"`
 	// Add new loggers here.
-}
-
-// Function takes input with the results from runtime.Caller(1). Depending on the boolean.
-// This function can either returned a shotFile form or a longFile form.
-func funcFromPC(pc uintptr, file string, line int, shortFile bool) string {
-	var fn, name string
-	if shortFile {
-		fn = strings.Replace(file, path.Join(filepath.ToSlash(GOPATH)+"/src/github.com/minio/minio/cmd/")+"/", "", -1)
-		name = strings.Replace(runtime.FuncForPC(pc).Name(), "github.com/minio/minio/cmd.", "", -1)
-	} else {
-		fn = strings.Replace(file, path.Join(filepath.ToSlash(GOPATH)+"/src/")+"/", "", -1)
-		name = strings.Replace(runtime.FuncForPC(pc).Name(), "github.com/minio/minio/cmd.", "", -1)
-	}
-	return fmt.Sprintf("%s [%s:%d]", name, fn, line)
-}
-
-// stackInfo returns printable stack trace.
-func stackInfo() string {
-	// Convert stack-trace bytes to io.Reader.
-	rawStack := bufio.NewReader(bytes.NewBuffer(debug.Stack()))
-	// Skip stack trace lines until our real caller.
-	for i := 0; i <= 4; i++ {
-		rawStack.ReadLine()
-	}
-
-	// Read the rest of useful stack trace.
-	stackBuf := new(bytes.Buffer)
-	stackBuf.ReadFrom(rawStack)
-
-	// Strip GOPATH of the build system and return.
-	return strings.Replace(stackBuf.String(), filepath.ToSlash(GOPATH)+"/src/", "", -1)
 }
 
 // Get file, line, function name of the caller.

--- a/cmd/logger_test.go
+++ b/cmd/logger_test.go
@@ -20,31 +20,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
 )
 
-// Tests func obtained from process stack counter.
-func TestFuncToPC(t *testing.T) {
-	GOPATH = filepath.ToSlash(os.Getenv("GOPATH"))
-	pc, file, line, success := runtime.Caller(0)
-	if !success {
-		file = "???"
-		line = 0
-	}
-	shortFile := true // We are only interested in short file form.
-	cLocation := funcFromPC(pc, file, line, shortFile)
-	if cLocation != "TestFuncToPC [logger_test.go:34]" {
-		t.Fatal("Unexpected caller location found", cLocation)
-	}
-	shortFile = false // We are not interested in short file form.
-	cLocation = funcFromPC(pc, file, line, shortFile)
-	if cLocation != "TestFuncToPC [github.com/minio/minio/cmd/logger_test.go:34]" {
-		t.Fatal("Unexpected caller location found", cLocation)
+// Tests callerLocation.
+func TestCallerLocation(t *testing.T) {
+	currentLocation := func() string { return callerLocation() }
+	gotLocation := currentLocation()
+	expectedLocation := "[logger_test.go:31:TestCallerLocation()]"
+	if gotLocation != expectedLocation {
+		t.Errorf("expected : %s, got : %s", expectedLocation, gotLocation)
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,9 +71,6 @@ VERSION:
 func init() {
 	// Check if minio was compiled using a supported version of Golang.
 	checkGoVersion()
-
-	// Set global trace flag.
-	globalTrace = os.Getenv("MINIO_TRACE") == "1"
 }
 
 func migrate() {

--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"net/url"
 	pathutil "path"
-	"runtime"
 	"sync"
 
 	"github.com/minio/dsync"
@@ -197,19 +196,7 @@ func (n *nsLockMap) unlock(volume, path, opsID string, readLock bool) {
 func (n *nsLockMap) Lock(volume, path, opsID string) {
 	readLock := false // This is a write lock.
 
-	// The caller information of the lock held has been obtained
-	// here before calling any other function.
-
-	// Fetching the package, function name and the line number of
-	// the caller from the runtime.
-	pc, file, line, success := runtime.Caller(1)
-	if !success {
-		file = "???"
-		line = 0
-	}
-	shortFile := true // We are only interested in short file form.
-	lockLocation := funcFromPC(pc, file, line, shortFile)
-
+	lockLocation := callerLocation() // Useful for debugging
 	n.lock(volume, path, lockLocation, opsID, readLock)
 }
 
@@ -223,19 +210,7 @@ func (n *nsLockMap) Unlock(volume, path, opsID string) {
 func (n *nsLockMap) RLock(volume, path, opsID string) {
 	readLock := true
 
-	// The caller information of the lock held has been obtained
-	// here before calling any other function.
-
-	// Fetching the package, function name and the line number of
-	// the caller from the runtime.
-	pc, file, line, success := runtime.Caller(1)
-	if !success {
-		file = "???"
-		line = 0
-	}
-	shortFile := true // We are only interested in short file form.
-	lockLocation := funcFromPC(pc, file, line, shortFile)
-
+	lockLocation := callerLocation() // Useful for debugging
 	n.lock(volume, path, lockLocation, opsID, readLock)
 }
 


### PR DESCRIPTION
previous output:

```
krishna@escape:~$ minio server export
FATA[0000] Port unavailable 9000                         cause=listen tcp :9000: bind: address already in use location=serverMain [/home/krishna/gocodeserver-main.go:400]
```

new output:

```
krishna@escape:~$ minio server export
FATA[0000] Port unavailable 9000                         cause=listen tcp :9000: bind: address already in use location=[server-main.go:400:serverMain()]
krishna@escape:~$ 
```
## Description

funcFromPC() removed, instead callerLocation() which is simpler is used.

funcFromPC's shortFile and:

```
-       if shortFile {
-               fn = strings.Replace(file, path.Join(filepath.ToSlash(GOPATH)+"/src/github.com/minio/minio/cmd/")+"/", "", -1)
-               name = strings.Replace(runtime.FuncForPC(pc).Name(), "github.com/minio/minio/cmd.", "", -1)
-       } else {
-               fn = strings.Replace(file, path.Join(filepath.ToSlash(GOPATH)+"/src/")+"/", "", -1)
-               name = strings.Replace(runtime.FuncForPC(pc).Name(), "github.com/minio/minio/cmd.", "", -1)
-       }

```

this is no longer useful as all the files are in the cmd package now. So just `filename.go` without any path info should be used.
## Motivation and Context

Context: https://github.com/minio/minio/issues/3125
## How Has This Been Tested?

manual testing, unit tests.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
