### PR TITLE
multipart-fs: Append multiparts parts in a Go routine in background.

### DIFF
--- a/cmd/fs-v1-append-parts.go
+++ b/cmd/fs-v1-append-parts.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"reflect"
+	"sync"
+	"time"
+)
+
+// Error sent by appendRoutine when there are holes in parts.
+// For ex. let's say client uploads part-2 before part-1 in which case we
+// can not append and have to wait till part-1 is uploaded. Hence we return
+// this error. Currently this error is not used in the caller.
+var errPartsMissing = errors.New("required parts missing")
+
+// Error sent when appendRoutine has waited long enough and timedout.
+var errAppendRoutineTimeout = errors.New("timeout")
+
+// Timeout value for the appendRoutine go-routine.
+var appendRoutineTimeout = 24 * 60 * 60 * time.Second
+
+// Holds a map of uploadID->appendRoutine
+type appendPartFS struct {
+	appendRoutineMap map[string]appendRoutineInfo
+	mu               sync.Mutex
+}
+
+// Input to the appendRoutine
+type appendRoutineInput struct {
+	meta  fsMetaV1   // list of parts that need to be appended
+	errCh chan error // error sent by appendRoutine
+}
+
+// Identifies an appendRoutine.
+type appendRoutineInfo struct {
+	inputCh   chan appendRoutineInput
+	timeoutCh chan struct{} // closed by appendRoutine when it timesout
+	endCh     chan struct{} // closed after complete/abort of upload to end the appendRoutine
+}
+
+// Called after a part is uploaded so that it can be appended in the background.
+func (m *appendPartFS) processPart(disk StorageAPI, bucket, object, uploadID string, meta fsMetaV1) chan error {
+	m.mu.Lock()
+	info, ok := m.appendRoutineMap[uploadID]
+	if !ok {
+		// Corresponding appendRoutine was not found, create a new one. Would happen when the first
+		// part of a multipart upload is uploaded.
+		inputCh := make(chan appendRoutineInput)
+		timeoutCh := make(chan struct{})
+		endCh := make(chan struct{})
+
+		info = appendRoutineInfo{inputCh, timeoutCh, endCh}
+		m.appendRoutineMap[uploadID] = info
+
+		go m.appendRoutine(disk, bucket, object, uploadID, info)
+	}
+	m.mu.Unlock()
+	errCh := make(chan error)
+	go func() {
+		// send input in a goroutine as send on the inputCh can block if appendRoutine
+		// is busy appending a part.
+		select {
+		case <-info.timeoutCh:
+			// This is to handle a rare race condition where we found info in m.appendRoutineMap
+			// but soon after that appendRoutine timedouted out.
+			errCh <- errAppendRoutineTimeout
+		case info.inputCh <- appendRoutineInput{meta, errCh}:
+		}
+	}()
+	return errCh
+}
+
+// Called after complete-multipart-upload or abort-multipart-upload so that the appendRoutine is not left dangling.
+func (m *appendPartFS) endAppendRoutine(uploadID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	info, ok := m.appendRoutineMap[uploadID]
+	if !ok {
+		return
+	}
+	delete(m.appendRoutineMap, uploadID)
+	close(info.endCh)
+}
+
+// The go-routine that appends the parts in the background.
+func (m *appendPartFS) appendRoutine(disk StorageAPI, bucket, object, uploadID string, info appendRoutineInfo) {
+	// Holds the list of parts that is already appended to the "append" file.
+	appendMeta := fsMetaV1{}
+	for {
+		select {
+		case input := <-info.inputCh:
+			// We receive on this channel when new part gets uploaded or when complete-multipart sends
+			// a value on this channel to confirm if all the required parts are appended.
+			meta := input.meta
+			for {
+				// Append should be done such a way that if part-3 and part-2 is uploaded before part-1, we
+				// wait till part-1 is uploaded after which we append part-2 and part-3 as well in this for-loop.
+				part, appendNeeded := partToAppend(meta, appendMeta)
+				if !appendNeeded {
+					if reflect.DeepEqual(meta.Parts, appendMeta.Parts) {
+						// Sending nil is useful so that the complete-multipart-upload knows that
+						// all the required parts have been appended.
+						input.errCh <- nil
+					} else {
+						// Sending error is useful so that complete-multipart-upload can fall-back to
+						// its own append process.
+						input.errCh <- errPartsMissing
+					}
+					break
+				}
+				if err := appendPart(disk, bucket, object, uploadID, part); err != nil {
+					input.errCh <- err
+					break
+				}
+				appendMeta.AddObjectPart(part.Number, part.Name, part.ETag, part.Size)
+			}
+		case <-info.endCh:
+			// Either complete-multipart-upload or abort-multipart-upload closed endCh to end the appendRoutine.
+			appendFilePath := getFSAppendDataPath(uploadID)
+			disk.DeleteFile(bucket, appendFilePath) // Delete the tmp append file in case abort-multipart was called.
+			return
+		case <-time.After(appendRoutineTimeout):
+			// Timeout the goroutine to garbage collect its resources. This would happen if the client initates
+			// a multipart upload and does not complete/abort it.
+			m.mu.Lock()
+			delete(m.appendRoutineMap, uploadID)
+			m.mu.Unlock()
+			close(info.timeoutCh)
+			// Delete the temporary append file as well.
+			appendFilePath := getFSAppendDataPath(uploadID)
+			disk.DeleteFile(bucket, appendFilePath)
+		}
+	}
+}
+
+// Appends the "part" to the append-file inside "tmp/" that finally gets moved to the actual location
+// upon complete-multipart-upload.
+func appendPart(disk StorageAPI, bucket, object, uploadID string, part objectPartInfo) error {
+	partPath := pathJoin(mpartMetaPrefix, bucket, object, uploadID, part.Name)
+	appendFilePath := getFSAppendDataPath(uploadID)
+
+	offset := int64(0)
+	totalLeft := part.Size
+	buf := make([]byte, readSizeV1)
+	for totalLeft > 0 {
+		curLeft := int64(readSizeV1)
+		if totalLeft < readSizeV1 {
+			curLeft = totalLeft
+		}
+		var n int64
+		n, err := disk.ReadFile(minioMetaBucket, partPath, offset, buf[:curLeft])
+		if n > 0 {
+			if err = disk.AppendFile(minioMetaBucket, appendFilePath, buf[:n]); err != nil {
+				disk.DeleteFile(bucket, appendFilePath)
+				return err
+			}
+		}
+		if err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			disk.DeleteFile(bucket, appendFilePath)
+			return err
+		}
+		offset += n
+		totalLeft -= n
+	}
+	return nil
+}

