### PR TITLE
gateway-s3: Avoid x2 double quotes in ListParts

### DIFF
--- a/cmd/gateway-s3.go
+++ b/cmd/gateway-s3.go
@@ -449,7 +449,7 @@ func (l *s3Gateway) CopyObjectPart(srcBucket string, srcObject string, destBucke
 func fromMinioClientObjectPart(op minio.ObjectPart) PartInfo {
 	return PartInfo{
 		Size:         op.Size,
-		ETag:         op.ETag,
+		ETag:         canonicalizeETag(op.ETag),
 		LastModified: op.LastModified,
 		PartNumber:   op.PartNumber,
 	}


### PR DESCRIPTION
## Description
ListParts response returns doubled double quotes in ETag field.
This commit cleans ETag when receiving it from minio client to
fix the issue.

## Motivation and Context
Fixes #4294 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.