### PR TITLE
heal: Fix new entries computation in listDirHeal 

### DIFF
--- a/cmd/xl-v1-list-objects-heal.go
+++ b/cmd/xl-v1-list-objects-heal.go
@@ -58,7 +58,9 @@ func listDirHealFactory(isLeaf isLeafFunc, disks ...StorageAPI) listDirFunc {
 			// find elements in entries which are not in mergedentries
 			for _, entry := range entries {
 				idx := sort.SearchStrings(mergedEntries, entry)
-				if mergedEntries[idx] == entry {
+				// idx different from len(mergedEntries) means entry is not found
+				// in mergedEntries
+				if idx < len(mergedEntries) {
 					continue
 				}
 				newEntries = append(newEntries, entry)


### PR DESCRIPTION
## Description
A crash was happening due to an incorrect interpreation of the return value of sort.SearchString()

## Motivation and Context
Manual tests - fixes #3000 

## How Has This Been Tested?
go test + manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.