### PR TITLE
Update Docker commands to use /data as example directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Minio server is light enough to be bundled with the application stack, similar t
 ### Stable
 ```
 docker pull minio/minio
-docker run -p 9000:9000 minio/minio server /export
+docker run -p 9000:9000 minio/minio server /data
 ```
 
 ### Edge
 ```
 docker pull minio/minio:edge
-docker run -p 9000:9000 minio/minio:edge server /export
+docker run -p 9000:9000 minio/minio:edge server /data
 ```
 Please visit Minio Docker quickstart guide for more [here](https://docs.minio.io/docs/minio-docker-quickstart-guide)
 

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -4,28 +4,28 @@
 Docker installed on your machine. Download the relevant installer from [here](https://www.docker.com/community-edition#/download).
 
 ## Run Standalone Minio on Docker.
-Minio needs a persistent volume to store configuration and application data. However, for testing purposes, you can launch Minio by simply passing a directory (`/export` in the example below). This directory gets created in the container filesystem at the time of container start. But all the data is lost after container exits.
+Minio needs a persistent volume to store configuration and application data. However, for testing purposes, you can launch Minio by simply passing a directory (`/data` in the example below). This directory gets created in the container filesystem at the time of container start. But all the data is lost after container exits.
 
 ```sh
-docker run -p 9000:9000 minio/minio server /export
+docker run -p 9000:9000 minio/minio server /data
 ```
 
-To create a Minio container with persistent storage, you need to map local persistent directories from the host OS to virtual config `~/.minio` and export `/export` directories. To do this, run the below commands
+To create a Minio container with persistent storage, you need to map local persistent directories from the host OS to virtual config `~/.minio` and export `/data` directories. To do this, run the below commands
 
 #### GNU/Linux and macOS
 ```sh
 docker run -p 9000:9000 --name minio1 \
-  -v /mnt/export/minio1:/export \
-  -v /mnt/config/minio1:/root/.minio \
-  minio/minio server /export
+  -v /mnt/data:/data \
+  -v /mnt/config:/root/.minio \
+  minio/minio server /data
 ```
 
 #### Windows
 ```sh
 docker run -p 9000:9000 --name minio1 \
-  -v D:\export\minio1:/export \
-  -v D:\export\minio1-config:/root/.minio \
-  minio/minio server /export
+  -v D:\data:/data \
+  -v D:\minio\config:/root/.minio \
+  minio/minio server /data
 ```
 
 ## Run Distributed Minio on Docker
@@ -43,9 +43,9 @@ To override Minio's auto-generated keys, you may pass secret and access keys exp
 docker run -p 9000:9000 --name minio1 \
   -e "MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE" \
   -e "MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
-  -v /mnt/export/minio1:/export \
-  -v /mnt/config/minio1:/root/.minio \
-  minio/minio server /export
+  -v /mnt/data:/data \
+  -v /mnt/config:/root/.minio \
+  minio/minio server /data
 ```
 
 #### Windows
@@ -53,9 +53,9 @@ docker run -p 9000:9000 --name minio1 \
 docker run -p 9000:9000 --name minio1 \
   -e "MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE" \
   -e "MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
-  -v D:\export\minio1:/export \
-  -v D:\export\minio1-config:/root/.minio \
-  minio/minio server /export
+  -v D:\data:/data \
+  -v D:\minio\config:/root/.minio \
+  minio/minio server /data
 ```
 
 ### Minio Custom Access and Secret Keys using Docker secrets
@@ -68,7 +68,7 @@ echo "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" | docker secret create secret_ke
 
 Create a Minio service using `docker service` to read from Docker secrets.
 ```
-docker service create --name="minio-service" --secret="access_key" --secret="secret_key" minio/minio server /export
+docker service create --name="minio-service" --secret="access_key" --secret="secret_key" minio/minio server /data
 ```
 
 Read more about `docker service` [here](https://docs.docker.com/engine/swarm/how-swarm-mode-works/services/)


### PR DESCRIPTION
## Description
`/data` as default makes it easy to understand and shortens the example Minio command for Docker.

## Motivation and Context
This was discussed during content review with @abperiasamy . 

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.