### PR TITLE
Removing 100MB part limit

### DIFF
--- a/docs/gateway/azure-limitations.md
+++ b/docs/gateway/azure-limitations.md
@@ -2,8 +2,7 @@
 
 Gateway inherits the following Azure limitations:
 
-- Maximum Multipart part size is 100MB.
-- Maximum Multipart object size is 10000*100 MB = 1TB
+- Maximum Multipart object size is 1TB
 - No support for prefix based bucket policies. Only top level bucket policy is supported.
 - Gateway restart implies all the ongoing multipart uploads must be restarted.
   i.e clients must again start with NewMultipartUpload


### PR DESCRIPTION
With https://github.com/minio/minio/pull/4869 maximum size of a single multipart upload part in not restricted to 100MB.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updating limits of Minio Gateway for Azure
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.