### PR TITLE
peer rpc: Fix typo in cluster credentials update

### DIFF
--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -108,7 +108,7 @@ func updateCredsOnPeers(creds credential) map[string]error {
 				serverAddr:      peers[ix],
 				secureConn:      globalIsSSL,
 				serviceEndpoint: path.Join(reservedBucket, browserPeerPath),
-				serviceName:     "Browser",
+				serviceName:     "BrowserPeer",
 			})
 
 			// Construct RPC call arguments.
@@ -116,14 +116,14 @@ func updateCredsOnPeers(creds credential) map[string]error {
 
 			// Make RPC call - we only care about error
 			// response and not the reply.
-			err := client.Call("Browser.SetAuthPeer", &args, &AuthRPCReply{})
+			err := client.Call("BrowserPeer.SetAuthPeer", &args, &AuthRPCReply{})
 
 			// We try a bit hard (3 attempts with 1 second delay)
 			// to set creds on peers in case of failure.
 			if err != nil {
 				for i := 0; i < 2; i++ {
 					time.Sleep(1 * time.Second) // 1 second delay.
-					err = client.Call("Browser.SetAuthPeer", &args, &AuthRPCReply{})
+					err = client.Call("BrowserPeer.SetAuthPeer", &args, &AuthRPCReply{})
 					if err == nil {
 						break
 					}


### PR DESCRIPTION
## Description
Update credentials in cluster wasn't working due to a typo

## Motivation and Context
Fixing a bug

## How Has This Been Tested?
Manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.