### PR TITLE
Add minimum requirements for MySQL notification

### DIFF
--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -547,9 +547,9 @@ key                 |                      value
 <a name="MySQL"></a>
 ## Publish Minio events via MySQL
 
-Install MySQL from [here](https://dev.mysql.com/downloads/mysql/). For illustrative purposes, we have set the root password as `password` and created a database called `miniodb` to store the events.
+Install MySQL from [here](https://dev.mysql.com/downloads/mysql/). To publish Minio events, you'll need `JSON` support in MySQL, available on MySQL `5.7.8` and above. We tested this setup on MySQL `5.7.17`. For illustrative purposes, we have set the root password as `password` and created a database called `miniodb` to store the events. 
 
-This notification target supports two formats: _namespace_ and _access_.
+This notification target supports two formats: _namespace_ and _access_. 
 
 When the _namespace_ format is used, Minio synchronizes objects in the bucket with rows in the table. It creates rows with two columns: key_name and value. The key_name is the bucket and object name of an object that exists in Minio. The value is JSON encoded event data about the operation that created/replaced the object in Minio. When objects are updated or deleted, the corresponding row from this table is updated or deleted respectively.
 

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -547,9 +547,9 @@ key                 |                      value
 <a name="MySQL"></a>
 ## Publish Minio events via MySQL
 
-Install MySQL from [here](https://dev.mysql.com/downloads/mysql/). To publish Minio events, you'll need `JSON` support in MySQL, available on MySQL `5.7.8` and above. We tested this setup on MySQL `5.7.17`. For illustrative purposes, we have set the root password as `password` and created a database called `miniodb` to store the events. 
+Install MySQL from [here](https://dev.mysql.com/downloads/mysql/). To publish Minio events, you'll need `JSON` support in MySQL, available on MySQL `5.7.8` and above. We tested this setup on MySQL `5.7.17`. For illustrative purposes, we have set the root password as `password` and created a database called `miniodb` to store the events.
 
-This notification target supports two formats: _namespace_ and _access_. 
+This notification target supports two formats: _namespace_ and _access_.
 
 When the _namespace_ format is used, Minio synchronizes objects in the bucket with rows in the table. It creates rows with two columns: key_name and value. The key_name is the bucket and object name of an object that exists in Minio. The value is JSON encoded event data about the operation that created/replaced the object in Minio. When objects are updated or deleted, the corresponding row from this table is updated or deleted respectively.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the minimum requirements for MySQL support in notification targets.

## Motivation and Context
This is important for users to know if they have proper setup to use Minio Mysql target.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.