### PR TITLE
Push max threads to little less than kernel limit

### DIFF
--- a/cmd/server-rlimit.go
+++ b/cmd/server-rlimit.go
@@ -16,9 +16,24 @@
 
 package cmd
 
-import "github.com/minio/minio/pkg/sys"
+import (
+	"runtime/debug"
+
+	"github.com/minio/minio/pkg/sys"
+)
 
 func setMaxResources() (err error) {
+	// Set the Go runtime max threads threshold to 90% of kernel setting.
+	// Do not return when an error when encountered since it is not a crucial task.
+	sysMaxThreads, mErr := sys.GetMaxThreads()
+	if mErr == nil {
+		minioMaxThreads := (sysMaxThreads * 90) / 100
+		// Only set max threads if it is greater than the default one
+		if minioMaxThreads > 10000 {
+			debug.SetMaxThreads(minioMaxThreads)
+		}
+	}
+
 	var maxLimit uint64
 
 	// Set open files limit to maximum.

--- a/pkg/sys/threads.go
+++ b/pkg/sys/threads.go
@@ -1,0 +1,38 @@
+// +build linux
+
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+// GetMaxThreads returns the maximum number of threads that the system can create.
+func GetMaxThreads() (int, error) {
+	sysMaxThreadsStr, err := ioutil.ReadFile("/proc/sys/kernel/threads-max")
+	if err != nil {
+		return 0, err
+	}
+	sysMaxThreads, err := strconv.Atoi(strings.TrimSpace(string(sysMaxThreadsStr)))
+	if err != nil {
+		return 0, err
+	}
+	return sysMaxThreads, nil
+}

--- a/pkg/sys/threads_other.go
+++ b/pkg/sys/threads_other.go
@@ -1,0 +1,26 @@
+// +build !linux
+
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sys
+
+import "errors"
+
+// GetMaxThreads returns the maximum number of threads that the system can create.
+func GetMaxThreads() (int, error) {
+	return 0, errors.New("getting max threads is not supported")
+}


### PR DESCRIPTION
## Description
Let Minio server use more threads than allowed by golang runtime. This
is important to better deal with high load.


## Motivation and Context
Fixes #4990 

## How Has This Been Tested?
Manually, by printing log

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.