### PR TITLE
azure: When container access type is private treat as no policy set

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -738,7 +738,7 @@ func (a *azureObjects) GetBucketPolicies(bucket string) (policy.BucketAccessPoli
 	}
 	switch perm.AccessType {
 	case storage.ContainerAccessTypePrivate:
-		// Do nothing
+		return policy.BucketAccessPolicy{}, traceError(PolicyNotFound{Bucket: bucket})
 	case storage.ContainerAccessTypeContainer:
 		policyInfo.Statements = policy.SetPolicy(policyInfo.Statements, policy.BucketPolicyReadOnly, bucket, "")
 	default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Azure gateway's response to GetBucketPolicies call is not consistent with 
S3 and server response when a bucket does not have a public policy 
defined for it. Both S3 And minio server respond with NoSuchBucketPolicy 
error, which is interpeted by the client SDK's as policy type None
In the case of Azure, by default container is set to access private 
meaning no anonymous access.  Azure gateway currently returns 
a policy object with empty statements when container is private 
access. Instead it should be interpreted as policy not found. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
<!--- If it fixes an open issue, please link to the issue here. -->
Azure gateway and minio server handling of GetBucketPolicies needs to be consistent . See #4718 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by running server in gateway mode for azure and testing with minio-py client SDK to connect to server and get bucket policy for a newly created bucket with no policy defined on it.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.