### PR TITLE
Honor overriding response headers for HEAD

### DIFF
--- a/cmd/gateway-handlers.go
+++ b/cmd/gateway-handlers.go
@@ -127,7 +127,7 @@ func (api gatewayAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Re
 			setObjectHeaders(w, objInfo, hrange)
 
 			// Set any additional requested response headers.
-			setGetRespHeaders(w, r.URL.Query())
+			setHeadGetRespHeaders(w, r.URL.Query())
 
 			dataWritten = true
 		}
@@ -397,6 +397,9 @@ func (api gatewayAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.R
 
 	// Set standard object headers.
 	setObjectHeaders(w, objInfo, nil)
+
+	// Set any additional requested response headers.
+	setHeadGetRespHeaders(w, r.URL.Query())
 
 	// Successful response.
 	w.WriteHeader(http.StatusOK)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -29,8 +29,8 @@ import (
 	mux "github.com/gorilla/mux"
 )
 
-// supportedGetReqParams - supported request parameters for GET presigned request.
-var supportedGetReqParams = map[string]string{
+// supportedHeadGetReqParams - supported request parameters for GET and HEAD presigned request.
+var supportedHeadGetReqParams = map[string]string{
 	"response-expires":             "Expires",
 	"response-content-type":        "Content-Type",
 	"response-cache-control":       "Cache-Control",
@@ -39,10 +39,10 @@ var supportedGetReqParams = map[string]string{
 	"response-content-disposition": "Content-Disposition",
 }
 
-// setGetRespHeaders - set any requested parameters as response headers.
-func setGetRespHeaders(w http.ResponseWriter, reqParams url.Values) {
+// setHeadGetRespHeaders - set any requested parameters as response headers.
+func setHeadGetRespHeaders(w http.ResponseWriter, reqParams url.Values) {
 	for k, v := range reqParams {
-		if header, ok := supportedGetReqParams[k]; ok {
+		if header, ok := supportedHeadGetReqParams[k]; ok {
 			w.Header()[header] = v
 		}
 	}
@@ -166,7 +166,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 			setObjectHeaders(w, objInfo, hrange)
 
 			// Set any additional requested response headers.
-			setGetRespHeaders(w, r.URL.Query())
+			setHeadGetRespHeaders(w, r.URL.Query())
 
 			dataWritten = true
 		}
@@ -253,6 +253,9 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 
 	// Set standard object headers.
 	setObjectHeaders(w, objInfo, nil)
+
+	// Set any additional requested response headers.
+	setHeadGetRespHeaders(w, r.URL.Query())
 
 	// Successful response.
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Though not clearly mentioned in S3 specification, we should override
response headers for presigned HEAD requests as we do for GET.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Though not clearly mentioned in S3 specification, we should override
response headers for presigned HEAD requests as we do for GET.

## Motivation and Context
Fixes #4746 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.