### PR TITLE
log: Enable loggers just after configuration loading

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -167,10 +167,15 @@ func Main() {
 
 		// Initialize config.
 		configCreated, err := initConfig()
-		fatalIf(err, "Unable to initialize minio config.")
+		if err != nil {
+			console.Fatalf("Unable to initialize minio config. Err: %s.\n", err)
+		}
 		if configCreated {
 			console.Println("Created minio configuration file at " + mustGetConfigPath())
 		}
+
+		// Enable all loggers by now so we can use errorIf() and fatalIf()
+		enableLoggers()
 
 		// Fetch access keys from environment variables and update the config.
 		accessKey := os.Getenv("MINIO_ACCESS_KEY")
@@ -188,9 +193,6 @@ func Main() {
 		if !isValidSecretKey(serverConfig.GetCredential().SecretAccessKey) {
 			fatalIf(errInvalidArgument, "Invalid secret key. Accept only a string containing from 8 to 40 characters.")
 		}
-
-		// Enable all loggers by now.
-		enableLoggers()
 
 		// Init the error tracing module.
 		initError()


### PR DESCRIPTION
## Description
It would make sense to enable console logger just after config initialisation.
That way, errorIf() and fatalIf() will be usable and can catch error
like invalid access and key errors.

## Motivation and Context
Fix recent regression after trying to make console logger prints text and file logger prints json

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
