### PR TITLE
gcs: Save partNumber as part of backend format.

### DIFF
--- a/cmd/gateway-gcs_test.go
+++ b/cmd/gateway-gcs_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -144,10 +145,13 @@ func TestGCSMultipartMetaName(t *testing.T) {
 
 // Test for gcsMultipartDataName.
 func TestGCSMultipartDataName(t *testing.T) {
-	uploadID := "a"
-	etag := "b"
-	expected := pathJoin(gcsMinioMultipartPathV1, uploadID, etag)
-	got := gcsMultipartDataName(uploadID, etag)
+	var (
+		uploadID   = "a"
+		etag       = "b"
+		partNumber = 1
+	)
+	expected := pathJoin(gcsMinioMultipartPathV1, uploadID, fmt.Sprintf("%05d.%s", partNumber, etag))
+	got := gcsMultipartDataName(uploadID, partNumber, etag)
 	if expected != got {
 		t.Errorf("expected: %s, got: %s", expected, got)
 	}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add partNumber to the GCS backend as future protection and also allowing users to reconstruct and compose object without using minio gateway. 
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4637

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.