### PR TITLE
config-migrate: Fix buggy continuous re-migration of v9 to v10 config

### DIFF
--- a/cmd/config-old.go
+++ b/cmd/config-old.go
@@ -441,8 +441,5 @@ func loadConfigV9() (*serverConfigV9, error) {
 	if err := qc.Load(configFile); err != nil {
 		return nil, err
 	}
-	// Set the version properly after the unmarshalled json is loaded.
-	srvCfg.Version = "9"
-
 	return srvCfg, nil
 }


### PR DESCRIPTION
## Description
 Fix buggy continuous re-migration of v9 to v10 config

## Motivation and Context
Fix migration problem from v9 to v10

## How Has This Been Tested?
Manually and go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
