### PR TITLE
xl/bootup: Server bootup shouldn't return for missing buckets.

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -54,6 +54,14 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 	}
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
+
+	_, err := objAPI.GetBucketInfo(bucket)
+	if err != nil {
+		errorIf(err, "Unable to find bucket info.")
+		writeErrorResponse(w, r, toAPIErrorCode(err), r.URL.Path)
+		return
+	}
+
 	// Attempt to successfully load notification config.
 	nConfig, err := loadNotificationConfig(bucket, objAPI)
 	if err != nil && err != errNoSuchNotifications {
@@ -177,8 +185,7 @@ func PutBucketNotificationConfig(bucket string, ncfg *notificationConfig, objAPI
 		return fmt.Errorf("Unable to persist Bucket notification config to object layer - config=%v errMsg=%v", *ncfg, err)
 	}
 
-	// All servers (including local) are told to update in-memory
-	// config
+	// All servers (including local) are told to update in-memory config
 	S3PeersUpdateBucketNotification(bucket, ncfg)
 
 	return nil

--- a/cmd/bucket-policy-handlers_test.go
+++ b/cmd/bucket-policy-handlers_test.go
@@ -250,6 +250,11 @@ func testPutBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 	credentials credential, t *testing.T) {
 	initBucketPolicies(obj)
 
+	bucketName1 := fmt.Sprintf("%s-1", bucketName)
+	if err := obj.MakeBucket(bucketName1); err != nil {
+		t.Fatal(err)
+	}
+
 	// template for constructing HTTP request body for PUT bucket policy.
 	bucketPolicyTemplate := `{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:GetBucketLocation","s3:ListBucket"],"Resource":["arn:aws:s3:::%s"]},{"Sid":"","Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:GetObject"],"Resource":["arn:aws:s3:::%s/this*"]}]}`
 
@@ -327,7 +332,7 @@ func testPutBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 		// setting an invalid bucket policy.
 		// the bucket policy parser will fail.
 		{
-			bucketName:         "non-existent-bucket",
+			bucketName:         bucketName,
 			bucketPolicyReader: bytes.NewReader([]byte("dummy-policy")),
 
 			policyLen:          len([]byte("dummy-policy")),
@@ -339,7 +344,7 @@ func testPutBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 		// Different bucket name used in the HTTP request and the policy string.
 		// checkBucketPolicyResources should fail.
 		{
-			bucketName:         "different-bucket",
+			bucketName:         bucketName1,
 			bucketPolicyReader: bytes.NewReader([]byte(fmt.Sprintf(bucketPolicyTemplate, bucketName, bucketName))),
 
 			policyLen:          len(fmt.Sprintf(bucketPolicyTemplate, bucketName, bucketName)),
@@ -358,7 +363,7 @@ func testPutBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 			policyLen:          len(fmt.Sprintf(bucketPolicyTemplate, bucketName, bucketName)),
 			accessKey:          credentials.AccessKeyID,
 			secretKey:          credentials.SecretAccessKey,
-			expectedRespStatus: http.StatusInternalServerError,
+			expectedRespStatus: http.StatusNotFound,
 		},
 		// Test case - 9.
 		// invalid bucket name is used.
@@ -527,7 +532,7 @@ func testGetBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 			accessKey:            credentials.AccessKeyID,
 			secretKey:            credentials.SecretAccessKey,
 			expectedBucketPolicy: bucketPolicyTemplate,
-			expectedRespStatus:   http.StatusInternalServerError,
+			expectedRespStatus:   http.StatusNotFound,
 		},
 		// Test case - 3.
 		// Case with invalid bucket name.
@@ -736,7 +741,7 @@ func testDeleteBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName str
 			bucketName:         "non-existent-bucket",
 			accessKey:          credentials.AccessKeyID,
 			secretKey:          credentials.SecretAccessKey,
-			expectedRespStatus: http.StatusInternalServerError,
+			expectedRespStatus: http.StatusNotFound,
 		},
 		// Test case - 3.
 		// Case with invalid bucket name.

--- a/cmd/bucket-policy.go
+++ b/cmd/bucket-policy.go
@@ -142,11 +142,6 @@ func getOldBucketsConfigPath() (string, error) {
 // readBucketPolicyJSON - reads bucket policy for an input bucket, returns BucketPolicyNotFound
 // if bucket policy is not found.
 func readBucketPolicyJSON(bucket string, objAPI ObjectLayer) (bucketPolicyReader io.Reader, err error) {
-	// Verify if bucket actually exists
-	if err = isBucketExist(bucket, objAPI); err != nil {
-		return nil, err
-	}
-
 	policyPath := pathJoin(bucketConfigPrefix, bucket, policyJSON)
 	objInfo, err := objAPI.GetObjectInfo(minioMetaBucket, policyPath)
 	err = errorCause(err)

--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -466,7 +466,6 @@ func loadAllBucketNotifications(objAPI ObjectLayer) (map[string]*notificationCon
 		} else {
 			nConfigs[bucket.Name] = nCfg
 		}
-
 		lCfg, lErr := loadListenerConfig(bucket.Name, objAPI)
 		if lErr != nil {
 			if lErr != errNoSuchNotifications {

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -1118,8 +1118,6 @@ func testWebSetBucketPolicyHandler(obj ObjectLayer, instanceType string, t TestE
 		policy     string
 		pass       bool
 	}{
-		// Inexistent bucket
-		{"fooo", "", "readonly", false},
 		// Invalid bucket name
 		{"", "", "readonly", false},
 		// Invalid policy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Server bootup shouldn't return error for missing buckets since the ListBuckets() view might be partial before healing.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3196
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and through chaos test framework.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
