### PR TITLE
Exitcode '1' when update is available

### DIFF
--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -44,7 +44,7 @@ var updateCmd = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "quiet",
-			Usage: "Disable any update messages.",
+			Usage: "Disable any update prompt message.",
 		},
 	},
 	CustomHelpTemplate: `Name:
@@ -63,7 +63,7 @@ EXIT STATUS:
 
 EXAMPLES:
    1. Check and update minio:
-       $ {{.HelpName}
+       $ {{.HelpName}}
 `,
 }
 
@@ -476,7 +476,7 @@ func shouldUpdate(quiet bool, sha256Hex string, latestReleaseTime time.Time) (ok
 
 var greenColorSprintf = color.New(color.FgGreen, color.Bold).SprintfFunc()
 
-func mainUpdate(ctx *cli.Context) error {
+func mainUpdate(ctx *cli.Context) {
 	if len(ctx.Args()) != 0 {
 		cli.ShowCommandHelpAndExit(ctx, "update", -1)
 	}
@@ -498,7 +498,7 @@ func mainUpdate(ctx *cli.Context) error {
 	// Nothing to update running the latest release.
 	if updateMsg == "" {
 		log.Println(greenColorSprintf("You are already running the most recent version of ‘minio’."))
-		return nil
+		os.Exit(0)
 	}
 
 	log.Println(updateMsg)
@@ -512,6 +512,6 @@ func mainUpdate(ctx *cli.Context) error {
 			os.Exit(-1)
 		}
 		log.Println(successMsg)
+		os.Exit(1)
 	}
-	return nil
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix update command with exitcode '1' when update is available
--quiet should simply update the binary without any prompt.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #5347

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
go test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.