### PR TITLE
fs: start even if there are not enough free space

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -154,11 +154,6 @@ func newFSObjectLayer(fsPath string) (ObjectLayer, error) {
 		},
 	}
 
-	// Validate if disk has enough free space to use.
-	if err = fs.checkDiskFree(); err != nil {
-		return nil, err
-	}
-
 	// Initialize and load bucket policies.
 	err = initBucketPolicies(fs)
 	if err != nil {


### PR DESCRIPTION
This is continuation of activity started at #3597 

Since minio already has check for free space in `PrepareFile`, it would be better if it starts regardless of available free space. So, user can delete some files and free space, but can't put new files until minio has enough space.