### PR TITLE
Close client connection after checking for update

### DIFF
--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -155,6 +155,10 @@ func downloadReleaseData(releaseChecksumURL string, timeout time.Duration) (data
 
 	client := &http.Client{
 		Timeout: timeout,
+		Transport: &http.Transport{
+			// need to close connection after usage.
+			DisableKeepAlives: true,
+		},
 	}
 
 	resp, err := client.Do(req)
@@ -164,6 +168,7 @@ func downloadReleaseData(releaseChecksumURL string, timeout time.Duration) (data
 	if resp == nil {
 		return data, fmt.Errorf("No response from server to download URL %s", releaseChecksumURL)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return data, fmt.Errorf("Error downloading URL %s. Response: %v", releaseChecksumURL, resp.Status)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

User jpalacios on slack reported that the connection to check for update lingers for a long time. This is not necessary, as the check happens only once at server startup. 


## Description
<!--- Describe your changes in detail -->
Closes connection after checking for update.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Same as description near the beginning.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually with "ss -tap -o state established". Connection is closed in a few seconds.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.