### PR TITLE
browser: Fix selecting a new bucket appends objects list to previous bucket's list.

### DIFF
--- a/browser/app/js/reducers.js
+++ b/browser/app/js/reducers.js
@@ -85,7 +85,7 @@ export default (state = {
     case actions.SET_OBJECTS:
       newState.objects = [...action.objects]
       break
-    case action.RESET_OBJECTS:
+    case actions.RESET_OBJECTS:
       newState.objects = []
       newState.marker = ""
       newState.istruncated = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Selecting a bucket on the UI was appending the objects list to previous bucket's objects list

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.