### PR TITLE
browser: Listing should append instead of replacing previous listing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "asi": true,
+  "esnext": true   
+}

--- a/browser/app/js/actions.js
+++ b/browser/app/js/actions.js
@@ -26,6 +26,8 @@ export const SET_BUCKETS = 'SET_BUCKETS'
 export const ADD_BUCKET = 'ADD_BUCKET'
 export const SET_VISIBLE_BUCKETS = 'SET_VISIBLE_BUCKETS'
 export const SET_OBJECTS = 'SET_OBJECTS'
+export const APPEND_OBJECTS = 'APPEND_OBJECTS'
+export const RESET_OBJECTS = 'RESET_OBJECTS'
 export const SET_STORAGE_INFO = 'SET_STORAGE_INFO'
 export const SET_SERVER_INFO = 'SET_SERVER_INFO'
 export const SHOW_MAKEBUCKET_MODAL = 'SHOW_MAKEBUCKET_MODAL'
@@ -240,12 +242,25 @@ export const setVisibleBuckets = visibleBuckets => {
   }
 }
 
-export const setObjects = (objects, marker, istruncated) => {
+const appendObjects = (objects, marker, istruncated) => {
   return {
-    type: SET_OBJECTS,
+    type: APPEND_OBJECTS,
     objects,
     marker,
     istruncated
+  }
+}
+
+export const setObjects = (objects) => {
+  return {
+    type: SET_OBJECTS,
+    objects,
+  }
+}
+
+export const resetObjects = () => {
+  return {
+    type: RESET_OBJECTS
   }
 }
 
@@ -316,7 +331,7 @@ export const listObjects = () => {
           object.name = object.name.replace(`${currentPath}`, '');
           return object
         })
-        dispatch(setObjects(objects, res.nextmarker, res.istruncated))
+        dispatch(appendObjects(objects, res.nextmarker, res.istruncated))
         dispatch(setPrefixWritable(res.writable))
         dispatch(setLoadBucket(''))
         dispatch(setLoadPath(''))
@@ -337,7 +352,7 @@ export const listObjects = () => {
 export const selectPrefix = prefix => {
   return (dispatch, getState) => {
     const {currentBucket, web} = getState()
-    dispatch(setObjects([], "", false))
+    dispatch(resetObjects())
     dispatch(setLoadPath(prefix))
     web.ListObjects({
       bucketName: currentBucket,
@@ -352,7 +367,7 @@ export const selectPrefix = prefix => {
           object.name = object.name.replace(`${prefix}`, '');
           return object
         })
-        dispatch(setObjects(
+        dispatch(appendObjects(
           objects,
           res.nextmarker,
           res.istruncated

--- a/browser/app/js/reducers.js
+++ b/browser/app/js/reducers.js
@@ -77,16 +77,18 @@ export default (state = {
     case actions.SET_CURRENT_BUCKET:
       newState.currentBucket = action.currentBucket
       break
+    case actions.APPEND_OBJECTS:
+      newState.objects = [...newState.objects, ...action.objects]
+      newState.marker = action.marker
+      newState.istruncated = action.istruncated
+      break
     case actions.SET_OBJECTS:
-      if (!action.objects.length) {
-        newState.objects = []
-        newState.marker = ""
-        newState.istruncated = action.istruncated
-      } else {
-        newState.objects = [...action.objects]
-        newState.marker = action.marker
-        newState.istruncated = action.istruncated
-      }
+      newState.objects = [...action.objects]
+      break
+    case action.RESET_OBJECTS:
+      newState.objects = []
+      newState.marker = ""
+      newState.istruncated = false
       break
     case actions.SET_CURRENT_PATH:
       newState.currentPath = action.currentPath

--- a/hound.yml
+++ b/hound.yml
@@ -1,0 +1,3 @@
+jshint:
+    enabled: false
+


### PR DESCRIPTION
fixes #4144

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If the number of objects are say 1001 in a bucket, browser would show first 1000 objects. Upon scroll down it would load the remaining 1 object. Instead of appending it would replace the current 1000 objects with the newly listed object.

This fix defines new actions RESET_OBJECTS and APPEND_OBJECTS

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #4144


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.