### PR TITLE
ssl: Set a global boolean to enable SSL across Minio

### DIFF
--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -125,7 +125,7 @@ func makeAdminPeers(eps []*url.URL) adminPeers {
 				accessKey:       serverCred.AccessKey,
 				secretKey:       serverCred.SecretKey,
 				serverAddr:      ep.Host,
-				secureConn:      isSSL(),
+				secureConn:      globalIsSSL,
 				serviceEndpoint: path.Join(reservedBucket, adminPath),
 				serviceName:     "Admin",
 			}

--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -106,7 +106,7 @@ func updateCredsOnPeers(creds credential) map[string]error {
 				accessKey:       serverCred.AccessKey,
 				secretKey:       serverCred.SecretKey,
 				serverAddr:      peers[ix],
-				secureConn:      isSSL(),
+				secureConn:      globalIsSSL,
 				serviceEndpoint: path.Join(reservedBucket, browserPeerPath),
 				serviceName:     "Browser",
 			})

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -90,6 +90,9 @@ var (
 	// CA root certificates, a nil value means system certs pool will be used
 	globalRootCAs *x509.CertPool
 
+	// IsSSL indicates if the server is configured with SSL.
+	globalIsSSL bool
+
 	// List of admin peers.
 	globalAdminPeers = adminPeers{}
 
@@ -124,4 +127,7 @@ func setGlobalsFromContext(c *cli.Context) {
 	}
 	// Set global quiet flag.
 	globalQuiet = c.Bool("quiet") || c.GlobalBool("quiet")
+
+	// Is TLS configured?.
+	globalIsSSL = isSSL()
 }

--- a/cmd/lock-rpc-server.go
+++ b/cmd/lock-rpc-server.go
@@ -289,7 +289,7 @@ func (l *lockServer) lockMaintenance(interval time.Duration) {
 			secretKey:       serverCred.SecretKey,
 			serverAddr:      nlrip.lri.node,
 			serviceEndpoint: nlrip.lri.rpcPath,
-			secureConn:      isSSL(),
+			secureConn:      globalIsSSL,
 			serviceName:     "Dsync",
 		})
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -164,7 +164,10 @@ func checkUpdate() {
 }
 
 // Generic Minio initialization to create/load config, prepare loggers, etc..
