### PR TITLE
config: Relax browser and region to be empty.

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -128,7 +128,7 @@ func initConfig() {
 			console.Fatalf("Invalid access/secret Key set in environment. Err: %s.\n", err)
 		}
 
-		// Envs are set globally.
+		// credential Envs are set globally.
 		globalIsEnvCreds = true
 	}
 
@@ -138,7 +138,9 @@ func initConfig() {
 			console.Fatalf("Invalid value ‘%s’ in MINIO_BROWSER environment variable.", browser)
 		}
 
-		globalIsEnvBrowser = strings.EqualFold(browser, "off")
+		// browser Envs are set globally, this doesn't represent
+		// if browser is turned off or on.
+		globalIsEnvBrowser = true
 	}
 
 	envs := envParams{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- If browser field is missing or empty
  then default to "on".

- If region field is empty or missing then
  default to "us-east-1" (S3 spec behavior)
<!--- Describe your changes in detail -->

## Motivation and Context
Starting from slack message 

```
@y4m4b4 if browser field is missing in config.json, it should not error out. It should instead proceed with the default value.
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using `go test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.