### PR TITLE
Update madmin package to return storage class parity

### DIFF
--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -45,8 +45,8 @@ type StorageInfo struct {
 		// Following fields are only meaningful if BackendType is Erasure.
 		OnlineDisks      int // Online disks during server startup.
 		OfflineDisks     int // Offline disks during server startup.
-		standardSCParity int // Parity disks for currently configured Standard storage class.
-		rrSCParity       int // Parity disks for currently configured Reduced Redundancy storage class.
+		StandardSCParity int // Parity disks for currently configured Standard storage class.
+		RRSCParity       int // Parity disks for currently configured Reduced Redundancy storage class.
 	}
 }
 

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -197,7 +197,7 @@ func printStorageClassInfoMsg(storageInfo StorageInfo) {
 
 func getStandardStorageClassInfoMsg(storageInfo StorageInfo) string {
 	var msg string
-	if maxDiskFailures := storageInfo.Backend.standardSCParity - storageInfo.Backend.OfflineDisks; maxDiskFailures >= 0 {
+	if maxDiskFailures := storageInfo.Backend.StandardSCParity - storageInfo.Backend.OfflineDisks; maxDiskFailures >= 0 {
 		msg += fmt.Sprintf("Objects with "+standardStorageClass+" class can withstand [%d] drive failure(s).\n", maxDiskFailures)
 	}
 	return msg
@@ -205,7 +205,7 @@ func getStandardStorageClassInfoMsg(storageInfo StorageInfo) string {
 
 func getRRSStorageClassInfoMsg(storageInfo StorageInfo) string {
 	var msg string
-	if maxDiskFailures := storageInfo.Backend.rrSCParity - storageInfo.Backend.OfflineDisks; maxDiskFailures >= 0 {
+	if maxDiskFailures := storageInfo.Backend.RRSCParity - storageInfo.Backend.OfflineDisks; maxDiskFailures >= 0 {
 		msg += fmt.Sprintf("Objects with "+reducedRedundancyStorageClass+" class can withstand [%d] drive failure(s).\n", maxDiskFailures)
 	}
 	return msg

--- a/cmd/server-startup-msg_test.go
+++ b/cmd/server-startup-msg_test.go
@@ -38,8 +38,8 @@ func TestStorageInfoMsg(t *testing.T) {
 			Type             BackendType
 			OnlineDisks      int
 			OfflineDisks     int
-			standardSCParity int
-			rrSCParity       int
+			StandardSCParity int
+			RRSCParity       int
 		}{Erasure, 7, 1, 4, 5},
 	}
 
@@ -169,8 +169,8 @@ func TestGetStandardStorageClassInfoMsg(t *testing.T) {
 				Type             BackendType
 				OnlineDisks      int
 				OfflineDisks     int
-				standardSCParity int
-				rrSCParity       int
+				StandardSCParity int
+				RRSCParity       int
 			}{Erasure, 15, 1, 5, 3},
 		}, "Objects with " + standardStorageClass + " class can withstand [4] drive failure(s).\n"},
 		{"2", StorageInfo{
@@ -180,8 +180,8 @@ func TestGetStandardStorageClassInfoMsg(t *testing.T) {
 				Type             BackendType
 				OnlineDisks      int
 				OfflineDisks     int
-				standardSCParity int
-				rrSCParity       int
+				StandardSCParity int
+				RRSCParity       int
 			}{Erasure, 10, 0, 5, 3},
 		}, "Objects with " + standardStorageClass + " class can withstand [5] drive failure(s).\n"},
 		{"3", StorageInfo{
@@ -191,8 +191,8 @@ func TestGetStandardStorageClassInfoMsg(t *testing.T) {
 				Type             BackendType
 				OnlineDisks      int
 				OfflineDisks     int
-				standardSCParity int
-				rrSCParity       int
+				StandardSCParity int
+				RRSCParity       int
 			}{Erasure, 12, 3, 6, 2},
 		}, "Objects with " + standardStorageClass + " class can withstand [3] drive failure(s).\n"},
 	}
@@ -216,8 +216,8 @@ func TestGetRRSStorageClassInfoMsg(t *testing.T) {
 				Type             BackendType
 				OnlineDisks      int
 				OfflineDisks     int
-				standardSCParity int
-				rrSCParity       int
+				StandardSCParity int
+				RRSCParity       int
 			}{Erasure, 15, 1, 5, 3},
 		}, "Objects with " + reducedRedundancyStorageClass + " class can withstand [2] drive failure(s).\n"},
 		{"2", StorageInfo{
@@ -227,8 +227,8 @@ func TestGetRRSStorageClassInfoMsg(t *testing.T) {
 				Type             BackendType
 				OnlineDisks      int
 				OfflineDisks     int
-				standardSCParity int
-				rrSCParity       int
+				StandardSCParity int
+				RRSCParity       int
 			}{Erasure, 16, 0, 5, 3},
 		}, "Objects with " + reducedRedundancyStorageClass + " class can withstand [3] drive failure(s).\n"},
 		{"3", StorageInfo{
@@ -238,8 +238,8 @@ func TestGetRRSStorageClassInfoMsg(t *testing.T) {
 				Type             BackendType
 				OnlineDisks      int
 				OfflineDisks     int
-				standardSCParity int
-				rrSCParity       int
+				StandardSCParity int
+				RRSCParity       int
 			}{Erasure, 12, 3, 6, 5},
 		}, "Objects with " + reducedRedundancyStorageClass + " class can withstand [2] drive failure(s).\n"},
 	}

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -247,10 +247,10 @@ func getStorageInfo(disks []StorageAPI) StorageInfo {
 	storageInfo.Backend.OfflineDisks = offlineDisks
 
 	_, scParity := getRedundancyCount(standardStorageClass, len(disks))
-	storageInfo.Backend.standardSCParity = scParity
+	storageInfo.Backend.StandardSCParity = scParity
 
 	_, rrSCparity := getRedundancyCount(reducedRedundancyStorageClass, len(disks))
-	storageInfo.Backend.rrSCParity = rrSCparity
+	storageInfo.Backend.RRSCParity = rrSCparity
 
 	return storageInfo
 }

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -87,8 +87,8 @@ Fetch service status, replies disk space used, backend type and total disks offl
 |`backend.Type` | _BackendType_ | Type of backend used by the server currently only FS or Erasure. |
 |`backend.OnlineDisks`| _int_ | Total number of disks online (only applies to Erasure backend), is empty for FS. |
 |`backend.OfflineDisks` | _int_ | Total number of disks offline (only applies to Erasure backend), is empty for FS. |
