### PR TITLE
Improve coverage of web-handlers.go

### DIFF
--- a/cmd/access-key.go
+++ b/cmd/access-key.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"regexp"
 )
 
 // credential container for access and secret keys.
@@ -33,11 +32,15 @@ const (
 	minioSecretID = 40
 )
 
-// isValidSecretKey - validate secret key.
-var isValidSecretKey = regexp.MustCompile(`^.{8,40}$`)
+// isValidAccessKey - validate access key for right length.
+func isValidAccessKey(accessKey string) bool {
+	return len(accessKey) >= 5 && len(accessKey) <= 20
+}
 
-// isValidAccessKey - validate access key.
-var isValidAccessKey = regexp.MustCompile(`^[a-zA-Z0-9\\-\\.\\_\\~]{5,20}$`)
+// isValidSecretKey - validate secret key for right length.
+func isValidSecretKey(secretKey string) bool {
+	return len(secretKey) >= 8 && len(secretKey) <= 40
+}
 
 // mustGenAccessKeys - must generate access credentials.
 func mustGenAccessKeys() (creds credential) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -184,10 +184,10 @@ func Main() {
 				SecretAccessKey: secretKey,
 			})
 		}
-		if !isValidAccessKey.MatchString(serverConfig.GetCredential().AccessKeyID) {
+		if !isValidAccessKey(serverConfig.GetCredential().AccessKeyID) {
 			fatalIf(errInvalidArgument, "Invalid access key. Accept only a string starting with a alphabetic and containing from 5 to 20 characters.")
 		}
-		if !isValidSecretKey.MatchString(serverConfig.GetCredential().SecretAccessKey) {
+		if !isValidSecretKey(serverConfig.GetCredential().SecretAccessKey) {
 			fatalIf(errInvalidArgument, "Invalid secret key. Accept only a string containing from 8 to 40 characters.")
 		}
 

--- a/cmd/signature-jwt.go
+++ b/cmd/signature-jwt.go
@@ -44,28 +44,30 @@ const (
 // newJWT - returns new JWT object.
 func newJWT(expiry time.Duration) (*JWT, error) {
 	if serverConfig == nil {
-		return nil, errors.New("Server not initialized")
+		return nil, errServerNotInitialized
 	}
 
 	// Save access, secret keys.
 	cred := serverConfig.GetCredential()
-	if !isValidAccessKey.MatchString(cred.AccessKeyID) {
-		return nil, errors.New("Invalid access key")
+	if !isValidAccessKey(cred.AccessKeyID) {
+		return nil, errInvalidAccessKeyLength
 	}
-	if !isValidSecretKey.MatchString(cred.SecretAccessKey) {
-		return nil, errors.New("Invalid secret key")
+	if !isValidSecretKey(cred.SecretAccessKey) {
+		return nil, errInvalidSecretKeyLength
 	}
-
 	return &JWT{cred, expiry}, nil
 }
+
+var errInvalidAccessKeyLength = errors.New("Invalid access key, access key should be 5 to 20 characters in length.")
+var errInvalidSecretKeyLength = errors.New("Invalid secret key, secret key should be 8 to 40 characters in length.")
 
 // GenerateToken - generates a new Json Web Token based on the incoming access key.
 func (jwt *JWT) GenerateToken(accessKey string) (string, error) {
 	// Trim spaces.
 	accessKey = strings.TrimSpace(accessKey)
 
-	if !isValidAccessKey.MatchString(accessKey) {
-		return "", errors.New("Invalid access key")
+	if !isValidAccessKey(accessKey) {
+		return "", errInvalidAccessKeyLength
 	}
 
 	tUTCNow := time.Now().UTC()
@@ -79,7 +81,6 @@ func (jwt *JWT) GenerateToken(accessKey string) (string, error) {
 }
 
 var errInvalidAccessKeyID = errors.New("The access key ID you provided does not exist in our records.")
-
 var errAuthentication = errors.New("Authentication failed, check your access credentials.")
 
 // Authenticate - authenticates incoming access key and secret key.
@@ -87,11 +88,11 @@ func (jwt *JWT) Authenticate(accessKey, secretKey string) error {
 	// Trim spaces.
 	accessKey = strings.TrimSpace(accessKey)
 
-	if !isValidAccessKey.MatchString(accessKey) {
-		return errors.New("Invalid access key")
+	if !isValidAccessKey(accessKey) {
+		return errInvalidAccessKeyLength
 	}
-	if !isValidSecretKey.MatchString(secretKey) {
-		return errors.New("Invalid secret key")
+	if !isValidSecretKey(secretKey) {
+		return errInvalidSecretKeyLength
 	}
 
 	if accessKey != jwt.AccessKeyID {

--- a/cmd/signature-jwt_test.go
+++ b/cmd/signature-jwt_test.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -72,25 +71,23 @@ func TestNewJWT(t *testing.T) {
 		expectedErr error
 	}{
 		// Test non-existent config directory.
-		{path.Join(path1, "non-existent-dir"), false, nil, fmt.Errorf("Server not initialized")},
+		{path.Join(path1, "non-existent-dir"), false, nil, errServerNotInitialized},
 		// Test empty config directory.
-		{path2, false, nil, fmt.Errorf("Server not initialized")},
+		{path2, false, nil, errServerNotInitialized},
 		// Test empty config file.
-		{path3, false, nil, fmt.Errorf("Server not initialized")},
+		{path3, false, nil, errServerNotInitialized},
 		// Test initialized config file.
 		{path4, true, nil, nil},
 		// Test to read already created config file.
 		{path4, false, nil, nil},
 		// Access key is too small.
-		{path4, false, &credential{"user", "pass"}, fmt.Errorf("Invalid access key")},
+		{path4, false, &credential{"user", "pass"}, errInvalidAccessKeyLength},
 		// Access key is too long.
-		{path4, false, &credential{"user12345678901234567", "pass"}, fmt.Errorf("Invalid access key")},
-		// Access key contains unsupported characters.
-		{path4, false, &credential{"!@#$%^&*()", "pass"}, fmt.Errorf("Invalid access key")},
+		{path4, false, &credential{"user12345678901234567", "pass"}, errInvalidAccessKeyLength},
 		// Secret key is too small.
-		{path4, false, &credential{"myuser", "pass"}, fmt.Errorf("Invalid secret key")},
+		{path4, false, &credential{"myuser", "pass"}, errInvalidSecretKeyLength},
 		// Secret key is too long.
-		{path4, false, &credential{"myuser", "pass1234567890123456789012345678901234567"}, fmt.Errorf("Invalid secret key")},
+		{path4, false, &credential{"myuser", "pass1234567890123456789012345678901234567"}, errInvalidSecretKeyLength},
 		// Valid access/secret keys.
 		{path4, false, &credential{"myuser", "mypassword"}, nil},
 	}
@@ -114,7 +111,6 @@ func TestNewJWT(t *testing.T) {
 			if err == nil {
 				t.Fatalf("%+v: expected: %s, got: <nil>", testCase, testCase.expectedErr)
 			}
-
 			if testCase.expectedErr.Error() != err.Error() {
 				t.Fatalf("%+v: expected: %s, got: %s", testCase, testCase.expectedErr, err)
 			}
@@ -143,11 +139,11 @@ func TestGenerateToken(t *testing.T) {
 		expectedErr error
 	}{
 		// Access key is too small.
-		{"user", fmt.Errorf("Invalid access key")},
+		{"user", errInvalidAccessKeyLength},
 		// Access key is too long.
-		{"user12345678901234567", fmt.Errorf("Invalid access key")},
+		{"user12345678901234567", errInvalidAccessKeyLength},
 		// Access key contains unsupported characters.
-		{"!@#$%^&*()", fmt.Errorf("Invalid access key")},
+		{"!@#$", errInvalidAccessKeyLength},
 		// Valid access key.
 		{"myuser", nil},
 		// Valid access key with leading/trailing spaces.
@@ -191,15 +187,15 @@ func TestAuthenticate(t *testing.T) {
 		expectedErr error
 	}{
 		// Access key too small.
-		{"user", "pass", fmt.Errorf("Invalid access key")},
+		{"user", "pass", errInvalidAccessKeyLength},
 		// Access key too long.
-		{"user12345678901234567", "pass", fmt.Errorf("Invalid access key")},
+		{"user12345678901234567", "pass", errInvalidAccessKeyLength},
 		// Access key contains unsuppported characters.
-		{"!@#$%^&*()", "pass", fmt.Errorf("Invalid access key")},
+		{"!@#$", "pass", errInvalidAccessKeyLength},
 		// Secret key too small.
-		{"myuser", "pass", fmt.Errorf("Invalid secret key")},
+		{"myuser", "pass", errInvalidSecretKeyLength},
 		// Secret key too long.
-		{"myuser", "pass1234567890123456789012345678901234567", fmt.Errorf("Invalid secret key")},
+		{"myuser", "pass1234567890123456789012345678901234567", errInvalidSecretKeyLength},
 		// Authentication error.
 		{"myuser", "mypassword", errInvalidAccessKeyID},
 		// Authentication error.

--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -47,7 +47,7 @@ func parseCredentialHeader(credElement string) (credentialHeader, APIErrorCode) 
 	if len(credElements) != 5 {
 		return credentialHeader{}, ErrCredMalformed
 	}
-	if !isValidAccessKey.MatchString(credElements[0]) {
+	if !isValidAccessKey(credElements[0]) {
 		return credentialHeader{}, ErrInvalidAccessKeyID
 	}
 	// Save access key id.

--- a/cmd/signature-v4-parser_test.go
+++ b/cmd/signature-v4-parser_test.go
@@ -116,10 +116,10 @@ func TestParseCredentialHeader(t *testing.T) {
 			expectedErrCode:     ErrCredMalformed,
 		},
 		// Test Case - 4.
-		// Test case with malformed AccessKey.
+		// Test case with AccessKey of length 4.
 		{
 			inputCredentialStr: generateCredentialStr(
-				"^#@..!23",
+				"^#@.",
 				time.Now().UTC().Format(yyyymmdd),
 				"ABCD",
 				"ABCD",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds more tests to web-handlers.go. This patch additionally relaxes the requirement for
accesskeys to be in a regexy set of values.

Fixes #3063
<!--- Describe your changes in detail -->

## Motivation and Context
Cover all the areas of testing for web-handlers.go and fixes #3063 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
