### PR TITLE
Fix free and total space reported in startup banner

### DIFF
--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -295,23 +295,27 @@ func getStorageInfo(disks []StorageAPI) StorageInfo {
 		}
 	}
 
+	_, sscParity := getRedundancyCount(standardStorageClass, len(disks))
+	_, rrscparity := getRedundancyCount(reducedRedundancyStorageClass, len(disks))
+
+	// Total number of online data drives available
+	// This is the number of drives we report free and total space for
+	availableDataDisks := uint64(onlineDisks - sscParity)
+
 	// Return calculated storage info, choose the lowest Total and
 	// Free as the total aggregated values. Total capacity is always
 	// the multiple of smallest disk among the disk list.
 	storageInfo := StorageInfo{
-		Total: validDisksInfo[0].Total * uint64(onlineDisks) / 2,
-		Free:  validDisksInfo[0].Free * uint64(onlineDisks) / 2,
+		Total: validDisksInfo[0].Total * availableDataDisks,
+		Free:  validDisksInfo[0].Free * availableDataDisks,
 	}
 
 	storageInfo.Backend.Type = Erasure
 	storageInfo.Backend.OnlineDisks = onlineDisks
 	storageInfo.Backend.OfflineDisks = offlineDisks
 
-	_, scParity := getRedundancyCount(standardStorageClass, len(disks))
-	storageInfo.Backend.StandardSCParity = scParity
-
-	_, rrSCparity := getRedundancyCount(reducedRedundancyStorageClass, len(disks))
-	storageInfo.Backend.RRSCParity = rrSCparity
+	storageInfo.Backend.StandardSCParity = sscParity
+	storageInfo.Backend.RRSCParity = rrscparity
 
 	return storageInfo
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With storage class support, the free and total space
reported in Minio XL startup banner should be based on
totalDisks - standardClassParityDisks, instead of totalDisks/2.

## Motivation and Context
Fixes #5416

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.