### PR TITLE
bootup-validation: Allow port configuration only using --address option.

### DIFF
--- a/cmd/object-common_test.go
+++ b/cmd/object-common_test.go
@@ -101,6 +101,7 @@ func TestHouseKeeping(t *testing.T) {
 
 // Test getPath() - the path that needs to be passed to newPosix()
 func TestGetPath(t *testing.T) {
+	globalMinioHost = ""
 	var testCases []struct {
 		epStr string
 		path  string

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -119,6 +119,14 @@ func parseStorageEndpoints(eps []string) (endpoints []*url.URL, err error) {
 			return nil, err
 		}
 		if u.Host != "" && globalMinioHost == "" {
+			// For ex.: minio server host1:port1 host2:port2...
+			// we return error as port is configurable only
+			// using "--address :port"
+			_, _, err := net.SplitHostPort(u.Host)
+			if err == nil {
+				// u.Host has ":"
+				return nil, fmt.Errorf("Invalid argument %s, port configurable using --address", u.Host)
+			}
 			u.Host = net.JoinHostPort(u.Host, globalMinioPort)
 		}
 		endpoints = append(endpoints, u)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -118,16 +118,31 @@ func parseStorageEndpoints(eps []string) (endpoints []*url.URL, err error) {
 		if err != nil {
 			return nil, err
 		}
-		if u.Host != "" && globalMinioHost == "" {
-			// For ex.: minio server host1:port1 host2:port2...
-			// we return error as port is configurable only
-			// using "--address :port"
-			_, _, err := net.SplitHostPort(u.Host)
-			if err == nil {
-				// u.Host has ":"
-				return nil, fmt.Errorf("Invalid argument %s, port configurable using --address", u.Host)
+		if u.Host != "" {
+			_, port, err := net.SplitHostPort(u.Host)
+			// Ignore the missing port error as the default port can be globalMinioPort.
+			if err != nil && !strings.Contains(err.Error(), "missing port in address") {
+				return nil, err
 			}
-			u.Host = net.JoinHostPort(u.Host, globalMinioPort)
+
+			if globalMinioHost == "" {
+				// For ex.: minio server host1:port1 host2:port2...
+				// we return error as port is configurable only
+				// using "--address :port"
+				if port != "" {
+					errorIf(fmt.Errorf("Invalid argument %s, port configurable using --address :<port>", u.Host), "")
+					return nil, errInvalidArgument
+				}
+				u.Host = net.JoinHostPort(u.Host, globalMinioPort)
+			} else {
+				// For ex.: minio server --address host:port host1:port1 host2:port2...
+				// i.e if "--address host:port" is specified
+				// port info in u.Host is mandatory else return error.
+				if port == "" {
+					errorIf(fmt.Errorf("Invalid argument %s, port mandatory when --address <host>:<port> is used", u.Host), "")
+					return nil, errInvalidArgument
+				}
+			}
 		}
 		endpoints = append(endpoints, u)
 	}

--- a/cmd/server-main_test.go
+++ b/cmd/server-main_test.go
@@ -177,6 +177,28 @@ func TestCheckSufficientDisks(t *testing.T) {
 	}
 }
 
+func TestParseStorageEndpoints(t *testing.T) {
+	testCases := []struct {
+		globalMinioHost string
+		host            string
+		expectedErr     error
+	}{
+		{"", "http://localhost/export", nil},
+		{"testhost", "http://localhost/export", errInvalidArgument},
+		{"", "http://localhost:9000/export", errInvalidArgument},
+		{"testhost", "http://localhost:9000/export", nil},
+	}
+	for i, test := range testCases {
+		globalMinioHost = test.globalMinioHost
+		_, err := parseStorageEndpoints([]string{test.host})
+		if err != test.expectedErr {
+			t.Errorf("Test %d : got %v, expected %v", i+1, err, test.expectedErr)
+		}
+	}
+	// Should be reset back to "" so that we don't affect other tests.
+	globalMinioHost = ""
+}
+
 func TestCheckEndpointsSyntax(t *testing.T) {
 	var testCases []string
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Description
If minio is started as:
minio server http://minio1:9001/export http://minio2:9002/export http://minio3:9003/export http://minio4:9004/export

we disallow such a setup as port should be same on all the minio processes and configurable only using --address option (9000 by default)

If port is specified as http://host:port/export we error out.

## Motivation and Context
https://github.com/minio/minio/issues/3153

## How Has This Been Tested?
manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
fixes #3153
