### PR TITLE
Avoid shadowing ignored errors listAllBuckets()

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -300,7 +300,7 @@ func listAllBuckets(storageDisks []StorageAPI) (buckets map[string]VolInfo,
 			if errors.IsErrIgnored(err, bucketMetadataOpIgnoredErrs...) {
 				continue
 			}
-			break
+			return nil, nil, err
 		}
 		for _, volInfo := range volsInfo {
 			// StorageAPI can send volume names which are
@@ -316,7 +316,7 @@ func listAllBuckets(storageDisks []StorageAPI) (buckets map[string]VolInfo,
 			buckets[volInfo.Name] = volInfo
 		}
 	}
-	return buckets, bucketsOcc, err
+	return buckets, bucketsOcc, nil
 }
 
 // ListBucketsHeal - Find all buckets that need to be healed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix returning error when last disk is down in listAllBuckets()
<!--- Describe your changes in detail -->

## Motivation and Context
It can happen such that one of the disks that was down would
return 'errDiskNotFound' but the err is preserved due to
loop shadowing which leads to issues when healing the bucket.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using `mc admin heal`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.