### PR TITLE
Separate the codebase for XL and FS format.json related code

### DIFF
--- a/cmd/format-fs.go
+++ b/cmd/format-fs.go
@@ -1,0 +1,226 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	errors2 "github.com/minio/minio/pkg/errors"
+	"github.com/minio/minio/pkg/lock"
+)
+
+// FS format version strings.
+const (
+	formatBackendFS   = "fs"
+	formatFSVersionV1 = "1"
+)
+
+// formatFSV1 - structure holds format version '1'.
+type formatFSV1 struct {
+	formatMetaV1
+	FS struct {
+		Version string `json:"version"`
+	} `json:"fs"`
+}
+
+// Used to detect the version of "fs" format.
+type formatFSVersionDetect struct {
+	FS struct {
+		Version string `json:"version"`
+	} `json:"fs"`
+}
+
+// Returns the latest "fs" format.
+func newFormatFSV1() (format *formatFSV1) {
+	f := &formatFSV1{}
+	f.Version = formatMetaVersionV1
+	f.Format = formatBackendFS
+	f.FS.Version = formatFSVersionV1
+	return f
+}
+
+// Save to fs format.json
+func formatFSSave(f *os.File, data interface{}) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return errors2.Trace(err)
+	}
+	if err = f.Truncate(0); err != nil {
+		return errors2.Trace(err)
+	}
+	if _, err = f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	_, err = f.Write(b)
+	if err != nil {
+		return errors2.Trace(err)
+	}
+	return nil
+}
+
+// Returns the field formatMetaV1.Format i.e the string "fs" which is never likely to change.
+// We do not use this function in XL to get the format as the file is not fcntl-locked on XL.
+func formatMetaGetFormatBackendFS(r io.ReadSeeker) (string, error) {
+	format := &formatMetaV1{}
+	if err := jsonLoadFromSeeker(r, format); err != nil {
+		return "", err
+	}
+	if format.Version == formatMetaVersionV1 {
+		return format.Format, nil
+	}
+	return "", fmt.Errorf(`format.Version expected: %s, got: %s`, formatMetaVersionV1, format.Version)
+}
+
+// Returns formatFS.FS.Version
+func formatFSGetVersion(r io.ReadSeeker) (string, error) {
+	format := &formatFSVersionDetect{}
+	if err := jsonLoadFromSeeker(r, format); err != nil {
+		return "", err
+	}
+	return format.FS.Version, nil
+}
+
+// Migrate the "fs" backend.
+// Migration should happen when formatFSV1.FS.Version changes. This version
+// can change when there is a change to the struct formatFSV1.FS or if there
+// is any change in the backend file system tree structure.
+func formatFSMigrate(wlk *lock.LockedFile) error {
+	// Add any migration code here in case we bump format.FS.Version
+
+	// Make sure that the version is what we expect after the migration.
+	version, err := formatFSGetVersion(wlk)
+	if err != nil {
+		return err
+	}
+	if version != formatFSVersionV1 {
+		return fmt.Errorf(`%s file: expected FS version: %s, found FS version: %s`, formatConfigFile, formatFSVersionV1, version)
+	}
+	return nil
+}
+
+// Creates a new format.json if unformatted.
+func createFormatFS(fsFormatPath string) error {
+	// Attempt a write lock on formatConfigFile `format.json`
+	// file stored in minioMetaBucket(.minio.sys) directory.
+	lk, err := lock.TryLockedOpenFile(fsFormatPath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return errors2.Trace(err)
+	}
+	// Close the locked file upon return.
+	defer lk.Close()
+
+	fi, err := lk.Stat()
+	if err != nil {
+		return errors2.Trace(err)
+	}
+	if fi.Size() != 0 {
+		// format.json already got created because of another minio process's createFormatFS()
+		return nil
+	}
+
+	return formatFSSave(lk.File, newFormatFSV1())
+}
+
+// This function returns a read-locked format.json reference to the caller.
+// The file descriptor should be kept open throughout the life
+// of the process so that another minio process does not try to
+// migrate the backend when we are actively working on the backend.
+func initFormatFS(fsPath string) (rlk *lock.RLockedFile, err error) {
+	fsFormatPath := pathJoin(fsPath, minioMetaBucket, formatConfigFile)
+	// Any read on format.json should be done with read-lock.
+	// Any write on format.json should be done with write-lock.
+	for {
+		isEmpty := false
+		rlk, err := lock.RLockedOpenFile(fsFormatPath)
+		if err == nil {
+			// format.json can be empty in a rare condition when another
+			// minio process just created the file but could not hold lock
+			// and write to it.
+			var fi os.FileInfo
+			fi, err = rlk.Stat()
+			if err != nil {
+				return nil, errors2.Trace(err)
+			}
+			isEmpty = fi.Size() == 0
+		}
+		if os.IsNotExist(err) || isEmpty {
+			if err == nil {
+				rlk.Close()
+			}
+			// Fresh disk - create format.json
+			err = createFormatFS(fsFormatPath)
+			if err == lock.ErrAlreadyLocked {
+				// Lock already present, sleep and attempt again.
+				// Can happen in a rare situation when a parallel minio process
+				// holds the lock and creates format.json
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			if err != nil {
+				return nil, errors2.Trace(err)
+			}
+			// After successfully creating format.json try to hold a read-lock on
+			// the file.
+			continue
+		}
+		if err != nil {
+			return nil, errors2.Trace(err)
+		}
+
+		formatBackend, err := formatMetaGetFormatBackendFS(rlk)
+		if err != nil {
+			return nil, errors2.Trace(err)
+		}
+		if formatBackend != formatBackendFS {
+			return nil, fmt.Errorf(`%s file: expected format-type: %s, found: %s`, formatConfigFile, formatBackendFS, formatBackend)
+		}
+		version, err := formatFSGetVersion(rlk)
+		if err != nil {
+			return nil, err
+		}
+		if version != formatFSVersionV1 {
+			// Format needs migration
+			rlk.Close()
+			// Hold write lock during migration so that we do not disturb any
+			// minio processes running in parallel.
+			wlk, err := lock.TryLockedOpenFile(fsFormatPath, os.O_RDWR, 0)
+			if err == lock.ErrAlreadyLocked {
+				// Lock already present, sleep and attempt again.
+				wlk.Close()
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			err = formatFSMigrate(wlk)
+			wlk.Close()
+			if err != nil {
+				// Migration failed, bail out so that the user can observe what happened.
+				return nil, err
+			}
+			// Successfully migrated, now try to hold a read-lock on format.json
+			continue
+		}
+
+		return rlk, nil
+	}
+}

--- a/cmd/format-fs_test.go
+++ b/cmd/format-fs_test.go
@@ -1,0 +1,102 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFSFormatFS - tests initFormatFS, formatMetaGetFormatBackendFS, formatFSGetVersion.
+func TestFSFormatFS(t *testing.T) {
+	// Prepare for testing
+	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
+	defer os.RemoveAll(disk)
+
+	fsFormatPath := pathJoin(disk, minioMetaBucket, formatConfigFile)
+
+	// Assign a new UUID.
+	uuid := mustGetUUID()
+
+	// Initialize meta volume, if volume already exists ignores it.
+	if err := initMetaVolumeFS(disk, uuid); err != nil {
+		t.Fatal(err)
+	}
+
+	rlk, err := initFormatFS(disk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rlk.Close()
+
+	// Do the basic sanity checks to check if initFormatFS() did its job.
+	f, err := os.OpenFile(fsFormatPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	format, err := formatMetaGetFormatBackendFS(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if format != formatBackendFS {
+		t.Fatalf(`expected: %s, got: %s`, formatBackendFS, format)
+	}
+	version, err := formatFSGetVersion(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != formatFSVersionV1 {
+		t.Fatalf(`expected: %s, got: %s`, formatFSVersionV1, version)
+	}
+
+	// Corrupt the format.json file and test the functions.
+	// formatMetaGetFormatBackendFS, formatFSGetVersion, initFormatFS should return errors.
+	if err = f.Truncate(0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = f.WriteString("b"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = formatMetaGetFormatBackendFS(f); err == nil {
+		t.Fatal("expected to fail")
+	}
+	if _, err = formatFSGetVersion(rlk); err == nil {
+		t.Fatal("expected to fail")
+	}
+	if _, err = initFormatFS(disk); err == nil {
+		t.Fatal("expected to fail")
+	}
+
+	// With unknown formatMetaV1.Version formatMetaGetFormatBackendFS, initFormatFS should return error.
+	if err = f.Truncate(0); err != nil {
+		t.Fatal(err)
+	}
+	// Here we set formatMetaV1.Version to "2"
+	if _, err = f.WriteString(`{"version":"2","format":"fs","fs":{"version":"1"}}`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = formatMetaGetFormatBackendFS(f); err == nil {
+		t.Fatal("expected to fail")
+	}
+	if _, err = initFormatFS(disk); err == nil {
+		t.Fatal("expected to fail")
+	}
+}

--- a/cmd/format-meta.go
+++ b/cmd/format-meta.go
@@ -1,0 +1,52 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+// Format related consts
+const (
+	// Format config file carries backend format specific details.
+	formatConfigFile = "format.json"
+
+	// Format config tmp file carries backend format.
+	formatConfigFileTmp = "format.json.tmp"
+)
+
+const (
+	// Version of the formatMetaV1
+	formatMetaVersionV1 = "1"
+)
+
+// format.json currently has the format:
+// {
+//   "version": "1",
+//   "format": "XXXXX",
+//   "XXXXX": {
+//
+//   }
+// }
+// Here "XXXXX" depends on the backend, currently we have "fs" and "xl" implementations.
+// formatMetaV1 should be inherited by backend format structs. Please look at format-fs.go
+// and format-xl.go for details.
+
+// Ideally we will never have a situation where we will have to change the
+// fields of this struct and deal with related migration.
+type formatMetaV1 struct {
+	// Version of the format config.
+	Version string `json:"version"`
+	// Format indicates the backend format type, supports two values 'xl' and 'fs'.
+	Format string `json:"format"`
+}

--- a/cmd/format-xl_test.go
+++ b/cmd/format-xl_test.go
@@ -18,54 +18,46 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
 	"os"
-	"path/filepath"
 	"testing"
 
-	errors2 "github.com/minio/minio/pkg/errors"
 	"github.com/minio/minio/pkg/hash"
-	"github.com/minio/minio/pkg/lock"
 )
 
 // generates a valid format.json for XL backend.
-func genFormatXLValid() []*formatConfigV1 {
+func genFormatXLValid() []*formatXLV1 {
 	jbod := make([]string, 8)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
 	return formatConfigs
 }
 
 // generates a invalid format.json version for XL backend.
-func genFormatXLInvalidVersion() []*formatConfigV1 {
+func genFormatXLInvalidVersion() []*formatXLV1 {
 	jbod := make([]string, 8)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
 	// Corrupt version numbers.
 	formatConfigs[0].Version = "2"
@@ -74,46 +66,42 @@ func genFormatXLInvalidVersion() []*formatConfigV1 {
 }
 
 // generates a invalid format.json version for XL backend.
-func genFormatXLInvalidFormat() []*formatConfigV1 {
+func genFormatXLInvalidFormat() []*formatXLV1 {
 	jbod := make([]string, 8)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
-	// Corrupt version numbers.
+	// Corrupt format.
 	formatConfigs[0].Format = "lx"
 	formatConfigs[3].Format = "lx"
 	return formatConfigs
 }
 
 // generates a invalid format.json version for XL backend.
-func genFormatXLInvalidXLVersion() []*formatConfigV1 {
+func genFormatXLInvalidXLVersion() []*formatXLV1 {
 	jbod := make([]string, 8)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
 	// Corrupt version numbers.
 	formatConfigs[0].XL.Version = "10"
@@ -121,51 +109,47 @@ func genFormatXLInvalidXLVersion() []*formatConfigV1 {
 	return formatConfigs
 }
 
-func genFormatFS() *formatConfigV1 {
-	return &formatConfigV1{
-		Version: formatFileV1,
-		Format:  formatBackendFS,
-	}
+func genFormatFS() *formatXLV1 {
+	format := &formatXLV1{}
+	format.Version = formatMetaVersionV1
+	format.Format = formatBackendFS
+	return format
 }
 
 // generates a invalid format.json version for XL backend.
-func genFormatXLInvalidJBODCount() []*formatConfigV1 {
+func genFormatXLInvalidJBODCount() []*formatXLV1 {
 	jbod := make([]string, 7)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
 	return formatConfigs
 }
 
 // generates a invalid format.json JBOD for XL backend.
-func genFormatXLInvalidJBOD() []*formatConfigV1 {
+func genFormatXLInvalidJBOD() []*formatXLV1 {
 	jbod := make([]string, 8)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
@@ -177,22 +161,20 @@ func genFormatXLInvalidJBOD() []*formatConfigV1 {
 }
 
 // generates a invalid format.json Disk UUID for XL backend.
-func genFormatXLInvalidDisks() []*formatConfigV1 {
+func genFormatXLInvalidDisks() []*formatXLV1 {
 	jbod := make([]string, 8)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
 	// Make disk 5 and disk 8 have inconsistent disk uuid's.
 	formatConfigs[4].XL.Disk = mustGetUUID()
@@ -201,22 +183,20 @@ func genFormatXLInvalidDisks() []*formatConfigV1 {
 }
 
 // generates a invalid format.json Disk UUID in wrong order for XL backend.
-func genFormatXLInvalidDisksOrder() []*formatConfigV1 {
+func genFormatXLInvalidDisksOrder() []*formatXLV1 {
 	jbod := make([]string, 8)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
 	// Re order jbod for failure case.
 	var jbod1 = make([]string, 8)
@@ -459,7 +439,7 @@ func TestFormatXLReorderByInspection(t *testing.T) {
 //  - invalid JBOD
 //  - invalid Disk uuid
 func TestFormatXL(t *testing.T) {
-	formatInputCases := [][]*formatConfigV1{
+	formatInputCases := [][]*formatXLV1{
 		genFormatXLValid(),
 		genFormatXLInvalidVersion(),
 		genFormatXLInvalidFormat(),
@@ -470,7 +450,7 @@ func TestFormatXL(t *testing.T) {
 		genFormatXLInvalidDisksOrder(),
 	}
 	testCases := []struct {
-		formatConfigs []*formatConfigV1
+		formatConfigs []*formatXLV1
 		shouldPass    bool
 	}{
 		{
@@ -525,22 +505,20 @@ func TestSavedUUIDOrder(t *testing.T) {
 		shouldPass bool
 	}, 8)
 	jbod := make([]string, 8)
-	formatConfigs := make([]*formatConfigV1, 8)
+	formatConfigs := make([]*formatXLV1, 8)
 	for index := range jbod {
 		jbod[index] = mustGetUUID()
 		uuidTestCases[index].uuid = jbod[index]
 		uuidTestCases[index].shouldPass = true
 	}
 	for index := range jbod {
-		formatConfigs[index] = &formatConfigV1{
-			Version: formatFileV1,
-			Format:  formatBackendXL,
-			XL: &xlFormat{
-				Version: xlFormatBackendV1,
-				Disk:    jbod[index],
-				JBOD:    jbod,
-			},
-		}
+		format := &formatXLV1{}
+		format.Version = formatMetaVersionV1
+		format.Format = formatBackendXL
+		format.XL.Version = formatXLVersionV1
+		format.XL.Disk = jbod[index]
+		format.XL.JBOD = jbod
+		formatConfigs[index] = format
 	}
 	// Re order jbod for failure case.
 	var jbod1 = make([]string, 8)
@@ -653,169 +631,15 @@ func TestGenericFormatCheckXL(t *testing.T) {
 		t.Fatalf("Should fail here")
 	}
 	errs = []error{nil}
-	if err := genericFormatCheckXL([]*formatConfigV1{genFormatFS()}, errs); err == nil {
+	format := &formatXLV1{}
+	format.Version = formatMetaVersionV1
+	format.Format = formatBackendFS
+	if err := genericFormatCheckXL([]*formatXLV1{format}, errs); err == nil {
 		t.Fatalf("Should fail here")
 	}
 	errs = []error{errFaultyDisk}
-	if err := genericFormatCheckXL([]*formatConfigV1{genFormatFS()}, errs); err == nil {
+	if err := genericFormatCheckXL([]*formatXLV1{format}, errs); err == nil {
 		t.Fatalf("Should fail here")
-	}
-}
-
-// TestFSCheckFormatFSErr - test loadFormatFS loading older format.
-func TestFSCheckFormatFSErr(t *testing.T) {
-	// Prepare for testing
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
-	defer os.RemoveAll(disk)
-
-	// Assign a new UUID.
-	uuid := mustGetUUID()
-
-	// Initialize meta volume, if volume already exists ignores it.
-	if err := initMetaVolumeFS(disk, uuid); err != nil {
-		t.Fatal(err)
-	}
-
-	testCases := []struct {
-		format         *formatConfigV1
-		formatWriteErr error
-		formatCheckErr error
-		shouldPass     bool
-	}{
-		{
-			format: &formatConfigV1{
-				Version: formatFileV1,
-				Format:  formatBackendFS,
-				FS: &fsFormat{
-					Version: fsFormatBackendV1,
-				},
-			},
-			formatCheckErr: nil,
-			shouldPass:     true,
-		},
-		{
-			format: &formatConfigV1{
-				Version: formatFileV1,
-				Format:  formatBackendFS,
-				FS: &fsFormat{
-					Version: "10",
-				},
-			},
-			formatCheckErr: errors.New("Unknown backend FS format version '10'"),
-			shouldPass:     false,
-		},
-		{
-			format: &formatConfigV1{
-				Version: formatFileV1,
-				Format:  "garbage",
-				FS: &fsFormat{
-					Version: fsFormatBackendV1,
-				},
-			},
-			formatCheckErr: errors.New("FS backend format required. Found 'garbage'"),
-		},
-		{
-			format: &formatConfigV1{
-				Version: "-1",
-				Format:  formatBackendFS,
-				FS: &fsFormat{
-					Version: fsFormatBackendV1,
-				},
-			},
-			formatCheckErr: errors.New("Unknown format file version '-1'"),
-		},
-	}
-
-	fsFormatPath := pathJoin(disk, minioMetaBucket, formatConfigFile)
-	for i, testCase := range testCases {
-		lk, err := lock.LockedOpenFile((fsFormatPath), os.O_RDWR|os.O_CREATE, 0600)
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = testCase.format.WriteTo(lk)
-		lk.Close()
-		if err != nil {
-			t.Fatalf("Test %d: Expected nil, got %s", i+1, err)
-		}
-
-		lk, err = lock.LockedOpenFile((fsFormatPath), os.O_RDWR|os.O_CREATE, 0600)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		formatCfg := &formatConfigV1{}
-		_, err = formatCfg.ReadFrom(lk)
-		lk.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = formatCfg.CheckFS()
-		if err != nil && testCase.shouldPass {
-			t.Errorf("Test %d: Should not fail with unexpected %s, expected nil", i+1, err)
-		}
-		if err == nil && !testCase.shouldPass {
-			t.Errorf("Test %d: Should fail with expected %s, got nil", i+1, testCase.formatCheckErr)
-		}
-		if err != nil && !testCase.shouldPass {
-			if errors2.Cause(err).Error() != testCase.formatCheckErr.Error() {
-				t.Errorf("Test %d: Should fail with expected %s, got %s", i+1, testCase.formatCheckErr, err)
-			}
-		}
-	}
-}
-
-// TestFSCheckFormatFS - test loadFormatFS with healty and faulty disks
-func TestFSCheckFormatFS(t *testing.T) {
-	// Prepare for testing
-	disk := filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
-	defer os.RemoveAll(disk)
-
-	// Assign a new UUID.
-	uuid := mustGetUUID()
-
-	// Initialize meta volume, if volume already exists ignores it.
-	if err := initMetaVolumeFS(disk, uuid); err != nil {
-		t.Fatal(err)
-	}
-
-	fsFormatPath := pathJoin(disk, minioMetaBucket, formatConfigFile)
-	lk, err := lock.LockedOpenFile((fsFormatPath), os.O_RDWR|os.O_CREATE, 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	format := newFSFormatV1()
-	_, err = format.WriteTo(lk)
-	lk.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Loading corrupted format file
-	file, err := os.OpenFile((fsFormatPath), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
-	if err != nil {
-		t.Fatal("Should not fail here", err)
-	}
-	file.Write([]byte{'b'})
-	file.Close()
-
-	lk, err = lock.LockedOpenFile((fsFormatPath), os.O_RDWR|os.O_CREATE, 0600)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	format = &formatConfigV1{}
-	_, err = format.ReadFrom(lk)
-	lk.Close()
-	if err == nil {
-		t.Fatal("Should return an error here")
-	}
-
-	// Loading format file from disk not found.
-	os.RemoveAll(disk)
-	_, err = lock.LockedOpenFile((fsFormatPath), os.O_RDONLY, 0600)
-	if err != nil && !os.IsNotExist(err) {
-		t.Fatal("Should return 'format.json' does not exist, but got", err)
 	}
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -263,3 +263,11 @@ func NewCustomHTTPTransport() http.RoundTripper {
 		DisableCompression:    true,
 	}
 }
+
+// Load the json (typically from disk file).
+func jsonLoadFromSeeker(r io.ReadSeeker, data interface{}) error {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	return json.NewDecoder(r).Decode(data)
+}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -361,5 +362,21 @@ func TestContains(t *testing.T) {
 		if found != testCase.found {
 			t.Fatalf("Test %v: expected: %v, got: %v", i+1, testCase.found, found)
 		}
+	}
+}
+
+// Test jsonLoadFromSeeker.
+func TestJSONLoadFromSeeker(t *testing.T) {
+	format := newFormatFSV1()
+	b, err := json.Marshal(format)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotFormat formatFSV1
+	if err = jsonLoadFromSeeker(bytes.NewReader(b), &gotFormat); err != nil {
+		t.Fatal(err)
+	}
+	if *format != gotFormat {
+		t.Fatal("jsonLoadFromSeeker() failed to decode json")
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change is needed as a ground work for https://github.com/minio/minio/pull/5160 which needs migration to the XL format.json

format.json code for FS and XL is completely separated out. Any format.json migration code will also be separate codebase.

Once this patch is merged, I will rebase https://github.com/minio/minio/pull/5160 with master and make changes for XL format.json migration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual, unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.