### PR TITLE
madmin: Do not require SSL to set credentials

### DIFF
--- a/pkg/madmin/generic-commands.go
+++ b/pkg/madmin/generic-commands.go
@@ -20,7 +20,6 @@ package madmin
 import (
 	"bytes"
 	"encoding/xml"
-	"errors"
 	"net/http"
 	"net/url"
 )
@@ -33,11 +32,6 @@ type setCredsReq struct {
 
 // SetCredentials - Call Set Credentials API to set new access and secret keys in the specified Minio server
 func (adm *AdminClient) SetCredentials(access, secret string) error {
-
-	// Disallow sending with the server if the connection is not secure
-	if !adm.secure {
-		return errors.New("setting new credentials requires HTTPS connection to the server")
-	}
 
 	// Setup new request
 	reqData := requestData{}


### PR DESCRIPTION
## Description
We need to relax this requirement and let the client decides
if it can allow to set credentials API over plain connection.

## Motivation and Context
mc client should be allowed to use plain http transport to
access this web service. 

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.