### PR TITLE
auth/rpc: Take remote disk offline after maximum allowed attempts.

### DIFF
--- a/cmd/auth-rpc-client_test.go
+++ b/cmd/auth-rpc-client_test.go
@@ -1,0 +1,51 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "testing"
+
+// Tests authorized RPC client.
+func TestAuthRPCClient(t *testing.T) {
+	authCfg := &authConfig{
+		accessKey:   "123",
+		secretKey:   "123",
+		secureConn:  false,
+		address:     "localhost:9000",
+		path:        "/rpc/disk",
+		loginMethod: "MyPackage.LoginHandler",
+	}
+	authRPC := newAuthClient(authCfg)
+	if authRPC.Node() != authCfg.address {
+		t.Fatalf("Unexpected node value %s, but expected %s", authRPC.Node(), authCfg.address)
+	}
+	if authRPC.RPCPath() != authCfg.path {
+		t.Fatalf("Unexpected node value %s, but expected %s", authRPC.RPCPath(), authCfg.path)
+	}
+	authCfg = &authConfig{
+		accessKey:   "123",
+		secretKey:   "123",
+		secureConn:  false,
+		loginMethod: "MyPackage.LoginHandler",
+	}
+	authRPC = newAuthClient(authCfg)
+	if authRPC.Node() != authCfg.address {
+		t.Fatalf("Unexpected node value %s, but expected %s", authRPC.Node(), authCfg.address)
+	}
+	if authRPC.RPCPath() != authCfg.path {
+		t.Fatalf("Unexpected node value %s, but expected %s", authRPC.RPCPath(), authCfg.path)
+	}
+}

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -47,8 +46,6 @@ type posix struct {
 	minFreeInodes int64
 	pool          sync.Pool
 }
-
-var errFaultyDisk = errors.New("Faulty disk")
 
 // checkPathLength - returns error if given path name length more than 255
 func checkPathLength(pathName string) error {

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -33,6 +33,12 @@ var errDiskFull = errors.New("disk path full")
 // errDiskNotFount - cannot find the underlying configured disk anymore.
 var errDiskNotFound = errors.New("disk not found")
 
+// errFaultyRemoteDisk - remote disk is faulty.
+var errFaultyRemoteDisk = errors.New("remote disk is faulty")
+
+// errFaultyDisk - disk is faulty.
+var errFaultyDisk = errors.New("disk is faulty")
+
 // errDiskAccessDenied - we don't have write permissions on disk.
 var errDiskAccessDenied = errors.New("disk access denied")
 

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -122,11 +122,7 @@ func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int) error
 	}
 
 	// Verify we have any other errors which should be returned as failure.
-	if reducedErr := reduceErrs(dErrs, []error{
-		errDiskNotFound,
-		errFaultyDisk,
-		errDiskAccessDenied,
-	}); reducedErr != nil {
+	if reducedErr := reduceErrs(dErrs, bucketOpIgnoredErrs); reducedErr != nil {
 		return toObjectErr(reducedErr, bucket)
 	}
 	return nil

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -211,6 +211,7 @@ var objMetadataOpIgnoredErrs = []error{
 	errDiskNotFound,
 	errDiskAccessDenied,
 	errFaultyDisk,
+	errFaultyRemoteDisk,
 	errVolumeNotFound,
 	errFileAccessDenied,
 	errFileNotFound,
@@ -336,11 +337,7 @@ func writeUniqueXLMetadata(disks []StorageAPI, bucket, prefix string, xlMetas []
 		return traceError(errXLWriteQuorum)
 	}
 
-	return reduceErrs(mErrs, []error{
-		errDiskNotFound,
-		errFaultyDisk,
-		errDiskAccessDenied,
-	})
+	return reduceErrs(mErrs, objectOpIgnoredErrs)
 }
 
 // writeSameXLMetadata - write `xl.json` on all disks in order.
@@ -380,9 +377,5 @@ func writeSameXLMetadata(disks []StorageAPI, bucket, prefix string, xlMeta xlMet
 		return traceError(errXLWriteQuorum)
 	}
 
-	return reduceErrs(mErrs, []error{
-		errDiskNotFound,
-		errFaultyDisk,
-		errDiskAccessDenied,
-	})
+	return reduceErrs(mErrs, objectOpIgnoredErrs)
 }

--- a/cmd/xl-v1-multipart-common.go
+++ b/cmd/xl-v1-multipart-common.go
@@ -140,13 +140,7 @@ func (xl xlObjects) updateUploadJSON(bucket, object string, uCh uploadIDChange) 
 	}
 	wg.Wait()
 
-	// Ignored errors list.
-	ignoredErrs := []error{
-		errDiskNotFound,
-		errFaultyDisk,
-		errDiskAccessDenied,
-	}
-	return reduceErrs(errs, ignoredErrs)
+	return reduceErrs(errs, objectOpIgnoredErrs)
 }
 
 // Returns if the prefix is a multipart upload.
@@ -257,11 +251,5 @@ func commitXLMetadata(disks []StorageAPI, srcPrefix, dstPrefix string, quorum in
 		return traceError(errXLWriteQuorum)
 	}
 
-	// List of ignored errors.
-	ignoredErrs := []error{
-		errDiskNotFound,
-		errDiskAccessDenied,
-		errFaultyDisk,
-	}
-	return reduceErrs(mErrs, ignoredErrs)
+	return reduceErrs(mErrs, objectOpIgnoredErrs)
 }

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -77,6 +77,7 @@ var xlTreeWalkIgnoredErrs = []error{
 	errDiskNotFound,
 	errDiskAccessDenied,
 	errFaultyDisk,
+	errFaultyRemoteDisk,
 }
 
 // newXLObjects - initialize new xl object layer.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Disks when are offline for a long period of time, we should
ignore the disk after trying Login upto 5 times.

This is to reduce the network chattiness, this also reduces
the overall time spent on `net.Dial`.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3286
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and through chaos test.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
