### PR TITLE
Fix lock rpc server maintenance loop go-routine leak

### DIFF
--- a/cmd/lock-rpc-server.go
+++ b/cmd/lock-rpc-server.go
@@ -76,11 +76,12 @@ func startLockMaintenance(lockServers []*lockServer) {
 			for {
 				// Verifies every minute for locks held more than 2minutes.
 				select {
+				case <-globalServiceDoneCh:
+					// Stop the timer upon service closure and cleanup the go-routine.
+					ticker.Stop()
+					return
 				case <-ticker.C:
 					lk.lockMaintenance(lockValidityCheckInterval)
-				case <-globalServiceDoneCh:
-					// Stop the timer.
-					ticker.Stop()
 				}
 			}
 		}(locker)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix lock rpc server maintainenance loop go-routine leak
<!--- Describe your changes in detail -->

## Motivation and Context
The problem was after the globalServiceDoneCh receives a
message, we cleanly stop the ticker as expected. But the
go-routine where the `select` loop is running is never
returned from. The stage at which point this may occur
i.e server is being restarted, doesn't seriously affect
servers usage. But any build up like this on server has
consequences as the new functionality would come in future.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.