### PR TITLE
Naming of return values 

### DIFF
--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -113,15 +113,15 @@ func (rc remoteAdminClient) ReInitDisks() error {
 }
 
 // ServerInfoData - Returns the server info of this server.
-func (lc localAdminClient) ServerInfoData() (ServerInfoData, error) {
+func (lc localAdminClient) ServerInfoData() (sid ServerInfoData, e error) {
 	if globalBootTime.IsZero() {
-		return ServerInfoData{}, errServerNotInitialized
+		return sid, errServerNotInitialized
 	}
 
 	// Build storage info
 	objLayer := newObjectLayerFn()
 	if objLayer == nil {
-		return ServerInfoData{}, errServerNotInitialized
+		return sid, errServerNotInitialized
 	}
 	storage := objLayer.StorageInfo()
 
@@ -145,12 +145,12 @@ func (lc localAdminClient) ServerInfoData() (ServerInfoData, error) {
 }
 
 // ServerInfo - returns the server info of the server to which the RPC call is made.
-func (rc remoteAdminClient) ServerInfoData() (ServerInfoData, error) {
+func (rc remoteAdminClient) ServerInfoData() (sid ServerInfoData, e error) {
 	args := AuthRPCArgs{}
 	reply := ServerInfoDataReply{}
 	err := rc.Call(serverInfoDataRPC, &args, &reply)
 	if err != nil {
-		return ServerInfoData{}, err
+		return sid, err
 	}
 
 	return reply.ServerInfoData, nil
@@ -493,7 +493,7 @@ func getPeerConfig(peers adminPeers) ([]byte, error) {
 
 // getValidServerConfig - finds the server config that is present in
 // quorum or more number of servers.
-func getValidServerConfig(serverConfigs []serverConfigV13, errs []error) (serverConfigV13, error) {
+func getValidServerConfig(serverConfigs []serverConfigV13, errs []error) (scv serverConfigV13, e error) {
 	// majority-based quorum
 	quorum := len(serverConfigs)/2 + 1
 
@@ -566,7 +566,7 @@ func getValidServerConfig(serverConfigs []serverConfigV13, errs []error) (server
 
 	// If quorum nodes don't agree.
 	if maxOccurrence < quorum {
-		return serverConfigV13{}, errXLWriteQuorum
+		return scv, errXLWriteQuorum
 	}
 
 	return configJSON, nil

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -77,14 +77,14 @@ func (endpoint Endpoint) SetHTTP() {
 }
 
 // NewEndpoint - returns new endpoint based on given arguments.
-func NewEndpoint(arg string) (Endpoint, error) {
+func NewEndpoint(arg string) (ep Endpoint, e error) {
 	// isEmptyPath - check whether given path is not empty.
 	isEmptyPath := func(path string) bool {
 		return path == "" || path == "/" || path == `\`
 	}
 
 	if isEmptyPath(arg) {
-		return Endpoint{}, fmt.Errorf("empty or root endpoint is not supported")
+		return ep, fmt.Errorf("empty or root endpoint is not supported")
 	}
 
 	var isLocal bool
@@ -96,13 +96,13 @@ func NewEndpoint(arg string) (Endpoint, error) {
 		// - All field should be empty except Host and Path.
 		if !((u.Scheme == "http" || u.Scheme == "https") &&
 			u.User == nil && u.Opaque == "" && u.ForceQuery == false && u.RawQuery == "" && u.Fragment == "") {
-			return Endpoint{}, fmt.Errorf("invalid URL endpoint format")
+			return ep, fmt.Errorf("invalid URL endpoint format")
 		}
 
 		host, port, err := net.SplitHostPort(u.Host)
 		if err != nil {
 			if !strings.Contains(err.Error(), "missing port in address") {
-				return Endpoint{}, fmt.Errorf("invalid URL endpoint format: %s", err)
+				return ep, fmt.Errorf("invalid URL endpoint format: %s", err)
 			}
 
 			host = u.Host
@@ -110,26 +110,26 @@ func NewEndpoint(arg string) (Endpoint, error) {
 			var p int
 			p, err = strconv.Atoi(port)
 			if err != nil {
-				return Endpoint{}, fmt.Errorf("invalid URL endpoint format: invalid port number")
+				return ep, fmt.Errorf("invalid URL endpoint format: invalid port number")
 			} else if p < 1 || p > 65535 {
-				return Endpoint{}, fmt.Errorf("invalid URL endpoint format: port number must be between 1 to 65535")
+				return ep, fmt.Errorf("invalid URL endpoint format: port number must be between 1 to 65535")
 			}
 		}
 
 		if host == "" {
-			return Endpoint{}, fmt.Errorf("invalid URL endpoint format: empty host name")
+			return ep, fmt.Errorf("invalid URL endpoint format: empty host name")
 		}
 
 		// As this is path in the URL, we should use path package, not filepath package.
 		// On MS Windows, filepath.Clean() converts into Windows path style ie `/foo` becomes `\foo`
 		u.Path = path.Clean(u.Path)
 		if isEmptyPath(u.Path) {
-			return Endpoint{}, fmt.Errorf("empty or root path is not supported in URL endpoint")
+			return ep, fmt.Errorf("empty or root path is not supported in URL endpoint")
 		}
 
 		isLocal, err = isLocalHost(host)
 		if err != nil {
-			return Endpoint{}, err
+			return ep, err
 		}
 	} else {
 		u = &url.URL{Path: path.Clean(arg)}

--- a/cmd/gateway-azure-unsupported.go
+++ b/cmd/gateway-azure-unsupported.go
@@ -32,12 +32,12 @@ func (a *azureObjects) HealObject(bucket, object string) (int, int, error) {
 }
 
 // ListObjectsHeal - Not relevant.
-func (a *azureObjects) ListObjectsHeal(bucket, prefix, marker, delimiter string, maxKeys int) (ListObjectsInfo, error) {
-	return ListObjectsInfo{}, traceError(NotImplemented{})
+func (a *azureObjects) ListObjectsHeal(bucket, prefix, marker, delimiter string, maxKeys int) (loi ListObjectsInfo, e error) {
+	return loi, traceError(NotImplemented{})
 }
 
 // ListUploadsHeal - Not relevant.
 func (a *azureObjects) ListUploadsHeal(bucket, prefix, marker, uploadIDMarker,
-	delimiter string, maxUploads int) (ListMultipartsInfo, error) {
-	return ListMultipartsInfo{}, traceError(NotImplemented{})
+	delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
+	return lmi, traceError(NotImplemented{})
 }

--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -179,8 +179,8 @@ func (a *azureObjects) Shutdown() error {
 }
 
 // StorageInfo - Not relevant to Azure backend.
-func (a *azureObjects) StorageInfo() StorageInfo {
-	return StorageInfo{}
+func (a *azureObjects) StorageInfo() (si StorageInfo) {
+	return si
 }
 
 // MakeBucketWithLocation - Create a new container on azure backend.
@@ -190,13 +190,13 @@ func (a *azureObjects) MakeBucketWithLocation(bucket, location string) error {
 }
 
 // GetBucketInfo - Get bucket metadata..
-func (a *azureObjects) GetBucketInfo(bucket string) (BucketInfo, error) {
+func (a *azureObjects) GetBucketInfo(bucket string) (bi BucketInfo, e error) {
 	// Azure does not have an equivalent call, hence use ListContainers.
 	resp, err := a.client.ListContainers(storage.ListContainersParameters{
 		Prefix: bucket,
 	})
 	if err != nil {
-		return BucketInfo{}, azureToObjectError(traceError(err), bucket)
+		return bi, azureToObjectError(traceError(err), bucket)
 	}
 	for _, container := range resp.Containers {
 		if container.Name == bucket {
@@ -209,7 +209,7 @@ func (a *azureObjects) GetBucketInfo(bucket string) (BucketInfo, error) {
 			} // else continue
 		}
 	}
-	return BucketInfo{}, traceError(BucketNotFound{Bucket: bucket})
+	return bi, traceError(BucketNotFound{Bucket: bucket})
 }
 
 // ListBuckets - Lists all azure containers, uses Azure equivalent ListContainers.

--- a/cmd/gateway-s3-unsupported.go
+++ b/cmd/gateway-s3-unsupported.go
@@ -32,11 +32,11 @@ func (l *s3Objects) HealObject(bucket string, object string) (int, int, error) {
 }
 
 // ListObjectsHeal - Not relevant.
-func (l *s3Objects) ListObjectsHeal(bucket string, prefix string, marker string, delimiter string, maxKeys int) (ListObjectsInfo, error) {
-	return ListObjectsInfo{}, traceError(NotImplemented{})
+func (l *s3Objects) ListObjectsHeal(bucket string, prefix string, marker string, delimiter string, maxKeys int) (loi ListObjectsInfo, e error) {
+	return loi, traceError(NotImplemented{})
 }
 
 // ListUploadsHeal - Not relevant.
-func (l *s3Objects) ListUploadsHeal(bucket string, prefix string, marker string, uploadIDMarker string, delimiter string, maxUploads int) (ListMultipartsInfo, error) {
-	return ListMultipartsInfo{}, traceError(NotImplemented{})
+func (l *s3Objects) ListUploadsHeal(bucket string, prefix string, marker string, uploadIDMarker string, delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
+	return lmi, traceError(NotImplemented{})
 }

--- a/cmd/gateway-s3.go
+++ b/cmd/gateway-s3.go
@@ -128,8 +128,8 @@ func (l *s3Objects) Shutdown() error {
 }
 
 // StorageInfo is not relevant to S3 backend.
-func (l *s3Objects) StorageInfo() StorageInfo {
-	return StorageInfo{}
+func (l *s3Objects) StorageInfo() (si StorageInfo) {
+	return si
 }
 
 // MakeBucket creates a new container on S3 backend.
@@ -142,10 +142,10 @@ func (l *s3Objects) MakeBucketWithLocation(bucket, location string) error {
 }
 
 // GetBucketInfo gets bucket metadata..
-func (l *s3Objects) GetBucketInfo(bucket string) (BucketInfo, error) {
+func (l *s3Objects) GetBucketInfo(bucket string) (bi BucketInfo, e error) {
 	buckets, err := l.Client.ListBuckets()
 	if err != nil {
-		return BucketInfo{}, s3ToObjectError(traceError(err), bucket)
+		return bi, s3ToObjectError(traceError(err), bucket)
 	}
 
 	for _, bi := range buckets {
@@ -159,7 +159,7 @@ func (l *s3Objects) GetBucketInfo(bucket string) (BucketInfo, error) {
 		}, nil
 	}
 
-	return BucketInfo{}, traceError(BucketNotFound{Bucket: bucket})
+	return bi, traceError(BucketNotFound{Bucket: bucket})
 }
 
 // ListBuckets lists all S3 buckets
@@ -190,20 +190,20 @@ func (l *s3Objects) DeleteBucket(bucket string) error {
 }
 
 // ListObjects lists all blobs in S3 bucket filtered by prefix
-func (l *s3Objects) ListObjects(bucket string, prefix string, marker string, delimiter string, maxKeys int) (ListObjectsInfo, error) {
+func (l *s3Objects) ListObjects(bucket string, prefix string, marker string, delimiter string, maxKeys int) (loi ListObjectsInfo, e error) {
 	result, err := l.Client.ListObjects(bucket, prefix, marker, delimiter, maxKeys)
 	if err != nil {
-		return ListObjectsInfo{}, s3ToObjectError(traceError(err), bucket)
+		return loi, s3ToObjectError(traceError(err), bucket)
 	}
 
 	return fromMinioClientListBucketResult(bucket, result), nil
 }
 
 // ListObjectsV2 lists all blobs in S3 bucket filtered by prefix
-func (l *s3Objects) ListObjectsV2(bucket, prefix, continuationToken string, fetchOwner bool, delimiter string, maxKeys int) (ListObjectsV2Info, error) {
+func (l *s3Objects) ListObjectsV2(bucket, prefix, continuationToken string, fetchOwner bool, delimiter string, maxKeys int) (loi ListObjectsV2Info, e error) {
 	result, err := l.Client.ListObjectsV2(bucket, prefix, continuationToken, fetchOwner, delimiter, maxKeys)
 	if err != nil {
-		return ListObjectsV2Info{}, s3ToObjectError(traceError(err), bucket)
+		return loi, s3ToObjectError(traceError(err), bucket)
 	}
 
 	return fromMinioClientListBucketV2Result(bucket, result), nil
@@ -313,14 +313,14 @@ func (l *s3Objects) GetObjectInfo(bucket string, object string) (objInfo ObjectI
 }
 
 // PutObject creates a new object with the incoming data,
-func (l *s3Objects) PutObject(bucket string, object string, size int64, data io.Reader, metadata map[string]string, sha256sum string) (ObjectInfo, error) {
+func (l *s3Objects) PutObject(bucket string, object string, size int64, data io.Reader, metadata map[string]string, sha256sum string) (objInfo ObjectInfo, e error) {
 	var sha256sumBytes []byte
 
 	var err error
 	if sha256sum != "" {
 		sha256sumBytes, err = hex.DecodeString(sha256sum)
 		if err != nil {
-			return ObjectInfo{}, s3ToObjectError(traceError(err), bucket, object)
+			return objInfo, s3ToObjectError(traceError(err), bucket, object)
 		}
 	}
 
@@ -329,29 +329,29 @@ func (l *s3Objects) PutObject(bucket string, object string, size int64, data io.
 	if md5sum != "" {
 		md5sumBytes, err = hex.DecodeString(md5sum)
 		if err != nil {
-			return ObjectInfo{}, s3ToObjectError(traceError(err), bucket, object)
+			return objInfo, s3ToObjectError(traceError(err), bucket, object)
 		}
 		delete(metadata, "etag")
 	}
 
 	oi, err := l.Client.PutObject(bucket, object, size, data, md5sumBytes, sha256sumBytes, toMinioClientMetadata(metadata))
 	if err != nil {
-		return ObjectInfo{}, s3ToObjectError(traceError(err), bucket, object)
+		return objInfo, s3ToObjectError(traceError(err), bucket, object)
 	}
 
 	return fromMinioClientObjectInfo(bucket, oi), nil
 }
 
 // CopyObject copies a blob from source container to destination container.
-func (l *s3Objects) CopyObject(srcBucket string, srcObject string, destBucket string, destObject string, metadata map[string]string) (ObjectInfo, error) {
+func (l *s3Objects) CopyObject(srcBucket string, srcObject string, destBucket string, destObject string, metadata map[string]string) (objInfo ObjectInfo, e error) {
 	err := l.Client.CopyObject(destBucket, destObject, path.Join(srcBucket, srcObject), minio.CopyConditions{})
 	if err != nil {
-		return ObjectInfo{}, s3ToObjectError(traceError(err), srcBucket, srcObject)
+		return objInfo, s3ToObjectError(traceError(err), srcBucket, srcObject)
 	}
 
 	oi, err := l.GetObjectInfo(destBucket, destObject)
 	if err != nil {
-		return ObjectInfo{}, s3ToObjectError(traceError(err), destBucket, destObject)
+		return objInfo, s3ToObjectError(traceError(err), destBucket, destObject)
 	}
 
 	return oi, nil
@@ -406,10 +406,10 @@ func fromMinioClientListMultipartsInfo(lmur minio.ListMultipartUploadsResult) Li
 }
 
 // ListMultipartUploads lists all multipart uploads.
-func (l *s3Objects) ListMultipartUploads(bucket string, prefix string, keyMarker string, uploadIDMarker string, delimiter string, maxUploads int) (ListMultipartsInfo, error) {
+func (l *s3Objects) ListMultipartUploads(bucket string, prefix string, keyMarker string, uploadIDMarker string, delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
 	result, err := l.Client.ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
 	if err != nil {
-		return ListMultipartsInfo{}, err
+		return lmi, err
 	}
 
 	return fromMinioClientListMultipartsInfo(result), nil
@@ -455,20 +455,20 @@ func fromMinioClientObjectPart(op minio.ObjectPart) PartInfo {
 }
 
 // PutObjectPart puts a part of object in bucket
-func (l *s3Objects) PutObjectPart(bucket string, object string, uploadID string, partID int, size int64, data io.Reader, md5Hex string, sha256sum string) (PartInfo, error) {
+func (l *s3Objects) PutObjectPart(bucket string, object string, uploadID string, partID int, size int64, data io.Reader, md5Hex string, sha256sum string) (pi PartInfo, e error) {
 	md5HexBytes, err := hex.DecodeString(md5Hex)
 	if err != nil {
-		return PartInfo{}, err
+		return pi, err
 	}
 
 	sha256sumBytes, err := hex.DecodeString(sha256sum)
 	if err != nil {
-		return PartInfo{}, err
+		return pi, err
 	}
 
 	info, err := l.Client.PutObjectPart(bucket, object, uploadID, partID, size, data, md5HexBytes, sha256sumBytes)
 	if err != nil {
-		return PartInfo{}, err
+		return pi, err
 	}
 
 	return fromMinioClientObjectPart(info), nil
@@ -500,10 +500,10 @@ func fromMinioClientListPartsInfo(lopr minio.ListObjectPartsResult) ListPartsInf
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket
-func (l *s3Objects) ListObjectParts(bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (ListPartsInfo, error) {
+func (l *s3Objects) ListObjectParts(bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi ListPartsInfo, e error) {
 	result, err := l.Client.ListObjectParts(bucket, object, uploadID, partNumberMarker, maxParts)
 	if err != nil {
-		return ListPartsInfo{}, err
+		return lpi, err
 	}
 
 	return fromMinioClientListPartsInfo(result), nil
@@ -532,10 +532,10 @@ func toMinioClientCompleteParts(parts []completePart) []minio.CompletePart {
 }
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object
-func (l *s3Objects) CompleteMultipartUpload(bucket string, object string, uploadID string, uploadedParts []completePart) (ObjectInfo, error) {
+func (l *s3Objects) CompleteMultipartUpload(bucket string, object string, uploadID string, uploadedParts []completePart) (oi ObjectInfo, e error) {
 	err := l.Client.CompleteMultipartUpload(bucket, object, uploadID, toMinioClientCompleteParts(uploadedParts))
 	if err != nil {
-		return ObjectInfo{}, s3ToObjectError(traceError(err), bucket, object)
+		return oi, s3ToObjectError(traceError(err), bucket, object)
 	}
 
 	return l.GetObjectInfo(bucket, object)

--- a/cmd/notify-amqp.go
+++ b/cmd/notify-amqp.go
@@ -59,13 +59,13 @@ type amqpConn struct {
 // dialAMQP - dials and returns an amqpConnection instance,
 // for sending notifications. Returns error if amqp logger
 // is not enabled.
-func dialAMQP(amqpL amqpNotify) (amqpConn, error) {
+func dialAMQP(amqpL amqpNotify) (ac amqpConn, e error) {
 	if !amqpL.Enable {
-		return amqpConn{}, errNotifyNotEnabled
+		return ac, errNotifyNotEnabled
 	}
 	conn, err := amqp.Dial(amqpL.URL)
 	if err != nil {
-		return amqpConn{}, err
+		return ac, err
 	}
 	return amqpConn{Connection: conn, params: amqpL}, nil
 }

--- a/cmd/notify-kafka.go
+++ b/cmd/notify-kafka.go
@@ -66,13 +66,13 @@ type kafkaConn struct {
 	topic    string
 }
 
-func dialKafka(kn kafkaNotify) (kafkaConn, error) {
+func dialKafka(kn kafkaNotify) (kc kafkaConn, e error) {
 	if !kn.Enable {
-		return kafkaConn{}, errNotifyNotEnabled
+		return kc, errNotifyNotEnabled
 	}
 
 	if kn.Topic == "" {
-		return kafkaConn{}, kkErrFunc(
+		return kc, kkErrFunc(
 			"Topic was not specified in configuration")
 	}
 
@@ -85,7 +85,7 @@ func dialKafka(kn kafkaNotify) (kafkaConn, error) {
 
 	p, err := sarama.NewSyncProducer(kn.Brokers, config)
 	if err != nil {
-		return kafkaConn{}, kkErrFunc("Failed to start producer: %v", err)
+		return kc, kkErrFunc("Failed to start producer: %v", err)
 	}
 
 	return kafkaConn{p, kn.Topic}, nil

--- a/cmd/notify-mqtt.go
+++ b/cmd/notify-mqtt.go
@@ -50,9 +50,9 @@ type mqttConn struct {
 	Client MQTT.Client
 }
 
-func dialMQTT(mqttL mqttNotify) (mqttConn, error) {
+func dialMQTT(mqttL mqttNotify) (mc mqttConn, e error) {
 	if !mqttL.Enable {
-		return mqttConn{}, errNotifyNotEnabled
+		return mc, errNotifyNotEnabled
 	}
 	connOpts := &MQTT.ClientOptions{
 		ClientID:             mqttL.ClientID,
@@ -66,7 +66,7 @@ func dialMQTT(mqttL mqttNotify) (mqttConn, error) {
 	connOpts.AddBroker(mqttL.Broker)
 	client := MQTT.NewClient(connOpts)
 	if token := client.Connect(); token.Wait() && token.Error() != nil {
-		return mqttConn{}, token.Error()
+		return mc, token.Error()
 	}
 	return mqttConn{Client: client, params: mqttL}, nil
 }

--- a/cmd/notify-nats.go
+++ b/cmd/notify-nats.go
@@ -69,9 +69,9 @@ type natsIOConn struct {
 // dialNATS - dials and returns an natsIOConn instance,
 // for sending notifications. Returns error if nats logger
 // is not enabled.
-func dialNATS(natsL natsNotify, testDial bool) (natsIOConn, error) {
+func dialNATS(natsL natsNotify, testDial bool) (nioc natsIOConn, e error) {
 	if !natsL.Enable {
-		return natsIOConn{}, errNotifyNotEnabled
+		return nioc, errNotifyNotEnabled
 	}
 
 	// Construct natsIOConn which holds all NATS connection information
@@ -105,7 +105,7 @@ func dialNATS(natsL natsNotify, testDial bool) (natsIOConn, error) {
 		// Do the real connection to the NATS server
 		sc, err := stan.Connect(natsL.Streaming.ClusterID, clientID, connOpts...)
 		if err != nil {
-			return natsIOConn{}, err
+			return nioc, err
 		}
 		// Save the created connection
 		conn.stanConn = sc
@@ -120,7 +120,7 @@ func dialNATS(natsL natsNotify, testDial bool) (natsIOConn, error) {
 		// Do the real connection
 		nc, err := natsC.Connect()
 		if err != nil {
-			return natsIOConn{}, err
+			return nioc, err
 		}
 		// Save the created connection
 		conn.natsConn = nc

--- a/cmd/postpolicyform.go
+++ b/cmd/postpolicyform.go
@@ -112,7 +112,7 @@ type PostPolicyForm struct {
 }
 
 // parsePostPolicyForm - Parse JSON policy string into typed POostPolicyForm structure.
-func parsePostPolicyForm(policy string) (PostPolicyForm, error) {
+func parsePostPolicyForm(policy string) (ppf PostPolicyForm, e error) {
 	// Convert po into interfaces and
 	// perform strict type conversion using reflection.
 	var rawPolicy struct {
@@ -122,7 +122,7 @@ func parsePostPolicyForm(policy string) (PostPolicyForm, error) {
 
 	err := json.Unmarshal([]byte(policy), &rawPolicy)
 	if err != nil {
-		return PostPolicyForm{}, err
+		return ppf, err
 	}
 
 	parsedPolicy := PostPolicyForm{}
@@ -130,7 +130,7 @@ func parsePostPolicyForm(policy string) (PostPolicyForm, error) {
 	// Parse expiry time.
 	parsedPolicy.Expiration, err = time.Parse(time.RFC3339Nano, rawPolicy.Expiration)
 	if err != nil {
-		return PostPolicyForm{}, err
+		return ppf, err
 	}
 	parsedPolicy.Conditions.Policies = make(map[string]struct {
 		Operator string

--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -45,20 +45,20 @@ func (c credentialHeader) getScope() string {
 }
 
 // parse credentialHeader string into its structured form.
-func parseCredentialHeader(credElement string) (credentialHeader, APIErrorCode) {
+func parseCredentialHeader(credElement string) (ch credentialHeader, aec APIErrorCode) {
 	creds := strings.Split(strings.TrimSpace(credElement), "=")
 	if len(creds) != 2 {
-		return credentialHeader{}, ErrMissingFields
+		return ch, ErrMissingFields
 	}
 	if creds[0] != "Credential" {
-		return credentialHeader{}, ErrMissingCredTag
+		return ch, ErrMissingCredTag
 	}
 	credElements := strings.Split(strings.TrimSpace(creds[1]), "/")
 	if len(credElements) != 5 {
-		return credentialHeader{}, ErrCredMalformed
+		return ch, ErrCredMalformed
 	}
 	if !isAccessKeyValid(credElements[0]) {
-		return credentialHeader{}, ErrInvalidAccessKeyID
+		return ch, ErrInvalidAccessKeyID
 	}
 	// Save access key id.
 	cred := credentialHeader{
@@ -67,15 +67,15 @@ func parseCredentialHeader(credElement string) (credentialHeader, APIErrorCode) 
 	var e error
 	cred.scope.date, e = time.Parse(yyyymmdd, credElements[1])
 	if e != nil {
-		return credentialHeader{}, ErrMalformedCredentialDate
+		return ch, ErrMalformedCredentialDate
 	}
 	cred.scope.region = credElements[2]
 	if credElements[3] != "s3" {
-		return credentialHeader{}, ErrInvalidService
+		return ch, ErrInvalidService
 	}
 	cred.scope.service = credElements[3]
 	if credElements[4] != "aws4_request" {
-		return credentialHeader{}, ErrInvalidRequestVersion
+		return ch, ErrInvalidRequestVersion
 	}
 	cred.scope.request = credElements[4]
 	return cred, ErrNone
@@ -148,17 +148,17 @@ func doesV4PresignParamsExist(query url.Values) APIErrorCode {
 }
 
 // Parses all the presigned signature values into separate elements.
-func parsePreSignV4(query url.Values) (preSignValues, APIErrorCode) {
+func parsePreSignV4(query url.Values) (psv preSignValues, aec APIErrorCode) {
 	var err APIErrorCode
 	// verify whether the required query params exist.
 	err = doesV4PresignParamsExist(query)
 	if err != ErrNone {
-		return preSignValues{}, err
+		return psv, err
 	}
 
 	// Verify if the query algorithm is supported or not.
 	if query.Get("X-Amz-Algorithm") != signV4Algorithm {
-		return preSignValues{}, ErrInvalidQuerySignatureAlgo
+		return psv, ErrInvalidQuerySignatureAlgo
 	}
 
 	// Initialize signature version '4' structured header.
@@ -167,35 +167,35 @@ func parsePreSignV4(query url.Values) (preSignValues, APIErrorCode) {
 	// Save credential.
 	preSignV4Values.Credential, err = parseCredentialHeader("Credential=" + query.Get("X-Amz-Credential"))
 	if err != ErrNone {
-		return preSignValues{}, err
+		return psv, err
 	}
 
 	var e error
 	// Save date in native time.Time.
 	preSignV4Values.Date, e = time.Parse(iso8601Format, query.Get("X-Amz-Date"))
 	if e != nil {
-		return preSignValues{}, ErrMalformedPresignedDate
+		return psv, ErrMalformedPresignedDate
 	}
 
 	// Save expires in native time.Duration.
 	preSignV4Values.Expires, e = time.ParseDuration(query.Get("X-Amz-Expires") + "s")
 	if e != nil {
-		return preSignValues{}, ErrMalformedExpires
+		return psv, ErrMalformedExpires
 	}
 
 	if preSignV4Values.Expires < 0 {
-		return preSignValues{}, ErrNegativeExpires
+		return psv, ErrNegativeExpires
 	}
 	// Save signed headers.
 	preSignV4Values.SignedHeaders, err = parseSignedHeader("SignedHeaders=" + query.Get("X-Amz-SignedHeaders"))
 	if err != ErrNone {
-		return preSignValues{}, err
+		return psv, err
 	}
 
 	// Save signature.
 	preSignV4Values.Signature, err = parseSignature("Signature=" + query.Get("X-Amz-Signature"))
 	if err != ErrNone {
-		return preSignValues{}, err
+		return psv, err
 	}
 
 	// Return structed form of signature query string.
@@ -207,25 +207,25 @@ func parsePreSignV4(query url.Values) (preSignValues, APIErrorCode) {
 //    Authorization: algorithm Credential=accessKeyID/credScope, \
 //            SignedHeaders=signedHeaders, Signature=signature
 //
-func parseSignV4(v4Auth string) (signValues, APIErrorCode) {
+func parseSignV4(v4Auth string) (sv signValues, aec APIErrorCode) {
 	// Replace all spaced strings, some clients can send spaced
 	// parameters and some won't. So we pro-actively remove any spaces
 	// to make parsing easier.
 	v4Auth = strings.Replace(v4Auth, " ", "", -1)
 	if v4Auth == "" {
-		return signValues{}, ErrAuthHeaderEmpty
+		return sv, ErrAuthHeaderEmpty
 	}
 
 	// Verify if the header algorithm is supported or not.
 	if !strings.HasPrefix(v4Auth, signV4Algorithm) {
-		return signValues{}, ErrSignatureVersionNotSupported
+		return sv, ErrSignatureVersionNotSupported
 	}
 
 	// Strip off the Algorithm prefix.
 	v4Auth = strings.TrimPrefix(v4Auth, signV4Algorithm)
 	authFields := strings.Split(strings.TrimSpace(v4Auth), ",")
 	if len(authFields) != 3 {
-		return signValues{}, ErrMissingFields
+		return sv, ErrMissingFields
 	}
 
 	// Initialize signature version '4' structured header.
@@ -235,19 +235,19 @@ func parseSignV4(v4Auth string) (signValues, APIErrorCode) {
 	// Save credentail values.
 	signV4Values.Credential, err = parseCredentialHeader(authFields[0])
 	if err != ErrNone {
-		return signValues{}, err
+		return sv, err
 	}
 
 	// Save signed headers.
 	signV4Values.SignedHeaders, err = parseSignedHeader(authFields[1])
 	if err != ErrNone {
-		return signValues{}, err
+		return sv, err
 	}
 
 	// Save signature.
 	signV4Values.Signature, err = parseSignature(authFields[2])
 	if err != ErrNone {
-		return signValues{}, err
+		return sv, err
 	}
 
 	// Return the structure here.

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -144,15 +144,15 @@ func (xl xlObjects) getBucketInfo(bucketName string) (bucketInfo BucketInfo, err
 }
 
 // GetBucketInfo - returns BucketInfo for a bucket.
-func (xl xlObjects) GetBucketInfo(bucket string) (BucketInfo, error) {
+func (xl xlObjects) GetBucketInfo(bucket string) (bi BucketInfo, e error) {
 	// Verify if bucket is valid.
 	if !IsValidBucketName(bucket) {
-		return BucketInfo{}, BucketNameInvalid{Bucket: bucket}
+		return bi, BucketNameInvalid{Bucket: bucket}
 	}
 
 	bucketInfo, err := xl.getBucketInfo(bucket)
 	if err != nil {
-		return BucketInfo{}, toObjectErr(err, bucket)
+		return bi, toObjectErr(err, bucket)
 	}
 	return bucketInfo, nil
 }

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -282,14 +282,14 @@ func (m xlMetaV1) ObjectToPartOffset(offset int64) (partIndex int, partOffset in
 // pickValidXLMeta - picks one valid xlMeta content and returns from a
 // slice of xlmeta content. If no value is found this function panics
 // and dies.
-func pickValidXLMeta(metaArr []xlMetaV1, modTime time.Time) (xlMetaV1, error) {
+func pickValidXLMeta(metaArr []xlMetaV1, modTime time.Time) (xmv xlMetaV1, e error) {
 	// Pick latest valid metadata.
 	for _, meta := range metaArr {
 		if meta.IsValid() && meta.Stat.ModTime.Equal(modTime) {
 			return meta, nil
 		}
 	}
-	return xlMetaV1{}, traceError(errors.New("No valid xl.json present"))
+	return xmv, traceError(errors.New("No valid xl.json present"))
 }
 
 // list of all errors that can be ignored in a metadata operation.

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -274,7 +274,7 @@ func commitXLMetadata(disks []StorageAPI, srcBucket, srcPrefix, dstBucket, dstPr
 }
 
 // listMultipartUploads - lists all multipart uploads.
-func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (ListMultipartsInfo, error) {
+func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
 	result := ListMultipartsInfo{
 		IsTruncated: true,
 		MaxUploads:  maxUploads,
@@ -324,7 +324,7 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 		}
 		keyMarkerLock.RUnlock()
 		if err != nil {
-			return ListMultipartsInfo{}, err
+			return lmi, err
 		}
 		maxUploads = maxUploads - len(uploads)
 	}
@@ -350,7 +350,7 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 			}
 			// For any walk error return right away.
 			if walkResult.err != nil {
-				return ListMultipartsInfo{}, walkResult.err
+				return lmi, walkResult.err
 			}
 			entry := strings.TrimPrefix(walkResult.entry, retainSlash(bucket))
 			// For an entry looking like a directory, store and
@@ -394,7 +394,7 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 				if isErrIgnored(err, xlTreeWalkIgnoredErrs...) {
 					continue
 				}
-				return ListMultipartsInfo{}, err
+				return lmi, err
 			}
 			uploads = append(uploads, newUploads...)
 			maxUploads -= len(newUploads)
@@ -446,9 +446,9 @@ func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMark
 // Implements S3 compatible ListMultipartUploads API. The resulting
 // ListMultipartsInfo structure is unmarshalled directly into XML and
 // replied back to the client.
-func (xl xlObjects) ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (ListMultipartsInfo, error) {
+func (xl xlObjects) ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
 	if err := checkListMultipartArgs(bucket, prefix, keyMarker, uploadIDMarker, delimiter, xl); err != nil {
-		return ListMultipartsInfo{}, err
+		return lmi, err
 	}
 
 	return xl.listMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
@@ -534,9 +534,9 @@ func (xl xlObjects) NewMultipartUpload(bucket, object string, meta map[string]st
 // data is read from an existing object.
 //
 // Implements S3 compatible Upload Part Copy API.
-func (xl xlObjects) CopyObjectPart(srcBucket, srcObject, dstBucket, dstObject, uploadID string, partID int, startOffset int64, length int64) (PartInfo, error) {
+func (xl xlObjects) CopyObjectPart(srcBucket, srcObject, dstBucket, dstObject, uploadID string, partID int, startOffset int64, length int64) (pi PartInfo, e error) {
 	if err := checkNewMultipartArgs(srcBucket, srcObject, xl); err != nil {
-		return PartInfo{}, err
+		return pi, err
 	}
 
 	// Initialize pipe.
@@ -553,7 +553,7 @@ func (xl xlObjects) CopyObjectPart(srcBucket, srcObject, dstBucket, dstObject, u
 
 	partInfo, err := xl.PutObjectPart(dstBucket, dstObject, uploadID, partID, length, pipeReader, "", "")
 	if err != nil {
-		return PartInfo{}, toObjectErr(err, dstBucket, dstObject)
+		return pi, toObjectErr(err, dstBucket, dstObject)
 	}
 
 	// Explicitly close the reader.
@@ -568,9 +568,9 @@ func (xl xlObjects) CopyObjectPart(srcBucket, srcObject, dstBucket, dstObject, u
 // of the multipart transaction.
 //
 // Implements S3 compatible Upload Part API.
-func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Hex string, sha256sum string) (PartInfo, error) {
+func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Hex string, sha256sum string) (pi PartInfo, e error) {
 	if err := checkPutObjectPartArgs(bucket, object, xl); err != nil {
-		return PartInfo{}, err
+		return pi, err
 	}
 
 	var partsMetadata []xlMetaV1
@@ -583,7 +583,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	// Validates if upload ID exists.
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
 		preUploadIDLock.RUnlock()
-		return PartInfo{}, traceError(InvalidUploadID{UploadID: uploadID})
+		return pi, traceError(InvalidUploadID{UploadID: uploadID})
 	}
 
 	// Read metadata associated with the object from all disks.
@@ -592,7 +592,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	reducedErr := reduceWriteQuorumErrs(errs, objectOpIgnoredErrs, xl.writeQuorum)
 	if errorCause(reducedErr) == errXLWriteQuorum {
 		preUploadIDLock.RUnlock()
-		return PartInfo{}, toObjectErr(reducedErr, bucket, object)
+		return pi, toObjectErr(reducedErr, bucket, object)
 	}
 	preUploadIDLock.RUnlock()
 
@@ -602,7 +602,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	// Pick one from the first valid metadata.
 	xlMeta, err := pickValidXLMeta(partsMetadata, modTime)
 	if err != nil {
-		return PartInfo{}, err
+		return pi, err
 	}
 
 	onlineDisks = shuffleDisks(onlineDisks, xlMeta.Erasure.Distribution)
@@ -646,7 +646,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 
 	if size > 0 {
 		if pErr := xl.prepareFile(minioMetaTmpBucket, tmpPartPath, size, onlineDisks, xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks); err != nil {
-			return PartInfo{}, toObjectErr(pErr, bucket, object)
+			return pi, toObjectErr(pErr, bucket, object)
 
 		}
 	}
@@ -657,13 +657,13 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	// Erasure code data and write across all disks.
 	onlineDisks, sizeWritten, checkSums, err := erasureCreateFile(onlineDisks, minioMetaTmpBucket, tmpPartPath, teeReader, allowEmpty, xlMeta.Erasure.BlockSize, xl.dataBlocks, xl.parityBlocks, bitRotAlgo, xl.writeQuorum)
 	if err != nil {
-		return PartInfo{}, toObjectErr(err, bucket, object)
+		return pi, toObjectErr(err, bucket, object)
 	}
 
 	// Should return IncompleteBody{} error when reader has fewer bytes
 	// than specified in request header.
 	if sizeWritten < size {
-		return PartInfo{}, traceError(IncompleteBody{})
+		return pi, traceError(IncompleteBody{})
 	}
 
 	// For size == -1, perhaps client is sending in chunked encoding
@@ -677,14 +677,14 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	if md5Hex != "" {
 		if newMD5Hex != md5Hex {
 			// Returns md5 mismatch.
-			return PartInfo{}, traceError(BadDigest{md5Hex, newMD5Hex})
+			return pi, traceError(BadDigest{md5Hex, newMD5Hex})
 		}
 	}
 
 	if sha256sum != "" {
 		newSHA256sum := hex.EncodeToString(sha256Writer.Sum(nil))
 		if newSHA256sum != sha256sum {
-			return PartInfo{}, traceError(SHA256Mismatch{})
+			return pi, traceError(SHA256Mismatch{})
 		}
 	}
 
@@ -695,21 +695,21 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 
 	// Validate again if upload ID still exists.
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
-		return PartInfo{}, traceError(InvalidUploadID{UploadID: uploadID})
+		return pi, traceError(InvalidUploadID{UploadID: uploadID})
 	}
 
 	// Rename temporary part file to its final location.
 	partPath := path.Join(uploadIDPath, partSuffix)
 	onlineDisks, err = renamePart(onlineDisks, minioMetaTmpBucket, tmpPartPath, minioMetaMultipartBucket, partPath, xl.writeQuorum)
 	if err != nil {
-		return PartInfo{}, toObjectErr(err, minioMetaMultipartBucket, partPath)
+		return pi, toObjectErr(err, minioMetaMultipartBucket, partPath)
 	}
 
 	// Read metadata again because it might be updated with parallel upload of another part.
 	partsMetadata, errs = readAllXLMetadata(onlineDisks, minioMetaMultipartBucket, uploadIDPath)
 	reducedErr = reduceWriteQuorumErrs(errs, objectOpIgnoredErrs, xl.writeQuorum)
 	if errorCause(reducedErr) == errXLWriteQuorum {
-		return PartInfo{}, toObjectErr(reducedErr, bucket, object)
+		return pi, toObjectErr(reducedErr, bucket, object)
 	}
 
 	// Get current highest version based on re-read partsMetadata.
@@ -718,7 +718,7 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	// Pick one from the first valid metadata.
 	xlMeta, err = pickValidXLMeta(partsMetadata, modTime)
 	if err != nil {
-		return PartInfo{}, err
+		return pi, err
 	}
 
 	// Once part is successfully committed, proceed with updating XL metadata.
@@ -745,17 +745,17 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 
 	// Writes a unique `xl.json` each disk carrying new checksum related information.
 	if onlineDisks, err = writeUniqueXLMetadata(onlineDisks, minioMetaTmpBucket, tempXLMetaPath, partsMetadata, xl.writeQuorum); err != nil {
-		return PartInfo{}, toObjectErr(err, minioMetaTmpBucket, tempXLMetaPath)
+		return pi, toObjectErr(err, minioMetaTmpBucket, tempXLMetaPath)
 	}
 	var rErr error
 	onlineDisks, rErr = commitXLMetadata(onlineDisks, minioMetaTmpBucket, tempXLMetaPath, minioMetaMultipartBucket, uploadIDPath, xl.writeQuorum)
 	if rErr != nil {
-		return PartInfo{}, toObjectErr(rErr, minioMetaMultipartBucket, uploadIDPath)
+		return pi, toObjectErr(rErr, minioMetaMultipartBucket, uploadIDPath)
 	}
 
 	fi, err := xl.statPart(bucket, object, uploadID, partSuffix)
 	if err != nil {
-		return PartInfo{}, toObjectErr(rErr, minioMetaMultipartBucket, partSuffix)
+		return pi, toObjectErr(rErr, minioMetaMultipartBucket, partSuffix)
 	}
 
 	// Return success.
@@ -769,14 +769,14 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 
 // listObjectParts - wrapper reading `xl.json` for a given object and
 // uploadID. Lists all the parts captured inside `xl.json` content.
-func (xl xlObjects) listObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (ListPartsInfo, error) {
+func (xl xlObjects) listObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (lpi ListPartsInfo, e error) {
 	result := ListPartsInfo{}
 
 	uploadIDPath := path.Join(bucket, object, uploadID)
 
 	xlParts, err := xl.readXLMetaParts(minioMetaMultipartBucket, uploadIDPath)
 	if err != nil {
-		return ListPartsInfo{}, toObjectErr(err, minioMetaMultipartBucket, uploadIDPath)
+		return lpi, toObjectErr(err, minioMetaMultipartBucket, uploadIDPath)
 	}
 
 	// Populate the result stub.
@@ -806,7 +806,7 @@ func (xl xlObjects) listObjectParts(bucket, object, uploadID string, partNumberM
 		var fi FileInfo
 		fi, err = xl.statPart(bucket, object, uploadID, part.Name)
 		if err != nil {
-			return ListPartsInfo{}, toObjectErr(err, minioMetaBucket, path.Join(uploadID, part.Name))
+			return lpi, toObjectErr(err, minioMetaBucket, path.Join(uploadID, part.Name))
 		}
 		result.Parts = append(result.Parts, PartInfo{
 			PartNumber:   part.Number,
@@ -837,9 +837,9 @@ func (xl xlObjects) listObjectParts(bucket, object, uploadID string, partNumberM
 // Implements S3 compatible ListObjectParts API. The resulting
 // ListPartsInfo structure is unmarshalled directly into XML and
 // replied back to the client.
-func (xl xlObjects) ListObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (ListPartsInfo, error) {
+func (xl xlObjects) ListObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (lpi ListPartsInfo, e error) {
 	if err := checkListPartsArgs(bucket, object, xl); err != nil {
-		return ListPartsInfo{}, err
+		return lpi, err
 	}
 
 	// Hold lock so that there is no competing
@@ -850,7 +850,7 @@ func (xl xlObjects) ListObjectParts(bucket, object, uploadID string, partNumberM
 	defer uploadIDLock.Unlock()
 
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
-		return ListPartsInfo{}, traceError(InvalidUploadID{UploadID: uploadID})
+		return lpi, traceError(InvalidUploadID{UploadID: uploadID})
 	}
 	result, err := xl.listObjectParts(bucket, object, uploadID, partNumberMarker, maxParts)
 	return result, err
@@ -862,9 +862,9 @@ func (xl xlObjects) ListObjectParts(bucket, object, uploadID string, partNumberM
 // md5sums of all the parts.
 //
 // Implements S3 compatible Complete multipart API.
-func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, uploadID string, parts []completePart) (ObjectInfo, error) {
+func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, uploadID string, parts []completePart) (oi ObjectInfo, e error) {
 	if err := checkCompleteMultipartArgs(bucket, object, xl); err != nil {
-		return ObjectInfo{}, err
+		return oi, err
 	}
 
 	// Hold lock so that
@@ -879,19 +879,19 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	defer uploadIDLock.Unlock()
 
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
-		return ObjectInfo{}, traceError(InvalidUploadID{UploadID: uploadID})
+		return oi, traceError(InvalidUploadID{UploadID: uploadID})
 	}
 
 	// Check if an object is present as one of the parent dir.
 	// -- FIXME. (needs a new kind of lock).
 	if xl.parentDirIsObject(bucket, path.Dir(object)) {
-		return ObjectInfo{}, toObjectErr(traceError(errFileAccessDenied), bucket, object)
+		return oi, toObjectErr(traceError(errFileAccessDenied), bucket, object)
 	}
 
 	// Calculate s3 compatible md5sum for complete multipart.
 	s3MD5, err := getCompleteMultipartMD5(parts)
 	if err != nil {
-		return ObjectInfo{}, err
+		return oi, err
 	}
 
 	uploadIDPath := pathJoin(bucket, object, uploadID)
@@ -900,7 +900,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	partsMetadata, errs := readAllXLMetadata(xl.storageDisks, minioMetaMultipartBucket, uploadIDPath)
 	reducedErr := reduceWriteQuorumErrs(errs, objectOpIgnoredErrs, xl.writeQuorum)
 	if errorCause(reducedErr) == errXLWriteQuorum {
-		return ObjectInfo{}, toObjectErr(reducedErr, bucket, object)
+		return oi, toObjectErr(reducedErr, bucket, object)
 	}
 
 	onlineDisks, modTime := listOnlineDisks(xl.storageDisks, partsMetadata, errs)
@@ -911,7 +911,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 	// Pick one from the first valid metadata.
 	xlMeta, err := pickValidXLMeta(partsMetadata, modTime)
 	if err != nil {
-		return ObjectInfo{}, err
+		return oi, err
 	}
 
 	// Order online disks in accordance with distribution order.
@@ -931,17 +931,17 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 		partIdx := objectPartIndex(currentXLMeta.Parts, part.PartNumber)
 		// All parts should have same part number.
 		if partIdx == -1 {
-			return ObjectInfo{}, traceError(InvalidPart{})
+			return oi, traceError(InvalidPart{})
 		}
 
 		// All parts should have same ETag as previously generated.
 		if currentXLMeta.Parts[partIdx].ETag != part.ETag {
-			return ObjectInfo{}, traceError(InvalidPart{})
+			return oi, traceError(InvalidPart{})
 		}
 
 		// All parts except the last part has to be atleast 5MB.
 		if (i < len(parts)-1) && !isMinAllowedPartSize(currentXLMeta.Parts[partIdx].Size) {
-			return ObjectInfo{}, traceError(PartTooSmall{
+			return oi, traceError(PartTooSmall{
 				PartNumber: part.PartNumber,
 				PartSize:   currentXLMeta.Parts[partIdx].Size,
 				PartETag:   part.ETag,
@@ -986,13 +986,13 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 
 	// Write unique `xl.json` for each disk.
 	if onlineDisks, err = writeUniqueXLMetadata(onlineDisks, minioMetaTmpBucket, tempUploadIDPath, partsMetadata, xl.writeQuorum); err != nil {
-		return ObjectInfo{}, toObjectErr(err, minioMetaTmpBucket, tempUploadIDPath)
+		return oi, toObjectErr(err, minioMetaTmpBucket, tempUploadIDPath)
 	}
 
 	var rErr error
 	onlineDisks, rErr = commitXLMetadata(onlineDisks, minioMetaTmpBucket, tempUploadIDPath, minioMetaMultipartBucket, uploadIDPath, xl.writeQuorum)
 	if rErr != nil {
-		return ObjectInfo{}, toObjectErr(rErr, minioMetaMultipartBucket, uploadIDPath)
+		return oi, toObjectErr(rErr, minioMetaMultipartBucket, uploadIDPath)
 	}
 
 	defer func() {
@@ -1020,7 +1020,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 		// regardless of `xl.json` status and rolled back in case of errors.
 		_, err = renameObject(xl.storageDisks, bucket, object, minioMetaTmpBucket, newUniqueID, xl.writeQuorum)
 		if err != nil {
-			return ObjectInfo{}, toObjectErr(err, bucket, object)
+			return oi, toObjectErr(err, bucket, object)
 		}
 	}
 
@@ -1039,7 +1039,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 
 	// Rename the multipart object to final location.
 	if onlineDisks, err = renameObject(onlineDisks, minioMetaMultipartBucket, uploadIDPath, bucket, object, xl.writeQuorum); err != nil {
-		return ObjectInfo{}, toObjectErr(err, bucket, object)
+		return oi, toObjectErr(err, bucket, object)
 	}
 
 	// Hold the lock so that two parallel
@@ -1052,7 +1052,7 @@ func (xl xlObjects) CompleteMultipartUpload(bucket string, object string, upload
 
 	// remove entry from uploads.json with quorum
 	if err = xl.removeUploadID(bucket, object, uploadID); err != nil {
-		return ObjectInfo{}, toObjectErr(err, minioMetaMultipartBucket, path.Join(bucket, object))
+		return oi, toObjectErr(err, minioMetaMultipartBucket, path.Join(bucket, object))
 	}
 
 	objInfo := ObjectInfo{


### PR DESCRIPTION
## Description
Name return values to prevent the need (and unnecessary code bloat) to explicitly instantiate objects for every return statement.

## Motivation and Context
It improves the code and generates less code by eliminating the explicit instantiation of an object for every return statement.

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.