### PR TITLE
Browser: Added character limit for Bucket Name.

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -805,7 +805,7 @@ func toJSONError(err error, params ...string) (jerr *json2.Error) {
 	case "InvalidBucketName":
 		if len(params) > 0 {
 			jerr = &json2.Error{
-				Message: fmt.Sprintf("Bucket Name %s is invalid. Lowercase letters, period and numerals are the only allowed characters. Bucket Name must be at least 3 characters.", params[0]),
+				Message: fmt.Sprintf("Bucket Name %s is invalid. Lowercase letters, period, numerals are the only allowed with minimum number of 3 characters.", params[0]),
 			}
 		}
 	// Bucket not found custom error message.

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -805,7 +805,7 @@ func toJSONError(err error, params ...string) (jerr *json2.Error) {
 	case "InvalidBucketName":
 		if len(params) > 0 {
 			jerr = &json2.Error{
-				Message: fmt.Sprintf("Bucket Name %s is invalid. Lowercase letters, period and numerals are the only allowed characters.", params[0]),
+				Message: fmt.Sprintf("Bucket Name %s is invalid. Lowercase letters, period and numerals are the only allowed characters. Bucket Name must be at least 3 characters.", params[0]),
 			}
 		}
 	// Bucket not found custom error message.

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -805,7 +805,7 @@ func toJSONError(err error, params ...string) (jerr *json2.Error) {
 	case "InvalidBucketName":
 		if len(params) > 0 {
 			jerr = &json2.Error{
-				Message: fmt.Sprintf("Bucket Name %s is invalid. Lowercase letters, period, numerals are the only allowed with minimum number of 3 characters.", params[0]),
+				Message: fmt.Sprintf("Bucket Name %s is invalid. Lowercase letters, period, numerals are the only allowed characters and should be minimum 3 characters in length.", params[0]),
 			}
 		}
 	// Bucket not found custom error message.


### PR DESCRIPTION
Currently ``cmd/web-handlers.go`` on Bucket Name option does not mention about  minimum 3 characters limit for  Bucket Name. This PR adds the same. 

## Description
Enhanced the output message to include minimum 3 characters Bucket Name limit. Current error code output does not mention about it.

## Motivation and Context
This PR will make the error output more informative especially when someone selects a Bucket Name with 2 characters. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
Name limit.