### PR TITLE
Add `access` format support for Redis notification target

### DIFF
--- a/cmd/notify-redis.go
+++ b/cmd/notify-redis.go
@@ -17,12 +17,23 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/garyburd/redigo/redis"
+)
+
+func makeRedisError(msg string, a ...interface{}) error {
+	s := fmt.Sprintf(msg, a...)
+	return fmt.Errorf("Redis Notifier Error: %s", s)
+}
+
+var (
+	rdNFormatError = makeRedisError(`"format" value is invalid - it must be one of "access" or "namespace".`)
+	rdNKeyError    = makeRedisError("Key was not specified in the configuration.")
 )
 
 // redisNotify to send logs to Redis server
@@ -38,13 +49,14 @@ func (r *redisNotify) Validate() error {
 	if !r.Enable {
 		return nil
 	}
-	if r.Format != formatNamespace {
-		return fmt.Errorf(
-			"Redis Notifier Error: \"format\" must be \"%s\"",
-			formatNamespace)
+	if r.Format != formatNamespace && r.Format != formatAccess {
+		return rdNFormatError
 	}
 	if _, err := checkURL(r.Addr); err != nil {
 		return err
+	}
+	if r.Key == "" {
+		return rdNKeyError
 	}
 	return nil
 }
@@ -92,7 +104,25 @@ func dialRedis(rNotify redisNotify) (*redis.Pool, error) {
 	// Check connection.
 	_, err := rConn.Do("PING")
 	if err != nil {
-		return nil, err
+		return nil, makeRedisError("Error connecting to server: %v", err)
+	}
+
+	// Test that Key is of desired type
+	reply, err := redis.String(rConn.Do("TYPE", rNotify.Key))
+	if err != nil {
+		return nil, makeRedisError("Error getting type of Key=%s: %v",
+			rNotify.Key, err)
+	}
+	if reply != "none" {
+		expectedType := "hash"
+		if rNotify.Format == formatAccess {
+			expectedType = "list"
+		}
+		if reply != expectedType {
+			return nil, makeRedisError(
+				"Key=%s has type %s, but we expect it to be a %s",
+				rNotify.Key, reply, expectedType)
+		}
 	}
 
 	// Return pool.
@@ -137,17 +167,51 @@ func (r redisConn) Fire(entry *logrus.Entry) error {
 		return nil
 	}
 
-	// Match the event if its a delete request, attempt to delete the key
-	if eventMatch(entryStr, []string{"s3:ObjectRemoved:*"}) {
-		if _, err := rConn.Do("DEL", entry.Data["Key"]); err != nil {
-			return err
+	switch r.params.Format {
+	case formatNamespace:
+		// Match the event if its a delete request, attempt to delete the key
+		if eventMatch(entryStr, []string{"s3:ObjectRemoved:*"}) {
+			_, err := rConn.Do("HDEL", r.params.Key, entry.Data["Key"])
+			if err != nil {
+				return makeRedisError("Error deleting entry: %v",
+					err)
+			}
+			return nil
+		} // else save this as new entry or update any existing ones.
+
+		value, err := json.Marshal(map[string]interface{}{
+			"Records": entry.Data["Records"],
+		})
+		if err != nil {
+			return makeRedisError(
+				"Unable to encode event %v to JSON: %v",
+				entry.Data["Records"], err)
 		}
-		return nil
-	} // else save this as new entry or update any existing ones.
-	if _, err := rConn.Do("SET", entry.Data["Key"], map[string]interface{}{
-		"Records": entry.Data["Records"],
-	}); err != nil {
-		return err
+		_, err = rConn.Do("HSET", r.params.Key, entry.Data["Key"],
+			value)
+		if err != nil {
+			return makeRedisError("Error updating hash entry: %v",
+				err)
+		}
+	case formatAccess:
+		// eventTime is taken from the first entry in the
+		// records.
+		events, ok := entry.Data["Records"].([]NotificationEvent)
+		if !ok {
+			return makeRedisError("unable to extract event time due to conversion error of entry.Data[\"Records\"]=%v", entry.Data["Records"])
+		}
+		eventTime := events[0].EventTime
+
+		listEntry := []interface{}{eventTime, entry.Data["Records"]}
+		jsonValue, err := json.Marshal(listEntry)
+		if err != nil {
+			return makeRedisError("JSON encoding error: %v", err)
+		}
+		_, err = rConn.Do("RPUSH", r.params.Key, jsonValue)
+		if err != nil {
+			return makeRedisError("Error appending to Redis list: %v",
+				err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This change adds `access` format support for notifications to a Redis
server, and it refactors `namespace` format support.

In the case of `access` format, a list is used to store Minio
operations in Redis. In the case of `namespace` format, a hash is
used. Entries in the hash may be updated or removed if objects in
Minio are updated or deleted respectively.

Also updates documentation on Redis notification target usage.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.