### PR TITLE
fs: Enable returning ETag along with ListObjects()

### DIFF
--- a/cmd/fs-v1-metadata_test.go
+++ b/cmd/fs-v1-metadata_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -72,18 +71,6 @@ func TestReadFSMetadata(t *testing.T) {
 	fsMeta := fsMetaV1{}
 	if _, err = fsMeta.ReadFrom(rlk.LockedFile); err != nil {
 		t.Fatal("Unexpected error ", err)
-	}
-
-	// Corrupted fs.json
-	file, err := os.OpenFile(preparePath(fsPath), os.O_APPEND|os.O_WRONLY, 0666)
-	if err != nil {
-		t.Fatal("Unexpected error ", err)
-	}
-	file.Write([]byte{'a'})
-	file.Close()
-	fsMeta = fsMetaV1{}
-	if _, err := fsMeta.ReadFrom(rlk.LockedFile); err == nil {
-		t.Fatal("Should fail", err)
 	}
 }
 

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -81,7 +81,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: false,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps.png", ContentType: "image/png"},
+				{Name: "Asia-maps.png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 				{Name: "newPrefix0"},
@@ -97,7 +97,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: true,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps.png", ContentType: "image/png"},
+				{Name: "Asia-maps.png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 				{Name: "newPrefix0"},
@@ -109,7 +109,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: true,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps.png", ContentType: "image/png"},
+				{Name: "Asia-maps.png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 				{Name: "newPrefix0"},
@@ -120,7 +120,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: true,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps.png", ContentType: "image/png"},
+				{Name: "Asia-maps.png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 			},
@@ -131,7 +131,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: true,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps.png", ContentType: "image/png"},
+				{Name: "Asia-maps.png"},
 			},
 		},
 		// ListObjectsResult-5.
@@ -234,7 +234,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: false,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps.png", ContentType: "image/png"},
+				{Name: "Asia-maps.png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 				{Name: "newPrefix0"},
@@ -343,7 +343,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: false,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps.png", ContentType: "image/png"},
+				{Name: "Asia-maps.png"},
 				{Name: "Asia/India/India-summer-photos-1"},
 				{Name: "Asia/India/Karnataka/Bangalore/Koramangala/pics"},
 			},
@@ -354,7 +354,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{
 			IsTruncated: false,
 			Objects: []ObjectInfo{
-				{Name: "Asia-maps.png", ContentType: "image/png"},
+				{Name: "Asia-maps.png"},
 			},
 		},
 		// ListObjectsResult-26.
@@ -549,8 +549,8 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 				if testCase.result.Objects[j].Name != result.Objects[j].Name {
 					t.Errorf("Test %d: %s: Expected object name to be \"%s\", but found \"%s\" instead", i+1, instanceType, testCase.result.Objects[j].Name, result.Objects[j].Name)
 				}
-				if testCase.result.Objects[j].ContentType != result.Objects[j].ContentType {
-					t.Errorf("Test %d: %s: Expected object contentType to be \"%s\", but found \"%s\" instead", i+1, instanceType, testCase.result.Objects[j].ContentType, result.Objects[j].ContentType)
+				if result.Objects[j].MD5Sum == "" {
+					t.Errorf("Test %d: %s: Expected md5sum to be not empty, but found empty instead", i+1, instanceType)
 				}
 
 			}

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -67,6 +67,9 @@ func init() {
 
 	// Set system resources to maximum.
 	setMaxResources()
+
+	// Quiet logging.
+	log.logger.Hooks = nil
 }
 
 func prepareFS() (ObjectLayer, string, error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is to comply with S3 behavior, we previously removed
reading `fs.json` for optimization reasons but we have a
reason to believe that providing ETag and using gjson
provides needed benefit of not having to deal with
unmarshalling overhead of golang stdlib.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4028

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually with benchmarks

With ETag
```
minio@minio3:~$ time mc ls -r test/dicom | wc -l 
230000

real    0m26.398s
user    0m15.928s
sys     0m2.196s
```

Without ETag
```
minio@minio3:~$ time mc ls -r test/dicom | wc -l 
230000

real    0m20.672s
user    0m17.100s
sys     0m2.548s
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.