### PR TITLE
postForm: Follow success_action_status requirement

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -251,6 +251,14 @@ type DeleteObjectsResponse struct {
 	Errors []DeleteError `xml:"Error,omitempty"`
 }
 
+// PostResponse container for POST object request when success_action_status is set to 201
+type PostResponse struct {
+	Bucket   string
+	Key      string
+	ETag     string
+	Location string
+}
+
 // getLocation get URL location.
 func getLocation(r *http.Request) string {
 	return path.Clean(r.URL.Path) // Clean any trailing slashes.
@@ -474,21 +482,24 @@ func generateMultiDeleteResponse(quiet bool, deletedObjects []ObjectIdentifier, 
 	return deleteResp
 }
 
-// writeSuccessResponse write success headers and response if any.
-func writeSuccessResponse(w http.ResponseWriter, response []byte) {
+func writeResponse(w http.ResponseWriter, statusCode int, response []byte) {
 	setCommonHeaders(w)
+	w.WriteHeader(statusCode)
 	if response == nil {
-		w.WriteHeader(http.StatusOK)
 		return
 	}
 	w.Write(response)
 	w.(http.Flusher).Flush()
 }
 
+// writeSuccessResponse write success headers and response if any.
+func writeSuccessResponse(w http.ResponseWriter, response []byte) {
+	writeResponse(w, http.StatusOK, response)
+}
+
 // writeSuccessNoContent write success headers with http status 204
 func writeSuccessNoContent(w http.ResponseWriter) {
-	setCommonHeaders(w)
-	w.WriteHeader(http.StatusNoContent)
+	writeResponse(w, http.StatusNoContent, nil)
 }
 
 // writeErrorRespone write error headers


### PR DESCRIPTION
## Description
S3 spec requires that Post Object response depends on the passed success_action_status. This commit implements that requirement.

## Motivation and Context
Fixes #3464 

## How Has This Been Tested?
go test and manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
