### PR TITLE
utils: reduceErrs returns and validates quorum errors.

### DIFF
--- a/cmd/erasure-createfile.go
+++ b/cmd/erasure-createfile.go
@@ -141,5 +141,5 @@ func appendFile(disks []StorageAPI, volume, path string, enBlocks [][]byte, hash
 	if !isDiskQuorum(wErrs, writeQuorum) {
 		return traceError(errXLWriteQuorum)
 	}
-	return nil
+	return reduceWriteQuorumErrs(wErrs, objectOpIgnoredErrs, writeQuorum)
 }

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -80,7 +80,7 @@ func (xl xlObjects) MakeBucket(bucket string) error {
 	}
 
 	// Verify we have any other errors which should undo make bucket.
-	if reducedErr := reduceErrs(dErrs, bucketOpIgnoredErrs); reducedErr != nil {
+	if reducedErr := reduceWriteQuorumErrs(dErrs, bucketOpIgnoredErrs, xl.writeQuorum); reducedErr != nil {
 		return toObjectErr(reducedErr, bucket)
 	}
 	return nil
@@ -289,7 +289,7 @@ func (xl xlObjects) DeleteBucket(bucket string) error {
 		return toObjectErr(traceError(errXLWriteQuorum), bucket)
 	}
 
-	if reducedErr := reduceErrs(dErrs, bucketOpIgnoredErrs); reducedErr != nil {
+	if reducedErr := reduceWriteQuorumErrs(dErrs, bucketOpIgnoredErrs, xl.writeQuorum); reducedErr != nil {
 		return toObjectErr(reducedErr, bucket)
 	}
 

--- a/cmd/xl-v1-healing_test.go
+++ b/cmd/xl-v1-healing_test.go
@@ -353,7 +353,7 @@ func TestQuickHeal(t *testing.T) {
 	}
 
 	// Heal the missing buckets.
-	if err = quickHeal(xl.storageDisks, xl.writeQuorum); err != nil {
+	if err = quickHeal(xl.storageDisks, xl.writeQuorum, xl.readQuorum); err != nil {
 		t.Fatal(err)
 	}
 
@@ -370,7 +370,7 @@ func TestQuickHeal(t *testing.T) {
 		t.Fatal("storage disk is not *posix type")
 	}
 	xl.storageDisks[0] = newNaughtyDisk(posixDisk, nil, errUnformattedDisk)
-	if err = quickHeal(xl.storageDisks, xl.writeQuorum); err != errUnformattedDisk {
+	if err = quickHeal(xl.storageDisks, xl.writeQuorum, xl.readQuorum); err != errUnformattedDisk {
 		t.Fatal(err)
 	}
 
@@ -392,7 +392,7 @@ func TestQuickHeal(t *testing.T) {
 	}
 	xl = obj.(*xlObjects)
 	xl.storageDisks[0] = nil
-	if err = quickHeal(xl.storageDisks, xl.writeQuorum); err != nil {
+	if err = quickHeal(xl.storageDisks, xl.writeQuorum, xl.readQuorum); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 
@@ -419,7 +419,7 @@ func TestQuickHeal(t *testing.T) {
 		t.Fatal("storage disk is not *posix type")
 	}
 	xl.storageDisks[0] = newNaughtyDisk(posixDisk, nil, errDiskNotFound)
-	if err = quickHeal(xl.storageDisks, xl.writeQuorum); err != nil {
+	if err = quickHeal(xl.storageDisks, xl.writeQuorum, xl.readQuorum); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 }

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -335,8 +335,7 @@ func writeUniqueXLMetadata(disks []StorageAPI, bucket, prefix string, xlMetas []
 		deleteAllXLMetadata(disks, bucket, prefix, mErrs)
 		return traceError(errXLWriteQuorum)
 	}
-
-	return reduceErrs(mErrs, objectOpIgnoredErrs)
+	return reduceWriteQuorumErrs(mErrs, objectOpIgnoredErrs, quorum)
 }
 
 // writeSameXLMetadata - write `xl.json` on all disks in order.
@@ -375,6 +374,5 @@ func writeSameXLMetadata(disks []StorageAPI, bucket, prefix string, xlMeta xlMet
 		deleteAllXLMetadata(disks, bucket, prefix, mErrs)
 		return traceError(errXLWriteQuorum)
 	}
-
-	return reduceErrs(mErrs, objectOpIgnoredErrs)
+	return reduceWriteQuorumErrs(mErrs, objectOpIgnoredErrs, writeQuorum)
 }

--- a/cmd/xl-v1-multipart-common.go
+++ b/cmd/xl-v1-multipart-common.go
@@ -140,7 +140,10 @@ func (xl xlObjects) updateUploadJSON(bucket, object string, uCh uploadIDChange) 
 	}
 	wg.Wait()
 
-	return reduceErrs(errs, objectOpIgnoredErrs)
+	if reducedErr := reduceWriteQuorumErrs(errs, objectOpIgnoredErrs, xl.writeQuorum); reducedErr != nil {
+		return reducedErr
+	}
+	return nil
 }
 
 // Returns if the prefix is a multipart upload.
@@ -251,5 +254,8 @@ func commitXLMetadata(disks []StorageAPI, srcPrefix, dstPrefix string, quorum in
 		return traceError(errXLWriteQuorum)
 	}
 
-	return reduceErrs(mErrs, objectOpIgnoredErrs)
+	if reducedErr := reduceWriteQuorumErrs(mErrs, objectOpIgnoredErrs, quorum); reducedErr != nil {
+		return reducedErr
+	}
+	return nil
 }

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -79,7 +79,7 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 		return traceError(InsufficientReadQuorum{}, errs...)
 	}
 
