### PR TITLE
Add steps to remove Minio volumes in the swarm

### DIFF
--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -51,12 +51,12 @@ Remove the distributed Minio services and related network by
 ```shell
 docker stack rm minio_stack
 ```
-Swarm doesn't automatically remove the host volumes created for the services. This may lead to courruption when a new Minio service is crated in the swarm. So, we recommend removing the all the volumes used by Minio, manually. To do this, go to each node in the swarm and list the volumes by 
+Swarm doesn't automatically remove host volumes created for services. This may lead to corruption when a new Minio service is created in the swarm. So, we recommend removing all the volumes used by Minio, manually. To do this, go to each node in the swarm and list the volumes by 
 
 ```shell
 docker volume ls
 ```
-Then remove the `minio_stack` volumes by 
+Then remove `minio_stack` volumes by 
 
 ```shell
 docker volume rm volume_name 

--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -51,6 +51,16 @@ Remove the distributed Minio services and related network by
 ```shell
 docker stack rm minio_stack
 ```
+Swarm doesn't automatically remove the host volumes created for the services. This may lead to courruption when a new Minio service is crated in the swarm. So, we recommend removing the all the volumes used by Minio, manually. To do this, go to each node in the swarm and list the volumes by 
+
+```shell
+docker volume ls
+```
+Then remove the `minio_stack` volumes by 
+
+```shell
+docker volume rm volume_name 
+```
 
 ### Notes
 


### PR DESCRIPTION
## Description
Added steps to remove Minio volumes while cleaning up Minio service in Swarm

## Motivation and Context
Swarm doesn't automatically remove the volumes when a service is deleted. This may lead to corruption if a new Minio service is started on the swarm. 

## How Has This Been Tested?
Manually 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.