### PR TITLE
fix: init nslocks in tests

### DIFF
--- a/cmd/namespace-lock_test.go
+++ b/cmd/namespace-lock_test.go
@@ -39,6 +39,8 @@ func TestGetSource(t *testing.T) {
 
 // Tests functionality provided by namespace lock.
 func TestNamespaceLockTest(t *testing.T) {
+	isDistXL := false
+	initNSLock(isDistXL)
 	// List of test cases.
 	testCases := []struct {
 		lk               func(s1, s2, s3 string, t time.Duration) bool
@@ -155,7 +157,8 @@ func TestNamespaceLockTest(t *testing.T) {
 }
 
 func TestNamespaceLockTimedOut(t *testing.T) {
-
+	isDistXL := false
+	initNSLock(isDistXL)
 	// Get write lock
 	if !globalNSMutex.Lock("my-bucket", "my-object", "abc", 60*time.Second) {
 		t.Fatalf("Failed to acquire lock")
@@ -199,7 +202,8 @@ func TestNamespaceLockTimedOut(t *testing.T) {
 
 // Tests functionality to forcefully unlock locks.
 func TestNamespaceForceUnlockTest(t *testing.T) {
-
+	isDistXL := false
+	initNSLock(isDistXL)
 	// Create lock.
 	lock := globalNSMutex.NewNSLock("bucket", "object")
 	if lock.GetLock(newDynamicTimeout(60*time.Second, time.Second)) != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 go test -v -run=TestListLocksInfo ./cmd should pass. 
Currently this test fails because the admin test bed is not being initialized. namespace lock tests also need to be fixed to init nslocks prior to the test.
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.