### PR TITLE
[SSE-C]: avoid encrypting empty objects.

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -556,7 +556,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if objectAPI.IsEncryptionSupported() {
-		if IsSSECustomerRequest(r.Header) { // handle SSE-C requests
+		if IsSSECustomerRequest(r.Header) && size > 0 { // handle SSE-C requests
 			reader, err = EncryptRequest(hashReader, r, metadata)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)


### PR DESCRIPTION
## Description

This change adds an object size check such that the server does not
encrypt empty objects (typically folders) for SSE-C. The server still
returns SSE-C headers but the object is not encrypted since there is no
point to encrypt such objects.

## Motivation and Context
Fixes #5493

## How Has This Been Tested?
manually

Opened mint test issue for testing: minio/mint#257

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.