### PR TITLE
Browser: Add Object.assign polyfill to support older browsers

### DIFF
--- a/browser/app/index.js
+++ b/browser/app/index.js
@@ -44,6 +44,8 @@ import Web from './js/web'
 window.Web = Web
 
 import storage from 'local-storage-fallback'
+import objectAssign from 'es6-object-assign'
+objectAssign.polyfill()
 
 const store = applyMiddleware(thunkMiddleware)(createStore)(reducer)
 const Browse = connect(state => state)(_Browse)

--- a/browser/app/js/actions.js
+++ b/browser/app/js/actions.js
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-import url from 'url'
 import Moment from 'moment'
 import browserHistory from 'react-router/lib/browserHistory'
-import web from './web'
-import * as utils from './utils'
 import storage from 'local-storage-fallback'
-
 import { minioBrowserPrefix } from './constants'
 
 export const SET_WEB = 'SET_WEB'

--- a/browser/package.json
+++ b/browser/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "bootstrap": "^3.3.6",
     "classnames": "^2.2.3",
+    "es6-object-assign": "^1.0.3",
     "font-awesome": "^4.7.0",
     "humanize": "0.0.9",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
## Description
Add Object.assign polyfill to support older browsers. 

## Motivation and Context
https://github.com/minio/minio/issues/3791

## How Has This Been Tested?
Tested locally with only the modern browsers(Safari 10, FF 51.0.1 and Chrome 56.0.2924.87). Need testing on older browsers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.