### PR TITLE
[proposal] Support creating empty directories.

### DIFF
--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -123,6 +123,24 @@ func fsMkdir(dirPath string) (err error) {
 	return nil
 }
 
+func fsStatAll(statLoc string) (os.FileInfo, error) {
+	fi, err := fsStat(statLoc)
+	if err != nil {
+		err = errorCause(err)
+		if os.IsNotExist(err) {
+			return nil, traceError(errFileNotFound)
+		} else if os.IsPermission(err) {
+			return nil, traceError(errFileAccessDenied)
+		} else if isSysErrNotDir(err) {
+			return nil, traceError(errFileAccessDenied)
+		} else if isSysErrPathNotFound(err) {
+			return nil, traceError(errFileNotFound)
+		}
+		return nil, traceError(err)
+	}
+	return fi, nil
+}
+
 func fsStat(statLoc string) (os.FileInfo, error) {
 	if statLoc == "" {
 		return nil, traceError(errInvalidArgument)

--- a/cmd/fs-v1-metadata.go
+++ b/cmd/fs-v1-metadata.go
@@ -91,6 +91,10 @@ func (m fsMetaV1) ToObjectInfo(bucket, object string, fi os.FileInfo) ObjectInfo
 		}
 	}
 
+	if hasSuffix(object, slashSeparator) {
+		m.Meta["content-type"] = "application/octet-stream"
+	}
+
 	objInfo := ObjectInfo{
 		Bucket: bucket,
 		Name:   object,

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -467,18 +467,23 @@ func (fs fsObjects) getObjectInfo(bucket, object string) (oi ObjectInfo, e error
 		return oi, toObjectErr(traceError(err), bucket, object)
 	}
 
-	// Stat the file to get file size.
-	fi, err := fsStatFile(pathJoin(fs.fsPath, bucket, object))
+	// Stat the object on disk, supports both file and directories.
+	fi, err := fsStatAll(pathJoin(fs.fsPath, bucket, object))
 	if err != nil {
 		return oi, toObjectErr(err, bucket, object)
 	}
-
+	if !hasSuffix(object, slashSeparator) && fi.IsDir() {
+		// Directory call needs to arrive with object ending with "/"
+		// if it didn't we need to return objectNotFound to be
+		// compatible with AWS S3.
+		return oi, toObjectErr(ObjectNotFound{bucket, object})
+	}
 	return fsMeta.ToObjectInfo(bucket, object, fi), nil
 }
 
 // GetObjectInfo - reads object metadata and replies back ObjectInfo.
 func (fs fsObjects) GetObjectInfo(bucket, object string) (oi ObjectInfo, e error) {
-	if err := checkGetObjArgs(bucket, object); err != nil {
+	if err := checkBucketAndObjectNamesFS(bucket, object); err != nil {
 		return oi, err
 	}
 
@@ -527,6 +532,11 @@ func (fs fsObjects) PutObject(bucket string, object string, size int64, data io.
 		// Check if an object is present as one of the parent dir.
 		if fs.parentDirIsObject(bucket, path.Dir(object)) {
 			return ObjectInfo{}, toObjectErr(traceError(errFileAccessDenied), bucket, object)
+		}
+		if err = fsMkdir(pathJoin(fs.fsPath, bucket, object)); err != nil {
+			if errorCause(err) != errVolumeExists {
+				return ObjectInfo{}, err
+			}
 		}
 		return dirObjectInfo(bucket, object, size, metadata), nil
 	}
@@ -669,7 +679,7 @@ func (fs fsObjects) PutObject(bucket string, object string, size int64, data io.
 // DeleteObject - deletes an object from a bucket, this operation is destructive
 // and there are no rollbacks supported.
 func (fs fsObjects) DeleteObject(bucket, object string) error {
-	if err := checkDelObjArgs(bucket, object); err != nil {
+	if err := checkBucketAndObjectNamesFS(bucket, object); err != nil {
 		return err
 	}
 
@@ -810,7 +820,7 @@ func (fs fsObjects) ListObjects(bucket, prefix, marker, delimiter string, maxKey
 			// Object name needs to be full path.
 			objInfo.Name = entry
 			objInfo.IsDir = true
-			return
+			return objInfo, nil
 		}
 
 		// Protect reading `fs.json`.
@@ -825,7 +835,7 @@ func (fs fsObjects) ListObjects(bucket, prefix, marker, delimiter string, maxKey
 
 		// Stat the file to get file size.
 		var fi os.FileInfo
-		fi, err = fsStatFile(pathJoin(fs.fsPath, bucket, entry))
+		fi, err = fsStatAll(pathJoin(fs.fsPath, bucket, entry))
 		if err != nil {
 			return ObjectInfo{}, toObjectErr(err, bucket, entry)
 		}

--- a/cmd/object-api-input-checks.go
+++ b/cmd/object-api-input-checks.go
@@ -18,6 +18,22 @@ package cmd
 
 import "github.com/skyrings/skyring-common/tools/uuid"
 
+// Checks bucket and object name validity, returns nil if both are valid.
+func checkBucketAndObjectNamesFS(bucket, object string) error {
+	// Verify if bucket is valid.
+	if !IsValidBucketName(bucket) {
+		return traceError(BucketNameInvalid{Bucket: bucket})
+	}
+	// Verify if object is valid.
+	if len(object) == 0 {
+		return traceError(ObjectNameInvalid{Bucket: bucket, Object: object})
+	}
+	if !IsValidObjectPrefix(object) {
+		return traceError(ObjectNameInvalid{Bucket: bucket, Object: object})
+	}
+	return nil
+}
+
 // Checks on GetObject arguments, bucket and object.
 func checkGetObjArgs(bucket, object string) error {
 	return checkBucketAndObjectNames(bucket, object)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Every so often we get requirements for creating
directories/prefixes and we end up rejecting
such requirements. This PR is a propoal to show
that its possible to in-fact have empty directories
and be able to manage them like without much
backend format changes etc.

Two new additional APIs were implemented on StorageAPI
layer to facilitate this for distributed and standalone
erasure coded backend.

- DeletePrefix(vol, prefix)
- MakePrefix(vol, prefix)

DeletePrefix() deletes prefix and also its parent directories
if they are empty just like how DeleteFile() does.

MakePrefix() creates prefix all the time as if overwriting it
also creates all the top level directories as well along the
way. Behavior is similar to `mkdir -p`

<!--- Describe your changes in detail -->

## Motivation and Context
More S3 compatibility. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using `go test` 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.