### PR TITLE
Fix checkdeps.sh on Mac

### DIFF
--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -72,9 +72,9 @@ check_minimum_version() {
     IFS='.' read -r -a varray2 <<< "$2"
 
     for i in "${!varray1[@]}"; do
-        if [[ ${varray1[i]} < ${varray2[i]} ]]; then
+        if [[ ${varray1[i]} -lt ${varray2[i]} ]]; then
             return 0
-        elif [[ ${varray1[i]} > ${varray2[i]} ]]; then
+        elif [[ ${varray1[i]} -gt ${varray2[i]} ]]; then
             return 1
         fi
     done


### PR DESCRIPTION
## Description
Update the `check_minimum_version` function to use numeric comparison (not
string comparison) on components of version numbers.

## Motivation and Context
I'm running Mac OS X El Capitan (10.11.6). Running `make` on the `master` branch currently gives the following output:

```
$ make
Checking deps:
ERROR
OSX version '10.11.6' not supported.
Minimum supported version: 10.8
make: *** [checks] Error 1
```

10.11.6 is greater than 10.8 in version numbering terms, but the `check_minimum_version` function is comparing lexicographically rather by integer value.

## How Has This Been Tested?
I ran `make` before the fix, corrected the script, and then verified that `make` then ran successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


