### PR TITLE
tests: use url.QueryEscape() when dealing with url query params.

### DIFF
--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -845,39 +845,6 @@ func newTestStreamingSignedRequest(method, urlStr string, contentLength, chunkSi
 	return req, err
 }
 
-// Replaces any occurring '/' in string, into its encoded
-// representation.
-func percentEncodeSlash(s string) string {
-	return strings.Replace(s, "/", "%2F", -1)
-}
-
-// queryEncode - encodes query values in their URL encoded form. In
-// addition to the percent encoding performed by getURLEncodedName()
-// used here, it also percent encodes '/' (forward slash)
-func queryEncode(v url.Values) string {
-	if v == nil {
-		return ""
-	}
-	var buf bytes.Buffer
-	keys := make([]string, 0, len(v))
-	for k := range v {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		vs := v[k]
-		prefix := percentEncodeSlash(getURLEncodedName(k)) + "="
-		for _, v := range vs {
-			if buf.Len() > 0 {
-				buf.WriteByte('&')
-			}
-			buf.WriteString(prefix)
-			buf.WriteString(percentEncodeSlash(getURLEncodedName(v)))
-		}
-	}
-	return buf.String()
-}
-
 // preSignV4 presign the request, in accordance with
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html.
 func preSignV4(req *http.Request, accessKeyID, secretAccessKey string, expires int64) error {
@@ -912,7 +879,7 @@ func preSignV4(req *http.Request, accessKeyID, secretAccessKey string, expires i
 	req.URL.RawQuery = query.Encode()
 
 	// Add signature header to RawQuery.
-	req.URL.RawQuery += "&X-Amz-Signature=" + signature
+	req.URL.RawQuery += "&X-Amz-Signature=" + url.QueryEscape(signature)
 
 	// Construct the final presigned URL.
 	return nil
@@ -963,10 +930,10 @@ func preSignV2(req *http.Request, accessKeyID, secretAccessKey string, expires i
 	query.Set("Expires", strconv.FormatInt(epochExpires, 10))
 
 	// Encode query and save.
-	req.URL.RawQuery = queryEncode(query)
+	req.URL.RawQuery = query.Encode()
 
 	// Save signature finally.
-	req.URL.RawQuery += "&Signature=" + getURLEncodedName(signature)
+	req.URL.RawQuery += "&Signature=" + url.QueryEscape(signature)
 
 	// Success.
 	return nil
@@ -1398,7 +1365,7 @@ func makeTestTargetURL(endPoint, bucketName, objectName string, queryValues url.
 		urlStr = urlStr + getURLEncodedName(objectName)
 	}
 	if len(queryValues) > 0 {
-		urlStr = urlStr + "?" + queryEncode(queryValues)
+		urlStr = urlStr + "?" + queryValues.Encode()
 	}
 	return urlStr
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
tests: use url.QueryEscape() when dealing with url query params.

<!--- Describe your changes in detail -->

## Motivation and Context
This is to keep the portability and also avoid errors that
might occur using the functions written for URL resource name
Since query param values have different escaping requirements.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and with other AWS sdks.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.