### PR TITLE
fix: OwnerID in response should be 64 character in length.

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -288,8 +288,6 @@ func generateListBucketsResponse(buckets []BucketInfo) ListBucketsResponse {
 	var owner = Owner{}
 
 	owner.ID = globalMinioDefaultOwnerID
-	owner.DisplayName = globalMinioDefaultOwnerID
-
 	for _, bucket := range buckets {
 		var listbucket = Bucket{}
 		listbucket.Name = bucket.Name
@@ -312,8 +310,6 @@ func generateListObjectsV1Response(bucket, prefix, marker, delimiter string, max
 	var data = ListObjectsResponse{}
 
 	owner.ID = globalMinioDefaultOwnerID
-	owner.DisplayName = globalMinioDefaultOwnerID
-
 	for _, object := range resp.Objects {
 		var content = Object{}
 		if object.Name == "" {
@@ -360,7 +356,6 @@ func generateListObjectsV2Response(bucket, prefix, token, nextToken, startAfter,
 
 	if fetchOwner {
 		owner.ID = globalMinioDefaultOwnerID
-		owner.DisplayName = globalMinioDefaultOwnerID
 	}
 
 	for _, object := range objects {
@@ -443,9 +438,7 @@ func generateListPartsResponse(partsInfo ListPartsInfo) ListPartsResponse {
 	listPartsResponse.UploadID = partsInfo.UploadID
 	listPartsResponse.StorageClass = globalMinioDefaultStorageClass
 	listPartsResponse.Initiator.ID = globalMinioDefaultOwnerID
-	listPartsResponse.Initiator.DisplayName = globalMinioDefaultOwnerID
 	listPartsResponse.Owner.ID = globalMinioDefaultOwnerID
-	listPartsResponse.Owner.DisplayName = globalMinioDefaultOwnerID
 
 	listPartsResponse.MaxParts = partsInfo.MaxParts
 	listPartsResponse.PartNumberMarker = partsInfo.PartNumberMarker

--- a/cmd/auth-rpc-server_test.go
+++ b/cmd/auth-rpc-server_test.go
@@ -77,7 +77,7 @@ func TestLogin(t *testing.T) {
 		// Invalid password length
 		{
 			args: LoginRPCArgs{
-				Username: globalMinioDefaultOwnerID,
+				Username: "minio",
 				Password: "aaa",
 				Version:  Version,
 			},

--- a/cmd/bucket-notification-handlers_test.go
+++ b/cmd/bucket-notification-handlers_test.go
@@ -185,7 +185,7 @@ func testGetBucketNotificationHandler(obj ObjectLayer, instanceType, bucketName 
 	filterRules := []filterRule{
 		{
 			Name:  "prefix",
-			Value: globalMinioDefaultOwnerID,
+			Value: "minio",
 		},
 		{
 			Name:  "suffix",

--- a/cmd/event-notifier_test.go
+++ b/cmd/event-notifier_test.go
@@ -312,7 +312,7 @@ func TestInitEventNotifier(t *testing.T) {
 	filterRules := []filterRule{
 		{
 			Name:  "prefix",
-			Value: globalMinioDefaultOwnerID,
+			Value: "minio",
 		},
 		{
 			Name:  "suffix",
@@ -535,7 +535,7 @@ func TestAddRemoveBucketListenerConfig(t *testing.T) {
 	filterRules := []filterRule{
 		{
 			Name:  "prefix",
-			Value: globalMinioDefaultOwnerID,
+			Value: "minio",
 		},
 		{
 			Name:  "suffix",

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -29,8 +29,17 @@ import (
 const (
 	globalMinioCertExpireWarnDays = time.Hour * 24 * 30 // 30 days.
 
-	globalMinioDefaultRegion       = ""
-	globalMinioDefaultOwnerID      = "minio"
+	globalMinioDefaultRegion = ""
+	// This is a sha256 output of ``arn:aws:iam::minio:user/admin``,
+	// this is kept in present form to be compatible with S3 owner ID
+	// requirements -
+	//
+	// ```
+	//    The canonical user ID is the Amazon S3–only concept.
+	//    It is 64-character obfuscated version of the account ID.
+	// ```
+	// http://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example4.html
+	globalMinioDefaultOwnerID      = "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
 	globalMinioDefaultStorageClass = "STANDARD"
 	globalWindowsOSName            = "windows"
 	globalNetBSDOSName             = "netbsd"

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1061,7 +1061,7 @@ func testListMultipartUploads(obj ObjectLayer, instanceType string, t TestErrHan
 		{
 			MaxUploads:     10,
 			IsTruncated:    false,
-			Prefix:         globalMinioDefaultOwnerID,
+			Prefix:         "minio",
 			UploadIDMarker: uploadIDs[4],
 			Uploads: []uploadMetadata{
 				{

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1619,7 +1619,8 @@ func (s *TestSuiteCommon) TestListObjectsHandler(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(strings.Contains(string(getContent), "<Key>bar</Key>"), Equals, true)
-	c.Assert(strings.Contains(string(getContent), "<Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner>"), Equals, true)
+	c.Assert(strings.Contains(string(getContent), fmt.Sprintf("<Owner><ID>%s</ID><DisplayName></DisplayName></Owner>",
+		globalMinioDefaultOwnerID)), Equals, true)
 
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Rather than sending a custom "minio" string, we can
change this to `sha256('arn:aws:iam::minio:user/admin')`.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4553

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using `go test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.