### PR TITLE
Fix a bug in dsync initialization and communication

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -186,8 +186,8 @@ func serverMain(ctx *cli.Context) {
 
 	// Set nodes for dsync for distributed setup.
 	if globalIsDistXL {
-		clnts, myNode := newDsyncNodes(globalEndpoints)
-		fatalIf(dsync.Init(clnts, myNode), "Unable to initialize distributed locking clients")
+		globalDsync, err = dsync.New(newDsyncNodes(globalEndpoints))
+		fatalIf(err, "Unable to initialize distributed locking clients")
 	}
 
 	// Initialize name space lock.

--- a/vendor/github.com/minio/dsync/README.md
+++ b/vendor/github.com/minio/dsync/README.md
@@ -87,22 +87,26 @@ The system can be pushed to 75K locks/sec at 50% CPU load.
 Usage
 -----
 
+> NOTE: Previously if you were using `dsync.Init([]NetLocker, nodeIndex)` to initialize dsync has
+been changed to `dsync.New([]NetLocker, nodeIndex)` which returns a `*Dsync` object to be used in
+every instance of `NewDRWMutex("test", *Dsync)`
+
 ### Exclusive lock 
 
 Here is a simple example showing how to protect a single resource (drop-in replacement for `sync.Mutex`):
 
-```
+```go
 import (
-    "github.com/minio/dsync"
+	"github.com/minio/dsync"
 )
 
 func lockSameResource() {
 
-    // Create distributed mutex to protect resource 'test'
-	dm := dsync.NewDRWMutex("test")
+	// Create distributed mutex to protect resource 'test'
+	dm := dsync.NewDRWMutex("test", ds)
 
 	dm.Lock()
-    log.Println("first lock granted")
+	log.Println("first lock granted")
 
 	// Release 1st lock after 5 seconds
 	go func() {
@@ -111,10 +115,10 @@ func lockSameResource() {
 		dm.Unlock()
 	}()
 
-    // Try to acquire lock again, will block until initial lock is released
-    log.Println("about to lock same resource again...")
+	// Try to acquire lock again, will block until initial lock is released
+	log.Println("about to lock same resource again...")
 	dm.Lock()
-    log.Println("second lock granted")
+	log.Println("second lock granted")
 
 	time.Sleep(2 * time.Second)
 	dm.Unlock()
@@ -137,7 +141,7 @@ DRWMutex also supports multiple simultaneous read locks as shown below (analogou
 ```
 func twoReadLocksAndSingleWriteLock() {
 
-	drwm := dsync.NewDRWMutex("resource")
+	drwm := dsync.NewDRWMutex("resource", ds)
 
 	drwm.RLock()
 	log.Println("1st read lock acquired, waiting...")
@@ -160,7 +164,7 @@ func twoReadLocksAndSingleWriteLock() {
 	log.Println("Trying to acquire write lock, waiting...")
 	drwm.Lock()
 	log.Println("Write lock acquired, waiting...")
-	
+
 	time.Sleep(3 * time.Second)
 
 	drwm.Unlock()

--- a/vendor/github.com/minio/dsync/dsync.go
+++ b/vendor/github.com/minio/dsync/dsync.go
@@ -16,51 +16,52 @@
 
 package dsync
 
-import "errors"
+import (
+	"errors"
+)
 
-// Number of nodes participating in the distributed locking.
-var dnodeCount int
+// Dsync represents dsync client object which is initialized with
+// authenticated clients, used to initiate lock RPC calls.
+type Dsync struct {
+	// Number of nodes participating in the distributed locking.
+	dNodeCount int
 
-// List of rpc client objects, one per lock server.
-var clnts []NetLocker
+	// List of rpc client objects, one per lock server.
+	rpcClnts []NetLocker
 
-// Index into rpc client array for server running on localhost
-var ownNode int
+	// Index into rpc client array for server running on localhost
+	ownNode int
 
-// Simple majority based quorum, set to dNodeCount/2+1
-var dquorum int
+	// Simple majority based quorum, set to dNodeCount/2+1
+	dquorum int
 
-// Simple quorum for read operations, set to dNodeCount/2
-var dquorumReads int
+	// Simple quorum for read operations, set to dNodeCount/2
+	dquorumReads int
+}
 
-// Init - initializes package-level global state variables such as clnts.
-// N B - This function should be called only once inside any program
-// that uses dsync.
-func Init(rpcClnts []NetLocker, rpcOwnNode int) (err error) {
-
-	// Validate if number of nodes is within allowable range.
-	if dnodeCount != 0 {
-		return errors.New("Cannot reinitialize dsync package")
-	}
+// New - initializes a new dsync object with input rpcClnts.
+func New(rpcClnts []NetLocker, rpcOwnNode int) (*Dsync, error) {
 	if len(rpcClnts) < 4 {
-		return errors.New("Dsync is not designed for less than 4 nodes")
+		return nil, errors.New("Dsync is not designed for less than 4 nodes")
 	} else if len(rpcClnts) > 16 {
-		return errors.New("Dsync is not designed for more than 16 nodes")
+		return nil, errors.New("Dsync is not designed for more than 16 nodes")
 	} else if len(rpcClnts)%2 != 0 {
-		return errors.New("Dsync is not designed for an uneven number of nodes")
+		return nil, errors.New("Dsync is not designed for an uneven number of nodes")
 	}
 
 	if rpcOwnNode > len(rpcClnts) {
-		return errors.New("Index for own node is too large")
+		return nil, errors.New("Index for own node is too large")
 	}
 
-	dnodeCount = len(rpcClnts)
-	dquorum = dnodeCount/2 + 1
-	dquorumReads = dnodeCount / 2
-	// Initialize node name and rpc path for each NetLocker object.
-	clnts = make([]NetLocker, dnodeCount)
-	copy(clnts, rpcClnts)
+	ds := &Dsync{}
+	ds.dNodeCount = len(rpcClnts)
+	ds.dquorum = ds.dNodeCount/2 + 1
+	ds.dquorumReads = ds.dNodeCount / 2
+	ds.ownNode = rpcOwnNode
 
-	ownNode = rpcOwnNode
-	return nil
+	// Initialize node name and rpc path for each NetLocker object.
+	ds.rpcClnts = make([]NetLocker, ds.dNodeCount)
+	copy(ds.rpcClnts, rpcClnts)
+
+	return ds, nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -380,10 +380,10 @@
 			"revisionTime": "2017-02-27T07:32:28Z"
 		},
 		{
-			"checksumSHA1": "hQ8i4UPTbFW68oPJP3uFxYTLfxk=",
+			"checksumSHA1": "qhWQM7xmqaxFqADNTj8YPjE/8Ws=",
 			"path": "github.com/minio/dsync",
-			"revision": "a26b9de6c8006208d10a9517720d3212b42c374e",
-			"revisionTime": "2017-05-25T17:53:53Z"
+			"revision": "ed0989bc6c7b199f749fa6be0b7ee98d689b88c7",
+			"revisionTime": "2017-11-22T09:16:00Z"
 		},
 		{
 			"path": "github.com/minio/go-homedir",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
In current implementation we used as many dsync clients
as per number of endpoints(along with path) which is not
the expected implementation. The implementation of Dsync
was expected to be just for the endpoint Host alone such
that if you have 4 servers and each with 4 disks we need
to only have 4 dsync clients and 4 dsync servers. But
we currently had 8 clients, servers which in-fact is
unexpected and should be avoided.

<!--- Describe your changes in detail -->

## Motivation and Context
This PR brings the implementation back to its original
intention. This issue was found #5160
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually, using mint and go tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.