### PR TITLE
api: CopyObjectPart was copying wrong offsets due to shadowing.

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -56,6 +56,8 @@ const (
 	ErrInvalidBucketName
 	ErrInvalidDigest
 	ErrInvalidRange
+	ErrInvalidCopyPartRange
+	ErrInvalidCopyPartRangeSource
 	ErrInvalidMaxKeys
 	ErrInvalidMaxUploads
 	ErrInvalidMaxParts
@@ -538,6 +540,16 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	ErrOverlappingConfigs: {
 		Code:           "InvalidArgument",
 		Description:    "Configurations overlap. Configurations on the same bucket cannot share a common event type.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidCopyPartRange: {
+		Code:           "InvalidArgument",
+		Description:    "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidCopyPartRangeSource: {
+		Code:           "InvalidArgument",
+		Description:    "Range specified is not valid for source object",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 

--- a/cmd/copy-part-range.go
+++ b/cmd/copy-part-range.go
@@ -1,0 +1,106 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Writes S3 compatible copy part range error.
+func writeCopyPartErr(w http.ResponseWriter, err error, url *url.URL) {
+	switch err {
+	case errInvalidRange:
+		writeErrorResponse(w, ErrInvalidCopyPartRange, url)
+		return
+	case errInvalidRangeSource:
+		writeErrorResponse(w, ErrInvalidCopyPartRangeSource, url)
+		return
+	default:
+		writeErrorResponse(w, ErrInternalError, url)
+		return
+	}
+}
+
+// Parses x-amz-copy-source-range for CopyObjectPart API. Specifically written to
+// differentiate the behavior between regular httpRange header v/s x-amz-copy-source-range.
+// The range of bytes to copy from the source object. The range value must use the form
+// bytes=first-last, where the first and last are the zero-based byte offsets to copy.
+// For example, bytes=0-9 indicates that you want to copy the first ten bytes of the source.
+// http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html
+func parseCopyPartRange(rangeString string, resourceSize int64) (hrange *httpRange, err error) {
+	// Return error if given range string doesn't start with byte range prefix.
+	if !strings.HasPrefix(rangeString, byteRangePrefix) {
+		return nil, fmt.Errorf("'%s' does not start with '%s'", rangeString, byteRangePrefix)
+	}
+
+	// Trim byte range prefix.
+	byteRangeString := strings.TrimPrefix(rangeString, byteRangePrefix)
+
+	// Check if range string contains delimiter '-', else return error. eg. "bytes=8"
+	sepIndex := strings.Index(byteRangeString, "-")
+	if sepIndex == -1 {
+		return nil, errInvalidRange
+	}
+
+	offsetBeginString := byteRangeString[:sepIndex]
+	offsetBegin := int64(-1)
+	// Convert offsetBeginString only if its not empty.
+	if len(offsetBeginString) > 0 {
+		if !validBytePos.MatchString(offsetBeginString) {
+			return nil, errInvalidRange
+		}
+		if offsetBegin, err = strconv.ParseInt(offsetBeginString, 10, 64); err != nil {
+			return nil, errInvalidRange
+		}
+	}
+
+	offsetEndString := byteRangeString[sepIndex+1:]
+	offsetEnd := int64(-1)
+	// Convert offsetEndString only if its not empty.
+	if len(offsetEndString) > 0 {
+		if !validBytePos.MatchString(offsetEndString) {
+			return nil, errInvalidRange
+		}
+		if offsetEnd, err = strconv.ParseInt(offsetEndString, 10, 64); err != nil {
+			return nil, errInvalidRange
+		}
+	}
+
+	// rangeString contains first byte positions. eg. "bytes=2-" or
+	// rangeString contains last bye positions. eg. "bytes=-2"
+	if offsetBegin == -1 || offsetEnd == -1 {
+		return nil, errInvalidRange
+	}
+
+	// Last byte position should not be greater than first byte
+	// position. eg. "bytes=5-2"
+	if offsetBegin > offsetEnd {
+		return nil, errInvalidRange
+	}
+
+	// First and last byte positions should not be >= resourceSize.
+	if offsetBegin >= resourceSize || offsetEnd >= resourceSize {
+		return nil, errInvalidRangeSource
+	}
+
+	// Success..
+	return &httpRange{offsetBegin, offsetEnd, resourceSize}, nil
+}

--- a/cmd/copy-part-range_test.go
+++ b/cmd/copy-part-range_test.go
@@ -1,0 +1,85 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "testing"
+
+// Test parseCopyPartRange()
+func TestParseCopyPartRange(t *testing.T) {
+	// Test success cases.
+	successCases := []struct {
+		rangeString string
+		offsetBegin int64
+		offsetEnd   int64
+		length      int64
+	}{
+		{"bytes=2-5", 2, 5, 4},
+		{"bytes=2-9", 2, 9, 8},
+		{"bytes=2-2", 2, 2, 1},
+		{"bytes=0000-0006", 0, 6, 7},
+	}
+
+	for _, successCase := range successCases {
+		hrange, err := parseCopyPartRange(successCase.rangeString, 10)
+		if err != nil {
+			t.Fatalf("expected: <nil>, got: %s", err)
+		}
+
+		if hrange.offsetBegin != successCase.offsetBegin {
+			t.Fatalf("expected: %d, got: %d", successCase.offsetBegin, hrange.offsetBegin)
+		}
+
+		if hrange.offsetEnd != successCase.offsetEnd {
+			t.Fatalf("expected: %d, got: %d", successCase.offsetEnd, hrange.offsetEnd)
+		}
+		if hrange.getLength() != successCase.length {
+			t.Fatalf("expected: %d, got: %d", successCase.length, hrange.getLength())
+		}
+	}
+
+	// Test invalid range strings.
+	invalidRangeStrings := []string{
+		"bytes=8",
+		"bytes=5-2",
+		"bytes=+2-5",
+		"bytes=2-+5",
+		"bytes=2--5",
+		"bytes=-",
+		"",
+		"2-5",
+		"bytes = 2-5",
+		"bytes=2 - 5",
+		"bytes=0-0,-1",
+		"bytes=2-5 ",
+	}
+	for _, rangeString := range invalidRangeStrings {
+		if _, err := parseCopyPartRange(rangeString, 10); err == nil {
+			t.Fatalf("expected: an error, got: <nil> for range %s", rangeString)
+		}
+	}
+
+	// Test error range strings.
+	errorRangeString := []string{
+		"bytes=10-10",
+		"bytes=20-30",
+	}
+	for _, rangeString := range errorRangeString {
+		if _, err := parseCopyPartRange(rangeString, 10); err != errInvalidRangeSource {
+			t.Fatalf("expected: %s, got: %s", errInvalidRangeSource, err)
+		}
+	}
+}

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -463,7 +463,6 @@ func (fs fsObjects) CopyObjectPart(srcBucket, srcObject, dstBucket, dstObject, u
 	pipeReader, pipeWriter := io.Pipe()
 
 	go func() {
-		var startOffset int64 // Read the whole file.
 		if gerr := fs.GetObject(srcBucket, srcObject, startOffset, length, pipeWriter); gerr != nil {
 			errorIf(gerr, "Unable to read %s/%s.", srcBucket, srcObject)
 			pipeWriter.CloseWithError(gerr)

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 )
@@ -251,9 +250,6 @@ type IncompleteBody GenericError
 func (e IncompleteBody) Error() string {
 	return e.Bucket + "#" + e.Object + "has incomplete body"
 }
-
-// errInvalidRange - returned when given range value is not valid.
-var errInvalidRange = errors.New("Invalid range")
 
 // InvalidRange - invalid range typed error.
 type InvalidRange struct {

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -54,3 +54,10 @@ var errServerTimeMismatch = errors.New("Server times are too far apart")
 // errReservedBucket - bucket name is reserved for Minio, usually
 // returned for 'minio', '.minio.sys'
 var errReservedBucket = errors.New("All access to this bucket is disabled")
+
+// errInvalidRange - returned when given range value is not valid.
+var errInvalidRange = errors.New("Invalid range")
+
+// errInvalidRangeSource - returned when given range value exceeds
+// the source object size.
+var errInvalidRangeSource = errors.New("Range specified exceeds source object size")

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -546,7 +546,6 @@ func (xl xlObjects) CopyObjectPart(srcBucket, srcObject, dstBucket, dstObject, u
 	pipeReader, pipeWriter := io.Pipe()
 
 	go func() {
-		var startOffset int64 // Read the whole file.
 		if gerr := xl.GetObject(srcBucket, srcObject, startOffset, length, pipeWriter); gerr != nil {
 			errorIf(gerr, "Unable to read %s of the object `%s/%s`.", srcBucket, srcObject)
 			pipeWriter.CloseWithError(toObjectErr(gerr, srcBucket, srcObject))


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
startOffset was re-assigned to '0' so it would end up
copying wrong content ignoring the requested startOffset.

This also fixes the corruption issue we observed with docker registry.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes https://github.com/docker/distribution/issues/2205

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
With `go test` and docker registry. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.