### PR TITLE
logger: Disassociate shared log config between console, file and syslog

### DIFF
--- a/cmd/logger-console-hook.go
+++ b/cmd/logger-console-hook.go
@@ -16,11 +16,7 @@
 
 package cmd
 
-import (
-	"io/ioutil"
-
-	"github.com/Sirupsen/logrus"
-)
+import "github.com/Sirupsen/logrus"
 
 // consoleLogger - default logger if not other logging is enabled.
 type consoleLogger struct {
@@ -32,15 +28,19 @@ type consoleLogger struct {
 func enableConsoleLogger() {
 	clogger := serverConfig.GetConsoleLogger()
 	if !clogger.Enable {
-		// Disable console logger if asked for.
-		log.Out = ioutil.Discard
 		return
 	}
+
+	consoleLogger := logrus.New()
 
 	// log.Out and log.Formatter use the default versions.
 	// Only set specific log level.
 	lvl, err := logrus.ParseLevel(clogger.Level)
 	fatalIf(err, "Unknown log level found in the config file.")
 
-	log.Level = lvl
+	consoleLogger.Level = lvl
+	consoleLogger.Formatter = new(logrus.TextFormatter)
+	log.mu.Lock()
+	log.loggers = append(log.loggers, consoleLogger)
+	log.mu.Unlock()
 }

--- a/cmd/logger_test.go
+++ b/cmd/logger_test.go
@@ -39,8 +39,12 @@ func TestCallerLocation(t *testing.T) {
 func TestLogger(t *testing.T) {
 	var buffer bytes.Buffer
 	var fields logrus.Fields
-	log.Out = &buffer
-	log.Formatter = new(logrus.JSONFormatter)
+	testLog := logrus.New()
+	testLog.Out = &buffer
+	testLog.Formatter = new(logrus.JSONFormatter)
+	log.mu.Lock()
+	log.loggers = append(log.loggers, testLog)
+	log.mu.Unlock()
 
 	errorIf(errors.New("Fake error"), "Failed with error.")
 	err := json.Unmarshal(buffer.Bytes(), &fields)


### PR DESCRIPTION
## Description
logurs is not helping us to set different log formats (json/text) to
different loggers. Now, we create different logurs instances and call
them in errorIf and fatalIf

## Motivation and Context
Fixes #3325 

## How Has This Been Tested?
Manually, go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
