### PR TITLE
Fix delays and iterim fix for the partial fix in #3502

### DIFF
--- a/cmd/auth-rpc-client.go
+++ b/cmd/auth-rpc-client.go
@@ -22,6 +22,10 @@ import (
 	"time"
 )
 
+// Attempt to retry only this many number of times before
+// giving up on the remote RPC entirely.
+const globalAuthRPCRetryThreshold = 1
+
 // GenericReply represents any generic RPC reply.
 type GenericReply struct{}
 
@@ -165,7 +169,7 @@ func (authClient *AuthRPCClient) Call(serviceMethod string, args interface {
 			authClient.Close()
 
 			// No need to return error until the retry count threshold has reached.
-			if i < globalMaxAuthRPCRetryThreshold {
+			if i < globalAuthRPCRetryThreshold {
 				continue
 			}
 		}

--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestNewFS - tests initialization of all input disks
@@ -86,7 +87,12 @@ func TestNewFS(t *testing.T) {
 	if err != errInvalidArgument {
 		t.Errorf("Expecting error invalid argument, got %s", err)
 	}
-	_, err = newFSObjects(&retryStorage{xlStorageDisks[0]})
+	_, err = newFSObjects(&retryStorage{
+		remoteStorage:    xlStorageDisks[0],
+		maxRetryAttempts: 1,
+		retryUnit:        time.Millisecond,
+		retryCap:         time.Millisecond * 10,
+	})
 	if err != nil {
 		errMsg := "Unable to recognize backend format, Disk is not in FS format."
 		if err.Error() == errMsg {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -89,14 +89,6 @@ var (
 	// List of admin peers.
 	globalAdminPeers = adminPeers{}
 
-	// Attempt to retry only this many number of times before
-	// giving up on the remote disk entirely.
-	globalMaxStorageRetryThreshold = 3
-
-	// Attempt to retry only this many number of times before
-	// giving up on the remote RPC entirely.
-	globalMaxAuthRPCRetryThreshold = 1
-
 	// Add new variable global values here.
 )
 

--- a/cmd/retry-storage_test.go
+++ b/cmd/retry-storage_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
+	"time"
 )
 
 // Tests retry storage.
@@ -39,9 +40,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	// Validate all the conditions for retrying calls.
@@ -52,9 +58,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -77,9 +88,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -97,9 +113,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -114,9 +135,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -131,9 +157,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -151,9 +182,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -168,9 +204,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -185,9 +226,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -202,9 +248,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -223,9 +274,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -248,9 +304,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -268,9 +329,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -285,9 +351,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {
@@ -306,9 +377,14 @@ func TestRetryStorage(t *testing.T) {
 		if !ok {
 			t.Fatal("storage disk is not *retryStorage type")
 		}
-		storageDisks[i] = &retryStorage{newNaughtyDisk(retryDisk, map[int]error{
-			1: errDiskNotFound,
-		}, nil)}
+		storageDisks[i] = &retryStorage{
+			remoteStorage: newNaughtyDisk(retryDisk, map[int]error{
+				1: errDiskNotFound,
+			}, nil),
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}
 	}
 
 	for _, disk := range storageDisks {

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -90,7 +90,7 @@ func newRetryTimer(unit time.Duration, cap time.Duration, jitter float64, doneCh
 
 	go func() {
 		defer close(attemptCh)
-		nextBackoff := 1
+		nextBackoff := 0
 		for {
 			select {
 			// Attempts starts.

--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -241,8 +241,14 @@ func (n *networkStorage) String() string {
 	return n.netAddr + ":" + n.netPath
 }
 
-// maximum allowed network IOError.
-const maxAllowedNetworkIOError = 1024
+// Network IO error count is kept at 256 with some simple
+// math. Before we reject the disk completely. The combination
+// of retry logic and total error count roughly comes around
+// 2.5secs ( 2 * 5 * time.Millisecond * 256) which is when we
+// basically take the disk offline completely. This is considered
+// sufficient time tradeoff to avoid large delays in-terms of
+// incoming i/o.
+const maxAllowedNetworkIOError = 256 // maximum allowed network IOError.
 
 // Initializes the remote RPC connection by attempting a login attempt.
 func (n *networkStorage) Init() (err error) {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -65,9 +65,6 @@ func init() {
 
 	// Enable caching.
 	setMaxMemory()
-
-	// Tests don't need to retry.
-	globalMaxStorageRetryThreshold = 1
 }
 
 func prepareFS() (ObjectLayer, string, error) {
@@ -1656,7 +1653,12 @@ func prepareNErroredDisks(storageDisks []StorageAPI, offline int, err error, t *
 	}
 
 	for i := 0; i < offline; i++ {
-		storageDisks[i] = &naughtyDisk{disk: &retryStorage{storageDisks[i]}, defaultErr: err}
+		storageDisks[i] = &naughtyDisk{disk: &retryStorage{
+			remoteStorage:    storageDisks[i],
+			maxRetryAttempts: 1,
+			retryUnit:        time.Millisecond,
+			retryCap:         time.Millisecond * 10,
+		}, defaultErr: err}
 	}
 	return storageDisks
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This patch uses a technique where in a retryable storage
before object layer initialization has a higher delay
and waits for longer period upto 4 times with time unit
of seconds.

And uses another set of configuration after the disks
have been formatted, i.e use a lower retry backoff rate
and retrying only once per 5 millisecond.

Network IO error count is reduced to a lower value i.e 256
before we reject the disk completely. This is done so that
combination of retry logic and total error count roughly
come to around 2.5secs which is when we basically take the
disk offline completely.

NOTE: This patch doesn't fix the issue of what if the disk
is completely dead and comes back again after the initialization. 
Such a mutating state requires a change in our startup sequence 
which will be done subsequently. This is an interim fix to alleviate
users from these issues.

<!--- Describe your changes in detail -->

## Motivation and Context
Ongoing problems to be addressed regarding re-connection of disks upon network disconnection.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using `y4m4/minio` based distributed setup. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.