### PR TITLE
server: forbid zero port in address flag since it confuses clients and other Minio nodes too.

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -369,6 +369,12 @@ func serverMain(c *cli.Context) {
 	// Check if requested port is available.
 	host, portStr, err := net.SplitHostPort(serverAddr)
 	fatalIf(err, "Unable to parse %s.", serverAddr)
+	if portStr == "0" || portStr == "" {
+		// Port zero or empty means use requested to choose any freely available
+		// port. Avoid this since it won't work with any configured clients,
+		// can lead to serious loss of availability.
+		fatalIf(errInvalidArgument, "Invalid port `%s`, please use `--address` to pick a specific port", portStr)
+	}
 	globalMinioHost = host
 
 	// Check if requested port is available.


### PR DESCRIPTION
## Description
address flag in server should not accept zero port since it confuses clients and other Minio nodes too.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
