### PR TITLE
config: Avoid stale credentials in memory.

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -181,8 +181,14 @@ func (adminAPI adminAPIHandlers) ServiceCredentialsHandler(w http.ResponseWriter
 	}
 
 	// Update local credentials in memory.
-	serverConfig.SetCredential(creds)
+	prevCred := serverConfig.SetCredential(creds)
+
+	// Save credentials to config file
 	if err = serverConfig.Save(); err != nil {
+		// Save the current creds when failed to update.
+		serverConfig.SetCredential(prevCred)
+
+		errorIf(err, "Unable to update the config with new credentials.")
 		writeErrorResponse(w, ErrInternalError, r.URL)
 		return
 	}

--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -69,11 +69,14 @@ func (br *browserPeerAPIHandlers) SetAuthPeer(args SetAuthPeerArgs, reply *AuthR
 	}
 
 	// Update credentials in memory
-	serverConfig.SetCredential(args.Creds)
+	prevCred := serverConfig.SetCredential(args.Creds)
 
 	// Save credentials to config file
 	if err := serverConfig.Save(); err != nil {
-		errorIf(err, "Error updating config file with new credentials sent from browser RPC.")
+		// Save the current creds when failed to update.
+		serverConfig.SetCredential(prevCred)
+
+		errorIf(err, "Unable to update the config with new credentials sent from browser RPC.")
 		return err
 	}
 

--- a/cmd/config-v19.go
+++ b/cmd/config-v19.go
@@ -61,11 +61,12 @@ func (s *serverConfigV19) GetVersion() string {
 	return s.Version
 }
 
-// SetRegion set new region.
+// SetRegion set a new region.
 func (s *serverConfigV19) SetRegion(region string) {
 	s.Lock()
 	defer s.Unlock()
 
+	// Save new region.
 	s.Region = region
 }
 
@@ -77,13 +78,19 @@ func (s *serverConfigV19) GetRegion() string {
 	return s.Region
 }
 
-// SetCredentials set new credentials.
-func (s *serverConfigV19) SetCredential(creds credential) {
+// SetCredentials set new credentials. SetCredential returns the previous credential.
+func (s *serverConfigV19) SetCredential(creds credential) (prevCred credential) {
 	s.Lock()
 	defer s.Unlock()
 
+	// Save previous credential.
+	prevCred = s.Credential
+
 	// Set updated credential.
 	s.Credential = creds
+
+	// Return previous credential.
+	return prevCred
 }
 
 // GetCredentials get current credentials.

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -405,10 +405,13 @@ func (web *webAPIHandlers) SetAuth(r *http.Request, args *SetAuthArgs, reply *Se
 	errsMap := updateCredsOnPeers(creds)
 
 	// Update local credentials
-	serverConfig.SetCredential(creds)
+	prevCred := serverConfig.SetCredential(creds)
 
 	// Persist updated credentials.
 	if err = serverConfig.Save(); err != nil {
+		// Save the current creds when failed to update.
+		serverConfig.SetCredential(prevCred)
+
 		errsMap[globalMinioAddr] = err
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Avoid saving stale credentials in memory.
<!--- Describe your changes in detail -->

## Motivation and Context
Stale credentials can cause cluster failure in case of issues in config save.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually, by triggering of saving config.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.