### PR TITLE
tests: Use testTmpDir var to specify tmp directory

### DIFF
--- a/cmd/fs-v1-metadata_test.go
+++ b/cmd/fs-v1-metadata_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -37,7 +36,7 @@ func initFSObjects(disk string, t *testing.T) (obj ObjectLayer) {
 
 // TestReadFsMetadata - readFSMetadata testing with a healthy and faulty disk
 func TestReadFSMetadata(t *testing.T) {
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
@@ -84,7 +83,7 @@ func TestReadFSMetadata(t *testing.T) {
 
 // TestWriteFsMetadata - tests of writeFSMetadata with healthy and faulty disks
 func TestWriteFSMetadata(t *testing.T) {
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 	obj := initFSObjects(disk, t)
 	fs := obj.(fsObjects)

--- a/cmd/fs-v1-multipart-common_test.go
+++ b/cmd/fs-v1-multipart-common_test.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -26,7 +25,7 @@ import (
 // TestFSIsUploadExists - complete test with valid and invalid cases
 func TestFSIsUploadExists(t *testing.T) {
 	// Prepare for testing
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
@@ -70,7 +69,7 @@ func TestFSIsUploadExists(t *testing.T) {
 // TestFSWriteUploadJSON - tests for writeUploadJSON for FS
 func TestFSWriteUploadJSON(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)

--- a/cmd/fs-v1-multipart_test.go
+++ b/cmd/fs-v1-multipart_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -27,7 +26,7 @@ import (
 // TestNewMultipartUploadFaultyDisk - test NewMultipartUpload with faulty disks
 func TestNewMultipartUploadFaultyDisk(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 	obj := initFSObjects(disk, t)
 
@@ -66,7 +65,7 @@ func TestPutObjectPartFaultyDisk(t *testing.T) {
 	defer removeAll(root)
 
 	// Prepare for tests
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 	obj := initFSObjects(disk, t)
 	fs := obj.(fsObjects)
@@ -117,7 +116,7 @@ func TestPutObjectPartFaultyDisk(t *testing.T) {
 // TestCompleteMultipartUploadFaultyDisk - test CompleteMultipartUpload with faulty disks
 func TestCompleteMultipartUploadFaultyDisk(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 	obj := initFSObjects(disk, t)
 
@@ -168,7 +167,7 @@ func TestCompleteMultipartUploadFaultyDisk(t *testing.T) {
 // TestListMultipartUploadsFaultyDisk - test ListMultipartUploads with faulty disks
 func TestListMultipartUploadsFaultyDisk(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 	obj := initFSObjects(disk, t)
 	fs := obj.(fsObjects)

--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,13 +28,13 @@ func TestNewFS(t *testing.T) {
 	// Do not attempt to create this path, the test validates
 	// so that newFSObjects initializes non existing paths
 	// and successfully returns initialized object layer.
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	// Setup to test errFSDiskFormat.
 	disks := []string{}
 	for i := 0; i < 6; i++ {
-		xlDisk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+		xlDisk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 		defer removeAll(xlDisk)
 		disks = append(disks, xlDisk)
 	}
@@ -109,7 +108,7 @@ func TestFSShutdown(t *testing.T) {
 	objectName := "object"
 	// Create and return an fsObject with its path in the disk
 	prepareTest := func() (fsObjects, string) {
-		disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+		disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 		obj := initFSObjects(disk, t)
 		fs := obj.(fsObjects)
 		objectContent := "12345"
@@ -142,7 +141,7 @@ func TestFSShutdown(t *testing.T) {
 // TestFSLoadFormatFS - test loadFormatFS with healty and faulty disks
 func TestFSLoadFormatFS(t *testing.T) {
 	// Prepare for testing
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
@@ -171,7 +170,7 @@ func TestFSLoadFormatFS(t *testing.T) {
 // TestFSGetBucketInfo - test GetBucketInfo with healty and faulty disks
 func TestFSGetBucketInfo(t *testing.T) {
 	// Prepare for testing
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
@@ -208,7 +207,7 @@ func TestFSGetBucketInfo(t *testing.T) {
 // TestFSDeleteObject - test fs.DeleteObject() with healthy and corrupted disks
 func TestFSDeleteObject(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
@@ -249,7 +248,7 @@ func TestFSDeleteObject(t *testing.T) {
 // TestFSDeleteBucket - tests for fs DeleteBucket
 func TestFSDeleteBucket(t *testing.T) {
 	// Prepare for testing
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
@@ -290,7 +289,7 @@ func TestFSDeleteBucket(t *testing.T) {
 // TestFSListBuckets - tests for fs ListBuckets
 func TestFSListBuckets(t *testing.T) {
 	// Prepare for tests
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
@@ -328,7 +327,7 @@ func TestFSListBuckets(t *testing.T) {
 
 // TestFSHealObject - tests for fs HealObject
 func TestFSHealObject(t *testing.T) {
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
@@ -340,7 +339,7 @@ func TestFSHealObject(t *testing.T) {
 
 // TestFSListObjectHeal - tests for fs ListObjectHeals
 func TestFSListObjectsHeal(t *testing.T) {
-	disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -587,7 +587,7 @@ func initFSObjectsB(disk string, t *testing.B) (obj ObjectLayer) {
 // BenchmarkListObjects - Run ListObject Repeatedly and benchmark.
 func BenchmarkListObjects(b *testing.B) {
 	// Make a temporary directory to use as the obj.
-	directory, err := ioutil.TempDir("", "minio-list-benchmark")
+	directory, err := ioutil.TempDir(globalTestTmpDir, "minio-list-benchmark")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/cmd/posix-list-dir_test.go
+++ b/cmd/posix-list-dir_test.go
@@ -55,7 +55,7 @@ type result struct {
 
 func mustSetupDir(t *testing.T) string {
 	// Create unique test directory.
-	dir, err := ioutil.TempDir("", "minio-posix-list-dir")
+	dir, err := ioutil.TempDir(globalTestTmpDir, "minio-posix-list-dir")
 	if err != nil {
 		t.Fatalf("Unable to setup directory, %s", err)
 	}

--- a/cmd/posix-utils_nix_test.go
+++ b/cmd/posix-utils_nix_test.go
@@ -36,7 +36,7 @@ func getUmask() int {
 
 // Tests if the directory and file creations happen with proper umask.
 func TestIsValidUmaskVol(t *testing.T) {
-	tmpPath, err := ioutil.TempDir(os.TempDir(), "minio-")
+	tmpPath, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Initializing temporary directory failed with %s.", err)
 	}
@@ -78,7 +78,7 @@ func TestIsValidUmaskVol(t *testing.T) {
 
 // Tests if the file creations happen with proper umask.
 func TestIsValidUmaskFile(t *testing.T) {
-	tmpPath, err := ioutil.TempDir(os.TempDir(), "minio-")
+	tmpPath, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Initializing temporary directory failed with %s.", err)
 	}

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -31,7 +31,7 @@ import (
 // creates a temp dir and sets up posix layer.
 // returns posix layer, temp dir path to be used for the purpose of tests.
 func newPosixTestSetup() (StorageAPI, string, error) {
-	diskPath, err := ioutil.TempDir(os.TempDir(), "minio-")
+	diskPath, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		return nil, "", err
 	}
@@ -45,7 +45,7 @@ func newPosixTestSetup() (StorageAPI, string, error) {
 
 // Tests posix.getDiskInfo()
 func TestGetDiskInfo(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "minio-")
+	path, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory, %s", err)
 	}
@@ -171,9 +171,9 @@ func TestReadAll(t *testing.T) {
 // TestNewPosix all the cases handled in posix storage layer initialization.
 func TestNewPosix(t *testing.T) {
 	// Temporary dir name.
-	tmpDirName := os.TempDir() + "/" + "minio-" + nextSuffix()
+	tmpDirName := globalTestTmpDir + "/" + "minio-" + nextSuffix()
 	// Temporary file name.
-	tmpFileName := os.TempDir() + "/" + "minio-" + nextSuffix()
+	tmpFileName := globalTestTmpDir + "/" + "minio-" + nextSuffix()
 	f, _ := os.Create(tmpFileName)
 	f.Close()
 	defer os.Remove(tmpFileName)

--- a/cmd/signature-jwt_test.go
+++ b/cmd/signature-jwt_test.go
@@ -32,21 +32,21 @@ func TestNewJWT(t *testing.T) {
 	serverConfig = nil
 
 	// Test non-existent config directory.
-	path1, err := ioutil.TempDir("", "minio-")
+	path1, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory, %s", err)
 	}
 	defer removeAll(path1)
 
 	// Test empty config directory.
-	path2, err := ioutil.TempDir("", "minio-")
+	path2, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory, %s", err)
 	}
 	defer removeAll(path2)
 
 	// Test empty config file.
-	path3, err := ioutil.TempDir("", "minio-")
+	path3, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory, %s", err)
 	}
@@ -57,7 +57,7 @@ func TestNewJWT(t *testing.T) {
 	}
 
 	// Test initialized config file.
-	path4, err := ioutil.TempDir("", "minio-")
+	path4, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory, %s", err)
 	}

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -133,6 +133,9 @@ const (
 var randN uint32
 var randmu sync.Mutex
 
+// Temp files created in default Tmp dir
+var globalTestTmpDir = os.TempDir()
+
 // reseed - returns a new seed every time the function is called.
 func reseed() uint32 {
 	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
@@ -1572,14 +1575,14 @@ func getListenBucketNotificationURL(endPoint, bucketName string, prefixes, suffi
 
 // returns temp root directory. `
 func getTestRoot() (string, error) {
-	return ioutil.TempDir(os.TempDir(), "api-")
+	return ioutil.TempDir(globalTestTmpDir, "api-")
 }
 
 // getRandomDisks - Creates a slice of N random disks, each of the form - minio-XXX
 func getRandomDisks(N int) ([]string, error) {
 	var erasureDisks []string
 	for i := 0; i < N; i++ {
-		path, err := ioutil.TempDir(os.TempDir(), "minio-")
+		path, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 		if err != nil {
 			// Remove directories created so far.
 			removeRoots(erasureDisks)

--- a/cmd/tree-walk_test.go
+++ b/cmd/tree-walk_test.go
@@ -161,7 +161,7 @@ func testTreeWalkMarker(t *testing.T, listDir listDirFunc, isLeaf isLeafFunc) {
 
 // Test tree-walk.
 func TestTreeWalk(t *testing.T) {
-	fsDir, err := ioutil.TempDir("", "minio-")
+	fsDir, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Unable to create tmp directory: %s", err)
 	}
@@ -202,7 +202,7 @@ func TestTreeWalk(t *testing.T) {
 
 // Test if tree walk go-routine exits cleanly if tree walk is aborted because of timeout.
 func TestTreeWalkTimeout(t *testing.T) {
-	fsDir, err := ioutil.TempDir("", "minio-")
+	fsDir, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Unable to create tmp directory: %s", err)
 	}
@@ -277,11 +277,11 @@ func TestListDir(t *testing.T) {
 	file1 := "file1"
 	file2 := "file2"
 	// Create two backend directories fsDir1 and fsDir2.
-	fsDir1, err := ioutil.TempDir("", "minio-")
+	fsDir1, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Errorf("Unable to create tmp directory: %s", err)
 	}
-	fsDir2, err := ioutil.TempDir("", "minio-")
+	fsDir2, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Errorf("Unable to create tmp directory: %s", err)
 	}
@@ -360,7 +360,7 @@ func TestListDir(t *testing.T) {
 // without recursively traversing prefixes.
 func TestRecursiveTreeWalk(t *testing.T) {
 	// Create a backend directories fsDir1.
-	fsDir1, err := ioutil.TempDir("", "minio-")
+	fsDir1, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Fatalf("Unable to create tmp directory: %s", err)
 	}
@@ -470,7 +470,7 @@ func TestRecursiveTreeWalk(t *testing.T) {
 
 func TestSortedness(t *testing.T) {
 	// Create a backend directories fsDir1.
-	fsDir1, err := ioutil.TempDir("", "minio-")
+	fsDir1, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Errorf("Unable to create tmp directory: %s", err)
 	}
@@ -548,7 +548,7 @@ func TestSortedness(t *testing.T) {
 
 func TestTreeWalkIsEnd(t *testing.T) {
 	// Create a backend directories fsDir1.
-	fsDir1, err := ioutil.TempDir("", "minio-")
+	fsDir1, err := ioutil.TempDir(globalTestTmpDir, "minio-")
 	if err != nil {
 		t.Errorf("Unable to create tmp directory: %s", err)
 	}

--- a/cmd/xl-v1_test.go
+++ b/cmd/xl-v1_test.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -135,7 +134,7 @@ func TestNewXL(t *testing.T) {
 		// Do not attempt to create this path, the test validates
 		// so that newFSObjects initializes non existing paths
 		// and successfully returns initialized object layer.
-		disk := filepath.Join(os.TempDir(), "minio-"+nextSuffix())
+		disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 		erasureDisks = append(erasureDisks, disk)
 		defer removeAll(disk)
 	}


### PR DESCRIPTION
## Description
To be able to specify the directory where tests will be done.  This way,
it will be easier to run Minio tests on a mounted directory like NFS, ..

## Motivation and Context
Testing go test on NFS

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
