### PR TITLE
Fix configuration handling bugs related to Admin API

### DIFF
--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -478,7 +477,7 @@ func getPeerConfig(peers adminPeers) ([]byte, error) {
 	// Find the maximally occurring config among peers in a
 	// distributed setup.
 
-	serverConfigs := make([]serverConfigV13, len(peers))
+	serverConfigs := make([]serverConfig, len(peers))
 	for i, configBytes := range configs {
 		if errs[i] != nil {
 			continue
@@ -505,7 +504,7 @@ func getPeerConfig(peers adminPeers) ([]byte, error) {
 
 // getValidServerConfig - finds the server config that is present in
 // quorum or more number of servers.
-func getValidServerConfig(serverConfigs []serverConfigV13, errs []error) (scv serverConfigV13, e error) {
+func getValidServerConfig(serverConfigs []serverConfig, errs []error) (scv serverConfig, e error) {
 	// majority-based quorum
 	quorum := len(serverConfigs)/2 + 1
 
@@ -548,7 +547,7 @@ func getValidServerConfig(serverConfigs []serverConfigV13, errs []error) (scv se
 				// seen. See example above for
 				// clarity.
 				continue
-			} else if j < i && reflect.DeepEqual(serverConfigs[i], serverConfigs[j]) {
+			} else if j < i && serverConfigs[i].ConfigDiff(&serverConfigs[j]) == "" {
 				// serverConfigs[i] is equal to
 				// serverConfigs[j], update
 				// serverConfigs[j]'s counter since it
@@ -567,7 +566,7 @@ func getValidServerConfig(serverConfigs []serverConfigV13, errs []error) (scv se
 
 	// We find the maximally occurring server config and check if
 	// there is quorum.
-	var configJSON serverConfigV13
+	var configJSON serverConfig
 	maxOccurrence := 0
 	for i, count := range configCounter {
 		if maxOccurrence < count {

--- a/cmd/admin-rpc-client_test.go
+++ b/cmd/admin-rpc-client_test.go
@@ -220,7 +220,7 @@ var (
 
 // TestGetValidServerConfig - test for getValidServerConfig.
 func TestGetValidServerConfig(t *testing.T) {
-	var c1, c2 serverConfigV13
+	var c1, c2 serverConfig
 	err := json.Unmarshal(config1, &c1)
 	if err != nil {
 		t.Fatalf("json unmarshal of %s failed: %v", string(config1), err)
@@ -233,7 +233,7 @@ func TestGetValidServerConfig(t *testing.T) {
 
 	// Valid config.
 	noErrs := []error{nil, nil, nil, nil}
-	serverConfigs := []serverConfigV13{c1, c2, c1, c1}
+	serverConfigs := []serverConfig{c1, c2, c1, c1}
 	validConfig, err := getValidServerConfig(serverConfigs, noErrs)
 	if err != nil {
 		t.Errorf("Expected a valid config but received %v instead", err)
@@ -244,7 +244,7 @@ func TestGetValidServerConfig(t *testing.T) {
 	}
 
 	// Invalid config - no quorum.
-	serverConfigs = []serverConfigV13{c1, c2, c2, c1}
+	serverConfigs = []serverConfig{c1, c2, c2, c1}
 	_, err = getValidServerConfig(serverConfigs, noErrs)
 	if err != errXLWriteQuorum {
 		t.Errorf("Expected to fail due to lack of quorum but received %v", err)
@@ -252,7 +252,7 @@ func TestGetValidServerConfig(t *testing.T) {
 
 	// All errors
 	allErrs := []error{errDiskNotFound, errDiskNotFound, errDiskNotFound, errDiskNotFound}
-	serverConfigs = []serverConfigV13{{}, {}, {}, {}}
+	serverConfigs = []serverConfig{{}, {}, {}, {}}
 	_, err = getValidServerConfig(serverConfigs, allErrs)
 	if err != errXLWriteQuorum {
 		t.Errorf("Expected to fail due to lack of quorum but received %v", err)

--- a/cmd/browser-peer-rpc.go
+++ b/cmd/browser-peer-rpc.go
@@ -50,6 +50,10 @@ func (br *browserPeerAPIHandlers) SetAuthPeer(args SetAuthPeerArgs, reply *AuthR
 		return fmt.Errorf("Invalid credential passed")
 	}
 
+	// Acquire lock before updating global configuration.
+	globalServerConfigMu.Lock()
+	defer globalServerConfigMu.Unlock()
+
 	// Update credentials in memory
 	prevCred := globalServerConfig.SetCredential(args.Creds)
 

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -1717,7 +1717,7 @@ func migrateV21ToV22() error {
 
 	// Copy over fields from V21 into V22 config struct
 	srvConfig := &serverConfigV22{
-		Notify: &notifier{},
+		Notify: notifier{},
 	}
 	srvConfig.Version = serverConfigVersion
 	srvConfig.Credential = cv21.Credential

--- a/cmd/config-versions.go
+++ b/cmd/config-versions.go
@@ -547,9 +547,11 @@ type serverConfigV21 struct {
 }
 
 // serverConfigV22 is just like version '21' with added support
-// for StorageClass
+// for StorageClass.
+//
+// IMPORTANT NOTE: When updating this struct make sure that
+// serverConfig.ConfigDiff() is updated as necessary.
 type serverConfigV22 struct {
-	sync.RWMutex
 	Version string `json:"version"`
 
 	// S3 API configuration.
@@ -562,5 +564,5 @@ type serverConfigV22 struct {
 	StorageClass storageClassConfig `json:"storageclass"`
 
 	// Notification queue configuration.
-	Notify *notifier `json:"notify"`
+	Notify notifier `json:"notify"`
 }

--- a/cmd/notifier-config.go
+++ b/cmd/notifier-config.go
@@ -18,12 +18,10 @@ package cmd
 
 import (
 	"fmt"
-	"sync"
 )
 
 // Notifier represents collection of supported notification queues.
 type notifier struct {
-	sync.RWMutex
 	AMQP          amqpConfigs          `json:"amqp"`
 	NATS          natsConfigs          `json:"nats"`
 	ElasticSearch elasticSearchConfigs `json:"elasticsearch"`
@@ -33,7 +31,9 @@ type notifier struct {
 	Webhook       webhookConfigs       `json:"webhook"`
 	MySQL         mySQLConfigs         `json:"mysql"`
 	MQTT          mqttConfigs          `json:"mqtt"`
-	// Add new notification queues.
+	// Add new notification queues. IMPORTANT: When new queues are
+	// added, update `serverConfig.ConfigDiff()` to reflect the
+	// change.
 }
 
 type amqpConfigs map[string]amqpNotify
@@ -239,163 +239,109 @@ func (n *notifier) Validate() error {
 }
 
 func (n *notifier) SetAMQPByID(accountID string, amqpn amqpNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.AMQP[accountID] = amqpn
 }
 
 func (n *notifier) GetAMQP() map[string]amqpNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.AMQP.Clone()
 }
 
 func (n *notifier) GetAMQPByID(accountID string) amqpNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.AMQP[accountID]
 }
 
 func (n *notifier) SetMQTTByID(accountID string, mqttn mqttNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.MQTT[accountID] = mqttn
 }
 
 func (n *notifier) GetMQTT() map[string]mqttNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.MQTT.Clone()
 }
 
 func (n *notifier) GetMQTTByID(accountID string) mqttNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.MQTT[accountID]
 }
 
 func (n *notifier) SetNATSByID(accountID string, natsn natsNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.NATS[accountID] = natsn
 }
 
 func (n *notifier) GetNATS() map[string]natsNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.NATS.Clone()
 }
 
 func (n *notifier) GetNATSByID(accountID string) natsNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.NATS[accountID]
 }
 
 func (n *notifier) SetElasticSearchByID(accountID string, es elasticSearchNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.ElasticSearch[accountID] = es
 }
 
 func (n *notifier) GetElasticSearchByID(accountID string) elasticSearchNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.ElasticSearch[accountID]
 }
 
 func (n *notifier) GetElasticSearch() map[string]elasticSearchNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.ElasticSearch.Clone()
 }
 
 func (n *notifier) SetRedisByID(accountID string, r redisNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.Redis[accountID] = r
 }
 
 func (n *notifier) GetRedis() map[string]redisNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.Redis.Clone()
 }
 
 func (n *notifier) GetRedisByID(accountID string) redisNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.Redis[accountID]
 }
 
 func (n *notifier) GetWebhook() map[string]webhookNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.Webhook.Clone()
 }
 
 func (n *notifier) GetWebhookByID(accountID string) webhookNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.Webhook[accountID]
 }
 
 func (n *notifier) SetWebhookByID(accountID string, pgn webhookNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.Webhook[accountID] = pgn
 }
 
 func (n *notifier) SetPostgreSQLByID(accountID string, pgn postgreSQLNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.PostgreSQL[accountID] = pgn
 }
 
 func (n *notifier) GetPostgreSQL() map[string]postgreSQLNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.PostgreSQL.Clone()
 }
 
 func (n *notifier) GetPostgreSQLByID(accountID string) postgreSQLNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.PostgreSQL[accountID]
 }
 
 func (n *notifier) SetMySQLByID(accountID string, pgn mySQLNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.MySQL[accountID] = pgn
 }
 
 func (n *notifier) GetMySQL() map[string]mySQLNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.MySQL.Clone()
 }
 
 func (n *notifier) GetMySQLByID(accountID string) mySQLNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.MySQL[accountID]
 }
 
 func (n *notifier) SetKafkaByID(accountID string, kn kafkaNotify) {
-	n.Lock()
-	defer n.Unlock()
 	n.Kafka[accountID] = kn
 }
 
 func (n *notifier) GetKafka() map[string]kafkaNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.Kafka.Clone()
 }
 
 func (n *notifier) GetKafkaByID(accountID string) kafkaNotify {
-	n.RLock()
-	defer n.RUnlock()
 	return n.Kafka[accountID]
 }

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -423,6 +423,10 @@ func (web *webAPIHandlers) SetAuth(r *http.Request, args *SetAuthArgs, reply *Se
 		return toJSONError(err)
 	}
 
+	// Acquire lock before updating global configuration.
+	globalServerConfigMu.Lock()
+	defer globalServerConfigMu.Unlock()
+
 	// Notify all other Minio peers to update credentials
 	errsMap := updateCredsOnPeers(creds)
 


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
* Update the GetConfig admin API to use the latest version of
  configuration, along with fixes to the corresponding RPCs.
* Remove mutex inside the configuration struct, and inside
  notification struct.
* Use global config mutex where needed.
* Add `serverConfig.ConfigDiff()` that provides a more granular diff
  of what is different between two configurations.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Following up from https://github.com/minio/minio/pull/5440 with an appropriate fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.