### PR TITLE
fix: use its own lock in serverConfigV17

### DIFF
--- a/cmd/config-v17_test.go
+++ b/cmd/config-v17_test.go
@@ -309,7 +309,7 @@ func TestValidateConfig(t *testing.T) {
 		if werr := ioutil.WriteFile(configPath, []byte(testCase.configData), 0700); werr != nil {
 			t.Fatal(werr)
 		}
-		verr := validateConfig()
+		_, verr := getValidConfig()
 		if testCase.shouldPass && verr != nil {
 			t.Errorf("Test %d, should pass but it failed with err = %v", i+1, verr)
 		}

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -104,16 +104,8 @@ func newGatewayConfig(accessKey, secretKey, region string) error {
 		SecretKey: secretKey,
 	})
 
-	// Set default printing to console.
-	srvCfg.Logger.SetConsole(NewConsoleLogger())
-
 	// Set custom region.
 	srvCfg.SetRegion(region)
-
-	// Create certs path for SSL configuration.
-	if err := createConfigDir(); err != nil {
-		return err
-	}
 
 	// hold the mutex lock before a new config is assigned.
 	// Save the new config globally.
@@ -139,8 +131,7 @@ func gatewayMain(ctx *cli.Context) {
 	// TODO: add support for custom region when we add
 	// support for S3 backend storage, currently this can
 	// default to "us-east-1"
-	err := newGatewayConfig(accessKey, secretKey, "us-east-1")
-	fatalIf(err, "Unable to initialize gateway config")
+	newGatewayConfig(accessKey, secretKey, globalMinioDefaultRegion)
 
 	// Get quiet flag from command line argument.
 	quietFlag := ctx.Bool("quiet") || ctx.GlobalBool("quiet")
@@ -150,6 +141,9 @@ func gatewayMain(ctx *cli.Context) {
 
 	// First argument is selected backend type.
 	backendType := ctx.Args().First()
+
+	// Create certs path for SSL configuration.
+	fatalIf(createConfigDir(), "Unable to create configuration directory")
 
 	newObject, err := newGatewayLayer(backendType, accessKey, secretKey)
 	fatalIf(err, "Unable to initialize gateway layer")

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -357,8 +357,7 @@ func initConfig() {
 	// Config file does not exist, we create it fresh and return upon success.
 	if isFile(getConfigFile()) {
 		fatalIf(migrateConfig(), "Config migration failed.")
-		fatalIf(validateConfig(), "Unable to validate configuration file")
-		fatalIf(loadConfig(), "Unable to initialize minio config")
+		fatalIf(loadConfig(), "Unable to load minio config file")
 	} else {
 		fatalIf(newConfig(), "Unable to initialize minio config for the first time.")
 		log.Println("Created minio configuration file successfully at " + getConfigDir())


### PR DESCRIPTION
Previously serverConfigV17 used a global lock that made any instance of
serverConfigV17 depended on single global serverConfigMu.

This patch fixes by having individual lock per instances.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.