### PR TITLE
Improve namespace lock API

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -166,10 +166,10 @@ func PutBucketNotificationConfig(bucket string, ncfg *notificationConfig, objAPI
 
 	// Acquire a write lock on bucket before modifying its
 	// configuration.
-	opsID := getOpsID()
-	nsMutex.Lock(bucket, "", opsID)
+	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock.Lock()
 	// Release lock after notifying peers
-	defer nsMutex.Unlock(bucket, "", opsID)
+	defer bucketLock.Unlock()
 
 	// persist config to disk
 	err := persistNotificationConfig(bucket, ncfg, objAPI)
@@ -374,10 +374,10 @@ func AddBucketListenerConfig(bucket string, lcfg *listenerConfig, objAPI ObjectL
 
 	// Acquire a write lock on bucket before modifying its
 	// configuration.
-	opsID := getOpsID()
-	nsMutex.Lock(bucket, "", opsID)
+	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock.Lock()
 	// Release lock after notifying peers
-	defer nsMutex.Unlock(bucket, "", opsID)
+	defer bucketLock.Unlock()
 
 	// update persistent config if dist XL
 	if globalIsDistXL {
@@ -416,10 +416,10 @@ func RemoveBucketListenerConfig(bucket string, lcfg *listenerConfig, objAPI Obje
 
 	// Acquire a write lock on bucket before modifying its
 	// configuration.
-	opsID := getOpsID()
-	nsMutex.Lock(bucket, "", opsID)
+	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock.Lock()
 	// Release lock after notifying peers
-	defer nsMutex.Unlock(bucket, "", opsID)
+	defer bucketLock.Unlock()
 
 	// update persistent config if dist XL
 	if globalIsDistXL {

--- a/cmd/bucket-policy-handlers.go
+++ b/cmd/bucket-policy-handlers.go
@@ -209,10 +209,10 @@ func persistAndNotifyBucketPolicyChange(bucket string, pCh policyChange, objAPI 
 
 	// Acquire a write lock on bucket before modifying its
 	// configuration.
-	opsID := getOpsID()
-	nsMutex.Lock(bucket, "", opsID)
+	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock.Lock()
 	// Release lock after notifying peers
-	defer nsMutex.Unlock(bucket, "", opsID)
+	defer bucketLock.Unlock()
 
 	if pCh.IsRemove {
 		if err := removeBucketPolicy(bucket, objAPI); err != nil {

--- a/cmd/control-lock-main_test.go
+++ b/cmd/control-lock-main_test.go
@@ -23,12 +23,13 @@ import (
 
 // Test print systemState.
 func TestPrintLockState(t *testing.T) {
-	nsMutex.Lock("testbucket", "1.txt", "11-11")
+	testLock := nsMutex.NewNSLock("testbucket", "1.txt")
+	testLock.Lock()
 	sysLockState, err := getSystemLockState()
 	if err != nil {
 		t.Fatal(err)
 	}
-	nsMutex.Unlock("testbucket", "1.txt", "11-11")
+	testLock.Unlock()
 	sysLockStateMap := map[string]SystemLockState{}
 	sysLockStateMap["bucket"] = sysLockState
 
@@ -66,7 +67,8 @@ func TestLockStateClear(t *testing.T) {
 		nsMutex.ForceUnlock(bucket, object)
 	}
 
-	nsMutex.Lock("testbucket", "1.txt", "11-11")
+	testLock := nsMutex.NewNSLock("testbucket", "1.txt")
+	testLock.Lock()
 
 	sysLockState, err := getSystemLockState()
 	if err != nil {
@@ -111,7 +113,8 @@ func TestLockStateClear(t *testing.T) {
 	}
 
 	// Create another lock
-	nsMutex.RLock("testbucket", "blob.txt", "22-22")
+	blobLock := nsMutex.NewNSLock("testbucket", "blob.txt")
+	blobLock.RLock()
 
 	if sysLockState, err = getSystemLockState(); err != nil {
 		t.Fatal(err)
@@ -142,7 +145,8 @@ func TestLockStateClear(t *testing.T) {
 	}
 
 	// Create yet another lock
-	nsMutex.RLock("testbucket", "exact.txt", "33-33")
+	exactLock := nsMutex.NewNSLock("testbucket", "exact.txt")
+	exactLock.RLock()
 
 	if sysLockState, err = getSystemLockState(); err != nil {
 		t.Fatal(err)

--- a/cmd/lock-instrument_test.go
+++ b/cmd/lock-instrument_test.go
@@ -256,7 +256,6 @@ func TestNsLockMapStatusBlockedToRunning(t *testing.T) {
 	}{
 		// Test case - 1.
 		{
-
 			volume:     "my-bucket",
 			path:       "my-object",
 			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
@@ -270,7 +269,6 @@ func TestNsLockMapStatusBlockedToRunning(t *testing.T) {
 		// No entry for <volume, path> pair.
 		// So an attempt to change the state of the lock from `Blocked`->`Running` should fail.
 		{
-
 			volume:     "my-bucket",
 			path:       "my-object-2",
 			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",
@@ -307,7 +305,6 @@ func TestNsLockMapStatusBlockedToRunning(t *testing.T) {
 		// Test case - 5.
 		// Test case with write lock.
 		{
-
 			volume:     "my-bucket",
 			path:       "my-object",
 			lockOrigin: "/home/vadmeste/work/go/src/github.com/minio/minio/xl-v1-object.go:683 +0x2a",

--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -256,3 +256,42 @@ func (n *nsLockMap) ForceUnlock(volume, path string) {
 		}
 	}
 }
+
+// lockInstance - frontend/top-level interface for namespace locks.
+type lockInstance struct {
+	n                   *nsLockMap
+	volume, path, opsID string
+}
+
+// NewNSLock - returns a lock instance for a given volume and
+// path. The returned lockInstance object encapsulates the nsLockMap,
+// volume, path and operation ID.
+func (n *nsLockMap) NewNSLock(volume, path string) *lockInstance {
+	return &lockInstance{n, volume, path, getOpsID()}
+}
+
+// Lock - block until write lock is taken.
+func (li *lockInstance) Lock() {
+	lockLocation := callerLocation()
+	readLock := false
+	li.n.lock(li.volume, li.path, lockLocation, li.opsID, readLock)
+}
+
+// Unlock - block until write lock is released.
+func (li *lockInstance) Unlock() {
+	readLock := false
+	li.n.unlock(li.volume, li.path, li.opsID, readLock)
+}
+
+// RLock - block until read lock is taken.
+func (li *lockInstance) RLock() {
+	lockLocation := callerLocation()
+	readLock := true
+	li.n.lock(li.volume, li.path, lockLocation, li.opsID, readLock)
+}
+
+// RUnlock - block until read lock is released.
+func (li *lockInstance) RUnlock() {
+	readLock := true
+	li.n.unlock(li.volume, li.path, li.opsID, readLock)
+}

--- a/cmd/namespace-lock_test.go
+++ b/cmd/namespace-lock_test.go
@@ -386,7 +386,8 @@ func TestLockStats(t *testing.T) {
 func TestNamespaceForceUnlockTest(t *testing.T) {
 
 	// Create lock.
-	nsMutex.Lock("bucket", "object", "11-11")
+	lock := nsMutex.NewNSLock("bucket", "object")
+	lock.Lock()
 	// Forcefully unlock lock.
 	nsMutex.ForceUnlock("bucket", "object")
 
@@ -394,7 +395,8 @@ func TestNamespaceForceUnlockTest(t *testing.T) {
 
 	go func() {
 		// Try to claim lock again.
-		nsMutex.Lock("bucket", "object", "22-22")
+		anotherLock := nsMutex.NewNSLock("bucket", "object")
+		anotherLock.Lock()
 		// And signal succes.
 		ch <- struct{}{}
 	}()

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -31,11 +31,9 @@ func (xl xlObjects) MakeBucket(bucket string) error {
 		return traceError(BucketNameInvalid{Bucket: bucket})
 	}
 
-	// get a random ID for lock instrumentation.
-	opsID := getOpsID()
-
-	nsMutex.Lock(bucket, "", opsID)
-	defer nsMutex.Unlock(bucket, "", opsID)
+	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock.Lock()
+	defer bucketLock.Unlock()
 
 	// Initialize sync waitgroup.
 	var wg = &sync.WaitGroup{}
@@ -174,11 +172,11 @@ func (xl xlObjects) GetBucketInfo(bucket string) (BucketInfo, error) {
 	if !IsValidBucketName(bucket) {
 		return BucketInfo{}, BucketNameInvalid{Bucket: bucket}
 	}
-	// get a random ID for lock instrumentation.
-	opsID := getOpsID()
 
-	nsMutex.RLock(bucket, "", opsID)
-	defer nsMutex.RUnlock(bucket, "", opsID)
+	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock.RLock()
+	defer bucketLock.RUnlock()
+
 	bucketInfo, err := xl.getBucketInfo(bucket)
 	if err != nil {
 		return BucketInfo{}, toObjectErr(err, bucket)
@@ -249,11 +247,9 @@ func (xl xlObjects) DeleteBucket(bucket string) error {
 		return BucketNameInvalid{Bucket: bucket}
 	}
 
-	// get a random ID for lock instrumentation.
-	opsID := getOpsID()
-
-	nsMutex.Lock(bucket, "", opsID)
-	defer nsMutex.Unlock(bucket, "", opsID)
+	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock.Lock()
+	defer bucketLock.Unlock()
 
 	// Collect if all disks report volume not found.
 	var wg = &sync.WaitGroup{}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve lock interface:

- abstract out instrumentation information.

- make code more readable


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, all namespace locking code is littered with a call to generate an opsID for instrumentation and is not very readable, for e.g. this snippet from `xl-v1-multipart.go` in `PutObjectPart`:

```go
	// get a random ID for lock instrumentation.
	opsID := getOpsID()

	nsMutex.RLock(minioMetaBucket, uploadIDPath, opsID)
	// Validates if upload ID exists.
	if !xl.isUploadIDExists(bucket, object, uploadID) {
		nsMutex.RUnlock(minioMetaBucket, uploadIDPath, opsID)
		return "", traceError(InvalidUploadID{UploadID: uploadID})
	}
	// Read metadata associated with the object from all disks.
	partsMetadata, errs = readAllXLMetadata(xl.storageDisks, minioMetaBucket,
		uploadIDPath)
	if !isDiskQuorum(errs, xl.writeQuorum) {
		nsMutex.RUnlock(minioMetaBucket, uploadIDPath, opsID)
		return "", toObjectErr(traceError(errXLWriteQuorum), bucket, object)
	}
	nsMutex.RUnlock(minioMetaBucket, uploadIDPath, opsID)

```

With the proposed interface change (please refer to the content of the commit in this PR), we could write this snippet as:

```go
	// initialize uploadIdPath lock
	uploadIDLock := nsMutex.NewNSLock(minioMetaBucket, uploadIDPath)

	uploadIDLock.RLock()
	// Validates if upload ID exists.
	if !xl.isUploadIDExists(bucket, object, uploadID) {
		uploadIDLock.RUnlock()
		return "", traceError(InvalidUploadID{UploadID: uploadID})
	}
	// Read metadata associated with the object from all disks.
	partsMetadata, errs = readAllXLMetadata(xl.storageDisks, minioMetaBucket,
		uploadIDPath)
	if !isDiskQuorum(errs, xl.writeQuorum) {
		uploadIDLock.RUnlock()
		return "", toObjectErr(traceError(errXLWriteQuorum), bucket, object)
	}
	uploadIDLock.RUnlock()

```

Tagging @harshavardhana @abperiasamy @krishnasrinivas @fwessels @hackintoshrao for inputs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code enhancement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
