### PR TITLE
TestInitListeners: Use port 0 pick available port

### DIFF
--- a/cmd/server-mux_test.go
+++ b/cmd/server-mux_test.go
@@ -109,20 +109,18 @@ func dial(addr string) error {
 
 // Tests initializing listeners.
 func TestInitListeners(t *testing.T) {
-	portTest1 := getFreePort()
-	portTest2 := getFreePort()
 	testCases := []struct {
 		serverAddr string
 		shouldPass bool
 	}{
 		// Test 1 with ip and port.
 		{
-			serverAddr: "127.0.0.1:" + portTest1,
+			serverAddr: net.JoinHostPort("127.0.0.1", "0"),
 			shouldPass: true,
 		},
 		// Test 2 only port.
 		{
-			serverAddr: ":" + portTest2,
+			serverAddr: net.JoinHostPort("", "0"),
 			shouldPass: true,
 		},
 		// Test 3 with no port error.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this change TestInitListeners picks port "0" to avoid failing with "Port already in use".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #4505 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.