### PR TITLE
xl.PutObject: Ignore disks which return an error

### DIFF
--- a/cmd/erasure-createfile.go
+++ b/cmd/erasure-createfile.go
@@ -114,6 +114,7 @@ func appendFile(disks []StorageAPI, volume, path string, enBlocks [][]byte, hash
 	// Write encoded data to quorum disks in parallel.
 	for index, disk := range disks {
 		if disk == nil {
+			wErrs[index] = traceError(errDiskNotFound)
 			continue
 		}
 		wg.Add(1)
@@ -123,6 +124,8 @@ func appendFile(disks []StorageAPI, volume, path string, enBlocks [][]byte, hash
 			wErr := disk.AppendFile(volume, path, enBlocks[index])
 			if wErr != nil {
 				wErrs[index] = traceError(wErr)
+				// Ignore disk which returned an error.
+				disks[index] = nil
 				return
 			}
 

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -361,6 +361,8 @@ func writeUniqueXLMetadata(disks []StorageAPI, bucket, prefix string, xlMetas []
 			err := writeXLMetadata(disk, bucket, prefix, xlMetas[index])
 			if err != nil {
 				mErrs[index] = err
+				// Ignore disk which returned an error.
+				disks[index] = nil
 			}
 		}(index, disk)
 	}
@@ -399,6 +401,8 @@ func writeSameXLMetadata(disks []StorageAPI, bucket, prefix string, xlMeta xlMet
 			err := writeXLMetadata(disk, bucket, prefix, metadata)
 			if err != nil {
 				mErrs[index] = err
+				// Ignore disk which returned an error.
+				disks[index] = nil
 			}
 		}(index, disk, xlMeta)
 	}

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -254,6 +254,8 @@ func commitXLMetadata(disks []StorageAPI, srcBucket, srcPrefix, dstBucket, dstPr
 			rErr := disk.RenameFile(srcBucket, srcJSONFile, dstBucket, dstJSONFile)
 			if rErr != nil {
 				mErrs[index] = traceError(rErr)
+				// Ignore disk which returned an error.
+				disks[index] = nil
 				return
 			}
 			mErrs[index] = nil

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -395,6 +395,8 @@ func rename(disks []StorageAPI, srcBucket, srcEntry, dstBucket, dstEntry string,
 			err := disk.RenameFile(srcBucket, srcEntry, dstBucket, dstEntry)
 			if err != nil && err != errFileNotFound {
 				errs[index] = traceError(err)
+				// Ignore disk which returned an error.
+				disks[index] = nil
 			}
 		}(index, disk)
 	}


### PR DESCRIPTION
## Description
Ignore a disk which wasn't able to successfully perform an action to
avoid eventual perturbations when the disk comes back in the middle
of PutObject().

## Motivation and Context
Review of code and possible f.i.x of https://github.com/minio/minio/issues/3784 

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.