### PR TITLE
Fix help subcommand for each minio gateway

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -91,9 +91,12 @@ EXAMPLES:
 
 // Handler for 'minio gateway azure' command line.
 func azureGatewayMain(ctx *cli.Context) {
+	if ctx.Args().Present() && ctx.Args().First() == "help" {
+		cli.ShowCommandHelpAndExit(ctx, azureBackend, 1)
+	}
+
 	// Validate gateway arguments.
 	host := ctx.Args().First()
-	// Validate gateway arguments.
 	fatalIf(validateGatewayArguments(ctx.GlobalString("address"), host), "Invalid argument")
 
 	startGateway(ctx, &AzureGateway{host})

--- a/cmd/gateway-b2.go
+++ b/cmd/gateway-b2.go
@@ -79,6 +79,10 @@ EXAMPLES:
 
 // Handler for 'minio gateway b2' command line.
 func b2GatewayMain(ctx *cli.Context) {
+	if ctx.Args().Present() && ctx.Args().First() == "help" {
+		cli.ShowCommandHelpAndExit(ctx, b2Backend, 1)
+	}
+
 	startGateway(ctx, &B2Gateway{})
 }
 

--- a/cmd/gateway-gcs.go
+++ b/cmd/gateway-gcs.go
@@ -127,6 +127,10 @@ EXAMPLES:
 
 // Handler for 'minio gateway gcs' command line.
 func gcsGatewayMain(ctx *cli.Context) {
+	if ctx.Args().Present() && ctx.Args().First() == "help" {
+		cli.ShowCommandHelpAndExit(ctx, gcsBackend, 1)
+	}
+
 	projectID := ctx.Args().First()
 	if projectID == "" && os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
 		errorIf(errGCSProjectIDNotFound, "project-id should be provided as argument or GOOGLE_APPLICATION_CREDENTIALS should be set with path to credentials.json")

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -166,10 +166,6 @@ func startGateway(ctx *cli.Context, gw Gateway) {
 
 	initNSLock(false) // Enable local namespace lock.
 
-	if ctx.Args().First() == "help" {
-		cli.ShowCommandHelpAndExit(ctx, gatewayName, 1)
-	}
-
 	newObject, err := gw.NewGatewayLayer()
 	fatalIf(err, "Unable to initialize gateway layer")
 

--- a/cmd/gateway-s3.go
+++ b/cmd/gateway-s3.go
@@ -76,9 +76,12 @@ EXAMPLES:
 
 // Handler for 'minio gateway s3' command line.
 func s3GatewayMain(ctx *cli.Context) {
+	if ctx.Args().Present() && ctx.Args().First() == "help" {
+		cli.ShowCommandHelpAndExit(ctx, s3Backend, 1)
+	}
+
 	// Validate gateway arguments.
 	host := ctx.Args().First()
-	// Validate gateway arguments.
 	fatalIf(validateGatewayArguments(ctx.GlobalString("address"), host), "Invalid argument")
 
 	startGateway(ctx, &S3Gateway{host})


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In #5111, 'help' subcommand was moved to `startGateway` during review,
but not get restored then. So the "help" subcommand won't function if
credentials are not provided.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.