### PR TITLE
build: ditch verifiers on make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ coverage: build
 
 # Builds minio locally.
 build:
-	@echo "Building minio to $(PWD)/minio"
+	@echo "Building minio to $(PWD)/minio ..."
 	@CGO_ENABLED=0 go build --ldflags $(BUILD_LDFLAGS) -o $(PWD)/minio
 
 pkg-add:
@@ -87,8 +87,9 @@ pkg-list:
 
 # Builds minio and installs it to $GOPATH/bin.
 install: build
-	@echo "Installing minio at $(GOPATH)/bin/minio"
+	@echo "Installing minio at $(GOPATH)/bin/minio ..."
 	@cp $(PWD)/minio $(GOPATH)/bin/minio
+	@echo "Minio installed successfully. Use 'minio server export' to start."
 
 release: verifiers
 	@MINIO_RELEASE=RELEASE ./buildscripts/build.sh

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ pkg-list:
 install: build
 	@echo "Installing minio at $(GOPATH)/bin/minio ..."
 	@cp $(PWD)/minio $(GOPATH)/bin/minio
-	@echo "Minio installed successfully. Use 'minio server export' to start."
+	@echo "Check 'minio -h' for help."
 
 release: verifiers
 	@MINIO_RELEASE=RELEASE ./buildscripts/build.sh

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ getdeps: checks
 	@echo "Installing misspell" && go get -u github.com/client9/misspell/cmd/misspell
 	@echo "Installing ineffassign" && go get -u github.com/gordonklaus/ineffassign
 
-verifiers: vet fmt lint cyclo spelling
+verifiers: getdeps vet fmt lint cyclo spelling
 
 vet:
 	@echo "Running $@"
@@ -45,7 +45,7 @@ cyclo:
 	@${GOPATH}/bin/gocyclo -over 100 cmd
 	@${GOPATH}/bin/gocyclo -over 100 pkg
 
-build: getdeps verifiers $(UI_ASSETS)
+build: $(UI_ASSETS)
 
 deadcode:
 	@${GOPATH}/bin/deadcode
@@ -55,7 +55,7 @@ spelling:
 	@${GOPATH}/bin/misspell -error `find pkg/`
 	@${GOPATH}/bin/misspell -error `find docs/`
 
-test: build
+test: verifiers build
 	@echo "Running all minio testing"
 	@go test $(GOFLAGS) .
 	@go test $(GOFLAGS) github.com/minio/minio/cmd...


### PR DESCRIPTION
## Description
This commit ditches running verifiers automatically when just building
the server. It retains the verifiers when running tests.

There is very little point to running the verifiers each time a
developer builds the library but has no intent of running the tests.
They're expensive in time; this commit halves the build time on my
system, from 57 seconds to 29 seconds. This is because verifiers updates
the libraries from GitHub each time, which is slightly wasteful.
Additionally, computing cyclomatic complexity is expensive
computationally and isn't necessary to build the library.

Additionally, this allows the library to be built offline. It no longer
requires internet to run make.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Motivation and Context
When the internet died I had to build the library
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
