### PR TITLE
Assume standard storage class if not set in metadata

### DIFF
--- a/cmd/storage-class.go
+++ b/cmd/storage-class.go
@@ -182,11 +182,13 @@ func validateSSParity(ssParity, rrsParity int) (err error) {
 
 // Returns the data and parity drive count based on storage class
 // If storage class is set using the env vars MINIO_STORAGE_CLASS_RRS and MINIO_STORAGE_CLASS_STANDARD
+// or config.json fields
 // -- corresponding values are returned
-// If storage class is not set using environment variables, default values are returned
+// If storage class is not set during startup, default values are returned
 // -- Default for Reduced Redundancy Storage class is, parity = 2 and data = N-Parity
 // -- Default for Standard Storage class is, parity = N/2, data = N/2
-// If storage class is not present in metadata, default value is data = N/2, parity = N/2
+// If storage class is empty
+// -- standard storage class is assumed and corresponding data and parity is returned
 func getRedundancyCount(sc string, totalDisks int) (data, parity int) {
 	parity = totalDisks / 2
 	switch sc {
@@ -198,7 +200,7 @@ func getRedundancyCount(sc string, totalDisks int) (data, parity int) {
 			// else fall back to default value
 			parity = defaultRRSParity
 		}
-	case standardStorageClass:
+	case standardStorageClass, "":
 		if globalStandardStorageClass.Parity != 0 {
 			// set the standard parity if available
 			parity = globalStandardStorageClass.Parity

--- a/cmd/storage-class_test.go
+++ b/cmd/storage-class_test.go
@@ -173,6 +173,7 @@ func testGetRedundancyCount(obj ObjectLayer, instanceType string, dirs []string,
 		{3, "", xl.storageDisks, 8, 8},
 		{4, reducedRedundancyStorageClass, xl.storageDisks, 9, 7},
 		{5, standardStorageClass, xl.storageDisks, 10, 6},
+		{6, "", xl.storageDisks, 9, 7},
 	}
 	for _, tt := range tests {
 		// Set env var for test case 4
@@ -182,6 +183,10 @@ func testGetRedundancyCount(obj ObjectLayer, instanceType string, dirs []string,
 		// Set env var for test case 5
 		if tt.name == 5 {
 			globalStandardStorageClass.Parity = 6
+		}
+		// Set env var for test case 6
+		if tt.name == 6 {
+			globalStandardStorageClass.Parity = 7
 		}
 		data, parity := getRedundancyCount(tt.sc, len(tt.disks))
 		if data != tt.expectedData {

--- a/cmd/xl-v1-object_test.go
+++ b/cmd/xl-v1-object_test.go
@@ -112,6 +112,8 @@ func TestXLDeleteObjectBasic(t *testing.T) {
 }
 
 func TestXLDeleteObjectDiskNotFound(t *testing.T) {
+	// Reset global storage class flags
+	resetGlobalStorageEnvs()
 	// Create an instance of xl backend.
 	obj, fsDirs, err := prepareXL16()
 	if err != nil {

--- a/docs/erasure/storage-class/README.md
+++ b/docs/erasure/storage-class/README.md
@@ -20,7 +20,7 @@ Parity blocks can not be higher than data blocks, so `STANDARD` storage class pa
 
 Default value for `STANDARD` storage class is `N/2` (N is the total number of drives).
 
-### Reduced redundancy storage class (REDUCED_REDUNDANCY)
+### Values for reduced redundancy storage class (REDUCED_REDUNDANCY)
 
 `REDUCED_REDUNDANCY` implies lesser parity than `STANDARD` class. So,`REDUCED_REDUNDANCY` parity disks should be
 
@@ -47,7 +47,15 @@ export MINIO_STORAGE_CLASS_STANDARD=EC:3
 export MINIO_STORAGE_CLASS_RRS=EC:2
 ```
 
-If storage class is not defined before starting Minio server, and subsequent PutObject metadata field has `x-amz-storage-class` present
+Storage class can also be set via `config.json` file. Refer [storage class](https://github.com/minio/minio/tree/master/docs/config#storage-class) for
+more details.
+
+*Note*
+
+- If `STANDARD` storage class is set via environment variables or `config.json` files, and `x-amz-storage-class` is not present in request metadata, Minio server will 
+apply `STANDARD` storage class to the object. This means the data and parity disks will be used as set in `STANDARD` storage class.
+
+- If storage class is not defined before starting Minio server, and subsequent PutObject metadata field has `x-amz-storage-class` present
 with values `REDUCED_REDUNDANCY` or `STANDARD`, Minio server uses default parity values.
 
 ### Set metadata


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If STANDARD storage class is set to a specific value before starting up
Minio server, but x-amz-storage-class metadata field is not set during
a PutObject request, Minio server defaults to N/2 data and N/2 parity disks.

This PR changes this behaviour to fallback to data and parity disks set in
STANDARD storage class, if x-amz-storage-class metadata field is not
present in PutObject requests.

## Motivation and Context
Based on discussion, it was understood that this is the correct behaviour

## How Has This Been Tested?
manually and with Mint

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.
  