### PR TITLE
Treat 0.0.0.0 as local address in --address flag

### DIFF
--- a/cmd/net.go
+++ b/cmd/net.go
@@ -319,7 +319,10 @@ func CheckLocalServerAddr(serverAddr string) error {
 		return fmt.Errorf("port number must be between 1 to 65535")
 	}
 
-	if host != "" {
+	// 0.0.0.0 is a wildcard address and refers to local network
+	// addresses. I.e, 0.0.0.0:9000 like ":9000" refers to port
+	// 9000 on localhost.
+	if host != "" && host != net.IPv4zero.String() {
 		isLocalHost, err := isLocalHost(host)
 		if err != nil {
 			return err

--- a/cmd/net_test.go
+++ b/cmd/net_test.go
@@ -221,6 +221,7 @@ func TestCheckLocalServerAddr(t *testing.T) {
 	}{
 		{":54321", nil},
 		{"localhost:54321", nil},
+		{"0.0.0.0:9000", nil},
 		{"", fmt.Errorf("missing port in address")},
 		{"localhost", fmt.Errorf("missing port in address localhost")},
 		{"example.org:54321", fmt.Errorf("host in server address should be this server")},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change treats 0.0.0.0 as a local network address for `--address` flag's argument.
Fixes #4382
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #4382 
`minio server --address "0.0.0.0:9000" /tmp/fs` is valid and should work. Without this change, it fails saying "0.0.0.0" is a non-local address, which is incorrect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and via unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.