### PR TITLE
Require content-length in POST & Upload requests

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -59,6 +59,9 @@ const (
 	// can reach that size according to https://aws.amazon.com/articles/1434
 	maxFormFieldSize = int64(1 * humanize.MiByte)
 
+	// Limit memory allocation to store multipart data
+	maxFormMemory = int64(5 * humanize.MiByte)
+
 	// The maximum allowed difference between the request generation time and the server processing time
 	globalMaxSkewTime = 15 * time.Minute
 )

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -106,13 +106,13 @@ func isAuthTokenValid(tokenString string) bool {
 }
 
 func isHTTPRequestValid(req *http.Request) bool {
-	return webReqestAuthenticate(req) == nil
+	return webRequestAuthenticate(req) == nil
 }
 
 // Check if the request is authenticated.
 // Returns nil if the request is authenticated. errNoAuthToken if token missing.
 // Returns errAuthentication for all other errors.
-func webReqestAuthenticate(req *http.Request) error {
+func webRequestAuthenticate(req *http.Request) error {
 	jwtToken, err := jwtreq.ParseFromRequest(req, jwtreq.AuthorizationHeaderExtractor, keyFuncCallback)
 	if err != nil {
 		if err == jwtreq.ErrNoTokenInRequest {

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -33,6 +33,9 @@ var errContentSHA256Mismatch = errors.New("Content checksum SHA256 mismatch")
 // used when we deal with data larger than expected
 var errSizeUnexpected = errors.New("Data size larger than expected")
 
+// used when we deal with data with unknown size
+var errSizeUnspecified = errors.New("Data size is unspecified")
+
 // When upload object size is greater than 5G in a single PUT/POST operation.
 var errDataTooLarge = errors.New("Object size larger than allowed limit")
 


### PR DESCRIPTION
## Description
Avoid passing size = -1 to PutObject API by requiring content-length
header in POST request (as AWS S3 does) and in Upload web handler.
Post handler is modified to completely store multipart file to know
its size before sending it to PutObject().

## Motivation and Context
Avoid passing size = -1 to PutObject()

## How Has This Been Tested?
go test & manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.