### PR TITLE
signature-v4: stringToSign and signingKey should use Scope's date.

### DIFF
--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -34,6 +34,16 @@ type credentialHeader struct {
 	}
 }
 
+// Return scope string.
+func (c credentialHeader) getScope() string {
+	return strings.Join([]string{
+		c.scope.date.Format(yyyymmdd),
+		c.scope.region,
+		c.scope.service,
+		c.scope.request,
+	}, "/")
+}
+
 // parse credentialHeader string into its structured form.
 func parseCredentialHeader(credElement string) (credentialHeader, APIErrorCode) {
 	creds := strings.Split(strings.TrimSpace(credElement), "=")

--- a/cmd/signature-v4_test.go
+++ b/cmd/signature-v4_test.go
@@ -61,14 +61,7 @@ func TestDoesPolicySignatureMatch(t *testing.T) {
 			},
 			expected: ErrInvalidRegion,
 		},
-		// (3) It should fail if the date is invalid (or missing, in this case).
-		{
-			form: map[string]string{
-				"X-Amz-Credential": fmt.Sprintf(credentialTemplate, accessKey, now.Format(yyyymmdd), globalMinioDefaultRegion),
-			},
-			expected: ErrMalformedDate,
-		},
-		// (4) It should fail with a bad signature.
+		// (3) It should fail with a bad signature.
 		{
 			form: map[string]string{
 				"X-Amz-Credential": fmt.Sprintf(credentialTemplate, accessKey, now.Format(yyyymmdd), globalMinioDefaultRegion),
@@ -78,7 +71,7 @@ func TestDoesPolicySignatureMatch(t *testing.T) {
 			},
 			expected: ErrSignatureDoesNotMatch,
 		},
-		// (5) It should succeed if everything is correct.
+		// (4) It should succeed if everything is correct.
 		{
 			form: map[string]string{
 				"X-Amz-Credential": fmt.Sprintf(credentialTemplate, accessKey, now.Format(yyyymmdd), globalMinioDefaultRegion),

--- a/cmd/streaming-signature-v4.go
+++ b/cmd/streaming-signature-v4.go
@@ -135,10 +135,10 @@ func calculateSeedSignature(r *http.Request) (signature string, date time.Time, 
 	canonicalRequest := getCanonicalRequest(extractedSignedHeaders, payload, queryStr, req.URL.Path, req.Method, req.Host)
 
 	// Get string to sign from canonical request.
-	stringToSign := getStringToSign(canonicalRequest, date, region)
+	stringToSign := getStringToSign(canonicalRequest, date, signV4Values.Credential.getScope())
 
 	// Get hmac signing key.
-	signingKey := getSigningKey(cred.SecretKey, date, region)
+	signingKey := getSigningKey(cred.SecretKey, signV4Values.Credential.scope.date, region)
 
 	// Calculate signature.
 	newSignature := getSignature(signingKey, stringToSign)

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -893,7 +893,8 @@ func preSignV4(req *http.Request, accessKeyID, secretAccessKey string, expires i
 
 	region := serverConfig.GetRegion()
 	date := time.Now().UTC()
-	credential := fmt.Sprintf("%s/%s", accessKeyID, getScope(date, region))
+	scope := getScope(date, region)
+	credential := fmt.Sprintf("%s/%s", accessKeyID, scope)
 
 	// Set URL query.
 	query := req.URL.Query()
@@ -909,7 +910,7 @@ func preSignV4(req *http.Request, accessKeyID, secretAccessKey string, expires i
 
 	queryStr := strings.Replace(query.Encode(), "+", "%20", -1)
 	canonicalRequest := getCanonicalRequest(extractedSignedHeaders, unsignedPayload, queryStr, req.URL.Path, req.Method, req.Host)
-	stringToSign := getStringToSign(canonicalRequest, date, region)
+	stringToSign := getStringToSign(canonicalRequest, date, scope)
 	signingKey := getSigningKey(secretAccessKey, date, region)
 	signature := getSignature(signingKey, stringToSign)
 

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -741,7 +741,7 @@ func presignedGet(host, bucket, object string, expiry int64) string {
 	var extractedSignedHeaders http.Header
 
 	canonicalRequest := getCanonicalRequest(extractedSignedHeaders, unsignedPayload, query, path, "GET", host)
-	stringToSign := getStringToSign(canonicalRequest, date, region)
+	stringToSign := getStringToSign(canonicalRequest, date, getScope(date, region))
 	signingKey := getSigningKey(secretKey, date, region)
 	signature := getSignature(signingKey, stringToSign)
 


### PR DESCRIPTION
fixes #3676

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
if the client chooses to it can put any date of the previous 7 days in the scope, and we should not look at the x-amz-date to calculate the scope, but use the client provided scope.

In http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html search for The signature is valid for seven days after the specified date.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.