### PR TITLE
fix: add white space in storage usage section

### DIFF
--- a/browser/app/js/components/Browse.js
+++ b/browser/app/js/components/Browse.js
@@ -469,11 +469,11 @@ export default class Browse extends React.Component {
                               </div>
                               <ul>
                                 <li>
-                                  Used:
+                                  <span>Used: </span>
                                   { humanize.filesize(total - free) }
                                 </li>
                                 <li className="pull-right">
-                                  Free:
+                                  <span>Free: </span>
                                   { humanize.filesize(total - used) }
                                 </li>
                               </ul>


### PR DESCRIPTION

## Description
Fix for #3962 - add whitespace before storage usage details section in
 Browse component

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.