### PR TITLE
Loosen RFC1123 and RFC1123Z time format parsing

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -241,8 +241,8 @@ func setTimeValidityHandler(h http.Handler) http.Handler {
 
 // Supported Amz date formats.
 var amzDateFormats = []string{
-	time.RFC1123,
-	time.RFC1123Z,
+	rfc1123Format,
+	rfc1123ZFormat,
 	iso8601Format,
 	// Add new AMZ date formats here.
 }

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -38,9 +38,14 @@ import (
 )
 
 // AWS Signature Version '4' constants.
+//
+// We define our own version of RFC1123(Z) to allow for single-digit days of
+// the month.
 const (
 	signV4Algorithm = "AWS4-HMAC-SHA256"
 	iso8601Format   = "20060102T150405Z"
+	rfc1123Format   = "Mon, _2 Jan 2006 15:04:05 MST"
+	rfc1123ZFormat  = "Mon, _2 Jan 2006 15:04:05 -0700"
 	yyyymmdd        = "20060102"
 )
 


### PR DESCRIPTION
Allow for single-digit days of the month when parsing HTTP requests. Closes #5007 

## Description
See #5007 

## Motivation and Context
See #5007 

## How Has This Been Tested?
Manually tested with git annex.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.