### PR TITLE
Implement proper reConnect logic for amqp notification target.

### DIFF
--- a/cmd/notifiers.go
+++ b/cmd/notifiers.go
@@ -78,7 +78,7 @@ func isAMQPQueue(sqsArn arnSQS) bool {
 		errorIf(err, "Unable to connect to amqp service. %#v", amqpL)
 		return false
 	}
-	defer amqpC.Close()
+	defer amqpC.conn.Close()
 	return true
 }
 

--- a/cmd/notify-amqp_test.go
+++ b/cmd/notify-amqp_test.go
@@ -1,0 +1,57 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/streadway/amqp"
+)
+
+// Tests for is closed network error.
+func TestIsClosedNetworkErr(t *testing.T) {
+	testCases := []struct {
+		err     error
+		success bool
+	}{
+		{
+			err:     amqp.ErrClosed,
+			success: true,
+		},
+		{
+			err:     &net.OpError{Err: errors.New("use of closed network connection")},
+			success: true,
+		},
+		{
+			err:     nil,
+			success: false,
+		},
+		{
+			err:     errors.New("testing error"),
+			success: false,
+		},
+	}
+
+	for i, testCase := range testCases {
+		ok := isAMQPClosedNetworkErr(testCase.err)
+		if ok != testCase.success {
+			t.Errorf("Test %d: Expected %t, got %t", i+1, testCase.success, ok)
+		}
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implement proper reConnect logic for amqp notification target.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4597
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
By manually disconnecting and reconnecting, we should only see single active TCP connection at any given point in time when using AMQP notification target.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.