### PR TITLE
Browser: Remove duplicate object entries while sorting

### DIFF
--- a/browser/app/js/reducers.js
+++ b/browser/app/js/reducers.js
@@ -83,7 +83,7 @@ export default (state = {
         newState.marker = ""
         newState.istruncated = action.istruncated
       } else {
-        newState.objects = [...newState.objects, ...action.objects]
+        newState.objects = [...action.objects]
         newState.marker = action.marker
         newState.istruncated = action.istruncated
       }


### PR DESCRIPTION
Remove duplicate object entries while sorting.

## Description
Fixed the sorting by updating the array to hold only new values.

## Motivation and Context
https://github.com/minio/minio/issues/3809

## How Has This Been Tested?
Locally tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.