### PR TITLE
config: Appropriate error message when newer config file is found

### DIFF
--- a/cmd/config-v17.go
+++ b/cmd/config-v17.go
@@ -215,9 +215,10 @@ func validateConfig() error {
 		return err
 	}
 
-	// Check if config version is valid
 	if srvCfg.Version != v17 {
-		return errors.New("bad config version, expected: " + v17)
+		// Older binary but newer config version.
+		// Config version can never be older as it would have migrated.
+		return fmt.Errorf("Expected config version: %s, newer config version found: %s", v17, srvCfg.Version)
 	}
 
 	// Load config file json and check for duplication json keys

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -169,7 +169,7 @@ func initConfig() {
 
 	// Validate config file
 	err = validateConfig()
-	fatalIf(err, "Cannot validate configuration file")
+	fatalIf(err, "Unable to validate configuration file")
 
 	// Once we have migrated all the old config, now load them.
 	err = loadConfig(envs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If newer config file is run with older binary it would do:
errors.New("bad config version, expected: " + v16)

which is a confusing error message. Provide a better error message of:
`"Expected config version: %s, newer config version found: %s"`
so that the user gets a hint on what is happening.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.