### PR TITLE
Refactor service stop signal message.

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -106,7 +106,7 @@ func (m *ServerMux) handleServiceSignals() error {
 			log.Println(" Exiting")
 			go func() {
 				time.Sleep(time.Millisecond * 600)
-				log.Println("Press ^C again to exit immediately")
+				log.Println("Waiting for active connections to terminate, press ^C again to exit immediately.")
 			}()
 			if err := m.Close(); err != nil {
 				errorIf(err, "Unable to close server gracefully")

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -102,7 +102,8 @@ func (m *ServerMux) handleServiceSignals() error {
 			}
 			runExitFn(nil)
 		case serviceStop:
-			log.Println("Exiting")
+			// Extra space will prevent showing "^CExiting" and rather show "^C Exiting" instead.
+			log.Println(" Exiting")
 			go func() {
 				time.Sleep(time.Millisecond * 600)
 				log.Println("Press ^C again to exit immediately")

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -102,11 +102,10 @@ func (m *ServerMux) handleServiceSignals() error {
 			}
 			runExitFn(nil)
 		case serviceStop:
-			// Extra space will prevent showing "^CExiting" and rather show "^C Exiting" instead.
-			log.Println(" Exiting")
+			log.Println("Received signal to exit.")
 			go func() {
-				time.Sleep(time.Millisecond * 600)
-				log.Println("Waiting for active connections to terminate, press ^C again to exit immediately.")
+				time.Sleep(serverShutdownPoll + time.Millisecond*100)
+				log.Println("Waiting for active connections to terminate - press Ctrl+C to quit immediately.")
 			}()
 			if err := m.Close(); err != nil {
 				errorIf(err, "Unable to close server gracefully")

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -102,7 +102,7 @@ func (m *ServerMux) handleServiceSignals() error {
 			}
 			runExitFn(nil)
 		case serviceStop:
-			log.Println("Exiting.")
+			log.Println("Exiting")
 			go func() {
 				time.Sleep(time.Millisecond * 600)
 				log.Println("press ^C again")

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -105,7 +105,7 @@ func (m *ServerMux) handleServiceSignals() error {
 			log.Println("Exiting")
 			go func() {
 				time.Sleep(time.Millisecond * 600)
-				log.Println("press ^C again")
+				log.Println("Press ^C again to exit immediately")
 			}()
 			if err := m.Close(); err != nil {
 				errorIf(err, "Unable to close server gracefully")

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 // Type of service signals currently supported.
@@ -79,7 +80,6 @@ func (m *ServerMux) handleServiceSignals() error {
 		// We are usually done here, close global service done channel.
 		globalServiceDoneCh <- struct{}{}
 	}
-
 	// Wait for SIGTERM in a go-routine.
 	trapCh := signalTrap(os.Interrupt, syscall.SIGTERM)
 	go func(trapCh <-chan bool) {
@@ -102,7 +102,11 @@ func (m *ServerMux) handleServiceSignals() error {
 			}
 			runExitFn(nil)
 		case serviceStop:
-			log.Println("Gracefully stopping... (press Ctrl+C again to force)")
+			log.Println("Exiting.")
+			go func() {
+				time.Sleep(time.Millisecond * 600)
+				log.Println("press ^C again")
+			}()
 			if err := m.Close(); err != nil {
 				errorIf(err, "Unable to close server gracefully")
 			}


### PR DESCRIPTION
 Changed to show : 
```
./minio server ~/Downloads/miniodata/

Endpoint:  http://192.168.1.225:9000  http://192.168.99.1:9000  http://127.0.0.1:9000
AccessKey: <> 
SecretKey:<>
Region:    us-east-1

Browser Access:
   http://192.168.1.225:9000  http://192.168.99.1:9000  http://127.0.0.1:9000

Command-line Access: https://docs.minio.io/docs/minio-client-quickstart-guide
   $ mc config host add myminio http://192.168.1.225:9000 <> <>

Object API (Amazon S3 compatible):
   Go:         https://docs.minio.io/docs/golang-client-quickstart-guide
   Java:       https://docs.minio.io/docs/java-client-quickstart-guide
   Python:     https://docs.minio.io/docs/python-client-quickstart-guide
   JavaScript: https://docs.minio.io/docs/javascript-client-quickstart-guide
   .NET:       https://docs.minio.io/docs/dotnet-client-quickstart-guide

Drive Capacity: 193 GiB Free, 465 GiB Total
^CExiting
```
## Description
Simple message change.

## Motivation and Context
Gracefully Stopping ... (press Ctrl+C again to force) was not accurate messaging.
 ```
Object API (Amazon S3 compatible):
   Go:         https://docs.minio.io/docs/golang-client-quickstart-guide
   Java:       https://docs.minio.io/docs/java-client-quickstart-guide
   Python:     https://docs.minio.io/docs/python-client-quickstart-guide
   JavaScript: https://docs.minio.io/docs/javascript-client-quickstart-guide

Drive Capacity: 193 GiB Free, 465 GiB Total
^CGracefully stopping... (press Ctrl+C again to force)
```

## How Has This Been Tested?
 Manual testing of regular ^C and it should say "Exiting."
Also tested when a large file was being uploaded and tried to shut down server in while putobject was happening. Minio server still exits with the appropriate messaging and show press ^C again only if the exit still does not happen on time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.