### PR TITLE
auth/rpc: Make auth rpc client retry configurable.

### DIFF
--- a/cmd/retry-storage.go
+++ b/cmd/retry-storage.go
@@ -220,9 +220,12 @@ func (f retryStorage) reInit() (err error) {
 	// Close the underlying connection.
 	f.remoteStorage.Close() // Error here is purposefully ignored.
 
+	// Done channel is used to close any lingering retry routine, as soon
+	// as this function returns.
 	doneCh := make(chan struct{})
 	defer close(doneCh)
-	for i := range newRetryTimer(f.retryUnit, f.retryCap, MaxJitter, doneCh) {
+
+	for i := range newRetryTimer(f.retryUnit, f.retryCap, doneCh) {
 		// Initialize and make a new login attempt.
 		err = f.remoteStorage.Init()
 		if err != nil {

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -48,7 +48,8 @@ func (r *lockedRandSource) Seed(seed int64) {
 // MaxJitter will randomize over the full exponential backoff time
 const MaxJitter = 1.0
 
-// NoJitter disables the use of jitter for randomizing the exponential backoff time
+// NoJitter disables the use of jitter for randomizing the
+// exponential backoff time
 const NoJitter = 0.0
 
 // Global random source for fetching random values.
@@ -56,9 +57,11 @@ var globalRandomSource = rand.New(&lockedRandSource{
 	src: rand.NewSource(time.Now().UTC().UnixNano()),
 })
 
-// newRetryTimer creates a timer with exponentially increasing delays
-// until the maximum retry attempts are reached.
-func newRetryTimer(unit time.Duration, cap time.Duration, jitter float64, doneCh chan struct{}) <-chan int {
+// newRetryTimerJitter creates a timer with exponentially increasing delays
+// until the maximum retry attempts are reached. - this function is a fully
+// configurable version, meant for only advanced use cases. For the most part
+// one should use newRetryTimerSimple and newRetryTimer.
+func newRetryTimerWithJitter(unit time.Duration, cap time.Duration, jitter float64, doneCh chan struct{}) <-chan int {
 	attemptCh := make(chan int)
 
 	// normalize jitter to the range [0, 1.0]
@@ -113,5 +116,27 @@ func newRetryTimer(unit time.Duration, cap time.Duration, jitter float64, doneCh
 
 		}
 	}()
+
+	// Start reading..
 	return attemptCh
+}
+
+// Default retry constants.
+var (
+	defaultRetryUnit = time.Second      // 1 second.
+	defaultRetryCap  = 30 * time.Second // 30 seconds.
+)
+
+// newRetryTimer creates a timer with exponentially increasing delays
+// until the maximum retry attempts are reached. - this function provides
+// resulting retry values to be of maximum jitter.
+func newRetryTimer(unit time.Duration, cap time.Duration, doneCh chan struct{}) <-chan int {
+	return newRetryTimerWithJitter(unit, cap, MaxJitter, doneCh)
+}
+
+// newRetryTimerSimple creates a timer with exponentially increasing delays
+// until the maximum retry attempts are reached. - this function is a
+// simpler version with all default values.
+func newRetryTimerSimple(doneCh chan struct{}) <-chan int {
+	return newRetryTimerWithJitter(defaultRetryUnit, defaultRetryCap, MaxJitter, doneCh)
 }

--- a/cmd/retry_test.go
+++ b/cmd/retry_test.go
@@ -1,0 +1,82 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for retry timer.
+func TestRetryTimerSimple(t *testing.T) {
+	doneCh := make(chan struct{})
+	attemptCh := newRetryTimerSimple(doneCh)
+	i := <-attemptCh
+	if i != 0 {
+		close(doneCh)
+		t.Fatalf("Invalid attempt counter returned should be 0, found %d instead", i)
+	}
+	i = <-attemptCh
+	if i <= 0 {
+		close(doneCh)
+		t.Fatalf("Invalid attempt counter returned should be greater than 0, found %d instead", i)
+	}
+	close(doneCh)
+	_, ok := <-attemptCh
+	if ok {
+		t.Fatal("Attempt counter should be closed")
+	}
+}
+
+// Test retry time with no jitter.
+func TestRetryTimerWithNoJitter(t *testing.T) {
+	doneCh := make(chan struct{})
+	// No jitter
+	attemptCh := newRetryTimerWithJitter(time.Millisecond, 5*time.Millisecond, NoJitter, doneCh)
+	i := <-attemptCh
+	if i != 0 {
+		close(doneCh)
+		t.Fatalf("Invalid attempt counter returned should be 0, found %d instead", i)
+	}
+	// Loop through the maximum possible attempt.
+	for i = range attemptCh {
+		if i == 30 {
+			close(doneCh)
+		}
+	}
+	_, ok := <-attemptCh
+	if ok {
+		t.Fatal("Attempt counter should be closed")
+	}
+}
+
+// Test retry time with Jitter greater than MaxJitter.
+func TestRetryTimerWithJitter(t *testing.T) {
+	doneCh := make(chan struct{})
+	// Jitter will be set back to 1.0
+	attemptCh := newRetryTimerWithJitter(defaultRetryUnit, defaultRetryCap, 2.0, doneCh)
+	i := <-attemptCh
+	if i != 0 {
+		close(doneCh)
+		t.Fatalf("Invalid attempt counter returned should be 0, found %d instead", i)
+	}
+	close(doneCh)
+	_, ok := <-attemptCh
+	if ok {
+		t.Fatal("Attempt counter should be closed")
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
auth/rpc: Make auth rpc client retry configurable.
<!--- Describe your changes in detail -->

## Motivation and Context
Currently the auth rpc client defaults to to a maximum
cap of 30seconds timeout. Make this to be configurable
by the caller of authRPCClient during initialization, if no
such config is provided then default to 30 seconds.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.