### PR TITLE
Fix a possible race during PutObject()

### DIFF
--- a/cmd/fs-v1-helpers_test.go
+++ b/cmd/fs-v1-helpers_test.go
@@ -28,28 +28,6 @@ import (
 	"github.com/minio/minio/pkg/lock"
 )
 
-// Tests - fsMkdirAll()
-func TestFSMkdirAll(t *testing.T) {
-	// create posix test setup
-	_, path, err := newPosixTestSetup()
-	if err != nil {
-		t.Fatalf("Unable to create posix test setup, %s", err)
-	}
-	defer os.RemoveAll(path)
-
-	if err = fsMkdirAll(""); errors.Cause(err) != errInvalidArgument {
-		t.Fatal("Unexpected error", err)
-	}
-
-	if err = fsMkdirAll(pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001")); errors.Cause(err) != errFileNameTooLong {
-		t.Fatal("Unexpected error", err)
-	}
-
-	if err = fsMkdirAll(pathJoin(path, "success-vol", "success-object")); err != nil {
-		t.Fatal("Unexpected error", err)
-	}
-}
-
 func TestFSRenameFile(t *testing.T) {
 	// create posix test setup
 	_, path, err := newPosixTestSetup()

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -575,7 +575,7 @@ func (fs fsObjects) PutObject(bucket string, object string, data *hash.Reader, m
 		if fs.parentDirIsObject(bucket, path.Dir(object)) {
 			return ObjectInfo{}, toObjectErr(errors.Trace(errFileAccessDenied), bucket, object)
 		}
-		if err = fsMkdirAll(pathJoin(fs.fsPath, bucket, object)); err != nil {
+		if err = mkdirAll(pathJoin(fs.fsPath, bucket, object), 0777); err != nil {
 			return ObjectInfo{}, toObjectErr(err, bucket, object)
 		}
 		var fi os.FileInfo

--- a/cmd/os-reliable.go
+++ b/cmd/os-reliable.go
@@ -1,0 +1,121 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+// Wrapper functions to os.MkdirAll, which calls reliableMkdirAll
+// this is to ensure that if there is a racy parent directory
+// delete in between we can simply retry the operation.
+func mkdirAll(dirPath string, mode os.FileMode) (err error) {
+	if dirPath == "" {
+		return errInvalidArgument
+	}
+
+	if err = checkPathLength(dirPath); err != nil {
+		return err
+	}
+
+	if err = reliableMkdirAll(dirPath, mode); err != nil {
+		// File path cannot be verified since one of the parents is a file.
+		if isSysErrNotDir(err) {
+			return errFileAccessDenied
+		} else if isSysErrPathNotFound(err) {
+			// This is a special case should be handled only for
+			// windows, because windows API does not return "not a
+			// directory" error message. Handle this specifically here.
+			return errFileAccessDenied
+		}
+	}
+	return err
+}
+
+// Reliably retries os.MkdirAll if for some reason os.MkdirAll returns
+// syscall.ENOENT (parent does not exist).
+func reliableMkdirAll(dirPath string, mode os.FileMode) (err error) {
+	i := 0
+	for {
+		// Creates all the parent directories, with mode 0777 mkdir honors system umask.
+		if err = os.MkdirAll(dirPath, mode); err != nil {
+			// Retry only for the first retryable error.
+			if os.IsNotExist(err) && i == 0 {
+				i++
+				continue
+			}
+		}
+		break
+	}
+	return err
+}
+
+// Wrapper function to os.Rename, which calls reliableMkdirAll
+// and reliableRenameAll. This is to ensure that if there is a
+// racy parent directory delete in between we can simply retry
+// the operation.
+func renameAll(srcFilePath, dstFilePath string) (err error) {
+	if srcFilePath == "" || dstFilePath == "" {
+		return errInvalidArgument
+	}
+
+	if err = checkPathLength(srcFilePath); err != nil {
+		return err
+	}
+	if err = checkPathLength(dstFilePath); err != nil {
+		return err
+	}
+
+	if err = reliableRename(srcFilePath, dstFilePath); err != nil {
+		if isSysErrNotDir(err) {
+			return errFileAccessDenied
+		} else if isSysErrPathNotFound(err) {
+			// This is a special case should be handled only for
+			// windows, because windows API does not return "not a
+			// directory" error message. Handle this specifically here.
+			return errFileAccessDenied
+		} else if isSysErrCrossDevice(err) {
+			return fmt.Errorf("%s (%s)->(%s)", errCrossDeviceLink, srcFilePath, dstFilePath)
+		} else if os.IsNotExist(err) {
+			return errFileNotFound
+		}
+	}
+	return err
+}
+
+// Reliably retries os.RenameAll if for some reason os.RenameAll returns
+// syscall.ENOENT (parent does not exist).
+func reliableRename(srcFilePath, dstFilePath string) (err error) {
+	i := 0
+	for {
+		if err = reliableMkdirAll(path.Dir(dstFilePath), 0777); err != nil {
+			return err
+		}
+		// After a successful parent directory create attempt a renameAll.
+		if err = os.Rename(srcFilePath, dstFilePath); err != nil {
+			// Retry only for the first retryable error.
+			if os.IsNotExist(err) && i == 0 {
+				i++
+				continue
+			}
+		}
+		break
+	}
+	return err
+}

--- a/cmd/os-reliable_test.go
+++ b/cmd/os-reliable_test.go
@@ -1,0 +1,78 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/minio/minio/pkg/errors"
+)
+
+// Tests - mkdirAll()
+func TestOSMkdirAll(t *testing.T) {
+	// create posix test setup
+	_, path, err := newPosixTestSetup()
+	if err != nil {
+		t.Fatalf("Unable to create posix test setup, %s", err)
+	}
+	defer os.RemoveAll(path)
+
+	if err = mkdirAll("", 0777); errors.Cause(err) != errInvalidArgument {
+		t.Fatal("Unexpected error", err)
+	}
+
+	if err = mkdirAll(pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"), 0777); errors.Cause(err) != errFileNameTooLong {
+		t.Fatal("Unexpected error", err)
+	}
+
+	if err = mkdirAll(pathJoin(path, "success-vol", "success-object"), 0777); err != nil {
+		t.Fatal("Unexpected error", err)
+	}
+}
+
+// Tests - renameAll()
+func TestOSRenameAll(t *testing.T) {
+	// create posix test setup
+	_, path, err := newPosixTestSetup()
+	if err != nil {
+		t.Fatalf("Unable to create posix test setup, %s", err)
+	}
+	defer os.RemoveAll(path)
+
+	if err = mkdirAll(pathJoin(path, "testvolume1"), 0777); err != nil {
+		t.Fatal(err)
+	}
+	if err = renameAll("", "foo"); err != errInvalidArgument {
+		t.Fatal(err)
+	}
+	if err = renameAll("foo", ""); err != errInvalidArgument {
+		t.Fatal(err)
+	}
+	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "testvolume2")); err != nil {
+		t.Fatal(err)
+	}
+	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "testvolume2")); errors.Cause(err) != errFileNotFound {
+		t.Fatal(err)
+	}
+	if err = renameAll(pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"), pathJoin(path, "testvolume2")); errors.Cause(err) != errFileNameTooLong {
+		t.Fatal("Unexpected error", err)
+	}
+	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001")); errors.Cause(err) != errFileNameTooLong {
+		t.Fatal("Unexpected error", err)
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Under any concurrent removeObjects in progress
might have removed the parents of the same prefix
for which there is an ongoing putObject request.
An inconsistent situation may arise as explained
below even under sufficient locking.

PutObject is almost successful at the last stage when
a temporary file is renamed to its actual namespace
at `a/b/c/object1`. Concurrently a RemoveObject is
also in progress at the same prefix for an `a/b/c/object2`.

To create the object1 at location `a/b/c` PutObject has
to create all the parents recursively.

```
a/b/c - os.MkdirAll loops through has now created
        'a/' and 'b/' about to create 'c/'
a/b/c/object2 - at this point 'c/' and 'object2'
        are deleted about to delete b/
```

Now for os.MkdirAll loop the expected situation is
that top level parent 'a/b/' exists which it created
, such that it can create 'c/' - since removeObject
and putObject do not compete for lock due to holding
locks at different resources. removeObject proceeds
to delete parent 'b/' since 'c/' is not yet present,
once deleted 'os.MkdirAll' would receive an error as
syscall.ENOENT which would fail the putObject request.

This PR tries to address this issue by implementing
a safer/guarded approach where we would retry an operation
such as `os.MkdirAll` and `os.Rename` if both operations
observe syscall.ENOENT.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #5254 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and `go test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.