### PR TITLE
api: Fix registering of s3 endpoint peers properly

### DIFF
--- a/cmd/s3-peer-client.go
+++ b/cmd/s3-peer-client.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"path"
 	"sync"
 
@@ -42,12 +41,8 @@ type s3Peers []s3Peer
 // slice. The urls slice is assumed to be non-empty and free of nil
 // values.
 func makeS3Peers(endpoints EndpointList) (s3PeerList s3Peers) {
-	thisPeer := globalMinioAddr
-	if globalMinioHost == "" {
-		thisPeer = net.JoinHostPort("localhost", globalMinioPort)
-	}
 	s3PeerList = append(s3PeerList, s3Peer{
-		thisPeer,
+		globalMinioAddr,
 		&localBucketMetaState{ObjectAPI: newObjectLayerFn},
 	})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We need to have local peer initialized properly
for listen bucket to work, current code did initialize
properly but the resulting code was initializing
peer on a wrong target v/s what listen bucket expected
it to be.

This regression came in de204a0a52e6b13fec2d25b73102239891e6de35
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4158

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using `mc watch` 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.