### PR TITLE
Add `withQuorum` flag to isUploadIDExists:

### DIFF
--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -229,15 +229,16 @@ func testPutObjectPartDiskNotFound(obj ObjectLayer, instanceType string, disks [
 		removeAll(disk)
 	}
 
-	// Object part upload should fail with quorum not available.
+	// Object part upload should fail with upload id invalid (as
+	// it is not present on quorum disks).
 	testCase := createPartCases[len(createPartCases)-1]
 	_, err = obj.PutObjectPart(testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, testCase.intputDataSize, bytes.NewBufferString(testCase.inputReaderData), testCase.inputMd5, sha256sum)
 	if err == nil {
 		t.Fatalf("Test %s: expected to fail but passed instead", instanceType)
 	}
-	expectedErr := InsufficientWriteQuorum{}
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("Test %s: expected error %s, got %s instead.", instanceType, expectedErr, err)
+	expectedErrPrefix := "Invalid upload id "
+	if !strings.HasPrefix(err.Error(), expectedErrPrefix) {
+		t.Fatalf("Test %s: expected error '%s<upload-id>', got '%s' instead.", instanceType, expectedErrPrefix, err)
 	}
 }
 

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -365,7 +365,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 
 	nsMutex.RLock(minioMetaBucket, uploadIDPath, opsID)
 	// Validates if upload ID exists.
-	if !xl.isUploadIDExists(bucket, object, uploadID) {
+	if !xl.isUploadIDExists(bucket, object, uploadID, true) {
 		nsMutex.RUnlock(minioMetaBucket, uploadIDPath, opsID)
 		return "", traceError(InvalidUploadID{UploadID: uploadID})
 	}
@@ -476,7 +476,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	defer nsMutex.Unlock(minioMetaBucket, uploadIDPath, opsID)
 
 	// Validate again if upload ID still exists.
-	if !xl.isUploadIDExists(bucket, object, uploadID) {
+	if !xl.isUploadIDExists(bucket, object, uploadID, true) {
 		return "", traceError(InvalidUploadID{UploadID: uploadID})
 	}
 
@@ -624,7 +624,7 @@ func (xl xlObjects) ListObjectParts(bucket, object, uploadID string, partNumberM
 	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
-	if !xl.isUploadIDExists(bucket, object, uploadID) {
+	if !xl.isUploadIDExists(bucket, object, uploadID, false) {
 		return ListPartsInfo{}, traceError(InvalidUploadID{UploadID: uploadID})
 	}
 	result, err := xl.listObjectParts(bucket, object, uploadID, partNumberMarker, maxParts)
@@ -662,7 +662,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
-	if !xl.isUploadIDExists(bucket, object, uploadID) {
+	if !xl.isUploadIDExists(bucket, object, uploadID, true) {
 		return "", traceError(InvalidUploadID{UploadID: uploadID})
 	}
 	// Calculate s3 compatible md5sum for complete multipart.
@@ -896,7 +896,7 @@ func (xl xlObjects) AbortMultipartUpload(bucket, object, uploadID string) error 
 	nsMutex.Lock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 	defer nsMutex.Unlock(minioMetaBucket, pathJoin(mpartMetaPrefix, bucket, object, uploadID), opsID)
 
-	if !xl.isUploadIDExists(bucket, object, uploadID) {
+	if !xl.isUploadIDExists(bucket, object, uploadID, true) {
 		return traceError(InvalidUploadID{UploadID: uploadID})
 	}
 	err := xl.abortMultipartUpload(bucket, object, uploadID)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- withQuorum flag is used to check if the uploadID exists on quorum
  disks and is used in all mutating operations in multipart
  uploads (i.e. put object part, abort multipart and complete
  multipart).

- in listObjectParts, isUploadIDExists is called with withQuorum=false
  for better average case performance.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Possible way to resolve https://github.com/minio/minio/issues/3149:

In case a stale upload id is attempted to be resumed, instead of returning misleading/buggy write quorum errors, the server will return that the upload id is invalid.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing test case validates it.

Manual testing with mc, now causes mc to return:

```
$ mc cp /tmp/stop.mp4 dminio1/testb
mc: <ERROR> Failed to copy ‘/tmp/stop.mp4’. The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.
```

mc is not returning a nonsensical quorum error any more.

[The fact that it is failing to upload is itself a bug, but an [independent one](https://github.com/minio/mc/issues/1874)]


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
