### PR TITLE
Prevent weird messages from rpc lib on start (Fixes #3209):

### DIFF
--- a/cmd/s3-peer-router.go
+++ b/cmd/s3-peer-router.go
@@ -27,7 +27,7 @@ const (
 )
 
 type s3PeerAPIHandlers struct {
-	*localBMS
+	bms BucketMetaState
 }
 
 func registerS3PeerRPCRouter(mux *router.Router) error {

--- a/cmd/s3-peer-rpc-handlers.go
+++ b/cmd/s3-peer-rpc-handlers.go
@@ -54,7 +54,7 @@ func (s3 *s3PeerAPIHandlers) SetBucketNotificationPeer(args *SetBNPArgs, reply *
 		return errInvalidToken
 	}
 
-	return s3.UpdateBucketNotification(args)
+	return s3.bms.UpdateBucketNotification(args)
 }
 
 // SetBLPArgs - Arguments collection to SetBucketListenerPeer RPC call
@@ -74,7 +74,7 @@ func (s3 *s3PeerAPIHandlers) SetBucketListenerPeer(args *SetBLPArgs, reply *Gene
 		return errInvalidToken
 	}
 
-	return s3.UpdateBucketListener(args)
+	return s3.bms.UpdateBucketListener(args)
 }
 
 // EventArgs - Arguments collection for Event RPC call
@@ -96,7 +96,7 @@ func (s3 *s3PeerAPIHandlers) Event(args *EventArgs, reply *GenericReply) error {
 		return errInvalidToken
 	}
 
-	return s3.SendEvent(args)
+	return s3.bms.SendEvent(args)
 }
 
 // SetBPPArgs - Arguments collection for SetBucketPolicyPeer RPC call
@@ -117,5 +117,5 @@ func (s3 *s3PeerAPIHandlers) SetBucketPolicyPeer(args *SetBPPArgs, reply *Generi
 		return errInvalidToken
 	}
 
-	return s3.UpdateBucketPolicy(args)
+	return s3.bms.UpdateBucketPolicy(args)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is done by not making the methods of the BucketMetaState interface
as methods (via type nesting) on the type implementing
RPCs (s3PeerAPIHandlers).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix for https://github.com/minio/minio/issues/3209

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing unit tests pass. Offending message are no longer printed at startup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
