### PR TITLE
Remove minimum inodes check

### DIFF
--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -34,9 +34,9 @@ const (
 // StorageInfo - represents total capacity of underlying storage.
 type StorageInfo struct {
 	// Total disk space.
-	Total int64
+	Total uint64
 	// Free available disk space.
-	Free int64
+	Free uint64
 	// Backend type.
 	Backend struct {
 		// Represents various backend types, currently on FS and Erasure.

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -35,11 +35,9 @@ import (
 )
 
 const (
-	diskMinFreeSpace   = 1 * humanize.GiByte // Min 1GiB free space.
-	diskMinTotalSpace  = diskMinFreeSpace    // Min 1GiB total space.
-	diskMinFreeInodes  = 10000               // Min 10000 free inodes.
-	diskMinTotalInodes = diskMinFreeInodes   // Min 10000 total inodes.
-	maxAllowedIOError  = 5
+	diskMinFreeSpace  = 1 * humanize.GiByte // Min 1GiB free space.
+	diskMinTotalSpace = diskMinFreeSpace    // Min 1GiB total space.
+	maxAllowedIOError = 5
 )
 
 // posix - implements StorageAPI interface.
@@ -177,18 +175,6 @@ func checkDiskMinTotal(di disk.Info) (err error) {
 	if int64(totalDiskSpace) <= diskMinTotalSpace {
 		return errDiskFull
 	}
-
-	// Some filesystems do not implement a way to provide total inodes available, instead
-	// inodes are allocated based on available disk space. For example CephDISK, StoreNext CVDISK,
-	// AzureFile driver. Allow for the available disk to be separately validated and we will
-	// validate inodes only if total inodes are provided by the underlying filesystem.
-	if di.Files != 0 && di.FSType != "NFS" {
-		totalFiles := int64(di.Files)
-		if totalFiles <= diskMinTotalInodes {
-			return errDiskFull
-		}
-	}
-
 	return nil
 }
 
@@ -198,17 +184,6 @@ func checkDiskMinFree(di disk.Info) error {
 	availableDiskSpace := float64(di.Free) * 0.95
 	if int64(availableDiskSpace) <= diskMinFreeSpace {
 		return errDiskFull
-	}
-
-	// Some filesystems do not implement a way to provide total inodes available, instead inodes
-	// are allocated based on available disk space. For example CephDISK, StoreNext CVDISK, AzureFile driver.
-	// Allow for the available disk to be separately validate and we will validate inodes only if
-	// total inodes are provided by the underlying filesystem.
-	if di.Files != 0 && di.FSType != "NFS" {
-		availableFiles := int64(di.Ffree)
-		if availableFiles <= diskMinFreeInodes {
-			return errDiskFull
-		}
 	}
 
 	// Success.

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -1686,14 +1686,14 @@ func TestCheckDiskTotalMin(t *testing.T) {
 			},
 			err: nil,
 		},
-		// Test 2 - when fstype is xfs and total inodes are small.
+		// Test 2 - when fstype is xfs and total inodes are less than 10k.
 		{
 			diskInfo: disk.Info{
 				Total:  diskMinTotalSpace * 3,
 				FSType: "XFS",
 				Files:  9999,
 			},
-			err: errDiskFull,
+			err: nil,
 		},
 		// Test 3 - when fstype is btrfs and total inodes is empty.
 		{
@@ -1737,7 +1737,7 @@ func TestCheckDiskFreeMin(t *testing.T) {
 			},
 			err: nil,
 		},
-		// Test 2 - when fstype is xfs and total inodes are small.
+		// Test 2 - when fstype is xfs and total inodes are less than 10k.
 		{
 			diskInfo: disk.Info{
 				Free:   diskMinTotalSpace * 3,
@@ -1745,7 +1745,7 @@ func TestCheckDiskFreeMin(t *testing.T) {
 				Files:  9999,
 				Ffree:  9999,
 			},
-			err: errDiskFull,
+			err: nil,
 		},
 		// Test 3 - when fstype is btrfs and total inodes are empty.
 		{

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -1594,8 +1594,9 @@ func TestWebObjectLayerFaultyDisks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed %v", err)
 	}
-	if storageInfoReply.StorageInfo.Total != -1 || storageInfoReply.StorageInfo.Free != -1 {
-		t.Fatalf("Should get negative values of Total and Free since disks are faulty ")
+	// if Total size is 0 it indicates faulty disk.
+	if storageInfoReply.StorageInfo.Total != 0 {
+		t.Fatalf("Should get zero Total size since disks are faulty ")
 	}
 
 	// Test authorization of Web.Download

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -231,10 +231,11 @@ func getStorageInfo(disks []StorageAPI) StorageInfo {
 
 	// Sort so that the first element is the smallest.
 	validDisksInfo := sortValidDisksInfo(disksInfo)
+	// If there are no valid disks, set total and free disks to 0
 	if len(validDisksInfo) == 0 {
 		return StorageInfo{
-			Total: -1,
-			Free:  -1,
+			Total: 0,
+			Free:  0,
 		}
 	}
 
@@ -242,8 +243,8 @@ func getStorageInfo(disks []StorageAPI) StorageInfo {
 	// Free as the total aggregated values. Total capacity is always
 	// the multiple of smallest disk among the disk list.
 	storageInfo := StorageInfo{
-		Total: validDisksInfo[0].Total * int64(onlineDisks) / 2,
-		Free:  validDisksInfo[0].Free * int64(onlineDisks) / 2,
+		Total: validDisksInfo[0].Total * uint64(onlineDisks) / 2,
+		Free:  validDisksInfo[0].Free * uint64(onlineDisks) / 2,
 	}
 
 	storageInfo.Backend.Type = Erasure

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -19,12 +19,14 @@ package disk
 // Info stat fs struct is container which holds following values
 // Total - total size of the volume / disk
 // Free - free size of the volume / disk
-// Type - file system type string
+// Files - total inodes available
+// Ffree - free inodes available
+// FSType - file system type
 type Info struct {
-	Total  int64
-	Free   int64
-	Files  int64
-	Ffree  int64
+	Total  uint64
+	Free   uint64
+	Files  uint64
+	Ffree  uint64
 	FSType string
 }
 

--- a/pkg/disk/stat_bsd.go
+++ b/pkg/disk/stat_bsd.go
@@ -30,10 +30,10 @@ func GetInfo(path string) (info Info, err error) {
 		return Info{}, err
 	}
 	info = Info{}
-	info.Total = int64(s.Bsize) * int64(s.Blocks)
-	info.Free = int64(s.Bsize) * int64(s.Bavail)
-	info.Files = int64(s.Files)
-	info.Ffree = int64(s.Ffree)
+	info.Total = uint64(s.Bsize) * uint64(s.Blocks)
+	info.Free = uint64(s.Bsize) * uint64(s.Bavail)
+	info.Files = uint64(s.Files)
+	info.Ffree = uint64(s.Ffree)
 	info.FSType = getFSType(s.Fstypename)
 	return info, nil
 }

--- a/pkg/disk/stat_linux.go
+++ b/pkg/disk/stat_linux.go
@@ -30,10 +30,10 @@ func GetInfo(path string) (info Info, err error) {
 		return Info{}, err
 	}
 	info = Info{}
-	info.Total = int64(s.Bsize) * int64(s.Blocks)
-	info.Free = int64(s.Bsize) * int64(s.Bavail)
-	info.Files = int64(s.Files)
-	info.Ffree = int64(s.Ffree)
+	info.Total = uint64(s.Bsize) * uint64(s.Blocks)
+	info.Free = uint64(s.Bsize) * uint64(s.Bavail)
+	info.Files = uint64(s.Files)
+	info.Ffree = uint64(s.Ffree)
 	info.FSType = getFSType(int64(s.Type))
 	return info, nil
 }

--- a/pkg/disk/stat_openbsd.go
+++ b/pkg/disk/stat_openbsd.go
@@ -30,10 +30,10 @@ func GetInfo(path string) (info Info, err error) {
 		return Info{}, err
 	}
 	info = Info{}
-	info.Total = int64(s.F_bsize) * int64(s.F_blocks)
-	info.Free = int64(s.F_bsize) * int64(s.F_bavail)
-	info.Files = int64(s.F_files)
-	info.Ffree = int64(s.F_ffree)
+	info.Total = uint64(s.F_bsize) * uint64(s.F_blocks)
+	info.Free = uint64(s.F_bsize) * uint64(s.F_bavail)
+	info.Files = uint64(s.F_files)
+	info.Ffree = uint64(s.F_ffree)
 	info.FSType = getFSType(s.F_fstypename)
 	return info, nil
 }

--- a/pkg/disk/stat_windows.go
+++ b/pkg/disk/stat_windows.go
@@ -64,8 +64,8 @@ func GetInfo(path string) (info Info, err error) {
 		uintptr(unsafe.Pointer(&lpTotalNumberOfBytes)),
 		uintptr(unsafe.Pointer(&lpTotalNumberOfFreeBytes)))
 	info = Info{}
-	info.Total = int64(lpTotalNumberOfBytes)
-	info.Free = int64(lpFreeBytesAvailable)
+	info.Total = uint64(lpTotalNumberOfBytes)
+	info.Free = uint64(lpFreeBytesAvailable)
 	info.FSType = getFSType(path)
 
 	// Return values of GetDiskFreeSpace()
@@ -88,8 +88,8 @@ func GetInfo(path string) (info Info, err error) {
 		uintptr(unsafe.Pointer(&lpNumberOfFreeClusters)),
 		uintptr(unsafe.Pointer(&lpTotalNumberOfClusters)))
 
-	info.Files = int64(lpTotalNumberOfClusters)
-	info.Ffree = int64(lpNumberOfFreeClusters)
+	info.Files = uint64(lpTotalNumberOfClusters)
+	info.Ffree = uint64(lpNumberOfFreeClusters)
 
 	return info, nil
 }


### PR DESCRIPTION
## Description
This PR removes the check for minimum number of inodes required for Minio server to get started. It also changes the variable to store Free and Total size from `int64` to `uint64` to avoid overflows. 

## Motivation and Context
File systems like EFS/NFS don't report inodes properly and may sometimes prevent Minio server from starting. While the inode check itself doesn't serve a purpose. So, it is probably better to remove the check. For more info see https://github.com/minio/minio/issues/4675

## How Has This Been Tested?
Manually. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.