### PR TITLE
Add base64 encoded MD5 output for Hash Reader

### DIFF
--- a/cmd/gateway/s3/gateway-s3-anonymous.go
+++ b/cmd/gateway/s3/gateway-s3-anonymous.go
@@ -28,7 +28,7 @@ import (
 
 // AnonPutObject creates a new object anonymously with the incoming data,
 func (l *s3Objects) AnonPutObject(bucket string, object string, data *hash.Reader, metadata map[string]string) (objInfo minio.ObjectInfo, e error) {
-	oi, err := l.anonClient.PutObject(bucket, object, data, data.Size(), data.MD5HexString(), data.SHA256HexString(), minio.ToMinioClientMetadata(metadata))
+	oi, err := l.anonClient.PutObject(bucket, object, data, data.Size(), data.MD5Base64String(), data.SHA256HexString(), minio.ToMinioClientMetadata(metadata))
 	if err != nil {
 		return objInfo, minio.ErrorRespToObjectError(errors.Trace(err), bucket, object)
 	}

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -289,7 +289,7 @@ func (l *s3Objects) GetObjectInfo(bucket string, object string) (objInfo minio.O
 
 // PutObject creates a new object with the incoming data,
 func (l *s3Objects) PutObject(bucket string, object string, data *hash.Reader, metadata map[string]string) (objInfo minio.ObjectInfo, err error) {
-	oi, err := l.Client.PutObject(bucket, object, data, data.Size(), data.MD5HexString(), data.SHA256HexString(), minio.ToMinioClientMetadata(metadata))
+	oi, err := l.Client.PutObject(bucket, object, data, data.Size(), data.MD5Base64String(), data.SHA256HexString(), minio.ToMinioClientMetadata(metadata))
 	if err != nil {
 		return objInfo, minio.ErrorRespToObjectError(errors.Trace(err), bucket, object)
 	}
@@ -343,7 +343,7 @@ func (l *s3Objects) NewMultipartUpload(bucket string, object string, metadata ma
 
 // PutObjectPart puts a part of object in bucket
 func (l *s3Objects) PutObjectPart(bucket string, object string, uploadID string, partID int, data *hash.Reader) (pi minio.PartInfo, e error) {
-	info, err := l.Client.PutObjectPart(bucket, object, uploadID, partID, data, data.Size(), data.MD5HexString(), data.SHA256HexString())
+	info, err := l.Client.PutObjectPart(bucket, object, uploadID, partID, data, data.Size(), data.MD5Base64String(), data.SHA256HexString())
 	if err != nil {
 		return pi, minio.ErrorRespToObjectError(errors.Trace(err), bucket, object)
 	}

--- a/pkg/hash/reader.go
+++ b/pkg/hash/reader.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"hash"
@@ -115,6 +116,11 @@ func (r *Reader) SHA256() []byte {
 // MD5HexString returns hex md5 value.
 func (r *Reader) MD5HexString() string {
 	return hex.EncodeToString(r.md5sum)
+}
+
+// MD5Base64String returns base64 encoded MD5sum value.
+func (r *Reader) MD5Base64String() string {
+	return base64.StdEncoding.EncodeToString(r.md5sum)
 }
 
 // SHA256HexString returns hex sha256 value.

--- a/pkg/hash/reader_test.go
+++ b/pkg/hash/reader_test.go
@@ -40,6 +40,9 @@ func TestHashReaderHelperMethods(t *testing.T) {
 	if r.SHA256HexString() != "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589" {
 		t.Errorf("Expected sha256hex \"88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\", got %s", r.SHA256HexString())
 	}
+	if r.MD5Base64String() != "4vxxTEcn7pOV8yTNLn8zHw==" {
+		t.Errorf("Expected md5base64 \"4vxxTEcn7pOV8yTNLn8zHw==\", got \"%s\"", r.MD5Base64String())
+	}
 	if r.Size() != 4 {
 		t.Errorf("Expected size 4, got %d", r.Size())
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Use base64 encoded MD5 function of Hash Reader to send the Content-MD5 header correctly encoded to S3 Gateway

- Fixes a bug in PutObject with S3 Gateway found when testing with
  Mint.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Found a bug during testing for server release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By running mint and make sure the failing test passes - specifically this one passed after the fix was applied:

```
{
  "name": "aws-sdk-ruby",
  "function": "putObject(bucket_name, file)",
  "args": {
    "bucket_name": "731612681f16",
    "file": "/mint/data/datafile-1-MB"
  },
  "duration": 2285.67,
  "error": "We encountered an internal error, please try again.",
  "status": "FAIL"
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.