### PR TITLE
connection muxer should use bufio.Reader to be simpler.

### DIFF
--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -86,10 +86,7 @@ func isKeyFileExists() bool {
 
 // isSSL - returns true with both cert and key exists.
 func isSSL() bool {
-	if isCertFileExists() && isKeyFileExists() {
-		return true
-	}
-	return false
+	return isCertFileExists() && isKeyFileExists()
 }
 
 // Reads certificated file and returns a list of parsed certificates.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change is rather regarding simplicity and readability of the net.Conn wrapper. 
<!--- Describe your changes in detail -->

## Motivation and Context
To simplify. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using 'go tests'. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
