### PR TITLE
xl: Avoid removing directory content in Delete API

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -24,6 +24,7 @@ import (
 	slashpath "path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -860,9 +861,13 @@ func deleteFile(basePath, deletePath string) error {
 		return err
 	}
 
-	// Recursively go down the next path and delete again.
-	// Errors for parent directories shouldn't trickle down.
-	deleteFile(basePath, slashpath.Dir(deletePath))
+	// Trailing slash is removed when found to ensure
+	// slashpath.Dir() to work as intended.
+	deletePath = strings.TrimSuffix(deletePath, slashSeparator)
+	deletePath = slashpath.Dir(deletePath)
+
+	// Delete parent directory. Errors for parent directories shouldn't trickle down.
+	deleteFile(basePath, deletePath)
 
 	return nil
 }


### PR DESCRIPTION
## Description
Delete & Multi Delete API should not try to remove the directory content.
The only permitted case is with zero size object with a trailing slash
in its name.

## Motivation and Context
#5547 

## How Has This Been Tested?
go test + Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.