### PR TITLE
handlers: Handle crash if r.URL.Path is empty.

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -311,18 +311,7 @@ var notimplementedObjectResourceNames = map[string]bool{
 
 // Resource handler ServeHTTP() wrapper
 func (h resourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Skip the first element which is usually '/' and split the rest.
-	splits := strings.SplitN(r.URL.Path[1:], "/", 2)
-
-	// Save bucketName and objectName extracted from url Path.
-	var bucketName, objectName string
-	if len(splits) == 1 {
-		bucketName = splits[0]
-	}
-	if len(splits) == 2 {
-		bucketName = splits[0]
-		objectName = splits[1]
-	}
+	bucketName, objectName := urlPath2BucketObjectName(r.URL)
 
 	// If bucketName is present and not objectName check for bucket level resource queries.
 	if bucketName != "" && objectName == "" {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -70,6 +70,38 @@ func checkDuplicateStrings(list []string) error {
 	return nil
 }
 
+// splitStr splits a string into n parts, empty strings are added
+// if we are not able to reach n elements
+func splitStr(path, sep string, n int) []string {
+	splits := strings.SplitN(path, sep, n)
+	// Add empty strings if we found elements less than nr
+	for i := n - len(splits); i > 0; i-- {
+		splits = append(splits, "")
+	}
+	return splits
+}
+
+// Convert url path into bucket and object name.
+func urlPath2BucketObjectName(u *url.URL) (bucketName, objectName string) {
+	if u == nil {
+		// Empty url, return bucket and object names.
+		return
+	}
+
+	// Trim any preceding slash separator.
+	urlPath := strings.TrimPrefix(u.Path, slashSeparator)
+
+	// Split urlpath using slash separator into a given number of
+	// expected tokens.
+	tokens := splitStr(urlPath, slashSeparator, 2)
+
+	// Extract bucket and objects.
+	bucketName, objectName = tokens[0], tokens[1]
+
+	// Success.
+	return bucketName, objectName
+}
+
 // checkDuplicates - function to validate if there are duplicates in a slice of endPoints.
 func checkDuplicateEndpoints(endpoints []*url.URL) error {
 	var strs []string

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -220,6 +220,94 @@ func TestMaxPartID(t *testing.T) {
 	}
 }
 
+// Tests extracting bucket and objectname from various types of URL paths.
+func TestURL2BucketObjectName(t *testing.T) {
+	testCases := []struct {
+		u              *url.URL
+		bucket, object string
+	}{
+		// Test case 1 normal case.
+		{
+			u: &url.URL{
+				Path: "/bucket/object",
+			},
+			bucket: "bucket",
+			object: "object",
+		},
+		// Test case 2 where url only has separator.
+		{
+			u: &url.URL{
+				Path: "/",
+			},
+			bucket: "",
+			object: "",
+		},
+		// Test case 3 only bucket is present.
+		{
+			u: &url.URL{
+				Path: "/bucket",
+			},
+			bucket: "bucket",
+			object: "",
+		},
+		// Test case 4 many separators and object is a directory.
+		{
+			u: &url.URL{
+				Path: "/bucket/object/1/",
+			},
+			bucket: "bucket",
+			object: "object/1/",
+		},
+		// Test case 5 object has many trailing separators.
+		{
+			u: &url.URL{
+				Path: "/bucket/object/1///",
+			},
+			bucket: "bucket",
+			object: "object/1///",
+		},
+		// Test case 6 object has only trailing separators.
+		{
+			u: &url.URL{
+				Path: "/bucket/object///////",
+			},
+			bucket: "bucket",
+			object: "object///////",
+		},
+		// Test case 7 object has preceding separators.
+		{
+			u: &url.URL{
+				Path: "/bucket////object////",
+			},
+			bucket: "bucket",
+			object: "///object////",
+		},
+		// Test case 8 url is not allocated.
+		{
+			u:      nil,
+			bucket: "",
+			object: "",
+		},
+		// Test case 9 url path is empty.
+		{
+			u:      &url.URL{},
+			bucket: "",
+			object: "",
+		},
+	}
+
+	// Validate all test cases.
+	for i, testCase := range testCases {
+		bucketName, objectName := urlPath2BucketObjectName(testCase.u)
+		if bucketName != testCase.bucket {
+			t.Errorf("Test %d: failed expected bucket name \"%s\", got \"%s\"", i+1, testCase.bucket, bucketName)
+		}
+		if objectName != testCase.object {
+			t.Errorf("Test %d: failed expected bucket name \"%s\", got \"%s\"", i+1, testCase.object, objectName)
+		}
+	}
+}
+
 // Add tests for starting and stopping different profilers.
 func TestStartProfiler(t *testing.T) {
 	if startProfiler("") != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
URL paths can be empty and not have preceding separator,
we do not yet know the conditions this can happen inside
Go http server.

This patch is to ensure that we do not crash ourselves
under conditions where r.URL.Path may be empty.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3553

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually no reproducible case available.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.