### PR TITLE
convert ETag properly for all gateways

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -162,11 +162,6 @@ func azurePropertiesToS3Meta(meta storage.BlobMetadata, props storage.BlobProper
 	return s3Metadata
 }
 
-// Append "-1" to etag so that clients do not interpret it as MD5.
-func azureToS3ETag(etag string) string {
-	return canonicalizeETag(etag) + "-1"
-}
-
 // azureObjects - Implements Object layer for Azure blob storage.
 type azureObjects struct {
 	gatewayUnsupported
@@ -420,7 +415,7 @@ func (a *azureObjects) ListObjects(bucket, prefix, marker, delimiter string, max
 				Name:            object.Name,
 				ModTime:         time.Time(object.Properties.LastModified),
 				Size:            object.Properties.ContentLength,
-				ETag:            azureToS3ETag(object.Properties.Etag),
+				ETag:            toS3ETag(object.Properties.Etag),
 				ContentType:     object.Properties.ContentType,
 				ContentEncoding: object.Properties.ContentEncoding,
 			})
@@ -510,7 +505,7 @@ func (a *azureObjects) GetObjectInfo(bucket, object string) (objInfo ObjectInfo,
 	objInfo = ObjectInfo{
 		Bucket:          bucket,
 		UserDefined:     meta,
-		ETag:            azureToS3ETag(blob.Properties.Etag),
+		ETag:            toS3ETag(blob.Properties.Etag),
 		ModTime:         time.Time(blob.Properties.LastModified),
 		Name:            object,
 		Size:            blob.Properties.ContentLength,
@@ -629,8 +624,7 @@ func (a *azureObjects) PutObjectPart(bucket, object, uploadID string, partID int
 
 	etag := data.MD5HexString()
 	if etag == "" {
-		// Generate random ETag.
-		etag = azureToS3ETag(getMD5Hash([]byte(mustGetUUID())))
+		etag = genETag()
 	}
 
 	subPartSize, subPartNumber := int64(azureBlockSize), 1

--- a/cmd/gateway-azure_test.go
+++ b/cmd/gateway-azure_test.go
@@ -25,23 +25,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/storage"
 )
 
-// Test azureToS3ETag.
-func TestAzureToS3ETag(t *testing.T) {
-	tests := []struct {
-		etag     string
-		expected string
-	}{
-		{`"etag"`, `etag-1`},
-		{"etag", "etag-1"},
-	}
-	for i, test := range tests {
-		got := azureToS3ETag(test.etag)
-		if got != test.expected {
-			t.Errorf("test %d: got:%s expected:%s", i+1, got, test.expected)
-		}
-	}
-}
-
 // Test canonical metadata.
 func TestS3MetaToAzureProperties(t *testing.T) {
 	headers := map[string]string{

--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -581,7 +581,7 @@ func (l *gcsGateway) ListObjects(bucket string, prefix string, marker string, de
 			Bucket:          attrs.Bucket,
 			ModTime:         attrs.Updated,
 			Size:            attrs.Size,
-			ETag:            fmt.Sprintf("%d", attrs.CRC32C),
+			ETag:            toS3ETag(fmt.Sprintf("%d", attrs.CRC32C)),
 			UserDefined:     attrs.Metadata,
 			ContentType:     attrs.ContentType,
 			ContentEncoding: attrs.ContentEncoding,
@@ -723,7 +723,7 @@ func fromGCSAttrsToObjectInfo(attrs *storage.ObjectAttrs) ObjectInfo {
 		Bucket:          attrs.Bucket,
 		ModTime:         attrs.Updated,
 		Size:            attrs.Size,
-		ETag:            fmt.Sprintf("%d", attrs.CRC32C),
+		ETag:            toS3ETag(fmt.Sprintf("%d", attrs.CRC32C)),
 		UserDefined:     attrs.Metadata,
 		ContentType:     attrs.ContentType,
 		ContentEncoding: attrs.ContentEncoding,
@@ -858,7 +858,7 @@ func (l *gcsGateway) PutObjectPart(bucket string, key string, uploadID string, p
 	etag := data.MD5HexString()
 	if etag == "" {
 		// Generate random ETag.
-		etag = getMD5Hash([]byte(mustGetUUID()))
+		etag = genETag()
 	}
 	object := l.client.Bucket(bucket).Object(gcsMultipartDataName(uploadID, partNumber, etag))
 	w := object.NewWriter(l.ctx)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -211,3 +211,21 @@ func checkURL(urlStr string) (*url.URL, error) {
 func UTCNow() time.Time {
 	return time.Now().UTC()
 }
+
+// genETag - generate UUID based ETag
+func genETag() string {
+	return toS3ETag(getMD5Hash([]byte(mustGetUUID())))
+}
+
+// toS3ETag - return checksum to ETag
+func toS3ETag(etag string) string {
+	etag = canonicalizeETag(etag)
+
+	if !strings.HasSuffix(etag, "-1") {
+		// Tools like s3cmd uses ETag as checksum of data to validate.
+		// Append "-1" to indicate ETag is not a checksum.
+		etag += "-1"
+	}
+
+	return etag
+}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -293,3 +293,22 @@ func TestDumpRequest(t *testing.T) {
 		t.Fatalf("Expected %#v, got %#v", expectedHeader, res.Header)
 	}
 }
+
+// Test toS3ETag()
+func TestToS3ETag(t *testing.T) {
+	testCases := []struct {
+		etag         string
+		expectedETag string
+	}{
+		{`"8019e762"`, `8019e762-1`},
+		{"5d57546eeb86b3eba68967292fba0644", "5d57546eeb86b3eba68967292fba0644-1"},
+		{`"8019e762-1"`, `8019e762-1`},
+		{"5d57546eeb86b3eba68967292fba0644-1", "5d57546eeb86b3eba68967292fba0644-1"},
+	}
+	for i, testCase := range testCases {
+		etag := toS3ETag(testCase.etag)
+		if etag != testCase.expectedETag {
+			t.Fatalf("test %v: expected: %v, got: %v", i+1, testCase.expectedETag, etag)
+		}
+	}
+}


### PR DESCRIPTION
Previously ID/ETag from backend service is used as is which causes
failure on s3cmd like tools where those tools use ETag as checksum to
validate data.  This is fixed by prepending "-1".

Refer minio/mint#193 minio/mint#201

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.