### PR TITLE
fix blake2b tests on non-amd64 machines

### DIFF
--- a/vendor/golang.org/x/crypto/blake2b/blake2b.go
+++ b/vendor/golang.org/x/crypto/blake2b/blake2b.go
@@ -23,6 +23,12 @@ const (
 	Size256 = 32
 )
 
+var (
+	useAVX2 bool
+	useAVX  bool
+	useSSE4 bool
+)
+
 var errKeySize = errors.New("blake2b: invalid key size")
 
 var iv = [8]uint64{

--- a/vendor/golang.org/x/crypto/blake2b/blake2bAVX2_amd64.go
+++ b/vendor/golang.org/x/crypto/blake2b/blake2bAVX2_amd64.go
@@ -6,18 +6,20 @@
 
 package blake2b
 
-var useAVX2 = supportAVX2()
-var useAVX = supportAVX()
-var useSSE4 = supportSSE4()
+func init() {
+	useAVX2 = supportsAVX2()
+	useAVX = supportsAVX()
+	useSSE4 = supportsSSE4()
+}
 
 //go:noescape
-func supportSSE4() bool
+func supportsSSE4() bool
 
 //go:noescape
-func supportAVX() bool
+func supportsAVX() bool
 
 //go:noescape
-func supportAVX2() bool
+func supportsAVX2() bool
 
 //go:noescape
 func hashBlocksAVX2(h *[8]uint64, c *[2]uint64, flag uint64, blocks []byte)

--- a/vendor/golang.org/x/crypto/blake2b/blake2bAVX2_amd64.s
+++ b/vendor/golang.org/x/crypto/blake2b/blake2bAVX2_amd64.s
@@ -489,14 +489,14 @@ noinc:
 	MOVQ BP, SP
 	RET
 
-// func supportAVX2() bool
-TEXT ·supportAVX2(SB), 4, $0-1
+// func supportsAVX2() bool
+TEXT ·supportsAVX2(SB), 4, $0-1
 	MOVQ runtime·support_avx2(SB), AX
 	MOVB AX, ret+0(FP)
 	RET
 
-// func supportAVX() bool
-TEXT ·supportAVX(SB), 4, $0-1
+// func supportsAVX() bool
+TEXT ·supportsAVX(SB), 4, $0-1
 	MOVQ runtime·support_avx(SB), AX
 	MOVB AX, ret+0(FP)
 	RET

--- a/vendor/golang.org/x/crypto/blake2b/blake2b_amd64.go
+++ b/vendor/golang.org/x/crypto/blake2b/blake2b_amd64.go
@@ -6,12 +6,12 @@
 
 package blake2b
 
-var useAVX2 = false
-var useAVX = false
-var useSSE4 = supportSSE4()
+func init() {
+	useSSE4 = supportsSSE4()
+}
 
 //go:noescape
-func supportSSE4() bool
+func supportsSSE4() bool
 
 //go:noescape
 func hashBlocksSSE4(h *[8]uint64, c *[2]uint64, flag uint64, blocks []byte)

--- a/vendor/golang.org/x/crypto/blake2b/blake2b_amd64.s
+++ b/vendor/golang.org/x/crypto/blake2b/blake2b_amd64.s
@@ -280,8 +280,8 @@ noinc:
 	MOVQ BP, SP
 	RET
 
-// func supportSSE4() bool
-TEXT ·supportSSE4(SB), 4, $0-1
+// func supportsSSE4() bool
+TEXT ·supportsSSE4(SB), 4, $0-1
 	MOVL $1, AX
 	CPUID
 	SHRL $19, CX  // Bit 19 indicates SSE4 support

--- a/vendor/golang.org/x/crypto/blake2b/blake2b_ref.go
+++ b/vendor/golang.org/x/crypto/blake2b/blake2b_ref.go
@@ -6,9 +6,6 @@
 
 package blake2b
 
-var useAVX2 = false
-var useSSE4 = false
-
 func hashBlocks(h *[8]uint64, c *[2]uint64, flag uint64, blocks []byte) {
 	hashBlocksGeneric(h, c, flag, blocks)
 }


### PR DESCRIPTION
## Description
Fix the TestHashes Test for non-amd64 machines

See [Gerrit](https://go-review.googlesource.com/#/c/34672/)

## How Has This Been Tested?
Compiled and ran all tests in /cmd for $GOARCH=386
Compiled all tests in /cmd for $GOARCH=arm64

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.