### PR TITLE
xl: prepare storage should Abort properly.

### DIFF
--- a/cmd/prepare-storage-msg.go
+++ b/cmd/prepare-storage-msg.go
@@ -133,6 +133,14 @@ func printConfigErrMsg(storageDisks []StorageAPI, sErrs []error, fn printOnceFun
 // Generate a formatted message when cluster is misconfigured.
 func getConfigErrMsg(storageDisks []StorageAPI, sErrs []error) string {
 	msg := colorBlue("\nDetected configuration inconsistencies in the cluster. Please fix following servers.")
+	return msg + combineDiskErrs(storageDisks, sErrs)
+}
+
+// Combines each disk errors in a newline formatted string.
+// this is a helper function in printing messages across
+// all disks.
+func combineDiskErrs(storageDisks []StorageAPI, sErrs []error) string {
+	var msg string
 	for i, disk := range storageDisks {
 		if disk == nil {
 			continue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current state-machine didn't honor a situation
which can arise when there is a combination of

 - formatted
 - unformatted
 - corrupted

disks - this combination invariably goes into a
mode where all servers are waiting perpetually
forever thinking we will get quorum in future.

At this point there is a distant possibility of
ever getting a quorum since we don't even have
quorum number of disks offline.

We should exit and print a proper message per disk
to indicate what went wrong and what was detected
by the server.

<!--- Describe your changes in detail -->

## Motivation and Context
Refer #4477

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually while testing the swarm cluster.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.