### PR TITLE
Take into account instance type during benchmarks.

### DIFF
--- a/cmd/benchmark-utils_test.go
+++ b/cmd/benchmark-utils_test.go
@@ -30,7 +30,18 @@ import (
 
 // Prepare benchmark backend
 func prepareBenchmarkBackend(instanceType string) (ObjectLayer, []string, error) {
-	nDisks := 16
+	var nDisks int
+	switch instanceType {
+	// Total number of disks for FS backend is set to 1.
+	case FSTestStr:
+		nDisks = 1
+		// Total number of disks for FS backend is set to 16.
+	case XLTestStr:
+		nDisks = 16
+	default:
+		nDisks = 1
+	}
+	// get `nDisks` random disks.
 	disks, err := getRandomDisks(nDisks)
 	if err != nil {
 		return nil, nil, err
@@ -39,11 +50,11 @@ func prepareBenchmarkBackend(instanceType string) (ObjectLayer, []string, error)
 	if err != nil {
 		return nil, nil, err
 	}
+	// initialize object layer.
 	obj, _, err := initObjectLayer(endpoints, nil)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return obj, disks, nil
 }
 

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -104,10 +104,10 @@ type TestErrHandler interface {
 }
 
 const (
-	// singleNodeTestStr is the string which is used as notation for Single node ObjectLayer in the unit tests.
-	singleNodeTestStr string = "FS"
-	// xLTestStr is the string which is used as notation for XL ObjectLayer in the unit tests.
-	xLTestStr string = "XL"
+	// FSTestStr is the string which is used as notation for Single node ObjectLayer in the unit tests.
+	FSTestStr string = "FS"
+	// XLTestStr is the string which is used as notation for XL ObjectLayer in the unit tests.
+	XLTestStr string = "XL"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyz01234569"
@@ -1850,7 +1850,7 @@ func ExecObjectLayerAPITest(t *testing.T, objAPITest objAPITestType, endpoints [
 	}
 	credentials := serverConfig.GetCredential()
 	// Executing the object layer tests for single node setup.
-	objAPITest(objLayer, singleNodeTestStr, bucketFS, fsAPIRouter, credentials, t)
+	objAPITest(objLayer, FSTestStr, bucketFS, fsAPIRouter, credentials, t)
 
 	objLayer, xlDisks, err := prepareXL()
 	if err != nil {
@@ -1862,7 +1862,7 @@ func ExecObjectLayerAPITest(t *testing.T, objAPITest objAPITestType, endpoints [
 	}
 	credentials = serverConfig.GetCredential()
 	// Executing the object layer tests for XL.
-	objAPITest(objLayer, xLTestStr, bucketXL, xlAPIRouter, credentials, t)
+	objAPITest(objLayer, XLTestStr, bucketXL, xlAPIRouter, credentials, t)
 	// clean up the temporary test backend.
 	removeRoots(append(xlDisks, fsDir, rootPath))
 }
@@ -1893,14 +1893,14 @@ func ExecObjectLayerTest(t TestErrHandler, objTest objTestType) {
 		t.Fatalf("Initialization of object layer failed for single node setup: %s", err)
 	}
 	// Executing the object layer tests for single node setup.
-	objTest(objLayer, singleNodeTestStr, t)
+	objTest(objLayer, FSTestStr, t)
 
 	objLayer, fsDirs, err := prepareXL()
 	if err != nil {
 		t.Fatalf("Initialization of object layer failed for XL setup: %s", err)
 	}
 	// Executing the object layer tests for XL.
-	objTest(objLayer, xLTestStr, t)
+	objTest(objLayer, XLTestStr, t)
 	defer removeRoots(append(fsDirs, fsDir))
 }
 
@@ -1912,7 +1912,7 @@ func ExecObjectLayerDiskAlteredTest(t *testing.T, objTest objTestDiskNotFoundTyp
 		t.Fatalf("Initialization of object layer failed for XL setup: %s", err)
 	}
 	// Executing the object layer tests for XL.
-	objTest(objLayer, xLTestStr, fsDirs, t)
+	objTest(objLayer, XLTestStr, fsDirs, t)
 	defer removeRoots(fsDirs)
 }
 
@@ -1936,7 +1936,7 @@ func ExecObjectLayerStaleFilesTest(t *testing.T, objTest objTestStaleFilesType) 
 		t.Fatalf("Initialization of object layer failed for XL setup: %s", err)
 	}
 	// Executing the object layer tests for XL.
-	objTest(objLayer, xLTestStr, erasureDisks, t)
+	objTest(objLayer, XLTestStr, erasureDisks, t)
 	defer removeRoots(erasureDisks)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently instance type (FS/XL) is ignored during benchmarks. This is leading to usage of XL backend even for FS related benchmarks.
## Description
<!--- Describe your changes in detail -->
 - The benchmark initialization function was not taking into account the
      instance type (FS/XL), was using XL ObjectLayer even for FS
      benchmarks.
 - This was leading to incorrect benchmark results for FS related
      benchmarks.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The benchmarks for FS backend was inaccurate since XL backend was used for it.
- The fix takes into account the instance type (FS/XL) and correctly
      returns FS backend for FS benchmarks.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By type asserting the object layer with `fsObjects` to make sure FS backend is returned for FS related benchmarks.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
