### PR TITLE
v4/presign: Fix presign requests when there are more signed headers.

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -163,9 +163,8 @@ func isReqAuthenticated(r *http.Request, region string) (s3Error APIErrorCode) {
 	}
 	// Populate back the payload.
 	r.Body = ioutil.NopCloser(bytes.NewReader(payload))
+	// Skips calculating sha256 on the payload on server, if client requested for it.
 	var sha256sum string
-	// Skips calculating sha256 on the payload on server,
-	// if client requested for it.
 	if skipContentSha256Cksum(r) {
 		sha256sum = unsignedPayload
 	} else {

--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -184,11 +184,6 @@ func parsePreSignV4(query url.Values) (preSignValues, APIErrorCode) {
 	if err != ErrNone {
 		return preSignValues{}, err
 	}
-	// `host` is the only header used during the presigned request.
-	// Malformed signed headers has be caught here, otherwise it'll lead to signature mismatch.
-	if preSignV4Values.SignedHeaders[0] != "host" {
-		return preSignValues{}, ErrUnsignedHeaders
-	}
 
 	// Save signature.
 	preSignV4Values.Signature, err = parseSignature("Signature=" + query.Get("X-Amz-Signature"))

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -796,7 +796,7 @@ func presignedGet(host, bucket, object string) string {
 	secretKey := cred.SecretAccessKey
 
 	date := time.Now().UTC()
-	dateStr := date.Format("20060102T150405Z")
+	dateStr := date.Format(iso8601Format)
 	credential := fmt.Sprintf("%s/%s", accessKey, getScope(date, region))
 
 	query := strings.Join([]string{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix removes a wrong logic which fails for requests which
have more signed headers in a presign request.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3217
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using aws-sdk-go. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
