### PR TITLE
sigv4: Trim and shrink spaces in headers values

### DIFF
--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -157,3 +157,19 @@ func extractSignedHeaders(signedHeaders []string, reqHeaders http.Header) (http.
 
 	return extractedSignedHeaders, ErrNone
 }
+
+// Trim leading and trailing spaces and replace sequential spaces with one space, following Trimall()
+// in http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+func signV4TrimAll(input string) string {
+	// Remove all whitespaces first
+	cleanWhiteSpaces := func(r rune) rune {
+		switch r {
+		case '\t', '\n', '\u000b', '\r', '\f':
+			return ' '
+		}
+		return r
+	}
+	input = strings.Map(cleanWhiteSpaces, input)
+	// Compress adjacent spaces to one space and return
+	return strings.Join(strings.Fields(input), " ")
+}

--- a/cmd/signature-v4-utils_test.go
+++ b/cmd/signature-v4-utils_test.go
@@ -211,3 +211,31 @@ func TestFindHost(t *testing.T) {
 		t.Fatalf("Expected the APIErrorCode to be %d, but got %d", ErrNone, errCode)
 	}
 }
+
+// TestSigV4TrimAll - tests the logic of TrimAll() function
+func TestSigV4TrimAll(t *testing.T) {
+	testCases := []struct {
+		// Input.
+		inputStr string
+		// Expected result.
+		result string
+	}{
+		{"本語", "本語"},
+		{" abc ", "abc"},
+		{" a b ", "a b"},
+		{"a b ", "a b"},
+		{"a  b", "a b"},
+		{"a   b", "a b"},
+		{"   a   b  c   ", "a b c"},
+		{"a \t b  c   ", "a b c"},
+		{"\"a \t b  c   ", "\"a b c"},
+	}
+
+	// Tests generated values from url encoded name.
+	for i, testCase := range testCases {
+		result := signV4TrimAll(testCase.inputStr)
+		if testCase.result != result {
+			t.Errorf("Test %d: Expected sigV4TrimAll result to be \"%s\", but found it to be \"%s\" instead", i+1, testCase.result, result)
+		}
+	}
+}

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -68,7 +68,7 @@ func getCanonicalHeaders(signedHeaders http.Header, host string) string {
 				if idx > 0 {
 					buf.WriteByte(',')
 				}
-				buf.WriteString(v)
+				buf.WriteString(signV4TrimAll(v))
 			}
 			buf.WriteByte('\n')
 		}


### PR DESCRIPTION
## Description
The current code doesn't use Trimall() described in  http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html to create the canonical request and calculate the signature

## Motivation and Context
Fixes #3158 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
