### PR TITLE
fixed typo `variable` under domain heading.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -74,7 +74,7 @@ minio server /data
 |:---|:---|:---|
 |``domain``| _string_ | Enable virtual-host-style requests i.e http://bucket.mydomain.com/object|
 
-By default, Minio supports path-style requests which look like http://mydomain.com/bucket/object. MINIO_DOMAIN environmental varialble (or `domain` in config.json) can be used to enable virtual-host-style requests. If the request `Host` header matches with `(.+).mydomain.com` then the mattched pattern `$1` is used as bucket and the path is used as object. More information on path-style and virtual-host-style [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAPI.html)
+By default, Minio supports path-style requests which look like http://mydomain.com/bucket/object. MINIO_DOMAIN environmental variable (or `domain` in config.json) can be used to enable virtual-host-style requests. If the request `Host` header matches with `(.+).mydomain.com` then the mattched pattern `$1` is used as bucket and the path is used as object. More information on path-style and virtual-host-style [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAPI.html)
 
 Example:
 


### PR DESCRIPTION
 Fixes a small typo in the doc under the heading Domain.