### PR TITLE
Give more specific error message on browser for nested policies

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -1018,41 +1018,46 @@ func toWebAPIError(err error) APIError {
 		}
 	}
 	// Convert error type to api error code.
-	var apiErrCode APIErrorCode
 	switch err.(type) {
 	case StorageFull:
-		apiErrCode = ErrStorageFull
+		return getAPIError(ErrStorageFull)
 	case BucketNotFound:
-		apiErrCode = ErrNoSuchBucket
+		return getAPIError(ErrNoSuchBucket)
 	case BucketExists:
-		apiErrCode = ErrBucketAlreadyOwnedByYou
+		return getAPIError(ErrBucketAlreadyOwnedByYou)
 	case BucketNameInvalid:
-		apiErrCode = ErrInvalidBucketName
+		return getAPIError(ErrInvalidBucketName)
 	case BadDigest:
-		apiErrCode = ErrBadDigest
+		return getAPIError(ErrBadDigest)
 	case IncompleteBody:
-		apiErrCode = ErrIncompleteBody
+		return getAPIError(ErrIncompleteBody)
 	case ObjectExistsAsDirectory:
-		apiErrCode = ErrObjectExistsAsDirectory
+		return getAPIError(ErrObjectExistsAsDirectory)
 	case ObjectNotFound:
-		apiErrCode = ErrNoSuchKey
+		return getAPIError(ErrNoSuchKey)
 	case ObjectNameInvalid:
-		apiErrCode = ErrNoSuchKey
+		return getAPIError(ErrNoSuchKey)
 	case InsufficientWriteQuorum:
-		apiErrCode = ErrWriteQuorum
+		return getAPIError(ErrWriteQuorum)
 	case InsufficientReadQuorum:
-		apiErrCode = ErrReadQuorum
+		return getAPIError(ErrReadQuorum)
 	case PolicyNesting:
-		apiErrCode = ErrPolicyNesting
+		return getAPIError(ErrPolicyNesting)
 	case NotImplemented:
-		apiErrCode = ErrNotImplemented
-	default:
-		// Log unexpected and unhandled errors.
-		errorIf(err, errUnexpected.Error())
-		apiErrCode = ErrInternalError
+		return APIError{
+			Code:           "NotImplemented",
+			HTTPStatusCode: http.StatusBadRequest,
+			Description:    "Functionality not implemented",
+		}
 	}
-	apiErr := getAPIError(apiErrCode)
-	return apiErr
+
+	// Log unexpected and unhandled errors.
+	errorIf(err, errUnexpected.Error())
+	return APIError{
+		Code:           "InternalError",
+		HTTPStatusCode: http.StatusInternalServerError,
+		Description:    err.Error(),
+	}
 }
 
 // writeWebErrorResponse - set HTTP status code and write error description to the body.

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -802,6 +802,13 @@ func (web *webAPIHandlers) SetBucketPolicy(r *http.Request, args *SetBucketPolic
 	policyInfo.Statements = policy.SetPolicy(policyInfo.Statements, bucketP, args.BucketName, args.Prefix)
 	switch g := objectAPI.(type) {
 	case GatewayLayer:
+		if len(policyInfo.Statements) == 0 {
+			err = g.DeleteBucketPolicies(args.BucketName)
+			if err != nil {
+				return toJSONError(err, args.BucketName)
+			}
+			return nil
+		}
 		err = g.SetBucketPolicies(args.BucketName, policyInfo)
 		if err != nil {
 			return toJSONError(err)
@@ -1037,6 +1044,8 @@ func toWebAPIError(err error) APIError {
 		apiErrCode = ErrReadQuorum
 	case PolicyNesting:
 		apiErrCode = ErrPolicyNesting
+	case NotImplemented:
+		apiErrCode = ErrNotImplemented
 	default:
 		// Log unexpected and unhandled errors.
 		errorIf(err, errUnexpected.Error())

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -86,12 +86,19 @@ func TestWriteWebErrorResponse(t *testing.T) {
 			webErr:     InsufficientReadQuorum{},
 			apiErrCode: ErrReadQuorum,
 		},
+		{
+			webErr:     NotImplemented{},
+			apiErrCode: ErrNotImplemented,
+		},
 	}
 
 	// Validate all the test cases.
 	for i, testCase := range testCases {
 		writeWebErrorResponse(newFlushWriter(&buffer), testCase.webErr)
 		desc := getAPIError(testCase.apiErrCode).Description
+		if testCase.apiErrCode == ErrNotImplemented {
+			desc = "Functionality not implemented"
+		}
 		recvDesc := buffer.Bytes()
 		// Check if the written desc is same as the one expected.
 		if !bytes.Equal(recvDesc, []byte(desc)) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
For Azure, nested policies are not implemented. Provide a more specific error message when user attempts to set nested policy. When all policies are removed for a bucket, the bucket policy also needs to be removed from gateway server.
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #4485 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually on Azure, S3 and server mode.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.