### PR TITLE
server/mux: Make sure gracefulTimeout is honored properly.

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -104,7 +104,7 @@ func (m *ServerMux) handleServiceSignals() error {
 		case serviceStop:
 			log.Println("Received signal to exit.")
 			go func() {
-				time.Sleep(serverShutdownPoll + time.Millisecond*100)
+				time.Sleep(globalServerShutdownPoll)
 				log.Println("Waiting for active connections to terminate - press Ctrl+C to quit immediately.")
 			}()
 			if err := m.Close(); err != nil {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This was reproduced by removing the Read deadlne timeout.
Once this was removed the `m.currentReqs` would always
be active `1` because net.Conn is remembered by net/rpc
after hijacking the incoming `CONNECT` request.

Now if `m.currenReqs` is `1` then the server-mux.go code

```go
for {
       select {
       case <-time.After(m.gracefulTimeout):
	       return nil
       case <-ticker.C:
	       if atomic.LoadInt32(&m.currentReqs) <= 0 {
	               return nil
	       }
       }
```

Here `time.After()` never gets control since `m.currentReqs` is `1`.
Now if a user presses `CTRL-C` then the server process would never
die and just hangs.

<!--- Describe your changes in detail -->

## Motivation and Context
Found this issue while debugging #4476

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.