### PR TITLE
tests: use url.QueryEscape() when dealing with url query params

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -516,8 +516,8 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		if successRedirect != "" {
 			redirectURL := successRedirect + "?" + fmt.Sprintf("bucket=%s&key=%s&etag=%s",
 				bucket,
-				getURLEncodedName(object),
-				getURLEncodedName("\""+objInfo.MD5Sum+"\""))
+				url.QueryEscape(object),
+				url.QueryEscape("\""+objInfo.MD5Sum+"\""))
 
 			writeRedirectSeeOther(w, redirectURL)
 		} else {

--- a/cmd/post-policy_test.go
+++ b/cmd/post-policy_test.go
@@ -24,6 +24,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -493,7 +494,7 @@ func testPostPolicyBucketHandlerRedirect(obj ObjectLayer, instanceType string, t
 	}
 
 	expectedLocation := fmt.Sprintf(redirectURL+"?bucket=%s&key=%s&etag=%s",
-		bucketName, getURLEncodedName(targetObj), getURLEncodedName("\""+info.MD5Sum+"\""))
+		bucketName, url.QueryEscape(targetObj), url.QueryEscape("\""+info.MD5Sum+"\""))
 
 	// Check the new location url
 	if rec.HeaderMap.Get("Location") != expectedLocation {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
url.QueryEscape() should be used everywhere when url query params are necessary.
<!--- Describe your changes in detail -->

## Motivation and Context
In lieu of go1.8 migration moving custom code to stdlib. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually with tests and `go test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.