### PR TITLE
Relax minio server start when disk threshold is reached and adds space check in FS

### DIFF
--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -228,20 +228,20 @@ func fsOpenFile(readPath string, offset int64) (io.ReadCloser, int64, error) {
 }
 
 // Creates a file and copies data from incoming reader. Staging buffer is used by io.CopyBuffer.
-func fsCreateFile(tempObjPath string, reader io.Reader, buf []byte, fallocSize int64) (int64, error) {
-	if tempObjPath == "" || reader == nil || buf == nil {
+func fsCreateFile(filePath string, reader io.Reader, buf []byte, fallocSize int64) (int64, error) {
+	if filePath == "" || reader == nil || buf == nil {
 		return 0, traceError(errInvalidArgument)
 	}
 
-	if err := checkPathLength(tempObjPath); err != nil {
+	if err := checkPathLength(filePath); err != nil {
 		return 0, traceError(err)
 	}
 
-	if err := mkdirAll(pathutil.Dir(tempObjPath), 0777); err != nil {
+	if err := mkdirAll(pathutil.Dir(filePath), 0777); err != nil {
 		return 0, traceError(err)
 	}
 
-	writer, err := os.OpenFile(preparePath(tempObjPath), os.O_CREATE|os.O_WRONLY, 0666)
+	writer, err := os.OpenFile(preparePath(filePath), os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		// File path cannot be verified since one of the parents is a file.
 		if isSysErrNotDir(err) {

--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -241,7 +241,7 @@ func fsCreateFile(filePath string, reader io.Reader, buf []byte, fallocSize int6
 		return 0, traceError(err)
 	}
 
-	if err := checkDiskFree(pathutil.Dir(filePath)); err != nil {
+	if err := checkDiskFree(pathutil.Dir(filePath), fallocSize); err != nil {
 		return 0, traceError(err)
 	}
 

--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -241,6 +241,10 @@ func fsCreateFile(filePath string, reader io.Reader, buf []byte, fallocSize int6
 		return 0, traceError(err)
 	}
 
+	if err := checkDiskFree(pathutil.Dir(filePath)); err != nil {
+		return 0, traceError(err)
+	}
+
 	writer, err := os.OpenFile(preparePath(filePath), os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		// File path cannot be verified since one of the parents is a file.

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -40,11 +40,9 @@ const (
 
 // posix - implements StorageAPI interface.
 type posix struct {
-	ioErrCount    int32 // ref: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
-	diskPath      string
-	minFreeSpace  int64
-	minFreeInodes int64
-	pool          sync.Pool
+	ioErrCount int32 // ref: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	diskPath   string
+	pool       sync.Pool
 }
 
 // checkPathLength - returns error if given path name length more than 255
@@ -109,9 +107,7 @@ func newPosix(path string) (StorageAPI, error) {
 		return nil, err
 	}
 	fs := &posix{
-		diskPath:      diskPath,
-		minFreeSpace:  fsMinFreeSpace,
-		minFreeInodes: fsMinFreeInodes,
+		diskPath: diskPath,
 		// 1MiB buffer pool for posix internal operations.
 		pool: sync.Pool{
 			New: func() interface{} {
@@ -133,7 +129,7 @@ func newPosix(path string) (StorageAPI, error) {
 			return nil, err
 		}
 	}
-	if err = fs.checkDiskFree(); err != nil {
+	if err = checkDiskFree(fs.diskPath); err != nil {
 		return nil, err
 	}
 	return fs, nil
@@ -161,7 +157,7 @@ var ignoreDiskFreeOS = []string{
 }
 
 // checkDiskFree verifies if disk path has sufficient minimum free disk space and files.
-func (s *posix) checkDiskFree() (err error) {
+func checkDiskFree(diskPath string) (err error) {
 	// We don't validate disk space or inode utilization on windows.
 	// Each windows calls to 'GetVolumeInformationW' takes around 3-5seconds.
 	// And StatFS is not supported by Go for solaris and netbsd.
@@ -170,14 +166,14 @@ func (s *posix) checkDiskFree() (err error) {
 	}
 
 	var di disk.Info
-	di, err = getDiskInfo(preparePath(s.diskPath))
+	di, err = getDiskInfo(preparePath(diskPath))
 	if err != nil {
 		return err
 	}
 
 	// Remove 5% from free space for cumulative disk space used for journalling, inodes etc.
 	availableDiskSpace := float64(di.Free) * 0.95
-	if int64(availableDiskSpace) <= s.minFreeSpace {
+	if int64(availableDiskSpace) <= fsMinFreeSpace {
 		return errDiskFull
 	}
 
@@ -187,7 +183,7 @@ func (s *posix) checkDiskFree() (err error) {
 	// total inodes are provided by the underlying filesystem.
 	if di.Files != 0 && di.FSType != "NFS" {
 		availableFiles := int64(di.Ffree)
-		if availableFiles <= s.minFreeInodes {
+		if availableFiles <= fsMinFreeInodes {
 			return errDiskFull
 		}
 	}
@@ -676,7 +672,7 @@ func (s *posix) PrepareFile(volume, path string, fileSize int64) (err error) {
 	}
 
 	// Validate if disk is indeed free.
-	if err = s.checkDiskFree(); err != nil {
+	if err = checkDiskFree(s.diskPath); err != nil {
 		return err
 	}
 

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -602,6 +602,11 @@ func (s *posix) createFile(volume, path string) (f *os.File, err error) {
 		return nil, err
 	}
 
+	// Validate if disk is indeed free.
+	if err = checkDiskFree(s.diskPath); err != nil {
+		return nil, err
+	}
+
 	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return nil, err
@@ -669,11 +674,6 @@ func (s *posix) PrepareFile(volume, path string, fileSize int64) (err error) {
 
 	if s.ioErrCount > maxAllowedIOError {
 		return errFaultyDisk
-	}
-
-	// Validate if disk is indeed free.
-	if err = checkDiskFree(s.diskPath); err != nil {
-		return err
 	}
 
 	// Create file if not found

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -129,9 +129,6 @@ func newPosix(path string) (StorageAPI, error) {
 			return nil, err
 		}
 	}
-	if err = checkDiskFree(fs.diskPath); err != nil {
-		return nil, err
-	}
 	return fs, nil
 }
 


### PR DESCRIPTION
## Description
This PR does the following fixes:
* fs: Rename tempObjPath variable in fsCreateFile()
* fs/posix: Factor checkDiskFree() function	
* fs: Add disk free check in fsCreateFile()	
* posix: Move free disk check to createFile()
* xl: Relax free disk check in POSIX initialization			
* fs: checkDiskFree checks for space to store data


## Motivation and Context
Simplify disk free check and relax minio server start


## How Has This Been Tested?
go test + manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.