### PR TITLE
fix: UIVersion not being sent in browser reply for SetPolicy

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -773,6 +773,8 @@ type SetBucketPolicyArgs struct {
 // SetBucketPolicy - set bucket policy.
 func (web *webAPIHandlers) SetBucketPolicy(r *http.Request, args *SetBucketPolicyArgs, reply *WebGenericRep) error {
 	objectAPI := web.ObjectAPI()
+	reply.UIVersion = browser.UIVersion
+
 	if objectAPI == nil {
 		return toJSONError(errServerNotInitialized)
 	}
@@ -804,7 +806,6 @@ func (web *webAPIHandlers) SetBucketPolicy(r *http.Request, args *SetBucketPolic
 		if err != nil {
 			return toJSONError(err)
 		}
-		reply.UIVersion = browser.UIVersion
 		return nil
 	}
 
@@ -813,7 +814,6 @@ func (web *webAPIHandlers) SetBucketPolicy(r *http.Request, args *SetBucketPolic
 		if err != nil {
 			return toJSONError(err, args.BucketName)
 		}
-		reply.UIVersion = browser.UIVersion
 		return nil
 	}
 	data, err := json.Marshal(policyInfo)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When setting policy in the browser in server mode, "Invalid UI version in the JSON-RPC response" msg  is displayed.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Regression due to PR enabling browser support for gateway. Reply.UIVersion is being set too late in code block. This causes issue when no existing policies exist for the bucket.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by starting server in gateway and server modes respectively
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.