### PR TITLE
Remove body from POST request in webhook

### DIFF
--- a/cmd/notify-webhook.go
+++ b/cmd/notify-webhook.go
@@ -91,10 +91,9 @@ func isNetErrorIgnored(err error) bool {
 }
 
 // Lookup endpoint address by successfully POSTting
-// a JSON which would send out minio release.
+// empty body.
 func lookupEndpoint(urlStr string) error {
-	minioRelease := bytes.NewReader([]byte(ReleaseTag))
-	req, err := http.NewRequest("POST", urlStr, minioRelease)
+	req, err := http.NewRequest("POST", urlStr, bytes.NewReader([]byte("")))
 	if err != nil {
 		return err
 	}
@@ -107,8 +106,8 @@ func lookupEndpoint(urlStr string) error {
 		},
 	}
 
-	// Set content-type.
-	req.Header.Set("Content-Type", "application/json")
+	// Set content-length to zero as there is no payload.
+	req.ContentLength = 0
 
 	// Set proper server user-agent.
 	req.Header.Set("User-Agent", globalServerUserAgent)


### PR DESCRIPTION
## Description
If webhook notification is configured, Minio server tries to lookup the
webhook endpoint by making a POST request with body set as releasetag.
We can remove the body from the POST request as the POST body does not
add any specific value.

This discussion on IETF group says empty POSTs are okay
http://lists.w3.org/Archives/Public/ietf-http-wg/2010JulSep/0272.html

## Motivation and Context
Fixes: https://github.com/minio/minio/issues/5066

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.