### PR TITLE
srv-mux: do not print peek protocol EOF err msg

### DIFF
--- a/cmd/server-mux.go
+++ b/cmd/server-mux.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -75,7 +76,9 @@ func NewConnMux(c net.Conn) *ConnMux {
 func (c *ConnMux) PeekProtocol() string {
 	buf, err := c.bufrw.Peek(maxHTTPVerbLen)
 	if err != nil {
-		errorIf(err, "Unable to peek into the protocol")
+		if err != io.EOF {
+			errorIf(err, "Unable to peek into the protocol")
+		}
 		return "http"
 	}
 	for _, m := range defaultHTTP1Methods {


### PR DESCRIPTION

## Description
EOF err message in Peek Protocol is shown when a client closes the
connection in the middle of peek protocol, this commit hides it since it
doesn't make sense to show it

## Motivation and Context
Hide an useless log

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
