### PR TITLE
Check for value > 7 days in X-Amz-Expires header.

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -120,6 +120,7 @@ const (
 	ErrBucketAlreadyExists
 	ErrMetadataTooLarge
 	ErrUnsupportedMetadata
+	ErrMaximumExpires
 	// Add new error codes here.
 
 	// Server-Side-Encryption (with Customer provided key) related API errors.
@@ -724,6 +725,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Code:           "XMinioObjectTampered",
 		Description:    errObjectTampered.Error(),
 		HTTPStatusCode: http.StatusPartialContent,
+	},
+	ErrMaximumExpires: {
+		Code:           "AuthorizationQueryParametersError",
+		Description:    "X-Amz-Expires must be less than a week (in seconds); that is, the given X-Amz-Expires must be less than 604800 seconds",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	// Add your error structure here.
 }

--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -188,6 +188,11 @@ func parsePreSignV4(query url.Values) (psv preSignValues, aec APIErrorCode) {
 	if preSignV4Values.Expires < 0 {
 		return psv, ErrNegativeExpires
 	}
+
+	// Check if Expiry time is less than 7 days (value in seconds).
+	if preSignV4Values.Expires.Seconds() > 604800 {
+		return psv, ErrMaximumExpires
+	}
 	// Save signed headers.
 	preSignV4Values.SignedHeaders, err = parseSignedHeader("SignedHeaders=" + query.Get("X-Amz-SignedHeaders"))
 	if err != ErrNone {

--- a/cmd/signature-v4-parser_test.go
+++ b/cmd/signature-v4-parser_test.go
@@ -750,6 +750,30 @@ func TestParsePreSignV4(t *testing.T) {
 			},
 			expectedErrCode: ErrNone,
 		},
+
+		// Test case - 9.
+		// Test case with value greater than 604800 in X-Amz-Expires header.
+		{
+			inputQueryKeyVals: []string{
+				// valid  "X-Amz-Algorithm" header.
+				"X-Amz-Algorithm", signV4Algorithm,
+				// valid  "X-Amz-Credential" header.
+				"X-Amz-Credential", joinWithSlash(
+					"Z7IXGOO6BZ0REAN1Q26I",
+					sampleTimeStr,
+					"us-west-1",
+					"s3",
+					"aws4_request"),
+				// valid "X-Amz-Date" query.
+				"X-Amz-Date", queryTime.UTC().Format(iso8601Format),
+				// Invalid Expiry time greater than 7 days (604800 in seconds).
+				"X-Amz-Expires", getDurationStr(605000),
+				"X-Amz-Signature", "abcd",
+				"X-Amz-SignedHeaders", "host;x-amz-content-sha256;x-amz-date",
+			},
+			expectedPreSignValues: preSignValues{},
+			expectedErrCode:       ErrMaximumExpires,
+		},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
Add a check to see if the X-Amz-Expires header in the presigned URL is less than 7 days.
## Description
<!--- Describe your changes in detail -->
If a presigned url has a X-AMZ-Expires header field with value greater than 604800, it should return error. So, added a check to see if the X-Amz-Expires header in the presigned URL is less than 7 days.

## Motivation and Context
Fixes #5162

## How Has This Been Tested?
This change has been tested manually, using a hacked version of the client that generated an expiry time greater than 7 days.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.