### PR TITLE
docs: Add Minikube deployment to k8s docs

### DIFF
--- a/docs/orchestration/kubernetes/README.md
+++ b/docs/orchestration/kubernetes/README.md
@@ -1,15 +1,20 @@
 # Deploy Minio on Kubernetes [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io) [![Go Report Card](https://goreportcard.com/badge/minio/minio)](https://goreportcard.com/report/minio/minio) [![Docker Pulls](https://img.shields.io/docker/pulls/minio/minio.svg?maxAge=604800)](https://hub.docker.com/r/minio/minio/) [![codecov](https://codecov.io/gh/minio/minio/branch/master/graph/badge.svg)](https://codecov.io/gh/minio/minio)
 
-Kubernetes constructs like Deployments and StatefulSets provide perfect platform to deploy Minio server in standalone, distributed or shared mode. In addition, using Minio [Helm](https://helm.sh) Chart, you can deploy Minio server with a single command on your cluster. 
+Kubernetes constructs like Deployments and StatefulSets provide perfect platform to deploy Minio server in standalone, distributed or shared mode. There are multiple options to deploy Minio on Kubernetes, you can choose the one that suits you the most.
 
-Minio Helm Chart offers great deal of [customizability](#configuration), still if you'd rather like to deploy Minio using custom config files, you can do that as well. This [blog post](https://blog.minio.io/build-aws-s3-compatible-cloud-storage-on-gcp-with-minio-and-kubernetes-159cc99caea8#.8zesfh6tc) offers an introduction to running Minio on Kubernetes using .yaml configuration files.
+- Minio [Helm](https://helm.sh) Chart offers a customizeable yet easy Minio deployment, with a single command. Read more about Minio Helm deployment [here](#prerequisites).
 
+- You can also explore Kubernetes [Minio example](https://github.com/kubernetes/kubernetes/blob/master/examples/storage/minio/README.md) to deploy Minio using `.yaml` files.
+
+- If you'd like get started with Minio on Kubernetes without having to create a real container cluster, you can also [deploy Minio locally](https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/README.md) with MiniKube.
+
+<a name="prerequisites"></a>
 ## 1. Prerequisites
 
 * Kubernetes 1.4+ with Beta APIs enabled for default standalone mode.
 * Kubernetes 1.5+ with Beta APIs enabled to run Minio in [distributed mode](#distributed-minio).
-* PV provisioner support in the underlying infrastructure. 
-* Helm package manager [installed](https://github.com/kubernetes/helm#install) on your Kubernetes cluster. 
+* PV provisioner support in the underlying infrastructure.
+* Helm package manager [installed](https://github.com/kubernetes/helm#install) on your Kubernetes cluster.
 
 ## 2. Deploy Minio using Helm Chart
 

--- a/docs/orchestration/kubernetes/README.md
+++ b/docs/orchestration/kubernetes/README.md
@@ -1,12 +1,12 @@
 # Deploy Minio on Kubernetes [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io) [![Go Report Card](https://goreportcard.com/badge/minio/minio)](https://goreportcard.com/report/minio/minio) [![Docker Pulls](https://img.shields.io/docker/pulls/minio/minio.svg?maxAge=604800)](https://hub.docker.com/r/minio/minio/) [![codecov](https://codecov.io/gh/minio/minio/branch/master/graph/badge.svg)](https://codecov.io/gh/minio/minio)
 
-Kubernetes constructs like Deployments and StatefulSets provide perfect platform to deploy Minio server in standalone, distributed or shared mode. There are multiple options to deploy Minio on Kubernetes, you can choose the one that suits you the most.
+Kubernetes concepts like Deployments and StatefulSets provide perfect platform to deploy Minio server in standalone, distributed or shared mode. There are multiple options to deploy Minio on Kubernetes, you can choose the one that suits you the most.
 
-- Minio [Helm](https://helm.sh) Chart offers a customizeable yet easy Minio deployment, with a single command. Read more about Minio Helm deployment [here](#prerequisites).
+- Minio [Helm](https://helm.sh) Chart offers a customizable and easy Minio deployment, with a single command. Read more about Minio Helm deployment [here](#prerequisites).
 
 - You can also explore Kubernetes [Minio example](https://github.com/kubernetes/kubernetes/blob/master/examples/storage/minio/README.md) to deploy Minio using `.yaml` files.
 
-- If you'd like get started with Minio on Kubernetes without having to create a real container cluster, you can also [deploy Minio locally](https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/README.md) with MiniKube.
+- If you'd like to get started with Minio on Kubernetes without having to create a real container cluster, you can also [deploy Minio locally](https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/README.md) with MiniKube.
 
 <a name="prerequisites"></a>
 ## 1. Prerequisites

--- a/docs/orchestration/minikube/README.md
+++ b/docs/orchestration/minikube/README.md
@@ -10,11 +10,22 @@ installed on your system.
 
 ## 2. Steps
 
-* Download [`minio_distributed.sh`](https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/minio_distributed.sh) and [`statefulset.yaml`](https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/statefulset.yaml) files on your computer.
+* Download `minio_distributed.sh` and `statefulset.yaml`
 
-* Execute the `minio_distributed.sh` script in command prompt. After the script is executed successfully, you should get an output like this
-
+```sh
+wget https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/minio_distributed.sh  
+wget https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/statefulset.yaml
 ```
+
+* Execute the `minio_distributed.sh` script in command prompt.
+
+```sh
+./minio_distributed.sh
+```
+
+After the script is executed successfully, you should get an output like this
+
+```sh
 service "minio-public" created
 service "minio" created
 statefulset "minio" created
@@ -27,11 +38,11 @@ Note that the service `minio-public` is a [clusterIP](https://kubernetes.io/docs
 kubectl port-forward minio-0 9000:9000
 ```
 
-Minio server can now be accessed at `http:localhost:9000`, with accessKey and secretKey as mentioned in the `statefulset.yaml` file.
+Minio server can now be accessed at `http://localhost:9000`, with accessKey and secretKey as mentioned in the `statefulset.yaml` file.
 
 ## 3. Notes
 
 Minikube currently does not support dynamic provisioning, so we manually create PersistentVolumes(PV) and PersistentVolumeClaims(PVC) to be
 used by the distributed Minio setup. Once the PVs and PVCs are created, we call the `statefulset.yaml` configuration file to create the distributed Minio setup.
 
-This setup is supposed to run on a laptop/computer. Hence only one disk is used as the backend for all the minio instance PVs. Minio sees these PVs as separate disks and reports the available storage incorrectly.
+This setup runs on a laptop/computer. Hence only one disk is used as the backend for all the minio instance PVs. Minio sees these PVs as separate disks and reports the available storage incorrectly.

--- a/docs/orchestration/minikube/README.md
+++ b/docs/orchestration/minikube/README.md
@@ -42,7 +42,6 @@ Minio server can now be accessed at `http://localhost:9000`, with accessKey and 
 
 ## 3. Notes
 
-Minikube currently does not support dynamic provisioning, so we manually create PersistentVolumes(PV) and PersistentVolumeClaims(PVC) to be
-used by the distributed Minio setup. Once the PVs and PVCs are created, we call the `statefulset.yaml` configuration file to create the distributed Minio setup.
+Minikube currently does not support dynamic provisioning, so we manually create PersistentVolumes(PV) and PersistentVolumeClaims(PVC). Once the PVs and PVCs are created, we call the `statefulset.yaml` configuration file to create the distributed Minio setup.
 
 This setup runs on a laptop/computer. Hence only one disk is used as the backend for all the minio instance PVs. Minio sees these PVs as separate disks and reports the available storage incorrectly.

--- a/docs/orchestration/minikube/README.md
+++ b/docs/orchestration/minikube/README.md
@@ -1,0 +1,37 @@
+# Deploy distributed Minio locally with minikube [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io) [![Go Report Card](https://goreportcard.com/badge/minio/minio)](https://goreportcard.com/report/minio/minio) [![Docker Pulls](https://img.shields.io/docker/pulls/minio/minio.svg?maxAge=604800)](https://hub.docker.com/r/minio/minio/) [![codecov](https://codecov.io/gh/minio/minio/branch/master/graph/badge.svg)](https://codecov.io/gh/minio/minio)
+
+Minikube runs a single-node Kubernetes cluster inside a VM on your computer. This makes it easy to deploy distributed Minio server on
+Kubernetes running locally on your computer.
+
+## 1. Prerequisites
+
+[Minikube](https://github.com/kubernetes/minikube/blob/master/README.md#installation) and [`kubectl`](https://kubernetes.io/docs/user-guide/prereqs/)
+installed on your system.
+
+## 2. Steps
+
+* Download [`minio_distributed.sh`](https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/minio_distributed.sh) and [`statefulset.yaml`](https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/minikube/statefulset.yaml) files on your computer.
+
+* Execute the `minio_distributed.sh` script in command prompt. After the script is executed successfully, you should get an output like this
+
+```
+service "minio-public" created
+service "minio" created
+statefulset "minio" created
+```
+This means Minio is deployed on your local Minikube installation.
+
+Note that the service `minio-public` is a [clusterIP](https://kubernetes.io/docs/user-guide/services/#publishing-services---service-types) service. It exposes the service on a cluster-internal IP. To connect to your Minio instances via `kubectl port-forward` command, execute
+
+```
+kubectl port-forward minio-0 9000:9000
+```
+
+Minio server can now be accessed at `http:localhost:9000`, with accessKey and secretKey as mentioned in the `statefulset.yaml` file.
+
+## 3. Notes
+
+Minikube currently does not support dynamic provisioning, so we manually create PersistentVolumes(PV) and PersistentVolumeClaims(PVC) to be
+used by the distributed Minio setup. Once the PVs and PVCs are created, we call the `statefulset.yaml` configuration file to create the distributed Minio setup.
+
+This setup is supposed to run on a laptop/computer. Hence only one disk is used as the backend for all the minio instance PVs. Minio sees these PVs as separate disks and reports the available storage incorrectly.

--- a/docs/orchestration/minikube/minio_distributed.sh
+++ b/docs/orchestration/minikube/minio_distributed.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Minio Cloud Storage, (C) 2014, 2015, 2016, 2017 Minio, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -exuo pipefail
+
+# Clean up anything from a prior run:
+kubectl delete statefulsets,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget -l app=minio
+
+# Make persistent volumes and (correctly named) claims. We must create the
+# claims here manually even though that sounds counter-intuitive. For details
+# see https://github.com/kubernetes/contrib/pull/1295#issuecomment-230180894.
+for i in $(seq 0 3); do
+  cat <<EOF | kubectl create -f -
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: pv${i}
+  labels:
+    type: local
+    app: minio
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/minio/data-store/${i}"
+EOF
+
+  cat <<EOF | kubectl create -f -
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: data-minio-${i}
+  labels:
+    app: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+EOF
+done;
+
+kubectl create -f statefulset.yaml

--- a/docs/orchestration/minikube/statefulset.yaml
+++ b/docs/orchestration/minikube/statefulset.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This service is meant to be used by clients of the object store. It exposes a ClusterIP that will
+  # automatically load balance connections to the different database pods.
+  name: minio-public
+  labels:
+    app: minio
+spec:
+  ports:
+  - port: 9000
+    targetPort: 9000
+  selector:
+    app: minio
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This service only exists to create DNS entries for each pod in the stateful
+  # set such that they can resolve each other's IP addresses. It does not
+  # create a load-balanced ClusterIP and should not be used directly by clients
+  # in most circumstances.
+  name: minio
+  labels:
+    app: minio
+spec:
+  ports:
+  - port: 9000
+    targetPort: 9000
+  clusterIP: None
+  selector:
+    app: minio
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: minio
+spec:
+  serviceName: "minio"
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: data-minio
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2017-02-16T01-47-30Z
+        imagePullPolicy: IfNotPresent
+        #command: ["df"]
+        #args: ["-i", "/data"]
+        command: ["minio"]
+        args: ["server", "http://minio-0.minio.default.svc.cluster.local/data", "http://minio-1.minio.default.svc.cluster.local/data", "http://minio-2.minio.default.svc.cluster.local/data", "http://minio-3.minio.default.svc.cluster.local/data"]
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 2Gi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds docs on how to deploy Minio on Minikube

## Motivation and Context
This will help users trying to get started with Minio on Kubernetes without having to set a real container cluster. 

## How Has This Been Tested?
Run locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.