### PR TITLE
check if have free space before creating file

### DIFF
--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -23,6 +23,7 @@ type ObjectLayer interface {
 	// Storage operations.
 	Shutdown() error
 	StorageInfo() StorageInfo
+	CanCreateFile(fileSize int64) error // check if have sufficient resources for the file
 
 	// Bucket operations.
 	MakeBucket(bucket string) error

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -326,6 +326,12 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Check if have available space
+	if err = objectAPI.CanCreateFile(objInfo.Size); err != nil {
+		writeErrorResponse(w, ErrStorageFull, r.URL)
+		return
+	}
+
 	defaultMeta := objInfo.UserDefined
 
 	// Make sure to remove saved md5sum, object might have been uploaded
@@ -417,6 +423,12 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	/// maximum Upload size for objects in a single operation
 	if isMaxObjectSize(size) {
 		writeErrorResponse(w, ErrEntityTooLarge, r.URL)
+		return
+	}
+
+	// Check if have available space
+	if err = objectAPI.CanCreateFile(size); err != nil {
+		writeErrorResponse(w, ErrStorageFull, r.URL)
 		return
 	}
 
@@ -572,6 +584,12 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	/// maximum Upload size for multipart objects in a single operation
 	if isMaxObjectSize(size) {
 		writeErrorResponse(w, ErrEntityTooLarge, r.URL)
+		return
+	}
+
+	// Check if have available space
+	if err = objectAPI.CanCreateFile(size); err != nil {
+		writeErrorResponse(w, ErrStorageFull, r.URL)
 		return
 	}
 

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -249,3 +249,12 @@ func (xl xlObjects) StorageInfo() StorageInfo {
 	storageInfo.Backend.WriteQuorum = xl.writeQuorum
 	return storageInfo
 }
+
+// Check if have sufficient resources for the file
+func (xl xlObjects) CanCreateFile(fileSize int64) error {
+	/* Currently xl storage backend doesn't check if it has available space when initializing
+	and when creating file.
+	TODO implement. See fs backend
+	*/
+	return nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Check if having available space before writing file to the storage


## Description
<!--- Describe your changes in detail -->
This PR adds check for free space for PutObject PutObjectPart and CopyObject.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We often face a situation when 
1. Files are written to minio until the storage is 100% full
2. Minio get's stopped
3. Minio refuses to start because of [this check](https://github.com/minio/minio/blob/master/cmd/fs-v1.go#L157)


It is impossible to start minio and delete some files from S3 to free space. The only way to get minio working again is mounting it's volume and manually deleting some files.

After this patch it will be still possible to get 100% full storage, i.e. by concurrent requests, but the probability is much less. Need to discuss, why minio refuses to start if FS is full. I'd prefer to have storage available for Read and Delete.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are tests for PutObject and PutObjectPart.
I've tried to make a test for CopyObject, but it requres stateful storage backend mock and is much more complicated then the code itself.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This patch decreases available storage capacity by `minFreeSpace`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.