### PR TITLE
Improve reconnection logic, allow jitters.

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -79,13 +79,20 @@ var (
 	globalMinioPort = "9000"
 	// Holds the host that was passed using --address
 	globalMinioHost = ""
+
 	// Peer communication struct
 	globalS3Peers = s3Peers{}
 
 	// CA root certificates, a nil value means system certs pool will be used
 	globalRootCAs *x509.CertPool
 
+	// List of admin peers.
 	globalAdminPeers = adminPeers{}
+
+	// Attempt to retry only this many number of times before
+	// giving up on the remote disk entirely.
+	globalMaxStorageRetryThreshold = 3
+
 	// Add new variable global values here.
 )
 

--- a/cmd/retry-storage_test.go
+++ b/cmd/retry-storage_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"net/rpc"
 	"reflect"
 	"testing"
 )
@@ -41,7 +40,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -54,14 +53,14 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
 	for _, disk := range storageDisks {
 		err = disk.Init()
-		if err != rpc.ErrShutdown {
-			t.Fatal("Expected rpc.ErrShutdown, got", err)
+		if err != errDiskNotFound {
+			t.Fatal("Expected errDiskNotFound, got", err)
 		}
 	}
 
@@ -79,7 +78,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -99,7 +98,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -116,7 +115,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -133,7 +132,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -153,7 +152,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -170,7 +169,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -187,7 +186,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -204,7 +203,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -225,7 +224,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -250,7 +249,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -270,7 +269,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -287,7 +286,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 
@@ -308,7 +307,7 @@ func TestRetryStorage(t *testing.T) {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
 		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: rpc.ErrShutdown,
+			1: errDiskNotFound,
 		}, nil)}
 	}
 

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -90,7 +90,7 @@ func newRetryTimer(unit time.Duration, cap time.Duration, jitter float64, doneCh
 
 	go func() {
 		defer close(attemptCh)
-		var nextBackoff int
+		nextBackoff := 1
 		for {
 			select {
 			// Attempts starts.

--- a/cmd/storage-rpc-client_test.go
+++ b/cmd/storage-rpc-client_test.go
@@ -52,7 +52,7 @@ func TestStorageErr(t *testing.T) {
 			err:         &net.OpError{},
 		},
 		{
-			expectedErr: rpc.ErrShutdown,
+			expectedErr: errDiskNotFound,
 			err:         rpc.ErrShutdown,
 		},
 		{

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -65,6 +65,9 @@ func init() {
 
 	// Enable caching.
 	setMaxMemory()
+
+	// Tests don't need to retry.
+	globalMaxStorageRetryThreshold = 1
 }
 
 func prepareFS() (ObjectLayer, string, error) {
@@ -1945,6 +1948,12 @@ func ExecObjectLayerTest(t TestErrHandler, objTest objTestType) {
 // ExecObjectLayerDiskAlteredTest - executes object layer tests while altering
 // disks in between tests. Creates XL ObjectLayer instance and runs test for XL layer.
 func ExecObjectLayerDiskAlteredTest(t *testing.T, objTest objTestDiskNotFoundType) {
+	configPath, err := newTestConfig("us-east-1")
+	if err != nil {
+		t.Fatal("Failed to create config directory", err)
+	}
+	defer removeAll(configPath)
+
 	objLayer, fsDirs, err := prepareXL()
 	if err != nil {
 		t.Fatalf("Initialization of object layer failed for XL setup: %s", err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is needed since any network operation error
is converted to disk not found but we also need
to make sure really if disk is not available.

Additionally we also need to retry more than
once because the server might be in startup
sequence which would render other servers to
wrongly think that the server is offline.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3372 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using a distributed setup using `y4m4/minio` docker image.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.