### PR TITLE
Add validation of xlMeta ErasureInfo field

### DIFF
--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -266,16 +266,23 @@ func newXLMetaV1(object string, dataBlocks, parityBlocks int) (xlMeta xlMetaV1) 
 }
 
 // IsValid - tells if the format is sane by validating the version
-// string and format style.
+// string, format and erasure info fields.
 func (m xlMetaV1) IsValid() bool {
-	return isXLMetaValid(m.Version, m.Format)
+	return isXLMetaFormatValid(m.Version, m.Format) &&
+		isXLMetaErasureInfoValid(m.Erasure.DataBlocks, m.Erasure.ParityBlocks)
 }
 
 // Verifies if the backend format metadata is sane by validating
 // the version string and format style.
-func isXLMetaValid(version, format string) bool {
+func isXLMetaFormatValid(version, format string) bool {
 	return ((version == xlMetaVersion || version == xlMetaVersion100) &&
 		format == xlMetaFormat)
+}
+
+// Verifies if the backend format metadata is sane by validating
+// the ErasureInfo, i.e. data and parity blocks.
+func isXLMetaErasureInfoValid(data, parity int) bool {
+	return ((data >= parity) && (data != 0) && (parity != 0))
 }
 
 // Converts metadata to object info.

--- a/cmd/xl-v1-metadata_test.go
+++ b/cmd/xl-v1-metadata_test.go
@@ -368,3 +368,45 @@ func TestPickValidXLMeta(t *testing.T) {
 		}
 	}
 }
+
+func TestIsXLMetaFormatValid(t *testing.T) {
+	tests := []struct {
+		name    int
+		version string
+		format  string
+		want    bool
+	}{
+		{1, "123", "fs", false},
+		{2, "123", xlMetaFormat, false},
+		{3, xlMetaVersion, "test", false},
+		{4, xlMetaVersion100, "hello", false},
+		{5, xlMetaVersion, xlMetaFormat, true},
+		{6, xlMetaVersion100, xlMetaFormat, true},
+	}
+	for _, tt := range tests {
+		if got := isXLMetaFormatValid(tt.version, tt.format); got != tt.want {
+			t.Errorf("Test %d: Expected %v but received %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestIsXLMetaErasureInfoValid(t *testing.T) {
+	tests := []struct {
+		name   int
+		data   int
+		parity int
+		want   bool
+	}{
+		{1, 5, 6, false},
+		{2, 5, 5, true},
+		{3, 0, 5, false},
+		{4, 5, 0, false},
+		{5, 5, 0, false},
+		{6, 5, 4, true},
+	}
+	for _, tt := range tests {
+		if got := isXLMetaErasureInfoValid(tt.data, tt.parity); got != tt.want {
+			t.Errorf("Test %d: Expected %v but received %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -269,7 +269,7 @@ func readXLMetaStat(disk StorageAPI, bucket string, object string) (si statInfo,
 	xlFormat := parseXLFormat(xlMetaBuf)
 
 	// Validate if the xl.json we read is sane, return corrupted format.
-	if !isXLMetaValid(xlVersion, xlFormat) {
+	if !isXLMetaFormatValid(xlVersion, xlFormat) {
 		// For version mismatchs and unrecognized format, return corrupted format.
 		return si, nil, errors2.Trace(errCorruptedFormat)
 	}


### PR DESCRIPTION
## Description
Add additional checks to verify if xlMeta is valid.

## Motivation and Context
Currently, the xlMeta.IsValid() method only checks for format and version of the metadata file. This may be insufficient. For example in `getLatestXLMeta` method, the calculation of object quorum is based on fetching the correct entries from xlMeta slice and that each of these entries have valid data and parity fields. 

So, it is required to check for data and parity fields in the xlMeta as well, before declaring it as valid.

## How Has This Been Tested?
Manually using Mint

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.