### PR TITLE
add the mount-observe plug to the snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ minio server ~/Photos
 If you previously installed minio using `brew install minio` then reinstall minio from `minio/stable/minio` official repo. Homebrew builds are unstable due to golang 1.8 bugs.
 
 ```
-brew uninstall minio 
+brew uninstall minio
 brew install minio/stable/minio
-```  
+```
 
 ### Binary Download
 | Platform| Architecture | URL|
@@ -61,6 +61,12 @@ sudo snap install minio --edge
 ```
 
 Every time a new version of `minio` is pushed to the store, you will get it updated automatically.
+
+You will need to allow the minio snap to observe mounts in the system:
+
+```sh
+sudo snap connect minio:mount-observe
+```
 
 ## Microsoft Windows
 ### Binary Download

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,12 @@ confinement: strict
 apps:
   minio:
     command: minio
-    plugs: [home, removable-media, network, network-bind]
+    plugs:
+      - home
+      - mount-observe
+      - network
+      - network-bind
+      - removable-media
 
 parts:
   minio:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow the snap to observe mounts, and added the command the user needs to execute to connect this interface.

## Motivation and Context
Some users try to mount directories inside the minio backend, which leads to errors during basic operations, like put object. Minio reads /proc/mounts to be sure that the backend doesn't contain any mounted dirs.
Rename() between partitions doesn't work, that's why we need to do that check

Thanks to @vadmeste for that explanation.

The mount observe is not autoconnect unlike the other plugs minio is using, because it gives privileged read access to mount arguments and should only be used with trusted apps.

You can ask to become a trusted app and get this plug autoconnected by explaining in the [forum](https://forum.snapcraft.io) how you are using it. Our security team will review the post, your code, and the continuous delivery to grant it, and the user will always be in control to disconnect it.

## How Has This Been Tested?
I tested without the plug connected and got an error.
I connected the plug and could start the minio server without errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.