### PR TITLE
Decrease default log level and log per request at info level

### DIFF
--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -157,7 +157,7 @@ func (log *Logger) Printf(format string, args ...interface{}) {
 func NewLogger() *Logger {
 	logger := logrus.New()
 	logger.Out = ioutil.Discard
-	logger.Level = logrus.DebugLevel
+	logger.Level = logrus.ErrorLevel
 
 	l := &Logger{
 		logger:        logger,

--- a/cmd/server-mux.go
+++ b/cmd/server-mux.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -441,6 +442,8 @@ func (m *ServerMux) ListenAndServe(certFile, keyFile string) (err error) {
 				RawQuery: r.URL.RawQuery,
 				Fragment: r.URL.Fragment,
 			}
+			lmsg := fmt.Sprintf("redirect for %s", u.String())
+			log.logger.Info(lmsg)
 			http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
 		} else {
 
@@ -457,6 +460,8 @@ func (m *ServerMux) ListenAndServe(certFile, keyFile string) (err error) {
 			// Execute registered handlers, update currentReqs to keep
 			// tracks of current requests currently processed by the server
 			atomic.AddInt32(&m.currentReqs, 1)
+			lmsg := fmt.Sprintf("serving for %s", r.URL.String())
+			log.logger.Info(lmsg)
 			m.handler.ServeHTTP(w, r)
 			atomic.AddInt32(&m.currentReqs, -1)
 		}


### PR DESCRIPTION
Add ability to log per HTTP request.

## Description
Add per request logrus calls at the info level, and decrease the default level so that per request logs are not active. Currently logrus is in place but not used for much other than fatal errors, so the default behavior is not changing at all.

## Motivation and Context
A constant complain with minio is that it does not log enough. It serves HTTP, why not have an option to log each request?

## How Has This Been Tested?
Verified logs unchanged by default. Change log level to info or greater, verify logs contain per request entries.
Tested on Ubuntu 14.04.5 virtual machines.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.