### PR TITLE
Add check to confirm remote configuration files match

### DIFF
--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -206,6 +206,9 @@ func (lc localAdminClient) CommitConfig(tmpFileName string) error {
 
 	err := os.Rename(tmpConfigFile, configFile)
 	errorIf(err, fmt.Sprintf("Failed to rename %s to %s", tmpConfigFile, configFile))
+	// save the md5 sum
+	SetServerConfigHash(configFile)
+
 	return err
 }
 

--- a/cmd/admin-rpc-server_test.go
+++ b/cmd/admin-rpc-server_test.go
@@ -43,6 +43,7 @@ func testAdminCmd(cmd cmdType, t *testing.T) {
 	args := LoginRPCArgs{
 		AuthToken:   token,
 		Version:     Version,
+		ConfigHash:  GetServerConfigHash(),
 		RequestTime: UTCNow(),
 	}
 	err = adminServer.Login(&args, &LoginRPCReply{})
@@ -104,6 +105,7 @@ func TestReInitDisks(t *testing.T) {
 	args := LoginRPCArgs{
 		AuthToken:   token,
 		Version:     Version,
+		ConfigHash:  GetServerConfigHash(),
 		RequestTime: UTCNow(),
 	}
 	err = adminServer.Login(&args, &LoginRPCReply{})
@@ -131,6 +133,7 @@ func TestReInitDisks(t *testing.T) {
 	fsArgs := LoginRPCArgs{
 		AuthToken:   token,
 		Version:     Version,
+		ConfigHash:  GetServerConfigHash(),
 		RequestTime: UTCNow(),
 	}
 	fsReply := LoginRPCReply{}
@@ -173,6 +176,7 @@ func TestGetConfig(t *testing.T) {
 	args := LoginRPCArgs{
 		AuthToken:   token,
 		Version:     Version,
+		ConfigHash:  GetServerConfigHash(),
 		RequestTime: UTCNow(),
 	}
 	reply := LoginRPCReply{}
@@ -220,6 +224,7 @@ func TestWriteAndCommitConfig(t *testing.T) {
 	args := LoginRPCArgs{
 		AuthToken:   token,
 		Version:     Version,
+		ConfigHash:  GetServerConfigHash(),
 		RequestTime: UTCNow(),
 	}
 	reply := LoginRPCReply{}

--- a/cmd/auth-rpc-client.go
+++ b/cmd/auth-rpc-client.go
@@ -109,6 +109,7 @@ func (authClient *AuthRPCClient) Login() (err error) {
 			loginArgs   = LoginRPCArgs{
 				AuthToken:   authClient.authToken,
 				Version:     Version,
+				ConfigHash:  GetServerConfigHash(),
 				RequestTime: UTCNow(),
 			}
 		)

--- a/cmd/auth-rpc-server_test.go
+++ b/cmd/auth-rpc-server_test.go
@@ -42,8 +42,9 @@ func TestLogin(t *testing.T) {
 		// Valid case.
 		{
 			args: LoginRPCArgs{
-				AuthToken: token,
-				Version:   Version,
+				AuthToken:  token,
+				Version:    Version,
+				ConfigHash: GetServerConfigHash(),
 			},
 			skewTime:    0,
 			expectedErr: nil,
@@ -51,8 +52,9 @@ func TestLogin(t *testing.T) {
 		// Valid username, password and request time, not version.
 		{
 			args: LoginRPCArgs{
-				AuthToken: token,
-				Version:   "INVALID-" + Version,
+				AuthToken:  token,
+				Version:    "INVALID-" + Version,
+				ConfigHash: GetServerConfigHash(),
 			},
 			skewTime:    0,
 			expectedErr: errServerVersionMismatch,
@@ -60,8 +62,9 @@ func TestLogin(t *testing.T) {
 		// Valid username, password and version, not request time
 		{
 			args: LoginRPCArgs{
-				AuthToken: token,
-				Version:   Version,
+				AuthToken:  token,
+				Version:    Version,
+				ConfigHash: GetServerConfigHash(),
 			},
 			skewTime:    20 * time.Minute,
 			expectedErr: errServerTimeMismatch,
@@ -69,8 +72,9 @@ func TestLogin(t *testing.T) {
 		// Invalid token, fails with authentication error
 		{
 			args: LoginRPCArgs{
-				AuthToken: "",
-				Version:   Version,
+				AuthToken:  "",
+				Version:    Version,
+				ConfigHash: GetServerConfigHash(),
 			},
 			skewTime:    0,
 			expectedErr: errAuthentication,

--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -57,7 +57,8 @@ func (br *browserPeerAPIHandlers) SetAuthPeer(args SetAuthPeerArgs, reply *AuthR
 	if err := globalServerConfig.Save(); err != nil {
 		// Save the current creds when failed to update.
 		globalServerConfig.SetCredential(prevCred)
-
+		// save the md5
+		SetServerConfigHash(getConfigFile())
 		errorIf(err, "Unable to update the config with new credentials sent from browser RPC.")
 		return err
 	}

--- a/cmd/browser-peer-rpc_test.go
+++ b/cmd/browser-peer-rpc_test.go
@@ -99,6 +99,7 @@ func (s *TestRPCBrowserPeerSuite) testBrowserPeerRPC(t *testing.T) {
 	rargs := &LoginRPCArgs{
 		AuthToken:   token,
 		Version:     Version,
+		ConfigHash:  GetServerConfigHash(),
 		RequestTime: UTCNow(),
 	}
 	rreply := &LoginRPCReply{}
@@ -113,10 +114,11 @@ func (s *TestRPCBrowserPeerSuite) testBrowserPeerRPC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Validate for success in loing handled with valid credetnails.
+	// Validate for success in login handled with valid credentials.
 	rargs = &LoginRPCArgs{
 		AuthToken:   token,
 		Version:     Version,
+		ConfigHash:  GetServerConfigHash(),
 		RequestTime: UTCNow(),
 	}
 	rreply = &LoginRPCReply{}

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -48,6 +48,8 @@ func initConfig() {
 		fatalIf(newConfig(), "Unable to initialize minio config for the first time.")
 		log.Println("Created minio configuration file successfully at " + getConfigDir())
 	}
+	// save the md5 sum
+	SetServerConfigHash(getConfigFile())
 }
 
 func handleCommonCmdArgs(ctx *cli.Context) {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -44,6 +44,7 @@ var (
 	// globalServerConfig server config.
 	globalServerConfig   *serverConfig
 	globalServerConfigMu sync.RWMutex
+	serverConfigHash     string
 )
 
 // GetVersion get current config version.
@@ -153,6 +154,16 @@ func (s *serverConfig) Save() error {
 
 	// Save config file.
 	return quick.Save(getConfigFile(), s)
+}
+
+// SetServerConfigHash sets the MD5 of current configuration
+func SetServerConfigHash(configFile string) {
+	serverConfigHash = md5FromFile(configFile)
+}
+
+// GetServerConfigHash returns the MD5 of current configuration
+func GetServerConfigHash() string {
+	return serverConfigHash
 }
 
 func newServerConfig() *serverConfig {

--- a/cmd/lock-rpc-server_test.go
+++ b/cmd/lock-rpc-server_test.go
@@ -65,6 +65,7 @@ func createLockTestServer(t *testing.T) (string, *lockServer, string) {
 	loginArgs := LoginRPCArgs{
 		AuthToken:   token,
 		Version:     Version,
+		ConfigHash:  GetServerConfigHash(),
 		RequestTime: UTCNow(),
 	}
 	loginReply := LoginRPCReply{}

--- a/cmd/rpc-common.go
+++ b/cmd/rpc-common.go
@@ -33,6 +33,12 @@ func isRequestTimeAllowed(requestTime time.Time) bool {
 		utcNow.Sub(requestTime) > rpcSkewTimeAllowed)
 }
 
+// Checks current server config file hash against remote config file hash
+func configMatch(configHash string) bool {
+	// Check whether hash of the configuration files match
+	return GetServerConfigHash() == configHash
+}
+
 // AuthRPCArgs represents minimum required arguments to make any authenticated RPC call.
 type AuthRPCArgs struct {
 	// Authentication token to be verified by the server for every RPC call.
@@ -62,6 +68,7 @@ type AuthRPCReply struct{}
 type LoginRPCArgs struct {
 	AuthToken   string
 	Version     string
+	ConfigHash  string
 	RequestTime time.Time
 }
 
@@ -70,6 +77,10 @@ func (args LoginRPCArgs) IsValid() error {
 	// Check if version matches.
 	if args.Version != Version {
 		return errServerVersionMismatch
+	}
+
+	if !configMatch(args.ConfigHash) {
+		return errServerConfigMismatch
 	}
 
 	if !isRequestTimeAllowed(args.RequestTime) {

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -48,6 +48,9 @@ var errServerVersionMismatch = errors.New("Server versions do not match")
 // errServerTimeMismatch - server times are too far apart.
 var errServerTimeMismatch = errors.New("Server times are too far apart")
 
+// errServerConfigMismatch - server configs do not match.
+var errServerConfigMismatch = errors.New("Server configuration files do not match")
+
 // errInvalidBucketName - bucket name is reserved for Minio, usually
 // returned for 'minio', '.minio.sys', buckets with capital letters.
 var errInvalidBucketName = errors.New("The specified bucket is not valid")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"crypto/md5"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -270,4 +271,17 @@ func jsonLoadFromSeeker(r io.ReadSeeker, data interface{}) error {
 		return err
 	}
 	return json.NewDecoder(r).Decode(data)
+}
+
+// calculate MD5 hash of the config file
+func md5FromFile(filePath string) string {
+	h := md5.New()
+
+	cf, err := os.Open(filePath)
+	fatalIf(err, "Could not open file %s", filePath)
+
+	_, err = io.Copy(h, cf)
+	fatalIf(err, "Could not calculate MD5 hash for %s", filePath)
+
+	return string(h.Sum(nil))
 }


### PR DESCRIPTION
## Description
Currently it is possible to run distributed Minio server instances
each with its own configuration file (having different settings
enabled).

For example one Minio instance in a distributed setup may
have event notifications enabled, while others don't. This doesn't
cause any functional issues, and only the instance with notifications
enabled will actually send out event notifications.

Such situation can however lead users to believe that all instances
will work in same manner. This PR adds a check to make sure MD5sum
of each instance's configuration files match, hence making sure all
instances are running same configuration file.

## Motivation and Context
Observed after addition of storage classes

## How Has This Been Tested?
Manually by running distributed Minio instances with different config files

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.