### PR TITLE
Add Cache-Control header support.

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -68,6 +69,9 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, contentRange *h
 
 	// Set all other user defined metadata.
 	for k, v := range objInfo.UserDefined {
+		if strings.EqualFold(k, "X-Amz-Meta-Cache-Control") {
+			k = "Cache-Control"
+		}
 		w.Header().Set(k, v)
 	}
 

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1143,6 +1143,31 @@ func newTestSignedRequest(method, urlStr string, contentLength int64, body io.Re
 }
 
 // Returns request with correct signature but with incorrect SHA256.
+func newTestSignedRequestWithHeaders(method, urlStr string, contentLength int64, body io.ReadSeeker, header http.Header, accessKey, secretKey string, signer signerType) (*http.Request, error) {
+	req, err := newTestRequest(method, urlStr, contentLength, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Anonymous request return early.
+	if accessKey == "" || secretKey == "" {
+		return req, nil
+	}
+
+	for k, _ := range header {
+		req.Header.Set(k, header.Get(k))
+	}
+
+	if signer == signerV2 {
+		err = signRequestV2(req, accessKey, secretKey)
+	} else {
+		err = signRequestV4(req, accessKey, secretKey)
+	}
+
+	return req, err
+}
+
+// Returns request with correct signature but with incorrect SHA256.
 func newTestSignedBadSHARequest(method, urlStr string, contentLength int64, body io.ReadSeeker, accessKey, secretKey string, signer signerType) (*http.Request, error) {
 	req, err := newTestRequest(method, urlStr, contentLength, body)
 	if err != nil {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Clients can specify Cache-Control header value during PutObject using `X-Amz-Meta-Cache-Control` header.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #4341


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.