### PR TITLE
Optimize healObject by eliminating extra data passes

### DIFF
--- a/cmd/erasure-healfile_test.go
+++ b/cmd/erasure-healfile_test.go
@@ -44,7 +44,7 @@ var erasureHealFileTests = []struct {
 	{dataBlocks: 5, disks: 10, offDisks: 3, badDisks: 1, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false},  // 3
 	{dataBlocks: 6, disks: 12, offDisks: 2, badDisks: 3, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: SHA256, shouldFail: false},                  // 4
 	{dataBlocks: 7, disks: 14, offDisks: 4, badDisks: 1, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false},  // 5
-	{dataBlocks: 8, disks: 16, offDisks: 6, badDisks: 1, badStaleDisks: 1, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: true},   // 6
+	{dataBlocks: 8, disks: 16, offDisks: 6, badDisks: 1, badStaleDisks: 1, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false},  // 6
 	{dataBlocks: 7, disks: 14, offDisks: 2, badDisks: 3, badStaleDisks: 0, blocksize: int64(oneMiByte / 2), size: oneMiByte, algorithm: BLAKE2b512, shouldFail: false},            // 7
 	{dataBlocks: 6, disks: 12, offDisks: 1, badDisks: 0, badStaleDisks: 1, blocksize: int64(oneMiByte - 1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: true}, // 8
 	{dataBlocks: 5, disks: 10, offDisks: 3, badDisks: 0, badStaleDisks: 3, blocksize: int64(oneMiByte / 2), size: oneMiByte, algorithm: SHA256, shouldFail: true},                 // 9
@@ -54,7 +54,7 @@ var erasureHealFileTests = []struct {
 	{dataBlocks: 7, disks: 14, offDisks: 3, badDisks: 4, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: BLAKE2b512, shouldFail: false},              // 13
 	{dataBlocks: 7, disks: 14, offDisks: 6, badDisks: 1, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false},  // 14
 	{dataBlocks: 8, disks: 16, offDisks: 4, badDisks: 5, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: true},   // 15
-	{dataBlocks: 2, disks: 4, offDisks: 0, badDisks: 0, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false},   // 16
+	{dataBlocks: 2, disks: 4, offDisks: 1, badDisks: 0, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false},   // 16
 	{dataBlocks: 2, disks: 4, offDisks: 0, badDisks: 0, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: 0, shouldFail: true},                         // 17
 	{dataBlocks: 12, disks: 16, offDisks: 2, badDisks: 1, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false}, // 18
 	{dataBlocks: 6, disks: 8, offDisks: 1, badDisks: 0, badStaleDisks: 0, blocksize: int64(blockSizeV1), size: oneMiByte, algorithm: BLAKE2b512, shouldFail: false},               // 19
@@ -130,7 +130,7 @@ func TestErasureHealFile(t *testing.T) {
 			// Verify that checksums of staleDisks
 			// match expected values
 			for i, disk := range staleDisks {
-				if disk == nil {
+				if disk == nil || info.Checksums[i] == nil {
 					continue
 				}
 				if !reflect.DeepEqual(info.Checksums[i], file.Checksums[i]) {

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -333,8 +333,7 @@ func quickHeal(storageDisks []StorageAPI, writeQuorum int, readQuorum int) error
 }
 
 // Heals an object only the corrupted/missing erasure blocks.
-func healObject(storageDisks []StorageAPI, bucket string, object string,
-	quorum int) (int, int, error) {
+func healObject(storageDisks []StorageAPI, bucket, object string, quorum int) (int, int, error) {
 
 	partsMetadata, errs := readAllXLMetadata(storageDisks, bucket, object)
 	// readQuorum suffices for xl.json since we use monotonic

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -333,25 +333,25 @@ func quickHeal(storageDisks []StorageAPI, writeQuorum int, readQuorum int) error
 }
 
 // Heals an object only the corrupted/missing erasure blocks.
-func healObject(storageDisks []StorageAPI, bucket string, object string, quorum int) (int, int, error) {
+func healObject(storageDisks []StorageAPI, bucket string, object string,
+	quorum int) (int, int, error) {
+
 	partsMetadata, errs := readAllXLMetadata(storageDisks, bucket, object)
 	// readQuorum suffices for xl.json since we use monotonic
 	// system time to break the tie when a split-brain situation
 	// arises.
-	if reducedErr := reduceReadQuorumErrs(errs, nil, quorum); reducedErr != nil {
-		return 0, 0, toObjectErr(reducedErr, bucket, object)
-	}
-
-	if !xlShouldHeal(storageDisks, partsMetadata, errs, bucket, object) {
-		// There is nothing to heal.
-		return 0, 0, nil
+	if rErr := reduceReadQuorumErrs(errs, nil, quorum); rErr != nil {
+		return 0, 0, toObjectErr(rErr, bucket, object)
 	}
 
 	// List of disks having latest version of the object.
 	latestDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
-	// List of disks having all parts as per latest xl.json.
-	availableDisks, errs, aErr := disksWithAllParts(latestDisks, partsMetadata, errs, bucket, object)
+	// List of disks having all parts as per latest xl.json - this
+	// does a full pass over the data and verifies all part files
+	// on disk
+	availableDisks, errs, aErr := disksWithAllParts(latestDisks, partsMetadata, errs, bucket,
+		object)
 	if aErr != nil {
 		return 0, 0, toObjectErr(aErr, bucket, object)
 	}
@@ -359,8 +359,7 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 	// Number of disks which don't serve data.
 	numOfflineDisks := 0
 	for index, disk := range storageDisks {
-		switch {
-		case disk == nil, errs[index] == errDiskNotFound:
+		if disk == nil || errs[index] == errDiskNotFound {
 			numOfflineDisks++
 		}
 	}
@@ -368,10 +367,14 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 	// Number of disks which have all parts of the given object.
 	numAvailableDisks := 0
 	for _, disk := range availableDisks {
-		switch {
-		case disk != nil:
+		if disk != nil {
 			numAvailableDisks++
 		}
+	}
+
+	if numAvailableDisks == len(storageDisks) {
+		// nothing to heal in this case
+		return 0, 0, nil
 	}
 
 	// If less than read quorum number of disks have all the parts
@@ -381,8 +384,8 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 	}
 
 	// List of disks having outdated version of the object or missing object.
-	outDatedDisks := outDatedDisks(storageDisks, availableDisks, errs, partsMetadata,
-		bucket, object)
+	outDatedDisks := outDatedDisks(storageDisks, availableDisks, errs, partsMetadata, bucket,
+		object)
 
 	// Number of disks that had outdated content of the given
 	// object and are online to be healed.
@@ -401,9 +404,10 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 	}
 
 	for index, disk := range outDatedDisks {
-		// Before healing outdated disks, we need to remove xl.json
-		// and part files from "bucket/object/" so that
-		// rename(minioMetaBucket, "tmp/tmpuuid/", "bucket", "object/") succeeds.
+		// Before healing outdated disks, we need to remove
+		// xl.json and part files from "bucket/object/" so
+		// that rename(minioMetaBucket, "tmp/tmpuuid/",
+		// "bucket", "object/") succeeds.
 		if disk == nil {
 			// Not an outdated disk.
 			continue
@@ -417,26 +421,14 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 			continue
 		}
 
-		// Outdated object with the same name exists that needs to be deleted.
-		outDatedMeta := partsMetadata[index]
-		// Consult valid metadata picked when there is no
-		// metadata available on this disk.
-		if isErr(errs[index], errFileNotFound) {
-			outDatedMeta = latestMeta
-		}
-
-		// Delete all the parts. Ignore if parts are not found.
-		for _, part := range outDatedMeta.Parts {
-			dErr := disk.DeleteFile(bucket, pathJoin(object, part.Name))
-			if dErr != nil && !isErr(dErr, errFileNotFound) {
-				return 0, 0, toObjectErr(traceError(dErr), bucket, object)
+		// List and delete the object directory, ignoring
+		// errors.
+		files, err := disk.ListDir(bucket, object)
+		if err == nil {
+			for _, entry := range files {
+				_ = disk.DeleteFile(bucket,
+					pathJoin(object, entry))
 			}
-		}
-
-		// Delete xl.json file. Ignore if xl.json not found.
-		dErr := disk.DeleteFile(bucket, pathJoin(object, xlMetaJSONFile))
-		if dErr != nil && !isErr(dErr, errFileNotFound) {
-			return 0, 0, toObjectErr(traceError(dErr), bucket, object)
 		}
 	}
 
@@ -445,16 +437,19 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 	outDatedDisks = shuffleDisks(outDatedDisks, latestMeta.Erasure.Distribution)
 	partsMetadata = shufflePartsMetadata(partsMetadata, latestMeta.Erasure.Distribution)
 
-	// We write at temporary location and then rename to fianal location.
+	// We write at temporary location and then rename to final location.
 	tmpID := mustGetUUID()
 
-	// Checksum of the part files. checkSumInfos[index] will contain checksums
-	// of all the part files in the outDatedDisks[index]
+	// Checksum of the part files. checkSumInfos[index] will
+	// contain checksums of all the part files in the
+	// outDatedDisks[index]
 	checksumInfos := make([][]ChecksumInfo, len(outDatedDisks))
 
-	// Heal each part. erasureHealFile() will write the healed part to
-	// .minio/tmp/uuid/ which needs to be renamed later to the final location.
-	storage, err := NewErasureStorage(latestDisks, latestMeta.Erasure.DataBlocks, latestMeta.Erasure.ParityBlocks)
+	// Heal each part. erasureHealFile() will write the healed
+	// part to .minio/tmp/uuid/ which needs to be renamed later to
+	// the final location.
+	storage, err := NewErasureStorage(latestDisks,
+		latestMeta.Erasure.DataBlocks, latestMeta.Erasure.ParityBlocks)
 	if err != nil {
 		return 0, 0, toObjectErr(err, bucket, object)
 	}
@@ -472,14 +467,33 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 			}
 		}
 		// Heal the part file.
-		file, hErr := storage.HealFile(outDatedDisks, bucket, pathJoin(object, partName), erasure.BlockSize, minioMetaTmpBucket, pathJoin(tmpID, partName), partSize, algorithm, checksums)
+		file, hErr := storage.HealFile(outDatedDisks, bucket, pathJoin(object, partName),
+			erasure.BlockSize, minioMetaTmpBucket, pathJoin(tmpID, partName), partSize,
+			algorithm, checksums)
 		if hErr != nil {
 			return 0, 0, toObjectErr(hErr, bucket, object)
 		}
-		for i := range outDatedDisks {
-			if outDatedDisks[i] != OfflineDisk {
-				checksumInfos[i] = append(checksumInfos[i], ChecksumInfo{partName, file.Algorithm, file.Checksums[i]})
+		// outDatedDisks that had write errors should not be
+		// written to for remaining parts, so we nil it out.
+		for i, disk := range outDatedDisks {
+			if disk == nil {
+				continue
 			}
+			// A non-nil stale disk which did not receive
+			// a healed part checksum had a write error.
+			if file.Checksums[i] == nil {
+				outDatedDisks[i] = nil
+				numHealedDisks--
+				continue
+			}
+			// append part checksums
+			checksumInfos[i] = append(checksumInfos[i],
+				ChecksumInfo{partName, file.Algorithm, file.Checksums[i]})
+		}
+
+		// If all disks are having errors, we give up.
+		if numHealedDisks == 0 {
+			return 0, 0, fmt.Errorf("all disks without up-to-date data had write errors")
 		}
 	}
 
@@ -493,7 +507,8 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 	}
 
 	// Generate and write `xl.json` generated from other disks.
-	outDatedDisks, aErr = writeUniqueXLMetadata(outDatedDisks, minioMetaTmpBucket, tmpID, partsMetadata, diskCount(outDatedDisks))
+	outDatedDisks, aErr = writeUniqueXLMetadata(outDatedDisks, minioMetaTmpBucket, tmpID,
+		partsMetadata, diskCount(outDatedDisks))
 	if aErr != nil {
 		return 0, 0, toObjectErr(aErr, bucket, object)
 	}
@@ -503,13 +518,10 @@ func healObject(storageDisks []StorageAPI, bucket string, object string, quorum 
 		if disk == nil {
 			continue
 		}
-		// Remove any lingering partial data from current namespace.
-		aErr = disk.DeleteFile(bucket, retainSlash(object))
-		if aErr != nil && aErr != errFileNotFound {
-			return 0, 0, toObjectErr(traceError(aErr), bucket, object)
-		}
+
 		// Attempt a rename now from healed data to final location.
-		aErr = disk.RenameFile(minioMetaTmpBucket, retainSlash(tmpID), bucket, retainSlash(object))
+		aErr = disk.RenameFile(minioMetaTmpBucket, retainSlash(tmpID), bucket,
+			retainSlash(object))
 		if aErr != nil {
 			return 0, 0, toObjectErr(traceError(aErr), bucket, object)
 		}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Eliminate extra data pass that was being done in `xlShouldHeal` in
  healObject, while still retaining the early return behaviour.

- Allow HealFile to work even if some staleDisks return errors.

- Use BitrotVerifier when verifying parts on disk.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Healing an object can be done with fewer passes that access data on disk:

1. First pass to verify all shards on disk don't have bitrot. This help identify disks on which healing is needed.
2. Next pass is to read valid data incrementally, reconstruct missing shards and write them to disk.

So two passes for reading data, and one pass to write reconstruct missing data are sufficient. Moreover, the second read pass happens simultaneously with the write pass but on different disks.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests are modified for the changed functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.