### PR TITLE
jwt,browser: allow short-expiry tokens for GETs

### DIFF
--- a/browser/app/js/components/Browse.js
+++ b/browser/app/js/components/Browse.js
@@ -150,7 +150,16 @@ export default class Browse extends React.Component {
       if (prefix === currentPath) return
       browserHistory.push(utils.pathJoin(currentBucket, encPrefix))
     } else {
-      window.location = `${window.location.origin}/minio/download/${currentBucket}/${encPrefix}?token=${storage.getItem('token')}`
+      // Download the selected file.
+      web.CreateURLToken()
+        .then(res => {
+          let url = `${window.location.origin}/minio/download/${currentBucket}/${encPrefix}?token=${res.token}`
+          window.location = url
+        })
+        .catch(err => dispatch(actions.showAlert({
+          type: 'danger',
+          message: err.message
+        })))
     }
   }
 
@@ -406,16 +415,24 @@ export default class Browse extends React.Component {
   }
 
   downloadSelected() {
-    const {dispatch} = this.props
+    const {dispatch, web} = this.props
     let req = {
       bucketName: this.props.currentBucket,
       objects: this.props.checkedObjects,
       prefix: this.props.currentPath
     }
-    let requestUrl = location.origin + "/minio/zip?token=" + localStorage.token
 
-    this.xhr = new XMLHttpRequest()
-    dispatch(actions.downloadSelected(requestUrl, req, this.xhr))
+    web.CreateURLToken()
+      .then(res => {
+        let requestUrl = location.origin + "/minio/zip?token=" + res.token
+
+        this.xhr = new XMLHttpRequest()
+        dispatch(actions.downloadSelected(requestUrl, req, this.xhr))
+      })
+      .catch(err => dispatch(actions.showAlert({
+        type: 'danger',
+        message: err.message
+      })))
   }
 
   clearSelected() {

--- a/browser/app/js/web.js
+++ b/browser/app/js/web.js
@@ -112,6 +112,9 @@ export default class Web {
         return res
       })
   }
+  CreateURLToken() {
+    return this.makeCall('CreateURLToken')
+  }
   GetBucketPolicy(args) {
     return this.makeCall('GetBucketPolicy', args)
   }

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -34,6 +34,9 @@ const (
 
 	// Inter-node JWT token expiry is 100 years approx.
 	defaultInterNodeJWTExpiry = 100 * 365 * 24 * time.Hour
+
+	// URL JWT token expiry is one minute (might be exposed).
+	defaultURLJWTExpiry = time.Minute
 )
 
 var (
@@ -75,6 +78,10 @@ func authenticateNode(accessKey, secretKey string) (string, error) {
 
 func authenticateWeb(accessKey, secretKey string) (string, error) {
 	return authenticateJWT(accessKey, secretKey, defaultJWTExpiry)
+}
+
+func authenticateURL(accessKey, secretKey string) (string, error) {
+	return authenticateJWT(accessKey, secretKey, defaultURLJWTExpiry)
 }
 
 func keyFuncCallback(jwtToken *jwtgo.Token) (interface{}, error) {

--- a/cmd/jwt_test.go
+++ b/cmd/jwt_test.go
@@ -60,6 +60,8 @@ func testAuthenticate(authType string, t *testing.T) {
 			_, err = authenticateNode(testCase.accessKey, testCase.secretKey)
 		} else if authType == "web" {
 			_, err = authenticateWeb(testCase.accessKey, testCase.secretKey)
+		} else if authType == "url" {
+			_, err = authenticateURL(testCase.accessKey, testCase.secretKey)
 		}
 
 		if testCase.expectedErr != nil {
@@ -81,6 +83,10 @@ func TestAuthenticateNode(t *testing.T) {
 
 func TestAuthenticateWeb(t *testing.T) {
 	testAuthenticate("web", t)
+}
+
+func TestAuthenticateURL(t *testing.T) {
+	testAuthenticate("url", t)
 }
 
 func BenchmarkAuthenticateNode(b *testing.B) {

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -467,6 +467,30 @@ func (web *webAPIHandlers) GetAuth(r *http.Request, args *WebGenericArgs, reply 
 	return nil
 }
 
+// URLTokenReply contains the reply for CreateURLToken.
+type URLTokenReply struct {
+	Token     string `json:"token"`
+	UIVersion string `json:"uiVersion"`
+}
+
+// CreateURLToken creates a URL token (short-lived) for GET requests.
+func (web *webAPIHandlers) CreateURLToken(r *http.Request, args *WebGenericArgs, reply *URLTokenReply) error {
+	if !isHTTPRequestValid(r) {
+		return toJSONError(errAuthentication)
+	}
+
+	creds := serverConfig.GetCredential()
+
+	token, err := authenticateURL(creds.AccessKey, creds.SecretKey)
+	if err != nil {
+		return toJSONError(err)
+	}
+
+	reply.Token = token
+	reply.UIVersion = browser.UIVersion
+	return nil
+}
+
 // Upload - file upload handler.
 func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 	objectAPI := web.ObjectAPI()

--- a/cmd/web-router.go
+++ b/cmd/web-router.go
@@ -83,6 +83,9 @@ func registerWebRouter(mux *router.Router) error {
 	// RPC handler at URI - /minio/webrpc
 	webBrowserRouter.Methods("POST").Path("/webrpc").Handler(webRPC)
 	webBrowserRouter.Methods("PUT").Path("/upload/{bucket}/{object:.+}").HandlerFunc(web.Upload)
+
+	// These methods use short-expiry tokens in the URLs. These tokens may unintentionally
+	// be logged, so a new one must be generated for each request.
 	webBrowserRouter.Methods("GET").Path("/download/{bucket}/{object:.+}").Queries("token", "{token:.*}").HandlerFunc(web.Download)
 	webBrowserRouter.Methods("POST").Path("/zip").Queries("token", "{token:.*}").HandlerFunc(web.DownloadZip)
 


### PR DESCRIPTION
## Description
This commit fixes a potential security issue, whereby a full-access
token to the server would be available in the GET URL of a download
request. This fixes that issue by introducing short-expiry tokens, which
are only valid for one minute, and are regenerated for every download
request.

This commit specifically introduces the short-lived tokens, adds tests
for the tokens, adds an RPC call for generating a token given a
full-access token, updates the browser to use the new tokens for
requests where the token is passed as a GET parameter, and adds some
tests with the new temporary tokens.

Refs: https://github.com/minio/minio/pull/4673

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Motivation and Context
cc @harshavardhana @krishnasrinivas @donatello 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tests have been added, printed tokens in console show different tokens each time.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.