### PR TITLE
Auto-reconnect for regular authRPC client.

### DIFF
--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"net/rpc"
 	"net/url"
 	"path"
 	"sync"
@@ -58,22 +57,14 @@ func (lc localAdminClient) Restart() error {
 func (rc remoteAdminClient) Stop() error {
 	args := GenericArgs{}
 	reply := GenericReply{}
-	err := rc.Call("Service.Shutdown", &args, &reply)
-	if err != nil && err == rpc.ErrShutdown {
-		rc.Close()
-	}
-	return err
+	return rc.Call("Service.Shutdown", &args, &reply)
 }
 
 // Restart - Sends restart command to remote server via RPC.
 func (rc remoteAdminClient) Restart() error {
 	args := GenericArgs{}
 	reply := GenericReply{}
-	err := rc.Call("Service.Restart", &args, &reply)
-	if err != nil && err == rpc.ErrShutdown {
-		rc.Close()
-	}
-	return err
+	return rc.Call("Service.Restart", &args, &reply)
 }
 
 // adminPeer - represents an entity that implements Stop and Restart methods.

--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -16,10 +16,7 @@
 
 package cmd
 
-import (
-	"encoding/json"
-	"net/rpc"
-)
+import "encoding/json"
 
 // BucketMetaState - Interface to update bucket metadata in-memory
 // state.
@@ -112,62 +109,26 @@ type remoteBucketMetaState struct {
 // change to remote peer via RPC call.
 func (rc *remoteBucketMetaState) UpdateBucketNotification(args *SetBucketNotificationPeerArgs) error {
 	reply := GenericReply{}
-	err := rc.Call("S3.SetBucketNotificationPeer", args, &reply)
-	// Check for network error and retry once.
-	if err != nil && err == rpc.ErrShutdown {
-		// Close the underlying connection to attempt once more.
-		rc.Close()
-
-		// Attempt again and proceed.
-		err = rc.Call("S3.SetBucketNotificationPeer", args, &reply)
-	}
-	return err
+	return rc.Call("S3.SetBucketNotificationPeer", args, &reply)
 }
 
 // remoteBucketMetaState.UpdateBucketListener - sends bucket listener change to
 // remote peer via RPC call.
 func (rc *remoteBucketMetaState) UpdateBucketListener(args *SetBucketListenerPeerArgs) error {
 	reply := GenericReply{}
-	err := rc.Call("S3.SetBucketListenerPeer", args, &reply)
-	// Check for network error and retry once.
-	if err != nil && err == rpc.ErrShutdown {
-		// Close the underlying connection to attempt once more.
-		rc.Close()
-
-		// Attempt again and proceed.
-		err = rc.Call("S3.SetBucketListenerPeer", args, &reply)
-	}
-	return err
+	return rc.Call("S3.SetBucketListenerPeer", args, &reply)
 }
 
 // remoteBucketMetaState.UpdateBucketPolicy - sends bucket policy change to remote
 // peer via RPC call.
 func (rc *remoteBucketMetaState) UpdateBucketPolicy(args *SetBucketPolicyPeerArgs) error {
 	reply := GenericReply{}
-	err := rc.Call("S3.SetBucketPolicyPeer", args, &reply)
-	// Check for network error and retry once.
-	if err != nil && err == rpc.ErrShutdown {
-		// Close the underlying connection to attempt once more.
-		rc.Close()
-
-		// Attempt again and proceed.
-		err = rc.Call("S3.SetBucketPolicyPeer", args, &reply)
-	}
-	return err
+	return rc.Call("S3.SetBucketPolicyPeer", args, &reply)
 }
 
 // remoteBucketMetaState.SendEvent - sends event for bucket listener to remote
 // peer via RPC call.
 func (rc *remoteBucketMetaState) SendEvent(args *EventArgs) error {
 	reply := GenericReply{}
-	err := rc.Call("S3.Event", args, &reply)
-	// Check for network error and retry once.
-	if err != nil && err == rpc.ErrShutdown {
-		// Close the underlying connection to attempt once more.
-		rc.Close()
-
-		// Attempt again and proceed.
-		err = rc.Call("S3.Event", args, &reply)
-	}
-	return err
+	return rc.Call("S3.Event", args, &reply)
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -93,6 +93,10 @@ var (
 	// giving up on the remote disk entirely.
 	globalMaxStorageRetryThreshold = 3
 
+	// Attempt to retry only this many number of times before
+	// giving up on the remote RPC entirely.
+	globalMaxAuthRPCRetryThreshold = 1
+
 	// Add new variable global values here.
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implement a storage rpc specific rpc client,
which does not reconnect unnecessarily.

Instead reconnect is handled at a different
layer for storage alone.

Rest of the calls using AuthRPC automatically
reconnect, i.e upon an error equal to `rpc.ErrShutdown`
they dial again and call the requested method again.

<!--- Describe your changes in detail -->

## Motivation and Context
To have auto reconnect login for all AuthRPC consumers.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually, distributed setup. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.