### PR TITLE
Report healthy status while distributed Minio starts

### DIFF
--- a/buildscripts/healthcheck.sh
+++ b/buildscripts/healthcheck.sh
@@ -19,25 +19,40 @@ _init () {
     scheme="http://"
     address="127.0.0.1:9000"
     resource="/minio/index.html"
+    start=$(stat -c "%Y" /proc/1)
 }
 
-HealthCheckMain () {
-    # Get the http response code
-    http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" ${scheme}${address}${resource})
+healthcheck_main () {
+    # In distributed environment like Swarm, traffic is routed 
+    # to a container only when it reports a `healthy` status. So, we exit 
+    # with 0 to ensure healthy status till distributed Minio starts (120s). 
+    #
+    # Refer: https://github.com/moby/moby/pull/28938#issuecomment-301753272
+    if [ $(( $(date +%s) - start )) -lt 120 ]; then
+        exit 0
+    else
+        # Get the http response code
+        http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" \
+            ${scheme}${address}${resource})
 
-    # Get the http response body
-    http_response_body=$(curl -k -s ${scheme}${address}${resource})
+        # Get the http response body
+        http_response_body=$(curl -k -s ${scheme}${address}${resource})
 
-    # server returns response 403 and body "SSL required" if non-TLS connection is attempted on a TLS-configured server. 
-    # change the scheme and try again
-    if [ "$http_response" = "403" ] && [ "$http_response_body" = "SSL required" ]; then
-        scheme="https://"
-        http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" ${scheme}${address}${resource})
+        # server returns response 403 and body "SSL required" if non-TLS 
+        # connection is attempted on a TLS-configured server. Change
+        # the scheme and try again
+        if [ "$http_response" = "403" ] && \
+        [ "$http_response_body" = "SSL required" ]; then
+            scheme="https://"
+            http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" \
+                ${scheme}${address}${resource})
+        fi
+
+        # If http_repsonse is 200 - server is up. When MINIO_BROWSER is 
+        # set to off, curl responds with 404. We assume that the server
+        # is up
+        [ "$http_response" = "200" ] || [ "$http_response" = "404" ]
     fi
-
-    # If http_repsonse is 200 - server is up. 
-    # When MINIO_BROWSER is set to off, curl responds with 404. We assume that the the server is up
-    [ "$http_response" = "200" ] || [ "$http_response" = "404" ]
 }
 
-_init && HealthCheckMain
+_init && healthcheck_main


### PR DESCRIPTION
## Description
Swarm routes traffic only to containers that report `healthy` status, while Minio in distributed mode needs to talk to other peers before it can respond to healthcheck probe. As the Minio containers are not able to talk to each other, distributed Minio is not getting started on Docker Swarm. 

This PR adds a section in `healthcheck.sh` script to send `healthy` status for initial 120s. After this period, normal healthcheck process starts. 

## Motivation and Context
See issue https://github.com/minio/minio/issues/4761

## How Has This Been Tested?
Manually on a Docker Swarm cluster 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.