### PR TITLE
restirct max size of http header and user metadata

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -116,6 +116,7 @@ const (
 	ErrInvalidDuration
 	ErrNotSupported
 	ErrBucketAlreadyExists
+	ErrMetadataTooLarge
 	// Add new error codes here.
 
 	// Bucket notification related errors.
@@ -630,7 +631,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Description:    "Cannot respond to plain-text request from TLS-encrypted server",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-
+	ErrMetadataTooLarge: {
+		Code:           "InvalidArgument",
+		Description:    "Your metadata headers exceed the maximum allowed metadata size.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
 	// Add your error structure here.
 }
 

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -97,6 +97,14 @@ func path2BucketAndObject(path string) (bucket, object string) {
 	return bucket, object
 }
 
+// userMetadataKeyPrefixes contains the prefixes of used-defined metadata keys.
+// All values stored with a key starting with one of the following prefixes
+// must be extracted from the header.
+var userMetadataKeyPrefixes = []string{
+	"X-Amz-Meta-",
+	"X-Minio-Meta-",
+}
+
 // extractMetadataFromHeader extracts metadata from HTTP header.
 func extractMetadataFromHeader(header http.Header) (map[string]string, error) {
 	if header == nil {
@@ -119,11 +127,11 @@ func extractMetadataFromHeader(header http.Header) (map[string]string, error) {
 		if key != http.CanonicalHeaderKey(key) {
 			return nil, traceError(errInvalidArgument)
 		}
-		if strings.HasPrefix(key, "X-Amz-Meta-") {
-			metadata[key] = header.Get(key)
-		}
-		if strings.HasPrefix(key, "X-Minio-Meta-") {
-			metadata[key] = header.Get(key)
+		for _, prefix := range userMetadataKeyPrefixes {
+			if strings.HasPrefix(key, prefix) {
+				metadata[key] = header.Get(key)
+				break
+			}
 		}
 	}
 	return metadata, nil

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -91,6 +91,8 @@ func configureServerHandler(endpoints EndpointList) (http.Handler, error) {
 		setHTTPStatsHandler,
 		// Limits all requests size to a maximum fixed limit
 		setRequestSizeLimitHandler,
+		// Limits all header sizes to a maximum fixed limit
+		setRequestHeaderSizeLimitHandler,
 		// Adds 'crossdomain.xml' policy handler to serve legacy flash clients.
 		setCrossDomainPolicy,
 		// Redirect some pre-defined browser request paths to a static location prefix.


### PR DESCRIPTION
## Description

S3 only allows http headers with a size of 8 KB and user-defined metadata
with a size of 2 KB. This change adds a new API error and returns this
error to clients which sends to large http requests.

## Motivation and Context
Fixes #4634 

## How Has This Been Tested?
Add test cases for PutObjectHandler

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.