### PR TITLE
creds: Secretkey should be generated upto 40 characters in length.

### DIFF
--- a/cmd/credential.go
+++ b/cmd/credential.go
@@ -25,19 +25,35 @@ import (
 )
 
 const (
-	accessKeyMinLen       = 5
-	accessKeyMaxLen       = 20
-	secretKeyMinLen       = 8
-	secretKeyMaxLenAmazon = 100
-	alphaNumericTable     = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	alphaNumericTableLen  = byte(len(alphaNumericTable))
+	// Minimum length for Minio access key.
+	accessKeyMinLen = 5
+
+	// Maximum length for Minio access key.
+	accessKeyMaxLen = 20
+
+	// Minimum length for Minio secret key for both server and gateway mode.
+	secretKeyMinLen = 8
+
+	// Maximum secret key length for Minio, this
+	// is used when autogenerating new credentials.
+	secretKeyMaxLenMinio = 40
+
+	// Maximum secret key length allowed from client side
+	// caters for both server and gateway mode.
+	secretKeyMaxLen = 100
+
+	// Alpha numeric table used for generating access keys.
+	alphaNumericTable = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	// Total length of the alpha numeric table.
+	alphaNumericTableLen = byte(len(alphaNumericTable))
 )
 
+// Common errors generated for access and secret key validation.
 var (
 	errInvalidAccessKeyLength = errors.New("Invalid access key, access key should be 5 to 20 characters in length")
 	errInvalidSecretKeyLength = errors.New("Invalid secret key, secret key should be 8 to 100 characters in length")
 )
-var secretKeyMaxLen = secretKeyMaxLenAmazon
 
 // isAccessKeyValid - validate access key for right length.
 func isAccessKeyValid(accessKey string) bool {
@@ -111,10 +127,10 @@ func mustGetNewCredential() credential {
 	accessKey := string(keyBytes)
 
 	// Generate secret key.
-	keyBytes = make([]byte, secretKeyMaxLen)
+	keyBytes = make([]byte, secretKeyMaxLenMinio)
 	_, err = rand.Read(keyBytes)
 	fatalIf(err, "Unable to generate secret key.")
-	secretKey := string([]byte(base64.StdEncoding.EncodeToString(keyBytes))[:secretKeyMaxLen])
+	secretKey := string([]byte(base64.StdEncoding.EncodeToString(keyBytes))[:secretKeyMaxLenMinio])
 
 	cred, err := createCredential(accessKey, secretKey)
 	fatalIf(err, "Unable to generate new credential.")

--- a/cmd/credential_test.go
+++ b/cmd/credential_test.go
@@ -23,6 +23,9 @@ func TestMustGetNewCredential(t *testing.T) {
 	if !cred.IsValid() {
 		t.Fatalf("Failed to get new valid credential")
 	}
+	if len(cred.SecretKey) != secretKeyMaxLenMinio {
+		t.Fatalf("Invalid length %d of the secretKey credential generated, expected %d", len(cred.SecretKey), secretKeyMaxLenMinio)
+	}
 }
 
 func TestCreateCredential(t *testing.T) {

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -19,11 +19,12 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/gorilla/mux"
-	"github.com/minio/cli"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/minio/cli"
 )
 
 var gatewayTemplate = `NAME:

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -93,13 +93,6 @@ func (s *TestSuiteCommon) TearDownSuite(c *C) {
 	s.testServer.Stop()
 }
 
-func (s *TestSuiteCommon) TestAuth(c *C) {
-	cred := mustGetNewCredential()
-
-	c.Assert(len(cred.AccessKey), Equals, accessKeyMaxLen)
-	c.Assert(len(cred.SecretKey), Equals, secretKeyMaxLen)
-}
-
 func (s *TestSuiteCommon) TestBucketSQSNotificationWebHook(c *C) {
 	// Sample bucket notification.
 	bucketNotificationBuf := `<NotificationConfiguration><QueueConfiguration><Event>s3:ObjectCreated:Put</Event><Filter><S3Key><FilterRule><Name>prefix</Name><Value>images/</Value></FilterRule></S3Key></Filter><Id>1</Id><Queue>arn:minio:sqs:us-east-1:444455556666:webhook</Queue></QueueConfiguration></NotificationConfiguration>`


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Current code allowed it wrongly to generate secret key upto 100
we should only use 100 as a value to validate but for generating
it should be 40.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4470

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.