### PR TITLE
xl: Fix GET of an empty multiparted object

### DIFF
--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -198,8 +198,14 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 		return traceError(InvalidRange{startOffset, length, xlMeta.Stat.Size})
 	}
 
+	// Calculate endOffset according to length
+	endOffset := startOffset
+	if length > 0 {
+		endOffset += length - 1
+	}
+
 	// Get last part index to read given length.
-	lastPartIndex, _, err := xlMeta.ObjectToPartOffset(startOffset + length - 1)
+	lastPartIndex, _, err := xlMeta.ObjectToPartOffset(endOffset)
 	if err != nil {
 		return traceError(InvalidRange{startOffset, length, xlMeta.Stat.Size})
 	}


### PR DESCRIPTION
## Description
GetObject returns unsatisfied range error when we try to download an object
uploaded using multipart mechanism.

## Motivation and Context
Fixes #3644 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.