### PR TITLE
notifiers: Stop using url.Parse in validating address format.

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -1377,7 +1377,7 @@ func TestWriteSetConfigResponse(t *testing.T) {
 		},
 	}
 
-	testURL, err := url.Parse("dummy.com")
+	testURL, err := url.Parse("http://dummy.com")
 	if err != nil {
 		t.Fatalf("Failed to parse a place-holder url")
 	}

--- a/cmd/config-v18_test.go
+++ b/cmd/config-v18_test.go
@@ -299,10 +299,10 @@ func TestValidateConfig(t *testing.T) {
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "elasticsearch": { "1": { "enable": true, "format": "namespace", "url": "example.com", "index": "myindex" } }}}`, true},
 
 		// Test 27 - Test Format for Redis
-		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "invalid", "address": "example.com", "password": "xxx", "key": "key1" } }}}`, false},
+		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "invalid", "address": "example.com:80", "password": "xxx", "key": "key1" } }}}`, false},
 
 		// Test 28 - Test valid Format for Redis
-		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "namespace", "address": "example.com", "password": "xxx", "key": "key1" } }}}`, true},
+		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "namespace", "address": "example.com:80", "password": "xxx", "key": "key1" } }}}`, true},
 	}
 
 	for i, testCase := range testCases {

--- a/cmd/notify-kafka.go
+++ b/cmd/notify-kafka.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 
 	"github.com/Sirupsen/logrus"
 
@@ -46,6 +47,12 @@ func (k *kafkaNotify) Validate() error {
 	}
 	if len(k.Brokers) == 0 {
 		return errors.New("No broker specified")
+	}
+	// Validate all specified brokers.
+	for _, brokerAddr := range k.Brokers {
+		if _, _, err := net.SplitHostPort(brokerAddr); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/notify-nats.go
+++ b/cmd/notify-nats.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"io/ioutil"
+	"net"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/nats-io/go-nats-streaming"
@@ -52,7 +53,7 @@ func (n *natsNotify) Validate() error {
 	if !n.Enable {
 		return nil
 	}
-	if _, err := checkURL(n.Address); err != nil {
+	if _, _, err := net.SplitHostPort(n.Address); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/notify-redis.go
+++ b/cmd/notify-redis.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -52,7 +53,7 @@ func (r *redisNotify) Validate() error {
 	if r.Format != formatNamespace && r.Format != formatAccess {
 		return rdNFormatError
 	}
-	if _, err := checkURL(r.Addr); err != nil {
+	if _, _, err := net.SplitHostPort(r.Addr); err != nil {
 		return err
 	}
 	if r.Key == "" {
@@ -73,6 +74,7 @@ func dialRedis(rNotify redisNotify) (*redis.Pool, error) {
 	if !rNotify.Enable {
 		return nil, errNotifyNotEnabled
 	}
+
 	addr := rNotify.Addr
 	password := rNotify.Password
 	rPool := &redis.Pool{

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -266,13 +266,13 @@ func isFile(path string) bool {
 }
 
 // checkURL - checks if passed address correspond
-func checkURL(address string) (*url.URL, error) {
-	if address == "" {
+func checkURL(urlStr string) (*url.URL, error) {
+	if urlStr == "" {
 		return nil, errors.New("Address cannot be empty")
 	}
-	u, err := url.Parse(address)
+	u, err := url.Parse(urlStr)
 	if err != nil {
-		return nil, fmt.Errorf("`%s` invalid: %s", address, err.Error())
+		return nil, fmt.Errorf("`%s` invalid: %s", urlStr, err.Error())
 	}
 	return u, nil
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -389,16 +389,14 @@ func TestLocalAddress(t *testing.T) {
 
 }
 
-// TestCheckURL tests valid address
+// TestCheckURL tests valid url.
 func TestCheckURL(t *testing.T) {
 	testCases := []struct {
-		addr       string
+		urlStr     string
 		shouldPass bool
 	}{
 		{"", false},
 		{":", false},
-		{"localhost", true},
-		{"127.0.0.1", true},
 		{"http://localhost/", true},
 		{"http://127.0.0.1/", true},
 		{"proto://myhostname/path", true},
@@ -406,7 +404,7 @@ func TestCheckURL(t *testing.T) {
 
 	// Validates fetching local address.
 	for i, testCase := range testCases {
-		_, err := checkURL(testCase.addr)
+		_, err := checkURL(testCase.urlStr)
 		if testCase.shouldPass && err != nil {
 			t.Errorf("Test %d: expected to pass but got an error: %v\n", i+1, err)
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
url.Parse() wrongly parses an address of format "address:port"
which is fixed in go1.8.  This inculcates a breaking change
on our end. We should fix this wrong usage everywhere so that
migrating to go1.8 eventually becomes smoother.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes future go1.8 issues - https://github.com/golang/go/commit/c5ccbdd22bdbdc43d541b7e7d4ed66ceb559030e#comments
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using go1.8
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.