### PR TITLE
browser: add delete bucket button

### DIFF
--- a/browser/app/js/components/Browse.js
+++ b/browser/app/js/components/Browse.js
@@ -216,6 +216,12 @@ export default class Browse extends React.Component {
     dispatch(actions.hideBucketPolicy())
   }
 
+  deleteBucket(e, bucket) {
+    e.preventDefault()
+    const {dispatch} = this.props
+    dispatch(actions.deleteBucket(bucket))
+  }
+
   uploadFile(e) {
     e.preventDefault()
     const {dispatch, buckets} = this.props
@@ -575,6 +581,7 @@ export default class Browse extends React.Component {
             selectBucket={ this.selectBucket.bind(this) }
             clickOutside={ this.hideSidebar.bind(this) }
             showPolicy={ this.showBucketPolicy.bind(this) }
+            deleteBucket={ this.deleteBucket.bind(this) }
             storageDetails={ storageUsageDetails } />
           <div className="objects">
             <header className="objects__row" data-type="folder">

--- a/browser/app/js/components/SideBar.js
+++ b/browser/app/js/components/SideBar.js
@@ -20,6 +20,7 @@ import ClickOutHandler from 'react-onclickout'
 import Scrollbars from 'react-custom-scrollbars/lib/Scrollbars'
 import connect from 'react-redux/lib/components/connect'
 import logo from '../../img/logo-dark.svg'
+import Dropdown from 'react-bootstrap/lib/Dropdown'
 
 let SideBar = ({visibleBuckets, loadBucket, currentBucket, selectBucket, searchBuckets, sidebarStatus, clickOutside, showPolicy, storageDetails}) => {
 
@@ -31,10 +32,22 @@ let SideBar = ({visibleBuckets, loadBucket, currentBucket, selectBucket, searchB
              <div className="buckets__list__name">
                { bucket }
              </div>
-             <div className="buckets__list__actions">
-               <span>read and write</span>
-               <span className="buckets__list__policy" onClick={ showPolicy }>edit policy</span>
+             <div className="buckets__list__policy">
+               read and write
              </div>
+             <Dropdown pullRight id="dropdown-bucket-actions" className={ 'buckets__list__actions' }>
+               <Dropdown.Toggle noCaret>
+                 <i className="zmdi zmdi-more-vert" />
+               </Dropdown.Toggle>
+               <Dropdown.Menu className="dropdown-menu-right">
+                 <li>
+                   <a onClick={ showPolicy }>Edit policy</a>
+                 </li>
+                 <li>
+                   <a href="">Delete</a>
+                 </li>
+               </Dropdown.Menu>
+             </Dropdown>
            </li>
   })
 

--- a/browser/app/js/components/SideBar.js
+++ b/browser/app/js/components/SideBar.js
@@ -22,7 +22,7 @@ import connect from 'react-redux/lib/components/connect'
 import logo from '../../img/logo-dark.svg'
 import Dropdown from 'react-bootstrap/lib/Dropdown'
 
-let SideBar = ({visibleBuckets, loadBucket, currentBucket, selectBucket, searchBuckets, sidebarStatus, clickOutside, showPolicy, storageDetails}) => {
+let SideBar = ({visibleBuckets, loadBucket, currentBucket, selectBucket, searchBuckets, sidebarStatus, clickOutside, showPolicy, deleteBucket, storageDetails}) => {
 
   const list = visibleBuckets.map((bucket, i) => {
     return <li className={ classNames({
@@ -44,7 +44,7 @@ let SideBar = ({visibleBuckets, loadBucket, currentBucket, selectBucket, searchB
                    <a onClick={ showPolicy }>Edit policy</a>
                  </li>
                  <li>
-                   <a href="">Delete</a>
+                   <a onClick={ (e) => deleteBucket(e, bucket) }>Delete</a>
                  </li>
                </Dropdown.Menu>
              </Dropdown>

--- a/browser/app/js/reducers.js
+++ b/browser/app/js/reducers.js
@@ -76,6 +76,10 @@ export default (state = {
       newState.buckets = [action.bucket, ...newState.buckets]
       newState.visibleBuckets = [action.bucket, ...newState.visibleBuckets]
       break
+    case actions.REMOVE_BUCKET:
+      newState.buckets = newState.buckets.filter(bucket => bucket != action.bucket)
+      newState.visibleBuckets = newState.visibleBuckets.filter(bucket => bucket != action.bucket)
+      break
     case actions.SET_VISIBLE_BUCKETS:
       newState.visibleBuckets = action.visibleBuckets
       break

--- a/browser/app/js/web.js
+++ b/browser/app/js/web.js
@@ -87,6 +87,9 @@ export default class Web {
   MakeBucket(args) {
     return this.makeCall('MakeBucket', args)
   }
+  DeleteBucket(args) {
+    return this.makeCall('DeleteBucket', args)
+  }
   ListObjects(args) {
     return this.makeCall('ListObjects', args)
   }

--- a/browser/app/less/inc/buttons.less
+++ b/browser/app/less/inc/buttons.less
@@ -5,12 +5,9 @@
     .transition-duration(300ms);
     border-radius: 2px;
     text-align: center;
-
-    &:not(.btn--link):not(.btn--lg) {
-        padding: 5px 10px;
-        font-size: 12px;
-        line-height: 1.5;
-    }
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
 }
 
 // Variants

--- a/browser/app/less/inc/sidebar.less
+++ b/browser/app/less/inc/sidebar.less
@@ -132,15 +132,10 @@
         }
 
         &:hover {
-            &:before, .buckets__list__policy {
+            .buckets__list__actions {
                 .opacity(1);
             }
-
-            .buckets__list__policy {
-                padding-left: 18px;
-            }
         }
-
     }
 }
 
@@ -150,40 +145,33 @@
     word-wrap: break-word;
 }
 
-.buckets__list__actions {
-    display: block;
+.buckets__list__policy {
     font-size: @font-size-base - 2;
     color: @text-muted-color;
     margin-top: 1px;
+}
 
-    & > span {
-        & + span {
-            padding-left: 18px;
-            position: relative;
+.buckets__list__actions {
+    position: absolute;
+    top: 13px;
+    right: 20px;
 
-            &:before {
-                content: '';
-                width: 3px;
-                height: 3px;
-                background-color: @text-muted-color;
-                border-radius: 50%;
-                display: inline-block;
-                position: relative;
-                top: -2px;
-                left: -9px;
-            }
-        }
+    &:not(.open) {
+        .opacity(0);
+        .transition(opacity 300ms);
+    }
 
-        &.buckets__list__policy {
-            padding-left: 30px;
-            .opacity(0);
-            .transition(all);
-            .transition-duration(300ms);
-            cursor: pointer;
+    & > .dropdown-toggle {
+        width: 35px;
+        height: 35px;
+        line-height: 32px;
+        font-size: 20px;
+        background-color: transparent;
+        padding: 0;
+        border-radius: 50%;
 
-            &:hover {
-                color: darken(@text-muted-color, 10%);
-            }
+        &:hover {
+            background-color: @muted-bg;
         }
     }
 }

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -734,7 +734,7 @@ func (web *webAPIHandlers) Thumbnail(w http.ResponseWriter, r *http.Request) {
 
 	options := thumbnail.Options{
 		Dimensions: "300x100",
-		Format:     "jpg",
+		Format:     "jpeg",
 	}
 
 	buffer := new(bytes.Buffer)

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -143,6 +143,34 @@ func (web *webAPIHandlers) MakeBucket(r *http.Request, args *MakeBucketArgs, rep
 	return nil
 }
 
+// RemoveBucketArgs - remove bucket args.
+type RemoveBucketArgs struct {
+	BucketName string `json:"bucketName"`
+}
+
+// DeleteBucket - removes a bucket, must be empty.
+func (web *webAPIHandlers) DeleteBucket(r *http.Request, args *RemoveBucketArgs, reply *WebGenericRep) error {
+	objectAPI := web.ObjectAPI()
+	if objectAPI == nil {
+		return toJSONError(errServerNotInitialized)
+	}
+	if !isHTTPRequestValid(r) {
+		return toJSONError(errAuthentication)
+	}
+
+	bucketLock := globalNSMutex.NewNSLock(args.BucketName, "")
+	bucketLock.Lock()
+	defer bucketLock.Unlock()
+
+	err := objectAPI.DeleteBucket(args.BucketName)
+	if err != nil {
+		return toJSONError(err, args.BucketName)
+	}
+
+	reply.UIVersion = browser.UIVersion
+	return nil
+}
+
 // ListBucketsRep - list buckets response
 type ListBucketsRep struct {
 	Buckets   []WebBucketInfo `json:"buckets"`

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -20,7 +20,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"crypto/md5"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1130,10 +1129,10 @@ func testThumbnailWebHandler(obj ObjectLayer, instanceType string, t TestErrHand
 		t.Fatalf("failed to create bucket %s (on %s)", err.Error(), instanceType)
 	}
 
-	// This is the smallest possible PNG image ever, base64-encoded.
-	content, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==")
+	// Upload an image from pkg/thumbnail.
+	content, err := ioutil.ReadFile("../pkg/thumbnail/testdata/beach.jpg")
 	if err != nil {
-		t.Fatalf("failed to decode png, %s", err.Error())
+		t.Fatalf("could not read file, %s", err.Error())
 	}
 
 	_, err = obj.PutObject(bucketName, objectName, int64(len(content)), bytes.NewReader(content), nil, "")
@@ -1196,10 +1195,10 @@ func BenchmarkWebHandlerThumbnail(b *testing.B) {
 		b.Fatalf("failed to create bucket %s", err.Error())
 	}
 
-	// This is the smallest possible PNG image ever, base64-encoded.
-	content, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==")
+	// Upload an image from pkg/thumbnail.
+	content, err := ioutil.ReadFile("../pkg/thumbnail/testdata/beach.jpg")
 	if err != nil {
-		b.Fatalf("failed to decode png, %s", err.Error())
+		b.Fatalf("could not read file, %s", err.Error())
 	}
 
 	_, err = obj.PutObject(bucketName, objectName, int64(len(content)), bytes.NewReader(content), nil, "")

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -305,6 +305,106 @@ func testMakeBucketWebHandler(obj ObjectLayer, instanceType string, t TestErrHan
 	}
 }
 
+// Wrapper for calling DeleteBucket handler
+func TestWebHandlerDeleteBucket(t *testing.T) {
+	ExecObjectLayerTest(t, testDeleteBucketWebHandler)
+}
+
+// testDeleteBucketWebHandler - Test DeleteBucket web handler
+func testDeleteBucketWebHandler(obj ObjectLayer, instanceType string, t TestErrHandler) {
+	apiRouter := initTestWebRPCEndPoint(obj)
+
+	credentials := serverConfig.GetCredential()
+	token, err := getWebRPCToken(apiRouter, credentials.AccessKey, credentials.SecretKey)
+	if err != nil {
+		t.Fatalf("could not get RPC token, %s", err.Error())
+	}
+
+	bucketName := getRandomBucketName()
+	err = obj.MakeBucketWithLocation(bucketName, "")
+	if err != nil {
+		t.Fatalf("failed to create bucket: %s (%s)", err.Error(), instanceType)
+	}
+
+	testCases := []struct {
+		bucketName string
+		// Whether or not to put an object into the bucket.
+		initWithObject bool
+		token          string
+		// Expected error (error must only contain this string to pass test)
+		// Empty string = no error
+		expect string
+	}{
+		{"", false, token, "Bucket Name  is invalid"},
+		{".", false, "auth", "Authentication failed"},
+		{".", false, token, "Bucket Name . is invalid"},
+		{"ab", false, token, "Bucket Name ab is invalid"},
+		{"minio", false, "false token", "Authentication failed"},
+		{"minio", false, token, "specified bucket minio does not exist"},
+		{bucketName, false, token, ""},
+		{bucketName, true, token, "Bucket not empty"},
+		{bucketName, false, "", "Authentication failed"},
+	}
+
+	for _, test := range testCases {
+		if test.initWithObject {
+			data := bytes.NewBufferString("hello")
+			_, err = obj.PutObject(test.bucketName, "object", int64(data.Len()), data, nil, "")
+			if err != nil {
+				t.Fatalf("could not put object to %s, %s", test.bucketName, err.Error())
+			}
+		}
+
+		rec := httptest.NewRecorder()
+
+		makeBucketRequest := MakeBucketArgs{BucketName: test.bucketName}
+		makeBucketReply := &WebGenericRep{}
+
+		req, err := newTestWebRPCRequest("Web.DeleteBucket", test.token, makeBucketRequest)
+		if err != nil {
+			t.Errorf("failed to create HTTP request: <ERROR> %v", err)
+		}
+
+		apiRouter.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected the response status to be `%d`, but instead found `%d`", http.StatusOK, rec.Code)
+		}
+		err = getTestWebRPCResponse(rec, &makeBucketReply)
+
+		if test.expect != "" {
+			if err == nil {
+				// If we expected an error, but didn't get one.
+				t.Errorf("expected `..%s..` but got nil error", test.expect)
+			} else if !strings.Contains(err.Error(), test.expect) {
+				// If we got an error that wasn't what we expected.
+				t.Errorf("expected `..%s..` but got `%s`", test.expect, err.Error())
+			}
+		} else if test.expect == "" && err != nil {
+			t.Errorf("expected test success, but got `%s`", err.Error())
+		}
+
+		// If we created the bucket with an object, now delete the object to cleanup.
+		if test.initWithObject {
+			err = obj.DeleteObject(test.bucketName, "object")
+			if err != nil {
+				t.Fatalf("could not delete object, %s", err.Error())
+			}
+		}
+
+		// If it did not succeed in deleting the bucket, don't try and recreate it.
+		// Or, it'll fail if there was an object.
+		if err != nil || test.initWithObject {
+			continue
+		}
+
+		err = obj.MakeBucketWithLocation(bucketName, "")
+		if err != nil {
+			// failed to create new bucket, abort.
+			t.Fatalf("failed to create new bucket (%s): %s", instanceType, err.Error())
+		}
+	}
+}
+
 // Wrapper for calling ListBuckets Web Handler
 func TestWebHandlerListBuckets(t *testing.T) {
 	ExecObjectLayerTest(t, testListBucketsWebHandler)


### PR DESCRIPTION
## Description

This PR (two commits, one functionality + one UI from @rushenn ) adds the ability to delete a bucket from the web UI. The bucket must be empty for the `DeleteBucket` RPC call to succeed. There is no confirmation on the UI because deleting an empty bucket is reversible (just create a new one).

![deletebucket](https://user-images.githubusercontent.com/3038254/29042685-cafaa942-7b6c-11e7-8e70-fe1ffa9bf09a.gif)



## Motivation and Context
Fixes: https://github.com/minio/minio/issues/4166, targets `newux`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tests have been added, also tested manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.