### PR TITLE
config: Accept more address format + unit test

### DIFF
--- a/cmd/notify-amqp.go
+++ b/cmd/notify-amqp.go
@@ -44,7 +44,7 @@ func (a *amqpNotify) Validate() error {
 	if !a.Enable {
 		return nil
 	}
-	if _, err := checkNetURL(a.URL); err != nil {
+	if _, err := checkURL(a.URL); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/notify-elasticsearch.go
+++ b/cmd/notify-elasticsearch.go
@@ -37,7 +37,7 @@ func (e *elasticSearchNotify) Validate() error {
 	if !e.Enable {
 		return nil
 	}
-	if _, err := checkNetURL(e.URL); err != nil {
+	if _, err := checkURL(e.URL); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/notify-nats.go
+++ b/cmd/notify-nats.go
@@ -52,7 +52,7 @@ func (n *natsNotify) Validate() error {
 	if !n.Enable {
 		return nil
 	}
-	if _, err := checkNetURL(n.Address); err != nil {
+	if _, err := checkURL(n.Address); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/notify-postgresql.go
+++ b/cmd/notify-postgresql.go
@@ -88,7 +88,7 @@ func (p *postgreSQLNotify) Validate() error {
 	if !p.Enable {
 		return nil
 	}
-	if _, err := checkNetURL(p.Host); err != nil {
+	if _, err := checkURL(p.Host); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/notify-redis.go
+++ b/cmd/notify-redis.go
@@ -36,7 +36,7 @@ func (r *redisNotify) Validate() error {
 	if !r.Enable {
 		return nil
 	}
-	if _, err := checkNetURL(r.Addr); err != nil {
+	if _, err := checkURL(r.Addr); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/notify-webhook.go
+++ b/cmd/notify-webhook.go
@@ -36,7 +36,7 @@ func (w *webhookNotify) Validate() error {
 	if !w.Enable {
 		return nil
 	}
-	if _, err := checkNetURL(w.Endpoint); err != nil {
+	if _, err := checkURL(w.Endpoint); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"encoding/base64"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -263,15 +264,14 @@ func isFile(path string) bool {
 	return false
 }
 
-// checkNetURL - checks if passed address correspond
-// to a network address (and not file system path)
-func checkNetURL(address string) (*url.URL, error) {
+// checkURL - checks if passed address correspond
+func checkURL(address string) (*url.URL, error) {
+	if address == "" {
+		return nil, errors.New("Address cannot be empty")
+	}
 	u, err := url.Parse(address)
 	if err != nil {
 		return nil, fmt.Errorf("`%s` invalid: %s", address, err.Error())
-	}
-	if u.Host == "" {
-		return nil, fmt.Errorf("`%s` invalid network URL", address)
 	}
 	return u, nil
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -388,3 +388,30 @@ func TestLocalAddress(t *testing.T) {
 	}
 
 }
+
+// TestCheckURL tests valid address
+func TestCheckURL(t *testing.T) {
+	testCases := []struct {
+		addr       string
+		shouldPass bool
+	}{
+		{"", false},
+		{":", false},
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"http://localhost/", true},
+		{"http://127.0.0.1/", true},
+		{"proto://myhostname/path", true},
+	}
+
+	// Validates fetching local address.
+	for i, testCase := range testCases {
+		_, err := checkURL(testCase.addr)
+		if testCase.shouldPass && err != nil {
+			t.Errorf("Test %d: expected to pass but got an error: %v\n", i+1, err)
+		}
+		if !testCase.shouldPass && err == nil {
+			t.Errorf("Test %d: expected to fail but passed.", i+1)
+		}
+	}
+}


### PR DESCRIPTION
## Description
checkURL() is a generic function to check if a passed address
is valid. This commit adds support for addresses like `m1`
and `172.16.3.1` which is needed in MySQL and NATS. This commit
also adds tests.

## Motivation and Context
Fix checkNetURL()

## How Has This Been Tested?
Manually + go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.