### PR TITLE
add traefik as load balancer for swarm

### DIFF
--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -57,7 +57,7 @@ docker stack rm minio_stack
 
 * By default the services use `local` volume driver. Refer to [Docker documentation](https://docs.docker.com/compose/compose-file/#/volume-configuration-reference) to explore further options.
 
-* Minio services in the Docker compose file expose ports 9001 to 9004. This allows multiple services to run on a host. Explore other configuration options in [Docker documentation](https://docs.docker.com/compose/compose-file/#/ports).
+* Minio services in the Docker compose file will be loadbalanced using [Træfik](https://traefik.io/) which is exposing port 9000.
 
 * Docker Swarm uses ingress load balancing by default. You can configure [external load balancer based](https://docs.docker.com/engine/swarm/ingress/#/configure-an-external-load-balancer) on requirements.
 

--- a/docs/orchestration/docker-swarm/docker-compose.yaml
+++ b/docs/orchestration/docker-swarm/docker-compose.yaml
@@ -5,8 +5,6 @@ services:
     image: minio/minio:RELEASE.2017-05-05T01-14-51Z
     volumes:
       - minio1-data:/export
-    ports:
-      - "9001:9000"
     networks:
       - minio_distributed
     environment:
@@ -17,14 +15,15 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      labels:
+        traefik.frontend.rule: "Host:minioproxy"
+        traefik.port: "9000"
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
 
   minio2:
     image: minio/minio:RELEASE.2017-05-05T01-14-51Z
     volumes:
       - minio2-data:/export
-    ports:
-      - "9002:9000"
     networks:
       - minio_distributed
     environment:
@@ -35,14 +34,15 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      labels:
+        traefik.frontend.rule: "Host:minioproxy"
+        traefik.port: "9000"
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
 
   minio3:
     image: minio/minio:RELEASE.2017-05-05T01-14-51Z
     volumes:
       - minio3-data:/export
-    ports:
-      - "9003:9000"
     networks:
       - minio_distributed
     environment:
@@ -53,14 +53,15 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      labels:
+        traefik.frontend.rule: "Host:minioproxy"
+        traefik.port: "9000"
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
 
   minio4:
     image: minio/minio:RELEASE.2017-05-05T01-14-51Z
     volumes:
       - minio4-data:/export
-    ports:
-      - "9004:9000"
     networks:
       - minio_distributed
     environment:
@@ -71,7 +72,23 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      labels:
+        traefik.frontend.rule: "Host:minioproxy"
+        traefik.port: "9000"
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
+
+  minioproxy:
+    image: traefik
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      -  minio_distributed
+    ports:
+      - 9000:80
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+    command: --docker --docker.swarmmode --docker.domain=minio --docker.watch --web
 
 volumes:
   minio1-data:


### PR DESCRIPTION
## Description

Added [Træfik](https://traefik.io/) load balancer to distributed swarm which allows us to access swarm internal minio using a generic name and also expose one port only (Træfik's port) which does the internal routing to minio's then.

## Motivation and Context

I could not access minio using a generic name from inside swarm (other containers), as each service is named `minio_x`. Adding this, i can have another container attached to network `minio_distributed` accessing minio at `http://minioproxy:80` and Træfik together with swarm makes sure it always is accessible. Bonus is we can expose only a single port.

## How Has This Been Tested?

* create attachable network

```
docker network create --attachable --driver overlay minio_distributed
```

* Spin up minio stack

```
docker stack deploy -c minio/distributed/docker-compose.yml minio
```

* On one of my swarm nodes, i've attached mc client

```
docker run --rm -it --network minio_distributed --entrypoint=/bin/sh minio/mc
mc config host add myminio http://minioproxy:80 foo bar
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] contrib/3rdparty improvement

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.