### PR TITLE
syntax highlighting : Remove sh from code block which incorrectly hig…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Minio server is light enough to be bundled with the application stack, similar t
 
 ## Docker Container
 ### Stable
-```sh
+```
 docker pull minio/minio
 docker run -p 9000:9000 minio/minio server /export
 ```
 
 ### Edge
-```sh
+```
 docker pull minio/minio:edge
 docker run -p 9000:9000 minio/minio:edge server /export
 ```


### PR DESCRIPTION
…hlights shell commands.

Shell commands are sometimes incorrectly highlighted. Turn off highlighting for those code blocks.

## Description
 
By removing ```sh and replacing with plain ``` we can turn off highlighting.

## Motivation and Context
 Presents better.
 https://github.com/minio/doctor/issues/266

## How Has This Been Tested?
Previewed on github.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.