### PR TITLE
Added support for macOS in TestNewHTTPListener

### DIFF
--- a/pkg/http/listener_test.go
+++ b/pkg/http/listener_test.go
@@ -184,6 +184,8 @@ func TestNewHTTPListener(t *testing.T) {
 	remoteAddrErrMsg := "listen tcp 93.184.216.34:9000: bind: cannot assign requested address"
 	if runtime.GOOS == "windows" {
 		remoteAddrErrMsg = "listen tcp 93.184.216.34:9000: bind: The requested address is not valid in its context."
+	} else if runtime.GOOS == "darwin" {
+		remoteAddrErrMsg = "listen tcp 93.184.216.34:9000: bind: can't assign requested address"
 	}
 
 	tlsConfig := getTLSConfig(t)


### PR DESCRIPTION
The test `TestNewHTTPListener` was failing on macOS when running `make test`

## Description
Added a separate string to match `remoteAddrErrMsg` for macOS. 

## Motivation and Context
It fixes the test `TestNewHTTPListener` which was previously failing and giving the following error.
```
--- FAIL: TestNewHTTPListener (0.00s)
	listener_test.go:238: error: expected = listen tcp 93.184.216.34:9000: bind: cannot assign requested address, got = listen tcp 93.184.216.34:9000: bind: can't assign requested address
```

## How Has This Been Tested?
This was tested by running `make test`
The tests were ran on macOS 10.12.6 using go 1.8.3.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.