### PR TITLE
Update bucket notification docs to mention events supported

### DIFF
--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -1,19 +1,23 @@
 # Minio Bucket Notification Guide [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
 
-Changes in a bucket, such as object uploads and removal, can be monitored using bucket event notification
-mechanism and can be published to the following targets:
+Events occurring on objects in a bucket can be monitored using bucket event notifications. Event types supported by Minio server are
 
-| Notification Targets|
-|:---|
-| [`AMQP`](#AMQP) |
-| [`MQTT`](#MQTT) |
-| [`Elasticsearch`](#Elasticsearch) |
-| [`Redis`](#Redis) |
-| [`NATS`](#NATS) |
-| [`PostgreSQL`](#PostgreSQL) |
-| [`MySQL`](#MySQL) |
-| [`Apache Kafka`](#apache-kafka) |
-| [`Webhooks`](#webhooks) |
+| Supported Event Types | | |
+|:---------------------------|--------------------------------------------|-------------------------|
+| `s3:ObjectCreated:Put`     | `s3:ObjectCreated:CompleteMultipartUpload` | `s3:ObjectAccessed:Head`|
+| `s3:ObjectCreated:Post`    | `s3:ObjectRemoved:Delete`                  |
+| `s3:ObjectCreated:Copy`    | `s3:ObjectAccessed:Get`                    |
+
+Use client tools like `mc` to set and listen for event notifications using the [`event` sub-command](https://docs.minio.io/docs/minio-client-complete-guide#events). Minio SDK's
+[`BucketNotification` APIs](https://docs.minio.io/docs/golang-client-api-reference#SetBucketNotification) can also be used.
+
+Bucket events can be published to the following targets:
+
+| Supported Notification Targets | | |
+|:---------------------------|--------------------------------------------|-------------------------|
+| [`AMQP`](#AMQP) | [`Redis`](#Redis) | [`MySQL`](#MySQL) |
+| [`MQTT`](#MQTT) | [`NATS`](#NATS) | [`Apache Kafka`](#apache-kafka) |
+| [`Elasticsearch`](#Elasticsearch) | [`PostgreSQL`](#PostgreSQL) | [`Webhooks`](#webhooks) |
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description
Updated the bucket notification docs to mention various event types supported and also added hint on how to set up events using `mc` and SDKs upfront. 

## Motivation and Context
Fixes #4898

## How Has This Been Tested?
Not tested, this is a documentation PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.