### PR TITLE
api: Handle content-length-range policy properly.

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -629,6 +629,8 @@ func toAPIErrorCode(err error) (apiErr APIErrorCode) {
 		apiErr = ErrContentSHA256Mismatch
 	case ObjectTooLarge:
 		apiErr = ErrEntityTooLarge
+	case ObjectTooSmall:
+		apiErr = ErrEntityTooSmall
 	default:
 		apiErr = ErrInternalError
 	}

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -470,14 +470,22 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		return
 	}
 
-	// Use limitReader to ensure that object size is within expected range.
+	// Use rangeReader to ensure that object size is within expected range.
 	lengthRange := postPolicyForm.Conditions.ContentLengthRange
 	if lengthRange.Valid {
 		// If policy restricted the size of the object.
-		fileBody = limitReader(fileBody, int64(lengthRange.Min), int64(lengthRange.Max))
+		fileBody = &rangeReader{
+			Reader: fileBody,
+			Min:    lengthRange.Min,
+			Max:    lengthRange.Max,
+		}
 	} else {
 		// Default values of min/max size of the object.
-		fileBody = limitReader(fileBody, 0, maxObjectSize)
+		fileBody = &rangeReader{
+			Reader: fileBody,
+			Min:    0,
+			Max:    maxObjectSize,
+		}
 	}
 
 	// Save metadata.

--- a/cmd/object-utils_test.go
+++ b/cmd/object-utils_test.go
@@ -116,8 +116,8 @@ func TestIsValidObjectName(t *testing.T) {
 	}
 }
 
-// Tests limitReader
-func TestLimitReader(t *testing.T) {
+// Tests rangeReader.
+func TestRangeReader(t *testing.T) {
 	testCases := []struct {
 		data   string
 		minLen int64
@@ -126,15 +126,19 @@ func TestLimitReader(t *testing.T) {
 	}{
 		{"1234567890", 0, 15, nil},
 		{"1234567890", 0, 10, nil},
-		{"1234567890", 0, 5, errDataTooLarge},
-		{"123", 5, 10, errDataTooSmall},
+		{"1234567890", 0, 5, toObjectErr(errDataTooLarge, "test", "test")},
+		{"123", 5, 10, toObjectErr(errDataTooSmall, "test", "test")},
 		{"123", 2, 10, nil},
 	}
 
 	for i, test := range testCases {
 		r := strings.NewReader(test.data)
-		_, err := ioutil.ReadAll(limitReader(r, test.minLen, test.maxLen))
-		if err != test.err {
+		_, err := ioutil.ReadAll(&rangeReader{
+			Reader: r,
+			Min:    test.minLen,
+			Max:    test.maxLen,
+		})
+		if toObjectErr(err, "test", "test") != test.err {
 			t.Fatalf("test %d failed: expected %v, got %v", i+1, test.err, err)
 		}
 	}

--- a/cmd/postpolicyform.go
+++ b/cmd/postpolicyform.go
@@ -34,10 +34,14 @@ func toString(val interface{}) string {
 }
 
 // toInteger _ Safely convert interface to integer without causing panic.
-func toInteger(val interface{}) int {
+func toInteger(val interface{}) int64 {
 	switch v := val.(type) {
-	case int:
+	case float64:
+		return int64(v)
+	case int64:
 		return v
+	case int:
+		return int64(v)
 	}
 	return 0
 }
@@ -53,8 +57,8 @@ func isString(val interface{}) bool {
 
 // ContentLengthRange - policy content-length-range field.
 type contentLengthRange struct {
-	Min   int
-	Max   int
+	Min   int64
+	Max   int64
 	Valid bool // If content-length-range was part of policy
 }
 
@@ -136,7 +140,11 @@ func parsePostPolicyForm(policy string) (PostPolicyForm, error) {
 					Value:    value,
 				}
 			case "content-length-range":
-				parsedPolicy.Conditions.ContentLengthRange = contentLengthRange{toInteger(condt[1]), toInteger(condt[2]), true}
+				parsedPolicy.Conditions.ContentLengthRange = contentLengthRange{
+					Min:   toInteger(condt[1]),
+					Max:   toInteger(condt[2]),
+					Valid: true,
+				}
 			default:
 				// Condition should be valid.
 				return parsedPolicy, fmt.Errorf("Unknown type %s of conditional field value %s found in POST policy form",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
content-length-range policy in postPolicy API was
not working properly handle it. The reflection
strategy used has changed in recent version of Go.
Any free form interface{} of any integer is treated
as `float64` this caused a bug where content-length-range
parsing failed to provide any value.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3295 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Using the following program

```go
package main

import (
	"bytes"
	"fmt"
	"io"
	"log"
	"mime/multipart"
	"net/http"
	"net/http/httputil"
	"os"
	"time"

	"github.com/minio/minio-go"
)

func main() {
	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and my-objectname
	// are dummy values, please replace them with original values.

	// Requests are always secure (HTTPS) by default. Set secure=false to enable insecure (HTTP) access.
	// This boolean value is the last argument for New().

	// New returns an Amazon S3 compatible client object. API compatibility (v2 or v4) is automatically
	// determined based on the Endpoint value.
	s3Client, err := minio.New("localhost:9000", "USWUXHGYZQYFYFFIT3RE", "MOJRH0mkL1IPauahWITSVvyDrQbEEIwljvmxdq03", false)
	if err != nil {
		log.Fatalln(err)
	}

	policy := minio.NewPostPolicy()
	policy.SetBucket("testbucket")
	policy.SetKey("works/for/me")
	// Expires in 10 days.
	policy.SetExpires(time.Now().UTC().AddDate(0, 0, 10))
	policy.SetContentLengthRange(1*1024*1024, 4*1024*1024)

	// Returns form data for POST form request.
	url, formData, err := s3Client.PresignedPostPolicy(policy)
	if err != nil {
		log.Fatalln(err)
	}
	var buf bytes.Buffer
	writer := multipart.NewWriter(&buf)
	for k, v := range formData {
		writer.WriteField(k, v)
	}
	f, err := os.Open("/etc/issue")
	if err != nil {
		log.Fatalln(err)
	}
	defer f.Close()
	w, err := writer.CreateFormFile("file", "/etc/issue")
	if err != nil {
		log.Fatalln(err)
	}
	_, err = io.Copy(w, f)
	if err != nil {
		log.Fatalln(err)
	}
	writer.Close()

	res, err := http.Post(url.String(), writer.FormDataContentType(), bytes.NewReader(buf.Bytes()))
	if err != nil {
		log.Fatalln(err)
	}
	dresp, err := httputil.DumpResponse(res, true)
	if err != nil {
		log.Fatalln(err)
	}
	fmt.Println(string(dresp))
}
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
