### PR TITLE
Change query param name to duration in list/clear locks API

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -334,12 +334,12 @@ func TestServiceSetCreds(t *testing.T) {
 }
 
 // mkLockQueryVal - helper function to build lock query param.
-func mkLockQueryVal(bucket, prefix, relTimeStr string) url.Values {
+func mkLockQueryVal(bucket, prefix, durationStr string) url.Values {
 	qVal := url.Values{}
 	qVal.Set("lock", "")
 	qVal.Set(string(mgmtBucket), bucket)
 	qVal.Set(string(mgmtPrefix), prefix)
-	qVal.Set(string(mgmtOlderThan), relTimeStr)
+	qVal.Set(string(mgmtLockDuration), durationStr)
 	return qVal
 }
 
@@ -364,41 +364,41 @@ func TestListLocksHandler(t *testing.T) {
 	testCases := []struct {
 		bucket         string
 		prefix         string
-		relTime        string
+		duration       string
 		expectedStatus int
 	}{
 		// Test 1 - valid testcase
 		{
 			bucket:         "mybucket",
 			prefix:         "myobject",
-			relTime:        "1s",
+			duration:       "1s",
 			expectedStatus: http.StatusOK,
 		},
 		// Test 2 - invalid duration
 		{
 			bucket:         "mybucket",
 			prefix:         "myprefix",
-			relTime:        "invalidDuration",
+			duration:       "invalidDuration",
 			expectedStatus: http.StatusBadRequest,
 		},
 		// Test 3 - invalid bucket name
 		{
 			bucket:         `invalid\\Bucket`,
 			prefix:         "myprefix",
-			relTime:        "1h",
+			duration:       "1h",
 			expectedStatus: http.StatusBadRequest,
 		},
 		// Test 4 - invalid prefix
 		{
 			bucket:         "mybucket",
 			prefix:         `invalid\\Prefix`,
-			relTime:        "1h",
+			duration:       "1h",
 			expectedStatus: http.StatusBadRequest,
 		},
 	}
 
 	for i, test := range testCases {
-		queryVal := mkLockQueryVal(test.bucket, test.prefix, test.relTime)
+		queryVal := mkLockQueryVal(test.bucket, test.prefix, test.duration)
 		req, err := newTestRequest("GET", "/?"+queryVal.Encode(), 0, nil)
 		if err != nil {
 			t.Fatalf("Test %d - Failed to construct list locks request - %v", i+1, err)
@@ -436,41 +436,41 @@ func TestClearLocksHandler(t *testing.T) {
 	testCases := []struct {
 		bucket         string
 		prefix         string
-		relTime        string
+		duration       string
 		expectedStatus int
 	}{
 		// Test 1 - valid testcase
 		{
 			bucket:         "mybucket",
 			prefix:         "myobject",
-			relTime:        "1s",
+			duration:       "1s",
 			expectedStatus: http.StatusOK,
 		},
 		// Test 2 - invalid duration
 		{
 			bucket:         "mybucket",
 			prefix:         "myprefix",
-			relTime:        "invalidDuration",
+			duration:       "invalidDuration",
 			expectedStatus: http.StatusBadRequest,
 		},
 		// Test 3 - invalid bucket name
 		{
 			bucket:         `invalid\\Bucket`,
 			prefix:         "myprefix",
-			relTime:        "1h",
+			duration:       "1h",
 			expectedStatus: http.StatusBadRequest,
 		},
 		// Test 4 - invalid prefix
 		{
 			bucket:         "mybucket",
 			prefix:         `invalid\\Prefix`,
-			relTime:        "1h",
+			duration:       "1h",
 			expectedStatus: http.StatusBadRequest,
 		},
 	}
 
 	for i, test := range testCases {
-		queryVal := mkLockQueryVal(test.bucket, test.prefix, test.relTime)
+		queryVal := mkLockQueryVal(test.bucket, test.prefix, test.duration)
 		req, err := newTestRequest("POST", "/?"+queryVal.Encode(), 0, nil)
 		if err != nil {
 			t.Fatalf("Test %d - Failed to construct clear locks request - %v", i+1, err)

--- a/cmd/admin-rpc-server.go
+++ b/cmd/admin-rpc-server.go
@@ -37,9 +37,9 @@ type adminCmd struct {
 // ListLocksQuery - wraps ListLocks API's query values to send over RPC.
 type ListLocksQuery struct {
 	AuthRPCArgs
-	bucket  string
-	prefix  string
-	relTime time.Duration
+	bucket   string
+	prefix   string
+	duration time.Duration
 }
 
 // ListLocksReply - wraps ListLocks response over RPC.
@@ -63,7 +63,7 @@ func (s *adminCmd) ListLocks(query *ListLocksQuery, reply *ListLocksReply) error
 	if err := query.IsAuthenticated(); err != nil {
 		return err
 	}
-	volLocks := listLocksInfo(query.bucket, query.prefix, query.relTime)
+	volLocks := listLocksInfo(query.bucket, query.prefix, query.duration)
 	*reply = ListLocksReply{volLocks: volLocks}
 	return nil
 }

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -483,7 +483,7 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	},
 	ErrInvalidDuration: {
 		Code:           "InvalidDuration",
-		Description:    "Relative duration provided in the request is invalid.",
+		Description:    "Duration provided in the request is invalid.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 

--- a/cmd/lockinfo-handlers.go
+++ b/cmd/lockinfo-handlers.go
@@ -68,8 +68,8 @@ type OpsLockState struct {
 	Duration    time.Duration `json:"duration"` // Duration since the lock was held.
 }
 
-// listLocksInfo - Fetches locks held on bucket, matching prefix older than relTime.
-func listLocksInfo(bucket, prefix string, relTime time.Duration) []VolumeLockInfo {
+// listLocksInfo - Fetches locks held on bucket, matching prefix held for longer than duration.
+func listLocksInfo(bucket, prefix string, duration time.Duration) []VolumeLockInfo {
 	globalNSMutex.lockMapMutex.Lock()
 	defer globalNSMutex.lockMapMutex.Unlock()
 
@@ -95,11 +95,12 @@ func listLocksInfo(bucket, prefix string, relTime time.Duration) []VolumeLockInf
 		}
 		// Filter locks that are held on bucket, prefix.
 		for opsID, lockInfo := range debugLock.lockInfo {
+			// filter locks that were held for longer than duration.
 			elapsed := timeNow.Sub(lockInfo.since)
-			if elapsed < relTime {
+			if elapsed < duration {
 				continue
 			}
-			// Add locks that are older than relTime.
+			// Add locks that are held for longer than duration.
 			volLockInfo.LockDetailsOnObject = append(volLockInfo.LockDetailsOnObject,
 				OpsLockState{
 					OperationID: opsID,

--- a/cmd/lockinfo-handlers_test.go
+++ b/cmd/lockinfo-handlers_test.go
@@ -45,34 +45,34 @@ func TestListLocksInfo(t *testing.T) {
 	testCases := []struct {
 		bucket   string
 		prefix   string
-		relTime  time.Duration
+		duration time.Duration
 		numLocks int
 	}{
 		// Test 1 - Matches all the locks acquired above.
 		{
 			bucket:   "bucket1",
 			prefix:   "prefix1",
-			relTime:  time.Duration(0 * time.Second),
+			duration: time.Duration(0 * time.Second),
 			numLocks: 20,
 		},
 		// Test 2 - Bucket doesn't match.
 		{
 			bucket:   "bucket",
 			prefix:   "prefix1",
-			relTime:  time.Duration(0 * time.Second),
+			duration: time.Duration(0 * time.Second),
 			numLocks: 0,
 		},
 		// Test 3 - Prefix doesn't match.
 		{
 			bucket:   "bucket1",
 			prefix:   "prefix11",
-			relTime:  time.Duration(0 * time.Second),
+			duration: time.Duration(0 * time.Second),
 			numLocks: 0,
 		},
 	}
 
 	for i, test := range testCases {
-		actual := listLocksInfo(test.bucket, test.prefix, test.relTime)
+		actual := listLocksInfo(test.bucket, test.prefix, test.duration)
 		if len(actual) != test.numLocks {
 			t.Errorf("Test %d - Expected %d locks but observed %d locks",
 				i+1, test.numLocks, len(actual))

--- a/docs/admin-api/README.md
+++ b/docs/admin-api/README.md
@@ -66,9 +66,9 @@
 
 ### Lock Management APIs
 * ListLocks
-  - GET /?lock&bucket=mybucket&prefix=myprefix&older-than=rel_time
+  - GET /?lock&bucket=mybucket&prefix=myprefix&duration=duration
   - x-minio-operation: list
-  - Response: On success 200, json encoded response containing all locks held, older than rel_time. e.g, older than 3 hours.
+  - Response: On success 200, json encoded response containing all locks held, for longer than duration.
   - Possible error responses
     - ErrInvalidBucketName
     <Error>
@@ -95,7 +95,7 @@
     - ErrInvalidDuration
       <Error>
           <Code>InvalidDuration</Code>
-          <Message>Relative duration provided in the request is invalid.</Message>
+          <Message>Duration provided in the request is invalid.</Message>
           <Key></Key>
           <BucketName></BucketName>
           <Resource>/</Resource>
@@ -105,9 +105,9 @@
 
 
 * ClearLocks
-  - POST /?lock&bucket=mybucket&prefix=myprefix&older-than=rel_time
+  - POST /?lock&bucket=mybucket&prefix=myprefix&duration=duration
   - x-minio-operation: clear
-  - Response: On success 200, json encoded response containing all locks cleared, older than rel_time. e.g, older than 3 hours.
+  - Response: On success 200, json encoded response containing all locks cleared, for longer than duration.
   - Possible error responses, similar to errors listed in ListLocks.
     - ErrInvalidBucketName
     - ErrInvalidObjectName

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -120,8 +120,8 @@ If successful restarts the running minio service, for distributed setup restarts
 
  ```
 <a name="ListLocks"></a>
-### ListLocks(bucket, prefix string, olderThan time.Duration) ([]VolumeLockInfo, error)
-If successful returns information on the list of locks held on ``bucket`` matching ``prefix`` older than ``olderThan`` seconds.
+### ListLocks(bucket, prefix string, duration time.Duration) ([]VolumeLockInfo, error)
+If successful returns information on the list of locks held on ``bucket`` matching ``prefix`` for  longer than ``duration`` seconds.
 
 __Example__
 
@@ -135,8 +135,8 @@ __Example__
 ```
 
 <a name="ClearLocks"></a>
-### ClearLocks(bucket, prefix string, olderThan time.Duration) ([]VolumeLockInfo, error)
-If successful returns information on the list of locks cleared on ``bucket`` matching ``prefix`` older than ``olderThan`` seconds.
+### ClearLocks(bucket, prefix string, duration time.Duration) ([]VolumeLockInfo, error)
+If successful returns information on the list of locks cleared on ``bucket`` matching ``prefix`` for longer than ``duration`` seconds.
 
 __Example__
 

--- a/pkg/madmin/examples/lock-clear.go
+++ b/pkg/madmin/examples/lock-clear.go
@@ -37,7 +37,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Clear locks held on mybucket/myprefix older than olderThan seconds.
+	// Clear locks held on mybucket/myprefix for longer than 30s.
 	olderThan := time.Duration(30 * time.Second)
 	locksCleared, err := madmClnt.ClearLocks("mybucket", "myprefix", olderThan)
 	if err != nil {

--- a/pkg/madmin/examples/lock-list.go
+++ b/pkg/madmin/examples/lock-list.go
@@ -37,7 +37,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// List locks held on mybucket/myprefix older than 30s.
+	// List locks held on mybucket/myprefix for longer than 30s.
 	locksHeld, err := madmClnt.ListLocks("mybucket", "myprefix", time.Duration(30*time.Second))
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
Following is a sample list lock API request schematic,

  /?lock&bucket=mybucket&prefix=myprefix&duration=holdDuration
  x-minio-operation: list

The response would contain the list of locks held on mybucket matching
myprefix for a duration longer than holdDuration.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change is to make the query params intention clear to lock management API consumers.
Previously, ``older-than`` query parameter was used to include locks that were held a duration of ``older-than`` units from current time. With this change, we rename the query parameter to ``duration`` to indicate that list/clear locks API will include locks held for a duration longer than the value specified using the ``duration`` query parameter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change intends to simplify the lock management APIs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.