### PR TITLE
madmin: Rename HealObjectResult to HealResult

### DIFF
--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -242,7 +242,7 @@ __Example__
 ```
 
 <a name="HealObject"></a>
-### HealObject(bucket, object string, isDryRun bool) (HealObjectResult, error)
+### HealObject(bucket, object string, isDryRun bool) (HealResult, error)
 If object is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the object is not healed, but heal object request is validated by the server. e.g, if the object exists, if object name is valid etc.
 
 __Example__
@@ -324,7 +324,7 @@ __Example__
 ```
 
 <a name="HealUpload"></a>
-### HealUpload(bucket, object, uploadID string, isDryRun bool) (HealObjectResult, error)
+### HealUpload(bucket, object, uploadID string, isDryRun bool) (HealResult, error)
 If upload is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the upload is not healed, but heal upload request is validated by the server. e.g, if the upload exists, if upload name is valid etc.
 
 ``` go

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -440,7 +440,7 @@ func (adm *AdminClient) HealBucket(bucket string, dryrun bool) error {
 }
 
 // HealUpload - Heal the given upload.
-func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool) (HealObjectResult, error) {
+func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool) (HealResult, error) {
 	// Construct query params.
 	queryVal := url.Values{}
 	queryVal.Set("heal", "")
@@ -466,40 +466,40 @@ func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool)
 
 	defer closeResponse(resp)
 	if err != nil {
-		return HealObjectResult{}, err
+		return HealResult{}, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return HealObjectResult{}, httpRespToErrorResponse(resp)
+		return HealResult{}, httpRespToErrorResponse(resp)
 	}
 
 	// Healing is not performed so heal object result is empty.
 	if dryrun {
-		return HealObjectResult{}, nil
+		return HealResult{}, nil
 	}
 
 	jsonBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return HealObjectResult{}, err
+		return HealResult{}, err
 	}
 
-	healResult := HealObjectResult{}
+	healResult := HealResult{}
 	err = json.Unmarshal(jsonBytes, &healResult)
 	if err != nil {
-		return HealObjectResult{}, err
+		return HealResult{}, err
 	}
 
 	return healResult, nil
 }
 
-// HealObjectResult - represents result of heal-object admin API.
-type HealObjectResult struct {
+// HealResult - represents result of heal-object admin API.
+type HealResult struct {
 	HealedCount  int // number of disks that were healed.
 	OfflineCount int // number of disks that needed healing but were offline.
 }
 
 // HealObject - Heal the given object.
-func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) (HealObjectResult, error) {
+func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) (HealResult, error) {
 	// Construct query params.
 	queryVal := url.Values{}
 	queryVal.Set("heal", "")
@@ -522,27 +522,27 @@ func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) (HealObje
 
 	defer closeResponse(resp)
 	if err != nil {
-		return HealObjectResult{}, err
+		return HealResult{}, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return HealObjectResult{}, httpRespToErrorResponse(resp)
+		return HealResult{}, httpRespToErrorResponse(resp)
 	}
 
 	// Healing is not performed so heal object result is empty.
 	if dryrun {
-		return HealObjectResult{}, nil
+		return HealResult{}, nil
 	}
 
 	jsonBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return HealObjectResult{}, err
+		return HealResult{}, err
 	}
 
-	healResult := HealObjectResult{}
+	healResult := HealResult{}
 	err = json.Unmarshal(jsonBytes, &healResult)
 	if err != nil {
-		return HealObjectResult{}, err
+		return HealResult{}, err
 	}
 
 	return healResult, nil


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
madmin.HealObjectResult is used in HealObject and HealUpload. It only
makes sense to rename it to HealResult.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.