### PR TITLE
Adjust /export permissions for arbitary-user support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ MAINTAINER Minio Inc <dev@minio.io>
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -S minio && adduser -S -G minio minio
 
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
 ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.5
 
 MAINTAINER Minio Inc <dev@minio.io>
 
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN addgroup -S minio && adduser -S -G minio minio
+
 ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0
@@ -11,11 +14,12 @@ WORKDIR /go/src/github.com/minio/
 RUN  \
      apk add --no-cache ca-certificates && \
      apk add --no-cache --virtual .build-deps git go musl-dev && \
-     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \     
+     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
      go get -v -d github.com/minio/minio && \
      cd /go/src/github.com/minio/minio && \
      go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)" && \
-     rm -rf /go/pkg /go/src /usr/local/go && apk del .build-deps
+     rm -rf /go/pkg /go/src /usr/local/go && apk del .build-deps && \
+     mkdir /export && chown minio:minio /export
 
 EXPOSE 9000
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,6 +5,9 @@ MAINTAINER Minio Inc <dev@minio.io>
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -S minio && adduser -S -G minio minio
 
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
 ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,6 +2,9 @@ FROM resin/aarch64-alpine:3.5
 
 MAINTAINER Minio Inc <dev@minio.io>
 
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN addgroup -S minio && adduser -S -G minio minio
+
 ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0
@@ -11,11 +14,12 @@ WORKDIR /go/src/github.com/minio/
 RUN  \
      apk add --no-cache ca-certificates && \
      apk add --no-cache --virtual .build-deps git go musl-dev && \
-     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \     
+     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
      go get -v -d github.com/minio/minio && \
      cd /go/src/github.com/minio/minio && \
      go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)" && \
-     rm -rf /go/pkg /go/src /usr/local/go && apk del .build-deps
+     rm -rf /go/pkg /go/src /usr/local/go && apk del .build-deps && \
+     mkdir /export && chown minio:minio /export
 
 EXPOSE 9000
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,6 +5,9 @@ MAINTAINER Minio Inc <dev@minio.io>
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -S minio && adduser -S -G minio minio
 
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
 ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -2,6 +2,9 @@ FROM resin/armhf-alpine:3.5
 
 MAINTAINER Minio Inc <dev@minio.io>
 
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN addgroup -S minio && adduser -S -G minio minio
+
 ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0
@@ -15,7 +18,8 @@ RUN  \
      go get -v -d github.com/minio/minio && \
      cd /go/src/github.com/minio/minio && \
      go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)" && \
-     rm -rf /go/pkg /go/src /usr/local/go && apk del .build-deps
+     rm -rf /go/pkg /go/src /usr/local/go && apk del .build-deps && \
+     mkdir /export && chown minio:minio /export
 
 EXPOSE 9000
 

--- a/buildscripts/docker-entrypoint.sh
+++ b/buildscripts/docker-entrypoint.sh
@@ -78,4 +78,10 @@ docker_secrets_env
 ## Wait for all the hosts to come online.
 docker_wait_hosts "$@"
 
+# allow the container to be started with `--user`
+if [ "$1" = 'minio' -a "$(id -u)" = '0' ]; then
+  chown -R minio .
+	exec su-exec minio "$0" "$@"
+fi
+
 exec "$@"


### PR DESCRIPTION
## Description
The export volume created in the base image is only allowing root to write to the volume 

Docker recommends running containers without root. On platforms like openshift, the root user is not allowed. Instead an arbitrary user ID attached to root is provided.

## Motivation and Context
Fixes https://github.com/minio/minio/issues/4381

## How Has This Been Tested?
```
FROM minio/minio
RUN adduser -S -u 1001 -G root default
USER default
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.