### PR TITLE
GCS does manual params validation

### DIFF
--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -22,9 +22,11 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -207,6 +209,14 @@ const googleStorageEndpoint = "storage.googleapis.com"
 // newGCSGateway returns gcs gatewaylayer
 func newGCSGateway(projectID string) (GatewayLayer, error) {
 	ctx := context.Background()
+
+	if !isValidGCSProjectID(projectID) {
+		fatalIf(errGCSInvalidProjectID, "Unable to initialize GCS gateway")
+	}
+
+	if os.Getenv("MINIO_ACCESS_KEY") == "" || os.Getenv("MINIO_SECRET_KEY") == "" {
+		return nil, errors.New("No credentials set")
+	}
 
 	// Initialize a GCS client.
 	client, err := storage.NewClient(ctx)

--- a/cmd/gateway-startup-msg.go
+++ b/cmd/gateway-startup-msg.go
@@ -50,8 +50,10 @@ func printGatewayCommonMsg(apiEndpoints []string) {
 	apiEndpointStr := strings.Join(apiEndpoints, "  ")
 	// Colorize the message and print.
 	log.Println(colorBlue("\nEndpoint: ") + colorBold(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 1), apiEndpointStr)))
-	log.Println(colorBlue("AccessKey: ") + colorBold(fmt.Sprintf("%s ", cred.AccessKey)))
-	log.Println(colorBlue("SecretKey: ") + colorBold(fmt.Sprintf("%s ", cred.SecretKey)))
+	if cred.AccessKey != "" && cred.SecretKey != "" {
+		log.Println(colorBlue("AccessKey: ") + colorBold(fmt.Sprintf("%s ", cred.AccessKey)))
+		log.Println(colorBlue("SecretKey: ") + colorBold(fmt.Sprintf("%s ", cred.SecretKey)))
+	}
 
 	log.Println(colorBlue("\nBrowser Access:"))
 	log.Println(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 3), apiEndpointStr))


### PR DESCRIPTION
## Description
To control the order of validation, gcs gateway checks project id
then access/secret keys.

```
$ minio gateway gcs
FATA[0000] Unable to initialize gateway layer            cause=GCS project ID expected source=[gateway-main.go:222:gatewayMain()]
```

## Motivation and Context
Fixed #4396 

## How Has This Been Tested?
go test + Manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.