### PR TITLE
Filter out internal object prefix during listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test: build
 	@echo "Done."
 
 coverage: build
-	@echo -n "Running all coverage for minio: "
+	@echo "Running all coverage for minio: "
 	@./buildscripts/go-coverage.sh
 	@echo "Done."
 

--- a/browser/app/js/components/Browse.js
+++ b/browser/app/js/components/Browse.js
@@ -68,7 +68,7 @@ export default class Browse extends React.Component {
           memory: res.MinioMemory,
           platform: res.MinioPlatform,
           runtime: res.MinioRuntime,
-          envVars: res.MinioEnvVars
+          info: res.MinioGlobalInfo
         })
         dispatch(actions.setServerInfo(serverInfo))
       })

--- a/browser/app/js/components/SettingsModal.js
+++ b/browser/app/js/components/SettingsModal.js
@@ -34,23 +34,12 @@ class SettingsModal extends React.Component {
 
     let accessKeyEnv = ''
     let secretKeyEnv = ''
-    // Check environment variables first. They may or may not have been
-    // loaded already; they load in Browse#componentDidMount.
-    if (serverInfo.envVars) {
-      serverInfo.envVars.forEach(envVar => {
-        let keyVal = envVar.split('=')
-        if (keyVal[0] == 'MINIO_ACCESS_KEY') {
-          accessKeyEnv = keyVal[1]
-        } else if (keyVal[0] == 'MINIO_SECRET_KEY') {
-          secretKeyEnv = keyVal[1]
-        }
-      })
-    }
-    if (accessKeyEnv != '' || secretKeyEnv != '') {
+    // Check environment variables first.
+    if (serverInfo.info.isEnvCreds) {
       dispatch(actions.setSettings({
-        accessKey: accessKeyEnv,
-        secretKey: secretKeyEnv,
-        keysReadOnly: true
+          accessKey: 'xxxxxxxxx',
+          secretKey: 'xxxxxxxxx',
+          keysReadOnly: true
       }))
     } else {
       web.GetAuth()

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -231,7 +231,7 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		HTTPStatusCode: http.StatusInternalServerError,
 	},
 	ErrInvalidAccessKeyID: {
-		Code:           "InvalidAccessKeyID",
+		Code:           "InvalidAccessKeyId",
 		Description:    "The access key ID you provided does not exist in our records.",
 		HTTPStatusCode: http.StatusForbidden,
 	},

--- a/cmd/bucket-handlers_test.go
+++ b/cmd/bucket-handlers_test.go
@@ -68,7 +68,7 @@ func testGetBucketLocationHandler(obj ObjectLayer, instanceType, bucketName stri
 			locationResponse:   []byte(""),
 			errorResponse: APIErrorResponse{
 				Resource: "/" + bucketName + "/",
-				Code:     "InvalidAccessKeyID",
+				Code:     "InvalidAccessKeyId",
 				Message:  "The access key ID you provided does not exist in our records.",
 			},
 			shouldPass: false,

--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -45,6 +45,11 @@ const (
 	ZZZZMinioPrefix = "ZZZZ-Minio"
 )
 
+// Check if object prefix is "ZZZZ_Minio".
+func isGCSPrefix(prefix string) bool {
+	return strings.TrimSuffix(prefix, slashSeparator) == ZZZZMinioPrefix
+}
+
 // Convert Minio errors to minio object layer errors.
 func gcsToObjectError(err error, params ...string) error {
 	if err == nil {
@@ -327,7 +332,7 @@ func (l *gcsGateway) ListObjects(bucket string, prefix string, marker string, de
 
 			attrs, _ := it.Next()
 			if attrs == nil {
-			} else if attrs.Prefix == ZZZZMinioPrefix {
+			} else if isGCSPrefix(attrs.Prefix) {
 				break
 			}
 
@@ -344,7 +349,7 @@ func (l *gcsGateway) ListObjects(bucket string, prefix string, marker string, de
 
 		nextMarker = toGCSPageToken(attrs.Name)
 
-		if attrs.Prefix == ZZZZMinioPrefix {
+		if isGCSPrefix(attrs.Prefix) {
 			// we don't return our metadata prefix
 			continue
 		} else if attrs.Prefix != "" {

--- a/cmd/gateway-gcs_test.go
+++ b/cmd/gateway-gcs_test.go
@@ -129,3 +129,38 @@ func TestValidGCSProjectID(t *testing.T) {
 		}
 	}
 }
+
+// Test for isGCSPrefix
+func TestIsGCSPrefix(t *testing.T) {
+	testCases := []struct {
+		prefix      string
+		expectedRes bool
+	}{
+		// Regular prefix without a trailing slash
+		{
+			prefix:      "hello",
+			expectedRes: false,
+		},
+		// Regular prefix with a trailing slash
+		{
+			prefix:      "hello/",
+			expectedRes: false,
+		},
+		// GCS prefix without a trailing slash
+		{
+			prefix:      ZZZZMinioPrefix,
+			expectedRes: true,
+		},
+		// GCS prefix with a trailing slash
+		{
+			prefix:      ZZZZMinioPrefix + "/",
+			expectedRes: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		if actualRes := isGCSPrefix(tc.prefix); actualRes != tc.expectedRes {
+			t.Errorf("%d: Expected isGCSPrefix to return %v but got %v", i, tc.expectedRes, actualRes)
+		}
+	}
+}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -65,6 +65,7 @@ var (
 
 	// This flag is set to 'true' by default
 	globalIsBrowserEnabled = true
+
 	// This flag is set to 'true' when MINIO_BROWSER env is set.
 	globalIsEnvBrowser = false
 
@@ -73,6 +74,7 @@ var (
 
 	// This flag is set to 'true' wen MINIO_REGION env is set.
 	globalIsEnvRegion = false
+
 	// This flag is set to 'us-east-1' by default
 	globalServerRegion = globalMinioDefaultRegion
 
@@ -129,3 +131,23 @@ var (
 	colorBold = color.New(color.Bold).SprintFunc()
 	colorBlue = color.New(color.FgBlue).SprintfFunc()
 )
+
+// Returns minio global information, as a key value map.
+// returned list of global values is not an exhaustive
+// list. Feel free to add new relevant fields.
+func getGlobalInfo() (globalInfo map[string]interface{}) {
+	globalInfo = map[string]interface{}{
+		"isDistXL":         globalIsDistXL,
+		"isXL":             globalIsXL,
+		"isBrowserEnabled": globalIsBrowserEnabled,
+		"isEnvBrowser":     globalIsEnvBrowser,
+		"isEnvCreds":       globalIsEnvCreds,
+		"isEnvRegion":      globalIsEnvRegion,
+		"isSSL":            globalIsSSL,
+		"serverRegion":     globalServerRegion,
+		"serverUserAgent":  globalServerUserAgent,
+		// Add more relevant global settings here.
+	}
+
+	return globalInfo
+}

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -319,7 +319,10 @@ func CheckLocalServerAddr(serverAddr string) error {
 		return fmt.Errorf("port number must be between 1 to 65535")
 	}
 
-	if host != "" {
+	// 0.0.0.0 is a wildcard address and refers to local network
+	// addresses. I.e, 0.0.0.0:9000 like ":9000" refers to port
+	// 9000 on localhost.
+	if host != "" && host != net.IPv4zero.String() {
 		isLocalHost, err := isLocalHost(host)
 		if err != nil {
 			return err

--- a/cmd/net_test.go
+++ b/cmd/net_test.go
@@ -221,6 +221,7 @@ func TestCheckLocalServerAddr(t *testing.T) {
 	}{
 		{":54321", nil},
 		{"localhost:54321", nil},
+		{"0.0.0.0:9000", nil},
 		{"", fmt.Errorf("missing port in address")},
 		{"localhost", fmt.Errorf("missing port in address localhost")},
 		{"example.org:54321", fmt.Errorf("host in server address should be this server")},

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -27,11 +27,12 @@ import (
 
 // Documentation links, these are part of message printing code.
 const (
-	mcQuickStartGuide   = "https://docs.minio.io/docs/minio-client-quickstart-guide"
-	goQuickStartGuide   = "https://docs.minio.io/docs/golang-client-quickstart-guide"
-	jsQuickStartGuide   = "https://docs.minio.io/docs/javascript-client-quickstart-guide"
-	javaQuickStartGuide = "https://docs.minio.io/docs/java-client-quickstart-guide"
-	pyQuickStartGuide   = "https://docs.minio.io/docs/python-client-quickstart-guide"
+	mcQuickStartGuide     = "https://docs.minio.io/docs/minio-client-quickstart-guide"
+	goQuickStartGuide     = "https://docs.minio.io/docs/golang-client-quickstart-guide"
+	jsQuickStartGuide     = "https://docs.minio.io/docs/javascript-client-quickstart-guide"
+	javaQuickStartGuide   = "https://docs.minio.io/docs/java-client-quickstart-guide"
+	pyQuickStartGuide     = "https://docs.minio.io/docs/python-client-quickstart-guide"
+	dotnetQuickStartGuide = "https://docs.minio.io/docs/dotnet-client-quickstart-guide"
 )
 
 // generates format string depending on the string length and padding.
@@ -130,6 +131,7 @@ func printObjectAPIMsg() {
 	log.Println(colorBlue("   Java: ") + fmt.Sprintf(getFormatStr(len(javaQuickStartGuide), 6), javaQuickStartGuide))
 	log.Println(colorBlue("   Python: ") + fmt.Sprintf(getFormatStr(len(pyQuickStartGuide), 4), pyQuickStartGuide))
 	log.Println(colorBlue("   JavaScript: ") + jsQuickStartGuide)
+	log.Println(colorBlue("   .NET: ") + fmt.Sprintf(getFormatStr(len(dotnetQuickStartGuide), 6), dotnetQuickStartGuide))
 }
 
 // Get formatted disk/storage info message.

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -50,12 +50,12 @@ type WebGenericRep struct {
 
 // ServerInfoRep - server info reply.
 type ServerInfoRep struct {
-	MinioVersion  string
-	MinioMemory   string
-	MinioPlatform string
-	MinioRuntime  string
-	MinioEnvVars  []string
-	UIVersion     string `json:"uiVersion"`
+	MinioVersion    string
+	MinioMemory     string
+	MinioPlatform   string
+	MinioRuntime    string
+	MinioGlobalInfo map[string]interface{}
+	UIVersion       string `json:"uiVersion"`
 }
 
 // ServerInfo - get server info.
@@ -80,8 +80,8 @@ func (web *webAPIHandlers) ServerInfo(r *http.Request, args *WebGenericArgs, rep
 		runtime.GOARCH)
 	goruntime := fmt.Sprintf("Version: %s | CPUs: %s", runtime.Version(), strconv.Itoa(runtime.NumCPU()))
 
-	reply.MinioEnvVars = os.Environ()
 	reply.MinioVersion = Version
+	reply.MinioGlobalInfo = getGlobalInfo()
 	reply.MinioMemory = mem
 	reply.MinioPlatform = platform
 	reply.MinioRuntime = goruntime

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -236,6 +236,10 @@ func testServerInfoWebHandler(obj ObjectLayer, instanceType string, t TestErrHan
 	if serverInfoReply.MinioVersion != Version {
 		t.Fatalf("Cannot get minio version from server info handler")
 	}
+	globalInfo := getGlobalInfo()
+	if !reflect.DeepEqual(serverInfoReply.MinioGlobalInfo, globalInfo) {
+		t.Fatalf("Global info did not match got %#v, expected %#v", serverInfoReply.MinioGlobalInfo, globalInfo)
+	}
 }
 
 // Wrapper for calling MakeBucket Web Handler


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We use ZZZZ-Minio/ prefix internally in our GCS gateway which should be
filtered out in the response to ListObjects.

Fixes #4415 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #4415 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a unit test for a helper function and manually tested functionality using the following program,
```go
package main

import (
	"encoding/json"
	"fmt"
	"log"

	minio "github.com/minio/minio-go"
)

func main() {
	clnt, err := minio.NewCore("localhost:9000", "minio", "minio123", false)
	if err != nil {
		log.Fatalln(err)
	}

	bucket := "krisis"
	res, err := clnt.ListObjects(bucket, "", "", "/", 1000)
	if err != nil {
		log.Fatalln(err)
	}

	if len(res.CommonPrefixes) != 1 {
		log.Fatalln("Expected only one prefix but have more %v", res.CommonPrefixes)
	}

	jsonBytes, err := json.Marshal(res)
	if err != nil {
		log.Fatalln(err)
	}
	fmt.Println(string(jsonBytes))
}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.