### PR TITLE
Accept forbidden as response code in health check

### DIFF
--- a/dockerscripts/healthcheck.sh
+++ b/dockerscripts/healthcheck.sh
@@ -50,10 +50,10 @@ healthcheck_main () {
                 ${scheme}${address}${resource})
         fi
 
-        # If http_repsonse is 200 - server is up. When MINIO_BROWSER is
-        # set to off, curl responds with 404. We assume that the server
-        # is up
-        [ "$http_response" = "200" ] || [ "$http_response" = "404" ]
+        # If http_repsonse is 200 - server is up. When MINIO_BROWSER
+        # is set to off, curl responds with 404 or 403. We assume that
+        # the server is up
+        [ "$http_response" = "200" ] || [ "$http_response" = "404" ] || [ "$http_response" = "403" ]
     fi
 }
 


### PR DESCRIPTION
## Description
minio response with a 403 during the healthcheck, if used with Google Cloud Storage and without the browser. 

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.