### PR TITLE
server: Redirection should use globalMinioPort with host without port.

### DIFF
--- a/cmd/server-mux.go
+++ b/cmd/server-mux.go
@@ -449,12 +449,20 @@ func (m *ServerMux) ListenAndServe(certFile, keyFile string) (err error) {
 	// All http requests start to be processed by httpHandler
 	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if tlsEnabled && r.TLS == nil {
+			// It is expected that r.Host might not have port
+			// for standard ports such as "80" and "443".
+			host, port, _ := net.SplitHostPort(r.Host)
+			if port == "" {
+				host = net.JoinHostPort(r.Host, globalMinioPort)
+			} else {
+				host = r.Host
+			}
 			// TLS is enabled but Request is not TLS configured
 			u := url.URL{
 				Scheme:   httpsScheme,
 				Opaque:   r.URL.Opaque,
 				User:     r.URL.User,
-				Host:     r.Host,
+				Host:     host,
 				Path:     r.URL.Path,
 				RawQuery: r.URL.RawQuery,
 				Fragment: r.URL.Fragment,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently redirection doesn't work in following scenarios

 - server started with port ":80" and TLS is configured
   client requested insecure request on port "80"
   gets redirected to port 443 and fails.
<!--- Describe your changes in detail -->

## Motivation and Context
Refer discussion on #4443 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.