### PR TITLE
Fix s3MetaToAzureProperties Content-Md5 key

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -100,7 +100,7 @@ func s3MetaToAzureProperties(s3Metadata map[string]string) (storage.BlobMetadata
 		case k == "Content-Length":
 			// assume this doesn't fail
 			props.ContentLength, _ = strconv.ParseInt(v, 10, 64)
-		case k == "Content-MD5":
+		case k == "Content-Md5":
 			props.ContentMD5 = v
 		case k == "Content-Type":
 			props.ContentType = v

--- a/cmd/gateway-azure_test.go
+++ b/cmd/gateway-azure_test.go
@@ -82,6 +82,14 @@ func TestS3MetaToAzureProperties(t *testing.T) {
 			t.Fatalf("Test failed with unexpected error %s, expected UnsupportedMetadata", err)
 		}
 	}
+
+	headers = map[string]string{
+		"Content-MD5": "d41d8cd98f00b204e9800998ecf8427e",
+	}
+	_, props, _ := s3MetaToAzureProperties(headers)
+	if props.ContentMD5 != headers["Content-MD5"] {
+		t.Fatalf("Test failed, expected %s, got %s", headers["Content-MD5"], props.ContentMD5)
+	}
 }
 
 func TestAzurePropertiesToS3Meta(t *testing.T) {

--- a/cmd/gateway-azure_test.go
+++ b/cmd/gateway-azure_test.go
@@ -86,7 +86,10 @@ func TestS3MetaToAzureProperties(t *testing.T) {
 	headers = map[string]string{
 		"content-md5": "Dce7bmCX61zvxzP5QmfelQ==",
 	}
-	_, props, _ := s3MetaToAzureProperties(headers)
+	_, props, err := s3MetaToAzureProperties(headers)
+	if err != nil {
+		t.Fatalf("Test failed, with %s", err)
+	}
 	if props.ContentMD5 != headers["content-md5"] {
 		t.Fatalf("Test failed, expected %s, got %s", headers["content-md5"], props.ContentMD5)
 	}

--- a/cmd/gateway-azure_test.go
+++ b/cmd/gateway-azure_test.go
@@ -84,11 +84,11 @@ func TestS3MetaToAzureProperties(t *testing.T) {
 	}
 
 	headers = map[string]string{
-		"Content-MD5": "d41d8cd98f00b204e9800998ecf8427e",
+		"content-md5": "Dce7bmCX61zvxzP5QmfelQ==",
 	}
 	_, props, _ := s3MetaToAzureProperties(headers)
-	if props.ContentMD5 != headers["Content-MD5"] {
-		t.Fatalf("Test failed, expected %s, got %s", headers["Content-MD5"], props.ContentMD5)
+	if props.ContentMD5 != headers["content-md5"] {
+		t.Fatalf("Test failed, expected %s, got %s", headers["content-md5"], props.ContentMD5)
 	}
 }
 


### PR DESCRIPTION
## Description
The key was not correctly checked because we `CanonicalHeaderKey`ise it just before

## Motivation and Context
Fix a part of #4994 

## How Has This Been Tested?
Testing by putting some new object on Azure

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.