### PR TITLE
Add strict type for Port, Host and URL

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -33,6 +33,7 @@ import (
 
 	router "github.com/gorilla/mux"
 	"github.com/minio/minio/pkg/auth"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 var configJSON = []byte(`{
@@ -298,7 +299,7 @@ func testServicesCmdHandler(cmd cmdType, t *testing.T) {
 	// Initialize admin peers to make admin RPC calls. Note: In a
 	// single node setup, this degenerates to a simple function
 	// call under the hood.
-	globalMinioAddr = "127.0.0.1:9000"
+	globalServerHost = xnet.MustParseHost("127.0.0.1:9000")
 	initGlobalAdminPeers(mustGetNewEndpointList("http://127.0.0.1:9000/d1"))
 
 	// Setting up a go routine to simulate ServerMux's
@@ -358,7 +359,7 @@ func TestServiceSetCreds(t *testing.T) {
 	// Initialize admin peers to make admin RPC calls. Note: In a
 	// single node setup, this degenerates to a simple function
 	// call under the hood.
-	globalMinioAddr = "127.0.0.1:9000"
+	globalServerHost = xnet.MustParseHost("127.0.0.1:9000")
 	initGlobalAdminPeers(mustGetNewEndpointList("http://127.0.0.1:9000/d1"))
 
 	credentials := serverConfig.GetCredential()
@@ -440,7 +441,7 @@ func TestListLocksHandler(t *testing.T) {
 	defer adminTestBed.TearDown()
 
 	// Initialize admin peers to make admin RPC calls.
-	globalMinioAddr = "127.0.0.1:9000"
+	globalServerHost = xnet.MustParseHost("127.0.0.1:9000")
 	initGlobalAdminPeers(mustGetNewEndpointList("http://127.0.0.1:9000/d1"))
 
 	testCases := []struct {
@@ -1213,7 +1214,7 @@ func TestGetConfigHandler(t *testing.T) {
 	defer adminTestBed.TearDown()
 
 	// Initialize admin peers to make admin RPC calls.
-	globalMinioAddr = "127.0.0.1:9000"
+	globalServerHost = xnet.MustParseHost("127.0.0.1:9000")
 	initGlobalAdminPeers(mustGetNewEndpointList("http://127.0.0.1:9000/d1"))
 
 	// Prepare query params for get-config mgmt REST API.
@@ -1242,7 +1243,7 @@ func TestSetConfigHandler(t *testing.T) {
 	defer adminTestBed.TearDown()
 
 	// Initialize admin peers to make admin RPC calls.
-	globalMinioAddr = "127.0.0.1:9000"
+	globalServerHost = xnet.MustParseHost("127.0.0.1:9000")
 	initGlobalAdminPeers(mustGetNewEndpointList("http://127.0.0.1:9000/d1"))
 
 	// SetConfigHandler restarts minio setup - need to start a
@@ -1284,7 +1285,7 @@ func TestAdminServerInfo(t *testing.T) {
 	defer adminTestBed.TearDown()
 
 	// Initialize admin peers to make admin RPC calls.
-	globalMinioAddr = "127.0.0.1:9000"
+	globalServerHost = xnet.MustParseHost("127.0.0.1:9000")
 	initGlobalAdminPeers(mustGetNewEndpointList("http://127.0.0.1:9000/d1"))
 
 	// Prepare query params for set-config mgmt REST API.

--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -236,16 +235,13 @@ type adminPeers []adminPeer
 
 // makeAdminPeers - helper function to construct a collection of adminPeer.
 func makeAdminPeers(endpoints EndpointList) (adminPeerList adminPeers) {
-	thisPeer := globalMinioAddr
-	if globalMinioHost == "" {
-		thisPeer = net.JoinHostPort("localhost", globalMinioPort)
-	}
+	thisPeer := globalServerHost.String()
 	adminPeerList = append(adminPeerList, adminPeer{
 		thisPeer,
 		localAdminClient{},
 	})
 
-	hostSet := set.CreateStringSet(globalMinioAddr)
+	hostSet := set.CreateStringSet(thisPeer)
 	cred := serverConfig.GetCredential()
 	serviceEndpoint := path.Join(minioReservedBucketPath, adminPath)
 	for _, host := range GetRemotePeers(endpoints) {

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -126,9 +126,9 @@ func checkRequestAuthType(r *http.Request, bucket, policyAction, region string) 
 
 	if reqAuthType == authTypeAnonymous && policyAction != "" {
 		// http://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html
-		sourceIP := getSourceIPAddress(r)
+		host := getSourceHost(r)
 		return enforceBucketPolicy(bucket, policyAction, r.URL.Path,
-			r.Referer(), sourceIP, r.URL.Query())
+			r.Referer(), host.Host, r.URL.Query())
 	}
 
 	// By default return ErrAccessDenied

--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -86,7 +86,7 @@ func updateCredsOnPeers(creds auth.Credentials) map[string]error {
 
 			// Exclude self to avoid race with
 			// invalidating the RPC token.
-			if peers[ix] == globalMinioAddr {
+			if peers[ix] == globalServerHost.String() {
 				errs[ix] = nil
 				return
 			}

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -349,12 +348,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 	// Write success response.
 	writeSuccessResponseXML(w, encodedSuccessResponse)
 
-	// Get host and port from Request.RemoteAddr failing which
-	// fill them with empty strings.
-	host, port, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host, port = "", ""
-	}
+	host := getSourceHost(r)
 
 	// Notify deleted event for objects.
 	for _, dobj := range deletedObjects {
@@ -366,8 +360,8 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 			},
 			ReqParams: extractReqParams(r),
 			UserAgent: r.UserAgent(),
-			Host:      host,
-			Port:      port,
+			Host:      host.Host,
+			Port:      host.PortNumber.String(),
 		})
 	}
 }
@@ -579,11 +573,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	w.Header().Set("ETag", `"`+objInfo.ETag+`"`)
 	w.Header().Set("Location", location)
 
-	// Get host and port from Request.RemoteAddr.
-	host, port, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host, port = "", ""
-	}
+	host := getSourceHost(r)
 
 	// Notify object created event.
 	defer eventNotify(eventData{
@@ -592,8 +582,8 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		ObjInfo:   objInfo,
 		ReqParams: extractReqParams(r),
 		UserAgent: r.UserAgent(),
-		Host:      host,
-		Port:      port,
+		Host:      host.Host,
+		Port:      host.PortNumber.String(),
 	})
 
 	if successRedirect != "" {

--- a/cmd/bucket-notification-utils.go
+++ b/cmd/bucket-notification-utils.go
@@ -147,19 +147,19 @@ func isValidQueueID(queueARN string) bool {
 
 	if isAMQPQueue(sqsARN) { // AMQP eueue.
 		amqpN := serverConfig.Notify.GetAMQPByID(sqsARN.AccountID)
-		return amqpN.Enable && amqpN.URL != ""
+		return amqpN.Enable && !amqpN.URL.IsEmpty()
 	} else if isMQTTQueue(sqsARN) {
 		mqttN := serverConfig.Notify.GetMQTTByID(sqsARN.AccountID)
-		return mqttN.Enable && mqttN.Broker != ""
+		return mqttN.Enable && !mqttN.Broker.IsEmpty()
 	} else if isNATSQueue(sqsARN) {
 		natsN := serverConfig.Notify.GetNATSByID(sqsARN.AccountID)
-		return natsN.Enable && natsN.Address != ""
+		return natsN.Enable && !natsN.Address.IsEmpty()
 	} else if isElasticQueue(sqsARN) { // Elastic queue.
 		elasticN := serverConfig.Notify.GetElasticSearchByID(sqsARN.AccountID)
-		return elasticN.Enable && elasticN.URL != ""
+		return elasticN.Enable && !elasticN.URL.IsEmpty()
 	} else if isRedisQueue(sqsARN) { // Redis queue.
 		redisN := serverConfig.Notify.GetRedisByID(sqsARN.AccountID)
-		return redisN.Enable && redisN.Addr != ""
+		return redisN.Enable && !redisN.Addr.IsEmpty()
 	} else if isPostgreSQLQueue(sqsARN) {
 		pgN := serverConfig.Notify.GetPostgreSQLByID(sqsARN.AccountID)
 		// Postgres can work with only default conn. info.
@@ -174,7 +174,7 @@ func isValidQueueID(queueARN string) bool {
 			kafkaN.Topic != "")
 	} else if isWebhookQueue(sqsARN) {
 		webhookN := serverConfig.Notify.GetWebhookByID(sqsARN.AccountID)
-		return webhookN.Enable && webhookN.Endpoint != ""
+		return webhookN.Enable && !webhookN.Endpoint.IsEmpty()
 	}
 	return false
 }

--- a/cmd/config-old.go
+++ b/cmd/config-old.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/minio/minio/pkg/auth"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 /////////////////// Config V1 ///////////////////
@@ -150,31 +151,31 @@ type loggerV5 struct {
 		Level  string `json:"level"`
 	} `json:"syslog"`
 	AMQP struct {
-		Enable       bool   `json:"enable"`
-		Level        string `json:"level"`
-		URL          string `json:"url"`
-		Exchange     string `json:"exchange"`
-		RoutingKey   string `json:"routingKey"`
-		ExchangeType string `json:"exchangeType"`
-		Mandatory    bool   `json:"mandatory"`
-		Immediate    bool   `json:"immediate"`
-		Durable      bool   `json:"durable"`
-		Internal     bool   `json:"internal"`
-		NoWait       bool   `json:"noWait"`
-		AutoDeleted  bool   `json:"autoDeleted"`
+		Enable       bool     `json:"enable"`
+		Level        string   `json:"level"`
+		URL          xnet.URL `json:"url"`
+		Exchange     string   `json:"exchange"`
+		RoutingKey   string   `json:"routingKey"`
+		ExchangeType string   `json:"exchangeType"`
+		Mandatory    bool     `json:"mandatory"`
+		Immediate    bool     `json:"immediate"`
+		Durable      bool     `json:"durable"`
+		Internal     bool     `json:"internal"`
+		NoWait       bool     `json:"noWait"`
+		AutoDeleted  bool     `json:"autoDeleted"`
 	} `json:"amqp"`
 	ElasticSearch struct {
-		Enable bool   `json:"enable"`
-		Level  string `json:"level"`
-		URL    string `json:"url"`
-		Index  string `json:"index"`
+		Enable bool     `json:"enable"`
+		Level  string   `json:"level"`
+		URL    xnet.URL `json:"url"`
+		Index  string   `json:"index"`
 	} `json:"elasticsearch"`
 	Redis struct {
-		Enable   bool   `json:"enable"`
-		Level    string `json:"level"`
-		Addr     string `json:"address"`
-		Password string `json:"password"`
-		Key      string `json:"key"`
+		Enable   bool      `json:"enable"`
+		Level    string    `json:"level"`
+		Addr     xnet.Host `json:"address"`
+		Password string    `json:"password"`
+		Key      string    `json:"key"`
 	} `json:"redis"`
 }
 
@@ -326,14 +327,14 @@ type serverConfigV10 struct {
 
 // natsNotifyV1 - structure was valid until config V 11
 type natsNotifyV1 struct {
-	Enable       bool   `json:"enable"`
-	Address      string `json:"address"`
-	Subject      string `json:"subject"`
-	Username     string `json:"username"`
-	Password     string `json:"password"`
-	Token        string `json:"token"`
-	Secure       bool   `json:"secure"`
-	PingInterval int64  `json:"pingInterval"`
+	Enable       bool      `json:"enable"`
+	Address      xnet.Host `json:"address"`
+	Subject      string    `json:"subject"`
+	Username     string    `json:"username"`
+	Password     string    `json:"password"`
+	Token        string    `json:"token"`
+	Secure       bool      `json:"secure"`
+	PingInterval int64     `json:"pingInterval"`
 }
 
 // serverConfigV11 server configuration version '11' which is like

--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -18,18 +18,19 @@ package cmd
 
 import (
 	"fmt"
-	"net/url"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 func TestNewEndpoint(t *testing.T) {
-	u1, _ := url.Parse("http://localhost/path")
-	u2, _ := url.Parse("https://example.org/path")
-	u3, _ := url.Parse("http://127.0.0.1:8080/path")
-	u4, _ := url.Parse("http://192.168.253.200/path")
+	u1, _ := xnet.ParseURL("http://localhost/path")
+	u2, _ := xnet.ParseURL("https://example.org/path")
+	u3, _ := xnet.ParseURL("http://127.0.0.1:8080/path")
+	u4, _ := xnet.ParseURL("http://192.168.253.200/path")
 
 	testCases := []struct {
 		arg              string
@@ -37,19 +38,19 @@ func TestNewEndpoint(t *testing.T) {
 		expectedType     EndpointType
 		expectedErr      error
 	}{
-		{"foo", Endpoint{URL: &url.URL{Path: "foo"}, IsLocal: true}, PathEndpointType, nil},
-		{"/foo", Endpoint{URL: &url.URL{Path: "/foo"}, IsLocal: true}, PathEndpointType, nil},
-		{`\foo`, Endpoint{URL: &url.URL{Path: `\foo`}, IsLocal: true}, PathEndpointType, nil},
-		{"C", Endpoint{URL: &url.URL{Path: `C`}, IsLocal: true}, PathEndpointType, nil},
-		{"C:", Endpoint{URL: &url.URL{Path: `C:`}, IsLocal: true}, PathEndpointType, nil},
-		{"C:/", Endpoint{URL: &url.URL{Path: "C:"}, IsLocal: true}, PathEndpointType, nil},
-		{`C:\`, Endpoint{URL: &url.URL{Path: `C:\`}, IsLocal: true}, PathEndpointType, nil},
-		{`C:\foo`, Endpoint{URL: &url.URL{Path: `C:\foo`}, IsLocal: true}, PathEndpointType, nil},
-		{"C:/foo", Endpoint{URL: &url.URL{Path: "C:/foo"}, IsLocal: true}, PathEndpointType, nil},
-		{`C:\\foo`, Endpoint{URL: &url.URL{Path: `C:\\foo`}, IsLocal: true}, PathEndpointType, nil},
-		{"http:path", Endpoint{URL: &url.URL{Path: "http:path"}, IsLocal: true}, PathEndpointType, nil},
-		{"http:/path", Endpoint{URL: &url.URL{Path: "http:/path"}, IsLocal: true}, PathEndpointType, nil},
-		{"http:///path", Endpoint{URL: &url.URL{Path: "http:/path"}, IsLocal: true}, PathEndpointType, nil},
+		{"foo", Endpoint{URL: &xnet.URL{Path: "foo"}, IsLocal: true}, PathEndpointType, nil},
+		{"/foo", Endpoint{URL: &xnet.URL{Path: "/foo"}, IsLocal: true}, PathEndpointType, nil},
+		{`\foo`, Endpoint{URL: &xnet.URL{Path: `\foo`}, IsLocal: true}, PathEndpointType, nil},
+		{"C", Endpoint{URL: &xnet.URL{Path: `C`}, IsLocal: true}, PathEndpointType, nil},
+		{"C:", Endpoint{URL: &xnet.URL{Path: `C:`}, IsLocal: true}, PathEndpointType, nil},
+		{"C:/", Endpoint{URL: &xnet.URL{Path: "C:"}, IsLocal: true}, PathEndpointType, nil},
+		{`C:\`, Endpoint{URL: &xnet.URL{Path: `C:\`}, IsLocal: true}, PathEndpointType, nil},
+		{`C:\foo`, Endpoint{URL: &xnet.URL{Path: `C:\foo`}, IsLocal: true}, PathEndpointType, nil},
+		{"C:/foo", Endpoint{URL: &xnet.URL{Path: "C:/foo"}, IsLocal: true}, PathEndpointType, nil},
+		{`C:\\foo`, Endpoint{URL: &xnet.URL{Path: `C:\\foo`}, IsLocal: true}, PathEndpointType, nil},
+		{"nat:path", Endpoint{URL: &xnet.URL{Path: "nat:path"}, IsLocal: true}, PathEndpointType, nil},
+		{"nat:/path", Endpoint{URL: &xnet.URL{Path: "nat:/path"}, IsLocal: true}, PathEndpointType, nil},
+		{"nat:///path", Endpoint{URL: &xnet.URL{Path: "nat:/path"}, IsLocal: true}, PathEndpointType, nil},
 		{"http://localhost/path", Endpoint{URL: u1, IsLocal: true}, URLEndpointType, nil},
 		{"http://localhost/path//", Endpoint{URL: u1, IsLocal: true}, URLEndpointType, nil},
 		{"https://example.org/path", Endpoint{URL: u2}, URLEndpointType, nil},
@@ -60,34 +61,41 @@ func TestNewEndpoint(t *testing.T) {
 		{`\`, Endpoint{}, -1, fmt.Errorf("empty or root endpoint is not supported")},
 		{"c://foo", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format")},
 		{"ftp://foo", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format")},
+		{"http:path", Endpoint{}, -1, fmt.Errorf("endpoint URL format must be {http|https}://SERVER[:{1..65535}]/PATH")},
+		{"http:/path", Endpoint{}, -1, fmt.Errorf("endpoint URL format must be {http|https}://SERVER[:{1..65535}]/PATH")},
+		{"http:///path", Endpoint{}, -1, fmt.Errorf("endpoint URL format must be {http|https}://SERVER[:{1..65535}]/PATH")},
+		{"http://:/path", Endpoint{}, -1, fmt.Errorf("endpoint URL format must be {http|https}://SERVER[:{1..65535}]/PATH")},
+		{"http://:8080/path", Endpoint{}, -1, fmt.Errorf("endpoint URL format must be {http|https}://SERVER[:{1..65535}]/PATH")},
+		{"http://server:/path", Endpoint{}, -1, fmt.Errorf("endpoint URL format must be {http|https}://SERVER[:{1..65535}]/PATH")},
+		{"https://93.184.216.34:808080/path", Endpoint{}, -1, fmt.Errorf("endpoint URL format must be {http|https}://SERVER[:{1..65535}]/PATH")},
 		{"http://server/path?location", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format")},
-		{"http://:/path", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format: invalid port number")},
-		{"http://:8080/path", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format: empty host name")},
-		{"http://server:/path", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format: invalid port number")},
-		{"https://93.184.216.34:808080/path", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format: port number must be between 1 to 65535")},
 		{"http://server:8080//", Endpoint{}, -1, fmt.Errorf("empty or root path is not supported in URL endpoint")},
 		{"http://server:8080/", Endpoint{}, -1, fmt.Errorf("empty or root path is not supported in URL endpoint")},
 		{"192.168.1.210:9000", Endpoint{}, -1, fmt.Errorf("invalid URL endpoint format: missing scheme http or https")},
 	}
 
-	for _, testCase := range testCases {
+	for i, testCase := range testCases {
 		endpoint, err := NewEndpoint(testCase.arg)
-		if testCase.expectedErr == nil {
-			if err != nil {
-				t.Fatalf("error: expected = <nil>, got = %v", err)
+
+		if err != nil {
+			if testCase.expectedErr == nil {
+				t.Fatalf("test %v: error: expected = <nil>, got = %v", i+1, err)
 			}
-		} else if err == nil {
-			t.Fatalf("error: expected = %v, got = <nil>", testCase.expectedErr)
-		} else if testCase.expectedErr.Error() != err.Error() {
-			t.Fatalf("error: expected = %v, got = %v", testCase.expectedErr, err)
-		}
+			if testCase.expectedErr.Error() != err.Error() {
+				t.Fatalf("test %v: error: expected = %v, got = %v", i+1, testCase.expectedErr, err)
+			}
+		} else {
+			if testCase.expectedErr != nil {
+				t.Fatalf("test %v: error: expected = %v, got = <nil>", i+1, testCase.expectedErr)
+			}
 
-		if err == nil && !reflect.DeepEqual(testCase.expectedEndpoint, endpoint) {
-			t.Fatalf("endpoint: expected = %+v, got = %+v", testCase.expectedEndpoint, endpoint)
-		}
+			if !reflect.DeepEqual(testCase.expectedEndpoint, endpoint) {
+				t.Fatalf("test %v: endpoint: expected = %+v, got = %+v", i+1, testCase.expectedEndpoint, endpoint)
+			}
 
-		if err == nil && testCase.expectedType != endpoint.Type() {
-			t.Fatalf("type: expected = %+v, got = %+v", testCase.expectedType, endpoint.Type())
+			if testCase.expectedType != endpoint.Type() {
+				t.Fatalf("test %v: type: expected = %+v, got = %+v", i+1, testCase.expectedType, endpoint.Type())
+			}
 		}
 	}
 }
@@ -139,12 +147,12 @@ func TestCreateEndpoints(t *testing.T) {
 	}
 	nonLoopBackIP := nonLoopBackIPs.ToSlice()[0]
 
-	getExpectedEndpoints := func(args []string, prefix string) ([]*url.URL, []bool) {
-		var URLs []*url.URL
+	getExpectedEndpoints := func(args []string, prefix string) ([]*xnet.URL, []bool) {
+		var URLs []*xnet.URL
 		var localFlags []bool
 		sort.Strings(args)
 		for _, arg := range args {
-			u, _ := url.Parse(arg)
+			u, _ := xnet.ParseURL(arg)
 			URLs = append(URLs, u)
 			localFlags = append(localFlags, strings.HasPrefix(arg, prefix))
 		}
@@ -212,84 +220,84 @@ func TestCreateEndpoints(t *testing.T) {
 	case6URLs, case6LocalFlags := getExpectedEndpoints(args, "http://"+nonLoopBackIP+":9003/")
 
 	testCases := []struct {
-		serverAddr         string
+		serverHost         *xnet.Host
 		args               []string
-		expectedServerAddr string
+		expectedServerHost *xnet.Host
 		expectedEndpoints  EndpointList
 		expectedSetupType  SetupType
 		expectedErr        error
 	}{
-		{"localhost", []string{}, "", EndpointList{}, -1, fmt.Errorf("address localhost: missing port in address")},
+		{xnet.MustParseHost("localhost"), []string{}, nil, EndpointList{}, -1, fmt.Errorf("empty endpoint arguments")},
 
 		// FS Setup
-		{"localhost:9000", []string{"http://localhost/d1"}, "", EndpointList{}, -1, fmt.Errorf("use path style endpoint for FS setup")},
-		{":443", []string{"d1"}, ":443", EndpointList{Endpoint{URL: &url.URL{Path: "d1"}, IsLocal: true}}, FSSetupType, nil},
-		{"localhost:10000", []string{"/d1"}, "localhost:10000", EndpointList{Endpoint{URL: &url.URL{Path: "/d1"}, IsLocal: true}}, FSSetupType, nil},
-		{"localhost:10000", []string{"./d1"}, "localhost:10000", EndpointList{Endpoint{URL: &url.URL{Path: "d1"}, IsLocal: true}}, FSSetupType, nil},
-		{"localhost:10000", []string{`\d1`}, "localhost:10000", EndpointList{Endpoint{URL: &url.URL{Path: `\d1`}, IsLocal: true}}, FSSetupType, nil},
-		{"localhost:10000", []string{`.\d1`}, "localhost:10000", EndpointList{Endpoint{URL: &url.URL{Path: `.\d1`}, IsLocal: true}}, FSSetupType, nil},
-		{":8080", []string{"https://example.org/d1", "https://example.org/d2", "https://example.org/d3", "https://example.org/d4"}, "", EndpointList{}, -1, fmt.Errorf("no endpoint found for this host")},
-		{":8080", []string{"https://example.org/d1", "https://example.com/d2", "https://example.net:8000/d3", "https://example.edu/d1"}, "", EndpointList{}, -1, fmt.Errorf("no endpoint found for this host")},
-		{"localhost:9000", []string{"https://127.0.0.1:9000/d1", "https://localhost:9001/d1", "https://example.com/d1", "https://example.com/d2"}, "", EndpointList{}, -1, fmt.Errorf("path '/d1' can not be served by different port on same address")},
-		{"localhost:9000", []string{"https://127.0.0.1:8000/d1", "https://localhost:9001/d2", "https://example.com/d1", "https://example.com/d2"}, "", EndpointList{}, -1, fmt.Errorf("port number in server address must match with one of the port in local endpoints")},
-		{"localhost:10000", []string{"https://127.0.0.1:8000/d1", "https://localhost:8000/d2", "https://example.com/d1", "https://example.com/d2"}, "", EndpointList{}, -1, fmt.Errorf("server address and local endpoint have different ports")},
+		{xnet.MustParseHost("localhost:9000"), []string{"http://localhost/d1"}, nil, EndpointList{}, -1, fmt.Errorf("use path style endpoint for FS setup")},
+		{xnet.MustParseHost("0.0.0.0:443"), []string{"d1"}, xnet.MustParseHost("0.0.0.0:443"), EndpointList{Endpoint{URL: &xnet.URL{Path: "d1"}, IsLocal: true}}, FSSetupType, nil},
+		{xnet.MustParseHost("localhost:10000"), []string{"/d1"}, xnet.MustParseHost("localhost:10000"), EndpointList{Endpoint{URL: &xnet.URL{Path: "/d1"}, IsLocal: true}}, FSSetupType, nil},
+		{xnet.MustParseHost("localhost:10000"), []string{"./d1"}, xnet.MustParseHost("localhost:10000"), EndpointList{Endpoint{URL: &xnet.URL{Path: "d1"}, IsLocal: true}}, FSSetupType, nil},
+		{xnet.MustParseHost("localhost:10000"), []string{`\d1`}, xnet.MustParseHost("localhost:10000"), EndpointList{Endpoint{URL: &xnet.URL{Path: `\d1`}, IsLocal: true}}, FSSetupType, nil},
+		{xnet.MustParseHost("localhost:10000"), []string{`.\d1`}, xnet.MustParseHost("localhost:10000"), EndpointList{Endpoint{URL: &xnet.URL{Path: `.\d1`}, IsLocal: true}}, FSSetupType, nil},
+		{xnet.MustParseHost("0.0.0.0:8080"), []string{"https://example.org/d1", "https://example.org/d2", "https://example.org/d3", "https://example.org/d4"}, nil, EndpointList{}, -1, fmt.Errorf("no endpoint found for this host")},
+		{xnet.MustParseHost("0.0.0.0:8080"), []string{"https://example.org/d1", "https://example.com/d2", "https://example.net:8000/d3", "https://example.edu/d1"}, nil, EndpointList{}, -1, fmt.Errorf("no endpoint found for this host")},
+		{xnet.MustParseHost("localhost:9000"), []string{"https://127.0.0.1:9000/d1", "https://localhost:9001/d1", "https://example.com/d1", "https://example.com/d2"}, nil, EndpointList{}, -1, fmt.Errorf("path '/d1' can not be served by different port on same address")},
+		{xnet.MustParseHost("localhost:9000"), []string{"https://127.0.0.1:8000/d1", "https://localhost:9001/d2", "https://example.com/d1", "https://example.com/d2"}, nil, EndpointList{}, -1, fmt.Errorf("port number in server address must match with one of the port in local endpoints")},
+		{xnet.MustParseHost("localhost:10000"), []string{"https://127.0.0.1:8000/d1", "https://localhost:8000/d2", "https://example.com/d1", "https://example.com/d2"}, nil, EndpointList{}, -1, fmt.Errorf("server address and local endpoint have different ports")},
 
 		// XL Setup with PathEndpointType
-		{":1234", []string{"/d1", "/d2", "d3", "d4"}, ":1234",
+		{xnet.MustParseHost("0.0.0.0:1234"), []string{"/d1", "/d2", "d3", "d4"}, xnet.MustParseHost("0.0.0.0:1234"),
 			EndpointList{
-				Endpoint{URL: &url.URL{Path: "/d1"}, IsLocal: true},
-				Endpoint{URL: &url.URL{Path: "/d2"}, IsLocal: true},
-				Endpoint{URL: &url.URL{Path: "d3"}, IsLocal: true},
-				Endpoint{URL: &url.URL{Path: "d4"}, IsLocal: true},
+				Endpoint{URL: &xnet.URL{Path: "/d1"}, IsLocal: true},
+				Endpoint{URL: &xnet.URL{Path: "/d2"}, IsLocal: true},
+				Endpoint{URL: &xnet.URL{Path: "d3"}, IsLocal: true},
+				Endpoint{URL: &xnet.URL{Path: "d4"}, IsLocal: true},
 			}, XLSetupType, nil},
 		// XL Setup with URLEndpointType
-		{":9000", []string{"http://localhost/d1", "http://localhost/d2", "http://localhost/d3", "http://localhost/d4"}, ":9000", EndpointList{
-			Endpoint{URL: &url.URL{Path: "/d1"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Path: "/d2"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Path: "/d3"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Path: "/d4"}, IsLocal: true},
+		{xnet.MustParseHost("0.0.0.0:9000"), []string{"http://localhost/d1", "http://localhost/d2", "http://localhost/d3", "http://localhost/d4"}, xnet.MustParseHost("0.0.0.0:9000"), EndpointList{
+			Endpoint{URL: &xnet.URL{Path: "/d1"}, IsLocal: true},
+			Endpoint{URL: &xnet.URL{Path: "/d2"}, IsLocal: true},
+			Endpoint{URL: &xnet.URL{Path: "/d3"}, IsLocal: true},
+			Endpoint{URL: &xnet.URL{Path: "/d4"}, IsLocal: true},
 		}, XLSetupType, nil},
 		// XL Setup with URLEndpointType having mixed naming to local host.
-		{"127.0.0.1:10000", []string{"http://localhost/d1", "http://localhost/d2", "http://127.0.0.1/d3", "http://127.0.0.1/d4"}, ":10000", EndpointList{
-			Endpoint{URL: &url.URL{Path: "/d1"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Path: "/d2"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Path: "/d3"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Path: "/d4"}, IsLocal: true},
+		{xnet.MustParseHost("127.0.0.1:10000"), []string{"http://localhost/d1", "http://localhost/d2", "http://127.0.0.1/d3", "http://127.0.0.1/d4"}, xnet.MustParseHost("0.0.0.0:10000"), EndpointList{
+			Endpoint{URL: &xnet.URL{Path: "/d1"}, IsLocal: true},
+			Endpoint{URL: &xnet.URL{Path: "/d2"}, IsLocal: true},
+			Endpoint{URL: &xnet.URL{Path: "/d3"}, IsLocal: true},
+			Endpoint{URL: &xnet.URL{Path: "/d4"}, IsLocal: true},
 		}, XLSetupType, nil},
-		{":9001", []string{"http://10.0.0.1:9000/export", "http://10.0.0.2:9000/export", "http://" + nonLoopBackIP + ":9001/export", "http://10.0.0.2:9001/export"}, "", EndpointList{}, -1, fmt.Errorf("path '/export' can not be served by different port on same address")},
+		{xnet.MustParseHost("0.0.0.0:9001"), []string{"http://10.0.0.1:9000/export", "http://10.0.0.2:9000/export", "http://" + nonLoopBackIP + ":9001/export", "http://10.0.0.2:9001/export"}, nil, EndpointList{}, -1, fmt.Errorf("path '/export' can not be served by different port on same address")},
 
-		{":9000", []string{"http://localhost/d1", "http://localhost/d2", "http://example.org/d3", "http://example.com/d4"}, "", EndpointList{}, -1, fmt.Errorf("'localhost' resolves to loopback address is not allowed for distributed XL")},
+		{xnet.MustParseHost("0.0.0.0:9000"), []string{"http://localhost/d1", "http://localhost/d2", "http://example.org/d3", "http://example.com/d4"}, nil, EndpointList{}, -1, fmt.Errorf("'localhost' resolves to loopback address is not allowed for distributed XL")},
 
 		// DistXL type
-		{"127.0.0.1:10000", []string{case1Endpoint1, case1Endpoint2, "http://example.org/d3", "http://example.com/d4"}, "127.0.0.1:10000", EndpointList{
+		{xnet.MustParseHost("127.0.0.1:10000"), []string{case1Endpoint1, case1Endpoint2, "http://example.org/d3", "http://example.com/d4"}, xnet.MustParseHost("127.0.0.1:10000"), EndpointList{
 			Endpoint{URL: case1URLs[0], IsLocal: case1LocalFlags[0]},
 			Endpoint{URL: case1URLs[1], IsLocal: case1LocalFlags[1]},
 			Endpoint{URL: case1URLs[2], IsLocal: case1LocalFlags[2]},
 			Endpoint{URL: case1URLs[3], IsLocal: case1LocalFlags[3]},
 		}, DistXLSetupType, nil},
 
-		{"127.0.0.1:10000", []string{case2Endpoint1, case2Endpoint2, "http://example.org/d3", "http://example.com/d4"}, "127.0.0.1:10000", EndpointList{
+		{xnet.MustParseHost("127.0.0.1:10000"), []string{case2Endpoint1, case2Endpoint2, "http://example.org/d3", "http://example.com/d4"}, xnet.MustParseHost("127.0.0.1:10000"), EndpointList{
 			Endpoint{URL: case2URLs[0], IsLocal: case2LocalFlags[0]},
 			Endpoint{URL: case2URLs[1], IsLocal: case2LocalFlags[1]},
 			Endpoint{URL: case2URLs[2], IsLocal: case2LocalFlags[2]},
 			Endpoint{URL: case2URLs[3], IsLocal: case2LocalFlags[3]},
 		}, DistXLSetupType, nil},
 
-		{":80", []string{case3Endpoint1, "http://example.org:9000/d2", "http://example.com/d3", "http://example.net/d4"}, ":80", EndpointList{
+		{xnet.MustParseHost("0.0.0.0:80"), []string{case3Endpoint1, "http://example.org:9000/d2", "http://example.com/d3", "http://example.net/d4"}, xnet.MustParseHost("0.0.0.0:80"), EndpointList{
 			Endpoint{URL: case3URLs[0], IsLocal: case3LocalFlags[0]},
 			Endpoint{URL: case3URLs[1], IsLocal: case3LocalFlags[1]},
 			Endpoint{URL: case3URLs[2], IsLocal: case3LocalFlags[2]},
 			Endpoint{URL: case3URLs[3], IsLocal: case3LocalFlags[3]},
 		}, DistXLSetupType, nil},
 
-		{":9000", []string{case4Endpoint1, "http://example.org/d2", "http://example.com/d3", "http://example.net/d4"}, ":9000", EndpointList{
+		{xnet.MustParseHost("0.0.0.0:9000"), []string{case4Endpoint1, "http://example.org/d2", "http://example.com/d3", "http://example.net/d4"}, xnet.MustParseHost("0.0.0.0:9000"), EndpointList{
 			Endpoint{URL: case4URLs[0], IsLocal: case4LocalFlags[0]},
 			Endpoint{URL: case4URLs[1], IsLocal: case4LocalFlags[1]},
 			Endpoint{URL: case4URLs[2], IsLocal: case4LocalFlags[2]},
 			Endpoint{URL: case4URLs[3], IsLocal: case4LocalFlags[3]},
 		}, DistXLSetupType, nil},
 
-		{":9000", []string{case5Endpoint1, case5Endpoint2, case5Endpoint3, case5Endpoint4}, ":9000", EndpointList{
+		{xnet.MustParseHost("0.0.0.0:9000"), []string{case5Endpoint1, case5Endpoint2, case5Endpoint3, case5Endpoint4}, xnet.MustParseHost("0.0.0.0:9000"), EndpointList{
 			Endpoint{URL: case5URLs[0], IsLocal: case5LocalFlags[0]},
 			Endpoint{URL: case5URLs[1], IsLocal: case5LocalFlags[1]},
 			Endpoint{URL: case5URLs[2], IsLocal: case5LocalFlags[2]},
@@ -297,7 +305,7 @@ func TestCreateEndpoints(t *testing.T) {
 		}, DistXLSetupType, nil},
 
 		// DistXL Setup using only local host.
-		{":9003", []string{"http://localhost:9000/d1", "http://localhost:9001/d2", "http://127.0.0.1:9002/d3", case6Endpoint}, ":9003", EndpointList{
+		{xnet.MustParseHost("0.0.0.0:9003"), []string{"http://localhost:9000/d1", "http://localhost:9001/d2", "http://127.0.0.1:9002/d3", case6Endpoint}, xnet.MustParseHost("0.0.0.0:9003"), EndpointList{
 			Endpoint{URL: case6URLs[0], IsLocal: case6LocalFlags[0]},
 			Endpoint{URL: case6URLs[1], IsLocal: case6LocalFlags[1]},
 			Endpoint{URL: case6URLs[2], IsLocal: case6LocalFlags[2]},
@@ -306,14 +314,14 @@ func TestCreateEndpoints(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		serverAddr, endpoints, setupType, err := CreateEndpoints(testCase.serverAddr, testCase.args...)
+		serverHost, endpoints, setupType, err := CreateEndpoints(testCase.serverHost, testCase.args...)
 
 		if err == nil {
 			if testCase.expectedErr != nil {
 				t.Fatalf("error: expected = %v, got = <nil>", testCase.expectedErr)
 			} else {
-				if serverAddr != testCase.expectedServerAddr {
-					t.Fatalf("serverAddr: expected = %v, got = %v", testCase.expectedServerAddr, serverAddr)
+				if !reflect.DeepEqual(serverHost, testCase.expectedServerHost) {
+					t.Fatalf("serverAddr: expected = %v, got = %v", testCase.expectedServerHost, serverHost)
 				}
 				if !reflect.DeepEqual(endpoints, testCase.expectedEndpoints) {
 					t.Fatalf("endpoints: expected = %v, got = %v", testCase.expectedEndpoints, endpoints)
@@ -334,17 +342,17 @@ func TestCreateEndpoints(t *testing.T) {
 // So it means that if you have say localhost:9000 and localhost:9001 as endpointArgs then localhost:9001
 // is considered a remote service from localhost:9000 perspective.
 func TestGetLocalPeer(t *testing.T) {
-	tempGlobalMinioAddr := globalMinioAddr
+	tempGlobalServerHost := globalServerHost
 	defer func() {
-		globalMinioAddr = tempGlobalMinioAddr
+		globalServerHost = tempGlobalServerHost
 	}()
-	globalMinioAddr = ":9000"
+	globalServerHost = xnet.MustParseHost("0.0.0.0:9000")
 
 	testCases := []struct {
 		endpointArgs   []string
 		expectedResult string
 	}{
-		{[]string{"/d1", "/d2", "d3", "d4"}, ":9000"},
+		{[]string{"/d1", "/d2", "d3", "d4"}, "0.0.0.0:9000"},
 		{[]string{"http://localhost:9000/d1", "http://localhost:9000/d2", "http://example.org:9000/d3", "http://example.com:9000/d4"},
 			"localhost:9000"},
 		{[]string{"http://localhost:9000/d1", "http://example.org:9000/d2", "http://example.com:9000/d3", "http://example.net:9000/d4"},
@@ -363,11 +371,11 @@ func TestGetLocalPeer(t *testing.T) {
 }
 
 func TestGetRemotePeers(t *testing.T) {
-	tempGlobalMinioPort := globalMinioPort
+	tempGlobalServerHost := globalServerHost
 	defer func() {
-		globalMinioPort = tempGlobalMinioPort
+		globalServerHost = tempGlobalServerHost
 	}()
-	globalMinioPort = "9000"
+	globalServerHost = xnet.MustParseHost("0.0.0.0:9000")
 
 	testCases := []struct {
 		endpointArgs   []string

--- a/cmd/event-notifier.go
+++ b/cmd/event-notifier.go
@@ -96,13 +96,8 @@ type eventData struct {
 // input request metadata which completed successfully.
 func newNotificationEvent(event eventData) NotificationEvent {
 	getResponseOriginEndpointKey := func() string {
-		host := globalMinioHost
-		if host == "" {
-			// FIXME: Send FQDN or hostname of this machine than sending IP address.
-			host = localIP4.ToSlice()[0]
-		}
-
-		return fmt.Sprintf("%s://%s:%s", getURLScheme(globalIsSSL), host, globalMinioPort)
+		// FIXME: Send FQDN or hostname of this machine than sending IP address.
+		return fmt.Sprintf("%s://%s", getURLScheme(globalIsSSL), globalServerHost)
 	}
 
 	// Fetch the region.

--- a/cmd/gateway-gcs_test.go
+++ b/cmd/gateway-gcs_test.go
@@ -18,8 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
 
@@ -179,32 +177,5 @@ func TestFromMinioClientListBucketResultToV2Info(t *testing.T) {
 
 	if got := fromMinioClientListBucketResultToV2Info("testbucket", listBucketResult); !reflect.DeepEqual(got, listBucketV2Info) {
 		t.Errorf("fromMinioClientListBucketResultToV2Info() = %v, want %v", got, listBucketV2Info)
-	}
-}
-
-// Test for gcsParseProjectID
-func TestGCSParseProjectID(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer os.Remove(f.Name())
-	defer f.Close()
-
-	contents := `
-{
-  "type": "service_account",
-  "project_id": "miniotesting"
-}
-`
-	f.WriteString(contents)
-	projectID, err := gcsParseProjectID(f.Name())
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if projectID != "miniotesting" {
-		t.Errorf(`Expected projectID value to be "miniotesting"`)
 	}
 }

--- a/cmd/gateway-handlers.go
+++ b/cmd/gateway-handlers.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strconv"
 
@@ -159,12 +158,7 @@ func (api gatewayAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Re
 		writer.Write(nil)
 	}
 
-	// Get host and port from Request.RemoteAddr.
-	host, port, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host, port = "", ""
-	}
-
+	host := getSourceHost(r)
 	// Notify object accessed via a GET request.
 	eventNotify(eventData{
 		Type:      ObjectAccessedGet,
@@ -172,8 +166,8 @@ func (api gatewayAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Re
 		ObjInfo:   objInfo,
 		ReqParams: extractReqParams(r),
 		UserAgent: r.UserAgent(),
-		Host:      host,
-		Port:      port,
+		Host:      host.Host,
+		Port:      host.PortNumber.String(),
 	})
 }
 
@@ -324,12 +318,7 @@ func (api gatewayAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Re
 	w.Header().Set("ETag", "\""+objInfo.ETag+"\"")
 	writeSuccessResponseHeadersOnly(w)
 
-	// Get host and port from Request.RemoteAddr.
-	host, port, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host, port = "", ""
-	}
-
+	host := getSourceHost(r)
 	// Notify object created event.
 	eventNotify(eventData{
 		Type:      ObjectCreatedPut,
@@ -337,8 +326,8 @@ func (api gatewayAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Re
 		ObjInfo:   objInfo,
 		ReqParams: extractReqParams(r),
 		UserAgent: r.UserAgent(),
-		Host:      host,
-		Port:      port,
+		Host:      host.Host,
+		Port:      host.PortNumber.String(),
 	})
 }
 
@@ -412,12 +401,7 @@ func (api gatewayAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.R
 	// Successful response.
 	w.WriteHeader(http.StatusOK)
 
-	// Get host and port from Request.RemoteAddr.
-	host, port, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host, port = "", ""
-	}
-
+	host := getSourceHost(r)
 	// Notify object accessed via a HEAD request.
 	eventNotify(eventData{
 		Type:      ObjectAccessedHead,
@@ -425,8 +409,8 @@ func (api gatewayAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.R
 		ObjInfo:   objInfo,
 		ReqParams: extractReqParams(r),
 		UserAgent: r.UserAgent(),
-		Host:      host,
-		Port:      port,
+		Host:      host.Host,
+		Port:      host.PortNumber.String(),
 	})
 }
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/minio/minio/pkg/auth"
 	miniohttp "github.com/minio/minio/pkg/http"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // minio configuration related constants.
@@ -101,12 +102,8 @@ var (
 	// Maximum size of internal objects parts
 	globalPutPartSize = int64(64 * 1024 * 1024)
 
-	// Minio local server address (in `host:port` format)
-	globalMinioAddr = ""
-	// Minio default port, can be changed through command line.
-	globalMinioPort = "9000"
-	// Holds the host that was passed using --address
-	globalMinioHost = ""
+	// Server address passed by command line argument.
+	globalServerHost *xnet.Host
 
 	// Peer communication struct
 	globalS3Peers = s3Peers{}

--- a/cmd/lock-rpc-server_test.go
+++ b/cmd/lock-rpc-server_test.go
@@ -466,7 +466,6 @@ func TestLockServers(t *testing.T) {
 		}
 	}
 
-	globalMinioHost = ""
 	testCases := []struct {
 		isDistXL         bool
 		endpoints        EndpointList

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -242,8 +241,7 @@ func deleteObject(obj ObjectLayer, bucket, object string, r *http.Request) (err 
 		return err
 	}
 
-	// Get host and port from Request.RemoteAddr.
-	host, port, _ := net.SplitHostPort(r.RemoteAddr)
+	host := getSourceHost(r)
 
 	// Notify object deleted event.
 	eventNotify(eventData{
@@ -254,8 +252,8 @@ func deleteObject(obj ObjectLayer, bucket, object string, r *http.Request) (err 
 		},
 		ReqParams: extractReqParams(r),
 		UserAgent: r.UserAgent(),
-		Host:      host,
-		Port:      port,
+		Host:      host.Host,
+		Port:      host.PortNumber.String(),
 	})
 
 	return nil

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -3596,9 +3596,9 @@ func TestGetSourceIPAddress(t *testing.T) {
 		},
 	}
 	for i, test := range testCases {
-		receivedIP := getSourceIPAddress(test.request)
-		if test.expectedIP != receivedIP {
-			t.Fatalf("Case %d: Expected the IP to be `%s`, but instead got `%s`", i+1, test.expectedIP, receivedIP)
+		host := getSourceHost(test.request)
+		if test.expectedIP != host.Host {
+			t.Fatalf("Case %d: Expected the IP to be `%s`, but instead got `%s`", i+1, test.expectedIP, host.Host)
 		}
 	}
 }

--- a/cmd/s3-peer-client_test.go
+++ b/cmd/s3-peer-client_test.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // Validates makeS3Peers, fetches all peers based on list of storage
@@ -52,7 +54,7 @@ func TestMakeS3Peers(t *testing.T) {
 
 	// execute tests
 	for i, testCase := range testCases {
-		globalMinioAddr = testCase.gMinioAddr
+		globalServerHost = xnet.MustParseHost(testCase.gMinioAddr)
 		s3peers := makeS3Peers(testCase.eps)
 		referencePeers := getPeersHelper(s3peers)
 		if !reflect.DeepEqual(testCase.peers, referencePeers) {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/minio/minio-go/pkg/s3signer"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/hash"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // Tests should initNSLock only once.
@@ -308,10 +309,7 @@ func UnstartedTestServer(t TestErrHandler, instanceType string) TestServer {
 	globalObjLayerMutex.Unlock()
 
 	// initialize peer rpc
-	host, port := mustSplitHostPort(testServer.Server.Listener.Addr().String())
-	globalMinioHost = host
-	globalMinioPort = port
-	globalMinioAddr = getEndpointsLocalAddr(testServer.Disks)
+	globalServerHost = xnet.MustParseHost(testServer.Server.Listener.Addr().String())
 	initGlobalS3Peers(testServer.Disks)
 
 	return testServer
@@ -2347,16 +2345,6 @@ func mustGetNewEndpointList(args ...string) (endpoints EndpointList) {
 	}
 
 	return endpoints
-}
-
-func getEndpointsLocalAddr(endpoints EndpointList) string {
-	for _, endpoint := range endpoints {
-		if endpoint.IsLocal && endpoint.Type() == URLEndpointType {
-			return endpoint.Host
-		}
-	}
-
-	return globalMinioHost + ":" + globalMinioPort
 }
 
 // fetches a random number between range min-max.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -193,18 +192,6 @@ func isFile(path string) bool {
 	}
 
 	return false
-}
-
-// checkURL - checks if passed address correspond
-func checkURL(urlStr string) (*url.URL, error) {
-	if urlStr == "" {
-		return nil, errors.New("Address cannot be empty")
-	}
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, fmt.Errorf("`%s` invalid: %s", urlStr, err.Error())
-	}
-	return u, nil
 }
 
 // UTCNow - returns current UTC time.

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -221,31 +221,6 @@ func TestStartProfiler(t *testing.T) {
 	}
 }
 
-// TestCheckURL tests valid url.
-func TestCheckURL(t *testing.T) {
-	testCases := []struct {
-		urlStr     string
-		shouldPass bool
-	}{
-		{"", false},
-		{":", false},
-		{"http://localhost/", true},
-		{"http://127.0.0.1/", true},
-		{"proto://myhostname/path", true},
-	}
-
-	// Validates fetching local address.
-	for i, testCase := range testCases {
-		_, err := checkURL(testCase.urlStr)
-		if testCase.shouldPass && err != nil {
-			t.Errorf("Test %d: expected to pass but got an error: %v\n", i+1, err)
-		}
-		if !testCase.shouldPass && err == nil {
-			t.Errorf("Test %d: expected to fail but passed.", i+1)
-		}
-	}
-}
-
 // Testing dumping request function.
 func TestDumpRequest(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://localhost:9000?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=USWUXHGYZQYFYFFIT3RE%2F20170529%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20170529T190139Z&X-Amz-Expires=600&X-Amz-Signature=19b58080999df54b446fc97304eb8dda60d3df1812ae97f3e8783351bfd9781d&X-Amz-SignedHeaders=host&prefix=Hello%2AWorld%2A", nil)

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -416,7 +416,7 @@ func (web *webAPIHandlers) SetAuth(r *http.Request, args *SetAuthArgs, reply *Se
 		// Save the current creds when failed to update.
 		serverConfig.SetCredential(prevCred)
 
-		errsMap[globalMinioAddr] = err
+		errsMap[globalServerHost.String()] = err
 	}
 
 	// Log all the peer related error messages, and populate the
@@ -429,7 +429,7 @@ func (web *webAPIHandlers) SetAuth(r *http.Request, args *SetAuthArgs, reply *Se
 	}
 
 	// If we were unable to update locally, we return an error to the user/browser.
-	if errsMap[globalMinioAddr] != nil {
+	if errsMap[globalServerHost.String()] != nil {
 		// Since the error message may be very long to display
 		// on the browser, we tell the user to check the
 		// server logs.

--- a/pkg/net/host.go
+++ b/pkg/net/host.go
@@ -1,0 +1,146 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"regexp"
+	"strings"
+)
+
+var hostLabelRegexp = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
+
+// Host - holds network host and its port.
+type Host struct {
+	Host       string
+	PortNumber Port
+	IsPortSet  bool
+}
+
+// IsEmpty - returns whether Host is empty or not
+func (hp Host) IsEmpty() bool {
+	return hp.Host == ""
+}
+
+// String - returns string representation of Host.
+func (hp Host) String() string {
+	if !hp.IsPortSet {
+		return hp.Host
+	}
+
+	return hp.Host + ":" + hp.PortNumber.String()
+}
+
+// MarshalJSON - converts Host into JSON data
+func (hp Host) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hp.String())
+}
+
+// UnmarshalJSON - parses data into Host.
+func (hp *Host) UnmarshalJSON(data []byte) (err error) {
+	var s string
+	if err = json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	// Allow empty string
+	if s == "" {
+		return nil
+	}
+
+	var h *Host
+	if h, err = ParseHost(s); err != nil {
+		return err
+	}
+
+	*hp = *h
+	return nil
+}
+
+// ParseHost - parses string into Host
+func ParseHost(s string) (h *Host, err error) {
+	isValidHost := func(host string) bool {
+		if host == "" {
+			return false
+		}
+
+		if ip := net.ParseIP(host); ip != nil {
+			return true
+		}
+
+		// host is not a valid IPv4 or IPv6 address
+		// host may be a hostname
+		// refer https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
+		// why checks are done like below
+		if len(host) < 1 || len(host) > 253 {
+			return false
+		}
+
+		for _, label := range strings.Split(host, ".") {
+			if len(label) < 1 || len(label) > 63 {
+				return false
+			}
+
+			if !hostLabelRegexp.MatchString(label) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	isPortSet := true
+	host, portStr, err := net.SplitHostPort(s)
+	if err != nil {
+		if !strings.Contains(err.Error(), "missing port in address") {
+			return nil, err
+		}
+
+		host = s
+		portStr = ""
+		isPortSet = false
+	}
+
+	var p Port
+	if isPortSet {
+		p, err = ParsePort(portStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !isValidHost(host) {
+		return nil, errors.New("invalid hostname")
+	}
+
+	return &Host{
+		Host:       host,
+		PortNumber: p,
+		IsPortSet:  isPortSet,
+	}, nil
+}
+
+// MustParseHost - parses given string to Host, else panics.
+func MustParseHost(s string) *Host {
+	h, err := ParseHost(s)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}

--- a/pkg/net/host_test.go
+++ b/pkg/net/host_test.go
@@ -1,0 +1,213 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHostIsEmpty(t *testing.T) {
+	testCases := []struct {
+		host           Host
+		expectedResult bool
+	}{
+		{Host{"", 0, false}, true},
+		{Host{"", 0, true}, true},
+		{Host{"play", 9000, false}, false},
+		{Host{"play", 9000, true}, false},
+	}
+
+	for i, testCase := range testCases {
+		result := testCase.host.IsEmpty()
+
+		if result != testCase.expectedResult {
+			t.Fatalf("test %v: result: expected: %v, got: %v", i+1, testCase.expectedResult, result)
+		}
+	}
+}
+
+func TestHostString(t *testing.T) {
+	testCases := []struct {
+		host        Host
+		expectedStr string
+	}{
+		{Host{"", 0, false}, ""},
+		{Host{"", 0, true}, ":0"},
+		{Host{"play", 9000, false}, "play"},
+		{Host{"play", 9000, true}, "play:9000"},
+	}
+
+	for i, testCase := range testCases {
+		str := testCase.host.String()
+
+		if str != testCase.expectedStr {
+			t.Fatalf("test %v: string: expected: %v, got: %v", i+1, testCase.expectedStr, str)
+		}
+	}
+}
+
+func TestHostMarshalJSON(t *testing.T) {
+	testCases := []struct {
+		host         Host
+		expectedData []byte
+		expectErr    bool
+	}{
+		{Host{}, []byte(`""`), false},
+		{Host{"play", 0, false}, []byte(`"play"`), false},
+		{Host{"play", 0, true}, []byte(`"play:0"`), false},
+		{Host{"play", 9000, true}, []byte(`"play:9000"`), false},
+		{Host{"play.minio.io", 0, false}, []byte(`"play.minio.io"`), false},
+		{Host{"play.minio.io", 9000, true}, []byte(`"play.minio.io:9000"`), false},
+		{Host{"147.75.201.93", 0, false}, []byte(`"147.75.201.93"`), false},
+		{Host{"147.75.201.93", 9000, true}, []byte(`"147.75.201.93:9000"`), false},
+		{Host{"play12", 0, false}, []byte(`"play12"`), false},
+		{Host{"12play", 0, false}, []byte(`"12play"`), false},
+		{Host{"play-minio-io", 0, false}, []byte(`"play-minio-io"`), false},
+		{Host{"play--minio.io", 0, false}, []byte(`"play--minio.io"`), false},
+	}
+
+	for i, testCase := range testCases {
+		data, err := testCase.host.MarshalJSON()
+		expectErr := (err != nil)
+
+		if expectErr != testCase.expectErr {
+			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+		}
+
+		if !testCase.expectErr {
+			if !reflect.DeepEqual(data, testCase.expectedData) {
+				t.Fatalf("test %v: data: expected: %v, got: %v", i+1, string(testCase.expectedData), string(data))
+			}
+		}
+	}
+}
+
+func TestHostUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		data         []byte
+		expectedHost *Host
+		expectErr    bool
+	}{
+		{[]byte(`""`), &Host{}, false},
+		{[]byte(`"play"`), &Host{"play", 0, false}, false},
+		{[]byte(`"play:0"`), &Host{"play", 0, true}, false},
+		{[]byte(`"play:9000"`), &Host{"play", 9000, true}, false},
+		{[]byte(`"play.minio.io"`), &Host{"play.minio.io", 0, false}, false},
+		{[]byte(`"play.minio.io:9000"`), &Host{"play.minio.io", 9000, true}, false},
+		{[]byte(`"147.75.201.93"`), &Host{"147.75.201.93", 0, false}, false},
+		{[]byte(`"147.75.201.93:9000"`), &Host{"147.75.201.93", 9000, true}, false},
+		{[]byte(`"play12"`), &Host{"play12", 0, false}, false},
+		{[]byte(`"12play"`), &Host{"12play", 0, false}, false},
+		{[]byte(`"play-minio-io"`), &Host{"play-minio-io", 0, false}, false},
+		{[]byte(`"play--minio.io"`), &Host{"play--minio.io", 0, false}, false},
+		{[]byte(`":9000"`), nil, true},
+		{[]byte(`"play:"`), nil, true},
+		{[]byte(`"play::"`), nil, true},
+		{[]byte(`"play:90000"`), nil, true},
+		{[]byte(`"play:-10"`), nil, true},
+		{[]byte(`"play-"`), nil, true},
+		{[]byte(`"play.minio..io"`), nil, true},
+		{[]byte(`":"`), nil, true},
+	}
+
+	for i, testCase := range testCases {
+		var host Host
+		err := host.UnmarshalJSON(testCase.data)
+		expectErr := (err != nil)
+
+		if expectErr != testCase.expectErr {
+			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+		}
+
+		if !testCase.expectErr {
+			if !reflect.DeepEqual(&host, testCase.expectedHost) {
+				t.Fatalf("test %v: host: expected: %#v, got: %#v", i+1, testCase.expectedHost, host)
+			}
+		}
+	}
+}
+
+func TestParseHost(t *testing.T) {
+	testCases := []struct {
+		s            string
+		expectedHost *Host
+		expectErr    bool
+	}{
+		{"play", &Host{"play", 0, false}, false},
+		{"play:0", &Host{"play", 0, true}, false},
+		{"play:9000", &Host{"play", 9000, true}, false},
+		{"play.minio.io", &Host{"play.minio.io", 0, false}, false},
+		{"play.minio.io:9000", &Host{"play.minio.io", 9000, true}, false},
+		{"147.75.201.93", &Host{"147.75.201.93", 0, false}, false},
+		{"147.75.201.93:9000", &Host{"147.75.201.93", 9000, true}, false},
+		{"play12", &Host{"play12", 0, false}, false},
+		{"12play", &Host{"12play", 0, false}, false},
+		{"play-minio-io", &Host{"play-minio-io", 0, false}, false},
+		{"play--minio.io", &Host{"play--minio.io", 0, false}, false},
+		{":9000", nil, true},
+		{"play:", nil, true},
+		{"play::", nil, true},
+		{"play:90000", nil, true},
+		{"play:-10", nil, true},
+		{"play-", nil, true},
+		{"play.minio..io", nil, true},
+		{":", nil, true},
+		{"", nil, true},
+	}
+
+	for i, testCase := range testCases {
+		host, err := ParseHost(testCase.s)
+		expectErr := (err != nil)
+
+		if expectErr != testCase.expectErr {
+			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+		}
+
+		if !testCase.expectErr {
+			if !reflect.DeepEqual(host, testCase.expectedHost) {
+				t.Fatalf("test %v: host: expected: %#v, got: %#v", i+1, testCase.expectedHost, host)
+			}
+		}
+	}
+}
+
+func TestMustParseHost(t *testing.T) {
+	testCases := []struct {
+		s            string
+		expectedHost *Host
+	}{
+		{"play", &Host{"play", 0, false}},
+		{"play:0", &Host{"play", 0, true}},
+		{"play:9000", &Host{"play", 9000, true}},
+		{"play.minio.io", &Host{"play.minio.io", 0, false}},
+		{"play.minio.io:9000", &Host{"play.minio.io", 9000, true}},
+		{"147.75.201.93", &Host{"147.75.201.93", 0, false}},
+		{"147.75.201.93:9000", &Host{"147.75.201.93", 9000, true}},
+		{"play12", &Host{"play12", 0, false}},
+		{"12play", &Host{"12play", 0, false}},
+		{"play-minio-io", &Host{"play-minio-io", 0, false}},
+		{"play--minio.io", &Host{"play--minio.io", 0, false}},
+	}
+
+	for i, testCase := range testCases {
+		host := MustParseHost(testCase.s)
+		if !reflect.DeepEqual(host, testCase.expectedHost) {
+			t.Fatalf("test %v: host: expected: %#v, got: %#v", i+1, testCase.expectedHost, host)
+		}
+	}
+}

--- a/pkg/net/port.go
+++ b/pkg/net/port.go
@@ -1,0 +1,54 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net
+
+import (
+	"errors"
+	"strconv"
+)
+
+// Port - network port
+type Port uint16
+
+// String - returns string representation of port.
+func (p Port) String() string {
+	return strconv.Itoa(int(p))
+}
+
+// ParsePort - parses string into Port
+func ParsePort(s string) (p Port, err error) {
+	var i int
+	if i, err = strconv.Atoi(s); err != nil {
+		return p, errors.New("invalid port number")
+	}
+
+	if i < 0 || i > 65535 {
+		return p, errors.New("port must be between 0 to 65535")
+	}
+
+	return Port(i), nil
+}
+
+// MustParsePort - parses string into Port, else panics
+func MustParsePort(s string) Port {
+	p, err := ParsePort(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return p
+}

--- a/pkg/net/port_test.go
+++ b/pkg/net/port_test.go
@@ -1,0 +1,92 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net
+
+import (
+	"testing"
+)
+
+func TestPortString(t *testing.T) {
+	testCases := []struct {
+		port        Port
+		expectedStr string
+	}{
+		{Port(0), "0"},
+		{Port(9000), "9000"},
+		{Port(65535), "65535"},
+		{Port(1024), "1024"},
+	}
+
+	for i, testCase := range testCases {
+		str := testCase.port.String()
+
+		if str != testCase.expectedStr {
+			t.Fatalf("test %v: error: port: %v, got: %v", i+1, testCase.expectedStr, str)
+		}
+	}
+}
+
+func TestParsePort(t *testing.T) {
+	testCases := []struct {
+		s            string
+		expectedPort Port
+		expectErr    bool
+	}{
+		{"0", Port(0), false},
+		{"9000", Port(9000), false},
+		{"65535", Port(65535), false},
+		{"90000", Port(0), true},
+		{"-10", Port(0), true},
+		{"", Port(0), true},
+		{"http", Port(0), true},
+		{" 1024", Port(0), true},
+	}
+
+	for i, testCase := range testCases {
+		port, err := ParsePort(testCase.s)
+		expectErr := (err != nil)
+
+		if expectErr != testCase.expectErr {
+			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+		}
+
+		if !testCase.expectErr {
+			if port != testCase.expectedPort {
+				t.Fatalf("test %v: error: port: %v, got: %v", i+1, testCase.expectedPort, port)
+			}
+		}
+	}
+}
+
+func TestMustParsePort(t *testing.T) {
+	testCases := []struct {
+		s            string
+		expectedPort Port
+	}{
+		{"0", Port(0)},
+		{"9000", Port(9000)},
+		{"65535", Port(65535)},
+	}
+
+	for i, testCase := range testCases {
+		port := MustParsePort(testCase.s)
+
+		if port != testCase.expectedPort {
+			t.Fatalf("test %v: error: port: %v, got: %v", i+1, testCase.expectedPort, port)
+		}
+	}
+}

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -1,0 +1,102 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+	"path"
+)
+
+// URL - improved JSON friendly url.URL.
+type URL url.URL
+
+// IsEmpty - checks URL is empty or not.
+func (u URL) IsEmpty() bool {
+	return u.String() == ""
+}
+
+// String - returns string representation of URL.
+func (u URL) String() string {
+	// if port number 80 and 443, remove for http and https scheme respectively
+	if u.Host != "" {
+		host := MustParseHost(u.Host)
+		switch {
+		case u.Scheme == "http" && host.PortNumber == 80:
+			fallthrough
+		case u.Scheme == "https" && host.PortNumber == 443:
+			u.Host = host.Host
+		}
+	}
+
+	uu := url.URL(u)
+	return uu.String()
+}
+
+// MarshalJSON - converts to JSON string data.
+func (u URL) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.String())
+}
+
+// UnmarshalJSON - parses given data into URL.
+func (u *URL) UnmarshalJSON(data []byte) (err error) {
+	var s string
+	if err = json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	// Allow empty string
+	if s == "" {
+		return nil
+	}
+
+	var ru *URL
+	if ru, err = ParseURL(s); err != nil {
+		return err
+	}
+
+	*u = *ru
+	return nil
+}
+
+// ParseURL - parses string into URL.
+func ParseURL(s string) (u *URL, err error) {
+	var uu *url.URL
+	if uu, err = url.Parse(s); err != nil {
+		return nil, err
+	}
+
+	if uu.Host == "" {
+		if uu.Scheme != "" {
+			return nil, errors.New("scheme appears with empty host")
+		}
+	} else if _, err = ParseHost(uu.Host); err != nil {
+		return nil, err
+	}
+
+	// Clean path in the URL.
+	// Note: path.Clean() is used on purpose because in MS Windows filepath.Clean() converts
+	// `/` into `\` ie `/foo` becomes `\foo`
+	if uu.Path != "" {
+		uu.Path = path.Clean(uu.Path)
+	}
+
+	v := URL(*uu)
+	u = &v
+	return u, nil
+}

--- a/pkg/net/url_test.go
+++ b/pkg/net/url_test.go
@@ -1,0 +1,167 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestURLIsEmpty(t *testing.T) {
+	testCases := []struct {
+		url            URL
+		expectedResult bool
+	}{
+		{URL{}, true},
+		{URL{Scheme: "http", Host: "play"}, false},
+		{URL{Path: "path/to/play"}, false},
+	}
+
+	for i, testCase := range testCases {
+		result := testCase.url.IsEmpty()
+
+		if result != testCase.expectedResult {
+			t.Fatalf("test %v: result: expected: %v, got: %v", i+1, testCase.expectedResult, result)
+		}
+	}
+}
+
+func TestURLString(t *testing.T) {
+	testCases := []struct {
+		url         URL
+		expectedStr string
+	}{
+		{URL{}, ""},
+		{URL{Scheme: "http", Host: "play"}, "http://play"},
+		{URL{Scheme: "https", Host: "play:443"}, "https://play"},
+		{URL{Scheme: "https", Host: "play.minio.io:80"}, "https://play.minio.io:80"},
+		{URL{Scheme: "https", Host: "147.75.201.93:9000", Path: "/"}, "https://147.75.201.93:9000/"},
+		{URL{Scheme: "https", Host: "s3.amazonaws.com", Path: "/", RawQuery: "location"}, "https://s3.amazonaws.com/?location"},
+		{URL{Scheme: "http", Host: "myminio:10000", Path: "/mybucket/myobject"}, "http://myminio:10000/mybucket/myobject"},
+		{URL{Scheme: "ftp", Host: "myftp.server:10000", Path: "/myuser"}, "ftp://myftp.server:10000/myuser"},
+		{URL{Path: "path/to/play"}, "path/to/play"},
+	}
+
+	for i, testCase := range testCases {
+		str := testCase.url.String()
+
+		if str != testCase.expectedStr {
+			t.Fatalf("test %v: string: expected: %v, got: %v", i+1, testCase.expectedStr, str)
+		}
+	}
+}
+
+func TestURLMarshalJSON(t *testing.T) {
+	testCases := []struct {
+		url          URL
+		expectedData []byte
+		expectErr    bool
+	}{
+		{URL{}, []byte(`""`), false},
+		{URL{Scheme: "http", Host: "play"}, []byte(`"http://play"`), false},
+		{URL{Scheme: "https", Host: "play.minio.io:0"}, []byte(`"https://play.minio.io:0"`), false},
+		{URL{Scheme: "https", Host: "147.75.201.93:9000", Path: "/"}, []byte(`"https://147.75.201.93:9000/"`), false},
+		{URL{Scheme: "https", Host: "s3.amazonaws.com", Path: "/", RawQuery: "location"}, []byte(`"https://s3.amazonaws.com/?location"`), false},
+		{URL{Scheme: "http", Host: "myminio:10000", Path: "/mybucket/myobject"}, []byte(`"http://myminio:10000/mybucket/myobject"`), false},
+		{URL{Scheme: "ftp", Host: "myftp.server:10000", Path: "/myuser"}, []byte(`"ftp://myftp.server:10000/myuser"`), false},
+	}
+
+	for i, testCase := range testCases {
+		data, err := testCase.url.MarshalJSON()
+		expectErr := (err != nil)
+
+		if expectErr != testCase.expectErr {
+			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+		}
+
+		if !testCase.expectErr {
+			if !reflect.DeepEqual(data, testCase.expectedData) {
+				t.Fatalf("test %v: data: expected: %v, got: %v", i+1, string(testCase.expectedData), string(data))
+			}
+		}
+	}
+}
+
+func TestURLUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		data        []byte
+		expectedURL *URL
+		expectErr   bool
+	}{
+		{[]byte(`""`), &URL{}, false},
+		{[]byte(`"http://play"`), &URL{Scheme: "http", Host: "play"}, false},
+		{[]byte(`"https://play.minio.io:0"`), &URL{Scheme: "https", Host: "play.minio.io:0"}, false},
+		{[]byte(`"https://147.75.201.93:9000/"`), &URL{Scheme: "https", Host: "147.75.201.93:9000", Path: "/"}, false},
+		{[]byte(`"https://s3.amazonaws.com/?location"`), &URL{Scheme: "https", Host: "s3.amazonaws.com", Path: "/", RawQuery: "location"}, false},
+		{[]byte(`"http://myminio:10000/mybucket//myobject/"`), &URL{Scheme: "http", Host: "myminio:10000", Path: "/mybucket/myobject"}, false},
+		{[]byte(`"ftp://myftp.server:10000/myuser"`), &URL{Scheme: "ftp", Host: "myftp.server:10000", Path: "/myuser"}, false},
+		{[]byte(`"myserver:1000"`), nil, true},
+		{[]byte(`"http://:1000/mybucket"`), nil, true},
+		{[]byte(`"https://147.75.201.93:90000/"`), nil, true},
+		{[]byte(`"http:/play"`), nil, true},
+	}
+
+	for i, testCase := range testCases {
+		var url URL
+		err := url.UnmarshalJSON(testCase.data)
+		expectErr := (err != nil)
+
+		if expectErr != testCase.expectErr {
+			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+		}
+
+		if !testCase.expectErr {
+			if !reflect.DeepEqual(&url, testCase.expectedURL) {
+				t.Fatalf("test %v: host: expected: %#v, got: %#v", i+1, testCase.expectedURL, url)
+			}
+		}
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	testCases := []struct {
+		s           string
+		expectedURL *URL
+		expectErr   bool
+	}{
+		{"http://play", &URL{Scheme: "http", Host: "play"}, false},
+		{"https://play.minio.io:0", &URL{Scheme: "https", Host: "play.minio.io:0"}, false},
+		{"https://147.75.201.93:9000/", &URL{Scheme: "https", Host: "147.75.201.93:9000", Path: "/"}, false},
+		{"https://s3.amazonaws.com/?location", &URL{Scheme: "https", Host: "s3.amazonaws.com", Path: "/", RawQuery: "location"}, false},
+		{"http://myminio:10000/mybucket//myobject/", &URL{Scheme: "http", Host: "myminio:10000", Path: "/mybucket/myobject"}, false},
+		{"ftp://myftp.server:10000/myuser", &URL{Scheme: "ftp", Host: "myftp.server:10000", Path: "/myuser"}, false},
+		{"myserver:1000", nil, true},
+		{"http://:1000/mybucket", nil, true},
+		{"https://147.75.201.93:90000/", nil, true},
+		{"http:/play", nil, true},
+	}
+
+	for i, testCase := range testCases {
+		url, err := ParseURL(testCase.s)
+		expectErr := (err != nil)
+
+		if expectErr != testCase.expectErr {
+			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+		}
+
+		if !testCase.expectErr {
+			if !reflect.DeepEqual(url, testCase.expectedURL) {
+				t.Fatalf("test %v: host: expected: %#v, got: %#v", i+1, testCase.expectedURL, url)
+			}
+		}
+	}
+}


### PR DESCRIPTION
New subpackage `net` has types
* Port - extended uint16 native type contains friendly methods and functions.
* Host - A type holds host and Port pairs where Port is optional.
* URL - extended url.URL native type which gives more validation and JSON friendly.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.