### PR TITLE
xl/fs: Return InvalidPart{} error for part ETag mismatch.

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -317,7 +317,7 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	},
 	ErrInvalidPart: {
 		Code:           "InvalidPart",
-		Description:    "One or more of the specified parts could not be found.",
+		Description:    "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidPartOrder: {

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -808,7 +808,7 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 
 			if fsMeta.Parts[partIdx].ETag != part.ETag {
 				fs.rwPool.Close(fsMetaPathMultipart)
-				return ObjectInfo{}, traceError(BadDigest{})
+				return ObjectInfo{}, traceError(InvalidPart{})
 			}
 
 			// All parts except the last part has to be atleast 5MB.

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -307,7 +307,7 @@ func (e InvalidUploadID) Error() string {
 type InvalidPart struct{}
 
 func (e InvalidPart) Error() string {
-	return "One or more of the specified parts could not be found"
+	return "One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part's entity tag."
 }
 
 // PartTooSmall - error if part size is less than 5MB.

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1895,7 +1895,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 		// Part number 0 doesn't exist, expecting InvalidPart error (Test number 12).
 		{bucketNames[0], objectNames[0], uploadIDs[0], []completePart{{ETag: "abcd", PartNumber: 0}}, "", InvalidPart{}, false},
 		// // Upload and PartNumber exists, But a deliberate ETag mismatch is introduced (Test number 13).
-		{bucketNames[0], objectNames[0], uploadIDs[0], inputParts[0].parts, "", BadDigest{}, false},
+		{bucketNames[0], objectNames[0], uploadIDs[0], inputParts[0].parts, "", InvalidPart{}, false},
 		// Test case with non existent object name (Test number 14).
 		{bucketNames[0], "my-object", uploadIDs[0], []completePart{{ETag: "abcd", PartNumber: 1}}, "", InvalidUploadID{UploadID: uploadIDs[0]}, false},
 		// Testing for Part being too small (Test number 15).

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -2252,7 +2252,7 @@ func testAPICompleteMultipartHandler(obj ObjectLayer, instanceType, bucketName s
 			accessKey: credentials.AccessKey,
 			secretKey: credentials.SecretKey,
 
-			expectedContent: encodeResponse(getAPIErrorResponse(getAPIError(toAPIErrorCode(BadDigest{})),
+			expectedContent: encodeResponse(getAPIErrorResponse(getAPIError(toAPIErrorCode(InvalidPart{})),
 				getGetObjectURL("", bucketName, objectName))),
 			expectedRespStatus: http.StatusBadRequest,
 		},

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -936,7 +936,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 
 		// All parts should have same ETag as previously generated.
 		if currentXLMeta.Parts[partIdx].ETag != part.ETag {
-			return ObjectInfo{}, traceError(BadDigest{})
+			return ObjectInfo{}, traceError(InvalidPart{})
 		}
 
 		// All parts except the last part has to be atleast 5MB.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Return InvalidPart{} error for part ETag mismatch.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4539

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually with reproducing steps in #4539 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.