### PR TITLE
conditions: datetime headers supports new TZs

### DIFF
--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -66,11 +66,13 @@ func checkCopyObjectPreconditions(w http.ResponseWriter, r *http.Request, objInf
 	// since the specified time otherwise return 412 (precondition failed).
 	ifModifiedSinceHeader := r.Header.Get("x-amz-copy-source-if-modified-since")
 	if ifModifiedSinceHeader != "" {
-		if !ifModifiedSince(objInfo.ModTime, ifModifiedSinceHeader) {
-			// If the object is not modified since the specified time.
-			writeHeaders()
-			writeErrorResponse(w, ErrPreconditionFailed, r.URL)
-			return true
+		if givenTime, err := parseTime(time.RFC1123, ifModifiedSinceHeader); err == nil {
+			if !ifModifiedSince(objInfo.ModTime, givenTime) {
+				// If the object is not modified since the specified time.
+				writeHeaders()
+				writeErrorResponse(w, ErrPreconditionFailed, r.URL)
+				return true
+			}
 		}
 	}
 
@@ -78,11 +80,13 @@ func checkCopyObjectPreconditions(w http.ResponseWriter, r *http.Request, objInf
 	// modified since the specified time, otherwise return a 412 (precondition failed).
 	ifUnmodifiedSinceHeader := r.Header.Get("x-amz-copy-source-if-unmodified-since")
 	if ifUnmodifiedSinceHeader != "" {
-		if ifModifiedSince(objInfo.ModTime, ifUnmodifiedSinceHeader) {
-			// If the object is modified since the specified time.
-			writeHeaders()
-			writeErrorResponse(w, ErrPreconditionFailed, r.URL)
-			return true
+		if givenTime, err := parseTime(time.RFC1123, ifUnmodifiedSinceHeader); err == nil {
+			if ifModifiedSince(objInfo.ModTime, givenTime) {
+				// If the object is modified since the specified time.
+				writeHeaders()
+				writeErrorResponse(w, ErrPreconditionFailed, r.URL)
+				return true
+			}
 		}
 	}
 
@@ -147,11 +151,13 @@ func checkPreconditions(w http.ResponseWriter, r *http.Request, objInfo ObjectIn
 	// otherwise return a 304 (not modified).
 	ifModifiedSinceHeader := r.Header.Get("If-Modified-Since")
 	if ifModifiedSinceHeader != "" {
-		if !ifModifiedSince(objInfo.ModTime, ifModifiedSinceHeader) {
-			// If the object is not modified since the specified time.
-			writeHeaders()
-			w.WriteHeader(http.StatusNotModified)
-			return true
+		if givenTime, err := parseTime(time.RFC1123, ifModifiedSinceHeader); err == nil {
+			if !ifModifiedSince(objInfo.ModTime, givenTime) {
+				// If the object is not modified since the specified time.
+				writeHeaders()
+				w.WriteHeader(http.StatusNotModified)
+				return true
+			}
 		}
 	}
 
@@ -159,11 +165,13 @@ func checkPreconditions(w http.ResponseWriter, r *http.Request, objInfo ObjectIn
 	// time, otherwise return a 412 (precondition failed).
 	ifUnmodifiedSinceHeader := r.Header.Get("If-Unmodified-Since")
 	if ifUnmodifiedSinceHeader != "" {
-		if ifModifiedSince(objInfo.ModTime, ifUnmodifiedSinceHeader) {
-			// If the object is modified since the specified time.
-			writeHeaders()
-			writeErrorResponse(w, ErrPreconditionFailed, r.URL)
-			return true
+		if givenTime, err := parseTime(time.RFC1123, ifUnmodifiedSinceHeader); err == nil {
+			if ifModifiedSince(objInfo.ModTime, givenTime) {
+				// If the object is modified since the specified time.
+				writeHeaders()
+				writeErrorResponse(w, ErrPreconditionFailed, r.URL)
+				return true
+			}
 		}
 	}
 
@@ -195,14 +203,10 @@ func checkPreconditions(w http.ResponseWriter, r *http.Request, objInfo ObjectIn
 }
 
 // returns true if object was modified after givenTime.
-func ifModifiedSince(objTime time.Time, givenTimeStr string) bool {
-	givenTime, err := time.Parse(http.TimeFormat, givenTimeStr)
-	if err != nil {
-		return true
-	}
+func ifModifiedSince(objTime time.Time, givenTime time.Time) bool {
 	// The Date-Modified header truncates sub-second precision, so
 	// use mtime < t+1s instead of mtime <= t to check for unmodified.
-	if objTime.After(givenTime.Add(1 * time.Second)) {
+	if objTime.UTC().After(givenTime.UTC().Add(1 * time.Second)) {
 		return true
 	}
 	return false

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1280,6 +1280,9 @@ func (s *TestSuiteCommon) TestHeadOnObjectLastModified(c *C) {
 		int64(buffer1.Len()), buffer1, s.accessKey, s.secretKey, s.signer)
 	c.Assert(err, IsNil)
 
+	laTZ, err := time.LoadLocation("America/Los_Angeles")
+	c.Assert(err, IsNil)
+
 	// executing the HTTP request to download the object.
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
@@ -1306,7 +1309,18 @@ func (s *TestSuiteCommon) TestHeadOnObjectLastModified(c *C) {
 	request, err = newTestSignedRequest("HEAD", getHeadObjectURL(s.endPoint, bucketName, objectName),
 		0, nil, s.accessKey, s.secretKey, s.signer)
 	c.Assert(err, IsNil)
-	request.Header.Set("If-Modified-Since", t.Add(10*time.Minute).UTC().Format(http.TimeFormat))
+	request.Header.Set("If-Modified-Since", t.Add(10*time.Minute).UTC().Format(time.RFC1123))
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	// Since the "If-Modified-Since" header was ahead in time compared to the actual
+	// modified time of the object expecting the response status to be http.StatusNotModified.
+	c.Assert(response.StatusCode, Equals, http.StatusNotModified)
+
+	// Test If-Unmodified-Since with a timezone other than GMT
+	request, err = newTestSignedRequest("HEAD", getHeadObjectURL(s.endPoint, bucketName, objectName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+	request.Header.Set("If-Modified-Since", t.Add(10*time.Minute).In(laTZ).Format(time.RFC1123))
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
 	// Since the "If-Modified-Since" header was ahead in time compared to the actual
@@ -1319,10 +1333,29 @@ func (s *TestSuiteCommon) TestHeadOnObjectLastModified(c *C) {
 	request, err = newTestSignedRequest("HEAD", getHeadObjectURL(s.endPoint, bucketName, objectName),
 		0, nil, s.accessKey, s.secretKey, s.signer)
 	c.Assert(err, IsNil)
-	request.Header.Set("If-Unmodified-Since", t.Add(-10*time.Minute).UTC().Format(http.TimeFormat))
+	request.Header.Set("If-Unmodified-Since", t.Add(-10*time.Minute).UTC().Format(time.RFC1123))
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusPreconditionFailed)
+
+	// Test If-Unmodified-Since with a timezone other than GMT
+	request, err = newTestSignedRequest("HEAD", getHeadObjectURL(s.endPoint, bucketName, objectName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+	request.Header.Set("If-Unmodified-Since", t.Add(-10*time.Minute).In(laTZ).Format(time.RFC1123))
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusPreconditionFailed)
+
+	// Test If-Unmodified-Since with a timezone other than GMT
+	request, err = newTestSignedRequest("HEAD", getHeadObjectURL(s.endPoint, bucketName, objectName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+	request.Header.Set("If-Unmodified-Since", t.Add(10*time.Minute).In(laTZ).Format(time.RFC1123))
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
 }
 
 // TestHeadOnBucket - Validates response for HEAD on the bucket.

--- a/cmd/time.go
+++ b/cmd/time.go
@@ -1,0 +1,67 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "time"
+
+var minioTZ = map[string]int{
+
+	"PST": -8 * 3600,
+	"PDT": -7 * 3600,
+
+	"EST": -5 * 3600,
+	"EDT": -4 * 3600,
+
+	"GMT": 0,
+	"UTC": 0,
+
+	"CET":  1 * 3600,
+	"CEST": 2 * 3600,
+}
+
+// parseTime returns the correct time when a timezone is provided
+// with the time string, if the specified timezone is not found in
+// minioTZ, call only the standard golang time parsing.
+func parseTime(layout, value string) (time.Time, error) {
+	// Standard golang time parsing
+	t, err := time.Parse(layout, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// Fetch the location of the passed time
+	loc := t.Location()
+
+	if loc == nil || loc == time.UTC || loc == time.Local {
+		// Nothing to do, even when location is set to time.Local
+		// since time will be obviously correct with the local
+		// machine's timezone
+		return t, nil
+	}
+
+	// Fetch the time offset associated to the passed timezone.
+	// If not found, return golang std time parser result.
+	offset, ok := minioTZ[loc.String()]
+	if !ok {
+		return t, nil
+	}
+
+	// Calculate the new time
+	newTime := t.Add(-time.Duration(offset) * time.Second)
+
+	return newTime, nil
+}

--- a/cmd/time_test.go
+++ b/cmd/time_test.go
@@ -1,0 +1,52 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseTime(t *testing.T) {
+	testCases := []struct {
+		timeStr    string
+		timeLayout string
+		timeUTC    time.Time
+		shouldPass bool
+	}{
+		{"", time.RFC1123, time.Time{}, false},
+		{"foo", time.RFC1123, time.Time{}, false},
+		{"Fri, 03 Apr 2015 17:10:00 GMT", time.RFC1123, time.Date(2015, 04, 03, 17, 10, 00, 00, time.UTC), true},
+		{"Fri, 03 Apr 2015 17:10:00 UTC", time.RFC1123, time.Date(2015, 04, 03, 17, 10, 00, 00, time.UTC), true},
+		{"Fri, 03 Apr 2015 18:10:00 CET", time.RFC1123, time.Date(2015, 04, 03, 17, 10, 00, 00, time.UTC), true},
+		{"Fri, 03 Apr 2015 19:10:00 CEST", time.RFC1123, time.Date(2015, 04, 03, 17, 10, 00, 00, time.UTC), true},
+		{"Fri, 03 Apr 2015 09:10:00 PST", time.RFC1123, time.Date(2015, 04, 03, 17, 10, 00, 00, time.UTC), true},
+	}
+
+	for i, testCase := range testCases {
+		parsedTime, err := parseTime(testCase.timeLayout, testCase.timeStr)
+		if err == nil && !testCase.shouldPass {
+			t.Errorf("Test %d expected to fail but passed instead\n", i+1)
+		}
+		if err != nil && testCase.shouldPass {
+			t.Errorf("Test %d expected to pass but failed with err: %v\n", i+1, err)
+		}
+		if !parsedTime.UTC().Equal(testCase.timeUTC) {
+			t.Errorf("Test %d found an unexpected result, found: %v, expected: %v\n", i+1, parsedTime.UTC(), testCase.timeUTC)
+		}
+	}
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Some headers of type date time, like If-Unmodified-Since, If-Modified-Since
and other can support timezones other than GMT, like UTC, PST, CEST etc..
Though the S3 spec explicitly requires GMT, AWS S3 in practice accepts
time.RFC1123 date format, so this PR follows the same behavior.

## Motivation and Context
Fixes https://github.com/minio/minio/issues/4082

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.