### PR TITLE
init: Honor config-dir flag when it is passed as global or local flag

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -53,10 +53,11 @@ const (
 )
 
 var (
-	globalQuiet    = false // Quiet flag set via command line.
-	globalIsDistXL = false // "Is Distributed?" flag.
-
+	globalQuiet     = false               // quiet flag set via command line.
+	globalConfigDir = mustGetConfigPath() // config-dir flag set via command line
 	// Add new global flags here.
+
+	globalIsDistXL = false // "Is Distributed?" flag.
 
 	// Maximum cache size.
 	globalMaxCacheSize = uint64(maxCacheSize)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,70 +148,84 @@ func checkMainSyntax(c *cli.Context) {
 	}
 }
 
+// Parse command arguments and set global variables accordingly
+func setGlobalsFromContext(c *cli.Context) {
+	// Set config dir
+	switch {
+	case c.IsSet("config-dir"):
+		globalConfigDir = c.String("config-dir")
+	case c.GlobalIsSet("config-dir"):
+		globalConfigDir = c.GlobalString("config-dir")
+	}
+	if globalConfigDir == "" {
+		fatalIf(errors.New("Config directory is empty"), "Unable to get config file.")
+	}
+	// Set global quiet flag.
+	globalQuiet = c.Bool("quiet") || c.GlobalBool("quiet")
+}
+
+// Check for updates and print a notification message
+func checkUpdate() {
+	// Do not print update messages, if quiet flag is set.
+	if !globalQuiet {
+		updateMsg, _, err := getReleaseUpdate(minioUpdateStableURL, 1*time.Second)
+		if err != nil {
+			// Ignore any errors during getReleaseUpdate(), possibly
+			// because of network errors.
+			return
+		}
+		if updateMsg.Update {
+			console.Println(updateMsg)
+		}
+	}
+}
+
+// Generic Minio initialization to create/load config, prepare loggers, etc..
+func minioInit() {
+	// Sets new config directory.
+	setGlobalConfigPath(globalConfigDir)
+
+	// Migrate any old version of config / state files to newer format.
+	migrate()
+
+	// Initialize config.
+	configCreated, err := initConfig()
+	fatalIf(err, "Unable to initialize minio config.")
+	if configCreated {
+		console.Println("Created minio configuration file at " + mustGetConfigPath())
+	}
+
+	// Fetch access keys from environment variables and update the config.
+	accessKey := os.Getenv("MINIO_ACCESS_KEY")
+	secretKey := os.Getenv("MINIO_SECRET_KEY")
+	if accessKey != "" && secretKey != "" {
+		// Set new credentials.
+		serverConfig.SetCredential(credential{
+			AccessKeyID:     accessKey,
+			SecretAccessKey: secretKey,
+		})
+	}
+	if !isValidAccessKey(serverConfig.GetCredential().AccessKeyID) {
+		fatalIf(errInvalidArgument, "Invalid access key. Accept only a string starting with a alphabetic and containing from 5 to 20 characters.")
+	}
+	if !isValidSecretKey(serverConfig.GetCredential().SecretAccessKey) {
+		fatalIf(errInvalidArgument, "Invalid secret key. Accept only a string containing from 8 to 40 characters.")
+	}
+
+	// Enable all loggers by now.
+	enableLoggers()
+
+	// Init the error tracing module.
+	initError()
+}
+
 // Main main for minio server.
 func Main() {
 	app := registerApp()
 	app.Before = func(c *cli.Context) error {
-		configDir := c.GlobalString("config-dir")
-		if configDir == "" {
-			fatalIf(errors.New("Config directory is empty"), "Unable to get config file.")
-		}
-		// Sets new config directory.
-		setGlobalConfigPath(configDir)
-
 		// Valid input arguments to main.
 		checkMainSyntax(c)
 
-		// Migrate any old version of config / state files to newer format.
-		migrate()
-
-		// Initialize config.
-		configCreated, err := initConfig()
-		fatalIf(err, "Unable to initialize minio config.")
-		if configCreated {
-			console.Println("Created minio configuration file at " + mustGetConfigPath())
-		}
-
-		// Fetch access keys from environment variables and update the config.
-		accessKey := os.Getenv("MINIO_ACCESS_KEY")
-		secretKey := os.Getenv("MINIO_SECRET_KEY")
-		if accessKey != "" && secretKey != "" {
-			// Set new credentials.
-			serverConfig.SetCredential(credential{
-				AccessKeyID:     accessKey,
-				SecretAccessKey: secretKey,
-			})
-		}
-		if !isValidAccessKey(serverConfig.GetCredential().AccessKeyID) {
-			fatalIf(errInvalidArgument, "Invalid access key. Accept only a string starting with a alphabetic and containing from 5 to 20 characters.")
-		}
-		if !isValidSecretKey(serverConfig.GetCredential().SecretAccessKey) {
-			fatalIf(errInvalidArgument, "Invalid secret key. Accept only a string containing from 8 to 40 characters.")
-		}
-
-		// Enable all loggers by now.
-		enableLoggers()
-
-		// Init the error tracing module.
-		initError()
-
-		// Set global quiet flag.
-		globalQuiet = c.Bool("quiet") || c.GlobalBool("quiet")
-
-		// Do not print update messages, if quiet flag is set.
-		if !globalQuiet {
-			if c.Args().Get(0) != "update" {
-				updateMsg, _, err := getReleaseUpdate(minioUpdateStableURL, 1*time.Second)
-				if err != nil {
-					// Ignore any errors during getReleaseUpdate(), possibly
-					// because of network errors.
-					return nil
-				}
-				if updateMsg.Update {
-					console.Println(updateMsg)
-				}
-			}
-		}
 		return nil
 	}
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -363,8 +363,13 @@ func serverMain(c *cli.Context) {
 		cli.ShowCommandHelpAndExit(c, "server", 1)
 	}
 
-	// Set global quiet flag.
-	globalQuiet = c.Bool("quiet") || c.GlobalBool("quiet")
+	// Set global variables after parsing passed arguments
+	setGlobalsFromContext(c)
+
+	checkUpdate()
+
+	// Generic initialization
+	minioInit()
 
 	// Server address.
 	serverAddr := c.String("address")

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -265,8 +265,9 @@ func getReleaseUpdate(updateURL string, duration time.Duration) (updateMsg updat
 
 // main entry point for update command.
 func mainUpdate(ctx *cli.Context) {
-	// Set global quiet flag.
-	if ctx.Bool("quiet") || ctx.GlobalBool("quiet") {
+
+	setGlobalsFromContext(ctx)
+	if globalQuiet {
 		return
 	}
 

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -44,6 +44,10 @@ func mainVersion(ctx *cli.Context) {
 		cli.ShowCommandHelpAndExit(ctx, "version", 1)
 	}
 
+	setGlobalsFromContext(ctx)
+
+	checkUpdate()
+
 	console.Println("Version: " + Version)
 	console.Println("Release-Tag: " + ReleaseTag)
 	console.Println("Commit-ID: " + CommitID)


### PR DESCRIPTION
## Description
setGlobalsFromContext() is added to sets global variable after parsing
command line arguments.

## Motivation and Context
minio server /tmp/fs -C configdir doesn't work 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
