### PR TITLE
Fix path comparing in checkgopath

### DIFF
--- a/buildscripts/checkgopath.sh
+++ b/buildscripts/checkgopath.sh
@@ -22,7 +22,7 @@ main() {
     for path in "${paths[@]}"; do
         minio_path="$path/src/github.com/minio/minio"
         if [ -d "$minio_path" ]; then
-            if [ "$minio_path" == "$PWD" ]; then
+            if [ "$minio_path" -ef "$PWD" ]; then
                exit 0
             fi
         fi


### PR DESCRIPTION
## Description
gocheckpath.sh wasn't working when GOPATH has a trailing slash.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
