### PR TITLE
config: Do not validate creds when set via env

### DIFF
--- a/cmd/config-v15.go
+++ b/cmd/config-v15.go
@@ -255,9 +255,12 @@ func validateConfig() error {
 		return fmt.Errorf("Browser config value %s is invalid", b)
 	}
 
-	// Validate credential field
-	if !srvCfg.Credential.IsValid() {
-		return errors.New("invalid credential")
+	// Validate credential fields only when
+	// they are not set via the environment
+	if !globalIsEnvCreds {
+		if !srvCfg.Credential.IsValid() {
+			return errors.New("invalid credential")
+		}
 	}
 
 	// Validate logger field


### PR DESCRIPTION
## Description
It is useless to validate access/secret keys stored in
config file when the user sets them in the environment.

## Motivation and Context
Fixes #3954 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.