### PR TITLE
New Admin API implementation

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -23,11 +23,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/madmin"
 )
@@ -41,18 +41,10 @@ type mgmtQueryKey string
 
 // Only valid query params for mgmt admin APIs.
 const (
-	mgmtBucket         mgmtQueryKey = "bucket"
-	mgmtObject         mgmtQueryKey = "object"
-	mgmtPrefix         mgmtQueryKey = "prefix"
-	mgmtLockOlderThan  mgmtQueryKey = "older-than"
-	mgmtDelimiter      mgmtQueryKey = "delimiter"
-	mgmtMarker         mgmtQueryKey = "marker"
-	mgmtKeyMarker      mgmtQueryKey = "key-marker"
-	mgmtMaxKey         mgmtQueryKey = "max-key"
-	mgmtDryRun         mgmtQueryKey = "dry-run"
-	mgmtUploadIDMarker mgmtQueryKey = "upload-id-marker"
-	mgmtMaxUploads     mgmtQueryKey = "max-uploads"
-	mgmtUploadID       mgmtQueryKey = "upload-id"
+	mgmtBucket        mgmtQueryKey = "bucket"
+	mgmtPrefix        mgmtQueryKey = "prefix"
+	mgmtLockOlderThan mgmtQueryKey = "older-than"
+	mgmtMarker        mgmtQueryKey = "marker"
 )
 
 var (
@@ -61,8 +53,10 @@ var (
 	adminAPIVersionInfo = madmin.AdminAPIVersionInfo{"1"}
 )
 
-func (adminAPI adminAPIHandlers) VersionHandler(w http.ResponseWriter,
-	r *http.Request) {
+// VersionHandler - GET /minio/admin/version
+// -----------
+// Returns Administration API version
+func (a adminAPIHandlers) VersionHandler(w http.ResponseWriter, r *http.Request) {
 
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
@@ -72,7 +66,7 @@ func (adminAPI adminAPIHandlers) VersionHandler(w http.ResponseWriter,
 
 	jsonBytes, err := json.Marshal(adminAPIVersionInfo)
 	if err != nil {
-		writeErrorResponse(w, ErrInternalError, r.URL)
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
 		errorIf(err, "Failed to marshal Admin API Version to JSON.")
 		return
 	}
@@ -83,10 +77,10 @@ func (adminAPI adminAPIHandlers) VersionHandler(w http.ResponseWriter,
 // ServiceStatusHandler - GET /minio/admin/v1/service
 // ----------
 // Returns server version and uptime.
-func (adminAPI adminAPIHandlers) ServiceStatusHandler(w http.ResponseWriter, r *http.Request) {
+func (a adminAPIHandlers) ServiceStatusHandler(w http.ResponseWriter, r *http.Request) {
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
@@ -100,7 +94,7 @@ func (adminAPI adminAPIHandlers) ServiceStatusHandler(w http.ResponseWriter, r *
 	// of read-quorum availability.
 	uptime, err := getPeerUptimes(globalAdminPeers)
 	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+		writeErrorResponseJSON(w, toAPIErrorCode(err), r.URL)
 		errorIf(err, "Possibly failed to get uptime from majority of servers.")
 		return
 	}
@@ -114,7 +108,7 @@ func (adminAPI adminAPIHandlers) ServiceStatusHandler(w http.ResponseWriter, r *
 	// Marshal API response
 	jsonBytes, err := json.Marshal(serverStatus)
 	if err != nil {
-		writeErrorResponse(w, ErrInternalError, r.URL)
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
 		errorIf(err, "Failed to marshal storage info into json.")
 		return
 	}
@@ -128,24 +122,24 @@ func (adminAPI adminAPIHandlers) ServiceStatusHandler(w http.ResponseWriter, r *
 // ----------
 // Restarts/Stops minio server gracefully. In a distributed setup,
 // restarts all the servers in the cluster.
-func (adminAPI adminAPIHandlers) ServiceStopNRestartHandler(w http.ResponseWriter, r *http.Request) {
+func (a adminAPIHandlers) ServiceStopNRestartHandler(w http.ResponseWriter, r *http.Request) {
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		errorIf(err, "Failed to read request body")
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+		writeErrorResponseJSON(w, toAPIErrorCode(err), r.URL)
 		return
 	}
 
 	var sa madmin.ServiceAction
 	err = json.Unmarshal(body, &sa)
 	if err != nil {
-		writeErrorResponse(w, ErrMalformedPOSTRequest, r.URL)
+		writeErrorResponseJSON(w, ErrMalformedPOSTRequest, r.URL)
 		errorIf(err, "Error parsing body JSON")
 		return
 	}
@@ -157,7 +151,7 @@ func (adminAPI adminAPIHandlers) ServiceStopNRestartHandler(w http.ResponseWrite
 	case madmin.ServiceActionValueStop:
 		serviceSig = serviceStop
 	default:
-		writeErrorResponse(w, ErrMalformedPOSTRequest, r.URL)
+		writeErrorResponseJSON(w, ErrMalformedPOSTRequest, r.URL)
 		errorIf(err, "Invalid service action received")
 		return
 	}
@@ -226,11 +220,11 @@ type ServerInfo struct {
 // ServerInfoHandler - GET /minio/admin/v1/info
 // ----------
 // Get server information
-func (adminAPI adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Request) {
+func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Request) {
 	// Authenticate request
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
@@ -266,7 +260,7 @@ func (adminAPI adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *htt
 	// Marshal API response
 	jsonBytes, err := json.Marshal(reply)
 	if err != nil {
-		writeErrorResponse(w, ErrInternalError, r.URL)
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
 		errorIf(err, "Failed to marshal storage info into json.")
 		return
 	}
@@ -313,19 +307,18 @@ func validateLockQueryParams(vars url.Values) (string, string, time.Duration,
 // - prefix and older-than are optional query parameters
 // ---------
 // Lists locks held on a given bucket, prefix and duration it was held for.
-func (adminAPI adminAPIHandlers) ListLocksHandler(w http.ResponseWriter,
-	r *http.Request) {
+func (a adminAPIHandlers) ListLocksHandler(w http.ResponseWriter, r *http.Request) {
 
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
 	vars := r.URL.Query()
 	bucket, prefix, duration, adminAPIErr := validateLockQueryParams(vars)
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
@@ -334,7 +327,7 @@ func (adminAPI adminAPIHandlers) ListLocksHandler(w http.ResponseWriter,
 	volLocks, err := listPeerLocksInfo(globalAdminPeers, bucket, prefix,
 		duration)
 	if err != nil {
-		writeErrorResponse(w, ErrInternalError, r.URL)
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
 		errorIf(err, "Failed to fetch lock information from remote nodes.")
 		return
 	}
@@ -342,7 +335,7 @@ func (adminAPI adminAPIHandlers) ListLocksHandler(w http.ResponseWriter,
 	// Marshal list of locks as json.
 	jsonBytes, err := json.Marshal(volLocks)
 	if err != nil {
-		writeErrorResponse(w, ErrInternalError, r.URL)
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
 		errorIf(err, "Failed to marshal lock information into json.")
 		return
 	}
@@ -358,19 +351,18 @@ func (adminAPI adminAPIHandlers) ListLocksHandler(w http.ResponseWriter,
 // HTTP header x-minio-operation: clear
 // ---------
 // Clear locks held on a given bucket, prefix and duration it was held for.
-func (adminAPI adminAPIHandlers) ClearLocksHandler(w http.ResponseWriter,
-	r *http.Request) {
+func (a adminAPIHandlers) ClearLocksHandler(w http.ResponseWriter, r *http.Request) {
 
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
 	vars := r.URL.Query()
 	bucket, prefix, duration, adminAPIErr := validateLockQueryParams(vars)
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
@@ -379,7 +371,7 @@ func (adminAPI adminAPIHandlers) ClearLocksHandler(w http.ResponseWriter,
 	volLocks, err := listPeerLocksInfo(globalAdminPeers, bucket, prefix,
 		duration)
 	if err != nil {
-		writeErrorResponse(w, ErrInternalError, r.URL)
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
 		errorIf(err, "Failed to fetch lock information from remote nodes.")
 		return
 	}
@@ -387,7 +379,7 @@ func (adminAPI adminAPIHandlers) ClearLocksHandler(w http.ResponseWriter,
 	// Marshal list of locks as json.
 	jsonBytes, err := json.Marshal(volLocks)
 	if err != nil {
-		writeErrorResponse(w, ErrInternalError, r.URL)
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
 		errorIf(err, "Failed to marshal lock information into json.")
 		return
 	}
@@ -401,459 +393,249 @@ func (adminAPI adminAPIHandlers) ClearLocksHandler(w http.ResponseWriter,
 	writeSuccessResponseJSON(w, jsonBytes)
 }
 
-// ListUploadsHealHandler - similar to listObjectsHealHandler
-// GET
-// /?heal&bucket=mybucket&prefix=myprefix&key-marker=mymarker&upload-id-marker=myuploadid&delimiter=mydelimiter&max-uploads=1000
-// - bucket is mandatory query parameter
-// - rest are optional query parameters List upto maxKey objects that
-// need healing in a given bucket matching the given prefix.
-func (adminAPI adminAPIHandlers) ListUploadsHealHandler(w http.ResponseWriter, r *http.Request) {
-	// Get object layer instance.
-	objLayer := newObjectLayerFn()
-	if objLayer == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
-		return
-	}
+// extractHealInitParams - Validates params for heal init API.
+func extractHealInitParams(r *http.Request) (bucket, objPrefix string,
+	hs madmin.HealOpts, err APIErrorCode) {
 
-	// Validate request signature.
-	adminAPIErr := checkRequestAuthType(r, "", "", "")
-	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
-		return
-	}
+	vars := mux.Vars(r)
+	bucket, objPrefix = vars[string(mgmtBucket)], vars[string(mgmtPrefix)]
 
-	// Validate query params.
-	vars := r.URL.Query()
-	bucket := vars.Get(string(mgmtBucket))
-	prefix, keyMarker, uploadIDMarker, delimiter, maxUploads, _ := getBucketMultipartResources(r.URL.Query())
-
-	if err := checkListMultipartArgs(bucket, prefix, keyMarker, uploadIDMarker, delimiter, objLayer); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	if maxUploads <= 0 || maxUploads > maxUploadsList {
-		writeErrorResponse(w, ErrInvalidMaxUploads, r.URL)
-		return
-	}
-
-	// Get the list objects to be healed.
-	listMultipartInfos, err := objLayer.ListUploadsHeal(bucket, prefix,
-		keyMarker, uploadIDMarker, delimiter, maxUploads)
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	listResponse := generateListMultipartUploadsResponse(bucket, listMultipartInfos)
-	// Write success response.
-	writeSuccessResponseXML(w, encodeResponse(listResponse))
-}
-
-// extractListObjectsHealQuery - Validates query params for heal objects list management API.
-func extractListObjectsHealQuery(vars url.Values) (string, string, string, string, int, APIErrorCode) {
-	bucket := vars.Get(string(mgmtBucket))
-	prefix := vars.Get(string(mgmtPrefix))
-	marker := vars.Get(string(mgmtMarker))
-	delimiter := vars.Get(string(mgmtDelimiter))
-	maxKeyStr := vars.Get(string(mgmtMaxKey))
-
-	// N B empty bucket name is invalid
-	if !IsValidBucketName(bucket) {
-		return "", "", "", "", 0, ErrInvalidBucketName
+	if bucket == "" {
+		if objPrefix != "" {
+			// Bucket is required if object-prefix is given
+			return bucket, objPrefix, hs, ErrHealMissingBucket
+		}
+	} else if !IsValidBucketName(bucket) {
+		return bucket, objPrefix, hs, ErrInvalidBucketName
 	}
 
 	// empty prefix is valid.
-	if !IsValidObjectPrefix(prefix) {
-		return "", "", "", "", 0, ErrInvalidObjectName
+	if !IsValidObjectPrefix(objPrefix) {
+		return bucket, objPrefix, hs, ErrInvalidObjectName
 	}
 
-	// check if maxKey is a valid integer, if present.
-	var maxKey int
-	var err error
-	if maxKeyStr != "" {
-		if maxKey, err = strconv.Atoi(maxKeyStr); err != nil {
-			return "", "", "", "", 0, ErrInvalidMaxKeys
-		}
+	body, berr := ioutil.ReadAll(r.Body)
+	if berr != nil {
+		return bucket, objPrefix, hs, ErrMalformedPOSTRequest
 	}
 
-	// Validate prefix, marker, delimiter and maxKey.
-	apiErr := validateListObjectsArgs(prefix, marker, delimiter, maxKey)
+	jerr := json.Unmarshal(body, &hs)
+	if jerr != nil {
+		return bucket, objPrefix, hs, ErrMalformedPOSTRequest
+	}
+	return bucket, objPrefix, hs, ErrNone
+}
+
+// HealStartHandler - POST /minio/admin/v1/heal
+// -----------
+// Initiates a heal sequence
+func (a adminAPIHandlers) HealStartHandler(w http.ResponseWriter, r *http.Request) {
+
+	// Get object layer instance.
+	objLayer := newObjectLayerFn()
+	if objLayer == nil {
+		writeErrorResponseJSON(w, ErrServerNotInitialized, r.URL)
+		return
+	}
+
+	// Validate request signature.
+	adminAPIErr := checkRequestAuthType(r, "", "", "")
+	if adminAPIErr != ErrNone {
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+
+	// Check if this setup is an erasure code backend, since
+	// heal-format is only applicable to single node XL and
+	// distributed XL setup. In this case, it is not a failure, we skip
+	if !globalIsXL {
+		writeErrorResponseJSON(w, ErrNotImplemented, r.URL)
+		return
+	}
+
+	bucket, objPrefix, hs, apiErr := extractHealInitParams(r)
 	if apiErr != ErrNone {
-		return "", "", "", "", 0, apiErr
-	}
-
-	return bucket, prefix, marker, delimiter, maxKey, ErrNone
-}
-
-// ListObjectsHealHandler - GET /?heal&bucket=mybucket&prefix=myprefix&marker=mymarker&delimiter=&mydelimiter&maxKey=1000
-// - bucket is mandatory query parameter
-// - rest are optional query parameters
-// List upto maxKey objects that need healing in a given bucket matching the given prefix.
-func (adminAPI adminAPIHandlers) ListObjectsHealHandler(w http.ResponseWriter, r *http.Request) {
-	// Get object layer instance.
-	objLayer := newObjectLayerFn()
-	if objLayer == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
+		writeErrorResponseJSON(w, apiErr, r.URL)
 		return
 	}
 
-	// Validate request signature.
-	adminAPIErr := checkRequestAuthType(r, "", "", "")
-	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+	// find number of disk in the setup
+	info := objLayer.StorageInfo()
+	numDisks := info.Backend.OfflineDisks + info.Backend.OnlineDisks
+	// read quorum gives the number of data shards for erasure
+	// coding, thus parity shard count is:
+	numParityDisks := numDisks - info.Backend.ReadQuorum
+
+	nh := newHealSequence(bucket, objPrefix, numDisks, numParityDisks, hs)
+	if err := globalAllHealState.LaunchNewHealSequence(nh); err != nil {
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
+		errorIf(err, "Failed to start heal sequence.")
 		return
 	}
 
-	// Validate query params.
-	vars := r.URL.Query()
-	bucket, prefix, marker, delimiter, maxKey, adminAPIErr := extractListObjectsHealQuery(vars)
-	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
-		return
-	}
-
-	// Get the list objects to be healed.
-	objectInfos, err := objLayer.ListObjectsHeal(bucket, prefix, marker, delimiter, maxKey)
+	// Marshal heal path in reply.
+	jsonBytes, err := json.Marshal(struct {
+		HealPath string `json:"healPathId"`
+	}{nh.path})
 	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
+		errorIf(err, "Failed to marshal JSON for heal start result.")
 		return
 	}
-
-	listResponse := generateListObjectsV1Response(bucket, prefix, marker, delimiter, maxKey, objectInfos)
-	// Write success response.
-	writeSuccessResponseXML(w, encodeResponse(listResponse))
-}
-
-// ListBucketsHealHandler - GET /?heal
-func (adminAPI adminAPIHandlers) ListBucketsHealHandler(w http.ResponseWriter, r *http.Request) {
-	// Get object layer instance.
-	objLayer := newObjectLayerFn()
-	if objLayer == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
-		return
-	}
-
-	// Validate request signature.
-	adminAPIErr := checkRequestAuthType(r, "", "", "")
-	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
-		return
-	}
-
-	// Get the list buckets to be healed.
-	bucketsInfo, err := objLayer.ListBucketsHeal()
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	listResponse := generateListBucketsResponse(bucketsInfo)
-	// Write success response.
-	writeSuccessResponseXML(w, encodeResponse(listResponse))
-}
-
-// HealBucketHandler - POST /?heal&bucket=mybucket&dry-run
-// - x-minio-operation = bucket
-// - bucket is mandatory query parameter
-// Heal a given bucket, if present.
-func (adminAPI adminAPIHandlers) HealBucketHandler(w http.ResponseWriter, r *http.Request) {
-	// Get object layer instance.
-	objLayer := newObjectLayerFn()
-	if objLayer == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
-		return
-	}
-
-	// Validate request signature.
-	adminAPIErr := checkRequestAuthType(r, "", "", "")
-	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
-		return
-	}
-
-	// Validate bucket name and check if it exists.
-	vars := r.URL.Query()
-	bucket := vars.Get(string(mgmtBucket))
-	if err := checkBucketExist(bucket, objLayer); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// if dry-run is present in query-params, then only perform validations and return success.
-	if isDryRun(vars) {
-		writeSuccessResponseHeadersOnly(w)
-		return
-	}
-
-	// Heal the given bucket.
-	err := objLayer.HealBucket(bucket)
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// Return 200 on success.
-	writeSuccessResponseHeadersOnly(w)
-}
-
-// isDryRun - returns true if dry-run query param was set and false otherwise.
-// otherwise.
-func isDryRun(qval url.Values) bool {
-	if _, dryRun := qval[string(mgmtDryRun)]; dryRun {
-		return true
-	}
-	return false
-}
-
-// healResult - represents result of a heal operation like
-// heal-object, heal-upload.
-type healResult struct {
-	State healState `json:"state"`
-}
-
-// healState - different states of heal operation
-type healState int
-
-const (
-	// healNone - none of the disks healed
-	healNone healState = iota
-	// healPartial - some disks were healed, others were offline
-	healPartial
-	// healOK - all disks were healed
-	healOK
-)
-
-// newHealResult - returns healResult given number of disks healed and
-// number of disks offline
-func newHealResult(numHealedDisks, numOfflineDisks int) healResult {
-	var state healState
-	switch {
-	case numHealedDisks == 0:
-		state = healNone
-
-	case numOfflineDisks > 0:
-		state = healPartial
-
-	default:
-		state = healOK
-	}
-
-	return healResult{State: state}
-}
-
-// HealObjectHandler - POST /?heal&bucket=mybucket&object=myobject&dry-run
-// - x-minio-operation = object
-// - bucket and object are both mandatory query parameters
-// Heal a given object, if present.
-func (adminAPI adminAPIHandlers) HealObjectHandler(w http.ResponseWriter, r *http.Request) {
-	// Get object layer instance.
-	objLayer := newObjectLayerFn()
-	if objLayer == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
-		return
-	}
-
-	// Validate request signature.
-	adminAPIErr := checkRequestAuthType(r, "", "", "")
-	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
-		return
-	}
-
-	vars := r.URL.Query()
-	bucket := vars.Get(string(mgmtBucket))
-	object := vars.Get(string(mgmtObject))
-
-	// Validate bucket and object names.
-	if err := checkBucketAndObjectNames(bucket, object); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// Check if object exists.
-	if _, err := objLayer.GetObjectInfo(bucket, object); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// if dry-run is set in query params then perform validations
-	// and return success.
-	if isDryRun(vars) {
-		writeSuccessResponseHeadersOnly(w)
-		return
-	}
-
-	numOfflineDisks, numHealedDisks, err := objLayer.HealObject(bucket, object)
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	jsonBytes, err := json.Marshal(newHealResult(numHealedDisks, numOfflineDisks))
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// Return 200 on success.
 	writeSuccessResponseJSON(w, jsonBytes)
+}
+
+func extractHealStatusParams(r *http.Request) (healPath string, marker int64,
+	errCode APIErrorCode) {
+
+	vars := mux.Vars(r)
+	bucket, objPrefix := vars[string(mgmtBucket)], vars[string(mgmtPrefix)]
+	healPath = bucket + "/" + objPrefix
+
+	qParams := r.URL.Query()
+	markerStrs := qParams[string(mgmtMarker)]
+	if len(markerStrs) > 1 {
+		return healPath, marker, ErrHealMarkerInvalid
+	}
+	if len(markerStrs) == 1 {
+		var err error
+		marker, err = strconv.ParseInt(markerStrs[0], 10, 64)
+		if err != nil {
+			return healPath, marker, ErrHealMarkerInvalid
+		}
+	} else {
+		marker = -1
+	}
+	return healPath, marker, ErrNone
+}
+
+// HealStatusHandler - POST /minio/admin/v1/heal-status/<bucket>/<obj-prefix>
+// -----------
+// Fetches heal sequence status
+func (a adminAPIHandlers) HealStatusHandler(w http.ResponseWriter, r *http.Request) {
+	// Get object layer instance.
+	objLayer := newObjectLayerFn()
+	if objLayer == nil {
+		writeErrorResponseJSON(w, ErrServerNotInitialized, r.URL)
+		return
+	}
+
+	// Validate request signature.
+	adminAPIErr := checkRequestAuthType(r, "", "", "")
+	if adminAPIErr != ErrNone {
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+
+	// Check if this setup is an erasure code backend, since
+	// heal-format is only applicable to single node XL and
+	// distributed XL setup. In this case, it is not a failure, we skip
+	if !globalIsXL {
+		writeErrorResponseJSON(w, ErrNotImplemented, r.URL)
+		return
+	}
+
+	healPath, marker, apiErr := extractHealStatusParams(r)
+	if apiErr != ErrNone {
+		writeErrorResponseJSON(w, apiErr, r.URL)
+		return
+	}
+
+	jbytes, errCode := globalAllHealState.UpdateNFetchHealStatusJSON(
+		healPath, marker)
+	if errCode != ErrNone {
+		writeErrorResponseJSON(w, errCode, r.URL)
+		return
+	}
+
+	writeSuccessResponseJSON(w, jbytes)
+}
+
+// HealStopHandler - DELETE /minio/admin/v1/heal-status/<bucket>/<obj-prefix>
+// -----------
+// Stops a running heal sequence
+func (a adminAPIHandlers) HealStopHandler(w http.ResponseWriter, r *http.Request) {
+	// Get object layer instance.
+	objLayer := newObjectLayerFn()
+	if objLayer == nil {
+		writeErrorResponseJSON(w, ErrServerNotInitialized, r.URL)
+		return
+	}
+
+	// Validate request signature.
+	adminAPIErr := checkRequestAuthType(r, "", "", "")
+	if adminAPIErr != ErrNone {
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+
+	vars := mux.Vars(r)
+	bucket, objPrefix := vars[string(mgmtBucket)], vars[string(mgmtPrefix)]
+	healPath := bucket + "/" + objPrefix
+
+	errCode := globalAllHealState.StopHealSequence(healPath)
+	if errCode != ErrNone {
+		writeErrorResponseJSON(w, errCode, r.URL)
+		return
+	}
+
+	jbytes, err := json.Marshal(struct {
+		Message string `json:"message"`
+	}{
+		"Heal processing on the requested path was stopped.",
+	})
+	if err != nil {
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
+		errorIf(err, "Failed to marshal heal stop result into json.")
+	}
+	// Return 200 on success.
+	writeSuccessResponseJSON(w, jbytes)
 }
 
 // HealUploadHandler - POST /?heal&bucket=mybucket&object=myobject&upload-id=myuploadID&dry-run
 // - x-minio-operation = upload
 // - bucket, object and upload-id are mandatory query parameters
 // Heal a given upload, if present.
-func (adminAPI adminAPIHandlers) HealUploadHandler(w http.ResponseWriter, r *http.Request) {
+func (a adminAPIHandlers) HealUploadHandler(w http.ResponseWriter, r *http.Request) {
 	// Get object layer instance.
 	objLayer := newObjectLayerFn()
 	if objLayer == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
+		writeErrorResponseJSON(w, ErrServerNotInitialized, r.URL)
 		return
 	}
 
 	// Validate request signature.
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
-	vars := r.URL.Query()
-	bucket := vars.Get(string(mgmtBucket))
-	object := vars.Get(string(mgmtObject))
-	uploadID := vars.Get(string(mgmtUploadID))
-	uploadObj := path.Join(bucket, object, uploadID)
+	vars := mux.Vars(r)
+	bucket, objPrefix := vars[string(mgmtBucket)], vars[string(mgmtPrefix)]
+	healPath := bucket + "/" + objPrefix
 
-	// Validate bucket and object names as supplied via query
-	// parameters.
-	if err := checkBucketAndObjectNames(bucket, object); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+	errCode := globalAllHealState.StopHealSequence(healPath)
+	if errCode != ErrNone {
+		writeErrorResponseJSON(w, errCode, r.URL)
 		return
 	}
 
-	// Validate the bucket and object w.r.t backend representation
-	// of an upload.
-	if err := checkBucketAndObjectNames(minioMetaMultipartBucket,
-		uploadObj); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// Check if upload exists.
-	if _, err := objLayer.GetObjectInfo(minioMetaMultipartBucket,
-		uploadObj); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// if dry-run is set in query params then perform validations
-	// and return success.
-	if isDryRun(vars) {
-		writeSuccessResponseHeadersOnly(w)
-		return
-	}
-
-	//We are able to use HealObject for healing an upload since an
-	//ongoing upload has the same backend representation as an
-	//object.  The 'object' corresponding to a given bucket,
-	//object and uploadID is
-	//.minio.sys/multipart/bucket/object/uploadID.
-	numOfflineDisks, numHealedDisks, err := objLayer.HealObject(minioMetaMultipartBucket, uploadObj)
+	jbytes, err := json.Marshal(struct {
+		Message string `json:"message"`
+	}{
+		"Heal processing on the requested path was stopped.",
+	})
 	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
+		writeErrorResponseJSON(w, ErrInternalError, r.URL)
+		errorIf(err, "Failed to marshal heal stop result into json.")
 	}
-
-	jsonBytes, err := json.Marshal(newHealResult(numHealedDisks, numOfflineDisks))
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// Return 200 on success.
-	writeSuccessResponseJSON(w, jsonBytes)
-}
-
-// HealFormatHandler - POST /?heal&dry-run
-// - x-minio-operation = format
-// - bucket and object are both mandatory query parameters
-// Heal a given object, if present.
-func (adminAPI adminAPIHandlers) HealFormatHandler(w http.ResponseWriter, r *http.Request) {
-	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
-	if objectAPI == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
-		return
-	}
-
-	// Validate request signature.
-	adminAPIErr := checkRequestAuthType(r, "", "", "")
-	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
-		return
-	}
-
-	// Check if this setup is an erasure code backend, since
-	// heal-format is only applicable to single node XL and
-	// distributed XL setup.
-	if !globalIsXL {
-		writeErrorResponse(w, ErrNotImplemented, r.URL)
-		return
-	}
-
-	// if dry-run is set in query-params, return success as
-	// validations are successful so far.
-	vars := r.URL.Query()
-	if isDryRun(vars) {
-		writeSuccessResponseHeadersOnly(w)
-		return
-	}
-
-	// Create a new set of storage instances to heal format.json.
-	bootstrapDisks, err := initStorageDisks(globalEndpoints)
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// Wrap into retrying disks
-	retryingDisks := initRetryableStorageDisks(bootstrapDisks,
-		time.Millisecond, time.Millisecond*5)
-
-	// Heal format.json on available storage.
-	err = healFormatXL(retryingDisks)
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// Instantiate new object layer with newly formatted storage.
-	newObjectAPI, err := newXLObjects(retryingDisks)
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
-	// Set object layer with newly formatted storage to globalObjectAPI.
-	globalObjLayerMutex.Lock()
-	globalObjectAPI = newObjectAPI
-	globalObjLayerMutex.Unlock()
-
-	// Shutdown storage belonging to old object layer instance.
-	objectAPI.Shutdown()
-
-	// Inform peers to reinitialize storage with newly formatted storage.
-	reInitPeerDisks(globalAdminPeers)
-
-	// Return 200 on success.
-	writeSuccessResponseHeadersOnly(w)
+	writeSuccessResponseJSON(w, jbytes)
 }
 
 // GetConfigHandler - GET /minio/admin/v1/config
 // Get config.json of this minio setup.
-func (adminAPI adminAPIHandlers) GetConfigHandler(w http.ResponseWriter,
-	r *http.Request) {
+func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Reject the request on non-TLS connection (though
 	// credentials/config have possibly been transmitted over the
@@ -866,13 +648,13 @@ func (adminAPI adminAPIHandlers) GetConfigHandler(w http.ResponseWriter,
 	// Validate request signature.
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
 	// check if objectLayer is initialized, if not return.
 	if newObjectLayerFn() == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
+		writeErrorResponseJSON(w, ErrServerNotInitialized, r.URL)
 		return
 	}
 
@@ -881,7 +663,7 @@ func (adminAPI adminAPIHandlers) GetConfigHandler(w http.ResponseWriter,
 	configBytes, err := getPeerConfig(globalAdminPeers)
 	if err != nil {
 		errorIf(err, "Failed to get config from peers")
-		writeErrorResponse(w, toAdminAPIErrCode(err), r.URL)
+		writeErrorResponseJSON(w, toAdminAPIErrCode(err), r.URL)
 		return
 	}
 
@@ -941,7 +723,7 @@ func writeSetConfigResponse(w http.ResponseWriter, peers adminPeers,
 	enc.SetEscapeHTML(false)
 	jsonErr := enc.Encode(result)
 	if jsonErr != nil {
-		writeErrorResponse(w, toAPIErrorCode(jsonErr), reqURL)
+		writeErrorResponseJSON(w, toAPIErrorCode(jsonErr), reqURL)
 		return
 	}
 
@@ -950,8 +732,7 @@ func writeSetConfigResponse(w http.ResponseWriter, peers adminPeers,
 }
 
 // SetConfigHandler - PUT /minio/admin/v1/config
-func (adminAPI adminAPIHandlers) SetConfigHandler(w http.ResponseWriter,
-	r *http.Request) {
+func (a adminAPIHandlers) SetConfigHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Reject the request on non-TLS connection (though
 	// credentials/config have possibly been transmitted over the
@@ -964,14 +745,14 @@ func (adminAPI adminAPIHandlers) SetConfigHandler(w http.ResponseWriter,
 	// Get current object layer instance.
 	objectAPI := newObjectLayerFn()
 	if objectAPI == nil {
-		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
+		writeErrorResponseJSON(w, ErrServerNotInitialized, r.URL)
 		return
 	}
 
 	// Validate request signature.
 	adminAPIErr := checkRequestAuthType(r, "", "", "")
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
 		return
 	}
 
@@ -979,7 +760,7 @@ func (adminAPI adminAPIHandlers) SetConfigHandler(w http.ResponseWriter,
 	configBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		errorIf(err, "Failed to read config from request body.")
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+		writeErrorResponseJSON(w, toAPIErrorCode(err), r.URL)
 		return
 	}
 
@@ -988,7 +769,7 @@ func (adminAPI adminAPIHandlers) SetConfigHandler(w http.ResponseWriter,
 
 	if err != nil {
 		errorIf(err, "Failed to unmarshal config from request body.")
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+		writeErrorResponseJSON(w, toAPIErrorCode(err), r.URL)
 		return
 	}
 
@@ -996,7 +777,7 @@ func (adminAPI adminAPIHandlers) SetConfigHandler(w http.ResponseWriter,
 		creds := globalServerConfig.GetCredential()
 		if config.Credential.AccessKey != creds.AccessKey ||
 			config.Credential.SecretKey != creds.SecretKey {
-			writeErrorResponse(w, ErrAdminCredentialsMismatch, r.URL)
+			writeErrorResponseJSON(w, ErrAdminCredentialsMismatch, r.URL)
 			return
 		}
 	}
@@ -1018,7 +799,7 @@ func (adminAPI adminAPIHandlers) SetConfigHandler(w http.ResponseWriter,
 	// operations.
 	configLock := globalNSMutex.NewNSLock(minioReservedBucket, minioConfigFile)
 	if configLock.GetLock(globalObjectTimeout) != nil {
-		writeErrorResponse(w, ErrOperationTimedOut, r.URL)
+		writeErrorResponseJSON(w, ErrOperationTimedOut, r.URL)
 		return
 	}
 	defer configLock.Unlock()
@@ -1039,4 +820,72 @@ func (adminAPI adminAPIHandlers) SetConfigHandler(w http.ResponseWriter,
 
 	// Restart all node for the modified config to take effect.
 	sendServiceCmd(globalAdminPeers, serviceRestart)
+}
+
+// ConfigCredsHandler - POST /minio/admin/v1/config/credential
+// ----------
+// Update credentials in a minio server. In a distributed setup,
+// update all the servers in the cluster.
+func (a adminAPIHandlers) UpdateCredentialsHandler(w http.ResponseWriter,
+	r *http.Request) {
+
+	// Reject the request on non-TLS connection (though
+	// credentials have possibly been transmitted over the wire
+	// already)
+	if r.TLS == nil {
+		writeErrorResponseJSON(w, ErrAdminNonTLSCredsUpdate, r.URL)
+		return
+	}
+
+	// Authenticate request
+	adminAPIErr := checkRequestAuthType(r, "", "", "")
+	if adminAPIErr != ErrNone {
+		writeErrorResponse(w, adminAPIErr, r.URL)
+		return
+	}
+
+	// Avoid setting new credentials when they are already passed
+	// by the environment.
+	if globalIsEnvCreds {
+		writeErrorResponse(w, ErrMethodNotAllowed, r.URL)
+		return
+	}
+
+	// Load request body
+	inputData, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		writeErrorResponse(w, ErrInternalError, r.URL)
+		return
+	}
+
+	// Unmarshal request body
+	var req madmin.SetCredsReq
+	err = json.Unmarshal(inputData, &req)
+	if err != nil {
+		errorIf(err, "Cannot unmarshal credentials request")
+		writeErrorResponse(w, ErrMalformedJSON, r.URL)
+		return
+	}
+
+	creds, err := auth.CreateCredentials(req.AccessKey, req.SecretKey)
+	if err != nil {
+		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+		return
+	}
+
+	// Notify all other Minio peers to update credentials
+	updateErrs := updateCredsOnPeers(creds)
+	for peer, err := range updateErrs {
+		errorIf(err, "Unable to update credentials on peer %s.", peer)
+	}
+
+	// Update local credentials in memory.
+	globalServerConfig.SetCredential(creds)
+	if err = globalServerConfig.Save(); err != nil {
+		writeErrorResponse(w, ErrInternalError, r.URL)
+		return
+	}
+
+	// At this stage, the operation is successful, return 200 OK
+	w.WriteHeader(http.StatusOK)
 }

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -1,0 +1,726 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+// healStatusSummary - overall short summary of a healing sequence
+type healStatusSummary string
+
+// healStatusSummary constants
+const (
+	healNotStartedStatus healStatusSummary = "not started"
+	healRunningStatus                      = "running"
+	healStoppedStatus                      = "stopped"
+	healFinishedStatus                     = "finished"
+)
+
+const (
+	// a heal sequence with this many un-consumed heal result
+	// items blocks until heal-status consumption resumes or is
+	// aborted due to timeout.
+	maxUnconsumedHealResultItems = 1000
+
+	// if no heal-results are consumed (via the heal-status API)
+	// for this timeout duration, the heal sequence is aborted.
+	healUnconsumedTimeout = 24 * time.Hour
+
+	// time-duration to keep heal sequence state after it
+	// completes.
+	keepHealSeqStateDuration = time.Hour
+)
+
+var (
+	errHealIdleTimeout      = fmt.Errorf("healing results were not consumed for too long")
+	errHealPushStopNDiscard = fmt.Errorf("heal push stopped due to heal stop signal")
+	errHealStopSignalled    = fmt.Errorf("heal stop signalled")
+
+	errFnHealInvalidOverlappedPaths = func(path1, path2 string) error {
+		return fmt.Errorf("Cannot start heal operation: requested new heal operation on %s overlaps with existing heal operation on %s", path1, path2)
+	}
+	errFnHealFromAPIErr = func(err error) error {
+		errCode := toAPIErrorCode(err)
+		apiErr := getAPIError(errCode)
+		return fmt.Errorf("Heal internal error: %s: %s",
+			apiErr.Code, apiErr.Description)
+	}
+)
+
+// healSequenceStatus - accumulated status of the heal sequence
+type healSequenceStatus struct {
+	// lock to update this structure as it is concurrently
+	// accessed
+	updateLock *sync.RWMutex
+
+	// summary and detail for failures
+	Summary       healStatusSummary `json:"Summary"`
+	FailureDetail string            `json:"Detail,omitempty"`
+	StartTime     time.Time         `json:"StartTime"`
+
+	// disk information
+	NumDisks       int `json:"NumDisks"`
+	NumParityDisks int `json:"NumParityDisks"`
+
+	// settings for the heal sequence
+	HealSettings madmin.HealOpts `json:"Settings"`
+
+	// slice of unacknowledged and available heal result records
+	Items []madmin.HealResultItem `json:"Items"`
+
+	// accumulated statistics of the heal sequence
+	Statistics *madmin.HealStatistics `json:"HealStatistics"`
+}
+
+// structure to hold state of all heal sequences in server memory
+type allHealState struct {
+	sync.Mutex
+
+	// map of heal path to heal sequence
+	healSeqMap map[string]*healSequence
+}
+
+var (
+	// global server heal state
+	globalAllHealState allHealState
+)
+
+// initAllHealState - initialize healing apparatus
+func initAllHealState(isErasureMode bool) {
+	if !isErasureMode {
+		return
+	}
+
+	globalAllHealState = allHealState{
+		healSeqMap: make(map[string]*healSequence),
+	}
+}
+
+// LaunchNewHealSequence - launches a background routine that performs
+// healing according to the healSequence argument. For each heal
+// sequence, state is stored in the `globalAllHealState`, which is a
+// map of the heal path to `healSequence` which holds state about the
+// heal sequence.
+//
+// Heal results are persisted in server memory for
+// `keepHealSeqStateDuration`. This function also launches a
+// background routine to clean up heal results after the
+// aforementioned duration.
+func (ahs *allHealState) LaunchNewHealSequence(h *healSequence) error {
+	ahs.Lock()
+	defer ahs.Unlock()
+
+	// Check if new heal sequence overlaps with any existing,
+	// running sequence
+	for k, hSeq := range ahs.healSeqMap {
+		if !hSeq.hasEnded() && (strings.HasPrefix(k, h.path) ||
+			strings.HasPrefix(h.path, k)) {
+
+			return errFnHealInvalidOverlappedPaths(h.path, k)
+		}
+	}
+
+	// Add heal state and start sequence
+	ahs.healSeqMap[h.path] = h
+
+	// Launch top-level background heal go-routine
+	go h.healSequenceStart()
+
+	// Launch clean-up routine to remove this heal sequence (after
+	// it ends) from the global state after timeout has elapsed.
+	go func() {
+		var keepStateTimeout <-chan time.Time
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		everyMinute := ticker.C
+		for {
+			select {
+			// Check every minute if heal sequence has ended.
+			case <-everyMinute:
+				if h.hasEnded() {
+					keepStateTimeout = time.After(keepHealSeqStateDuration)
+					everyMinute = nil
+				}
+
+			// This case does not fire until the heal
+			// sequence completes.
+			case <-keepStateTimeout:
+				// Heal sequence has ended, keep
+				// results state duration has elapsed,
+				// so purge state.
+				ahs.Lock()
+				defer ahs.Unlock()
+				delete(ahs.healSeqMap, h.path)
+				return
+
+			case <-globalServiceDoneCh:
+				// server could be restarting - need
+				// to exit immediately
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// UpdateNFetchHealStatusJSON - Called by heal-status API. It fetches
+// the heal status results from global state and returns its JSON
+// representation. The marker parameter allows the heal-sequence to
+// discard results that have been acknowledged by a client.
+func (ahs *allHealState) UpdateNFetchHealStatusJSON(path string,
+	marker int64) ([]byte, APIErrorCode) {
+
+	// fetch heal state for given path
+	h, ok := func() (*healSequence, bool) {
+		ahs.Lock()
+		defer ahs.Unlock()
+
+		h, ok := ahs.healSeqMap[path]
+		return h, ok
+	}()
+	if !ok {
+		// If there is no such heal sequence, return error.
+		return nil, ErrHealNoSuchProcess
+	}
+
+	// For a statistics only heal sequence, just return it. The
+	// marker value is ignored.
+	if h.settings.StatisticsOnly {
+		return nil, ErrNone
+	}
+
+	// Check if marker is invalid
+	if marker < 0 {
+		return nil, ErrHealMarkerInvalid
+	}
+	// Check if marker is stale
+	if marker < h.lastAckResultIndex {
+		return nil, ErrHealStaleStatusMarker
+	}
+
+	// Take lock to access and update the heal-sequence
+	h.currentStatus.updateLock.Lock()
+	defer h.currentStatus.updateLock.Unlock()
+
+	numItems := len(h.currentStatus.Items)
+
+	// calculate index of most recently available heal result
+	// record.
+	latestResultIndex := h.lastAckResultIndex
+	if numItems > 0 {
+		latestResultIndex = h.currentStatus.Items[numItems-1].ResultIndex
+	}
+
+	// check if the ack-index is in future
+	if marker > latestResultIndex {
+		return nil, ErrHealInvalidFutureStatusMarker
+	}
+
+	// ack-index looks good, remove acknowledged records.
+	h.lastAckResultIndex = marker
+	if len(h.currentStatus.Items) > 0 {
+		startResultIndex := h.currentStatus.Items[0].ResultIndex
+		removeCount := marker - startResultIndex + 1
+		h.currentStatus.Items = h.currentStatus.Items[removeCount:]
+	}
+
+	jbytes, err := json.Marshal(h.currentStatus)
+	if err != nil {
+		errorIf(err, "Failed to marshal heal result into json.")
+		return nil, ErrInternalError
+	}
+
+	return jbytes, ErrNone
+}
+
+// StopHealSequence - stops heal sequence. It does not remove it from
+// global state - that happens after the background heal-sequence
+// routine quits and some time has elapsed (see LaunchNewHealSequence
+// for details).
+func (ahs *allHealState) StopHealSequence(path string) APIErrorCode {
+	ahs.Lock()
+	defer ahs.Unlock()
+
+	// Check if a heal sequence with the given path exists.
+	h, ok := ahs.healSeqMap[path]
+	if !ok {
+		return ErrHealNoSuchProcess
+	}
+
+	// Check if it is already stopped
+	if h.isQuitting() || h.hasEnded() {
+		return ErrHealAlreadyStopped
+	}
+
+	close(h.stopSignalCh)
+	return ErrNone
+}
+
+// healSequence - state for each heal sequence initiated on the
+// server.
+type healSequence struct {
+	// bucket, and prefix on which heal seq. was initiated
+	bucket, objPrefix string
+
+	// path is just bucket + "/" + objPrefix
+	path string
+
+	// heal settings applied to this heal sequence
+	settings madmin.HealOpts
+
+	// current accumulated status of the heal sequence
+	currentStatus healSequenceStatus
+
+	// channel signalled by background routine when traversal has
+	// completed
+	traverseAndHealDoneCh chan error
+
+	// channel to signal heal sequence to stop (e.g. from the
+	// heal-stop API)
+	stopSignalCh chan struct{}
+
+	// the last acknowledged heal result
+	lastAckResultIndex int64
+}
+
+// NewHealSequence - creates healSettings, assumes bucket and
+// objPrefix are already validated.
+func newHealSequence(bucket, objPrefix string, numDisks, numParityDisks int,
+	hs madmin.HealOpts) *healSequence {
+
+	return &healSequence{
+		path:      bucket + "/" + objPrefix,
+		bucket:    bucket,
+		objPrefix: objPrefix,
+		settings:  hs,
+		currentStatus: healSequenceStatus{
+			Summary:        healNotStartedStatus,
+			HealSettings:   hs,
+			NumDisks:       numDisks,
+			NumParityDisks: numParityDisks,
+			updateLock:     &sync.RWMutex{},
+			Statistics:     madmin.NewHealStatistics(),
+		},
+		traverseAndHealDoneCh: make(chan error),
+		stopSignalCh:          make(chan struct{}),
+	}
+}
+
+// isQuitting - determines if the heal sequence is quitting (due to an
+// external signal)
+func (h *healSequence) isQuitting() bool {
+	select {
+	case <-h.stopSignalCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// check if the heal sequence has ended
+func (h *healSequence) hasEnded() bool {
+	h.currentStatus.updateLock.RLock()
+	summary := h.currentStatus.Summary
+	h.currentStatus.updateLock.RUnlock()
+	return summary == healStoppedStatus || summary == healFinishedStatus
+}
+
+// pushHealResultItem - pushes a heal result item for consumption in
+// the heal-status API. It blocks if there are
+// maxUnconsumedHealResultItems. When it blocks, the heal sequence
+// routine is effectively paused - this happens when the server has
+// accumulated the maximum number of heal records per heal
+// sequence. When the client consumes further records, the heal
+// sequence automatically resumes. The return value indicates if the
+// operation succeeded.
+func (h *healSequence) pushHealResultItem(r madmin.HealResultItem) error {
+
+	// start a timer to keep an upper time limit to find an empty
+	// slot to add the given heal result - if no slot is found it
+	// means that the server is holding the maximum amount of
+	// heal-results in memory and the client has not consumed it
+	// for too long.
+	unconsumedTimer := time.NewTimer(healUnconsumedTimeout)
+	defer func() {
+		// stop the timeout timer so it is garbage collected.
+		if !unconsumedTimer.Stop() {
+			<-unconsumedTimer.C
+		}
+	}()
+
+	var itemsLen int
+	for {
+		h.currentStatus.updateLock.Lock()
+		itemsLen = len(h.currentStatus.Items)
+		if itemsLen == maxUnconsumedHealResultItems {
+			// unlock and wait to check again if we can push
+			h.currentStatus.updateLock.Unlock()
+
+			// wait for a second, or quit if an external
+			// stop signal is received or the
+			// unconsumedTimer fires.
+			select {
+			// Check after a second
+			case <-time.After(time.Second):
+				continue
+
+			case <-h.stopSignalCh:
+				// discard result and return.
+				return errHealPushStopNDiscard
+
+			// Timeout if no results consumed for too
+			// long.
+			case <-unconsumedTimer.C:
+				return errHealIdleTimeout
+
+			}
+		}
+		break
+	}
+
+	if !h.currentStatus.HealSettings.StatisticsOnly {
+		// set the correct result index for the new result
+		// item
+		if itemsLen > 0 {
+			r.ResultIndex = 1 + h.currentStatus.Items[itemsLen-1].ResultIndex
+		} else {
+			r.ResultIndex = 1 + h.lastAckResultIndex
+		}
+
+		// append to results
+		h.currentStatus.Items = append(h.currentStatus.Items, r)
+	}
+
+	// update statistics
+	numDisks := h.currentStatus.NumDisks
+	h.currentStatus.Statistics.UpdateHealStats(numDisks, r)
+
+	// release lock
+	h.currentStatus.updateLock.Unlock()
+
+	// This is a "safe" point for the heal sequence to quit if
+	// signalled externally.
+	if h.isQuitting() {
+		return errHealStopSignalled
+	}
+
+	return nil
+}
+
+// healSequenceStart - this is the top-level background heal
+// routine. It launches another go-routine that actually traverses
+// on-disk data, checks and heals according to the selected
+// settings. This go-routine itself, (1) monitors the traversal
+// routine for completion, and (2) listens for external stop
+// signals. When either event happens, it sets the finish status for
+// the heal-sequence.
+func (h *healSequence) healSequenceStart() {
+	// Set status as running
+	h.currentStatus.updateLock.Lock()
+	h.currentStatus.Summary = healRunningStatus
+	h.currentStatus.StartTime = UTCNow()
+	h.currentStatus.updateLock.Unlock()
+
+	go h.traverseAndHeal()
+
+	select {
+	case err, ok := <-h.traverseAndHealDoneCh:
+		h.currentStatus.updateLock.Lock()
+		defer h.currentStatus.updateLock.Unlock()
+		// Heal traversal is complete.
+		if ok {
+			// heal traversal had an error.
+			h.currentStatus.Summary = healStoppedStatus
+			h.currentStatus.FailureDetail = err.Error()
+		} else {
+			// heal traversal succeeded.
+			h.currentStatus.Summary = healFinishedStatus
+		}
+
+	case <-h.stopSignalCh:
+		h.currentStatus.updateLock.Lock()
+		h.currentStatus.Summary = healStoppedStatus
+		h.currentStatus.FailureDetail = errHealStopSignalled.Error()
+		h.currentStatus.updateLock.Unlock()
+
+		// drain traverse channel so the traversal
+		// go-routine does not leak.
+		go func() {
+			// Eventually the traversal go-routine closes
+			// the channel and returns, so this go-routine
+			// itself will not leak.
+			<-h.traverseAndHealDoneCh
+		}()
+	}
+}
+
+// traverseAndHeal - traverses on-disk data and performs healing
+// according to settings. At each "safe" point it also checks if an
+// external quit signal has been received and quits if so. Since the
+// healing traversal may be mutating on-disk data when an external
+// quit signal is received, this routine cannot quit immediately and
+// has to wait until a safe point is reached, such as between scanning
+// two objects.
+func (h *healSequence) traverseAndHeal() {
+	var err error
+	checkErr := func(f func() error) {
+		switch {
+		case err != nil:
+			return
+		case h.isQuitting():
+			err = errHealStopSignalled
+			return
+		}
+		err = f()
+	}
+
+	// Start with format healing
+	checkErr(h.healDiskFormat)
+
+	// Heal buckets and objects
+	checkErr(h.healBuckets)
+
+	if err != nil {
+		h.traverseAndHealDoneCh <- err
+	}
+
+	close(h.traverseAndHealDoneCh)
+}
+
+// healDiskFormat - heals format.json, return value indicates if a
+// failure error occurred.
+func (h *healSequence) healDiskFormat() error {
+	// Get current object layer instance.
+	objectAPI := newObjectLayerFn()
+	if objectAPI == nil {
+		return errServerNotInitialized
+	}
+
+	// Create a new set of storage instances to heal format.json.
+	bootstrapDisks, err := initStorageDisks(globalEndpoints)
+	if err != nil {
+		return errFnHealFromAPIErr(err)
+	}
+
+	// Wrap into retrying disks
+	retryingDisks := initRetryableStorageDisks(bootstrapDisks,
+		time.Millisecond, time.Millisecond*5)
+
+	// Heal format.json on available storage.
+	hres, err := healFormatXL(retryingDisks, h.settings.DryRun)
+	if err != nil {
+		return errFnHealFromAPIErr(err)
+	}
+
+	// reload object layer global only if we healed some disk
+	onlineBefore, onlineAfter := hres.GetOnlineCounts()
+	numHealed := onlineAfter - onlineBefore
+	if numHealed > 0 {
+		// Instantiate new object layer with newly formatted
+		// storage.
+		newObjectAPI, err := newXLObjects(retryingDisks)
+		if err != nil {
+			return errFnHealFromAPIErr(err)
+		}
+
+		// Set object layer with newly formatted storage to
+		// globalObjectAPI.
+		globalObjLayerMutex.Lock()
+		globalObjectAPI = newObjectAPI
+		globalObjLayerMutex.Unlock()
+
+		// Shutdown storage belonging to old object layer
+		// instance.
+		objectAPI.Shutdown()
+
+		// Inform peers to reinitialize storage with newly
+		// formatted storage.
+		reInitPeerDisks(globalAdminPeers)
+	}
+
+	// Push format heal result
+	return h.pushHealResultItem(hres)
+}
+
+// healBuckets - check for all buckets heal or just particular bucket.
+func (h *healSequence) healBuckets() error {
+	// 1. If a bucket was specified, heal only the bucket.
+	if h.bucket != "" {
+		return h.healBucket(h.bucket)
+	}
+
+	// Get current object layer instance.
+	objectAPI := newObjectLayerFn()
+	if objectAPI == nil {
+		return errServerNotInitialized
+	}
+
+	buckets, err := objectAPI.ListBucketsHeal()
+	if err != nil {
+		return errFnHealFromAPIErr(err)
+	}
+
+	for _, bucket := range buckets {
+		err = h.healBucket(bucket.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// healBucket - traverses and heals given bucket
+func (h *healSequence) healBucket(bucket string) error {
+	if h.isQuitting() {
+		return errHealStopSignalled
+	}
+	// Get current object layer instance.
+	objectAPI := newObjectLayerFn()
+	if objectAPI == nil {
+		return errServerNotInitialized
+	}
+
+	results, err := objectAPI.HealBucket(bucket, h.settings.DryRun)
+	// push any available results before checking for error
+	for _, result := range results {
+		if perr := h.pushHealResultItem(result); perr != nil {
+			return perr
+		}
+	}
+	// handle heal-bucket error
+	if err != nil {
+		return err
+	}
+
+	if h.objPrefix != "" {
+		// Check if an object named as the objPrefix exists,
+		// and if so heal it.
+		_, err = objectAPI.GetObjectInfo(bucket, h.objPrefix)
+		if err == nil {
+			err = h.healObject(bucket, h.objPrefix, false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if !h.settings.Recursive {
+		return nil
+	}
+
+	marker := ""
+	isTruncated := true
+	for isTruncated {
+		// TODO: FIXME: listobjectsheal does not seem to set
+		// the bucketname in the object info that it returns.
+		objectInfos, err := objectAPI.ListObjectsHeal(bucket,
+			h.objPrefix, marker, "", 1000)
+		if err != nil {
+			return errFnHealFromAPIErr(err)
+		}
+
+		for _, o := range objectInfos.Objects {
+			if err := h.healObject(bucket, o.Name, false); err != nil {
+				return err
+			}
+		}
+
+		isTruncated = objectInfos.IsTruncated
+		marker = objectInfos.NextMarker
+	}
+
+	// bucket healing is completed - return if don't have to heal
+	// ongoing multipart uploads.
+	if !h.settings.Incomplete {
+		return nil
+	}
+
+	// list and heal multipart uploads
+	iMarker, iUploadIDMarker := "", ""
+	isTruncated = true
+	// if the recursive flag is not set, search for uploads at
+	// object prefix only.
+	delimiter := ""
+	if !h.settings.Recursive {
+		delimiter = "/"
+	}
+	for isTruncated {
+		lmi, err := objectAPI.ListMultipartUploads(bucket,
+			h.objPrefix, iMarker, iUploadIDMarker, delimiter, 1000)
+		if err != nil {
+			return errFnHealFromAPIErr(err)
+		}
+
+		// heal each listed upload
+		for _, upload := range lmi.Uploads {
+			// multipart upload can be healed by
+			// HealObject because the backend
+			// representation within the multipart
+			// directory is the same as an object.
+			objPath := path.Join(bucket, upload.Object,
+				upload.UploadID)
+
+			err := h.healObject(minioMetaMultipartBucket,
+				objPath, true)
+			if err != nil {
+				return err
+			}
+		}
+
+		// update vars for next iteration of loop
+		isTruncated = lmi.IsTruncated
+		iMarker = lmi.NextKeyMarker
+		iUploadIDMarker = lmi.NextUploadIDMarker
+	}
+	return nil
+}
+
+// healObject - heal the given object and record result
+func (h *healSequence) healObject(bucket, object string, isMultipartUpload bool) error {
+	if h.isQuitting() {
+		return errHealStopSignalled
+	}
+
+	// Get current object layer instance.
+	objectAPI := newObjectLayerFn()
+	if objectAPI == nil {
+		return errServerNotInitialized
+	}
+
+	hri, err := objectAPI.HealObject(bucket, object, h.settings.DryRun)
+	if err != nil {
+		hri.Detail = err.Error()
+	}
+
+	if isMultipartUpload {
+		hri.Type = madmin.HealItemMultipartUpload
+		parts := strings.Split(object, "/")
+		hri.Bucket = parts[0]
+		hri.Object = strings.Join(parts[1:len(parts)-1], "/")
+		hri.Detail = parts[len(parts)-1]
+	}
+	return h.pushHealResultItem(hri)
+}

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -18,6 +18,10 @@ package cmd
 
 import router "github.com/gorilla/mux"
 
+const (
+	adminAPIPathPrefix = "/minio/admin"
+)
+
 // adminAPIHandlers provides HTTP handlers for Minio admin API.
 type adminAPIHandlers struct {
 }
@@ -27,50 +31,55 @@ func registerAdminRouter(mux *router.Router) {
 
 	adminAPI := adminAPIHandlers{}
 	// Admin router
-	adminRouter := mux.NewRoute().PathPrefix("/").Subrouter()
+	adminRouter := mux.NewRoute().PathPrefix(adminAPIPathPrefix).Subrouter()
+
+	// Version handler
+	adminRouter.Methods("GET").Path("/version").HandlerFunc(adminAPI.VersionHandler)
+
+	adminV1Router := mux.NewRoute().PathPrefix("/minio/admin/v1").Subrouter()
 
 	/// Service operations
 
 	// Service status
-	adminRouter.Methods("GET").Queries("service", "").Headers(minioAdminOpHeader, "status").HandlerFunc(adminAPI.ServiceStatusHandler)
+	adminV1Router.Methods("GET").Path("/service").HandlerFunc(adminAPI.ServiceStatusHandler)
 
-	// Service restart
-	adminRouter.Methods("POST").Queries("service", "").Headers(minioAdminOpHeader, "restart").HandlerFunc(adminAPI.ServiceRestartHandler)
-	// Service update credentials
-	adminRouter.Methods("POST").Queries("service", "").Headers(minioAdminOpHeader, "set-credentials").HandlerFunc(adminAPI.ServiceCredentialsHandler)
+	// Service restart and stop - TODO
+	adminV1Router.Methods("POST").Path("/service").HandlerFunc(adminAPI.ServiceStopNRestartHandler)
 
 	// Info operations
-	adminRouter.Methods("GET").Queries("info", "").HandlerFunc(adminAPI.ServerInfoHandler)
+	adminV1Router.Methods("GET").Path("/info").HandlerFunc(adminAPI.ServerInfoHandler)
 
 	/// Lock operations
 
 	// List Locks
-	adminRouter.Methods("GET").Queries("lock", "").Headers(minioAdminOpHeader, "list").HandlerFunc(adminAPI.ListLocksHandler)
+	adminV1Router.Methods("GET").Path("/locks").HandlerFunc(adminAPI.ListLocksHandler)
 	// Clear locks
-	adminRouter.Methods("POST").Queries("lock", "").Headers(minioAdminOpHeader, "clear").HandlerFunc(adminAPI.ClearLocksHandler)
+	adminV1Router.Methods("DELETE").Path("/locks").HandlerFunc(adminAPI.ClearLocksHandler)
 
-	/// Heal operations
+	// /// Heal operations
 
-	// List Objects needing heal.
-	adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-objects").HandlerFunc(adminAPI.ListObjectsHealHandler)
-	// List Uploads needing heal.
-	adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-uploads").HandlerFunc(adminAPI.ListUploadsHealHandler)
-	// List Buckets needing heal.
-	adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-buckets").HandlerFunc(adminAPI.ListBucketsHealHandler)
+	// // List Objects needing heal.
+	// adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-objects").HandlerFunc(adminAPI.ListObjectsHealHandler)
+	// // List Uploads needing heal.
+	// adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-uploads").HandlerFunc(adminAPI.ListUploadsHealHandler)
+	// // List Buckets needing heal.
+	// adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-buckets").HandlerFunc(adminAPI.ListBucketsHealHandler)
 
-	// Heal Buckets.
-	adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "bucket").HandlerFunc(adminAPI.HealBucketHandler)
-	// Heal Objects.
-	adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "object").HandlerFunc(adminAPI.HealObjectHandler)
-	// Heal Format.
-	adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "format").HandlerFunc(adminAPI.HealFormatHandler)
-	// Heal Uploads.
-	adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "upload").HandlerFunc(adminAPI.HealUploadHandler)
+	// // Heal Buckets.
+	// adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "bucket").HandlerFunc(adminAPI.HealBucketHandler)
+	// // Heal Objects.
+	// adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "object").HandlerFunc(adminAPI.HealObjectHandler)
+	// // Heal Format.
+	// adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "format").HandlerFunc(adminAPI.HealFormatHandler)
+	// // Heal Uploads.
+	// adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "upload").HandlerFunc(adminAPI.HealUploadHandler)
 
 	/// Config operations
 
+	// Update credentials
+	adminV1Router.Methods("POST").Path("/config/credential").HandlerFunc(adminAPI.UpdateCredentialsHandler)
 	// Get config
-	adminRouter.Methods("GET").Queries("config", "").Headers(minioAdminOpHeader, "get").HandlerFunc(adminAPI.GetConfigHandler)
-	// Set Config
-	adminRouter.Methods("PUT").Queries("config", "").Headers(minioAdminOpHeader, "set").HandlerFunc(adminAPI.SetConfigHandler)
+	adminV1Router.Methods("GET").Path("/config").HandlerFunc(adminAPI.GetConfigHandler)
+	// Set config
+	adminV1Router.Methods("POST").Path("/config").HandlerFunc(adminAPI.SetConfigHandler)
 }

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -16,7 +16,11 @@
 
 package cmd
 
-import router "github.com/gorilla/mux"
+import (
+	"net/http"
+
+	router "github.com/gorilla/mux"
+)
 
 const (
 	adminAPIPathPrefix = "/minio/admin"
@@ -34,52 +38,51 @@ func registerAdminRouter(mux *router.Router) {
 	adminRouter := mux.NewRoute().PathPrefix(adminAPIPathPrefix).Subrouter()
 
 	// Version handler
-	adminRouter.Methods("GET").Path("/version").HandlerFunc(adminAPI.VersionHandler)
+	adminRouter.Methods(http.MethodGet).Path("/version").HandlerFunc(adminAPI.VersionHandler)
 
-	adminV1Router := mux.NewRoute().PathPrefix("/minio/admin/v1").Subrouter()
+	adminV1Router := adminRouter.PathPrefix("/v1").Subrouter()
 
 	/// Service operations
 
 	// Service status
-	adminV1Router.Methods("GET").Path("/service").HandlerFunc(adminAPI.ServiceStatusHandler)
+	adminV1Router.Methods(http.MethodGet).Path("/service").HandlerFunc(adminAPI.ServiceStatusHandler)
 
 	// Service restart and stop - TODO
-	adminV1Router.Methods("POST").Path("/service").HandlerFunc(adminAPI.ServiceStopNRestartHandler)
+	adminV1Router.Methods(http.MethodPost).Path("/service").HandlerFunc(adminAPI.ServiceStopNRestartHandler)
 
 	// Info operations
-	adminV1Router.Methods("GET").Path("/info").HandlerFunc(adminAPI.ServerInfoHandler)
+	adminV1Router.Methods(http.MethodGet).Path("/info").HandlerFunc(adminAPI.ServerInfoHandler)
 
 	/// Lock operations
 
 	// List Locks
-	adminV1Router.Methods("GET").Path("/locks").HandlerFunc(adminAPI.ListLocksHandler)
+	adminV1Router.Methods(http.MethodGet).Path("/locks").HandlerFunc(adminAPI.ListLocksHandler)
 	// Clear locks
-	adminV1Router.Methods("DELETE").Path("/locks").HandlerFunc(adminAPI.ClearLocksHandler)
+	adminV1Router.Methods(http.MethodDelete).Path("/locks").HandlerFunc(adminAPI.ClearLocksHandler)
 
-	// /// Heal operations
+	/// Heal operations
 
-	// // List Objects needing heal.
-	// adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-objects").HandlerFunc(adminAPI.ListObjectsHealHandler)
-	// // List Uploads needing heal.
-	// adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-uploads").HandlerFunc(adminAPI.ListUploadsHealHandler)
-	// // List Buckets needing heal.
-	// adminRouter.Methods("GET").Queries("heal", "").Headers(minioAdminOpHeader, "list-buckets").HandlerFunc(adminAPI.ListBucketsHealHandler)
+	// Fetch and return dynamic heal status.
+	adminV1Router.Methods(http.MethodGet).Path("/heal/").HandlerFunc(adminAPI.HealStatusHandler)
+	adminV1Router.Methods(http.MethodGet).Path("/heal/{bucket}").HandlerFunc(adminAPI.HealStatusHandler)
+	adminV1Router.Methods(http.MethodGet).Path("/heal/{bucket}/{prefix:.*}").HandlerFunc(adminAPI.HealStatusHandler)
 
-	// // Heal Buckets.
-	// adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "bucket").HandlerFunc(adminAPI.HealBucketHandler)
-	// // Heal Objects.
-	// adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "object").HandlerFunc(adminAPI.HealObjectHandler)
-	// // Heal Format.
-	// adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "format").HandlerFunc(adminAPI.HealFormatHandler)
-	// // Heal Uploads.
-	// adminRouter.Methods("POST").Queries("heal", "").Headers(minioAdminOpHeader, "upload").HandlerFunc(adminAPI.HealUploadHandler)
+	// Start heal operation.
+	adminV1Router.Methods(http.MethodPost).Path("/heal/").HandlerFunc(adminAPI.HealStartHandler)
+	adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}").HandlerFunc(adminAPI.HealStartHandler)
+	adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}/{prefix:.*}").HandlerFunc(adminAPI.HealStartHandler)
+
+	// Stop a healing operation.
+	adminV1Router.Methods(http.MethodDelete).Path("/heal/").HandlerFunc(adminAPI.HealStopHandler)
+	adminV1Router.Methods(http.MethodDelete).Path("/heal/{bucket}").HandlerFunc(adminAPI.HealStopHandler)
+	adminV1Router.Methods(http.MethodDelete).Path("/heal/{bucket}/{prefix:.*}").HandlerFunc(adminAPI.HealStopHandler)
 
 	/// Config operations
 
 	// Update credentials
-	adminV1Router.Methods("POST").Path("/config/credential").HandlerFunc(adminAPI.UpdateCredentialsHandler)
+	adminV1Router.Methods(http.MethodPut).Path("/config/credential").HandlerFunc(adminAPI.UpdateCredentialsHandler)
 	// Get config
-	adminV1Router.Methods("GET").Path("/config").HandlerFunc(adminAPI.GetConfigHandler)
+	adminV1Router.Methods(http.MethodGet).Path("/config").HandlerFunc(adminAPI.GetConfigHandler)
 	// Set config
-	adminV1Router.Methods("POST").Path("/config").HandlerFunc(adminAPI.SetConfigHandler)
+	adminV1Router.Methods(http.MethodPut).Path("/config").HandlerFunc(adminAPI.SetConfigHandler)
 }

--- a/cmd/admin-rpc-server.go
+++ b/cmd/admin-rpc-server.go
@@ -38,18 +38,24 @@ type adminCmd struct {
 	AuthRPCServer
 }
 
+// SignalServiceArgs - provides the signal argument to SignalService RPC
+type SignalServiceArgs struct {
+	AuthRPCArgs
+	Sig serviceSignal
+}
+
 // ListLocksQuery - wraps ListLocks API's query values to send over RPC.
 type ListLocksQuery struct {
 	AuthRPCArgs
-	bucket   string
-	prefix   string
-	duration time.Duration
+	Bucket   string
+	Prefix   string
+	Duration time.Duration
 }
 
 // ListLocksReply - wraps ListLocks response over RPC.
 type ListLocksReply struct {
 	AuthRPCReply
-	volLocks []VolumeLockInfo
+	VolLocks []VolumeLockInfo
 }
 
 // ServerInfoDataReply - wraps the server info response over RPC.
@@ -64,13 +70,13 @@ type ConfigReply struct {
 	Config []byte // json-marshalled bytes of serverConfigV13
 }
 
-// Restart - Restart this instance of minio server.
-func (s *adminCmd) Restart(args *AuthRPCArgs, reply *AuthRPCReply) error {
+// SignalService - Send a restart or stop signal to the service
+func (s *adminCmd) SignalService(args *SignalServiceArgs, reply *AuthRPCReply) error {
 	if err := args.IsAuthenticated(); err != nil {
 		return err
 	}
 
-	globalServiceSignalCh <- serviceRestart
+	globalServiceSignalCh <- args.Sig
 	return nil
 }
 
@@ -79,8 +85,8 @@ func (s *adminCmd) ListLocks(query *ListLocksQuery, reply *ListLocksReply) error
 	if err := query.IsAuthenticated(); err != nil {
 		return err
 	}
-	volLocks := listLocksInfo(query.bucket, query.prefix, query.duration)
-	*reply = ListLocksReply{volLocks: volLocks}
+	volLocks := listLocksInfo(query.Bucket, query.Prefix, query.Duration)
+	*reply = ListLocksReply{VolLocks: volLocks}
 	return nil
 }
 

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -168,10 +168,12 @@ const (
 	// Please open a https://github.com/minio/minio/issues before adding
 	// new error codes here.
 
+	ErrMalformedJSON
 	ErrAdminInvalidAccessKey
 	ErrAdminInvalidSecretKey
 	ErrAdminConfigNoQuorum
 	ErrAdminCredentialsMismatch
+	ErrAdminNonTLSCredsUpdate
 	ErrInsecureClientRequest
 	ErrObjectTampered
 )
@@ -683,6 +685,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Description:    "Server not initialized, please try again.",
 		HTTPStatusCode: http.StatusServiceUnavailable,
 	},
+	ErrMalformedJSON: {
+		Code:           "XMinioMalformedJSON",
+		Description:    "The JSON you provided was not well-formed or did not validate against our published format.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
 	ErrAdminInvalidAccessKey: {
 		Code:           "XMinioAdminInvalidAccessKey",
 		Description:    "The access key is invalid.",
@@ -702,6 +709,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Code:           "XMinioAdminCredentialsMismatch",
 		Description:    "Credentials in config mismatch with server environment variables",
 		HTTPStatusCode: http.StatusServiceUnavailable,
+	},
+	ErrAdminNonTLSCredsUpdate: {
+		Code:           "XMinioAdminNonTLSCredentialsUpdate",
+		Description:    "Credentials/Configuration cannot be updated/retrieved over a non-TLS connection",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInsecureClientRequest: {
 		Code:           "XMinioInsecureClientRequest",

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -40,8 +40,8 @@ type APIErrorResponse struct {
 	Key        string
 	BucketName string
 	Resource   string
-	RequestID  string `xml:"RequestId"`
-	HostID     string `xml:"HostId"`
+	RequestID  string `xml:"RequestId" json:"RequestId"`
+	HostID     string `xml:"HostId" json:"HostId"`
 }
 
 // APIErrorCode type of error status.
@@ -176,6 +176,12 @@ const (
 	ErrAdminNonTLSCredsUpdate
 	ErrInsecureClientRequest
 	ErrObjectTampered
+	ErrHealMarkerInvalid
+	ErrHealNoSuchProcess
+	ErrHealAlreadyStopped
+	ErrHealStaleStatusMarker
+	ErrHealInvalidFutureStatusMarker
+	ErrHealMissingBucket
 )
 
 // error code to APIError structure, these fields carry respective
@@ -751,6 +757,36 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	ErrInvalidRequest: {
 		Code:           "InvalidRequest",
 		Description:    "Invalid Request",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrHealMarkerInvalid: {
+		Code:           "XMinioHealMarkerInvalid",
+		Description:    "Heal status request requires a valid `marker` query parameter",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrHealNoSuchProcess: {
+		Code:           "XMinioHealNoSuchProcess",
+		Description:    "No such heal process is running on the server",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrHealAlreadyStopped: {
+		Code:           "XMinioHealAlreadyStopped",
+		Description:    "The heal sequence has already been stopped",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrHealStaleStatusMarker: {
+		Code:           "XMinioHealStaleStatusMarker",
+		Description:    "Provided `marker` is too stale. A newer result index has already been consumed.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrHealInvalidFutureStatusMarker: {
+		Code:           "XMinioHealInvalidFutureStatusMarker",
+		Description:    "Provided `marker` is invalid as a heal result with given index has not yet been produced.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrHealMissingBucket: {
+		Code:           "XMinioHealMissingBucket",
+		Description:    "A heal start request with a non-empty object-prefix parameter requires a bucket to be specified.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 

--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -49,6 +50,14 @@ func encodeResponse(response interface{}) []byte {
 	var bytesBuffer bytes.Buffer
 	bytesBuffer.WriteString(xml.Header)
 	e := xml.NewEncoder(&bytesBuffer)
+	e.Encode(response)
+	return bytesBuffer.Bytes()
+}
+
+// Encodes the response headers into JSON format.
+func encodeResponseJSON(response interface{}) []byte {
+	var bytesBuffer bytes.Buffer
+	e := json.NewEncoder(&bytesBuffer)
 	e.Encode(response)
 	return bytesBuffer.Bytes()
 }

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -186,6 +186,15 @@ func (endpoints EndpointList) IsHTTPS() bool {
 	return endpoints[0].IsHTTPS()
 }
 
+// GetString - returns endpoint string of i-th endpoint (0-based),
+// and empty string for invalid indexes.
+func (endpoints EndpointList) GetString(i int) string {
+	if i < 0 || i >= len(endpoints) {
+		return ""
+	}
+	return endpoints[i].String()
+}
+
 // NewEndpointList - returns new endpoint list based on input args.
 func NewEndpointList(args ...string) (endpoints EndpointList, err error) {
 	// isValidDistribution - checks whether given count is a valid distribution for erasure coding.

--- a/cmd/format-config-v1.go
+++ b/cmd/format-config-v1.go
@@ -536,7 +536,7 @@ func loadFormat(disk StorageAPI) (format *formatConfigV1, err error) {
 // the reference config and saves it on all disks, this is to be
 // called from healFormatXL* functions.
 func collectNSaveNewFormatConfigs(referenceConfig *formatConfigV1,
-	orderedDisks []StorageAPI) error {
+	orderedDisks []StorageAPI, dryRun bool) error {
 
 	// Collect new format configs that need to be written.
 	var newFormatConfigs = make([]*formatConfigV1, len(orderedDisks))

--- a/cmd/format-config-v1.go
+++ b/cmd/format-config-v1.go
@@ -281,14 +281,14 @@ func loadAllFormats(bootstrapDisks []StorageAPI) ([]*formatConfigV1, []error) {
 	// Initialize format configs.
 	var formatConfigs = make([]*formatConfigV1, len(bootstrapDisks))
 
-	// Make a volume entry on all underlying storage disks.
+	// Load format from each disk in parallel
 	for index, disk := range bootstrapDisks {
 		if disk == nil {
 			sErrs[index] = errDiskNotFound
 			continue
 		}
 		wg.Add(1)
-		// Make a volume inside a go-routine.
+		// Launch go-routine per disk.
 		go func(index int, disk StorageAPI) {
 			defer wg.Done()
 			formatConfig, lErr := loadFormat(disk)
@@ -300,15 +300,9 @@ func loadAllFormats(bootstrapDisks []StorageAPI) ([]*formatConfigV1, []error) {
 		}(index, disk)
 	}
 
-	// Wait for all make vol to finish.
+	// Wait for all go-routines to finish.
 	wg.Wait()
 
-	for _, err := range sErrs {
-		if err != nil {
-			// Return all formats and errors.
-			return formatConfigs, sErrs
-		}
-	}
 	// Return all formats and nil
 	return formatConfigs, sErrs
 }
@@ -403,7 +397,6 @@ func checkDisksConsistency(formatConfigs []*formatConfigV1) error {
 	// Collect currently available disk uuids.
 	for index, formatConfig := range formatConfigs {
 		if formatConfig == nil {
-			disks[index] = ""
 			continue
 		}
 		disks[index] = formatConfig.XL.Disk
@@ -512,8 +505,10 @@ func loadFormat(disk StorageAPI) (format *formatConfigV1, err error) {
 			if err != nil {
 				return nil, err
 			}
-			if len(vols) > 1 {
-				// 'format.json' not found, but we found user data.
+			if len(vols) > 1 || (len(vols) == 1 &&
+				vols[0].Name != minioMetaBucket) {
+				// 'format.json' not found, but we
+				// found user data.
 				return nil, errCorruptedFormat
 			}
 			// No other data found, its a fresh disk.
@@ -532,9 +527,8 @@ func loadFormat(disk StorageAPI) (format *formatConfigV1, err error) {
 	return format, nil
 }
 
-// collectNSaveNewFormatConfigs - creates new format configs based on
-// the reference config and saves it on all disks, this is to be
-// called from healFormatXL* functions.
+// collectNSaveNewFormatConfigs - generates new format configs based on
+// the given ref. config and saves on each disk
 func collectNSaveNewFormatConfigs(referenceConfig *formatConfigV1,
 	orderedDisks []StorageAPI, dryRun bool) error {
 
@@ -543,7 +537,7 @@ func collectNSaveNewFormatConfigs(referenceConfig *formatConfigV1,
 	for index := range orderedDisks {
 		// New configs are generated since we are going
 		// to re-populate across all disks.
-		config := &formatConfigV1{
+		newFormatConfigs[index] = &formatConfigV1{
 			Version: referenceConfig.Version,
 			Format:  referenceConfig.Format,
 			XL: &xlFormat{
@@ -552,7 +546,6 @@ func collectNSaveNewFormatConfigs(referenceConfig *formatConfigV1,
 				JBOD:    referenceConfig.XL.JBOD,
 			},
 		}
-		newFormatConfigs[index] = config
 	}
 
 	// Initialize meta volume, if volume already exists ignores it.
@@ -561,16 +554,19 @@ func collectNSaveNewFormatConfigs(referenceConfig *formatConfigV1,
 	}
 
 	// Save new `format.json` across all disks, in JBOD order.
-	return saveFormatXL(orderedDisks, newFormatConfigs)
+	if !dryRun {
+		return saveFormatXL(orderedDisks, newFormatConfigs)
+	}
+	return nil
 }
 
 // Heals any missing format.json on the drives. Returns error only for
 // unexpected errors as regular errors can be ignored since there
 // might be enough quorum to be operational.  Heals only fresh disks.
 func healFormatXLFreshDisks(storageDisks []StorageAPI,
-	formatConfigs []*formatConfigV1) error {
+	formatConfigs []*formatConfigV1, dryRun bool) error {
 
-	// Reorder the disks based on the JBOD order.
+	// Reorder disks based on JBOD order, and get reference config.
 	referenceConfig, orderedDisks, err := reorderDisks(storageDisks,
 		formatConfigs, true)
 	if err != nil {
@@ -582,21 +578,23 @@ func healFormatXLFreshDisks(storageDisks []StorageAPI,
 	// and allowed fresh disks to be arranged anywhere.
 	// Following block facilitates to put fresh disks.
 	for index, format := range formatConfigs {
+		if format != nil {
+			continue
+		}
 		// Format is missing so we go through ordered disks.
-		if format == nil {
-			// At this point when disk is missing the fresh disk
-			// in the stack get it back from storageDisks.
-			for oIndex, disk := range orderedDisks {
-				if disk == nil {
-					orderedDisks[oIndex] = storageDisks[index]
-					break
-				}
+		// At this point when disk is missing the fresh disk
+		// in the stack get it back from storageDisks.
+		for oIndex, disk := range orderedDisks {
+			if disk == nil {
+				orderedDisks[oIndex] = storageDisks[index]
+				break
 			}
 		}
 	}
 
 	// apply new format config and save to all disks
-	return collectNSaveNewFormatConfigs(referenceConfig, orderedDisks)
+	return collectNSaveNewFormatConfigs(referenceConfig, orderedDisks,
+		dryRun)
 }
 
 // collectUnAssignedDisks - collect disks unassigned to orderedDisks
@@ -681,9 +679,9 @@ func reorderDisksByInspection(orderedDisks, storageDisks []StorageAPI,
 
 // Heals corrupted format json in all disks
 func healFormatXLCorruptedDisks(storageDisks []StorageAPI,
-	formatConfigs []*formatConfigV1) error {
+	formatConfigs []*formatConfigV1, dryRun bool) error {
 
-	// Reorder the disks based on the JBOD order.
+	// Reorder disks based on JBOD order, and update ref. config.
 	referenceConfig, orderedDisks, err := reorderDisks(storageDisks,
 		formatConfigs, true)
 	if err != nil {
@@ -711,8 +709,9 @@ func healFormatXLCorruptedDisks(storageDisks []StorageAPI,
 		}
 	}
 
-	// apply new format config and save to all disks
-	return collectNSaveNewFormatConfigs(referenceConfig, orderedDisks)
+	// generate and write new configs to all disks
+	return collectNSaveNewFormatConfigs(referenceConfig, orderedDisks,
+		dryRun)
 }
 
 // loadFormatXL - loads XL `format.json` and returns back properly

--- a/cmd/format-config-v1_test.go
+++ b/cmd/format-config-v1_test.go
@@ -298,7 +298,7 @@ func TestFormatXLHealFreshDisks(t *testing.T) {
 	formatConfigs, _ := loadAllFormats(storageDisks)
 
 	// Start healing disks
-	err = healFormatXLFreshDisks(storageDisks, formatConfigs)
+	err = healFormatXLFreshDisks(storageDisks, formatConfigs, false)
 	if err != nil {
 		t.Fatal("healing corrupted disk failed: ", err)
 	}
@@ -372,7 +372,7 @@ func TestFormatXLHealCorruptedDisks(t *testing.T) {
 	formatConfigs, _ := loadAllFormats(permutedStorageDisks)
 
 	// Start healing disks
-	err = healFormatXLCorruptedDisks(permutedStorageDisks, formatConfigs)
+	err = healFormatXLCorruptedDisks(permutedStorageDisks, formatConfigs, false)
 	if err != nil {
 		t.Fatal("healing corrupted disk failed: ", err)
 	}
@@ -937,7 +937,7 @@ func TestHealFormatXLCorruptedDisksErrs(t *testing.T) {
 
 	xl := obj.(*xlObjects)
 	formatConfigs, _ := loadAllFormats(xl.storageDisks)
-	if err = healFormatXLCorruptedDisks(xl.storageDisks, formatConfigs); err != nil {
+	if err = healFormatXLCorruptedDisks(xl.storageDisks, formatConfigs, false); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 
@@ -960,7 +960,7 @@ func TestHealFormatXLCorruptedDisksErrs(t *testing.T) {
 	}
 	xl.storageDisks[0] = newNaughtyDisk(posixDisk, nil, errFaultyDisk)
 	formatConfigs, _ = loadAllFormats(xl.storageDisks)
-	if err = healFormatXLCorruptedDisks(xl.storageDisks, formatConfigs); err != errFaultyDisk {
+	if err = healFormatXLCorruptedDisks(xl.storageDisks, formatConfigs, false); err != errFaultyDisk {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -982,7 +982,7 @@ func TestHealFormatXLCorruptedDisksErrs(t *testing.T) {
 		}
 	}
 	formatConfigs, _ = loadAllFormats(xl.storageDisks)
-	if err = healFormatXLCorruptedDisks(xl.storageDisks, formatConfigs); err == nil {
+	if err = healFormatXLCorruptedDisks(xl.storageDisks, formatConfigs, false); err == nil {
 		t.Fatal("Should get a json parsing error, ")
 	}
 	removeRoots(fsDirs)
@@ -1009,7 +1009,7 @@ func TestHealFormatXLFreshDisksErrs(t *testing.T) {
 	}
 	xl := obj.(*xlObjects)
 	formatConfigs, _ := loadAllFormats(xl.storageDisks)
-	if err = healFormatXLFreshDisks(xl.storageDisks, formatConfigs); err != nil {
+	if err = healFormatXLFreshDisks(xl.storageDisks, formatConfigs, false); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -1031,7 +1031,7 @@ func TestHealFormatXLFreshDisksErrs(t *testing.T) {
 	}
 	xl.storageDisks[0] = newNaughtyDisk(posixDisk, nil, errFaultyDisk)
 	formatConfigs, _ = loadAllFormats(xl.storageDisks)
-	if err = healFormatXLFreshDisks(xl.storageDisks, formatConfigs); err != errFaultyDisk {
+	if err = healFormatXLFreshDisks(xl.storageDisks, formatConfigs, false); err != errFaultyDisk {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -1049,7 +1049,7 @@ func TestHealFormatXLFreshDisksErrs(t *testing.T) {
 	xl = obj.(*xlObjects)
 	xl.storageDisks[0] = nil
 	formatConfigs, _ = loadAllFormats(xl.storageDisks)
-	if err = healFormatXLFreshDisks(xl.storageDisks, formatConfigs); err != nil {
+	if err = healFormatXLFreshDisks(xl.storageDisks, formatConfigs, false); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -30,6 +30,7 @@ import (
 	"github.com/minio/minio/pkg/errors"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/lock"
+	"github.com/minio/minio/pkg/madmin"
 )
 
 // fsObjects - Implements fs object layer.
@@ -943,13 +944,17 @@ func (fs fsObjects) ListObjects(bucket, prefix, marker, delimiter string, maxKey
 }
 
 // HealObject - no-op for fs. Valid only for XL.
-func (fs fsObjects) HealObject(bucket, object string) (int, int, error) {
-	return 0, 0, errors.Trace(NotImplemented{})
+func (fs fsObjects) HealObject(bucket, object string, dryRun bool) (
+	res madmin.HealResultItem, err error) {
+
+	return res, errors.Trace(NotImplemented{})
 }
 
 // HealBucket - no-op for fs, Valid only for XL.
-func (fs fsObjects) HealBucket(bucket string) error {
-	return errors.Trace(NotImplemented{})
+func (fs fsObjects) HealBucket(bucket string, dryRun bool) ([]madmin.HealResultItem,
+	error) {
+
+	return nil, errors.Trace(NotImplemented{})
 }
 
 // ListObjectsHeal - list all objects to be healed. Valid only for XL
@@ -960,9 +965,4 @@ func (fs fsObjects) ListObjectsHeal(bucket, prefix, marker, delimiter string, ma
 // ListBucketsHeal - list all buckets to be healed. Valid only for XL
 func (fs fsObjects) ListBucketsHeal() ([]BucketInfo, error) {
 	return []BucketInfo{}, errors.Trace(NotImplemented{})
-}
-
-func (fs fsObjects) ListUploadsHeal(bucket, prefix, marker, uploadIDMarker,
-	delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
-	return lmi, errors.Trace(NotImplemented{})
 }

--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -400,7 +400,7 @@ func TestFSHealObject(t *testing.T) {
 	defer os.RemoveAll(disk)
 
 	obj := initFSObjects(disk, t)
-	_, _, err := obj.HealObject("bucket", "object")
+	_, err := obj.HealObject("bucket", "object", false)
 	if err == nil || !isSameType(errors.Cause(err), NotImplemented{}) {
 		t.Fatalf("Heal Object should return NotImplemented error ")
 	}

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -22,6 +22,7 @@ import (
 	"github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/minio/pkg/errors"
 	"github.com/minio/minio/pkg/hash"
+	"github.com/minio/minio/pkg/madmin"
 )
 
 // GatewayUnsupported list of unsupported call stubs for gateway.
@@ -35,11 +36,6 @@ func (a GatewayUnsupported) ListMultipartUploads(bucket string, prefix string, k
 // NewMultipartUpload upload object in multiple parts
 func (a GatewayUnsupported) NewMultipartUpload(bucket string, object string, metadata map[string]string) (uploadID string, err error) {
 	return "", errors.Trace(NotImplemented{})
-}
-
-// CopyObjectPart copy part of object to other bucket and object
-func (a GatewayUnsupported) CopyObjectPart(srcBucket string, srcObject string, destBucket string, destObject string, uploadID string, partID int, startOffset int64, length int64, metadata map[string]string) (pi PartInfo, err error) {
-	return pi, errors.Trace(NotImplemented{})
 }
 
 // PutObjectPart puts a part of object in bucket
@@ -77,9 +73,15 @@ func (a GatewayUnsupported) DeleteBucketPolicies(bucket string) error {
 	return errors.Trace(NotImplemented{})
 }
 
+// CopyObjectPart - Not implemented stub
+func (a GatewayUnsupported) CopyObjectPart(srcBucket, srcObject, destBucket, destObject string, uploadID string,
+	partID int, startOffset int64, length int64, metadata map[string]string) (info PartInfo, err error) {
+	return info, errors.Trace(NotImplemented{})
+}
+
 // HealBucket - Not implemented stub
-func (a GatewayUnsupported) HealBucket(bucket string) error {
-	return errors.Trace(NotImplemented{})
+func (a GatewayUnsupported) HealBucket(bucket string, dryRun bool) ([]madmin.HealResultItem, error) {
+	return nil, errors.Trace(NotImplemented{})
 }
 
 // ListBucketsHeal - Not implemented stub
@@ -88,8 +90,8 @@ func (a GatewayUnsupported) ListBucketsHeal() (buckets []BucketInfo, err error) 
 }
 
 // HealObject - Not implemented stub
-func (a GatewayUnsupported) HealObject(bucket, object string) (int, int, error) {
-	return 0, 0, errors.Trace(NotImplemented{})
+func (a GatewayUnsupported) HealObject(bucket, object string, dryRun bool) (h madmin.HealResultItem, e error) {
+	return h, errors.Trace(NotImplemented{})
 }
 
 // ListObjectsV2 - Not implemented stub

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -50,21 +50,6 @@ type StorageInfo struct {
 	}
 }
 
-type healStatus int
-
-const (
-	healthy           healStatus = iota // Object is healthy
-	canHeal                             // Object can be healed
-	corrupted                           // Object can't be healed
-	quorumUnavailable                   // Object can't be healed until read quorum is available
-	canPartiallyHeal                    // Object can't be healed completely until outdated disk(s) are online.
-)
-
-// HealBucketInfo - represents healing related information of a bucket.
-type HealBucketInfo struct {
-	Status healStatus
-}
-
 // BucketInfo - represents bucket metadata.
 type BucketInfo struct {
 	// Name of the bucket.
@@ -72,16 +57,6 @@ type BucketInfo struct {
 
 	// Date and time when the bucket was created.
 	Created time.Time
-
-	// Healing information
-	HealBucketInfo *HealBucketInfo `xml:"HealBucketInfo,omitempty"`
-}
-
-// HealObjectInfo - represents healing related information of an object.
-type HealObjectInfo struct {
-	Status             healStatus
-	MissingDataCount   int
-	MissingParityCount int
 }
 
 // ObjectInfo - represents object metadata.
@@ -113,8 +88,7 @@ type ObjectInfo struct {
 	ContentEncoding string
 
 	// User-Defined metadata
-	UserDefined    map[string]string
-	HealObjectInfo *HealObjectInfo `xml:"HealObjectInfo,omitempty"`
+	UserDefined map[string]string
 }
 
 // ListPartsInfo - represents list of all parts.
@@ -273,8 +247,6 @@ type MultipartInfo struct {
 	Initiated time.Time
 
 	StorageClass string // Not supported yet.
-
-	HealUploadInfo *HealObjectInfo `xml:"HealUploadInfo,omitempty"`
 }
 
 // CompletePart - represents the part that was completed, this is sent by the client

--- a/cmd/object-api-input-checks.go
+++ b/cmd/object-api-input-checks.go
@@ -153,9 +153,6 @@ func checkPutObjectArgs(bucket, object string, obj ObjectLayer) error {
 
 // Checks whether bucket exists and returns appropriate error if not.
 func checkBucketExist(bucket string, obj ObjectLayer) error {
-	if !IsValidBucketName(bucket) {
-		return BucketNameInvalid{Bucket: bucket}
-	}
 	_, err := obj.GetBucketInfo(bucket)
 	if err != nil {
 		return errors.Cause(err)

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/minio/minio/pkg/hash"
+	"github.com/minio/minio/pkg/madmin"
 )
 
 // ObjectLayer implements primitives for object API layer.
@@ -52,10 +53,8 @@ type ObjectLayer interface {
 	CompleteMultipartUpload(bucket, object, uploadID string, uploadedParts []CompletePart) (objInfo ObjectInfo, err error)
 
 	// Healing operations.
-	HealBucket(bucket string) error
+	HealBucket(bucket string, dryRun bool) ([]madmin.HealResultItem, error)
+	HealObject(bucket, object string, dryRun bool) (madmin.HealResultItem, error)
 	ListBucketsHeal() (buckets []BucketInfo, err error)
-	HealObject(bucket, object string) (int, int, error)
 	ListObjectsHeal(bucket, prefix, marker, delimiter string, maxKeys int) (ListObjectsInfo, error)
-	ListUploadsHeal(bucket, prefix, marker, uploadIDMarker,
-		delimiter string, maxUploads int) (ListMultipartsInfo, error)
 }

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -70,15 +70,15 @@ func configureServerHandler(endpoints EndpointList) (http.Handler, error) {
 		return nil, err
 	}
 
+	// Add Admin router.
+	registerAdminRouter(mux)
+
 	// Register web router when its enabled.
 	if globalIsBrowserEnabled {
 		if err := registerWebRouter(mux); err != nil {
 			return nil, err
 		}
 	}
-
-	// Add Admin router.
-	registerAdminRouter(mux)
 
 	// Add API router.
 	registerAPIRouter(mux)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -183,6 +183,9 @@ func serverMain(ctx *cli.Context) {
 	// Initialize name space lock.
 	initNSLock(globalIsDistXL)
 
+	// Init global heal state
+	initAllHealState(globalIsXL)
+
 	// Configure server.
 	var handler http.Handler
 	handler, err = configureServerHandler(globalEndpoints)

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -491,6 +491,17 @@ func resetGlobalIsEnvs() {
 	globalIsEnvRegion = false
 }
 
+// reset global heal state
+func resetGlobalHealState() {
+	globalAllHealState.Lock()
+	defer globalAllHealState.Unlock()
+	for k, v := range globalAllHealState.healSeqMap {
+		if !v.hasEnded() {
+			globalAllHealState.StopHealSequence(k)
+		}
+	}
+}
+
 // Resets all the globals used modified in tests.
 // Resetting ensures that the changes made to globals by one test doesn't affect others.
 func resetTestGlobals() {
@@ -510,6 +521,8 @@ func resetTestGlobals() {
 	resetGlobalIsXL()
 	// Reset global isEnvCreds flag.
 	resetGlobalIsEnvs()
+	// Reset global heal state
+	resetGlobalHealState()
 }
 
 // Configure the server for the test run.

--- a/cmd/xl-v1-healing-common.go
+++ b/cmd/xl-v1-healing-common.go
@@ -37,11 +37,7 @@ func commonTime(modTimes []time.Time) (modTime time.Time, count int) {
 	// Find the common cardinality from previously collected
 	// occurrences of elements.
 	for time, count := range timeOccurenceMap {
-		if count == maxima && time.After(modTime) {
-			maxima = count
-			modTime = time
-
-		} else if count > maxima {
+		if count > maxima || (count == maxima && time.After(modTime)) {
 			maxima = count
 			modTime = time
 		}
@@ -123,12 +119,13 @@ func listOnlineDisks(disks []StorageAPI, partsMetadata []xlMetaV1, errs []error)
 
 // outDatedDisks - return disks which don't have the latest object (i.e xl.json).
 // disks that are offline are not 'marked' outdated.
-func outDatedDisks(disks, latestDisks []StorageAPI, errs []error, partsMetadata []xlMetaV1,
-	bucket, object string) (outDatedDisks []StorageAPI) {
+func outDatedDisks(disks, availableDisks []StorageAPI, errs []error,
+	partsMetadata []xlMetaV1, bucket, object string) (
+	outDatedDisks []StorageAPI) {
 
 	outDatedDisks = make([]StorageAPI, len(disks))
-	for index, latestDisk := range latestDisks {
-		if latestDisk != nil {
+	for index, disk := range availableDisks {
+		if disk != nil {
 			continue
 		}
 		// disk either has an older xl.json or doesn't have one.
@@ -139,109 +136,6 @@ func outDatedDisks(disks, latestDisks []StorageAPI, errs []error, partsMetadata 
 	}
 
 	return outDatedDisks
-}
-
-// Returns if the object should be healed.
-func xlShouldHeal(disks []StorageAPI, partsMetadata []xlMetaV1, errs []error, bucket, object string) bool {
-	onlineDisks, _ := listOnlineDisks(disks, partsMetadata,
-		errs)
-	// Return true even if one of the disks have stale data.
-	for _, disk := range onlineDisks {
-		if disk == nil {
-			return true
-		}
-	}
-
-	// Check if all parts of an object are available and their
-	// checksums are valid.
-	availableDisks, _, err := disksWithAllParts(onlineDisks, partsMetadata,
-		errs, bucket, object)
-	if err != nil {
-		// Note: This error is due to failure of blake2b
-		// checksum computation of a part. It doesn't clearly
-		// indicate if the object needs healing. At this
-		// juncture healing could fail with the same
-		// error. So, we choose to return that there is no
-		// need to heal.
-		return false
-	}
-
-	// Return true even if one disk has xl.json or one or more
-	// parts missing.
-	for _, disk := range availableDisks {
-		if disk == nil {
-			return true
-		}
-	}
-
-	return false
-}
-
-// xlHealStat - returns a structure which describes how many data,
-// parity erasure blocks are missing and if it is possible to heal
-// with the blocks present.
-func xlHealStat(xl xlObjects, partsMetadata []xlMetaV1, errs []error) HealObjectInfo {
-	// Less than quorum erasure coded blocks of the object have the same create time.
-	// This object can't be healed with the information we have.
-	modTime, count := commonTime(listObjectModtimes(partsMetadata, errs))
-	if count < xl.readQuorum {
-		return HealObjectInfo{
-			Status:             quorumUnavailable,
-			MissingDataCount:   0,
-			MissingParityCount: 0,
-		}
-	}
-
-	// If there isn't a valid xlMeta then we can't heal the object.
-	xlMeta, err := pickValidXLMeta(partsMetadata, modTime)
-	if err != nil {
-		return HealObjectInfo{
-			Status:             corrupted,
-			MissingDataCount:   0,
-			MissingParityCount: 0,
-		}
-	}
-
-	// Compute heal statistics like bytes to be healed, missing
-	// data and missing parity count.
-	missingDataCount := 0
-	missingParityCount := 0
-
-	disksMissing := false
-	for i, err := range errs {
-		// xl.json is not found, which implies the erasure
-		// coded blocks are unavailable in the corresponding disk.
-		// First half of the disks are data and the rest are parity.
-		switch realErr := errors.Cause(err); realErr {
-		case errDiskNotFound:
-			disksMissing = true
-			fallthrough
-		case errFileNotFound:
-			if xlMeta.Erasure.Distribution[i]-1 < xl.dataBlocks {
-				missingDataCount++
-			} else {
-				missingParityCount++
-			}
-		}
-	}
-
-	// The object may not be healed completely, since some of the
-	// disks needing healing are unavailable.
-	if disksMissing {
-		return HealObjectInfo{
-			Status:             canPartiallyHeal,
-			MissingDataCount:   missingDataCount,
-			MissingParityCount: missingParityCount,
-		}
-	}
-
-	// This object can be healed. We have enough object metadata
-	// to reconstruct missing erasure coded blocks.
-	return HealObjectInfo{
-		Status:             canHeal,
-		MissingDataCount:   missingDataCount,
-		MissingParityCount: missingParityCount,
-	}
 }
 
 // disksWithAllParts - This function needs to be called with

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -23,11 +23,14 @@ import (
 	"sync"
 
 	"github.com/minio/minio/pkg/errors"
+	"github.com/minio/minio/pkg/madmin"
 )
 
 // healFormatXL - heals missing `format.json` on freshly or corrupted
 // disks (missing format.json but does have erasure coded data in it).
-func healFormatXL(storageDisks []StorageAPI) (err error) {
+func healFormatXL(storageDisks []StorageAPI, dryRun bool) (res madmin.HealResultItem,
+	err error) {
+
 	// Attempt to load all `format.json`.
 	formatConfigs, sErrs := loadAllFormats(storageDisks)
 
@@ -35,7 +38,28 @@ func healFormatXL(storageDisks []StorageAPI) (err error) {
 	// - if (no quorum) return error
 	// - if (disks not recognized) // Always error.
 	if err = genericFormatCheckXL(formatConfigs, sErrs); err != nil {
-		return err
+		return res, err
+	}
+
+	// Prepare heal-result
+	res = madmin.HealResultItem{Type: madmin.HealItemMetadata, Detail: "disk-format"}
+	res.InitDrives()
+	// Existing formats are available (i.e. ok), so save it in
+	// result, also populate disks to be healed.
+	for i, format := range formatConfigs {
+		drive := globalEndpoints.GetString(i)
+		switch {
+		case format != nil:
+			res.DriveInfo.Before[drive] = madmin.OnlineDriveState
+		case sErrs[i] == errCorruptedFormat:
+			res.DriveInfo.Before[drive] = madmin.CorruptDriveState
+		default:
+			res.DriveInfo.Before[drive] = madmin.OfflineDriveState
+		}
+	}
+	// Copy "after" drive state too
+	for k, v := range res.DriveInfo.Before {
+		res.DriveInfo.After[k] = v
 	}
 
 	numDisks := len(storageDisks)
@@ -45,56 +69,93 @@ func healFormatXL(storageDisks []StorageAPI) (err error) {
 	switch {
 	case unformattedDiskCount == numDisks:
 		// all unformatted.
-		if err = initFormatXL(storageDisks); err != nil {
-			return err
+		if !dryRun {
+			err = initFormatXL(storageDisks)
+			if err != nil {
+				return res, err
+			}
+			for i := 0; i < len(storageDisks); i++ {
+				drive := globalEndpoints.GetString(i)
+				res.DriveInfo.After[drive] = madmin.OnlineDriveState
+			}
 		}
+		return res, nil
 
 	case diskNotFoundCount > 0:
-		return fmt.Errorf("cannot proceed with heal as %s",
+		return res, fmt.Errorf("cannot proceed with heal as %s",
 			errSomeDiskOffline)
 
 	case otherErrCount > 0:
-		return fmt.Errorf("cannot proceed with heal as some disks had unhandled errors")
+		return res, fmt.Errorf("cannot proceed with heal as some disks had unhandled errors")
 
 	case corruptedFormatCount > 0:
-		if err = healFormatXLCorruptedDisks(storageDisks, formatConfigs); err != nil {
-			return fmt.Errorf("Unable to repair corrupted format, %s", err)
+		// heal corrupted disks
+		err = healFormatXLCorruptedDisks(storageDisks, formatConfigs,
+			dryRun)
+		if err != nil {
+			return res, err
 		}
+		// success
+		if !dryRun {
+			for i := 0; i < len(storageDisks); i++ {
+				drive := globalEndpoints.GetString(i)
+				res.DriveInfo.After[drive] = madmin.OnlineDriveState
+			}
+		}
+		return res, nil
 
 	case unformattedDiskCount > 0:
-		// All drives online but some report missing format.json.
-		if err = healFormatXLFreshDisks(storageDisks, formatConfigs); err != nil {
-			// There was an unexpected unrecoverable error
-			// during healing.
-			return fmt.Errorf("Unable to heal backend %s", err)
+		// heal unformatted disks
+		err = healFormatXLFreshDisks(storageDisks, formatConfigs,
+			dryRun)
+		if err != nil {
+			return res, err
 		}
-
+		// success
+		if !dryRun {
+			for i := 0; i < len(storageDisks); i++ {
+				drive := globalEndpoints.GetString(i)
+				res.DriveInfo.After[drive] = madmin.OnlineDriveState
+			}
+		}
+		return res, nil
 	}
-	return nil
+
+	return res, nil
 }
 
 // Heals a bucket if it doesn't exist on one of the disks, additionally
 // also heals the missing entries for bucket metadata files
 // `policy.json, notification.xml, listeners.json`.
-func (xl xlObjects) HealBucket(bucket string) error {
-	if err := checkBucketExist(bucket, xl); err != nil {
-		return err
+func (xl xlObjects) HealBucket(bucket string, dryRun bool) (
+	results []madmin.HealResultItem, err error) {
+
+	if err = checkBucketExist(bucket, xl); err != nil {
+		return nil, err
 	}
 
 	// Heal bucket.
-	if err := healBucket(xl.storageDisks, bucket, xl.writeQuorum); err != nil {
-		return err
+	result, err := healBucket(xl.storageDisks, bucket, xl.writeQuorum,
+		dryRun)
+	if err != nil {
+		return results, err
 	}
+	results = append(results, result)
 
 	// Proceed to heal bucket metadata.
-	return healBucketMetadata(xl.storageDisks, bucket, xl.readQuorum)
+	metaResults, err := healBucketMetadata(xl.storageDisks, bucket,
+		xl.readQuorum, dryRun)
+	results = append(results, metaResults...)
+	return results, err
 }
 
 // Heal bucket - create buckets on disks where it does not exist.
-func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int) error {
+func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int,
+	dryRun bool) (res madmin.HealResultItem, err error) {
+
 	bucketLock := globalNSMutex.NewNSLock(bucket, "")
 	if err := bucketLock.GetLock(globalHealingTimeout); err != nil {
-		return err
+		return res, err
 	}
 	defer bucketLock.Unlock()
 
@@ -104,10 +165,21 @@ func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int) error
 	// Initialize list of errors.
 	var dErrs = make([]error, len(storageDisks))
 
+	// Initialize heal result info
+	res.Type = madmin.HealItemBucket
+	res.Bucket = bucket
+	res.InitDrives()
+	beforeOnline := make([]bool, len(storageDisks))
+	beforeOffline := make([]bool, len(storageDisks))
+	afterOnline := make([]bool, len(storageDisks))
+	afterOffline := make([]bool, len(storageDisks))
+
 	// Make a volume entry on all underlying storage disks.
 	for index, disk := range storageDisks {
 		if disk == nil {
 			dErrs[index] = errors.Trace(errDiskNotFound)
+			beforeOffline[index] = true
+			afterOffline[index] = true
 			continue
 		}
 		wg.Add(1)
@@ -115,13 +187,23 @@ func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int) error
 		go func(index int, disk StorageAPI) {
 			defer wg.Done()
 			if _, err := disk.StatVol(bucket); err != nil {
+				beforeOffline[index] = true
+				afterOffline[index] = true
 				if err != errVolumeNotFound {
 					dErrs[index] = errors.Trace(err)
 					return
 				}
-				if err = disk.MakeVol(bucket); err != nil {
-					dErrs[index] = errors.Trace(err)
+				// mutate only if not a dry-run
+				if dryRun {
+					return
 				}
+				makeErr := disk.MakeVol(bucket)
+				dErrs[index] = errors.Trace(makeErr)
+				afterOffline[index] = makeErr != nil
+				afterOnline[index] = makeErr == nil
+			} else {
+				beforeOnline[index] = true
+				afterOnline[index] = true
 			}
 		}(index, disk)
 	}
@@ -129,50 +211,85 @@ func healBucket(storageDisks []StorageAPI, bucket string, writeQuorum int) error
 	// Wait for all make vol to finish.
 	wg.Wait()
 
+	for i := 0; i < len(storageDisks); i++ {
+		drive := globalEndpoints.GetString(i)
+		if beforeOffline[i] {
+			res.DriveInfo.Before[drive] = madmin.OfflineDriveState
+		}
+		if beforeOnline[i] {
+			res.DriveInfo.Before[drive] = madmin.OnlineDriveState
+		}
+		if afterOffline[i] {
+			res.DriveInfo.After[drive] = madmin.OfflineDriveState
+		}
+		if afterOnline[i] {
+			res.DriveInfo.After[drive] = madmin.OnlineDriveState
+		}
+	}
+
 	reducedErr := reduceWriteQuorumErrs(dErrs, bucketOpIgnoredErrs, writeQuorum)
 	if errors.Cause(reducedErr) == errXLWriteQuorum {
 		// Purge successfully created buckets if we don't have writeQuorum.
 		undoMakeBucket(storageDisks, bucket)
 	}
-	return reducedErr
+	return res, reducedErr
 }
 
 // Heals all the metadata associated for a given bucket, this function
 // heals `policy.json`, `notification.xml` and `listeners.json`.
-func healBucketMetadata(storageDisks []StorageAPI, bucket string, readQuorum int) error {
+func healBucketMetadata(storageDisks []StorageAPI, bucket string,
+	readQuorum int, dryRun bool) (results []madmin.HealResultItem, err error) {
+
 	healBucketMetaFn := func(metaPath string) error {
 		metaLock := globalNSMutex.NewNSLock(minioMetaBucket, metaPath)
-		if err := metaLock.GetRLock(globalHealingTimeout); err != nil {
-			return err
+		if lerr := metaLock.GetRLock(globalHealingTimeout); lerr != nil {
+			return lerr
 		}
 		defer metaLock.RUnlock()
 		// Heals the given file at metaPath.
-		if _, _, err := healObject(storageDisks, minioMetaBucket, metaPath, readQuorum); err != nil && !isErrObjectNotFound(err) {
-			return err
-		} // Success.
+		result, lerr := healObject(storageDisks, minioMetaBucket,
+			metaPath, readQuorum, dryRun)
+		// If object is not found, no result to add.
+		if isErrObjectNotFound(lerr) {
+			return nil
+		}
+		if lerr != nil {
+			return lerr
+		}
+		result.Type = madmin.HealItemBucketMetadata
+		results = append(results, result)
 		return nil
 	}
 
-	// Heal `policy.json` for missing entries, ignores if `policy.json` is not found.
+	// Heal `policy.json` for missing entries, ignores if
+	// `policy.json` is not found.
 	policyPath := pathJoin(bucketConfigPrefix, bucket, bucketPolicyConfig)
-	if err := healBucketMetaFn(policyPath); err != nil {
-		return err
+	err = healBucketMetaFn(policyPath)
+	if err != nil {
+		return results, err
 	}
 
-	// Heal `notification.xml` for missing entries, ignores if `notification.xml` is not found.
-	nConfigPath := path.Join(bucketConfigPrefix, bucket, bucketNotificationConfig)
-	if err := healBucketMetaFn(nConfigPath); err != nil {
-		return err
+	// Heal `notification.xml` for missing entries, ignores if
+	// `notification.xml` is not found.
+	nConfigPath := path.Join(bucketConfigPrefix, bucket,
+		bucketNotificationConfig)
+	err = healBucketMetaFn(nConfigPath)
+	if err != nil {
+		return results, err
 	}
 
-	// Heal `listeners.json` for missing entries, ignores if `listeners.json` is not found.
+	// Heal `listeners.json` for missing entries, ignores if
+	// `listeners.json` is not found.
 	lConfigPath := path.Join(bucketConfigPrefix, bucket, bucketListenerConfig)
-	return healBucketMetaFn(lConfigPath)
+	err = healBucketMetaFn(lConfigPath)
+	return results, err
 }
 
 // listAllBuckets lists all buckets from all disks. It also
 // returns the occurrence of each buckets in all disks
-func listAllBuckets(storageDisks []StorageAPI) (buckets map[string]VolInfo, bucketsOcc map[string]int, err error) {
+func listAllBuckets(storageDisks []StorageAPI) (buckets map[string]VolInfo,
+	bucketsOcc map[string]int, err error) {
+
 	buckets = make(map[string]VolInfo)
 	bucketsOcc = make(map[string]int)
 	for _, disk := range storageDisks {
@@ -181,89 +298,27 @@ func listAllBuckets(storageDisks []StorageAPI) (buckets map[string]VolInfo, buck
 		}
 		var volsInfo []VolInfo
 		volsInfo, err = disk.ListVols()
-		if err == nil {
-			for _, volInfo := range volsInfo {
-				// StorageAPI can send volume names which are
-				// incompatible with buckets, handle it and skip them.
-				if !IsValidBucketName(volInfo.Name) {
-					continue
-				}
-				// Skip special volume buckets.
-				if isMinioMetaBucketName(volInfo.Name) {
-					continue
-				}
-				// Increase counter per bucket name
-				bucketsOcc[volInfo.Name]++
-				// Save volume info under bucket name
-				buckets[volInfo.Name] = volInfo
+		if err != nil {
+			if errors.IsErrIgnored(err, bucketMetadataOpIgnoredErrs...) {
+				continue
 			}
-			continue
+			break
 		}
-		// Ignore any disks not found.
-		if errors.IsErrIgnored(err, bucketMetadataOpIgnoredErrs...) {
-			continue
+		for _, volInfo := range volsInfo {
+			// StorageAPI can send volume names which are
+			// incompatible with buckets - these are
+			// skipped, like the meta-bucket.
+			if !IsValidBucketName(volInfo.Name) ||
+				isMinioMetaBucketName(volInfo.Name) {
+				continue
+			}
+			// Increase counter per bucket name
+			bucketsOcc[volInfo.Name]++
+			// Save volume info under bucket name
+			buckets[volInfo.Name] = volInfo
 		}
-		break
 	}
 	return buckets, bucketsOcc, err
-}
-
-// reduceHealStatus - fetches the worst heal status in a provided slice
-func reduceHealStatus(status []healStatus) healStatus {
-	worstStatus := healthy
-	for _, st := range status {
-		if st > worstStatus {
-			worstStatus = st
-		}
-	}
-	return worstStatus
-}
-
-// bucketHealStatus - returns the heal status of the provided bucket. Internally,
-// this function lists all object heal status of objects inside meta bucket config
-// directory and returns the worst heal status that can be found
-func (xl xlObjects) bucketHealStatus(bucketName string) (healStatus, error) {
-	// A list of all the bucket config files
-	configFiles := []string{bucketPolicyConfig, bucketNotificationConfig, bucketListenerConfig}
-	// The status of buckets config files
-	configsHealStatus := make([]healStatus, len(configFiles))
-	// The list of errors found during checking heal status of each config file
-	configsErrs := make([]error, len(configFiles))
-	// The path of meta bucket that contains all config files
-	configBucket := path.Join(minioMetaBucket, bucketConfigPrefix, bucketName)
-
-	// Check of config files heal status in go-routines
-	var wg sync.WaitGroup
-	// Loop over config files
-	for idx, configFile := range configFiles {
-		wg.Add(1)
-		// Compute heal status of current config file
-		go func(bucket, object string, index int) {
-			defer wg.Done()
-			// Check
-			listObjectsHeal, err := xl.listObjectsHeal(bucket, object, "", "", 1)
-			// If any error, save and immediately quit
-			if err != nil {
-				configsErrs[index] = err
-				return
-			}
-			// Check if current bucket contains any not healthy config file and save heal status
-			if len(listObjectsHeal.Objects) > 0 {
-				configsHealStatus[index] = listObjectsHeal.Objects[0].HealObjectInfo.Status
-			}
-		}(configBucket, configFile, idx)
-	}
-	wg.Wait()
-
-	// Return any found error
-	for _, err := range configsErrs {
-		if err != nil {
-			return healthy, err
-		}
-	}
-
-	// Reduce and return heal status
-	return reduceHealStatus(configsHealStatus), nil
 }
 
 // ListBucketsHeal - Find all buckets that need to be healed
@@ -276,27 +331,15 @@ func (xl xlObjects) ListBucketsHeal() ([]BucketInfo, error) {
 	}
 
 	// Iterate over all buckets
-	for _, currBucket := range buckets {
-		// Check the status of bucket metadata
-		bucketHealStatus, err := xl.bucketHealStatus(currBucket.Name)
-		if err != nil {
-			return []BucketInfo{}, err
-		}
-		// If all metadata are sane, check if the bucket directory is present in all disks
-		if bucketHealStatus == healthy && occ[currBucket.Name] != len(xl.storageDisks) {
-			// Current bucket is missing in some of the storage disks
-			bucketHealStatus = canHeal
-		}
-		// Add current bucket to the returned result if not healthy
-		if bucketHealStatus != healthy {
-			listBuckets = append(listBuckets,
-				BucketInfo{
-					Name:           currBucket.Name,
-					Created:        currBucket.Created,
-					HealBucketInfo: &HealBucketInfo{Status: bucketHealStatus},
-				})
+	for k, currBucket := range buckets {
+		// skip buckets occurring in less than read-quorum
+		// disks
+		if occ[k] < xl.readQuorum {
+			continue
 		}
 
+		listBuckets = append(listBuckets,
+			BucketInfo{currBucket.Name, currBucket.Created})
 	}
 
 	// Sort found buckets
@@ -320,8 +363,8 @@ func quickHeal(storageDisks []StorageAPI, writeQuorum int, readQuorum int) error
 		// Heal bucket only if healing is needed.
 		if occCount != len(storageDisks) {
 			// Heal bucket and then proceed to heal bucket metadata if any.
-			if err = healBucket(storageDisks, bucketName, writeQuorum); err == nil {
-				if err = healBucketMetadata(storageDisks, bucketName, readQuorum); err == nil {
+			if _, err = healBucket(storageDisks, bucketName, writeQuorum, false); err == nil {
+				if _, err = healBucketMetadata(storageDisks, bucketName, readQuorum, false); err == nil {
 					continue
 				}
 				return err
@@ -335,75 +378,87 @@ func quickHeal(storageDisks []StorageAPI, writeQuorum int, readQuorum int) error
 }
 
 // Heals an object only the corrupted/missing erasure blocks.
-func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (int, int, error) {
+func healObject(storageDisks []StorageAPI, bucket string, object string,
+	quorum int, dryRun bool) (result madmin.HealResultItem, err error) {
 
 	partsMetadata, errs := readAllXLMetadata(storageDisks, bucket, object)
 	// readQuorum suffices for xl.json since we use monotonic
 	// system time to break the tie when a split-brain situation
 	// arises.
-	if rErr := reduceReadQuorumErrs(errs, nil, quorum); rErr != nil {
-		return 0, 0, toObjectErr(rErr, bucket, object)
+	if reducedErr := reduceReadQuorumErrs(errs, nil, quorum); reducedErr != nil {
+		return result, toObjectErr(reducedErr, bucket, object)
 	}
 
 	// List of disks having latest version of the object.
 	latestDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
-	// List of disks having all parts as per latest xl.json - this
-	// does a full pass over the data and verifies all part files
-	// on disk
-	availableDisks, errs, aErr := disksWithAllParts(latestDisks, partsMetadata, errs, bucket,
-		object)
+	// List of disks having all parts as per latest xl.json.
+	availableDisks, errs, aErr := disksWithAllParts(latestDisks, partsMetadata, errs, bucket, object)
 	if aErr != nil {
-		return 0, 0, toObjectErr(aErr, bucket, object)
+		return result, toObjectErr(aErr, bucket, object)
 	}
 
-	// Number of disks which don't serve data.
-	numOfflineDisks := 0
-	for index, disk := range storageDisks {
-		if disk == nil || errs[index] == errDiskNotFound {
-			numOfflineDisks++
-		}
-	}
-
-	// Number of disks which have all parts of the given object.
+	// Initialize heal result object
+	result.Type = madmin.HealItemObject
+	result.Bucket = bucket
+	result.Object = object
+	result.ObjectSize = partsMetadata[0].Stat.Size
+	result.InitDrives()
 	numAvailableDisks := 0
-	for _, disk := range availableDisks {
-		if disk != nil {
-			numAvailableDisks++
+	for i, v := range availableDisks {
+		drive := globalEndpoints.GetString(i)
+		if v == nil {
+			if latestDisks[i] == nil {
+				// drives without latest version of
+				// object is considered offline.
+				result.DriveInfo.Before[drive] = madmin.OfflineDriveState
+			} else {
+				// drives with latest version of
+				// xl.json but not having valid object
+				// data (i.e due to bit)
+				result.DriveInfo.Before[drive] = madmin.CorruptDriveState
+			}
+			continue
 		}
+
+		result.DriveInfo.Before[drive] = madmin.OnlineDriveState
+		numAvailableDisks++
+	}
+	// Before heal drive-state is now initialized. Make a copy for
+	// "after" drive-state.
+	for k, v := range result.DriveInfo.Before {
+		result.DriveInfo.After[k] = v
 	}
 
 	if numAvailableDisks == len(storageDisks) {
-		// nothing to heal in this case
-		return 0, 0, nil
+		// Nothing to heal!
+		return result, nil
 	}
 
 	// If less than read quorum number of disks have all the parts
 	// of the data, we can't reconstruct the erasure-coded data.
 	if numAvailableDisks < quorum {
-		return 0, 0, toObjectErr(errXLReadQuorum, bucket, object)
+		return result, toObjectErr(errXLReadQuorum, bucket, object)
+	}
+
+	// After this point, only have to repair data on disk - so
+	// return if it is a dry-run
+	if dryRun {
+		return result, nil
 	}
 
 	// List of disks having outdated version of the object or missing object.
-	outDatedDisks := outDatedDisks(storageDisks, availableDisks, errs, partsMetadata, bucket,
-		object)
-
-	// Number of disks that had outdated content of the given
-	// object and are online to be healed.
-	numHealedDisks := 0
-	for _, disk := range outDatedDisks {
-		if disk != nil {
-			numHealedDisks++
-		}
-	}
+	outDatedDisks := outDatedDisks(storageDisks, availableDisks, errs,
+		partsMetadata, bucket, object)
 
 	// Latest xlMetaV1 for reference. If a valid metadata is not
 	// present, it is as good as object not found.
 	latestMeta, pErr := pickValidXLMeta(partsMetadata, modTime)
 	if pErr != nil {
-		return 0, 0, toObjectErr(pErr, bucket, object)
+		return result, toObjectErr(pErr, bucket, object)
 	}
 
+	disksToHealCount := 0
 	for index, disk := range outDatedDisks {
 		// Before healing outdated disks, we need to remove
 		// xl.json and part files from "bucket/object/" so
@@ -413,6 +468,8 @@ func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (i
 			// Not an outdated disk.
 			continue
 		}
+
+		disksToHealCount++
 
 		// errFileNotFound implies that xl.json is missing. We
 		// may have object parts still present in the object
@@ -424,8 +481,8 @@ func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (i
 
 		// List and delete the object directory, ignoring
 		// errors.
-		files, err := disk.ListDir(bucket, object)
-		if err == nil {
+		files, derr := disk.ListDir(bucket, object)
+		if derr == nil {
 			for _, entry := range files {
 				_ = disk.DeleteFile(bucket,
 					pathJoin(object, entry))
@@ -449,10 +506,10 @@ func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (i
 	// Heal each part. erasureHealFile() will write the healed
 	// part to .minio/tmp/uuid/ which needs to be renamed later to
 	// the final location.
-	storage, err := NewErasureStorage(latestDisks,
-		latestMeta.Erasure.DataBlocks, latestMeta.Erasure.ParityBlocks)
+	storage, err := NewErasureStorage(latestDisks, latestMeta.Erasure.DataBlocks,
+		latestMeta.Erasure.ParityBlocks)
 	if err != nil {
-		return 0, 0, toObjectErr(err, bucket, object)
+		return result, toObjectErr(err, bucket, object)
 	}
 	checksums := make([][]byte, len(latestDisks))
 	for partIndex := 0; partIndex < len(latestMeta.Parts); partIndex++ {
@@ -472,7 +529,7 @@ func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (i
 			erasure.BlockSize, minioMetaTmpBucket, pathJoin(tmpID, partName), partSize,
 			algorithm, checksums)
 		if hErr != nil {
-			return 0, 0, toObjectErr(hErr, bucket, object)
+			return result, toObjectErr(hErr, bucket, object)
 		}
 		// outDatedDisks that had write errors should not be
 		// written to for remaining parts, so we nil it out.
@@ -484,7 +541,7 @@ func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (i
 			// a healed part checksum had a write error.
 			if file.Checksums[i] == nil {
 				outDatedDisks[i] = nil
-				numHealedDisks--
+				disksToHealCount--
 				continue
 			}
 			// append part checksums
@@ -493,8 +550,8 @@ func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (i
 		}
 
 		// If all disks are having errors, we give up.
-		if numHealedDisks == 0 {
-			return 0, 0, fmt.Errorf("all disks without up-to-date data had write errors")
+		if disksToHealCount == 0 {
+			return result, fmt.Errorf("all disks without up-to-date data had write errors")
 		}
 	}
 
@@ -511,11 +568,11 @@ func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (i
 	outDatedDisks, aErr = writeUniqueXLMetadata(outDatedDisks, minioMetaTmpBucket, tmpID,
 		partsMetadata, diskCount(outDatedDisks))
 	if aErr != nil {
-		return 0, 0, toObjectErr(aErr, bucket, object)
+		return result, toObjectErr(aErr, bucket, object)
 	}
 
 	// Rename from tmp location to the actual location.
-	for _, disk := range outDatedDisks {
+	for diskIndex, disk := range outDatedDisks {
 		if disk == nil {
 			continue
 		}
@@ -524,24 +581,37 @@ func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (i
 		aErr = disk.RenameFile(minioMetaTmpBucket, retainSlash(tmpID), bucket,
 			retainSlash(object))
 		if aErr != nil {
-			return 0, 0, toObjectErr(errors.Trace(aErr), bucket, object)
+			return result, toObjectErr(errors.Trace(aErr), bucket, object)
 		}
+
+		realDiskIdx := unshuffleIndex(diskIndex,
+			latestMeta.Erasure.Distribution)
+		drive := globalEndpoints.GetString(realDiskIdx)
+		result.DriveInfo.After[drive] = madmin.OnlineDriveState
 	}
-	return numOfflineDisks, numHealedDisks, nil
+
+	// Set the size of the object in the heal result
+	result.ObjectSize = latestMeta.Stat.Size
+
+	return result, nil
 }
 
-// HealObject heals a given object for all its missing entries.
+// HealObject - heal the given object. Returns list of disk indices on
+// which latest data is present.
+//
 // FIXME: If an object object was deleted and one disk was down,
 // and later the disk comes back up again, heal on the object
 // should delete it.
-func (xl xlObjects) HealObject(bucket, object string) (int, int, error) {
+func (xl xlObjects) HealObject(bucket, object string, dryRun bool) (
+	hr madmin.HealResultItem, err error) {
+
 	// Lock the object before healing.
 	objectLock := globalNSMutex.NewNSLock(bucket, object)
-	if err := objectLock.GetRLock(globalHealingTimeout); err != nil {
-		return 0, 0, err
+	if lerr := objectLock.GetRLock(globalHealingTimeout); lerr != nil {
+		return hr, lerr
 	}
 	defer objectLock.RUnlock()
 
 	// Heal the object.
-	return healObject(xl.storageDisks, bucket, object, xl.readQuorum)
+	return healObject(xl.storageDisks, bucket, object, xl.readQuorum, dryRun)
 }

--- a/cmd/xl-v1-healing_test.go
+++ b/cmd/xl-v1-healing_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/minio/minio-go/pkg/set"
 	"github.com/minio/minio/pkg/errors"
 )
 
@@ -46,7 +47,7 @@ func TestHealFormatXL(t *testing.T) {
 		t.Fatal(err)
 	}
 	xl := obj.(*xlObjects)
-	if err = healFormatXL(xl.storageDisks); err != nil {
+	if _, err = healFormatXL(xl.storageDisks, false); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 
@@ -67,7 +68,7 @@ func TestHealFormatXL(t *testing.T) {
 		xl.storageDisks[i] = nil
 	}
 
-	if err = healFormatXL(xl.storageDisks); err != errXLReadQuorum {
+	if _, err = healFormatXL(xl.storageDisks, false); err != errXLReadQuorum {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -90,7 +91,7 @@ func TestHealFormatXL(t *testing.T) {
 		}
 		xl.storageDisks[i] = newNaughtyDisk(posixDisk, nil, errDiskFull)
 	}
-	if err = healFormatXL(xl.storageDisks); err != errXLReadQuorum {
+	if _, err = healFormatXL(xl.storageDisks, false); err != errXLReadQuorum {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -108,7 +109,7 @@ func TestHealFormatXL(t *testing.T) {
 	}
 	xl = obj.(*xlObjects)
 	xl.storageDisks[0] = nil
-	if err = healFormatXL(xl.storageDisks); err != nil && err.Error() != "cannot proceed with heal as some disks are offline" {
+	if _, err = healFormatXL(xl.storageDisks, false); err != nil && err.Error() != "cannot proceed with heal as some disks are offline" {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -129,7 +130,7 @@ func TestHealFormatXL(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err = healFormatXL(xl.storageDisks); err != nil {
+	if _, err = healFormatXL(xl.storageDisks, false); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -150,7 +151,7 @@ func TestHealFormatXL(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err = healFormatXL(xl.storageDisks); err == nil {
+	if _, err = healFormatXL(xl.storageDisks, false); err == nil {
 		t.Fatal("Should get a json parsing error, ")
 	}
 	removeRoots(fsDirs)
@@ -171,7 +172,7 @@ func TestHealFormatXL(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err = healFormatXL(xl.storageDisks); err != nil {
+	if _, err = healFormatXL(xl.storageDisks, false); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -198,7 +199,7 @@ func TestHealFormatXL(t *testing.T) {
 	}
 	xl.storageDisks[3] = newNaughtyDisk(posixDisk, nil, errDiskNotFound)
 	expectedErr := fmt.Errorf("cannot proceed with heal as %s", errSomeDiskOffline)
-	if err = healFormatXL(xl.storageDisks); err != nil {
+	if _, err = healFormatXL(xl.storageDisks, false); err != nil {
 		if err.Error() != expectedErr.Error() {
 			t.Fatal("Got an unexpected error: ", err)
 		}
@@ -228,7 +229,7 @@ func TestHealFormatXL(t *testing.T) {
 	}
 	xl.storageDisks[3] = newNaughtyDisk(posixDisk, nil, errDiskAccessDenied)
 	expectedErr = fmt.Errorf("cannot proceed with heal as some disks had unhandled errors")
-	if err = healFormatXL(xl.storageDisks); err != nil {
+	if _, err = healFormatXL(xl.storageDisks, false); err != nil {
 		if err.Error() != expectedErr.Error() {
 			t.Fatal("Got an unexpected error: ", err)
 		}
@@ -254,7 +255,7 @@ func TestHealFormatXL(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err = healFormatXL(xl.storageDisks); err != nil {
+	if _, err = healFormatXL(xl.storageDisks, false); err != nil {
 		t.Fatal("Got an unexpected error: ", err)
 	}
 	removeRoots(fsDirs)
@@ -442,14 +443,18 @@ func TestListBucketsHeal(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	bucketSet := set.CreateStringSet(saneBucket, corruptedBucketName)
+
 	// Check the number of buckets in list buckets heal result
-	if len(buckets) != 1 {
-		t.Fatalf("Length of missing buckets is incorrect, expected: 1, found: %d", len(buckets))
+	if len(buckets) != len(bucketSet) {
+		t.Fatalf("Length of missing buckets is incorrect, expected: 2, found: %d", len(buckets))
 	}
 
-	// Check the name of bucket in list buckets heal result
-	if buckets[0].Name != corruptedBucketName {
-		t.Fatalf("Name of missing bucket is incorrect, expected: %s, found: %s", corruptedBucketName, buckets[0].Name)
+	// Check each bucket name is in `bucketSet`v
+	for _, b := range buckets {
+		if !bucketSet.Contains(b.Name) {
+			t.Errorf("Bucket %v is missing from bucket set", b.Name)
+		}
 	}
 }
 
@@ -516,7 +521,7 @@ func TestHealObjectXL(t *testing.T) {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
 
-	_, _, err = obj.HealObject(bucket, object)
+	_, err = obj.HealObject(bucket, object, false)
 	if err != nil {
 		t.Fatalf("Failed to heal object - %v", err)
 	}
@@ -532,7 +537,7 @@ func TestHealObjectXL(t *testing.T) {
 	}
 
 	// Try healing now, expect to receive errDiskNotFound.
-	_, _, err = obj.HealObject(bucket, object)
+	_, err = obj.HealObject(bucket, object, false)
 	if errors.Cause(err) != errDiskNotFound {
 		t.Errorf("Expected %v but received %v", errDiskNotFound, err)
 	}

--- a/cmd/xl-v1-list-objects-heal.go
+++ b/cmd/xl-v1-list-objects-heal.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -142,23 +141,14 @@ func (xl xlObjects) listObjectsHeal(bucket, prefix, marker, delimiter string, ma
 			continue
 		}
 
-		// Check if the current object needs healing
-		objectLock := globalNSMutex.NewNSLock(bucket, objInfo.Name)
-		if err := objectLock.GetRLock(globalHealingTimeout); err != nil {
-			return loi, err
-		}
-		partsMetadata, errs := readAllXLMetadata(xl.storageDisks, bucket, objInfo.Name)
-		if xlShouldHeal(xl.storageDisks, partsMetadata, errs, bucket, objInfo.Name) {
-			healStat := xlHealStat(xl, partsMetadata, errs)
-			result.Objects = append(result.Objects, ObjectInfo{
-				Name:           objInfo.Name,
-				ModTime:        objInfo.ModTime,
-				Size:           objInfo.Size,
-				IsDir:          false,
-				HealObjectInfo: &healStat,
-			})
-		}
-		objectLock.RUnlock()
+		// Add each object seen to the result - objects are
+		// checked for healing later.
+		result.Objects = append(result.Objects, ObjectInfo{
+			Name:    objInfo.Name,
+			ModTime: objInfo.ModTime,
+			Size:    objInfo.Size,
+			IsDir:   false,
+		})
 	}
 	return result, nil
 }
@@ -196,225 +186,4 @@ func (xl xlObjects) ListObjectsHeal(bucket, prefix, marker, delimiter string, ma
 
 	// Return error at the end.
 	return loi, toObjectErr(err, bucket, prefix)
-}
-
-// ListUploadsHeal - lists ongoing multipart uploads that require
-// healing in one or more disks.
-func (xl xlObjects) ListUploadsHeal(bucket, prefix, marker, uploadIDMarker,
-	delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
-
-	// For delimiter and prefix as '/' we do not list anything at all
-	// since according to s3 spec we stop at the 'delimiter' along
-	// with the prefix. On a flat namespace with 'prefix' as '/'
-	// we don't have any entries, since all the keys are of form 'keyName/...'
-	if delimiter == slashSeparator && prefix == slashSeparator {
-		return lmi, nil
-	}
-
-	// Initiate a list operation.
-	listMultipartInfo, err := xl.listMultipartUploadsHeal(bucket, prefix,
-		marker, uploadIDMarker, delimiter, maxUploads)
-	if err != nil {
-		return lmi, toObjectErr(err, bucket, prefix)
-	}
-
-	// We got the entries successfully return.
-	return listMultipartInfo, nil
-}
-
-// Fetches list of multipart uploadIDs given bucket, keyMarker, uploadIDMarker.
-func fetchMultipartUploadIDs(bucket, keyMarker, uploadIDMarker string,
-	maxUploads int, disks []StorageAPI) (uploads []MultipartInfo, end bool,
-	err error) {
-
-	// Hold a read lock on keyMarker path.
-	keyMarkerLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
-		pathJoin(bucket, keyMarker))
-	if err = keyMarkerLock.GetRLock(globalHealingTimeout); err != nil {
-		return uploads, end, err
-	}
-	for _, disk := range disks {
-		if disk == nil {
-			continue
-		}
-		uploads, end, err = listMultipartUploadIDs(bucket, keyMarker,
-			uploadIDMarker, maxUploads, disk)
-		if err == nil ||
-			!errors.IsErrIgnored(err, objMetadataOpIgnoredErrs...) {
-			break
-		}
-	}
-	keyMarkerLock.RUnlock()
-	return uploads, end, err
-}
-
-// listMultipartUploadsHeal - Returns a list of incomplete multipart
-// uploads that need to be healed.
-func (xl xlObjects) listMultipartUploadsHeal(bucket, prefix, keyMarker,
-	uploadIDMarker, delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
-
-	result := ListMultipartsInfo{
-		IsTruncated: true,
-		MaxUploads:  maxUploads,
-		KeyMarker:   keyMarker,
-		Prefix:      prefix,
-		Delimiter:   delimiter,
-	}
-
-	recursive := delimiter != slashSeparator
-
-	var uploads []MultipartInfo
-	var err error
-	// List all upload ids for the given keyMarker, starting from
-	// uploadIDMarker.
-	if uploadIDMarker != "" {
-		uploads, _, err = fetchMultipartUploadIDs(bucket, keyMarker,
-			uploadIDMarker, maxUploads, xl.getLoadBalancedDisks())
-		if err != nil {
-			return lmi, err
-		}
-		maxUploads = maxUploads - len(uploads)
-	}
-
-	// We can't use path.Join() as it strips off the trailing '/'.
-	multipartPrefixPath := pathJoin(bucket, prefix)
-	// multipartPrefixPath should have a trailing '/' when prefix = "".
-	if prefix == "" {
-		multipartPrefixPath += slashSeparator
-	}
-
-	multipartMarkerPath := ""
-	if keyMarker != "" {
-		multipartMarkerPath = pathJoin(bucket, keyMarker)
-	}
-
-	// `heal bool` is used to differentiate listing of incomplete
-	// uploads (and parts) from a regular listing of incomplete
-	// parts by client SDKs or mc-like commands, within a treewalk
-	// pool.
-	heal := true
-	// The listing is truncated if we have maxUploads entries and
-	// there are more entries to be listed.
-	truncated := true
-	var walkerCh chan treeWalkResult
-	var walkerDoneCh chan struct{}
-	// Check if we have room left to send more uploads.
-	if maxUploads > 0 {
-		uploadsLeft := maxUploads
-
-		walkerCh, walkerDoneCh = xl.listPool.Release(listParams{
-			bucket:    minioMetaMultipartBucket,
-			recursive: recursive,
-			marker:    multipartMarkerPath,
-			prefix:    multipartPrefixPath,
-			heal:      heal,
-		})
-		if walkerCh == nil {
-			walkerDoneCh = make(chan struct{})
-			isLeaf := xl.isMultipartUpload
-			listDir := listDirFactory(isLeaf, xlTreeWalkIgnoredErrs,
-				xl.getLoadBalancedDisks()...)
-			walkerCh = startTreeWalk(minioMetaMultipartBucket,
-				multipartPrefixPath, multipartMarkerPath,
-				recursive, listDir, isLeaf, walkerDoneCh)
-		}
-		// Collect uploads until leftUploads limit is reached.
-		for {
-			walkResult, ok := <-walkerCh
-			if !ok {
-				truncated = false
-				break
-			}
-			// For any error during tree walk, we should return right away.
-			if walkResult.err != nil {
-				return lmi, walkResult.err
-			}
-
-			entry := strings.TrimPrefix(walkResult.entry,
-				retainSlash(bucket))
-			// Skip entries that are not object directory.
-			if hasSuffix(walkResult.entry, slashSeparator) {
-				uploads = append(uploads, MultipartInfo{
-					Object: entry,
-				})
-				uploadsLeft--
-				if uploadsLeft == 0 {
-					break
-				}
-				continue
-			}
-
-			// For an object entry we get all its pending
-			// uploadIDs.
-			var newUploads []MultipartInfo
-			var end bool
-			uploadIDMarker = ""
-			newUploads, end, err = fetchMultipartUploadIDs(bucket, entry, uploadIDMarker,
-				uploadsLeft, xl.getLoadBalancedDisks())
-			if err != nil {
-				return lmi, err
-			}
-			uploads = append(uploads, newUploads...)
-			uploadsLeft -= len(newUploads)
-			if end && walkResult.end {
-				truncated = false
-				break
-			}
-			if uploadsLeft == 0 {
-				break
-			}
-		}
-
-	}
-
-	// For all received uploads fill in the multiparts result.
-	for _, upload := range uploads {
-		var objectName string
-		var uploadID string
-		if hasSuffix(upload.Object, slashSeparator) {
-			// All directory entries are common
-			// prefixes. For common prefixes, upload ids
-			// are empty.
-			uploadID = ""
-			objectName = upload.Object
-			result.CommonPrefixes = append(result.CommonPrefixes, objectName)
-		} else {
-			// Check if upload needs healing.
-			uploadIDPath := filepath.Join(bucket, upload.Object, upload.UploadID)
-			partsMetadata, errs := readAllXLMetadata(xl.storageDisks,
-				minioMetaMultipartBucket, uploadIDPath)
-			if xlShouldHeal(xl.storageDisks, partsMetadata, errs,
-				minioMetaMultipartBucket, uploadIDPath) {
-
-				healUploadInfo := xlHealStat(xl, partsMetadata, errs)
-				upload.HealUploadInfo = &healUploadInfo
-				result.Uploads = append(result.Uploads, upload)
-			}
-			uploadID = upload.UploadID
-			objectName = upload.Object
-		}
-
-		result.NextKeyMarker = objectName
-		result.NextUploadIDMarker = uploadID
-	}
-
-	if truncated {
-		// Put back the tree walk go-routine into the pool for
-		// subsequent use.
-		xl.listPool.Set(listParams{
-			bucket:    bucket,
-			recursive: recursive,
-			marker:    result.NextKeyMarker,
-			prefix:    prefix,
-			heal:      heal,
-		}, walkerCh, walkerDoneCh)
-	}
-
-	result.IsTruncated = truncated
-	// Result is not truncated, reset the markers.
-	if !result.IsTruncated {
-		result.NextKeyMarker = ""
-		result.NextUploadIDMarker = ""
-	}
-	return result, nil
 }

--- a/cmd/xl-v1-object_test.go
+++ b/cmd/xl-v1-object_test.go
@@ -313,7 +313,7 @@ func TestHealing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = xl.HealObject(bucket, object)
+	_, err = xl.HealObject(bucket, object, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +337,7 @@ func TestHealing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = xl.HealObject(bucket, object)
+	_, err = xl.HealObject(bucket, object, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +359,7 @@ func TestHealing(t *testing.T) {
 		t.Fatal(err)
 	}
 	// This would create the bucket.
-	err = xl.HealBucket(bucket)
+	_, err = xl.HealBucket(bucket, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -36,15 +36,12 @@ func main() {
 
 ```
 
-| Service operations|LockInfo operations|Healing operations|Config operations| Misc |
-|:---|:---|:---|:---|:---|
-|[`ServiceStatus`](#ServiceStatus)| [`ListLocks`](#ListLocks)| [`ListObjectsHeal`](#ListObjectsHeal)|[`GetConfig`](#GetConfig)| [`SetCredentials`](#SetCredentials)|
-|[`ServiceRestart`](#ServiceRestart)| [`ClearLocks`](#ClearLocks)| [`ListBucketsHeal`](#ListBucketsHeal)|[`SetConfig`](#SetConfig)||
-| | |[`HealBucket`](#HealBucket) |||
-| | |[`HealObject`](#HealObject)|||
-| | |[`HealFormat`](#HealFormat)|||
-| | |[`ListUploadsHeal`](#ListUploadsHeal)|||
-| | |[`HealUpload`](#HealUpload)|||
+| Service operations                  | LockInfo operations         | Healing operations                    | Config operations         | Misc                                |
+|:------------------------------------|:----------------------------|:--------------------------------------|:--------------------------|:------------------------------------|
+| [`ServiceStatus`](#ServiceStatus)   | [`ListLocks`](#ListLocks)   | [`HealStart`](#HealStart)             | [`GetConfig`](#GetConfig) | [`SetCredentials`](#SetCredentials) |
+| [`ServiceSendAction`](#ServiceSendAction) | [`ClearLocks`](#ClearLocks) | [`HealStatus`](#HealStatus)           | [`SetConfig`](#SetConfig) |                                     |
+|                                     |                             | [`HealStop`](#HealStop)               |                           |                                     |
+
 
 ## 1. Constructor
 <a name="Minio"></a>
@@ -62,8 +59,25 @@ __Parameters__
 |`secretAccessKey`  | _string_  |Secret key for the object storage endpoint.   |
 |`ssl`   | _bool_  | Set this value to 'true' to enable secure (HTTPS) access.  |
 
+## 2. Admin API Version
 
-## 2. Service operations
+<a name="VersionInfo"></a>
+### VersionInfo() (AdminAPIVersionInfo, error)
+Fetch server's supported Administrative API version.
+
+ __Example__
+
+``` go
+
+	info, err := madmClnt.VersionInfo()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Printf("%s\n", info.Version)
+
+```
+
+## 3. Service operations
 
 <a name="ServiceStatus"></a>
 ### ServiceStatus() (ServiceStatusMetadata, error)
@@ -104,17 +118,19 @@ Fetch service status, replies disk space used, backend type and total disks offl
 
  ```
 
-<a name="ServiceRestart"></a>
-### ServiceRestart() (error)
-If successful restarts the running minio service, for distributed setup restarts all remote minio servers.
+<a name="ServiceSendAction"></a>
+### ServiceSendAction(act ServiceActionValue) (error)
+Sends a service action command to service - possible actions are restarting and stopping the server.
 
  __Example__
 
 
  ```go
 
-
-	st, err := madmClnt.ServiceRestart()
+    // to restart
+	st, err := madmClnt.ServiceSendAction(ServiceActionValueRestart)
+    // or to stop
+    // st, err := madmClnt.ServiceSendAction(ServiceActionValueStop)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -122,7 +138,7 @@ If successful restarts the running minio service, for distributed setup restarts
 
  ```
 
-## 3. Info operations
+## 4. Info operations
 
 <a name="ServerInfo"></a>
 ### ServerInfo() ([]ServerInfo, error)
@@ -145,7 +161,7 @@ Fetch all information for all cluster nodes, such as uptime, region, network sta
  ```
 
 
-## 4. Lock operations
+## 5. Lock operations
 
 <a name="ListLocks"></a>
 ### ListLocks(bucket, prefix string, duration time.Duration) ([]VolumeLockInfo, error)
@@ -177,213 +193,128 @@ __Example__
 
 ```
 
-## 5. Heal operations
+## 6. Heal operations
 
-<a name="ListObjectsHeal"></a>
-### ListObjectsHeal(bucket, prefix string, recursive bool, doneCh <-chan struct{}) (<-chan ObjectInfo, error)
-If successful returns information on the list of objects that need healing in ``bucket`` matching ``prefix``.
+<a name="HealStart"></a>
+### HealStart(bucket, prefix string, recursive, dryRun, incomplete, removeBadFiles, statisticsOnly bool) (healPath string, err error)
 
-__Example__
+Start a heal sequence that scans data under given (possible empty)
+`bucket` and `prefix`. The `recursive` bool turns on recursive
+traversal under the given path. `dryRun` does not mutate on-disk data,
+but performs data validation. `incomplete` enables healing of
+multipart uploads that are in progress. `removeBadFiles` removes
+unrecoverable files. `statisticsOnly` turns off detailed
+heal-operations reporting in the status call.
 
-``` go
-    // Create a done channel to control 'ListObjectsHeal' go routine.
-    doneCh := make(chan struct{})
+Two heal sequences on overlapping paths may not be initiated.
 
-    // Indicate to our routine to exit cleanly upon return.
-    defer close(doneCh)
-
-    // Set true if recursive listing is needed.
-    isRecursive := true
-    // List objects that need healing for a given bucket and
-    // prefix.
-    healObjectCh, err := madmClnt.ListObjectsHeal("mybucket", "myprefix", isRecursive, doneCh)
-    if err != nil {
-        fmt.Println(err)
-        return
-    }
-    for object := range healObjectsCh {
-        if object.Err != nil {
-            log.Fatalln(err)
-            return
-        }
-        if object.HealObjectInfo != nil {
-            switch healInfo := *object.HealObjectInfo; healInfo.Status {
-            case madmin.CanHeal:
-                fmt.Println(object.Key, " can be healed.")
-            case madmin.QuorumUnavailable:
-                fmt.Println(object.Key, " can't be healed until quorum is available.")
-            case madmin.Corrupted:
-                fmt.Println(object.Key, " can't be healed, not enough information.")
-            }
-        }
-        fmt.Println("object: ", object)
-    }
-```
-
-<a name="ListBucketsHeal"></a>
-### ListBucketsHeal() error
-If successful returns information on the list of buckets that need healing.
+The progress of a heal should be followed using the `HealStatus`
+API. The server accumulates results of the heal traversal and waits
+for the client to receive and acknowledge them using the status
+API. When the statistics-only option is set, the server only maintains
+aggregates statistics - in this case, no acknowledgement of results is
+required.
 
 __Example__
 
 ``` go
-    // List buckets that need healing
-    healBucketsList, err := madmClnt.ListBucketsHeal()
-    if err != nil {
-        fmt.Println(err)
-        return
-    }
-    for bucket := range healBucketsList {
-        if bucket.HealBucketInfo != nil {
-            switch healInfo := *object.HealBucketInfo; healInfo.Status {
-            case madmin.CanHeal:
-                fmt.Println(bucket.Key, " can be healed.")
-            case madmin.QuorumUnavailable:
-                fmt.Println(bucket.Key, " can't be healed until quorum is available.")
-            case madmin.Corrupted:
-                fmt.Println(bucket.Key, " can't be healed, not enough information.")
-            }
-        }
-        fmt.Println("bucket: ", bucket)
-    }
-```
 
-<a name="HealBucket"></a>
-### HealBucket(bucket string, isDryRun bool) error
-If bucket is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the bucket is not healed, but heal bucket request is validated by the server. e.g, if the bucket exists, if bucket name is valid etc.
-
-__Example__
-
-``` go
-    isDryRun := false
-    err := madmClnt.HealBucket("mybucket", isDryRun)
+    healPath, err := madmClnt.HealStart("", "", true, false, true, false, false)
     if err != nil {
         log.Fatalln(err)
     }
-    log.Println("successfully healed mybucket")
+    log.Printf("Heal sequence started at %s", healPath)
 
 ```
 
-<a name="HealObject"></a>
-### HealObject(bucket, object string, isDryRun bool) (HealResult, error)
-If object is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the object is not healed, but heal object request is validated by the server. e.g, if the object exists, if object name is valid etc.
+<a name="HealStatus"></a>
+### HealStatus(bucket, prefix string, marker int64) (s HealTaskStatus, err error)
 
-| Param  | Type  | Description  |
-|---|---|---|
-|`h.State` | _HealState_ | Represents the result of heal operation. It could be one of `HealNone`, `HealPartial` or `HealOK`. |
+Fetch status of a heal sequence running at the given `bucket` and
+`prefix`. The `marker` parameter acknowledges that heal result items
+upto `marker` have been received by the client. In case of
+`statisticsOnly` mode this parameter is ignored.
 
+In each call, the server returns any available heal result records
+with index starting from `marker + 1`, and upto 1000 records. Also,
+once acknowledged, results upto `marker` are removed from server
+memory.
 
-| Value | Description |
-|---|---|
-|`HealNone` | Object/Upload wasn't healed on any of the disks |
-|`HealPartial` | Object/Upload was healed on some of the disks needing heal |
-| `HealOK` | Object/Upload was healed on all the disks needing heal |
+#### HealTaskStatus structure
 
+| Param | Type | Description |
+|----|--------|--------|
+| s.Summary | _string_ | Short status of heal sequence |
+| s.FailureDetail | _string_ | Error message in case of heal sequence failure |
+| s.HealSettings | _HealOpts_ | Contains the booleans set in the `HealStart` call |
+| s.Items | _[]HealResultItem_ | Heal records for actions performed by server |
+| s.Statistics | _HealStatistics_ | Aggregate of heal records from beginning |
 
-__Example__
+#### HealResultItem structure
 
-``` go
-    isDryRun = false
-    healResult, err := madmClnt.HealObject("mybucket", "myobject", isDryRun)
-    if err != nil {
-        log.Fatalln(err)
-    }
+| Param | Type | Description |
+|------|-------|---------|
+| ResultIndex | _int64_ | Index of the heal-result record |
+| Type | _HealItemType_ | Represents kind of heal operation in the heal record |
+| Bucket | _string_ | Bucket name |
+| Object | _string_ | Object name |
+| Detail | _string_ | Details about heal operation |
+| DiskInfo.AvailableOn | _[]int_ | List of disks on which the healed entity is present and healthy |
+| DiskInfo.HealedOn | _[]int_ | List of disks on which the healed entity was restored |
 
-    log.Println("Heal-object result: ", healResult)
+#### HealStatistics structure
 
-```
+Most parameters represent the aggregation of heal operations since the
+start of the heal sequence.
 
-<a name="HealFormat"></a>
-### HealFormat(isDryRun bool) error
-Heal storage format on available disks. This is used when disks were replaced or were found with missing format. This is supported only for erasure-coded backend.
-
-__Example__
-
-``` go
-    isDryRun := true
-    err := madmClnt.HealFormat(isDryRun)
-    if err != nil {
-        log.Fatalln(err)
-    }
-
-    isDryRun = false
-    err = madmClnt.HealFormat(isDryRun)
-    if err != nil {
-        log.Fatalln(err)
-    }
-
-    log.Println("successfully healed storage format on available disks.")
-
-```
-<a name="ListUploadsHeal"> </a>
-### ListUploadsHeal(bucket, prefix string, recursive bool, doneCh <-chan struct{}) (<-chan UploadInfo, error)
-List ongoing multipart uploads that need healing.
-
-| Param  | Type  | Description  |
-|---|---|---|
-|`ui.Key` | _string_ | Name of the object being uploaded |
-|`ui.UploadID` | _string_ | UploadID of the ongoing multipart upload |
-|`ui.HealUploadInfo.Status` | _HealStatus_| One of `Healthy`, `CanHeal`, `Corrupted`, `QuorumUnavailable`|
-|`ui.Err`| _error_ | non-nil if fetching fetching healing information failed |
+| Param | Type | Description |
+|-------|-----|----------|
+| NumDisks | _int_ | Number of disks configured in the backend |
+| NumBucketsScanned | _int64_ | Number of buckets scanned |
+| BucketsMissingByDisk | _map[int]int64_ | Map of disk to number of buckets missing |
+| BucketsAvailableByDisk | _map[int]int64_ | Map of disk to number of buckets available |
+| BucketsHealedByDisk | _map[int]int64_ | Map of disk to number of buckets healed on |
+| NumObjectsScanned | _int64_ | Number of objects scanned |
+| NumUploadsScanned | _int64_ | Number of uploads scanned |
+| ObjectsByAvailablePC | _map[int64]_ | Map of available part counts (after heal) to number of objects |
+| ObjectsByHealedPC | _map[int64]_ | Map of healed part counts to number of objects |
+| ObjectsMissingByDisk | _map[int64]_ | Map of disk number to number of objects with parts missing on that disk |
+| ObjectsAvailableByDisk | _map[int64]_ | Map of disk number to number of objects available on that disk |
+| ObjectsHealedByDisk | _map[int64]_ | Map of disk number to number of objects healed on that disk |
 
 __Example__
 
 ``` go
 
-    // Set true if recursive listing is needed.
-    isRecursive := true
-    // List objects that need healing for a given bucket and
-    // prefix.
-    healUploadsCh, err := madmClnt.ListUploadsHeal(bucket, prefix, isRecursive, doneCh)
-    if err != nil {
-        log.Fatalln("Failed to get list of uploads to be healed: ", err)
-    }
-
-    for upload := range healUploadsCh {
-        if upload.Err != nil {
-            log.Println("upload listing error: ", upload.Err)
-        }
-
-        if upload.HealUploadInfo != nil {
-            switch healInfo := *upload.HealUploadInfo; healInfo.Status {
-            case madmin.CanHeal:
-                fmt.Println(upload.Key, " can be healed.")
-            case madmin.QuorumUnavailable:
-                fmt.Println(upload.Key, " can't be healed until quorum is available.")
-            case madmin.Corrupted:
-                fmt.Println(upload.Key, " can't be healed, not enough information.")
-            }
-        }
-    }
-
-```
-
-<a name="HealUpload"></a>
-### HealUpload(bucket, object, uploadID string, isDryRun bool) (HealResult, error)
-If upload is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the upload is not healed, but heal upload request is validated by the server. e.g, if the upload exists, if upload name is valid etc.
-
-| Param  | Type  | Description  |
-|---|---|---|
-|`h.State` | _HealState_ | Represents the result of heal operation. It could be one of `HealNone`, `HealPartial` or `HealOK`. |
-
-
-| Value | Description |
-|---|---|
-| `HealNone` | Object/Upload wasn't healed on any of the disks |
-| `HealPartial` | Object/Upload was healed on some of the disks needing heal |
-| `HealOK` | Object/Upload was healed on all the disks needing heal |
-
-``` go
-    isDryRun = false
-    healResult, err := madmClnt.HealUpload("mybucket", "myobject", "myUploadID", isDryRun)
+    res, err := madmClnt.HealStatus("", "")
     if err != nil {
         log.Fatalln(err)
     }
+    log.Printf("Heal sequence status data %#v", res)
 
-    log.Println("Heal-upload result: ", healResult)
 ```
 
-## 6. Config operations
+<a name="HealStop"></a>
+### HealStop(bucket, prefix string) error
+
+Stops a running heal sequence. Since the server may be mutating
+on-disk data, the stop does not happen immediately, but happens at the
+first safe point reached by the server.
+
+__Example__
+
+``` go
+
+    err := madmClnt.HealStop("", "")
+    if err != nil {
+        log.Fatalln(err)
+    }
+    log.Println("Heal sequence stopped!")
+
+```
+
+
+## 7. Config operations
 
 <a name="GetConfig"></a>
 ### GetConfig() ([]byte, error)
@@ -442,7 +373,7 @@ __Example__
     log.Println("SetConfig: ", string(buf.Bytes()))
 ```
 
-## 7. Misc operations
+## 8. Misc operations
 
 <a name="SetCredentials"></a>
 
@@ -459,4 +390,3 @@ __Example__
     log.Println("New credentials successfully set.")
 
 ```
-

--- a/pkg/madmin/api-error-response.go
+++ b/pkg/madmin/api-error-response.go
@@ -54,7 +54,7 @@ func (e ErrorResponse) Error() string {
 }
 
 const (
-	reportIssue = "Please report this issue at https://github.com/minio/minio-go/issues."
+	reportIssue = "Please report this issue at https://github.com/minio/minio/issues."
 )
 
 // httpRespToErrorResponse returns a new encoded ErrorResponse
@@ -65,8 +65,8 @@ func httpRespToErrorResponse(resp *http.Response) error {
 		return ErrInvalidArgument(msg)
 	}
 	var errResp ErrorResponse
-	// Decode the xml error
-	err := xmlDecoder(resp.Body, &errResp)
+	// Decode the json error
+	err := jsonDecoder(resp.Body, &errResp)
 	if err != nil {
 		return ErrorResponse{
 			Code:    resp.Status,

--- a/pkg/madmin/api.go
+++ b/pkg/madmin/api.go
@@ -71,6 +71,8 @@ type AdminClient struct {
 const (
 	libraryName    = "madmin-go"
 	libraryVersion = "0.0.1"
+
+	libraryAdminURLPrefix = "/minio/admin"
 )
 
 // User Agent should always following the below style.
@@ -175,6 +177,9 @@ func (c *AdminClient) TraceOff() {
 type requestData struct {
 	customHeaders http.Header
 	queryValues   url.Values
+
+	// Url path relative to admin API base endpoint
+	relPath string
 
 	contentBody        io.Reader
 	contentLength      int64
@@ -388,7 +393,7 @@ func (c AdminClient) newRequest(method string, reqData requestData) (req *http.R
 	location := "us-east-1"
 
 	// Construct a new target URL.
-	targetURL, err := c.makeTargetURL(reqData.queryValues)
+	targetURL, err := c.makeTargetURL(reqData)
 	if err != nil {
 		return nil, err
 	}
@@ -440,16 +445,16 @@ func (c AdminClient) newRequest(method string, reqData requestData) (req *http.R
 }
 
 // makeTargetURL make a new target url.
-func (c AdminClient) makeTargetURL(queryValues url.Values) (*url.URL, error) {
+func (c AdminClient) makeTargetURL(r requestData) (*url.URL, error) {
 
 	host := c.endpointURL.Host
 	scheme := c.endpointURL.Scheme
 
-	urlStr := scheme + "://" + host + "/"
+	urlStr := scheme + "://" + host + libraryAdminURLPrefix + r.relPath
 
 	// If there are any query values, add them to the end.
-	if len(queryValues) > 0 {
-		urlStr = urlStr + "?" + s3utils.QueryEncode(queryValues)
+	if len(r.queryValues) > 0 {
+		urlStr = urlStr + "?" + s3utils.QueryEncode(r.queryValues)
 	}
 	u, err := url.Parse(urlStr)
 	if err != nil {

--- a/pkg/madmin/constants.go
+++ b/pkg/madmin/constants.go
@@ -19,7 +19,4 @@ package madmin
 const (
 	// Unsigned payload.
 	unsignedPayload = "UNSIGNED-PAYLOAD"
-
-	// Admin operation header.
-	minioAdminOpHeader = "X-Minio-Operation"
 )

--- a/pkg/madmin/generic-commands.go
+++ b/pkg/madmin/generic-commands.go
@@ -54,7 +54,7 @@ func (adm *AdminClient) SetCredentials(access, secret string) error {
 	}
 
 	// Execute GET on bucket to list objects.
-	resp, err := adm.executeMethod("POST", reqData)
+	resp, err := adm.executeMethod("PUT", reqData)
 
 	defer closeResponse(resp)
 	if err != nil {

--- a/pkg/madmin/generic-commands.go
+++ b/pkg/madmin/generic-commands.go
@@ -19,36 +19,39 @@ package madmin
 
 import (
 	"bytes"
-	"encoding/xml"
+	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/url"
 )
 
-// setCredsReq - xml to send to the server to set new credentials
-type setCredsReq struct {
-	Username string `xml:"username"`
-	Password string `xml:"password"`
+// SetCredsReq - xml to send to the server to set new credentials
+type SetCredsReq struct {
+	AccessKey string `json:"accessKey"`
+	SecretKey string `json:"secretKey"`
 }
 
-// SetCredentials - Call Set Credentials API to set new access and secret keys in the specified Minio server
+// SetCredentials - Call Set Credentials API to set new access and
+// secret keys in the specified Minio server
 func (adm *AdminClient) SetCredentials(access, secret string) error {
-
-	// Setup new request
-	reqData := requestData{}
-	reqData.queryValues = make(url.Values)
-	reqData.queryValues.Set("service", "")
-	reqData.customHeaders = make(http.Header)
-	reqData.customHeaders.Set(minioAdminOpHeader, "set-credentials")
-
 	// Setup request's body
-	body, err := xml.Marshal(setCredsReq{Username: access, Password: secret})
+	body, err := json.Marshal(SetCredsReq{access, secret})
 	if err != nil {
 		return err
 	}
-	reqData.contentBody = bytes.NewReader(body)
-	reqData.contentLength = int64(len(body))
-	reqData.contentMD5Bytes = sumMD5(body)
-	reqData.contentSHA256Bytes = sum256(body)
+
+	// No TLS?
+	if !adm.secure {
+		return fmt.Errorf("credentials cannot be updated over an insecure connection")
+	}
+
+	// Setup new request
+	reqData := requestData{
+		relPath:            "/v1/config/credential",
+		contentBody:        bytes.NewReader(body),
+		contentLength:      int64(len(body)),
+		contentMD5Bytes:    sumMD5(body),
+		contentSHA256Bytes: sum256(body),
+	}
 
 	// Execute GET on bucket to list objects.
 	resp, err := adm.executeMethod("POST", reqData)
@@ -58,7 +61,8 @@ func (adm *AdminClient) SetCredentials(access, secret string) error {
 		return err
 	}
 
-	// Return error to the caller if http response code is different from 200
+	// Return error to the caller if http response code is
+	// different from 200
 	if resp.StatusCode != http.StatusOK {
 		return httpRespToErrorResponse(resp)
 	}

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -20,8 +20,8 @@
 package madmin
 
 import (
+	"bytes"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -29,403 +29,71 @@ import (
 	"time"
 )
 
-const (
-	maxUploadsList = 1000
-)
-
-// listBucketHealResult container for listObjects response.
-type listBucketHealResult struct {
-	// A response can contain CommonPrefixes only if you have
-	// specified a delimiter.
-	CommonPrefixes []commonPrefix
-	// Metadata about each object returned.
-	Contents  []ObjectInfo
-	Delimiter string
-
-	// Encoding type used to encode object keys in the response.
-	EncodingType string
-
-	// A flag that indicates whether or not ListObjects returned all of the results
-	// that satisfied the search criteria.
-	IsTruncated bool
-	Marker      string
-	MaxKeys     int64
-	Name        string
-
-	// When response is truncated (the IsTruncated element value in
-	// the response is true), you can use the key name in this field
-	// as marker in the subsequent request to get next set of objects.
-	// Object storage lists objects in alphabetical order Note: This
-	// element is returned only if you have delimiter request
-	// parameter specified. If response does not include the NextMaker
-	// and it is truncated, you can use the value of the last Key in
-	// the response as the marker in the subsequent request to get the
-	// next set of object keys.
-	NextMarker string
-	Prefix     string
+// HealOpts - collection of options for a heal sequence
+type HealOpts struct {
+	Recursive      bool `json:"recursive"`
+	DryRun         bool `json:"dryRun"`
+	Incomplete     bool `json:"incomplete"`
+	StatisticsOnly bool `json:"statisticsOnly"`
+	// RemoveBadFiles bool `json:"removeBadFiles"`
 }
 
-// commonPrefix container for prefix response.
-type commonPrefix struct {
-	Prefix string
-}
+// HealStart - starts a heal task with given parameters
+func (adm *AdminClient) HealStart(bucket, prefix string,
+	healOpts HealOpts) (
+	healPath string, err error) {
 
-// Owner - bucket owner/principal
-type Owner struct {
-	ID          string
-	DisplayName string
-}
-
-// Bucket container for bucket metadata
-type Bucket struct {
-	Name         string
-	CreationDate string // time string of format "2006-01-02T15:04:05.000Z"
-
-	HealBucketInfo *HealBucketInfo `xml:"HealBucketInfo,omitempty"`
-}
-
-// ListBucketsHealResponse - format for list buckets response
-type ListBucketsHealResponse struct {
-	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ListAllMyBucketsResult" json:"-"`
-
-	Owner Owner
-
-	// Container for one or more buckets.
-	Buckets struct {
-		Buckets []Bucket `xml:"Bucket"`
-	} // Buckets are nested
-}
-
-// HealStatus - represents different states of healing an object could be in.
-type HealStatus int
-
-const (
-	// Healthy - Object that is already healthy
-	Healthy HealStatus = iota
-	// CanHeal - Object can be healed
-	CanHeal
-	// Corrupted - Object can't be healed
-	Corrupted
-	// QuorumUnavailable - Object can't be healed until read
-	// quorum is available
-	QuorumUnavailable
-	// CanPartiallyHeal - Object can't be healed completely until
-	// disks with missing parts come online
-	CanPartiallyHeal
-)
-
-// HealBucketInfo - represents healing related information of a bucket.
-type HealBucketInfo struct {
-	Status HealStatus
-}
-
-// BucketInfo - represents bucket metadata.
-type BucketInfo struct {
-	// Name of the bucket.
-	Name string
-
-	// Date and time when the bucket was created.
-	Created time.Time
-
-	// Healing information
-	HealBucketInfo *HealBucketInfo `xml:"HealBucketInfo,omitempty"`
-}
-
-// HealObjectInfo - represents healing related information of an object.
-type HealObjectInfo struct {
-	Status             HealStatus
-	MissingDataCount   int
-	MissingParityCount int
-}
-
-// ObjectInfo container for object metadata.
-type ObjectInfo struct {
-	// An ETag is optionally set to md5sum of an object.  In case of multipart objects,
-	// ETag is of the form MD5SUM-N where MD5SUM is md5sum of all individual md5sums of
-	// each parts concatenated into one string.
-	ETag string `json:"etag"`
-
-	Key          string    `json:"name"`         // Name of the object
-	LastModified time.Time `json:"lastModified"` // Date and time the object was last modified.
-	Size         int64     `json:"size"`         // Size in bytes of the object.
-	ContentType  string    `json:"contentType"`  // A standard MIME type describing the format of the object data.
-
-	// Collection of additional metadata on the object.
-	// eg: x-amz-meta-*, content-encoding etc.
-	Metadata http.Header `json:"metadata"`
-
-	// Owner name.
-	Owner struct {
-		DisplayName string `json:"name"`
-		ID          string `json:"id"`
-	} `json:"owner"`
-
-	// The class of storage used to store the object.
-	StorageClass string `json:"storageClass"`
-
-	// Error
-	Err            error           `json:"-"`
-	HealObjectInfo *HealObjectInfo `json:"healObjectInfo,omitempty"`
-}
-
-// UploadInfo - represents an ongoing upload that needs to be healed.
-type UploadInfo struct {
-	Key string `json:"name"` // Name of the object being uploaded.
-
-	UploadID string `json:"uploadId"` // UploadID
-	// Owner name.
-	Owner struct {
-		DisplayName string `json:"name"`
-		ID          string `json:"id"`
-	} `json:"owner"`
-
-	// The class of storage used to store the object.
-	StorageClass string `json:"storageClass"`
-
-	Initiated time.Time `json:"initiated"` // Time at which upload was initiated.
-
-	// Error
-	Err            error           `json:"-"`
-	HealUploadInfo *HealObjectInfo `json:"healObjectInfo,omitempty"`
-}
-
-// Initiator - has same properties as Owner.
-type Initiator Owner
-
-// upload - represents an ongoing multipart upload.
-type upload struct {
-	Key            string
-	UploadID       string `xml:"UploadId"`
-	Initiator      Initiator
-	Owner          Owner
-	StorageClass   string
-	Initiated      time.Time
-	HealUploadInfo *HealObjectInfo `xml:"HealObjectInfo,omitempty"`
-}
-
-// listUploadsHealResponse - represents ListUploadsHeal response.
-type listUploadsHealResponse struct {
-	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ListMultipartUploadsResult" json:"-"`
-
-	Bucket             string
-	KeyMarker          string
-	UploadIDMarker     string `xml:"UploadIdMarker"`
-	NextKeyMarker      string
-	NextUploadIDMarker string `xml:"NextUploadIdMarker"`
-	Delimiter          string
-	Prefix             string
-	EncodingType       string `xml:"EncodingType,omitempty"`
-	MaxUploads         int
-	IsTruncated        bool
-
-	// List of pending uploads.
-	Uploads []upload `xml:"Upload"`
-
-	// Delimed common prefixes.
-	CommonPrefixes []commonPrefix
-}
-
-type healQueryKey string
-
-const (
-	healBucket         healQueryKey = "bucket"
-	healObject         healQueryKey = "object"
-	healPrefix         healQueryKey = "prefix"
-	healMarker         healQueryKey = "marker"
-	healDelimiter      healQueryKey = "delimiter"
-	healMaxKey         healQueryKey = "max-key"
-	healDryRun         healQueryKey = "dry-run"
-	healUploadIDMarker healQueryKey = "upload-id-marker"
-	healMaxUpload      healQueryKey = "max-uploads"
-	healUploadID       healQueryKey = "upload-id"
-)
-
-// mkHealQueryVal - helper function to construct heal REST API query params.
-func mkHealQueryVal(bucket, prefix, marker, delimiter, maxKeyStr string) url.Values {
-	queryVal := make(url.Values)
-	queryVal.Set("heal", "")
-	queryVal.Set(string(healBucket), bucket)
-	queryVal.Set(string(healPrefix), prefix)
-	queryVal.Set(string(healMarker), marker)
-	queryVal.Set(string(healDelimiter), delimiter)
-	queryVal.Set(string(healMaxKey), maxKeyStr)
-	return queryVal
-}
-
-// listObjectsHeal - issues heal list API request for a batch of maxKeys objects to be healed.
-func (adm *AdminClient) listObjectsHeal(bucket, prefix, marker, delimiter string, maxKeys int) (listBucketHealResult, error) {
-	// Construct query params.
-	maxKeyStr := fmt.Sprintf("%d", maxKeys)
-	queryVal := mkHealQueryVal(bucket, prefix, marker, delimiter, maxKeyStr)
-
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "list-objects")
-
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
+	body, err := json.Marshal(healOpts)
+	if err != nil {
+		return healPath, err
 	}
 
-	// Empty 'list' of objects to be healed.
-	toBeHealedObjects := listBucketHealResult{}
+	path := fmt.Sprintf("/v1/heal/%s", bucket)
+	if bucket != "" && prefix != "" {
+		path += "/" + prefix
+	}
 
-	// Execute GET on /?heal to list objects needing heal.
-	resp, err := adm.executeMethod("GET", reqData)
-
+	// execute POST request to heal api
+	resp, err := adm.executeMethod("POST", requestData{
+		relPath:            path,
+		contentBody:        bytes.NewReader(body),
+		contentSHA256Bytes: sum256(body),
+	})
 	defer closeResponse(resp)
 	if err != nil {
-		return listBucketHealResult{}, err
+		return healPath, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return toBeHealedObjects, httpRespToErrorResponse(resp)
-
+		return healPath, httpRespToErrorResponse(resp)
 	}
 
-	err = xml.NewDecoder(resp.Body).Decode(&toBeHealedObjects)
-	return toBeHealedObjects, err
-}
-
-// ListObjectsHeal - Lists upto maxKeys objects that needing heal matching bucket, prefix, marker, delimiter.
-func (adm *AdminClient) ListObjectsHeal(bucket, prefix string, recursive bool, doneCh <-chan struct{}) (<-chan ObjectInfo, error) {
-	// Allocate new list objects channel.
-	objectStatCh := make(chan ObjectInfo, 1)
-	// Default listing is delimited at "/"
-	delimiter := "/"
-	if recursive {
-		// If recursive we do not delimit.
-		delimiter = ""
-	}
-
-	// Initiate list objects goroutine here.
-	go func(objectStatCh chan<- ObjectInfo) {
-		defer close(objectStatCh)
-		// Save marker for next request.
-		var marker string
-		for {
-			// Get list of objects a maximum of 1000 per request.
-			result, err := adm.listObjectsHeal(bucket, prefix, marker, delimiter, 1000)
-			if err != nil {
-				objectStatCh <- ObjectInfo{
-					Err: err,
-				}
-				return
-			}
-
-			// If contents are available loop through and send over channel.
-			for _, object := range result.Contents {
-				// Save the marker.
-				marker = object.Key
-				select {
-				// Send object content.
-				case objectStatCh <- object:
-				// If receives done from the caller, return here.
-				case <-doneCh:
-					return
-				}
-			}
-
-			// Send all common prefixes if any.
-			// NOTE: prefixes are only present if the request is delimited.
-			for _, obj := range result.CommonPrefixes {
-				object := ObjectInfo{}
-				object.Key = obj.Prefix
-				object.Size = 0
-				select {
-				// Send object prefixes.
-				case objectStatCh <- object:
-				// If receives done from the caller, return here.
-				case <-doneCh:
-					return
-				}
-			}
-
-			// If next marker present, save it for next request.
-			if result.NextMarker != "" {
-				marker = result.NextMarker
-			}
-
-			// Listing ends result is not truncated, return right here.
-			if !result.IsTruncated {
-				return
-			}
-		}
-	}(objectStatCh)
-	return objectStatCh, nil
-}
-
-const timeFormatAMZLong = "2006-01-02T15:04:05.000Z" // Reply date format with nanosecond precision.
-
-// ListBucketsHeal - issues heal bucket list API request
-func (adm *AdminClient) ListBucketsHeal() ([]BucketInfo, error) {
-	queryVal := url.Values{}
-	queryVal.Set("heal", "")
-
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "list-buckets")
-
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
-	}
-
-	// Execute GET on /?heal to list objects needing heal.
-	resp, err := adm.executeMethod("GET", reqData)
-
-	defer closeResponse(resp)
+	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return []BucketInfo{}, err
+		return healPath, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return []BucketInfo{}, httpRespToErrorResponse(resp)
-	}
-
-	var listBucketsHealResult ListBucketsHealResponse
-
-	err = xml.NewDecoder(resp.Body).Decode(&listBucketsHealResult)
+	respMap := make(map[string]string)
+	err = json.Unmarshal(respBytes, &respMap)
 	if err != nil {
-		return []BucketInfo{}, err
+		return healPath, err
 	}
 
-	var bucketsToBeHealed []BucketInfo
-
-	for _, bucket := range listBucketsHealResult.Buckets.Buckets {
-		creationDate, err := time.Parse(timeFormatAMZLong, bucket.CreationDate)
-		if err != nil {
-			return []BucketInfo{}, err
-		}
-		bucketsToBeHealed = append(bucketsToBeHealed,
-			BucketInfo{
-				Name:           bucket.Name,
-				Created:        creationDate,
-				HealBucketInfo: bucket.HealBucketInfo,
-			})
-	}
-
-	return bucketsToBeHealed, nil
+	return respMap["healPathId"], nil
 }
 
-// HealBucket - Heal the given bucket
-func (adm *AdminClient) HealBucket(bucket string, dryrun bool) error {
-	// Construct query params.
-	queryVal := url.Values{}
-	queryVal.Set("heal", "")
-	queryVal.Set(string(healBucket), bucket)
-	if dryrun {
-		queryVal.Set(string(healDryRun), "")
+// HealStop - stop a heal task
+func (adm *AdminClient) HealStop(bucket, prefix string) error {
+
+	path := "/v1/heal/" + bucket
+	if bucket != "" && prefix != "" {
+		path += "/" + prefix
 	}
 
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "bucket")
-
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
-	}
-
-	// Execute POST on /?heal&bucket=mybucket to heal a bucket.
-	resp, err := adm.executeMethod("POST", reqData)
+	// execute DELETE request to heal api
+	resp, err := adm.executeMethod("DELETE", requestData{
+		relPath: path,
+	})
 
 	defer closeResponse(resp)
 	if err != nil {
@@ -435,295 +103,188 @@ func (adm *AdminClient) HealBucket(bucket string, dryrun bool) error {
 	if resp.StatusCode != http.StatusOK {
 		return httpRespToErrorResponse(resp)
 	}
-
 	return nil
 }
 
-// HealUpload - Heal the given upload.
-func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool) (HealResult, error) {
-	// Construct query params.
-	queryVal := url.Values{}
-	queryVal.Set("heal", "")
-	queryVal.Set(string(healBucket), bucket)
-	queryVal.Set(string(healObject), object)
-	queryVal.Set(string(healUploadID), uploadID)
-	if dryrun {
-		queryVal.Set(string(healDryRun), "")
-	}
+// HealStatistics - heal sequence summary stats
+type HealStatistics struct {
+	// Specifies if drive metadata was healed
+	DriveMetadataHealed bool `json:"drive_metadata_healed"`
 
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "upload")
+	NumBucketsScanned int64 `json:"buckets_scanned"`
 
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
-	}
+	// Number of buckets which were healed on at least 1 disk
+	NumBucketsHealed int64 `json:"buckets_healed"`
 
-	// Execute POST on
-	// /?heal&bucket=mybucket&object=myobject&upload-id=uploadID
-	// to heal an upload.
-	resp, err := adm.executeMethod("POST", reqData)
+	// total bytes of object data scanned (accumulates object
+	// size, not part file sizes)
+	ObjectBytesScanned int64 `json:"object_bytes_scanned"`
 
-	defer closeResponse(resp)
-	if err != nil {
-		return HealResult{}, err
-	}
+	NumObjectsScanned int64 `json:"objects_scanned"`
 
-	if resp.StatusCode != http.StatusOK {
-		return HealResult{}, httpRespToErrorResponse(resp)
-	}
+	// Number of objects healed on at least 1 disk
+	NumObjectsHealed int64 `json:"objects_healed"`
 
-	// Healing is not performed so heal object result is empty.
-	if dryrun {
-		return HealResult{}, nil
-	}
+	// Map of number of online drives to number of objects with
+	// that many online drives.
+	ObjectsByOnlineDrives map[int]int64 `json:"objects_by_online_drives"`
 
-	jsonBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return HealResult{}, err
-	}
+	NumUploadsScanned int64 `json:"multipart_uploads_scanned"`
 
-	healResult := HealResult{}
-	err = json.Unmarshal(jsonBytes, &healResult)
-	if err != nil {
-		return HealResult{}, err
-	}
-
-	return healResult, nil
+	// Number of multipart uploads healed on at least 1 disk
+	NumUploadsHealed int64 `json:"multipart_uploads_healed"`
 }
 
-// HealResult - represents result of heal-object admin API.
-type HealResult struct {
-	State HealState `json:"state"`
+// NewHealStatistics - returns an initialized statistics object
+func NewHealStatistics() *HealStatistics {
+	return &HealStatistics{
+		ObjectsByOnlineDrives: make(map[int]int64),
+	}
 }
 
-// HealState - different states of heal operation
-type HealState int
+// UpdateHealStats - update statistics based on given heal result
+func (s *HealStatistics) UpdateHealStats(numDisks int, r HealResultItem) error {
+	onlineBefore, onlineAfter := r.GetOnlineCounts()
+	switch {
+	case r.Type == HealItemMetadata && r.Detail == "disk-format":
+		s.DriveMetadataHealed = true
 
+	case r.Type == HealItemBucket:
+		s.NumBucketsScanned++
+		if onlineAfter > onlineBefore {
+			s.NumBucketsHealed++
+		}
+
+	case r.Type == HealItemMultipartUpload:
+		s.NumUploadsScanned++
+		if onlineAfter > onlineBefore {
+			s.NumUploadsHealed++
+		}
+
+	case r.Type == HealItemObject || r.Type == HealItemBucketMetadata:
+		s.NumObjectsScanned++
+		if onlineAfter > onlineBefore {
+			s.NumObjectsHealed++
+		}
+		s.ObjectsByOnlineDrives[onlineAfter]++
+
+		// accumulate object size
+		s.ObjectBytesScanned += r.ObjectSize
+
+	default:
+		return fmt.Errorf(
+			"Unknown heal result type (this is a bug): %#v", r)
+	}
+	return nil
+}
+
+// HealTaskStatus - status struct for a heal task
+type HealTaskStatus struct {
+	Summary        string    `json:"Summary"`
+	FailureDetail  string    `json:"Detail"`
+	StartTime      time.Time `json:"StartTime"`
+	HealSettings   HealOpts  `json:"Settings"`
+	NumDisks       int       `json:"NumDisks"`
+	NumParityDisks int       `json:"NumParityDisks"`
+
+	Items []HealResultItem `json:"Items,omitempty"`
+
+	Statistics HealStatistics `json:"HealStatistics"`
+}
+
+// HealItemType - specify the type of heal operation in a healing
+// result
+type HealItemType string
+
+// HealItemType constants
 const (
-	// HealNone - none of the disks healed
-	HealNone HealState = iota
-	// HealPartial - some disks were healed, others were offline
-	HealPartial
-	// HealOK - all disks were healed
-	HealOK
+	HealItemMetadata        HealItemType = "metadata"
+	HealItemBucket                       = "bucket"
+	HealItemBucketMetadata               = "bucket-metadata"
+	HealItemObject                       = "object"
+	HealItemMultipartUpload              = "multipart-upload"
 )
 
-// HealObject - Heal the given object.
-func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) (HealResult, error) {
-	// Construct query params.
-	queryVal := url.Values{}
-	queryVal.Set("heal", "")
-	queryVal.Set(string(healBucket), bucket)
-	queryVal.Set(string(healObject), object)
-	if dryrun {
-		queryVal.Set(string(healDryRun), "")
-	}
+// Drive state constants
+const (
+	OnlineDriveState  string = "online"
+	OfflineDriveState        = "offline"
+	CorruptDriveState        = "corrupt"
+)
 
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "object")
-
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
-	}
-
-	// Execute POST on /?heal&bucket=mybucket&object=myobject to heal an object.
-	resp, err := adm.executeMethod("POST", reqData)
-
-	defer closeResponse(resp)
-	if err != nil {
-		return HealResult{}, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return HealResult{}, httpRespToErrorResponse(resp)
-	}
-
-	// Healing is not performed so heal object result is empty.
-	if dryrun {
-		return HealResult{}, nil
-	}
-
-	jsonBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return HealResult{}, err
-	}
-
-	healResult := HealResult{}
-	err = json.Unmarshal(jsonBytes, &healResult)
-	if err != nil {
-		return HealResult{}, err
-	}
-
-	return healResult, nil
+// HealResultItem - struct for an individual heal result item
+type HealResultItem struct {
+	ResultIndex int64        `json:"resultId"`
+	Type        HealItemType `json:"type"`
+	Bucket      string       `json:"bucket"`
+	Object      string       `json:"object"`
+	Detail      string       `json:"detail"`
+	DriveInfo   struct {
+		// below maps are from drive endpoint to drive state
+		Before map[string]string `json:"before"`
+		After  map[string]string `json:"after"`
+	} `json:"drives"`
+	ObjectSize int64 `json:"objectSize"`
 }
 
-// HealFormat - heal storage format on available disks.
-func (adm *AdminClient) HealFormat(dryrun bool) error {
-	queryVal := url.Values{}
-	queryVal.Set("heal", "")
-	if dryrun {
-		queryVal.Set(string(healDryRun), "")
-	}
-
-	// Set x-minio-operation to format.
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "format")
-
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
-	}
-
-	// Execute POST on /?heal to heal storage format.
-	resp, err := adm.executeMethod("POST", reqData)
-
-	defer closeResponse(resp)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return httpRespToErrorResponse(resp)
-	}
-
-	return nil
+// InitDrives - initialize maps used to represent drive info
+func (hri *HealResultItem) InitDrives() {
+	hri.DriveInfo.Before = make(map[string]string)
+	hri.DriveInfo.After = make(map[string]string)
 }
 
-// mkUploadsHealQuery - helper function to construct query params for
-// ListUploadsHeal API.
-func mkUploadsHealQuery(bucket, prefix, marker, uploadIDMarker, delimiter, maxUploadsStr string) url.Values {
+// GetOnlineCounts - returns the number of online disks before and
+// after heal
+func (hri *HealResultItem) GetOnlineCounts() (b, a int) {
+	if hri == nil {
+		return
+	}
+	for _, v := range hri.DriveInfo.Before {
+		if v == OnlineDriveState {
+			b++
+		}
+	}
+	for _, v := range hri.DriveInfo.After {
+		if v == OnlineDriveState {
+			a++
+		}
+	}
+	return
+}
+
+// HealStatus - Fetch status of a heal sequence
+func (adm *AdminClient) HealStatus(bucket, prefix string, marker int64) (
+	res HealTaskStatus, err error) {
+
+	path := "/v1/heal/" + bucket
+	if bucket != "" && prefix != "" {
+		path += "/" + prefix
+	}
 
 	queryVal := make(url.Values)
-	queryVal.Set("heal", "")
-	queryVal.Set(string(healBucket), bucket)
-	queryVal.Set(string(healPrefix), prefix)
-	queryVal.Set(string(healMarker), marker)
-	queryVal.Set(string(healUploadIDMarker), uploadIDMarker)
-	queryVal.Set(string(healDelimiter), delimiter)
-	queryVal.Set(string(healMaxUpload), maxUploadsStr)
-	return queryVal
-}
-
-func (adm *AdminClient) listUploadsHeal(bucket, prefix, marker, uploadIDMarker, delimiter string, maxUploads int) (listUploadsHealResponse, error) {
-	// Construct query params.
-	maxUploadsStr := fmt.Sprintf("%d", maxUploads)
-	queryVal := mkUploadsHealQuery(bucket, prefix, marker, uploadIDMarker, delimiter, maxUploadsStr)
-
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "list-uploads")
-
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
+	if marker != -1 {
+		queryVal.Set("marker", fmt.Sprintf("%d", marker))
 	}
-
-	// Empty 'list' of objects to be healed.
-	toBeHealedUploads := listUploadsHealResponse{}
-
-	// Execute GET on /?heal to list objects needing heal.
-	resp, err := adm.executeMethod("GET", reqData)
+	// execute POST request to heal api
+	resp, err := adm.executeMethod("GET", requestData{
+		relPath:     path,
+		queryValues: queryVal,
+	})
 
 	defer closeResponse(resp)
 	if err != nil {
-		return listUploadsHealResponse{}, err
+		return res, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return toBeHealedUploads, httpRespToErrorResponse(resp)
-
+		return res, httpRespToErrorResponse(resp)
 	}
 
-	err = xml.NewDecoder(resp.Body).Decode(&toBeHealedUploads)
+	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return listUploadsHealResponse{}, err
+		return res, err
 	}
 
-	return toBeHealedUploads, nil
-}
-
-// ListUploadsHeal - issues list heal uploads API request
-func (adm *AdminClient) ListUploadsHeal(bucket, prefix string, recursive bool,
-	doneCh <-chan struct{}) (<-chan UploadInfo, error) {
-
-	// Default listing is delimited at "/"
-	delimiter := "/"
-	if recursive {
-		// If recursive we do not delimit.
-		delimiter = ""
-	}
-
-	uploadIDMarker := ""
-
-	// Allocate new list objects channel.
-	uploadStatCh := make(chan UploadInfo, maxUploadsList)
-
-	// Initiate list objects goroutine here.
-	go func(uploadStatCh chan<- UploadInfo) {
-		defer close(uploadStatCh)
-		// Save marker for next request.
-		var marker string
-		for {
-			// Get list of objects a maximum of 1000 per request.
-			result, err := adm.listUploadsHeal(bucket, prefix, marker,
-				uploadIDMarker, delimiter, maxUploadsList)
-			if err != nil {
-				uploadStatCh <- UploadInfo{
-					Err: err,
-				}
-				return
-			}
-
-			// If contents are available loop through and
-			// send over channel.
-			for _, upload := range result.Uploads {
-				select {
-				// Send upload info.
-				case uploadStatCh <- UploadInfo{
-					Key:            upload.Key,
-					UploadID:       upload.UploadID,
-					Initiated:      upload.Initiated,
-					HealUploadInfo: upload.HealUploadInfo,
-				}:
-				// If receives done from the caller, return here.
-				case <-doneCh:
-					return
-				}
-			}
-
-			// Send all common prefixes if any.  NOTE:
-			// prefixes are only present if the request is
-			// delimited.
-			for _, prefix := range result.CommonPrefixes {
-				upload := UploadInfo{}
-				upload.Key = prefix.Prefix
-				select {
-				// Send object prefixes.
-				case uploadStatCh <- upload:
-				// If receives done from the caller, return here.
-				case <-doneCh:
-					return
-				}
-			}
-
-			// If next uploadID marker is present, set it
-			// for the next request.
-			if result.NextUploadIDMarker != "" {
-				uploadIDMarker = result.NextUploadIDMarker
-			}
-
-			// If next marker present, save it for next request.
-			if result.KeyMarker != "" {
-				marker = result.KeyMarker
-			}
-
-			// Listing ends result is not truncated,
-			// return right here.
-			if !result.IsTruncated {
-				return
-			}
-		}
-	}(uploadStatCh)
-	return uploadStatCh, nil
+	err = json.Unmarshal(respBytes, &res)
+	return res, err
 }

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"time"
 )
 
@@ -92,13 +91,7 @@ type ServerInfo struct {
 // ServerInfo - Connect to a minio server and call Server Info Management API
 // to fetch server's information represented by ServerInfo structure
 func (adm *AdminClient) ServerInfo() ([]ServerInfo, error) {
-	// Prepare web service request
-	reqData := requestData{}
-	reqData.queryValues = make(url.Values)
-	reqData.queryValues.Set("info", "")
-	reqData.customHeaders = make(http.Header)
-
-	resp, err := adm.executeMethod("GET", reqData)
+	resp, err := adm.executeMethod("GET", requestData{relPath: "/v1/info"})
 	defer closeResponse(resp)
 	if err != nil {
 		return nil, err

--- a/pkg/madmin/lock-commands.go
+++ b/pkg/madmin/lock-commands.go
@@ -82,24 +82,19 @@ func getLockInfos(body io.Reader) ([]VolumeLockInfo, error) {
 
 // ListLocks - Calls List Locks Management API to fetch locks matching
 // bucket, prefix and held before the duration supplied.
-func (adm *AdminClient) ListLocks(bucket, prefix string, duration time.Duration) ([]VolumeLockInfo, error) {
+func (adm *AdminClient) ListLocks(bucket, prefix string,
+	duration time.Duration) ([]VolumeLockInfo, error) {
+
 	queryVal := make(url.Values)
-	queryVal.Set("lock", "")
 	queryVal.Set("bucket", bucket)
 	queryVal.Set("prefix", prefix)
-	queryVal.Set("duration", duration.String())
+	queryVal.Set("older-than", duration.String())
 
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "list")
-
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
-	}
-
-	// Execute GET on /?lock to list locks.
-	resp, err := adm.executeMethod("GET", reqData)
-
+	// Execute GET on /minio/admin/v1/locks to list locks.
+	resp, err := adm.executeMethod("GET", requestData{
+		queryValues: queryVal,
+		relPath:     "/v1/locks",
+	})
 	defer closeResponse(resp)
 	if err != nil {
 		return nil, err
@@ -114,24 +109,19 @@ func (adm *AdminClient) ListLocks(bucket, prefix string, duration time.Duration)
 
 // ClearLocks - Calls Clear Locks Management API to clear locks held
 // on bucket, matching prefix older than duration supplied.
-func (adm *AdminClient) ClearLocks(bucket, prefix string, duration time.Duration) ([]VolumeLockInfo, error) {
+func (adm *AdminClient) ClearLocks(bucket, prefix string,
+	duration time.Duration) ([]VolumeLockInfo, error) {
+
 	queryVal := make(url.Values)
-	queryVal.Set("lock", "")
 	queryVal.Set("bucket", bucket)
 	queryVal.Set("prefix", prefix)
 	queryVal.Set("duration", duration.String())
 
-	hdrs := make(http.Header)
-	hdrs.Set(minioAdminOpHeader, "clear")
-
-	reqData := requestData{
-		queryValues:   queryVal,
-		customHeaders: hdrs,
-	}
-
 	// Execute POST on /?lock to clear locks.
-	resp, err := adm.executeMethod("POST", reqData)
-
+	resp, err := adm.executeMethod("DELETE", requestData{
+		queryValues: queryVal,
+		relPath:     "/v1/locks",
+	})
 	defer closeResponse(resp)
 	if err != nil {
 		return nil, err

--- a/pkg/madmin/utils.go
+++ b/pkg/madmin/utils.go
@@ -19,7 +19,7 @@ package madmin
 import (
 	"crypto/md5"
 	"crypto/sha256"
-	"encoding/xml"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net"
@@ -44,9 +44,9 @@ func sumMD5(data []byte) []byte {
 	return hash.Sum(nil)
 }
 
-// xmlDecoder provide decoded value in xml.
-func xmlDecoder(body io.Reader, v interface{}) error {
-	d := xml.NewDecoder(body)
+// jsonDecoder decode json to go type.
+func jsonDecoder(body io.Reader, v interface{}) error {
+	d := json.NewDecoder(body)
 	return d.Decode(v)
 }
 

--- a/pkg/madmin/version-commands.go
+++ b/pkg/madmin/version-commands.go
@@ -1,0 +1,54 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package madmin
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+// AdminAPIVersionInfo - contains admin API version information
+type AdminAPIVersionInfo struct {
+	Version string `json:"version"`
+}
+
+// VersionInfo - Connect to minio server and call the version API to
+// retrieve the server API version
+func (adm *AdminClient) VersionInfo() (verInfo AdminAPIVersionInfo, err error) {
+	var resp *http.Response
+	resp, err = adm.executeMethod("GET", requestData{relPath: "/version"})
+	defer closeResponse(resp)
+	if err != nil {
+		return verInfo, err
+	}
+
+	// Check response http status code
+	if resp.StatusCode != http.StatusOK {
+		return verInfo, httpRespToErrorResponse(resp)
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return verInfo, err
+	}
+
+	// Unmarshal the server's json response
+	err = json.Unmarshal(respBytes, &verInfo)
+	return verInfo, err
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
* Move Admin APIs to new endpoint starting with `/minio/admin/v1`.
* Add admin version endpoint at `/minio/admin/version`
* Change heal related APIs to work like a server-side background service. Now it has heal-start, heal-stop and heal-status-fetch operations.


## Description
<!--- Describe your changes in detail -->
This change is a rewrite of the Minio server administration APIs.

Admin APIs are now versioned, and this change brings in version 1.

Technical details about the REST API implemented in this PR are documented temporarily at https://gist.github.com/donatello/e520308bf83adddc70366ea01ef505e5

Non-heal admin APIs are moved to new endpoints and have a more REST API style using JSON to encode parameters.

Heal APIs are reimplemented like a server-side background service. Three operations are possible - start a heal sequence (with various options at a path), stop a heal sequence (stops when the server reaches the earliest safe point), and to fetch status/progress information on a heal sequence.
 
Each heal sequence starts by healing disk formats, then heals the bucket specified or all buckets if none are specified, and then heals objects at and under a given (possible empty) prefix. Two heal operations on overlapping paths (i.e. specified bucket and object prefix combination) may not be started (and the implementation will return an error in such cases).

A heal sequence may be stopped by invoking the heal-stop API. In this case, the server aborts the heal operation only at the earliest safe point reached (i.e. between healing buckets or objects), since it may be in the process of mutating on-disk data. 

Heal results are sent to the client when the client invokes the fetch-heal-status API. Heal results include details of each operation performed by the server, in the form of object level heal-result records. In addition statistics of the aggregate of heal operations performed in this heal sequence are also sent back in each fetch-status request.

The client is required to acknowledge results it receives from the server, so that the server can remove consumed records. The server accumulates records until the client consumes them, upto a limit of 1000 records at which point, the server pauses the heal sequence waiting for the client to catch up. After a timeout with no records consumed by the client, the heal sequence aborts.

When the `statisticsOnly` option is specified, no details of heal-operations are sent back to the client. Only statistics are sent. In this case, the client need not acknowledge consumption of results.

~TODOs:~
* ~Add support for healing parts in an in-progress multipart upload.~
* ~Update `madmin` package documentation in codebase.~

EDIT: Handling of unrecoverable objects requires some discussion and is deferred to after getting this change in.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Brings REST-style Admin APIs. Heal APIs are now easier to use, consisting of just three high-level operations - start a heal sequence, stop a heal sequence and fetch status data about a heal operation.

Context of earlier heal proposal - https://gist.github.com/krishnasrinivas/4b216a6ec03925645253788d8e0e241d

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested. 
~TODO: more unit tests to be added.~
New test cases are added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.