### PR TITLE
Add disksUnavailable healStatus const

### DIFF
--- a/cmd/azure-unsupported.go
+++ b/cmd/azure-unsupported.go
@@ -27,8 +27,8 @@ func (a AzureObjects) ListBucketsHeal() (buckets []BucketInfo, err error) {
 }
 
 // HealObject - Not relevant.
-func (a AzureObjects) HealObject(bucket, object string) error {
-	return traceError(NotImplemented{})
+func (a AzureObjects) HealObject(bucket, object string) (int, int, error) {
+	return 0, 0, traceError(NotImplemented{})
 }
 
 // ListObjectsHeal - Not relevant.

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -809,8 +809,8 @@ func (fs fsObjects) ListObjects(bucket, prefix, marker, delimiter string, maxKey
 }
 
 // HealObject - no-op for fs. Valid only for XL.
-func (fs fsObjects) HealObject(bucket, object string) error {
-	return traceError(NotImplemented{})
+func (fs fsObjects) HealObject(bucket, object string) (int, int, error) {
+	return 0, 0, traceError(NotImplemented{})
 }
 
 // HealBucket - no-op for fs, Valid only for XL.

--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -303,7 +303,7 @@ func TestFSHealObject(t *testing.T) {
 	defer removeAll(disk)
 
 	obj := initFSObjects(disk, t)
-	err := obj.HealObject("bucket", "object")
+	_, _, err := obj.HealObject("bucket", "object")
 	if err == nil || !isSameType(errorCause(err), NotImplemented{}) {
 		t.Fatalf("Heal Object should return NotImplemented error ")
 	}

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -57,6 +57,7 @@ const (
 	canHeal                             // Object can be healed
 	corrupted                           // Object can't be healed
 	quorumUnavailable                   // Object can't be healed until read quorum is available
+	canPartiallyHeal                    // Object can't be healed completely until outdated disk(s) are online.
 )
 
 // HealBucketInfo - represents healing related information of a bucket.
@@ -78,9 +79,9 @@ type BucketInfo struct {
 
 // HealObjectInfo - represents healing related information of an object.
 type HealObjectInfo struct {
-	Status              healStatus
-	MissingDataCount    int
-	MissingPartityCount int
+	Status             healStatus
+	MissingDataCount   int
+	MissingParityCount int
 }
 
 // ObjectInfo - represents object metadata.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -50,7 +50,7 @@ type ObjectLayer interface {
 	// Healing operations.
 	HealBucket(bucket string) error
 	ListBucketsHeal() (buckets []BucketInfo, err error)
-	HealObject(bucket, object string) error
+	HealObject(bucket, object string) (int, int, error)
 	ListObjectsHeal(bucket, prefix, marker, delimiter string, maxKeys int) (ListObjectsInfo, error)
 	ListUploadsHeal(bucket, prefix, marker, uploadIDMarker,
 		delimiter string, maxUploads int) (ListMultipartsInfo, error)

--- a/cmd/xl-v1-healing_test.go
+++ b/cmd/xl-v1-healing_test.go
@@ -558,7 +558,7 @@ func TestHealObjectXL(t *testing.T) {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
 
-	err = obj.HealObject(bucket, object)
+	_, _, err = obj.HealObject(bucket, object)
 	if err != nil {
 		t.Fatalf("Failed to heal object - %v", err)
 	}
@@ -574,7 +574,7 @@ func TestHealObjectXL(t *testing.T) {
 	}
 
 	// Try healing now, expect to receive errDiskNotFound.
-	err = obj.HealObject(bucket, object)
+	_, _, err = obj.HealObject(bucket, object)
 	if errorCause(err) != errDiskNotFound {
 		t.Errorf("Expected %v but received %v", errDiskNotFound, err)
 	}

--- a/cmd/xl-v1-object_test.go
+++ b/cmd/xl-v1-object_test.go
@@ -312,7 +312,7 @@ func TestHealing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = xl.HealObject(bucket, object)
+	_, _, err = xl.HealObject(bucket, object)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +336,7 @@ func TestHealing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = xl.HealObject(bucket, object)
+	_, _, err = xl.HealObject(bucket, object)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -242,18 +242,19 @@ __Example__
 ```
 
 <a name="HealObject"></a>
-### HealObject(bucket, object string, isDryRun bool) error
+### HealObject(bucket, object string, isDryRun bool) (HealObjectResult, error)
 If object is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the object is not healed, but heal object request is validated by the server. e.g, if the object exists, if object name is valid etc.
 
 __Example__
 
 ``` go
-    isDryRun := false
-    err := madmClnt.HealObject("mybucket", "myobject", isDryRun)
+    isDryRun = false
+    healResult, err := madmClnt.HealObject("mybucket", "myobject", isDryRun)
     if err != nil {
         log.Fatalln(err)
     }
-    log.Println("successfully healed mybucket/myobject")
+
+    log.Println("Heal-object result: ", healResult)
 
 ```
 
@@ -323,17 +324,17 @@ __Example__
 ```
 
 <a name="HealUpload"></a>
-### HealUpload(bucket, object, uploadID string, isDryRun bool) error
+### HealUpload(bucket, object, uploadID string, isDryRun bool) (HealObjectResult, error)
 If upload is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the upload is not healed, but heal upload request is validated by the server. e.g, if the upload exists, if upload name is valid etc.
 
 ``` go
     isDryRun = false
-    err = madmClnt.HealUpload("mybucket", "myobject", "myuploadID", isDryRun)
+    healResult, err := madmClnt.HealUpload("mybucket", "myobject", "myUploadID", isDryRun)
     if err != nil {
         log.Fatalln(err)
     }
 
-    log.Println("successfully healed mybucket/myobject/myuploadID")
+    log.Println("Heal-upload result: ", healResult)
 ```
 
 ## 5. Config operations

--- a/pkg/madmin/examples/heal-object.go
+++ b/pkg/madmin/examples/heal-object.go
@@ -41,17 +41,17 @@ func main() {
 
 	// Heal object mybucket/myobject - dry run.
 	isDryRun := true
-	err = madmClnt.HealObject("mybucket", "myobject", isDryRun)
+	_, err = madmClnt.HealObject("mybucket", "myobject", isDryRun)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	// Heal object mybucket/myobject - this time for real.
 	isDryRun = false
-	err = madmClnt.HealObject("mybucket", "myobject", isDryRun)
+	healResult, err := madmClnt.HealObject("mybucket", "myobject", isDryRun)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	log.Println("successfully healed mybucket/myobject")
+	log.Printf("heal result: %#v\n", healResult)
 }

--- a/pkg/madmin/examples/heal-objects-list.go
+++ b/pkg/madmin/examples/heal-objects-list.go
@@ -65,6 +65,8 @@ func main() {
 			switch healInfo := *object.HealObjectInfo; healInfo.Status {
 			case madmin.CanHeal:
 				fmt.Println(object.Key, " can be healed.")
+			case madmin.CanPartiallyHeal:
+				fmt.Println(object.Key, " can't be healed completely, some disks are offline.")
 			case madmin.QuorumUnavailable:
 				fmt.Println(object.Key, " can't be healed until quorum is available.")
 			case madmin.Corrupted:

--- a/pkg/madmin/examples/heal-upload.go
+++ b/pkg/madmin/examples/heal-upload.go
@@ -41,17 +41,17 @@ func main() {
 
 	// Heal upload mybucket/myobject/uploadID - dry run.
 	isDryRun := true
-	err = madmClnt.HealUpload("mybucket", "myobject", "myuploadID", isDryRun)
+	_, err = madmClnt.HealUpload("mybucket", "myobject", "myUploadID", isDryRun)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	// Heal upload mybucket/myobject/uploadID - this time for real.
 	isDryRun = false
-	err = madmClnt.HealUpload("mybucket", "myobject", "myuploadID", isDryRun)
+	healResult, err := madmClnt.HealUpload("mybucket", "myobject", "myUploadID", isDryRun)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	log.Println("successfully healed mybucket/myobject/myuploadID")
+	log.Printf("Heal result for mybucket/myobject/myUploadID: %#v\n", healResult)
 }

--- a/pkg/madmin/examples/heal-uploads-list.go
+++ b/pkg/madmin/examples/heal-uploads-list.go
@@ -64,6 +64,8 @@ func main() {
 			switch healInfo := *upload.HealUploadInfo; healInfo.Status {
 			case madmin.CanHeal:
 				fmt.Println(upload.Key, " can be healed.")
+			case madmin.CanPartiallyHeal:
+				fmt.Println(upload.Key, " can be healed partially. Some disks may be offline.")
 			case madmin.QuorumUnavailable:
 				fmt.Println(upload.Key, " can't be healed until quorum is available.")
 			case madmin.Corrupted:

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -104,8 +104,12 @@ const (
 	CanHeal
 	// Corrupted - Object can't be healed
 	Corrupted
-	// QuorumUnavailable - Object can't be healed until read quorum is available
+	// QuorumUnavailable - Object can't be healed until read
+	// quorum is available
 	QuorumUnavailable
+	// CanPartiallyHeal - Object can't be healed completely until
+	// disks with missing parts come online
+	CanPartiallyHeal
 )
 
 // HealBucketInfo - represents healing related information of a bucket.
@@ -127,9 +131,9 @@ type BucketInfo struct {
 
 // HealObjectInfo - represents healing related information of an object.
 type HealObjectInfo struct {
-	Status              HealStatus
-	MissingDataCount    int
-	MissingPartityCount int
+	Status             HealStatus
+	MissingDataCount   int
+	MissingParityCount int
 }
 
 // ObjectInfo container for object metadata.

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -20,8 +20,10 @@
 package madmin
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -438,7 +440,7 @@ func (adm *AdminClient) HealBucket(bucket string, dryrun bool) error {
 }
 
 // HealUpload - Heal the given upload.
-func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool) error {
+func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool) (HealObjectResult, error) {
 	// Construct query params.
 	queryVal := url.Values{}
 	queryVal.Set("heal", "")
@@ -464,18 +466,40 @@ func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool)
 
 	defer closeResponse(resp)
 	if err != nil {
-		return err
+		return HealObjectResult{}, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return httpRespToErrorResponse(resp)
+		return HealObjectResult{}, httpRespToErrorResponse(resp)
 	}
 
-	return nil
+	// Healing is not performed so heal object result is empty.
+	if dryrun {
+		return HealObjectResult{}, nil
+	}
+
+	jsonBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return HealObjectResult{}, err
+	}
+
+	healResult := HealObjectResult{}
+	err = json.Unmarshal(jsonBytes, &healResult)
+	if err != nil {
+		return HealObjectResult{}, err
+	}
+
+	return healResult, nil
+}
+
+// HealObjectResult - represents result of heal-object admin API.
+type HealObjectResult struct {
+	HealedCount  int // number of disks that were healed.
+	OfflineCount int // number of disks that needed healing but were offline.
 }
 
 // HealObject - Heal the given object.
-func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) error {
+func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) (HealObjectResult, error) {
 	// Construct query params.
 	queryVal := url.Values{}
 	queryVal.Set("heal", "")
@@ -498,14 +522,30 @@ func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) error {
 
 	defer closeResponse(resp)
 	if err != nil {
-		return err
+		return HealObjectResult{}, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return httpRespToErrorResponse(resp)
+		return HealObjectResult{}, httpRespToErrorResponse(resp)
 	}
 
-	return nil
+	// Healing is not performed so heal object result is empty.
+	if dryrun {
+		return HealObjectResult{}, nil
+	}
+
+	jsonBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return HealObjectResult{}, err
+	}
+
+	healResult := HealObjectResult{}
+	err = json.Unmarshal(jsonBytes, &healResult)
+	if err != nil {
+		return HealObjectResult{}, err
+	}
+
+	return healResult, nil
 }
 
 // HealFormat - heal storage format on available disks.


### PR DESCRIPTION
This is one of a two part fix for #3980. `mc admin heal` needs a change to interpret `canPartiallyHeal` heal status and inform user if an object can be healed or some disks with missing object parts are offline.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`canPartiallyHeal` healStatus constant indicates that a given object needs healing but one or more of disks requiring heal are offline. This can be used by admin heal API consumers to distinguish between a successful heal and a no-op since the outdated disks were offline. In addition, heal-object and heal-upload admin APIs now return the number of disks the object/upload was healed and the number of disks that were offline during the heal operation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #3980 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested the scenario described in #3980 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.