### PR TITLE
fs: make multipart clean config configurable

### DIFF
--- a/cmd/config-v19.go
+++ b/cmd/config-v19.go
@@ -51,6 +51,7 @@ type serverConfigV19 struct {
 
 	// Notification queue configuration.
 	Notify *notifier `json:"notify"`
+	Multipart *fsMultipart `json:"multipart"`
 }
 
 // GetVersion get current config version.
@@ -135,6 +136,7 @@ func newServerConfigV19() *serverConfigV19 {
 		Browser:    true,
 		Logger:     &loggers{},
 		Notify:     &notifier{},
+		Multipart:  &fsMultipart{},
 	}
 
 	// Enable console logger by default on a fresh run.

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -38,6 +38,12 @@ const (
 	fsMultipartCleanupInterval = time.Hour * 24 // 24 hrs.
 )
 
+type fsMultipart struct {
+        Expiry int64 `json:"expiry"`
+        CleanupInterval int64 `json:"cleanupInterval"`
+        Unit string `json:"unit"`
+}
+
 // Returns if the prefix is a multipart upload.
 func (fs fsObjects) isMultipartUpload(bucket, prefix string) bool {
 	uploadsIDPath := pathJoin(fs.fsPath, bucket, prefix, uploadsJSONFile)


### PR DESCRIPTION
make multipart clean config configurable

## Description
we can configure multipart clean config in config.json, which is smarter. And a new configuration entry 'unit' is also added to control the time unit of the config.

## Motivation and Context
currently, multipart clean config is static written in codes, we have to rebuild the executable if we want to change it
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.