### PR TITLE
posix: Fix windows performance issues.

### DIFF
--- a/cmd/posix-errors.go
+++ b/cmd/posix-errors.go
@@ -42,7 +42,7 @@ func isSysErrIO(err error) bool {
 	return err != nil && err == syscall.EIO
 }
 
-// Check if the given error corresponds to ENOTDIR (is not a directory)
+// Check if the given error corresponds to ENOTDIR (is not a directory).
 func isSysErrNotDir(err error) bool {
 	if pathErr, ok := err.(*os.PathError); ok {
 		switch pathErr.Err {
@@ -53,8 +53,19 @@ func isSysErrNotDir(err error) bool {
 	return false
 }
 
+// Check if the given error corresponds to the ENAMETOOLONG (name too long).
+func isSysErrTooLong(err error) bool {
+	if pathErr, ok := err.(*os.PathError); ok {
+		switch pathErr.Err {
+		case syscall.ENAMETOOLONG:
+			return true
+		}
+	}
+	return false
+}
+
 // Check if the given error corresponds to ENOTEMPTY for unix
-// and ERROR_DIR_NOT_EMPTY for windows (directory not empty)
+// and ERROR_DIR_NOT_EMPTY for windows (directory not empty).
 func isSysErrNotEmpty(err error) bool {
 	if pathErr, ok := err.(*os.PathError); ok {
 		if runtime.GOOS == "windows" {

--- a/cmd/posix-errors_test.go
+++ b/cmd/posix-errors_test.go
@@ -1,0 +1,57 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func TestSysErrors(t *testing.T) {
+	pathErr := &os.PathError{Err: syscall.ENAMETOOLONG}
+	ok := isSysErrTooLong(pathErr)
+	if !ok {
+		t.Fatalf("Unexpected error expecting %s", syscall.ENAMETOOLONG)
+	}
+	pathErr = &os.PathError{Err: syscall.ENOTDIR}
+	ok = isSysErrNotDir(pathErr)
+	if !ok {
+		t.Fatalf("Unexpected error expecting %s", syscall.ENOTDIR)
+	}
+	if runtime.GOOS != "windows" {
+		pathErr = &os.PathError{Err: syscall.ENOTEMPTY}
+		ok = isSysErrNotEmpty(pathErr)
+		if !ok {
+			t.Fatalf("Unexpected error expecting %s", syscall.ENOTEMPTY)
+		}
+	} else {
+		pathErr = &os.PathError{Err: syscall.Errno(0x91)}
+		ok = isSysErrNotEmpty(pathErr)
+		if !ok {
+			t.Fatal("Unexpected error expecting 0x91")
+		}
+	}
+	if runtime.GOOS == "windows" {
+		pathErr = &os.PathError{Err: syscall.Errno(0x03)}
+		ok = isSysErrPathNotFound(pathErr)
+		if !ok {
+			t.Fatal("Unexpected error expecting 0x03")
+		}
+	}
+}

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -536,23 +536,6 @@ func TestListVols(t *testing.T) {
 	if _, err = posixStorage.ListVols(); err != errDiskNotFound {
 		t.Errorf("Expected to fail with \"%s\", but instead failed with \"%s\"", errDiskNotFound, err)
 	}
-	// creating a new posix instance.
-	posixStorage, path, err = newPosixTestSetup()
-	if err != nil {
-		t.Fatalf("Unable to create posix test setup, %s", err)
-	}
-	defer removeAll(path)
-	// adding the segment of the path length of the volume to be > 255.
-	if posixType, ok := posixStorage.(*posix); ok {
-		// setting the disk Path with name whose segment length > 255.
-		posixType.diskPath = "my-vol-name-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
-	} else {
-		t.Errorf("Expected the StorageAPI to be of type *posix")
-	}
-	if _, err = posixStorage.ListVols(); err != errFileNameTooLong {
-		t.Errorf("Expected to fail with \"%s\", but instead failed with \"%s\"", errFileNameTooLong, err)
-	}
-
 }
 
 // TestPosixListDir -  Tests validate the directory listing functionality provided by posix.ListDir .

--- a/pkg/disk/type_windows.go
+++ b/pkg/disk/type_windows.go
@@ -24,11 +24,13 @@ import (
 	"unsafe"
 )
 
+var (
+	// GetVolumeInformation provides windows drive volume information.
+	GetVolumeInformation = kernel32.NewProc("GetVolumeInformationW")
+)
+
 // getFSType returns the filesystem type of the underlying mounted filesystem
 func getFSType(path string) string {
-	dll := syscall.MustLoadDLL("kernel32.dll")
-	GetVolumeInformation := dll.MustFindProc("GetVolumeInformationW")
-
 	var volumeNameSize uint32 = 260
 	var nFileSystemNameSize, lpVolumeSerialNumber uint32
 	var lpFileSystemFlags, lpMaximumComponentLength uint32


### PR DESCRIPTION
Do not attempt to fetch volume/drive information for
each i/o situation. In our case we do this in all calls
`posix.go` this in-turn created a terrible situation for
windows. This issue does not affect the i/o path on Unix
platforms since statvfs calls are in the range of micro
seconds on these platforms.

This verification is only needed during startup and we
let things fail at a later stage on windows.

<!--- Provide a general summary of your changes in the Title above -->
## Description

Do not attempt to fetch volume/drive information for each i/o situation on windows.

<!--- Describe your changes in detail -->
## Motivation and Context

Fixes lingering windows performance issues.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

Compile and run on windows. 

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
