### PR TITLE
Avoid modifying object layer after initialization

### DIFF
--- a/cmd/bucket-handlers_test.go
+++ b/cmd/bucket-handlers_test.go
@@ -35,7 +35,6 @@ func TestGetBucketLocationHandler(t *testing.T) {
 
 func testGetBucketLocationHandler(obj ObjectLayer, instanceType, bucketName string, apiRouter http.Handler,
 	credentials auth.Credentials, t *testing.T) {
-	initBucketPolicies(obj)
 
 	// test cases with sample input and expected output.
 	testCases := []struct {
@@ -180,7 +179,6 @@ func TestHeadBucketHandler(t *testing.T) {
 
 func testHeadBucketHandler(obj ObjectLayer, instanceType, bucketName string, apiRouter http.Handler,
 	credentials auth.Credentials, t *testing.T) {
-	initBucketPolicies(obj)
 
 	// test cases with sample input and expected output.
 	testCases := []struct {
@@ -287,7 +285,6 @@ func TestListMultipartUploadsHandler(t *testing.T) {
 // testListMultipartUploadsHandler - Tests validate listing of multipart uploads.
 func testListMultipartUploadsHandler(obj ObjectLayer, instanceType, bucketName string, apiRouter http.Handler,
 	credentials auth.Credentials, t *testing.T) {
-	initBucketPolicies(obj)
 
 	// Collection of non-exhaustive ListMultipartUploads test cases, valid errors
 	// and success responses.
@@ -618,7 +615,6 @@ func TestAPIDeleteMultipleObjectsHandler(t *testing.T) {
 
 func testAPIDeleteMultipleObjectsHandler(obj ObjectLayer, instanceType, bucketName string, apiRouter http.Handler,
 	credentials auth.Credentials, t *testing.T) {
-	initBucketPolicies(obj)
 
 	var err error
 	// register event notifier.
@@ -822,7 +818,6 @@ func testIsBucketActionAllowedHandler(obj ObjectLayer, instanceType, bucketName 
 		{"s3:ListObject", "mybucket", "abc", false, false},
 	}
 	for i, testCase := range testCases {
-		initBucketPolicies(obj)
 		isAllowed := isBucketActionAllowed(testCase.action, testCase.bucket, testCase.prefix, obj)
 		if isAllowed != testCase.shouldPass {
 			t.Errorf("Case %d: Expected the response status to be `%t`, but instead found `%t`", i+1, testCase.shouldPass, isAllowed)

--- a/cmd/bucket-policy-handlers_test.go
+++ b/cmd/bucket-policy-handlers_test.go
@@ -250,7 +250,6 @@ func TestPutBucketPolicyHandler(t *testing.T) {
 // testPutBucketPolicyHandler - Test for Bucket policy end point.
 func testPutBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string, apiRouter http.Handler,
 	credentials auth.Credentials, t *testing.T) {
-	initBucketPolicies(obj)
 
 	bucketName1 := fmt.Sprintf("%s-1", bucketName)
 	if err := obj.MakeBucketWithLocation(bucketName1, ""); err != nil {
@@ -458,9 +457,6 @@ func TestGetBucketPolicyHandler(t *testing.T) {
 // testGetBucketPolicyHandler - Test for end point which fetches the access policy json of the given bucket.
 func testGetBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string, apiRouter http.Handler,
 	credentials auth.Credentials, t *testing.T) {
-	// initialize bucket policy.
-	initBucketPolicies(obj)
-
 	// template for constructing HTTP request body for PUT bucket policy.
 	bucketPolicyTemplate := `{"Version":"2012-10-17","Statement":[{"Action":["s3:GetBucketLocation","s3:ListBucket"],"Effect":"Allow","Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::%s"],"Sid":""},{"Action":["s3:GetObject"],"Effect":"Allow","Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::%s/this*"],"Sid":""}]}`
 
@@ -647,8 +643,6 @@ func TestDeleteBucketPolicyHandler(t *testing.T) {
 // testDeleteBucketPolicyHandler - Test for Delete bucket policy end point.
 func testDeleteBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string, apiRouter http.Handler,
 	credentials auth.Credentials, t *testing.T) {
-	// initialize bucket policy.
-	initBucketPolicies(obj)
 
 	// template for constructing HTTP request body for PUT bucket policy.
 	bucketPolicyTemplate := `{

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -164,7 +164,8 @@ func newFSObjectLayer(fsPath string) (ObjectLayer, error) {
 	fs.fsFormatRlk = rlk
 
 	// Initialize and load bucket policies.
-	if err = initBucketPolicies(fs); err != nil {
+	fs.bucketPolicies, err = loadBucketPolicies(fs)
+	if err != nil {
 		return nil, fmt.Errorf("Unable to load all bucket policies. %s", err)
 	}
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -271,8 +271,8 @@ func newObjectLayer(endpoints EndpointList) (newObject ObjectLayer, err error) {
 		return nil, err
 	}
 
-	// Once XL formatted, initialize object layer.
-	newObject, err = newXLObjectLayer(formattedDisks)
+	// Once disks are formatted, initialize object layer.
+	newObject, err = newXLObjects(formattedDisks)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1652,7 +1652,7 @@ func initObjectLayer(endpoints EndpointList) (ObjectLayer, []StorageAPI, error) 
 		return nil, nil, err
 	}
 
-	objLayer, err := newXLObjectLayer(formattedDisks)
+	objLayer, err := newXLObjects(formattedDisks)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -59,24 +59,6 @@ type xlObjects struct {
 // list of all errors that can be ignored in tree walk operation in XL
 var xlTreeWalkIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errVolumeNotFound, errFileNotFound)
 
-// newXLObjectLayer - initialize any object layer depending on the number of disks.
-func newXLObjectLayer(storageDisks []StorageAPI) (ObjectLayer, error) {
-	// Initialize XL object layer.
-	objAPI, err := newXLObjects(storageDisks)
-	fatalIf(err, "Unable to initialize XL object layer.")
-
-	// Initialize and load bucket policies.
-	err = initBucketPolicies(objAPI)
-	fatalIf(err, "Unable to load all bucket policies.")
-
-	// Initialize a new event notifier.
-	err = initEventNotifier(objAPI)
-	fatalIf(err, "Unable to initialize event notification.")
-
-	// Success.
-	return objAPI, nil
-}
-
 // newXLObjects - initialize new xl object layer.
 func newXLObjects(storageDisks []StorageAPI) (ObjectLayer, error) {
 	if storageDisks == nil {
@@ -121,6 +103,16 @@ func newXLObjects(storageDisks []StorageAPI) (ObjectLayer, error) {
 
 	// Perform a quick heal on the buckets and bucket metadata for any discrepancies.
 	if err = quickHeal(*xl, writeQuorum, readQuorum); err != nil {
+		return nil, err
+	}
+
+	xl.bucketPolicies, err = loadBucketPolicies(xl)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize a new event notifier.
+	if err = initEventNotifier(xl); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Avoid modifying object layer after initialization
<!--- Describe your changes in detail -->

## Motivation and Context
Keep reflection-less code and move loading bucket policies
and initialize event nofitier into each object layer
initialization.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually, code cleanup
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.