### PR TITLE
Use 307 StatusTemporaryRedirect to redirect clients from http to https with forcing them to keep HTTP Verb

### DIFF
--- a/cmd/server-mux.go
+++ b/cmd/server-mux.go
@@ -350,7 +350,7 @@ func (m *ServerMux) ListenAndServe(certFile, keyFile string) (err error) {
 				RawQuery: r.URL.RawQuery,
 				Fragment: r.URL.Fragment,
 			}
-			http.Redirect(w, r, u.String(), http.StatusMovedPermanently)
+			http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
 		} else {
 			// Execute registered handlers
 			m.Server.Handler.ServeHTTP(w, r)


### PR DESCRIPTION
## Description
307 StatusTemporaryRedirect asks clients to keep the HTTP verb when redirecting from http to https, otherwise clients will change POST to GET which is inconvenient in our case.

## Motivation and Context
Fix http to https redirection

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
