### PR TITLE
Lower object name length when running in docker to support aufs.

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1254,6 +1254,9 @@ func (s *TestSuiteCommon) TestPutObjectLongName(c *C) {
 	buffer := bytes.NewReader([]byte("hello world"))
 	// make long object name.
 	longObjName := fmt.Sprintf("%0255d/%0255d/%0255d", 1, 1, 1)
+	if IsDocker() || IsKubernetes() {
+		longObjName = fmt.Sprintf("%0242d/%0242d/%0242d", 1, 1, 1)
+	}
 	// create new HTTP request to insert the object.
 	request, err = newTestSignedRequest("PUT", getPutObjectURL(s.endPoint, bucketName, longObjName),
 		int64(buffer.Len()), buffer, s.accessKey, s.secretKey, s.signer)


### PR DESCRIPTION
## Description
Currently the `TestPutObjectLongName` will fail when ran in a docker container due to the file name length in [aufs](http://aufs.sourceforge.net/aufs3/man.html) which is being used by docker.

> Since aufs has several filename prefixes reserved, the maximum filename length is shorter than ordinary 255. Actually 242 (defined as ${AUFS_MAX_NAMELEN})


## Motivation and Context
In order to address the issue the length is lowered to 242 in the test since running the tests inside a docker container is relevant for CI purposes.

## How Has This Been Tested?
Tested manually and with Gitlab CI by running the tests inside a docker container using the [official golang:1.8.3](https://hub.docker.com/_/golang/) base image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.