### PR TITLE
s3: canonical resource string should not be unescaped

### DIFF
--- a/cmd/signature-v2.go
+++ b/cmd/signature-v2.go
@@ -290,13 +290,7 @@ func canonicalizedResourceV2(encodedPath string, encodedQuery string) string {
 			canonicalQueries = append(canonicalQueries, key)
 			continue
 		}
-		// Resources values should be unescaped
-		unescapedVal, err := url.QueryUnescape(val)
-		if err != nil {
-			errorIf(err, "Unable to unescape query value (query = `%s`, value = `%s`)", key, val)
-			continue
-		}
-		canonicalQueries = append(canonicalQueries, key+"="+unescapedVal)
+		canonicalQueries = append(canonicalQueries, key+"="+val)
 	}
 	if len(canonicalQueries) == 0 {
 		return encodedPath


### PR DESCRIPTION
In authentication v2 with query string, canonical resource string should not be unescaped per aws s3.

## Description
don't escape the canonical resource string 

## Motivation and Context
is different from aws s3, will cause signature mismatch err if query string has special character.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.