### PR TITLE
Fix: Typo in non canonicalized header extraction

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -83,9 +83,9 @@ func extractMetadataFromHeader(header http.Header) map[string]string {
 	for key := range header {
 		cKey := http.CanonicalHeaderKey(key)
 		if strings.HasPrefix(cKey, "X-Amz-Meta-") {
-			metadata[cKey] = header.Get(cKey)
+			metadata[cKey] = header.Get(key)
 		} else if strings.HasPrefix(key, "X-Minio-Meta-") {
-			metadata[cKey] = header.Get(cKey)
+			metadata[cKey] = header.Get(key)
 		}
 	}
 	// Return.


### PR DESCRIPTION
Extracting metadata from headers was doing wrong when Headers are not well canonicalized, fixing typo.

## Motivation and Context
Manual review

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.