### PR TITLE
xl: GetObject should validate parts before reading.

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -607,6 +607,8 @@ func toAPIErrorCode(err error) (apiErr APIErrorCode) {
 		apiErr = ErrNoSuchKey
 	case ObjectNameInvalid:
 		apiErr = ErrInvalidObjectName
+	case InvalidObjectState:
+		apiErr = ErrInvalidObjectState
 	case InvalidUploadID:
 		apiErr = ErrNoSuchUpload
 	case InvalidPart:

--- a/cmd/bucket-policy.go
+++ b/cmd/bucket-policy.go
@@ -72,7 +72,7 @@ func (bp *bucketPolicies) SetBucketPolicy(bucket string, pCh policyChange) error
 
 // Loads all bucket policies from persistent layer.
 func loadAllBucketPolicies(objAPI ObjectLayer) (policies map[string]*bucketPolicy, err error) {
-	// List buckets to proceed loading all notification configuration.
+	// List buckets to proceed loading all bucket policies.
 	buckets, err := objAPI.ListBuckets()
 	errorIf(err, "Unable to list buckets.")
 	err = errorCause(err)

--- a/cmd/object-errors.go
+++ b/cmd/object-errors.go
@@ -325,6 +325,17 @@ func (e NotImplemented) Error() string {
 	return "Not Implemented"
 }
 
+// InvalidObjectState represents a state of an object either is its corrupted
+// or unreadable.
+type InvalidObjectState struct {
+	Bucket string
+	Object string
+}
+
+func (e InvalidObjectState) Error() string {
+	return "Bucket: " + e.Bucket + " Object " + e.Object + " is in invalid state"
+}
+
 // Check if error type is ObjectNameInvalid.
 func isErrObjectNameInvalid(err error) bool {
 	err = errorCause(err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This patch addresses a specific situation when `xl.json`
has an additional `part.N` which was never written fully
to the disk or renamed from temporary location.

This can potentially occur in cases where we don't have
enough disk space.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3278
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


