### PR TITLE
browser: Component attr names should not clash with redux state keys.

### DIFF
--- a/browser/app/js/components/Browse.js
+++ b/browser/app/js/components/Browse.js
@@ -414,10 +414,10 @@ export default class Browse extends React.Component {
     let freePercent = free * 100 / total
 
     if (web.LoggedIn()) {
-      browserDropdownButton = <BrowserDropdown fullScreen={ this.fullScreen.bind(this) }
-                                showAbout={ this.showAbout.bind(this) }
-                                showSettings={ this.showSettings.bind(this) }
-                                logout={ this.logout.bind(this) } />
+      browserDropdownButton = <BrowserDropdown fullScreenFunc={ this.fullScreen.bind(this) }
+                                aboutFunc={ this.showAbout.bind(this) }
+                                settingsFunc={ this.showSettings.bind(this) }
+                                logoutFunc={ this.logout.bind(this) } />
     } else {
       loginButton = <a className='btn btn-danger' href='/minio/login'>Login</a>
     }

--- a/browser/app/js/components/BrowserDropdown.js
+++ b/browser/app/js/components/BrowserDropdown.js
@@ -18,7 +18,7 @@ import React from 'react'
 import connect from 'react-redux/lib/components/connect'
 import Dropdown from 'react-bootstrap/lib/Dropdown'
 
-let BrowserDropdown = ({fullScreen, showAbout, showSettings, logout}) => {
+let BrowserDropdown = ({fullScreenFunc, aboutFunc, settingsFunc, logoutFunc}) => {
   return (
     <li>
       <Dropdown pullRight id="top-right-menu">
@@ -30,7 +30,7 @@ let BrowserDropdown = ({fullScreen, showAbout, showSettings, logout}) => {
             <a target="_blank" href="https://github.com/minio/miniobrowser">Github <i className="fa fa-github"></i></a>
           </li>
           <li>
-            <a href="" onClick={ fullScreen }>Fullscreen <i className="fa fa-expand"></i></a>
+            <a href="" onClick={ fullScreenFunc }>Fullscreen <i className="fa fa-expand"></i></a>
           </li>
           <li>
             <a target="_blank" href="https://docs.minio.io/">Documentation <i className="fa fa-book"></i></a>
@@ -39,13 +39,13 @@ let BrowserDropdown = ({fullScreen, showAbout, showSettings, logout}) => {
             <a target="_blank" href="https://slack.minio.io">Ask for help <i className="fa fa-question-circle"></i></a>
           </li>
           <li>
-            <a href="" onClick={ showAbout }>About <i className="fa fa-info-circle"></i></a>
+            <a href="" onClick={ aboutFunc }>About <i className="fa fa-info-circle"></i></a>
           </li>
           <li>
-            <a href="" onClick={ showSettings }>Settings <i className="fa fa-cog"></i></a>
+            <a href="" onClick={ settingsFunc }>Settings <i className="fa fa-cog"></i></a>
           </li>
           <li>
-            <a href="" onClick={ logout }>Sign Out <i className="fa fa-sign-out"></i></a>
+            <a href="" onClick={ logoutFunc }>Sign Out <i className="fa fa-sign-out"></i></a>
           </li>
         </Dropdown.Menu>
       </Dropdown>


### PR DESCRIPTION
fixes #270

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
showAbout and showSettings attr values were being over ridden by redux state values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/minio/miniobrowser/issues/270

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.