### PR TITLE
Consolidate Quickstart Guide links on server console

### DIFF
--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -29,11 +29,7 @@ import (
 // Documentation links, these are part of message printing code.
 const (
 	mcQuickStartGuide     = "https://docs.minio.io/docs/minio-client-quickstart-guide"
-	goQuickStartGuide     = "https://docs.minio.io/docs/golang-client-quickstart-guide"
-	jsQuickStartGuide     = "https://docs.minio.io/docs/javascript-client-quickstart-guide"
-	javaQuickStartGuide   = "https://docs.minio.io/docs/java-client-quickstart-guide"
-	pyQuickStartGuide     = "https://docs.minio.io/docs/python-client-quickstart-guide"
-	dotnetQuickStartGuide = "https://docs.minio.io/docs/dotnet-client-quickstart-guide"
+	quickStartGuide       = "https://docs.minio.io/docs/minio-sdks-quickstart-guide"
 )
 
 // generates format string depending on the string length and padding.
@@ -159,11 +155,7 @@ func printCLIAccessMsg(endPoint string, alias string) {
 // Prints startup message for Object API acces, prints link to our SDK documentation.
 func printObjectAPIMsg() {
 	log.Println(colorBlue("\nObject API (Amazon S3 compatible):"))
-	log.Println(colorBlue("   Go: ") + fmt.Sprintf(getFormatStr(len(goQuickStartGuide), 8), goQuickStartGuide))
-	log.Println(colorBlue("   Java: ") + fmt.Sprintf(getFormatStr(len(javaQuickStartGuide), 6), javaQuickStartGuide))
-	log.Println(colorBlue("   Python: ") + fmt.Sprintf(getFormatStr(len(pyQuickStartGuide), 4), pyQuickStartGuide))
-	log.Println(colorBlue("   JavaScript: ") + jsQuickStartGuide)
-	log.Println(colorBlue("   .NET: ") + fmt.Sprintf(getFormatStr(len(dotnetQuickStartGuide), 6), dotnetQuickStartGuide))
+        log.Println(colorBlue(" Go, Java, Python, JavaScript & .NET : ") + quickStartGuide)
 }
 
 // Get formatted disk/storage info message.

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -29,7 +29,7 @@ import (
 // Documentation links, these are part of message printing code.
 const (
 	mcQuickStartGuide     = "https://docs.minio.io/docs/minio-client-quickstart-guide"
-	quickStartGuide       = "https://docs.minio.io/docs/minio-sdks-quickstart-guide"
+	quickStartGuide       = "https://docs.minio.io/docs/sdk-quickstart-guide"
 )
 
 // generates format string depending on the string length and padding.

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -155,7 +155,7 @@ func printCLIAccessMsg(endPoint string, alias string) {
 // Prints startup message for Object API acces, prints link to our SDK documentation.
 func printObjectAPIMsg() {
 	log.Println(colorBlue("\nObject API (Amazon S3 compatible):"))
-        log.Println(colorBlue(" Go, Java, Python, JavaScript & .NET : ") + quickStartGuide)
+       log.Println(colorBlue(" Go, Java, Python, JavaScript & .NET : ") + quickStartGuide)
 }
 
 // Get formatted disk/storage info message.

--- a/docs/sdks/README.md
+++ b/docs/sdks/README.md
@@ -1,10 +1,7 @@
-
-
 ## Minio SDKs
 Minio SDKs are available in different languages and contain the library, examples and documentation. Object APIs exposed by the SDKs help users build cloud-native applications for multi-cloud environments.
 
 Click on the links below to know more about the SDKs and APIs.
-
 
 | SDK | Quick start guide | API reference |
 |:--- |:--- |:--- |

--- a/docs/sdks/README.md
+++ b/docs/sdks/README.md
@@ -1,0 +1,15 @@
+
+
+## Minio SDKs
+Minio SDKs are available in different languages and contain the library, examples and documentation. Object APIs exposed by the SDKs help users build cloud-native applications for multi-cloud environments.
+
+Click on the links below to know more about the SDKs and APIs.
+
+
+| SDK | Quick start guide | API reference |
+|:--- |:--- |:--- |
+| `Golang` | [Quick start guide](https://docs.minio.io/docs/golang-client-quickstart-guide)| [API Reference](https://docs.minio.io/docs/golang-client-api-reference) |
+| `Java` | [Quick start guide](https://docs.minio.io/docs/java-client-quickstart-guide) | [API Reference](https://docs.minio.io/docs/java-client-api-reference) |
+| `JavaScript` | [Quick start guide](https://docs.minio.io/docs/javascript-client-quickstart-guide) | [API Reference](https://docs.minio.io/docs/javascript-client-api-reference) |
+| `Python` | [Quick start guide](https://docs.minio.io/docs/python-client-quickstart-guide) | [API Reference](https://docs.minio.io/docs/python-client-api-reference) |
+| `.NET` | [Quick start guide](https://docs.minio.io/docs/dotnet-client-quickstart-guide) | [API Reference](https://docs.minio.io/docs/dotnet-client-api-reference) |


### PR DESCRIPTION
Added README file under sdks folder describing Minio SDKs along with
quickstart guides and API reference links.
Modified the code in the server startup message file accordingly.
Fixes #5238
