### PR TITLE
Browser: Use babel-polyfill to support ES6 built-ins in older browsers

### DIFF
--- a/browser/app/index.js
+++ b/browser/app/index.js
@@ -44,8 +44,6 @@ import Web from './js/web'
 window.Web = Web
 
 import storage from 'local-storage-fallback'
-import objectAssign from 'es6-object-assign'
-objectAssign.polyfill()
 
 const store = applyMiddleware(thunkMiddleware)(createStore)(reducer)
 const Browse = connect(state => state)(_Browse)

--- a/browser/package.json
+++ b/browser/package.json
@@ -26,6 +26,7 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-register": "^6.14.0",
@@ -67,7 +68,6 @@
   "dependencies": {
     "bootstrap": "^3.3.6",
     "classnames": "^2.2.3",
-    "es6-object-assign": "^1.0.3",
     "font-awesome": "^4.7.0",
     "humanize": "0.0.9",
     "json-loader": "^0.5.4",

--- a/browser/webpack.config.js
+++ b/browser/webpack.config.js
@@ -22,6 +22,7 @@ var purify = require("purifycss-webpack-plugin")
 var exports = {
   context: __dirname,
   entry: [
+    "babel-polyfill",
     path.resolve(__dirname, 'app/index.js')
   ],
   output: {
@@ -100,6 +101,7 @@ var exports = {
 
 if (process.env.NODE_ENV === 'dev') {
   exports.entry = [
+    "babel-polyfill",
     'webpack/hot/dev-server',
     'webpack-dev-server/client?http://localhost:8080',
     path.resolve(__dirname, 'app/index.js')


### PR DESCRIPTION
## Description
Use [babel-polyfill](https://babeljs.io/docs/usage/polyfill/) to support new ES6 built-ins such as `Promise`, `Object.assign` in older browsers.

## Motivation and Context
https://github.com/minio/minio/issues/3898

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.