### PR TITLE
server-mux: Return 503 when reqs num hits the max

### DIFF
--- a/cmd/server-mux.go
+++ b/cmd/server-mux.go
@@ -32,6 +32,10 @@ import (
 
 const (
 	serverShutdownPoll = 500 * time.Millisecond
+
+	// Maximum number of concurrent connections, to avoid creating
+	// too many threads in the OS and get killed by golang runtime
+	serverMaxConcurrentConns = 9000
 )
 
 // The value chosen below is longest word chosen
@@ -331,6 +335,9 @@ type ServerMux struct {
 
 	// Current number of concurrent http requests
 	currentReqs int32
+	// Max number of concurrent http requests
+	maxConcurrentReqs int32
+
 	// Time to wait before forcing server shutdown
 	gracefulTimeout time.Duration
 
@@ -341,8 +348,9 @@ type ServerMux struct {
 // NewServerMux constructor to create a ServerMux
 func NewServerMux(addr string, handler http.Handler) *ServerMux {
 	m := &ServerMux{
-		Addr:    addr,
-		handler: handler,
+		Addr:              addr,
+		handler:           handler,
+		maxConcurrentReqs: serverMaxConcurrentConns,
 		// Wait for 5 seconds for new incoming connnections, otherwise
 		// forcibly close them during graceful stop or restart.
 		gracefulTimeout: 5 * time.Second,
@@ -465,6 +473,12 @@ func (m *ServerMux) ListenAndServe(certFile, keyFile string) (err error) {
 			closing := m.closing
 			m.mu.RUnlock()
 			if closing {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+
+			// Return HTTP service unavailable when we have reached maximum concurrent HTTP requests.
+			if atomic.LoadInt32(&m.currentReqs) >= m.maxConcurrentReqs {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}


### PR DESCRIPTION
## Description
Parallel requests should have a maximum number to avoid
crashing our server when we have too many of them. Go, at least,
intentionally crashes the server when we hit 10k threads.

## Motivation and Context
Fixes #3883 

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.