### PR TITLE
Filter out internal object prefix during listing

### DIFF
--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -44,6 +44,11 @@ const (
 	ZZZZMinioPrefix = "ZZZZ-Minio"
 )
 
+// Check if object prefix is "ZZZZ_Minio".
+func isGCSPrefix(prefix string) bool {
+	return strings.TrimSuffix(prefix, slashSeparator) == ZZZZMinioPrefix
+}
+
 // Convert Minio errors to minio object layer errors.
 func gcsToObjectError(err error, params ...string) error {
 	if err == nil {
@@ -326,7 +331,7 @@ func (l *gcsGateway) ListObjects(bucket string, prefix string, marker string, de
 
 			attrs, _ := it.Next()
 			if attrs == nil {
-			} else if attrs.Prefix == ZZZZMinioPrefix {
+			} else if isGCSPrefix(attrs.Prefix) {
 				break
 			}
 
@@ -343,7 +348,7 @@ func (l *gcsGateway) ListObjects(bucket string, prefix string, marker string, de
 
 		nextMarker = toGCSPageToken(attrs.Name)
 
-		if attrs.Prefix == ZZZZMinioPrefix {
+		if isGCSPrefix(attrs.Prefix) {
 			// we don't return our metadata prefix
 			continue
 		} else if attrs.Prefix != "" {

--- a/cmd/gateway-gcs_test.go
+++ b/cmd/gateway-gcs_test.go
@@ -129,3 +129,38 @@ func TestValidGCSProjectID(t *testing.T) {
 		}
 	}
 }
+
+// Test for isGCSPrefix
+func TestIsGCSPrefix(t *testing.T) {
+	testCases := []struct {
+		prefix      string
+		expectedRes bool
+	}{
+		// Regular prefix without a trailing slash
+		{
+			prefix:      "hello",
+			expectedRes: false,
+		},
+		// Regular prefix with a trailing slash
+		{
+			prefix:      "hello/",
+			expectedRes: false,
+		},
+		// GCS prefix without a trailing slash
+		{
+			prefix:      ZZZZMinioPrefix,
+			expectedRes: true,
+		},
+		// GCS prefix with a trailing slash
+		{
+			prefix:      ZZZZMinioPrefix + "/",
+			expectedRes: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		if actualRes := isGCSPrefix(tc.prefix); actualRes != tc.expectedRes {
+			t.Errorf("%d: Expected isGCSPrefix to return %v but got %v", i, tc.expectedRes, actualRes)
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We use ZZZZ-Minio/ prefix internally in our GCS gateway which should be
filtered out in the response to ListObjects.

Fixes #4415
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #4415
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a unit test for a helper function and manually tested functionality using the following program,

```go
package main

import (
	"encoding/json"
	"fmt"
	"log"

	minio "github.com/minio/minio-go"
)

func main() {
	clnt, err := minio.NewCore("localhost:9000", "minio", "minio123", false)
	if err != nil {
		log.Fatalln(err)
	}

	bucket := "krisis"
	res, err := clnt.ListObjects(bucket, "", "", "/", 1000)
	if err != nil {
		log.Fatalln(err)
	}

	if len(res.CommonPrefixes) != 1 {
		log.Fatalln("Expected only one prefix but have more %v", res.CommonPrefixes)
	}

	jsonBytes, err := json.Marshal(res)
	if err != nil {
		log.Fatalln(err)
	}
	fmt.Println(string(jsonBytes))
}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.