### PR TITLE
Remove list multipart uploads for XL

### DIFF
--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -1407,9 +1407,6 @@ func testAPICopyObjectPartHandler(obj ObjectLayer, instanceType, bucketName stri
 			if err != nil {
 				t.Fatalf("Test %d: %s: Failed to look for copied object part: <ERROR> %s", i+1, instanceType, err)
 			}
-			if instanceType != FSTestStr && len(results.Parts) != 1 {
-				t.Fatalf("Test %d: %s: Expected only one entry returned %d entries", i+1, instanceType, len(results.Parts))
-			}
 		}
 
 		// Verify response of the V2 signed HTTP request.

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -1402,8 +1402,7 @@ func testAPICopyObjectPartHandler(obj ObjectLayer, instanceType, bucketName stri
 		if rec.Code == http.StatusOK {
 			// See if the new part has been uploaded.
 			// testing whether the copy was successful.
-			var results ListPartsInfo
-			results, err = obj.ListObjectParts(testCase.bucketName, testObject, testCase.uploadID, 0, 1)
+			_, err = obj.ListObjectParts(testCase.bucketName, testObject, testCase.uploadID, 0, 1)
 			if err != nil {
 				t.Fatalf("Test %d: %s: Failed to look for copied object part: <ERROR> %s", i+1, instanceType, err)
 			}

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -373,32 +373,6 @@ func pickValidXLMeta(metaArr []xlMetaV1, modTime time.Time) (xmv xlMetaV1, e err
 // list of all errors that can be ignored in a metadata operation.
 var objMetadataOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errVolumeNotFound, errFileNotFound, errFileAccessDenied, errCorruptedFormat)
 
-// readXLMetaParts - returns the XL Metadata Parts from xl.json of one of the disks picked at random.
-func (xl xlObjects) readXLMetaParts(bucket, object string) (xlMetaParts []objectPartInfo, err error) {
-	var ignoredErrs []error
-	for _, disk := range xl.getLoadBalancedDisks() {
-		if disk == nil {
-			ignoredErrs = append(ignoredErrs, errDiskNotFound)
-			continue
-		}
-		xlMetaParts, err = readXLMetaParts(disk, bucket, object)
-		if err == nil {
-			return xlMetaParts, nil
-		}
-		// For any reason disk or bucket is not available continue
-		// and read from other disks.
-		if isErrIgnored(err, objMetadataOpIgnoredErrs...) {
-			ignoredErrs = append(ignoredErrs, err)
-			continue
-		}
-		// Error is not ignored, return right here.
-		return nil, err
-	}
-	// If all errors were ignored, reduce to maximal occurrence
-	// based on the read quorum.
-	return nil, reduceReadQuorumErrs(ignoredErrs, nil, xl.readQuorum)
-}
-
 // readXLMetaStat - return xlMetaV1.Stat and xlMetaV1.Meta from  one of the disks picked at random.
 func (xl xlObjects) readXLMetaStat(bucket, object string) (xlStat statInfo, xlMeta map[string]string, err error) {
 	var ignoredErrs []error

--- a/cmd/xl-v1-metadata_test.go
+++ b/cmd/xl-v1-metadata_test.go
@@ -156,32 +156,6 @@ func testXLReadMetaParts(obj ObjectLayer, instanceType string, disks []string, t
 			t.Fatalf("%s : %s", instanceType, perr)
 		}
 	}
-
-	uploadIDPath := path.Join(bucketNames[0], objectNames[0], uploadIDs[0])
-
-	_, err = obj.(*xlObjects).readXLMetaParts(minioMetaMultipartBucket, uploadIDPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Remove one disk.
-	removeDiskN(disks, 7)
-
-	// Removing disk shouldn't affect reading object parts info.
-	_, err = obj.(*xlObjects).readXLMetaParts(minioMetaMultipartBucket, uploadIDPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, disk := range disks {
-		os.RemoveAll(path.Join(disk, bucketNames[0]))
-		os.RemoveAll(path.Join(disk, minioMetaMultipartBucket, bucketNames[0]))
-	}
-
-	_, err = obj.(*xlObjects).readXLMetaParts(minioMetaMultipartBucket, uploadIDPath)
-	if errorCause(err) != errFileNotFound {
-		t.Fatal(err)
-	}
 }
 
 // Test xlMetaV1.AddObjectPart()

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -273,189 +273,26 @@ func commitXLMetadata(disks []StorageAPI, srcBucket, srcPrefix, dstBucket, dstPr
 	return evalDisks(disks, mErrs), err
 }
 
-// listMultipartUploads - lists all multipart uploads.
-func (xl xlObjects) listMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
-	result := ListMultipartsInfo{
-		IsTruncated: true,
-		MaxUploads:  maxUploads,
-		KeyMarker:   keyMarker,
-		Prefix:      prefix,
-		Delimiter:   delimiter,
-	}
-
-	recursive := true
-	if delimiter == slashSeparator {
-		recursive = false
-	}
-
-	// Not using path.Join() as it strips off the trailing '/'.
-	multipartPrefixPath := pathJoin(bucket, prefix)
-	if prefix == "" {
-		// Should have a trailing "/" if prefix is ""
-		// For ex. multipartPrefixPath should be "multipart/bucket/" if prefix is ""
-		multipartPrefixPath += slashSeparator
-	}
-	multipartMarkerPath := ""
-	if keyMarker != "" {
-		multipartMarkerPath = pathJoin(bucket, keyMarker)
-	}
-	var uploads []uploadMetadata
-	var err error
-	var eof bool
-	// List all upload ids for the keyMarker starting from
-	// uploadIDMarker first.
-	if uploadIDMarker != "" {
-		// hold lock on keyMarker path
-		keyMarkerLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
-			pathJoin(bucket, keyMarker))
-		if err = keyMarkerLock.GetRLock(globalListingTimeout); err != nil {
-			return lmi, err
-		}
-		for _, disk := range xl.getLoadBalancedDisks() {
-			if disk == nil {
-				continue
-			}
-			uploads, _, err = listMultipartUploadIDs(bucket, keyMarker, uploadIDMarker, maxUploads, disk)
-			if err == nil {
-				break
-			}
-			if isErrIgnored(err, objMetadataOpIgnoredErrs...) {
-				continue
-			}
-			break
-		}
-		keyMarkerLock.RUnlock()
-		if err != nil {
-			return lmi, err
-		}
-		maxUploads = maxUploads - len(uploads)
-	}
-	var walkerCh chan treeWalkResult
-	var walkerDoneCh chan struct{}
-	heal := false // true only for xl.ListObjectsHeal
-	// Validate if we need to list further depending on maxUploads.
-	if maxUploads > 0 {
-		walkerCh, walkerDoneCh = xl.listPool.Release(listParams{minioMetaMultipartBucket, recursive, multipartMarkerPath, multipartPrefixPath, heal})
-		if walkerCh == nil {
-			walkerDoneCh = make(chan struct{})
-			isLeaf := xl.isMultipartUpload
-			listDir := listDirFactory(isLeaf, xlTreeWalkIgnoredErrs, xl.getLoadBalancedDisks()...)
-			walkerCh = startTreeWalk(minioMetaMultipartBucket, multipartPrefixPath, multipartMarkerPath, recursive, listDir, isLeaf, walkerDoneCh)
-		}
-		// Collect uploads until we have reached maxUploads count to 0.
-		for maxUploads > 0 {
-			walkResult, ok := <-walkerCh
-			if !ok {
-				// Closed channel.
-				eof = true
-				break
-			}
-			// For any walk error return right away.
-			if walkResult.err != nil {
-				return lmi, walkResult.err
-			}
-			entry := strings.TrimPrefix(walkResult.entry, retainSlash(bucket))
-			// For an entry looking like a directory, store and
-			// continue the loop not need to fetch uploads.
-			if hasSuffix(walkResult.entry, slashSeparator) {
-				uploads = append(uploads, uploadMetadata{
-					Object: entry,
-				})
-				maxUploads--
-				if maxUploads == 0 {
-					eof = true
-					break
-				}
-				continue
-			}
-			var newUploads []uploadMetadata
-			var end bool
-			uploadIDMarker = ""
-
-			// For the new object entry we get all its
-			// pending uploadIDs.
-			entryLock := globalNSMutex.NewNSLock(minioMetaMultipartBucket,
-				pathJoin(bucket, entry))
-			if err = entryLock.GetRLock(globalListingTimeout); err != nil {
-				return lmi, err
-			}
-			var disk StorageAPI
-			for _, disk = range xl.getLoadBalancedDisks() {
-				if disk == nil {
-					continue
-				}
-				newUploads, end, err = listMultipartUploadIDs(bucket, entry, uploadIDMarker, maxUploads, disk)
-				if err == nil {
-					break
-				}
-				if isErrIgnored(err, objMetadataOpIgnoredErrs...) {
-					continue
-				}
-				break
-			}
-			entryLock.RUnlock()
-			if err != nil {
-				if isErrIgnored(err, xlTreeWalkIgnoredErrs...) {
-					continue
-				}
-				return lmi, err
-			}
-			uploads = append(uploads, newUploads...)
-			maxUploads -= len(newUploads)
-			if end && walkResult.end {
-				eof = true
-				break
-			}
-		}
-	}
-	// For all received uploads fill in the multiparts result.
-	for _, upload := range uploads {
-		var objectName string
-		var uploadID string
-		if hasSuffix(upload.Object, slashSeparator) {
-			// All directory entries are common prefixes.
-			uploadID = "" // For common prefixes, upload ids are empty.
-			objectName = upload.Object
-			result.CommonPrefixes = append(result.CommonPrefixes, objectName)
-		} else {
-			uploadID = upload.UploadID
-			objectName = upload.Object
-			result.Uploads = append(result.Uploads, upload)
-		}
-		result.NextKeyMarker = objectName
-		result.NextUploadIDMarker = uploadID
-	}
-
-	if !eof {
-		// Save the go-routine state in the pool so that it can continue from where it left off on
-		// the next request.
-		xl.listPool.Set(listParams{bucket, recursive, result.NextKeyMarker, prefix, heal}, walkerCh, walkerDoneCh)
-	}
-
-	result.IsTruncated = !eof
-	// Result is not truncated, reset the markers.
-	if !result.IsTruncated {
-		result.NextKeyMarker = ""
-		result.NextUploadIDMarker = ""
-	}
-	return result, nil
-}
-
-// ListMultipartUploads - lists all the pending multipart uploads on a
-// bucket. Additionally takes 'prefix, keyMarker, uploadIDmarker and a
-// delimiter' which allows us to list uploads match a particular
-// prefix or lexically starting from 'keyMarker' or delimiting the
-// output to get a directory like listing.
-//
-// Implements S3 compatible ListMultipartUploads API. The resulting
-// ListMultipartsInfo structure is unmarshalled directly into XML and
-// replied back to the client.
+// ListMultipartUploads - returns empty response always. The onus is
+// on applications to remember uploadId of the multipart uploads that
+// are in progress.
 func (xl xlObjects) ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (lmi ListMultipartsInfo, e error) {
-	if err := checkListMultipartArgs(bucket, prefix, keyMarker, uploadIDMarker, delimiter, xl); err != nil {
-		return lmi, err
+	if e = checkListMultipartArgs(bucket, prefix, keyMarker, uploadIDMarker, delimiter, xl); e != nil {
+		return lmi, e
 	}
 
-	return xl.listMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
+	if _, err := xl.getBucketInfo(bucket); err != nil {
+		return lmi, toObjectErr(err, bucket)
+	}
+
+	return ListMultipartsInfo{
+		Prefix:         prefix,
+		KeyMarker:      keyMarker,
+		UploadIDMarker: uploadIDMarker,
+		Delimiter:      delimiter,
+		MaxUploads:     maxUploads,
+		IsTruncated:    false,
+	}, nil
 }
 
 // newMultipartUpload - wrapper for initializing a new multipart
@@ -767,76 +604,9 @@ func (xl xlObjects) PutObjectPart(bucket, object, uploadID string, partID int, s
 	}, nil
 }
 
-// listObjectParts - wrapper reading `xl.json` for a given object and
-// uploadID. Lists all the parts captured inside `xl.json` content.
-func (xl xlObjects) listObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (lpi ListPartsInfo, e error) {
-	result := ListPartsInfo{}
-
-	uploadIDPath := path.Join(bucket, object, uploadID)
-
-	xlParts, err := xl.readXLMetaParts(minioMetaMultipartBucket, uploadIDPath)
-	if err != nil {
-		return lpi, toObjectErr(err, minioMetaMultipartBucket, uploadIDPath)
-	}
-
-	// Populate the result stub.
-	result.Bucket = bucket
-	result.Object = object
-	result.UploadID = uploadID
-	result.MaxParts = maxParts
-
-	// For empty number of parts or maxParts as zero, return right here.
-	if len(xlParts) == 0 || maxParts == 0 {
-		return result, nil
-	}
-
-	// Limit output to maxPartsList.
-	if maxParts > maxPartsList {
-		maxParts = maxPartsList
-	}
-
-	// Only parts with higher part numbers will be listed.
-	partIdx := objectPartIndex(xlParts, partNumberMarker)
-	parts := xlParts
-	if partIdx != -1 {
-		parts = xlParts[partIdx+1:]
-	}
-	count := maxParts
-	for _, part := range parts {
-		var fi FileInfo
-		fi, err = xl.statPart(bucket, object, uploadID, part.Name)
-		if err != nil {
-			return lpi, toObjectErr(err, minioMetaBucket, path.Join(uploadID, part.Name))
-		}
-		result.Parts = append(result.Parts, PartInfo{
-			PartNumber:   part.Number,
-			ETag:         part.ETag,
-			LastModified: fi.ModTime,
-			Size:         part.Size,
-		})
-		count--
-		if count == 0 {
-			break
-		}
-	}
-	// If listed entries are more than maxParts, we set IsTruncated as true.
-	if len(parts) > len(result.Parts) {
-		result.IsTruncated = true
-		// Make sure to fill next part number marker if IsTruncated is
-		// true for subsequent listing.
-		nextPartNumberMarker := result.Parts[len(result.Parts)-1].PartNumber
-		result.NextPartNumberMarker = nextPartNumberMarker
-	}
-	return result, nil
-}
-
-// ListObjectParts - lists all previously uploaded parts for a given
-// object and uploadID.  Takes additional input of part-number-marker
-// to indicate where the listing should begin from.
-//
-// Implements S3 compatible ListObjectParts API. The resulting
-// ListPartsInfo structure is unmarshalled directly into XML and
-// replied back to the client.
+// ListObjectParts - returns empty response always. Applications are
+// expected to remember the uploaded part numbers and corresponding
+// etags.
 func (xl xlObjects) ListObjectParts(bucket, object, uploadID string, partNumberMarker, maxParts int) (lpi ListPartsInfo, e error) {
 	if err := checkListPartsArgs(bucket, object, xl); err != nil {
 		return lpi, err
@@ -854,8 +624,15 @@ func (xl xlObjects) ListObjectParts(bucket, object, uploadID string, partNumberM
 	if !xl.isUploadIDExists(bucket, object, uploadID) {
 		return lpi, traceError(InvalidUploadID{UploadID: uploadID})
 	}
-	result, err := xl.listObjectParts(bucket, object, uploadID, partNumberMarker, maxParts)
-	return result, err
+
+	// Return empty list parts response
+	return ListPartsInfo{
+		Bucket:           bucket,
+		Object:           object,
+		UploadID:         uploadID,
+		PartNumberMarker: 0,
+		MaxParts:         maxParts,
+	}, nil
 }
 
 // CompleteMultipartUpload - completes an ongoing multipart

--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -240,19 +240,6 @@ func xlMetaV1UnmarshalJSON(xlMetaBuf []byte) (xlMeta xlMetaV1, e error) {
 	return xlMeta, nil
 }
 
-// read xl.json from the given disk, parse and return xlV1MetaV1.Parts.
-func readXLMetaParts(disk StorageAPI, bucket string, object string) ([]objectPartInfo, error) {
-	// Reads entire `xl.json`.
-	xlMetaBuf, err := disk.ReadAll(bucket, path.Join(object, xlMetaJSONFile))
-	if err != nil {
-		return nil, traceError(err)
-	}
-	// obtain xlMetaV1{}.Partsusing `github.com/tidwall/gjson`.
-	xlMetaParts := parseXLParts(xlMetaBuf)
-
-	return xlMetaParts, nil
-}
-
 // read xl.json from the given disk and parse xlV1Meta.Stat and xlV1Meta.Meta using gjson.
 func readXLMetaStat(disk StorageAPI, bucket string, object string) (si statInfo, mp map[string]string, e error) {
 	// Reads entire `xl.json`.


### PR DESCRIPTION
Bring XL in sync with FS by removing ListMultipartUploads and ListObjectParts

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.