### PR TITLE
disable settings change on browser in gateway mode

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -233,6 +233,11 @@ func gatewayMain(ctx *cli.Context) {
 
 	router := mux.NewRouter().SkipClean(true)
 
+	if gatewayBackend(backendType) == azureBackend ||
+		gatewayBackend(backendType) == s3Backend {
+		globalIsEnvCreds = true
+	}
+
 	// Register web router when its enabled.
 	if globalIsBrowserEnabled {
 		aerr := registerWebRouter(router)

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -233,10 +233,8 @@ func gatewayMain(ctx *cli.Context) {
 
 	router := mux.NewRouter().SkipClean(true)
 
-	if gatewayBackend(backendType) == azureBackend ||
-		gatewayBackend(backendType) == s3Backend {
-		globalIsEnvCreds = true
-	}
+	// credentials Envs are set globally.
+	globalIsEnvCreds = true
 
 	// Register web router when its enabled.
 	if globalIsBrowserEnabled {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Browser should not allow accesskey /secret key to be changed in gateway mode for azure and s3
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since settings for gateway mode are controlled through environment vars, browser should not allow changing these credentials
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.