### PR TITLE
Move LoginHandler into LoginServer which others embed

### DIFF
--- a/cmd/lock-rpc-server.go
+++ b/cmd/lock-rpc-server.go
@@ -34,6 +34,7 @@ const lockCheckValidityInterval = 2 * time.Minute
 // LockArgs besides lock name, holds Token and Timestamp for session
 // authentication and validation server restart.
 type LockArgs struct {
+	loginServer
 	Name      string
 	Token     string
 	Timestamp time.Time
@@ -124,25 +125,6 @@ func registerStorageLockers(mux *router.Router, lockServers []*lockServer) error
 }
 
 ///  Distributed lock handlers
-
-// LoginHandler - handles LoginHandler RPC call.
-func (l *lockServer) LoginHandler(args *RPCLoginArgs, reply *RPCLoginReply) error {
-	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
-	if err != nil {
-		return err
-	}
-	if err = jwt.Authenticate(args.Username, args.Password); err != nil {
-		return err
-	}
-	token, err := jwt.GenerateToken(args.Username)
-	if err != nil {
-		return err
-	}
-	reply.Token = token
-	reply.Timestamp = time.Now().UTC()
-	reply.ServerVersion = Version
-	return nil
-}
 
 // Lock - rpc handler for (single) write lock operation.
 func (l *lockServer) Lock(args *LockArgs, reply *bool) error {

--- a/cmd/login-server.go
+++ b/cmd/login-server.go
@@ -1,0 +1,41 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "time"
+
+type loginServer struct {
+}
+
+// LoginHandler - Handles JWT based RPC logic.
+func (b loginServer) LoginHandler(args *RPCLoginArgs, reply *RPCLoginReply) error {
+	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
+	if err != nil {
+		return err
+	}
+	if err = jwt.Authenticate(args.Username, args.Password); err != nil {
+		return err
+	}
+	token, err := jwt.GenerateToken(args.Username)
+	if err != nil {
+		return err
+	}
+	reply.Token = token
+	reply.Timestamp = time.Now().UTC()
+	reply.ServerVersion = Version
+	return nil
+}

--- a/cmd/login-server_test.go
+++ b/cmd/login-server_test.go
@@ -1,0 +1,67 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "testing"
+
+func TestLoginHandler(t *testing.T) {
+	rootPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		t.Fatalf("Failed to create test config - %v", err)
+	}
+	defer removeAll(rootPath)
+	creds := serverConfig.GetCredential()
+	ls := loginServer{}
+	testCases := []struct {
+		args        RPCLoginArgs
+		expectedErr error
+	}{
+		// Valid username and password
+		{
+			args:        RPCLoginArgs{Username: creds.AccessKeyID, Password: creds.SecretAccessKey},
+			expectedErr: nil,
+		},
+		// Invalid username length
+		{
+			args:        RPCLoginArgs{Username: "aaa", Password: "minio123"},
+			expectedErr: errInvalidAccessKeyLength,
+		},
+		// Invalid password length
+		{
+			args:        RPCLoginArgs{Username: "minio", Password: "aaa"},
+			expectedErr: errInvalidSecretKeyLength,
+		},
+		// Invalid username
+		{
+			args:        RPCLoginArgs{Username: "aaaaa", Password: creds.SecretAccessKey},
+			expectedErr: errInvalidAccessKeyID,
+		},
+		// Invalid password
+		{
+			args:        RPCLoginArgs{Username: creds.AccessKeyID, Password: "aaaaaaaa"},
+			expectedErr: errAuthentication,
+		},
+	}
+	for i, test := range testCases {
+		reply := RPCLoginReply{}
+		err := ls.LoginHandler(&test.args, &reply)
+		if err != test.expectedErr {
+			t.Errorf("Test %d: Expected error %v but received %v",
+				i+1, test.expectedErr, err)
+		}
+	}
+}

--- a/cmd/s3-peer-router.go
+++ b/cmd/s3-peer-router.go
@@ -27,11 +27,13 @@ const (
 )
 
 type s3PeerAPIHandlers struct {
+	loginServer
 	bms BucketMetaState
 }
 
 func registerS3PeerRPCRouter(mux *router.Router) error {
 	s3PeerHandlers := &s3PeerAPIHandlers{
+		loginServer{},
 		&localBucketMetaState{
 			ObjectAPI: newObjectLayerFn,
 		},

--- a/cmd/s3-peer-rpc-handlers.go
+++ b/cmd/s3-peer-rpc-handlers.go
@@ -16,26 +16,6 @@
 
 package cmd
 
-import "time"
-
-func (s3 *s3PeerAPIHandlers) LoginHandler(args *RPCLoginArgs, reply *RPCLoginReply) error {
-	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
-	if err != nil {
-		return err
-	}
-	if err = jwt.Authenticate(args.Username, args.Password); err != nil {
-		return err
-	}
-	token, err := jwt.GenerateToken(args.Username)
-	if err != nil {
-		return err
-	}
-	reply.Token = token
-	reply.ServerVersion = Version
-	reply.Timestamp = time.Now().UTC()
-	return nil
-}
-
 // SetBucketNotificationPeerArgs - Arguments collection to SetBucketNotificationPeer RPC
 // call
 type SetBucketNotificationPeerArgs struct {

--- a/cmd/storage-rpc-server.go
+++ b/cmd/storage-rpc-server.go
@@ -29,30 +29,10 @@ import (
 // Storage server implements rpc primitives to facilitate exporting a
 // disk over a network.
 type storageServer struct {
+	loginServer
 	storage   StorageAPI
 	path      string
 	timestamp time.Time
-}
-
-/// Auth operations
-
-// Login - login handler.
-func (s *storageServer) LoginHandler(args *RPCLoginArgs, reply *RPCLoginReply) error {
-	jwt, err := newJWT(defaultInterNodeJWTExpiry, serverConfig.GetCredential())
-	if err != nil {
-		return err
-	}
-	if err = jwt.Authenticate(args.Username, args.Password); err != nil {
-		return err
-	}
-	token, err := jwt.GenerateToken(args.Username)
-	if err != nil {
-		return err
-	}
-	reply.Token = token
-	reply.Timestamp = time.Now().UTC()
-	reply.ServerVersion = Version
-	return nil
 }
 
 /// Storage operations handlers.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
LoginHandler method implementation is repeated for each rpc server like storageServer, lockServer and s3PeerAPIHandler.

## Description
<!--- Describe your changes in detail -->
The repetition described above can be reduced by adding a new type which implements the LoginHandler method and embedding it in each of these server types.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid code repetition.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make test
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
