### PR TITLE
web: Encode path in presigned GET urls

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -919,7 +919,7 @@ func presignedGet(host, bucket, object string, expiry int64) string {
 	signature := getSignature(signingKey, stringToSign)
 
 	// Construct the final presigned URL.
-	return host + path + "?" + query + "&" + "X-Amz-Signature=" + signature
+	return host + getURLEncodedName(path) + "?" + query + "&" + "X-Amz-Signature=" + signature
 }
 
 // toJSONError converts regular errors into more user friendly


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
When the browser asks for a GET presigned url, this latter is not
encoded and can be confusing when the user copies-pastes it somewhere,
especially when the path contains a space.


## Motivation and Context
Fixes #4573 

## How Has This Been Tested?
go test + Manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.