### PR TITLE
Fixes last item in the list menu being blocked.

### DIFF
--- a/browser/app/less/inc/file-explorer.less
+++ b/browser/app/less/inc/file-explorer.less
@@ -14,7 +14,7 @@
 
 .fe-body {
 	@media(min-width: @screen-md-min) {
-		padding: 0 0 40px @fe-sidebar-width;
+		padding: 0 0 80px @fe-sidebar-width;
 	}
 
 	@media(max-width: @screen-sm-max) {
@@ -79,7 +79,7 @@
 	text-align: center;
 	border: 0;
 	padding: 0;
-	
+
 	span {
 		display: inline-block;
 		height: 100%;


### PR DESCRIPTION
This commit fixes an issue where the last item's menu on a list of files
that scrolls gets blocked by the floating add button.

The fix is simply add the same padding that we use for the responsive
view, since it works just fine in responsive.

## Description
Whenever you have a list of items that reach the bottom of the screen the add button goes on top of the last item's menu.

![image](https://user-images.githubusercontent.com/1114422/33227098-88a51e7e-d161-11e7-9998-0176e6ec084e.png)

This fix just uses the same bottom padding that we're currently using in the responsive view to allow the last item's menu to be used.

**How it looks with the fix**
![image](https://user-images.githubusercontent.com/1114422/33227110-af48c3c8-d161-11e7-94b0-e1143a6d948b.png)

## Motivation and Context
It allows for the last item's menu to be used in all of the screen resolutions.

## How Has This Been Tested?
This code is pretty self contained, tested if the issue existed in other browsers (chrome, safari and firefox) and the issue is in all of them, tested the fix in all of them and it was satisfactory, reviewed if the responsive view or the menus broke but they work just fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.