### PR TITLE
add delete and options methods to CORS whitelist

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -253,7 +253,7 @@ type resourceHandler struct {
 func setCorsHandler(h http.Handler) http.Handler {
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
-		AllowedMethods: []string{"GET", "HEAD", "POST", "PUT"},
+		AllowedMethods: []string{"GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders: []string{"*"},
 		ExposedHeaders: []string{"ETag"},
 	})


### PR DESCRIPTION
## Description
Adds `DELETE` and `OPTIONS` to CORS allowed methods.

## Motivation and Context
Noticed a CORS issue when deleting an object. Since `PUT` and `PATCH` are already destructive methods, omitting `DELETE` from whitelisted methods no longer makes sense.

## How Has This Been Tested?
Ensured existed automated tests pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.