### PR TITLE
Fix typo

### DIFF
--- a/docs/config/config.sample.json
+++ b/docs/config/config.sample.json
@@ -41,7 +41,7 @@
                 "password": "yoursecret",
                 "token": "",
                 "secure": false,
-                "pingInterval": 0
+                "pingInterval": 0,
                 "streaming": {
                     "enable": false,
                     "clusterID": "",


### PR DESCRIPTION
Add missing comma to config sample in order to have a valid JSON file.