### PR TITLE
Bypass network in lock requests to local server

### DIFF
--- a/cmd/lock-rpc-server-common.go
+++ b/cmd/lock-rpc-server-common.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Similar to removeEntry but only removes an entry only if the lock entry exists in map.
-func (l *lockServer) removeEntryIfExists(nlrip nameLockRequesterInfoPair) {
+func (l *localLocker) removeEntryIfExists(nlrip nameLockRequesterInfoPair) {
 	// Check if entry is still in map (could have been removed altogether by 'concurrent' (R)Unlock of last entry)
 	if lri, ok := l.lockMap[nlrip.name]; ok {
 		if !l.removeEntry(nlrip.name, nlrip.lri.uid, &lri) {
@@ -38,7 +38,7 @@ func (l *lockServer) removeEntryIfExists(nlrip nameLockRequesterInfoPair) {
 
 // removeEntry either, based on the uid of the lock message, removes a single entry from the
 // lockRequesterInfo array or the whole array from the map (in case of a write lock or last read lock)
-func (l *lockServer) removeEntry(name, uid string, lri *[]lockRequesterInfo) bool {
+func (l *localLocker) removeEntry(name, uid string, lri *[]lockRequesterInfo) bool {
 	// Find correct entry to remove based on uid.
 	for index, entry := range *lri {
 		if entry.uid == uid {

--- a/cmd/lock-rpc-server-common_test.go
+++ b/cmd/lock-rpc-server-common_test.go
@@ -38,9 +38,9 @@ func TestLockRpcServerRemoveEntryIfExists(t *testing.T) {
 	nlrip := nameLockRequesterInfoPair{name: "name", lri: lri}
 
 	// first test by simulating item has already been deleted
-	locker.removeEntryIfExists(nlrip)
+	locker.ll.removeEntryIfExists(nlrip)
 	{
-		gotLri, _ := locker.lockMap["name"]
+		gotLri, _ := locker.ll.lockMap["name"]
 		expectedLri := []lockRequesterInfo(nil)
 		if !reflect.DeepEqual(expectedLri, gotLri) {
 			t.Errorf("Expected %#v, got %#v", expectedLri, gotLri)
@@ -48,10 +48,10 @@ func TestLockRpcServerRemoveEntryIfExists(t *testing.T) {
 	}
 
 	// then test normal deletion
-	locker.lockMap["name"] = []lockRequesterInfo{lri} // add item
-	locker.removeEntryIfExists(nlrip)
+	locker.ll.lockMap["name"] = []lockRequesterInfo{lri} // add item
+	locker.ll.removeEntryIfExists(nlrip)
 	{
-		gotLri, _ := locker.lockMap["name"]
+		gotLri, _ := locker.ll.lockMap["name"]
 		expectedLri := []lockRequesterInfo(nil)
 		if !reflect.DeepEqual(expectedLri, gotLri) {
 			t.Errorf("Expected %#v, got %#v", expectedLri, gotLri)
@@ -81,32 +81,32 @@ func TestLockRpcServerRemoveEntry(t *testing.T) {
 		timeLastCheck:   UTCNow(),
 	}
 
-	locker.lockMap["name"] = []lockRequesterInfo{
+	locker.ll.lockMap["name"] = []lockRequesterInfo{
 		lockRequesterInfo1,
 		lockRequesterInfo2,
 	}
 
-	lri, _ := locker.lockMap["name"]
+	lri, _ := locker.ll.lockMap["name"]
 
 	// test unknown uid
-	if locker.removeEntry("name", "unknown-uid", &lri) {
+	if locker.ll.removeEntry("name", "unknown-uid", &lri) {
 		t.Errorf("Expected %#v, got %#v", false, true)
 	}
 
-	if !locker.removeEntry("name", "0123-4567", &lri) {
+	if !locker.ll.removeEntry("name", "0123-4567", &lri) {
 		t.Errorf("Expected %#v, got %#v", true, false)
 	} else {
-		gotLri, _ := locker.lockMap["name"]
+		gotLri, _ := locker.ll.lockMap["name"]
 		expectedLri := []lockRequesterInfo{lockRequesterInfo2}
 		if !reflect.DeepEqual(expectedLri, gotLri) {
 			t.Errorf("Expected %#v, got %#v", expectedLri, gotLri)
 		}
 	}
 
-	if !locker.removeEntry("name", "89ab-cdef", &lri) {
+	if !locker.ll.removeEntry("name", "89ab-cdef", &lri) {
 		t.Errorf("Expected %#v, got %#v", true, false)
 	} else {
-		gotLri, _ := locker.lockMap["name"]
+		gotLri, _ := locker.ll.lockMap["name"]
 		expectedLri := []lockRequesterInfo(nil)
 		if !reflect.DeepEqual(expectedLri, gotLri) {
 			t.Errorf("Expected %#v, got %#v", expectedLri, gotLri)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/minio/cli"
+	"github.com/minio/dsync"
 )
 
 var serverFlags = []cli.Flag{
@@ -244,7 +245,8 @@ func serverMain(ctx *cli.Context) {
 
 	// Set nodes for dsync for distributed setup.
 	if globalIsDistXL {
-		fatalIf(initDsyncNodes(), "Unable to initialize distributed locking clients")
+		clnts, myNode := newDsyncNodes(globalEndpoints)
+		fatalIf(dsync.Init(clnts, myNode), "Unable to initialize distributed locking clients")
 	}
 
 	// Initialize name space lock.

--- a/cmd/server-mux_test.go
+++ b/cmd/server-mux_test.go
@@ -340,10 +340,11 @@ func TestServerListenAndServePlain(t *testing.T) {
 }
 
 func TestServerListenAndServeTLS(t *testing.T) {
-	_, err := newTestConfig(globalMinioDefaultRegion)
+	rootPath, err := newTestConfig(globalMinioDefaultRegion)
 	if err != nil {
 		t.Fatalf("Init Test config failed")
 	}
+	defer removeAll(rootPath)
 
 	wait := make(chan struct{})
 	addr := net.JoinHostPort("127.0.0.1", getFreePort())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This makes lock RPCs similar to other RPCs where requests to the local
server bypass the network. Requests to the local lock-subsystem may
bypass the network layer and directly access the locking
data-structures.

This incidentally fixes #4451.

## Description
<!--- Describe your changes in detail -->
With this change, there should finally be no more scenarios in which the minio server sends a request to itself via the network - instead it directly accesses the associated data-structures in-process.

This resolves #4451 - the CA for own TLS certificate need not be added as a trusted root certificate. WIthout this change, it is required for the sole (unnecessary) purpose of making network requests to same process.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Makes all RPCs similar - remote requests actually perform a RPC call, and local requests directly access the concerned data-structures in-process, bypassing the network.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

~~Manually tested - but some tests are yet to be done. **Please do not merge yet.**~~
**EDIT:** Manually tested and validated. Ready for review.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.