### PR TITLE
lock: Implement shared locking used for shared backend semantics.

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -174,7 +174,7 @@ func PutBucketNotificationConfig(bucket string, ncfg *notificationConfig, objAPI
 
 	// Acquire a write lock on bucket before modifying its
 	// configuration.
-	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	bucketLock.Lock()
 	// Release lock after notifying peers
 	defer bucketLock.Unlock()
@@ -381,7 +381,7 @@ func AddBucketListenerConfig(bucket string, lcfg *listenerConfig, objAPI ObjectL
 
 	// Acquire a write lock on bucket before modifying its
 	// configuration.
-	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	bucketLock.Lock()
 	// Release lock after notifying peers
 	defer bucketLock.Unlock()
@@ -423,7 +423,7 @@ func RemoveBucketListenerConfig(bucket string, lcfg *listenerConfig, objAPI Obje
 
 	// Acquire a write lock on bucket before modifying its
 	// configuration.
-	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	bucketLock.Lock()
 	// Release lock after notifying peers
 	defer bucketLock.Unlock()

--- a/cmd/bucket-policy-handlers.go
+++ b/cmd/bucket-policy-handlers.go
@@ -202,7 +202,7 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 func persistAndNotifyBucketPolicyChange(bucket string, pCh policyChange, objAPI ObjectLayer) error {
 	// Acquire a write lock on bucket before modifying its
 	// configuration.
-	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	bucketLock.Lock()
 	// Release lock after notifying peers
 	defer bucketLock.Unlock()

--- a/cmd/event-notifier_test.go
+++ b/cmd/event-notifier_test.go
@@ -289,7 +289,7 @@ func TestInitEventNotifier(t *testing.T) {
 	}
 
 	// needed to load listener config from disk for testing (in
-	// single peer mode, the listener config is ingored, but here
+	// single peer mode, the listener config is ignored, but here
 	// we want to test the loading from disk too.)
 	globalIsDistXL = true
 

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -59,7 +59,7 @@ func (fs fsObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 	var err error
 	var eof bool
 	if uploadIDMarker != "" {
-		keyMarkerLock := nsMutex.NewNSLock(minioMetaMultipartBucket,
+		keyMarkerLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
 			pathJoin(bucket, keyMarker))
 		keyMarkerLock.RLock()
 		uploads, _, err = listMultipartUploadIDs(bucket, keyMarker, uploadIDMarker, maxUploads, fs.storage)
@@ -114,7 +114,7 @@ func (fs fsObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 			var end bool
 			uploadIDMarker = ""
 
-			entryLock := nsMutex.NewNSLock(minioMetaMultipartBucket,
+			entryLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
 				pathJoin(bucket, entry))
 			entryLock.RLock()
 			tmpUploads, end, err = listMultipartUploadIDs(bucket, entry, uploadIDMarker, maxUploads, fs.storage)
@@ -231,7 +231,7 @@ func (fs fsObjects) newMultipartUpload(bucket string, object string, meta map[st
 
 	// This lock needs to be held for any changes to the directory
 	// contents of ".minio.sys/multipart/object/"
-	objectMPartPathLock := nsMutex.NewNSLock(minioMetaMultipartBucket,
+	objectMPartPathLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
 		pathJoin(bucket, object))
 	objectMPartPathLock.Lock()
 	defer objectMPartPathLock.Unlock()
@@ -304,7 +304,7 @@ func (fs fsObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 
 	uploadIDPath := path.Join(bucket, object, uploadID)
 
-	preUploadIDLock := nsMutex.NewNSLock(minioMetaMultipartBucket, uploadIDPath)
+	preUploadIDLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket, uploadIDPath)
 	preUploadIDLock.RLock()
 	// Just check if the uploadID exists to avoid copy if it doesn't.
 	uploadIDExists := fs.isUploadIDExists(bucket, object, uploadID)
@@ -384,7 +384,7 @@ func (fs fsObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	}
 
 	// Hold write lock as we are updating fs.json
-	postUploadIDLock := nsMutex.NewNSLock(minioMetaMultipartBucket, uploadIDPath)
+	postUploadIDLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket, uploadIDPath)
 	postUploadIDLock.Lock()
 	defer postUploadIDLock.Unlock()
 
@@ -403,7 +403,7 @@ func (fs fsObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	partPath := path.Join(bucket, object, uploadID, partSuffix)
 	// Lock the part so that another part upload with same part-number gets blocked
 	// while the part is getting appended in the background.
-	partLock := nsMutex.NewNSLock(minioMetaMultipartBucket, partPath)
+	partLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket, partPath)
 	partLock.Lock()
 	err = fs.storage.RenameFile(minioMetaTmpBucket, tmpPartPath, minioMetaMultipartBucket, partPath)
 	if err != nil {
@@ -502,7 +502,7 @@ func (fs fsObjects) ListObjectParts(bucket, object, uploadID string, partNumberM
 
 	// Hold lock so that there is no competing
 	// abort-multipart-upload or complete-multipart-upload.
-	uploadIDLock := nsMutex.NewNSLock(minioMetaMultipartBucket,
+	uploadIDLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
 		pathJoin(bucket, object, uploadID))
 	uploadIDLock.Lock()
 	defer uploadIDLock.Unlock()
@@ -553,7 +553,7 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 	// 1) no one aborts this multipart upload
 	// 2) no one does a parallel complete-multipart-upload on this
 	// multipart upload
-	uploadIDLock := nsMutex.NewNSLock(minioMetaMultipartBucket, uploadIDPath)
+	uploadIDLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket, uploadIDPath)
 	uploadIDLock.Lock()
 	defer uploadIDLock.Unlock()
 
@@ -576,7 +576,7 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 
 	// This lock is held during rename of the appended tmp file to the actual
 	// location so that any competing GetObject/PutObject/DeleteObject do not race.
-	objectLock := nsMutex.NewNSLock(bucket, object)
+	objectLock := globalNSMutex.NewNSLock(bucket, object)
 	appendFallback := true // In case background-append did not append the required parts.
 	if isPartsSame(fsMeta.Parts, parts) {
 		err = fs.bgAppend.complete(fs.storage, bucket, object, uploadID, fsMeta)
@@ -693,7 +693,7 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 	// Hold the lock so that two parallel
 	// complete-multipart-uploads do not leave a stale
 	// uploads.json behind.
-	objectMPartPathLock := nsMutex.NewNSLock(minioMetaMultipartBucket,
+	objectMPartPathLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
 		pathJoin(bucket, object))
 	objectMPartPathLock.Lock()
 	defer objectMPartPathLock.Unlock()
@@ -752,7 +752,7 @@ func (fs fsObjects) AbortMultipartUpload(bucket, object, uploadID string) error 
 
 	// Hold lock so that there is no competing
 	// complete-multipart-upload or put-object-part.
-	uploadIDLock := nsMutex.NewNSLock(minioMetaMultipartBucket,
+	uploadIDLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
 		pathJoin(bucket, object, uploadID))
 	uploadIDLock.Lock()
 	defer uploadIDLock.Unlock()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -59,7 +59,11 @@ var (
 	globalConfigDir = mustGetConfigPath() // config-dir flag set via command line
 	// Add new global flags here.
 
-	globalIsDistXL = false // "Is Distributed?" flag.
+	// Indicates if the running minio server is distributed setup.
+	globalIsDistXL = false
+
+	// Indicates if the running minio server is on a shared backend.
+	globalIsSharedBackend = false
 
 	// Maximum cache size.
 	globalMaxCacheSize = uint64(maxCacheSize)

--- a/cmd/lockinfo-handlers.go
+++ b/cmd/lockinfo-handlers.go
@@ -61,16 +61,16 @@ type OpsLockState struct {
 
 // Read entire state of the locks in the system and return.
 func getSystemLockState() (SystemLockState, error) {
-	nsMutex.lockMapMutex.Lock()
-	defer nsMutex.lockMapMutex.Unlock()
+	globalNSMutex.lockMapMutex.Lock()
+	defer globalNSMutex.lockMapMutex.Unlock()
 
 	lockState := SystemLockState{}
 
-	lockState.TotalBlockedLocks = nsMutex.blockedCounter
-	lockState.TotalLocks = nsMutex.globalLockCounter
-	lockState.TotalAcquiredLocks = nsMutex.runningLockCounter
+	lockState.TotalBlockedLocks = globalNSMutex.blockedCounter
+	lockState.TotalLocks = globalNSMutex.globalLockCounter
+	lockState.TotalAcquiredLocks = globalNSMutex.runningLockCounter
 
-	for param, debugLock := range nsMutex.debugLockMap {
+	for param, debugLock := range globalNSMutex.debugLockMap {
 		volLockInfo := VolumeLockInfo{}
 		volLockInfo.Bucket = param.volume
 		volLockInfo.Object = param.path

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -56,9 +56,9 @@ import (
 
 // Tests should initNSLock only once.
 func init() {
+	isDistXL := false
 	// Initialize name space lock.
-	isDist := false
-	initNSLock(isDist)
+	initNSLock(isDistXL)
 
 	// Disable printing console messages during tests.
 	color.Output = ioutil.Discard

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -36,7 +36,7 @@ func (xl xlObjects) MakeBucket(bucket string) error {
 		return traceError(BucketNameInvalid{Bucket: bucket})
 	}
 
-	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	bucketLock.Lock()
 	defer bucketLock.Unlock()
 
@@ -166,7 +166,7 @@ func (xl xlObjects) GetBucketInfo(bucket string) (BucketInfo, error) {
 		return BucketInfo{}, BucketNameInvalid{Bucket: bucket}
 	}
 
-	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	bucketLock.RLock()
 	defer bucketLock.RUnlock()
 
@@ -240,7 +240,7 @@ func (xl xlObjects) DeleteBucket(bucket string) error {
 		return BucketNameInvalid{Bucket: bucket}
 	}
 
-	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	bucketLock.Lock()
 	defer bucketLock.Unlock()
 

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -79,7 +79,7 @@ func (xl xlObjects) HealBucket(bucket string) error {
 
 // Heal bucket - create buckets on disks where it does not exist.
 func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int) error {
-	bucketLock := nsMutex.NewNSLock(bucket, "")
+	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	bucketLock.Lock()
 	defer bucketLock.Unlock()
 
@@ -132,7 +132,7 @@ func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int) error
 // heals `policy.json`, `notification.xml` and `listeners.json`.
 func healBucketMetadata(storageDisks []StorageAPI, bucket string, readQuorum int) error {
 	healBucketMetaFn := func(metaPath string) error {
-		metaLock := nsMutex.NewNSLock(minioMetaBucket, metaPath)
+		metaLock := globalNSMutex.NewNSLock(minioMetaBucket, metaPath)
 		metaLock.RLock()
 		defer metaLock.RUnlock()
 		// Heals the given file at metaPath.
@@ -358,7 +358,7 @@ func (xl xlObjects) HealObject(bucket, object string) error {
 	}
 
 	// Lock the object before healing.
-	objectLock := nsMutex.NewNSLock(bucket, object)
+	objectLock := globalNSMutex.NewNSLock(bucket, object)
 	objectLock.RLock()
 	defer objectLock.RUnlock()
 

--- a/cmd/xl-v1-list-objects-heal.go
+++ b/cmd/xl-v1-list-objects-heal.go
@@ -144,7 +144,7 @@ func (xl xlObjects) listObjectsHeal(bucket, prefix, marker, delimiter string, ma
 		}
 
 		// Check if the current object needs healing
-		objectLock := nsMutex.NewNSLock(bucket, objInfo.Name)
+		objectLock := globalNSMutex.NewNSLock(bucket, objInfo.Name)
 		objectLock.RLock()
 		partsMetadata, errs := readAllXLMetadata(xl.storageDisks, bucket, objInfo.Name)
 		if xlShouldHeal(partsMetadata, errs) {

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -68,7 +68,7 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 	}
 
 	// Lock the object before reading.
-	objectLock := nsMutex.NewNSLock(bucket, object)
+	objectLock := globalNSMutex.NewNSLock(bucket, object)
 	objectLock.RLock()
 	defer objectLock.RUnlock()
 
@@ -232,7 +232,7 @@ func (xl xlObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
 		return ObjectInfo{}, ObjectNameInvalid{Bucket: bucket, Object: object}
 	}
 
-	objectLock := nsMutex.NewNSLock(bucket, object)
+	objectLock := globalNSMutex.NewNSLock(bucket, object)
 	objectLock.RLock()
 	defer objectLock.RUnlock()
 
@@ -507,7 +507,7 @@ func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.
 	}
 
 	// Lock the object.
-	objectLock := nsMutex.NewNSLock(bucket, object)
+	objectLock := globalNSMutex.NewNSLock(bucket, object)
 	objectLock.Lock()
 	defer objectLock.Unlock()
 
@@ -631,7 +631,7 @@ func (xl xlObjects) DeleteObject(bucket, object string) (err error) {
 		return traceError(ObjectNameInvalid{Bucket: bucket, Object: object})
 	}
 
-	objectLock := nsMutex.NewNSLock(bucket, object)
+	objectLock := globalNSMutex.NewNSLock(bucket, object)
 	objectLock.Lock()
 	defer objectLock.Unlock()
 

--- a/pkg/lock/.gitignore
+++ b/pkg/lock/.gitignore
@@ -1,0 +1,2 @@
+*.test
+cover.out

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -1,0 +1,103 @@
+package lock
+
+import (
+	"os"
+	"sync"
+)
+
+// RWLocker - interface that any read-write locking library should implement.
+type RWLocker interface {
+	sync.Locker
+	RLock()
+	RUnlock()
+}
+
+// Locker - file based lock/unlock implementation.
+type Locker struct {
+	name   string
+	wfiles []*os.File
+	rfiles []*os.File
+	wMutex sync.Mutex
+	rMutex sync.Mutex
+}
+
+// Private file mode.
+var privateFileMode = os.FileMode(0600)
+
+// Lock locks f. If the lock is already in use, the calling
+// goroutine blocks until the mutex is available.
+func (f *Locker) Lock() {
+	f.wMutex.Lock()
+	defer f.wMutex.Unlock()
+	file, err := open(f.name, os.O_WRONLY, os.ModeExclusive)
+	if err != nil {
+		panic(err)
+	}
+	if err := lock(file); err != nil {
+		panic(err)
+	}
+	f.wfiles = append(f.wfiles, file)
+}
+
+// Unlock unlocks f. A locked Mutex is not associated with a
+// particular goroutine. It is allowed for one goroutine to
+// lock a Mutex and then arrange for another goroutine to unlock it.
+func (f *Locker) Unlock() {
+	f.wMutex.Lock()
+	defer f.wMutex.Unlock()
+	if len(f.wfiles) == 0 {
+		panic("Trying to Unlock() while no Lock() is active")
+	}
+	file := f.wfiles[0]
+	if file == nil {
+		panic("Trying to Unlock() while no Lock() is active")
+	}
+	if err := unlock(file); err != nil {
+		panic(err)
+	}
+	if err := file.Close(); err != nil {
+		panic(err)
+	}
+	f.wfiles = f.wfiles[1:]
+}
+
+// RLock locks f for reading.
+func (f *Locker) RLock() {
+	f.rMutex.Lock()
+	defer f.rMutex.Unlock()
+	file, err := open(f.name, os.O_RDONLY, os.ModeExclusive)
+	if err != nil {
+		panic(err)
+	}
+	if err := rlock(file); err != nil {
+		panic(err)
+	}
+	f.rfiles = append(f.rfiles, file)
+}
+
+// RUnlock undoes a single RLock call; it does not affect other
+// simultaneous readers.
+func (f *Locker) RUnlock() {
+	f.rMutex.Lock()
+	defer f.rMutex.Unlock()
+	if len(f.rfiles) == 0 {
+		panic("Trying to RUnlock() while no RLock() is active")
+	}
+	file := f.rfiles[0]
+	if file == nil {
+		panic("Trying to RUnlock() while no RLock() is active")
+	}
+	if err := runlock(file); err != nil {
+		panic(err)
+	}
+	if err := file.Close(); err != nil {
+		panic(err)
+	}
+	f.rfiles = f.rfiles[1:]
+}
+
+// NewFlock - initializes a new lock, if the path doesn't
+// exist NewFlock will panic.
+func NewFlock(name string) RWLocker {
+	return &Locker{name: name}
+}

--- a/pkg/lock/lock_nix.go
+++ b/pkg/lock/lock_nix.go
@@ -1,0 +1,61 @@
+// +build !windows,!plan9
+
+package lock
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	pid   = int32(os.Getpid())
+	wrlck = syscall.Flock_t{
+		Type:   syscall.F_WRLCK,
+		Whence: 0,
+		Start:  0,
+		Len:    0,
+		Pid:    pid,
+	}
+	rdlck = syscall.Flock_t{
+		Type:   syscall.F_RDLCK,
+		Whence: 0,
+		Start:  0,
+		Len:    0,
+		Pid:    pid,
+	}
+	unlck = syscall.Flock_t{
+		Type:   syscall.F_UNLCK,
+		Whence: 0,
+		Start:  0,
+		Len:    0,
+		Pid:    pid,
+	}
+)
+
+func open(path string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, flag, perm)
+}
+
+func lock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+	//	lock := wrlck
+	//	return syscall.FcntlFlock(f.Fd(), syscall.F_SETLKW, &lock)
+}
+
+func unlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	//	lock := unlck
+	//	return syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, &lock)
+}
+
+func rlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_SH)
+	//	lock := rdlck
+	//	return syscall.FcntlFlock(f.Fd(), syscall.F_SETLKW, &lock)
+}
+
+func runlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	//	lock := unlck
+	//	return syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, &lock)
+}

--- a/pkg/lock/lock_test.go
+++ b/pkg/lock/lock_test.go
@@ -1,0 +1,338 @@
+package lock_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/minio/minio/pkg/lock"
+)
+
+func TestLockAndUnlock(t *testing.T) {
+	f, err := ioutil.TempFile("", "lock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer func() {
+		err = os.Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	frw := NewFlock(f.Name())
+
+	frw.RLock()
+	// fmt.Println("1st read lock acquired, waiting...")
+
+	frw.RLock()
+	// fmt.Println("2nd read lock acquired, waiting...")
+
+	go func() {
+		time.Sleep(1000 * time.Millisecond)
+		frw.RUnlock()
+		// fmt.Println("1st read lock released, waiting...")
+	}()
+
+	go func() {
+		time.Sleep(2000 * time.Millisecond)
+		frw.RUnlock()
+		// fmt.Println("2nd read lock released, waiting...")
+	}()
+
+	// fmt.Println("Trying to acquire write lock, waiting...")
+	frw.Lock()
+
+	// fmt.Println("Write lock acquired, waiting...")
+	time.Sleep(2500 * time.Millisecond)
+
+	frw.Unlock()
+}
+
+// Test cases below are copied 1 to 1 from sync/rwmutex_test.go (adapted to use DRWMutex)
+
+// Borrowed from rwmutex_test.go
+func parallelReader(m RWLocker, clocked, cunlock, cdone chan bool) {
+	m.RLock()
+	clocked <- true
+	<-cunlock
+	m.RUnlock()
+	cdone <- true
+}
+
+// Borrowed from rwmutex_test.go
+func doTestParallelReaders(numReaders, gomaxprocs int, name string) {
+	runtime.GOMAXPROCS(gomaxprocs)
+	m := NewFlock(name)
+
+	clocked := make(chan bool)
+	cunlock := make(chan bool)
+	cdone := make(chan bool)
+	for i := 0; i < numReaders; i++ {
+		go parallelReader(m, clocked, cunlock, cdone)
+	}
+	// Wait for all parallel RLock()s to succeed.
+	for i := 0; i < numReaders; i++ {
+		<-clocked
+	}
+	for i := 0; i < numReaders; i++ {
+		cunlock <- true
+	}
+	// Wait for the goroutines to finish.
+	for i := 0; i < numReaders; i++ {
+		<-cdone
+	}
+}
+
+// Borrowed from rwmutex_test.go
+func TestParallelReaders(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
+	f, err := ioutil.TempFile("", "test-parallel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer func() {
+		err = os.Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	doTestParallelReaders(1, 4, f.Name())
+	doTestParallelReaders(3, 4, f.Name())
+	doTestParallelReaders(4, 2, f.Name())
+}
+
+// Borrowed from rwmutex_test.go
+func reader(rwm RWLocker, num_iterations int, activity *int32, cdone chan bool) {
+	for i := 0; i < num_iterations; i++ {
+		rwm.RLock()
+		n := atomic.AddInt32(activity, 1)
+		if n < 1 || n >= 10000 {
+			panic(fmt.Sprintf("rlock(%d)\n", n))
+		}
+		for i := 0; i < 100; i++ {
+		}
+		atomic.AddInt32(activity, -1)
+		rwm.RUnlock()
+	}
+	cdone <- true
+}
+
+// Borrowed from rwmutex_test.go
+func writer(rwm RWLocker, num_iterations int, activity *int32, cdone chan bool) {
+	for i := 0; i < num_iterations; i++ {
+		rwm.Lock()
+		n := atomic.AddInt32(activity, 10000)
+		if n != 10000 {
+			panic(fmt.Sprintf("wlock(%d)\n", n))
+		}
+		for i := 0; i < 100; i++ {
+		}
+		atomic.AddInt32(activity, -10000)
+		rwm.Unlock()
+	}
+	cdone <- true
+}
+
+// Borrowed from rwmutex_test.go
+func HammerRWMutex(gomaxprocs, numReaders, num_iterations int, t *testing.T) {
+	runtime.GOMAXPROCS(gomaxprocs)
+	// Number of active readers + 10000 * number of active writers.
+	var activity int32
+	cdone := make(chan bool)
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer func() {
+		err = os.Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	rwm := NewFlock(f.Name())
+	go writer(rwm, num_iterations, &activity, cdone)
+	var i int
+	for i = 0; i < numReaders/2; i++ {
+		go reader(rwm, num_iterations, &activity, cdone)
+	}
+	go writer(rwm, num_iterations, &activity, cdone)
+	for ; i < numReaders; i++ {
+		go reader(rwm, num_iterations, &activity, cdone)
+	}
+	// Wait for the 2 writers and all readers to finish.
+	for i := 0; i < 2+numReaders; i++ {
+		<-cdone
+	}
+}
+
+// Borrowed from rwmutex_test.go
+func TestRWMutex(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
+	n := 1000
+	if testing.Short() {
+		n = 5
+	}
+	HammerRWMutex(1, 1, n, t)
+	HammerRWMutex(1, 3, n, t)
+	HammerRWMutex(1, 10, n, t)
+	/* FIXME.
+	HammerRWMutex(4, 3, n, t)
+	HammerRWMutex(4, 10, n, t)
+	HammerRWMutex(10, 1, n, t)
+	HammerRWMutex(10, 3, n, t)
+	HammerRWMutex(10, 10, n, t)
+	HammerRWMutex(10, 5, n, t)
+	*/
+}
+
+// Borrowed from rwmutex_test.go
+func TestUnlockPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("unlock of unlocked RWMutex did not panic")
+		}
+	}()
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer func() {
+		err = os.Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	mu := NewFlock(f.Name())
+	mu.Unlock()
+}
+
+// Borrowed from rwmutex_test.go
+func TestUnlockPanic2(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("unlock of unlocked RWMutex did not panic")
+		}
+	}()
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer func() {
+		err = os.Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	mu := NewFlock(f.Name())
+	mu.RLock()
+	mu.Unlock()
+}
+
+// Borrowed from rwmutex_test.go
+func TestRUnlockPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("read unlock of unlocked RWMutex did not panic")
+		}
+	}()
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer func() {
+		err = os.Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	mu := NewFlock(f.Name())
+	mu.RUnlock()
+}
+
+// Borrowed from rwmutex_test.go
+func TestRUnlockPanic2(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("read unlock of unlocked RWMutex did not panic")
+		}
+	}()
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer func() {
+		err = os.Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	mu := NewFlock(f.Name())
+	mu.Lock()
+	mu.RUnlock()
+}
+
+// Borrowed from rwmutex_test.go
+func benchmarkRWMutex(b *testing.B, localWork, writeRatio int) {
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	f.Close()
+	defer func() {
+		err = os.Remove(f.Name())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}()
+	rwm := NewFlock(f.Name())
+	b.RunParallel(func(pb *testing.PB) {
+		foo := 0
+		for pb.Next() {
+			foo++
+			if foo%writeRatio == 0 {
+				rwm.Lock()
+				rwm.Unlock()
+			} else {
+				rwm.RLock()
+				for i := 0; i != localWork; i += 1 {
+					foo *= 2
+					foo /= 2
+				}
+				rwm.RUnlock()
+			}
+		}
+		_ = foo
+	})
+}
+
+// Borrowed from rwmutex_test.go
+func BenchmarkRWMutexWrite100(b *testing.B) {
+	benchmarkRWMutex(b, 0, 100)
+}
+
+// Borrowed from rwmutex_test.go
+func BenchmarkRWMutexWrite10(b *testing.B) {
+	benchmarkRWMutex(b, 0, 10)
+}
+
+// Borrowed from rwmutex_test.go
+func BenchmarkRWMutexWorkWrite100(b *testing.B) {
+	benchmarkRWMutex(b, 100, 100)
+}
+
+// Borrowed from rwmutex_test.go
+func BenchmarkRWMutexWorkWrite10(b *testing.B) {
+	benchmarkRWMutex(b, 100, 10)
+}

--- a/pkg/lock/lock_windows.go
+++ b/pkg/lock/lock_windows.go
@@ -1,0 +1,119 @@
+// +build windows
+
+package lock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+
+	errLocked = errors.New("The process cannot access the file because another process has locked a portion of the file.")
+)
+
+// see https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
+const errLockViolation syscall.Errno = 0x21
+
+func lock(f *os.File) error {
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
+	return lockFileEx(syscall.Handle(f.Fd()), 2)
+}
+
+func rlock(f *os.File) error {
+	return lockFileEx(syscall.Handle(f.Fd()), 0)
+}
+
+func runlock(f *os.File) error {
+	return unlockFileEx(syscall.Handle(f.Fd()))
+}
+
+func unlock(f *os.File) error {
+	return unlockFileEx(syscall.Handle(f.Fd()))
+}
+
+func open(path string, flag int, perm os.FileMode) (*os.File, error) {
+	if path == "" {
+		return nil, fmt.Errorf("cannot open empty filename")
+	}
+	var access uint32
+	switch flag {
+	case syscall.O_RDONLY:
+		access = syscall.GENERIC_READ
+	case syscall.O_WRONLY:
+		access = syscall.GENERIC_WRITE
+	case syscall.O_RDWR:
+		access = syscall.GENERIC_READ | syscall.GENERIC_WRITE
+	case syscall.O_WRONLY | syscall.O_CREAT:
+		access = syscall.GENERIC_ALL
+	default:
+		panic(fmt.Errorf("flag %v is not supported", flag))
+	}
+	fd, err := syscall.CreateFile(&(syscall.StringToUTF16(path)[0]),
+		access,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|syscall.FILE_SHARE_DELETE,
+		nil,
+		syscall.OPEN_ALWAYS,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0)
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+func unlockFileEx(fd syscall.Handle) error {
+	if fd == syscall.InvalidHandle {
+		return nil
+	}
+	err := unlockFileExSyscall(fd, 1, 0, &syscall.Overlapped{})
+	if err == nil {
+		return nil
+	} else if err.Error() == errLocked.Error() {
+		return err
+	} else if err != errLockViolation {
+		return err
+	}
+	return nil
+
+}
+
+func lockFileEx(fd syscall.Handle, flag uint32) error {
+	if fd == syscall.InvalidHandle {
+		return nil
+	}
+	err := lockFileExSyscall(fd, flag, 1, 0, &syscall.Overlapped{})
+	if err == nil {
+		return nil
+	} else if err.Error() == errLocked.Error() {
+		return err
+	} else if err != errLockViolation {
+		return err
+	}
+	return nil
+}
+
+func unlockFileExSyscall(h syscall.Handle, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	var reserved uint32
+	_, _, err = procUnlockFileEx.Call(uintptr(h), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
+	return err
+}
+
+func lockFileExSyscall(h syscall.Handle, flags, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	var reserved uint32
+	r1, _, e1 := syscall.Syscall6(procLockFileEx.Addr(), 6, uintptr(h), uintptr(flags), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This patch implements two things.

- Implements lock package implementing filesystem locks using
  FcntlFlock() syscall, also implements a compatible version
  on windows as well using win32 APIs.

- Adds a new ENV which indicates minio server to enable shared
  backend feature, while holding the locks on `format.json`

So two competing locks from two different minio processes compete
at filesystem level on a shared backend while performing an i/o.

This code is an attempt to allow this feature.
<!--- Describe your changes in detail -->

## Motivation and Context
Refer #3160 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
make test and local shared backend setup.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
