### PR TITLE
"0" offset is ignored in  GetObject method in Azure Gateway code

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -474,8 +474,13 @@ func (a *azureObjects) ListObjectsV2(bucket, prefix, continuationToken, delimite
 // startOffset indicates the starting read location of the object.
 // length indicates the total length of the object.
 func (a *azureObjects) GetObject(bucket, object string, startOffset int64, length int64, writer io.Writer) error {
+	// startOffset cannot be negative.
+	if startOffset < 0 {
+		return toObjectErr(traceError(errUnexpected), bucket, object)
+	}
+
 	blobRange := &storage.BlobRange{Start: uint64(startOffset)}
-	if length > 0 && startOffset > 0 {
+	if length > 0 {
 		blobRange.End = uint64(startOffset + length - 1)
 	}
 


### PR DESCRIPTION
## Description
In GetObject method, Check if startoffset is a non-negative value.
Ignore check for startOffset > and check for only length > 0.

Fixes minio/mint#191

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran functional tests for minio-js against Minio server and Azure S3, and GCS gateways.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.