### PR TITLE
(WIP) Disable weaker signature V2 algorithm by default

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -165,6 +165,7 @@ const (
 	ErrOperationTimedOut
 	ErrPartsSizeUnequal
 	ErrInvalidRequest
+	ErrAccessDeniedAuthV2
 
 	// Minio storage class error codes
 	ErrInvalidStorageClass
@@ -775,7 +776,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Description:    "Invalid Request",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-
+	ErrAccessDeniedAuthV2: {
+		Code:           "XMinioAccessDeniedAuthV2",
+		Description:    "This server has disabled authentication using Signature V2, please use Signature V4 instead.",
+		HTTPStatusCode: http.StatusForbidden,
+	},
 	// Add your error structure here.
 }
 

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -79,6 +79,12 @@ func handleCommonEnvVars() {
 	// Check if object cache is disabled.
 	globalXLObjCacheDisabled = strings.EqualFold(os.Getenv("_MINIO_CACHE"), "off")
 
+	// Check if weaker signature V2 is enabled
+	isSigV2Enabled := os.Getenv("MINIO_ENABLE_WEAK_V2_SIGNATURE")
+	if isSigV2Enabled != "" {
+		globalSignatureV2Enabled = true
+	}
+
 	accessKey := os.Getenv("MINIO_ACCESS_KEY")
 	secretKey := os.Getenv("MINIO_SECRET_KEY")
 	if accessKey != "" && secretKey != "" {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -86,6 +86,9 @@ var (
 	// This flag is set to 'true' when MINIO_BROWSER env is set.
 	globalIsEnvBrowser = false
 
+	// This flag is true when MINIO_ENABLE_WEAK_SIGNATURE_V2 is set.
+	globalSignatureV2Enabled = false
+
 	// Set to true if credentials were passed from env, default is false.
 	globalIsEnvCreds = false
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If required, it can be enabled by setting the environment variable
MINIO_ENABLE_WEAK_SIGNATURE_V2.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

V2 uses legacy crypto and can be avoided by most users since most client tools use signature V4 already.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.