### PR TITLE
Presign-v4: Allow requests that were signed slightly ahead of the cur…

### DIFF
--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -250,7 +250,9 @@ func doesPresignedSignatureMatch(hashedPayload string, r *http.Request, region s
 
 	query.Set("X-Amz-Algorithm", signV4Algorithm)
 
-	if pSignValues.Date.After(time.Now().UTC()) {
+	// If the host which signed the request is slightly ahead in time (by less than globalMaxSkewTime) the
+	// request should still be allowed.
+	if pSignValues.Date.After(time.Now().UTC().Add(globalMaxSkewTime)) {
 		return ErrRequestNotReadyYet
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The presigning host's time can be slightly ahead in time from the minio host's time but not more than `globalMaxSkewTime`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@g-cassie reported the problem on gitter that the presigned urls generated by his host were rejected by minio.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
…rent time.
