### PR TITLE
Do not send envVars in ServerInfo()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test: build
 	@echo "Done."
 
 coverage: build
-	@echo -n "Running all coverage for minio: "
+	@echo "Running all coverage for minio: "
 	@./buildscripts/go-coverage.sh
 	@echo "Done."
 

--- a/browser/app/js/components/Browse.js
+++ b/browser/app/js/components/Browse.js
@@ -68,7 +68,7 @@ export default class Browse extends React.Component {
           memory: res.MinioMemory,
           platform: res.MinioPlatform,
           runtime: res.MinioRuntime,
-          envVars: res.MinioEnvVars
+          info: res.MinioGlobalInfo
         })
         dispatch(actions.setServerInfo(serverInfo))
       })

--- a/browser/app/js/components/SettingsModal.js
+++ b/browser/app/js/components/SettingsModal.js
@@ -34,23 +34,12 @@ class SettingsModal extends React.Component {
 
     let accessKeyEnv = ''
     let secretKeyEnv = ''
-    // Check environment variables first. They may or may not have been
-    // loaded already; they load in Browse#componentDidMount.
-    if (serverInfo.envVars) {
-      serverInfo.envVars.forEach(envVar => {
-        let keyVal = envVar.split('=')
-        if (keyVal[0] == 'MINIO_ACCESS_KEY') {
-          accessKeyEnv = keyVal[1]
-        } else if (keyVal[0] == 'MINIO_SECRET_KEY') {
-          secretKeyEnv = keyVal[1]
-        }
-      })
-    }
-    if (accessKeyEnv != '' || secretKeyEnv != '') {
+    // Check environment variables first.
+    if (serverInfo.info.isEnvCreds) {
       dispatch(actions.setSettings({
-        accessKey: accessKeyEnv,
-        secretKey: secretKeyEnv,
-        keysReadOnly: true
+          accessKey: 'xxxxxxxxx',
+          secretKey: 'xxxxxxxxx',
+          keysReadOnly: true
       }))
     } else {
       web.GetAuth()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -64,6 +64,7 @@ var (
 
 	// This flag is set to 'true' by default
 	globalIsBrowserEnabled = true
+
 	// This flag is set to 'true' when MINIO_BROWSER env is set.
 	globalIsEnvBrowser = false
 
@@ -72,6 +73,7 @@ var (
 
 	// This flag is set to 'true' wen MINIO_REGION env is set.
 	globalIsEnvRegion = false
+
 	// This flag is set to 'us-east-1' by default
 	globalServerRegion = globalMinioDefaultRegion
 
@@ -128,3 +130,23 @@ var (
 	colorBold = color.New(color.Bold).SprintFunc()
 	colorBlue = color.New(color.FgBlue).SprintfFunc()
 )
+
+// Returns minio global information, as a key value map.
+// returned list of global values is not an exhaustive
+// list. Feel free to add new relevant fields.
+func getGlobalInfo() (globalInfo map[string]interface{}) {
+	globalInfo = map[string]interface{}{
+		"isDistXL":         globalIsDistXL,
+		"isXL":             globalIsXL,
+		"isBrowserEnabled": globalIsBrowserEnabled,
+		"isEnvBrowser":     globalIsEnvBrowser,
+		"isEnvCreds":       globalIsEnvCreds,
+		"isEnvRegion":      globalIsEnvRegion,
+		"isSSL":            globalIsSSL,
+		"serverRegion":     globalServerRegion,
+		"serverUserAgent":  globalServerUserAgent,
+		// Add more relevant global settings here.
+	}
+
+	return globalInfo
+}

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -50,12 +50,12 @@ type WebGenericRep struct {
 
 // ServerInfoRep - server info reply.
 type ServerInfoRep struct {
-	MinioVersion  string
-	MinioMemory   string
-	MinioPlatform string
-	MinioRuntime  string
-	MinioEnvVars  []string
-	UIVersion     string `json:"uiVersion"`
+	MinioVersion    string
+	MinioMemory     string
+	MinioPlatform   string
+	MinioRuntime    string
+	MinioGlobalInfo map[string]interface{}
+	UIVersion       string `json:"uiVersion"`
 }
 
 // ServerInfo - get server info.
@@ -80,8 +80,8 @@ func (web *webAPIHandlers) ServerInfo(r *http.Request, args *WebGenericArgs, rep
 		runtime.GOARCH)
 	goruntime := fmt.Sprintf("Version: %s | CPUs: %s", runtime.Version(), strconv.Itoa(runtime.NumCPU()))
 
-	reply.MinioEnvVars = os.Environ()
 	reply.MinioVersion = Version
+	reply.MinioGlobalInfo = getGlobalInfo()
 	reply.MinioMemory = mem
 	reply.MinioPlatform = platform
 	reply.MinioRuntime = goruntime

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -236,6 +236,10 @@ func testServerInfoWebHandler(obj ObjectLayer, instanceType string, t TestErrHan
 	if serverInfoReply.MinioVersion != Version {
 		t.Fatalf("Cannot get minio version from server info handler")
 	}
+	globalInfo := getGlobalInfo()
+	if !reflect.DeepEqual(serverInfoReply.MinioGlobalInfo, globalInfo) {
+		t.Fatalf("Global info did not match got %#v, expected %#v", serverInfoReply.MinioGlobalInfo, globalInfo)
+	}
 }
 
 // Wrapper for calling MakeBucket Web Handler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sending envVars along with access and secret
exposes the entire minio server's sensitive
information. This will be an unexpected
situation for all users.

If at all we need to look for things like if
credentials are set through env, we should
only have access to only this information
not the entire set of system envs.
<!--- Describe your changes in detail -->

## Motivation and Context
Security and avoid sending sensitive information
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.