### PR TITLE
Reduce Minio access key minimum length to 3 

### DIFF
--- a/cmd/jwt_test.go
+++ b/cmd/jwt_test.go
@@ -39,8 +39,8 @@ func testAuthenticate(authType string, t *testing.T) {
 		secretKey   string
 		expectedErr error
 	}{
-		// Access key (less than 5 chrs) too small.
-		{"user", cred.SecretKey, auth.ErrInvalidAccessKeyLength},
+		// Access key (less than 3 chrs) too small.
+		{"u1", cred.SecretKey, auth.ErrInvalidAccessKeyLength},
 		// Secret key (less than 8 chrs) too small.
 		{cred.AccessKey, "pass", auth.ErrInvalidSecretKeyLength},
 		// Authentication error.

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -53,7 +53,7 @@ FLAGS:
   {{end}}{{end}}
 ENVIRONMENT VARIABLES:
   ACCESS:
-     MINIO_ACCESS_KEY: Custom username or access key of minimum 5 characters in length.
+     MINIO_ACCESS_KEY: Custom username or access key of minimum 3 characters in length.
      MINIO_SECRET_KEY: Custom password or secret key of minimum 8 characters in length.
 
   BROWSER:

--- a/cmd/signature-v4-parser_test.go
+++ b/cmd/signature-v4-parser_test.go
@@ -116,10 +116,10 @@ func TestParseCredentialHeader(t *testing.T) {
 			expectedErrCode:     ErrCredMalformed,
 		},
 		// Test Case - 4.
-		// Test case with AccessKey of length 4.
+		// Test case with AccessKey of length 2.
 		{
 			inputCredentialStr: generateCredentialStr(
-				"^#@.",
+				"^#",
 				UTCNow().Format(yyyymmdd),
 				"ABCD",
 				"ABCD",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -34,7 +34,7 @@ $ tree ~/.minio
 |Field|Type|Description|
 |:---|:---|:---|
 |``credential``| | Auth credential for object storage and web access.|
-|``credential.accessKey`` | _string_ | Access key of minimum 5 characters in length. You may override this field with `MINIO_ACCESS_KEY` environment variable.|
+|``credential.accessKey`` | _string_ | Access key of minimum 3 characters in length. You may override this field with `MINIO_ACCESS_KEY` environment variable.|
 |``credential.secretKey`` | _string_ | Secret key of minimum 8 characters in length. You may override this field with `MINIO_SECRET_KEY` environment variable.|
 
 Example:

--- a/pkg/auth/credentials.go
+++ b/pkg/auth/credentials.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// Minimum length for Minio access key.
-	accessKeyMinLen = 5
+	accessKeyMinLen = 3
 
 	// Maximum length for Minio access key.
 	// There is no max length enforcement for access keys


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a generic minimum value. The current reason is to support
Azure blob storage accounts name whose length is less than 5. 3 is the
minimum length for Azure.


## Motivation and Context
Fixes #5477 

## How Has This Been Tested?
go test + Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.