### PR TITLE
fs: PutObject create 0byte objects properly.

### DIFF
--- a/cmd/fs-createfile.go
+++ b/cmd/fs-createfile.go
@@ -27,11 +27,9 @@ func fsCreateFile(disk StorageAPI, reader io.Reader, buf []byte, tmpBucket, temp
 			return 0, traceError(rErr)
 		}
 		bytesWritten += int64(n)
-		if n > 0 {
-			wErr := disk.AppendFile(tmpBucket, tempObj, buf[0:n])
-			if wErr != nil {
-				return 0, traceError(wErr)
-			}
+		wErr := disk.AppendFile(tmpBucket, tempObj, buf[0:n])
+		if wErr != nil {
+			return 0, traceError(wErr)
 		}
 		if rErr == io.EOF {
 			break

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -301,6 +301,7 @@ func (fs fsObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 		fs.storage.DeleteFile(minioMetaTmpBucket, tmpPartPath)
 		return "", toObjectErr(cErr, minioMetaTmpBucket, tmpPartPath)
 	}
+
 	// Should return IncompleteBody{} error when reader has fewer
 	// bytes than specified in request header.
 	if bytesWritten < size {

--- a/cmd/fs-v1-multipart_test.go
+++ b/cmd/fs-v1-multipart_test.go
@@ -59,6 +59,12 @@ func TestNewMultipartUploadFaultyDisk(t *testing.T) {
 
 // TestPutObjectPartFaultyDisk - test PutObjectPart with faulty disks
 func TestPutObjectPartFaultyDisk(t *testing.T) {
+	root, err := newTestConfig("us-east-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeAll(root)
+
 	// Prepare for tests
 	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
 	defer removeAll(disk)
@@ -69,7 +75,7 @@ func TestPutObjectPartFaultyDisk(t *testing.T) {
 	data := []byte("12345")
 	dataLen := int64(len(data))
 
-	if err := obj.MakeBucket(bucketName); err != nil {
+	if err = obj.MakeBucket(bucketName); err != nil {
 		t.Fatal("Cannot create bucket, err: ", err)
 	}
 
@@ -97,7 +103,7 @@ func TestPutObjectPartFaultyDisk(t *testing.T) {
 					t.Fatal("Unexpected error ", err)
 				}
 			case 3:
-			case 2, 4, 5:
+			case 2, 4, 5, 6:
 				if !isSameType(errorCause(err), InvalidUploadID{}) {
 					t.Fatal("Unexpected error ", err)
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current code always appends to a file only if 1byte or
more was sent on the wire was affecting both PutObject
and PutObjectPart uploads.

This patch fixes such a situation and resolves #3385
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3385
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
make test and curl  (manually)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
