### PR TITLE
Removes Title() for capitalization of error cause

### DIFF
--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -172,7 +172,8 @@ func logIf(level Level, err error, msg string,
 	if err == nil || isErrIgnored(err) {
 		return
 	}
-	cause := strings.Title(err.Error())
+	// Get the cause for the Error
+	cause := err.Error()
 	// Get full stack trace
 	trace := getTrace(3)
 	// Get time


### PR DESCRIPTION
`Title()` library function was used for error cause string and it was capitalizing the first letters of every word in the error cause string.

## Description
`Title()` library function call is removed and no capitalization is needed. Error cause messages are expected to be defined correctly when they are created.

## Motivation and Context
#5462

## How Has This Been Tested?
minio server is rebuilt locally and ran against mint test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.