### PR TITLE
Removed references to docker-machine in Swarm guide

### DIFF
--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -10,19 +10,19 @@ As of [Docker Engine v1.13.0](https://blog.docker.com/2017/01/whats-new-in-docke
 * Docker engine v1.13.0 running on a cluster of [networked host machines](https://docs.docker.com/engine/swarm/swarm-tutorial/#/three-networked-host-machines).
 
 ## 2. Create a Swarm
-
-SSH into the machine supposed to serve as Swarm manager. If the machine is named `manager`, you can SSH by
-
-```shell
-docker-machine ssh manager
-```
-After logging in to the designated manager node, create the Swarm by
+Logon to the machine supposed to work as Swarm manager machines, and initialize the Swarm by
 
 ```shell
 docker swarm init --advertise-addr <MANAGER-IP>
 ```
+Once the Swarm is initialized, you'll get a response like , 
 
-After the manager is up, [add worker nodes](https://docs.docker.com/engine/swarm/swarm-tutorial/add-nodes/) to the Swarm. Find detailed steps to create the Swarm on [Docker documentation site](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/).
+```shell
+docker swarm join \
+  --token  SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
+  192.168.99.100:2377
+```
+To add other nodes to the Swarm, run the above command to [add worker nodes](https://docs.docker.com/engine/swarm/swarm-tutorial/add-nodes/) to the Swarm. Find detailed steps to create the Swarm on [Docker documentation site](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/).
 
 ## 3. Create Docker secrets for Minio
 

--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -15,7 +15,7 @@ Create a swarm on the manager node by running
 ```shell
 docker swarm init --advertise-addr <MANAGER-IP>
 ```
-Once the Swarm is initialized, you'll see the below response. 
+Once the swarm is initialized, you'll see the below response. 
 
 ```shell
 docker swarm join \
@@ -23,7 +23,7 @@ docker swarm join \
   192.168.99.100:2377
 ```
 
-You can now [add worker nodes](https://docs.docker.com/engine/swarm/swarm-tutorial/add-nodes/) to the swarm by running the above command. Find detailed steps to create the Swarm on [Docker documentation site](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/).
+You can now [add worker nodes](https://docs.docker.com/engine/swarm/swarm-tutorial/add-nodes/) to the swarm by running the above command. Find detailed steps to create the swarm on [Docker documentation site](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/).
 
 ## 3. Create Docker secrets for Minio
 

--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -10,19 +10,20 @@ As of [Docker Engine v1.13.0](https://blog.docker.com/2017/01/whats-new-in-docke
 * Docker engine v1.13.0 running on a cluster of [networked host machines](https://docs.docker.com/engine/swarm/swarm-tutorial/#/three-networked-host-machines).
 
 ## 2. Create a Swarm
-Logon to the machine supposed to work as Swarm manager machines, and initialize the Swarm by
+Create a swarm on the manager node by running
 
 ```shell
 docker swarm init --advertise-addr <MANAGER-IP>
 ```
-Once the Swarm is initialized, you'll get a response like , 
+Once the Swarm is initialized, you'll see the below response. 
 
 ```shell
 docker swarm join \
   --token  SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
   192.168.99.100:2377
 ```
-To add other nodes to the Swarm, run the above command to [add worker nodes](https://docs.docker.com/engine/swarm/swarm-tutorial/add-nodes/) to the Swarm. Find detailed steps to create the Swarm on [Docker documentation site](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/).
+
+You can now [add worker nodes](https://docs.docker.com/engine/swarm/swarm-tutorial/add-nodes/) to the swarm by running the above command. Find detailed steps to create the Swarm on [Docker documentation site](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/).
 
 ## 3. Create Docker secrets for Minio
 


### PR DESCRIPTION
## Description
Removed references to docker-machine in Swarm guide

## Motivation and Context
`docker-machine` command is not relevant for Swarm mode. It makes sense to remove all the references to `docker-machine` and just provide steps on using Swarm related commands. Also see https://github.com/minio/minio/issues/4477

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.