### PR TITLE
Update docker swarm doc to use docker volume prune

### DIFF
--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -51,16 +51,13 @@ Remove the distributed Minio services and related network by
 ```shell
 docker stack rm minio_stack
 ```
-Swarm doesn't automatically remove host volumes created for services. This may lead to corruption when a new Minio service is created in the swarm. So, we recommend removing all the volumes used by Minio, manually. To do this, go to each node in the swarm and list the volumes by 
+Swarm doesn't automatically remove host volumes created for services. This may lead to corruption when a new Minio service is created in the swarm. So, we recommend removing all the volumes used by Minio, manually. To do this, logon to each node in the swarm and run
 
 ```shell
-docker volume ls
+docker volume prune
 ```
-Then remove `minio_stack` volumes by 
+This will remove all the volumes not associated with any container.
 
-```shell
-docker volume rm volume_name 
-```
 
 ### Notes
 


### PR DESCRIPTION
## Description
This PR updates the Docker Swarm deployment doc to indicate that users can use `docker volume prune` command to cleanup volumes from previous stacks.

## Motivation and Context
docker prune command is an improvement over previous two step process
of removal of unused volumes in Swarm.

## How Has This Been Tested?
Manually on a Swarm cluster

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.