### PR TITLE
presign-v2: Compute signature on encoded URL path

### DIFF
--- a/cmd/signature-v2.go
+++ b/cmd/signature-v2.go
@@ -92,9 +92,10 @@ func doesPresignV2SignatureMatch(r *http.Request) APIErrorCode {
 	if encodedResource == "" {
 		splits := strings.Split(r.URL.Path, "?")
 		if len(splits) > 0 {
-			encodedResource = splits[0]
+			encodedResource = getURLEncodedName(splits[0])
 		}
 	}
+
 	queries := strings.Split(encodedQuery, "&")
 	var filteredQueries []string
 	var gotSignature string


### PR DESCRIPTION
## Description
Encode the path of the passed presigned url before calculating the signature. This fixes
presigning objects whose names contain characters that are found encoded in urls.

## Motivation and Context
Fixes #3611 

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.