### PR TITLE
Updated policy fetch to always fetch from disk instead of cache

### DIFF
--- a/cmd/bucket-policy.go
+++ b/cmd/bucket-policy.go
@@ -58,7 +58,13 @@ type policyChange struct {
 func (bp bucketPolicies) GetBucketPolicy(bucket string) *bucketPolicy {
 	bp.rwMutex.RLock()
 	defer bp.rwMutex.RUnlock()
-	return bp.bucketPolicyConfigs[bucket]
+  
+    	policy, err := readBucketPolicy(bucket,globalObjectAPI)
+    	if err != nil {
+		return nil
+	}
+  
+	return policy
 }
 
 // Set a new bucket policy for a bucket, this operation will overwrite


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed GetBucketPolicy to always read policy from JSON config on disk, via readBucketPolicy (and therefore readBucketPolicyJSON) instead of cached global variable.

## Motivation and Context

Workaround for 
 - https://github.com/minio/minio/issues/4957
 - https://github.com/minio/minio/issues/4458

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] All new and existing tests passed.