### PR TITLE
Use endpoint url when printing disks status in distributed mode

### DIFF
--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -61,7 +61,7 @@ func TestNewFS(t *testing.T) {
 	}
 
 	// Initializes all disks with XL
-	err = waitForFormatDisks(true, endpoints[0], xlStorageDisks)
+	err = waitForFormatDisks(true, endpoints, xlStorageDisks)
 	if err != nil {
 		t.Fatalf("Unable to format XL %s", err)
 	}
@@ -79,7 +79,7 @@ func TestNewFS(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if err = waitForFormatDisks(true, endpoints[0], []StorageAPI{testCase.disk}); err != testCase.expectedErr {
+		if err = waitForFormatDisks(true, endpoints, []StorageAPI{testCase.disk}); err != testCase.expectedErr {
 			t.Errorf("expected: %s, got :%s", testCase.expectedErr, err)
 		}
 	}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -480,7 +480,7 @@ func serverMain(c *cli.Context) {
 	}(tls)
 
 	// Wait for formatting of disks.
-	err = waitForFormatDisks(firstDisk, endpoints[0], storageDisks)
+	err = waitForFormatDisks(firstDisk, endpoints, storageDisks)
 	fatalIf(err, "formatting storage disks failed")
 
 	// Once formatted, initialize object layer.

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1560,7 +1560,7 @@ func initObjectLayer(endpoints, ignoredEndpoints []*url.URL) (ObjectLayer, []Sto
 		return nil, nil, err
 	}
 
-	err = waitForFormatDisks(true, endpoints[0], storageDisks)
+	err = waitForFormatDisks(true, endpoints, storageDisks)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/xl-v1_test.go
+++ b/cmd/xl-v1_test.go
@@ -161,7 +161,7 @@ func TestNewXL(t *testing.T) {
 		t.Fatal("Unexpected error: ", err)
 	}
 
-	err = waitForFormatDisks(true, endpoints[0], nil)
+	err = waitForFormatDisks(true, endpoints, nil)
 	if err != errInvalidArgument {
 		t.Fatalf("Expecting error, got %s", err)
 	}
@@ -172,7 +172,7 @@ func TestNewXL(t *testing.T) {
 	}
 
 	// Initializes all erasure disks
-	err = waitForFormatDisks(true, endpoints[0], storageDisks)
+	err = waitForFormatDisks(true, endpoints, storageDisks)
 	if err != nil {
 		t.Fatalf("Unable to format disks for erasure, %s", err)
 	}


### PR DESCRIPTION
## Description
Print endpoints path instead of local path for local disks when printing disks status in distributed init phase.

## Motivation and Context
Less confusion for the user
Fixes #3141 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
