### PR TITLE
Make PutObject a nop for an object which ends with "/" and size is '0'

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -115,13 +115,11 @@ func (api objectAPIHandlers) PutBucketNotificationHandler(w http.ResponseWriter,
 		return
 	}
 
-	// If Content-Length is unknown or zero, deny the request. PutBucketNotification
-	// always needs a Content-Length if incoming request is not chunked.
-	if !contains(r.TransferEncoding, "chunked") {
-		if r.ContentLength == -1 {
-			writeErrorResponse(w, ErrMissingContentLength, r.URL)
-			return
-		}
+	// If Content-Length is unknown or zero, deny the request.
+	// PutBucketNotification always needs a Content-Length.
+	if r.ContentLength == -1 || r.ContentLength == 0 {
+		writeErrorResponse(w, ErrMissingContentLength, r.URL)
+		return
 	}
 
 	// Reads the incoming notification configuration.

--- a/cmd/bucket-policy-handlers.go
+++ b/cmd/bucket-policy-handlers.go
@@ -142,18 +142,15 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 	}
 
 	// If Content-Length is unknown or zero, deny the
-	// request. PutBucketPolicy always needs a Content-Length if
-	// incoming request is not chunked.
-	if !contains(r.TransferEncoding, "chunked") {
-		if r.ContentLength == -1 || r.ContentLength == 0 {
-			writeErrorResponse(w, ErrMissingContentLength, r.URL)
-			return
-		}
-		// If Content-Length is greater than maximum allowed policy size.
-		if r.ContentLength > maxAccessPolicySize {
-			writeErrorResponse(w, ErrEntityTooLarge, r.URL)
-			return
-		}
+	// request. PutBucketPolicy always needs a Content-Length.
+	if r.ContentLength == -1 || r.ContentLength == 0 {
+		writeErrorResponse(w, ErrMissingContentLength, r.URL)
+		return
+	}
+	// If Content-Length is greater than maximum allowed policy size.
+	if r.ContentLength > maxAccessPolicySize {
+		writeErrorResponse(w, ErrEntityTooLarge, r.URL)
+		return
 	}
 
 	// Read access policy up to maxAccessPolicySize.

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -542,6 +542,12 @@ func (fs fsObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
 // Additionally writes `fs.json` which carries the necessary metadata
 // for future object operations.
 func (fs fsObjects) PutObject(bucket string, object string, size int64, data io.Reader, metadata map[string]string, sha256sum string) (objInfo ObjectInfo, err error) {
+	// This is a special case with size as '0' and object ends with
+	// a slash separator, we treat it like a valid operation and
+	// return success.
+	if isObjectDir(object, size) {
+		return dirObjectInfo(bucket, object, size, metadata), nil
+	}
 	if err = checkPutObjectArgs(bucket, object, fs); err != nil {
 		return ObjectInfo{}, err
 	}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -409,7 +409,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 			return
 		}
 	}
-	if size == -1 && !contains(r.TransferEncoding, "chunked") {
+	if size == -1 {
 		writeErrorResponse(w, ErrMissingContentLength, r.URL)
 		return
 	}

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -130,6 +130,49 @@ func (s *TestSuiteCommon) TestBucketSQSNotificationWebHook(c *C) {
 	verifyError(c, response, "InvalidArgument", "A specified destination ARN does not exist or is not well-formed. Verify the destination ARN.", http.StatusBadRequest)
 }
 
+func (s *TestSuiteCommon) TestObjectDir(c *C) {
+	bucketName := getRandomBucketName()
+	// HTTP request to create the bucket.
+	request, err := newTestSignedRequest("PUT", getMakeBucketURL(s.endPoint, bucketName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+
+	client := http.Client{Transport: s.transport}
+	// execute the request.
+	response, err := client.Do(request)
+	c.Assert(err, IsNil)
+
+	// assert the http response status code.
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	request, err = newTestSignedRequest("PUT", getPutObjectURL(s.endPoint, bucketName, "my-object-directory/"),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+
+	client = http.Client{Transport: s.transport}
+	// execute the HTTP request.
+	response, err = client.Do(request)
+
+	c.Assert(err, IsNil)
+	// assert the http response status code.
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	request, err = newTestSignedRequest("PUT", getPutObjectURL(s.endPoint, bucketName, "my-object-directory/"),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+
+	helloReader := bytes.NewReader([]byte("Hello, World"))
+	request.ContentLength = helloReader.Size()
+	request.Body = ioutil.NopCloser(helloReader)
+
+	client = http.Client{Transport: s.transport}
+	// execute the HTTP request.
+	response, err = client.Do(request)
+
+	c.Assert(err, IsNil)
+	verifyError(c, response, "XMinioInvalidObjectName", "Object name contains unsupported characters. Unsupported characters are `^*|\\\"", http.StatusBadRequest)
+}
+
 func (s *TestSuiteCommon) TestBucketSQSNotificationAMQP(c *C) {
 	// Sample bucket notification.
 	bucketNotificationBuf := `<NotificationConfiguration><QueueConfiguration><Event>s3:ObjectCreated:Put</Event><Filter><S3Key><FilterRule><Name>prefix</Name><Value>images/</Value></FilterRule></S3Key></Filter><Id>1</Id><Queue>arn:minio:sqs:us-east-1:444455556666:amqp</Queue></QueueConfiguration></NotificationConfiguration>`
@@ -1135,7 +1178,9 @@ func (s *TestSuiteCommon) TestSHA256Mismatch(c *C) {
 		c.Assert(request.Header.Get("x-amz-content-sha256"), Equals, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 	}
 	// Set the body to generate signature mismatch.
-	request.Body = ioutil.NopCloser(bytes.NewReader([]byte("Hello, World")))
+	helloReader := bytes.NewReader([]byte("Hello, World"))
+	request.ContentLength = helloReader.Size()
+	request.Body = ioutil.NopCloser(helloReader)
 	c.Assert(err, IsNil)
 	// execute the HTTP request.
 	response, err = client.Do(request)

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -440,6 +440,12 @@ func renameObject(disks []StorageAPI, srcBucket, srcObject, dstBucket, dstObject
 // writes `xl.json` which carries the necessary metadata for future
 // object operations.
 func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.Reader, metadata map[string]string, sha256sum string) (objInfo ObjectInfo, err error) {
+	// This is a special case with size as '0' and object ends with
+	// a slash separator, we treat it like a valid operation and
+	// return success.
+	if isObjectDir(object, size) {
+		return dirObjectInfo(bucket, object, size, metadata), nil
+	}
 	if err = checkPutObjectArgs(bucket, object, xl); err != nil {
 		return ObjectInfo{}, err
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make PutObject a nop for an object which ends with "/" and size is '0'
<!--- Describe your changes in detail -->

## Motivation and Context
This helps majority of S3 compatible applications while not returning
an error upon directory create request.

Fixes #2965 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.