### PR TITLE
Make gateway help for s3/azure similar

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -38,7 +38,7 @@ FLAGS:
   {{end}}{{end}}
 BACKEND:
   azure: Microsoft Azure Blob Storage. Default ENDPOINT is https://core.windows.net
-  s3: Amazon Simple Storage Service (S3).
+  s3: Amazon Simple Storage Service (S3). Default ENDPOINT is https://s3.amazonaws.com
 
 ENVIRONMENT VARIABLES:
   ACCESS:
@@ -51,7 +51,7 @@ EXAMPLES:
       $ export MINIO_SECRET_KEY=azureaccountkey
       $ {{.HelpName}} azure
 
-  2. Start minio gateway server for S3 backend.
+  2. Start minio gateway server for AWS S3 backend.
       $ export MINIO_ACCESS_KEY=accesskey
       $ export MINIO_SECRET_KEY=secretkey
       $ {{.HelpName}} s3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some portions of `minio gateway` help message are different for azure and s3. This needn't be and this change makes the necessary changes. E.g,

I 
```
BACKEND:
  azure: Microsoft Azure Blob Storage. Default ENDPOINT is https://core.windows.net
  s3: Amazon Simple Storage Service (S3).
```
`s3` backend type should also display default endpoint picked.

||
```
 2. Start minio gateway server for S3 backend.
      $ export MINIO_ACCESS_KEY=accesskey
      $ export MINIO_SECRET_KEY=secretkey
      $ minio gateway s3

  3. Start minio gateway server for S3 backend on custom endpoint.
      $ export MINIO_ACCESS_KEY=Q3AM3UQ867SPQQA43P2F
      $ export MINIO_SECRET_KEY=zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
      $ minio gateway s3 https://play.minio.io:9000

```
Examples 2 is illustrating use of gateway with AWS S3. The text should highlight that to contrast with example 3.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.