-func minioInit() {
+func minioInit(ctx *cli.Context) {
+	// Set global variables after parsing passed arguments
+	setGlobalsFromContext(ctx)
+
 	// Sets new config directory.
 	setGlobalConfigPath(globalConfigDir)
 

--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -44,7 +44,7 @@ func initDsyncNodes(eps []*url.URL) error {
 			secretKey:       cred.SecretKey,
 			serverAddr:      ep.Host,
 			serviceEndpoint: pathutil.Join(lockRPCPath, getPath(ep)),
-			secureConn:      isSSL(),
+			secureConn:      globalIsSSL,
 			serviceName:     "Dsync",
 		})
 		if isLocalStorage(ep) && myNode == -1 {

--- a/cmd/prepare-storage-msg.go
+++ b/cmd/prepare-storage-msg.go
@@ -99,11 +99,7 @@ func getHealEndpoint(tls bool, firstEndpoint *url.URL) (cEndpoint *url.URL) {
 func getHealMsg(endpoints []*url.URL, storageDisks []StorageAPI) string {
 	msg := fmt.Sprintln("\nData volume requires HEALING. Healing is not implemented yet stay tuned:")
 	// FIXME:  Enable this after we bring in healing.
-	//	msg += "MINIO_ACCESS_KEY=%s "
-	//	msg += "MINIO_SECRET_KEY=%s "
-	//	msg += "minio control heal %s"
-	//	creds := serverConfig.GetCredential()
-	//	msg = fmt.Sprintf(msg, creds.AccessKey, creds.SecretKey, getHealEndpoint(isSSL(), endpoints[0]))
+	//	msg := "mc admin heal myminio"
 	disksInfo, _, _ := getDisksInfo(storageDisks)
 	for i, info := range disksInfo {
 		if storageDisks[i] == nil {

--- a/cmd/s3-peer-client.go
+++ b/cmd/s3-peer-client.go
@@ -67,7 +67,7 @@ func makeS3Peers(eps []*url.URL) s3Peers {
 				secretKey:       serverCred.SecretKey,
 				serverAddr:      ep.Host,
 				serviceEndpoint: path.Join(reservedBucket, s3Path),
-				secureConn:      isSSL(),
+				secureConn:      globalIsSSL,
 				serviceName:     "S3",
 			}
 

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -67,7 +67,7 @@ func printStartupMessage(apiEndPoints []string) {
 
 	// SSL is configured reads certification chain, prints
 	// authority and expiry.
-	if isSSL() {
+	if globalIsSSL {
 		certs, err := readCertificateChain()
 		fatalIf(err, "Unable to read certificate chain.")
 		printCertificateMsg(certs)

--- a/cmd/server-startup-utils.go
+++ b/cmd/server-startup-utils.go
@@ -40,22 +40,27 @@ func getListenIPs(serverAddr string) (hosts []string, port string, err error) {
 		}
 		return hosts, port, nil
 	} // if host != "" {
+
 	// Proceed to append itself, since user requested a specific endpoint.
 	hosts = append(hosts, host)
+
+	// Success.
 	return hosts, port, nil
 }
 
 // Finalizes the API endpoints based on the host list and port.
-func finalizeAPIEndpoints(tls bool, apiServer *http.Server) (endPoints []string) {
+func finalizeAPIEndpoints(apiServer *http.Server) (endPoints []string, err error) {
 	// Verify current scheme.
 	scheme := "http"
-	if tls {
+	if globalIsSSL {
 		scheme = "https"
 	}
 
 	// Get list of listen ips and port.
-	hosts, port, err := getListenIPs(apiServer.Addr)
-	fatalIf(err, "Unable to get list of ips to listen on")
+	hosts, port, err1 := getListenIPs(apiServer.Addr)
+	if err1 != nil {
+		return nil, err1
+	}
 
 	// Construct proper endpoints.
 	for _, host := range hosts {
@@ -63,5 +68,5 @@ func finalizeAPIEndpoints(tls bool, apiServer *http.Server) (endPoints []string)
 	}
 
 	// Success.
-	return endPoints
+	return endPoints, nil
 }

--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -121,7 +121,7 @@ func newStorageRPC(ep *url.URL) (StorageAPI, error) {
 			secretKey:        secretKey,
 			serverAddr:       rpcAddr,
 			serviceEndpoint:  rpcPath,
-			secureConn:       isSSL(),
+			secureConn:       globalIsSSL,
 			serviceName:      "Storage",
 			disableReconnect: true,
 		}),

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -265,12 +265,8 @@ func getReleaseUpdate(updateURL string, duration time.Duration) (updateMsg updat
 
 // main entry point for update command.
 func mainUpdate(ctx *cli.Context) {
-
-	// Set global variables after parsing passed arguments
-	setGlobalsFromContext(ctx)
-
 	// Initialization routine, such as config loading, enable logging, ..
-	minioInit()
+	minioInit(ctx)
 
 	if globalQuiet {
 		return

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -44,11 +44,8 @@ func mainVersion(ctx *cli.Context) {
 		cli.ShowCommandHelpAndExit(ctx, "version", 1)
 	}
 
-	// Set global variables after parsing passed arguments
-	setGlobalsFromContext(ctx)
-
 	// Initialization routine, such as config loading, enable logging, ..
-	minioInit()
+	minioInit(ctx)
 
 	if globalQuiet {
 		return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We have been using `isSSL()` everywhere we can set
a global value once and re-use it again.
<!--- Describe your changes in detail -->

## Motivation and Context
Cleanup and some simplification.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using local certs.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.