### PR TITLE
Prevent minio server starting in standalone erasure mode when  distributed erasure was intended

### DIFF
--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -70,6 +70,7 @@ func TestNewEndpoint(t *testing.T) {
 		{"http://server:8080//", Endpoint{}, -1, fmt.Errorf("empty or root path is not supported in URL endpoint")},
 		{"http://server:8080/", Endpoint{}, -1, fmt.Errorf("empty or root path is not supported in URL endpoint")},
 		{"http://server/path", Endpoint{}, -1, fmt.Errorf("lookup server" + errMsg)},
+		{"192.168.1.210:9000", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format: missing scheme http or https")},
 	}
 
 	for _, testCase := range testCases {
@@ -122,6 +123,7 @@ func TestNewEndpointList(t *testing.T) {
 		{[]string{"ftp://server/d1", "http://server/d2", "http://server/d3", "http://server/d4"}, fmt.Errorf("'ftp://server/d1': invalid URL endpoint format")},
 		{[]string{"d1", "http://localhost/d2", "d3", "d4"}, fmt.Errorf("mixed style endpoints are not supported")},
 		{[]string{"http://example.org/d1", "https://example.com/d1", "http://example.net/d1", "https://example.edut/d1"}, fmt.Errorf("mixed scheme is not supported")},
+		{[]string{"192.168.1.210:9000/tmp/dir0", "192.168.1.210:9000/tmp/dir1", "192.168.1.210:9000/tmp/dir2", "192.168.110:9000/tmp/dir3"}, fmt.Errorf("'192.168.1.210:9000/tmp/dir0': invalid URL endpoint format: missing scheme http or https")},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -153,6 +153,15 @@ func getAPIEndpoints(serverAddr string) (apiEndpoints []string) {
 	return apiEndpoints
 }
 
+// isHostIPv4 - helper for validating if the provided arg is an ip address.
+func isHostIPv4(ipAddress string) bool {
+	host, _, err := net.SplitHostPort(ipAddress)
+	if err != nil {
+		host = ipAddress
+	}
+	return net.ParseIP(host) != nil
+}
+
 // checkPortAvailability - check if given port is already in use.
 // Note: The check method tries to listen on given port and closes it.
 // It is possible to have a disconnected client in this tiny window of time.

--- a/cmd/net_test.go
+++ b/cmd/net_test.go
@@ -317,3 +317,23 @@ func TestSameLocalAddrs(t *testing.T) {
 		}
 	}
 }
+func TestIsHostIPv4(t *testing.T) {
+	testCases := []struct {
+		args           string
+		expectedResult bool
+	}{
+		{"localhost", false},
+		{"localhost:9000", false},
+		{"example.com", false},
+		{"http://192.168.1.0", false},
+		{"http://192.168.1.0:9000", false},
+		{"192.168.1.0", true},
+	}
+
+	for _, testCase := range testCases {
+		ret := isHostIPv4(testCase.args)
+		if testCase.expectedResult != ret {
+			t.Fatalf("expected: %v , got: %v", testCase.expectedResult, ret)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4686

<!--- Provide a general summary of your changes in the Title above -->
When there are multiple args, we assume and start in standalone erasure mode when scheme is absent for ips or localhost. Ask user to provide scheme to start correctly in distributed erasure mode.

## Description
Ask explicitly for a scheme to be specified when starting in a distributed erasure mode so that the minio server wont think that the user intends to run this in standalone distributed mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this change : 
```
minio server 192.168.1.210:9000/tmp/dir0 192.168.1.210:9000/tmp/dir1 192.168.1.210:9000/tmp/dir2 192.168.110:9000/tmp/dir3
```
The server starts giving the user that minio started in distributed erasure mode when you can see this locally : 

```
find 192.168.1.210\:9000/
192.168.1.210:9000/
192.168.1.210:9000/tmp
192.168.1.210:9000/tmp/dir1
192.168.1.210:9000/tmp/dir1/.minio.sys
192.168.1.210:9000/tmp/dir1/.minio.sys/format.json
192.168.1.210:9000/tmp/dir1/.minio.sys/tmp
192.168.1.210:9000/tmp/dir1/.minio.sys/multipart
192.168.1.210:9000/tmp/dir2
192.168.1.210:9000/tmp/dir2/.minio.sys
192.168.1.210:9000/tmp/dir2/.minio.sys/format.json
192.168.1.210:9000/tmp/dir2/.minio.sys/tmp
192.168.1.210:9000/tmp/dir2/.minio.sys/multipart
192.168.1.210:9000/tmp/dir0
192.168.1.210:9000/tmp/dir0/.minio.sys
192.168.1.210:9000/tmp/dir0/.minio.sys/format.json
192.168.1.210:9000/tmp/dir0/.minio.sys/tmp
192.168.1.210:9000/tmp/dir0/.minio.sys/multipart
```
<!--- If it fixes an open issue, please link to the issue here. -->
#4686 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested after change : 
```
./minio server 192.168.1.210:9000/tmp/dir0 192.168.1.210:9000/tmp/dir1 192.168.1.210:9000/tmp/dir2 192.168.110:9000/tmp/dir3
FATA[0000] Invalid command line arguments server=‘:9000’, args=[192.168.1.210:9000/tmp/dir0 192.168.1.210:9000/tmp/dir1 192.168.1.210:9000/tmp/dir2 192.168.110:9000/tmp/dir3]  cause='192.168.1.210:9000/tmp/dir0': invalid URL endpoint format: missing scheme http or https source=[server-main.go:95:serverHandleCmdArgs()]
```
and 
```
./minio server localhost:9000/tmp/dir0 localhost:9000/tmp/dir1 localhost:9000/tmp/dir2 localhost:9000/tmp/dir3
FATA[0000] Invalid command line arguments server=‘:9000’, args=[localhost:9000/tmp/dir0 localhost:9000/tmp/dir1 localhost:9000/tmp/dir2 localhost:9000/tmp/dir3]  cause='localhost:9000/tmp/dir0': invalid URL endpoint format: missing scheme http or https source=[server-main.go:95:serverHandleCmdArgs()]
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.