### PR TITLE
[docs]: add steps to run GCS gateway on Kubernetes via YAML files

### DIFF
--- a/docs/orchestration/kubernetes-yaml/README.md
+++ b/docs/orchestration/kubernetes-yaml/README.md
@@ -19,6 +19,14 @@
   - [Update existing Minio StatefulSet](#update-existing-minio-statefulset)
   - [Resource cleanup](#distributed-resource-cleanup)
 
+- [Minio GCS Gateway Deployment](#minio-gcs-gateway-deployment)
+    - [GCS Gateway Quickstart](#gcs-gateway-quickstart)
+    - [Create GCS Credentials Secret](#create-gcs-credentials-secret)
+    - [Create Minio GCS Gateway Deployment](#create-minio-gcs-gateway-deployment)
+    - [Create Minio LoadBalancer Service](#create-minio-loadbalancer-service)
+    - [Update Existing Minio GCS Deployment](#update-existing-minio-gcs-deployment)
+  - [Resource cleanup](#gcs-gateway-resource-cleanup) 
+
 ## Prerequisites
 
 To run this example, you need Kubernetes version >=1.4 cluster installed and running, and that you have installed the [`kubectl`](https://kubernetes.io/docs/tasks/kubectl/install/) command line tool in your path. Please see the
@@ -371,4 +379,169 @@ You can cleanup the cluster using
 kubectl delete statefulset minio \
 &&  kubectl delete svc minio \
 && kubectl delete svc minio-service
+```
+
+## Minio GCS Gateway Deployment
+
+The following section describes the process to deploy [Minio](https://minio.io/) GCS Gateway on Kubernetes. The deployment uses the [official Minio Docker image](https://hub.docker.com/r/minio/minio/~/dockerfile/) from Docker Hub.
+
+This section uses following core components of Kubernetes:
+
+- [_Secrets_](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [_Services_](https://kubernetes.io/docs/user-guide/services/)
+- [_Deployments_](https://kubernetes.io/docs/user-guide/deployments/)
+
+### GCS Gateway Quickstart
+
+Create the Google Cloud Service credentials file using the steps mentioned [here](https://github.com/minio/minio/blob/master/docs/gateway/gcs.md#create-service-account-key-for-gcs-and-get-the-credentials-file). 
+
+Use the path of file generated above to create a Kubernetes `secret`.
+
+```sh
+kubectl create secret generic gcs-credentials --from-file=/path/to/gcloud/credentials/application_default_credentials.json
+```
+
+Then download the `minio-gcs-gateway-deployment.yaml` file
+
+```sh
+wget https://github.com/minio/minio/blob/master/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-deployment.yaml?raw=true
+```
+
+Update the section `gcp_project_id` with your GCS project ID. Then run
+
+```sh
+kubectl create -f minio-gcs-gateway-deployment.yaml
+kubectl create -f https://github.com/minio/minio/blob/master/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-service.yaml?raw=true
+```
+
+### Create GCS Credentials Secret
+
+A `secret` is intended to hold sensitive information, such as passwords, OAuth tokens, and ssh keys. Putting this information in a secret is safer and more flexible than putting it verbatim in a pod definition or in a docker image.
+
+Create the Google Cloud Service credentials file using the steps mentioned [here](https://github.com/minio/minio/blob/master/docs/gateway/gcs.md#create-service-account-key-for-gcs-and-get-the-credentials-file). 
+
+Use the path of file generated above to create a Kubernetes `secret`.
+
+```sh
+kubectl create secret generic gcs-credentials --from-file=/path/to/gcloud/credentials/application_default_credentials.json
+```
+
+### Create Minio GCS Gateway Deployment
+
+A deployment encapsulates replica sets and pods — so, if a pod goes down, replication controller makes sure another pod comes up automatically. This way you won’t need to bother about pod failures and will have a stable Minio service available.
+
+Minio Gateway uses GCS as its storage backend and need to use a GCP `projectid` to identify your credentials. Update the section `gcp_project_id` with your
+GCS project ID. This is the deployment description.
+
+```sh
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio-deployment
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        app: minio
+    spec:
+      # Refer to the secret created earlier
+      volumes:
+      - name: gcs-credentials
+        secret:
+          # Name of the Secret created earlier
+          secretName: gcs-credentials
+      containers:
+      - name: minio
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio:RELEASE.2017-08-05T00-00-53Z
+        args:
+        - gateway
+        - gcs
+        - gcp_project_id
+        env:
+        # Minio access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        # Google Cloud Service uses this variable
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/etc/credentials/application_default_credentials.json"
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+        # Mount the volume into the pod
+        volumeMounts:
+        - name: gcs-credentials
+          mountPath: "/etc/credentials"
+          readOnly: true
+```
+
+Create the Deployment
+
+```sh
+kubectl create -f https://github.com/minio/minio/blob/master/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-deployment.yaml?raw=true
+deployment "minio-deployment" created
+```
+
+### Create Minio LoadBalancer Service
+
+Now that you have a Minio deployment running, you may either want to access it internally (within the cluster) or expose it as a Service onto an external (outside of your cluster, maybe public internet) IP address, depending on your use case. You can achieve this using Services. There are 3 major service types — default type is ClusterIP, which exposes a service to connection from inside the cluster. NodePort and LoadBalancer are two types that expose services to external traffic.
+
+In this example, we expose the Minio Deployment by creating a LoadBalancer service. This is the service description.
+
+```sh
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: minio
+```
+Create the Minio service
+
+```sh
+kubectl create -f https://github.com/minio/minio/blob/master/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-service.yaml?raw=true
+service "minio-service" created
+```
+
+The `LoadBalancer` service takes couple of minutes to launch. To check if the service was created successfully, run the command
+
+```sh
+kubectl get svc minio-service
+NAME            CLUSTER-IP     EXTERNAL-IP       PORT(S)          AGE
+minio-service   10.55.248.23   104.199.249.165   9000:31852/TCP   1m
+```
+
+### Update Existing Minio GCS Deployment
+
+You can update an existing Minio deployment to use a newer Minio release. To do this, use the `kubectl set image` command:
+
+```sh
+kubectl set image deployment/minio-deployment minio=<replace-with-new-minio-image>
+```
+
+Kubernetes will restart the deployment to update the image. You will get a message as shown below, on successful update:
+
+```
+deployment "minio-deployment" image updated
+```
+
+### GCS Gateway Resource Cleanup
+
+You can cleanup the cluster using
+
+```sh
+kubectl delete deployment minio-deployment \
+&&  kubectl delete secret gcs-credentials 
 ```

--- a/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-deployment.yaml
+++ b/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio-deployment
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        app: minio
+    spec:
+      # Refer to the secret created earlier
+      volumes:
+      - name: gcs-credentials
+        secret:
+          # Name of the Secret created earlier
+          secretName: gcs-credentials
+      containers:
+      - name: minio
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio:RELEASE.2017-08-05T00-00-53Z
+        args:
+        - gateway
+        - gcs
+        - gcp_project_id
+        env:
+        # Minio access key and secret key
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        # Google Cloud Service uses this variable
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/etc/credentials/application_default_credentials.json"
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+        # Mount the volume into the pod
+        volumeMounts:
+        - name: gcs-credentials
+          mountPath: "/etc/credentials"
+          readOnly: true

--- a/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-service.yaml
+++ b/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: minio


### PR DESCRIPTION
## Description
This PR adds docs on how to deploy Minio GCS Gateway on a Kubernetes cluster. 

## Motivation and Context
During content review with @abperiasamy we concluded that this is an important aspect of Minio that needs to tested and documented. 

## How Has This Been Tested?
Manually on `minikube`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.