### PR TITLE
xl,fs: Return 404 if object ends with a separator

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -470,6 +470,12 @@ func (fs fsObjects) getObjectInfo(bucket, object string) (ObjectInfo, error) {
 
 // GetObjectInfo - reads object metadata and replies back ObjectInfo.
 func (fs fsObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
+	// This is a special case with object whose name ends with
+	// a slash separator, we always return object not found here.
+	if hasSuffix(object, slashSeparator) {
+		return ObjectInfo{}, toObjectErr(traceError(errFileNotFound), bucket, object)
+	}
+
 	if err := checkGetObjArgs(bucket, object); err != nil {
 		return ObjectInfo{}, err
 	}

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -321,6 +321,12 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 
 // GetObjectInfo - reads object metadata and replies back ObjectInfo.
 func (xl xlObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
+	// This is a special case with object whose name ends with
+	// a slash separator, we always return object not found here.
+	if hasSuffix(object, slashSeparator) {
+		return ObjectInfo{}, toObjectErr(traceError(errFileNotFound), bucket, object)
+	}
+
 	if err := checkGetObjArgs(bucket, object); err != nil {
 		return ObjectInfo{}, err
 	}


### PR DESCRIPTION
## Description
HEAD Object for FS and XL was returning invalid object name when
an object name has a trailing slash separator, this PR changes the
behavior and will always return 404 object not found, this guarantees
a better compatibility with S3 spec.

## Motivation and Context
Partially f.i.x.e.s #3895 

## How Has This Been Tested?
go test + Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.