### PR TITLE
Return MethodNotAllowed error in PostPolicyBucketHandler if URL has object name

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -438,6 +439,13 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		return
 	}
 
+	// Make sure that the URL  does not contain object name.
+	bucket := mux.Vars(r)["bucket"]
+	if bucket != filepath.Clean(r.URL.Path[1:]) {
+		writeErrorResponse(w, ErrMethodNotAllowed, r.URL)
+		return
+	}
+
 	// Require Content-Length to be set in the request
 	size := r.ContentLength
 	if size < 0 {
@@ -482,7 +490,6 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	// Close multipart file
 	defer fileBody.Close()
 
-	bucket := mux.Vars(r)["bucket"]
 	formValues.Set("Bucket", bucket)
 
 	if fileName != "" && strings.Contains(formValues.Get("Key"), "${filename}") {

--- a/cmd/post-policy_test.go
+++ b/cmd/post-policy_test.go
@@ -558,7 +558,7 @@ func newPostRequestV2(endPoint, bucketName, objectName string, accessKey, secret
 	// Set the body equal to the created policy.
 	reader := bytes.NewReader(buf.Bytes())
 
-	req, err := http.NewRequest("POST", makeTestTargetURL(endPoint, bucketName, objectName, nil), reader)
+	req, err := http.NewRequest("POST", makeTestTargetURL(endPoint, bucketName, "", nil), reader)
 	if err != nil {
 		return nil, err
 	}
@@ -636,7 +636,7 @@ func newPostRequestV4Generic(endPoint, bucketName, objectName string, objData []
 	// Set the body equal to the created policy.
 	reader := bytes.NewReader(buf.Bytes())
 
-	req, err := http.NewRequest("POST", makeTestTargetURL(endPoint, bucketName, objectName, nil), reader)
+	req, err := http.NewRequest("POST", makeTestTargetURL(endPoint, bucketName, "", nil), reader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
S3 spec requires that MethodNotAllowed error be return if object name is part
of the URL.
Fixes #5141
## Motivation and Context
A functional test in Minio-java client mistakenly sent the object name as part of the URL when issuing a post object method with a presigned policy. Amazon s3 correctly returns MethodNotAllowed error, where as Minio succeeds in creating the object.

## How Has This Been Tested?
This has been tested manually using both mc and minio-java clients.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.