### PR TITLE
For streaming signature do not save content-encoding in PutObject()

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -63,7 +63,9 @@ func isRequestPostPolicySignatureV4(r *http.Request) bool {
 
 // Verify if the request has AWS Streaming Signature Version '4'. This is only valid for 'PUT' operation.
 func isRequestSignStreamingV4(r *http.Request) bool {
-	return r.Header.Get("x-amz-content-sha256") == streamingContentSHA256 && r.Method == httpPUT
+	return r.Header.Get("x-amz-content-sha256") == streamingContentSHA256 &&
+		r.Header.Get("content-encoding") == streamingContentEncoding &&
+		r.Method == httpPUT
 }
 
 // Authorization type.

--- a/cmd/auth-handler_test.go
+++ b/cmd/auth-handler_test.go
@@ -43,6 +43,7 @@ func TestGetRequestAuthType(t *testing.T) {
 				Header: http.Header{
 					"Authorization":        []string{"AWS4-HMAC-SHA256 <cred_string>"},
 					"X-Amz-Content-Sha256": []string{streamingContentSHA256},
+					"Content-Encoding":     []string{streamingContentEncoding},
 				},
 				Method: "PUT",
 			},

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -421,6 +421,13 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 
 	// Extract metadata to be saved from incoming HTTP header.
 	metadata := extractMetadataFromHeader(r.Header)
+	if rAuthType == authTypeStreamingSigned {
+		// Make sure to delete the content-encoding parameter
+		// for a streaming signature which is set to value
+		// "aws-chunked"
+		delete(metadata, "content-encoding")
+	}
+
 	// Make sure we hex encode md5sum here.
 	metadata["md5Sum"] = hex.EncodeToString(md5Bytes)
 

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -682,6 +682,13 @@ func testAPIPutObjectStreamSigV4Handler(obj ObjectLayer, instanceType, bucketNam
 				continue
 			}
 
+			objInfo, err := obj.GetObjectInfo(testCase.bucketName, testCase.objectName)
+			if err != nil {
+				t.Fatalf("Test %d: %s: Failed to fetch the copied object: <ERROR> %s", i+1, instanceType, err)
+			}
+			if objInfo.ContentEncoding == streamingContentEncoding {
+				t.Fatalf("Test %d: %s: ContentEncoding is set to \"aws-chunked\" which is unexpected", i+1, instanceType)
+			}
 			buffer := new(bytes.Buffer)
 			err = obj.GetObject(testCase.bucketName, testCase.objectName, 0, int64(testCase.dataLen), buffer)
 			if err != nil {

--- a/cmd/streaming-signature-v4.go
+++ b/cmd/streaming-signature-v4.go
@@ -34,9 +34,10 @@ import (
 
 // Streaming AWS Signature Version '4' constants.
 const (
-	emptySHA256            = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	streamingContentSHA256 = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
-	signV4ChunkedAlgorithm = "AWS4-HMAC-SHA256-PAYLOAD"
+	emptySHA256              = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	streamingContentSHA256   = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
+	signV4ChunkedAlgorithm   = "AWS4-HMAC-SHA256-PAYLOAD"
+	streamingContentEncoding = "aws-chunked"
 )
 
 // getChunkSignature - get chunk signature.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For streaming signature do not save content-encoding in PutObject()
<!--- Describe your changes in detail -->

## Motivation and Context
Content-Encoding is set to "aws-chunked" which is an S3 specific
API value which is no meaning for an object. This is how S3
behaves as well for a streaming signature uploaded object.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using new streaming signature patch for minio-go
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.