### PR TITLE
notify/webhook: Handle webendpoints without port

### DIFF
--- a/cmd/notify-webhook.go
+++ b/cmd/notify-webhook.go
@@ -37,13 +37,13 @@ type httpConn struct {
 	Endpoint string
 }
 
-// Lookup host address by dialing.
-func lookupHost(addr string) error {
+// Lookup endpoint address by successfully dialing.
+func lookupEndpoint(u *url.URL) error {
 	dialer := &net.Dialer{
 		Timeout:   300 * time.Millisecond,
 		KeepAlive: 300 * time.Millisecond,
 	}
-	nconn, err := dialer.Dial("tcp", addr)
+	nconn, err := dialer.Dial("tcp", canonicalAddr(u))
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func newWebhookNotify(accountID string) (*logrus.Logger, error) {
 		return nil, err
 	}
 
-	if err = lookupHost(u.Host); err != nil {
+	if err = lookupEndpoint(u); err != nil {
 		return nil, err
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -102,6 +102,24 @@ func urlPath2BucketObjectName(u *url.URL) (bucketName, objectName string) {
 	return bucketName, objectName
 }
 
+var portMap = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }
+
+// canonicalAddr returns url.Host but always with a ":port" suffix
+func canonicalAddr(u *url.URL) string {
+	addr := u.Host
+	if !hasPort(addr) {
+		return addr + ":" + portMap[u.Scheme]
+	}
+	return addr
+}
+
 // checkDuplicates - function to validate if there are duplicates in a slice of endPoints.
 func checkDuplicateEndpoints(endpoints []*url.URL) error {
 	var strs []string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes and issue initializing webhook notification

```
FATA[0000] Initializing object layer failed              cause=Unable to initialize event \
    notification. dial tcp: missing port in address requestb.in source=[server-main.go:448:serverMain()]
```

<!--- Describe your changes in detail -->

## Motivation and Context
Handle generic endpoints
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Using request.bin
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.