### PR TITLE
tests: Fix test server

### DIFF
--- a/cmd/benchmark-utils_test.go
+++ b/cmd/benchmark-utils_test.go
@@ -28,25 +28,9 @@ import (
 	humanize "github.com/dustin/go-humanize"
 )
 
-// Prepare benchmark backend
+// Prepare XL/FS backend for benchmark.
 func prepareBenchmarkBackend(instanceType string) (ObjectLayer, []string, error) {
-	switch instanceType {
-	// Total number of disks for FS backend is set to 1.
-	case FSTestStr:
-		obj, disk, err := prepareFS()
-		if err != nil {
-			return nil, nil, err
-		}
-		return obj, []string{disk}, nil
-	// Total number of disks for XL backend is set to 16.
-	case XLTestStr:
-		return prepareXL()
-	}
-	obj, disk, err := prepareFS()
-	if err != nil {
-		return nil, nil, err
-	}
-	return obj, []string{disk}, nil
+	return prepareTestBackend(instanceType)
 }
 
 // Benchmark utility functions for ObjectLayer.PutObject().

--- a/cmd/fs-v1-rwpool.go
+++ b/cmd/fs-v1-rwpool.go
@@ -49,7 +49,6 @@ func (fsi *fsIOPool) Open(path string) (*lock.RLockedFile, error) {
 	}
 
 	fsi.Lock()
-
 	rlkFile, ok := fsi.readersMap[path]
 	// File reference exists on map, validate if its
 	// really closed and we are safe to purge it.
@@ -68,7 +67,6 @@ func (fsi *fsIOPool) Open(path string) (*lock.RLockedFile, error) {
 			// Increment the lock ref, since the file is not closed yet
 			// and caller requested to read the file again.
 			rlkFile.IncLockRef()
-			fsi.readersMap[path] = rlkFile
 		}
 	}
 	fsi.Unlock()
@@ -115,7 +113,11 @@ func (fsi *fsIOPool) Open(path string) (*lock.RLockedFile, error) {
 				rlkFile.IncLockRef()
 				newRlkFile.Close()
 			}
+		} else {
+			// Save the newly acquired read locked file.
+			rlkFile = newRlkFile
 		}
+
 		// Save the rlkFile back on the map.
 		fsi.readersMap[path] = rlkFile
 		fsi.Unlock()

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -20,7 +20,7 @@ package lock
 
 import (
 	"os"
-	"sync/atomic"
+	"sync"
 )
 
 // RLockedFile represents a read locked file, implements a special
@@ -28,31 +28,38 @@ import (
 // has reached zero, i.e when all the readers have given up their locks.
 type RLockedFile struct {
 	*LockedFile
-	refs int64 // Holds read lock refs.
+	mutex sync.Mutex
+	refs  int // Holds read lock refs.
 }
 
 // IsClosed - Check if the rlocked file is already closed.
 func (r *RLockedFile) IsClosed() bool {
-	return atomic.LoadInt64(&r.refs) == 0
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.refs == 0
 }
 
 // IncLockRef - is used by called to indicate lock refs.
 func (r *RLockedFile) IncLockRef() {
-	atomic.AddInt64(&r.refs, 1)
+	r.mutex.Lock()
+	r.refs++
+	r.mutex.Unlock()
 }
 
 // Close - this closer implements a special closer
 // closes the underlying fd only when the refs
 // reach zero.
 func (r *RLockedFile) Close() (err error) {
-	refs := atomic.LoadInt64(&r.refs)
-	if refs == 0 {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.refs == 0 {
 		return os.ErrInvalid
 	}
 
-	refs = atomic.AddInt64(&r.refs, -1)
-	if refs == 0 {
-		err = r.LockedFile.Close()
+	r.refs--
+	if r.refs == 0 {
+		err = r.File.Close()
 	}
 
 	return err


### PR DESCRIPTION
- Test server for the suite test was only initializing XL is 16 disks.
- The `instanceType`(FS/XL) has to be taken into account and create a FS
  backend when the value is set to `FSTestStr`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.