### PR TITLE
Remove stable sort usage when not needed

### DIFF
--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -417,7 +417,7 @@ func (fs *FSObjects) ListObjectParts(bucket, object, uploadID string, partNumber
 	for partNumber, etag := range partsMap {
 		parts = append(parts, PartInfo{PartNumber: partNumber, ETag: etag})
 	}
-	sort.SliceStable(parts, func(i int, j int) bool {
+	sort.Slice(parts, func(i int, j int) bool {
 		return parts[i].PartNumber < parts[j].PartNumber
 	})
 	i := 0

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -806,7 +806,7 @@ func (a *azureObjects) ListObjectParts(bucket, object, uploadID string, partNumb
 	for _, part := range partsMap {
 		parts = append(parts, part)
 	}
-	sort.SliceStable(parts, func(i int, j int) bool {
+	sort.Slice(parts, func(i int, j int) bool {
 		return parts[i].PartNumber < parts[j].PartNumber
 	})
 	partsCount := 0


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove stable sort usage when not needed
<!--- Describe your changes in detail -->

## Motivation and Context
Stable sort is needed when we are sorting based on two or more
distinct elements. When equal elements are indistinguishable,
such as with integers, or more generally, any data where the
entire element is the key like `PartNumber`, stability is not
an issue.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.