--- a/cmd/fs-v1-background-append.go
+++ b/cmd/fs-v1-background-append.go
@@ -1,3 +1,19 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cmd
 
 import (

--- a/cmd/fs-v1-background-append.go
+++ b/cmd/fs-v1-background-append.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"errors"
-	"io"
 	"reflect"
 	"sync"
 	"time"
@@ -192,13 +191,11 @@ func appendPart(disk StorageAPI, bucket, object, uploadID string, part objectPar
 		}
 		var n int64
 		n, err := disk.ReadFile(minioMetaBucket, partPath, offset, buf[:curLeft])
-		if err == io.EOF {
-			break
-		}
 		if err != nil {
-			// Check for ErrUnexpectedEOF not needed as it should never happen as we know
-			// the size of the file and never read more than its size. Hence any non io.EOF
-			// error condition can be considered as an error.
+			// Check for EOF/ErrUnexpectedEOF not needed as it should never happen as we know
+			// the exact size of the file and hence know the size of buf[]
+			// EOF/ErrUnexpectedEOF indicates that the length of file was shorter than part.Size and
+			// hence considered as an error condition.
 			disk.DeleteFile(bucket, appendFilePath)
 			return err
 		}

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -24,7 +24,6 @@ import (
 	"hash"
 	"io"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -286,108 +285,9 @@ func partToAppend(fsMeta fsMetaV1, fsAppendMeta fsMetaV1) (part objectPartInfo, 
 	return fsMeta.Parts[nextPartIndex], true
 }
 
-// Returns metadata path for the file holding info about the parts that
-// have been appended to the "append-file"
-func getFSAppendMetaPath(uploadID string) string {
-	return uploadID + ".json"
-}
-
 // Returns path for the append-file.
 func getFSAppendDataPath(uploadID string) string {
-	return uploadID + ".data"
-}
-
-// Append parts to fsAppendDataFile.
-func appendParts(disk StorageAPI, bucket, object, uploadID string) {
-	cleanupAppendPaths := func() {
-		// In case of any error, cleanup the append data and json files
-		// from the tmp so that we do not have any inconsistent append
-		// data/json files.
-		disk.DeleteFile(minioMetaTmpBucket, getFSAppendDataPath(uploadID))
-		disk.DeleteFile(minioMetaTmpBucket, getFSAppendMetaPath(uploadID))
-	}
-	uploadIDPath := path.Join(mpartMetaPrefix, bucket, object, uploadID)
-	// fs-append.json path
-	fsAppendMetaPath := getFSAppendMetaPath(uploadID)
-	// fs.json path
-	fsMetaPath := path.Join(mpartMetaPrefix, bucket, object, uploadID, fsMetaJSONFile)
-
-	// Lock the uploadID so that no one modifies fs.json
-	uploadIDLock := nsMutex.NewNSLock(minioMetaBucket, uploadIDPath)
-	uploadIDLock.RLock()
-	fsMeta, err := readFSMetadata(disk, minioMetaBucket, fsMetaPath)
-	uploadIDLock.RUnlock()
-	if err != nil {
-		return
-	}
-
-	// Lock fs-append.json so that there is no parallel append to the file.
-	appendPathLock := nsMutex.NewNSLock(minioMetaTmpBucket, fsAppendMetaPath)
-	appendPathLock.Lock()
-	defer appendPathLock.Unlock()
-
-	fsAppendMeta, err := readFSMetadata(disk, minioMetaTmpBucket, fsAppendMetaPath)
-	if err != nil {
-		if errorCause(err) != errFileNotFound {
-			cleanupAppendPaths()
-			return
-		}
-		fsAppendMeta = fsMeta
-		fsAppendMeta.Parts = nil
-	}
-
-	// Check if a part needs to be appended to
-	part, appendNeeded := partToAppend(fsMeta, fsAppendMeta)
-	if !appendNeeded {
-		return
-	}
-	// Hold write lock on the part so that there is no parallel upload on the part.
-	partPath := pathJoin(mpartMetaPrefix, bucket, object, uploadID, strconv.Itoa(part.Number))
-	partPathLock := nsMutex.NewNSLock(minioMetaBucket, partPath)
-	partPathLock.Lock()
-	defer partPathLock.Unlock()
-
-	// Proceed to append "part"
-	fsAppendDataPath := getFSAppendDataPath(uploadID)
-	// Path to the part that needs to be appended.
-	partPath = path.Join(mpartMetaPrefix, bucket, object, uploadID, part.Name)
-	offset := int64(0)
-	totalLeft := part.Size
-	buf := make([]byte, readSizeV1)
-	for totalLeft > 0 {
-		curLeft := int64(readSizeV1)
-		if totalLeft < readSizeV1 {
-			curLeft = totalLeft
-		}
-		var n int64
-		n, err = disk.ReadFile(minioMetaBucket, partPath, offset, buf[:curLeft])
-		if n > 0 {
-			if err = disk.AppendFile(minioMetaTmpBucket, fsAppendDataPath, buf[:n]); err != nil {
-				cleanupAppendPaths()
-				return
-			}
-		}
-		if err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				break
-			}
-			cleanupAppendPaths()
-			return
-		}
-		offset += n
-		totalLeft -= n
-	}
-	fsAppendMeta.AddObjectPart(part.Number, part.Name, part.ETag, part.Size)
-	// Overwrite previous fs-append.json
-	if err = writeFSMetadata(disk, minioMetaTmpBucket, fsAppendMetaPath, fsAppendMeta); err != nil {
-		cleanupAppendPaths()
-		return
-	}
-	// If there are more parts that need to be appended to fsAppendDataFile
-	_, appendNeeded = partToAppend(fsMeta, fsAppendMeta)
-	if appendNeeded {
-		go appendParts(disk, bucket, object, uploadID)
-	}
+	return path.Join(minioMetaTmpBucket, uploadID)
 }
 
 // PutObjectPart - reads incoming data until EOF for the part file on
