### PR TITLE
GCS gateway allows apps to supply their own marker

### DIFF
--- a/cmd/gateway-gcs_test.go
+++ b/cmd/gateway-gcs_test.go
@@ -164,3 +164,35 @@ func TestIsGCSPrefix(t *testing.T) {
 		}
 	}
 }
+
+// Test for isGCSMarker.
+func TestIsGCSMarker(t *testing.T) {
+	testCases := []struct {
+		marker   string
+		expected bool
+	}{
+		{
+			marker:   "##miniogcs123",
+			expected: true,
+		},
+		{
+			marker:   "##mini_notgcs123",
+			expected: false,
+		},
+		{
+			marker:   "#minioagainnotgcs123",
+			expected: false,
+		},
+		{
+			marker:   "obj1",
+			expected: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		if actual := isGCSMarker(tc.marker); actual != tc.expected {
+			t.Errorf("Test %d: marker is %s, expected %v but got %v",
+				i+1, tc.marker, tc.expected, actual)
+		}
+	}
+}

--- a/cmd/gateway-handlers.go
+++ b/cmd/gateway-handlers.go
@@ -741,14 +741,10 @@ func (api gatewayAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Extract all the litsObjectsV1 query params to their native values.
+	// Extract all the listObjectsV1 query params to their native
+	// values.  N B We delegate validation of params to respective
+	// gateway backends.
 	prefix, marker, delimiter, maxKeys, _ := getListObjectsV1Args(r.URL.Query())
-
-	// Validate all the query params before beginning to serve the request.
-	if s3Error := validateListObjectsArgs(prefix, marker, delimiter, maxKeys); s3Error != ErrNone {
-		writeErrorResponse(w, s3Error, r.URL)
-		return
-	}
 
 	listObjects := objectAPI.ListObjects
 	if reqAuthType == authTypeAnonymous {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Most s3 compatible apps use object keys returned in listing as
marker. This change allows this behaviour with gateway-gcs too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #4411 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually using both the methods discussed in #4411 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.