### PR TITLE
fix: do port availability check only on macOS.

### DIFF
--- a/cmd/checkport.go
+++ b/cmd/checkport.go
@@ -22,25 +22,13 @@ import (
 	"syscall"
 )
 
-// Make sure that none of the other processes are listening on the
-// specified port on any of the interfaces.
-//
-// On linux if a process is listening on 127.0.0.1:9000 then Listen()
-// on ":9000" fails with the error "port already in use".
-// However on Mac OSX Listen() on ":9000" falls back to the IPv6 address.
-// This causes confusion on Mac OSX that minio server is not reachable
-// on 127.0.0.1 even though minio server is running. So before we start
-// the minio server we make sure that the port is free on each tcp network.
-//
-// Port is string on purpose here.
-// https://github.com/golang/go/issues/16142#issuecomment-245912773
-//
-// "Keep in mind that ports in Go are strings: https://play.golang.org/p/zk2WEri_E9"
-//                 - @bradfitz
-func checkPortAvailability(portStr string) error {
+// checkPortAvailability - check if given port is already in use.
+// Note: The check method tries to listen on given port and closes it.
+// It is possible to have a disconnected client in this tiny window of time.
+func checkPortAvailability(port string) error {
 	network := [3]string{"tcp", "tcp4", "tcp6"}
 	for _, n := range network {
-		l, err := net.Listen(n, net.JoinHostPort("", portStr))
+		l, err := net.Listen(n, net.JoinHostPort("", port))
 		if err != nil {
 			if isAddrInUse(err) {
 				// Return error if another process is listening on the

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -352,9 +352,14 @@ func getHostPort(address string) (host, port string, err error) {
 		return "", "", err
 	}
 
-	// Check if port is available.
-	if err = checkPortAvailability(port); err != nil {
-		return "", "", err
+	if runtime.GOOS == "darwin" {
+		// On macOS, if a process already listens on 127.0.0.1:PORT, net.Listen() falls back
+		// to IPv6 address ie minio will start listening on IPv6 address whereas another
+		// (non-)minio process is listening on IPv4 of given port.
+		// To avoid this error sutiation we check for port availability only for macOS.
+		if err = checkPortAvailability(port); err != nil {
+			return "", "", err
+		}
 	}
 
 	// Success.


### PR DESCRIPTION
On macOS, if a process already listens on 127.0.0.1:PORT, net.Listen() falls back
to IPv6 address ie minio will start listening on IPv6 address whereas another
(non-)minio process is listening on IPv4 of given port.
To avoid this error sutiation we check for port availability only for macOS.

Note: checkPortAvailability() tries to listen on given port and closes it.
It is possible to have a disconnected client in this tiny window of time.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.