### PR TITLE
Fix data race bug in the testcase TestHTTPListenerAcceptParallel

### DIFF
--- a/pkg/http/listener_test.go
+++ b/pkg/http/listener_test.go
@@ -734,7 +734,6 @@ func TestHTTPListenerAcceptParallel(t *testing.T) {
 	}
 
 	handleConnection := func(i int, wg *sync.WaitGroup, serverConn net.Conn, request, reply string) {
-		wg.Add(1)
 		defer wg.Done()
 
 		received, err := bufio.NewReader(serverConn).ReadString('\n')
@@ -778,12 +777,14 @@ func TestHTTPListenerAcceptParallel(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Test %d: accept: expected = <nil>, got = %v", i+1, err)
 			}
+			wg.Add(1)
 			go handleConnection(i, &wg, serverConn, "GET /2 HTTP/1.0\n", testCase.reply)
 
 			serverConn, err = listener.Accept()
 			if err != nil {
 				t.Fatalf("Test %d: accept: expected = <nil>, got = %v", i+1, err)
 			}
+			wg.Add(1)
 			go handleConnection(i, &wg, serverConn, "GET /1 HTTP/1.0\n", testCase.reply)
 
 			wg.Wait()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With current code there is a possibility of wg.Add being called at the same time of wg.Wait. This cause travis failure in one of the PRs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.