### PR TITLE
bucket-policy: Add IPAddress/NotIPAddress conditions support

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -126,8 +126,9 @@ func checkRequestAuthType(r *http.Request, bucket, policyAction, region string) 
 
 	if reqAuthType == authTypeAnonymous && policyAction != "" {
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
+		sourceIP := getSourceIPAddress(r)
 		return enforceBucketPolicy(bucket, policyAction, r.URL.Path,
-			r.Referer(), r.URL.Query())
+			r.Referer(), sourceIP, r.URL.Query())
 	}
 
 	// By default return ErrAccessDenied

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -33,7 +33,7 @@ import (
 
 // http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
 // Enforces bucket policies for a bucket for a given tatusaction.
-func enforceBucketPolicy(bucket, action, resource, referer string, queryParams url.Values) (s3Error APIErrorCode) {
+func enforceBucketPolicy(bucket, action, resource, referer, sourceIP string, queryParams url.Values) (s3Error APIErrorCode) {
 	// Verify if bucket actually exists
 	if err := checkBucketExist(bucket, newObjectLayerFn()); err != nil {
 		err = errorCause(err)
@@ -73,6 +73,8 @@ func enforceBucketPolicy(bucket, action, resource, referer string, queryParams u
 	if referer != "" {
 		conditionKeyMap["referer"] = set.CreateStringSet(referer)
 	}
+	// Add request source Ip to conditionKeyMap.
+	conditionKeyMap["ip"] = set.CreateStringSet(sourceIP)
 
 	// Validate action, resource and conditions with current policy statements.
 	if !bucketPolicyEvalStatements(action, arn, conditionKeyMap, policy.Statements) {

--- a/cmd/bucket-policy-handlers_test.go
+++ b/cmd/bucket-policy-handlers_test.go
@@ -843,7 +843,7 @@ func testDeleteBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName str
 
 // TestBucketPolicyConditionMatch - Tests to validate whether bucket policy conditions match.
 func TestBucketPolicyConditionMatch(t *testing.T) {
-	// obtain the inner map[string]set.StringSet for policyStatement.Conditions .
+	// obtain the inner map[string]set.StringSet for policyStatement.Conditions.
 	getInnerMap := func(key2, value string) map[string]set.StringSet {
 		innerMap := make(map[string]set.StringSet)
 		innerMap[key2] = set.CreateStringSet(value)
@@ -969,6 +969,34 @@ func TestBucketPolicyConditionMatch(t *testing.T) {
 			statementCondition: getStatementWithCondition("StringNotLike", "aws:Referer", "http://www.example.com/"),
 			condition:          getInnerMap("referer", "http://somethingelse.com/"),
 			expectedMatch:      true,
+		},
+		// Test case 13.
+		// IpAddress condition evaluates to true.
+		{
+			statementCondition: getStatementWithCondition("IpAddress", "aws:SourceIp", "54.240.143.0/24"),
+			condition:          getInnerMap("ip", "54.240.143.2"),
+			expectedMatch:      true,
+		},
+		// Test case 14.
+		// IpAddress condition evaluates to false.
+		{
+			statementCondition: getStatementWithCondition("IpAddress", "aws:SourceIp", "54.240.143.0/24"),
+			condition:          getInnerMap("ip", "127.240.143.224"),
+			expectedMatch:      false,
+		},
+		// Test case 15.
+		// NotIpAddress condition evaluates to true.
+		{
+			statementCondition: getStatementWithCondition("NotIpAddress", "aws:SourceIp", "54.240.143.0/24"),
+			condition:          getInnerMap("ip", "54.240.144.188"),
+			expectedMatch:      true,
+		},
+		// Test case 16.
+		// NotIpAddress condition evaluates to false.
+		{
+			statementCondition: getStatementWithCondition("NotIpAddress", "aws:SourceIp", "54.240.143.0/24"),
+			condition:          getInnerMap("ip", "54.240.143.243"),
+			expectedMatch:      false,
 		},
 	}
 

--- a/cmd/bucket-policy-parser.go
+++ b/cmd/bucket-policy-parser.go
@@ -40,11 +40,11 @@ var supportedActionMap = set.CreateStringSet("*", "s3:*", "s3:GetObject",
 	"s3:AbortMultipartUpload", "s3:ListBucketMultipartUploads", "s3:ListMultipartUploadParts")
 
 // supported Conditions type.
-var supportedConditionsType = set.CreateStringSet("StringEquals", "StringNotEquals", "StringLike", "StringNotLike")
+var supportedConditionsType = set.CreateStringSet("StringEquals", "StringNotEquals", "StringLike", "StringNotLike", "IpAddress", "NotIpAddress")
 
 // Validate s3:prefix, s3:max-keys are present if not
 // supported keys for the conditions.
-var supportedConditionsKey = set.CreateStringSet("s3:prefix", "s3:max-keys", "aws:Referer")
+var supportedConditionsKey = set.CreateStringSet("s3:prefix", "s3:max-keys", "aws:Referer", "aws:SourceIp")
 
 // supportedEffectMap - supported effects.
 var supportedEffectMap = set.CreateStringSet("Allow", "Deny")

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
-	"strings"
 
 	mux "github.com/gorilla/mux"
 )
@@ -51,20 +50,14 @@ func setGetRespHeaders(w http.ResponseWriter, reqParams url.Values) {
 
 // getSourceIPAddress - get the source ip address of the request.
 func getSourceIPAddress(r *http.Request) string {
-	// Attempt to get ip from standard headers.
 	var ip string
-	for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
-		addresses := r.Header[h]
-		// Get most recently used ip.
-		for i := len(addresses) - 1; i >= 0; i-- {
-			ip = strings.TrimSpace(addresses[i])
-			parsedIP := net.ParseIP(ip)
-			// Skip non valid IP address.
-			if parsedIP == nil {
-				continue
-			}
-			return ip
-		}
+	// Attempt to get ip from standard headers.
+	// Do not support X-Forwarded-For because it is easy to spoof.
+	ip = r.Header.Get("X-Real-Ip")
+	parsedIP := net.ParseIP(ip)
+	// Skip non valid IP address.
+	if parsedIP != nil {
+		return ip
 	}
 	// Default to remote address if headers not set.
 	ip, _, _ = net.SplitHostPort(r.RemoteAddr)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -52,11 +52,12 @@ func setGetRespHeaders(w http.ResponseWriter, reqParams url.Values) {
 // getSourceIPAddress - get the source ip address of the request.
 func getSourceIPAddress(r *http.Request) string {
 	// Attempt to get ip from standard headers.
+	var ip string
 	for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
 		addresses := strings.Split(r.Header.Get(h), ",")
 		// Get most recently used ip.
 		for i := len(addresses) - 1; i >= 0; i-- {
-			ip := strings.TrimSpace(addresses[i])
+			ip = strings.TrimSpace(addresses[i])
 			parsedIP := net.ParseIP(ip)
 			// Skip non valid IP address.
 			if parsedIP == nil {
@@ -66,7 +67,8 @@ func getSourceIPAddress(r *http.Request) string {
 		}
 	}
 	// Default to remote address if headers not set.
-	return r.RemoteAddr
+	ip, _, _ = net.SplitHostPort(r.RemoteAddr)
+	return ip
 }
 
 // errAllowableNotFound - For an anon user, return 404 if have ListBucket, 403 otherwise

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 
 	mux "github.com/gorilla/mux"
 )
@@ -48,16 +49,37 @@ func setGetRespHeaders(w http.ResponseWriter, reqParams url.Values) {
 	}
 }
 
+// getSourceIPAddress - get the source ip address of the request.
+func getSourceIPAddress(r *http.Request) string {
+	// Attempt to get ip from standard headers.
+	for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
+		addresses := strings.Split(r.Header.Get(h), ",")
+		// Get most recently used ip.
+		for i := len(addresses) - 1; i >= 0; i-- {
+			ip := strings.TrimSpace(addresses[i])
+			parsedIP := net.ParseIP(ip)
+			// Skip non valid IP address.
+			if parsedIP == nil {
+				continue
+			}
+			return ip
+		}
+	}
+	// Default to remote address if headers not set.
+	return r.RemoteAddr
+}
+
 // errAllowableNotFound - For an anon user, return 404 if have ListBucket, 403 otherwise
 // this is in keeping with the permissions sections of the docs of both:
 //   HEAD Object: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html
 //   GET Object: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html
 func errAllowableObjectNotFound(bucket string, r *http.Request) APIErrorCode {
 	if getRequestAuthType(r) == authTypeAnonymous {
-		//we care about the bucket as a whole, not a particular resource
+		// We care about the bucket as a whole, not a particular resource.
 		resource := "/" + bucket
+		sourceIP := getSourceIPAddress(r)
 		if s3Error := enforceBucketPolicy(bucket, "s3:ListBucket", resource,
-			r.Referer(), r.URL.Query()); s3Error != ErrNone {
+			r.Referer(), sourceIP, r.URL.Query()); s3Error != ErrNone {
 			return ErrAccessDenied
 		}
 	}
@@ -505,8 +527,9 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
+		sourceIP := getSourceIPAddress(r)
 		if s3Error := enforceBucketPolicy(bucket, "s3:PutObject", r.URL.Path,
-			r.Referer(), r.URL.Query()); s3Error != ErrNone {
+			r.Referer(), sourceIP, r.URL.Query()); s3Error != ErrNone {
 			writeErrorResponse(w, s3Error, r.URL)
 			return
 		}
@@ -791,8 +814,9 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		return
 	case authTypeAnonymous:
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html
+		sourceIP := getSourceIPAddress(r)
 		if s3Error := enforceBucketPolicy(bucket, "s3:PutObject", r.URL.Path,
-			r.Referer(), r.URL.Query()); s3Error != ErrNone {
+			r.Referer(), sourceIP, r.URL.Query()); s3Error != ErrNone {
 			writeErrorResponse(w, s3Error, r.URL)
 			return
 		}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -54,7 +54,7 @@ func getSourceIPAddress(r *http.Request) string {
 	// Attempt to get ip from standard headers.
 	var ip string
 	for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
-		addresses := strings.Split(r.Header.Get(h), ",")
+		addresses := r.Header[h]
 		// Get most recently used ip.
 		for i := len(addresses) - 1; i >= 0; i-- {
 			ip = strings.TrimSpace(addresses[i])

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -3571,24 +3571,24 @@ func TestGetSourceIPAddress(t *testing.T) {
 			request: &http.Request{
 				RemoteAddr: "127.0.0.1:9000",
 				Header: map[string][]string{
-					"X-Forwarded-For": {"54.240.143.0"},
+					"X-Real-Ip": {"54.240.143.0"},
 				},
 			},
 			expectedIP: "54.240.143.0", // Use headers before RemoteAddr.
 		},
 		{
 			// Test Case 3. Use both RemoteAddr and several header vals.
-			// Check that last val in header is used.
+			// Check that first val in header is used.
 			request: &http.Request{
 				RemoteAddr: "127.0.0.1:9000",
 				Header: map[string][]string{
-					"X-Forwarded-For": {"54.240.143.0", "54.240.143.188"},
+					"X-Real-Ip": {"54.240.143.0", "54.240.143.188"},
 				},
 			},
-			expectedIP: "54.240.143.188",
+			expectedIP: "54.240.143.0",
 		},
 		{
-			// Test Case 4. Different header and corrupt header value.
+			// Test Case 4. Use header and corrupt header value.
 			request: &http.Request{
 				RemoteAddr: "127.0.0.1:9000",
 				Header: map[string][]string{

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -3552,3 +3552,56 @@ func testAPIListObjectPartsHandler(obj ObjectLayer, instanceType, bucketName str
 	// `ExecObjectLayerAPINilTest` sets the Object Layer to `nil` and calls the handler.
 	ExecObjectLayerAPINilTest(t, nilBucket, nilObject, instanceType, apiRouter, nilReq)
 }
+
+// TestGetSourceIPAddress - check the source ip of a request is parsed correctly.
+func TestGetSourceIPAddress(t *testing.T) {
+	testCases := []struct {
+		request    *http.Request
+		expectedIP string
+	}{
+		{
+			// Test Case 1. Use only RemoteAddr as host and port.
+			request: &http.Request{
+				RemoteAddr: "127.0.0.1:9000",
+			},
+			expectedIP: "127.0.0.1",
+		},
+		{
+			// Test Case 2. Use both RemoteAddr and single header.
+			request: &http.Request{
+				RemoteAddr: "127.0.0.1:9000",
+				Header: map[string][]string{
+					"X-Forwarded-For": {"54.240.143.0"},
+				},
+			},
+			expectedIP: "54.240.143.0", // Use headers before RemoteAddr.
+		},
+		{
+			// Test Case 3. Use both RemoteAddr and several header vals.
+			// Check that last val in header is used.
+			request: &http.Request{
+				RemoteAddr: "127.0.0.1:9000",
+				Header: map[string][]string{
+					"X-Forwarded-For": {"54.240.143.0", "54.240.143.188"},
+				},
+			},
+			expectedIP: "54.240.143.188",
+		},
+		{
+			// Test Case 4. Different header and corrupt header value.
+			request: &http.Request{
+				RemoteAddr: "127.0.0.1:9000",
+				Header: map[string][]string{
+					"X-Real-Ip": {"54.240.143.188", "corrupt"},
+				},
+			},
+			expectedIP: "54.240.143.188",
+		},
+	}
+	for i, test := range testCases {
+		receivedIP := getSourceIPAddress(test.request)
+		if test.expectedIP != receivedIP {
+			t.Fatalf("Case %d: Expected the IP to be `%s`, but instead got `%s`", i+1, test.expectedIP, receivedIP)
+		}
+	}
+}

--- a/docs/bucket/policy/README.md
+++ b/docs/bucket/policy/README.md
@@ -24,12 +24,15 @@ This package implements parsing and validating bucket access policies based on A
     StringNotEquals
     StringLike
     StringNotLike
+    IpAddress
+    NotIpAddress
 
 Supported applicable condition keys for each conditions.
 
     s3:prefix
     s3:max-keys
     aws:Referer
+    aws:SourceIp
 
 ### Nested policy support.
 


### PR DESCRIPTION
## Description
Adds the ability to restrict bucket access by IP addresses. See for more detail.
https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-3
## Motivation and Context
Fixes: #4369 

## How Has This Been Tested?
Manually and Unit tests.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.