### PR TITLE
Reserve login bucketname from web browser access.

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -988,7 +988,7 @@ func (adminAPI adminAPIHandlers) SetConfigHandler(w http.ResponseWriter, r *http
 	// Take a lock on minio/config.json. NB minio is a reserved
 	// bucket name and wouldn't conflict with normal object
 	// operations.
-	configLock := globalNSMutex.NewNSLock(minioReservedBucket, minioConfigFile)
+	configLock := globalNSMutex.NewNSLock(minioReservedKeyword, minioConfigFile)
 	configLock.Lock()
 	defer configLock.Unlock()
 

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -65,10 +65,10 @@ func (h requestSizeLimitHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	h.handler.ServeHTTP(w, r)
 }
 
-// Reserved bucket.
+// Reserved keyword and paths.
 const (
-	minioReservedBucket     = "minio"
-	minioReservedBucketPath = "/" + minioReservedBucket
+	minioReservedKeyword    = "minio"
+	minioReservedBucketPath = "/" + minioReservedKeyword
 )
 
 // Adds redirect rules for incoming requests.

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -258,9 +258,17 @@ func isMinioMetaBucket(bucketName string) bool {
 	return bucketName == minioMetaBucket
 }
 
-// Returns true if input bucket is a reserved minio bucket 'minio'.
+// Returns true if input bucket is a reserved minio bucket.
 func isMinioReservedBucket(bucketName string) bool {
-	return bucketName == minioReservedBucket
+	// Reserved buckets - minio, login are reserved buckets for
+	// Minio browser access. Explanation for reserving buckets is
+	// - bucket named minio conflicts with base URI
+	// - bucket name login conflicts with login page's URI
+	minioReservedBuckets := []string{"minio", "login"}
+	if contains(minioReservedBuckets, bucketName) {
+		return true
+	}
+	return false
 }
 
 // byBucketName is a collection satisfying sort.Interface.


### PR DESCRIPTION
## Description
A bucket named `login` will conflict with login page URI on Minio Browser. This PR reserves the bucket name `login` for browser access. 

- An attempt to create a bucket called `login` will be rejected on browser with error `All access to this Bucket is disabled`. 
- An existing directory called `login` in FS mode will be ignored in listing buckets. 
- Attempts to create `login` bucket via `mc` or `SDKs` will be successful. 

## Motivation and Context
See issue https://github.com/minio/minio/issues/4766

## How Has This Been Tested?
manually and `go test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.