### PR TITLE
obj: Make checkBucketExist() returns all errors

### DIFF
--- a/cmd/object-api-input-checks.go
+++ b/cmd/object-api-input-checks.go
@@ -151,7 +151,7 @@ func checkBucketExist(bucket string, obj ObjectLayer) error {
 	}
 	_, err := obj.GetBucketInfo(bucket)
 	if err != nil {
-		return BucketNotFound{Bucket: bucket}
+		return errorCause(err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
This function was returning BucketNotFound for all errors
which at least hides the fact that disks could be faulty.
This commit fixes the behavior by returning all errors that,
are, by the way, Object API errors.

## Motivation and Context
One step to f.i.x.e.s #3811

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.