### PR TITLE
Use getObjectInfo() in both FS and XL ListObjects() to simplify and to return complete object information

### DIFF
--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -51,20 +51,21 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 	testObjects := []struct {
 		name    string
 		content string
+		meta    map[string]string
 	}{
-		{"Asia-maps", "asis-maps"},
-		{"Asia/India/India-summer-photos-1", "contentstring"},
-		{"Asia/India/Karnataka/Bangalore/Koramangala/pics", "contentstring"},
-		{"newPrefix0", "newPrefix0"},
-		{"newPrefix1", "newPrefix1"},
-		{"newzen/zen/recurse/again/again/again/pics", "recurse"},
-		{"obj0", "obj0"},
-		{"obj1", "obj1"},
-		{"obj2", "obj2"},
+		{"Asia-maps.png", "asis-maps", map[string]string{"content-type": "image/png"}},
+		{"Asia/India/India-summer-photos-1", "contentstring", nil},
+		{"Asia/India/Karnataka/Bangalore/Koramangala/pics", "contentstring", nil},
+		{"newPrefix0", "newPrefix0", nil},
+		{"newPrefix1", "newPrefix1", nil},
+		{"newzen/zen/recurse/again/again/again/pics", "recurse", nil},
+		{"obj0", "obj0", nil},
+		{"obj1", "obj1", nil},
+		{"obj2", "obj2", nil},
 	}
 	sha256sum := ""
 	for _, object := range testObjects {
-		_, err = obj.PutObject(testBuckets[0], object.name, int64(len(object.content)), bytes.NewBufferString(object.content), nil, sha256sum)
+		_, err = obj.PutObject(testBuckets[0], object.name, int64(len(object.content)), bytes.NewBufferString(object.content), object.meta, sha256sum)
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err.Error())
 		}
@@ -80,7 +81,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: false,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps"},
+				{Name: "Asia-maps.png", ContentType: "image/png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 				{Name: "newPrefix0"},
@@ -96,7 +97,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: true,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps"},
+				{Name: "Asia-maps.png", ContentType: "image/png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 				{Name: "newPrefix0"},
@@ -108,7 +109,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: true,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps"},
+				{Name: "Asia-maps.png", ContentType: "image/png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 				{Name: "newPrefix0"},
@@ -119,7 +120,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: true,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps"},
+				{Name: "Asia-maps.png", ContentType: "image/png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 			},
@@ -130,7 +131,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: true,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps"},
+				{Name: "Asia-maps.png", ContentType: "image/png"},
 			},
 		},
 		// ListObjectsResult-5.
@@ -233,7 +234,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: false,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps"},
+				{Name: "Asia-maps.png", ContentType: "image/png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 				{Name: "newPrefix0"},
@@ -342,7 +343,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: false,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps"},
+				{Name: "Asia-maps.png", ContentType: "image/png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 			},
@@ -353,7 +354,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: false,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps"},
+				{Name: "Asia-maps.png", ContentType: "image/png"},
 			},
 		},
 		// ListObjectsResult-26.
@@ -548,6 +549,10 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 				if testCase.result.Objects[j].Name != result.Objects[j].Name {
 					t.Errorf("Test %d: %s: Expected object name to be \"%s\", but found \"%s\" instead", i+1, instanceType, testCase.result.Objects[j].Name, result.Objects[j].Name)
 				}
+				if testCase.result.Objects[j].ContentType != result.Objects[j].ContentType {
+					t.Errorf("Test %d: %s: Expected object contentType to be \"%s\", but found \"%s\" instead", i+1, instanceType, testCase.result.Objects[j].ContentType, result.Objects[j].ContentType)
+				}
+
 			}
 			if testCase.result.IsTruncated != result.IsTruncated {
 				t.Errorf("Test %d: %s: Expected IsTruncated flag to be %v, but instead found it to be %v", i+1, instanceType, testCase.result.IsTruncated, result.IsTruncated)

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -46,7 +46,4 @@ type FileInfo struct {
 
 	// File mode bits.
 	Mode os.FileMode
-
-	// Hex encoded md5 checksum of the file.
-	MD5Sum string
 }

--- a/cmd/xl-v1-list-objects.go
+++ b/cmd/xl-v1-list-objects.go
@@ -93,13 +93,7 @@ func (xl xlObjects) listObjects(bucket, prefix, marker, delimiter string, maxKey
 			result.Prefixes = append(result.Prefixes, objInfo.Name)
 			continue
 		}
-		result.Objects = append(result.Objects, ObjectInfo{
-			Name:    objInfo.Name,
-			ModTime: objInfo.ModTime,
-			Size:    objInfo.Size,
-			MD5Sum:  objInfo.MD5Sum,
-			IsDir:   false,
-		})
+		result.Objects = append(result.Objects, objInfo)
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Description
Currently, list objects for both FS and XL don't return content type information for objects. Simplify the list code to return complete information 

## Motivation and Context
Minio browser will need this change to show correct icons in object lists

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.