### PR TITLE
[Docker] Add custom secret names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0
 ENV MINIO_UPDATE off
+ENV MINIO_ACCESS_KEY_FILE=access_key \
+    MINIO_SECRET_KEY_FILE=secret_key
 
 WORKDIR /go/src/github.com/minio/
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,6 +6,8 @@ ENV GOPATH /go
 ENV PATH $PATH:$GOPATH/bin
 ENV CGO_ENABLED 0
 ENV MINIO_UPDATE off
+ENV MINIO_ACCESS_KEY_FILE=access_key \
+    MINIO_SECRET_KEY_FILE=secret_key
 
 WORKDIR /go/src/github.com/minio/
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -5,6 +5,8 @@ MAINTAINER Minio Inc <dev@minio.io>
 COPY dockerscripts/docker-entrypoint.sh dockerscripts/healthcheck.sh /usr/bin/
 
 ENV MINIO_UPDATE off
+ENV MINIO_ACCESS_KEY_FILE=access_key \
+    MINIO_SECRET_KEY_FILE=secret_key
 
 RUN \
      apk add --no-cache ca-certificates && \

--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -24,15 +24,15 @@ fi
 
 ## Look for docker secrets in default documented location.
 docker_secrets_env() {
-    local MINIO_ACCESS_KEY_FILE="/run/secrets/access_key"
-    local MINIO_SECRET_KEY_FILE="/run/secrets/secret_key"
+    local ACCESS_KEY_FILE="/run/secrets/$MINIO_ACCESS_KEY_FILE"
+    local SECRET_KEY_FILE="/run/secrets/$MINIO_SECRET_KEY_FILE"
 
-    if [ -f $MINIO_ACCESS_KEY_FILE -a -f $MINIO_SECRET_KEY_FILE ]; then
-        if [ -f $MINIO_ACCESS_KEY_FILE ]; then
-            export MINIO_ACCESS_KEY="$(cat "$MINIO_ACCESS_KEY_FILE")"
+    if [ -f $ACCESS_KEY_FILE -a -f $SECRET_KEY_FILE ]; then
+        if [ -f $ACCESS_KEY_FILE ]; then
+            export MINIO_ACCESS_KEY="$(cat "$ACCESS_KEY_FILE")"
         fi
-        if [ -f $MINIO_SECRET_KEY_FILE ]; then
-            export MINIO_SECRET_KEY="$(cat "$MINIO_SECRET_KEY_FILE")"
+        if [ -f $SECRET_KEY_FILE ]; then
+            export MINIO_SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
         fi
     fi
 }

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -73,6 +73,17 @@ docker service create --name="minio-service" --secret="access_key" --secret="sec
 
 Read more about `docker service` [here](https://docs.docker.com/engine/swarm/how-swarm-mode-works/services/)
 
+#### Minio Custom Access and Secret Key files
+To use other secret names follow the instuctions above and replace `access_key` and `secret_key` with your custom names (e.g. `my_secret_key`,`my_custom_key`). Run your service with
+```
+docker service create --name="minio-service" \
+  --secret="my_access_key" \
+  --secret="my_secret_key" \
+  --env="MINIO_ACCESS_KEY_FILE=my_access_key" \
+  --env="MINIO_SECRET_KEY_FILE=my_secret_key" \
+  minio/minio server /data
+```
+
 ### Retrieving Container ID
 To use Docker commands on a specific container, you need to know the `Container ID` for that container. To get the `Container ID`, run
 


### PR DESCRIPTION
## Description
`MINIO_ACCESS_KEY_FILE` and `MINIO_SECRET_KEY_FILE` are now changeable through docker environment variables.

## Motivation and Context
Resolves #5349

## How Has This Been Tested?
Build and run successfully with custom key file paths 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.