### PR TITLE
Remove pre go1.8 code and cleanup

### DIFF
--- a/cmd/notify-webhook_test.go
+++ b/cmd/notify-webhook_test.go
@@ -106,7 +106,7 @@ func TestLookupEndpoint(t *testing.T) {
 		},
 		{
 			endpoint: server.URL,
-			err:      fmt.Errorf("Unexpected response from webhook server %s: (400 Bad Request)", server.URL),
+			err:      fmt.Errorf("Unable to lookup webhook endpoint %s response(400 Bad Request)", server.URL),
 		},
 	}
 	for _, test := range testCases {


### PR DESCRIPTION
We don't need certain go1.7.x custom code anymore, since
we have migrated to go1.8

<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove pre go1.8 code and cleanup
<!--- Describe your changes in detail -->

## Motivation and Context
Migrate to go1.8 cleanup.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.