### PR TITLE
admin: Set Config returns errSet and errMsg

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -718,9 +718,11 @@ func toAdminAPIErrCode(err error) APIErrorCode {
 // SetConfigResult - represents detailed results of a set-config
 // operation.
 type nodeSummary struct {
-	Name string `json:"name"`
-	Err  string `json:"err"`
+	Name   string `json:"name"`
+	ErrSet bool   `json:"errSet"`
+	ErrMsg string `json:"errMsg"`
 }
+
 type setConfigResult struct {
 	NodeResults []nodeSummary `json:"nodeResults"`
 	Status      bool          `json:"status"`
@@ -733,8 +735,9 @@ func writeSetConfigResponse(w http.ResponseWriter, peers adminPeers, errs []erro
 	// set-config operation.
 	for i := range errs {
 		nodeResults = append(nodeResults, nodeSummary{
-			Name: peers[i].addr,
-			Err:  fmt.Sprintf("%v", errs[i]),
+			Name:   peers[i].addr,
+			ErrSet: errs[i] != nil,
+			ErrMsg: fmt.Sprintf("%v", errs[i]),
 		})
 
 	}

--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -1279,9 +1279,13 @@ func TestWriteSetConfigResponse(t *testing.T) {
 			if res.Name != testPeers[p].addr {
 				t.Errorf("Test %d: Expected node name %s but received %s", i+1, testPeers[p].addr, res.Name)
 			}
-			expectedErrStr := fmt.Sprintf("%v", test.errs[p])
-			if res.Err != expectedErrStr {
-				t.Errorf("Test %d: Expected error %s but received %s", i+1, expectedErrStr, res.Err)
+			expectedErrMsg := fmt.Sprintf("%v", test.errs[p])
+			if res.ErrMsg != expectedErrMsg {
+				t.Errorf("Test %d: Expected error %s but received %s", i+1, expectedErrMsg, res.ErrMsg)
+			}
+			expectedErrSet := test.errs[p] != nil
+			if res.ErrSet != expectedErrSet {
+				t.Errorf("Test %d: Expected ErrSet %v but received %v", i+1, expectedErrSet, res.ErrSet)
 			}
 		}
 	}

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -330,7 +330,8 @@ change to take effect.
 |---|---|---|
 |`st.Status`            | _bool_  | true if set-config succeeded, false otherwise. |
 |`st.NodeSummary.Name`  | _string_  | Network address of the node. |
-|`st.NodeSummary.Err`   | _string_ | String representation of the error (if any) on the node.|
+|`st.NodeSummary.ErrSet`   | _bool_ | Bool representation indicating if an error is encountered with the node.|
+|`st.NodeSummary.ErrMsg`   | _string_ | String representation of the error (if any) on the node.|
 
 
 __Example__

--- a/pkg/madmin/config-commands.go
+++ b/pkg/madmin/config-commands.go
@@ -33,8 +33,9 @@ const (
 // NodeSummary - represents the result of an operation part of
 // set-config on a node.
 type NodeSummary struct {
-	Name string `json:"name"`
-	Err  string `json:"err"`
+	Name   string `json:"name"`
+	ErrSet bool   `json:"errSet"`
+	ErrMsg string `json:"errMsg"`
 }
 
 // SetConfigResult - represents detailed results of a set-config


### PR DESCRIPTION
## Description
There is no way to see if a node encountered an error
when trying to set a new config set, this commit adds
a bool errSet field.

## Motivation and Context
Implement mc set config 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.