### PR TITLE
Figure out projectID for GCS automatically from credentials.json

### DIFF
--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -23,7 +23,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -64,6 +66,9 @@ const (
 
 	// The cleanup routine deletes files older than 2 weeks in minio.sys.tmp
 	gcsMultipartExpiry = time.Hour * 24 * 14
+
+	// Project ID key in credentials.json
+	gcsProjectIDKey = "project_id"
 )
 
 // Stored in gcs.json - Contents of this file is not used anywhere. It can be
@@ -248,11 +253,34 @@ type gcsGateway struct {
 
 const googleStorageEndpoint = "storage.googleapis.com"
 
+// Returns projectID from the GOOGLE_APPLICATION_CREDENTIALS file.
+func gcsParseProjectID(credsFile string) (projectID string, err error) {
+	contents, err := ioutil.ReadFile(credsFile)
+	if err != nil {
+		return projectID, err
+	}
+	googleCreds := make(map[string]string)
+	if err = json.Unmarshal(contents, &googleCreds); err != nil {
+		return projectID, err
+	}
+	return googleCreds[gcsProjectIDKey], err
+}
+
 // newGCSGateway returns gcs gatewaylayer
 func newGCSGateway(projectID string) (GatewayLayer, error) {
 	ctx := context.Background()
 
-	err := checkGCSProjectID(ctx, projectID)
+	var err error
+	if projectID == "" {
+		// If project ID is not provided on command line, we figure it out
+		// from the credentials.json file.
+		projectID, err = gcsParseProjectID(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = checkGCSProjectID(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gateway-gcs_test.go
+++ b/cmd/gateway-gcs_test.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -177,5 +179,32 @@ func TestFromMinioClientListBucketResultToV2Info(t *testing.T) {
 
 	if got := fromMinioClientListBucketResultToV2Info("testbucket", listBucketResult); !reflect.DeepEqual(got, listBucketV2Info) {
 		t.Errorf("fromMinioClientListBucketResultToV2Info() = %v, want %v", got, listBucketV2Info)
+	}
+}
+
+// Test for gcsParseProjectID
+func TestGCSParseProjectID(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	contents := `
+{
+  "type": "service_account",
+  "project_id": "miniotesting"
+}
+`
+	f.WriteString(contents)
+	projectID, err := gcsParseProjectID(f.Name())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if projectID != "miniotesting" {
+		t.Errorf(`Expected projectID value to be "miniotesting"`)
 	}
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -99,13 +99,13 @@ const gcsGatewayTemplate = `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} {{if .VisibleFlags}}[FLAGS]{{end}} PROJECTID
+  {{.HelpName}} {{if .VisibleFlags}}[FLAGS]{{end}} [PROJECTID]
 {{if .VisibleFlags}}
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}{{end}}
 PROJECTID:
-  GCS project id, there are no defaults this is mandatory.
+  GCS project-id should be provided if GOOGLE_APPLICATION_CREDENTIALS environmental variable is not set.
 
 ENVIRONMENT VARIABLES:
   ACCESS:
@@ -114,6 +114,9 @@ ENVIRONMENT VARIABLES:
 
   BROWSER:
      MINIO_BROWSER: To disable web browser access, set this value to "off".
+
+  GCS credentials file:
+     GOOGLE_APPLICATION_CREDENTIALS: Path to credentials.json
 
 EXAMPLES:
   1. Start minio gateway server for GCS backend.
@@ -277,7 +280,12 @@ func gcsGatewayMain(ctx *cli.Context) {
 		cli.ShowCommandHelpAndExit(ctx, "gcs", 1)
 	}
 
-	if !isValidGCSProjectIDFormat(ctx.Args().First()) {
+	projectID := ctx.Args().First()
+	if projectID == "" && os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+		errorIf(errGCSProjectIDNotFound, "project-id should be provided as argument or GOOGLE_APPLICATION_CREDENTIALS should be set with path to credentials.json")
+		cli.ShowCommandHelpAndExit(ctx, "gcs", 1)
+	}
+	if projectID != "" && !isValidGCSProjectIDFormat(projectID) {
 		errorIf(errGCSInvalidProjectID, "Unable to start GCS gateway with %s", ctx.Args().First())
 		cli.ShowCommandHelpAndExit(ctx, "gcs", 1)
 	}


### PR DESCRIPTION
fixes #5027

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We parse projectID from credentials.json file, hence it need not be passed in the command line if GOOGLE_APPLICATION_CREDENTIALS is set to the path of credentials.json

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual, unit testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.