### PR TITLE
Add errCorruptedFormat to list of ignored errors for metadata operations

### DIFF
--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -293,7 +293,7 @@ func pickValidXLMeta(metaArr []xlMetaV1, modTime time.Time) (xlMetaV1, error) {
 }
 
 // list of all errors that can be ignored in a metadata operation.
-var objMetadataOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errVolumeNotFound, errFileNotFound, errFileAccessDenied)
+var objMetadataOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errVolumeNotFound, errFileNotFound, errFileAccessDenied, errCorruptedFormat)
 
 // readXLMetaParts - returns the XL Metadata Parts from xl.json of one of the disks picked at random.
 func (xl xlObjects) readXLMetaParts(bucket, object string) (xlMetaParts []objectPartInfo, err error) {


### PR DESCRIPTION
Fixes listing of objects where xl.json is empty or corrupted to skip to the next disk/server (issue #4354).

## How Has This Been Tested?
Tested manually by emptying several xj.json files in the backend format.

## Types of changes
- [x] Bug fix

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.