### PR TITLE
XL: pickValidXLMeta should return error instead of panic'ing

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -243,7 +243,7 @@ func healObject(storageDisks []StorageAPI, bucket string, object string) error {
 	// Latest xlMetaV1 for reference. If a valid metadata is not present, it is as good as object not found.
 	latestMeta, pErr := pickValidXLMeta(partsMetadata, modTime)
 	if pErr != nil {
-		return traceError(ObjectNotFound{Bucket: bucket, Object: object})
+		return pErr
 	}
 
 	for index, disk := range outDatedDisks {

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -240,8 +240,11 @@ func healObject(storageDisks []StorageAPI, bucket string, object string) error {
 	latestDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 	// List of disks having outdated version of the object or missing object.
 	outDatedDisks := outDatedDisks(storageDisks, partsMetadata, errs)
-	// Latest xlMetaV1 for reference.
-	latestMeta := pickValidXLMeta(partsMetadata, modTime)
+	// Latest xlMetaV1 for reference. If a valid metadata is not present, it is as good as object not found.
+	latestMeta, pErr := pickValidXLMeta(partsMetadata, modTime)
+	if pErr != nil {
+		return traceError(ObjectNotFound{Bucket: bucket, Object: object})
+	}
 
 	for index, disk := range outDatedDisks {
 		// Before healing outdated disks, we need to remove xl.json

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"path"
 	"sort"
 	"sync"
@@ -195,15 +195,14 @@ func (m xlMetaV1) ObjectToPartOffset(offset int64) (partIndex int, partOffset in
 // pickValidXLMeta - picks one valid xlMeta content and returns from a
 // slice of xlmeta content. If no value is found this function panics
 // and dies.
-func pickValidXLMeta(metaArr []xlMetaV1, modTime time.Time) xlMetaV1 {
+func pickValidXLMeta(metaArr []xlMetaV1, modTime time.Time) (xlMetaV1, error) {
 	// Pick latest valid metadata.
 	for _, meta := range metaArr {
 		if meta.IsValid() && meta.Stat.ModTime.Equal(modTime) {
-			return meta
+			return meta, nil
 		}
 	}
-	pmsg := fmt.Sprintf("Unable to look for valid XL metadata content - %v %s", metaArr, modTime)
-	panic(pmsg)
+	return xlMetaV1{}, errors.New("No valid xl.json present")
 }
 
 // list of all errors that can be ignored in a metadata operation.

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -202,7 +202,7 @@ func pickValidXLMeta(metaArr []xlMetaV1, modTime time.Time) (xlMetaV1, error) {
 			return meta, nil
 		}
 	}
-	return xlMetaV1{}, errors.New("No valid xl.json present")
+	return xlMetaV1{}, traceError(errors.New("No valid xl.json present"))
 }
 
 // list of all errors that can be ignored in a metadata operation.

--- a/cmd/xl-v1-metadata_test.go
+++ b/cmd/xl-v1-metadata_test.go
@@ -197,7 +197,7 @@ func TestPickValidXLMeta(t *testing.T) {
 	for i, test := range testCases {
 		xlMeta, err := pickValidXLMeta(test.metaArr, test.modTime)
 		if test.expectedErr != nil {
-			if err.Error() != test.expectedErr.Error() {
+			if errorCause(err).Error() != test.expectedErr.Error() {
 				t.Errorf("Test %d: Expected to fail with %v but received %v",
 					i+1, test.expectedErr, err)
 			}

--- a/cmd/xl-v1-metadata_test.go
+++ b/cmd/xl-v1-metadata_test.go
@@ -17,8 +17,10 @@
 package cmd
 
 import (
+	"errors"
 	"strconv"
 	"testing"
+	"time"
 )
 
 const MiB = 1024 * 1024
@@ -146,6 +148,64 @@ func TestObjectToPartOffset(t *testing.T) {
 		}
 		if offset != testCase.expectedOffset {
 			t.Fatalf("%+v: offset: expected = %d, got: %d", testCase, testCase.expectedOffset, offset)
+		}
+	}
+}
+
+// Helper function to check if two xlMetaV1 values are similar.
+func isXLMetaSimilar(m, n xlMetaV1) bool {
+	if m.Version != n.Version {
+		return false
+	}
+	if m.Format != n.Format {
+		return false
+	}
+	if len(m.Parts) != len(n.Parts) {
+		return false
+	}
+	return true
+}
+
+func TestPickValidXLMeta(t *testing.T) {
+	obj := "object"
+	x1 := newXLMetaV1(obj, 4, 4)
+	now := time.Now().UTC()
+	x1.Stat.ModTime = now
+	invalidX1 := x1
+	invalidX1.Version = "invalid-version"
+	xs := []xlMetaV1{x1, x1, x1, x1}
+	invalidXS := []xlMetaV1{invalidX1, invalidX1, invalidX1, invalidX1}
+	testCases := []struct {
+		metaArr     []xlMetaV1
+		modTime     time.Time
+		xlMeta      xlMetaV1
+		expectedErr error
+	}{
+		{
+			metaArr:     xs,
+			modTime:     now,
+			xlMeta:      x1,
+			expectedErr: nil,
+		},
+		{
+			metaArr:     invalidXS,
+			modTime:     now,
+			xlMeta:      invalidX1,
+			expectedErr: errors.New("No valid xl.json present"),
+		},
+	}
+	for i, test := range testCases {
+		xlMeta, err := pickValidXLMeta(test.metaArr, test.modTime)
+		if test.expectedErr != nil {
+			if err.Error() != test.expectedErr.Error() {
+				t.Errorf("Test %d: Expected to fail with %v but received %v",
+					i+1, test.expectedErr, err)
+			}
+		} else {
+			if !isXLMetaSimilar(xlMeta, test.xlMeta) {
+				t.Errorf("Test %d: Expected %v but received %v",
+					i+1, test.xlMeta, xlMeta)
+			}
 		}
 	}
 }

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -380,11 +380,10 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	// List all online disks.
 	onlineDisks, modTime := listOnlineDisks(xl.storageDisks, partsMetadata, errs)
 
-	// Pick one from the first valid metadata. If no valid metadata exists, it as good
-	// as the corresponding upload not found.
+	// Pick one from the first valid metadata.
 	xlMeta, err := pickValidXLMeta(partsMetadata, modTime)
 	if err != nil {
-		return "", toObjectErr(traceError(InvalidUploadID{UploadID: uploadID}), bucket, object)
+		return "", err
 	}
 
 	onlineDisks = getOrderedDisks(xlMeta.Erasure.Distribution, onlineDisks)
@@ -496,11 +495,10 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	// Get current highest version based on re-read partsMetadata.
 	onlineDisks, modTime = listOnlineDisks(onlineDisks, partsMetadata, errs)
 
-	// Pick one from the first valid metadata. If no valid metadata is present
-	// then the multipart upload is as good as not found.
+	// Pick one from the first valid metadata.
 	xlMeta, err = pickValidXLMeta(partsMetadata, modTime)
 	if err != nil {
-		return "", toObjectErr(traceError(InvalidUploadID{UploadID: uploadID}), bucket, object)
+		return "", err
 	}
 
 	// Once part is successfully committed, proceed with updating XL metadata.
@@ -691,11 +689,10 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	// Calculate full object size.
 	var objectSize int64
 
-	// Pick one from the first valid metadata. If no valid metadata is found,
-	// it is as good as the corresponding upload not found.
+	// Pick one from the first valid metadata.
 	xlMeta, err := pickValidXLMeta(partsMetadata, modTime)
 	if err != nil {
-		return "", toObjectErr(traceError(InvalidUploadID{UploadID: uploadID}), bucket, object)
+		return "", err
 	}
 
 	// Order online disks in accordance with distribution order.

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -82,8 +82,11 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 	// List all online disks.
 	onlineDisks, modTime := listOnlineDisks(xl.storageDisks, metaArr, errs)
 
-	// Pick latest valid metadata.
-	xlMeta := pickValidXLMeta(metaArr, modTime)
+	// Pick latest valid metadata. If a valid metadata wasn't found, it is as good as object not being found.
+	xlMeta, err := pickValidXLMeta(metaArr, modTime)
+	if err != nil {
+		return traceError(ObjectNotFound{Bucket: bucket, Object: object})
+	}
 
 	// Reorder online disks based on erasure distribution order.
 	onlineDisks = getOrderedDisks(xlMeta.Erasure.Distribution, onlineDisks)

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -82,10 +82,10 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 	// List all online disks.
 	onlineDisks, modTime := listOnlineDisks(xl.storageDisks, metaArr, errs)
 
-	// Pick latest valid metadata. If a valid metadata wasn't found, it is as good as object not being found.
+	// Pick latest valid metadata.
 	xlMeta, err := pickValidXLMeta(metaArr, modTime)
 	if err != nil {
-		return traceError(ObjectNotFound{Bucket: bucket, Object: object})
+		return err
 	}
 
 	// Reorder online disks based on erasure distribution order.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
pickValidXLMeta is changed to return error when there is no valid ``xlMetaV1`` value in ``[]xlMetaV1`` provided to it. Previously, it  would panic if this were the case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
pickValidXLMeta is a helper function that expects at least one of the online disks to have a valid ``xl.json``. This need not be the case, e.g when the corresponding object is not present in quorum number of disks.
This fix changes this function to return error when there is no valid ``xl.json`` found, so that the caller can return appropriately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using docker-compose.
### Test Output
```
['localhost:9001:kp-test-minio-py/my-boring-object-0: upload failure - got error: ResponseError: code: InternalError, message: We encountered an internal error, please try again., bucket_name: None, object_name: None, request_id: LKP9K7P8B0AAWKXL, host_id: 3L137, region: ', 'localhost:9001:kp-test-minio-py/my-boring-object-1: upload success - took 0:00:17.208415', 'localhost:9001:kp-test-minio-py/my-boring-object-2: upload success - took 0:00:21.086257', 'localhost:9001:kp-test-minio-py/my-boring-object-3: upload success - took 0:00:18.962685', 'localhost:9001:kp-test-minio-py/my-boring-object-4: upload success - took 0:00:19.420467', 'localhost:9001:kp-test-minio-py/my-boring-object-5: upload failure - got error: ResponseError: code: NoSuchUpload, message: The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed., bucket_name: None, object_name: None, request_id: P1R8EFXMEMENWU7J, host_id: 3L137, region: ', 'localhost:9001:kp-test-minio-py/my-boring-object-6: upload success - took 0:00:25.568387', 'localhost:9001:kp-test-minio-py/my-boring-object-7: upload failure - got error: ResponseError: code: NoSuchUpload, message: The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed., bucket_name: None, object_name: None, request_id: DB0M4FZCGHY516Q0, host_id: 3L137, region: ', 'localhost:9001:kp-test-minio-py/my-boring-object-8: upload success - took 0:00:12.249470', 'localhost:9001:kp-test-minio-py/my-boring-object-9: upload failure - got error: ResponseError: code: NoSuchUpload, message: The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed., bucket_name: None, object_name: None, request_id: Y1KWG43W4NS973P8, host_id: 3L137, region: ']
```
Note: ``ResponseError:code:`` is ``InternalError``, i.e ``pickValidXLMeta`` failed or ``NoSuchUpload``, i.e a ``CompleteMultipartUpload`` raced a ``PutObjectPart`` request. This shows that the results are as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.