### PR TITLE
[WIP] gateway: forward GetBucketLocation request to gateway layer

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -652,3 +652,13 @@ func (a AzureObjects) DeleteBucketPolicies(bucket string) error {
 	err := a.client.SetContainerPermissions(bucket, perm, 0, "")
 	return azureToObjectError(traceError(err))
 }
+
+// GetBucketLocation returns "us-east-1" as region is not relevant for Azure
+func (a AzureObjects) GetBucketLocation(bucket string) (string, error) {
+	return globalMinioDefaultRegion, nil
+}
+
+// AnonGetBucketLocation returns "us-east-1" as region is not relevant for Azure
+func (a AzureObjects) AnonGetBucketLocation(bucket string) (string, error) {
+	return globalMinioDefaultRegion, nil
+}

--- a/cmd/gateway-router.go
+++ b/cmd/gateway-router.go
@@ -28,14 +28,16 @@ type GatewayLayer interface {
 	ObjectLayer
 
 	MakeBucketWithLocation(bucket, location string) error
+	GetBucketLocation(bucket string) (string, error)
+	DeleteBucketPolicies(string) error
+	SetBucketPolicies(string, policy.BucketAccessPolicy) error
+	GetBucketPolicies(string) (policy.BucketAccessPolicy, error)
 
 	AnonGetObject(bucket, object string, startOffset int64, length int64, writer io.Writer) (err error)
 	AnonGetObjectInfo(bucket, object string) (objInfo ObjectInfo, err error)
-	SetBucketPolicies(string, policy.BucketAccessPolicy) error
-	GetBucketPolicies(string) (policy.BucketAccessPolicy, error)
-	DeleteBucketPolicies(string) error
 	AnonListObjects(bucket, prefix, marker, delimiter string, maxKeys int) (result ListObjectsInfo, err error)
 	AnonGetBucketInfo(bucket string) (bucketInfo BucketInfo, err error)
+	AnonGetBucketLocation(bucket string) (string, error)
 }
 
 // Implements and provides http handlers for S3 API.

--- a/cmd/gateway-s3.go
+++ b/cmd/gateway-s3.go
@@ -563,3 +563,21 @@ func (l *s3Gateway) DeleteBucketPolicies(bucket string) error {
 
 	return nil
 }
+
+// GetBucketLocation returns the bucket region
+func (l *s3Gateway) GetBucketLocation(bucket string) (string, error) {
+	location, err := l.Client.GetBucketLocation(bucket)
+	if err != nil {
+		return "", s3ToObjectError(traceError(err), bucket, "")
+	}
+	return location, nil
+}
+
+// AnonGetBucketLocation - Anonymous version of GetBucketLocation
+func (l *s3Gateway) AnonGetBucketLocation(bucket string) (string, error) {
+	location, err := l.anonClient.GetBucketLocation(bucket)
+	if err != nil {
+		return "", s3ToObjectError(traceError(err), bucket, "")
+	}
+	return location, nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In gateway mode we forward the GetBucketLocation request to gateway layer. Also use client provided region for the MakeBucketWithLocation call.

For signature calculation we need bucket region for which we can use gateway layer's GetBucketLocation call. But at the S3 layer, gateway and object share code for multipart calls. This shared code uses `serverConfig.GetRegion()` which is relevant for `server` mode and not for `gateway` mode. We need to discuss on the solution for this.

@deekoder blocked on @abperiasamy 

This PR is related to https://github.com/minio/minio/issues/4092 and https://github.com/minio/minio/issues/4241

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.