### PR TITLE
posix: Check for min disk space and inodes

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -103,6 +103,16 @@ func newFSObjectLayer(fsPath string) (ObjectLayer, error) {
 		}
 	}
 
+	di, err := getDiskInfo(preparePath(fsPath))
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if disk has minimum required total space.
+	if err = checkDiskMinTotal(di); err != nil {
+		return nil, err
+	}
+
 	// Assign a new UUID for FS minio mode. Each server instance
 	// gets its own UUID for temporary file transaction.
 	fsUUID := mustGetUUID()
@@ -138,14 +148,12 @@ func newFSObjectLayer(fsPath string) (ObjectLayer, error) {
 	fs.fsFormatRlk = rlk
 
 	// Initialize and load bucket policies.
-	err = initBucketPolicies(fs)
-	if err != nil {
+	if err = initBucketPolicies(fs); err != nil {
 		return nil, fmt.Errorf("Unable to load all bucket policies. %s", err)
 	}
 
 	// Initialize a new event notifier.
-	err = initEventNotifier(fs)
-	if err != nil {
+	if err = initEventNotifier(fs); err != nil {
 		return nil, fmt.Errorf("Unable to initialize event notification. %s", err)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is needed such that we don't start or
allow writing to a posix disk which doesn't
have minimum disk free available.

<!--- Describe your changes in detail -->

## Motivation and Context
One part fix for #4617

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using a disk of size smaller than 1GiB
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.