### PR TITLE
browser: Remove currentPath prefix in object names from list result.

### DIFF
--- a/browser/app/js/actions.js
+++ b/browser/app/js/actions.js
@@ -304,9 +304,13 @@ export const listObjects = () => {
       marker: marker
     })
       .then(res => {
-        let objects = res.objects
-        if (!objects.length)
+	let objects = res.objects
+        if (!objects)
           objects = []
+        objects = objects.map(object => {
+	  object.name = object.name.replace(`${currentPath}`, '');
+	  return object
+	})
         dispatch(setObjects(objects, res.nextmarker, res.istruncated))
         dispatch(setPrefixWritable(res.writable))
         dispatch(setLoadBucket(''))
@@ -328,7 +332,7 @@ export const listObjects = () => {
 export const selectPrefix = prefix => {
   return (dispatch, getState) => {
     const {currentBucket, web} = getState()
-    dispatch(setObjects([], "", true))
+    dispatch(setObjects([], "", false))
     dispatch(setLoadPath(prefix))
     web.ListObjects({
       bucketName: currentBucket,
@@ -339,6 +343,10 @@ export const selectPrefix = prefix => {
         let objects = res.objects
         if (!objects)
           objects = []
+        objects = objects.map(object => {
+	  object.name = object.name.replace(`${prefix}`, '');
+	  return object
+	})
         dispatch(setObjects(
           objects,
           res.nextmarker,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

13c3b9cbcb089bed1557bd5d82bd3f6dfa9817de introduced a bug where the currentPath prefix was not stripped from the listObjects result. Hence UI was showing full path instead of just the object name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.