### PR TITLE
Browser: Fix Safari Blob download issue

### DIFF
--- a/browser/app/js/actions.js
+++ b/browser/app/js/actions.js
@@ -432,6 +432,8 @@ export const setLoginError = () => {
 
 export const downloadSelected = (url, req, xhr) => {
   return (dispatch) => {
+    var anchor = document.createElement('a')
+    document.body.appendChild(anchor);
     xhr.open('POST', url, true)
     xhr.responseType = 'blob'
 
@@ -439,10 +441,20 @@ export const downloadSelected = (url, req, xhr) => {
       if (this.status == 200) {
         dispatch(checkedObjectsReset())
         var blob = new Blob([this.response], {
-          type: 'application/zip'
+          type: 'octet/stream'
         })
         var blobUrl = window.URL.createObjectURL(blob);
-        window.location = blobUrl
+        var separator = req.prefix.length > 1 ? '-' : ''
+
+        anchor.href = blobUrl
+        anchor.download = req.bucketName+separator+req.prefix.slice(0, -1)+'.zip';
+
+
+
+
+        anchor.click()
+        window.URL.revokeObjectURL(blobUrl)
+        anchor.remove()
       }
     };
     xhr.send(JSON.stringify(req));


### PR DESCRIPTION
## Description
Make "Download all as zip" button functional in Safari by setting proper Blob type and filename.

## Motivation and Context
https://github.com/minio/minio/issues/3943

## How Has This Been Tested?
Tested manually on latest Safari (10.1).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.