### PR TITLE
Display help when access/secret key is not set

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -144,7 +144,8 @@ func startGateway(ctx *cli.Context, gw Gateway) {
 	// Validate if we have access, secret set through environment.
 	gatewayName := gw.Name()
 	if !globalIsEnvCreds {
-		fatalIf(fmt.Errorf("Access and Secret keys should be set through ENVs for backend [%s]", gatewayName), "")
+		errorIf(errors.New("Access and secret keys not set"), "Access and Secret keys should be set through ENVs for backend [%s]", gatewayName)
+		cli.ShowCommandHelpAndExit(ctx, gatewayName, 1)
 	}
 
 	// Create certs path.


### PR DESCRIPTION
## Description
Display help message, when access and secret keys are not set in
any of the gateway.

Fixes #5124

## Motivation and Context
Gateway help to be consistent regarding access/secret requirement

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ x] All new and existing tests passed.