### PR TITLE
Browser: Make login form browser auto-fill compatible

### DIFF
--- a/browser/app/js/components/Login.js
+++ b/browser/app/js/components/Login.js
@@ -89,10 +89,6 @@ export default class Login extends React.Component {
         { alertBox }
         <div className="l-wrap">
           <form onSubmit={ this.handleSubmit.bind(this) }>
-            <input name="fixBrowser"
-              autoComplete="username"
-              type="text"
-              style={ { display: 'none' } } />
             <InputGroup className="ig-dark"
               label="Access Key"
               id="accessKey"
@@ -102,7 +98,6 @@ export default class Login extends React.Component {
               required="required"
               autoComplete="username">
             </InputGroup>
-            <input type="text" autoComplete="new-password" style={ { display: 'none' } } />
             <InputGroup className="ig-dark"
               label="Secret Key"
               id="secretKey"

--- a/browser/app/less/inc/form.less
+++ b/browser/app/less/inc/form.less
@@ -81,7 +81,7 @@ select.form-control {
     width: 100%;
     height: 40px;
     border: 0;
-    background: transparent;
+    background: transparent !important;
     text-align: center;
     position: relative;
     z-index: 1;
@@ -114,8 +114,8 @@ select.form-control {
 
 .ig-dark {
     .ig-text {
-        color: @white;
-        border-color: rgba(255,255,255,0.1);
+        color: @white !important;
+        border-color: rgba(255,255,255,0.1) !important;
     }
 
     .ig-helpers {


### PR DESCRIPTION
## Description
Make login form browser auto-fill compatible by removing empty form fields which were used to fix browser auto-fill styling on older browsers.

![autofill](https://cloud.githubusercontent.com/assets/13393018/24908941/acbd5fd6-1edf-11e7-865a-78df945d1149.png)

## Motivation and Context
https://github.com/minio/minio/issues/4084

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.