### PR TITLE
args: Honor config-dir & quiet wherever they are

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -22,6 +22,8 @@ import (
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/objcache"
 )
 
@@ -53,10 +55,11 @@ const (
 )
 
 var (
-	globalQuiet    = false // Quiet flag set via command line.
-	globalIsDistXL = false // "Is Distributed?" flag.
-
+	globalQuiet     = false               // quiet flag set via command line.
+	globalConfigDir = mustGetConfigPath() // config-dir flag set via command line
 	// Add new global flags here.
+
+	globalIsDistXL = false // "Is Distributed?" flag.
 
 	// Maximum cache size.
 	globalMaxCacheSize = uint64(maxCacheSize)
@@ -90,3 +93,19 @@ var (
 	colorBlue  = color.New(color.FgBlue).SprintfFunc()
 	colorGreen = color.New(color.FgGreen).SprintfFunc()
 )
+
+// Parse command arguments and set global variables accordingly
+func setGlobalsFromContext(c *cli.Context) {
+	// Set config dir
+	switch {
+	case c.IsSet("config-dir"):
+		globalConfigDir = c.String("config-dir")
+	case c.GlobalIsSet("config-dir"):
+		globalConfigDir = c.GlobalString("config-dir")
+	}
+	if globalConfigDir == "" {
+		console.Fatalf("Unable to get config file. Config directory is empty.")
+	}
+	// Set global quiet flag.
+	globalQuiet = c.Bool("quiet") || c.GlobalBool("quiet")
+}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -363,8 +363,13 @@ func serverMain(c *cli.Context) {
 		cli.ShowCommandHelpAndExit(c, "server", 1)
 	}
 
-	// Set global quiet flag.
-	globalQuiet = c.Bool("quiet") || c.GlobalBool("quiet")
+	// Set global variables after parsing passed arguments
+	setGlobalsFromContext(c)
+
+	// Initialization routine, such as config loading, enable logging, ..
+	minioInit()
+
+	checkUpdate()
 
 	// Server address.
 	serverAddr := c.String("address")

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -265,8 +265,14 @@ func getReleaseUpdate(updateURL string, duration time.Duration) (updateMsg updat
 
 // main entry point for update command.
 func mainUpdate(ctx *cli.Context) {
-	// Set global quiet flag.
-	if ctx.Bool("quiet") || ctx.GlobalBool("quiet") {
+
+	// Set global variables after parsing passed arguments
+	setGlobalsFromContext(ctx)
+
+	// Initialization routine, such as config loading, enable logging, ..
+	minioInit()
+
+	if globalQuiet {
 		return
 	}
 

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -43,8 +43,14 @@ func mainVersion(ctx *cli.Context) {
 	if len(ctx.Args()) != 0 {
 		cli.ShowCommandHelpAndExit(ctx, "version", 1)
 	}
-	// Set global quiet flag.
-	if ctx.Bool("quiet") || ctx.GlobalBool("quiet") {
+
+	// Set global variables after parsing passed arguments
+	setGlobalsFromContext(ctx)
+
+	// Initialization routine, such as config loading, enable logging, ..
+	minioInit()
+
+	if globalQuiet {
 		return
 	}
 


### PR DESCRIPTION
## Description
setGlobalsFromContext() is added to set global variables after parsing
command line arguments. Thus, global flags will be honored wherever
they are placed in the command.

## Motivation and Context
Fixes #3354 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
