### PR TITLE
notify: Webhook endpoints can fail, but we must start the server.

### DIFF
--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -645,7 +645,6 @@ func loadAllQueueTargets() (map[string]*logrus.Logger, error) {
 		if !webhookN.Enable {
 			continue
 		}
-
 		if _, err := addQueueTarget(queueTargets, accountID, queueTypeWebhook, newWebhookNotify); err != nil {
 			return nil, err
 		}

--- a/cmd/notify-webhook_test.go
+++ b/cmd/notify-webhook_test.go
@@ -51,7 +51,7 @@ func TestNewWebHookNotify(t *testing.T) {
 		t.Fatal("Unexpected should fail")
 	}
 
-	serverConfig.Notify.SetWebhookByID("10", webhookNotify{Enable: true, Endpoint: "http://www."})
+	serverConfig.Notify.SetWebhookByID("10", webhookNotify{Enable: true, Endpoint: "http://127.0.0.1:xxx"})
 	_, err = newWebhookNotify("10")
 	if err == nil {
 		t.Fatal("Unexpected should fail with lookupHost")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -111,24 +111,6 @@ const (
 	httpsScheme = "https"
 )
 
-var portMap = map[string]string{
-	httpScheme:  "80",
-	httpsScheme: "443",
-}
-
-// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
-// return true if the string includes a port.
-func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }
-
-// canonicalAddr returns url.Host but always with a ":port" suffix
-func canonicalAddr(u *url.URL) string {
-	addr := u.Host
-	if !hasPort(addr) {
-		return addr + ":" + portMap[u.Scheme]
-	}
-	return addr
-}
-
 // checkDuplicates - function to validate if there are duplicates in a slice of endPoints.
 func checkDuplicateEndpoints(endpoints []*url.URL) error {
 	var strs []string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignore any network errors when registering a webhook
notifier during Minio startup sequence. This way server
can be started even if the webhook endpoint is not available
and unreachable.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4050

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually with wrong config.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.