### PR TITLE
Return objects content types in Web List Objects handler

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -239,6 +239,7 @@ func (web *webAPIHandlers) ListObjects(r *http.Request, args *ListObjectsArgs, r
 				Key:          obj.Name,
 				LastModified: obj.ModTime,
 				Size:         obj.Size,
+				ContentType:  obj.ContentType,
 			})
 		}
 		for _, prefix := range lo.Prefixes {


### PR DESCRIPTION
## Description
Minio Browser doesn't receive objects content types because we don't pass them through List Objects web handler, this PR fixes it.

## Motivation and Context
Minio Browser should receive object content type

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
