### PR TITLE
Don't Check Available Inodes on NFS

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -199,7 +199,7 @@ func (fs fsObjects) checkDiskFree() (err error) {
 	// are allocated based on available disk space. For example CephFS, StoreNext CVFS, AzureFile driver.
 	// Allow for the available disk to be separately validate and we will validate inodes only if
 	// total inodes are provided by the underlying filesystem.
-	if di.Files != 0 {
+	if di.Files != 0 && di.FSType != "NFS" {
 		availableFiles := int64(di.Ffree)
 		if availableFiles <= fs.minFreeInodes {
 			return errDiskFull

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -177,7 +177,7 @@ func (s *posix) checkDiskFree() (err error) {
 	// are allocated based on available disk space. For example CephFS, StoreNext CVFS, AzureFile driver.
 	// Allow for the available disk to be separately validate and we will validate inodes only if
 	// total inodes are provided by the underlying filesystem.
-	if di.Files != 0 {
+	if di.Files != 0 && di.FSType != "NFS" {
 		availableFiles := int64(di.Ffree)
 		if availableFiles <= s.minFreeInodes {
 			return errDiskFull


### PR DESCRIPTION
## Description
Skipping the free inode check on startup when the filesystem is NFS

## Motivation and Context
In some cases (such as with VirutualBox, this value gets hardcoded
to 1000, which is less than the required minimum of 10000.

Fixes #3592

## How Has This Been Tested?
* With docker-machine on OSX:
* Ran this: `docker run --rm -v $(pwd)/data:/export minio server /export` which would previously fail

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.