### PR TITLE
fs: support data IO sync through env MINIO_FSYNC

### DIFF
--- a/cmd/fs-v1-background-append.go
+++ b/cmd/fs-v1-background-append.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"syscall"
 	"reflect"
 	"sync"
 	"time"
@@ -236,5 +237,8 @@ func (fs fsObjects) appendPart(bucket, object, uploadID string, part objectPartI
 	}
 
 	_, err = io.CopyBuffer(wfile, file, buf)
+	if fsUseSync() {
+		syscall.Fsync(int(wfile.Fd()))
+	}
 	return err
 }

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 	pathutil "path"
 	"strings"
 	"time"
@@ -791,6 +792,10 @@ func (fs fsObjects) CompleteMultipartUpload(bucket string, object string, upload
 				fs.rwPool.Close(fsMetaPathMultipart)
 				return oi, toObjectErr(traceError(err), bucket, object)
 			}
+
+		        if fsUseSync() {
+				syscall.Fsync(int(wfile.Fd()))
+		        }
 
 			wfile.Close()
 			reader.Close()


### PR DESCRIPTION
Now, minio use buffer io when write temp data file, which might bring consistent issue. we add support for syncing IO through env in order to enhance consistence.

## Description
call Fsync when MINIO_FSYNC == true once all data in single http request is written into temp data file.
when MINIO_FSYNC is not specified to be true,  Fsync will not be called

## Motivation and Context
enhance consistence for minio over fs

## How Has This Been Tested?
once can do it as bellow:
MINIO_FSYNC=true ./minio server /mnt/minio/ -C ./

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.