### PR TITLE
Fix mobile issue where checkbox was seen over sidebar on list item hover

### DIFF
--- a/browser/app/less/inc/list.less
+++ b/browser/app/less/inc/list.less
@@ -159,7 +159,7 @@ div.fesl-row {
         top: 0;
         width: 35px;
         height: 35px;
-        z-index: 20;
+        z-index: 8;
         opacity: 0;
         cursor: pointer;
 
@@ -223,7 +223,7 @@ div.fesl-row {
         width: 15px;
         height: 15px;
         border: 2px solid @white;
-        z-index: 10;
+        z-index: 7;
         border-radius: 2px;
         top: 10px;
         left: 10px;


### PR DESCRIPTION
Fixes #5287 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The z-index of the checkboxes have been made smaller than the z-index of the sidebar, so that they are under the sidebar.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This commit fixes #5287

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This commit has been tested manually. On the mobile view, the sidebar has been enabled and it has been verified that hovering over items doesn't make their checkboxes appear over the sidebar. Also, the existing functionality which allows a user to select, delete and download files have also been tested to ensure nothing was broken.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.