### PR TITLE
return AWS compliant error if SSE-C key is wrong

### DIFF
--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -253,7 +253,9 @@ func DecryptRequest(client io.Writer, r *http.Request, metadata map[string]strin
 		Key: keyEncryptionKey,
 	})
 	if n != 32 || err != nil {
-		return nil, errObjectTampered
+		// Either the provided key does not match or the object was tampered.
+		// To provide strict AWS S3 compatibility we return: access denied.
+		return nil, errSSEKeyMismatch
 	}
 
 	writer, err := sio.DecryptWriter(client, sio.Config{Key: objectEncryptionKey.Bytes()})


### PR DESCRIPTION

## Description
This PR changes the behavior of DecryptRequest.
Instead of returning `object-tampered` if the client provided
key is wrong DecryptRequest will return `access-denied`.

This is AWS S3 behavior.

## Motivation and Context
Fixes #5202

## How Has This Been Tested?
manually - bug was detected during minio-go encryption refactoring

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.