### PR TITLE
build: Fix compilation in 32 bits platforms

### DIFF
--- a/pkg/sys/stats_linux.go
+++ b/pkg/sys/stats_linux.go
@@ -62,9 +62,14 @@ func getSysinfoMemoryLimit() (limit uint64, err error) {
 		return 0, err
 	}
 
+	// Some fields in syscall.Sysinfo_t have different  integer sizes
+	// in different platform architectures. Cast all fields to uint64.
+	totalRAM := uint64(si.Totalram)
+	unit := uint64(si.Unit)
+
 	// Total RAM is always the multiplicative value
 	// of unit size and total ram.
-	limit = uint64(si.Unit) * si.Totalram
+	limit = unit * totalRAM
 	return limit, nil
 }
 


### PR DESCRIPTION
## Description
go fails to build Minio under at least, armv6 and 386 due to some
inconsistencies in the type of one syscall variable in different
architectures. This PR casts that variable to uint64 to achieve
the desired consistency.

## Motivation and Context
Fixes #4051 

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.