### PR TITLE
build/release: Generate sha256sums for built binaries.

### DIFF
--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -43,8 +43,8 @@ go_build() {
     release_bin="$release_str/$os-$arch/$(basename $package).$release_tag"
     # Release binary downloadable name
     release_real_bin="$release_str/$os-$arch/$(basename $package)"
-    # Release shasum name
-    release_shasum="$release_str/$os-$arch/$(basename $package).shasum"
+    # Release sha256sum name
+    release_sha256sum="$release_str/$os-$arch/$(basename $package).${release_tag}.sha256sum"
 
     # Go build to build the binary.
     if [ "${arch}" == "arm" ]; then
@@ -58,12 +58,12 @@ go_build() {
         ## Copy
         $CP -p $release_bin_6 $release_real_bin_6
 
-        # Release shasum name
-        release_shasum_6="$release_str/$os-${arch}6vl/$(basename $package).shasum"
+        # Release sha256sum name
+        release_sha256sum_6="$release_str/$os-${arch}6vl/$(basename $package).${release_tag}.sha256sum"
 
         # Calculate shasum
-        shasum_str=$(${SHASUM} ${release_bin_6})
-        echo ${shasum_str} | $SED "s/$release_str\/$os-${arch}6vl\///g" > $release_shasum_6
+        shasum_str=$(${SHASUM} -a 256 ${release_bin_6})
+        echo ${shasum_str} | $SED "s/$release_str\/$os-${arch}6vl\///g" > $release_sha256sum_6
 
         # Release binary downloadable name
         release_real_bin_7="$release_str/$os-$arch/$(basename $package)"
@@ -75,12 +75,12 @@ go_build() {
         ## Copy
         $CP -p $release_bin_7 $release_real_bin_7
 
-        # Release shasum name
-        release_shasum_7="$release_str/$os-$arch/$(basename $package).shasum"
+        # Release sha256sum name
+        release_sha256sum_7="$release_str/$os-$arch/$(basename $package).${release_tag}.sha256sum"
 
-        # Calculate shasum
-        shasum_str=$(${SHASUM} ${release_bin_7})
-        echo ${shasum_str} | $SED "s/$release_str\/$os-$arch\///g" > $release_shasum_7
+        # Calculate sha256sum
+        shasum_str=$(${SHASUM} -a 256 ${release_bin_7})
+        echo ${shasum_str} | $SED "s/$release_str\/$os-$arch\///g" > $release_sha256sum_7
     else
         GOOS=$os GOARCH=$arch go build --ldflags "${LDFLAGS}" -o $release_bin
 
@@ -92,8 +92,8 @@ go_build() {
         fi
 
         # Calculate shasum
-        shasum_str=$(${SHASUM} ${release_bin})
-        echo ${shasum_str} | $SED "s/$release_str\/$os-$arch\///g" > $release_shasum
+        sha256sum_str=$(${SHASUM} -a 256 ${release_bin})
+        echo ${sha256sum_str} | $SED "s/$release_str\/$os-$arch\///g" > $release_sha256sum
     fi
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Generate sha256sums for built binaries. We used to build sha1sum deprecate it and use sha256sum instead.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4306

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using `make release`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.