### PR TITLE
erasure: simplify XL backend operations

### DIFF
--- a/cmd/erasure-healfile_test.go
+++ b/cmd/erasure-healfile_test.go
@@ -19,111 +19,124 @@ package cmd
 import (
 	"bytes"
 	"crypto/rand"
-	"os"
-	"path"
+	"io"
+	"reflect"
 	"testing"
-
-	humanize "github.com/dustin/go-humanize"
 )
 
-// Test erasureHealFile()
+var erasureHealFileTests = []struct {
+	dataBlocks                             int
+	disks, offDisks, badDisks, badOffDisks int
+	blocksize, size                        int64
+	algorithm                              BitrotAlgorithm
+	shouldFail                             bool
+	shouldFailQuorum                       bool
+}{
+	{dataBlocks: 2, disks: 4, offDisks: 1, badDisks: 0, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: SHA256, shouldFail: false, shouldFailQuorum: false},                   // 0
+	{dataBlocks: 3, disks: 6, offDisks: 2, badDisks: 0, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},               // 1
+	{dataBlocks: 4, disks: 8, offDisks: 2, badDisks: 1, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},               // 2
+	{dataBlocks: 5, disks: 10, offDisks: 3, badDisks: 1, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},  // 3
+	{dataBlocks: 6, disks: 12, offDisks: 2, badDisks: 3, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: SHA256, shouldFail: false, shouldFailQuorum: false},                  // 4
+	{dataBlocks: 7, disks: 14, offDisks: 4, badDisks: 1, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},  // 5
+	{dataBlocks: 8, disks: 16, offDisks: 6, badDisks: 1, badOffDisks: 1, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: true},   // 6
+	{dataBlocks: 7, disks: 14, offDisks: 2, badDisks: 3, badOffDisks: 0, blocksize: int64(oneMiByte / 2), size: oneMiByte, algorithm: BLAKE2b512, shouldFail: true, shouldFailQuorum: false},             // 7
+	{dataBlocks: 6, disks: 12, offDisks: 1, badDisks: 0, badOffDisks: 1, blocksize: int64(oneMiByte - 1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: true, shouldFailQuorum: false}, // 8
+	{dataBlocks: 5, disks: 10, offDisks: 3, badDisks: 0, badOffDisks: 3, blocksize: int64(oneMiByte / 2), size: oneMiByte, algorithm: SHA256, shouldFail: true, shouldFailQuorum: false},                 // 9
+	{dataBlocks: 4, disks: 8, offDisks: 1, badDisks: 1, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},   // 10
+	{dataBlocks: 2, disks: 4, offDisks: 1, badDisks: 0, badOffDisks: 1, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: true},    // 11
+	{dataBlocks: 6, disks: 12, offDisks: 8, badDisks: 3, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: true},   // 12
+	{dataBlocks: 7, disks: 14, offDisks: 3, badDisks: 4, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},              // 13
+	{dataBlocks: 7, disks: 14, offDisks: 6, badDisks: 1, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},  // 14
+	{dataBlocks: 8, disks: 16, offDisks: 4, badDisks: 5, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: true},   // 15
+	{dataBlocks: 2, disks: 4, offDisks: 0, badDisks: 0, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},   // 16
+	{dataBlocks: 2, disks: 4, offDisks: 0, badDisks: 0, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: 0, shouldFail: true, shouldFailQuorum: false},                         // 17
+	{dataBlocks: 12, disks: 16, offDisks: 2, badDisks: 1, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false}, // 18
+	{dataBlocks: 6, disks: 8, offDisks: 1, badDisks: 0, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},               // 19
+	{dataBlocks: 7, disks: 10, offDisks: 1, badDisks: 0, badOffDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: 0, shouldFail: true, shouldFailQuorum: false},                        // 20
+}
+
 func TestErasureHealFile(t *testing.T) {
-	// Initialize environment needed for the test.
-	dataBlocks := 7
-	parityBlocks := 7
-	blockSize := int64(blockSizeV1)
-	setup, err := newErasureTestSetup(dataBlocks, parityBlocks, blockSize)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer setup.Remove()
-
-	disks := setup.disks
-
-	// Prepare a slice of 1MiB with random data.
-	data := make([]byte, 1*humanize.MiByte)
-	_, err = rand.Read(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Create a test file.
-	_, size, checkSums, err := erasureCreateFile(disks, "testbucket", "testobject1", bytes.NewReader(data), true, blockSize, dataBlocks, parityBlocks, bitRotAlgo, dataBlocks+1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if size != int64(len(data)) {
-		t.Errorf("erasureCreateFile returned %d, expected %d", size, len(data))
-	}
-
-	latest := make([]StorageAPI, len(disks))   // Slice of latest disks
-	outDated := make([]StorageAPI, len(disks)) // Slice of outdated disks
-
-	// Test case when one part needs to be healed.
-	dataPath := path.Join(setup.diskPaths[0], "testbucket", "testobject1")
-	err = os.Remove(dataPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	copy(latest, disks)
-	latest[0] = nil
-	outDated[0] = disks[0]
-
-	healCheckSums, err := erasureHealFile(latest, outDated, "testbucket", "testobject1", "testbucket", "testobject1", 1*humanize.MiByte, blockSize, dataBlocks, parityBlocks, bitRotAlgo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Checksum of the healed file should match.
-	if checkSums[0] != healCheckSums[0] {
-		t.Error("Healing failed, data does not match.")
-	}
-
-	// Test case when parityBlocks number of disks need to be healed.
-	// Should succeed.
-	copy(latest, disks)
-	for index := 0; index < parityBlocks; index++ {
-		dataPath := path.Join(setup.diskPaths[index], "testbucket", "testobject1")
-		err = os.Remove(dataPath)
+	for i, test := range erasureHealFileTests {
+		setup, err := newErasureTestSetup(test.dataBlocks, test.disks-test.dataBlocks, test.blocksize)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("Test %d: failed to setup XL environment: %v", i, err)
 		}
-
-		latest[index] = nil
-		outDated[index] = disks[index]
-	}
-
-	healCheckSums, err = erasureHealFile(latest, outDated, "testbucket", "testobject1", "testbucket", "testobject1", 1*humanize.MiByte, blockSize, dataBlocks, parityBlocks, bitRotAlgo)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Checksums of the healed files should match.
-	for index := 0; index < parityBlocks; index++ {
-		if checkSums[index] != healCheckSums[index] {
-			t.Error("Healing failed, data does not match.")
-		}
-	}
-	for index := dataBlocks; index < len(disks); index++ {
-		if healCheckSums[index] != "" {
-			t.Errorf("expected healCheckSums[%d] to be empty", index)
-		}
-	}
-
-	// Test case when parityBlocks+1 number of disks need to be healed.
-	// Should fail.
-	copy(latest, disks)
-	for index := 0; index < parityBlocks+1; index++ {
-		dataPath := path.Join(setup.diskPaths[index], "testbucket", "testobject1")
-		err = os.Remove(dataPath)
+		storage, err := NewErasureStorage(setup.disks, test.dataBlocks, test.disks-test.dataBlocks)
 		if err != nil {
-			t.Fatal(err)
+			setup.Remove()
+			t.Fatalf("Test %d: failed to create ErasureStorage: %v", i, err)
+		}
+		offline := make([]StorageAPI, len(storage.disks))
+		copy(offline, storage.disks)
+
+		data := make([]byte, test.size)
+		if _, err = io.ReadFull(rand.Reader, data); err != nil {
+			setup.Remove()
+			t.Fatalf("Test %d: failed to create random test data: %v", i, err)
 		}
 
-		latest[index] = nil
-		outDated[index] = disks[index]
-	}
-	_, err = erasureHealFile(latest, outDated, "testbucket", "testobject1", "testbucket", "testobject1", 1*humanize.MiByte, blockSize, dataBlocks, parityBlocks, bitRotAlgo)
-	if err == nil {
-		t.Error("Expected erasureHealFile() to fail when the number of available disks <= parityBlocks")
+		algorithm := test.algorithm
+		if !algorithm.Available() {
+			algorithm = DefaultBitrotAlgorithm
+		}
+		buffer := make([]byte, test.blocksize, 2*test.blocksize)
+		file, err := storage.CreateFile(bytes.NewReader(data), "testbucket", "testobject", buffer, algorithm, test.dataBlocks+1)
+		if err != nil {
+			setup.Remove()
+			t.Fatalf("Test %d: failed to create random test data: %v", i, err)
+		}
+
+		info, err := storage.HealFile(offline, "testbucket", "testobject", test.blocksize, "testbucket", "healedobject", test.size, test.algorithm, file.Checksums)
+		if err != nil && !test.shouldFail {
+			t.Errorf("Test %d: should pass but it failed with: %v", i, err)
+		}
+		if err == nil && test.shouldFail {
+			t.Errorf("Test %d: should fail but it passed", i)
+		}
+		if err == nil {
+			if info.Size != test.size {
+				t.Errorf("Test %d: healed wrong number of bytes: got: #%d want: #%d", i, info.Size, test.size)
+			}
+			if info.Algorithm != test.algorithm {
+				t.Errorf("Test %d: healed with wrong algorithm: got: %v want: %v", i, info.Algorithm, test.algorithm)
+			}
+			if !reflect.DeepEqual(info.Checksums, file.Checksums) {
+				t.Errorf("Test %d: heal returned different bitrot keys", i)
+			}
+		}
+		if err == nil && !test.shouldFail {
+			for j := 0; j < len(storage.disks); j++ {
+				if j < test.offDisks {
+					storage.disks[j] = OfflineDisk
+				} else {
+					offline[j] = OfflineDisk
+				}
+			}
+			for j := 0; j < test.badDisks; j++ {
+				storage.disks[test.offDisks+j] = badDisk{nil}
+			}
+			for j := 0; j < test.badOffDisks; j++ {
+				offline[j] = badDisk{nil}
+			}
+			info, err := storage.HealFile(offline, "testbucket", "testobject", test.blocksize, "testbucket", "healedobject", test.size, test.algorithm, file.Checksums)
+			if err != nil && !test.shouldFailQuorum {
+				t.Errorf("Test %d: should pass but it failed with: %v", i, err)
+			}
+			if err == nil && test.shouldFailQuorum {
+				t.Errorf("Test %d: should fail but it passed", i)
+			}
+			if err == nil {
+				if info.Size != test.size {
+					t.Errorf("Test %d: healed wrong number of bytes: got: #%d want: #%d", i, info.Size, test.size)
+				}
+				if info.Algorithm != test.algorithm {
+					t.Errorf("Test %d: healed with wrong algorithm: got: %v want: %v", i, info.Algorithm, test.algorithm)
+				}
+				if !reflect.DeepEqual(info.Checksums, file.Checksums) {
+					t.Errorf("Test %d: heal returned different bitrot checksums", i)
+				}
+			}
+		}
+		setup.Remove()
 	}
 }

--- a/cmd/erasure-readfile.go
+++ b/cmd/erasure-readfile.go
@@ -18,321 +18,150 @@ package cmd
 
 import (
 	"io"
-	"sync"
 
-	"github.com/klauspost/reedsolomon"
 	"github.com/minio/minio/pkg/bpool"
 )
 
-// isSuccessDecodeBlocks - do we have all the blocks to be
-// successfully decoded?. Input encoded blocks ordered matrix.
-func isSuccessDecodeBlocks(enBlocks [][]byte, dataBlocks int) bool {
-	// Count number of data and parity blocks that were read.
-	var successDataBlocksCount = 0
-	var successParityBlocksCount = 0
-	for index := range enBlocks {
-		if enBlocks[index] == nil {
-			continue
-		}
-		// block index lesser than data blocks, update data block count.
-		if index < dataBlocks {
-			successDataBlocksCount++
-			continue
-		} // else { // update parity block count.
-		successParityBlocksCount++
-	}
-	// Returns true if we have atleast dataBlocks parity.
-	return successDataBlocksCount == dataBlocks || successDataBlocksCount+successParityBlocksCount >= dataBlocks
-}
-
-// isSuccessDataBlocks - do we have all the data blocks?
-// Input encoded blocks ordered matrix.
-func isSuccessDataBlocks(enBlocks [][]byte, dataBlocks int) bool {
-	// Count number of data blocks that were read.
-	var successDataBlocksCount = 0
-	for index := range enBlocks[:dataBlocks] {
-		if enBlocks[index] == nil {
-			continue
-		}
-		// block index lesser than data blocks, update data block count.
-		if index < dataBlocks {
-			successDataBlocksCount++
-		}
-	}
-	// Returns true if we have atleast the dataBlocks.
-	return successDataBlocksCount >= dataBlocks
-}
-
-// Return readable disks slice from which we can read parallelly.
-func getReadDisks(orderedDisks []StorageAPI, index int, dataBlocks int) (readDisks []StorageAPI, nextIndex int, err error) {
-	readDisks = make([]StorageAPI, len(orderedDisks))
-	dataDisks := 0
-	parityDisks := 0
-	// Count already read data and parity chunks.
-	for i := 0; i < index; i++ {
-		if orderedDisks[i] == nil {
-			continue
-		}
-		if i < dataBlocks {
-			dataDisks++
-		} else {
-			parityDisks++
-		}
-	}
-
-	// Sanity checks - we should never have this situation.
-	if dataDisks == dataBlocks {
-		return nil, 0, traceError(errUnexpected)
-	}
-	if dataDisks+parityDisks >= dataBlocks {
-		return nil, 0, traceError(errUnexpected)
-	}
-
-	// Find the disks from which next set of parallel reads should happen.
-	for i := index; i < len(orderedDisks); i++ {
-		if orderedDisks[i] == nil {
-			continue
-		}
-		if i < dataBlocks {
-			dataDisks++
-		} else {
-			parityDisks++
-		}
-		readDisks[i] = orderedDisks[i]
-		if dataDisks == dataBlocks {
-			return readDisks, i + 1, nil
-		} else if dataDisks+parityDisks == dataBlocks {
-			return readDisks, i + 1, nil
-		}
-	}
-	return nil, 0, traceError(errXLReadQuorum)
-}
-
-// parallelRead - reads chunks in parallel from the disks specified in []readDisks.
-func parallelRead(volume, path string, readDisks, orderedDisks []StorageAPI, enBlocks [][]byte,
-	blockOffset, curChunkSize int64, brVerifiers []bitRotVerifier, pool *bpool.BytePool) {
-
-	// WaitGroup to synchronise the read go-routines.
-	wg := &sync.WaitGroup{}
-
-	// Read disks in parallel.
-	for index := range readDisks {
-		if readDisks[index] == nil {
-			continue
-		}
-		wg.Add(1)
-		// Reads chunk from readDisk[index] in routine.
-		go func(index int) {
-			defer wg.Done()
-
-			// evaluate if we need to perform bit-rot checking
-			needBitRotVerification := true
-			if brVerifiers[index].isVerified {
-				needBitRotVerification = false
-				// if file has bit-rot, do not reuse disk
-				if brVerifiers[index].hasBitRot {
-					orderedDisks[index] = nil
-					return
-				}
-			}
-
-			buf, err := pool.Get()
-			if err != nil {
-				errorIf(err, "unable to get buffer from byte pool")
-				orderedDisks[index] = nil
-				return
-			}
-			buf = buf[:curChunkSize]
-
-			if needBitRotVerification {
-				_, err = readDisks[index].ReadFileWithVerify(
-					volume, path, blockOffset, buf,
-					brVerifiers[index].algo,
-					brVerifiers[index].checkSum)
-			} else {
-				_, err = readDisks[index].ReadFile(volume, path,
-					blockOffset, buf)
-			}
-
-			// if bit-rot verification was done, store the
-			// result of verification so we can skip
-			// re-doing it next time
-			if needBitRotVerification {
-				brVerifiers[index].isVerified = true
-				_, ok := err.(hashMismatchError)
-				brVerifiers[index].hasBitRot = ok
-			}
-
-			if err != nil {
-				orderedDisks[index] = nil
-				return
-			}
-			enBlocks[index] = buf
-		}(index)
-	}
-
-	// Waiting for first routines to finish.
-	wg.Wait()
-}
-
-// erasureReadFile - read bytes from erasure coded files and writes to
-// given writer.  Erasure coded files are read block by block as per
-// given erasureInfo and data chunks are decoded into a data
-// block. Data block is trimmed for given offset and length, then
-// written to given writer. This function also supports bit-rot
-// detection by verifying checksum of individual block's checksum.
-func erasureReadFile(writer io.Writer, disks []StorageAPI, volume, path string,
-	offset, length, totalLength, blockSize int64, dataBlocks, parityBlocks int,
-	checkSums []string, algo HashAlgo, pool *bpool.BytePool) (int64, error) {
-
-	// Offset and length cannot be negative.
+// ReadFile reads as much data as requested from the file under the given volume and path and writes the data to the provided writer.
+// The algorithm and the keys/checksums are used to verify the integrity of the given file. ReadFile will read data from the given offset
+// up to the given length. If parts of the file are corrupted ReadFile tries to reconstruct the data.
+func (s ErasureStorage) ReadFile(writer io.Writer, volume, path string, offset, length int64, totalLength int64, checksums [][]byte, algorithm BitrotAlgorithm, blocksize int64, pool *bpool.BytePool) (f ErasureFileInfo, err error) {
 	if offset < 0 || length < 0 {
-		return 0, traceError(errUnexpected)
+		return f, traceError(errUnexpected)
 	}
-
-	// Can't request more data than what is available.
 	if offset+length > totalLength {
-		return 0, traceError(errUnexpected)
+		return f, traceError(errUnexpected)
+	}
+	if !algorithm.Available() {
+		return f, traceError(errBitrotHashAlgoInvalid)
 	}
 
-	// chunkSize is the amount of data that needs to be read from
-	// each disk at a time.
-	chunkSize := getChunkSize(blockSize, dataBlocks)
-
-	brVerifiers := make([]bitRotVerifier, len(disks))
-	for i := range brVerifiers {
-		brVerifiers[i].algo = algo
-		brVerifiers[i].checkSum = checkSums[i]
+	f.Checksums = make([][]byte, len(s.disks))
+	verifiers := make([]*BitrotVerifier, len(s.disks))
+	for i, disk := range s.disks {
+		if disk == OfflineDisk {
+			continue
+		}
+		verifiers[i] = NewBitrotVerifier(algorithm, checksums[i])
 	}
+	errChans := make([]chan error, len(s.disks))
+	for i := range errChans {
+		errChans[i] = make(chan error, 1)
+	}
+	lastBlock := totalLength / blocksize
+	startOffset := offset % blocksize
+	chunksize := getChunkSize(blocksize, s.dataBlocks)
 
-	// Total bytes written to writer
-	var bytesWritten int64
-
-	startBlock := offset / blockSize
-	endBlock := (offset + length) / blockSize
-
-	// curChunkSize = chunk size for the current block in the for loop below.
-	// curBlockSize = block size for the current block in the for loop below.
-	// curChunkSize and curBlockSize can change for the last block if totalLength%blockSize != 0
-	curChunkSize := chunkSize
-	curBlockSize := blockSize
-
-	// For each block, read chunk from each disk. If we are able to read all the data disks then we don't
-	// need to read parity disks. If one of the data disk is missing we need to read DataBlocks+1 number
-	// of disks. Once read, we Reconstruct() missing data if needed and write it to the given writer.
-	for block := startBlock; block <= endBlock; block++ {
-		// Mark all buffers as unused at the start of the loop so that the buffers
-		// can be reused.
+	blocks := make([][]byte, len(s.disks))
+	for off := offset / blocksize; length > 0; off++ {
+		blockOffset := off * chunksize
 		pool.Reset()
 
-		// Each element of enBlocks holds curChunkSize'd amount of data read from its corresponding disk.
-		enBlocks := make([][]byte, len(disks))
-
-		if ((offset + bytesWritten) / blockSize) == (totalLength / blockSize) {
-			// This is the last block for which curBlockSize and curChunkSize can change.
-			// For ex. if totalLength is 15M and blockSize is 10MB, curBlockSize for
-			// the last block should be 5MB.
-			curBlockSize = totalLength % blockSize
-			curChunkSize = getChunkSize(curBlockSize, dataBlocks)
+		if currentBlock := (offset + f.Size) / blocksize; currentBlock == lastBlock {
+			blocksize = totalLength % blocksize
+			chunksize = getChunkSize(blocksize, s.dataBlocks)
 		}
-
-		// NOTE: That for the offset calculation we have to use chunkSize and
-		// not curChunkSize. If we use curChunkSize for offset calculation
-		// then it can result in wrong offset for the last block.
-		blockOffset := block * chunkSize
-
-		// nextIndex - index from which next set of parallel reads
-		// should happen.
-		nextIndex := 0
-
-		for {
-			// readDisks - disks from which we need to read in parallel.
-			var readDisks []StorageAPI
-			var err error
-			// get readable disks slice from which we can read parallelly.
-			readDisks, nextIndex, err = getReadDisks(disks, nextIndex, dataBlocks)
-			if err != nil {
-				return bytesWritten, err
-			}
-			// Issue a parallel read across the disks specified in readDisks.
-			parallelRead(volume, path, readDisks, disks, enBlocks, blockOffset, curChunkSize, brVerifiers, pool)
-			if isSuccessDecodeBlocks(enBlocks, dataBlocks) {
-				// If enough blocks are available to do rs.Reconstruct()
-				break
-			}
-			if nextIndex == len(disks) {
-				// No more disks to read from.
-				return bytesWritten, traceError(errXLReadQuorum)
-			}
-			// We do not have enough enough data blocks to reconstruct the data
-			// hence continue the for-loop till we have enough data blocks.
-		}
-
-		// If we have all the data blocks no need to decode, continue to write.
-		if !isSuccessDataBlocks(enBlocks, dataBlocks) {
-			// Reconstruct the missing data blocks.
-			if err := decodeMissingData(enBlocks, dataBlocks, parityBlocks); err != nil {
-				return bytesWritten, err
-			}
-		}
-
-		// Offset in enBlocks from where data should be read from.
-		var enBlocksOffset int64
-
-		// Total data to be read from enBlocks.
-		enBlocksLength := curBlockSize
-
-		// If this is the start block then enBlocksOffset might not be 0.
-		if block == startBlock {
-			enBlocksOffset = offset % blockSize
-			enBlocksLength -= enBlocksOffset
-		}
-
-		remaining := length - bytesWritten
-		if remaining < enBlocksLength {
-			// We should not send more data than what was requested.
-			enBlocksLength = remaining
-		}
-
-		// Write data blocks.
-		n, err := writeDataBlocks(writer, enBlocks, dataBlocks, enBlocksOffset, enBlocksLength)
+		err = s.readConcurrent(volume, path, blockOffset, chunksize, blocks, verifiers, errChans, pool)
 		if err != nil {
-			return bytesWritten, err
+			return f, traceError(errXLReadQuorum)
 		}
 
-		// Update total bytes written.
-		bytesWritten += n
+		writeLength := blocksize - startOffset
+		if length < writeLength {
+			writeLength = length
+		}
+		n, err := writeDataBlocks(writer, blocks, s.dataBlocks, startOffset, writeLength)
+		if err != nil {
+			return f, err
+		}
+		startOffset = 0
+		f.Size += int64(n)
+		length -= int64(n)
+	}
 
-		if bytesWritten == length {
-			// Done writing all the requested data.
-			break
+	f.Algorithm = algorithm
+	for i, disk := range s.disks {
+		if disk == OfflineDisk {
+			continue
+		}
+		f.Checksums[i] = verifiers[i].Sum(nil)
+	}
+	return f, nil
+}
+
+func erasureCountMissingBlocks(blocks [][]byte, limit int) int {
+	missing := 0
+	for i := range blocks[:limit] {
+		if blocks[i] == nil {
+			missing++
 		}
 	}
-
-	// Success.
-	return bytesWritten, nil
+	return missing
 }
 
-// decodeMissingData - decode any missing data blocks.
-func decodeMissingData(enBlocks [][]byte, dataBlocks, parityBlocks int) error {
-	// Initialize reedsolomon.
-	rs, err := reedsolomon.New(dataBlocks, parityBlocks)
-	if err != nil {
-		return traceError(err)
+// readConcurrent reads all requested data concurrently from the disks into blocks. It returns an error if
+// too many disks failed while reading.
+func (s *ErasureStorage) readConcurrent(volume, path string, offset int64, length int64, blocks [][]byte, verifiers []*BitrotVerifier, errChans []chan error, pool *bpool.BytePool) (err error) {
+	errs := make([]error, len(s.disks))
+	for i := range blocks {
+		blocks[i], err = pool.Get()
+		if err != nil {
+			return traceErrorf("failed to get new buffer from pool: %v", err)
+		}
+		blocks[i] = blocks[i][:length]
 	}
 
-	// Reconstruct any missing data blocks.
-	return rs.ReconstructData(enBlocks)
+	erasureReadBlocksConcurrent(s.disks[:s.dataBlocks], volume, path, offset, blocks[:s.dataBlocks], verifiers[:s.dataBlocks], errs[:s.dataBlocks], errChans[:s.dataBlocks])
+	missingDataBlocks := erasureCountMissingBlocks(blocks, s.dataBlocks)
+	mustReconstruct := missingDataBlocks > 0
+	if mustReconstruct {
+		requiredReads := s.dataBlocks + missingDataBlocks
+		if requiredReads > s.dataBlocks+s.parityBlocks {
+			return errXLReadQuorum
+		}
+		erasureReadBlocksConcurrent(s.disks[s.dataBlocks:requiredReads], volume, path, offset, blocks[s.dataBlocks:requiredReads], verifiers[s.dataBlocks:requiredReads], errs[s.dataBlocks:requiredReads], errChans[s.dataBlocks:requiredReads])
+		if erasureCountMissingBlocks(blocks, requiredReads) > 0 {
+			erasureReadBlocksConcurrent(s.disks[requiredReads:], volume, path, offset, blocks[requiredReads:], verifiers[requiredReads:], errs[requiredReads:], errChans[requiredReads:])
+		}
+	}
+	if err = reduceReadQuorumErrs(errs, []error{}, s.dataBlocks); err != nil {
+		return err
+	}
+	if mustReconstruct {
+		if err = s.ErasureDecodeDataBlocks(blocks); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// decodeDataAndParity - decode all encoded data and parity blocks.
-func decodeDataAndParity(enBlocks [][]byte, dataBlocks, parityBlocks int) error {
-	// Initialize reedsolomon.
-	rs, err := reedsolomon.New(dataBlocks, parityBlocks)
-	if err != nil {
-		return traceError(err)
+// erasureReadBlocksConcurrent reads all data from each disk to each data block in parallel.
+// Therefore disks, blocks, verifiers errors and locks must have the same length.
+func erasureReadBlocksConcurrent(disks []StorageAPI, volume, path string, offset int64, blocks [][]byte, verifiers []*BitrotVerifier, errors []error, errChans []chan error) {
+	for i := range errChans {
+		go erasureReadFromFile(disks[i], volume, path, offset, blocks[i], verifiers[i], errChans[i])
 	}
+	for i := range errChans {
+		errors[i] = <-errChans[i] // blocks until the go routine 'i' is done - no data race
+		if errors[i] != nil {
+			disks[i] = OfflineDisk
+			blocks[i] = nil
+		}
+	}
+}
 
-	// Reconstruct encoded blocks.
-	return rs.Reconstruct(enBlocks)
+// erasureReadFromFile reads data from the disk to buffer in parallel.
+// It sends the returned error through the error channel.
+func erasureReadFromFile(disk StorageAPI, volume, path string, offset int64, buffer []byte, verifier *BitrotVerifier, errChan chan<- error) {
+	if disk == OfflineDisk {
+		errChan <- traceError(errDiskNotFound)
+		return
+	}
+	var err error
+	if !verifier.IsVerified() {
+		_, err = disk.ReadFileWithVerify(volume, path, offset, buffer, verifier)
+	} else {
+		_, err = disk.ReadFile(volume, path, offset, buffer)
+	}
+	errChan <- err
 }

--- a/cmd/erasure-utils.go
+++ b/cmd/erasure-utils.go
@@ -18,71 +18,10 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
-	"hash"
 	"io"
-	"sync"
 
 	"github.com/klauspost/reedsolomon"
-	"github.com/minio/sha256-simd"
-	"golang.org/x/crypto/blake2b"
 )
-
-// newHashWriters - inititialize a slice of hashes for the disk count.
-func newHashWriters(diskCount int, algo HashAlgo) []hash.Hash {
-	hashWriters := make([]hash.Hash, diskCount)
-	for index := range hashWriters {
-		hashWriters[index] = newHash(algo)
-	}
-	return hashWriters
-}
-
-// newHash - gives you a newly allocated hash depending on the input algorithm.
-func newHash(algo HashAlgo) (h hash.Hash) {
-	switch algo {
-	case HashSha256:
-		// sha256 checksum specially on ARM64 platforms or whenever
-		// requested as dictated by `xl.json` entry.
-		h = sha256.New()
-	case HashBlake2b:
-		// ignore the error, because New512 without a key never fails
-		// New512 only returns a non-nil error, if the length of the passed
-		// key > 64 bytes - but we use blake2b as hash function (no key)
-		h, _ = blake2b.New512(nil)
-	// Add new hashes here.
-	default:
-		// Default to blake2b.
-		// ignore the error, because New512 without a key never fails
-		// New512 only returns a non-nil error, if the length of the passed
-		// key > 64 bytes - but we use blake2b as hash function (no key)
-		h, _ = blake2b.New512(nil)
-	}
-	return h
-}
-
-// Hash buffer pool is a pool of reusable
-// buffers used while checksumming a stream.
-var hashBufferPool = sync.Pool{
-	New: func() interface{} {
-		b := make([]byte, readSizeV1)
-		return &b
-	},
-}
-
-// hashSum calculates the hash of the entire path and returns.
-func hashSum(disk StorageAPI, volume, path string, writer hash.Hash) ([]byte, error) {
-	// Fetch a new staging buffer from the pool.
-	bufp := hashBufferPool.Get().(*[]byte)
-	defer hashBufferPool.Put(bufp)
-
-	// Copy entire buffer to writer.
-	if err := copyBuffer(writer, disk, volume, path, *bufp); err != nil {
-		return nil, err
-	}
-
-	// Return the final hash sum.
-	return writer.Sum(nil), nil
-}
 
 // getDataBlockLen - get length of data blocks from encoded blocks.
 func getDataBlockLen(enBlocks [][]byte, dataBlocks int) int {
@@ -165,58 +104,4 @@ func writeDataBlocks(dst io.Writer, enBlocks [][]byte, dataBlocks int, offset in
 // DataBlocks. The extra space will have 0-padding.
 func getChunkSize(blockSize int64, dataBlocks int) int64 {
 	return (blockSize + int64(dataBlocks) - 1) / int64(dataBlocks)
-}
-
-// copyBuffer - copies from disk, volume, path to input writer until either EOF
-// is reached at volume, path or an error occurs. A success copyBuffer returns
-// err == nil, not err == EOF. Because copyBuffer is defined to read from path
-// until EOF. It does not treat an EOF from ReadFile an error to be reported.
-// Additionally copyBuffer stages through the provided buffer; otherwise if it
-// has zero length, returns error.
-func copyBuffer(writer io.Writer, disk StorageAPI, volume string, path string, buf []byte) error {
-	// Error condition of zero length buffer.
-	if buf != nil && len(buf) == 0 {
-		return errors.New("empty buffer in readBuffer")
-	}
-
-	// Starting offset for Reading the file.
-	var startOffset int64
-
-	// Read until io.EOF.
-	for {
-		n, err := disk.ReadFile(volume, path, startOffset, buf)
-		if n > 0 {
-			m, wErr := writer.Write(buf[:n])
-			if wErr != nil {
-				return wErr
-			}
-			if int64(m) != n {
-				return io.ErrShortWrite
-			}
-		}
-		if err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				break
-			}
-			return err
-		}
-		// Progress the offset.
-		startOffset += n
-	}
-
-	// Success.
-	return nil
-}
-
-// bitRotVerifier - type representing bit-rot verification process for
-// a single under-lying object (currently whole files)
-type bitRotVerifier struct {
-	// has the bit-rot verification been done?
-	isVerified bool
-	// is the data free of bit-rot?
-	hasBitRot bool
-	// hashing algorithm
-	algo HashAlgo
-	// hex-encoded expected raw-hash value
-	checkSum string
 }

--- a/cmd/erasure-utils_test.go
+++ b/cmd/erasure-utils_test.go
@@ -16,23 +16,7 @@
 
 package cmd
 
-import (
-	"bytes"
-	"errors"
-	"io"
-	"os"
-	"testing"
-)
-
-// Test validates the number hash writers returned.
-func TestNewHashWriters(t *testing.T) {
-	diskNum := 8
-	hashWriters := newHashWriters(diskNum, bitRotAlgo)
-	if len(hashWriters) != diskNum {
-		t.Errorf("Expected %d hashWriters, but instead got %d", diskNum, len(hashWriters))
-	}
-
-}
+import "testing"
 
 // Tests validate the output of getChunkSize.
 func TestGetChunkSize(t *testing.T) {
@@ -64,98 +48,6 @@ func TestGetChunkSize(t *testing.T) {
 		got := getChunkSize(testCase.blockSize, testCase.dataBlocks)
 		if testCase.expectedChunkSize != got {
 			t.Errorf("Test %d : expected=%d got=%d", i+1, testCase.expectedChunkSize, got)
-		}
-	}
-}
-
-// TestCopyBuffer - Tests validate the result and errors produced when `copyBuffer` is called with sample inputs.
-func TestCopyBuffer(t *testing.T) {
-	// create posix test setup
-	disk, diskPath, err := newPosixTestSetup()
-	if err != nil {
-		t.Fatalf("Unable to create posix test setup, %s", err)
-	}
-	defer os.RemoveAll(diskPath)
-
-	volume := "success-vol"
-	// Setup test environment.
-	if err = disk.MakeVol(volume); err != nil {
-		t.Fatalf("Unable to create volume, %s", err)
-	}
-
-	// creating io.Writer for the input to copyBuffer.
-	buffers := []*bytes.Buffer{
-		new(bytes.Buffer),
-		new(bytes.Buffer),
-		new(bytes.Buffer),
-	}
-
-	testFile := "testFile"
-	testContent := []byte("hello, world")
-	err = disk.AppendFile(volume, testFile, testContent)
-	if err != nil {
-		t.Fatalf("AppendFile failed: <ERROR> %s", err)
-	}
-
-	testCases := []struct {
-		writer io.Writer
-		disk   StorageAPI
-		volume string
-		path   string
-		buf    []byte
-
-		expectedResult []byte
-		// flag to indicate whether test case should pass.
-		shouldPass  bool
-		expectedErr error
-	}{
-		// Test case - 1.
-		// case with empty buffer.
-		{nil, nil, "", "", []byte{}, nil, false, errors.New("empty buffer in readBuffer")},
-		// Test case - 2.
-		// Test case with empty volume.
-		{buffers[0], disk, "", "", make([]byte, 5), nil, false, errInvalidArgument},
-		// Test case - 3.
-		// Test case with non existent volume.
-		{buffers[0], disk, "abc", "", make([]byte, 5), nil, false, errVolumeNotFound},
-		// Test case - 4.
-		// Test case with empty filename/path.
-		{buffers[0], disk, volume, "", make([]byte, 5), nil, false, errIsNotRegular},
-		// Test case - 5.
-		// Test case with non existent file name.
-		{buffers[0], disk, volume, "abcd", make([]byte, 5), nil, false, errFileNotFound},
-		// Test case - 6.
-		// Test case where the writer returns EOF.
-		{NewEOFWriter(buffers[0], 3), disk, volume, testFile, make([]byte, 5), nil, false, io.EOF},
-		// Test case - 7.
-		// Test case to produce io.ErrShortWrite, the TruncateWriter returns after writing 3 bytes.
-		{TruncateWriter(buffers[1], 3), disk, volume, testFile, make([]byte, 5), nil, false, io.ErrShortWrite},
-		// Teset case - 8.
-		// Valid case, expected to read till EOF and write the contents into the writer.
-		{buffers[2], disk, volume, testFile, make([]byte, 5), testContent, true, nil},
-	}
-	// iterate over the test cases and call copy Buffer with data.
-	for i, testCase := range testCases {
-		actualErr := copyBuffer(testCase.writer, testCase.disk, testCase.volume, testCase.path, testCase.buf)
-
-		if actualErr != nil && testCase.shouldPass {
-			t.Errorf("Test %d: Expected to pass but failed instead with \"%s\"", i+1, actualErr)
-		}
-
-		if actualErr == nil && !testCase.shouldPass {
-			t.Errorf("Test %d: Expected to fail with error <Error> \"%v\", but instead passed", i+1, testCase.expectedErr)
-		}
-		// Failed as expected, but does it fail for the expected reason.
-		if actualErr != nil && !testCase.shouldPass {
-			if testCase.expectedErr.Error() != actualErr.Error() {
-				t.Errorf("Test %d: Expected Error to be \"%v\", but instead found \"%v\" ", i+1, testCase.expectedErr, actualErr)
-			}
-		}
-		// test passed as expected, asserting the result.
-		if actualErr == nil && testCase.shouldPass {
-			if !bytes.Equal(testCase.expectedResult, buffers[2].Bytes()) {
-				t.Errorf("Test %d: copied buffer differs from the expected one.", i+1)
-			}
 		}
 	}
 }

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -1,0 +1,115 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"crypto/subtle"
+	"hash"
+
+	"github.com/klauspost/reedsolomon"
+)
+
+// OfflineDisk represents an unavailable disk.
+var OfflineDisk StorageAPI // zero value is nil
+
+// ErasureFileInfo contains information about an erasure file operation (create, read, heal).
+type ErasureFileInfo struct {
+	Size      int64
+	Algorithm BitrotAlgorithm
+	Checksums [][]byte
+}
+
+// ErasureStorage represents an array of disks.
+// The disks contain erasure coded and bitrot-protected data.
+type ErasureStorage struct {
+	disks                    []StorageAPI
+	erasure                  reedsolomon.Encoder
+	dataBlocks, parityBlocks int
+}
+
+// NewErasureStorage creates a new ErasureStorage. The storage erasure codes and protects all data written to
+// the disks.
+func NewErasureStorage(disks []StorageAPI, dataBlocks, parityBlocks int) (s ErasureStorage, err error) {
+	erasure, err := reedsolomon.New(dataBlocks, parityBlocks)
+	if err != nil {
+		return s, traceErrorf("failed to create erasure coding: %v", err)
+	}
+	s = ErasureStorage{
+		disks:        make([]StorageAPI, len(disks)),
+		erasure:      erasure,
+		dataBlocks:   dataBlocks,
+		parityBlocks: parityBlocks,
+	}
+	copy(s.disks, disks)
+	return
+}
+
+// ErasureEncode encodes the given data and returns the erasure-coded data.
+// It returns an error if the erasure coding failed.
+func (s *ErasureStorage) ErasureEncode(data []byte) ([][]byte, error) {
+	encoded, err := s.erasure.Split(data)
+	if err != nil {
+		return nil, traceErrorf("failed to split data: %v", err)
+	}
+	if err = s.erasure.Encode(encoded); err != nil {
+		return nil, traceErrorf("failed to encode data: %v", err)
+	}
+	return encoded, nil
+}
+
+// ErasureDecodeDataBlocks decodes the given erasure-coded data.
+// It only decodes the data blocks but does not verify them.
+// It returns an error if the decoding failed.
+func (s *ErasureStorage) ErasureDecodeDataBlocks(data [][]byte) error {
+	if err := s.erasure.ReconstructData(data); err != nil {
+		return traceErrorf("failed to reconstruct data: %v", err)
+	}
+	return nil
+}
+
+// ErasureDecodeDataAndParityBlocks decodes the given erasure-coded data and verifies it.
+// It returns an error if the decoding failed.
+func (s *ErasureStorage) ErasureDecodeDataAndParityBlocks(data [][]byte) error {
+	if err := s.erasure.Reconstruct(data); err != nil {
+		return traceErrorf("failed to reconstruct data: %v", err)
+	}
+	return nil
+}
+
+// NewBitrotVerifier returns a new BitrotVerifier implementing the given algorithm.
+func NewBitrotVerifier(algorithm BitrotAlgorithm, checksum []byte) *BitrotVerifier {
+	return &BitrotVerifier{algorithm.New(), algorithm, checksum, false}
+}
+
+// BitrotVerifier can be used to verify protected data.
+type BitrotVerifier struct {
+	hash.Hash
+
+	algorithm BitrotAlgorithm
+	sum       []byte
+	verified  bool
+}
+
+// Verify returns true iff the computed checksum of the verifier matches the the checksum provided when the verifier
+// was created.
+func (v *BitrotVerifier) Verify() bool {
+	v.verified = true
+	return subtle.ConstantTimeCompare(v.Sum(nil), v.sum) == 1
+}
+
+// IsVerified returns true iff Verify was called at least once.
+func (v *BitrotVerifier) IsVerified() bool { return v.verified }

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -151,3 +151,8 @@ func isErr(err error, errs ...error) bool {
 	}
 	return false
 }
+
+// traceErrorf behaves like fmt.traceErrorf but also traces the returned error.
+func traceErrorf(format string, args ...interface{}) error {
+	return traceError(fmt.Errorf(format, args...))
+}

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -122,13 +122,11 @@ func (d *naughtyDisk) ReadFile(volume string, path string, offset int64, buf []b
 	return d.disk.ReadFile(volume, path, offset, buf)
 }
 
-func (d *naughtyDisk) ReadFileWithVerify(volume, path string, offset int64,
-	buf []byte, algo HashAlgo, expectedHash string) (n int64, err error) {
-
+func (d *naughtyDisk) ReadFileWithVerify(volume, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
 	if err := d.calcError(); err != nil {
 		return 0, err
 	}
-	return d.disk.ReadFileWithVerify(volume, path, offset, buf, algo, expectedHash)
+	return d.disk.ReadFileWithVerify(volume, path, offset, buf, verifier)
 }
 
 func (d *naughtyDisk) PrepareFile(volume, path string, length int64) error {

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -17,9 +17,7 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/hex"
-	"hash"
 	"io"
 	"io/ioutil"
 	"os"
@@ -539,8 +537,7 @@ func (s *posix) ReadAll(volume, path string) (buf []byte, err error) {
 // Additionally ReadFile also starts reading from an offset. ReadFile
 // semantics are same as io.ReadFull.
 func (s *posix) ReadFile(volume, path string, offset int64, buf []byte) (n int64, err error) {
-
-	return s.ReadFileWithVerify(volume, path, offset, buf, "", "")
+	return s.ReadFileWithVerify(volume, path, offset, buf, &BitrotVerifier{verified: true})
 }
 
 // ReadFileWithVerify is the same as ReadFile but with hashsum
@@ -553,9 +550,7 @@ func (s *posix) ReadFile(volume, path string, offset int64, buf []byte) (n int64
 //
 // The function takes care to minimize the number of disk read
 // operations.
-func (s *posix) ReadFileWithVerify(volume, path string, offset int64, buf []byte,
-	algo HashAlgo, expectedHash string) (n int64, err error) {
-
+func (s *posix) ReadFileWithVerify(volume, path string, offset int64, buffer []byte, verifier *BitrotVerifier) (n int64, err error) {
 	defer func() {
 		if err == syscall.EIO {
 			atomic.AddInt32(&s.ioErrCount, 1)
@@ -616,62 +611,34 @@ func (s *posix) ReadFileWithVerify(volume, path string, offset int64, buf []byte
 		return 0, errIsNotRegular
 	}
 
-	// If expected hash string is empty hash verification is
-	// skipped.
-	needToHash := expectedHash != ""
-	var hasher hash.Hash
+	if !verifier.IsVerified() {
+		bufp := s.pool.Get().(*[]byte)
+		defer s.pool.Put(bufp)
 
-	if needToHash {
-		// If the hashing algo is invalid, return an error.
-		if !isValidHashAlgo(algo) {
-			return 0, errBitrotHashAlgoInvalid
-		}
-
-		// Compute hash of object from start to the byte at
-		// (offset - 1), and as a result of this read, seek to
-		// `offset`.
-		hasher = newHash(algo)
-		if offset > 0 {
-			_, err = io.CopyN(hasher, file, offset)
-			if err != nil {
+		if offset != 0 {
+			if _, err = io.CopyBuffer(verifier, io.LimitReader(file, offset), *bufp); err != nil {
 				return 0, err
 			}
 		}
-	} else {
-		// Seek to requested offset.
-		_, err = file.Seek(offset, os.SEEK_SET)
-		if err != nil {
+		if _, err = file.Read(buffer); err != nil {
 			return 0, err
 		}
-	}
-
-	// Read until buffer is full.
-	m, err := io.ReadFull(file, buf)
-	if err == io.EOF {
-		return 0, err
-	}
-
-	if needToHash {
-		// Continue computing hash with buf.
-		_, err = hasher.Write(buf)
-		if err != nil {
+		if _, err = verifier.Write(buffer); err != nil {
 			return 0, err
 		}
-
-		// Continue computing hash until end of file.
-		_, err = io.Copy(hasher, file)
-		if err != nil {
+		if _, err = io.CopyBuffer(verifier, file, *bufp); err != nil {
 			return 0, err
 		}
-
-		// Verify the computed hash.
-		computedHash := hex.EncodeToString(hasher.Sum(nil))
-		if computedHash != expectedHash {
-			return 0, hashMismatchError{expectedHash, computedHash}
+		if !verifier.Verify() {
+			return 0, hashMismatchError{hex.EncodeToString(verifier.sum), hex.EncodeToString(verifier.Sum(nil))}
 		}
+		return int64(len(buffer)), err
 	}
 
-	// Success.
+	m, err := file.ReadAt(buffer, offset)
+	if m > 0 && m < len(buffer) {
+		err = io.ErrUnexpectedEOF
+	}
 	return int64(m), err
 }
 
@@ -811,17 +778,8 @@ func (s *posix) AppendFile(volume, path string, buf []byte) (err error) {
 	if err != nil {
 		return err
 	}
-
-	// Close upon return.
-	defer w.Close()
-
-	bufp := s.pool.Get().(*[]byte)
-
-	// Reuse buffer.
-	defer s.pool.Put(bufp)
-
-	// Return io.Copy
-	_, err = io.CopyBuffer(w, bytes.NewReader(buf), *bufp)
+	_, err = w.Write(buf)
+	w.Close()
 	return err
 }
 

--- a/cmd/retry-storage.go
+++ b/cmd/retry-storage.go
@@ -221,18 +221,11 @@ func (f *retryStorage) ReadFile(volume, path string, offset int64, buffer []byte
 
 // ReadFileWithVerify - a retryable implementation of reading at
 // offset from a file with verification.
-func (f *retryStorage) ReadFileWithVerify(volume, path string, offset int64, buffer []byte,
-	algo HashAlgo, expectedHash string) (m int64, err error) {
-	if f.IsOffline() {
-		return m, errDiskNotFound
-	}
+func (f retryStorage) ReadFileWithVerify(volume, path string, offset int64, buffer []byte, verifier *BitrotVerifier) (m int64, err error) {
 
-	m, err = f.remoteStorage.ReadFileWithVerify(volume, path, offset, buffer,
-		algo, expectedHash)
+	m, err = f.remoteStorage.ReadFileWithVerify(volume, path, offset, buffer, verifier)
 	if f.reInitUponDiskNotFound(err) {
-		m, err = f.remoteStorage.ReadFileWithVerify(volume, path,
-			offset, buffer, algo, expectedHash)
-		return m, retryToStorageErr(err)
+		m, err = f.remoteStorage.ReadFileWithVerify(volume, path, offset, buffer, verifier)
 	}
 	return m, retryToStorageErr(err)
 }

--- a/cmd/retry-storage_test.go
+++ b/cmd/retry-storage_test.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"os"
 	"reflect"
@@ -305,15 +304,15 @@ func TestRetryStorage(t *testing.T) {
 		}
 	}
 
-	sha256Hash := func(s string) string {
-		k := sha256.Sum256([]byte(s))
-		return hex.EncodeToString(k[:])
+	sha256Hash := func(b []byte) []byte {
+		k := sha256.Sum256(b)
+		return k[:]
 	}
 	for _, disk := range storageDisks {
 		var buf2 = make([]byte, 5)
+		verifier := NewBitrotVerifier(SHA256, sha256Hash([]byte("Hello, World")))
 		var n int64
-		if n, err = disk.ReadFileWithVerify("existent", "path", 7, buf2,
-			HashSha256, sha256Hash("Hello, World")); err != nil {
+		if n, err = disk.ReadFileWithVerify("existent", "path", 7, buf2, verifier); err != nil {
 			t.Fatal(err)
 		}
 		if err != nil {

--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -262,8 +262,7 @@ func (n *networkStorage) ReadFile(volume string, path string, offset int64, buff
 }
 
 // ReadFileWithVerify - reads a file at remote path and fills the buffer.
-func (n *networkStorage) ReadFileWithVerify(volume string, path string, offset int64,
-	buffer []byte, algo HashAlgo, expectedHash string) (m int64, err error) {
+func (n *networkStorage) ReadFileWithVerify(volume string, path string, offset int64, buffer []byte, verifier *BitrotVerifier) (m int64, err error) {
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -279,8 +278,8 @@ func (n *networkStorage) ReadFileWithVerify(volume string, path string, offset i
 			Path:         path,
 			Offset:       offset,
 			Buffer:       buffer,
-			Algo:         algo,
-			ExpectedHash: expectedHash,
+			Algo:         verifier.algorithm,
+			ExpectedHash: verifier.sum,
 		}, &result)
 
 	// Copy results to buffer.

--- a/cmd/storage-rpc-client_test.go
+++ b/cmd/storage-rpc-client_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -391,13 +390,13 @@ func (s *TestRPCStorageSuite) testRPCStorageFileOps(t *testing.T) {
 			t.Errorf("Expected %s, got %s", string(buf[4:9]), string(buf1))
 		}
 
-		blakeHash := func(s string) string {
-			k := blake2b.Sum512([]byte(s))
-			return hex.EncodeToString(k[:])
+		blakeHash := func(b []byte) []byte {
+			k := blake2b.Sum512(b)
+			return k[:]
 		}
+		verifier := NewBitrotVerifier(BLAKE2b512, blakeHash(buf))
 		buf2 := make([]byte, 2)
-		n, err = storageDisk.ReadFileWithVerify("myvol", "file1", 1,
-			buf2, HashBlake2b, blakeHash(string(buf)))
+		n, err = storageDisk.ReadFileWithVerify("myvol", "file1", 1, buf2, verifier)
 		if err != nil {
 			t.Error("Error in ReadFileWithVerify", err)
 		}

--- a/cmd/storage-rpc-server-datatypes.go
+++ b/cmd/storage-rpc-server-datatypes.go
@@ -79,11 +79,10 @@ type ReadFileWithVerifyArgs struct {
 	Buffer []byte
 
 	// Algorithm used in bit-rot hash computation.
-	Algo HashAlgo
+	Algo BitrotAlgorithm
 
-	// Stored hash value (hex-encoded) used to compare with
-	// computed value.
-	ExpectedHash string
+	// Stored hash value used to compare with computed value.
+	ExpectedHash []byte
 }
 
 // PrepareFileArgs represents append file RPC arguments.

--- a/cmd/storage-rpc-server.go
+++ b/cmd/storage-rpc-server.go
@@ -164,10 +164,7 @@ func (s *storageServer) ReadFileWithVerifyHandler(args *ReadFileWithVerifyArgs, 
 	if err = args.IsAuthenticated(); err != nil {
 		return err
 	}
-
-	var n int64
-	n, err = s.storage.ReadFileWithVerify(args.Vol, args.Path, args.Offset, args.Buffer,
-		args.Algo, args.ExpectedHash)
+	n, err := s.storage.ReadFileWithVerify(args.Vol, args.Path, args.Offset, args.Buffer, NewBitrotVerifier(args.Algo, args.ExpectedHash))
 	// Sending an error over the rpc layer, would cause unmarshalling to fail. In situations
 	// when we have short read i.e `io.ErrUnexpectedEOF` treat it as good condition and copy
 	// the buffer properly.

--- a/cmd/xl-v1-healing-common_test.go
+++ b/cmd/xl-v1-healing-common_test.go
@@ -87,12 +87,12 @@ func TestCommonTime(t *testing.T) {
 
 // partsMetaFromModTimes - returns slice of modTimes given metadata of
 // an object part.
-func partsMetaFromModTimes(modTimes []time.Time, checksums []checkSumInfo) []xlMetaV1 {
+func partsMetaFromModTimes(modTimes []time.Time, algorithm BitrotAlgorithm, checksums []ChecksumInfo) []xlMetaV1 {
 	var partsMetadata []xlMetaV1
 	for _, modTime := range modTimes {
 		partsMetadata = append(partsMetadata, xlMetaV1{
-			Erasure: erasureInfo{
-				Checksum: checksums,
+			Erasure: ErasureInfo{
+				Checksums: checksums,
 			},
 			Stat: statInfo{
 				ModTime: modTime,
@@ -270,7 +270,7 @@ func TestListOnlineDisks(t *testing.T) {
 
 		}
 
-		partsMetadata := partsMetaFromModTimes(test.modTimes, xlMeta.Erasure.Checksum)
+		partsMetadata := partsMetaFromModTimes(test.modTimes, DefaultBitrotAlgorithm, xlMeta.Erasure.Checksums)
 
 		onlineDisks, modTime := listOnlineDisks(xlDisks, partsMetadata, test.errs)
 		availableDisks, newErrs, _ := disksWithAllParts(onlineDisks, partsMetadata, test.errs, bucket, object)
@@ -357,8 +357,7 @@ func TestDisksWithAllParts(t *testing.T) {
 		t.Fatalf("Failed to make a bucket %v", err)
 	}
 
-	_, err = obj.PutObject(bucket, object, int64(len(data)),
-		bytes.NewReader(data), nil, "")
+	_, err = obj.PutObject(bucket, object, int64(len(data)), bytes.NewReader(data), nil, "")
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}
@@ -368,8 +367,6 @@ func TestDisksWithAllParts(t *testing.T) {
 		t.Fatalf("Failed to read xl meta data %v", err)
 	}
 
-	// Replace the default blake2b erasure algorithm to HashSha256 and test that
-	// disks are excluded
 	diskFailures := make(map[int]string)
 	// key = disk index, value = part name with hash mismatch
 	diskFailures[0] = "part.3"
@@ -377,16 +374,15 @@ func TestDisksWithAllParts(t *testing.T) {
 	diskFailures[15] = "part.2"
 
 	for diskIndex, partName := range diskFailures {
-		for index, info := range partsMetadata[diskIndex].Erasure.Checksum {
+		for index, info := range partsMetadata[diskIndex].Erasure.Checksums {
 			if info.Name == partName {
-				partsMetadata[diskIndex].Erasure.Checksum[index].Algorithm = HashSha256
+				partsMetadata[diskIndex].Erasure.Checksums[index].Hash[0]++
 			}
 		}
 	}
 
 	errs = make([]error, len(xlDisks))
-	filteredDisks, errs, err :=
-		disksWithAllParts(xlDisks, partsMetadata, errs, bucket, object)
+	filteredDisks, errs, err := disksWithAllParts(xlDisks, partsMetadata, errs, bucket, object)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -396,7 +392,6 @@ func TestDisksWithAllParts(t *testing.T) {
 	}
 
 	for diskIndex, disk := range filteredDisks {
-
 		if _, ok := diskFailures[diskIndex]; ok {
 			if disk != nil {
 				t.Errorf("Disk not filtered as expected, disk: %d", diskIndex)
@@ -422,8 +417,7 @@ func TestDisksWithAllParts(t *testing.T) {
 		t.Fatalf("Failed to read xl meta data %v", err)
 	}
 
-	filteredDisks, errs, err =
-		disksWithAllParts(xlDisks, partsMetadata, errs, bucket, object)
+	filteredDisks, errs, err = disksWithAllParts(xlDisks, partsMetadata, errs, bucket, object)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}

--- a/cmd/xl-v1-healing_test.go
+++ b/cmd/xl-v1-healing_test.go
@@ -491,8 +491,7 @@ func TestHealObjectXL(t *testing.T) {
 
 	var uploadedParts []completePart
 	for _, partID := range []int{2, 1} {
-		pInfo, err1 := obj.PutObjectPart(bucket, object, uploadID, partID,
-			int64(len(data)), bytes.NewReader(data), "", "")
+		pInfo, err1 := obj.PutObjectPart(bucket, object, uploadID, partID, int64(len(data)), bytes.NewReader(data), "", "")
 		if err1 != nil {
 			t.Fatalf("Failed to upload a part - %v", err1)
 		}

--- a/vendor/github.com/klauspost/reedsolomon/README.md
+++ b/vendor/github.com/klauspost/reedsolomon/README.md
@@ -22,6 +22,19 @@ To get the package use the standard:
 go get github.com/klauspost/reedsolomon
 ```
 
+# Changes
+
+## July 20, 2017
+
+`ReconstructData` added to [`Encoder`](https://godoc.org/github.com/klauspost/reedsolomon#Encoder) interface. This can cause compatibility issues if you implement your own Encoder. A simple workaround can be added:
+```Go
+func (e *YourEnc) ReconstructData(shards [][]byte) error {
+	return ReconstructData(shards)
+}
+```
+
+You can of course also do your own implementation. The [`StreamEncoder`](https://godoc.org/github.com/klauspost/reedsolomon#StreamEncoder) handles this without modifying the interface. This is a good lesson on why returning interfaces is not a good design.
+
 # Usage
 
 This section assumes you know the basics of Reed-Solomon encoding. A good start is this [Backblaze blog post](https://www.backblaze.com/blog/reed-solomon/).

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -243,10 +243,10 @@
 			"revisionTime": "2016-10-16T15:41:25Z"
 		},
 		{
-			"checksumSHA1": "DnS7x0Gqc93p4hQ88FgE35vfIRw=",
+			"checksumSHA1": "gYAsuckCW3o4veePKZzEHvCcJro=",
 			"path": "github.com/klauspost/reedsolomon",
-			"revision": "a9202d772777d8d2264c3e0c6159be5047697380",
-			"revisionTime": "2017-07-19T04:51:23Z"
+			"revision": "48a4fd05f1730dd3ef9c3f9e943f6091d063f2c4",
+			"revisionTime": "2017-07-22T14:16:58Z"
 		},
 		{
 			"checksumSHA1": "dNYxHiBLalTqluak2/Z8c3RsSEM=",


### PR DESCRIPTION
## Description

This change provides new implementations of the XL backend operations:
 - create file
 - read file
 - heal file

This affects also the bitrot algorithm integration. Algorithms are now
integrated in an idiomatic way (like crypto.Hash).

## Motivation and Context
Fixes #4696
Fixes #4649
Fixes #4359

## How Has This Been Tested?
Added table based tests 
 - create file
 - read file
 - heal file

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.