### PR TITLE
web: Validate if bucket names are reserved

### DIFF
--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -194,7 +194,17 @@ func isReservedOrInvalidBucket(bucketEntry string) bool {
 	if !IsValidBucketName(bucketEntry) {
 		return true
 	}
-	return bucketEntry == minioMetaBucket || bucketEntry == minioReservedBucket
+	return isMinioMetaBucket(bucketEntry) || isMinioReservedBucket(bucketEntry)
+}
+
+// Returns true if input bucket is a reserved minio meta bucket '.minio.sys'.
+func isMinioMetaBucket(bucketName string) bool {
+	return bucketName == minioMetaBucket
+}
+
+// Returns true if input bucket is a reserved minio bucket 'minio'.
+func isMinioReservedBucket(bucketName string) bool {
+	return bucketName == minioReservedBucket
 }
 
 // byBucketName is a collection satisfying sort.Interface.

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -50,3 +50,7 @@ var errServerVersionMismatch = errors.New("Server versions do not match")
 
 // errServerTimeMismatch - server times are too far apart.
 var errServerTimeMismatch = errors.New("Server times are too far apart")
+
+// errReservedBucket - bucket name is reserved for Minio, usually
+// returned for 'minio', '.minio.sys'
+var errReservedBucket = errors.New("All access to this bucket is disabled")

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -265,6 +265,8 @@ func testMakeBucketWebHandler(obj ObjectLayer, instanceType string, t TestErrHan
 		{"", false},
 		{".", false},
 		{"ab", false},
+		{"minio", false},
+		{".minio.sys", false},
 		{bucketName, true},
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Both '.minio.sys' and 'minio' should be never allowed
to be created from web-ui and then fail to list it
by filtering them out.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3840

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using browser, go test and mc.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.