### PR TITLE
xl/bootup: Upon bootup handle errors loading bucket and event configs.

### DIFF
--- a/cmd/object-errors.go
+++ b/cmd/object-errors.go
@@ -325,6 +325,26 @@ func (e NotImplemented) Error() string {
 	return "Not Implemented"
 }
 
+// Check if error type is IncompleteBody.
+func isErrIncompleteBody(err error) bool {
+	err = errorCause(err)
+	switch err.(type) {
+	case IncompleteBody:
+		return true
+	}
+	return false
+}
+
+// Check if error type is BucketPolicyNotFound.
+func isErrBucketPolicyNotFound(err error) bool {
+	err = errorCause(err)
+	switch err.(type) {
+	case BucketPolicyNotFound:
+		return true
+	}
+	return false
+}
+
 // Check if error type is ObjectNameInvalid.
 func isErrObjectNameInvalid(err error) bool {
 	err = errorCause(err)

--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -140,7 +140,7 @@ func (n networkStorage) String() string {
 func (n networkStorage) DiskInfo() (info disk.Info, err error) {
 	args := GenericArgs{}
 	if err = n.rpcClient.Call("Storage.DiskInfoHandler", &args, &info); err != nil {
-		return disk.Info{}, err
+		return disk.Info{}, toStorageErr(err)
 	}
 	return info, nil
 }
@@ -160,7 +160,7 @@ func (n networkStorage) ListVols() (vols []VolInfo, err error) {
 	ListVols := ListVolsReply{}
 	err = n.rpcClient.Call("Storage.ListVolsHandler", &GenericArgs{}, &ListVols)
 	if err != nil {
-		return nil, err
+		return nil, toStorageErr(err)
 	}
 	return ListVols.Vols, nil
 }

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -77,8 +77,8 @@ func (xl xlObjects) HealBucket(bucket string) error {
 	return healBucketMetadata(xl.storageDisks, bucket)
 }
 
+// Heal bucket - create buckets on disks where it does not exist.
 func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int) error {
-	// Heal bucket - create buckets on disks where it does not exist.
 	bucketLock := nsMutex.NewNSLock(bucket, "")
 	bucketLock.Lock()
 	defer bucketLock.Unlock()
@@ -139,7 +139,7 @@ func healBucketMetadata(storageDisks []StorageAPI, bucket string) error {
 		metaLock := nsMutex.NewNSLock(minioMetaBucket, metaPath)
 		metaLock.RLock()
 		defer metaLock.RUnlock()
-		// Heals the metaPath.
+		// Heals the given file at metaPath.
 		if err := healObject(storageDisks, minioMetaBucket, metaPath); err != nil && !isErrObjectNotFound(err) {
 			return err
 		} // Success.
@@ -299,10 +299,13 @@ func healObject(storageDisks []StorageAPI, bucket string, object string) error {
 			return err
 		}
 		for index, sum := range checkSums {
-			if outDatedDisks[index] == nil {
-				continue
+			if outDatedDisks[index] != nil {
+				checkSumInfos[index] = append(checkSumInfos[index], checkSumInfo{
+					Name:      partName,
+					Algorithm: sumInfo.Algorithm,
+					Hash:      sum,
+				})
 			}
-			checkSumInfos[index] = append(checkSumInfos[index], checkSumInfo{partName, sumInfo.Algorithm, sum})
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In a situation when we have lots of buckets the bootup time
might have slowed down a bit but during this situation the
servers quickly going up and down would be an in-transit state.

Certain calls which do not use quorum like `readXLMetaStat`
might return an error saying `errDiskNotFound` this is returned
in place of expected `errFileNotFound` which leads to an issue
where server doesn't start.

To avoid this situation we need to ignore them as safe values
to be ignored, for the most part these are network related errors.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3275
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Running through chaos test.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

