### PR TITLE
heal: Should delete stale object parts before healing

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -344,22 +344,34 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 			// Not an outdated disk.
 			continue
 		}
-		if errs[index] != nil {
-			// If there was an error (most likely errFileNotFound)
+
+		// errFileNotFound implies that xl.json is missing. We
+		// may have object parts still present in the object
+		// directory. This needs to be deleted for object to
+		// healed successfully.
+		if errs[index] != nil && !isErr(errs[index], errFileNotFound) {
 			continue
 		}
+
 		// Outdated object with the same name exists that needs to be deleted.
 		outDatedMeta := partsMetadata[index]
-		// Delete all the parts.
-		for partIndex := 0; partIndex < len(outDatedMeta.Parts); partIndex++ {
-			err := disk.DeleteFile(bucket, pathJoin(object, outDatedMeta.Parts[partIndex].Name))
-			if err != nil {
+		// Consult valid metadata picked when there is no
+		// metadata available on this disk.
+		if isErr(errs[index], errFileNotFound) {
+			outDatedMeta = latestMeta
+		}
+
+		// Delete all the parts. Ignore if parts are not found.
+		for _, part := range outDatedMeta.Parts {
+			err := disk.DeleteFile(bucket, pathJoin(object, part.Name))
+			if err != nil && !isErr(err, errFileNotFound) {
 				return traceError(err)
 			}
 		}
-		// Delete xl.json file.
+
+		// Delete xl.json file. Ignore if xl.json not found.
 		err := disk.DeleteFile(bucket, pathJoin(object, xlMetaJSONFile))
-		if err != nil {
+		if err != nil && !isErr(err, errFileNotFound) {
 			return traceError(err)
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Heal objects uses object metadata read from a disk to remove stale parts of an object on that disk. This doesn't work if xl.json is missing on that disk. In this change, we use the object metadata that is agreed by read-quorum or more number of the disks to identify and delete remaining stale parts of the object in the 'out-dated' disks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #3631 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested using ``pkg/madmin/examples/heal-object.go``.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.