### PR TITLE
Prevent unnecessary (superfluous) initialization of return variable

### DIFF
--- a/cmd/bucket-notification-utils.go
+++ b/cmd/bucket-notification-utils.go
@@ -259,15 +259,14 @@ func validateNotificationConfig(nConfig notificationConfig) APIErrorCode {
 // - kafka
 // - webhook
 func unmarshalSqsARN(queueARN string) (mSqs arnSQS) {
-	mSqs = arnSQS{}
 	strs := strings.SplitN(queueARN, ":", -1)
 	if len(strs) != 6 {
-		return mSqs
+		return
 	}
 	if serverConfig.GetRegion() != "" {
 		region := strs[3]
 		if region != serverConfig.GetRegion() {
-			return mSqs
+			return
 		}
 	}
 	sqsType := strs[5]
@@ -294,5 +293,5 @@ func unmarshalSqsARN(queueARN string) (mSqs arnSQS) {
 
 	mSqs.AccountID = strs[4]
 
-	return mSqs
+	return
 }


### PR DESCRIPTION
While unmarshalling the SQS ARN, the return variable is unnecessarily reinstantiated (has already been done as part of defining the named return value).

## Motivation and Context
Found during testing/code review.

## How Has This Been Tested?
Manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.