### PR TITLE
Return ErrContentSHA256Mismatch if sha256 sum is invalid

### DIFF
--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -289,7 +289,7 @@ func doesPresignedSignatureMatch(hashedPayload string, r *http.Request, region s
 	/// Verify finally if signature is same.
 
 	// Get canonical request.
-	presignedCanonicalReq := getCanonicalRequest(extractedSignedHeaders, unsignedPayload, encodedQuery, req.URL.Path, req.Method)
+	presignedCanonicalReq := getCanonicalRequest(extractedSignedHeaders, hashedPayload, encodedQuery, req.URL.Path, req.Method)
 
 	// Get string to sign from canonical request.
 	presignedStringToSign := getStringToSign(presignedCanonicalReq, t, pSignValues.Credential.getScope())

--- a/pkg/hash/reader.go
+++ b/pkg/hash/reader.go
@@ -26,6 +26,8 @@ import (
 	"io"
 )
 
+var errNestedReader = errors.New("Nesting of Reader detected, not allowed")
+
 // Reader writes what it reads from an io.Reader to an MD5 and SHA256 hash.Hash.
 // Reader verifies that the content of the io.Reader matches the expected checksums.
 type Reader struct {
@@ -40,17 +42,17 @@ type Reader struct {
 // SHA256 sum (if set) of the provided io.Reader at EOF.
 func NewReader(src io.Reader, size int64, md5Hex, sha256Hex string) (*Reader, error) {
 	if _, ok := src.(*Reader); ok {
-		return nil, errors.New("Nesting of Reader detected, not allowed")
+		return nil, errNestedReader
 	}
 
 	sha256sum, err := hex.DecodeString(sha256Hex)
 	if err != nil {
-		return nil, err
+		return nil, SHA256Mismatch{}
 	}
 
 	md5sum, err := hex.DecodeString(md5Hex)
 	if err != nil {
-		return nil, err
+		return nil, BadDigest{}
 	}
 
 	var sha256Hash hash.Hash

--- a/pkg/hash/reader_test.go
+++ b/pkg/hash/reader_test.go
@@ -114,26 +114,30 @@ func TestHashReaderInvalidArguments(t *testing.T) {
 		size              int64
 		md5hex, sha256hex string
 		success           bool
+		expectedErr       error
 	}{
 		// Invalid md5sum NewReader() will fail.
 		{
-			src:     bytes.NewReader([]byte("abcd")),
-			size:    4,
-			md5hex:  "invalid-md5",
-			success: false,
+			src:         bytes.NewReader([]byte("abcd")),
+			size:        4,
+			md5hex:      "invalid-md5",
+			success:     false,
+			expectedErr: BadDigest{},
 		},
 		// Invalid sha256 NewReader() will fail.
 		{
-			src:       bytes.NewReader([]byte("abcd")),
-			size:      4,
-			sha256hex: "invalid-sha256",
-			success:   false,
+			src:         bytes.NewReader([]byte("abcd")),
+			size:        4,
+			sha256hex:   "invalid-sha256",
+			success:     false,
+			expectedErr: SHA256Mismatch{},
 		},
 		// Nested hash reader NewReader() will fail.
 		{
-			src:     &Reader{src: bytes.NewReader([]byte("abcd"))},
-			size:    4,
-			success: false,
+			src:         &Reader{src: bytes.NewReader([]byte("abcd"))},
+			size:        4,
+			success:     false,
+			expectedErr: errNestedReader,
 		},
 		// Expected inputs, NewReader() will succeed.
 		{
@@ -150,6 +154,9 @@ func TestHashReaderInvalidArguments(t *testing.T) {
 		}
 		if err == nil && !testCase.success {
 			t.Errorf("Test %d: Expected error, but got success", i+1)
+		}
+		if err != testCase.expectedErr {
+			t.Errorf("Test %d: Expected error %v, but got %v", i+1, testCase.expectedErr, err)
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Minio server and gateway returned `500 Internal Error` if `X-Amz-Content-SHA256` had an invalid hex. 
With this change, we would return ErrContentSHA256Mismatch if the underlying hash reader fails to decode the sha256 sum hex. This is because no payload can have an invalid sha256sum and trivially an invalid sha256 sum hex would be a mismatch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes minio/mint#216
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using mint
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.