### PR TITLE
Enhanced newObjectLayerFn

### DIFF
--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -38,14 +38,14 @@ const (
 )
 
 // Global object layer mutex, used for safely updating object layer.
-var globalObjLayerMutex *sync.Mutex
+var globalObjLayerMutex *sync.RWMutex
 
 // Global object layer, only accessed by newObjectLayerFn().
 var globalObjectAPI ObjectLayer
 
 func init() {
 	// Initialize this once per server initialization.
-	globalObjLayerMutex = &sync.Mutex{}
+	globalObjLayerMutex = &sync.RWMutex{}
 }
 
 // Check if the disk is remote.

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -22,10 +22,11 @@ import (
 	router "github.com/gorilla/mux"
 )
 
-func newObjectLayerFn() ObjectLayer {
-	globalObjLayerMutex.Lock()
-	defer globalObjLayerMutex.Unlock()
-	return globalObjectAPI
+func newObjectLayerFn() (layer ObjectLayer) {
+	globalObjLayerMutex.RLock()
+	layer = globalObjectAPI
+	globalObjLayerMutex.RUnlock()
+	return
 }
 
 // Composed function registering routers for only distributed XL setup.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Using RWMutex to guard globalObjectAPI in the newObjectLayerFn, and reduce the overhead of deferred function call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make test GOFLAGS="-timeout 15m -race -v"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.