-	if reducedErr := reduceErrs(errs, objectOpIgnoredErrs); reducedErr != nil {
+	if reducedErr := reduceReadQuorumErrs(errs, objectOpIgnoredErrs, xl.readQuorum); reducedErr != nil {
 		return toObjectErr(reducedErr, bucket, object)
 	}
 
@@ -339,8 +339,7 @@ func rename(disks []StorageAPI, srcBucket, srcEntry, dstBucket, dstEntry string,
 		undoRename(disks, srcBucket, srcEntry, dstBucket, dstEntry, isPart, errs)
 		return traceError(errXLWriteQuorum)
 	}
-	// Return on first error, also undo any partially successful rename operations.
-	return reduceErrs(errs, objectOpIgnoredErrs)
+	return reduceWriteQuorumErrs(errs, objectOpIgnoredErrs, quorum)
 }
 
 // renamePart - renames a part of the source object to the destination

--- a/cmd/xl-v1-utils_test.go
+++ b/cmd/xl-v1-utils_test.go
@@ -63,28 +63,34 @@ func TestReduceErrs(t *testing.T) {
 			errDiskNotFound,
 			errDiskNotFound,
 			errDiskFull,
-		}, []error{}, errDiskNotFound},
+		}, []error{}, errXLReadQuorum},
 		// Validate if have no consensus.
 		{[]error{
 			errDiskFull,
 			errDiskNotFound,
 			nil, nil,
-		}, []error{}, nil},
+		}, []error{}, errXLReadQuorum},
 		// Validate if have consensus and errors ignored.
 		{[]error{
+			errVolumeNotFound,
+			errVolumeNotFound,
 			errVolumeNotFound,
 			errVolumeNotFound,
 			errVolumeNotFound,
 			errDiskNotFound,
 			errDiskNotFound,
 		}, []error{errDiskNotFound}, errVolumeNotFound},
-		{[]error{}, []error{}, nil},
+		{[]error{}, []error{}, errXLReadQuorum},
 	}
 	// Validates list of all the testcases for returning valid errors.
 	for i, testCase := range testCases {
-		gotErr := reduceErrs(testCase.errs, testCase.ignoredErrs)
+		gotErr := reduceReadQuorumErrs(testCase.errs, testCase.ignoredErrs, 5)
 		if errorCause(gotErr) != testCase.err {
 			t.Errorf("Test %d : expected %s, got %s", i+1, testCase.err, gotErr)
+		}
+		gotNewErr := reduceWriteQuorumErrs(testCase.errs, testCase.ignoredErrs, 6)
+		if errorCause(gotNewErr) != errXLWriteQuorum {
+			t.Errorf("Test %d : expected %s, got %s", i+1, errXLWriteQuorum, gotErr)
 		}
 	}
 }

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -124,7 +124,7 @@ func newXLObjects(storageDisks []StorageAPI) (ObjectLayer, error) {
 	xl.writeQuorum = writeQuorum
 
 	// Do a quick heal on the buckets themselves for any discrepancies.
-	if err := quickHeal(xl.storageDisks, xl.writeQuorum); err != nil {
+	if err := quickHeal(xl.storageDisks, xl.writeQuorum, xl.readQuorum); err != nil {
 		return xl, err
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is needed as explained by @krisis 

Lets say we have following errors.

```
[]error{nil, errFileNotFound, errDiskAccessDenied, errDiskAccesDenied}
```

Since the last two errors are filtered, the maximum is nil,
depending on map order.

Let's say we get nil from reduceErr. Clearly at this point
we don't have quorum nodes agreeing about the data and since
GetObject only requires N/2 (Read quorum) and isDiskQuorum
would have returned true. This is problematic and can lead to
undersiable consequences.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3298 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Theoretical 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
