### PR TITLE
xl: bit-rot algo was not set in get-object.

### DIFF
--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -281,7 +281,7 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 			// Set checksum algo only once, while it is possible to have
 			// different algos per block because of our `xl.json`.
 			// It is not a requirement, set this only once for all the disks.
-			if ckSumAlgo != "" {
+			if ckSumAlgo == "" {
 				ckSumAlgo = ckSumInfo.Algorithm
 			}
 		}


### PR DESCRIPTION
fixes #3650

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
bit rot algo was not set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/minio/minio/issues/3650

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make test
manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.