### PR TITLE
objcache: Return io.ReaderAt to avoid Seeking and Reading.

### DIFF
--- a/pkg/objcache/objcache.go
+++ b/pkg/objcache/objcache.go
@@ -217,7 +217,7 @@ func (c *Cache) Create(key string, size int64) (w io.WriteCloser, err error) {
 // returns an error ErrNotFoundInCache, if the key does not exist.
 // Returns ErrKeyNotFoundInCache if entry's lastAccessedTime is older
 // than objModTime.
-func (c *Cache) Open(key string, objModTime time.Time) (io.ReadSeeker, error) {
+func (c *Cache) Open(key string, objModTime time.Time) (io.ReaderAt, error) {
 	// Entry exists, return the readable buffer.
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/pkg/objcache/objcache_test.go
+++ b/pkg/objcache/objcache_test.go
@@ -20,7 +20,6 @@ package objcache
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 )
@@ -173,7 +172,8 @@ func TestObjCache(t *testing.T) {
 		t.Errorf("Test case 4 expected to pass, failed instead %s", err)
 	}
 	// Reads everything stored for key "test".
-	cbytes, err := ioutil.ReadAll(r)
+	cbytes := make([]byte, 5)
+	_, err = r.ReadAt(cbytes, 0)
 	if err != nil {
 		t.Errorf("Test case 4 expected to pass, failed instead %s", err)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`io.ReaderAt` allows for reading sections directly with offset and length. 
<!--- Describe your changes in detail -->

## Motivation and Context
Cleanup, minor improvement. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.