### PR TITLE
loginServer should be a member of lockServer

### DIFF
--- a/cmd/lock-rpc-server.go
+++ b/cmd/lock-rpc-server.go
@@ -34,7 +34,6 @@ const lockCheckValidityInterval = 2 * time.Minute
 // LockArgs besides lock name, holds Token and Timestamp for session
 // authentication and validation server restart.
 type LockArgs struct {
-	loginServer
 	Name      string
 	Token     string
 	Timestamp time.Time
@@ -70,6 +69,7 @@ func isWriteLock(lri []lockRequesterInfo) bool {
 
 // lockServer is type for RPC handlers
 type lockServer struct {
+	loginServer
 	rpcPath string
 	mutex   sync.Mutex
 	lockMap map[string][]lockRequesterInfo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
loginServer should be a member of lockServer type. It is incorrectly placed as a member of lockArgs.
## Description
<!--- Describe your changes in detail -->
The change embeds loginServer type into lockServer as opposed to lockArgs. It also adds a unit test that would catch this class of bugs at the time of ``make test``.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change fixes a breakage in lockServer implementation. Without this change lockServer doesn't have a LoginHandler method.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using make test with the added test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
Add a unit test to catch a missing LoginHandler method in lockServer.