### PR TITLE
Fix S3-Gateway PutObject

### DIFF
--- a/cmd/gateway-s3_test.go
+++ b/cmd/gateway-s3_test.go
@@ -1,0 +1,58 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+)
+
+// Tests extracting md5/sha256 bytes.
+func TestGetMD5AndSha256Bytes(t *testing.T) {
+	testCases := []struct {
+		md5Hex    string
+		sha256Hex string
+		success   bool
+	}{
+		// Test 1: Hex encoding failure.
+		{
+			md5Hex:    "a",
+			sha256Hex: "b",
+			success:   false,
+		},
+		// Test 2: Hex encoding success.
+		{
+			md5Hex:    "91be0b892e47ede9de06aac14ca0369e",
+			sha256Hex: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			success:   true,
+		},
+		// Test 3: hex values are empty should return success.
+		{
+			md5Hex:    "",
+			sha256Hex: "",
+			success:   true,
+		},
+	}
+	for i, testCase := range testCases {
+		_, _, err := getMD5AndSha256SumBytes(testCase.md5Hex, testCase.sha256Hex)
+		if err != nil && testCase.success {
+			t.Errorf("Test %d: Expected success, but got failure %s", i+1, err)
+		}
+		if err == nil && !testCase.success {
+			t.Errorf("Test %d: Expected failure, but got success", i+1)
+		}
+	}
+}


### PR DESCRIPTION
## Description
PutObject and PutObjectPart should parse md5 and shaSum only if present in metadata/data. 

## Motivation and Context
See https://github.com/minio/minio-java/issues/615

## How Has This Been Tested?
Running `minio-java` functional tests. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.