### PR TITLE
set http transport config for gateway (#4765)

### DIFF
--- a/cmd/gateway-anonymous.go
+++ b/cmd/gateway-anonymous.go
@@ -16,7 +16,12 @@
 
 package cmd
 
-import "net/http"
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
 
 func anonErrToObjectErr(statusCode int, params ...string) error {
 	bucket := ""
@@ -46,4 +51,24 @@ func anonErrToObjectErr(statusCode int, params ...string) error {
 	}
 
 	return errUnexpected
+}
+
+// newCustomHTTPTransport returns a new http configuration
+// used while communicating with the cloud backends.
+// This sets the value for MaxIdleConns from 2 (go default) to
+// 100.
+func newCustomHTTPTransport() http.RoundTripper {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       &tls.Config{RootCAs: globalRootCAs},
+		DisableCompression:    true,
+	}
 }

--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -179,6 +179,7 @@ func newAzureLayer(host string) (GatewayLayer, error) {
 	if err != nil {
 		return &azureObjects{}, err
 	}
+	c.HTTPClient.Transport = newCustomHTTPTransport()
 
 	return &azureObjects{
 		client: c.GetBlobService(),

--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -277,6 +277,7 @@ func newGCSGateway(projectID string) (GatewayLayer, error) {
 	if err != nil {
 		return nil, err
 	}
+	anonClient.SetCustomTransport(newCustomHTTPTransport())
 
 	gateway := &gcsGateway{
 		client:     client,

--- a/cmd/gateway-s3.go
+++ b/cmd/gateway-s3.go
@@ -130,6 +130,7 @@ func newS3Gateway(host string) (GatewayLayer, error) {
 	if err != nil {
 		return nil, err
 	}
+	anonClient.SetCustomTransport(newCustomHTTPTransport())
 
 	return &s3Objects{
 		Client:     client,


### PR DESCRIPTION
## Description

This change sets the http config for the minio client used by the
minio server in gateway mode.

Fixes #4765

## Motivation and Context
The server should set not garbage-collect all connections (except 2 - default). This is a performance
optimization  for the gateway layer.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.