### PR TITLE
bit-rot: Default to sha256 on ARM64.

### DIFF
--- a/cmd/erasure-utils.go
+++ b/cmd/erasure-utils.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/klauspost/reedsolomon"
+	"github.com/minio/sha256-simd"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -37,23 +38,26 @@ func newHashWriters(diskCount int, algo string) []hash.Hash {
 }
 
 // newHash - gives you a newly allocated hash depending on the input algorithm.
-func newHash(algo string) hash.Hash {
+func newHash(algo string) (h hash.Hash) {
 	switch algo {
+	case "sha256":
+		// sha256 checksum specially on ARM64 platforms or whenever
+		// requested as dictated by `xl.json` entry.
+		h = sha256.New()
 	case "blake2b":
 		// ignore the error, because New512 without a key never fails
 		// New512 only returns a non-nil error, if the length of the passed
 		// key > 64 bytes - but we use blake2b as hash fucntion (no key)
-		h, _ := blake2b.New512(nil)
-		return h
+		h, _ = blake2b.New512(nil)
 	// Add new hashes here.
 	default:
 		// Default to blake2b.
 		// ignore the error, because New512 without a key never fails
 		// New512 only returns a non-nil error, if the length of the passed
 		// key > 64 bytes - but we use blake2b as hash fucntion (no key)
-		h, _ := blake2b.New512(nil)
-		return h
+		h, _ = blake2b.New512(nil)
 	}
+	return h
 }
 
 // Hash buffer pool is a pool of reusable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is to utilize an optimized version of
sha256 checksum which @fwessels implemented.

blake2b lacks such optimizations on ARM platform,
this can provide us significant boost in performance.

blake2b on ARM64 as expected would be slower.
```
BenchmarkSize1K-4           	   30000	     44015 ns/op	  23.26 MB/s
BenchmarkSize8K-4           	    5000	    335448 ns/op	  24.42 MB/s
BenchmarkSize32K-4          	    1000	   1333960 ns/op	  24.56 MB/s
BenchmarkSize128K-4         	     300	   5328286 ns/op	  24.60 MB/s
```

sha256 on ARM64 is faster by orders of magnitude giving close to AVX 
performance of blake2b on x86_64.

```
BenchmarkHash8Bytes-4	 1000000	      1446 ns/op	   5.53 MB/s
BenchmarkHash1K-4    	  500000	      3229 ns/op	 317.12 MB/s
BenchmarkHash8K-4    	  100000	     14430 ns/op	 567.69 MB/s
BenchmarkHash1M-4    	    1000	   1640126 ns/op	 639.33 MB/s
```

<!--- Describe your changes in detail -->

## Motivation and Context
Performance gains on ARM64.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and `go test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.