### PR TITLE
[security] rpc: Do not transfer access/secret key.

### DIFF
--- a/cmd/auth-rpc-client.go
+++ b/cmd/auth-rpc-client.go
@@ -99,21 +99,22 @@ func (authClient *AuthRPCClient) Login() (err error) {
 
 	// Attempt to login if not logged in already.
 	if authClient.authToken == "" {
-		// Login to authenticate and acquire a new auth token.
+		authClient.authToken, err = authenticateNode(authClient.config.accessKey, authClient.config.secretKey)
+		if err != nil {
+			return err
+		}
+		// Login to authenticate your token.
 		var (
 			loginMethod = authClient.config.serviceName + loginMethodName
 			loginArgs   = LoginRPCArgs{
-				Username:    authClient.config.accessKey,
-				Password:    authClient.config.secretKey,
+				AuthToken:   authClient.authToken,
 				Version:     Version,
 				RequestTime: UTCNow(),
 			}
-			loginReply = LoginRPCReply{}
 		)
-		if err = authClient.rpcClient.Call(loginMethod, &loginArgs, &loginReply); err != nil {
+		if err = authClient.rpcClient.Call(loginMethod, &loginArgs, &LoginRPCReply{}); err != nil {
 			return err
 		}
-		authClient.authToken = loginReply.AuthToken
 	}
 	return nil
 }

--- a/cmd/auth-rpc-server.go
+++ b/cmd/auth-rpc-server.go
@@ -20,8 +20,7 @@ package cmd
 const loginMethodName = ".Login"
 
 // AuthRPCServer RPC server authenticates using JWT.
-type AuthRPCServer struct {
-}
+type AuthRPCServer struct{}
 
 // Login - Handles JWT based RPC login.
 func (b AuthRPCServer) Login(args *LoginRPCArgs, reply *LoginRPCReply) error {
@@ -30,14 +29,10 @@ func (b AuthRPCServer) Login(args *LoginRPCArgs, reply *LoginRPCReply) error {
 		return err
 	}
 
-	// Authenticate using JWT.
-	token, err := authenticateNode(args.Username, args.Password)
-	if err != nil {
-		return err
+	// Return an error if token is not valid.
+	if !isAuthTokenValid(args.AuthToken) {
+		return errAuthentication
 	}
-
-	// Return the token.
-	reply.AuthToken = token
 
 	return nil
 }

--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -23,26 +23,6 @@ import (
 	"time"
 )
 
-// Login handler implements JWT login token generator, which upon login request
-// along with username and password is generated.
-func (br *browserPeerAPIHandlers) Login(args *LoginRPCArgs, reply *LoginRPCReply) error {
-	// Validate LoginRPCArgs
-	if err := args.IsValid(); err != nil {
-		return err
-	}
-
-	// Authenticate using JWT.
-	token, err := authenticateWeb(args.Username, args.Password)
-	if err != nil {
-		return err
-	}
-
-	// Return the token.
-	reply.AuthToken = token
-
-	return nil
-}
-
 // SetAuthPeerArgs - Arguments collection for SetAuth RPC call
 type SetAuthPeerArgs struct {
 	// For Auth

--- a/cmd/browser-peer-rpc_test.go
+++ b/cmd/browser-peer-rpc_test.go
@@ -91,9 +91,12 @@ func (s *TestRPCBrowserPeerSuite) testBrowserPeerRPC(t *testing.T) {
 	// Validate for failure in login handler with previous credentials.
 	rclient = newRPCClient(s.testAuthConf.serverAddr, s.testAuthConf.serviceEndpoint, false)
 	defer rclient.Close()
+	token, err := authenticateNode(creds.AccessKey, creds.SecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rargs := &LoginRPCArgs{
-		Username:    creds.AccessKey,
-		Password:    creds.SecretKey,
+		AuthToken:   token,
 		Version:     Version,
 		RequestTime: UTCNow(),
 	}
@@ -105,20 +108,18 @@ func (s *TestRPCBrowserPeerSuite) testBrowserPeerRPC(t *testing.T) {
 		}
 	}
 
+	token, err = authenticateNode(creds.AccessKey, creds.SecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Validate for success in loing handled with valid credetnails.
 	rargs = &LoginRPCArgs{
-		Username:    creds.AccessKey,
-		Password:    creds.SecretKey,
+		AuthToken:   token,
 		Version:     Version,
 		RequestTime: UTCNow(),
 	}
 	rreply = &LoginRPCReply{}
-	err = rclient.Call("BrowserPeer"+loginMethodName, rargs, rreply)
-	if err != nil {
+	if err = rclient.Call("BrowserPeer"+loginMethodName, rargs, rreply); err != nil {
 		t.Fatal(err)
-	}
-	// Validate all the replied fields after successful login.
-	if rreply.AuthToken == "" {
-		t.Fatalf("Generated token cannot be empty %s", errInvalidToken)
 	}
 }

--- a/cmd/browser-rpc-router.go
+++ b/cmd/browser-rpc-router.go
@@ -35,7 +35,7 @@ type browserPeerAPIHandlers struct {
 
 // Register RPC router
 func registerBrowserPeerRPCRouter(mux *router.Router) error {
-	bpHandlers := &browserPeerAPIHandlers{}
+	bpHandlers := &browserPeerAPIHandlers{AuthRPCServer{}}
 
 	bpRPCServer := newRPCServer()
 	err := bpRPCServer.RegisterName("BrowserPeer", bpHandlers)

--- a/cmd/lock-rpc-server_test.go
+++ b/cmd/lock-rpc-server_test.go
@@ -58,9 +58,12 @@ func createLockTestServer(t *testing.T) (string, *lockServer, string) {
 		},
 	}
 	creds := serverConfig.GetCredential()
+	token, err := authenticateNode(creds.AccessKey, creds.SecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 	loginArgs := LoginRPCArgs{
-		Username:    creds.AccessKey,
-		Password:    creds.SecretKey,
+		AuthToken:   token,
 		Version:     Version,
 		RequestTime: UTCNow(),
 	}
@@ -69,8 +72,6 @@ func createLockTestServer(t *testing.T) (string, *lockServer, string) {
 	if err != nil {
 		t.Fatalf("Failed to login to lock server - %v", err)
 	}
-	token := loginReply.AuthToken
-
 	return testPath, locker, token
 }
 

--- a/cmd/notifier-config.go
+++ b/cmd/notifier-config.go
@@ -235,10 +235,7 @@ func (n *notifier) Validate() error {
 	if err := n.MySQL.Validate(); err != nil {
 		return err
 	}
-	if err := n.MQTT.Validate(); err != nil {
-		return err
-	}
-	return nil
+	return n.MQTT.Validate()
 }
 
 func (n *notifier) SetAMQPByID(accountID string, amqpn amqpNotify) {

--- a/cmd/rpc-common.go
+++ b/cmd/rpc-common.go
@@ -60,8 +60,7 @@ type AuthRPCReply struct{}
 
 // LoginRPCArgs - login username and password for RPC.
 type LoginRPCArgs struct {
-	Username    string
-	Password    string
+	AuthToken   string
 	Version     string
 	RequestTime time.Time
 }
@@ -80,11 +79,8 @@ func (args LoginRPCArgs) IsValid() error {
 	return nil
 }
 
-// LoginRPCReply - login reply provides generated token to be used
-// with subsequent requests.
-type LoginRPCReply struct {
-	AuthToken string
-}
+// LoginRPCReply - login reply is a dummy struct perhaps for future use.
+type LoginRPCReply struct{}
 
 // LockArgs represents arguments for any authenticated lock RPC call.
 type LockArgs struct {

--- a/pkg/quick/quick.go
+++ b/pkg/quick/quick.go
@@ -92,12 +92,7 @@ func (d config) Save(filename string) error {
 func (d config) Load(filename string) error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
-
-	if err := loadFileConfig(filename, d.data); err != nil {
-		return err
-	}
-
-	return nil
+	return loadFileConfig(filename, d.data)
 }
 
 // Data - grab internal data map for reading


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is an improvement upon existing implementation
by avoiding transfer of access and secret keys over
the network. This change only exchanges JWT tokens
generated by an rpc client. Even if the JWT can be
traced over the network on a non-TLS connection, this
change makes sure that we never really expose the
secret key over the network.

<!--- Describe your changes in detail -->

## Motivation and Context
Securing network transfer.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.