### PR TITLE
Start all listeners when a given host resolves to multiple IPs.

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -96,12 +96,6 @@ EXAMPLES:
       $ minio {{.Name}} http://192.168.1.11/mnt/export/ http://192.168.1.12/mnt/export/ \
           http://192.168.1.13/mnt/export/ http://192.168.1.14/mnt/export/
 
-  7. Start minio server on a 4 node distributed setup. Type the following command on all the 4 nodes exactly.
-      $ minio {{.Name}} http://minio:miniostorage@192.168.1.11/mnt/export/ \
-          http://minio:miniostorage@192.168.1.12/mnt/export/ \
-          http://minio:miniostorage@192.168.1.13/mnt/export/ \
-          http://minio:miniostorage@192.168.1.14/mnt/export/
-
 `,
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Default golang net.Listen only listens on the first IP when
host resolves to multiple IPs.

This change addresses a problem for example your ``/etc/hosts``
has entries as following

```
127.0.1.1  minio1

192.168.1.10 minio1
```

Trying to start minio as

```
minio server --address "minio1:9001" ~/Photos
```

Causes the minio server to be bound only to "127.0.1.1" which
is an incorrect behavior since we are generally interested in
`192.168.1.10` as well.

This patch addresses this issue if the hostname is resolvable
and gives back list of addresses associated with that hostname
we just bind on all of them as it is the expected behavior.

<!--- Describe your changes in detail -->

## How Has This Been Tested?
Add multiple IPs to share the same hostname in your `/etc/hosts` and then start minio server

`` minio server --address "hostname:port" ~/Photos ``

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
