### PR TITLE
sign/streaming: Content-Encoding is not set in newer aws-java-sdks

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -64,7 +64,6 @@ func isRequestPostPolicySignatureV4(r *http.Request) bool {
 // Verify if the request has AWS Streaming Signature Version '4'. This is only valid for 'PUT' operation.
 func isRequestSignStreamingV4(r *http.Request) bool {
 	return r.Header.Get("x-amz-content-sha256") == streamingContentSHA256 &&
-		r.Header.Get("content-encoding") == streamingContentEncoding &&
 		r.Method == httpPUT
 }
 

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -158,6 +158,23 @@ func extractReqParams(r *http.Request) map[string]string {
 	}
 }
 
+// Trims away `aws-chunked` from the content-encoding header if present.
+// Streaming signature clients can have custom content-encoding such as
+// `aws-chunked,gzip` here we need to only save `gzip`.
+// For more refer http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
+func trimAwsChunkedContentEncoding(contentEnc string) (trimmedContentEnc string) {
+	if contentEnc == "" {
+		return contentEnc
+	}
+	var newEncs []string
+	for _, enc := range strings.Split(contentEnc, ",") {
+		if enc != streamingContentEncoding {
+			newEncs = append(newEncs, enc)
+		}
+	}
+	return strings.Join(newEncs, ",")
+}
+
 // extractMetadataFromForm extracts metadata from Post Form.
 func extractMetadataFromForm(formValues http.Header) map[string]string {
 	return extractMetadataFromHeader(formValues)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -445,10 +445,23 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	// Extract metadata to be saved from incoming HTTP header.
 	metadata := extractMetadataFromHeader(r.Header)
 	if rAuthType == authTypeStreamingSigned {
-		// Make sure to delete the content-encoding parameter
-		// for a streaming signature which is set to value
-		// "aws-chunked"
-		delete(metadata, "content-encoding")
+		if contentEncoding, ok := metadata["content-encoding"]; ok {
+			contentEncoding = trimAwsChunkedContentEncoding(contentEncoding)
+			if contentEncoding != "" {
+				// Make sure to trim and save the content-encoding
+				// parameter for a streaming signature which is set
+				// to a custom value for example: "aws-chunked,gzip".
+				metadata["content-encoding"] = contentEncoding
+			} else {
+				// Trimmed content encoding is empty when the header
+				// value is set to "aws-chunked" only.
+
+				// Make sure to delete the content-encoding parameter
+				// for a streaming signature which is set to value
+				// for example: "aws-chunked"
+				delete(metadata, "content-encoding")
+			}
+		}
 	}
 
 	// Make sure we hex encode md5sum here.

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -828,6 +828,25 @@ func newTestStreamingSignedBadChunkDateRequest(method, urlStr string, contentLen
 	return req, err
 }
 
+func newTestStreamingSignedCustomEncodingRequest(method, urlStr string, contentLength, chunkSize int64, body io.ReadSeeker, accessKey, secretKey, contentEncoding string) (*http.Request, error) {
+	req, err := newTestStreamingRequest(method, urlStr, contentLength, chunkSize, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set custom encoding.
+	req.Header.Set("content-encoding", contentEncoding)
+
+	currTime := UTCNow()
+	signature, err := signStreamingRequest(req, accessKey, secretKey, currTime)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err = assembleStreamingChunks(req, body, chunkSize, secretKey, signature, currTime)
+	return req, err
+}
+
 // Returns new HTTP request object signed with streaming signature v4.
 func newTestStreamingSignedRequest(method, urlStr string, contentLength, chunkSize int64, body io.ReadSeeker, accessKey, secretKey string) (*http.Request, error) {
 	req, err := newTestStreamingRequest(method, urlStr, contentLength, chunkSize, body)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We can't use Content-Encoding to verify if `aws-chunked` is set 
or not. Just use 'streaming' signature header instead.

While this is considered mandatory, on the contrary aws-sdk-java
doesn't set this value

http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html

```
Set the value to aws-chunked.
```

We will relax it and behave appropriately. Also this PR supports
saving custom encoding after trimming off the `aws-chunked`
parameter.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3983

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually, added new tests, using aws-sdk-java, kafka connect and cloudexplorer.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.