### PR TITLE
[WIP]: Switch to non-root user for new Minio Docker deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,20 @@ ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0
 
+COPY . /go/src/github.com/minio/minio
 WORKDIR /go/src/github.com/minio/
+
+# add our user and group first with fixed uid and gid, this ensures
+# multiple updates to the minio image dont have permission issues.
+RUN addgroup -g 190 -S minio && adduser -u 190 -S -G minio minio
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
 
 RUN  \
      apk add --no-cache ca-certificates && \
      apk add --no-cache --virtual .build-deps git go musl-dev && \
      echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-     go get -v -d github.com/minio/minio && \
      cd /go/src/github.com/minio/minio && \
      go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)" && \
      rm -rf /go/pkg /go/src /usr/local/go && apk del .build-deps

--- a/buildscripts/docker-entrypoint.sh
+++ b/buildscripts/docker-entrypoint.sh
@@ -22,6 +22,78 @@ if [ "${1}" != "minio" ]; then
     fi
 fi
 
+# helper function to check if a string contains another string
+string_match () { 
+    case "$2" in *$1*)
+        return 0
+    esac
+    return 1
+}
+
+# switch to non root (minio) user if there isn't an existing Minio data directory or
+# if its an empty data directory. We dont switch to minio user if there is an existing
+# data directory, this is because we'll need to chown all the files -- which may take 
+# too long, ruining the user's experience.
+docker_switch_non_root() {
+    arguments_processed=0
+    # loop through all the arguements
+    for var in "$@"
+    do
+        echo "1"
+        # ignore minio, server, gateway or minio server flags
+        if [ "${var}" = "minio" ] || [ "${var}" = "server" ] \
+            || [ "${var}" = "gateway" ] || string_match '--*' "${var}" || \
+            string_match ':*' "${var}" ; then
+            # count as processed
+            arguments_processed=$((arguments_processed+1))
+            echo "2"
+            continue
+        fi
+        # strip scheme and hostname if present in an arg
+        if [ "${var:0:4}" = "http" ]; then
+            echo "3"
+            echo "${var}"
+            if ! string_match "$(hostname)" "${var}"; then 
+                echo "Didnt match $(hostname) ""${var}"
+                continue
+            fi
+            var=$(printf -- "%s" "${var}" | cut -d/ -f4-)
+        fi
+        # if the given directory exists
+        if [ -d "${var}" ];then
+            echo "directory $var exists"
+            # if the directory is empty
+            if [ "$(ls -A $var)" = "" ]; then
+                echo "directory $var was empty so chowning"
+                # change owner to minio user
+                chown -R minio:minio "${var}"
+            fi 
+            # find the owner of the directory
+            owner=$(ls -ld "${var}" | awk '{print $3}')
+            # if minio is the owner, count as processed
+            if [ "${owner}" = "minio" ];then
+                echo "previous owner = minio"
+                arguments_processed=$((arguments_processed+1))
+            fi
+        else
+            echo "Created $var directory"
+            # if the directory doesn't exist, this is a new deployment.
+            mkdir -p "${var}"
+            # change owner to minio user
+            chown minio:minio "${var}"
+            # count as processed
+            arguments_processed=$((arguments_processed+1))
+        fi
+    done
+    # if all arguements are processed, and allowed, switch to minio user
+    if [ "${arguments_processed}" = $# ]; then
+        exec su-exec minio "$@"
+    else 
+        # else run as root user 
+        exec "$@"
+    fi
+}
+
 ## Look for docker secrets in default documented location.
 docker_secrets_env() {
     local MINIO_ACCESS_KEY_FILE="/run/secrets/access_key"
@@ -39,5 +111,5 @@ docker_secrets_env() {
 
 ## Set access env from secrets if necessary.
 docker_secrets_env
-
-exec "$@"
+## Switch to non root user minio if applicable.
+docker_switch_non_root "$@"


### PR DESCRIPTION
## Description
Docker [recommends](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#user) running as non-root if the service can run without privileges.
With this PR, we switch to non-root (minio) user while running inside a Docker
container, if there isn't an existing Minio data directory or if its an empty
data directory.

We don't switch to minio user if there is an existing data directory, this is because
we'll need to chown all the files, which may take too long, ruining user's experience.

## Motivation and Context
See: https://github.com/minio/minio/issues/4381

## How Has This Been Tested?
Manually with Docker. Testing ongoing with Kubernetes/Docker Swarm

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.