### PR TITLE
fs: Do not block during writing `format.json`.

### DIFF
--- a/cmd/fs-v1-metadata.go
+++ b/cmd/fs-v1-metadata.go
@@ -390,7 +390,8 @@ func initFormatFS(fsPath, fsUUID string) (err error) {
 	fsFormatPath := pathJoin(fsPath, minioMetaBucket, fsFormatJSONFile)
 
 	// fsFormatJSONFile - format.json file stored in minioMetaBucket(.minio.sys) directory.
-	lk, err := lock.LockedOpenFile(preparePath(fsFormatPath), os.O_RDWR|os.O_CREATE, 0600)
+	// Attempt to hold a write lock if there are conflicting processes, fail and return.
+	lk, err := lock.TryLockedOpenFile(preparePath(fsFormatPath), os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return traceError(err)
 	}

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -254,6 +254,11 @@ func newFSObjectLayer(fsPath string) (ObjectLayer, error) {
 
 	// Initialize `format.json`.
 	if err = initFormatFS(fsPath, fsUUID); err != nil {
+		// The follow error would occur if there is a conflicting lock held.
+		// we should simply proceed to attempt a read lock.
+		if errorCause(err) == lock.ErrLocked {
+			return nil, fmt.Errorf("Another server already has an exclusive lock on `format.json`, please wait until you start this server. %s", err)
+		}
 		return nil, err
 	}
 

--- a/pkg/lock/lock.go
+++ b/pkg/lock/lock.go
@@ -19,8 +19,14 @@
 package lock
 
 import (
+	"errors"
 	"os"
 	"sync"
+)
+
+var (
+	// ErrLocked is returned if the underlying fd is already locked.
+	ErrLocked = errors.New("lock: file already locked")
 )
 
 // RLockedFile represents a read locked file, implements a special

--- a/pkg/lock/lock_nix.go
+++ b/pkg/lock/lock_nix.go
@@ -24,16 +24,12 @@ import (
 	"syscall"
 )
 
-// LockedOpenFile - initializes a new lock and protects
-// the file from concurrent access across mount points.
-// This implementation doesn't support all the open
-// flags and shouldn't be considered as replacement
-// for os.OpenFile().
-func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
-	var lockType int
+// Internal function implements support for both
+// blocking and non blocking lock type.
+func lockedOpenFile(path string, flag int, perm os.FileMode, lockType int) (*LockedFile, error) {
 	switch flag {
 	case syscall.O_RDONLY:
-		lockType = syscall.LOCK_SH
+		lockType |= syscall.LOCK_SH
 	case syscall.O_WRONLY:
 		fallthrough
 	case syscall.O_RDWR:
@@ -41,7 +37,7 @@ func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error
 	case syscall.O_WRONLY | syscall.O_CREAT:
 		fallthrough
 	case syscall.O_RDWR | syscall.O_CREAT:
-		lockType = syscall.LOCK_EX
+		lockType |= syscall.LOCK_EX
 	default:
 		return nil, fmt.Errorf("Unsupported flag (%d)", flag)
 	}
@@ -53,6 +49,9 @@ func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error
 
 	if err = syscall.Flock(int(f.Fd()), lockType); err != nil {
 		f.Close()
+		if err == syscall.EWOULDBLOCK {
+			err = ErrLocked
+		}
 		return nil, err
 	}
 
@@ -72,4 +71,22 @@ func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error
 	}
 
 	return &LockedFile{File: f}, nil
+}
+
+// TryLockedOpenFile - tries a new write lock, functionality
+// it is similar to LockedOpenFile with with syscall.LOCK_EX
+// mode but along with syscall.LOCK_NB such that the function
+// doesn't wait forever but instead returns if it cannot
+// acquire a write lock.
+func TryLockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	return lockedOpenFile(path, flag, perm, syscall.LOCK_NB)
+}
+
+// LockedOpenFile - initializes a new lock and protects
+// the file from concurrent access across mount points.
+// This implementation doesn't support all the open
+// flags and shouldn't be considered as replacement
+// for os.OpenFile().
+func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	return lockedOpenFile(path, flag, perm, 0)
 }

--- a/pkg/lock/lock_windows.go
+++ b/pkg/lock/lock_windows.go
@@ -36,19 +36,22 @@ var (
 )
 
 const (
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
+	lockFileExclusiveLock   = 2
+	lockFileFailImmediately = 1
+
 	// see https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
 	errLockViolation syscall.Errno = 0x21
 )
 
-// LockedOpenFile - initializes a new lock and protects
-// the file from concurrent access.
-func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+// lockedOpenFile is an internal function.
+func lockedOpenFile(path string, flag int, perm os.FileMode, alock int) (*LockedFile, error) {
 	f, err := open(path, flag, perm)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = lockFile(syscall.Handle(f.Fd()), 0); err != nil {
+	if err = lockFile(syscall.Handle(f.Fd()), alock); err != nil {
 		f.Close()
 		return nil, err
 	}
@@ -69,6 +72,21 @@ func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error
 	}
 
 	return &LockedFile{File: f}, nil
+}
+
+// TryLockedOpenFile - tries a new write lock, functionality
+// it is similar to LockedOpenFile with with syscall.LOCK_EX
+// mode but along with syscall.LOCK_NB such that the function
+// doesn't wait forever but instead returns if it cannot
+// acquire a write lock.
+func TryLockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	return lockedOpenFile(path, flag, perm, lockFileFailImmediately)
+}
+
+// LockedOpenFile - initializes a new lock and protects
+// the file from concurrent access.
+func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
+	return lockedOpenFile(path, flag, perm, 0)
 }
 
 // perm param is ignored, on windows file perms/NT acls
@@ -121,7 +139,7 @@ func open(path string, flag int, perm os.FileMode) (*os.File, error) {
 
 func lockFile(fd syscall.Handle, flags uint32) error {
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
-	var flag uint32 = 2 // Lockfile exlusive.
+	var flag uint32 = lockFileExclusiveLock // Lockfile exlusive.
 	flag |= flags
 
 	if fd == syscall.InvalidHandle {
@@ -132,7 +150,7 @@ func lockFile(fd syscall.Handle, flags uint32) error {
 	if err == nil {
 		return nil
 	} else if err.Error() == errLocked.Error() {
-		return errors.New("lock already acquired")
+		return ErrLocked
 	} else if err != errLockViolation {
 		return err
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR changes the behavior of the write lock attempted
over `format.json` for the purposes to avoid the situation
where the server would indefinitely hang waiting on each
other
<!--- Describe your changes in detail -->

## Motivation and Context
A possible fix for #4511 and #4517

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.