### PR TITLE
Append "-1" to etag when it is not MD5

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -67,6 +67,11 @@ func azureToS3Metadata(meta map[string]string) (newMeta map[string]string) {
 	return newMeta
 }
 
+// Append "-1" to etag so that clients do not interpret it as MD5.
+func azureToS3ETag(etag string) string {
+	return canonicalizeETag(etag) + "-1"
+}
+
 // To store metadata during NewMultipartUpload which will be used after
 // CompleteMultipartUpload to call SetBlobMetadata.
 type azureMultipartMetaInfo struct {
@@ -270,7 +275,7 @@ func (a *azureObjects) ListObjects(bucket, prefix, marker, delimiter string, max
 			Name:            object.Name,
 			ModTime:         t,
 			Size:            object.Properties.ContentLength,
-			ETag:            canonicalizeETag(object.Properties.Etag),
+			ETag:            azureToS3ETag(object.Properties.Etag),
 			ContentType:     object.Properties.ContentType,
 			ContentEncoding: object.Properties.ContentEncoding,
 		})
@@ -305,7 +310,7 @@ func (a *azureObjects) ListObjectsV2(bucket, prefix, continuationToken string, f
 			Name:            object.Name,
 			ModTime:         t,
 			Size:            object.Properties.ContentLength,
-			ETag:            canonicalizeETag(object.Properties.Etag),
+			ETag:            azureToS3ETag(object.Properties.Etag),
 			ContentType:     object.Properties.ContentType,
 			ContentEncoding: object.Properties.ContentEncoding,
 		})
@@ -368,7 +373,7 @@ func (a *azureObjects) GetObjectInfo(bucket, object string) (objInfo ObjectInfo,
 	objInfo = ObjectInfo{
 		Bucket:      bucket,
 		UserDefined: meta,
-		ETag:        canonicalizeETag(prop.Etag),
+		ETag:        azureToS3ETag(prop.Etag),
 		ModTime:     t,
 		Name:        object,
 		Size:        prop.ContentLength,

--- a/cmd/gateway-azure_test.go
+++ b/cmd/gateway-azure_test.go
@@ -25,15 +25,34 @@ import (
 	"github.com/Azure/azure-sdk-for-go/storage"
 )
 
+// Test azureToS3ETag.
+func TestAzureToS3ETag(t *testing.T) {
+	tests := []struct {
+		etag     string
+		expected string
+	}{
+		{`"etag"`, `etag-1`},
+		{"etag", "etag-1"},
+	}
+	for i, test := range tests {
+		got := azureToS3ETag(test.etag)
+		if got != test.expected {
+			t.Errorf("test %d: got:%s expected:%s", i+1, got, test.expected)
+		}
+	}
+}
+
 // Test canonical metadata.
 func TestS3ToAzureHeaders(t *testing.T) {
 	headers := map[string]string{
 		"accept-encoding":  "gzip",
 		"content-encoding": "gzip",
+		"X-Amz-Meta-Hdr":   "value",
 	}
 	expectedHeaders := map[string]string{
 		"Accept-Encoding":  "gzip",
 		"Content-Encoding": "gzip",
+		"X-Ms-Meta-Hdr":    "value",
 	}
 	actualHeaders := s3ToAzureHeaders(headers)
 	if !reflect.DeepEqual(actualHeaders, expectedHeaders) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
"-1" is appended to ETag returned from Azure so that clients do not interpret it as MD5.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/minio/minio/issues/4537

https://github.com/s3tools/s3cmd/issues/880

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual, test case

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.