### PR TITLE
Adds 'gcs not ready for production' msg

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -181,6 +181,10 @@ func newGatewayLayer(backendType gatewayBackend, arg string) (GatewayLayer, erro
 	case s3Backend:
 		return newS3Gateway(arg)
 	case gcsBackend:
+		// The following print command is temporary and
+		// will be removed when gcs is ready for Production.
+		// 06/27/2017  -- Ersan Bozduman
+		log.Println(colorYellow("\n               *** Warning: Not Ready for Production ***"))
 		return newGCSGateway(arg)
 	}
 

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -181,9 +181,8 @@ func newGatewayLayer(backendType gatewayBackend, arg string) (GatewayLayer, erro
 	case s3Backend:
 		return newS3Gateway(arg)
 	case gcsBackend:
-		// The following print command is temporary and
-		// will be removed when gcs is ready for Production.
-		// 06/27/2017  -- Ersan Bozduman
+		// FIXME: The following print command is temporary and
+		// will be removed when gcs is ready for production use.
 		log.Println(colorYellow("\n               *** Warning: Not Ready for Production ***"))
 		return newGCSGateway(arg)
 	}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -137,8 +137,8 @@ var (
 
 // global colors.
 var (
-	colorBold = color.New(color.Bold).SprintFunc()
-	colorBlue = color.New(color.FgBlue).SprintfFunc()
+	colorBold   = color.New(color.Bold).SprintFunc()
+	colorBlue   = color.New(color.FgBlue).SprintfFunc()
 	colorYellow = color.New(color.FgYellow).SprintfFunc()
 )
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -139,6 +139,7 @@ var (
 var (
 	colorBold = color.New(color.Bold).SprintFunc()
 	colorBlue = color.New(color.FgBlue).SprintfFunc()
+	colorYellow = color.New(color.FgYellow).SprintfFunc()
 )
 
 // Returns minio global information, as a key value map.


### PR DESCRIPTION
Fixes #4581

## Description
` *** Warning: Not Ready for Production ***` message is added to warn user when minio server is started with `gcs` gateway option.
I also added a comment to remind us that this code will be removed when `gcs` is ready for show-time.

## Motivation and Context
`gcs` is not ready for production yet.

## How Has This Been Tested?
I tested the change by manually starting the server with all possible gateway options and without any gateway option to make sure the warning message only appears for `gcs`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.