### PR TITLE
posix: do not upstream errors in deleteFile

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -916,7 +916,10 @@ func deleteFile(basePath, deletePath string) error {
 	}
 
 	// Recursively go down the next path and delete again.
-	return deleteFile(basePath, slashpath.Dir(deletePath))
+	// Errors for parent directories shouldn't trickle down.
+	deleteFile(basePath, slashpath.Dir(deletePath))
+
+	return nil
 }
 
 // DeleteFile - delete a file at path.

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -706,6 +706,17 @@ func TestPosixDeleteFile(t *testing.T) {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 
+	if err = posixStorage.MakeVol("no-permissions"); err != nil {
+		t.Fatalf("Unable to create volume, %s", err.Error())
+	}
+	if err = posixStorage.AppendFile("no-permissions", "dir/file", []byte("Hello, world")); err != nil {
+		t.Fatalf("Unable to create file, %s", err.Error())
+	}
+	// Parent directory must have write permissions, this is read + execute.
+	if err = os.Chmod(pathJoin(path, "no-permissions"), 0555); err != nil {
+		t.Fatalf("Unable to chmod directory, %s", err.Error())
+	}
+
 	testCases := []struct {
 		srcVol      string
 		srcPath     string
@@ -759,6 +770,15 @@ func TestPosixDeleteFile(t *testing.T) {
 			srcPath:     "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
 			ioErrCnt:    0,
 			expectedErr: errFileNameTooLong,
+		},
+		// TestPosix case - 7.
+		// TestPosix case with undeletable parent directory.
+		// File can delete, dir cannot delete because no-permissions doesn't have write perms.
+		{
+			srcVol:      "no-permissions",
+			srcPath:     "dir/file",
+			ioErrCnt:    0,
+			expectedErr: nil,
 		},
 	}
 


### PR DESCRIPTION
## Description
This commit changes posix's `deleteFile()` to not upstream errors from
removing parent directories. This fixes a race condition.

The race condition occurs when multiple `deleteFile()`s are called on the
same parent directory, but different child files. Because `deleteFile()`
recursively removes parent directories if they are empty, but
`deleteFile()` errors if the selected `deletePath` does not exist, there was
an opportunity for a race condition. The two processes would remove the
child directories successfully, then depend on the parent directory
still existing. In some cases this is an invalid assumption, because
other processes can remove the parent directory beforehand. This commit
changes `deleteFile()` to not upstream an error if one occurs, because the
only required error should be from the immediate `deletePath`, not from a
parent path.

In the specific bug report, multiple `CompleteMultipartUpload` requests
would launch multiple `deleteFile()` requests. Because they chain up on
parent directories, ultimately at the end, there would be multiple
remove files for the ultimate parent directory,
`.minio.sys/multipart/{bucket}`. Because only one will succeed and one
will fail, an error would be upstreamed saying that the file does not
exist, and the `CompleteMultipartUpload` code interpreted this as
`NoSuchKey`, or that the object/part id doesn't exist. This was faulty
behavior and is now fixed.

The added test fails before this change and passes after this change.

## Motivation and Context

Fixes: https://github.com/minio/minio/issues/4727

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Locally (upstream.patch has fix to `cmd/posix.go`):
```
brendanashworth in ~/Go/src/github.com/minio/minio/cmd $ go test -test.run PosixDeleteFile -v
=== RUN   TestPosixDeleteFile
--- FAIL: TestPosixDeleteFile (0.34s)
	posix_test.go:795: TestPosix case 7: Expected: "%!s(<nil>)", got: "file access denied"
FAIL
exit status 1
FAIL	github.com/minio/minio/cmd	0.493s
brendanashworth in ~/Go/src/github.com/minio/minio/cmd $ git apply ../upstream.patch
brendanashworth in ~/Go/src/github.com/minio/minio/cmd $ go test -test.run PosixDeleteFile -v
=== RUN   TestPosixDeleteFile
--- PASS: TestPosixDeleteFile (0.18s)
PASS
ok  	github.com/minio/minio/cmd	0.261s
```

The test uses permissions (parent directory lacks write permission) to fail, but it fails similarly to how a non-existent directory fails.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.