### PR TITLE
Fix acquiring locks in some admin APIs

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -528,6 +528,13 @@ func (h *healSequence) healDiskFormat() error {
 		return errServerNotInitialized
 	}
 
+	// Acquire lock on format.json
+	formatLock := globalNSMutex.NewNSLock(minioMetaBucket, formatConfigFile)
+	if err := formatLock.GetLock(globalHealingTimeout); err != nil {
+		return errFnHealFromAPIErr(err)
+	}
+	defer formatLock.Unlock()
+
 	// Create a new set of storage instances to heal format.json.
 	bootstrapDisks, err := initStorageDisks(globalEndpoints)
 	if err != nil {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some locking bugs were found - these are fixed by:

Acquire:
- read lock on config file during get config
- write lock on config file during update credentials
- write lock on format config

The last item causes HealFormat to be added as an object layer
function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.