### PR TITLE
Add sourceInfo to NotificationEvent

### DIFF
--- a/cmd/bucket-notification-datatypes.go
+++ b/cmd/bucket-notification-datatypes.go
@@ -168,6 +168,14 @@ const (
 	eventVersion = "2.0"
 )
 
+// sourceInfo represents information on the client that triggered the
+// event notification.
+type sourceInfo struct {
+	Host      string `json:"host"`
+	Port      string `json:"port"`
+	UserAgent string `json:"userAgent"`
+}
+
 // NotificationEvent represents an Amazon an S3 bucket notification event.
 type NotificationEvent struct {
 	EventVersion      string            `json:"eventVersion"`
@@ -179,6 +187,7 @@ type NotificationEvent struct {
 	RequestParameters map[string]string `json:"requestParameters"`
 	ResponseElements  map[string]string `json:"responseElements"`
 	S3                eventMeta         `json:"s3"`
+	Source            sourceInfo        `json:"source"`
 }
 
 // Represents the minio sqs type and account id's.

--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -29,6 +29,10 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+const (
+	minioEventSource = "minio:s3"
+)
+
 type externalNotifier struct {
 	// Per-bucket notification config. This is updated via
 	// PutBucketNotification API.
@@ -82,6 +86,9 @@ type eventData struct {
 	Bucket    string
 	ObjInfo   ObjectInfo
 	ReqParams map[string]string
+	Host      string
+	Port      string
+	UserAgent string
 }
 
 // New notification event constructs a new notification event message from
@@ -114,7 +121,7 @@ func newNotificationEvent(event eventData) NotificationEvent {
 	// http://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
 	nEvent := NotificationEvent{
 		EventVersion:      eventVersion,
-		EventSource:       eventSource,
+		EventSource:       minioEventSource,
 		AwsRegion:         region,
 		EventTime:         eventTime.Format(timeFormatAMZ),
 		EventName:         event.Type.String(),
@@ -134,6 +141,11 @@ func newNotificationEvent(event eventData) NotificationEvent {
 				OwnerIdentity: identity{creds.AccessKey},
 				ARN:           bucketARNPrefix + event.Bucket,
 			},
+		},
+		Source: sourceInfo{
+			Host:      event.Host,
+			Port:      event.Port,
+			UserAgent: event.UserAgent,
 		},
 	}
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/xml"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -356,12 +357,21 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	// Write success response.
 	writeSuccessResponseXML(w, encodedSuccessResponse)
 
+	// Get host and port from Request.RemoteAddr.
+	host, port, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host, port = "", ""
+	}
+
 	// Notify object created event.
 	eventNotify(eventData{
 		Type:      ObjectCreatedCopy,
 		Bucket:    dstBucket,
 		ObjInfo:   objInfo,
 		ReqParams: extractReqParams(r),
+		UserAgent: r.UserAgent(),
+		Host:      host,
+		Port:      port,
 	})
 }
 
@@ -487,12 +497,21 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	w.Header().Set("ETag", "\""+objInfo.MD5Sum+"\"")
 	writeSuccessResponseHeadersOnly(w)
 
+	// Get host and port from Request.RemoteAddr.
+	host, port, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host, port = "", ""
+	}
+
 	// Notify object created event.
 	eventNotify(eventData{
 		Type:      ObjectCreatedPut,
 		Bucket:    bucket,
 		ObjInfo:   objInfo,
 		ReqParams: extractReqParams(r),
+		UserAgent: r.UserAgent(),
+		Host:      host,
+		Port:      port,
 	})
 }
 
@@ -914,12 +933,21 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 	// Write success response.
 	writeSuccessResponseXML(w, encodedSuccessResponse)
 
+	// Get host and port from Request.RemoteAddr.
+	host, port, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host, port = "", ""
+	}
+
 	// Notify object created event.
 	eventNotify(eventData{
 		Type:      ObjectCreatedCompleteMultipartUpload,
 		Bucket:    bucket,
 		ObjInfo:   objInfo,
 		ReqParams: extractReqParams(r),
+		UserAgent: r.UserAgent(),
+		Host:      host,
+		Port:      port,
 	})
 }
 
@@ -955,6 +983,12 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 	}
 	writeSuccessNoContent(w)
 
+	// Get host and port from Request.RemoteAddr.
+	host, port, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host, port = "", ""
+	}
+
 	// Notify object deleted event.
 	eventNotify(eventData{
 		Type:   ObjectRemovedDelete,
@@ -963,5 +997,8 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			Name: object,
 		},
 		ReqParams: extractReqParams(r),
+		UserAgent: r.UserAgent(),
+		Host:      host,
+		Port:      port,
 	})
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds information like host, port and user-agent of the
client whose request triggered an event notification.

E.g, if someone uploads an object to a bucket using mc. If notifications
were configured on that bucket, the host, port and user-agent of mc
would be sent as part of event notification data.

Sample output:
```
"source": {
          "host": "127.0.0.1",
          "port": "55808",
          "userAgent": "Minio (linux; amd64) minio-go/2.0.4 mc ..."
}
```
Fixes #3917 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #3917 for more details.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually using a minio-go based program using `ListenBucketNotification` API.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.