### PR TITLE
Avoid removing tmp directory inside .minio.sys

### DIFF
--- a/cmd/fs-v1-metadata.go
+++ b/cmd/fs-v1-metadata.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"path"
 	"sort"
 )
 
@@ -93,17 +92,17 @@ func readFSMetadata(disk StorageAPI, bucket, filePath string) (fsMeta fsMetaV1, 
 
 // Write fsMeta to fs.json or fs-append.json.
 func writeFSMetadata(disk StorageAPI, bucket, filePath string, fsMeta fsMetaV1) error {
-	tmpPath := path.Join(tmpMetaPrefix, getUUID())
+	tmpPath := getUUID()
 	metadataBytes, err := json.Marshal(fsMeta)
 	if err != nil {
 		return traceError(err)
 	}
-	if err = disk.AppendFile(minioMetaBucket, tmpPath, metadataBytes); err != nil {
+	if err = disk.AppendFile(minioMetaTmpBucket, tmpPath, metadataBytes); err != nil {
 		return traceError(err)
 	}
-	err = disk.RenameFile(minioMetaBucket, tmpPath, bucket, filePath)
+	err = disk.RenameFile(minioMetaTmpBucket, tmpPath, bucket, filePath)
 	if err != nil {
-		err = disk.DeleteFile(minioMetaBucket, tmpPath)
+		err = disk.DeleteFile(minioMetaTmpBucket, tmpPath)
 		if err != nil {
 			return traceError(err)
 		}

--- a/cmd/fs-v1-multipart-common.go
+++ b/cmd/fs-v1-multipart-common.go
@@ -56,7 +56,7 @@ func (fs fsObjects) isUploadIDExists(bucket, object, uploadID string) bool {
 func (fs fsObjects) updateUploadJSON(bucket, object string, uCh uploadIDChange) error {
 	uploadsPath := path.Join(mpartMetaPrefix, bucket, object, uploadsJSONFile)
 	uniqueID := getUUID()
-	tmpUploadsPath := path.Join(tmpMetaPrefix, uniqueID)
+	tmpUploadsPath := uniqueID
 
 	uploadsJSON, err := readUploadsJSON(bucket, object, fs.storage)
 	if errorCause(err) == errFileNotFound {

--- a/cmd/object-api-putobject_test.go
+++ b/cmd/object-api-putobject_test.go
@@ -325,9 +325,9 @@ func testObjectAPIPutObjectStaleFiles(obj ObjectLayer, instanceType string, disk
 	}
 
 	for _, disk := range disks {
-		tmpMetaDir := path.Join(disk, minioMetaBucket, tmpMetaPrefix)
+		tmpMetaDir := path.Join(disk, minioMetaTmpBucket)
 		if !isDirEmpty(tmpMetaDir) {
-			t.Fatalf("%s: expected: empty, got: non-empty", tmpMetaDir)
+			t.Fatalf("%s: expected: empty, got: non-empty", minioMetaTmpBucket)
 		}
 	}
 }
@@ -392,7 +392,7 @@ func testObjectAPIMultipartPutObjectStaleFiles(obj ObjectLayer, instanceType str
 	}
 
 	for _, disk := range disks {
-		tmpMetaDir := path.Join(disk, minioMetaBucket, tmpMetaPrefix)
+		tmpMetaDir := path.Join(disk, minioMetaTmpBucket)
 		files, err := ioutil.ReadDir(tmpMetaDir)
 		if err != nil {
 			// Its OK to have non-existen tmpMetaDir.

--- a/cmd/object-common.go
+++ b/cmd/object-common.go
@@ -79,7 +79,7 @@ func houseKeeping(storageDisks []StorageAPI) error {
 			defer wg.Done()
 
 			// Cleanup all temp entries upon start.
-			err := cleanupDir(disk, minioMetaBucket, tmpMetaPrefix)
+			err := cleanupDir(disk, minioMetaTmpBucket, "")
 			if err != nil {
 				switch errorCause(err) {
 				case errDiskNotFound, errVolumeNotFound, errFileNotFound:
@@ -98,7 +98,7 @@ func houseKeeping(storageDisks []StorageAPI) error {
 		if err == nil {
 			continue
 		}
-		return toObjectErr(err, minioMetaBucket, tmpMetaPrefix)
+		return toObjectErr(err, minioMetaTmpBucket, "*")
 	}
 
 	// Return success here.
@@ -224,6 +224,17 @@ func initMetaVolume(storageDisks []StorageAPI) error {
 				default:
 					errs[index] = err
 				}
+				return
+			}
+			err = disk.MakeVol(minioMetaTmpBucket)
+			if err != nil {
+				switch err {
+				// Ignored errors.
+				case errVolumeExists, errDiskNotFound, errFaultyDisk:
+				default:
+					errs[index] = err
+				}
+				return
 			}
 		}(index, disk)
 	}

--- a/cmd/object-common_test.go
+++ b/cmd/object-common_test.go
@@ -66,11 +66,11 @@ func TestHouseKeeping(t *testing.T) {
 			if errs[index] != nil {
 				return
 			}
-			errs[index] = store.MakeVol(pathJoin(minioMetaBucket, tmpMetaPrefix))
+			errs[index] = store.MakeVol(minioMetaTmpBucket)
 			if errs[index] != nil {
 				return
 			}
-			errs[index] = store.AppendFile(pathJoin(minioMetaBucket, tmpMetaPrefix), "hello.txt", []byte("hello"))
+			errs[index] = store.AppendFile(minioMetaTmpBucket, "hello.txt", []byte("hello"))
 		}(i, store)
 	}
 	wg.Wait()

--- a/cmd/object-multipart-common.go
+++ b/cmd/object-multipart-common.go
@@ -113,12 +113,12 @@ func writeUploadJSON(u *uploadsV1, uploadsPath, tmpPath string, disk StorageAPI)
 
 	// Write `uploads.json` to disk. First to tmp location and
 	// then rename.
-	if wErr = disk.AppendFile(minioMetaBucket, tmpPath, uplBytes); wErr != nil {
+	if wErr = disk.AppendFile(minioMetaTmpBucket, tmpPath, uplBytes); wErr != nil {
 		return traceError(wErr)
 	}
-	wErr = disk.RenameFile(minioMetaBucket, tmpPath, minioMetaBucket, uploadsPath)
+	wErr = disk.RenameFile(minioMetaTmpBucket, tmpPath, minioMetaBucket, uploadsPath)
 	if wErr != nil {
-		if dErr := disk.DeleteFile(minioMetaBucket, tmpPath); dErr != nil {
+		if dErr := disk.DeleteFile(minioMetaTmpBucket, tmpPath); dErr != nil {
 			// we return the most recent error.
 			return traceError(dErr)
 		}

--- a/cmd/object-utils.go
+++ b/cmd/object-utils.go
@@ -34,8 +34,8 @@ const (
 	minioMetaBucket = ".minio.sys"
 	// Multipart meta prefix.
 	mpartMetaPrefix = "multipart"
-	// Tmp meta prefix.
-	tmpMetaPrefix = "tmp"
+	// Minio Tmp meta prefix.
+	minioMetaTmpBucket = minioMetaBucket + "/tmp"
 )
 
 // validBucket regexp.

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -293,7 +293,7 @@ func healObject(storageDisks []StorageAPI, bucket string, object string) error {
 		// Heal the part file.
 		checkSums, err := erasureHealFile(latestDisks, outDatedDisks,
 			bucket, pathJoin(object, partName),
-			minioMetaBucket, pathJoin(tmpMetaPrefix, tmpID, partName),
+			minioMetaTmpBucket, pathJoin(tmpID, partName),
 			partSize, erasure.BlockSize, erasure.DataBlocks, erasure.ParityBlocks, sumInfo.Algorithm)
 		if err != nil {
 			return err
@@ -316,7 +316,7 @@ func healObject(storageDisks []StorageAPI, bucket string, object string) error {
 	}
 
 	// Generate and write `xl.json` generated from other disks.
-	err := writeUniqueXLMetadata(outDatedDisks, minioMetaBucket, pathJoin(tmpMetaPrefix, tmpID), partsMetadata, diskCount(outDatedDisks))
+	err := writeUniqueXLMetadata(outDatedDisks, minioMetaTmpBucket, tmpID, partsMetadata, diskCount(outDatedDisks))
 	if err != nil {
 		return toObjectErr(err, bucket, object)
 	}
@@ -332,7 +332,7 @@ func healObject(storageDisks []StorageAPI, bucket string, object string) error {
 			return traceError(err)
 		}
 		// Attempt a rename now from healed data to final location.
-		err = disk.RenameFile(minioMetaBucket, retainSlash(pathJoin(tmpMetaPrefix, tmpID)), bucket, retainSlash(object))
+		err = disk.RenameFile(minioMetaTmpBucket, retainSlash(tmpID), bucket, retainSlash(object))
 		if err != nil {
 			return traceError(err)
 		}


### PR DESCRIPTION
## Description
Removing tmp directory adds complexity and introduces new bugs. Avoid that by passing .minio.sys/tmp/ as a bucket name which is protected from deletion

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
