### PR TITLE
server: Sort disk arguments for consistent ordering

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	"runtime"
@@ -428,6 +429,12 @@ func serverMain(c *cli.Context) {
 	if !isAnyEndpointLocal(endpoints) {
 		fatalIf(errInvalidArgument, "None of the disks passed as command line args are local to this server.")
 	}
+
+	// Sort endpoints for consistent ordering across multiple
+	// nodes in a distributed setup. This is to avoid format.json
+	// corruption if the disks aren't supplied in the same order
+	// on all nodes.
+	sort.Sort(byHostPath(endpoints))
 
 	storageDisks, err := initStorageDisks(endpoints)
 	fatalIf(err, "Unable to initialize storage disk(s).")

--- a/cmd/url-sort.go
+++ b/cmd/url-sort.go
@@ -1,0 +1,34 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "net/url"
+
+type byHostPath []*url.URL
+
+func (s byHostPath) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byHostPath) Len() int {
+	return len(s)
+}
+
+// Note: Host in url.URL includes the port too.
+func (s byHostPath) Less(i, j int) bool {
+	return (s[i].Host + s[i].Path) < (s[j].Host + s[j].Path)
+}

--- a/cmd/url-sort_test.go
+++ b/cmd/url-sort_test.go
@@ -1,0 +1,99 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"net/url"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestSortByHostPath - tests if ordering of urls are based on
+// host+path concatenated.
+func TestSortByHostPath(t *testing.T) {
+	testCases := []struct {
+		given    []string
+		expected []*url.URL
+	}{
+		{
+			given: []string{
+				"http://abcd.com/a/b/d",
+				"http://abcd.com/a/b/c",
+				"http://abcd.com/a/b/e",
+			},
+			expected: []*url.URL{
+				{
+					Scheme: "http",
+					Host:   "abcd.com:9000",
+					Path:   "/a/b/c",
+				},
+				{
+					Scheme: "http",
+					Host:   "abcd.com:9000",
+					Path:   "/a/b/d",
+				},
+				{
+					Scheme: "http",
+					Host:   "abcd.com:9000",
+					Path:   "/a/b/e",
+				},
+			},
+		},
+		{
+			given: []string{
+				"http://defg.com/a/b/c",
+				"http://abcd.com/a/b/c",
+				"http://hijk.com/a/b/c",
+			},
+			expected: []*url.URL{
+				{
+					Scheme: "http",
+					Host:   "abcd.com:9000",
+					Path:   "/a/b/c",
+				},
+				{
+					Scheme: "http",
+					Host:   "defg.com:9000",
+					Path:   "/a/b/c",
+				},
+				{
+					Scheme: "http",
+					Host:   "hijk.com:9000",
+					Path:   "/a/b/c",
+				},
+			},
+		},
+	}
+
+	saveGlobalPort := globalMinioPort
+	globalMinioPort = "9000"
+	for i, test := range testCases {
+		eps, err := parseStorageEndpoints(test.given)
+		if err != nil {
+			t.Fatalf("Test %d - Failed to parse storage endpoint %v", i+1, err)
+		}
+		sort.Sort(byHostPath(eps))
+		if !sort.IsSorted(byHostPath(eps)) {
+			t.Errorf("Test %d - Expected order %v but got %v", i+1, test.expected, eps)
+		}
+		if !reflect.DeepEqual(eps, test.expected) {
+			t.Errorf("Test %d - Expected order %v but got %v", i+1, test.expected, eps)
+		}
+	}
+	globalMinioPort = saveGlobalPort
+}


### PR DESCRIPTION
This is important in a distributed setup, where the server hosting the
first disk formats a fresh setup. Sorting ensures that all servers
arrive at the same 'first' server.

Note: This change doesn't protect against different disk arguments
with some disks being same across servers.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change implements the sort interface for url.URL type such that disk arguments are sorted based on concatenated Host (incl. port too) and Path. The sorted disk arguments ensure consistent order across servers in a distributed setup.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3425 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested using steps described in #3425 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.