### PR TITLE
postform: fix check when ${filename} is provided

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -374,13 +374,13 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	}
 	bucket := mux.Vars(r)["bucket"]
 	formValues["Bucket"] = bucket
-	object := formValues["Key"]
 
-	if fileName != "" && strings.Contains(object, "${filename}") {
+	if fileName != "" && strings.Contains(formValues["Key"], "${filename}") {
 		// S3 feature to replace ${filename} found in Key form field
 		// by the filename attribute passed in multipart
-		object = strings.Replace(object, "${filename}", fileName, -1)
+		formValues["Key"] = strings.Replace(formValues["Key"], "${filename}", fileName, -1)
 	}
+	object := formValues["Key"]
 
 	// Verify policy signature.
 	apiErr := doesPolicySignatureMatch(formValues)


### PR DESCRIPTION
## Description
Checking key condition when ${filename} is provided wasn't working well,
this patch fixes the wrong behavior

## Motivation and Context
Fix found bug

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
