### PR TITLE
tests: Reduce two functions work to gain test time

### DIFF
--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -77,13 +77,11 @@ func TestFSShutdown(t *testing.T) {
 	removeAll(disk)
 
 	// Test Shutdown with faulty disk
-	for i := 1; i <= 5; i++ {
-		fs, disk := prepareTest()
-		fs.DeleteObject(bucketName, objectName)
-		removeAll(disk)
-		if err := fs.Shutdown(); err != nil {
-			t.Fatal(i, ", Got unexpected fs shutdown error: ", err)
-		}
+	fs, disk = prepareTest()
+	fs.DeleteObject(bucketName, objectName)
+	removeAll(disk)
+	if err := fs.Shutdown(); err != nil {
+		t.Fatal("Got unexpected fs shutdown error: ", err)
 	}
 }
 


### PR DESCRIPTION
## Description
TestListObjectsHeal and TestFSShutdown takes around 3 min,
this PR reduces the number of created test objects

## Motivation and Context
Reduce test time since it takes little long time under Windows

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.