### PR TITLE
browser: Implement infinite scrolling for object listing.

### DIFF
--- a/browser/app/js/components/Path.js
+++ b/browser/app/js/components/Path.js
@@ -29,7 +29,7 @@ let Path = ({currentBucket, currentPath, selectPrefix}) => {
   }
 
   return (
-      <h2><span className="main"><a onClick={ (e) => selectPrefix(e, '') } href="">{ currentBucket }</a></span>{ path }</h2>
+    <h2><span className="main"><a onClick={ (e) => selectPrefix(e, '') } href="">{ currentBucket }</a></span>{ path }</h2>
   )
 }
 

--- a/browser/app/js/reducers.js
+++ b/browser/app/js/reducers.js
@@ -21,6 +21,7 @@ export default (state = {
     buckets: [],
     visibleBuckets: [],
     objects: [],
+    istruncated: true,
     storageInfo: {},
     serverInfo: {},
     currentBucket: '',
@@ -76,7 +77,15 @@ export default (state = {
       newState.currentBucket = action.currentBucket
       break
     case actions.SET_OBJECTS:
-      newState.objects = action.objects
+      if (!action.objects.length) {
+        newState.objects = []
+        newState.marker = ""
+        newState.istruncated = action.istruncated
+      } else {
+        newState.objects = [...newState.objects, ...action.objects]
+        newState.marker = action.marker
+        newState.istruncated = action.istruncated
+      }
       break
     case actions.SET_CURRENT_PATH:
       newState.currentPath = action.currentPath
@@ -170,6 +179,11 @@ export default (state = {
       break
     case actions.SET_PREFIX_WRITABLE:
       newState.prefixWritable = action.prefixWritable
+      break
+    case actions.REMOVE_OBJECT:
+      let idx = newState.objects.findIndex(object => object.name === action.object)
+      if (idx == -1) break
+      newState.objects = [...newState.objects.slice(0, idx), ...newState.objects.slice(idx + 1)]
       break
   }
   return newState

--- a/browser/package.json
+++ b/browser/package.json
@@ -32,6 +32,7 @@
     "copy-webpack-plugin": "^0.3.3",
     "css-loader": "^0.23.1",
     "esformatter": "^0.10.0",
+    "esformatter-jsx": "^7.4.1",
     "esformatter-jsx-ignore": "^1.0.6",
     "expect": "^1.20.2",
     "history": "^1.17.0",
@@ -77,6 +78,7 @@
     "react-custom-scrollbars": "^2.2.2",
     "react-dom": "^0.14.6",
     "react-dropzone": "^3.5.3",
+    "react-infinite-scroller": "^1.0.6",
     "react-onclickout": "2.0.4"
   }
 }

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -177,13 +177,16 @@ func (web *webAPIHandlers) ListBuckets(r *http.Request, args *WebGenericArgs, re
 type ListObjectsArgs struct {
 	BucketName string `json:"bucketName"`
 	Prefix     string `json:"prefix"`
+	Marker     string `json:"marker"`
 }
 
 // ListObjectsRep - list objects response.
 type ListObjectsRep struct {
-	Objects   []WebObjectInfo `json:"objects"`
-	Writable  bool            `json:"writable"` // Used by client to show "upload file" button.
-	UIVersion string          `json:"uiVersion"`
+	Objects     []WebObjectInfo `json:"objects"`
+	NextMarker  string          `json:"nextmarker"`
+	IsTruncated bool            `json:"istruncated"`
+	Writable    bool            `json:"writable"` // Used by client to show "upload file" button.
+	UIVersion   string          `json:"uiVersion"`
 }
 
 // WebObjectInfo container for list objects metadata.
@@ -225,30 +228,26 @@ func (web *webAPIHandlers) ListObjects(r *http.Request, args *ListObjectsArgs, r
 	default:
 		return errAuthentication
 	}
-	marker := ""
-	for {
-		lo, err := objectAPI.ListObjects(args.BucketName, args.Prefix, marker, "/", 1000)
-		if err != nil {
-			return &json2.Error{Message: err.Error()}
-		}
-		marker = lo.NextMarker
-		for _, obj := range lo.Objects {
-			reply.Objects = append(reply.Objects, WebObjectInfo{
-				Key:          obj.Name,
-				LastModified: obj.ModTime,
-				Size:         obj.Size,
-				ContentType:  obj.ContentType,
-			})
-		}
-		for _, prefix := range lo.Prefixes {
-			reply.Objects = append(reply.Objects, WebObjectInfo{
-				Key: prefix,
-			})
-		}
-		if !lo.IsTruncated {
-			break
-		}
+	lo, err := objectAPI.ListObjects(args.BucketName, args.Prefix, args.Marker, slashSeparator, 1000)
+	if err != nil {
+		return &json2.Error{Message: err.Error()}
 	}
+	reply.NextMarker = lo.NextMarker
+	reply.IsTruncated = lo.IsTruncated
+	for _, obj := range lo.Objects {
+		reply.Objects = append(reply.Objects, WebObjectInfo{
+			Key:          obj.Name,
+			LastModified: obj.ModTime,
+			Size:         obj.Size,
+			ContentType:  obj.ContentType,
+		})
+	}
+	for _, prefix := range lo.Prefixes {
+		reply.Objects = append(reply.Objects, WebObjectInfo{
+			Key: prefix,
+		})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
fixes #2831

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implement infinite scrolling for object listing. Need to figure out how to automatically load more objects on scroll. Right now we have a "more" button. @rushenn can you make this button look better? For this button to appear you need to have more than 100 objects in a bucket. In the backend you can do:
`for i in {1..200}; do touch $i; done` to create 200 files (1 to 200)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/minio/minio/issues/2831

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.