### PR TITLE
Add support for DCOS host detection, improve Docker detection.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,11 +138,11 @@ func newApp(name string) *cli.App {
 
 // Main main for minio server.
 func Main(args []string) {
-	name := filepath.Base(args[0])
-	app := newApp(name)
+	// Set the minio app name.
+	appName := filepath.Base(args[0])
 
 	// Run the app - exit on error.
-	if err := app.Run(args); err != nil {
+	if err := newApp(appName).Run(args); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/update-main_test.go
+++ b/cmd/update-main_test.go
@@ -44,12 +44,18 @@ func TestDownloadURL(t *testing.T) {
 	}
 
 	os.Setenv("KUBERNETES_SERVICE_HOST", "10.11.148.5")
-	defer os.Unsetenv("KUBERNETES_SERVICE_HOST")
-
 	durl = getDownloadURL(minioVersion1)
 	if durl != kubernetesDeploymentDoc {
 		t.Errorf("Expected %s, got %s", kubernetesDeploymentDoc, durl)
 	}
+	os.Unsetenv("KUBERNETES_SERVICE_HOST")
+
+	os.Setenv("MESOS_CONTAINER_NAME", "mesos-1111")
+	durl = getDownloadURL(minioVersion1)
+	if durl != mesosDeploymentDoc {
+		t.Errorf("Expected %s, got %s", mesosDeploymentDoc, durl)
+	}
+	os.Unsetenv("MESOS_CONTAINER_NAME")
 }
 
 func TestGetCurrentReleaseTime(t *testing.T) {
@@ -158,6 +164,63 @@ func TestGetCurrentReleaseTime(t *testing.T) {
 	}
 }
 
+// Tests user agent string.
+func TestUserAgent(t *testing.T) {
+	testCases := []struct {
+		envName     string
+		envValue    string
+		mode        string
+		expectedStr string
+	}{
+		{
+			envName:     "",
+			envValue:    "",
+			mode:        globalMinioModeFS,
+			expectedStr: fmt.Sprintf("Minio (%s; %s; %s; source) Minio/DEVELOPMENT.GOGET Minio/DEVELOPMENT.GOGET Minio/DEVELOPMENT.GOGET", runtime.GOOS, runtime.GOARCH, globalMinioModeFS),
+		},
+		{
+			envName:     "MESOS_CONTAINER_NAME",
+			envValue:    "mesos-11111",
+			mode:        globalMinioModeXL,
+			expectedStr: fmt.Sprintf("Minio (%s; %s; %s; %s; source) Minio/DEVELOPMENT.GOGET Minio/DEVELOPMENT.GOGET Minio/DEVELOPMENT.GOGET Minio/universe-%s", runtime.GOOS, runtime.GOARCH, globalMinioModeXL, "dcos", "mesos-1111"),
+		},
+		{
+			envName:     "KUBERNETES_SERVICE_HOST",
+			envValue:    "10.11.148.5",
+			mode:        globalMinioModeXL,
+			expectedStr: fmt.Sprintf("Minio (%s; %s; %s; %s; source) Minio/DEVELOPMENT.GOGET Minio/DEVELOPMENT.GOGET Minio/DEVELOPMENT.GOGET", runtime.GOOS, runtime.GOARCH, globalMinioModeXL, "kubernetes"),
+		},
+	}
+
+	for i, testCase := range testCases {
+		os.Setenv(testCase.envName, testCase.envValue)
+		if testCase.envName == "MESOS_CONTAINER_NAME" {
+			os.Setenv("MARATHON_APP_LABEL_DCOS_PACKAGE_VERSION", "mesos-1111")
+		}
+		str := getUserAgent(testCase.mode)
+		if str != testCase.expectedStr {
+			t.Errorf("Test %d: expected: %s, got: %s", i+1, testCase.expectedStr, str)
+		}
+		os.Unsetenv("MARATHON_APP_LABEL_DCOS_PACKAGE_VERSION")
+		os.Unsetenv(testCase.envName)
+	}
+}
+
+// Tests if the environment we are running is in DCOS.
+func TestIsDCOS(t *testing.T) {
+	os.Setenv("MESOS_CONTAINER_NAME", "mesos-1111")
+	dcos := IsDCOS()
+	if !dcos {
+		t.Fatalf("Expected %t, got %t", true, dcos)
+	}
+
+	os.Unsetenv("MESOS_CONTAINER_NAME")
+	dcos = IsDCOS()
+	if dcos {
+		t.Fatalf("Expected %t, got %t", false, dcos)
+	}
+}
+
 // Tests if the environment we are running is in kubernetes.
 func TestIsKubernetes(t *testing.T) {
 	os.Setenv("KUBERNETES_SERVICE_HOST", "10.11.148.5")
@@ -188,36 +251,8 @@ func TestIsDocker(t *testing.T) {
 		return tmpfile.Name()
 	}
 
-	filename1 := createTempFile(`11:pids:/user.slice/user-1000.slice/user@1000.service
-10:blkio:/
-9:hugetlb:/
-8:perf_event:/
-7:cpuset:/
-6:devices:/user.slice
-5:net_cls,net_prio:/
-4:cpu,cpuacct:/
-3:memory:/user/bala/0
-2:freezer:/user/bala/0
-1:name=systemd:/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service
-`)
-	defer os.Remove(filename1)
-
-	filename2 := createTempFile(`14:name=systemd:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-13:pids:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-12:hugetlb:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-11:net_prio:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-10:perf_event:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-9:net_cls:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-8:freezer:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-7:devices:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-6:memory:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-5:blkio:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-4:cpuacct:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-3:cpu:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-2:cpuset:/docker/d5eb950884d828237f60f624ff575a1a7a4daa28a8d4d750040527ed9545e727
-1:name=openrc:/docker
-`)
-	defer os.Remove(filename2)
+	filename := createTempFile("")
+	defer os.Remove(filename)
 
 	testCases := []struct {
 		filename       string
@@ -226,8 +261,7 @@ func TestIsDocker(t *testing.T) {
 	}{
 		{"", false, nil},
 		{"/tmp/non-existing-file", false, nil},
-		{filename1, false, nil},
-		{filename2, true, nil},
+		{filename, true, nil},
 	}
 
 	if runtime.GOOS == "linux" {
@@ -235,7 +269,7 @@ func TestIsDocker(t *testing.T) {
 			filename       string
 			expectedResult bool
 			expectedErr    error
-		}{"/proc/1/cwd", false, fmt.Errorf("open /proc/1/cwd: permission denied")})
+		}{"/proc/1/cwd", false, errors.New("stat /proc/1/cwd: permission denied")})
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for DCOS host detection, improve Docker detection

isDocker was currently reading from `/proc/cgroup` file. But
this file alone is rather not conclusive evidence. Docker
internally has `.dockerenv` as a special file which we should
use instead.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4456

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and with tests. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.