### PR TITLE
Remove globalMaxCacheSize and globalCacheExpiry variables

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -26,7 +26,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/console"
-	"github.com/minio/minio/pkg/objcache"
 )
 
 // minio configuration related constants.
@@ -78,15 +77,8 @@ var (
 	// Set to true if credentials were passed from env, default is false.
 	globalIsEnvCreds = false
 
-	// Maximum cache size. Defaults to disabled.
-	// Caching is enabled only for RAM size > 8GiB.
-	globalMaxCacheSize = uint64(0)
-
 	// Maximum size of internal objects parts
 	globalPutPartSize = int64(64 * 1024 * 1024)
-
-	// Cache expiry.
-	globalCacheExpiry = objcache.DefaultExpiry
 
 	// Minio local server address (in `host:port` format)
 	globalMinioAddr = ""

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -138,16 +138,8 @@ func initServerConfig(c *cli.Context) {
 	// Load user supplied root CAs
 	loadRootCAs()
 
-	// Set maxOpenFiles, This is necessary since default operating
-	// system limits of 1024, 2048 are not enough for Minio server.
-	setMaxOpenFiles()
-
-	// Set maxMemory, This is necessary since default operating
-	// system limits might be changed and we need to make sure we
-	// do not crash the server so the set the maxCacheSize appropriately.
-	setMaxMemory()
-
-	// Do not fail if this is not allowed, lower limits are fine as well.
+	// Set system resources to maximum.
+	errorIf(setMaxResources(), "Unable to change resource limit")
 }
 
 // Validate if input disks are sufficient for initializing XL.

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -65,8 +65,8 @@ func init() {
 	// Disable printing console messages during tests.
 	color.Output = ioutil.Discard
 
-	// Enable caching.
-	setMaxMemory()
+	// Set system resources to maximum.
+	setMaxResources()
 }
 
 func prepareFS() (ObjectLayer, string, error) {

--- a/pkg/objcache/README.md
+++ b/pkg/objcache/README.md
@@ -6,21 +6,23 @@ package objcache
 
     Package objcache implements in memory caching methods.
 
+CONSTANTS
+
+    const (
+    	// NoExpiry represents caches to be permanent and can only be deleted.
+    	NoExpiry = time.Duration(0)
+
+    	// DefaultExpiry represents three days time duration when individual entries will be expired.
+    	DefaultExpiry = time.Duration(3 * 24 * time.Hour)
+    )
+
 VARIABLES
-
-var DefaultExpiry = time.Duration(72 * time.Hour) // 72hrs.
-
-    DefaultExpiry represents default time duration value when individual
-    entries will be expired.
 
 var ErrCacheFull = errors.New("Not enough space in cache")
     ErrCacheFull - cache is full.
 
 var ErrKeyNotFoundInCache = errors.New("Key not found in cache")
     ErrKeyNotFoundInCache - key not found in cache.
-
-var NoExpiry = time.Duration(0)
-    NoExpiry represents caches to be permanent and can only be deleted.
 
 TYPES
 

--- a/pkg/objcache/objcache_test.go
+++ b/pkg/objcache/objcache_test.go
@@ -43,7 +43,11 @@ func TestObjExpiry(t *testing.T) {
 
 	// Test case 1 validates running of GC.
 	testCase := testCases[0]
-	cache := New(testCase.cacheSize, testCase.expiry)
+	cache, err := New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	cache.OnEviction = func(key string) {}
 	w, err := cache.Create("test", 1)
 	if err != nil {
@@ -126,15 +130,23 @@ func TestObjCache(t *testing.T) {
 
 	// Test 1 validating Open failure.
 	testCase := testCases[0]
-	cache := New(testCase.cacheSize, testCase.expiry)
-	_, err := cache.Open("test", fakeObjModTime)
+	cache, err := New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
+	_, err = cache.Open("test", fakeObjModTime)
 	if testCase.err != err {
 		t.Errorf("Test case 2 expected to pass, failed instead %s", err)
 	}
 
 	// Test 2 validating Create failure.
 	testCase = testCases[1]
-	cache = New(testCase.cacheSize, testCase.expiry)
+	cache, err = New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	_, err = cache.Create("test", 2)
 	if testCase.err != err {
 		t.Errorf("Test case 2 expected to pass, failed instead %s", err)
@@ -144,7 +156,11 @@ func TestObjCache(t *testing.T) {
 	// Subsequently we Close() without writing any data, to receive
 	// `io.ErrShortBuffer`
 	testCase = testCases[2]
-	cache = New(testCase.cacheSize, testCase.expiry)
+	cache, err = New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	w, err := cache.Create("test", 1)
 	if testCase.err != err {
 		t.Errorf("Test case 3 expected to pass, failed instead %s", err)
@@ -156,7 +172,11 @@ func TestObjCache(t *testing.T) {
 	// Test 4 validates Create and Close succeeds successfully caching
 	// the writes.
 	testCase = testCases[3]
-	cache = New(testCase.cacheSize, testCase.expiry)
+	cache, err = New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	w, err = cache.Create("test", 5)
 	if testCase.err != err {
 		t.Errorf("Test case 4 expected to pass, failed instead %s", err)
@@ -184,7 +204,11 @@ func TestObjCache(t *testing.T) {
 
 	// Test 5 validates Delete succeeds and Open fails with err
 	testCase = testCases[4]
-	cache = New(testCase.cacheSize, testCase.expiry)
+	cache, err = New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	w, err = cache.Create("test", 5)
 	if err != nil {
 		t.Errorf("Test case 5 expected to pass, failed instead %s", err)
@@ -204,7 +228,11 @@ func TestObjCache(t *testing.T) {
 
 	// Test 6 validates OnEviction being called upon Delete is being invoked.
 	testCase = testCases[5]
-	cache = New(testCase.cacheSize, testCase.expiry)
+	cache, err = New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	w, err = cache.Create("test", 5)
 	if err != nil {
 		t.Errorf("Test case 6 expected to pass, failed instead %s", err)
@@ -227,7 +255,11 @@ func TestObjCache(t *testing.T) {
 
 	// Test 7 validates rejecting requests when excess data is being saved.
 	testCase = testCases[6]
-	cache = New(testCase.cacheSize, testCase.expiry)
+	cache, err = New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	w, err = cache.Create("test1", 5)
 	if err != nil {
 		t.Errorf("Test case 7 expected to pass, failed instead %s", err)
@@ -245,7 +277,11 @@ func TestObjCache(t *testing.T) {
 
 	// Test 8 validates rejecting Writes which write excess data.
 	testCase = testCases[7]
-	cache = New(testCase.cacheSize, testCase.expiry)
+	cache, err = New(testCase.cacheSize, testCase.expiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	w, err = cache.Create("test1", 5)
 	if err != nil {
 		t.Errorf("Test case 8 expected to pass, failed instead %s", err)
@@ -267,7 +303,11 @@ func TestObjCache(t *testing.T) {
 
 // TestStateEntryPurge - tests if objCache purges stale entry and returns ErrKeyNotFoundInCache.
 func TestStaleEntryPurge(t *testing.T) {
-	cache := New(1024, NoExpiry)
+	cache, err := New(1024, NoExpiry)
+	if err != nil {
+		t.Fatalf("Unable to create new objcache")
+	}
+
 	w, err := cache.Create("test", 5)
 	if err != nil {
 		t.Errorf("Test case expected to pass, failed instead %s", err)


### PR DESCRIPTION
This patch fixes below
* Remove global variables globalMaxCacheSize and globalCacheExpiry.
* Make global variables into constant in objcache package.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.