### PR TITLE
Put quorum lock connection on cooldown after net timeout -error.

### DIFF
--- a/cmd/lock-rpc-client.go
+++ b/cmd/lock-rpc-client.go
@@ -16,56 +16,95 @@
 
 package cmd
 
-import "github.com/minio/dsync"
+import (
+	"fmt"
+	"github.com/minio/dsync"
+	"net"
+	"time"
+)
+
+// So we try arguing lock 2 times more often than we check the disk status
+const lockTimeoutRetryTime = globalStorageHealthCheckInterval / 2
 
 // LockRPCClient is authenticable lock RPC client compatible to dsync.NetLocker
 type LockRPCClient struct {
 	*AuthRPCClient
+	lastTimeoutError time.Time
 }
 
 // newLockRPCClient returns new lock RPC client object.
 func newLockRPCClient(config authConfig) *LockRPCClient {
-	return &LockRPCClient{newAuthRPCClient(config)}
+	return &LockRPCClient{newAuthRPCClient(config), time.Time{}}
 }
 
 // RLock calls read lock RPC.
 func (lockRPCClient *LockRPCClient) RLock(args dsync.LockArgs) (reply bool, err error) {
 	lockArgs := newLockArgs(args)
-	err = lockRPCClient.AuthRPCClient.Call("Dsync.RLock", &lockArgs, &reply)
+	err = lockRPCClient.call("Dsync.RLock", &lockArgs, &reply)
 	return reply, err
 }
 
 // Lock calls write lock RPC.
 func (lockRPCClient *LockRPCClient) Lock(args dsync.LockArgs) (reply bool, err error) {
 	lockArgs := newLockArgs(args)
-	err = lockRPCClient.AuthRPCClient.Call("Dsync.Lock", &lockArgs, &reply)
+	err = lockRPCClient.call("Dsync.Lock", &lockArgs, &reply)
 	return reply, err
 }
 
 // RUnlock calls read unlock RPC.
 func (lockRPCClient *LockRPCClient) RUnlock(args dsync.LockArgs) (reply bool, err error) {
 	lockArgs := newLockArgs(args)
-	err = lockRPCClient.AuthRPCClient.Call("Dsync.RUnlock", &lockArgs, &reply)
+	err = lockRPCClient.call("Dsync.RUnlock", &lockArgs, &reply)
 	return reply, err
 }
 
 // Unlock calls write unlock RPC.
 func (lockRPCClient *LockRPCClient) Unlock(args dsync.LockArgs) (reply bool, err error) {
 	lockArgs := newLockArgs(args)
-	err = lockRPCClient.AuthRPCClient.Call("Dsync.Unlock", &lockArgs, &reply)
+	err = lockRPCClient.call("Dsync.Unlock", &lockArgs, &reply)
 	return reply, err
 }
 
 // ForceUnlock calls force unlock RPC.
 func (lockRPCClient *LockRPCClient) ForceUnlock(args dsync.LockArgs) (reply bool, err error) {
 	lockArgs := newLockArgs(args)
-	err = lockRPCClient.AuthRPCClient.Call("Dsync.ForceUnlock", &lockArgs, &reply)
+	err = lockRPCClient.call("Dsync.ForceUnlock", &lockArgs, &reply)
 	return reply, err
 }
 
 // Expired calls expired RPC.
 func (lockRPCClient *LockRPCClient) Expired(args dsync.LockArgs) (reply bool, err error) {
 	lockArgs := newLockArgs(args)
-	err = lockRPCClient.AuthRPCClient.Call("Dsync.Expired", &lockArgs, &reply)
+	err = lockRPCClient.call("Dsync.Expired", &lockArgs, &reply)
 	return reply, err
+}
+
+// Make RPC call with timeout error cooldown check.
+func (lockRPCClient *LockRPCClient) call(serviceMethod string, args interface {
+	SetAuthToken(authToken string)
+}, reply interface{}) (err error) {
+
+	if lockRPCClient.lastTimeoutError.Add(lockTimeoutRetryTime).After(time.Now()) {
+		// we are still in cooldown period
+		return &net.OpError{
+			Op:   "dial-http",
+			Net:  lockRPCClient.config.serverAddr,
+			Addr: nil,
+			Err:  fmt.Errorf("%s rpc connection for locking timeouted in near history, next retry in %v seconds", lockRPCClient.config.serverAddr, lockRPCClient.lastTimeoutError.Add(lockTimeoutRetryTime).Sub(time.Now()).Seconds()),
+		}
+	}
+
+	err = lockRPCClient.AuthRPCClient.Call(serviceMethod, args, reply)
+
+	// if it's timeouterror, mark time and start cooldown for this rpc connection
+	switch err.(type) {
+	case *net.OpError:
+		if err.(*net.OpError).Timeout() {
+			lockRPCClient.lastTimeoutError = time.Now()
+
+			log.Printf("%s: RPC connection for locking timeouted, Retrying next time to that server in %v seconds\n", lockRPCClient.config.serverAddr, lockTimeoutRetryTime.Seconds())
+		}
+	}
+
+	return err
 }


### PR DESCRIPTION
Put lock connection on cooldown after net timeout -error.

## Description
Lock request to each server is done with every action, multible times on some actions. If server is totally offline, it will wait for timeout on each lock request, which slows things up.
Implements cooldown -period for lock connection, which is _only_ enabled after timeout -error. Default cooldown -period is globalStorageHealthCheckInterval / 2, so we try twice same time disk tries once.

This basically is same thing that the offline -mode for disk

## Motivation and Context
While fixing freeze problem (https://github.com/remodoy/minio/commit/13aa21b5ea1342628941d20b190dbf0a7ac8cbb2) I did notice that minio is still slow if one node is down -> lock request waiting for connection to timeout where the reason.

## How Has This Been Tested?
2 virtual machines in virtualbox (which is in my development laptop) and one minio instance in same laptop's goland. 2 disks on each minio. Bring everything up. test that it works (mainly using mc from different servers). Kill one sever from virtualbox control panel. Test again reading, writing, etc. files. Bring virtual machine back up.Test. Wait disk cooldown time (5min). Test again. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x]  All test passes which passes against current master.