### PR TITLE
Update Kubernetes deployment docs

### DIFF
--- a/docs/orchestration/kubernetes/README.md
+++ b/docs/orchestration/kubernetes/README.md
@@ -109,7 +109,21 @@ $ helm install --set persistence.enabled=false stable/minio
 
 > *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
 
-## 3. Uninstalling the Chart
+## 3. Updating Minio Release using Helm
+
+You can update an existing Minio Helm Release to use a newer Minio Docker image. To do this, use the `helm upgrade` command:
+
+```bash
+$ helm upgrade --set imageTag=<replace-with-minio-docker-image-tag> <helm-release-name> stable/minio
+```
+
+On successful update, you should see the output below
+
+```bash
+Release "your-helm-release" has been upgraded. Happy Helming!
+```
+
+## 4. Uninstalling the Chart
 
 Assuming your release is named as `my-release`, delete it using the command:
 


### PR DESCRIPTION
## Description
Added steps for updating Minio deployment in 
- Kubernetes-yaml example 
- Helm deployment doc 

## Motivation and Context
Minio users should be able to update their deployment on Kubernetes with minimal downtime. This PR adds steps on how to update Minio Docker image in a Kubernetes cluster.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.