### PR TITLE
xl: Abort multipart upload should honor quorum properly.

### DIFF
--- a/cmd/erasure-createfile.go
+++ b/cmd/erasure-createfile.go
@@ -137,9 +137,5 @@ func appendFile(disks []StorageAPI, volume, path string, enBlocks [][]byte, hash
 	// Wait for all the appends to finish.
 	wg.Wait()
 
-	// Do we have write quorum?.
-	if !isDiskQuorum(wErrs, writeQuorum) {
-		return traceError(errXLWriteQuorum)
-	}
 	return reduceWriteQuorumErrs(wErrs, objectOpIgnoredErrs, writeQuorum)
 }

--- a/cmd/to_err_test.go
+++ b/cmd/to_err_test.go
@@ -1,0 +1,31 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "testing"
+
+func TestToErrIsNil(t *testing.T) {
+	if toObjectErr(nil) != nil {
+		t.Errorf("Test expected to return nil, failed instead got a non-nil value %s", toObjectErr(nil))
+	}
+	if toStorageErr(nil) != nil {
+		t.Errorf("Test expected to return nil, failed instead got a non-nil value %s", toStorageErr(nil))
+	}
+	if toAPIErrorCode(nil) != ErrNone {
+		t.Errorf("Test expected error code to be ErrNone, failed instead provided %d", toAPIErrorCode(nil))
+	}
+}

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -368,13 +368,12 @@ func writeUniqueXLMetadata(disks []StorageAPI, bucket, prefix string, xlMetas []
 	// Wait for all the routines.
 	wg.Wait()
 
-	// Do we have write quorum?.
-	if !isDiskQuorum(mErrs, quorum) {
+	err := reduceWriteQuorumErrs(mErrs, objectOpIgnoredErrs, quorum)
+	if errorCause(err) == errXLWriteQuorum {
 		// Delete all `xl.json` successfully renamed.
 		deleteAllXLMetadata(disks, bucket, prefix, mErrs)
-		return traceError(errXLWriteQuorum)
 	}
-	return reduceWriteQuorumErrs(mErrs, objectOpIgnoredErrs, quorum)
+	return err
 }
 
 // writeSameXLMetadata - write `xl.json` on all disks in order.
@@ -407,11 +406,10 @@ func writeSameXLMetadata(disks []StorageAPI, bucket, prefix string, xlMeta xlMet
 	// Wait for all the routines.
 	wg.Wait()
 
-	// Do we have write Quorum?.
-	if !isDiskQuorum(mErrs, writeQuorum) {
+	err := reduceWriteQuorumErrs(mErrs, objectOpIgnoredErrs, writeQuorum)
+	if errorCause(err) == errXLWriteQuorum {
 		// Delete all `xl.json` successfully renamed.
 		deleteAllXLMetadata(disks, bucket, prefix, mErrs)
-		return traceError(errXLWriteQuorum)
 	}
-	return reduceWriteQuorumErrs(mErrs, objectOpIgnoredErrs, writeQuorum)
+	return err
 }

--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -83,23 +83,6 @@ func reduceWriteQuorumErrs(errs []error, ignoredErrs []error, writeQuorum int) (
 	return reduceQuorumErrs(errs, ignoredErrs, writeQuorum, errXLWriteQuorum)
 }
 
-// List of all errors which are ignored while verifying quorum.
-var quorumIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied)
-
-// Validates if we have quorum based on the errors related to disk only.
-// Returns 'true' if we have quorum, 'false' if we don't.
-func isDiskQuorum(errs []error, minQuorumCount int) bool {
-	var count int
-	errs = errorsCause(errs)
-	for _, err := range errs {
-		// Check if the error can be ignored for quorum verification.
-		if !isErrIgnored(err, quorumIgnoredErrs...) {
-			count++
-		}
-	}
-	return count >= minQuorumCount
-}
-
 // Similar to 'len(slice)' but returns  the actual elements count
 // skipping the unallocated elements.
 func diskCount(disks []StorageAPI) int {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current implementation didn't honor quorum properly and didn't
handle the errors generated properly. This patch addresses that
and also moves common code `cleanupMultipartUploads` into xl
specific private function.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3665

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually taking down the 4th server.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.