### PR TITLE
admin: Move SetCredentials from Service to Generic

### DIFF
--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -36,13 +36,13 @@ func main() {
 
 ```
 
-| Service operations|LockInfo operations|Healing operations|Config operations|
-|:---|:---|:---|:---|
-|[`ServiceStatus`](#ServiceStatus)| [`ListLocks`](#ListLocks)| [`ListObjectsHeal`](#ListObjectsHeal)|[`GetConfig`](#GetConfig)|
-|[`ServiceRestart`](#ServiceRestart)| [`ClearLocks`](#ClearLocks)| [`ListBucketsHeal`](#ListBucketsHeal)||
-| | |[`HealBucket`](#HealBucket) ||
-| | |[`HealObject`](#HealObject)||
-| | |[`HealFormat`](#HealFormat)||
+| Service operations|LockInfo operations|Healing operations|Config operations| Misc |
+|:---|:---|:---|:---|:---|
+|[`ServiceStatus`](#ServiceStatus)| [`ListLocks`](#ListLocks)| [`ListObjectsHeal`](#ListObjectsHeal)|[`GetConfig`](#GetConfig)| [`SetCredentials`](#SetCredentials)|
+|[`ServiceRestart`](#ServiceRestart)| [`ClearLocks`](#ClearLocks)| [`ListBucketsHeal`](#ListBucketsHeal)|||
+| | |[`HealBucket`](#HealBucket) |||
+| | |[`HealObject`](#HealObject)|||
+| | |[`HealFormat`](#HealFormat)|||
 
 ## 1. Constructor
 <a name="Minio"></a>
@@ -119,6 +119,9 @@ If successful restarts the running minio service, for distributed setup restarts
 	log.Printf("Success")
 
  ```
+
+## 3. Lock operations
+
 <a name="ListLocks"></a>
 ### ListLocks(bucket, prefix string, duration time.Duration) ([]VolumeLockInfo, error)
 If successful returns information on the list of locks held on ``bucket`` matching ``prefix`` for  longer than ``duration`` seconds.
@@ -148,6 +151,8 @@ __Example__
     log.Println("List of locks cleared: ", volLocks)
 
 ```
+
+## 4. Heal operations
 
 <a name="ListObjectsHeal"></a>
 ### ListObjectsHeal(bucket, prefix string, recursive bool, doneCh <-chan struct{}) (<-chan ObjectInfo, error)
@@ -272,6 +277,9 @@ __Example__
     log.Println("successfully healed storage format on available disks.")
 
 ```
+
+## 5. Config operations
+
 <a name="GetConfig"></a>
 ### GetConfig() ([]byte, error)
 Get config.json of a minio setup.
@@ -293,3 +301,23 @@ __Example__
 
     log.Println("config received successfully: ", string(buf.Bytes()))
 ```
+
+## 6. Misc operations
+
+<a name="SetCredentials"></a>
+
+### SetCredentials() error 
+Set new credentials of a Minio setup.
+
+__Example__
+
+``` go
+    err = madmClnt.SetCredentials("YOUR-NEW-ACCESSKEY", "YOUR-NEW-SECRETKEY")
+    if err != nil {
+            log.Fatalln(err)
+    }
+    log.Println("New credentials successfully set.")
+
+```
+
+

--- a/pkg/madmin/examples/set-credentials.go
+++ b/pkg/madmin/examples/set-credentials.go
@@ -36,7 +36,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	err = madmClnt.ServiceSetCredentials("YOUR-NEW-ACCESSKEY", "YOUR-NEW-SECRETKEY")
+	err = madmClnt.SetCredentials("YOUR-NEW-ACCESSKEY", "YOUR-NEW-SECRETKEY")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/madmin/generic-commands.go
+++ b/pkg/madmin/generic-commands.go
@@ -1,0 +1,72 @@
+/*
+ * Minio Cloud Storage, (C) 2016, 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package madmin
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"net/url"
+)
+
+// setCredsReq - xml to send to the server to set new credentials
+type setCredsReq struct {
+	Username string `xml:"username"`
+	Password string `xml:"password"`
+}
+
+// SetCredentials - Call Set Credentials API to set new access and secret keys in the specified Minio server
+func (adm *AdminClient) SetCredentials(access, secret string) error {
+
+	// Disallow sending with the server if the connection is not secure
+	if !adm.secure {
+		return errors.New("setting new credentials requires HTTPS connection to the server")
+	}
+
+	// Setup new request
+	reqData := requestData{}
+	reqData.queryValues = make(url.Values)
+	reqData.queryValues.Set("service", "")
+	reqData.customHeaders = make(http.Header)
+	reqData.customHeaders.Set(minioAdminOpHeader, "set-credentials")
+
+	// Setup request's body
+	body, err := xml.Marshal(setCredsReq{Username: access, Password: secret})
+	if err != nil {
+		return err
+	}
+	reqData.contentBody = bytes.NewReader(body)
+	reqData.contentLength = int64(len(body))
+	reqData.contentMD5Bytes = sumMD5(body)
+	reqData.contentSHA256Bytes = sum256(body)
+
+	// Execute GET on bucket to list objects.
+	resp, err := adm.executeMethod("POST", reqData)
+
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	// Return error to the caller if http response code is different from 200
+	if resp.StatusCode != http.StatusOK {
+		return httpRespToErrorResponse(resp)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description
Setting credentials doesn't belong to service management API
anymore.

## Motivation and Context
Moving setting credentials from service management api

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.