### PR TITLE
Fix writes from Apache Spark.

### DIFF
--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -34,6 +34,9 @@ const (
 
 	// Buckets meta prefix.
 	bucketMetaPrefix = "buckets"
+
+	// Md5Sum of empty string.
+	emptyStrMd5Sum = "d41d8cd98f00b204e9800998ecf8427e"
 )
 
 // Global object layer mutex, used for safely updating object layer.
@@ -67,6 +70,10 @@ func dirObjectInfo(bucket, object string, size int64, metadata map[string]string
 	// return success.
 	md5Sum := metadata["md5Sum"]
 	delete(metadata, "md5Sum")
+	if md5Sum == "" {
+		md5Sum = emptyStrMd5Sum
+	}
+
 	return ObjectInfo{
 		Bucket:      bucket,
 		Name:        object,

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1100,6 +1100,26 @@ func (s *TestSuiteCommon) TestPutObject(c *C) {
 	// asserted the contents of the fetched object with the expected result.
 	c.Assert(true, Equals, bytes.Equal(buffer2.Bytes(), []byte("hello world")))
 
+	// Test the response when object name ends with a slash.
+	// This is a special case with size as '0' and object ends with
+	// a slash separator, we treat it like a valid operation and
+	// return success.
+	// The response Etag headers should contain Md5Sum of empty string.
+	objectName = "objectwith/"
+	// create HTTP request for object upload.
+	request, err = newTestSignedRequest("PUT", getPutObjectURL(s.endPoint, bucketName, objectName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	if s.signer == signerV2 {
+		c.Assert(err, IsNil)
+		err = signRequestV2(request, s.accessKey, s.secretKey)
+	}
+	c.Assert(err, IsNil)
+	// execute the HTTP request for object upload.
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+	// The response Etag header should contain Md5sum of an empty string.
+	c.Assert(response.Header.Get("Etag"), Equals, "\""+emptyStrMd5Sum+"\"")
 }
 
 // TestListBuckets - Make request for listing of all buckets.


### PR DESCRIPTION
- Due to usage of amazon SDK, spark expects md5sum of empty string to be
  returned when it does PUT on a directory.
- The fix returns md5sum of a empty string for the above mentioned case.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing the writes of Apache Spark into Minio . Fixes https://github.com/minio/minio/issues/2965 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using the setup described in https://github.com/minio/minio/issues/2965

The softwares are used, 
- Minio master at f44f2e341c931222a8f1e3f1e9911dda80bb2dc0
- Hadoop 3.0.0-alpha
- Apache Spark 2.1.0
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.