### PR TITLE
posix.RenameFile(): Allow overwriting an empty directory

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -932,14 +932,14 @@ func (s *posix) RenameFile(srcVolume, srcPath, dstVolume, dstPath string) (err e
 		return err
 	}
 	// Stat a volume entry.
-	_, err = os.Stat((srcVolumeDir))
+	_, err = os.Stat(srcVolumeDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return errVolumeNotFound
 		}
 		return err
 	}
-	_, err = os.Stat((dstVolumeDir))
+	_, err = os.Stat(dstVolumeDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return errVolumeNotFound
@@ -953,23 +953,24 @@ func (s *posix) RenameFile(srcVolume, srcPath, dstVolume, dstPath string) (err e
 		return errFileAccessDenied
 	}
 	srcFilePath := slashpath.Join(srcVolumeDir, srcPath)
-	if err = checkPathLength((srcFilePath)); err != nil {
+	if err = checkPathLength(srcFilePath); err != nil {
 		return err
 	}
 	dstFilePath := slashpath.Join(dstVolumeDir, dstPath)
-	if err = checkPathLength((dstFilePath)); err != nil {
+	if err = checkPathLength(dstFilePath); err != nil {
 		return err
 	}
 	if srcIsDir {
-		// If source is a directory we expect the destination to be non-existent always.
-		_, err = os.Stat((dstFilePath))
-		if err == nil {
+		// If source is a directory, we expect the destination to be non-existent but we
+		// we still need to allow overwriting an empty directory since it represents
+		// an object empty directory.
+		_, err = os.Stat(dstFilePath)
+		if err == nil && !isDirEmpty(dstFilePath) {
 			return errFileAccessDenied
 		}
 		if !os.IsNotExist(err) {
 			return err
 		}
-		// Destination does not exist, hence proceed with the rename.
 	}
 
 	if err = renameAll(srcFilePath, dstFilePath); err != nil {


### PR DESCRIPTION
## Description
Overwriting files is allowed, but since the introduction of
the object directory, we will aslo need to allow overwriting
an empty directory. Putting twice the same object directory
won't fail with 403 error anymore.

## Motivation and Context
Fixes #5549 

## How Has This Been Tested?
go test + Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.