### PR TITLE
lock: slice length of lock clients should be precisely urls.

### DIFF
--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -33,13 +33,13 @@ var nsMutex *nsLockMap
 func initDsyncNodes(eps []*url.URL) error {
 	cred := serverConfig.GetCredential()
 	// Initialize rpc lock client information only if this instance is a distributed setup.
-	var clnts []dsync.RPC
+	clnts := make([]dsync.RPC, len(eps))
 	myNode := -1
-	for _, ep := range eps {
+	for index, ep := range eps {
 		if ep == nil {
 			return errInvalidArgument
 		}
-		clnts = append(clnts, newAuthClient(&authConfig{
+		clnts[index] = newAuthClient(&authConfig{
 			accessKey: cred.AccessKeyID,
 			secretKey: cred.SecretAccessKey,
 			// Construct a new dsync server addr.
@@ -48,9 +48,9 @@ func initDsyncNodes(eps []*url.URL) error {
 			// Construct a new rpc path for the endpoint.
 			path:        pathutil.Join(lockRPCPath, getPath(ep)),
 			loginMethod: "Dsync.LoginHandler",
-		}))
+		})
 		if isLocalStorage(ep) && myNode == -1 {
-			myNode = len(clnts) - 1
+			myNode = index
 		}
 	}
 	return dsync.SetNodesWithClients(clnts, myNode)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a possible run-away bug of index mismatch.
<!--- Describe your changes in detail -->

## Motivation and Context
This patch fixes a possible bug, reproduced rarely only seen once.
```
panic: runtime error: index out of range

goroutine 136 [running]:
panic(0xac1a40, 0xc4200120b0)
    /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/minio/minio/vendor/github.com/minio/dsync.lock.func1(0xc4203d2240, 0x4, 0xc420474080, 0x4, 0x4, 0xc4202abb60, 0x0, 0xa86d01, 0xefcfc0, 0xc420417a80)
    /go/src/github.com/minio/minio/vendor/github.com/minio/dsync/drwmutex.go:170 +0x69b
created by github.com/minio/minio/vendor/github.com/minio/dsync.lock
    /go/src/github.com/minio/minio/vendor/github.com/minio/dsync/drwmutex.go:191 +0xf4
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Hard to reproduce, just a intuitive fix.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
