### PR TITLE
Fix rare test crash.

### DIFF
--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -2361,3 +2361,28 @@ func getEndpointsLocalAddr(endpoints EndpointList) string {
 
 	return globalMinioHost + ":" + globalMinioPort
 }
+
+// fetches a random number between range min-max.
+func getRandomRange(min, max int, seed int64) int {
+	// special value -1 means no explicit seeding.
+	if seed != -1 {
+		rand.Seed(seed)
+	}
+	return rand.Intn(max-min) + min
+}
+
+// Randomizes the order of bytes in the byte array
+// using Knuth Fisher-Yates shuffle algorithm.
+func randomizeBytes(s []byte, seed int64) []byte {
+	// special value -1 means no explicit seeding.
+	if seed != -1 {
+		rand.Seed(seed)
+	}
+	n := len(s)
+	var j int
+	for i := 0; i < n-1; i++ {
+		j = i + rand.Intn(n-i)
+		s[i], s[j] = s[j], s[i]
+	}
+	return s
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fix rare crash of TestSuiteCommon.TestGetPartialObjectMisAligned
- Since the size of the buffer used depends on the random number
  generated the guarantee of 13 bytes of data is not assured.
- This is fixed by initially writing 13 bytes of data into the buffer.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing https://github.com/minio/minio/issues/4160
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.