### PR TITLE
Fix max cache size calculation when system RAM is inferior to the default cache size

### DIFF
--- a/cmd/server-rlimit-nix.go
+++ b/cmd/server-rlimit-nix.go
@@ -77,7 +77,7 @@ func setMaxMemory() error {
 		return err
 	}
 	if err == nil && stats.TotalRAM < globalMaxCacheSize {
-		globalMaxCacheSize = (80 / 100) * stats.TotalRAM
+		globalMaxCacheSize = uint64(float64(80*stats.TotalRAM) / 100)
 	}
 	return nil
 }

--- a/pkg/objcache/objcache.go
+++ b/pkg/objcache/objcache.go
@@ -73,6 +73,9 @@ type Cache struct {
 // the items in the cache never expire (by default), and must be deleted
 // manually.
 func New(maxSize uint64, expiry time.Duration) *Cache {
+	if maxSize == 0 {
+		panic("objcache: setting maximum cache size to zero is forbidden.")
+	}
 	C := &Cache{
 		maxSize: maxSize,
 		entries: make(map[string]*buffer),


### PR DESCRIPTION
## Description
objcache: New() panics when max cache size is zero
cache: Set correct maxCacheSize when avail. mem is <= 8Gb 

## Motivation and Context
Found bug after manual testing

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
