### PR TITLE
move notification/listener config updates to object layer

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -33,9 +33,11 @@ import (
 
 	"github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/minio/pkg/errors"
+	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/lock"
 	"github.com/minio/minio/pkg/madmin"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // FSObjects - Implements fs object layer.
@@ -173,7 +175,7 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 	}
 
 	// Initialize notification system.
-	if err = globalNotificationSys.Init(fs); err != nil {
+	if err = globalNotificationSys.Init(context.Background(), fs); err != nil {
 		return nil, fmt.Errorf("Unable to initialize event notification. %s", err)
 	}
 
@@ -1100,4 +1102,24 @@ func (fs *FSObjects) IsNotificationSupported() bool {
 // IsEncryptionSupported returns whether server side encryption is applicable for this layer.
 func (fs *FSObjects) IsEncryptionSupported() bool {
 	return true
+}
+
+// SetBucketNotificationConfig saves notification config to disk
+func (fs *FSObjects) SetBucketNotificationConfig(ctx context.Context, bucket string, config *event.Config) error {
+	return saveNotificationConfig(ctx, fs, bucket, config)
+}
+
+// GetBucketNotificationConfig fetches bucket notification config from disk.
+func (fs *FSObjects) GetBucketNotificationConfig(ctx context.Context, bucket string) (*event.Config, error) {
+	return readNotificationConfig(ctx, fs, bucket)
+}
+
+// SetBucketListenerConfig updates listener to listener config on disk
+func (fs *FSObjects) SetBucketListenerConfig(ctx context.Context, bucketName string, eventNames []event.Name, pattern string, targetID event.TargetID, addr xnet.Host) error {
+	return saveListener(ctx, fs, bucketName, eventNames, pattern, targetID, addr)
+}
+
+// DeleteBucketListenerConfig deletes listener from listener config on disk
+func (fs *FSObjects) DeleteBucketListenerConfig(ctx context.Context, bucketName string, targetID event.TargetID, addr xnet.Host) error {
+	return removeListener(ctx, fs, bucketName, targetID, addr)
 }

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/minio/pkg/errors"
+	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/madmin"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // GatewayUnsupported list of unsupported call stubs for gateway.
@@ -140,4 +142,24 @@ func (a GatewayUnsupported) IsNotificationSupported() bool {
 // IsEncryptionSupported returns whether server side encryption is applicable for this layer.
 func (a GatewayUnsupported) IsEncryptionSupported() bool {
 	return false
+}
+
+// SetBucketNotificationConfig saves notification config to disk
+func (a GatewayUnsupported) SetBucketNotificationConfig(context.Context, string, *event.Config) error {
+	return errors.Trace(NotImplemented{})
+}
+
+// GetBucketNotificationConfig fetches bucket notification config from disk.
+func (a GatewayUnsupported) GetBucketNotificationConfig(ctx context.Context, bucketName string) (*event.Config, error) {
+	return nil, errors.Trace(NotImplemented{})
+}
+
+// SetBucketListenerConfig updates listener to listener config on disk
+func (a GatewayUnsupported) SetBucketListenerConfig(ctx context.Context, bucketName string, eventNames []event.Name, pattern string, targetID event.TargetID, addr xnet.Host) error {
+	return errors.Trace(NotImplemented{})
+}
+
+// DeleteBucketListenerConfig deletes listener from listener config on disk
+func (a GatewayUnsupported) DeleteBucketListenerConfig(ctx context.Context, bucketName string, targetID event.TargetID, addr xnet.Host) error {
+	return errors.Trace(NotImplemented{})
 }

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -21,6 +21,9 @@ import (
 	"io"
 	"time"
 
+	"github.com/minio/minio/pkg/event"
+	xnet "github.com/minio/minio/pkg/net"
+
 	"github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/madmin"
@@ -74,6 +77,11 @@ type ObjectLayer interface {
 	RefreshBucketPolicy(context.Context, string) error
 	DeleteBucketPolicy(context.Context, string) error
 
+	// Notification operations
+	SetBucketNotificationConfig(context.Context, string, *event.Config) error
+	GetBucketNotificationConfig(context.Context, string) (*event.Config, error)
+	SetBucketListenerConfig(ctx context.Context, bucketName string, eventNames []event.Name, pattern string, targetID event.TargetID, addr xnet.Host) error
+	DeleteBucketListenerConfig(ctx context.Context, bucketName string, targetID event.TargetID, addr xnet.Host) error
 	// Supported operations check
 	IsNotificationSupported() bool
 	IsEncryptionSupported() bool

--- a/cmd/peer-rpc.go
+++ b/cmd/peer-rpc.go
@@ -198,7 +198,7 @@ func (rpcClient *PeerRPCClient) UpdateBucketPolicy(bucketName string) error {
 	return rpcClient.Call("Peer.UpdateBucketPolicy", &args, &reply)
 }
 
-// PutBucketNotification - calls put bukcet notification RPC.
+// PutBucketNotification - calls put bucket notification RPC.
 func (rpcClient *PeerRPCClient) PutBucketNotification(bucketName string, rulesMap event.RulesMap) error {
 	args := PutBucketNotificationArgs{
 		BucketName: bucketName,

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -30,8 +30,10 @@ import (
 	"github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/minio/pkg/bpool"
 	"github.com/minio/minio/pkg/errors"
+	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/madmin"
+	xnet "github.com/minio/minio/pkg/net"
 	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
@@ -237,7 +239,7 @@ func newXLSets(endpoints EndpointList, format *formatXLV3, setCount int, drivesP
 	}
 
 	// Initialize notification system.
-	if err = globalNotificationSys.Init(s); err != nil {
+	if err = globalNotificationSys.Init(context.Background(), s); err != nil {
 		return nil, fmt.Errorf("Unable to initialize event notification. %s", err)
 	}
 
@@ -471,6 +473,26 @@ func (s *xlSets) IsNotificationSupported() bool {
 // IsEncryptionSupported returns whether server side encryption is applicable for this layer.
 func (s *xlSets) IsEncryptionSupported() bool {
 	return s.getHashedSet("").IsEncryptionSupported()
+}
+
+// GetBucketNotificationConfig returns bucket notification config from disk
+func (s *xlSets) GetBucketNotificationConfig(ctx context.Context, bucket string) (*event.Config, error) {
+	return s.getHashedSet(bucket).GetBucketNotificationConfig(ctx, bucket)
+}
+
+// SetBucketNotificationConfig saves notification config for the bucket to disk.
+func (s *xlSets) SetBucketNotificationConfig(ctx context.Context, bucket string, config *event.Config) error {
+	return s.getHashedSet(bucket).SetBucketNotificationConfig(ctx, bucket, config)
+}
+
+// SetBucketListenerConfig updates listener to listener config on disk
+func (s *xlSets) SetBucketListenerConfig(ctx context.Context, bucket string, eventNames []event.Name, pattern string, targetID event.TargetID, addr xnet.Host) error {
+	return s.getHashedSet(bucket).SetBucketListenerConfig(ctx, bucket, eventNames, pattern, targetID, addr)
+}
+
+// DeleteBucketListenerConfig deletes listener from listener config on disk
+func (s *xlSets) DeleteBucketListenerConfig(ctx context.Context, bucket string, targetID event.TargetID, addr xnet.Host) error {
+	return s.getHashedSet(bucket).DeleteBucketListenerConfig(ctx, bucket, targetID, addr)
 }
 
 // DeleteBucket - deletes a bucket on all sets simultaneously,

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/minio/pkg/errors"
+	"github.com/minio/minio/pkg/event"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // list all errors that can be ignore in a bucket operation.
@@ -323,4 +325,24 @@ func (xl xlObjects) IsNotificationSupported() bool {
 // IsEncryptionSupported returns whether server side encryption is applicable for this layer.
 func (xl xlObjects) IsEncryptionSupported() bool {
 	return true
+}
+
+// SetBucketNotificationConfig saves notification config to disk
+func (xl xlObjects) SetBucketNotificationConfig(ctx context.Context, bucket string, config *event.Config) error {
+	return saveNotificationConfig(ctx, xl, bucket, config)
+}
+
+// GetBucketNotificationConfig fetches bucket notification config from disk.
+func (xl xlObjects) GetBucketNotificationConfig(ctx context.Context, bucketName string) (*event.Config, error) {
+	return readNotificationConfig(ctx, xl, bucketName)
+}
+
+// SetBucketListenerConfig updates listener to listener config on disk
+func (xl xlObjects) SetBucketListenerConfig(ctx context.Context, bucketName string, eventNames []event.Name, pattern string, targetID event.TargetID, addr xnet.Host) error {
+	return saveListener(ctx, xl, bucketName, eventNames, pattern, targetID, addr)
+}
+
+// DeleteBucketListenerConfig deletes listener from listener config on disk
+func (xl xlObjects) DeleteBucketListenerConfig(ctx context.Context, bucketName string, targetID event.TargetID, addr xnet.Host) error {
+	return removeListener(ctx, xl, bucketName, targetID, addr)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #4978

Move the notification config and listener config updates from S3 layer so that the S3 layer is agnostic to object layer specifics such as location on disk where notifications/listener configs are stored.  
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.