### PR TITLE
web: Add more data for jsonrpc responses.

### DIFF
--- a/cmd/auth-rpc-client.go
+++ b/cmd/auth-rpc-client.go
@@ -65,7 +65,7 @@ type RPCLoginReply struct {
 
 // Validates if incoming token is valid.
 func isRPCTokenValid(tokenStr string) bool {
-	jwt, err := newJWT(defaultInterNodeJWTExpiry)
+	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		errorIf(err, "Unable to initialize JWT")
 		return false

--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -25,7 +25,7 @@ import (
 // Login handler implements JWT login token generator, which upon login request
 // along with username and password is generated.
 func (br *browserPeerAPIHandlers) LoginHandler(args *RPCLoginArgs, reply *RPCLoginReply) error {
-	jwt, err := newJWT(defaultInterNodeJWTExpiry)
+	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		return err
 	}

--- a/cmd/lock-rpc-server.go
+++ b/cmd/lock-rpc-server.go
@@ -127,7 +127,7 @@ func registerStorageLockers(mux *router.Router, lockServers []*lockServer) error
 
 // LoginHandler - handles LoginHandler RPC call.
 func (l *lockServer) LoginHandler(args *RPCLoginArgs, reply *RPCLoginReply) error {
-	jwt, err := newJWT(defaultInterNodeJWTExpiry)
+	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		return err
 	}

--- a/cmd/lock-rpc-server_test.go
+++ b/cmd/lock-rpc-server_test.go
@@ -48,7 +48,7 @@ func createLockTestServer(t *testing.T) (string, *lockServer, string) {
 		t.Fatalf("unable initialize config file, %s", err)
 	}
 
-	jwt, err := newJWT(defaultJWTExpiry)
+	jwt, err := newJWT(defaultJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		t.Fatalf("unable to get new JWT, %s", err)
 	}

--- a/cmd/s3-peer-rpc-handlers.go
+++ b/cmd/s3-peer-rpc-handlers.go
@@ -19,7 +19,7 @@ package cmd
 import "time"
 
 func (s3 *s3PeerAPIHandlers) LoginHandler(args *RPCLoginArgs, reply *RPCLoginReply) error {
-	jwt, err := newJWT(defaultInterNodeJWTExpiry)
+	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		return err
 	}

--- a/cmd/signature-jwt.go
+++ b/cmd/signature-jwt.go
@@ -42,13 +42,7 @@ const (
 )
 
 // newJWT - returns new JWT object.
-func newJWT(expiry time.Duration) (*JWT, error) {
-	if serverConfig == nil {
-		return nil, errServerNotInitialized
-	}
-
-	// Save access, secret keys.
-	cred := serverConfig.GetCredential()
+func newJWT(expiry time.Duration, cred credential) (*JWT, error) {
 	if !isValidAccessKey(cred.AccessKeyID) {
 		return nil, errInvalidAccessKeyLength
 	}

--- a/cmd/signature-jwt_test.go
+++ b/cmd/signature-jwt_test.go
@@ -70,16 +70,10 @@ func TestNewJWT(t *testing.T) {
 		cred        *credential
 		expectedErr error
 	}{
-		// Test non-existent config directory.
-		{path.Join(path1, "non-existent-dir"), false, nil, errServerNotInitialized},
-		// Test empty config directory.
-		{path2, false, nil, errServerNotInitialized},
-		// Test empty config file.
-		{path3, false, nil, errServerNotInitialized},
 		// Test initialized config file.
 		{path4, true, nil, nil},
 		// Test to read already created config file.
-		{path4, false, nil, nil},
+		{path4, true, nil, nil},
 		// Access key is too small.
 		{path4, false, &credential{"user", "pass"}, errInvalidAccessKeyLength},
 		// Access key is too long.
@@ -100,13 +94,10 @@ func TestNewJWT(t *testing.T) {
 				t.Fatalf("unable initialize config file, %s", err)
 			}
 		}
-
 		if testCase.cred != nil {
 			serverConfig.SetCredential(*testCase.cred)
 		}
-
-		_, err := newJWT(defaultJWTExpiry)
-
+		_, err := newJWT(defaultJWTExpiry, serverConfig.GetCredential())
 		if testCase.expectedErr != nil {
 			if err == nil {
 				t.Fatalf("%+v: expected: %s, got: <nil>", testCase, testCase.expectedErr)
@@ -128,7 +119,7 @@ func TestGenerateToken(t *testing.T) {
 	}
 	defer removeAll(testPath)
 
-	jwt, err := newJWT(defaultJWTExpiry)
+	jwt, err := newJWT(defaultJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		t.Fatalf("unable get new JWT, %s", err)
 	}
@@ -175,7 +166,7 @@ func TestAuthenticate(t *testing.T) {
 	}
 	defer removeAll(testPath)
 
-	jwt, err := newJWT(defaultJWTExpiry)
+	jwt, err := newJWT(defaultJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		t.Fatalf("unable get new JWT, %s", err)
 	}

--- a/cmd/storage-rpc-server.go
+++ b/cmd/storage-rpc-server.go
@@ -39,7 +39,7 @@ type storageServer struct {
 
 // Login - login handler.
 func (s *storageServer) LoginHandler(args *RPCLoginArgs, reply *RPCLoginReply) error {
-	jwt, err := newJWT(defaultInterNodeJWTExpiry)
+	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		return err
 	}

--- a/cmd/storage-rpc-server_test.go
+++ b/cmd/storage-rpc-server_test.go
@@ -40,7 +40,7 @@ func createTestStorageServer(t *testing.T) *testStorageRPCServer {
 		t.Fatalf("unable initialize config file, %s", err)
 	}
 
-	jwt, err := newJWT(defaultInterNodeJWTExpiry)
+	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
 	if err != nil {
 		t.Fatalf("unable to get new JWT, %s", err)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds more richer error response
for JSON-RPC by interpreting object layer
errors to corresponding meaningful errors
for the web browser.

```go
&json2.Error{
   Message: "Bucket Name Invalid, Only lowercase letters, full stops, and numbers are allowed.",
}
```

Additionally this patch also allows PresignedGetObject()
to take expiry parameter to have variable expiry.
<!--- Describe your changes in detail -->

## Motivation and Context
Refer https://github.com/minio/miniobrowser/issues/224 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
With miniobrowser locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
