### PR TITLE
Reconstruct only missing data shards when reading erasure coded file

### DIFF
--- a/cmd/erasure-healfile.go
+++ b/cmd/erasure-healfile.go
@@ -53,8 +53,8 @@ func erasureHealFile(latestDisks []StorageAPI, outDatedDisks []StorageAPI, volum
 			}
 		}
 
-		// Reconstruct missing data.
-		err := decodeData(enBlocks, dataBlocks, parityBlocks)
+		// Reconstruct any missing data and parity blocks.
+		err := decodeDataAndParity(enBlocks, dataBlocks, parityBlocks)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/erasure-readfile.go
+++ b/cmd/erasure-readfile.go
@@ -323,8 +323,7 @@ func decodeMissingData(enBlocks [][]byte, dataBlocks, parityBlocks int) error {
 	}
 
 	// Reconstruct any missing data blocks.
-	// TODO: Implement ReconstructMissingData method to just reconstruct the data blocks
-	return rs.Reconstruct(enBlocks)
+	return rs.ReconstructMissingData(enBlocks)
 }
 
 // decodeDataAndParity - decode all encoded data and parity blocks.

--- a/cmd/erasure-readfile.go
+++ b/cmd/erasure-readfile.go
@@ -272,7 +272,7 @@ func erasureReadFile(writer io.Writer, disks []StorageAPI, volume, path string,
 		// If we have all the data blocks no need to decode, continue to write.
 		if !isSuccessDataBlocks(enBlocks, dataBlocks) {
 			// Reconstruct the missing data blocks.
-			if err := decodeData(enBlocks, dataBlocks, parityBlocks); err != nil {
+			if err := decodeMissingData(enBlocks, dataBlocks, parityBlocks); err != nil {
 				return bytesWritten, err
 			}
 		}
@@ -314,9 +314,22 @@ func erasureReadFile(writer io.Writer, disks []StorageAPI, volume, path string,
 	return bytesWritten, nil
 }
 
-// decodeData - decode encoded blocks.
-func decodeData(enBlocks [][]byte, dataBlocks, parityBlocks int) error {
-	// Initialized reedsolomon.
+// decodeMissingData - decode any missing data blocks.
+func decodeMissingData(enBlocks [][]byte, dataBlocks, parityBlocks int) error {
+	// Initialize reedsolomon.
+	rs, err := reedsolomon.New(dataBlocks, parityBlocks)
+	if err != nil {
+		return traceError(err)
+	}
+
+	// Reconstruct any missing data blocks.
+	// TODO: Implement ReconstructMissingData method to just reconstruct the data blocks
+	return rs.Reconstruct(enBlocks)
+}
+
+// decodeDataAndParity - decode all encoded data and parity blocks.
+func decodeDataAndParity(enBlocks [][]byte, dataBlocks, parityBlocks int) error {
+	// Initialize reedsolomon.
 	rs, err := reedsolomon.New(dataBlocks, parityBlocks)
 	if err != nil {
 		return traceError(err)
@@ -328,14 +341,23 @@ func decodeData(enBlocks [][]byte, dataBlocks, parityBlocks int) error {
 		return traceError(err)
 	}
 
-	// Verify reconstructed blocks (parity).
+	// Verify correctness of all parity blocks.
 	ok, err := rs.Verify(enBlocks)
 	if err != nil {
 		return traceError(err)
 	}
 	if !ok {
-		// Blocks cannot be reconstructed, corrupted data.
-		err = errors.New("Verification failed after reconstruction, data likely corrupted")
+		// Verification of the parity blocks failed, this means one of two things:
+		// - either one (or more) of the data blocks is corrupted,
+		// - or one (or more) of the parity blocks is corrupted.
+		//
+		// Unfortunately it is not possible to state which one of the two possibilities
+		// it is, so while the data may still be intact, we have no way of saying this
+		// definitively.
+		//
+		// Note that in the presence of bit-rot protection (as is present in Minio)
+		// you really should never see this message.
+		err = errors.New("Unable to verify parity blocks, either existing data or parity blocks corrupted")
 		return traceError(err)
 	}
 

--- a/cmd/erasure_test.go
+++ b/cmd/erasure_test.go
@@ -124,26 +124,54 @@ func TestErasureDecode(t *testing.T) {
 			// Data block size.
 			blockSize := len(data)
 
-			// Generates encoded data based on type of testCase function.
-			encodedData := testCase.enFn(data, dataBlocks, parityBlocks)
+			// Test decoder for just the missing data blocks
+			{
+				// Generates encoded data based on type of testCase function.
+				encodedData := testCase.enFn(data, dataBlocks, parityBlocks)
 
-			// Decodes the data.
-			err := decodeData(encodedData, dataBlocks, parityBlocks)
-			if err != nil && testCase.shouldPass {
-				t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+				// Decodes the data.
+				err := decodeMissingData(encodedData, dataBlocks, parityBlocks)
+				if err != nil && testCase.shouldPass {
+					t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+				}
+
+				// Proceed to extract the data blocks.
+				decodedDataWriter := new(bytes.Buffer)
+				_, err = writeDataBlocks(decodedDataWriter, encodedData, dataBlocks, 0, int64(blockSize))
+				if err != nil && testCase.shouldPass {
+					t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+				}
+
+				// Validate if decoded data is what we expected.
+				if bytes.Equal(decodedDataWriter.Bytes(), data) != testCase.shouldPass {
+					err := errUnexpected
+					t.Errorf("Test %d: Expected to pass by failed instead %s", i+1, err)
+				}
 			}
 
-			// Proceed to extract the data blocks.
-			decodedDataWriter := new(bytes.Buffer)
-			_, err = writeDataBlocks(decodedDataWriter, encodedData, dataBlocks, 0, int64(blockSize))
-			if err != nil && testCase.shouldPass {
-				t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
-			}
+			// Test decoder for all missing data and parity blocks
+			{
+				// Generates encoded data based on type of testCase function.
+				encodedData := testCase.enFn(data, dataBlocks, parityBlocks)
 
-			// Validate if decoded data is what we expected.
-			if bytes.Equal(decodedDataWriter.Bytes(), data) != testCase.shouldPass {
-				err := errUnexpected
-				t.Errorf("Test %d: Expected to pass by failed instead %s", i+1, err)
+				// Decodes the data.
+				err := decodeDataAndParity(encodedData, dataBlocks, parityBlocks)
+				if err != nil && testCase.shouldPass {
+					t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+				}
+
+				// Proceed to extract the data blocks.
+				decodedDataWriter := new(bytes.Buffer)
+				_, err = writeDataBlocks(decodedDataWriter, encodedData, dataBlocks, 0, int64(blockSize))
+				if err != nil && testCase.shouldPass {
+					t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+				}
+
+				// Validate if decoded data is what we expected.
+				if bytes.Equal(decodedDataWriter.Bytes(), data) != testCase.shouldPass {
+					err := errUnexpected
+					t.Errorf("Test %d: Expected to pass by failed instead %s", i+1, err)
+				}
 			}
 		}
 	}

--- a/cmd/erasure_test.go
+++ b/cmd/erasure_test.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"bytes"
 	"testing"
+	"math/rand"
 )
 
 // mustEncodeData - encodes data slice and provides encoded 2 dimensional slice.
@@ -34,20 +35,20 @@ func mustEncodeData(data []byte, dataBlocks, parityBlocks int) [][]byte {
 // Generates good encoded data with one parity block and data block missing.
 func getGoodEncodedData(data []byte, dataBlocks, parityBlocks int) [][]byte {
 	encodedData := mustEncodeData(data, dataBlocks, parityBlocks)
-	encodedData[3] = nil
-	encodedData[1] = nil
+	encodedData[rand.Intn(dataBlocks)+parityBlocks] = nil
+	encodedData[rand.Intn(dataBlocks)] = nil
 	return encodedData
 }
 
 // Generates bad encoded data with one parity block and data block with garbage data.
 func getBadEncodedData(data []byte, dataBlocks, parityBlocks int) [][]byte {
 	encodedData := mustEncodeData(data, dataBlocks, parityBlocks)
-	encodedData[3] = []byte("garbage")
-	encodedData[1] = []byte("garbage")
+	encodedData[rand.Intn(dataBlocks)+parityBlocks] = []byte("garbage")
+	encodedData[rand.Intn(dataBlocks)] = []byte("garbage")
 	return encodedData
 }
 
-// Generates encoded data with all data blocks missing.
+// Generates encoded data with all data blocks and first parity block missing.
 func getMissingData(data []byte, dataBlocks, parityBlocks int) [][]byte {
 	encodedData := mustEncodeData(data, dataBlocks, parityBlocks)
 	for i := 0; i < dataBlocks+1; i++ {
@@ -77,6 +78,17 @@ var encodingMatrices = []encodingMatrix{
 	{6, 6}, // 6 data, 6 parity blocks.
 	{7, 7}, // 7 data, 7 parity blocks.
 	{8, 8}, // 8 data, 8 parity blocks.
+}
+
+// Count the number of parity blocks in the encode slice
+func countParityBlocks(enBlocks [][]byte, dataBlocks int) int {
+	blocks := 0
+	for _, parBlock := range enBlocks[dataBlocks:] {
+		if parBlock != nil {
+			blocks++
+		}
+	}
+	return blocks
 }
 
 // Tests erasure decoding functionality for various types of inputs.
@@ -132,20 +144,24 @@ func TestErasureDecode(t *testing.T) {
 				// Decodes the data.
 				err := decodeMissingData(encodedData, dataBlocks, parityBlocks)
 				if err != nil && testCase.shouldPass {
-					t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+					t.Errorf("Test %d: Expected to pass but failed instead with %s", i+1, err)
+				}
+
+				if testCase.shouldPass && countParityBlocks(encodedData, dataBlocks) != parityBlocks - 1 {
+					t.Errorf("Test %d: Expected %d parity blocks to be found: got %d", i+1, parityBlocks - 1, countParityBlocks(encodedData, dataBlocks))
 				}
 
 				// Proceed to extract the data blocks.
 				decodedDataWriter := new(bytes.Buffer)
 				_, err = writeDataBlocks(decodedDataWriter, encodedData, dataBlocks, 0, int64(blockSize))
 				if err != nil && testCase.shouldPass {
-					t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+					t.Errorf("Test %d: Expected to pass but failed instead with %s", i+1, err)
 				}
 
 				// Validate if decoded data is what we expected.
 				if bytes.Equal(decodedDataWriter.Bytes(), data) != testCase.shouldPass {
 					err := errUnexpected
-					t.Errorf("Test %d: Expected to pass by failed instead %s", i+1, err)
+					t.Errorf("Test %d: Expected to pass but failed instead %s", i+1, err)
 				}
 			}
 
@@ -157,20 +173,24 @@ func TestErasureDecode(t *testing.T) {
 				// Decodes the data.
 				err := decodeDataAndParity(encodedData, dataBlocks, parityBlocks)
 				if err != nil && testCase.shouldPass {
-					t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+					t.Errorf("Test %d: Expected to pass but failed instead with %s", i+1, err)
+				}
+
+				if testCase.shouldPass && countParityBlocks(encodedData, dataBlocks) != parityBlocks {
+					t.Errorf("Test %d: Expected %d parity blocks to be found: got %d", i+1, parityBlocks, countParityBlocks(encodedData, dataBlocks))
 				}
 
 				// Proceed to extract the data blocks.
 				decodedDataWriter := new(bytes.Buffer)
 				_, err = writeDataBlocks(decodedDataWriter, encodedData, dataBlocks, 0, int64(blockSize))
 				if err != nil && testCase.shouldPass {
-					t.Errorf("Test %d: Expected to pass by failed instead with %s", i+1, err)
+					t.Errorf("Test %d: Expected to pass but failed instead with %s", i+1, err)
 				}
 
 				// Validate if decoded data is what we expected.
 				if bytes.Equal(decodedDataWriter.Bytes(), data) != testCase.shouldPass {
 					err := errUnexpected
-					t.Errorf("Test %d: Expected to pass by failed instead %s", i+1, err)
+					t.Errorf("Test %d: Expected to pass but failed instead %s", i+1, err)
 				}
 			}
 		}

--- a/vendor/github.com/klauspost/reedsolomon/reedsolomon.go
+++ b/vendor/github.com/klauspost/reedsolomon/reedsolomon.go
@@ -50,6 +50,21 @@ type Encoder interface {
 	// Use the Verify function to check if data set is ok.
 	Reconstruct(shards [][]byte) error
 
+	// ReconstructMissingData will recreate any missing data shards, if possible.
+	//
+	// Given a list of shards, some of which contain data, fills in the
+	// data shards that don't have data.
+	//
+	// The length of the array must be equal to Shards.
+	// You indicate that a shard is missing by setting it to nil.
+	//
+	// If there are too few shards to reconstruct the missing
+	// ones, ErrTooFewShards will be returned.
+	//
+	// As the reconstructed shard set may contain missing parity shards,
+	// calling the Verify function is likely to fail.
+	ReconstructMissingData(shards [][]byte) error
+
 	// Split a data slice into the number of shards given to the encoder,
 	// and create empty parity shards.
 	//
@@ -358,6 +373,35 @@ func shardSize(shards [][]byte) int {
 // The reconstructed shard set is complete, but integrity is not verified.
 // Use the Verify function to check if data set is ok.
 func (r reedSolomon) Reconstruct(shards [][]byte) error {
+	return r.reconstruct(shards, false)
+}
+
+// ReconstructMissingData will recreate any missing data shards, if possible.
+//
+// Given a list of shards, some of which contain data, fills in the
+// data shards that don't have data.
+//
+// The length of the array must be equal to Shards.
+// You indicate that a shard is missing by setting it to nil.
+//
+// If there are too few shards to reconstruct the missing
+// ones, ErrTooFewShards will be returned.
+//
+// As the reconstructed shard set may contain missing parity shards,
+// calling the Verify function is likely to fail.
+func (r reedSolomon) ReconstructMissingData(shards [][]byte) error {
+	return r.reconstruct(shards, true)
+}
+
+// reconstruct will recreate the missing data shards, and unless
+// justData is true, also the missing parity shards
+//
+// The length of the array must be equal to Shards.
+// You indicate that a shard is missing by setting it to nil.
+//
+// If there are too few shards to reconstruct the missing
+// ones, ErrTooFewShards will be returned.
+func (r reedSolomon) reconstruct(shards [][]byte, justData bool) error {
 	if len(shards) != r.Shards {
 		return ErrTooFewShards
 	}
@@ -463,6 +507,11 @@ func (r reedSolomon) Reconstruct(shards [][]byte) error {
 		}
 	}
 	r.codeSomeShards(matrixRows, subShards, outputs[:outputCount], outputCount, shardSize)
+
+	if justData {
+		// Exit out early if we are only interested in the data blocks
+		return nil
+	}
 
 	// Now that we have all of the data shards intact, we can
 	// compute any of the parity that is missing.


### PR DESCRIPTION
Building on PR #4683, this is an optimization to only reconstruct any missing data blocks when reading an erasure coded file.

NB Do not merge (yet), we should probably see if we can get the ReconstructMissingData method implemented in the official repo from @klauspost 

## Motivation and Context
Optimization to not reconstruct any parity blocks that are not used anyway.

## How Has This Been Tested?
Tested manually.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.