### PR TITLE
Cleanup on webhook events

### DIFF
--- a/cmd/notify-webhook.go
+++ b/cmd/notify-webhook.go
@@ -119,6 +119,9 @@ func (n httpConn) Fire(entry *logrus.Entry) error {
 		return err
 	}
 
+	// Make sure to close the response body so the connection can be re-used.
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK &&
 		resp.StatusCode != http.StatusAccepted &&
 		resp.StatusCode != http.StatusContinue {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix issue with webhook events not closing Response body, leaving connections open on remote server.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a bug that manifested during stress testing of one of a (standard) Golang webserver.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created webhook event with `mc` client and updated minio server config:

```
                "webhook": {
                        "1": {
                                "enable": true,
                                "endpoint": "http://localhost:8080/"
                        }
                }
```

```
mc mb myminio/mm1
mc events add myminio/mm1 arn:minio:sqs:us-east-1:1:webhook
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

