### PR TITLE
Add bucket metadata state client/handler (Fixes #3022)

### DIFF
--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -78,8 +78,11 @@ func (br *browserPeerAPIHandlers) SetAuthPeer(args SetAuthPeerArgs, reply *Gener
 
 // Sends SetAuthPeer RPCs to all peers in the Minio cluster
 func updateCredsOnPeers(creds credential) map[string]error {
-	// Get list of peers (from globalS3Peers)
-	peers := globalS3Peers.GetPeers()
+	// Get list of peer addresses (from globalS3Peers)
+	peers := []string{}
+	for _, p := range globalS3Peers {
+		peers = append(peers, p.addr)
+	}
 
 	// Array of errors for each peer
 	errs := make([]error, len(peers))

--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -1,0 +1,152 @@
+/*
+ * Minio Cloud Storage, (C) 2014-2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"net/rpc"
+)
+
+// BucketMetaState - Interface to update bucket metadata in-memory
+// state.
+type BucketMetaState interface {
+	// Updates bucket notification
+	UpdateBucketNotification(args *SetBNPArgs) error
+
+	// Updates bucket listener
+	UpdateBucketListener(args *SetBLPArgs) error
+
+	// Updates bucket policy
+	UpdateBucketPolicy(args *SetBPPArgs) error
+
+	// Sends event
+	SendEvent(args *EventArgs) error
+}
+
+// Type that implements BucketMetaState for local node.
+type localBMS struct {
+	ObjectAPI func() ObjectLayer
+}
+
+// localBMS.UpdateBucketNotification - updates in-memory global bucket
+// notification info.
+func (lc *localBMS) UpdateBucketNotification(args *SetBNPArgs) error {
+	// check if object layer is available.
+	objAPI := lc.ObjectAPI()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
+	globalEventNotifier.SetBucketNotificationConfig(args.Bucket, args.NCfg)
+
+	return nil
+}
+
+// localBMS.UpdateBucketListener - updates in-memory global bucket
+// listeners info.
+func (lc *localBMS) UpdateBucketListener(args *SetBLPArgs) error {
+	// check if object layer is available.
+	objAPI := lc.ObjectAPI()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
+	// Update in-memory notification config.
+	return globalEventNotifier.SetBucketListenerConfig(args.Bucket, args.LCfg)
+}
+
+// localBMS.UpdateBucketPolicy - updates in-memory global bucket
+// policy info.
+func (lc *localBMS) UpdateBucketPolicy(args *SetBPPArgs) error {
+	// check if object layer is available.
+	objAPI := lc.ObjectAPI()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
+	var pCh policyChange
+	if err := json.Unmarshal(args.PChBytes, &pCh); err != nil {
+		return err
+	}
+
+	return globalBucketPolicies.SetBucketPolicy(args.Bucket, pCh)
+}
+
+// localBMS.SendEvent - sends event to local event notifier via
+// `globalEventNotifier`
+func (lc *localBMS) SendEvent(args *EventArgs) error {
+	// check if object layer is available.
+	objAPI := lc.ObjectAPI()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
+	return globalEventNotifier.SendListenerEvent(args.Arn, args.Event)
+}
+
+// Type that implements BucketMetaState for remote node.
+type remoteBMS struct {
+	*AuthRPCClient
+}
+
+// remoteBMS.UpdateBucketNotification - sends bucket notification
+// change to remote peer via RPC call.
+func (rc *remoteBMS) UpdateBucketNotification(args *SetBNPArgs) error {
+	reply := GenericReply{}
+	err := rc.Call("S3.SetBucketNotificationPeer", args, &reply)
+	// Check for network error and retry once.
+	if err != nil && err.Error() == rpc.ErrShutdown.Error() {
+		err = rc.Call("S3.SetBucketNotificationPeer", args, &reply)
+	}
+	return err
+}
+
+// remoteBMS.UpdateBucketListener - sends bucket listener change to
+// remote peer via RPC call.
+func (rc *remoteBMS) UpdateBucketListener(args *SetBLPArgs) error {
+	reply := GenericReply{}
+	err := rc.Call("S3.SetBucketListenerPeer", args, &reply)
+	// Check for network error and retry once.
+	if err != nil && err.Error() == rpc.ErrShutdown.Error() {
+		err = rc.Call("S3.SetBucketListenerPeer", args, &reply)
+	}
+	return err
+}
+
+// remoteBMS.UpdateBucketPolicy - sends bucket policy change to remote
+// peer via RPC call.
+func (rc *remoteBMS) UpdateBucketPolicy(args *SetBPPArgs) error {
+	reply := GenericReply{}
+	err := rc.Call("S3.SetBucketPolicyPeer", args, &reply)
+	// Check for network error and retry once.
+	if err != nil && err.Error() == rpc.ErrShutdown.Error() {
+		err = rc.Call("S3.SetBucketPolicyPeer", args, &reply)
+	}
+	return err
+}
+
+// remoteBMS.SendEvent - sends event for bucket listener to remote
+// peer via RPC call.
+func (rc *remoteBMS) SendEvent(args *EventArgs) error {
+	reply := GenericReply{}
+	err := rc.Call("S3.Event", args, &reply)
+	// Check for network error and retry once.
+	if err != nil && err.Error() == rpc.ErrShutdown.Error() {
+		err = rc.Call("S3.Event", args, &reply)
+	}
+	return err
+}

--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -380,7 +380,7 @@ func AddBucketListenerConfig(bucket string, lcfg *listenerConfig, objAPI ObjectL
 	defer nsMutex.Unlock(bucket, "", opsID)
 
 	// update persistent config if dist XL
-	if globalS3Peers.isDistXL {
+	if globalIsDistXL {
 		err := persistListenerConfig(bucket, listenerCfgs, objAPI)
 		if err != nil {
 			errorIf(err, "Error persisting listener config when adding a listener.")
@@ -422,7 +422,7 @@ func RemoveBucketListenerConfig(bucket string, lcfg *listenerConfig, objAPI Obje
 	defer nsMutex.Unlock(bucket, "", opsID)
 
 	// update persistent config if dist XL
-	if globalS3Peers.isDistXL {
+	if globalIsDistXL {
 		err := persistListenerConfig(bucket, updatedLcfgs, objAPI)
 		if err != nil {
 			errorIf(err, "Error persisting listener config when removing a listener.")

--- a/cmd/control-router.go
+++ b/cmd/control-router.go
@@ -30,7 +30,7 @@ const (
 
 // Initializes remote control clients for making remote requests.
 func initRemoteControlClients(srvCmdConfig serverCmdConfig) []*AuthRPCClient {
-	if !srvCmdConfig.isDistXL {
+	if !globalIsDistXL {
 		return nil
 	}
 	// Initialize auth rpc clients.
@@ -72,7 +72,7 @@ func registerControlRPCRouter(mux *router.Router, srvCmdConfig serverCmdConfig) 
 	// Initialize Control.
 	ctrlHandlers := &controlAPIHandlers{
 		ObjectAPI:      newObjectLayerFn,
-		IsXL:           srvCmdConfig.isDistXL || len(srvCmdConfig.storageDisks) > 1,
+		IsXL:           globalIsDistXL || len(srvCmdConfig.storageDisks) > 1,
 		RemoteControls: initRemoteControlClients(srvCmdConfig),
 		LocalNode:      getLocalAddress(srvCmdConfig),
 		StorageDisks:   srvCmdConfig.storageDisks,

--- a/cmd/control-router_test.go
+++ b/cmd/control-router_test.go
@@ -30,20 +30,20 @@ func TestInitRemoteControlClients(t *testing.T) {
 	defer removeAll(rootPath)
 
 	testCases := []struct {
+		isDistXL     bool
 		srvCmdConfig serverCmdConfig
 		totalClients int
 	}{
 		// Test - 1 no allocation if server config is not distributed XL.
 		{
-			srvCmdConfig: serverCmdConfig{
-				isDistXL: false,
-			},
+			isDistXL:     false,
+			srvCmdConfig: serverCmdConfig{},
 			totalClients: 0,
 		},
 		// Test - 2 two clients allocated with 4 disks with 2 disks on same node each.
 		{
+			isDistXL: true,
 			srvCmdConfig: serverCmdConfig{
-				isDistXL: true,
 				endpoints: []*url.URL{{
 					Scheme: "http",
 					Host:   "10.1.10.1:9000",
@@ -63,8 +63,8 @@ func TestInitRemoteControlClients(t *testing.T) {
 		},
 		// Test - 3 4 clients allocated with 4 disks with 1 disk on each node.
 		{
+			isDistXL: true,
 			srvCmdConfig: serverCmdConfig{
-				isDistXL: true,
 				endpoints: []*url.URL{{
 					Scheme: "http",
 					Host:   "10.1.10.1:9000", Path: "/mnt/disk1",
@@ -85,6 +85,7 @@ func TestInitRemoteControlClients(t *testing.T) {
 
 	// Evaluate and validate all test cases.
 	for i, testCase := range testCases {
+		globalIsDistXL = testCase.isDistXL
 		rclients := initRemoteControlClients(testCase.srvCmdConfig)
 		if len(rclients) != testCase.totalClients {
 			t.Errorf("Test %d, Expected %d, got %d RPC clients.", i+1, testCase.totalClients, len(rclients))

--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -350,7 +350,7 @@ func loadListenerConfig(bucket string, objAPI ObjectLayer) ([]listenerConfig, er
 	// in single node mode, there are no peers, so in this case
 	// there is no configuration to load, as any previously
 	// connected listen clients have been disconnected
-	if !globalS3Peers.isDistXL {
+	if !globalIsDistXL {
 		return nil, nil
 	}
 

--- a/cmd/event-notifier_test.go
+++ b/cmd/event-notifier_test.go
@@ -291,7 +291,7 @@ func TestInitEventNotifier(t *testing.T) {
 	// needed to load listener config from disk for testing (in
 	// single peer mode, the listener config is ingored, but here
 	// we want to test the loading from disk too.)
-	globalS3Peers.isDistXL = true
+	globalIsDistXL = true
 
 	// test event notifier init
 	if err := initEventNotifier(obj); err != nil {
@@ -366,7 +366,7 @@ func TestListenBucketNotification(t *testing.T) {
 	// needed to load listener config from disk for testing (in
 	// single peer mode, the listener config is ingored, but here
 	// we want to test the loading from disk too.)
-	globalS3Peers.isDistXL = true
+	globalIsDistXL = true
 
 	// Init event notifier
 	if err := initEventNotifier(obj); err != nil {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -41,7 +41,8 @@ const (
 )
 
 var (
-	globalQuiet = false // Quiet flag set via command line
+	globalQuiet    = false // Quiet flag set via command line
+	globalIsDistXL = false // "Is Distributed?" flag.
 
 	// Add new global flags here.
 

--- a/cmd/lock-rpc-server_test.go
+++ b/cmd/lock-rpc-server_test.go
@@ -447,13 +447,14 @@ func TestLockServers(t *testing.T) {
 	}
 	globalMinioHost = ""
 	testCases := []struct {
+		isDistXL         bool
 		srvCmdConfig     serverCmdConfig
 		totalLockServers int
 	}{
 		// Test - 1 one lock server initialized.
 		{
+			isDistXL: true,
 			srvCmdConfig: serverCmdConfig{
-				isDistXL: true,
 				endpoints: []*url.URL{{
 					Scheme: "http",
 					Host:   "localhost:9000",
@@ -476,8 +477,8 @@ func TestLockServers(t *testing.T) {
 		},
 		// Test - 2 two servers possible, 1 ignored.
 		{
+			isDistXL: true,
 			srvCmdConfig: serverCmdConfig{
-				isDistXL: true,
 				endpoints: []*url.URL{{
 					Scheme: "http",
 					Host:   "localhost:9000",
@@ -507,6 +508,7 @@ func TestLockServers(t *testing.T) {
 
 	// Validates lock server initialization.
 	for i, testCase := range testCases {
+		globalIsDistXL = testCase.isDistXL
 		lockServers := newLockServers(testCase.srvCmdConfig)
 		if len(lockServers) != testCase.totalLockServers {
 			t.Fatalf("Test %d: Expected total %d, got %d", i+1, testCase.totalLockServers, len(lockServers))

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -83,7 +83,7 @@ func configureServerHandler(srvCmdConfig serverCmdConfig) (http.Handler, error) 
 	mux := router.NewRouter()
 
 	// Initialize distributed NS lock.
-	if srvCmdConfig.isDistXL {
+	if globalIsDistXL {
 		// Register storage rpc router only if its a distributed setup.
 		err := registerStorageRPCRouters(mux, srvCmdConfig)
 		if err != nil {

--- a/cmd/s3-peer-router.go
+++ b/cmd/s3-peer-router.go
@@ -27,12 +27,14 @@ const (
 )
 
 type s3PeerAPIHandlers struct {
-	ObjectAPI func() ObjectLayer
+	*localBMS
 }
 
 func registerS3PeerRPCRouter(mux *router.Router) error {
 	s3PeerHandlers := &s3PeerAPIHandlers{
-		ObjectAPI: newObjectLayerFn,
+		&localBMS{
+			ObjectAPI: newObjectLayerFn,
+		},
 	}
 
 	s3PeerRPCServer := rpc.NewServer()

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -411,8 +411,10 @@ func StartTestPeersRPCServer(t TestErrHandler, instanceType string) TestServer {
 	// Run TestServer.
 	testRPCServer.Server = httptest.NewServer(mux)
 
+	// Set as non-distributed.
+	globalIsDistXL = false
+
 	// initialize remainder of serverCmdConfig
-	srvCfg.isDistXL = false
 	testRPCServer.SrvCmdCfg = srvCfg
 
 	return testRPCServer

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -81,7 +81,7 @@ func checkDuplicateEndpoints(endpoints []*url.URL) error {
 
 // Find local node through the command line arguments. Returns in `host:port` format.
 func getLocalAddress(srvCmdConfig serverCmdConfig) string {
-	if !srvCmdConfig.isDistXL {
+	if !globalIsDistXL {
 		return srvCmdConfig.serverAddr
 	}
 	for _, ep := range srvCmdConfig.endpoints {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -229,13 +229,14 @@ func TestLocalAddress(t *testing.T) {
 	globalMinioPort = "9000"
 	globalMinioHost = ""
 	testCases := []struct {
+		isDistXL     bool
 		srvCmdConfig serverCmdConfig
 		localAddr    string
 	}{
 		// Test 1 - local address is found.
 		{
+			isDistXL: true,
 			srvCmdConfig: serverCmdConfig{
-				isDistXL: true,
 				endpoints: []*url.URL{{
 					Scheme: "http",
 					Host:   "localhost:9000",
@@ -258,9 +259,9 @@ func TestLocalAddress(t *testing.T) {
 		},
 		// Test 2 - local address is everything.
 		{
+			isDistXL: false,
 			srvCmdConfig: serverCmdConfig{
 				serverAddr: net.JoinHostPort("", globalMinioPort),
-				isDistXL:   false,
 				endpoints: []*url.URL{{
 					Path: "/mnt/disk1",
 				}, {
@@ -275,8 +276,8 @@ func TestLocalAddress(t *testing.T) {
 		},
 		// Test 3 - local address is not found.
 		{
+			isDistXL: true,
 			srvCmdConfig: serverCmdConfig{
-				isDistXL: true,
 				endpoints: []*url.URL{{
 					Scheme: "http",
 					Host:   "1.1.1.1:9000",
@@ -301,9 +302,9 @@ func TestLocalAddress(t *testing.T) {
 		// name is specified in the --address option on the
 		// server command line.
 		{
+			isDistXL: false,
 			srvCmdConfig: serverCmdConfig{
 				serverAddr: "play.minio.io:9000",
-				isDistXL:   false,
 				endpoints: []*url.URL{{
 					Path: "/mnt/disk1",
 				}, {
@@ -320,6 +321,7 @@ func TestLocalAddress(t *testing.T) {
 
 	// Validates fetching local address.
 	for i, testCase := range testCases {
+		globalIsDistXL = testCase.isDistXL
 		localAddr := getLocalAddress(testCase.srvCmdConfig)
 		if localAddr != testCase.localAddr {
 			t.Fatalf("Test %d: Expected %s, got %s", i+1, testCase.localAddr, localAddr)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Adds an interface to update in-memory bucket metadata state called
  BucketMetaState - this interface has functions to:
     - update bucket notification configuration,
     - bucket listener configuration,
     - bucket policy configuration, and
     - send bucket event

- This interface is implemented by `localBMS` a type for manipulating
  local node in-memory bucket metadata, and by `remoteBMS` a type for
  manipulating remote node in-memory bucket metadata.

- The remote node interface, makes an RPC call, but the local node
  interface does not - it updates in-memory bucket state directly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#3022 

We avoid making a RPC call to the same (self) node in this change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on single and distributed minio policy and listen features.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.