### PR TITLE
dynamic port in docker’s healthcheck

### DIFF
--- a/dockerscripts/healthcheck.sh
+++ b/dockerscripts/healthcheck.sh
@@ -19,7 +19,7 @@ set -x
 
 _init () {
     scheme="http://"
-    address="127.0.0.1:9000"
+    address="$(netstat -nplt 2>/dev/null | awk ' /(.*\/minio)/ { gsub(":::","127.0.0.1:",$4); print $4}')"
     resource="/minio/index.html"
     start=$(stat -c "%Y" /proc/1)
 }


### PR DESCRIPTION
Because :9000 is not always the way it is

## Description
Made the minio port in docker's healthcheck dynamic. Falls back to 9000 if can't define the port. If you find a better (more elegant) way to dynamically find the listening port, feel free to bash me!

## Motivation and Context
When starting a docker container with `server --address ":80" /export` command for instance, the healthcheck.sh script fails after the 120s grace period and marks the container as "unhealthy". And an unhealthy container is not dns-resolvable anymore. And a non-resolvable container is often not a good thing.

## How Has This Been Tested?
I rebuilt an image and ran it in a docker-compose setup with a custom listener port command (`command: server --address ":80" /data`). I waited for 120s and yay, the container was still healthy!



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.