### PR TITLE
signv4: Read always returns EOF when stream ends

### DIFF
--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -489,6 +489,20 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			shouldPass:         true,
 		},
 		// Test case - 3
+		// Empty data
+		{
+			bucketName:         bucketName,
+			objectName:         objectName,
+			data:               []byte{},
+			dataLen:            0,
+			chunkSize:          64 * humanize.KiByte,
+			expectedContent:    []byte{},
+			expectedRespStatus: http.StatusOK,
+			accessKey:          credentials.AccessKey,
+			secretKey:          credentials.SecretKey,
+			shouldPass:         true,
+		},
+		// Test case - 4
 		// Invalid access key id.
 		{
 			bucketName:         bucketName,
@@ -502,7 +516,7 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			secretKey:          "",
 			shouldPass:         false,
 		},
-		// Test case - 4
+		// Test case - 5
 		// Wrong auth header returns as bad request.
 		{
 			bucketName:         bucketName,
@@ -517,7 +531,7 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			shouldPass:         false,
 			removeAuthHeader:   true,
 		},
-		// Test case - 5
+		// Test case - 6
 		// Large chunk size.. also passes.
 		{
 			bucketName:         bucketName,
@@ -531,7 +545,7 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			secretKey:          credentials.SecretKey,
 			shouldPass:         false,
 		},
-		// Test case - 6
+		// Test case - 7
 		// Chunk with malformed encoding.
 		{
 			bucketName:         bucketName,
@@ -546,7 +560,7 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			shouldPass:         false,
 			fault:              malformedEncoding,
 		},
-		// Test case - 7
+		// Test case - 8
 		// Chunk with shorter than advertised chunk data.
 		{
 			bucketName:         bucketName,
@@ -561,7 +575,7 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			shouldPass:         false,
 			fault:              unexpectedEOF,
 		},
-		// Test case - 8
+		// Test case - 9
 		// Chunk with first chunk data byte tampered.
 		{
 			bucketName:         bucketName,
@@ -576,7 +590,7 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			shouldPass:         false,
 			fault:              signatureMismatch,
 		},
-		// Test case - 9
+		// Test case - 10
 		// Different date (timestamps) used in seed signature calculation
 		// and chunks signature calculation.
 		{
@@ -592,7 +606,7 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			shouldPass:         false,
 			fault:              chunkDateMismatch,
 		},
-		// Test case - 10
+		// Test case - 11
 		// Set x-amz-decoded-content-length to a value too big to hold in int64.
 		{
 			bucketName:         bucketName,
@@ -669,11 +683,11 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 			}
 
 			buffer := new(bytes.Buffer)
-			err = obj.GetObject(testCase.bucketName, testCase.objectName, 0, int64(bytesDataLen), buffer)
+			err = obj.GetObject(testCase.bucketName, testCase.objectName, 0, int64(testCase.dataLen), buffer)
 			if err != nil {
 				t.Fatalf("Test %d: %s: Failed to fetch the copied object: <ERROR> %s", i+1, instanceType, err)
 			}
-			if !bytes.Equal(bytesData, buffer.Bytes()) {
+			if !bytes.Equal(testCase.data, buffer.Bytes()) {
 				t.Errorf("Test %d: %s: Data Mismatch: Data fetched back from the uploaded object doesn't match the original one.", i+1, instanceType)
 			}
 			buffer.Reset()


### PR DESCRIPTION
## Description
When EOF is reached, further calls of Read() doesn't return io.EOF
but continue to work as it expects to have more data, this PR fixes
the behavior

## Motivation and Context
Fixes #3691 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.