### PR TITLE
Make clearing of stale debug lock info independent 

### DIFF
--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -240,14 +240,12 @@ func (n *nsLockMap) ForceUnlock(volume, path string) {
 	if _, found := n.lockMap[param]; found {
 		// Remove lock from the map.
 		delete(n.lockMap, param)
-
-		// delete the lock state entry for given
-		// <volume, path> pair.
-		err := n.deleteLockInfoEntryForVolumePath(param)
-		if err != nil {
-			errorIf(err, "Failed to delete lock info entry")
-		}
 	}
+
+	// delete the lock state entry for given
+	// <volume, path> pair. Ignore error as there
+	// is no way to report it back
+	n.deleteLockInfoEntryForVolumePath(param)
 }
 
 // lockInstance - frontend/top-level interface for namespace locks.


### PR DESCRIPTION
Make clearing of stale debug lock info independent of deleting map entry of lock itself for forcefully clearing locks as per ForceUnlock() or `mc admin lock clear --force`.

## Motivation and Context
This is believed to address issue #4337 where stale information for debug locks in shown.

## How Has This Been Tested?
Manually tested (although exact case as in #4337 is not reproducible.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.