### PR TITLE
Remove duration field from lock instrumentation

### DIFF
--- a/cmd/lock-instrument_test.go
+++ b/cmd/lock-instrument_test.go
@@ -141,7 +141,6 @@ func getSystemLockState() (SystemLockState, error) {
 				LockType:    lockInfo.lType,
 				Status:      lockInfo.status,
 				Since:       lockInfo.since,
-				Duration:    UTCNow().Sub(lockInfo.since),
 			})
 		}
 		lockState.LocksInfoPerObject = append(lockState.LocksInfoPerObject, volLockInfo)

--- a/cmd/lockinfo-handlers.go
+++ b/cmd/lockinfo-handlers.go
@@ -57,12 +57,11 @@ type VolumeLockInfo struct {
 // OpsLockState - structure to fill in state information of the lock.
 // structure to fill in status information for each operation with given operation ID.
 type OpsLockState struct {
-	OperationID string        `json:"id"`       // String containing operation ID.
-	LockSource  string        `json:"source"`   // Operation type (GetObject, PutObject...)
-	LockType    lockType      `json:"type"`     // Lock type (RLock, WLock)
-	Status      statusType    `json:"status"`   // Status can be Running/Ready/Blocked.
-	Since       time.Time     `json:"since"`    // Time when the lock was initially held.
-	Duration    time.Duration `json:"duration"` // Duration since the lock was held.
+	OperationID string     `json:"id"`     // String containing operation ID.
+	LockSource  string     `json:"source"` // Operation type (GetObject, PutObject...)
+	LockType    lockType   `json:"type"`   // Lock type (RLock, WLock)
+	Status      statusType `json:"status"` // Status can be Running/Ready/Blocked.
+	Since       time.Time  `json:"since"`  // Time when the lock was initially held.
 }
 
 // listLocksInfo - Fetches locks held on bucket, matching prefix held for longer than duration.
@@ -105,7 +104,6 @@ func listLocksInfo(bucket, prefix string, duration time.Duration) []VolumeLockIn
 					LockType:    lockInfo.lType,
 					Status:      lockInfo.status,
 					Since:       lockInfo.since,
-					Duration:    elapsed,
 				})
 			volumeLocks = append(volumeLocks, volLockInfo)
 		}

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -435,7 +435,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		{"test-bucket-list-object", "", "", "*", 0, ListObjectsInfo{}, fmt.Errorf("delimiter '%s' is not supported", "*"), false},
 		{"test-bucket-list-object", "", "", "-", 0, ListObjectsInfo{}, fmt.Errorf("delimiter '%s' is not supported", "-"), false},
 		// Testing for failure cases with both perfix and marker (11).
-		// The prefix and marker combination to be valid it should satisy strings.HasPrefix(marker, prefix).
+		// The prefix and marker combination to be valid it should satisfy strings.HasPrefix(marker, prefix).
 		{"test-bucket-list-object", "asia", "europe-object", "", 0, ListObjectsInfo{}, fmt.Errorf("Invalid combination of marker '%s' and prefix '%s'", "europe-object", "asia"), false},
 		// Setting a non-existing directory to be prefix (12-13).
 		{"empty-bucket", "europe/france/", "", "", 1, ListObjectsInfo{}, nil, true},

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1110,7 +1110,7 @@ func testListMultipartUploads(obj ObjectLayer, instanceType string, t TestErrHan
 		{bucketNames[0], "", "", "", "*", 0, ListMultipartsInfo{}, fmt.Errorf("delimiter '%s' is not supported", "*"), false},
 		{bucketNames[0], "", "", "", "-", 0, ListMultipartsInfo{}, fmt.Errorf("delimiter '%s' is not supported", "-"), false},
 		// Testing for failure cases with both perfix and marker (Test number 10).
-		// The prefix and marker combination to be valid it should satisy strings.HasPrefix(marker, prefix).
+		// The prefix and marker combination to be valid it should satisfy strings.HasPrefix(marker, prefix).
 		{bucketNames[0], "asia", "europe-object", "", "", 0, ListMultipartsInfo{},
 			fmt.Errorf("Invalid combination of marker '%s' and prefix '%s'", "europe-object", "asia"), false},
 		// Setting an invalid combination of uploadIDMarker and Marker (Test number 11-12).

--- a/pkg/madmin/lock-commands.go
+++ b/pkg/madmin/lock-commands.go
@@ -42,12 +42,11 @@ const (
 
 // OpsLockState - represents lock specific details.
 type OpsLockState struct {
-	OperationID string        `json:"id"`       // String containing operation ID.
-	LockSource  string        `json:"source"`   // Operation type (GetObject, PutObject...)
-	LockType    lockType      `json:"type"`     // Lock type (RLock, WLock)
-	Status      statusType    `json:"status"`   // Status can be Running/Ready/Blocked.
-	Since       time.Time     `json:"since"`    // Time when the lock was initially held.
-	Duration    time.Duration `json:"duration"` // Duration since the lock was held.
+	OperationID string     `json:"id"`     // String containing operation ID.
+	LockSource  string     `json:"source"` // Operation type (GetObject, PutObject...)
+	LockType    lockType   `json:"type"`   // Lock type (RLock, WLock)
+	Status      statusType `json:"status"` // Status can be Running/Ready/Blocked.
+	Since       time.Time  `json:"since"`  // Time when the lock was initially held.
 }
 
 // VolumeLockInfo - represents summary and individual lock details of all


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Duration for which a lock was held can be computed from the `Since`
field of `OpsLockState`. It is the difference between current time and
time at which the namespace lock was held. This change avoids
superfluous instrumentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #4110 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.