### PR TITLE
tests: Fix failed notify webhook test

### DIFF
--- a/cmd/notify-webhook_test.go
+++ b/cmd/notify-webhook_test.go
@@ -54,12 +54,15 @@ func TestNewWebHookNotify(t *testing.T) {
 	}
 	defer os.RemoveAll(root)
 
+	server := httptest.NewServer(postHandler{})
+	defer server.Close()
+
 	_, err = newWebhookNotify("1")
 	if err == nil {
 		t.Fatal("Unexpected should fail")
 	}
 
-	globalServerConfig.Notify.SetWebhookByID("10", webhookNotify{Enable: true, Endpoint: "http://127.0.0.1:80"})
+	globalServerConfig.Notify.SetWebhookByID("10", webhookNotify{Enable: true, Endpoint: server.URL})
 	_, err = newWebhookNotify("10")
 	if err != nil {
 		t.Fatal("Unexpected should not fail with lookupEndpoint", err)
@@ -70,9 +73,6 @@ func TestNewWebHookNotify(t *testing.T) {
 	if err == nil {
 		t.Fatal("Unexpected should fail with invalid URL escape")
 	}
-
-	server := httptest.NewServer(postHandler{})
-	defer server.Close()
 
 	globalServerConfig.Notify.SetWebhookByID("20", webhookNotify{Enable: true, Endpoint: server.URL})
 	webhook, err := newWebhookNotify("20")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
TestNewWebHookNotify wasn't passing in my local machine. The reason is
that the test expects the POST handler (as a webhook endpoint) is always
running on port 80, which is not always the case.

## Motivation and Context
Fix one bug in tests

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.