### PR TITLE
Fix docker file to use binary entrypoint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.7-alpine
 WORKDIR /go/src/app
 
 COPY . /go/src/app
+
 RUN \
 	apk add --no-cache git && \
 	go-wrapper download && \
@@ -13,5 +14,5 @@ RUN \
 	apk del git
 
 EXPOSE 9000
-ENTRYPOINT ["go-wrapper", "run"]
+ENTRYPOINT ["minio"]
 VOLUME ["/export"]

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package main
+package main // import "github.com/minio/minio"
 
 import minio "github.com/minio/minio/cmd"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the docker file to use - https://golang.org/doc/go1.4#canonicalimports so that we can generate consistent binary names.
<!--- Describe your changes in detail -->

## Motivation and Context
To fix the consistent binary names and not use "go-wrapper run" anymore.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Building a local docker image.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
