### PR TITLE
Adding functions for resetting globals.

### DIFF
--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -432,6 +432,39 @@ func StartTestPeersRPCServer(t TestErrHandler, instanceType string) TestServer {
 	return testRPCServer
 }
 
+// Sets the global config path to empty string.
+func resetGlobalConfigPath() {
+	setGlobalConfigPath("")
+}
+
+// sets globalObjectAPI to `nil`.
+func resetGlobalObjectAPI() {
+	globalObjLayerMutex.Lock()
+	globalObjectAPI = nil
+	globalObjLayerMutex.Unlock()
+}
+
+// reset the value of the Global server config.
+// set it to `nil`.
+func resetGlobalConfig() {
+	// hold the mutex lock before a new config is assigned.
+	serverConfigMu.Lock()
+	// Save the loaded config globally.
+	serverConfig = nil
+	serverConfigMu.Unlock()
+}
+
+// Resets all the globals used modified in tests.
+// Resetting ensures that the changes made to globals by one test doesn't affect others.
+func resetTestGlobals() {
+	// set globalObjectAPI to `nil`.
+	resetGlobalObjectAPI()
+	// Reset config path set.
+	resetGlobalConfigPath()
+	// Reset Global server config.
+	resetGlobalConfig()
+}
+
 // Configure the server for the test run.
 func newTestConfig(bucketLocation string) (rootPath string, err error) {
 	// Get test root.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Function for resetting Globals.
## Description
<!--- Describe your changes in detail -->
- Helps to reset globals during tests. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Helps to make sure tests don't get affected by modifications to globals by each other.
- Fix for https://github.com/minio/minio/issues/3198 . 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
