### PR TITLE
Added HEALTHCHECK in release Dockerfiles

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,23 +1,26 @@
 FROM alpine:3.5
 
 MAINTAINER Minio Inc <dev@minio.io>
+ 
+COPY buildscripts/docker-entrypoint.sh buildscripts/healthcheck.sh /usr/bin/ 
 
 RUN \
      apk add --no-cache ca-certificates && \
      apk add --no-cache --virtual .build-deps curl && \
      echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
      curl https://dl.minio.io/server/minio/release/linux-amd64/minio > /usr/bin/minio && \
-     chmod +x /usr/bin/minio && apk del .build-deps
+     chmod +x /usr/bin/minio  && \
+     chmod +x /usr/bin/docker-entrypoint.sh && \
+     chmod +x /usr/bin/healthcheck.sh
 
 EXPOSE 9000
-
-COPY buildscripts/docker-entrypoint.sh /usr/bin/
-
-RUN chmod +x /usr/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
 VOLUME ["/export"]
+
+HEALTHCHECK --interval=30s --timeout=5s \
+    CMD /usr/bin/healthcheck.sh
 
 CMD ["minio"]
 

--- a/Dockerfile.release.aarch64
+++ b/Dockerfile.release.aarch64
@@ -2,21 +2,24 @@ FROM resin/aarch64-alpine:3.5
 
 MAINTAINER Minio Inc <dev@minio.io>
 
+COPY buildscripts/docker-entrypoint.sh buildscripts/healthcheck.sh /usr/bin/ 
+
 RUN \
      apk add --no-cache ca-certificates && \
      apk add --no-cache --virtual .build-deps curl && \
      echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
      curl https://dl.minio.io/server/minio/release/linux-arm64/minio > /usr/bin/minio && \
-     chmod +x /usr/bin/minio && apk del .build-deps
+     chmod +x /usr/bin/minio  && \
+     chmod +x /usr/bin/docker-entrypoint.sh && \
+     chmod +x /usr/bin/healthcheck.sh
 
 EXPOSE 9000
-
-COPY buildscripts/docker-entrypoint.sh /usr/bin/
-
-RUN chmod +x /usr/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
 VOLUME ["/export"]
+
+HEALTHCHECK --interval=30s --timeout=5s \
+    CMD /usr/bin/healthcheck.sh
 
 CMD ["minio"]

--- a/Dockerfile.release.armhf
+++ b/Dockerfile.release.armhf
@@ -2,21 +2,24 @@ FROM resin/armhf-alpine:3.5
 
 MAINTAINER Minio Inc <dev@minio.io>
 
+COPY buildscripts/docker-entrypoint.sh buildscripts/healthcheck.sh /usr/bin/ 
+
 RUN \
      apk add --no-cache ca-certificates && \
      apk add --no-cache --virtual .build-deps curl && \
      echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
      curl https://dl.minio.io/server/minio/release/linux-arm/minio > /usr/bin/minio && \
-     chmod +x /usr/bin/minio && apk del .build-deps
+     chmod +x /usr/bin/minio  && \
+     chmod +x /usr/bin/docker-entrypoint.sh && \
+     chmod +x /usr/bin/healthcheck.sh
 
 EXPOSE 9000
-
-COPY buildscripts/docker-entrypoint.sh /usr/bin/
-
-RUN chmod +x /usr/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
 VOLUME ["/export"]
+
+HEALTHCHECK --interval=30s --timeout=5s \
+    CMD /usr/bin/healthcheck.sh
 
 CMD ["minio"]

--- a/buildscripts/healthcheck.sh
+++ b/buildscripts/healthcheck.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Minio Cloud Storage, (C) 2017 Minio, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+_init () {
+    address="http://127.0.0.1:9000"
+    resource="/minio/index.html"
+}
+
+HealthCheckMain () {
+    # Get the http response code
+    http_response=$(curl -s -o /dev/null -I -w "%{http_code}" ${address}${resource})
+
+    # If http_repsonse is 200 - server is up. 
+    # When MINIO_BROWSER is set to off, curl responds with 404. We assume that the the server is up
+    [ "$http_response" == "200" ] || [ "$http_response" == "404" ]
+}
+
+_init && HealthCheckMain


### PR DESCRIPTION
## Description
Added `HEALTHCHECK` in release related Dockerfiles

## Motivation and Context
This is needed to check Minio Docker container health status. With this PR Docker will perform curl to http://127.0.0.1:9000/minio/index.html every `30s` with a timeout of `5s`. After straight 3 failures, Docker will mark the container as `unhealthy`. 

More on HEALTHCHECK [here](https://docs.docker.com/engine/reference/builder/#healthcheck)

## How Has This Been Tested?
Manually 

```
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                   PORTS               NAMES
51415f1ac8f3        31d1385dfe2e        "/usr/bin/docker-e..."   5 minutes ago       Up 5 minutes (healthy)   9000/tcp            elegant_lalande

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.