### PR TITLE
presign/v2: unescape non-std queries in urls

### DIFF
--- a/cmd/signature-v2.go
+++ b/cmd/signature-v2.go
@@ -111,13 +111,18 @@ func doesPresignV2SignatureMatch(r *http.Request) APIErrorCode {
 		case "Expires":
 			expires, err = url.QueryUnescape(keyval[1])
 		default:
-			filteredQueries = append(filteredQueries, query)
+			unescapedQuery, qerr := url.QueryUnescape(query)
+			if qerr == nil {
+				filteredQueries = append(filteredQueries, unescapedQuery)
+			} else {
+				err = qerr
+			}
 		}
-	}
-	// Check if the query unescaped properly.
-	if err != nil {
-		errorIf(err, "Unable to unescape query values", queries)
-		return ErrInvalidQueryParams
+		// Check if the query unescaped properly.
+		if err != nil {
+			errorIf(err, "Unable to unescape query values", queries)
+			return ErrInvalidQueryParams
+		}
 	}
 
 	// Invalid access key.


### PR DESCRIPTION
A client sends escaped characters in values of some query parameters in a presign url.
This commit properly unescapes queires to fix signature calculation.

## Motivation and Context
Fixes #3547 

## How Has This Been Tested?
go test + Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.