### PR TITLE
checkdeps.sh: support unusual git version strings (for OS X et. al.)

### DIFF
--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -144,7 +144,8 @@ assert_check_golang_env() {
 }
 
 assert_check_deps() {
-    installed_git_version=$(git version | awk '{print $NF}')
+    # support unusual Git versions such as: 2.7.4 (Apple Git-66)
+    installed_git_version=$(git version | perl -ne '$_ =~ m/git version (.*?)( |$)/; print "$1\n";')
     if ! check_minimum_version "${GIT_VERSION}" "${installed_git_version}"; then
         echo "ERROR"
         echo "Git version '${installed_git_version}' not supported."


### PR DESCRIPTION
## Description
Fixes shell errors that will occur if Apple Git is used for development:

```sh
/Users/mhall/go/src/github.com/minio/minio/buildscripts/checkdeps.sh: line 75: [[: Git-66): syntax error in expression (error token is ")")
/Users/mhall/go/src/github.com/minio/minio/buildscripts/checkdeps.sh: line 77: [[: Git-66): syntax error in expression (error token is ")")
```

## Motivation and Context
Prevents potential problems / cleans up the Minio development process for a common type of environment.

## How Has This Been Tested?

1. Fed in unusual Apple and standard Git versions by hand on the CLI and it works.
2. Reran the build with the added code and it works.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I don't believe the other items apply here but let me know.