### PR TITLE
(wip) browser: remove token from GET URLs

### DIFF
--- a/browser/app/js/actions.js
+++ b/browser/app/js/actions.js
@@ -436,6 +436,7 @@ export const downloadSelected = (url, req, xhr) => {
     document.body.appendChild(anchor);
     xhr.open('POST', url, true)
     xhr.responseType = 'blob'
+    xhr.setRequestHeader('Authorization', 'Bearer ' + storage.getItem('token'))
 
     xhr.onload = function(e) {
       if (this.status == 200) {
@@ -448,9 +449,6 @@ export const downloadSelected = (url, req, xhr) => {
 
         anchor.href = blobUrl
         anchor.download = req.bucketName+separator+req.prefix.slice(0, -1)+'.zip';
-
-
-
 
         anchor.click()
         window.URL.revokeObjectURL(blobUrl)

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -776,12 +776,14 @@ func testDownloadWebHandler(obj ObjectLayer, instanceType string, t TestErrHandl
 
 	test := func(token string) (int, []byte) {
 		rec := httptest.NewRecorder()
-		path := "/minio/download/" + bucketName + "/" + objectName + "?token="
-		if token != "" {
-			path = path + token
-		}
+		path := "/minio/download/" + bucketName + "/" + objectName
+
 		var req *http.Request
 		req, err = http.NewRequest("GET", path, nil)
+
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
 
 		if err != nil {
 			t.Fatalf("Cannot create upload request, %v", err)
@@ -871,10 +873,8 @@ func testWebHandlerDownloadZip(obj ObjectLayer, instanceType string, t TestErrHa
 
 	test := func(token string) (int, []byte) {
 		rec := httptest.NewRecorder()
-		path := "/minio/zip" + "?token="
-		if token != "" {
-			path = path + token
-		}
+		path := "/minio/zip"
+
 		args := DownloadZipArgs{
 			Objects:    []string{"one", "b/", "c/"},
 			Prefix:     "a/",
@@ -888,9 +888,12 @@ func testWebHandlerDownloadZip(obj ObjectLayer, instanceType string, t TestErrHa
 		}
 		var req *http.Request
 		req, err = http.NewRequest("POST", path, bytes.NewBuffer(argsData))
-
 		if err != nil {
 			t.Fatalf("Cannot create upload request, %v", err)
+		}
+
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
 		}
 
 		apiRouter.ServeHTTP(rec, req)

--- a/cmd/web-router.go
+++ b/cmd/web-router.go
@@ -83,8 +83,8 @@ func registerWebRouter(mux *router.Router) error {
 	// RPC handler at URI - /minio/webrpc
 	webBrowserRouter.Methods("POST").Path("/webrpc").Handler(webRPC)
 	webBrowserRouter.Methods("PUT").Path("/upload/{bucket}/{object:.+}").HandlerFunc(web.Upload)
-	webBrowserRouter.Methods("GET").Path("/download/{bucket}/{object:.+}").Queries("token", "{token:.*}").HandlerFunc(web.Download)
-	webBrowserRouter.Methods("POST").Path("/zip").Queries("token", "{token:.*}").HandlerFunc(web.DownloadZip)
+	webBrowserRouter.Methods("GET").Path("/download/{bucket}/{object:.+}").HandlerFunc(web.Download)
+	webBrowserRouter.Methods("POST").Path("/zip").HandlerFunc(web.DownloadZip)
 
 	// Add compression for assets.
 	compressedAssets := handlers.CompressHandler(http.StripPrefix(minioReservedBucketPath, http.FileServer(assetFS())))


### PR DESCRIPTION
## Description
This commit removes the token from all browser-operated GET URLs. It
moves the tokens into the Authorization: header. This should be more
idiomatic and slightly more secure. This commit updates the tests.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From discussion with @krishnasrinivas 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.