### PR TITLE
server: Fix a regression in printing startup banner.

### DIFF
--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -42,6 +42,7 @@ func getFormatStr(strLen int, padding int) string {
 
 // Prints the formatted startup message.
 func printStartupMessage(apiEndPoints []string) {
+
 	// Prints credential, region and browser access.
 	printServerCommonMsg(apiEndPoints)
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Octet based sorting was lost in the previous commit

de204a0a52e6b13fec2d25b73102239891e6de35

<!--- Describe your changes in detail -->

## Motivation and Context
This PR fixes a regression - fixes #4099

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using `go test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.