### PR TITLE
Make globalNSMutex the only nsLock instance

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -154,6 +154,15 @@ func prepareAdminXLTestBed() (*adminXLTestBed, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Set globalIsXL to indicate that the setup uses an erasure
+	// code backend.
+	globalIsXL = true
+
+	// initialize NSLock.
+	isDistXL := false
+	initNSLock(isDistXL)
+
 	// Initializing objectLayer for HealFormatHandler.
 	objLayer, xlDirs, xlErr := initTestXLObjLayer()
 	if xlErr != nil {
@@ -164,14 +173,6 @@ func prepareAdminXLTestBed() (*adminXLTestBed, error) {
 	globalBootTime = UTCNow()
 
 	globalEndpoints = mustGetNewEndpointList(xlDirs...)
-
-	// Set globalIsXL to indicate that the setup uses an erasure
-	// code backend.
-	globalIsXL = true
-
-	// initialize NSLock.
-	isDistXL := false
-	initNSLock(isDistXL)
 
 	// Init global heal state
 	initAllHealState(globalIsXL)

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -147,7 +147,7 @@ func newFSObjectLayer(fsPath string) (ObjectLayer, error) {
 		rwPool: &fsIOPool{
 			readersMap: make(map[string]*lock.RLockedFile),
 		},
-		nsMutex:       newNSLock(false),
+		nsMutex:       globalNSMutex,
 		listPool:      newTreeWalkPool(globalLookupTimeout),
 		appendFileMap: make(map[string]*fsAppendFile),
 	}

--- a/cmd/lockinfo-handlers_test.go
+++ b/cmd/lockinfo-handlers_test.go
@@ -33,6 +33,11 @@ func TestListLocksInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(rootPath)
+
+	// initialize NSLock before initializing object layer
+	isDistXL := false
+	initNSLock(isDistXL)
+
 	// Initializing new XL objectLayer.
 	objAPI, _, xlErr := initTestXLObjLayer()
 	if xlErr != nil {
@@ -42,10 +47,6 @@ func TestListLocksInfo(t *testing.T) {
 	globalObjLayerMutex.Lock()
 	globalObjectAPI = objAPI
 	globalObjLayerMutex.Unlock()
-	// Set globalIsXL to indicate that the setup uses an erasure code backend.
-	// initialize NSLock.
-	isDistXL := false
-	initNSLock(isDistXL)
 
 	var nsMutex *nsLockMap
 

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -110,7 +110,7 @@ func newXLObjects(storageDisks []StorageAPI) (ObjectLayer, error) {
 		mutex:        &sync.Mutex{},
 		storageDisks: newStorageDisks,
 		listPool:     listPool,
-		nsMutex:      newNSLock(globalIsDistXL),
+		nsMutex:      globalNSMutex,
 	}
 	// Get cache size if _MINIO_CACHE environment variable is set.
 	var maxCacheSize uint64


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Both FS and XL object layer implementations are initialized with `globalNSMutex` in this change. This ensures that there is only one instance of `nsLockMap`.
Ideally, object layer implementations don't need a private copy of `nsLockMap`. If reviewers agree `xlObjects.nsMutex` and `fsObjects.nsMutex` can be removed in this PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Admin API and S3 handlers should share the lock namespace for
correctness of healing process. Other admin operations could hold
locks in a separate namespace, using a different nsMutex instance.
But the same effect is achieved by holding locks on the reserved
"/minio/*" sub-namespace on the globalNSMutex. So, for simplicity sake
it is sufficient to have a single instance of nsMutex for all locking
purposes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.