### PR TITLE
config/path: Figure out absolute paths properly on windows.

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -480,6 +481,14 @@ func serverMain(c *cli.Context) {
 	}
 	if configDir == "" {
 		fatalIf(errors.New("empty directory"), "Configuration directory cannot be empty.")
+	}
+
+	// Disallow relative paths, figure out absolute paths.
+	{
+		configDirAbs, err := filepath.Abs(configDir)
+		fatalIf(err, "Unable to fetch absolute path for config directory %s", configDir)
+
+		configDir = configDirAbs
 	}
 
 	// Set configuration directory.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The following form of arguments such as

```
minio.exe -C some_dir server dir
```

has stopped working because of lack of handling of
absolute paths for config directory. Always calculate
absolute path for any relative paths on any operating
system.

The following fix converts all config directory relative
paths into absolute paths.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #3991 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually in Windows 2012 R2
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.