### PR TITLE
Return possible states a heal operation

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -1586,3 +1586,29 @@ func TestListHealUploadsHandler(t *testing.T) {
 
 	}
 }
+
+// Test for newHealResult helper function.
+func TestNewHealResult(t *testing.T) {
+	testCases := []struct {
+		healedDisks  int
+		offlineDisks int
+		state        healState
+	}{
+		// 1. No disks healed, no disks offline.
+		{0, 0, healNone},
+		// 2. No disks healed, non-zero disks offline.
+		{0, 1, healNone},
+		// 3. Non-zero disks healed, no disks offline.
+		{1, 0, healOK},
+		// 4. Non-zero disks healed, non-zero disks offline.
+		{1, 1, healPartial},
+	}
+
+	for i, test := range testCases {
+		actual := newHealResult(test.healedDisks, test.offlineDisks)
+		if actual.State != test.state {
+			t.Errorf("Test %d: Expected %v but received %v", i+1,
+				test.state, actual.State)
+		}
+	}
+}

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -336,12 +336,19 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 		return 0, 0, toObjectErr(aErr, bucket, object)
 	}
 
-	numAvailableDisks := 0
+	// Number of disks which don't serve data.
 	numOfflineDisks := 0
-	for index, disk := range availableDisks {
+	for index, disk := range storageDisks {
 		switch {
 		case disk == nil, errs[index] == errDiskNotFound:
 			numOfflineDisks++
+		}
+	}
+
+	// Number of disks which have all parts of the given object.
+	numAvailableDisks := 0
+	for _, disk := range availableDisks {
+		switch {
 		case disk != nil:
 			numAvailableDisks++
 		}
@@ -357,6 +364,8 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 	outDatedDisks := outDatedDisks(storageDisks, availableDisks, errs, partsMetadata,
 		bucket, object)
 
+	// Number of disks that had outdated content of the given
+	// object and are online to be healed.
 	numHealedDisks := 0
 	for _, disk := range outDatedDisks {
 		if disk != nil {

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -245,6 +245,18 @@ __Example__
 ### HealObject(bucket, object string, isDryRun bool) (HealResult, error)
 If object is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the object is not healed, but heal object request is validated by the server. e.g, if the object exists, if object name is valid etc.
 
+| Param  | Type  | Description  |
+|---|---|---|
+|`h.State` | _HealState_ | Represents the result of heal operation. It could be one of `HealNone`, `HealPartial` or `HealOK`. |
+
+
+| Value | Description |
+|---|---|
+|`HealNone` | Object/Upload wasn't healed on any of the disks |
+|`HealPartial` | Object/Upload was healed on some of the disks needing heal |
+| `HealOK` | Object/Upload was healed on all the disks needing heal |
+
+
 __Example__
 
 ``` go
@@ -326,6 +338,17 @@ __Example__
 <a name="HealUpload"></a>
 ### HealUpload(bucket, object, uploadID string, isDryRun bool) (HealResult, error)
 If upload is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the upload is not healed, but heal upload request is validated by the server. e.g, if the upload exists, if upload name is valid etc.
+
+| Param  | Type  | Description  |
+|---|---|---|
+|`h.State` | _HealState_ | Represents the result of heal operation. It could be one of `HealNone`, `HealPartial` or `HealOK`. |
+
+
+| Value | Description |
+|---|---|
+| `HealNone` | Object/Upload wasn't healed on any of the disks |
+| `HealPartial` | Object/Upload was healed on some of the disks needing heal |
+| `HealOK` | Object/Upload was healed on all the disks needing heal |
 
 ``` go
     isDryRun = false

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -494,9 +494,20 @@ func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool)
 
 // HealResult - represents result of heal-object admin API.
 type HealResult struct {
-	HealedCount  int // number of disks that were healed.
-	OfflineCount int // number of disks that needed healing but were offline.
+	State HealState `json:"state"`
 }
+
+// HealState - different states of heal operation
+type HealState int
+
+const (
+	// HealNone - none of the disks healed
+	HealNone HealState = iota
+	// HealPartial - some disks were healed, others were offline
+	HealPartial
+	// HealOK - all disks were healed
+	HealOK
+)
 
 // HealObject - Heal the given object.
 func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) (HealResult, error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
## Background
Healing algorithm returns failure only if an attempt to heal any of the disks failed. It returns success even if all disks needing heal were offline.
In its current form, heal admin REST APIs returns the above boolean state making it impossible for clients like `mc` to distinguish between an object being healed completely, partially and not.

## Solution
The fix (so far) is to return `struct { HealedCount int, OfflineCount int}` in addition to `error` for a heal-object and heal-upload operation. `mc` can make use of this to guide users better.

## Future-proof solution
This brings us to whether it is right by design to provide internal details of the healing process in admin API. We return an enumerated constant in heal-object and heal-upload API that captures the 3 result states of the heal operation, namely, `CompletelyHealed`, `PartiallyHealed` and `NotHealed`. In addition, we would return `error` to indicate if the healing operation failed to due to other I/O related errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.