### PR TITLE
rpm: Add RPM spec for minio build.

### DIFF
--- a/minio.spec
+++ b/minio.spec
@@ -1,0 +1,83 @@
+%define         tag     RELEASE.2017-02-16T01-47-30Z
+%define         subver  %(echo %{tag} | sed -e 's/[^0-9]//g')
+# git fetch https://github.com/minio/minio.git refs/tags/RELEASE.2017-02-16T01-47-30Z
+# git rev-list -n 1 FETCH_HEAD
+%define         commitid        3d98311d9f4ceb78dba996dcdc0751253241e697
+Summary:        Cloud Storage Server.
+Name:           minio
+Version:        0.0.%{subver}
+Release:        1
+Vendor:         Minio, Inc.
+License:        Apache v2.0
+Group:          Applications/File
+Source0:        https://github.com/minio/minio/archive/%{tag}.tar.gz
+URL:            https://www.minio.io/
+BuildRequires:  golang >= 1.7
+BuildRoot:      %{tmpdir}/%{name}-%{version}-root-%(id -u -n)
+
+## Disable debug packages.
+%define         debug_package %{nil}
+
+## Go related tags.
+%define         gobuild(o:) go build -ldflags "${LDFLAGS:-}" %{?**};
+%define         gopath          %{_libdir}/golang
+%define         import_path     github.com/minio/minio
+
+%description
+Minio is an object storage server released under Apache License v2.0.
+It is compatible with Amazon S3 cloud storage service. It is best
+suited for storing unstructured data such as photos, videos, log
+files, backups and container / VM images. Size of an object can
+range from a few KBs to a maximum of 5TB.
+
+%prep
+%setup -qc
+mv %{name}-*/* .
+
+install -d src/$(dirname %{import_path})
+ln -s ../../.. src/%{import_path}
+
+%build
+export GOPATH=$(pwd)
+
+# setup flags like 'go run buildscripts/gen-ldflags.go' would do
+tag=%{tag}
+version=${tag#RELEASE.}
+commitid=%{commitid}
+scommitid=$(echo $commitid | cut -c1-12)
+prefix=%{import_path}/cmd
+
+LDFLAGS="
+-X $prefix.Version=$version
+-X $prefix.ReleaseTag=$tag
+-X $prefix.CommitID=$commitid
+-X $prefix.ShortCommitID=$scommitid
+"
+
+%gobuild -o %{name} %{import_path}
+
+# check that version set properly
+./%{name} version | tee v
+
+#Version: 2016-09-11T17-42-18Z
+#Release-Tag: RELEASE.2016-09-11T17-42-18Z
+#Commit-ID: 85e2d886bcb005d49f3876d6849a2b5a55e03cd3
+v=$(awk '/Version:/{print $2}' v)
+test "$v" = $version
+v=$(awk '/Release-Tag:/{print $2}' v)
+test "$v" = $tag
+v=$(awk '/Commit-ID:/{print $2}' v)
+test "$v" = $commitid
+
+%install
+rm -rf $RPM_BUILD_ROOT
+install -d $RPM_BUILD_ROOT%{_sbindir}
+install -p %{name} $RPM_BUILD_ROOT%{_sbindir}
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(644,root,root,755)
+%doc README.md README_ZH.md
+%attr(755,root,root) %{_sbindir}/minio


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the package is built and hosted at

https://copr.fedorainfracloud.org/coprs/minio/minio/

To enable minio repo one has to download.

Fedora - 25
https://copr.fedorainfracloud.org/coprs/minio/minio/repo/fedora-25/minio-minio-fedora-25.repo

Fedora - 26
https://copr.fedorainfracloud.org/coprs/minio/minio/repo/fedora-26/minio-minio-fedora-26.repo

Enables for both i386 and x86_64.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3576

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually on CentOS, Fedora etc.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.