### PR TITLE
Stop attempting to close nil Listener

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -118,6 +118,10 @@ func (srv *Server) Start() (err error) {
 
 // Shutdown - shuts down HTTP server.
 func (srv *Server) Shutdown() error {
+	if srv.listener == nil {
+		return errors.New("server not initialized")
+	}
+
 	if atomic.AddUint32(&srv.inShutdown, 1) > 1 {
 		// shutdown in progress
 		return errors.New("http server already in shutdown")


### PR DESCRIPTION
## Description
If HTTP server is not up and running and if the Listener is attempted to be closed when the server could not even started up, then the offending panic/crash happens. 
To prevent crash from happening, this fix introduces a new HTTP server variable `upAndRunning` to keep track of the server's state. When we try to shut down the server, we just check if it was up before moving ahead with cleaning things up. This prevents the panic causing close attempt on the non-existing Listener.

## Motivation and Context
Crash in FS mode when Erasure coded mode is already running [#4715](https://github.com/minio/minio/issues/4715)

## How Has This Been Tested?
Started Minio in distributed mode and tried to start a 2nd Minio with one of the disks/resources that has been already used by the other Minio instance.
Also tested the opposite case.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.