### PR TITLE
copyObject: Be case sensitive for windows only server.

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strings"
 	"syscall"
 
 	"github.com/minio/minio/pkg/disk"
@@ -367,7 +366,7 @@ func (fs fsObjects) CopyObject(srcBucket, srcObject, dstBucket, dstObject string
 	}
 
 	// Check if this request is only metadata update.
-	cpMetadataOnly := strings.EqualFold(pathJoin(srcBucket, srcObject), pathJoin(dstBucket, dstObject))
+	cpMetadataOnly := isStringEqual(pathJoin(srcBucket, srcObject), pathJoin(dstBucket, dstObject))
 	if cpMetadataOnly {
 		fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, srcBucket, srcObject, fsMetaJSONFile)
 		var wlk *lock.LockedFile

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -164,7 +164,7 @@ func getCompleteMultipartMD5(parts []completePart) (string, error) {
 // For example on windows since its case insensitive we are supposed
 // to do case insensitive checks.
 func hasPrefix(s string, prefix string) bool {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == globalWindowsOSName {
 		return strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix))
 	}
 	return strings.HasPrefix(s, prefix)
@@ -174,10 +174,18 @@ func hasPrefix(s string, prefix string) bool {
 // For example on windows since its case insensitive we are supposed
 // to do case insensitive checks.
 func hasSuffix(s string, suffix string) bool {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == globalWindowsOSName {
 		return strings.HasSuffix(strings.ToLower(s), strings.ToLower(suffix))
 	}
 	return strings.HasSuffix(s, suffix)
+}
+
+// Validates if two strings are equal.
+func isStringEqual(s1 string, s2 string) bool {
+	if runtime.GOOS == globalWindowsOSName {
+		return strings.EqualFold(s1, s2)
+	}
+	return s1 == s2
 }
 
 // Ignores all reserved bucket names or invalid bucket names.

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -64,7 +64,7 @@ func (xl xlObjects) CopyObject(srcBucket, srcObject, dstBucket, dstObject string
 	length := xlMeta.Stat.Size
 
 	// Check if this request is only metadata update.
-	cpMetadataOnly := strings.EqualFold(pathJoin(srcBucket, srcObject), pathJoin(dstBucket, dstObject))
+	cpMetadataOnly := isStringEqual(pathJoin(srcBucket, srcObject), pathJoin(dstBucket, dstObject))
 	if cpMetadataOnly {
 		xlMeta.Meta = metadata
 		partsMetadata := make([]xlMetaV1, len(xl.storageDisks))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
copyObject: Be case sensitive for windows only server.
<!--- Describe your changes in detail -->

## Motivation and Context
For case sensitive platforms we should honor case.

Fixes #3765
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

```
1) python s3cmd -c s3cfg_localminio put logo.png s3://testbucket/xyz/etc2/logo.PNG

2) python s3cmd -c s3cfg_localminio ls s3://testbucket/xyz/etc2/
2017-02-18 10:58     22059   s3://testbucket/xyz/etc2/logo.PNG

3) python s3cmd -c s3cfg_localminio cp s3://testbucket/xyz/etc2/logo.PNG s3://testbucket/xyz/etc2/logo.png
remote copy: 's3://testbucket/xyz/etc2/logo.PNG' -> 's3://testbucket/xyz/etc2/logo.png'

4) python s3cmd -c s3cfg_localminio ls s3://testbucket/xyz/etc2/
2017-02-18 10:58     22059   s3://testbucket/xyz/etc2/logo.PNG
2017-02-18 11:10     22059   s3://testbucket/xyz/etc2/logo.png
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.