### PR TITLE
Rewrite connection muxer to avoid blocking server by silent clients

### DIFF
--- a/cmd/server-mux_test.go
+++ b/cmd/server-mux_test.go
@@ -59,11 +59,8 @@ func runTest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ln = &ListenerMux{
-		Listener: ln,
-		config:   &tls.Config{},
-		cond:     sync.NewCond(&sync.Mutex{}),
-	}
+
+	ln = newListenerMux(ln, &tls.Config{})
 
 	addr := ln.Addr().String()
 	waitForListener := make(chan error)


### PR DESCRIPTION
Need rebase and code reread and test again for edge cases

## Description
Fix one problem with connection peeker which was blocking when a client opens a connection and doesn't send any data. Peeking is moved in a go routine, more changes are done to satisfy the new code flow.

## Motivation and Context
Fixes #3159 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.