### PR TITLE
fs: Enable shutdown test with faulty disks

### DIFF
--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -126,9 +126,8 @@ func TestFSShutdown(t *testing.T) {
 	}
 	removeAll(disk)
 
-	// FIXME: Check why Shutdown returns success when second posix call returns faulty disk error
 	// Test Shutdown with faulty disk
-	/* for i := 1; i <= 5; i++ {
+	for i := 1; i <= 5; i++ {
 		fs, disk := prepareTest()
 		fs.DeleteObject(bucketName, objectName)
 		fsStorage := fs.storage.(*retryStorage)
@@ -137,7 +136,7 @@ func TestFSShutdown(t *testing.T) {
 			t.Fatal(i, ", Got unexpected fs shutdown error: ", err)
 		}
 		removeAll(disk)
-	} */
+	}
 }
 
 // TestFSLoadFormatFS - test loadFormatFS with healty and faulty disks


### PR DESCRIPTION
## Description
Test shutdown FS with faulty disks is enabled again and it is fixed with this commit https://github.com/minio/minio/commit/bcd1a2308b9ef3066388cebc72148e262b9fb728

## Motivation and Context
Fixes https://github.com/minio/minio/issues/3317

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
