### PR TITLE
browser: Remove hardcoding of minioBrowserPrefix=/minio

### DIFF
--- a/browser/app/index.html
+++ b/browser/app/index.html
@@ -5,13 +5,13 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Minio Browser</title>
-        <link rel="stylesheet" href="/minio/loader.css" type="text/css">
+        <link rel="stylesheet" href="loader.css" type="text/css">
     </head>
 
     <body>
         <div class="page-load">
             <div class="pl-inner">
-                <img src="/minio/logo.svg" alt="">
+                <img src="logo.svg" alt="">
             </div>
         </div>
         <div id="root"></div>
@@ -27,19 +27,19 @@
                     <ul>
                         <li>
                             <a href="http://www.google.com/chrome/">
-                                <img src="/minio/chrome.png" alt="">
+                                <img src="chrome.png" alt="">
                                 <div>Chrome</div>
                             </a>
                         </li>
                         <li>
                             <a href="https://www.mozilla.org/en-US/firefox/new/">
-                                <img src="/minio/firefox.png" alt="">
+                                <img src="firefox.png" alt="">
                                 <div>Firefox</div>
                             </a>
                         </li>
                         <li>
                             <a href="https://www.apple.com/safari/">
-                                <img src="/minio/safari.png" alt="">
+                                <img src="safari.png" alt="">
                                 <div>Safari</div>
                             </a>
                         </li>
@@ -51,6 +51,6 @@
         <![endif]-->
 
         <script>currentUiVersion = 'MINIO_UI_VERSION'</script>
-        <script src="/minio/index_bundle.js"></script>
+        <script src="index_bundle.js"></script>
     </body>
 </html>

--- a/browser/app/index.js
+++ b/browser/app/index.js
@@ -81,7 +81,7 @@ ReactDOM.render((
   <Provider store={ store } web={ web }>
     <Router history={ browserHistory }>
       <Route path='/' component={ App }>
-        <Route path='minio' component={ App }>
+        <Route path={ minioBrowserPrefix } component={ App }>
           <IndexRoute component={ Browse } onEnter={ authNeeded } />
           <Route path='login' component={ Login } onEnter={ authNotNeeded } />
           <Route path=':bucket' component={ Browse } onEnter={ authNeeded } />

--- a/browser/app/js/actions.js
+++ b/browser/app/js/actions.js
@@ -465,7 +465,7 @@ export const uploadFile = (file, xhr) => {
   return (dispatch, getState) => {
     const {currentBucket, currentPath} = getState()
     const objectName = `${currentPath}${file.name}`
-    const uploadUrl = `${window.location.origin}/minio/upload/${currentBucket}/${objectName}`
+    const uploadUrl = `${window.location.origin}${minioBrowserPrefix}/upload/${currentBucket}/${objectName}`
     // The slug is a unique identifer for the file upload.
     const slug = `${currentBucket}-${currentPath}-${file.name}`
 

--- a/browser/app/js/components/Browse.js
+++ b/browser/app/js/components/Browse.js
@@ -157,7 +157,7 @@ export default class Browse extends React.Component {
         // Download the selected file.
         web.CreateURLToken()
           .then(res => {
-            let url = `${window.location.origin}/minio/download/${currentBucket}/${encPrefix}?token=${res.token}`
+            let url = `${window.location.origin}${minioBrowserPrefix}/download/${currentBucket}/${encPrefix}?token=${res.token}`
             window.location = url
           })
           .catch(err => dispatch(actions.showAlert({
@@ -433,8 +433,7 @@ export default class Browse extends React.Component {
     } else {
       web.CreateURLToken()
         .then(res => {
-          let requestUrl = location.origin + "/minio/zip?token=" + res.token
-
+          let requestUrl = location.origin + minioBrowserPrefix + "/zip?token=" + res.token
           this.xhr = new XMLHttpRequest()
           dispatch(actions.downloadSelected(requestUrl, req, this.xhr))
         })
@@ -503,7 +502,7 @@ export default class Browse extends React.Component {
                                 settingsFunc={ this.showSettings.bind(this) }
                                 logoutFunc={ this.logout.bind(this) } />
     } else {
-      loginButton = <a className='btn btn-danger' href='/minio/login'>Login</a>
+      loginButton = <a className='btn btn-danger' href={minioBrowserPrefix+'/login'}>Login</a>
     }
 
     if (web.LoggedIn()) {

--- a/browser/app/js/constants.js
+++ b/browser/app/js/constants.js
@@ -17,7 +17,9 @@
 // File for all the browser constants.
 
 // minioBrowserPrefix absolute path.
-export const minioBrowserPrefix = '/minio'
+var p = window.location.pathname
+export const minioBrowserPrefix = p.slice(0, p.indexOf("/", 1))
+
 export const READ_ONLY = 'readonly'
 export const WRITE_ONLY = 'writeonly'
 export const READ_WRITE = 'readwrite'

--- a/cmd/web-router.go
+++ b/cmd/web-router.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/handlers"
@@ -55,7 +56,7 @@ func assetFS() *assetfs.AssetFS {
 }
 
 // specialAssets are files which are unique files not embedded inside index_bundle.js.
-const specialAssets = "loader.css|logo.svg|firefox.png|safari.png|chrome.png|favicon.ico"
+const specialAssets = ".*index_bundle.*.js$|.*loader.css$|.*logo.svg$|.*firefox.png$|.*safari.png$|.*chrome.png$|.*favicon.ico$"
 
 // registerWebRouter - registers web router for serving minio browser.
 func registerWebRouter(mux *router.Router) error {
@@ -90,13 +91,20 @@ func registerWebRouter(mux *router.Router) error {
 	webBrowserRouter.Methods("POST").Path("/zip").Queries("token", "{token:.*}").HandlerFunc(web.DownloadZip)
 
 	// Add compression for assets.
-	compressedAssets := handlers.CompressHandler(http.StripPrefix(minioReservedBucketPath, http.FileServer(assetFS())))
+	h := http.FileServer(assetFS())
+	compressedAssets := handlers.CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := strings.LastIndex(r.URL.Path, slashSeparator)
+		if idx != -1 {
+			r.URL.Path = r.URL.Path[idx+1:]
+		}
+		h.ServeHTTP(w, r)
+	}))
 
 	// Serve javascript files and favicon from assets.
-	webBrowserRouter.Path(fmt.Sprintf("/{assets:[^/]+.js|%s}", specialAssets)).Handler(compressedAssets)
+	webBrowserRouter.Path(fmt.Sprintf("/{assets:%s}", specialAssets)).Handler(compressedAssets)
 
 	// Serve index.html for rest of the requests.
-	webBrowserRouter.Path("/{index:.*}").Handler(indexHandler{http.StripPrefix(minioReservedBucketPath, http.FileServer(assetFS()))})
+	webBrowserRouter.Path("/{index:.*}").Handler(indexHandler{http.StripPrefix(minioReservedBucketPath, h)})
 
 	return nil
 }


### PR DESCRIPTION
This enable reverse proxy of minio-browser. Fixes #5040

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Detailed explanation is available at: https://github.com/minio/minio/issues/5040

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual testing using nginx
```
http {
     server {
    	   listen       80;
	   location ~* ^/user1(.*)$ {
		rewrite ^/user1(.*)$ /minio$1 break;
		proxy_redirect     off;
		proxy_set_header Host $http_host;
		proxy_pass http://localhost:9000;
	   }
     }
}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.