### PR TITLE
split hash.Reader logic into simple PUT and Gateway.

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -522,7 +522,7 @@ func (a *azureObjects) GetObjectInfo(bucket, object string) (objInfo ObjectInfo,
 
 // PutObject - Create a new blob with the incoming data,
 // uses Azure equivalent CreateBlockBlobFromReader.
-func (a *azureObjects) PutObject(bucket, object string, data *hash.Reader, metadata map[string]string) (objInfo ObjectInfo, err error) {
+func (a *azureObjects) PutObject(bucket, object string, data hash.Reader, metadata map[string]string) (objInfo ObjectInfo, err error) {
 	blob := a.client.GetContainerReference(bucket).GetBlobReference(object)
 	blob.Metadata, blob.Properties, err = s3MetaToAzureProperties(metadata)
 	if err != nil {
@@ -618,7 +618,7 @@ func (a *azureObjects) NewMultipartUpload(bucket, object string, metadata map[st
 }
 
 // PutObjectPart - Use Azure equivalent PutBlockWithLength.
-func (a *azureObjects) PutObjectPart(bucket, object, uploadID string, partID int, data *hash.Reader) (info PartInfo, err error) {
+func (a *azureObjects) PutObjectPart(bucket, object, uploadID string, partID int, data hash.Reader) (info PartInfo, err error) {
 	if err = a.checkUploadIDExists(bucket, object, uploadID); err != nil {
 		return info, err
 	}
@@ -627,7 +627,7 @@ func (a *azureObjects) PutObjectPart(bucket, object, uploadID string, partID int
 		return info, err
 	}
 
-	etag := data.MD5HexString()
+	etag := hex.EncodeToString(data.Etag())
 	if etag == "" {
 		// Generate random ETag.
 		etag = azureToS3ETag(getMD5Hash([]byte(mustGetUUID())))

--- a/cmd/gateway-b2.go
+++ b/cmd/gateway-b2.go
@@ -378,7 +378,7 @@ const (
 // Additionally this reader also verifies Hash encapsulated inside hash.Reader
 // at io.EOF if the verification failed we return an error and do not send
 // the content to server.
-func newB2Reader(r *h2.Reader, size int64) *B2Reader {
+func newB2Reader(r h2.Reader, size int64) *B2Reader {
 	return &B2Reader{
 		r:        r,
 		size:     size,
@@ -392,7 +392,7 @@ func newB2Reader(r *h2.Reader, size int64) *B2Reader {
 // Hash encapsulated inside hash.Reader at io.EOF if the verification
 // failed we return an error and do not send the content to server.
 type B2Reader struct {
-	r        *h2.Reader
+	r        h2.Reader
 	size     int64
 	sha1Hash hash.Hash
 
@@ -421,7 +421,7 @@ func (nb *B2Reader) Read(p []byte) (int, error) {
 }
 
 // PutObject uploads the single upload to B2 backend by using *b2_upload_file* API, uploads upto 5GiB.
-func (l *b2Objects) PutObject(bucket string, object string, data *h2.Reader, metadata map[string]string) (ObjectInfo, error) {
+func (l *b2Objects) PutObject(bucket string, object string, data h2.Reader, metadata map[string]string) (ObjectInfo, error) {
 	var objInfo ObjectInfo
 	bkt, err := l.Bucket(bucket)
 	if err != nil {
@@ -546,7 +546,7 @@ func (l *b2Objects) CopyObjectPart(srcBucket string, srcObject string, destBucke
 }
 
 // PutObjectPart puts a part of object in bucket, uses B2's LargeFile upload API.
-func (l *b2Objects) PutObjectPart(bucket string, object string, uploadID string, partID int, data *h2.Reader) (pi PartInfo, err error) {
+func (l *b2Objects) PutObjectPart(bucket string, object string, uploadID string, partID int, data h2.Reader) (pi PartInfo, err error) {
 	bkt, err := l.Bucket(bucket)
 	if err != nil {
 		return pi, err

--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -747,7 +748,7 @@ func (l *gcsGateway) GetObjectInfo(bucket string, object string) (ObjectInfo, er
 }
 
 // PutObject - Create a new object with the incoming data,
-func (l *gcsGateway) PutObject(bucket string, key string, data *hash.Reader, metadata map[string]string) (ObjectInfo, error) {
+func (l *gcsGateway) PutObject(bucket string, key string, data hash.Reader, metadata map[string]string) (ObjectInfo, error) {
 	// if we want to mimic S3 behavior exactly, we need to verify if bucket exists first,
 	// otherwise gcs will just return object not exist in case of non-existing bucket
 	if _, err := l.client.Bucket(bucket).Attrs(l.ctx); err != nil {
@@ -851,11 +852,11 @@ func (l *gcsGateway) checkUploadIDExists(bucket string, key string, uploadID str
 }
 
 // PutObjectPart puts a part of object in bucket
-func (l *gcsGateway) PutObjectPart(bucket string, key string, uploadID string, partNumber int, data *hash.Reader) (PartInfo, error) {
+func (l *gcsGateway) PutObjectPart(bucket string, key string, uploadID string, partNumber int, data hash.Reader) (PartInfo, error) {
 	if err := l.checkUploadIDExists(bucket, key, uploadID); err != nil {
 		return PartInfo{}, err
 	}
-	etag := data.MD5HexString()
+	etag := hex.EncodeToString(data.Etag())
 	if etag == "" {
 		// Generate random ETag.
 		etag = getMD5Hash([]byte(mustGetUUID()))

--- a/cmd/gateway-handlers.go
+++ b/cmd/gateway-handlers.go
@@ -308,7 +308,7 @@ func (api gatewayAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	hashReader, err := hash.NewReader(reader, size, md5hex, sha256hex)
+	hashReader, err := hash.NewGatewayReader(reader, size, md5hex, sha256hex)
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return

--- a/cmd/gateway-router.go
+++ b/cmd/gateway-router.go
@@ -31,7 +31,7 @@ type GatewayLayer interface {
 	AnonGetObject(bucket, object string, startOffset int64, length int64, writer io.Writer) (err error)
 	AnonGetObjectInfo(bucket, object string) (objInfo ObjectInfo, err error)
 
-	AnonPutObject(bucket string, object string, data *hash.Reader, metadata map[string]string) (ObjectInfo, error)
+	AnonPutObject(bucket string, object string, data hash.Reader, metadata map[string]string) (ObjectInfo, error)
 
 	SetBucketPolicies(string, policy.BucketAccessPolicy) error
 	GetBucketPolicies(string) (policy.BucketAccessPolicy, error)

--- a/cmd/gateway-s3-anonymous.go
+++ b/cmd/gateway-s3-anonymous.go
@@ -24,8 +24,8 @@ import (
 )
 
 // AnonPutObject creates a new object anonymously with the incoming data,
-func (l *s3Objects) AnonPutObject(bucket string, object string, data *hash.Reader, metadata map[string]string) (objInfo ObjectInfo, e error) {
-	oi, err := l.anonClient.PutObject(bucket, object, data, data.Size(), data.MD5(), data.SHA256(), toMinioClientMetadata(metadata))
+func (l *s3Objects) AnonPutObject(bucket string, object string, data hash.Reader, metadata map[string]string) (objInfo ObjectInfo, e error) {
+	oi, err := l.anonClient.PutObject(bucket, object, data, data.Size(), data.MD5, data.SHA256, toMinioClientMetadata(metadata))
 	if err != nil {
 		return objInfo, s3ToObjectError(traceError(err), bucket, object)
 	}

--- a/cmd/gateway-s3.go
+++ b/cmd/gateway-s3.go
@@ -342,8 +342,8 @@ func (l *s3Objects) GetObjectInfo(bucket string, object string) (objInfo ObjectI
 }
 
 // PutObject creates a new object with the incoming data,
-func (l *s3Objects) PutObject(bucket string, object string, data *hash.Reader, metadata map[string]string) (objInfo ObjectInfo, err error) {
-	oi, err := l.Client.PutObject(bucket, object, data, data.Size(), data.MD5(), data.SHA256(), toMinioClientMetadata(metadata))
+func (l *s3Objects) PutObject(bucket string, object string, data hash.Reader, metadata map[string]string) (objInfo ObjectInfo, err error) {
+	oi, err := l.Client.PutObject(bucket, object, data, data.Size(), data.MD5, data.SHA256, toMinioClientMetadata(metadata))
 	if err != nil {
 		return objInfo, s3ToObjectError(traceError(err), bucket, object)
 	}
@@ -462,8 +462,8 @@ func fromMinioClientObjectPart(op minio.ObjectPart) PartInfo {
 }
 
 // PutObjectPart puts a part of object in bucket
-func (l *s3Objects) PutObjectPart(bucket string, object string, uploadID string, partID int, data *hash.Reader) (pi PartInfo, e error) {
-	info, err := l.Client.PutObjectPart(bucket, object, uploadID, partID, data, data.Size(), data.MD5(), data.SHA256())
+func (l *s3Objects) PutObjectPart(bucket string, object string, uploadID string, partID int, data hash.Reader) (pi PartInfo, e error) {
+	info, err := l.Client.PutObjectPart(bucket, object, uploadID, partID, data, data.Size(), data.MD5, data.SHA256)
 	if err != nil {
 		return pi, s3ToObjectError(traceError(err), bucket, object)
 	}

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -72,7 +72,7 @@ func (a gatewayUnsupported) AnonGetBucketInfo(bucket string) (bi BucketInfo, err
 }
 
 // AnonPutObject creates a new object anonymously with the incoming data,
-func (a gatewayUnsupported) AnonPutObject(bucket, object string, data *hash.Reader,
+func (a gatewayUnsupported) AnonPutObject(bucket, object string, data hash.Reader,
 	metadata map[string]string) (ObjectInfo, error) {
 	return ObjectInfo{}, traceError(NotImplemented{})
 }

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -38,7 +38,7 @@ type ObjectLayer interface {
 	// Object operations.
 	GetObject(bucket, object string, startOffset int64, length int64, writer io.Writer) (err error)
 	GetObjectInfo(bucket, object string) (objInfo ObjectInfo, err error)
-	PutObject(bucket, object string, data *hash.Reader, metadata map[string]string) (objInfo ObjectInfo, err error)
+	PutObject(bucket, object string, data hash.Reader, metadata map[string]string) (objInfo ObjectInfo, err error)
 	CopyObject(srcBucket, srcObject, destBucket, destObject string, metadata map[string]string) (objInfo ObjectInfo, err error)
 	DeleteObject(bucket, object string) error
 
@@ -46,7 +46,7 @@ type ObjectLayer interface {
 	ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (result ListMultipartsInfo, err error)
 	NewMultipartUpload(bucket, object string, metadata map[string]string) (uploadID string, err error)
 	CopyObjectPart(srcBucket, srcObject, destBucket, destObject string, uploadID string, partID int, startOffset int64, length int64) (info PartInfo, err error)
-	PutObjectPart(bucket, object, uploadID string, partID int, data *hash.Reader) (info PartInfo, err error)
+	PutObjectPart(bucket, object, uploadID string, partID int, data hash.Reader) (info PartInfo, err error)
 	ListObjectParts(bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error)
 	AbortMultipartUpload(bucket, object, uploadID string) error
 	CompleteMultipartUpload(bucket, object, uploadID string, uploadedParts []completePart) (objInfo ObjectInfo, err error)

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -130,7 +130,7 @@ func calculateSignedChunkLength(chunkDataSize int64) int64 {
 		2 // CRLF
 }
 
-func mustGetHashReader(t TestErrHandler, data io.Reader, size int64, md5hex, sha256hex string) *hash.Reader {
+func mustGetHashReader(t TestErrHandler, data io.Reader, size int64, md5hex, sha256hex string) hash.Reader {
 	hr, err := hash.NewReader(data, size, md5hex, sha256hex)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"encoding/hex"
 	"io"
 	"path"
 	"strconv"
@@ -429,7 +430,7 @@ func renameObject(disks []StorageAPI, srcBucket, srcObject, dstBucket, dstObject
 // until EOF, erasure codes the data across all disk and additionally
 // writes `xl.json` which carries the necessary metadata for future
 // object operations.
-func (xl xlObjects) PutObject(bucket string, object string, data *hash.Reader, metadata map[string]string) (objInfo ObjectInfo, err error) {
+func (xl xlObjects) PutObject(bucket string, object string, data hash.Reader, metadata map[string]string) (objInfo ObjectInfo, err error) {
 	// This is a special case with size as '0' and object ends with
 	// a slash separator, we treat it like a valid operation and
 	// return success.
@@ -579,7 +580,7 @@ func (xl xlObjects) PutObject(bucket string, object string, data *hash.Reader, m
 
 	// Save additional erasureMetadata.
 	modTime := UTCNow()
-	metadata["etag"] = data.MD5HexString()
+	metadata["etag"] = hex.EncodeToString(data.Etag())
 
 	// Guess content-type from the extension if possible.
 	if metadata["content-type"] == "" {

--- a/pkg/hash/reader.go
+++ b/pkg/hash/reader.go
@@ -26,59 +26,111 @@ import (
 	"io"
 )
 
-// Reader writes what it reads from an io.Reader to an MD5 and SHA256 hash.Hash.
-// Reader verifies that the content of the io.Reader matches the expected checksums.
-type Reader struct {
-	src  io.Reader
-	size int64
-
-	md5sum, sha256sum   []byte // Byte values of md5sum, sha256sum of client sent values.
-	md5Hash, sha256Hash hash.Hash
-}
-
-// NewReader returns a new hash Reader which computes the MD5 sum and
-// SHA256 sum (if set) of the provided io.Reader at EOF.
-func NewReader(src io.Reader, size int64, md5Hex, sha256Hex string) (*Reader, error) {
-	if _, ok := src.(*Reader); ok {
-		return nil, errors.New("Nesting of Reader detected, not allowed")
+// NewReader returns a new hash.Reader which computes the MD5 sum and
+// SHA256 sum (if set) of the provided io.Reader at EOF. The returned Reader
+// uses the computed MD5 sum as etag.
+func NewReader(src io.Reader, size int64, md5Hex, sha256Hex string) (Reader, error) {
+	if _, ok := src.(Reader); ok {
+		return Reader{}, errors.New("Nesting of Reader detected, not allowed")
 	}
 
 	sha256sum, err := hex.DecodeString(sha256Hex)
 	if err != nil {
-		return nil, err
+		return Reader{}, err
 	}
-
 	md5sum, err := hex.DecodeString(md5Hex)
 	if err != nil {
-		return nil, err
+		return Reader{}, err
 	}
-	var (
-		md5Hash    hash.Hash
-		sha256Hash hash.Hash
-	)
-	if len(md5sum) != 0 {
-		md5Hash = md5.New()
-	}
+
+	var sha256Hash hash.Hash
 	if len(sha256sum) != 0 {
 		sha256Hash = sha256.New()
 	}
-
-	return &Reader{
-		md5sum:     md5sum,
-		sha256sum:  sha256sum,
-		src:        io.LimitReader(src, size),
-		size:       size,
-		md5Hash:    md5Hash,
-		sha256Hash: sha256Hash,
+	if size >= 0 {
+		src = io.LimitReader(src, size)
+	} else {
+		size = -1
+	}
+	return Reader{
+		tagger: &reader{
+			src:        src,
+			md5sum:     md5sum,
+			sha256sum:  sha256sum,
+			md5Hash:    md5.New(),
+			sha256Hash: sha256Hash,
+		},
+		size:   size,
+		MD5:    md5sum,
+		SHA256: sha256sum,
 	}, nil
 }
 
-func (r *Reader) Read(p []byte) (n int, err error) {
+// NewGatewayReader returns a new hash.Reader implementation. It will not compute any
+// etag and can only be used to pass the provided hash values to the backend.
+func NewGatewayReader(src io.Reader, size int64, md5Hex, sha256Hex string) (Reader, error) {
+	sha256sum, err := hex.DecodeString(sha256Hex)
+	if err != nil {
+		return Reader{}, err
+	}
+	md5sum, err := hex.DecodeString(md5Hex)
+	if err != nil {
+		return Reader{}, err
+	}
+	if size >= 0 {
+		src = io.LimitReader(src, size)
+	} else {
+		size = -1
+	}
+	return Reader{
+		tagger: gatewayReader{src, md5sum},
+		size:   size,
+		MD5:    md5sum,
+		SHA256: sha256sum,
+	}, nil
+}
+
+// Reader computes an etag value of the data it reads.
+type Reader struct {
+	tagger
+	size        int64
+	MD5, SHA256 []byte
+}
+
+// Size returns the absolute number of bytes the Reader
+// will return during reading. It returns -1 for unlimited
+// data.
+func (r Reader) Size() int64 { return r.size }
+
+type tagger interface {
+	io.Reader
+	Etag() []byte
+}
+
+// gatewayReader implements tagger and returns the client provided
+// content-md5 as etag.
+type gatewayReader struct {
+	io.Reader
+	etag []byte
+}
+
+// Etag returns client provided content-md5 as etag.
+func (r gatewayReader) Etag() []byte { return r.etag }
+
+// reader writes what it reads from an io.Reader to an MD5 and (if specified) SHA256 hash.Hash.
+// reader verifies that the content of the io.Reader matches the expected checksums.
+//
+// reader is the hash.Reader implementation for simple PUT operations.
+type reader struct {
+	src                 io.Reader
+	md5sum, sha256sum   []byte // Byte values of md5sum, sha256sum of client sent values.
+	md5Hash, sha256Hash hash.Hash
+}
+
+func (r *reader) Read(p []byte) (n int, err error) {
 	n, err = r.src.Read(p)
 	if n > 0 {
-		if r.md5Hash != nil {
-			r.md5Hash.Write(p[:n])
-		}
+		r.md5Hash.Write(p[:n])
 		if r.sha256Hash != nil {
 			r.sha256Hash.Write(p[:n])
 		}
@@ -86,51 +138,26 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 
 	// At io.EOF verify if the checksums are right.
 	if err == io.EOF {
-		if cerr := r.Verify(); cerr != nil {
+		if cerr := r.verify(); cerr != nil {
 			return 0, cerr
 		}
 	}
-
 	return
 }
 
-// Size returns the absolute number of bytes the Reader
-// will return during reading. It returns -1 for unlimited
-// data.
-func (r *Reader) Size() int64 { return r.size }
-
-// MD5 - returns byte md5 value
-func (r *Reader) MD5() []byte {
-	return r.md5sum
-}
-
-// SHA256 - returns byte sha256 value
-func (r *Reader) SHA256() []byte {
-	return r.sha256sum
-}
-
-// MD5HexString returns hex md5 value.
-func (r *Reader) MD5HexString() string {
-	return hex.EncodeToString(r.md5sum)
-}
-
-// SHA256HexString returns hex sha256 value.
-func (r *Reader) SHA256HexString() string {
-	return hex.EncodeToString(r.sha256sum)
-}
-
-// Verify verifies if the computed MD5 sum and SHA256 sum are
+// verify verifies if the computed MD5 sum and SHA256 sum are
 // equal to the ones specified when creating the Reader.
-func (r *Reader) Verify() error {
+func (r *reader) verify() error {
 	if r.sha256Hash != nil {
 		if sum := r.sha256Hash.Sum(nil); !bytes.Equal(r.sha256sum, sum) {
 			return SHA256Mismatch{hex.EncodeToString(r.sha256sum), hex.EncodeToString(sum)}
 		}
 	}
-	if r.md5Hash != nil {
-		if sum := r.md5Hash.Sum(nil); !bytes.Equal(r.md5sum, sum) {
-			return BadDigest{hex.EncodeToString(r.md5sum), hex.EncodeToString(sum)}
-		}
+	if sum := r.Etag(); len(r.md5sum) > 0 && !bytes.Equal(r.md5sum, sum) {
+		return BadDigest{hex.EncodeToString(r.md5sum), hex.EncodeToString(sum)}
 	}
 	return nil
 }
+
+// Etag returns md5 sum of the processed content as etag.
+func (r *reader) Etag() []byte { return r.md5Hash.Sum(nil) }


### PR DESCRIPTION
## Description
Minio has to support 3 types of etag validation/computation.

1. The client does a simple PUT with FS or XL backend.
There the server verifies that the provided content-md5 is the same
as the MD5 sum of the uploaded object. If the content-md5 is not set
the server computes it and uses it as etag.

2. The client does a multipart PUT operation with FS or XL backend.
There the server can generate a random etag (followed by a -'part-number')
per part. Currently this is done by computing the MD5 sum, too. See #4641.

3. The client does a PUT operation in gateway mode.
There the etag is computed by the cloud-provider (GCS, Azure, AWS).
In this case we should avoid computing the MD5 sum twice.

This change implements the 1. and 3. case correctly. The 2. case can be fixed
in a separate commit/PR.

## Motivation and Context
Fixes #5100

## How Has This Been Tested?
manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.