### PR TITLE
Provide the correct free block size volume/disk information

### DIFF
--- a/pkg/disk/stat_bsd.go
+++ b/pkg/disk/stat_bsd.go
@@ -29,11 +29,13 @@ func GetInfo(path string) (info Info, err error) {
 	if err != nil {
 		return Info{}, err
 	}
-	info = Info{}
-	info.Total = uint64(s.Bsize) * uint64(s.Blocks)
-	info.Free = uint64(s.Bsize) * uint64(s.Bavail)
-	info.Files = uint64(s.Files)
-	info.Ffree = uint64(s.Ffree)
-	info.FSType = getFSType(s.Fstypename)
+	fsReservedBlocks := uint64(s.Bfree) - uint64(s.Bavail)
+	info = Info{
+		Total:  uint64(s.Bsize) * (uint64(s.Blocks) - fsReservedBlocks),
+		Free:   uint64(s.Bsize) * uint64(s.Bavail),
+		Files:  uint64(s.Files),
+		Ffree:  uint64(s.Ffree),
+		FSType: getFSType(s.Fstypename),
+	}
 	return info, nil
 }

--- a/pkg/disk/stat_linux.go
+++ b/pkg/disk/stat_linux.go
@@ -29,11 +29,13 @@ func GetInfo(path string) (info Info, err error) {
 	if err != nil {
 		return Info{}, err
 	}
-	info = Info{}
-	info.Total = uint64(s.Bsize) * uint64(s.Blocks)
-	info.Free = uint64(s.Bsize) * uint64(s.Bavail)
-	info.Files = uint64(s.Files)
-	info.Ffree = uint64(s.Ffree)
-	info.FSType = getFSType(int64(s.Type))
+	fsReservedBlocks := uint64(s.Bfree) - uint64(s.Bavail)
+	info = Info{
+		Total:  uint64(s.Bsize) * (uint64(s.Blocks) - fsReservedBlocks),
+		Free:   uint64(s.Bsize) * uint64(s.Bavail),
+		Files:  uint64(s.Files),
+		Ffree:  uint64(s.Ffree),
+		FSType: getFSType(int64(s.Type)),
+	}
 	return info, nil
 }

--- a/pkg/disk/stat_openbsd.go
+++ b/pkg/disk/stat_openbsd.go
@@ -29,11 +29,13 @@ func GetInfo(path string) (info Info, err error) {
 	if err != nil {
 		return Info{}, err
 	}
-	info = Info{}
-	info.Total = uint64(s.F_bsize) * uint64(s.F_blocks)
-	info.Free = uint64(s.F_bsize) * uint64(s.F_bavail)
-	info.Files = uint64(s.F_files)
-	info.Ffree = uint64(s.F_ffree)
-	info.FSType = getFSType(s.F_fstypename)
+	fsReservedBlocks := uint64(s.F_bfree) - uint64(s.F_bavail)
+	info = Info{
+		Total:  uint64(s.F_bsize) * (uint64(s.F_blocks) - fsReservedBlocks),
+		Free:   uint64(s.F_bsize) * uint64(s.F_bavail),
+		Files:  uint64(s.F_files),
+		Ffree:  uint64(s.F_ffree),
+		FSType: getFSType(s.F_fstypename),
+	}
 	return info, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

On *NIX platforms the statfs(2) system call returns a struct containing both the
free blocks in the filesystem (Statfs_t.Bfree) and the free blocks available to
the unprivileged or non-superuser (Statfs_t.Bavail).

The `Bfree` and `Bavail` fields (with `Bfree >= Bavail`) will be set to
different values on e.g. filesystems such as ext4 that reserve a certain
percentage of the filesystem blocks which may only be allocated by admnistrative
privileged processes.

The calculations for the `Total` disk space need to subtract the difference
between the `Bfree` and `Bavail` fields for it to correctly show the total
available storage space available for unprivileged users.

This implicitly fixes a bug where the `Used = Total - Free` calculation yielded
different (and also incorrect) results for identical contents stored when only
the sizes of the disks or backing volumes differed. (as can be witnessed in the
`Used:` value displayed in the Minio browser)

See:
- https://wiki.archlinux.org/index.php/ext4#Reserved_blocks
- http://man7.org/linux/man-pages/man2/statfs.2.html
- https://man.openbsd.org/statfs
- http://lingrok.org/xref/coreutils/src/df.c#893

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When mirroring the exact contents of 2 Minio S3 instances I noticed that the output of the `Used:` Information in the Minio Browser differed when the backing storage sizes were different (e.g. 100G vs 500G). 

After verifying that the contents were transmitted correctly to the 2nd instance with the smaller backing storage and finding them identical, the output of a `du -hs /export` also showed the exact same used count.

Suspecting initially a bug in the calculation in the user interface, I finally found that the root cause was actually the incorrect usage of the _Bavail_ field instead of the _Bfree_ field as explained in the commit message.

Validating in how the `df` utility calculates its displayed _Used_ value, I devised the contributed patch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I built a Linux minio binary (CGO_ENABLED) using the patch from this PR using _Go 1.9_. I uploaded and tested it on both affected Minio setups where I then visually verified that the number of the `Used: ` output in the Minio Browser matches the _Used_  column of a `df -h /export` invocation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**N.B.:** This might subtly break external tests if they relied on the previous wrong value using e.g. the StorageInfo JSON-RPC call. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I couldn't find any information on _StorageInfo_ in the documentation so this change should not affect it.

I solely compiled and tested on Linux, but applied the fix for both BSD/Darwin (same field name as on Linux) and the OpenBSD flavor (F_bfree).

However, on both BSD platforms the typecast to _uint64_ is not strictly necessary anymore as the _Bfree_ and _F_bfree_ fields are of type _uint64_ different to their _Bavail_ fields that were of type _int64_, see:

- https://golang.org/src/syscall/ztypes_linux_amd64.go?#L123
- https://golang.org/src/syscall/ztypes_freebsd_amd64.go?#L103 
- https://golang.org/src/syscall/ztypes_openbsd_amd64.go?#L102

I tested with _Go 1.9_ where I ran into an (I believe) unrelated Go runtime specific implementation change. Negative offset errors are now seemingly reported more specifically from earlier Go versions and use `readat` as the operation (see: https://golang.org/src/os/file.go?h=negative+offset#L107):

```patch
diff --git a/cmd/posix_test.go b/cmd/posix_test.go
index d366fce7..91b87f74 100644
--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -20,6 +20,7 @@ import (
        "bytes"
        "crypto/rand"
        "encoding/hex"
+       "errors"
        "fmt"
        "io"
        "io/ioutil"
@@ -1030,9 +1031,9 @@ func TestPosixReadFile(t *testing.T) {
                                        }
                                }
                                return &os.PathError{
-                                       Op:   "read",
+                                       Op:   "readat",
                                        Path: slashpath.Join(path, "success-vol", "myobject"),
-                                       Err:  os.ErrInvalid,
+                                       Err:  errors.New("negative offset"),
                                }
                        }(),
                },
```
