### PR TITLE
signature-v2: encode path and query strings when calculating signature

### DIFF
--- a/cmd/signature-v2.go
+++ b/cmd/signature-v2.go
@@ -191,16 +191,19 @@ func doesSignV2Match(r *http.Request) APIErrorCode {
 		return apiError
 	}
 
-	// url.RawPath will be valid if path has any encoded characters, if not it will
-	// be empty - in which case we need to consider url.Path (bug in net/http?)
+	// Encode path:
+	//   url.RawPath will be valid if path has any encoded characters, if not it will
+	//   be empty - in which case we need to consider url.Path (bug in net/http?)
 	encodedResource := r.URL.RawPath
-	encodedQuery := r.URL.RawQuery
 	if encodedResource == "" {
 		splits := strings.Split(r.URL.Path, "?")
 		if len(splits) > 0 {
-			encodedResource = splits[0]
+			encodedResource = getURLEncodedName(splits[0])
 		}
 	}
+
+	// Encode query strings
+	encodedQuery := r.URL.Query().Encode()
 
 	expectedAuth := signatureV2(r.Method, encodedResource, encodedQuery, r.Header)
 	if v2Auth != expectedAuth {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -950,13 +950,13 @@ func signRequestV2(req *http.Request, accessKey, secretKey string) error {
 	// url.RawPath will be valid if path has any encoded characters, if not it will
 	// be empty - in which case we need to consider url.Path (bug in net/http?)
 	encodedResource := req.URL.RawPath
-	encodedQuery := req.URL.RawQuery
 	if encodedResource == "" {
 		splits := strings.Split(req.URL.Path, "?")
 		if len(splits) > 0 {
-			encodedResource = splits[0]
+			encodedResource = getURLEncodedName(splits[0])
 		}
 	}
+	encodedQuery := req.URL.Query().Encode()
 
 	// Calculate HMAC for secretAccessKey.
 	stringToSign := signV2STS(req.Method, encodedResource, encodedQuery, req.Header)


### PR DESCRIPTION
## Description
signature-v2 wasn't encoding path and query when calculating signature v2, fixing that..

## Motivation and Context
Fixes #3251 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [Not Yet] All new and existing tests passed.
