### PR TITLE
Adjust dynamic timeout implementation to support 32-bit systems

### DIFF
--- a/cmd/dynamic-timeouts.go
+++ b/cmd/dynamic-timeouts.go
@@ -88,16 +88,16 @@ func (dt *dynamicTimeout) logEntry(duration time.Duration) {
 // previous results
 func (dt *dynamicTimeout) adjust(entries [dynamicTimeoutLogSize]time.Duration) {
 
-	failures, average := 0, 0
+	failures, average := 0, int64(0)
 	for i := 0; i < len(entries); i++ {
 		if entries[i] == maxDuration {
 			failures++
 		} else {
-			average += int(entries[i])
+			average += int64(entries[i])
 		}
 	}
 	if failures < len(entries) {
-		average /= len(entries) - failures
+		average /= int64(len(entries) - failures)
 	}
 
 	timeOutHitPct := float64(failures) / float64(len(entries))


### PR DESCRIPTION
## Description
The dynamic timeout implementation currently causes `TestDynamicTimeoutManyDecreases` to fail on 32-bit systems.
This pull request modifies the data type of the property average from int to int64 in order to make sure that the casting is done correctly on 32-bit systems.  

According to the [go tour](https://tour.golang.org/basics/11) : `The int, uint, and uintptr types are usually 32 bits wide on 32-bit systems and 64 bits wide on 64-bit systems.` which means that the type will vary between the systems.

## Motivation and Context
Changes were made to make `TestDynamicTimeoutManyDecreases` pass on 32-bit systems.

## How Has This Been Tested?
This was tested manually on a Raspberry Pi by running:
`$ go test -run TestDynamicTimeoutManyDecreases`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.