### PR TITLE
XL: Make listOnlineDisks and outDatedDisks consistent w/ each other.

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -323,7 +323,7 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 	// List of disks having latest version of the object.
 	latestDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 	// List of disks having outdated version of the object or missing object.
-	outDatedDisks := outDatedDisks(storageDisks, partsMetadata, errs)
+	outDatedDisks := outDatedDisks(storageDisks, latestDisks, partsMetadata, errs)
 	// Latest xlMetaV1 for reference. If a valid metadata is not present, it is as good as object not found.
 	latestMeta, pErr := pickValidXLMeta(partsMetadata, modTime)
 	if pErr != nil {

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -322,9 +322,13 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 
 	// List of disks having latest version of the object.
 	latestDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
+
 	// List of disks having outdated version of the object or missing object.
-	outDatedDisks := outDatedDisks(storageDisks, latestDisks, partsMetadata, errs)
-	// Latest xlMetaV1 for reference. If a valid metadata is not present, it is as good as object not found.
+	outDatedDisks := outDatedDisks(storageDisks, latestDisks, partsMetadata,
+		bucket, object)
+
+	// Latest xlMetaV1 for reference. If a valid metadata is not
+	// present, it is as good as object not found.
 	latestMeta, pErr := pickValidXLMeta(partsMetadata, modTime)
 	if pErr != nil {
 		return pErr

--- a/cmd/xl-v1-object_test.go
+++ b/cmd/xl-v1-object_test.go
@@ -265,6 +265,12 @@ func TestPutObjectNoQuorum(t *testing.T) {
 
 // Tests both object and bucket healing.
 func TestHealing(t *testing.T) {
+	rootPath, err := newTestConfig(globalMinioDefaultRegion)
+	if err != nil {
+		t.Fatalf("Failed to initialize test config %v", err)
+	}
+	defer removeAll(rootPath)
+
 	obj, fsDirs, err := prepareXL()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Checks if object parts match their checksum in `xl.json`
- Checks if all parts mentioned in `xl.json` are present.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When disks in a distributed (Erasure coded) Minio setup have `xl.json` but have one or more parts missing or corrupt for a given object, we should heal them if there are enough 'good' parts.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.