### PR TITLE
Fix rabbitmq reconnect problem

### DIFF
--- a/cmd/notify-amqp.go
+++ b/cmd/notify-amqp.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"io/ioutil"
+	"net"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/streadway/amqp"
@@ -87,7 +88,14 @@ func (q amqpConn) Fire(entry *logrus.Entry) error {
 	ch, err := q.Connection.Channel()
 	if err != nil {
 		// Any other error other than connection closed, return.
-		if err != amqp.ErrClosed {
+		isClosedErr := false
+		if neterr, ok := err.(*net.OpError); ok &&
+			neterr.Err.Error() == "use of closed network connection" {
+			isClosedErr = true
+		} else if err == amqp.ErrClosed {
+			isClosedErr = true
+		}
+		if !isClosedErr {
 			return err
 		}
 		// Attempt to connect again.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes https://github.com/minio/minio/issues/3732 by fixing error checking for closed connection.


## Description
<!--- Describe your changes in detail -->
The closed connection does not seem to be detected by the check `err == amqp.ErrClosed`, and so this more clumsy error checking appears to be required. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/minio/minio/issues/3732


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.