### PR TITLE
Honor global flags irrespective of the position

### DIFF
--- a/cmd/config-dir.go
+++ b/cmd/config-dir.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2015, 2016, 2017 Minio, Inc.
+ * Minio Cloud Storage, (C) 2015, 2016, 2017, 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,14 +95,16 @@ func (config *ConfigDir) GetPrivateKeyFile() string {
 	return filepath.Join(config.getCertsDir(), privateKeyFile)
 }
 
-func mustGetDefaultConfigDir() string {
+func getDefaultConfigDir() string {
 	homeDir, err := homedir.Dir()
-	fatalIf(err, "Unable to get home directory.")
+	if err != nil {
+		return ""
+	}
 
 	return filepath.Join(homeDir, defaultMinioConfigDir)
 }
 
-var configDir = &ConfigDir{dir: mustGetDefaultConfigDir()}
+var configDir = &ConfigDir{dir: getDefaultConfigDir()}
 
 func setConfigDir(dir string) {
 	configDir.Set(dir)

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ * Minio Cloud Storage, (C) 2017, 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,13 +114,13 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 
 	// Get "json" flag from command line argument and
 	// enable json and quite modes if jason flag is turned on.
-	jsonFlag := ctx.Bool("json") || ctx.GlobalBool("json")
+	jsonFlag := ctx.IsSet("json") || ctx.GlobalIsSet("json")
 	if jsonFlag {
 		log.EnableJSON()
 	}
 
 	// Get quiet flag from command line argument.
-	quietFlag := ctx.Bool("quiet") || ctx.GlobalBool("quiet")
+	quietFlag := ctx.IsSet("quiet") || ctx.GlobalIsSet("quiet")
 	if quietFlag {
 		log.EnableQuiet()
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2015, 2016, 2017 Minio, Inc.
+ * Minio Cloud Storage, (C) 2015, 2016, 2017, 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,13 @@ var globalFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "config-dir, C",
 		Value: getConfigDir(),
-		Usage: "Path to configuration directory.",
+		Usage: func() string {
+			usage := "Path to configuration directory."
+			if getConfigDir() == "" {
+				usage = usage + "  This option must be set."
+			}
+			return usage
+		}(),
 	},
 	cli.BoolFlag{
 		Name:  "quiet",

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -134,13 +134,13 @@ func serverMain(ctx *cli.Context) {
 
 	// Get "json" flag from command line argument and
 	// enable json and quite modes if jason flag is turned on.
-	jsonFlag := ctx.Bool("json") || ctx.GlobalBool("json")
+	jsonFlag := ctx.IsSet("json") || ctx.GlobalIsSet("json")
 	if jsonFlag {
 		log.EnableJSON()
 	}
 
 	// Get quiet flag from command line argument.
-	quietFlag := ctx.Bool("quiet") || ctx.GlobalBool("quiet")
+	quietFlag := ctx.IsSet("quiet") || ctx.GlobalIsSet("quiet")
 	if quietFlag {
 		log.EnableQuiet()
 	}


### PR DESCRIPTION
## Description
Flags like `json, config-dir, quiet` are now honored even if they are
between minio and gateway in the cli, like, `minio --json gateway s3`.

mustGetDefaultConfigDir need not be called if config-dir flag is set.

Fixes #5403

## Motivation and Context
If a user launches minio with the following command
`minio --quiet gateway s3` it does not silence the startup messages also from #5403
```When a user tries to launch minio via launchd (launchctl) on boot it does not work because it cannot find a home directory. A home directory seems to be a requirement even if --config-dir is used on the command line.```


## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.