### PR TITLE
Implement ServerConfig admin REST API

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -62,4 +62,9 @@ func registerAdminRouter(mux *router.Router) {
 	adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "object").HandlerFunc(adminAPI.HealObjectHandler)
 	// Heal Format.
 	adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "format").HandlerFunc(adminAPI.HealFormatHandler)
+
+	/// Config operations
+
+	// Get config
+	adminRouter.Methods("GET").Queries("config", "").Headers(minioAdminOpHeader, "get").HandlerFunc(adminAPI.GetConfigHandler)
 }

--- a/cmd/admin-rpc-client_test.go
+++ b/cmd/admin-rpc-client_test.go
@@ -1,0 +1,260 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+var (
+	config1 = []byte(`{
+	"version": "13",
+	"credential": {
+		"accessKey": "minio",
+		"secretKey": "minio123"
+	},
+	"region": "us-east-1",
+	"logger": {
+		"console": {
+			"enable": true,
+			"level": "debug"
+		},
+		"file": {
+			"enable": false,
+			"fileName": "",
+			"level": ""
+		}
+	},
+	"notify": {
+		"amqp": {
+			"1": {
+				"enable": false,
+				"url": "",
+				"exchange": "",
+				"routingKey": "",
+				"exchangeType": "",
+				"mandatory": false,
+				"immediate": false,
+				"durable": false,
+				"internal": false,
+				"noWait": false,
+				"autoDeleted": false
+			}
+		},
+		"nats": {
+			"1": {
+				"enable": false,
+				"address": "",
+				"subject": "",
+				"username": "",
+				"password": "",
+				"token": "",
+				"secure": false,
+				"pingInterval": 0,
+				"streaming": {
+					"enable": false,
+					"clusterID": "",
+					"clientID": "",
+					"async": false,
+					"maxPubAcksInflight": 0
+				}
+			}
+		},
+		"elasticsearch": {
+			"1": {
+				"enable": false,
+				"url": "",
+				"index": ""
+			}
+		},
+		"redis": {
+			"1": {
+				"enable": false,
+				"address": "",
+				"password": "",
+				"key": ""
+			}
+		},
+		"postgresql": {
+			"1": {
+				"enable": false,
+				"connectionString": "",
+				"table": "",
+				"host": "",
+				"port": "",
+				"user": "",
+				"password": "",
+				"database": ""
+			}
+		},
+		"kafka": {
+			"1": {
+				"enable": false,
+				"brokers": null,
+				"topic": ""
+			}
+		},
+		"webhook": {
+			"1": {
+				"enable": false,
+				"endpoint": ""
+			}
+		}
+	}
+}
+`)
+	// diff from config1 - amqp.Enable is True
+	config2 = []byte(`{
+	"version": "13",
+	"credential": {
+		"accessKey": "minio",
+		"secretKey": "minio123"
+	},
+	"region": "us-east-1",
+	"logger": {
+		"console": {
+			"enable": true,
+			"level": "debug"
+		},
+		"file": {
+			"enable": false,
+			"fileName": "",
+			"level": ""
+		}
+	},
+	"notify": {
+		"amqp": {
+			"1": {
+				"enable": true,
+				"url": "",
+				"exchange": "",
+				"routingKey": "",
+				"exchangeType": "",
+				"mandatory": false,
+				"immediate": false,
+				"durable": false,
+				"internal": false,
+				"noWait": false,
+				"autoDeleted": false
+			}
+		},
+		"nats": {
+			"1": {
+				"enable": false,
+				"address": "",
+				"subject": "",
+				"username": "",
+				"password": "",
+				"token": "",
+				"secure": false,
+				"pingInterval": 0,
+				"streaming": {
+					"enable": false,
+					"clusterID": "",
+					"clientID": "",
+					"async": false,
+					"maxPubAcksInflight": 0
+				}
+			}
+		},
+		"elasticsearch": {
+			"1": {
+				"enable": false,
+				"url": "",
+				"index": ""
+			}
+		},
+		"redis": {
+			"1": {
+				"enable": false,
+				"address": "",
+				"password": "",
+				"key": ""
+			}
+		},
+		"postgresql": {
+			"1": {
+				"enable": false,
+				"connectionString": "",
+				"table": "",
+				"host": "",
+				"port": "",
+				"user": "",
+				"password": "",
+				"database": ""
+			}
+		},
+		"kafka": {
+			"1": {
+				"enable": false,
+				"brokers": null,
+				"topic": ""
+			}
+		},
+		"webhook": {
+			"1": {
+				"enable": false,
+				"endpoint": ""
+			}
+		}
+	}
+}
+`)
+)
+
+// TestGetValidServerConfig - test for getValidServerConfig.
+func TestGetValidServerConfig(t *testing.T) {
+	var c1, c2 serverConfigV13
+	err := json.Unmarshal(config1, &c1)
+	if err != nil {
+		t.Fatalf("json unmarshal of %s failed: %v", string(config1), err)
+	}
+
+	err = json.Unmarshal(config2, &c2)
+	if err != nil {
+		t.Fatalf("json unmarshal of %s failed: %v", string(config2), err)
+	}
+
+	// Valid config.
+	noErrs := []error{nil, nil, nil, nil}
+	serverConfigs := []serverConfigV13{c1, c2, c1, c1}
+	validConfig, err := getValidServerConfig(serverConfigs, noErrs)
+	if err != nil {
+		t.Errorf("Expected a valid config but received %v instead", err)
+	}
+
+	if !reflect.DeepEqual(validConfig, c1) {
+		t.Errorf("Expected valid config to be %v but received %v", config1, validConfig)
+	}
+
+	// Invalid config - no quorum.
+	serverConfigs = []serverConfigV13{c1, c2, c2, c1}
+	validConfig, err = getValidServerConfig(serverConfigs, noErrs)
+	if err != errXLWriteQuorum {
+		t.Errorf("Expected to fail due to lack of quorum but received %v", err)
+	}
+
+	// All errors
+	allErrs := []error{errDiskNotFound, errDiskNotFound, errDiskNotFound, errDiskNotFound}
+	serverConfigs = []serverConfigV13{serverConfigV13{}, serverConfigV13{}, serverConfigV13{}, serverConfigV13{}}
+	validConfig, err = getValidServerConfig(serverConfigs, allErrs)
+	if err != errXLWriteQuorum {
+		t.Errorf("Expected to fail due to lack of quorum but received %v", err)
+	}
+}

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -36,13 +36,13 @@ func main() {
 
 ```
 
-| Service operations|LockInfo operations|Healing operations|
-|:---|:---|:---|
-|[`ServiceStatus`](#ServiceStatus)| [`ListLocks`](#ListLocks)| [`ListObjectsHeal`](#ListObjectsHeal)|
-|[`ServiceRestart`](#ServiceRestart)| [`ClearLocks`](#ClearLocks)| [`ListBucketsHeal`](#ListBucketsHeal)|
-| | |[`HealBucket`](#HealBucket) |
-| | |[`HealObject`](#HealObject)|
-| | |[`HealFormat`](#HealFormat)|
+| Service operations|LockInfo operations|Healing operations|Config operations|
+|:---|:---|:---|:---|
+|[`ServiceStatus`](#ServiceStatus)| [`ListLocks`](#ListLocks)| [`ListObjectsHeal`](#ListObjectsHeal)|[`GetConfig`](#GetConfig)|
+|[`ServiceRestart`](#ServiceRestart)| [`ClearLocks`](#ClearLocks)| [`ListBucketsHeal`](#ListBucketsHeal)||
+| | |[`HealBucket`](#HealBucket) ||
+| | |[`HealObject`](#HealObject)||
+| | |[`HealFormat`](#HealFormat)||
 
 ## 1. Constructor
 <a name="Minio"></a>
@@ -271,4 +271,25 @@ __Example__
 
     log.Println("successfully healed storage format on available disks.")
 
+```
+<a name="GetConfig"></a>
+### GetConfig() ([]byte, error)
+Get config.json of a minio setup.
+
+__Example__
+
+``` go
+    configBytes, err := madmClnt.GetConfig()
+    if err != nil {
+        log.Fatalf("failed due to: %v", err)
+    }
+
+    // Pretty-print config received as json.
+    var buf bytes.Buffer
+    err = json.Indent(buf, configBytes, "", "\t")
+    if err != nil {
+        log.Fatalf("failed due to: %v", err)
+    }
+
+    log.Println("config received successfully: ", string(buf.Bytes()))
 ```

--- a/pkg/madmin/config-commands.go
+++ b/pkg/madmin/config-commands.go
@@ -1,0 +1,49 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package madmin
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// GetConfig - returns the config.json of a minio setup.
+func (adm *AdminClient) GetConfig() ([]byte, error) {
+	queryVal := make(url.Values)
+	queryVal.Set("config", "")
+
+	hdrs := make(http.Header)
+	hdrs.Set(minioAdminOpHeader, "get")
+
+	reqData := requestData{
+		queryValues:   queryVal,
+		customHeaders: hdrs,
+	}
+
+	// Execute GET on /?lock to list locks.
+	resp, err := adm.executeMethod("GET", reqData)
+
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the JSON marshalled bytes to user.
+	return ioutil.ReadAll(resp.Body)
+}

--- a/pkg/madmin/examples/get-config.go
+++ b/pkg/madmin/examples/get-config.go
@@ -1,6 +1,4 @@
-// +build ignore
-
-/*
+/* +build ignore
  * Minio Cloud Storage, (C) 2017 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +18,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"log"
 
 	"github.com/minio/minio/pkg/madmin"
@@ -36,20 +36,17 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// Heal bucket mybucket - dry run
-	isDryRun := true
-	err = madmClnt.HealBucket("mybucket", isDryRun)
+	configBytes, err := madmClnt.GetConfig()
 	if err != nil {
-		log.Fatalln(err)
-
+		log.Fatalf("failed due to: %v", err)
 	}
 
-	// Heal bucket mybucket - for real this time.
-	isDryRun := false
-	err = madmClnt.HealBucket("mybucket", isDryRun)
+	// Pretty-print config received as json.
+	var buf bytes.Buffer
+	err = json.Indent(&buf, configBytes, "", "\t")
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalf("failed due to: %v", err)
 	}
 
-	log.Println("successfully healed mybucket")
+	log.Println("config received successfully: ", string(buf.Bytes()))
 }


### PR DESCRIPTION
Returns a valid config.json of the setup. In case of distributed
setup, it checks if quorum or more number of nodes have the same
config.json.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fetches config.json from all disks and returns a valid config.json if present.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For users to be able to read config.json of a minio instance without having to log onto the corresponding server and fetch the config.json.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested using pkg/madmin API also part of this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.