### PR TITLE
madmin: Fix a typo in Locks duration query name

### DIFF
--- a/pkg/madmin/lock-commands.go
+++ b/pkg/madmin/lock-commands.go
@@ -93,12 +93,12 @@ func getLockInfos(body io.Reader) ([]VolumeLockInfo, error) {
 
 // ListLocks - Calls List Locks Management API to fetch locks matching
 // bucket, prefix and held before the duration supplied.
-func (adm *AdminClient) ListLocks(bucket, prefix string, olderThan time.Duration) ([]VolumeLockInfo, error) {
+func (adm *AdminClient) ListLocks(bucket, prefix string, duration time.Duration) ([]VolumeLockInfo, error) {
 	queryVal := make(url.Values)
 	queryVal.Set("lock", "")
 	queryVal.Set("bucket", bucket)
 	queryVal.Set("prefix", prefix)
-	queryVal.Set("older-than", olderThan.String())
+	queryVal.Set("duration", duration.String())
 
 	hdrs := make(http.Header)
 	hdrs.Set(minioAdminOpHeader, "list")
@@ -125,12 +125,12 @@ func (adm *AdminClient) ListLocks(bucket, prefix string, olderThan time.Duration
 
 // ClearLocks - Calls Clear Locks Management API to clear locks held
 // on bucket, matching prefix older than duration supplied.
-func (adm *AdminClient) ClearLocks(bucket, prefix string, olderThan time.Duration) ([]VolumeLockInfo, error) {
+func (adm *AdminClient) ClearLocks(bucket, prefix string, duration time.Duration) ([]VolumeLockInfo, error) {
 	queryVal := make(url.Values)
 	queryVal.Set("lock", "")
 	queryVal.Set("bucket", bucket)
 	queryVal.Set("prefix", prefix)
-	queryVal.Set("older-than", olderThan.String())
+	queryVal.Set("duration", duration.String())
 
 	hdrs := make(http.Header)
 	hdrs.Set(minioAdminOpHeader, "clear")


### PR DESCRIPTION
## Description
older-than paramter's name was mistakenly left not modified when changing to duration 

## Motivation and Context
Manual test 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.