### PR TITLE
Add bucketName checks for azure and s3 gateway in GetBucketInfo.

### DIFF
--- a/cmd/gateway-azure-anonymous.go
+++ b/cmd/gateway-azure-anonymous.go
@@ -133,10 +133,12 @@ func (a *azureObjects) AnonGetBucketInfo(bucket string) (bucketInfo BucketInfo, 
 	if err != nil {
 		return bucketInfo, traceError(err)
 	}
+
 	bucketInfo = BucketInfo{
 		Name:    bucket,
 		Created: t,
 	}
+
 	return bucketInfo, nil
 }
 

--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -327,6 +327,14 @@ func (a *azureObjects) MakeBucketWithLocation(bucket, location string) error {
 
 // GetBucketInfo - Get bucket metadata..
 func (a *azureObjects) GetBucketInfo(bucket string) (bi BucketInfo, e error) {
+	// Verify if bucket (container-name) is valid.
+	// IsValidBucketName has same restrictions as container names mentioned
+	// in azure documentation, so we will simply use the same function here.
+	// Ref - https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata
+	if !IsValidBucketName(bucket) {
+		return bi, traceError(BucketNameInvalid{Bucket: bucket})
+	}
+
 	// Azure does not have an equivalent call, hence use
 	// ListContainers with prefix
 	resp, err := a.client.ListContainers(storage.ListContainersParameters{

--- a/cmd/gateway-gcs-anonymous.go
+++ b/cmd/gateway-gcs-anonymous.go
@@ -135,8 +135,14 @@ func (l *gcsGateway) AnonGetBucketInfo(bucket string) (bucketInfo BucketInfo, er
 		return bucketInfo, gcsToObjectError(traceError(anonErrToObjectErr(resp.StatusCode, bucket)), bucket)
 	}
 
+	t, err := time.Parse(time.RFC1123, resp.Header.Get("Last-Modified"))
+	if err != nil {
+		return bucketInfo, traceError(err)
+	}
+
 	// Last-Modified date being returned by GCS
 	return BucketInfo{
-		Name: bucket,
+		Name:    bucket,
+		Created: t,
 	}, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Gateway interface implementations of GetBucketInfo() under
azure and s3 gateway did not perform any bucketname input
validation resulting in incorrect responses when the tests
are expecting InvalidBucketName.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #4983

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using relevant mint test.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.