-|`backend.ReadQuorum` | _int_ | Current total read quorum threshold before reads will be unavailable, is empty for FS. |
-|`backend.WriteQuorum` | _int_ | Current total write quorum threshold before writes will be unavailable, is empty for FS. |
+|`backend.StandardSCParity` | _int_ | Parity disks set for standard storage class, is empty for FS. |
+|`backend.RRSCParity` | _int_ | Parity disks set for reduced redundancy storage class, is empty for FS. |
 
 
  __Example__

--- a/pkg/madmin/README.md
+++ b/pkg/madmin/README.md
@@ -96,7 +96,7 @@ func main() {
 ```sh
 
 go run service-status.go
-2016/12/20 16:46:01 madmin.ServiceStatusMetadata{Total:177038229504, Free:120365559808, Backend:struct { Type madmin.BackendType; OnlineDisks int; OfflineDisks int; ReadQuorum int; WriteQuorum int }{Type:1, OnlineDisks:0, OfflineDisks:0, ReadQuorum:0, WriteQuorum:0}}
+2016/12/20 16:46:01 madmin.ServiceStatusMetadata{Total:177038229504, Free:120365559808, Backend:struct { Type madmin.BackendType; OnlineDisks int; OfflineDisks int; ReadQuorum int; WriteQuorum int }{Type:1, OnlineDisks:0, OfflineDisks:0, StandardSCParity:0, RRSCParity:0}}
 
 ```
 

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -51,10 +51,10 @@ type StorageInfo struct {
 		Type BackendType
 
 		// Following fields are only meaningful if BackendType is Erasure.
-		OnlineDisks  int // Online disks during server startup.
-		OfflineDisks int // Offline disks during server startup.
-		ReadQuorum   int // Minimum disks required for successful read operations.
-		WriteQuorum  int // Minimum disks required for successful write operations.
+		OnlineDisks      int // Online disks during server startup.
+		OfflineDisks     int // Offline disks during server startup.
+		StandardSCParity int // Parity disks for currently configured Standard storage class.
+		RRSCParity       int // Parity disks for currently configured Reduced Redundancy storage class.
 	}
 }
 


### PR DESCRIPTION
## Description
After the addition of Storage Class support, readQuorum and writeQuorum are decided on a per object basis, instead of deployment wide static quorums. 

This PR updates madmin api to remove readQuorum/writeQuorum and add Standard storage class and reduced redundancy storage class parity as return values. Since these parity values are used to decide 
the quorum for each object.

## Motivation and Context
Fixes #5378

## How Has This Been Tested?
Manually using snippet provided in #5378 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.