### PR TITLE
Fix config.json parsing to fetch correct storage class

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -113,13 +113,13 @@ func (s *serverConfig) SetStorageClass(standardClass, rrsClass storageClass) {
 	s.StorageClass.RRS = rrsClass.Scheme + strconv.Itoa(rrsClass.Parity)
 }
 
-func (s *serverConfig) GetStorageClass() (standardStorageClass, rrsStorageClass storageClass) {
+// GetStorageClass reads storage class fields from current config, parses and validates it.
+// It returns the standard and reduced redundancy storage class struct
+func (s *serverConfig) GetStorageClass() (ssc, rrsc storageClass) {
 	s.RLock()
 	defer s.RUnlock()
 
 	var err error
-	var ssc storageClass
-	var rrsc storageClass
 
 	if s.StorageClass.Standard != "" {
 		// Parse the values read from config file into storageClass struct
@@ -136,13 +136,13 @@ func (s *serverConfig) GetStorageClass() (standardStorageClass, rrsStorageClass 
 	// Validation is done after parsing both the storage classes. This is needed because we need one
 	// storage class value to deduce the correct value of the other storage class.
 	if rrsc.Scheme != "" {
-		err := validateRRSParity(rrsc.Parity, ssc.Parity)
+		err = validateRRSParity(rrsc.Parity, ssc.Parity)
 		fatalIf(err, "Invalid value %s set in config.json", s.StorageClass.RRS)
 		globalIsStorageClass = true
 	}
 
 	if ssc.Scheme != "" {
-		err := validateSSParity(ssc.Parity, rrsc.Parity)
+		err = validateSSParity(ssc.Parity, rrsc.Parity)
 		fatalIf(err, "Invalid value %s set in config.json", s.StorageClass.Standard)
 		globalIsStorageClass = true
 	}


### PR DESCRIPTION
## Description
This PR updates the method that reads `config.json` to correctly return the storage class values.

## Motivation and Context
Without this change `func (s *serverConfig) GetStorageClass()` method returns incorrect values for storage class set in the `config.json` file. 

## How Has This Been Tested?
Manually by setting `config.json` storage class to different values

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.