### PR TITLE
gateway-gcs: cleanup minio.sys.temp before deleting the bucket

### DIFF
--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -294,8 +294,48 @@ func (l *gcsGateway) ListBuckets() ([]BucketInfo, error) {
 	return b, nil
 }
 
-// DeleteBucket delete a bucket on GCS
+// DeleteBucket delete a bucket on GCS.
 func (l *gcsGateway) DeleteBucket(bucket string) error {
+	itObject := l.client.Bucket(bucket).Objects(l.ctx, &storage.Query{Delimiter: slashSeparator, Versions: false})
+	// We list the bucket and if we find any objects we return BucketNotEmpty error. If we
+	// find only "minio.sys.temp/" then we remove it before deleting the bucket.
+	gcsMinioPathFound := false
+	nonGCSMinioPathFound := false
+	for {
+		objAttrs, err := itObject.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return gcsToObjectError(traceError(err))
+		}
+		if isGCSPrefix(objAttrs.Prefix) {
+			gcsMinioPathFound = true
+			continue
+		}
+		nonGCSMinioPathFound = true
+		break
+	}
+	if nonGCSMinioPathFound {
+		return gcsToObjectError(traceError(BucketNotEmpty{}))
+	}
+	if gcsMinioPathFound {
+		// Remove minio.sys.temp before deleting the bucket.
+		itObject = l.client.Bucket(bucket).Objects(l.ctx, &storage.Query{Versions: false})
+		for {
+			objAttrs, err := itObject.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return gcsToObjectError(traceError(err))
+			}
+			err = l.client.Bucket(bucket).Object(objAttrs.Name).Delete(l.ctx)
+			if err != nil {
+				return gcsToObjectError(traceError(err))
+			}
+		}
+	}
 	err := l.client.Bucket(bucket).Delete(l.ctx)
 	return gcsToObjectError(traceError(err), bucket)
 }

--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -321,7 +321,7 @@ func (l *gcsGateway) DeleteBucket(bucket string) error {
 	}
 	if gcsMinioPathFound {
 		// Remove minio.sys.temp before deleting the bucket.
-		itObject = l.client.Bucket(bucket).Objects(l.ctx, &storage.Query{Versions: false})
+		itObject = l.client.Bucket(bucket).Objects(l.ctx, &storage.Query{Versions: false, Prefix: gcsMinioPath + slashSeparator})
 		for {
 			objAttrs, err := itObject.Next()
 			if err == iterator.Done {

--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -409,8 +409,17 @@ func (l *gcsGateway) ListObjects(bucket string, prefix string, marker string, de
 		nextMarker = toGCSPageToken(attrs.Name)
 
 		if attrs.Prefix == gcsMinioPath {
-			// we don't return our metadata prefix
+			// We don't return our metadata prefix.
 			continue
+		}
+		if !strings.HasPrefix(prefix, gcsMinioPath) {
+			// If client lists outside gcsMinioPath then we filter out gcsMinioPath/* entries.
+			// But if the client lists inside gcsMinioPath then we return the entries in gcsMinioPath/
+			// which will be helpful to observe the "directory structure" for debugging purposes.
+			if strings.HasPrefix(attrs.Prefix, gcsMinioPath) ||
+				strings.HasPrefix(attrs.Name, gcsMinioPath) {
+				continue
+			}
 		}
 		if attrs.Prefix != "" {
 			prefixes = append(prefixes, attrs.Prefix)

--- a/cmd/gateway-gcs_test.go
+++ b/cmd/gateway-gcs_test.go
@@ -94,41 +94,6 @@ func TestValidGCSProjectID(t *testing.T) {
 	}
 }
 
-// Test for isGCSPrefix
-func TestIsGCSPrefix(t *testing.T) {
-	testCases := []struct {
-		prefix      string
-		expectedRes bool
-	}{
-		// Regular prefix without a trailing slash
-		{
-			prefix:      "hello",
-			expectedRes: false,
-		},
-		// Regular prefix with a trailing slash
-		{
-			prefix:      "hello/",
-			expectedRes: false,
-		},
-		// GCS prefix without a trailing slash
-		{
-			prefix:      gcsMinioPath,
-			expectedRes: true,
-		},
-		// GCS prefix with a trailing slash
-		{
-			prefix:      gcsMinioPath + "/",
-			expectedRes: true,
-		},
-	}
-
-	for i, tc := range testCases {
-		if actualRes := isGCSPrefix(tc.prefix); actualRes != tc.expectedRes {
-			t.Errorf("%d: Expected isGCSPrefix to return %v but got %v", i, tc.expectedRes, actualRes)
-		}
-	}
-}
-
 // Test for isGCSMarker.
 func TestIsGCSMarker(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
Previous PR https://github.com/minio/minio/pull/4566 was closed as the feature-gcs branch got merged to master

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We list the bucket and if we find any objects we return BucketNotEmpty error. If we
find only "minio.sys.temp/" then we remove it before deleting the bucket.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #4560
fixes #4569

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.