### PR TITLE
gateway: Use default params when no args provided

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/minio/cli"
 	"github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/sha256-simd"
 )
@@ -125,14 +126,20 @@ func azureToObjectError(err error, params ...string) error {
 }
 
 // Inits azure blob storage client and returns AzureObjects.
-func newAzureLayer(args []string) (GatewayLayer, error) {
-	endPoint, secure, err := parseGatewayEndpoint(args[0])
-	if err != nil {
-		return nil, err
-	}
+func newAzureLayer(args cli.Args) (GatewayLayer, error) {
 
-	if endPoint == "" {
-		endPoint = storage.DefaultBaseURL
+	var err error
+
+	// Default endpoint parameters
+	endPoint := storage.DefaultBaseURL
+	secure := true
+
+	// If user provided some parameters
+	if len(args) > 0 {
+		endPoint, secure, err = parseGatewayEndpoint(args.First())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	account := os.Getenv("MINIO_ACCESS_KEY")

--- a/cmd/gateway-gcs-layer.go
+++ b/cmd/gateway-gcs-layer.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 
+	"github.com/minio/cli"
 	minio "github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/policy"
 )
@@ -161,7 +162,7 @@ type gcsGateway struct {
 }
 
 // newGCSGateway returns gcs gatewaylayer
-func newGCSGateway(args []string) (GatewayLayer, error) {
+func newGCSGateway(args cli.Args) (GatewayLayer, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("ProjectID expected")
 	}
@@ -173,7 +174,7 @@ func newGCSGateway(args []string) (GatewayLayer, error) {
 	endpoint := "storage.googleapis.com"
 	secure := true
 
-	projectID := args[0]
+	projectID := args.First()
 
 	ctx := context.Background()
 

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -94,7 +94,7 @@ const (
 )
 
 // GatewayFn returns the GatewayLayer for the backend
-type GatewayFn func([]string) (GatewayLayer, error)
+type GatewayFn func(cli.Args) (GatewayLayer, error)
 
 var (
 	backends = map[gatewayBackend]GatewayFn{

--- a/cmd/gateway-s3.go
+++ b/cmd/gateway-s3.go
@@ -25,6 +25,7 @@ import (
 
 	"encoding/hex"
 
+	"github.com/minio/cli"
 	minio "github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/policy"
 )
@@ -100,15 +101,21 @@ type s3Gateway struct {
 }
 
 // newS3Gateway returns s3 gatewaylayer
-func newS3Gateway(args []string) (GatewayLayer, error) {
-	endpoint, secure, err := parseGatewayEndpoint(args[0])
-	if err != nil {
-		return nil, err
-	}
+func newS3Gateway(args cli.Args) (GatewayLayer, error) {
 
-	if endpoint == "" {
-		endpoint = "s3.amazonaws.com"
-		secure = true
+	var err error
+
+	// Default endpoint parameters
+	endpoint := "s3.amazonaws.com"
+	secure := true
+
+	// Check if user provided some parameters
+	if len(args) > 0 {
+		// Override default params if the endpoint is provided
+		endpoint, secure, err = parseGatewayEndpoint(args.First())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	accessKey := os.Getenv("MINIO_ACCESS_KEY")


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
For S3 & Azure, use default parameters when no arguments (endpoint) are
provided. This also avoids a crash.

## Motivation and Context
Fixes #4314 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.