### PR TITLE
windows: Support all REPARSE_POINT attrib files properly.

### DIFF
--- a/cmd/config-migrate_test.go
+++ b/cmd/config-migrate_test.go
@@ -45,7 +45,7 @@ func TestServerConfigMigrateV1(t *testing.T) {
 		t.Fatal("Unexpected error: ", err)
 	}
 	// Check if config v1 is removed from filesystem
-	if _, err := os.Stat(configPath); err == nil || !os.IsNotExist(err) {
+	if _, err := osStat(configPath); err == nil || !os.IsNotExist(err) {
 		t.Fatal("Config V1 file is not purged")
 	}
 

--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -133,7 +133,7 @@ func fsStatDir(statDir string) (os.FileInfo, error) {
 		return nil, traceError(err)
 	}
 
-	fi, err := os.Stat(preparePath(statDir))
+	fi, err := osStat(preparePath(statDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, traceError(errVolumeNotFound)
@@ -160,7 +160,7 @@ func fsStatFile(statFile string) (os.FileInfo, error) {
 		return nil, traceError(err)
 	}
 
-	fi, err := os.Stat(preparePath(statFile))
+	fi, err := osStat(preparePath(statFile))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, traceError(errFileNotFound)
@@ -206,7 +206,7 @@ func fsOpenFile(readPath string, offset int64) (io.ReadCloser, int64, error) {
 	}
 
 	// Stat to get the size of the file at path.
-	st, err := fr.Stat()
+	st, err := osStat(preparePath(readPath))
 	if err != nil {
 		return nil, 0, traceError(err)
 	}
@@ -344,7 +344,7 @@ func fsDeleteFile(basePath, deletePath string) error {
 	}
 
 	// Verify if the path exists.
-	pathSt, err := os.Stat(preparePath(deletePath))
+	pathSt, err := osStat(preparePath(deletePath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return traceError(errFileNotFound)

--- a/cmd/fs-v1-helpers_test.go
+++ b/cmd/fs-v1-helpers_test.go
@@ -442,11 +442,11 @@ func TestFSRemoveMeta(t *testing.T) {
 		t.Fatalf("Unable to remove file, %s", err)
 	}
 
-	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+	if _, err := osStat(preparePath(filePath)); !os.IsNotExist(err) {
 		t.Fatalf("`%s` file found though it should have been deleted.", filePath)
 	}
 
-	if _, err := os.Stat(path.Dir(filePath)); !os.IsNotExist(err) {
+	if _, err := osStat(preparePath(path.Dir(filePath))); !os.IsNotExist(err) {
 		t.Fatalf("`%s` parent directory found though it should have been deleted.", filePath)
 	}
 }

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -85,7 +85,7 @@ func newFSObjectLayer(fsPath string) (ObjectLayer, error) {
 		return nil, err
 	}
 
-	fi, err := os.Stat(preparePath(fsPath))
+	fi, err := osStat(preparePath(fsPath))
 	if err == nil {
 		if !fi.IsDir() {
 			return nil, syscall.ENOTDIR
@@ -224,7 +224,7 @@ func (fs fsObjects) GetBucketInfo(bucket string) (BucketInfo, error) {
 		return BucketInfo{}, toObjectErr(err, bucket)
 	}
 
-	// As os.Stat() doesn't carry other than ModTime(), use ModTime() as CreatedTime.
+	// As osStat() doesn't carry other than ModTime(), use ModTime() as CreatedTime.
 	createdTime := st.ModTime()
 	return BucketInfo{
 		Name:    bucket,
@@ -263,7 +263,7 @@ func (fs fsObjects) ListBuckets() ([]BucketInfo, error) {
 
 		bucketInfos = append(bucketInfos, BucketInfo{
 			Name: fi.Name(),
-			// As os.Stat() doesnt carry CreatedTime, use ModTime() as CreatedTime.
+			// As osStat() doesnt carry CreatedTime, use ModTime() as CreatedTime.
 			Created: fi.ModTime(),
 		})
 	}

--- a/cmd/posix-list-dir-nix.go
+++ b/cmd/posix-list-dir-nix.go
@@ -75,12 +75,12 @@ func parseDirents(dirPath string, buf []byte) (entries []string, err error) {
 		case syscall.DT_REG:
 			entries = append(entries, name)
 		case syscall.DT_LNK, syscall.DT_UNKNOWN:
-			// If its symbolic link, follow the link using os.Stat()
+			// If its symbolic link, follow the link using osStat()
 
 			// On Linux XFS does not implement d_type for on disk
-			// format << v5. Fall back to Stat().
+			// format << v5. Fall back to OsStat().
 			var fi os.FileInfo
-			fi, err = os.Stat(path.Join(dirPath, name))
+			fi, err = osStat(path.Join(dirPath, name))
 			if err != nil {
 				// If file does not exist, we continue and skip it.
 				// Could happen if it was deleted in the middle while

--- a/cmd/posix-list-dir-others.go
+++ b/cmd/posix-list-dir-others.go
@@ -55,7 +55,7 @@ func readDir(dirPath string) (entries []string, err error) {
 			// Stat symbolic link and follow to get the final value.
 			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 				var st os.FileInfo
-				st, err = os.Stat(preparePath(path.Join(dirPath, fi.Name())))
+				st, err = osStat(preparePath(path.Join(dirPath, fi.Name())))
 				if err != nil {
 					errorIf(err, "Unable to stat path %s", path.Join(dirPath, fi.Name()))
 					continue

--- a/cmd/posix-utils_nix.go
+++ b/cmd/posix-utils_nix.go
@@ -1,4 +1,4 @@
-// +build linux darwin dragonfly freebsd netbsd openbsd solaris
+// +build !windows
 
 /*
  * Minio Cloud Storage, (C) 2016, 2017 Minio, Inc.
@@ -19,6 +19,12 @@
 package cmd
 
 import "os"
+
+// osStat returns a FileInfo structure describing the named file.
+// If there is an error, it will be of type *PathError.
+func osStat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
 
 // isValidVolname verifies a volname name in accordance with object
 // layer requirements.

--- a/cmd/posix-utils_nix_test.go
+++ b/cmd/posix-utils_nix_test.go
@@ -20,7 +20,6 @@ package cmd
 
 import (
 	"io/ioutil"
-	"os"
 	"path"
 	"syscall"
 	"testing"
@@ -62,7 +61,7 @@ func TestIsValidUmaskVol(t *testing.T) {
 	defer removeAll(tmpPath)
 
 	// Stat to get permissions bits.
-	st, err := os.Stat(path.Join(tmpPath, testCase.volName))
+	st, err := osStat(path.Join(tmpPath, testCase.volName))
 	if err != nil {
 		t.Fatalf("Stat failed with %s expected to pass.", err)
 	}

--- a/cmd/posix-utils_windows.go
+++ b/cmd/posix-utils_windows.go
@@ -1,7 +1,7 @@
 // +build windows
 
 /*
- * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,14 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	os2 "github.com/minio/minio/pkg/x/os"
 )
+
+// Wrapper around safe stat implementation to avoid windows bugs.
+func osStat(name string) (os.FileInfo, error) {
+	return os2.Stat(name)
+}
 
 // isValidVolname verifies a volname name in accordance with object
 // layer requirements.
@@ -44,7 +51,7 @@ func isValidVolname(volname string) bool {
 func mkdirAll(path string, perm os.FileMode) error {
 	path = preparePath(path)
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
-	dir, err := os.Stat(path)
+	dir, err := osStat(path)
 	if err == nil {
 		if dir.IsDir() {
 			return nil

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -116,7 +116,7 @@ func newPosix(path string) (StorageAPI, error) {
 			},
 		},
 	}
-	fi, err := os.Stat(preparePath(diskPath))
+	fi, err := osStat(preparePath(diskPath))
 	if err == nil {
 		if !fi.IsDir() {
 			return nil, syscall.ENOTDIR
@@ -230,7 +230,7 @@ func (s *posix) getVolDir(volume string) (string, error) {
 // checkDiskFound - validates if disk is available,
 // returns errDiskNotFound if not found.
 func (s *posix) checkDiskFound() (err error) {
-	_, err = os.Stat(preparePath(s.diskPath))
+	_, err = osStat(preparePath(s.diskPath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return errDiskNotFound
@@ -321,7 +321,7 @@ func listVols(dirPath string) ([]VolInfo, error) {
 			continue
 		}
 		var fi os.FileInfo
-		fi, err = os.Stat(preparePath(pathJoin(dirPath, entry)))
+		fi, err = osStat(preparePath(pathJoin(dirPath, entry)))
 		if err != nil {
 			// If the file does not exist, skip the entry.
 			if os.IsNotExist(err) {
@@ -331,7 +331,7 @@ func listVols(dirPath string) ([]VolInfo, error) {
 		}
 		volsInfo = append(volsInfo, VolInfo{
 			Name: fi.Name(),
-			// As os.Stat() doesn't carry other than ModTime(), use
+			// As osStat() doesn't carry other than ModTime(), use
 			// ModTime() as CreatedTime.
 			Created: fi.ModTime(),
 		})
@@ -362,14 +362,14 @@ func (s *posix) StatVol(volume string) (volInfo VolInfo, err error) {
 	}
 	// Stat a volume entry.
 	var st os.FileInfo
-	st, err = os.Stat(preparePath(volumeDir))
+	st, err = osStat(preparePath(volumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return VolInfo{}, errVolumeNotFound
 		}
 		return VolInfo{}, err
 	}
-	// As os.Stat() doesn't carry other than ModTime(), use ModTime()
+	// As osStat() doesn't carry other than ModTime(), use ModTime()
 	// as CreatedTime.
 	createdTime := st.ModTime()
 	return VolInfo{
@@ -434,7 +434,7 @@ func (s *posix) ListDir(volume, dirPath string) (entries []string, err error) {
 		return nil, err
 	}
 	// Stat a volume entry.
-	_, err = os.Stat(preparePath(volumeDir))
+	_, err = osStat(preparePath(volumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errVolumeNotFound
@@ -470,7 +470,7 @@ func (s *posix) ReadAll(volume, path string) (buf []byte, err error) {
 		return nil, err
 	}
 	// Stat a volume entry.
-	_, err = os.Stat(preparePath(volumeDir))
+	_, err = osStat(preparePath(volumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errVolumeNotFound
@@ -536,7 +536,7 @@ func (s *posix) ReadFile(volume string, path string, offset int64, buf []byte) (
 		return 0, err
 	}
 	// Stat a volume entry.
-	_, err = os.Stat(preparePath(volumeDir))
+	_, err = osStat(preparePath(volumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, errVolumeNotFound
@@ -609,7 +609,7 @@ func (s *posix) createFile(volume, path string) (f *os.File, err error) {
 		return nil, err
 	}
 	// Stat a volume entry.
-	_, err = os.Stat(preparePath(volumeDir))
+	_, err = osStat(preparePath(volumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errVolumeNotFound
@@ -624,7 +624,7 @@ func (s *posix) createFile(volume, path string) (f *os.File, err error) {
 
 	// Verify if the file already exists and is not of regular type.
 	var st os.FileInfo
-	if st, err = os.Stat(preparePath(filePath)); err == nil {
+	if st, err = osStat(preparePath(filePath)); err == nil {
 		if !st.Mode().IsRegular() {
 			return nil, errIsNotRegular
 		}
@@ -760,7 +760,7 @@ func (s *posix) StatFile(volume, path string) (file FileInfo, err error) {
 		return FileInfo{}, err
 	}
 	// Stat a volume entry.
-	_, err = os.Stat(preparePath(volumeDir))
+	_, err = osStat(preparePath(volumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return FileInfo{}, errVolumeNotFound
@@ -772,7 +772,7 @@ func (s *posix) StatFile(volume, path string) (file FileInfo, err error) {
 	if err = checkPathLength(preparePath(filePath)); err != nil {
 		return FileInfo{}, err
 	}
-	st, err := os.Stat(preparePath(filePath))
+	st, err := osStat(preparePath(filePath))
 	if err != nil {
 		// File is really not found.
 		if os.IsNotExist(err) {
@@ -806,7 +806,7 @@ func deleteFile(basePath, deletePath string) error {
 		return nil
 	}
 	// Verify if the path exists.
-	pathSt, err := os.Stat(preparePath(deletePath))
+	pathSt, err := osStat(preparePath(deletePath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return errFileNotFound
@@ -856,7 +856,7 @@ func (s *posix) DeleteFile(volume, path string) (err error) {
 		return err
 	}
 	// Stat a volume entry.
-	_, err = os.Stat(preparePath(volumeDir))
+	_, err = osStat(preparePath(volumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return errVolumeNotFound
@@ -900,14 +900,14 @@ func (s *posix) RenameFile(srcVolume, srcPath, dstVolume, dstPath string) (err e
 		return err
 	}
 	// Stat a volume entry.
-	_, err = os.Stat(preparePath(srcVolumeDir))
+	_, err = osStat(preparePath(srcVolumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return errVolumeNotFound
 		}
 		return err
 	}
-	_, err = os.Stat(preparePath(dstVolumeDir))
+	_, err = osStat(preparePath(dstVolumeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return errVolumeNotFound
@@ -930,7 +930,7 @@ func (s *posix) RenameFile(srcVolume, srcPath, dstVolume, dstPath string) (err e
 	}
 	if srcIsDir {
 		// If source is a directory we expect the destination to be non-existent always.
-		_, err = os.Stat(preparePath(dstFilePath))
+		_, err = osStat(preparePath(dstFilePath))
 		if err == nil {
 			return errFileAccessDenied
 		}

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -82,7 +82,7 @@ func getCurrentReleaseTime(minioVersion, minioBinaryPath string) (releaseTime ti
 	}
 
 	// Looks like version is minio non-standard, we use minio binary's ModTime as release time.
-	fi, err := os.Stat(minioBinaryPath)
+	fi, err := osStat(minioBinaryPath)
 	if err != nil {
 		err = fmt.Errorf("Unable to get ModTime of %s. %s", minioBinaryPath, err)
 	} else {

--- a/cmd/update-main_test.go
+++ b/cmd/update-main_test.go
@@ -59,7 +59,7 @@ func TestGetCurrentReleaseTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fi, err = os.Stat(goBinAbsPath)
+	fi, err = osStat(goBinAbsPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestGetCurrentReleaseTime(t *testing.T) {
 	}
 	errorMessage4 := "Unable to get ModTime of /tmp/non-existent-file. stat /tmp/non-existent-file: no such file or directory"
 	if runtime.GOOS == "windows" {
-		errorMessage4 = "Unable to get ModTime of C:\\tmp\\non-existent-file. GetFileAttributesEx C:\\tmp\\non-existent-file: The system cannot find the path specified."
+		errorMessage4 = "Unable to get ModTime of C:\\tmp\\non-existent-file. CreateFile C:\\tmp\\non-existent-file: The system cannot find the path specified."
 	}
 
 	testCases := []struct {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -182,7 +181,7 @@ func dumpRequest(r *http.Request) string {
 
 // isFile - returns whether given path is a file or not.
 func isFile(path string) bool {
-	if fi, err := os.Stat(path); err == nil {
+	if fi, err := osStat(path); err == nil {
 		return fi.Mode().IsRegular()
 	}
 

--- a/pkg/disk/stat_windows.go
+++ b/pkg/disk/stat_windows.go
@@ -19,9 +19,10 @@
 package disk
 
 import (
-	"os"
 	"syscall"
 	"unsafe"
+
+	os2 "github.com/minio/minio/pkg/x/os"
 )
 
 var (
@@ -43,7 +44,7 @@ var (
 // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364937(v=vs.85).aspx
 func GetInfo(path string) (info Info, err error) {
 	// Stat to know if the path exists.
-	if _, err = os.Stat(path); err != nil {
+	if _, err = os2.Stat(path); err != nil {
 		return Info{}, err
 	}
 

--- a/pkg/lock/lock_windows.go
+++ b/pkg/lock/lock_windows.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"syscall"
 	"unsafe"
+
+	os2 "github.com/minio/minio/pkg/x/os"
 )
 
 var (
@@ -51,7 +53,7 @@ func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error
 		return nil, err
 	}
 
-	st, err := os.Stat(path)
+	st, err := os2.Stat(path)
 	if err != nil {
 		f.Close()
 		return nil, err
@@ -140,7 +142,8 @@ func lockFile(fd syscall.Handle, flags uint32) error {
 
 func lockFileEx(h syscall.Handle, flags, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
 	var reserved = uint32(0)
-	r1, _, e1 := syscall.Syscall6(procLockFileEx.Addr(), 6, uintptr(h), uintptr(flags), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
+	r1, _, e1 := syscall.Syscall6(procLockFileEx.Addr(), 6, uintptr(h), uintptr(flags),
+		uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)

--- a/pkg/quick/encoding.go
+++ b/pkg/quick/encoding.go
@@ -22,11 +22,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
+	os2 "github.com/minio/minio/pkg/x/os"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -122,7 +122,7 @@ func saveFileConfig(filename string, v interface{}) error {
 // decoder format according to the filename extension. If no
 // extension is provided, json will be selected by default.
 func loadFileConfig(filename string, v interface{}) error {
-	if _, err := os.Stat(filename); err != nil {
+	if _, err := os2.Stat(filename); err != nil {
 		return err
 	}
 	fileData, err := ioutil.ReadFile(filename)

--- a/pkg/safe/safe_test.go
+++ b/pkg/safe/safe_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * Minio Client (C) 2015, 2016, 2017 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"path"
 	"testing"
 
+	os2 "github.com/minio/minio/pkg/x/os"
 	. "gopkg.in/check.v1"
 )
 
@@ -47,7 +48,7 @@ func (s *MySuite) TearDownSuite(c *C) {
 func (s *MySuite) TestSafeAbort(c *C) {
 	f, err := CreateFile(path.Join(s.root, "testfile-abort"))
 	c.Assert(err, IsNil)
-	_, err = os.Stat(path.Join(s.root, "testfile-abort"))
+	_, err = os2.Stat(path.Join(s.root, "testfile-abort"))
 	c.Assert(err, Not(IsNil))
 	err = f.Abort()
 	c.Assert(err, IsNil)
@@ -58,11 +59,11 @@ func (s *MySuite) TestSafeAbort(c *C) {
 func (s *MySuite) TestSafeClose(c *C) {
 	f, err := CreateFile(path.Join(s.root, "testfile-close"))
 	c.Assert(err, IsNil)
-	_, err = os.Stat(path.Join(s.root, "testfile-close"))
+	_, err = os2.Stat(path.Join(s.root, "testfile-close"))
 	c.Assert(err, Not(IsNil))
 	err = f.Close()
 	c.Assert(err, IsNil)
-	_, err = os.Stat(path.Join(s.root, "testfile-close"))
+	_, err = os2.Stat(path.Join(s.root, "testfile-close"))
 	c.Assert(err, IsNil)
 	err = os.Remove(path.Join(s.root, "testfile-close"))
 	c.Assert(err, IsNil)
@@ -73,7 +74,7 @@ func (s *MySuite) TestSafeClose(c *C) {
 func (s *MySuite) TestSafe(c *C) {
 	f, err := CreateFile(path.Join(s.root, "testfile-safe"))
 	c.Assert(err, IsNil)
-	_, err = os.Stat(path.Join(s.root, "testfile-safe"))
+	_, err = os2.Stat(path.Join(s.root, "testfile-safe"))
 	c.Assert(err, Not(IsNil))
 	err = f.Close()
 	c.Assert(err, IsNil)
@@ -81,7 +82,7 @@ func (s *MySuite) TestSafe(c *C) {
 	c.Assert(err.Error(), Equals, "write on closed file")
 	err = f.Close()
 	c.Assert(err.Error(), Equals, "close on closed file")
-	_, err = os.Stat(path.Join(s.root, "testfile-safe"))
+	_, err = os2.Stat(path.Join(s.root, "testfile-safe"))
 	c.Assert(err, IsNil)
 	err = os.Remove(path.Join(s.root, "testfile-safe"))
 	c.Assert(err, IsNil)
@@ -90,11 +91,11 @@ func (s *MySuite) TestSafe(c *C) {
 func (s *MySuite) TestSafeAbortWrite(c *C) {
 	f, err := CreateFile(path.Join(s.root, "purgefile-abort"))
 	c.Assert(err, IsNil)
-	_, err = os.Stat(path.Join(s.root, "purgefile-abort"))
+	_, err = os2.Stat(path.Join(s.root, "purgefile-abort"))
 	c.Assert(err, Not(IsNil))
 	err = f.Abort()
 	c.Assert(err, IsNil)
-	_, err = os.Stat(path.Join(s.root, "purgefile-abort"))
+	_, err = os2.Stat(path.Join(s.root, "purgefile-abort"))
 	c.Assert(err, Not(IsNil))
 	err = f.Abort()
 	c.Assert(err.Error(), Equals, "abort on aborted file")

--- a/pkg/x/os/stat_others.go
+++ b/pkg/x/os/stat_others.go
@@ -1,0 +1,28 @@
+// +build !windows
+
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package os
+
+import os1 "os"
+
+// Stat returns a FileInfo structure describing the
+// named file. If there is an error, it will be of type
+// *PathError.
+func Stat(name string) (os1.FileInfo, error) {
+	return os1.Stat(name)
+}

--- a/pkg/x/os/stat_windows.go
+++ b/pkg/x/os/stat_windows.go
@@ -1,0 +1,188 @@
+// +build windows
+
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// FIXME: Once we have a go version released with the
+// following fix https://go-review.googlesource.com/#/c/41834/.
+// We should actively purge this block.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package os implements extended safe functions
+// for stdlib "os".
+package os
+
+import (
+	os1 "os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+const errSharingViolation syscall.Errno = 32
+
+// Stat returns a FileInfo structure describing the
+// named file. If there is an error, it will be of type
+// *PathError.
+func Stat(name string) (os1.FileInfo, error) {
+	if len(name) == 0 {
+		return nil, &os1.PathError{
+			Op:   "Stat",
+			Path: name,
+			Err:  syscall.Errno(syscall.ERROR_PATH_NOT_FOUND),
+		}
+	}
+	if name == os1.DevNull {
+		return &devNullStat, nil
+	}
+	namep, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, &os1.PathError{Op: "Stat", Path: name, Err: err}
+	}
+
+	// Use Windows I/O manager to dereference the symbolic link, as per
+	// https://blogs.msdn.microsoft.com/oldnewthing/20100212-00/?p=14963/
+	h, err := syscall.CreateFile(namep, 0, 0, nil,
+		syscall.OPEN_EXISTING, syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		if err == errSharingViolation {
+			// try FindFirstFile now that CreateFile failed
+			return statWithFindFirstFile(name, namep)
+		}
+		return nil, &os1.PathError{Op: "CreateFile", Path: name, Err: err}
+	}
+	defer syscall.CloseHandle(h)
+
+	var d syscall.ByHandleFileInformation
+	if err = syscall.GetFileInformationByHandle(h, &d); err != nil {
+		return nil, &os1.PathError{
+			Op:   "GetFileInformationByHandle",
+			Path: name,
+			Err:  err,
+		}
+	}
+	return &fileStat{
+		name: filepath.Base(name),
+		sys: syscall.Win32FileAttributeData{
+			FileAttributes: d.FileAttributes,
+			CreationTime:   d.CreationTime,
+			LastAccessTime: d.LastAccessTime,
+			LastWriteTime:  d.LastWriteTime,
+			FileSizeHigh:   d.FileSizeHigh,
+			FileSizeLow:    d.FileSizeLow,
+		},
+		vol:   d.VolumeSerialNumber,
+		idxhi: d.FileIndexHigh,
+		idxlo: d.FileIndexLow,
+		// fileStat.path is used by os1.SameFile to decide, if it needs
+		// to fetch vol, idxhi and idxlo. But these are already set,
+		// so set fileStat.path to "" to prevent os1.SameFile doing it again.
+		// Also do not set fileStat.filetype, because it is only used for
+		// console and stdin/stdout. But you cannot call os1.Stat for these.
+	}, nil
+}
+
+// statWithFindFirstFile is used by Stat to handle special case of stating
+// c:\pagefile.sys. We might discovered other files need similar treatment.
+func statWithFindFirstFile(name string, namep *uint16) (os1.FileInfo, error) {
+	var fd syscall.Win32finddata
+	h, err := syscall.FindFirstFile(namep, &fd)
+	if err != nil {
+		return nil, &os1.PathError{Op: "FindFirstFile", Path: name, Err: err}
+	}
+	syscall.FindClose(h)
+
+	fullpath := name
+	if !filepath.IsAbs(fullpath) {
+		fullpath, err = syscall.FullPath(fullpath)
+		if err != nil {
+			return nil, &os1.PathError{Op: "FullPath", Path: name, Err: err}
+		}
+	}
+	return &fileStat{
+		name: filepath.Base(name),
+		path: fullpath,
+		sys: syscall.Win32FileAttributeData{
+			FileAttributes: fd.FileAttributes,
+			CreationTime:   fd.CreationTime,
+			LastAccessTime: fd.LastAccessTime,
+			LastWriteTime:  fd.LastWriteTime,
+			FileSizeHigh:   fd.FileSizeHigh,
+			FileSizeLow:    fd.FileSizeLow,
+		},
+	}, nil
+}
+
+// A fileStat is the implementation of os1.FileInfo returned by stat.
+type fileStat struct {
+	name     string
+	sys      syscall.Win32FileAttributeData
+	filetype uint32 // what syscall.GetFileType returns
+
+	path  string
+	vol   uint32
+	idxhi uint32
+	idxlo uint32
+}
+
+func (fs *fileStat) Name() string { return fs.name }
+func (fs *fileStat) IsDir() bool  { return fs.Mode().IsDir() }
+
+func (fs *fileStat) Size() int64 {
+	return int64(fs.sys.FileSizeHigh)<<32 + int64(fs.sys.FileSizeLow)
+}
+
+// devNullStat is fileStat structure describing DevNull file ("NUL").
+var devNullStat = fileStat{
+	name:  os1.DevNull,
+	vol:   0,
+	idxhi: 0,
+	idxlo: 0,
+}
+
+func (fs *fileStat) Mode() (m os1.FileMode) {
+	if fs == &devNullStat {
+		return os1.ModeDevice | os1.ModeCharDevice | 0666
+	}
+	if fs.sys.FileAttributes&syscall.FILE_ATTRIBUTE_READONLY != 0 {
+		m |= 0444
+	} else {
+		m |= 0666
+	}
+	if fs.sys.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return m | os1.ModeSymlink
+	}
+	if fs.sys.FileAttributes&syscall.FILE_ATTRIBUTE_DIRECTORY != 0 {
+		m |= os1.ModeDir | 0111
+	}
+	switch fs.filetype {
+	case syscall.FILE_TYPE_PIPE:
+		m |= os1.ModeNamedPipe
+	case syscall.FILE_TYPE_CHAR:
+		m |= os1.ModeCharDevice
+	}
+	return m
+}
+
+func (fs *fileStat) ModTime() time.Time {
+	return time.Unix(0, fs.sys.LastWriteTime.Nanoseconds())
+}
+
+// Sys returns syscall.Win32FileAttributeData for file fs.
+func (fs *fileStat) Sys() interface{} { return &fs.sys }

--- a/pkg/x/os/stat_windows_test.go
+++ b/pkg/x/os/stat_windows_test.go
@@ -1,0 +1,209 @@
+// +build windows
+
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package os
+
+import (
+	"io/ioutil"
+	os1 "os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+var (
+	modnetapi32 = syscall.NewLazyDLL("netapi32.dll")
+
+	procNetShareAdd = modnetapi32.NewProc("NetShareAdd")
+	procNetShareDel = modnetapi32.NewProc("NetShareDel")
+)
+
+func netShareAdd(serverName *uint16, level uint32, buf *byte, parmErr *uint16) (neterr error) {
+	r0, _, _ := syscall.Syscall6(procNetShareAdd.Addr(), 4, uintptr(unsafe.Pointer(serverName)), uintptr(level), uintptr(unsafe.Pointer(buf)), uintptr(unsafe.Pointer(parmErr)), 0, 0)
+	if r0 != 0 {
+		neterr = syscall.Errno(r0)
+	}
+	return
+}
+
+func netShareDel(serverName *uint16, netName *uint16, reserved uint32) (neterr error) {
+	r0, _, _ := syscall.Syscall(procNetShareDel.Addr(), 3, uintptr(unsafe.Pointer(serverName)), uintptr(unsafe.Pointer(netName)), uintptr(reserved))
+	if r0 != 0 {
+		neterr = syscall.Errno(r0)
+	}
+	return
+}
+
+type shareInfo2 struct {
+	Netname     *uint16
+	Type        uint32
+	Remark      *uint16
+	Permissions uint32
+	MaxUses     uint32
+	CurrentUses uint32
+	Path        *uint16
+	Passwd      *uint16
+}
+
+func sameFile(fi1, fi2 os1.FileInfo) bool {
+	fii1, ok1 := fi1.(*fileStat)
+	fii2, ok2 := fi2.(*fileStat)
+	if !ok1 || !ok2 {
+		return false
+	}
+	return fii1.vol == fii2.vol && fii1.idxhi == fii2.idxhi && fii1.idxlo == fii2.idxlo
+}
+
+func TestNetworkSymbolicLink(t *testing.T) {
+	dir, err := ioutil.TempDir("", "TestNetworkSymbolicLink")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os1.RemoveAll(dir)
+
+	oldwd, err := os1.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os1.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os1.Chdir(oldwd)
+
+	shareName := "GoSymbolicLinkTestShare" // hope no conflicts.
+	sharePath := filepath.Join(dir, shareName)
+	testDir := "TestDir"
+
+	err = os1.MkdirAll(filepath.Join(sharePath, testDir), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wShareName, err := syscall.UTF16PtrFromString(shareName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wSharePath, err := syscall.UTF16PtrFromString(sharePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := shareInfo2{
+		Netname:     wShareName,
+		Type:        0x00, // STYPE_DISKTREE
+		Remark:      nil,
+		Permissions: 0,
+		MaxUses:     1,
+		CurrentUses: 0,
+		Path:        wSharePath,
+		Passwd:      nil,
+	}
+
+	err = netShareAdd(nil, 2, (*byte)(unsafe.Pointer(&p)), nil)
+	if err != nil {
+		if err == syscall.ERROR_ACCESS_DENIED {
+			t.Skip("you don't have enough privileges to add network share")
+		}
+		t.Fatal(err)
+	}
+	defer func() {
+		err := netShareDel(nil, wShareName, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	UNCPath := `\\localhost\` + shareName + `\`
+
+	fi1, err := Stat(sharePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fi2, err := Stat(UNCPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameFile(fi1, fi2) {
+		t.Fatalf("%q and %q should be the same directory, but not", sharePath, UNCPath)
+	}
+
+	target := filepath.Join(UNCPath, testDir)
+	link := "link"
+
+	err = os1.Symlink(target, link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os1.Remove(link)
+
+	got, err := os1.Readlink(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got != target {
+		t.Errorf(`os1.Readlink("%s"): got %v, want %v`, link, got, target)
+	}
+}
+
+func TestShareNotExistError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow test that uses network; skipping")
+	}
+	_, err := Stat(`\\no_such_server\no_such_share\no_such_file`)
+	if err == nil {
+		t.Fatal("Stat succeeded, but expected to fail")
+	}
+	if !os1.IsNotExist(err) {
+		t.Fatalf("os1.Stat failed with %q, but os1.IsNotExist(err) is false", err)
+	}
+}
+
+func TestStatPagefile(t *testing.T) {
+	_, err := Stat(`c:\pagefile.sys`)
+	if err == nil {
+		return
+	}
+	if os1.IsNotExist(err) {
+		t.Skip(`skipping because c:\pagefile.sys is not found`)
+	}
+	t.Fatal(err)
+}
+
+func TestStatSymlinkLoop(t *testing.T) {
+	err := os1.Symlink("x", "y")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os1.Remove("y")
+
+	err = os1.Symlink("y", "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os1.Remove("x")
+
+	_, err = Stat("x")
+	if err != nil {
+		if _, ok := err.(*os1.PathError); !ok {
+			t.Errorf("expected *PathError, got %T: %v\n", err, err)
+		}
+	}
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adopts the upstream fix in this regard at
https://go-review.googlesource.com/#/c/41834/ for Minio's
purposes.

Go's current os.Stat() lacks support for lot of strange
windows files such as

 - share symlinks on SMB2
 - symlinks on docker nanoserver
 - de-duplicated files on NTFS de-duplicated volume.

This PR attempts to incorporate the change mentioned here

   https://blogs.msdn.microsoft.com/oldnewthing/20100212-00/?p=14963/

The article suggests to use Windows I/O manager to
dereferences the symbolic link.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4122

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually on Windows with NTFS volume. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.