### PR TITLE
Bring semantic versioning to provide for rolling upgrades

### DIFF
--- a/cmd/admin-rpc-server_test.go
+++ b/cmd/admin-rpc-server_test.go
@@ -42,7 +42,7 @@ func testAdminCmd(cmd cmdType, t *testing.T) {
 	adminServer := adminCmd{}
 	args := LoginRPCArgs{
 		AuthToken:   token,
-		Version:     Version,
+		Version:     globalRPCAPIVersion,
 		RequestTime: UTCNow(),
 	}
 	err = adminServer.Login(&args, &LoginRPCReply{})
@@ -56,9 +56,10 @@ func testAdminCmd(cmd cmdType, t *testing.T) {
 	}()
 
 	sa := SignalServiceArgs{
-		AuthRPCArgs: AuthRPCArgs{AuthToken: token},
+		AuthRPCArgs: AuthRPCArgs{AuthToken: token, Version: globalRPCAPIVersion},
 		Sig:         cmd.toServiceSignal(),
 	}
+
 	genReply := AuthRPCReply{}
 	switch cmd {
 	case restartCmd, stopCmd:
@@ -123,7 +124,7 @@ func TestReInitDisks(t *testing.T) {
 
 	args := LoginRPCArgs{
 		AuthToken:   token,
-		Version:     Version,
+		Version:     globalRPCAPIVersion,
 		RequestTime: UTCNow(),
 	}
 	err = adminServer.Login(&args, &LoginRPCReply{})
@@ -133,6 +134,7 @@ func TestReInitDisks(t *testing.T) {
 
 	authArgs := AuthRPCArgs{
 		AuthToken: token,
+		Version:   globalRPCAPIVersion,
 	}
 	authReply := AuthRPCReply{}
 
@@ -150,7 +152,7 @@ func TestReInitDisks(t *testing.T) {
 	fsAdminServer := adminCmd{}
 	fsArgs := LoginRPCArgs{
 		AuthToken:   token,
-		Version:     Version,
+		Version:     globalRPCAPIVersion,
 		RequestTime: UTCNow(),
 	}
 	fsReply := LoginRPCReply{}
@@ -161,6 +163,7 @@ func TestReInitDisks(t *testing.T) {
 
 	authArgs = AuthRPCArgs{
 		AuthToken: token,
+		Version:   globalRPCAPIVersion,
 	}
 	authReply = AuthRPCReply{}
 	// Attempt ReInitDisks service on a FS backend.
@@ -192,7 +195,7 @@ func TestGetConfig(t *testing.T) {
 
 	args := LoginRPCArgs{
 		AuthToken:   token,
-		Version:     Version,
+		Version:     globalRPCAPIVersion,
 		RequestTime: UTCNow(),
 	}
 	reply := LoginRPCReply{}
@@ -203,6 +206,7 @@ func TestGetConfig(t *testing.T) {
 
 	authArgs := AuthRPCArgs{
 		AuthToken: token,
+		Version:   globalRPCAPIVersion,
 	}
 
 	configReply := ConfigReply{}
@@ -239,7 +243,7 @@ func TestWriteAndCommitConfig(t *testing.T) {
 	}
 	args := LoginRPCArgs{
 		AuthToken:   token,
-		Version:     Version,
+		Version:     globalRPCAPIVersion,
 		RequestTime: UTCNow(),
 	}
 	reply := LoginRPCReply{}
@@ -254,6 +258,7 @@ func TestWriteAndCommitConfig(t *testing.T) {
 	wArgs := WriteConfigArgs{
 		AuthRPCArgs: AuthRPCArgs{
 			AuthToken: token,
+			Version:   globalRPCAPIVersion,
 		},
 		TmpFileName: tmpFileName,
 		Buf:         buf,
@@ -271,6 +276,7 @@ func TestWriteAndCommitConfig(t *testing.T) {
 	cArgs := CommitConfigArgs{
 		AuthRPCArgs: AuthRPCArgs{
 			AuthToken: token,
+			Version:   globalRPCAPIVersion,
 		},
 		FileName: tmpFileName,
 	}

--- a/cmd/auth-rpc-server_test.go
+++ b/cmd/auth-rpc-server_test.go
@@ -43,7 +43,7 @@ func TestLogin(t *testing.T) {
 		{
 			args: LoginRPCArgs{
 				AuthToken: token,
-				Version:   Version,
+				Version:   globalRPCAPIVersion,
 			},
 			skewTime:    0,
 			expectedErr: nil,
@@ -52,16 +52,16 @@ func TestLogin(t *testing.T) {
 		{
 			args: LoginRPCArgs{
 				AuthToken: token,
-				Version:   "INVALID-" + Version,
+				Version:   semVersion{2, 0, 0},
 			},
 			skewTime:    0,
-			expectedErr: errServerVersionMismatch,
+			expectedErr: errRPCAPIVersionUnsupported,
 		},
 		// Valid username, password and version, not request time
 		{
 			args: LoginRPCArgs{
 				AuthToken: token,
-				Version:   Version,
+				Version:   globalRPCAPIVersion,
 			},
 			skewTime:    20 * time.Minute,
 			expectedErr: errServerTimeMismatch,
@@ -70,7 +70,7 @@ func TestLogin(t *testing.T) {
 		{
 			args: LoginRPCArgs{
 				AuthToken: "",
-				Version:   Version,
+				Version:   globalRPCAPIVersion,
 			},
 			skewTime:    0,
 			expectedErr: errAuthentication,

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -165,6 +165,9 @@ var (
 	// Set to store standard storage class
 	globalStandardStorageClass storageClass
 
+	// RPC version.
+	globalRPCAPIVersion = semVersion{1, 0, 0}
+
 	// Add new variable global values here.
 )
 

--- a/cmd/lock-rpc-server_test.go
+++ b/cmd/lock-rpc-server_test.go
@@ -64,7 +64,7 @@ func createLockTestServer(t *testing.T) (string, *lockServer, string) {
 	}
 	loginArgs := LoginRPCArgs{
 		AuthToken:   token,
-		Version:     Version,
+		Version:     globalRPCAPIVersion,
 		RequestTime: UTCNow(),
 	}
 	loginReply := LoginRPCReply{}
@@ -87,6 +87,7 @@ func TestLockRpcServerLock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la.SetAuthToken(token)
+	la.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	// Claim a lock
 	var result bool
@@ -120,6 +121,7 @@ func TestLockRpcServerLock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la2.SetAuthToken(token)
+	la2.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	err = locker.Lock(&la2, &result)
 	if err != nil {
@@ -143,6 +145,7 @@ func TestLockRpcServerUnlock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la.SetAuthToken(token)
+	la.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	// First test return of error when attempting to unlock a lock that does not exist
 	var result bool
@@ -188,6 +191,7 @@ func TestLockRpcServerRLock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la.SetAuthToken(token)
+	la.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	// Claim a lock
 	var result bool
@@ -221,6 +225,7 @@ func TestLockRpcServerRLock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la2.SetAuthToken(token)
+	la2.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	err = locker.RLock(&la2, &result)
 	if err != nil {
@@ -244,6 +249,7 @@ func TestLockRpcServerRUnlock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la.SetAuthToken(token)
+	la.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	// First test return of error when attempting to unlock a read-lock that does not exist
 	var result bool
@@ -268,6 +274,7 @@ func TestLockRpcServerRUnlock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la2.SetAuthToken(token)
+	la2.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	// ... and create a second lock on same resource
 	err = locker.RLock(&la2, &result)
@@ -330,6 +337,7 @@ func TestLockRpcServerForceUnlock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	laForce.SetAuthToken(token)
+	laForce.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	// First test that UID should be empty
 	var result bool
@@ -352,6 +360,7 @@ func TestLockRpcServerForceUnlock(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la.SetAuthToken(token)
+	la.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	// Create lock ... (so that we can force unlock)
 	err = locker.Lock(&la, &result)
@@ -394,6 +403,7 @@ func TestLockRpcServerExpired(t *testing.T) {
 		ServiceEndpoint: "rpc-path",
 	})
 	la.SetAuthToken(token)
+	la.SetRPCAPIVersion(globalRPCAPIVersion)
 
 	// Unknown lock at server will return expired = true
 	var expired bool

--- a/cmd/rpc-common_test.go
+++ b/cmd/rpc-common_test.go
@@ -1,0 +1,56 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, semVersion 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "testing"
+
+// Tests version comparator.
+func TestCompare(t *testing.T) {
+	type compareTest struct {
+		v1     semVersion
+		v2     semVersion
+		result int
+	}
+
+	var compareTests = []compareTest{
+		{semVersion{1, 0, 0}, semVersion{1, 0, 0}, 0},
+		{semVersion{2, 0, 0}, semVersion{1, 0, 0}, 1},
+		{semVersion{0, 1, 0}, semVersion{0, 1, 0}, 0},
+		{semVersion{0, 2, 0}, semVersion{0, 1, 0}, 1},
+		{semVersion{0, 0, 1}, semVersion{0, 0, 1}, 0},
+		{semVersion{0, 0, 2}, semVersion{0, 0, 1}, 1},
+		{semVersion{1, 2, 3}, semVersion{1, 2, 3}, 0},
+		{semVersion{2, 2, 4}, semVersion{1, 2, 4}, 1},
+		{semVersion{1, 3, 3}, semVersion{1, 2, 3}, 1},
+		{semVersion{1, 2, 4}, semVersion{1, 2, 3}, 1},
+
+		// Spec Examples #11
+		{semVersion{1, 0, 0}, semVersion{2, 0, 0}, -1},
+		{semVersion{2, 0, 0}, semVersion{2, 1, 0}, -1},
+		{semVersion{2, 1, 0}, semVersion{2, 1, 1}, -1},
+	}
+
+	for _, test := range compareTests {
+		if res := test.v1.Compare(test.v2); res != test.result {
+			t.Errorf("Comparing %q : %q, expected %d but got %d", test.v1, test.v2, test.result, res)
+		}
+		// Test if reverse is true as well.
+		if res := test.v2.Compare(test.v1); res != -test.result {
+			t.Errorf("Comparing %q : %q, expected %d but got %d", test.v2, test.v1, -test.result, res)
+		}
+	}
+}

--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -85,8 +85,8 @@ func toStorageErr(err error) error {
 		return errInvalidAccessKeyID
 	case errAuthentication.Error():
 		return errAuthentication
-	case errServerVersionMismatch.Error():
-		return errServerVersionMismatch
+	case errRPCAPIVersionUnsupported.Error():
+		return errRPCAPIVersionUnsupported
 	case errServerTimeMismatch.Error():
 		return errServerTimeMismatch
 	}

--- a/cmd/storage-rpc-client_test.go
+++ b/cmd/storage-rpc-client_test.go
@@ -190,8 +190,8 @@ func TestStorageErr(t *testing.T) {
 			err:         fmt.Errorf("%s", errAuthentication.Error()),
 		},
 		{
-			expectedErr: errServerVersionMismatch,
-			err:         fmt.Errorf("%s", errServerVersionMismatch.Error()),
+			expectedErr: errRPCAPIVersionUnsupported,
+			err:         fmt.Errorf("%s", errRPCAPIVersionUnsupported.Error()),
 		},
 		{
 			expectedErr: errServerTimeMismatch,

--- a/cmd/storage-rpc-server_test.go
+++ b/cmd/storage-rpc-server_test.go
@@ -55,9 +55,8 @@ func createTestStorageServer(t *testing.T) *testStorageRPCServer {
 		t.Fatalf("unable to initialize storage disks, %s", err)
 	}
 	stServer := &storageServer{
-		storage:   storageDisks[0],
-		path:      "/disk1",
-		timestamp: UTCNow(),
+		storage: storageDisks[0],
+		path:    "/disk1",
 	}
 	return &testStorageRPCServer{
 		token:     token,
@@ -85,7 +84,10 @@ func TestStorageRPCInvalidToken(t *testing.T) {
 	// Following test cases are meant to exercise the invalid
 	// token code path of the storage RPC methods.
 	var err error
-	badAuthRPCArgs := AuthRPCArgs{AuthToken: "invalidToken"}
+	badAuthRPCArgs := AuthRPCArgs{
+		Version:   globalRPCAPIVersion,
+		AuthToken: "invalidToken",
+	}
 	badGenericVolArgs := GenericVolArgs{
 		AuthRPCArgs: badAuthRPCArgs,
 		Vol:         "myvol",

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -42,8 +42,8 @@ var errDataTooSmall = errors.New("Object size smaller than expected")
 // errServerNotInitialized - server not initialized.
 var errServerNotInitialized = errors.New("Server not initialized, please try again")
 
-// errServerVersionMismatch - server versions do not match.
-var errServerVersionMismatch = errors.New("Server versions do not match")
+// errRPCAPIVersionUnsupported - unsupported rpc API version.
+var errRPCAPIVersionUnsupported = errors.New("Unsupported rpc API version")
 
 // errServerTimeMismatch - server times are too far apart.
 var errServerTimeMismatch = errors.New("Server times are too far apart")

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -192,7 +192,9 @@ func testStorageInfoWebHandler(obj ObjectLayer, instanceType string, t TestErrHa
 
 	rec := httptest.NewRecorder()
 
-	storageInfoRequest := AuthRPCArgs{}
+	storageInfoRequest := AuthRPCArgs{
+		Version: globalRPCAPIVersion,
+	}
 	storageInfoReply := &StorageInfoRep{}
 	req, err := newTestWebRPCRequest("Web.StorageInfo", authorization, storageInfoRequest)
 	if err != nil {
@@ -229,7 +231,9 @@ func testServerInfoWebHandler(obj ObjectLayer, instanceType string, t TestErrHan
 
 	rec := httptest.NewRecorder()
 
-	serverInfoRequest := AuthRPCArgs{}
+	serverInfoRequest := AuthRPCArgs{
+		Version: globalRPCAPIVersion,
+	}
 	serverInfoReply := &ServerInfoRep{}
 	req, err := newTestWebRPCRequest("Web.ServerInfo", authorization, serverInfoRequest)
 	if err != nil {
@@ -1493,7 +1497,9 @@ func TestWebCheckAuthorization(t *testing.T) {
 		"PresignedGet",
 	}
 	for _, rpcCall := range webRPCs {
-		args := &AuthRPCArgs{}
+		args := &AuthRPCArgs{
+			Version: globalRPCAPIVersion,
+		}
 		reply := &WebGenericRep{}
 		req, nerr := newTestWebRPCRequest("Web."+rpcCall, "Bearer fooauthorization", args)
 		if nerr != nil {
@@ -1577,7 +1583,9 @@ func TestWebObjectLayerNotReady(t *testing.T) {
 	webRPCs := []string{"StorageInfo", "MakeBucket", "ListBuckets", "ListObjects", "RemoveObject",
 		"GetBucketPolicy", "SetBucketPolicy", "ListAllBucketPolicies"}
 	for _, rpcCall := range webRPCs {
-		args := &AuthRPCArgs{}
+		args := &AuthRPCArgs{
+			Version: globalRPCAPIVersion,
+		}
 		reply := &WebGenericRep{}
 		req, nerr := newTestWebRPCRequest("Web."+rpcCall, authorization, args)
 		if nerr != nil {
@@ -1690,7 +1698,7 @@ func TestWebObjectLayerFaultyDisks(t *testing.T) {
 		RepArgs    interface{}
 	}{
 		{"MakeBucket", MakeBucketArgs{BucketName: bucketName}, WebGenericRep{}},
-		{"ListBuckets", AuthRPCArgs{}, ListBucketsRep{}},
+		{"ListBuckets", AuthRPCArgs{Version: globalRPCAPIVersion}, ListBucketsRep{}},
 		{"ListObjects", ListObjectsArgs{BucketName: bucketName, Prefix: ""}, ListObjectsRep{}},
 		{"GetBucketPolicy", GetBucketPolicyArgs{BucketName: bucketName, Prefix: ""}, GetBucketPolicyRep{}},
 		{"SetBucketPolicy", SetBucketPolicyArgs{BucketName: bucketName, Prefix: "", Policy: "none"}, WebGenericRep{}},
@@ -1714,7 +1722,9 @@ func TestWebObjectLayerFaultyDisks(t *testing.T) {
 	}
 
 	// Test Web.StorageInfo
-	storageInfoRequest := AuthRPCArgs{}
+	storageInfoRequest := AuthRPCArgs{
+		Version: globalRPCAPIVersion,
+	}
 	storageInfoReply := &StorageInfoRep{}
 	req, err := newTestWebRPCRequest("Web.StorageInfo", authorization, storageInfoRequest)
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR brings semver capabilities in our RPC layer to
ensure that we can upgrade the servers in rolling fashion
while keeping I/O in progress. This is only a framework change
the functionality remains the same as such and we do not
have any special API changes for now. But in future when
we bring in API changes we will be able to upgrade servers
without a downtime.

Additional change in this PR is to not abort when serverVersions
mismatch in a distributed cluster, instead wait for the quorum
treat the situation as if the server is down. This allows
for administrator to properly upgrade all the servers in the cluster.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #5393

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and using `go test`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.