### PR TITLE
gateway-gcs: use minio.sys.temp/multipart/v1 as url base

### DIFF
--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -43,7 +43,9 @@ const (
 	// ListObjects we filter out this entry.
 	gcsMinioPath = "minio.sys.temp"
 	// Path where multipart objects are saved.
-	gcsMinioMultipartPath = gcsMinioPath + "/multipart"
+	// If we change the backend format we will use a different url path like /multipart/v2
+	// but we will not migrate old data.
+	gcsMinioMultipartPathV1 = gcsMinioPath + "/multipart/v1"
 	// Multipart meta file.
 	gcsMinioMultipartMeta = "gcs.json"
 	// gcs.json version number
@@ -68,12 +70,12 @@ func isGCSPrefix(prefix string) bool {
 
 // Returns name of the multipart meta object.
 func gcsMultipartMetaName(uploadID string) string {
-	return fmt.Sprintf("%s/%s/%s", gcsMinioMultipartPath, uploadID, gcsMinioMultipartMeta)
+	return fmt.Sprintf("%s/%s/%s", gcsMinioMultipartPathV1, uploadID, gcsMinioMultipartMeta)
 }
 
 // Returns name of the part object.
 func gcsMultipartDataName(uploadID, etag string) string {
-	return fmt.Sprintf("%s/%s/%s", gcsMinioMultipartPath, uploadID, etag)
+	return fmt.Sprintf("%s/%s/%s", gcsMinioMultipartPathV1, uploadID, etag)
 }
 
 // Convert Minio errors to minio object layer errors.
@@ -726,7 +728,7 @@ func (l *gcsGateway) cleanupMultipartUpload(bucket, key, uploadID string) error 
 		return gcsToObjectError(traceError(err), bucket, key)
 	}
 
-	prefix := fmt.Sprintf("%s/%s/", gcsMinioMultipartPath, uploadID)
+	prefix := fmt.Sprintf("%s/%s/", gcsMinioMultipartPathV1, uploadID)
 
 	// iterate through all parts and delete them
 	it := l.client.Bucket(bucket).Objects(l.ctx, &storage.Query{Prefix: prefix, Versions: false})

--- a/cmd/gateway-gcs_test.go
+++ b/cmd/gateway-gcs_test.go
@@ -164,7 +164,7 @@ func TestIsGCSMarker(t *testing.T) {
 // Test for gcsMultipartMetaName.
 func TestGCSMultipartMetaName(t *testing.T) {
 	uploadID := "a"
-	expected := pathJoin(gcsMinioMultipartPath, uploadID, gcsMinioMultipartMeta)
+	expected := pathJoin(gcsMinioMultipartPathV1, uploadID, gcsMinioMultipartMeta)
 	got := gcsMultipartMetaName(uploadID)
 	if expected != got {
 		t.Errorf("expected: %s, got: %s", expected, got)
@@ -175,7 +175,7 @@ func TestGCSMultipartMetaName(t *testing.T) {
 func TestGCSMultipartDataName(t *testing.T) {
 	uploadID := "a"
 	etag := "b"
-	expected := pathJoin(gcsMinioMultipartPath, uploadID, etag)
+	expected := pathJoin(gcsMinioMultipartPathV1, uploadID, etag)
 	got := gcsMultipartDataName(uploadID, etag)
 	if expected != got {
 		t.Errorf("expected: %s, got: %s", expected, got)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This helps when we want to use a different backend format in future.

As discussed in today's meeting we will handle the backend format this way. i.e when we move to a different format we will start using minio.sys.temp/multipart/v2 and not worry about migrating the data in v1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To support change in backend format for multipart files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.