### PR TITLE
Don't delete lock ops entry during state change

### DIFF
--- a/cmd/lock-instrument.go
+++ b/cmd/lock-instrument.go
@@ -201,8 +201,6 @@ func (n *nsLockMap) statusBlockedToNone(param nsParam, lockSource, opsID string,
 	if lockInfo.status != blockedStatus {
 		return errors.Trace(LockInfoStateNotBlocked{param.volume, param.path, opsID})
 	}
-	// Clear the status by removing the entry for the given `opsID`.
-	delete(n.debugLockMap[param].lockInfo, opsID)
 
 	// Update global lock stats.
 	n.counters.lockTimedOut()


### PR DESCRIPTION
lock ops entry is removed in deleteLockEntryForOps, it shouldn't be removed
in status*To* functions.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.