### PR TITLE
Allow cluster to start when only n/2 servers are up

### DIFF
--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -132,13 +132,14 @@ func prepForInitXL(firstDisk bool, sErrs []error, diskCount int) InitActions {
 	}
 
 	quorum := diskCount/2 + 1
+	readQuorum := diskCount / 2
 	disksOffline := errMap[errDiskNotFound]
 	disksFormatted := errMap[nil]
 	disksUnformatted := errMap[errUnformattedDisk]
 	disksCorrupted := errMap[errCorruptedFormat]
 
 	// No Quorum lots of offline disks, wait for quorum.
-	if disksOffline >= quorum {
+	if disksOffline > readQuorum {
 		return WaitForQuorum
 	}
 
@@ -168,7 +169,7 @@ func prepForInitXL(firstDisk bool, sErrs []error, diskCount int) InitActions {
 	}
 
 	// Already formatted and in quorum, proceed to initialization of object layer.
-	if disksFormatted >= quorum {
+	if disksFormatted >= readQuorum {
 		if disksFormatted+disksOffline == diskCount {
 			return InitObjectLayer
 		}
@@ -293,7 +294,7 @@ func initStorageDisks(endpoints []*url.URL) ([]StorageAPI, error) {
 	return storageDisks, nil
 }
 
-// Format disks before initialization object layer.
+// Format disks before initialization of object layer.
 func waitForFormatXLDisks(firstDisk bool, endpoints []*url.URL, storageDisks []StorageAPI) (formattedDisks []StorageAPI, err error) {
 	if len(endpoints) == 0 {
 		return nil, errInvalidArgument

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -155,6 +155,16 @@ func newXLObjects(storageDisks []StorageAPI) (ObjectLayer, error) {
 	xl.readQuorum = readQuorum
 	xl.writeQuorum = writeQuorum
 
+	// If the number of offline servers is equal to the readQuorum
+	// (i.e. the number of online servers also equals the
+	// readQuorum), we cannot perform quick-heal (no
+	// write-quorum). However reads may still be possible, so we
+	// skip quick-heal in this case, and continue.
+	offlineCount := len(newStorageDisks) - diskCount(newStorageDisks)
+	if offlineCount == readQuorum {
+		return xl, nil
+	}
+
 	// Do a quick heal on the buckets themselves for any discrepancies.
 	return xl, quickHeal(xl.storageDisks, xl.writeQuorum, xl.readQuorum)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes #3234.

Relaxes the quorum requirement to start the object layer, and skips
quick-healing at start-up (as no write quorum is present).

This fix allows reads to work after start-up, but it does hang on writes. The hang is because no write quorum servers are available and the lock interface currently does not have a possibility of failing/returning an error. In my view, this is a separate issue - #3185 ought to be re-opened.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Toward resolving #3234. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.