### PR TITLE
[WIP] FS: policy.json and notification.xml are reserved object names.

### DIFF
--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -268,6 +268,9 @@ func (fs fsObjects) NewMultipartUpload(bucket, object string, meta map[string]st
 	if !IsValidObjectName(object) {
 		return "", traceError(ObjectNameInvalid{Bucket: bucket, Object: object})
 	}
+	if !IsValidObjectNameFS(bucket, object) {
+		return "", traceError(ObjectNameInvalid{Bucket: bucket, Object: object})
+	}
 	return fs.newMultipartUpload(bucket, object, meta)
 }
 

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -48,6 +48,19 @@ var fsTreeWalkIgnoredErrs = []error{
 	errVolumeNotFound,
 }
 
+// policy.json and notification.xml allowed only in .minio.sys
+func IsValidObjectNameFS(bucket, object string) bool {
+	var reservedObjectNames = map[string]bool{
+		"policy.json":      true,
+		"notification.xml": true,
+	}
+
+	if bucket != minioMetaBucket && reservedObjectNames[object] {
+		return false
+	}
+	return true
+}
+
 // newFSObjects - initialize new fs object layer.
 func newFSObjects(storage StorageAPI) (ObjectLayer, error) {
 	if storage == nil {
@@ -349,6 +362,12 @@ func (fs fsObjects) PutObject(bucket string, object string, size int64, data io.
 		return ObjectInfo{}, traceError(BucketNameInvalid{Bucket: bucket})
 	}
 	if !IsValidObjectName(object) {
+		return ObjectInfo{}, traceError(ObjectNameInvalid{
+			Bucket: bucket,
+			Object: object,
+		})
+	}
+	if !IsValidObjectNameFS(bucket, object) {
 		return ObjectInfo{}, traceError(ObjectNameInvalid{
 			Bucket: bucket,
 			Object: object,


### PR DESCRIPTION
Note: I will add test cases once we confirm that this is the right approach. The other option is to migrate policy.json/notification.xml to a better place during server init.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
when you upload an object by the name policy.json (i.e not minio created, but actual mc cp) it takes up the namespace .minio.sys/buckets/testbucket/policy.json/fs.json and hence minio can not now create .minio.sys/buckets/testbucket/policy.json

Hence we don't allow policy.json and notification.xml in non `.minio.sys` buckets

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
refer to https://github.com/minio/minio/issues/3352

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
Fixes: #3352