### PR TITLE
server: set maximum allowed request body.

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -42,9 +42,13 @@ func registerHandlers(mux *router.Router, handlerFns ...HandlerFunc) http.Handle
 
 // Adds limiting body size middleware
 
-// Set the body size limit to 6 Gb = Maximum object size + other possible data
-// in the same request
-const requestMaxBodySize = (5 + 1) * humanize.GiByte
+// Maximum allowed form data field values. 64MiB is a guessed practical value
+// which is more than enough to accommodate any form data fields and headers.
+const requestFormDataSize = 64 * humanize.MiByte
+
+// For any HTTP request, request body should be not more than 5GiB + requestFormDataSize
+// where, 5GiB is the maximum allowed object size for object upload.
+const requestMaxBodySize = 5*humanize.GiByte + requestFormDataSize
 
 type requestSizeLimitHandler struct {
 	handler     http.Handler


### PR DESCRIPTION
## Description
This patch sets the value as 5GiB + 64MiB.  5GiB is the maximum
allowed object size and 64MiB is for form data fields and headers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
