### PR TITLE
Ignore reservedBucket checks for net/rpc requests

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -351,7 +351,7 @@ func gatewayMain(ctx *cli.Context, backendType gatewayBackend) {
 		// Redirect some pre-defined browser request paths to a static location prefix.
 		setBrowserRedirectHandler,
 		// Validates if incoming request is for restricted buckets.
-		setPrivateBucketHandler,
+		setReservedBucketHandler,
 		// Adds cache control for all browser requests.
 		setBrowserCacheControlHandler,
 		// Validates all incoming requests to have a valid date header.

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -156,6 +156,14 @@ func guessIsBrowserReq(req *http.Request) bool {
 	return strings.Contains(req.Header.Get("User-Agent"), "Mozilla")
 }
 
+// guessIsRPCReq - returns true if the request is for an RPC endpoint.
+func guessIsRPCReq(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	return req.Method == http.MethodConnect && req.Proto == "HTTP/1.0"
+}
+
 func (h redirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	aType := getRequestAuthType(r)
 	// Re-direct only for JWT and anonymous requests from browser.
@@ -202,20 +210,22 @@ func (h cacheControlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Adds verification for incoming paths.
-type minioPrivateBucketHandler struct {
+type minioReservedBucketHandler struct {
 	handler http.Handler
 }
 
-func setPrivateBucketHandler(h http.Handler) http.Handler {
-	return minioPrivateBucketHandler{h}
+func setReservedBucketHandler(h http.Handler) http.Handler {
+	return minioReservedBucketHandler{h}
 }
 
-func (h minioPrivateBucketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// For all non browser requests, reject access to 'minioReservedBucketPath'.
-	bucketName, _ := urlPath2BucketObjectName(r.URL)
-	if !guessIsBrowserReq(r) && (isMinioReservedBucket(bucketName) || isMinioMetaBucket(bucketName)) {
-		writeErrorResponse(w, ErrAllAccessDisabled, r.URL)
-		return
+func (h minioReservedBucketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !guessIsRPCReq(r) && !guessIsBrowserReq(r) {
+		// For all non browser, non RPC requests, reject access to 'minioReservedBucketPath'.
+		bucketName, _ := urlPath2BucketObjectName(r.URL)
+		if isMinioReservedBucket(bucketName) || isMinioMetaBucket(bucketName) {
+			writeErrorResponse(w, ErrAllAccessDisabled, r.URL)
+			return
+		}
 	}
 	h.handler.ServeHTTP(w, r)
 }

--- a/cmd/generic-handlers_test.go
+++ b/cmd/generic-handlers_test.go
@@ -69,6 +69,27 @@ func TestRedirectLocation(t *testing.T) {
 	}
 }
 
+// Tests request guess function for net/rpc requests.
+func TestGuessIsRPC(t *testing.T) {
+	if guessIsRPCReq(nil) {
+		t.Fatal("Unexpected return for nil request")
+	}
+	r := &http.Request{
+		Proto:  "HTTP/1.0",
+		Method: http.MethodConnect,
+	}
+	if !guessIsRPCReq(r) {
+		t.Fatal("Test shouldn't fail for a possible net/rpc request.")
+	}
+	r = &http.Request{
+		Proto:  "HTTP/1.1",
+		Method: http.MethodGet,
+	}
+	if guessIsRPCReq(r) {
+		t.Fatal("Test shouldn't report as net/rpc for a non net/rpc request.")
+	}
+}
+
 // Tests browser request guess function.
 func TestGuessIsBrowser(t *testing.T) {
 	if guessIsBrowserReq(nil) {

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -98,7 +98,7 @@ func configureServerHandler(endpoints EndpointList) (http.Handler, error) {
 		// Redirect some pre-defined browser request paths to a static location prefix.
 		setBrowserRedirectHandler,
 		// Validates if incoming request is for restricted buckets.
-		setPrivateBucketHandler,
+		setReservedBucketHandler,
 		// Adds cache control for all browser requests.
 		setBrowserCacheControlHandler,
 		// Validates all incoming requests to have a valid date header.

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -51,9 +51,9 @@ var errServerVersionMismatch = errors.New("Server versions do not match")
 // errServerTimeMismatch - server times are too far apart.
 var errServerTimeMismatch = errors.New("Server times are too far apart")
 
-// errReservedBucket - bucket name is reserved for Minio, usually
-// returned for 'minio', '.minio.sys'
-var errReservedBucket = errors.New("All access to this bucket is disabled")
+// errInvalidBucketName - bucket name is reserved for Minio, usually
+// returned for 'minio', '.minio.sys', buckets with capital letters.
+var errInvalidBucketName = errors.New("The specified bucket is not valid")
 
 // errInvalidRange - returned when given range value is not valid.
 var errInvalidRange = errors.New("Invalid range")

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -124,9 +124,9 @@ func (web *webAPIHandlers) MakeBucket(r *http.Request, args *MakeBucketArgs, rep
 		return toJSONError(errAuthentication)
 	}
 
-	// Check if bucket is a reserved bucket name.
-	if isMinioMetaBucket(args.BucketName) || isMinioReservedBucket(args.BucketName) {
-		return toJSONError(errReservedBucket)
+	// Check if bucket is a reserved bucket name or invalid.
+	if isReservedOrInvalidBucket(args.BucketName) {
+		return toJSONError(errInvalidBucketName)
 	}
 
 	bucketLock := globalNSMutex.NewNSLock(args.BucketName, "")
@@ -1048,10 +1048,10 @@ func toWebAPIError(err error) APIError {
 			HTTPStatusCode: http.StatusMethodNotAllowed,
 			Description:    err.Error(),
 		}
-	} else if err == errReservedBucket {
+	} else if err == errInvalidBucketName {
 		return APIError{
-			Code:           "AllAccessDisabled",
-			HTTPStatusCode: http.StatusForbidden,
+			Code:           "InvalidBucketName",
+			HTTPStatusCode: http.StatusBadRequest,
 			Description:    err.Error(),
 		}
 	} else if err == errInvalidArgument {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignore reservedBucket checks for net/rpc requests
<!--- Describe your changes in detail -->

## Motivation and Context
All `net/rpc` requests go to `/minio`, so the existing
generic handler for reserved bucket check would essentially
erroneously send errors leading to distributed setups to
wait infinitely.

For `net/rpc` requests alone we should skip this check and
allow resource bucket names to be from `/minio` .
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using the following script.

```sh
#!/bin/bash

$(minio server --address localhost:9001 https://localhost:9001/tmp/1/1 https://localhost:9002/tmp/2/2 https://localhost:9003/tmp/3/3 https://localhost:9004/tmp/4/4)&
$(minio server --address localhost:9002 https://localhost:9001/tmp/1/1 https://localhost:9002/tmp/2/2 https://localhost:9003/tmp/3/3 https://localhost:9004/tmp/4/4)&
$(minio server --address localhost:9003 https://localhost:9001/tmp/1/1 https://localhost:9002/tmp/2/2 https://localhost:9003/tmp/3/3 https://localhost:9004/tmp/4/4)&
minio server --address localhost:9004 https://localhost:9001/tmp/1/1 https://localhost:9002/tmp/2/2 https://localhost:9003/tmp/3/3 https://localhost:9004/tmp/4/4
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.