### PR TITLE
Provide more descriptive error during erasure init

### DIFF
--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -24,8 +24,9 @@ import (
 
 	"encoding/hex"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/minio/pkg/errors"
-	"github.com/minio/sha256-simd"
+	sha256 "github.com/minio/sha256-simd"
 )
 
 const (
@@ -373,7 +374,7 @@ func checkFormatXLValue(formatXL *formatXLV2) error {
 
 // Check all format values.
 func checkFormatXLValues(formats []*formatXLV2) error {
-	for _, formatXL := range formats {
+	for i, formatXL := range formats {
 		if formatXL == nil {
 			continue
 		}
@@ -381,8 +382,8 @@ func checkFormatXLValues(formats []*formatXLV2) error {
 			return err
 		}
 		if len(formats) != len(formatXL.XL.Sets)*len(formatXL.XL.Sets[0]) {
-			return fmt.Errorf("Number of disks %d did not match the backend format %d",
-				len(formats), len(formatXL.XL.Sets)*len(formatXL.XL.Sets[0]))
+			return fmt.Errorf("%s disk is already being used in another erasure deployment. (Number of disks specified: %d but the number of disks found in the %s disk's format.json: %d)",
+				humanize.Ordinal(i+1), len(formats), humanize.Ordinal(i+1), len(formatXL.XL.Sets)*len(formatXL.XL.Sets[0]))
 		}
 	}
 	return nil


### PR DESCRIPTION
fixes ##5239

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Now it errors out like this:
```
krishna@escape:~$ minio server export-xl/disk{1..8}

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ You are running an older version of Minio released 3 weeks ago     ┃
┃ Update: https://dl.minio.io/server/minio/release/linux-amd64/minio ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

ERRO[0000] Initializing object layer failed              cause=1st disk is already being used in another erasure deployment. (Number of disks specified: 8 but the number of disks found in the 1st disk's format.json: 4.) source=[server-main.go:211:serverMain()]
krishna@escape:~$ 
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.