### PR TITLE
Allow x-amz-content-sha256 to be optional for PutObject()

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -23,11 +23,6 @@ import (
 	"strings"
 )
 
-// Verify if the request http Header "x-amz-content-sha256" == "UNSIGNED-PAYLOAD"
-func isRequestUnsignedPayload(r *http.Request) bool {
-	return r.Header.Get("x-amz-content-sha256") == unsignedPayload
-}
-
 // Verify if request has JWT.
 func isRequestJWT(r *http.Request) bool {
 	return strings.HasPrefix(r.Header.Get("Authorization"), jwtAlgorithm)

--- a/cmd/auth-handler_test.go
+++ b/cmd/auth-handler_test.go
@@ -190,40 +190,6 @@ func TestS3SupportedAuthType(t *testing.T) {
 	}
 }
 
-// TestIsRequestUnsignedPayload - Test validates the Unsigned payload detection logic.
-func TestIsRequestUnsignedPayload(t *testing.T) {
-	testCases := []struct {
-		inputAmzContentHeader string
-		expectedResult        bool
-	}{
-		// Test case - 1.
-		// Test case with "X-Amz-Content-Sha256" header set to empty value.
-		{"", false},
-		// Test case - 2.
-		// Test case with "X-Amz-Content-Sha256" header set to  "UNSIGNED-PAYLOAD"
-		// The payload is flagged as unsigned When "X-Amz-Content-Sha256" header is set to  "UNSIGNED-PAYLOAD".
-		{unsignedPayload, true},
-		// Test case - 3.
-		// set to a random value.
-		{"abcd", false},
-	}
-
-	// creating an input HTTP request.
-	// Only the headers are relevant for this particular test.
-	inputReq, err := http.NewRequest("GET", "http://example.com", nil)
-	if err != nil {
-		t.Fatalf("Error initializing input HTTP request: %v", err)
-	}
-
-	for i, testCase := range testCases {
-		inputReq.Header.Set("X-Amz-Content-Sha256", testCase.inputAmzContentHeader)
-		actualResult := isRequestUnsignedPayload(inputReq)
-		if testCase.expectedResult != actualResult {
-			t.Errorf("Test %d: Expected the result to `%v`, but instead got `%v`", i+1, testCase.expectedResult, actualResult)
-		}
-	}
-}
-
 func TestIsRequestPresignedSignatureV2(t *testing.T) {
 	testCases := []struct {
 		inputQueryKey   string

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -585,6 +585,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 			writeErrorResponse(w, s3Err, r.URL)
 			return
 		}
+
 	case authTypePresigned, authTypeSigned:
 		if s3Err = reqSignatureV4Verify(r, globalServerConfig.GetRegion()); s3Err != ErrNone {
 			errorIf(errSignatureMismatch, "%s", dumpRequest(r))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
x-amz-content-sha256 can be optional for any AWS signature v4
requests, make sure to skip sha256 calculation when payload
checksum is not set.

<!--- Describe your changes in detail -->
## Motivation and Context
Fixes #5339

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using a custom request
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.
  