### PR TITLE
Improve FreeBSD installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,20 @@ minio.exe server D:\Photos
 Install minio packages using [pkg](https://github.com/freebsd/pkg)
 
 ```sh
-pkg install minio
+pkg install minio minio-client
 sysrc minio_enable=yes
 sysrc minio_disks=/home/user/Photos
+chown minio:minio /home/user/Photos
 service minio start
 ```
+
+On FreeBSD, minio service starts using configuration files from `/usr/local/etc/minio/config.json`, with:
+
+* Credentials
+* Region
+* Browser
+* Logging
+* Notify
 
 ## Install from Source
 


### PR DESCRIPTION
When started as a service, minio runs with the unpriviledged minio user. The file system must belong to that user. Minio service also runs with a pre built configuration file that might need editing.


## Description
Documentation improvement

## Motivation and Context
The current documentation does not allow minio to start as a service on FreeBSD because of permission issues

## How Has This Been Tested?

Tested while setting up a FreeBSD cluster

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.