### PR TITLE
Add support for helm package info in useragent

### DIFF
--- a/cmd/update-main_test.go
+++ b/cmd/update-main_test.go
@@ -235,6 +235,48 @@ func TestIsKubernetes(t *testing.T) {
 	}
 }
 
+// Tests if the environment we are running is Helm chart.
+func TestGetHelmVersion(t *testing.T) {
+	createTempFile := func(content string) string {
+		tmpfile, err := ioutil.TempFile("", "helm-testfile-")
+		if err != nil {
+			t.Fatalf("Unable to create temporary file. %s", err)
+		}
+		if _, err = tmpfile.Write([]byte(content)); err != nil {
+			t.Fatalf("Unable to create temporary file. %s", err)
+		}
+		if err = tmpfile.Close(); err != nil {
+			t.Fatalf("Unable to create temporary file. %s", err)
+		}
+		return tmpfile.Name()
+	}
+
+	filename := createTempFile(
+		`app="virtuous-rat-minio"
+chart="minio-0.1.3"
+heritage="Tiller"
+pod-template-hash="818089471"`)
+
+	defer os.Remove(filename)
+
+	testCases := []struct {
+		filename       string
+		expectedResult string
+	}{
+		{"", ""},
+		{"/tmp/non-existing-file", ""},
+		{filename, "minio-0.1.3"},
+	}
+
+	for _, testCase := range testCases {
+		result := getHelmVersion(testCase.filename)
+
+		if testCase.expectedResult != result {
+			t.Fatalf("result: expected: %v, got: %v", testCase.expectedResult, result)
+		}
+	}
+}
+
 // Tests if the environment we are running is in docker.
 func TestIsDocker(t *testing.T) {
 	createTempFile := func(content string) string {


### PR DESCRIPTION
## Description
Adds helm chart version detection

Minio Helm Chart uses DownwardFileAPI to create a file with pod labels in the path `/podinfo/labels`. This file has info about the Helm Chart version. We check if this file exists to read the chart version. 

## Motivation and Context
See issue https://github.com/minio/minio/issues/4456

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.