### PR TITLE
Simplify running cmd.Main() from external tests

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -110,11 +110,11 @@ var (
 	// Minio server user agent string.
 	globalServerUserAgent = "Minio/" + ReleaseTag + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 
-	// Access key passed from the environment
-	globalEnvAccessKey = os.Getenv("MINIO_ACCESS_KEY")
+	// Global server's access key
+	globalEnvAccessKey = ""
 
-	// Secret key passed from the environment
-	globalEnvSecretKey = os.Getenv("MINIO_SECRET_KEY")
+	// Global server's secret key
+	globalEnvSecretKey = ""
 
 	// url.URL endpoints of disks that belong to the object storage.
 	globalEndpoints = []*url.URL{}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -190,6 +190,8 @@ func minioInit(ctx *cli.Context) {
 	enableLoggers()
 
 	// Fetch access keys from environment variables and update the config.
+	globalEnvAccessKey = os.Getenv("MINIO_ACCESS_KEY")
+	globalEnvSecretKey = os.Getenv("MINIO_SECRET_KEY")
 	if globalEnvAccessKey != "" && globalEnvSecretKey != "" {
 		// Set new credentials.
 		serverConfig.SetCredential(credential{
@@ -210,7 +212,7 @@ func minioInit(ctx *cli.Context) {
 }
 
 // Main main for minio server.
-func Main() {
+func Main(args []string, exitFn func(int)) {
 	app := registerApp()
 	app.Before = func(c *cli.Context) error {
 		// Valid input arguments to main.
@@ -224,5 +226,7 @@ func Main() {
 	}
 
 	// Run the app - exit on error.
-	app.RunAndExitOnError()
+	if err := app.Run(args); err != nil {
+		exitFn(1)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -22,8 +22,12 @@
 
 package main // import "github.com/minio/minio"
 
-import minio "github.com/minio/minio/cmd"
+import (
+	"os"
+
+	minio "github.com/minio/minio/cmd"
+)
 
 func main() {
-	minio.Main()
+	minio.Main(os.Args, os.Exit)
 }


### PR DESCRIPTION
## Description

An external test that runs cmd.Main() has a difficulty to set cmd arguments
and MINIO_{ACCESS,SECRET}_KEY values, this commit changes a little the current
behavior in a way that helps external tests.

## Motivation and Context
Packages such madmin or minio-go rely on an already configured server to run tests on, this
PR is a first step to simplify running Minio server from external tests.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.