### PR TITLE
Increase default read/write timeouts from 30sec to 15minutes

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -64,8 +64,13 @@ const (
 	// Limit memory allocation to store multipart data
 	maxFormMemory = int64(5 * humanize.MiByte)
 
-	// The maximum allowed difference between the request generation time and the server processing time
-	globalMaxSkewTime = 15 * time.Minute
+	// The maximum allowed time difference between the incoming request
+	// date and server date during signature verification.
+	globalMaxSkewTime = 15 * time.Minute // 15 minutes skew allowed.
+
+	// Default Read/Write timeouts for each connection.
+	globalConnReadTimeout  = 15 * time.Minute // Timeout after 15 minutes of no data sent by the client.
+	globalConnWriteTimeout = 15 * time.Minute // Timeout after 15 minutes if no data received by the client.
 )
 
 var (
@@ -141,12 +146,9 @@ var (
 	globalObjectTimeout    = newDynamicTimeout( /*1*/ 10*time.Minute /*10*/, 600*time.Second)  // timeout for Object API related ops
 	globalOperationTimeout = newDynamicTimeout(10*time.Minute /*30*/, 600*time.Second)         // default timeout for general ops
 	globalHealingTimeout   = newDynamicTimeout(30*time.Minute /*1*/, 30*time.Minute)           // timeout for healing related ops
-)
 
-var (
-	// Keeps the connection active by waiting for following amount of time.
-	// Primarily used in ListenBucketNotification.
-	globalSNSConnAlive = 5 * time.Second
+	// Keep connection active for clients actively using ListenBucketNotification.
+	globalSNSConnAlive = 5 * time.Second // Send a whitespace every 5 seconds.
 )
 
 // global colors.

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -193,6 +193,8 @@ func serverMain(ctx *cli.Context) {
 	initGlobalAdminPeers(globalEndpoints)
 
 	globalHTTPServer = miniohttp.NewServer([]string{globalMinioAddr}, handler, globalTLSCertificate)
+	globalHTTPServer.ReadTimeout = globalConnReadTimeout
+	globalHTTPServer.WriteTimeout = globalConnWriteTimeout
 	globalHTTPServer.UpdateBytesReadFunc = globalConnStats.incInputBytes
 	globalHTTPServer.UpdateBytesWrittenFunc = globalConnStats.incOutputBytes
 	globalHTTPServer.ErrorLogFunc = errorIf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The default timeout of 30secs is not enough for high latency
environments, change these values to use 15 minutes instead.

With 30secs I/O timeouts seem to be quite common, this leads
to pretty much most SDKs and clients reconnect. This in-turn
causes significant performance problems. On a low latency
interconnect this can be quite challenging to transfer large
amounts of data. Setting this value to 15minutes covers
pretty much all known cases.

This PR was tested with `wondershaper <NIC> 20000 20000` by
limiting the network bandwidth to 20Mbit/sec. Default timeout
caused a significant amount of I/O timeouts, leading to
constant retires from the client. This seems to be more common
with tools like rclone, restic which have high concurrency set
by default. Once the value was fixed to 15minutes i/o timeouts
stopped and client could steadily upload data to the server
even while saturating the network.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4670

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.