### PR TITLE
Removes max limit requirement on accessKey and secretKey length

### DIFF
--- a/cmd/credential_test.go
+++ b/cmd/credential_test.go
@@ -23,8 +23,8 @@ func TestMustGetNewCredential(t *testing.T) {
 	if !cred.IsValid() {
 		t.Fatalf("Failed to get new valid credential")
 	}
-	if len(cred.SecretKey) != secretKeyMaxLenMinio {
-		t.Fatalf("Invalid length %d of the secretKey credential generated, expected %d", len(cred.SecretKey), secretKeyMaxLenMinio)
+	if len(cred.SecretKey) != secretKeyMaxLen {
+		t.Fatalf("Invalid length %d of the secretKey credential generated, expected %d", len(cred.SecretKey), secretKeyMaxLen)
 	}
 }
 
@@ -36,18 +36,14 @@ func TestCreateCredential(t *testing.T) {
 		expectedResult bool
 		expectedErr    error
 	}{
-		// Access key too small.
+		// Access key too small (min 5 chars).
 		{"user", "pass", false, errInvalidAccessKeyLength},
-		// Access key too long.
-		{"user12345678901234567", "pass", false, errInvalidAccessKeyLength},
-		// Access key contains unsuppported characters.
-		{"!@#$", "pass", false, errInvalidAccessKeyLength},
-		// Secret key too small.
+		// Long access key is ok.
+		{"user123456789012345678901234567890", "password", true, nil},
+		// Secret key too small (min 8 chars).
 		{"myuser", "pass", false, errInvalidSecretKeyLength},
-		// Secret key too long.
-		{"myuser", "pass1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890", false, errInvalidSecretKeyLength},
-		// Success when access key contains leading/trailing spaces.
-		{" user ", cred.SecretKey, true, nil},
+		// Long secret key is ok.
+		{"myuser", "pass1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890", true, nil},
 		{"myuser", "mypassword", true, nil},
 		{cred.AccessKey, cred.SecretKey, true, nil},
 	}

--- a/cmd/jwt_test.go
+++ b/cmd/jwt_test.go
@@ -24,8 +24,12 @@ func testAuthenticate(authType string, t *testing.T) {
 		t.Fatalf("unable initialize config file, %s", err)
 	}
 	defer removeAll(testPath)
-
-	serverCred := serverConfig.GetCredential()
+	// Create access and secret keys in length, 300 and 600
+	cred, err := getNewCredential(300, 600)
+	if err != nil {
+		t.Fatalf("unable to get new credential, %v", err)
+	}
+	serverConfig.SetCredential(cred)
 
 	// Define test cases.
 	testCases := []struct {
@@ -33,24 +37,16 @@ func testAuthenticate(authType string, t *testing.T) {
 		secretKey   string
 		expectedErr error
 	}{
-		// Access key too small.
-		{"user", "pass", errInvalidAccessKeyLength},
-		// Access key too long.
-		{"user12345678901234567", "pass", errInvalidAccessKeyLength},
-		// Access key contains unsuppported characters.
-		{"!@#$", "pass", errInvalidAccessKeyLength},
-		// Success when access key contains leading/trailing spaces.
-		{" " + serverCred.AccessKey + " ", serverCred.SecretKey, errInvalidAccessKeyLength},
-		// Secret key too small.
-		{"myuser", "pass", errInvalidSecretKeyLength},
-		// Secret key too long.
-		{"myuser", "pass1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890", errInvalidSecretKeyLength},
+		// Access key (less than 5 chrs) too small.
+		{"user", cred.SecretKey, errInvalidAccessKeyLength},
+		// Secret key (less than 8 chrs) too small.
+		{cred.AccessKey, "pass", errInvalidSecretKeyLength},
 		// Authentication error.
 		{"myuser", "mypassword", errInvalidAccessKeyID},
 		// Authentication error.
-		{serverCred.AccessKey, "mypassword", errAuthentication},
+		{cred.AccessKey, "mypassword", errAuthentication},
 		// Success.
-		{serverCred.AccessKey, serverCred.SecretKey, nil},
+		{cred.AccessKey, cred.SecretKey, nil},
 	}
 
 	// Run tests.

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -52,8 +52,8 @@ FLAGS:
   {{end}}{{end}}
 ENVIRONMENT VARIABLES:
   ACCESS:
-     MINIO_ACCESS_KEY: Custom username or access key of 5 to 20 characters in length.
-     MINIO_SECRET_KEY: Custom password or secret key of 8 to 40 characters in length.
+     MINIO_ACCESS_KEY: Custom username or access key of minimum 5 characters in length.
+     MINIO_SECRET_KEY: Custom password or secret key of minimum 8 characters in length.
 
   BROWSER:
      MINIO_BROWSER: To disable web browser access, set this value to "off".

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -34,8 +34,8 @@ $ tree ~/.minio
 |Field|Type|Description|
 |:---|:---|:---|
 |``credential``| | Auth credential for object storage and web access.|
-|``credential.accessKey`` | _string_ | Access key of 5 to 20 characters in length. You may override this field with `MINIO_ACCESS_KEY` environment variable.|
-|``credential.secretKey`` | _string_ | Secret key of 8 to 40 characters in length. You may override this field with `MINIO_SECRET_KEY` environment variable.|
+|``credential.accessKey`` | _string_ | Access key of minimum 5 characters in length. You may override this field with `MINIO_ACCESS_KEY` environment variable.|
+|``credential.secretKey`` | _string_ | Secret key of minimum 8 characters in length. You may override this field with `MINIO_SECRET_KEY` environment variable.|
 
 Example:
 


### PR DESCRIPTION
## Description
Fixes Issue #4721 by removing the max limit variable and check 
so that there is no max limit on both accessKey and secretKey. 
We are still using minio specific max length to generate accessKey 
and secretKey. Corresponding tests and README file are also modified.

## Motivation and Context
Issue #4721: Increase access key to 24 chars for compatibility with Azure

## How Has This Been Tested?
- Started minio in gateway (azure) and standalone modes with a 30 byte long accessKey successfully without getting max length error message.
- Ran with less than 4 bytes accessKey and less than 8 secretKey to make sure correct error messages are displayed.
- Ran existing test cases.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated existing tests to cover my changes.
- [x] All new and existing tests passed.