### PR TITLE
handlers: Ignore malformatted datetime type header

### DIFF
--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -66,11 +66,13 @@ func checkCopyObjectPreconditions(w http.ResponseWriter, r *http.Request, objInf
 	// since the specified time otherwise return 412 (precondition failed).
 	ifModifiedSinceHeader := r.Header.Get("x-amz-copy-source-if-modified-since")
 	if ifModifiedSinceHeader != "" {
-		if !ifModifiedSince(objInfo.ModTime, ifModifiedSinceHeader) {
-			// If the object is not modified since the specified time.
-			writeHeaders()
-			writeErrorResponse(w, ErrPreconditionFailed, r.URL)
-			return true
+		if givenTime, err := time.Parse(http.TimeFormat, ifModifiedSinceHeader); err == nil {
+			if !ifModifiedSince(objInfo.ModTime, givenTime) {
+				// If the object is not modified since the specified time.
+				writeHeaders()
+				writeErrorResponse(w, ErrPreconditionFailed, r.URL)
+				return true
+			}
 		}
 	}
 
@@ -78,11 +80,13 @@ func checkCopyObjectPreconditions(w http.ResponseWriter, r *http.Request, objInf
 	// modified since the specified time, otherwise return a 412 (precondition failed).
 	ifUnmodifiedSinceHeader := r.Header.Get("x-amz-copy-source-if-unmodified-since")
 	if ifUnmodifiedSinceHeader != "" {
-		if ifModifiedSince(objInfo.ModTime, ifUnmodifiedSinceHeader) {
-			// If the object is modified since the specified time.
-			writeHeaders()
-			writeErrorResponse(w, ErrPreconditionFailed, r.URL)
-			return true
+		if givenTime, err := time.Parse(http.TimeFormat, ifUnmodifiedSinceHeader); err == nil {
+			if ifModifiedSince(objInfo.ModTime, givenTime) {
+				// If the object is modified since the specified time.
+				writeHeaders()
+				writeErrorResponse(w, ErrPreconditionFailed, r.URL)
+				return true
+			}
 		}
 	}
 
@@ -147,11 +151,13 @@ func checkPreconditions(w http.ResponseWriter, r *http.Request, objInfo ObjectIn
 	// otherwise return a 304 (not modified).
 	ifModifiedSinceHeader := r.Header.Get("If-Modified-Since")
 	if ifModifiedSinceHeader != "" {
-		if !ifModifiedSince(objInfo.ModTime, ifModifiedSinceHeader) {
-			// If the object is not modified since the specified time.
-			writeHeaders()
-			w.WriteHeader(http.StatusNotModified)
-			return true
+		if givenTime, err := time.Parse(http.TimeFormat, ifModifiedSinceHeader); err == nil {
+			if !ifModifiedSince(objInfo.ModTime, givenTime) {
+				// If the object is not modified since the specified time.
+				writeHeaders()
+				w.WriteHeader(http.StatusNotModified)
+				return true
+			}
 		}
 	}
 
@@ -159,11 +165,13 @@ func checkPreconditions(w http.ResponseWriter, r *http.Request, objInfo ObjectIn
 	// time, otherwise return a 412 (precondition failed).
 	ifUnmodifiedSinceHeader := r.Header.Get("If-Unmodified-Since")
 	if ifUnmodifiedSinceHeader != "" {
-		if ifModifiedSince(objInfo.ModTime, ifUnmodifiedSinceHeader) {
-			// If the object is modified since the specified time.
-			writeHeaders()
-			writeErrorResponse(w, ErrPreconditionFailed, r.URL)
-			return true
+		if givenTime, err := time.Parse(http.TimeFormat, ifUnmodifiedSinceHeader); err == nil {
+			if ifModifiedSince(objInfo.ModTime, givenTime) {
+				// If the object is modified since the specified time.
+				writeHeaders()
+				writeErrorResponse(w, ErrPreconditionFailed, r.URL)
+				return true
+			}
 		}
 	}
 
@@ -195,11 +203,7 @@ func checkPreconditions(w http.ResponseWriter, r *http.Request, objInfo ObjectIn
 }
 
 // returns true if object was modified after givenTime.
-func ifModifiedSince(objTime time.Time, givenTimeStr string) bool {
-	givenTime, err := time.Parse(http.TimeFormat, givenTimeStr)
-	if err != nil {
-		return true
-	}
+func ifModifiedSince(objTime time.Time, givenTime time.Time) bool {
 	// The Date-Modified header truncates sub-second precision, so
 	// use mtime < t+1s instead of mtime <= t to check for unmodified.
 	if objTime.After(givenTime.Add(1 * time.Second)) {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1342,6 +1342,19 @@ func (s *TestSuiteCommon) TestHeadOnObjectLastModified(c *C) {
 	response, err = client.Do(request)
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusPreconditionFailed)
+
+	// make HTTP request to obtain object info.
+	// But this time set a date with unrecognized format to the "If-Modified-Since" header
+	request, err = newTestSignedRequest("HEAD", getHeadObjectURL(s.endPoint, bucketName, objectName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+	request.Header.Set("If-Unmodified-Since", "Mon, 02 Jan 2006 15:04:05 +00:00")
+	response, err = client.Do(request)
+	c.Assert(err, IsNil)
+	// Since the "If-Modified-Since" header was ahead in time compared to the actual
+	// modified time of the object expecting the response status to be http.StatusNotModified.
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
 }
 
 // TestHeadOnBucket - Validates response for HEAD on the bucket.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignore headers, such as If-Modified-Since, If-Unmodified-Since, etc.. when they
are received with a format other than HTTP date.

## Motivation and Context
Fixes #4082 

## How Has This Been Tested?
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.