### PR TITLE
fs/erasure: Ignore objects with / even for DeleteObject()

### DIFF
--- a/cmd/object-api-input-checks.go
+++ b/cmd/object-api-input-checks.go
@@ -36,6 +36,10 @@ func checkBucketAndObjectNames(bucket, object string) error {
 	}
 	// Verify if object is valid.
 	if !IsValidObjectName(object) {
+		// Objects with "/" are invalid, verify to return a different error.
+		if hasSuffix(object, slashSeparator) || hasPrefix(object, slashSeparator) {
+			return traceError(ObjectNotFound{Bucket: bucket, Object: object})
+		}
 		return traceError(ObjectNameInvalid{Bucket: bucket, Object: object})
 	}
 	return nil

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -119,10 +119,7 @@ func IsValidObjectName(object string) bool {
 	if len(object) == 0 {
 		return false
 	}
-	if hasSuffix(object, slashSeparator) {
-		return false
-	}
-	if hasPrefix(object, slashSeparator) {
+	if hasSuffix(object, slashSeparator) || hasPrefix(object, slashSeparator) {
 		return false
 	}
 	return IsValidObjectPrefix(object)

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -171,6 +171,39 @@ func (s *TestSuiteCommon) TestObjectDir(c *C) {
 
 	c.Assert(err, IsNil)
 	verifyError(c, response, "XMinioInvalidObjectName", "Object name contains unsupported characters.", http.StatusBadRequest)
+
+	request, err = newTestSignedRequest("HEAD", getHeadObjectURL(s.endPoint, bucketName, "my-object-directory/"),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+
+	client = http.Client{Transport: s.transport}
+	// execute the HTTP request.
+	response, err = client.Do(request)
+
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusNotFound)
+
+	request, err = newTestSignedRequest("GET", getGetObjectURL(s.endPoint, bucketName, "my-object-directory/"),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+
+	client = http.Client{Transport: s.transport}
+	// execute the HTTP request.
+	response, err = client.Do(request)
+
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusNotFound)
+
+	request, err = newTestSignedRequest("DELETE", getDeleteObjectURL(s.endPoint, bucketName, "my-object-directory/"),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, IsNil)
+
+	client = http.Client{Transport: s.transport}
+	// execute the HTTP request.
+	response, err = client.Do(request)
+
+	c.Assert(err, IsNil)
+	c.Assert(response.StatusCode, Equals, http.StatusNoContent)
 }
 
 func (s *TestSuiteCommon) TestBucketSQSNotificationAMQP(c *C) {

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -320,12 +320,6 @@ func (xl xlObjects) GetObject(bucket, object string, startOffset int64, length i
 
 // GetObjectInfo - reads object metadata and replies back ObjectInfo.
 func (xl xlObjects) GetObjectInfo(bucket, object string) (ObjectInfo, error) {
-	// This is a special case with object whose name ends with
-	// a slash separator, we always return object not found here.
-	if hasSuffix(object, slashSeparator) {
-		return ObjectInfo{}, toObjectErr(traceError(errFileNotFound), bucket, object)
-	}
-
 	if err := checkGetObjArgs(bucket, object); err != nil {
 		return ObjectInfo{}, err
 	}
@@ -467,6 +461,7 @@ func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.
 	if isObjectDir(object, size) {
 		// Check if an object is present as one of the parent dir.
 		// -- FIXME. (needs a new kind of lock).
+		// -- FIXME (this also causes performance issue when disks are down).
 		if xl.parentDirIsObject(bucket, path.Dir(object)) {
 			return ObjectInfo{}, toObjectErr(traceError(errFileAccessDenied), bucket, object)
 		}
@@ -480,6 +475,7 @@ func (xl xlObjects) PutObject(bucket string, object string, size int64, data io.
 
 	// Check if an object is present as one of the parent dir.
 	// -- FIXME. (needs a new kind of lock).
+	// -- FIXME (this also causes performance issue when disks are down).
 	if xl.parentDirIsObject(bucket, path.Dir(object)) {
 		return ObjectInfo{}, toObjectErr(traceError(errFileAccessDenied), bucket, object)
 	}

--- a/cmd/xl-v1-object_test.go
+++ b/cmd/xl-v1-object_test.go
@@ -73,9 +73,9 @@ func TestXLDeleteObjectBasic(t *testing.T) {
 		{".test", "obj", BucketNameInvalid{Bucket: ".test"}},
 		{"----", "obj", BucketNameInvalid{Bucket: "----"}},
 		{"bucket", "", ObjectNameInvalid{Bucket: "bucket", Object: ""}},
-		{"bucket", "obj/", ObjectNameInvalid{Bucket: "bucket", Object: "obj/"}},
-		{"bucket", "/obj", ObjectNameInvalid{Bucket: "bucket", Object: "/obj"}},
 		{"bucket", "doesnotexist", ObjectNotFound{Bucket: "bucket", Object: "doesnotexist"}},
+		{"bucket", "obj/", ObjectNotFound{Bucket: "bucket", Object: "obj/"}},
+		{"bucket", "/obj", ObjectNotFound{Bucket: "bucket", Object: "/obj"}},
 		{"bucket", "obj", nil},
 	}
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignore objects with / even for DeleteObject(). Additionally GetObject() also returns errFileNotFound similar to HeadObject().

<!--- Describe your changes in detail -->
## Motivation and Context
Fixes #4302

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and `go tests` 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.