### PR TITLE
server/mux: Close the connection even if buffer.Flush() returns error.

### DIFF
--- a/cmd/server-mux.go
+++ b/cmd/server-mux.go
@@ -108,10 +108,12 @@ func (c *ConnMux) Read(b []byte) (int, error) {
 
 // Close the connection.
 func (c *ConnMux) Close() (err error) {
-	if err = c.bufrw.Flush(); err != nil {
-		return err
-	}
-	return c.Conn.Close()
+	// Make sure that we always close a connection,
+	// even if the bufioWriter flush sends an error.
+	defer c.Conn.Close()
+
+	// Flush and write to the connection.
+	return c.bufrw.Flush()
 }
 
 // ListenerMux wraps the standard net.Listener to inspect


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Close the connection even if buffer.Flush() returns error.
<!--- Describe your changes in detail -->

## Motivation and Context
It is possible that buf.Flush() might return an error, leading to a
potential leak in active sockets.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Theoretical
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.