### PR TITLE
gateway/azure: Return an empty list if no chunks uploaded yet

### DIFF
--- a/cmd/gateway-azure.go
+++ b/cmd/gateway-azure.go
@@ -746,6 +746,11 @@ func (a *azureObjects) ListObjectParts(bucket, object, uploadID string, partNumb
 
 	objBlob := a.client.GetContainerReference(bucket).GetBlobReference(object)
 	resp, err := objBlob.GetBlockList(storage.BlockListTypeUncommitted, nil)
+	azureErr, ok := err.(storage.AzureStorageServiceError)
+	if ok && azureErr.StatusCode == http.StatusNotFound {
+		// If no parts are uploaded yet then we return empty list.
+		return result, nil
+	}
 	if err != nil {
 		return result, azureToObjectError(traceError(err), bucket, object)
 	}


### PR DESCRIPTION
This makes ListParts behave more like S3 by returning an empty list rather than an error if no chunks/blocks have been uploaded yet.

This is a replacement for #5226, suggested by @krishnasrinivas in the comments on that PR.

## Description
See #5226 for more background on and discussion about this fix.

## Motivation and Context
As discussed in #5169, this is required for tus/tusd to be able to use Minio Azure Gateway.

## How Has This Been Tested?
Tested manually, using `tusd` to send a repeatable and realistic set of calls which work as expected on S3 but don't currently work on Minio Azure Gateway.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.