### PR TITLE
Add dry-run query param for HealFormat API

### DIFF
--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -251,13 +251,20 @@ __Example__
 ```
 
 <a name="HealFormat"></a>
-### HealFormat() error
+### HealFormat(isDryRun bool) error
 Heal storage format on available disks. This is used when disks were replaced or were found with missing format. This is supported only for erasure-coded backend.
 
 __Example__
 
 ``` go
-    err := madmClnt.HealFormat()
+    isDryRun := true
+    err := madmClnt.HealFormat(isDryRun)
+    if err != nil {
+        log.Fatalln(err)
+    }
+
+    isDryRun = false
+    err = madmClnt.HealFormat(isDryRun)
     if err != nil {
         log.Fatalln(err)
     }

--- a/pkg/madmin/examples/heal-format.go
+++ b/pkg/madmin/examples/heal-format.go
@@ -39,8 +39,16 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Heal storage format on available disks.
-	err = madmClnt.HealFormat()
+	// Attempt healing format in dry-run mode.
+	isDryRun := true
+	err = madmClnt.HealFormat(isDryRun)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Perform actual healing of format.
+	isDryRun = false
+	err = madmClnt.HealFormat(isDryRun)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -344,7 +344,7 @@ func (adm *AdminClient) HealBucket(bucket string, dryrun bool) error {
 	queryVal.Set("heal", "")
 	queryVal.Set(string(healBucket), bucket)
 	if dryrun {
-		queryVal.Set(string(healDryRun), "yes")
+		queryVal.Set(string(healDryRun), "")
 	}
 
 	hdrs := make(http.Header)
@@ -378,7 +378,7 @@ func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) error {
 	queryVal.Set(string(healBucket), bucket)
 	queryVal.Set(string(healObject), object)
 	if dryrun {
-		queryVal.Set(string(healDryRun), "yes")
+		queryVal.Set(string(healDryRun), "")
 	}
 
 	hdrs := make(http.Header)
@@ -405,9 +405,12 @@ func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) error {
 }
 
 // HealFormat - heal storage format on available disks.
-func (adm *AdminClient) HealFormat() error {
+func (adm *AdminClient) HealFormat(dryrun bool) error {
 	queryVal := url.Values{}
 	queryVal.Set("heal", "")
+	if dryrun {
+		queryVal.Set(string(healDryRun), "")
+	}
 
 	// Set x-minio-operation to format.
 	hdrs := make(http.Header)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change supports dry-run option in heal-format API, similar to heal-object and heal-bucket.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows users to validate the heal format command before executing it for real.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [  ] I have added tests to cover my changes.
- [x] All new and existing tests passed.