### PR TITLE
XL: Don't return ignored errors in listDirFactory

### DIFF
--- a/cmd/tree-walk_test.go
+++ b/cmd/tree-walk_test.go
@@ -348,10 +348,12 @@ func TestListDir(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// None of the disks are available, should get errDiskNotFound.
+	// None of the disks are available, should get
+	// errDiskNotFound. Since errDiskNotFound is an ignored error,
+	// we should get nil.
 	_, _, err = listDir(volume, "", "")
-	if errorCause(err) != errDiskNotFound {
-		t.Error("expected errDiskNotFound error.")
+	if err != nil {
+		t.Errorf("expected nil error but found %v.", err)
 	}
 }
 

--- a/cmd/xl-v1-list-objects-heal.go
+++ b/cmd/xl-v1-list-objects-heal.go
@@ -107,10 +107,6 @@ func (xl xlObjects) listObjectsHeal(bucket, prefix, marker, delimiter string, ma
 		}
 		// For any walk error return right away.
 		if walkResult.err != nil {
-			// File not found is a valid case.
-			if walkResult.err == errFileNotFound {
-				return ListObjectsInfo{}, nil
-			}
 			return ListObjectsInfo{}, toObjectErr(walkResult.err, bucket, prefix)
 		}
 		entry := walkResult.entry
@@ -325,12 +321,6 @@ func (xl xlObjects) listMultipartUploadsHeal(bucket, prefix, keyMarker,
 		}
 		// Collect uploads until maxUploads limit is reached.
 		for walkResult := range walkerCh {
-			// Ignore errors like errDiskNotFound
-			// and errFileNotFound.
-			if isErrIgnored(walkResult.err,
-				xlTreeWalkIgnoredErrs...) {
-				continue
-			}
 			// For any error during tree walk we should
 			// return right away.
 			if walkResult.err != nil {

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -349,10 +349,6 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 			}
 			// For any walk error return right away.
 			if walkResult.err != nil {
-				// File not found or Disk not found is a valid case.
-				if isErrIgnored(walkResult.err, xlTreeWalkIgnoredErrs...) {
-					continue
-				}
 				return ListMultipartsInfo{}, err
 			}
 			entry := strings.TrimPrefix(walkResult.entry, retainSlash(bucket))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change fixes `listDirFactory` used for listing in Erasure backend. Previously, it was possible that `listDirFactory` could return an error which was explicitly asked to be ignored. With this change, it will return `nil`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.