### PR TITLE
disallow DELETE for SSE-C encrypted objects

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -125,6 +125,7 @@ const (
 	ErrMaximumExpires
 	ErrSlowDown
 	ErrInvalidPrefixMarker
+	ErrDeleteFailed
 	// Add new error codes here.
 
 	// Server-Side-Encryption (with Customer provided key) related API errors.
@@ -664,6 +665,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	ErrSSECustomerKeyMD5Mismatch: {
 		Code:           "InvalidArgument",
 		Description:    errSSEKeyMD5Mismatch.Error(),
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrDeleteFailed: {
+		Code:           "InvalidRequest",
+		Description:    "Failed to delete object",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1083,6 +1083,17 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
+	info, err := objectAPI.GetObjectInfo(bucket, object)
+	if err != nil {
+		errorIf(err, "Unable to get an object info %s", pathJoin(bucket, object))
+		writeErrorResponse(w, ErrDeleteFailed, r.URL)
+		return
+	}
+	if info.IsEncrypted() {
+		writeErrorResponse(w, ErrDeleteFailed, r.URL)
+		return
+	}
+
 	// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html
 	// Ignore delete object errors while replying to client, since we are
 	// suppposed to reply only 204. Additionally log the error for


### PR DESCRIPTION
## Description

AWS S3 does not allow to delete an encrypted object.
This change adds a new error returned if a client tries to delete an encrypted
object.

## Motivation and Context
Fixes #5572

## How Has This Been Tested?
manually

Needs mint test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.