### PR TITLE
Fix signature v2 handling for resource names

### DIFF
--- a/cmd/signature-v2_test.go
+++ b/cmd/signature-v2_test.go
@@ -105,12 +105,17 @@ func TestDoesPresignedV2SignatureMatch(t *testing.T) {
 			},
 			expected: ErrSignatureDoesNotMatch,
 		},
-		// (6) Should error when the signature does not match.
+		// (6) Should not error signature matches with extra query params.
 		{
 			queryParams: map[string]string{
 				"response-content-disposition": "attachment; filename=\"4K%2d4M.txt\"",
 			},
 			expected: ErrNone,
+		},
+		// (7) Should not error signature matches with no special query params.
+		{
+			queryParams: map[string]string{},
+			expected:    ErrNone,
 		},
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously we were wrongly adding `?` as part
of the resource name, add a test case to check
if this is handled properly.

Thanks to @kannappanr for reproducing this.

Without this change presigned URL generated with following
command would fail with signature mismatch.
```
aws s3 presign s3://testbucket/functional-tests.sh
```
<!--- Describe your changes in detail -->

## Motivation and Context
Bug reproduced by @kannappanr 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and also using `go test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.