### PR TITLE
cmd: fix race in fsDeleteFile, make isDirEmpty deterministic, drop stat in deleteFile, DRY

### DIFF
--- a/cmd/fs-v1-helpers_test.go
+++ b/cmd/fs-v1-helpers_test.go
@@ -265,44 +265,117 @@ func TestFSDeletes(t *testing.T) {
 	// Seek back.
 	reader.Seek(0, 0)
 
+	// folder is not empty
+	err = fsMkdir(pathJoin(path, "success-vol", "not-empty"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(pathJoin(path, "success-vol", "not-empty", "file"), []byte("data"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// recursive
+	if err = fsMkdir(pathJoin(path, "success-vol", "parent")); err != nil {
+		t.Fatal(err)
+	}
+	if err = fsMkdir(pathJoin(path, "success-vol", "parent", "dir")); err != nil {
+		t.Fatal(err)
+	}
+
 	testCases := []struct {
+		basePath    string
 		srcVol      string
 		srcPath     string
 		expectedErr error
 	}{
-		// Test case - 1.
 		// valid case with existing volume and file to delete.
 		{
+			basePath:    path,
 			srcVol:      "success-vol",
 			srcPath:     "success-file",
 			expectedErr: nil,
 		},
-		// Test case - 2.
 		// The file was deleted in the last case, so DeleteFile should fail.
 		{
+			basePath:    path,
 			srcVol:      "success-vol",
 			srcPath:     "success-file",
 			expectedErr: errFileNotFound,
 		},
-		// Test case - 3.
 		// Test case with segment of the volume name > 255.
 		{
+			basePath:    path,
 			srcVol:      "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
 			srcPath:     "success-file",
 			expectedErr: errFileNameTooLong,
 		},
-		// Test case - 4.
 		// Test case with src path segment > 255.
 		{
+			basePath:    path,
 			srcVol:      "success-vol",
 			srcPath:     "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
 			expectedErr: errFileNameTooLong,
 		},
+		// Base path is way too long.
+		{
+			basePath:    "path03333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+			srcVol:      "success-vol",
+			srcPath:     "object",
+			expectedErr: errFileNameTooLong,
+		},
+		// Directory is not empty. Should give nil, but won't delete.
+		{
+			basePath:    path,
+			srcVol:      "success-vol",
+			srcPath:     "not-empty",
+			expectedErr: nil,
+		},
+		// Should delete recursively.
+		{
+			basePath:    path,
+			srcVol:      "success-vol",
+			srcPath:     pathJoin("parent", "dir"),
+			expectedErr: nil,
+		},
 	}
 
 	for i, testCase := range testCases {
-		if err = fsDeleteFile(path, pathJoin(path, testCase.srcVol, testCase.srcPath)); errorCause(err) != testCase.expectedErr {
+		if err = fsDeleteFile(testCase.basePath, pathJoin(testCase.basePath, testCase.srcVol, testCase.srcPath)); errorCause(err) != testCase.expectedErr {
 			t.Errorf("Test case %d: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
+		}
+	}
+}
+
+func BenchmarkFSDeleteFile(b *testing.B) {
+	// create posix test setup
+	_, path, err := newPosixTestSetup()
+	if err != nil {
+		b.Fatalf("Unable to create posix test setup, %s", err)
+	}
+	defer removeAll(path)
+
+	// Setup test environment.
+	if err = fsMkdir(pathJoin(path, "benchmark")); err != nil {
+		b.Fatalf("Unable to create directory, %s", err)
+	}
+
+	benchDir := pathJoin(path, "benchmark")
+	filename := pathJoin(benchDir, "file.txt")
+
+	b.ResetTimer()
+	// We need to create and delete the file sequentially inside the benchmark.
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		err = ioutil.WriteFile(filename, []byte("data"), 0777)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+
+		err = fsDeleteFile(benchDir, filename)
+		if err != nil {
+			b.Fatal(err)
 		}
 	}
 }

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -911,39 +911,28 @@ func (s *posix) StatFile(volume, path string) (file FileInfo, err error) {
 	}, nil
 }
 
-// deleteFile - delete file path if its empty.
+// deleteFile deletes a file path if its empty. If it's successfully deleted,
+// it will recursively move up the tree, deleting empty parent directories
+// until it finds one with files in it. Returns nil for a non-empty directory.
 func deleteFile(basePath, deletePath string) error {
 	if basePath == deletePath {
 		return nil
 	}
-	// Verify if the path exists.
-	pathSt, err := osStat(preparePath(deletePath))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return errFileNotFound
-		} else if os.IsPermission(err) {
-			return errFileAccessDenied
-		}
-		return err
-	}
-	if pathSt.IsDir() && !isDirEmpty(deletePath) {
-		// Verify if directory is empty.
-		return nil
-	}
+
 	// Attempt to remove path.
 	if err := os.Remove(preparePath(deletePath)); err != nil {
 		if os.IsNotExist(err) {
 			return errFileNotFound
 		} else if os.IsPermission(err) {
 			return errFileAccessDenied
+		} else if isSysErrNotEmpty(err) {
+			return nil
 		}
 		return err
 	}
+
 	// Recursively go down the next path and delete again.
-	if err := deleteFile(basePath, slashpath.Dir(deletePath)); err != nil {
-		return err
-	}
-	return nil
+	return deleteFile(basePath, slashpath.Dir(deletePath))
 }
 
 // DeleteFile - delete a file at path.

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -76,24 +76,20 @@ func checkPathLength(pathName string) error {
 func isDirEmpty(dirname string) bool {
 	f, err := os.Open(preparePath(dirname))
 	if err != nil {
-		errorIf(func() error {
-			if !os.IsNotExist(err) {
-				return err
-			}
-			return nil
-		}(), "Unable to access directory.")
+		if !os.IsNotExist(err) {
+			errorIf(err, "Unable to access directory")
+		}
+
 		return false
 	}
 	defer f.Close()
 	// List one entry.
 	_, err = f.Readdirnames(1)
 	if err != io.EOF {
-		errorIf(func() error {
-			if !os.IsNotExist(err) {
-				return err
-			}
-			return nil
-		}(), "Unable to list directory.")
+		if !os.IsNotExist(err) {
+			errorIf(err, "Unable to list directory")
+		}
+
 		return false
 	}
 	// Returns true if we have reached EOF, directory is indeed empty.

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -932,7 +932,10 @@ func deleteFile(basePath, deletePath string) error {
 	}
 
 	// Recursively go down the next path and delete again.
-	return deleteFile(basePath, slashpath.Dir(deletePath))
+	// Errors for parent directories shouldn't trickle down.
+	deleteFile(basePath, slashpath.Dir(deletePath))
+
+	return nil
 }
 
 // DeleteFile - delete a file at path.

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -73,6 +73,31 @@ func TestPosixGetDiskInfo(t *testing.T) {
 	}
 }
 
+func TestPosixIsDirEmpty(t *testing.T) {
+	tmp, err := ioutil.TempDir(globalTestTmpDir, "minio-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeAll(tmp)
+
+	// Should give false on non-existent directory.
+	dir1 := slashpath.Join(tmp, "non-existent-directory")
+	if isDirEmpty(dir1) != false {
+		t.Error("expected false for non-existent directory, got true")
+	}
+
+	// Should give false for not-a-directory.
+	dir2 := slashpath.Join(tmp, "file")
+	err = ioutil.WriteFile(dir2, []byte("hello"), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if isDirEmpty(dir2) != false {
+		t.Error("expected false for a file, got true")
+	}
+}
+
 // TestPosixReadAll - TestPosixs the functionality implemented by posix ReadAll storage API.
 func TestPosixReadAll(t *testing.T) {
 	// create posix test setup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
```
commit fdbb13799b411b539fca7d9e5b9c05211da2545d
Author: Brendan Ashworth <brendan.ashworth@me.com>
Date:   Mon Jul 31 15:54:22 2017 -0700

    posix: do not upstream errors in deleteFile
    
    This commit changes posix's deleteFile() to not upstream errors from
    removing parent directories. This fixes a race condition.
    
    The race condition occurs when multiple deleteFile()s are called on the
    same parent directory, but different child files. Because deleteFile()
    recursively removes parent directories if they are empty, but
    deleteFile() errors if the selected deletePath does not exist, there was
    an opportunity for a race condition. The two processes would remove the
    child directories successfully, then depend on the parent directory
    still existing. In some cases this is an invalid assumption, because
    other processes can remove the parent directory beforehand. This commit
    changes deleteFile() to not upstream an error if one occurs, because the
    only required error should be from the immediate deletePath, not from a
    parent path.
    
    In the specific bug report, multiple CompleteMultipartUpload requests
    would launch multiple deleteFile() requests. Because they chain up on
    parent directories, ultimately at the end, there would be multiple
    remove files for the ultimate parent directory,
    .minio.sys/multipart/{bucket}. Because only one will succeed and one
    will fail, an error would be upstreamed saying that the file does not
    exist, and the CompleteMultipartUpload code interpreted this as
    NoSuchKey, or that the object/part id doesn't exist. This was faulty
    behavior and is now fixed.
    
    Fixes: https://github.com/minio/minio/issues/4727

commit 52e058583012560c1d7b26a191ee904e422fbb5f
Author: Brendan Ashworth <brendan.ashworth@me.com>
Date:   Fri Jul 28 15:34:01 2017 -0700

    fs: drop Stat() call from fsDeleteFile,deleteFile
    
    This commit makes fsDeleteFile() simply call deleteFile() after calling
    the relevant path length checking functions. This DRYs the code base.
    
    This commit removes the Stat() call from deleteFile(). This improves
    performance and removes any possibility of a race condition.
    
    This additionally adds tests and a benchmark for said function. Here are
    the results from before and after this commit:
    
    benchmark                   old ns/op     new ns/op     delta
    BenchmarkFSDeleteFile-4     2694884       1900661       -29.47%

commit 1778101f5e830f0afea18de67d5c8ce10e4af972
Author: Brendan Ashworth <brendan.ashworth@me.com>
Date:   Thu Jul 20 17:13:15 2017 -0700

    posix: test isDirEmpty, change error conditional
    
    This commit adds a new test for isDirEmpty (for code coverage) and
    changes around the error conditional. Previously, there was a `return
    nil` statement that would only be triggered under a race condition and
    would trip up our test coverage for no reason. With this new error
    conditional, there's no awkward 'else'-esque condition, which means test
    coverage will not change between runs for no reason in this specific
    test. It's also a cleaner read.
```

## Motivation and Context
Fixes the race condition in https://github.com/minio/minio/issues/4727.

Fixes `posix.go` and `fs-v1-helpers.go` in https://github.com/minio/minio/issues/4658#issuecomment-318495587.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
well

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.