### PR TITLE
Reject anonymous requests to gateways if browser is disabled

### DIFF
--- a/cmd/gateway-azure-anonymous.go
+++ b/cmd/gateway-azure-anonymous.go
@@ -113,6 +113,11 @@ func azureAnonRequest(verb, urlStr string, header http.Header) (*http.Response, 
 
 // AnonGetBucketInfo - Get bucket metadata from azure anonymously.
 func (a *azureObjects) AnonGetBucketInfo(bucket string) (bucketInfo BucketInfo, err error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return bucketInfo, traceError(BucketNotFound{Bucket: bucket})
+	}
+
 	blobURL := a.client.GetContainerReference(bucket).GetBlobReference("").GetURL()
 	url, err := url.Parse(blobURL)
 	if err != nil {
@@ -145,6 +150,11 @@ func (a *azureObjects) AnonGetBucketInfo(bucket string) (bucketInfo BucketInfo, 
 // AnonGetObject - SendGET request without authentication.
 // This is needed when clients send GET requests on objects that can be downloaded without auth.
 func (a *azureObjects) AnonGetObject(bucket, object string, startOffset int64, length int64, writer io.Writer) (err error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return traceError(BucketNotFound{Bucket: bucket})
+	}
+
 	h := make(http.Header)
 	if length > 0 && startOffset > 0 {
 		h.Add("Range", fmt.Sprintf("bytes=%d-%d", startOffset, startOffset+length-1))
@@ -170,6 +180,11 @@ func (a *azureObjects) AnonGetObject(bucket, object string, startOffset int64, l
 // AnonGetObjectInfo - Send HEAD request without authentication and convert the
 // result to ObjectInfo.
 func (a *azureObjects) AnonGetObjectInfo(bucket, object string) (objInfo ObjectInfo, err error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return objInfo, traceError(BucketNotFound{Bucket: bucket})
+	}
+
 	blobURL := a.client.GetContainerReference(bucket).GetBlobReference(object).GetURL()
 	resp, err := azureAnonRequest(httpHEAD, blobURL, nil)
 	if err != nil {
@@ -211,6 +226,11 @@ func (a *azureObjects) AnonGetObjectInfo(bucket, object string) (objInfo ObjectI
 
 // AnonListObjects - Use Azure equivalent ListBlobs.
 func (a *azureObjects) AnonListObjects(bucket, prefix, marker, delimiter string, maxKeys int) (result ListObjectsInfo, err error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return result, traceError(BucketNotFound{Bucket: bucket})
+	}
+
 	params := storage.ListBlobsParameters{
 		Prefix:     prefix,
 		Marker:     marker,
@@ -265,6 +285,10 @@ func (a *azureObjects) AnonListObjects(bucket, prefix, marker, delimiter string,
 
 // AnonListObjectsV2 - List objects in V2 mode, anonymously
 func (a *azureObjects) AnonListObjectsV2(bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (result ListObjectsV2Info, err error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return result, traceError(BucketNotFound{Bucket: bucket})
+	}
 	params := storage.ListBlobsParameters{
 		Prefix:     prefix,
 		Marker:     continuationToken,

--- a/cmd/gateway-b2-anonymous.go
+++ b/cmd/gateway-b2-anonymous.go
@@ -41,6 +41,10 @@ func mkRange(offset, size int64) string {
 // AnonGetObject - performs a plain http GET request on a public resource,
 // fails if the resource is not public.
 func (l *b2Objects) AnonGetObject(bucket string, object string, startOffset int64, length int64, writer io.Writer) error {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return traceError(BucketNotFound{Bucket: bucket})
+	}
 	uri := fmt.Sprintf("%s/file/%s/%s", l.b2Client.DownloadURI, bucket, object)
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
@@ -116,6 +120,10 @@ func headerToObjectInfo(bucket, object string, header http.Header) (objInfo Obje
 // AnonGetObjectInfo - performs a plain http HEAD request on a public resource,
 // fails if the resource is not public.
 func (l *b2Objects) AnonGetObjectInfo(bucket string, object string) (objInfo ObjectInfo, err error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return objInfo, traceError(BucketNotFound{Bucket: bucket})
+	}
 	uri := fmt.Sprintf("%s/file/%s/%s", l.b2Client.DownloadURI, bucket, object)
 	req, err := http.NewRequest("HEAD", uri, nil)
 	if err != nil {

--- a/cmd/gateway-gcs-anonymous.go
+++ b/cmd/gateway-gcs-anonymous.go
@@ -30,6 +30,11 @@ func toGCSPublicURL(bucket, object string) string {
 
 // AnonGetObject - Get object anonymously
 func (l *gcsGateway) AnonGetObject(bucket string, object string, startOffset int64, length int64, writer io.Writer) error {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return traceError(BucketNotFound{Bucket: bucket})
+	}
+
 	req, err := http.NewRequest("GET", toGCSPublicURL(bucket, object), nil)
 	if err != nil {
 		return gcsToObjectError(traceError(err), bucket, object)
@@ -57,6 +62,11 @@ func (l *gcsGateway) AnonGetObject(bucket string, object string, startOffset int
 
 // AnonGetObjectInfo - Get object info anonymously
 func (l *gcsGateway) AnonGetObjectInfo(bucket string, object string) (objInfo ObjectInfo, err error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return objInfo, traceError(BucketNotFound{Bucket: bucket})
+	}
+
 	resp, err := http.Head(toGCSPublicURL(bucket, object))
 	if err != nil {
 		return objInfo, gcsToObjectError(traceError(err), bucket, object)
@@ -97,6 +107,11 @@ func (l *gcsGateway) AnonGetObjectInfo(bucket string, object string) (objInfo Ob
 
 // AnonListObjects - List objects anonymously
 func (l *gcsGateway) AnonListObjects(bucket string, prefix string, marker string, delimiter string, maxKeys int) (ListObjectsInfo, error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return ListObjectsInfo{}, traceError(BucketNotFound{Bucket: bucket})
+	}
+
 	result, err := l.anonClient.ListObjects(bucket, prefix, marker, delimiter, maxKeys)
 	if err != nil {
 		return ListObjectsInfo{}, s3ToObjectError(traceError(err), bucket)
@@ -107,6 +122,10 @@ func (l *gcsGateway) AnonListObjects(bucket string, prefix string, marker string
 
 // AnonListObjectsV2 - List objects in V2 mode, anonymously
 func (l *gcsGateway) AnonListObjectsV2(bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (ListObjectsV2Info, error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return ListObjectsV2Info{}, traceError(BucketNotFound{Bucket: bucket})
+	}
 	// Request V1 List Object to the backend
 	result, err := l.anonClient.ListObjects(bucket, prefix, continuationToken, delimiter, maxKeys)
 	if err != nil {
@@ -118,6 +137,10 @@ func (l *gcsGateway) AnonListObjectsV2(bucket, prefix, continuationToken, delimi
 
 // AnonGetBucketInfo - Get bucket metadata anonymously.
 func (l *gcsGateway) AnonGetBucketInfo(bucket string) (bucketInfo BucketInfo, err error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return bucketInfo, traceError(BucketNotFound{Bucket: bucket})
+	}
 	resp, err := http.Head(toGCSPublicURL(bucket, ""))
 	if err != nil {
 		return bucketInfo, gcsToObjectError(traceError(err))

--- a/cmd/gateway-s3-anonymous.go
+++ b/cmd/gateway-s3-anonymous.go
@@ -25,6 +25,10 @@ import (
 
 // AnonPutObject creates a new object anonymously with the incoming data,
 func (l *s3Objects) AnonPutObject(bucket string, object string, data *hash.Reader, metadata map[string]string) (objInfo ObjectInfo, e error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return objInfo, traceError(BucketNotFound{Bucket: bucket})
+	}
 	oi, err := l.anonClient.PutObject(bucket, object, data, data.Size(), data.MD5(), data.SHA256(), toMinioClientMetadata(metadata))
 	if err != nil {
 		return objInfo, s3ToObjectError(traceError(err), bucket, object)
@@ -35,6 +39,10 @@ func (l *s3Objects) AnonPutObject(bucket string, object string, data *hash.Reade
 
 // AnonGetObject - Get object anonymously
 func (l *s3Objects) AnonGetObject(bucket string, key string, startOffset int64, length int64, writer io.Writer) error {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return traceError(BucketNotFound{Bucket: bucket})
+	}
 	opts := minio.GetObjectOptions{}
 	if err := opts.SetRange(startOffset, startOffset+length-1); err != nil {
 		return s3ToObjectError(traceError(err), bucket, key)
@@ -55,6 +63,10 @@ func (l *s3Objects) AnonGetObject(bucket string, key string, startOffset int64, 
 
 // AnonGetObjectInfo - Get object info anonymously
 func (l *s3Objects) AnonGetObjectInfo(bucket string, object string) (objInfo ObjectInfo, e error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return objInfo, traceError(BucketNotFound{Bucket: bucket})
+	}
 	oi, err := l.anonClient.StatObject(bucket, object, minio.StatObjectOptions{})
 	if err != nil {
 		return objInfo, s3ToObjectError(traceError(err), bucket, object)
@@ -65,6 +77,10 @@ func (l *s3Objects) AnonGetObjectInfo(bucket string, object string) (objInfo Obj
 
 // AnonListObjects - List objects anonymously
 func (l *s3Objects) AnonListObjects(bucket string, prefix string, marker string, delimiter string, maxKeys int) (loi ListObjectsInfo, e error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return loi, traceError(BucketNotFound{Bucket: bucket})
+	}
 	result, err := l.anonClient.ListObjects(bucket, prefix, marker, delimiter, maxKeys)
 	if err != nil {
 		return loi, s3ToObjectError(traceError(err), bucket)
@@ -75,6 +91,10 @@ func (l *s3Objects) AnonListObjects(bucket string, prefix string, marker string,
 
 // AnonListObjectsV2 - List objects in V2 mode, anonymously
 func (l *s3Objects) AnonListObjectsV2(bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (loi ListObjectsV2Info, e error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return loi, traceError(BucketNotFound{Bucket: bucket})
+	}
 	result, err := l.anonClient.ListObjectsV2(bucket, prefix, continuationToken, fetchOwner, delimiter, maxKeys)
 	if err != nil {
 		return loi, s3ToObjectError(traceError(err), bucket)
@@ -85,6 +105,10 @@ func (l *s3Objects) AnonListObjectsV2(bucket, prefix, continuationToken, delimit
 
 // AnonGetBucketInfo - Get bucket metadata anonymously.
 func (l *s3Objects) AnonGetBucketInfo(bucket string) (bi BucketInfo, e error) {
+	// if browser is not enabled and bucket requested is reserved bucket, return 404
+	if !globalIsBrowserEnabled && isMinioReservedBucket(bucket) {
+		return bi, traceError(BucketNotFound{Bucket: bucket})
+	}
 	if exists, err := l.anonClient.BucketExists(bucket); err != nil {
 		return bi, s3ToObjectError(traceError(err), bucket)
 	} else if !exists {


### PR DESCRIPTION
## Description
Minio broswer can be disabled by setting the env MINIO_BROWSER=off.
When browser is disabled, Minio should respond with ErrNoSuchBucket
uniformly across server and gateway modes.

## Motivation and Context
Currently minio server responds with 404 and gateways respond with 403 for a browser request (when browser is disabled)

## How Has This Been Tested?
Manually with curl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.