### PR TITLE
replace all "crypto/sha256" imports with "github.com/minio/sha256-simd"

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -19,7 +19,6 @@ package azure
 import (
 	"bytes"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -38,6 +37,7 @@ import (
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/errors"
 	"github.com/minio/minio/pkg/hash"
+	sha256 "github.com/minio/sha256-simd"
 
 	minio "github.com/minio/minio/cmd"
 )

--- a/cmd/retry-storage_test.go
+++ b/cmd/retry-storage_test.go
@@ -18,12 +18,13 @@ package cmd
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"errors"
 	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	sha256 "github.com/minio/sha256-simd"
 )
 
 // Tests retry storage.

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bufio"
 	"crypto"
-	_ "crypto/sha256" // Needed for sha256 hash verifier.
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -33,6 +32,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/inconshreveable/go-update"
 	"github.com/minio/cli"
+	_ "github.com/minio/sha256-simd" // Needed for sha256 hash verifier.
 	"github.com/segmentio/go-prompt"
 )
 

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"crypto"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -30,6 +29,7 @@ import (
 	"time"
 
 	"github.com/minio/minio/pkg/errors"
+	sha256 "github.com/minio/sha256-simd"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/pkg/hash/reader.go
+++ b/pkg/hash/reader.go
@@ -19,12 +19,13 @@ package hash
 import (
 	"bytes"
 	"crypto/md5"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"hash"
 	"io"
+
+	sha256 "github.com/minio/sha256-simd"
 )
 
 var errNestedReader = errors.New("Nesting of Reader detected, not allowed")

--- a/pkg/madmin/utils.go
+++ b/pkg/madmin/utils.go
@@ -18,7 +18,6 @@ package madmin
 
 import (
 	"crypto/md5"
-	"crypto/sha256"
 	"encoding/xml"
 	"io"
 	"io/ioutil"
@@ -26,6 +25,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	sha256 "github.com/minio/sha256-simd"
 
 	"github.com/minio/minio-go/pkg/s3utils"
 )


### PR DESCRIPTION
## Description

This change replaces all imports of "crypto/sha256" with
"github.com/minio/sha256-simd". The sha256-simd package
is faster on ARM64 (NEON instructions) and can take advantage
of AVX-512 in certain scenarios.



## Motivation and Context
Fixes #5374

## How Has This Been Tested?
Manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.