### PR TITLE
HealObject should succeed when only N/2 disks have data

### DIFF
--- a/cmd/xl-v1-healing-common.go
+++ b/cmd/xl-v1-healing-common.go
@@ -225,10 +225,10 @@ func disksWithAllParts(onlineDisks []StorageAPI, partsMetadata []xlMetaV1, errs 
 		// disk has a valid xl.json but may not have all the
 		// parts. This is considered an outdated disk, since
 		// it needs healing too.
-		for pIndex, part := range partsMetadata[index].Parts {
+		for _, part := range partsMetadata[index].Parts {
 			// compute blake2b sum of part.
 			partPath := filepath.Join(object, part.Name)
-			hash := newHash(blake2bAlgo)
+			hash := newHash(partsMetadata[index].Erasure.Algorithm)
 			blakeBytes, hErr := hashSum(onlineDisk, bucket, partPath, hash)
 			if hErr == errFileNotFound {
 				errs[index] = errFileNotFound
@@ -239,7 +239,7 @@ func disksWithAllParts(onlineDisks []StorageAPI, partsMetadata []xlMetaV1, errs 
 				return nil, nil, traceError(hErr)
 			}
 
-			partChecksum := partsMetadata[index].Erasure.Checksum[pIndex].Hash
+			partChecksum := partsMetadata[index].Erasure.GetCheckSumInfo(part.Name).Hash
 			blakeSum := hex.EncodeToString(blakeBytes)
 			// if blake2b sum doesn't match for a part
 			// then this disk is outdated and needs

--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -41,10 +41,17 @@ func reduceErrs(errs []error, ignoredErrs []error) (maxCount int, maxErr error) 
 		}
 		errorCounts[err]++
 	}
+
 	max := 0
 	for err, count := range errorCounts {
-		if max < count {
+		switch {
+		case max < count:
 			max = count
+			maxErr = err
+
+		// Prefer `nil` over other error values with the same
+		// number of occurrences.
+		case max == count && err == nil:
 			maxErr = err
 		}
 	}

--- a/cmd/xl-v1-utils_test.go
+++ b/cmd/xl-v1-utils_test.go
@@ -82,6 +82,9 @@ func TestReduceErrs(t *testing.T) {
 			errDiskNotFound,
 		}, []error{errDiskNotFound}, errVolumeNotFound},
 		{[]error{}, []error{}, errXLReadQuorum},
+		{[]error{errFileNotFound, errFileNotFound, errFileNotFound,
+			errFileNotFound, errFileNotFound, nil, nil, nil, nil, nil},
+			nil, nil},
 	}
 	// Validates list of all the testcases for returning valid errors.
 	for i, testCase := range testCases {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #3950 
## Description
<!--- Describe your changes in detail -->
* reduceErrs should prefer nil over other errors
  Consider the following slice of error,
      `[]error {errFileNotFound, errFileNotFound, nil, nil}`

  `reduceErrs` should return `nil` to allow higher-level functionality
  like `erasureReadfile` to reconstruct data when it can.

* heal: Validate part checksums correctly
  Previously, the validation of part checksums assumed checksumInfo in
  xl.json appears in increasing order of part number. This change removes
  that assumption.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.