### PR TITLE
config: Support kafka brokers to be specified dynamically.

### DIFF
--- a/cmd/config-v18.go
+++ b/cmd/config-v18.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"sync"
 
+	"github.com/minio/minio-go/pkg/set"
 	"github.com/minio/minio/pkg/quick"
 	"github.com/tidwall/gjson"
 )
@@ -148,7 +149,7 @@ func newServerConfigV18() *serverConfigV18 {
 	srvCfg.Notify.MySQL = make(map[string]mySQLNotify)
 	srvCfg.Notify.MySQL["1"] = mySQLNotify{}
 	srvCfg.Notify.Kafka = make(map[string]kafkaNotify)
-	srvCfg.Notify.Kafka["1"] = kafkaNotify{}
+	srvCfg.Notify.Kafka["1"] = kafkaNotify{Brokers: set.NewStringSet()}
 	srvCfg.Notify.Webhook = make(map[string]webhookNotify)
 	srvCfg.Notify.Webhook["1"] = webhookNotify{}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the brokers have a strict []string requirement. To
make it easier for users to consume it is easier to allow this
field to be dynamic.

This PR adds support for following styles

  - "addr:port" as a single broker address.
  - [ "addr1:port1", "addr2:port2"... ] as a list of brokers.
  - "addr1:port1, addr2:port2, ..." as a comma separated list of brokers.

<!--- Describe your changes in detail -->

## Motivation and Context
Ease of usability for user.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.