### PR TITLE
Expose Content-Length header in CORS setting

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -270,11 +270,14 @@ var defaultAllowableHTTPMethods = []string{
 
 // setCorsHandler handler for CORS (Cross Origin Resource Sharing)
 func setCorsHandler(h http.Handler) http.Handler {
+	commonS3Headers := []string{"Content-Length", "Content-Type", "Connection",
+		"Date", "ETag", "Server", "x-amz-delete-marker", "x-amz-id-2",
+		"x-amz-request-id", "x-amz-version-id"}
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   defaultAllowableHTTPMethods,
 		AllowedHeaders:   []string{"*"},
-		ExposedHeaders:   []string{"ETag"},
+		ExposedHeaders:   commonS3Headers,
 		AllowCredentials: true,
 	})
 	return c.Handler(h)


### PR DESCRIPTION
fixes #4838

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When minio is accessed in browser using a JS lib like aws-sdk-js the browser does not expose content-length to JS unless there is a CORS setting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #4838

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.