### PR TITLE
signature-v2: Use request.RequestURI for signature calculation.

### DIFF
--- a/cmd/signature-v2.go
+++ b/cmd/signature-v2.go
@@ -85,15 +85,12 @@ func doesPresignV2SignatureMatch(r *http.Request) APIErrorCode {
 	// Access credentials.
 	cred := serverConfig.GetCredential()
 
-	// url.RawPath will be valid if path has any encoded characters, if not it will
-	// be empty - in which case we need to consider url.Path (bug in net/http?)
-	encodedResource := r.URL.RawPath
-	encodedQuery := r.URL.RawQuery
-	if encodedResource == "" {
-		splits := strings.Split(r.URL.Path, "?")
-		if len(splits) > 0 {
-			encodedResource = getURLEncodedName(splits[0])
-		}
+	// r.RequestURI will have raw encoded URI as sent by the client.
+	splits := strings.Split(r.RequestURI, "?")
+	encodedResource := splits[0]
+	encodedQuery := ""
+	if len(splits) > 1 {
+		encodedQuery = splits[1]
 	}
 
 	queries := strings.Split(encodedQuery, "&")
@@ -213,19 +210,13 @@ func doesSignV2Match(r *http.Request) APIErrorCode {
 		return apiError
 	}
 
-	// Encode path:
-	//   url.RawPath will be valid if path has any encoded characters, if not it will
-	//   be empty - in which case we need to consider url.Path (bug in net/http?)
-	encodedResource := r.URL.RawPath
-	if encodedResource == "" {
-		splits := strings.Split(r.URL.Path, "?")
-		if len(splits) > 0 {
-			encodedResource = getURLEncodedName(splits[0])
-		}
+	// r.RequestURI will have raw encoded URI as sent by the client.
+	splits := strings.Split(r.RequestURI, "?")
+	encodedResource := splits[0]
+	encodedQuery := ""
+	if len(splits) > 1 {
+		encodedQuery = splits[1]
 	}
-
-	// Encode query strings
-	encodedQuery := r.URL.Query().Encode()
 
 	expectedAuth := signatureV2(r.Method, encodedResource, encodedQuery, r.Header)
 	if v2Auth != expectedAuth {

--- a/cmd/signature-v2.go
+++ b/cmd/signature-v2.go
@@ -86,12 +86,8 @@ func doesPresignV2SignatureMatch(r *http.Request) APIErrorCode {
 	cred := serverConfig.GetCredential()
 
 	// r.RequestURI will have raw encoded URI as sent by the client.
-	splits := strings.Split(r.RequestURI, "?")
-	encodedResource := splits[0]
-	encodedQuery := ""
-	if len(splits) > 1 {
-		encodedQuery = splits[1]
-	}
+	splits := splitStr(r.RequestURI, "?", 2)
+	encodedResource, encodedQuery := splits[0], splits[1]
 
 	queries := strings.Split(encodedQuery, "&")
 	var filteredQueries []string
@@ -211,12 +207,8 @@ func doesSignV2Match(r *http.Request) APIErrorCode {
 	}
 
 	// r.RequestURI will have raw encoded URI as sent by the client.
-	splits := strings.Split(r.RequestURI, "?")
-	encodedResource := splits[0]
-	encodedQuery := ""
-	if len(splits) > 1 {
-		encodedQuery = splits[1]
-	}
+	splits := splitStr(r.RequestURI, "?", 2)
+	encodedResource, encodedQuery := splits[0], splits[1]
 
 	expectedAuth := signatureV2(r.Method, encodedResource, encodedQuery, r.Header)
 	if v2Auth != expectedAuth {

--- a/cmd/signature-v2_test.go
+++ b/cmd/signature-v2_test.go
@@ -101,6 +101,8 @@ func TestDoesPresignedV2SignatureMatch(t *testing.T) {
 		if e != nil {
 			t.Errorf("(%d) failed to create http.Request, got %v", i, e)
 		}
+		// Should be set since we are simulating a http server.
+		req.RequestURI = req.URL.RequestURI()
 
 		// Do the same for the headers.
 		for key, value := range testCase.headers {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1739,20 +1739,25 @@ func prepareXLStorageDisks(t *testing.T) ([]StorageAPI, []string) {
 // initializes the specified API endpoints for the tests.
 // initialies the root and returns its path.
 // return credentials.
-func initAPIHandlerTest(obj ObjectLayer, endpoints []string) (bucketName string, apiRouter http.Handler, err error) {
+func initAPIHandlerTest(obj ObjectLayer, endpoints []string) (string, http.Handler, error) {
 	// get random bucket name.
-	bucketName = getRandomBucketName()
+	bucketName := getRandomBucketName()
 
 	// Create bucket.
-	err = obj.MakeBucket(bucketName)
+	err := obj.MakeBucket(bucketName)
 	if err != nil {
 		// failed to create newbucket, return err.
 		return "", nil, err
 	}
 	// Register the API end points with XL object layer.
 	// Registering only the GetObject handler.
-	apiRouter = initTestAPIEndPoints(obj, endpoints)
-	return bucketName, apiRouter, nil
+	apiRouter := initTestAPIEndPoints(obj, endpoints)
+	var f http.HandlerFunc
+	f = func(w http.ResponseWriter, r *http.Request) {
+		r.RequestURI = r.URL.RequestURI()
+		apiRouter.ServeHTTP(w, r)
+	}
+	return bucketName, f, nil
 }
 
 // ExecObjectLayerAPIAnonTest - Helper function to validate object Layer API handler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
http.Request.RequestURI should be used for Signature V2 calculation because:
* using url.Path will give incorrect results because it would contain decoded values. i.e if client used %2F for signature calculation url.Path will contain "/" and hence cause incorrect signature calculation
* using url.RawPath is unreliable, for ex. it does not get set if %20 is used for space

http.Request.RequestURI is the only reliable way to calculate signature v2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual and make test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

