### PR TITLE
Fix handling of StringNotEquals condition operator

### DIFF
--- a/cmd/bucket-policy-handlers_test.go
+++ b/cmd/bucket-policy-handlers_test.go
@@ -913,7 +913,7 @@ func TestBucketPolicyConditionMatch(t *testing.T) {
 			statementCondition: getStatementWithCondition("StringNotEquals", "s3:prefix", "Asia/"),
 			condition:          getInnerMap("prefix", "Asia/"),
 
-			expectedMatch: true,
+			expectedMatch: false,
 		},
 		// Test case - 6.
 		// StringNotEquals condition doesn't match.
@@ -922,7 +922,7 @@ func TestBucketPolicyConditionMatch(t *testing.T) {
 			statementCondition: getStatementWithCondition("StringNotEquals", "s3:prefix", "Asia/"),
 			condition:          getInnerMap("prefix", "Africa/"),
 
-			expectedMatch: false,
+			expectedMatch: true,
 		},
 		// Test case - 7.
 		// StringNotEquals condition matches.
@@ -931,7 +931,7 @@ func TestBucketPolicyConditionMatch(t *testing.T) {
 			statementCondition: getStatementWithCondition("StringNotEquals", "s3:max-keys", "Asia/"),
 			condition:          getInnerMap("max-keys", "Asia/"),
 
-			expectedMatch: true,
+			expectedMatch: false,
 		},
 		// Test case - 8.
 		// StringNotEquals condition doesn't match.
@@ -940,7 +940,7 @@ func TestBucketPolicyConditionMatch(t *testing.T) {
 			statementCondition: getStatementWithCondition("StringNotEquals", "s3:max-keys", "Asia/"),
 			condition:          getInnerMap("max-keys", "Africa/"),
 
-			expectedMatch: false,
+			expectedMatch: true,
 		},
 		// Test case - 9.
 		// StringLike condition matches.
@@ -977,7 +977,8 @@ func TestBucketPolicyConditionMatch(t *testing.T) {
 			// call the function under test and assert the result with the expected result.
 			doesMatch := bucketPolicyConditionMatch(tc.condition, tc.statementCondition)
 			if tc.expectedMatch != doesMatch {
-				t.Errorf("Expected the match to be `%v`; got `%v`.", tc.expectedMatch, doesMatch)
+				t.Errorf("Expected the match to be `%v`; got `%v` - %v %v.",
+					tc.expectedMatch, doesMatch, tc.condition, tc.statementCondition)
 			}
 		})
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A condition with StringNotEquals condition operator evaluates to true if the condition key's value doesn't match with the string sent with the request. This is explained with an example [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html#condition-key-bucket-ops-2). This change fixes the current implementation to behave as explained above.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We handle StringEquals and StringNotEquals condition operator alike, which is incorrect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.