### PR TITLE
server-info: Change Error type to string

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -241,9 +241,9 @@ type ServerInfoData struct {
 
 // ServerInfo holds server information result of one node
 type ServerInfo struct {
-	Error error
-	Addr  string
-	Data  *ServerInfoData
+	Error string          `json:"error"`
+	Addr  string          `json:"addr"`
+	Data  *ServerInfoData `json:"data"`
 }
 
 // ServerInfoHandler - GET /?info
@@ -276,7 +276,7 @@ func (adminAPI adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *htt
 			serverInfoData, err := peer.cmdRunner.ServerInfoData()
 			if err != nil {
 				errorIf(err, "Unable to get server info from %s.", peer.addr)
-				reply[idx].Error = err
+				reply[idx].Error = err.Error()
 				return
 			}
 

--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -1314,7 +1314,7 @@ func TestAdminServerInfo(t *testing.T) {
 		if len(serverInfo.Addr) == 0 {
 			t.Error("Expected server address to be non empty")
 		}
-		if serverInfo.Error != nil {
+		if serverInfo.Error != "" {
 			t.Errorf("Unexpected error = %v\n", serverInfo.Error)
 		}
 		if serverInfo.Data.StorageInfo.Free == 0 {

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -84,7 +84,7 @@ type ServerInfoData struct {
 
 // ServerInfo holds server information result of one node
 type ServerInfo struct {
-	Error error           `json:"error"`
+	Error string          `json:"error"`
 	Addr  string          `json:"addr"`
 	Data  *ServerInfoData `json:"data"`
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Golang std error type doesn't marshal/unmarshal with json. So errors
are not actually being sent when a client calls ServerInfo() API.


## Motivation and Context
Testing

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.