### PR TITLE
fix content-sha256 verification for presigned PUT

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -569,7 +569,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 			return
 		}
 		if !skipContentSha256Cksum(r) {
-			sha256hex = r.Header.Get("X-Amz-Content-Sha256")
+			sha256hex = getContentSha256Cksum(r)
 		}
 	}
 
@@ -866,7 +866,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		}
 
 		if !skipContentSha256Cksum(r) {
-			sha256hex = r.Header.Get("X-Amz-Content-Sha256")
+			sha256hex = getContentSha256Cksum(r)
 		}
 	}
 

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -289,7 +289,7 @@ func doesPresignedSignatureMatch(hashedPayload string, r *http.Request, region s
 	/// Verify finally if signature is same.
 
 	// Get canonical request.
-	presignedCanonicalReq := getCanonicalRequest(extractedSignedHeaders, hashedPayload, encodedQuery, req.URL.Path, req.Method)
+	presignedCanonicalReq := getCanonicalRequest(extractedSignedHeaders, unsignedPayload, encodedQuery, req.URL.Path, req.Method)
 
 	// Get string to sign from canonical request.
 	presignedStringToSign := getStringToSign(presignedCanonicalReq, t, pSignValues.Credential.getScope())


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
It is possible that x-amz-content-sha256 is set through
the query params in case of presigned PUT calls, make sure
that we validate the incoming x-amz-content-sha256 properly.

Current code simply just allows this without honoring the
set x-amz-content-sha256, fix it.

<!--- Describe your changes in detail -->

## Motivation and Context
AWS S3 compatiblity
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using test code.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [x] I have added/updated functional tests in [mint](https://github.com/minio/mint). (https://github.com/minio/mint/pull/209)
- [x] All new and existing tests passed.