@@ -514,7 +414,13 @@ func (fs fsObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	if err = writeFSMetadata(fs.storage, minioMetaBucket, path.Join(uploadIDPath, fsMetaJSONFile), fsMeta); err != nil {
 		return "", toObjectErr(err, minioMetaBucket, uploadIDPath)
 	}
-	go appendParts(fs.storage, bucket, object, uploadID)
+
+	// Append the part in background.
+	go func() {
+		// Result is ignored as we would have already replied to the client.
+		<-fs.appendPart.processPart(fs.storage, bucket, object, uploadID, fsMeta)
+	}()
+
 	return newMD5Hex, nil
 }
 
@@ -650,20 +556,11 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 		return "", traceError(InvalidUploadID{UploadID: uploadID})
 	}
 
-	// fs-append.json path
-	fsAppendMetaPath := getFSAppendMetaPath(uploadID)
-	// Lock fs-append.json so that no parallel appendParts() is being done.
-	appendPathLock := nsMutex.NewNSLock(minioMetaTmpBucket, fsAppendMetaPath)
-	appendPathLock.Lock()
-	defer appendPathLock.Unlock()
-
 	// Calculate s3 compatible md5sum for complete multipart.
 	s3MD5, err := getCompleteMultipartMD5(parts)
 	if err != nil {
 		return "", err
 	}
