### PR TITLE
GCS backend ListObjectV2 now honours Continuation Token

### DIFF
--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -506,17 +506,25 @@ func (l *gcsGateway) ListObjectsV2(bucket, prefix, continuationToken string, fet
 	it := l.client.Bucket(bucket).Objects(l.ctx, &storage.Query{Delimiter: delimiter, Prefix: prefix, Versions: false})
 
 	isTruncated := false
-	nextMarker := ""
-	prefixes := []string{}
+	it.PageInfo().MaxSize = maxKeys
 
-	objects := []ObjectInfo{}
-	for {
-		if maxKeys < len(objects) {
+	if continuationToken != "" {
+		// If client sends continuationToken, set it
+		it.PageInfo().Token = continuationToken
+	} else {
+		// else set the continuationToken to return
+		continuationToken = it.PageInfo().Token
+		if continuationToken != "" {
+			// If GCS SDK sets continuationToken, it means there are more than maxKeys in the current page
+			// and the response will be truncated
 			isTruncated = true
-			nextMarker = it.PageInfo().Token
-			break
 		}
+	}
 
+	prefixes := []string{}
+	objects := []ObjectInfo{}
+
+	for {
 		attrs, err := it.Next()
 		if err == iterator.Done {
 			break
@@ -524,6 +532,20 @@ func (l *gcsGateway) ListObjectsV2(bucket, prefix, continuationToken string, fet
 
 		if err != nil {
 			return ListObjectsV2Info{}, gcsToObjectError(traceError(err), bucket, prefix)
+		}
+
+		if attrs.Prefix == gcsMinioPath {
+			// We don't return our metadata prefix.
+			continue
+		}
+		if !strings.HasPrefix(prefix, gcsMinioPath) {
+			// If client lists outside gcsMinioPath then we filter out gcsMinioPath/* entries.
+			// But if the client lists inside gcsMinioPath then we return the entries in gcsMinioPath/
+			// which will be helpful to observe the "directory structure" for debugging purposes.
+			if strings.HasPrefix(attrs.Prefix, gcsMinioPath) ||
+				strings.HasPrefix(attrs.Name, gcsMinioPath) {
+				continue
+			}
 		}
 
 		if attrs.Prefix != "" {
@@ -537,7 +559,7 @@ func (l *gcsGateway) ListObjectsV2(bucket, prefix, continuationToken string, fet
 	return ListObjectsV2Info{
 		IsTruncated:           isTruncated,
 		ContinuationToken:     continuationToken,
-		NextContinuationToken: nextMarker,
+		NextContinuationToken: continuationToken,
 		Prefixes:              prefixes,
 		Objects:               objects,
 	}, nil


### PR DESCRIPTION
## Description
- Set `continuationToken` to make sure proper values are sent to GCS backend
- Set `isTruncated` flag only if there is remaining data to be sent back

## Motivation and Context
`continationToken` was not handled properly. 

See https://github.com/minio/minio/issues/4601

## How Has This Been Tested?
Manually and Java functional tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.