### PR TITLE
Fix listDirHealFactory merging of entries across disks

### DIFF
--- a/cmd/xl-v1-list-objects-heal.go
+++ b/cmd/xl-v1-list-objects-heal.go
@@ -59,9 +59,8 @@ func listDirHealFactory(isLeaf isLeafFunc, disks ...StorageAPI) listDirFunc {
 			// find elements in entries which are not in mergedentries
 			for _, entry := range entries {
 				idx := sort.SearchStrings(mergedEntries, entry)
-				// idx different from len(mergedEntries) means entry is not found
-				// in mergedEntries
-				if idx < len(mergedEntries) {
+				// if entry is already present in mergedEntries don't add.
+				if idx < len(mergedEntries) && mergedEntries[idx] == entry {
 					continue
 				}
 				newEntries = append(newEntries, entry)

--- a/cmd/xl-v1-list-objects-heal.go
+++ b/cmd/xl-v1-list-objects-heal.go
@@ -35,28 +35,19 @@ func listDirHealFactory(isLeaf isLeafFunc, disks ...StorageAPI) listDirFunc {
 			if err != nil {
 				continue
 			}
-			// Listing needs to be sorted.
-			sort.Strings(entries)
 
 			// Filter entries that have the prefix prefixEntry.
 			entries = filterMatchingPrefix(entries, prefixEntry)
 
-			// isLeaf() check has to happen here so that trailing "/" for objects can be removed.
+			// isLeaf() check has to happen here so that
+			// trailing "/" for objects can be removed.
 			for i, entry := range entries {
 				if isLeaf(bucket, pathJoin(prefixDir, entry)) {
 					entries[i] = strings.TrimSuffix(entry, slashSeparator)
 				}
 			}
-			// Sort again after removing trailing "/" for objects as the previous sort
-			// does not hold good anymore.
-			sort.Strings(entries)
-			if len(mergedEntries) == 0 {
-				// For the first successful disk.ListDir()
-				mergedEntries = entries
-				sort.Strings(mergedEntries)
-				continue
-			}
-			// find elements in entries which are not in mergedentries
+
+			// Find elements in entries which are not in mergedEntries
 			for _, entry := range entries {
 				idx := sort.SearchStrings(mergedEntries, entry)
 				// if entry is already present in mergedEntries don't add.
@@ -65,6 +56,7 @@ func listDirHealFactory(isLeaf isLeafFunc, disks ...StorageAPI) listDirFunc {
 				}
 				newEntries = append(newEntries, entry)
 			}
+
 			if len(newEntries) > 0 {
 				// Merge the entries and sort it.
 				mergedEntries = append(mergedEntries, newEntries...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For listing of objects needing heal, we list all objects present on all
the disks and return the set union. We were incorrectly dropping objects
that weren't already seen in disks so far.

Sample directory layout of disks in a 4-disk setup:
`/tmp/1`, `/tmp/2`, `/tmp/3`, `/tmp/4` are directories used as disks here.
`test` is the bucket, `obj1` and obj2` are the objects.
```
/tmp/1/test
└── obj2
    ├── part.1
    ├── part.2
    └── xl.json
/tmp/2/test
└── obj1
    ├── part.1
    ├── part.2
    └── xl.json
/tmp/3/test
├── obj1
│   ├── part.1
│   ├── part.2
│   └── xl.json
└── obj2
    ├── part.1
    ├── part.2
    └── xl.json
/tmp/4/test
[This is empty]

```
Fixes #3958 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using  `mc admin heal list`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.