### PR TITLE
main/cli: Don't print hidden flags/commands in help template.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,13 +53,13 @@ DESCRIPTION:
   {{.Description}}
 
 USAGE:
-  minio {{if .Flags}}[flags] {{end}}command{{if .Flags}}{{end}} [arguments...]
+  minio {{if .VisibleFlags}}[flags] {{end}}command{{if .VisibleFlags}}{{end}} [arguments...]
 
 COMMANDS:
-  {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-  {{end}}{{if .Flags}}
+  {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+  {{end}}{{if .VisibleFlags}}
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}{{end}}
 VERSION:
   ` + Version +

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -52,7 +52,7 @@ USAGE:
   minio {{.Name}} [FLAGS] PATH [PATH...]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 ENVIRONMENT VARIABLES:
   ACCESS:

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -53,7 +53,7 @@ USAGE:
    minio {{.Name}} [FLAGS]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXIT STATUS:
    0 - You are already running the most recent version.

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -38,7 +38,7 @@ USAGE:
    minio {{.Name}}
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 VERSION:
   ` + Version + `{{"\n"}}`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Always use .VisibleFlags and .VisibleCommands to not print
Hidden flags as expected from help template.
<!--- Describe your changes in detail -->

## Motivation and Context
Cleanup and fixes.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using `Hidden: true` for commands and flags.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.