### PR TITLE
Updates to lastest release, fixes startup bug

### DIFF
--- a/docs/orchestration/minikube/statefulset.yaml
+++ b/docs/orchestration/minikube/statefulset.yaml
@@ -54,11 +54,10 @@ spec:
           value: "minio"
         - name: MINIO_SECRET_KEY
           value: "minio123"
-        image: minio/minio:RELEASE.2017-06-13T19-01-01Z
+        image: minio/minio:RELEASE.2017-08-05T00-00-53Z
         imagePullPolicy: IfNotPresent
         #command: ["df"]
         #args: ["-i", "/data"]
-        command: ["minio"]
         args: ["server", "http://minio-0.minio.default.svc.cluster.local/data", "http://minio-1.minio.default.svc.cluster.local/data", "http://minio-2.minio.default.svc.cluster.local/data", "http://minio-3.minio.default.svc.cluster.local/data"]
         ports:
         - containerPort: 9000


### PR DESCRIPTION
## Description
- updates to RELEASE.2017-08-05T00-00-53Z
- fixes minio stopping with an error message as noted here #4225

## Motivation and Context
While testing minio on minikube, I experienced a bug, which prevents minio from been starting. The bug was discussed in the issue #4225 and the solution were also stated there. As it's proposed as a out of the box usage, it is a stopper for a beginner, so I fixed it.

## How Has This Been Tested?
I tested the creation of the kubernete cluster, and that minio is working as expected. As I didn't change any code, there was no need to write any new tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.