### PR TITLE
Remove profile option for gcs from gateway help message

### DIFF
--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -168,10 +168,6 @@ func newGCSGateway(args cli.Args) (GatewayLayer, error) {
 		return nil, fmt.Errorf("ProjectID expected")
 	}
 
-	profile := "default"
-	// TODO: don't know where to set profile yet
-	_ = profile
-
 	endpoint := "storage.googleapis.com"
 	secure := true
 

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -66,7 +66,7 @@ EXAMPLES:
       $ gcloud init --console-only # this will configure your google account
       $ export MINIO_ACCESS_KEY=accesskey
       $ export MINIO_SECRET_KEY=secretkey
-      $ {{.HelpName}} gcs [PROFILE:]PROJECTID
+      $ {{.HelpName}} gcs PROJECTID
 `
 
 var gatewayCmd = cli.Command{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
minio gateway command currently lists profile as an optional argument to start the gcs gateway. Only projectid is supported, and this PR removes the profile option from help message to make it consistent.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #4417
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally unit tested 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.