-
-	fsAppendDataPath := getFSAppendDataPath(uploadID)
 
 	// Read saved fs metadata for ongoing multipart.
 	fsMetaPath := pathJoin(uploadIDPath, fsMetaJSONFile)
@@ -672,16 +569,24 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 		return "", toObjectErr(err, minioMetaBucket, fsMetaPath)
 	}
 
-	fsAppendMeta, err := readFSMetadata(fs.storage, minioMetaTmpBucket, fsAppendMetaPath)
-	if err == nil && isPartsSame(fsAppendMeta.Parts, parts) {
-		if err = fs.storage.RenameFile(minioMetaTmpBucket, fsAppendDataPath, bucket, object); err != nil {
-			return "", toObjectErr(traceError(err), minioMetaTmpBucket, fsAppendDataPath)
+	appendFallback := true // In case background appendRoutine() did not append the required parts.
+	if isPartsSame(fsMeta.Parts, parts) {
+		err = <-fs.appendPart.processPart(fs.storage, bucket, object, uploadID, fsMeta)
+		if err == nil {
+			appendFallback = false
+			fsAppendDataPath := getFSAppendDataPath(uploadID)
+			if err = fs.storage.RenameFile(minioMetaBucket, fsAppendDataPath, bucket, object); err != nil {
+				return "", toObjectErr(traceError(err), minioMetaBucket, fsAppendDataPath)
+			}
 		}
-	} else {
-		// Remove append data temporary file since it is no longer needed at this point
-		fs.storage.DeleteFile(minioMetaTmpBucket, fsAppendDataPath)
+	}
 
-		tempObj := uploadID + "-" + "part.1"
+	// End the background go-routine.
+	fs.appendPart.endAppendRoutine(uploadID)
+
+	if appendFallback {
+		// appendRoutine could not do append all the required parts, hence we do it here.
+		tempObj := path.Join(minioMetaTmpBucket, uploadID+"-"+"part.1")
 
 		// Allocate staging buffer.
 		var buf = make([]byte, readSizeV1)
@@ -757,9 +662,6 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 		}
 	}
 
-	// Remove the append-file metadata file in tmp location as we no longer need it.
-	fs.storage.DeleteFile(minioMetaTmpBucket, fsAppendMetaPath)
-
 	// No need to save part info, since we have concatenated all parts.
 	fsMeta.Parts = nil
 
@@ -806,7 +708,7 @@ func (fs fsObjects) abortMultipartUpload(bucket, object, uploadID string) error 
 	if err := cleanupUploadedParts(bucket, object, uploadID, fs.storage); err != nil {
 		return err
 	}
-
+	fs.appendPart.endAppendRoutine(uploadID)
 	// remove entry from uploads.json with quorum
 	if err := fs.updateUploadJSON(bucket, object, uploadIDChange{uploadID: uploadID, isRemove: true}); err != nil {
 		return toObjectErr(err, bucket, object)
@@ -850,12 +752,6 @@ func (fs fsObjects) AbortMultipartUpload(bucket, object, uploadID string) error 
 	if !fs.isUploadIDExists(bucket, object, uploadID) {
 		return traceError(InvalidUploadID{UploadID: uploadID})
 	}
-
-	fsAppendMetaPath := getFSAppendMetaPath(uploadID)
-	// Lock fs-append.json so that no parallel appendParts() is being done.
-	appendPathLock := nsMutex.NewNSLock(minioMetaTmpBucket, fsAppendMetaPath)
-	appendPathLock.Lock()
-	defer appendPathLock.Unlock()
 
 	err := fs.abortMultipartUpload(bucket, object, uploadID)
 	return err

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -27,7 +27,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/minio/minio/pkg/mimedb"
 )
@@ -40,7 +39,7 @@ type fsObjects struct {
 	listPool *treeWalkPool
 
 	// To manage the appendRoutine go0routines
-	appendPart *appendPartFS
+	bgAppend *backgroundAppend
 }
 
 // list of all errors that can be ignored in tree walk operation in FS
@@ -65,9 +64,8 @@ func newFSObjects(storage StorageAPI) (ObjectLayer, error) {
 	fs := fsObjects{
 		storage:  storage,
 		listPool: newTreeWalkPool(globalLookupTimeout),
-		appendPart: &appendPartFS{
-			appendRoutineMap: make(map[string]appendRoutineInfo),
-			mu:               sync.Mutex{},
+		bgAppend: &backgroundAppend{
+			infoMap: make(map[string]bgAppendPartsInfo),
 		},
 	}
 

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -494,8 +494,11 @@ func (s *posix) ReadAll(volume, path string) (buf []byte, err error) {
 // ReadFile reads exactly len(buf) bytes into buf. It returns the
 // number of bytes copied. The error is EOF only if no bytes were
 // read. On return, n == len(buf) if and only if err == nil. n == 0
-// for io.EOF. Additionally ReadFile also starts reading from an
-// offset.
+// for io.EOF.
+// If an EOF happens after reading some but not all the bytes,
+// ReadFull returns ErrUnexpectedEOF.
+// Additionally ReadFile also starts reading from an offset.
+// ReadFile symantics are same as io.ReadFull
 func (s *posix) ReadFile(volume string, path string, offset int64, buf []byte) (n int64, err error) {
 	defer func() {
 		if err == syscall.EIO {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Do the background append process in a go-routine. Simplifies the code flow.

## Motivation and Context
Simplify the appendParts code flow. Also fix a race where completeMultipart overtakes appendPart of the last part. Explained in https://github.com/minio/minio/pull/3139 review comments.

## How Has This Been Tested?
manual testing and `make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
