### PR TITLE
Hardcode snap version while a store bug is fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ release
 *.syso
 coverage.txt
 settings.json
+.snap
+*.tar.bz2
+parts/
+prime/
+snap/.snapcraft/
+stage/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: minio
-version: git
-summary: open source object storage server compatible with Amazon S3 APIs
+version: master
+summary: Open source object storage server compatible with Amazon S3 APIs
 description: |
   Minio is an object storage server released under Apache License v2.0. It is
   compatible with Amazon S3 cloud storage service. It is best suited for


### PR DESCRIPTION
## Description

This is a workaround for for a failure in the store, which limits the version to 32 characters.
https://forum.snapcraft.io/t/versions-can-be-at-most-32-characters/1642

## Motivation and Context

This is required to get the snap in the edge channel of the Ubuntu store, and to enable the continuous delivery with build.snapcraft.io

## How Has This Been Tested?

"master" has less than 32 chars.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.