### PR TITLE
Add a a PoC for #5305 to enable multiple credential pairs

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -61,9 +61,14 @@ var (
 // -----------
 // Returns Administration API version
 func (a adminAPIHandlers) VersionHandler(w http.ResponseWriter, r *http.Request) {
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -81,9 +86,14 @@ func (a adminAPIHandlers) VersionHandler(w http.ResponseWriter, r *http.Request)
 // ----------
 // Returns server version and uptime.
 func (a adminAPIHandlers) ServiceStatusHandler(w http.ResponseWriter, r *http.Request) {
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
 		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -126,9 +136,14 @@ func (a adminAPIHandlers) ServiceStatusHandler(w http.ResponseWriter, r *http.Re
 // Restarts/Stops minio server gracefully. In a distributed setup,
 // restarts all the servers in the cluster.
 func (a adminAPIHandlers) ServiceStopNRestartHandler(w http.ResponseWriter, r *http.Request) {
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
 		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -218,9 +233,14 @@ type ServerInfo struct {
 // Get server information
 func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Request) {
 	// Authenticate request
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
 		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -305,9 +325,14 @@ func validateLockQueryParams(vars url.Values) (string, string, time.Duration,
 // Lists locks held on a given bucket, prefix and duration it was held for.
 func (a adminAPIHandlers) ListLocksHandler(w http.ResponseWriter, r *http.Request) {
 
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
 		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -348,9 +373,14 @@ func (a adminAPIHandlers) ListLocksHandler(w http.ResponseWriter, r *http.Reques
 // Clear locks held on a given bucket, prefix and duration it was held for.
 func (a adminAPIHandlers) ClearLocksHandler(w http.ResponseWriter, r *http.Request) {
 
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
 		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -454,9 +484,14 @@ func (a adminAPIHandlers) HealHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate request signature.
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
 		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -563,9 +598,14 @@ func (a adminAPIHandlers) HealHandler(w http.ResponseWriter, r *http.Request) {
 func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Validate request signature.
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
 		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -669,9 +709,14 @@ func (a adminAPIHandlers) SetConfigHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Validate request signature.
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
 		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
@@ -766,16 +811,21 @@ func (a adminAPIHandlers) UpdateCredentialsHandler(w http.ResponseWriter,
 	r *http.Request) {
 
 	// Authenticate request
-	adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
+	cred, adminAPIErr := checkAdminRequestAuthType(r, globalServerConfig.GetRegion())
 	if adminAPIErr != ErrNone {
-		writeErrorResponse(w, adminAPIErr, r.URL)
+		writeErrorResponseJSON(w, adminAPIErr, r.URL)
+		return
+	}
+	serverCred := globalServerConfig.GetCredential()
+	if cred.AccessKey != serverCred.AccessKey {
+		writeErrorResponseJSON(w, ErrAccessDenied, r.URL)
 		return
 	}
 
 	// Avoid setting new credentials when they are already passed
 	// by the environment.
 	if globalIsEnvCreds {
-		writeErrorResponse(w, ErrMethodNotAllowed, r.URL)
+		writeErrorResponseJSON(w, ErrMethodNotAllowed, r.URL)
 		return
 	}
 
@@ -790,7 +840,7 @@ func (a adminAPIHandlers) UpdateCredentialsHandler(w http.ResponseWriter,
 
 	creds, err := auth.CreateCredentials(req.AccessKey, req.SecretKey)
 	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+		writeErrorResponseJSON(w, toAPIErrorCode(err), r.URL)
 		return
 	}
 

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -104,34 +104,34 @@ func getRequestAuthType(r *http.Request) authType {
 
 // checkAdminRequestAuthType checks whether the request is a valid signature V2 or V4 request.
 // It does not accept presigned or JWT or anonymous requests.
-func checkAdminRequestAuthType(r *http.Request, region string) APIErrorCode {
-	s3Err := ErrAccessDenied
+func checkAdminRequestAuthType(r *http.Request, region string) (cred CustomCredentials, s3Error APIErrorCode) {
+	s3Error = ErrAccessDenied
 	if getRequestAuthType(r) == authTypeSigned { // we only support V4 (no presign)
-		s3Err = isReqAuthenticated(r, region)
+		cred, s3Error = isReqAuthenticated(r, region)
 	}
-	if s3Err != ErrNone {
-		errorIf(errors.New(getAPIError(s3Err).Description), "%s", dumpRequest(r))
+	if s3Error != ErrNone {
+		errorIf(errors.New(getAPIError(s3Error).Description), "%s", dumpRequest(r))
 	}
-	return s3Err
+	return
 }
 
-func checkRequestAuthType(r *http.Request, bucket, policyAction, region string) APIErrorCode {
+func checkRequestAuthType(r *http.Request, bucket, policyAction, region string) (cred CustomCredentials, s3Error APIErrorCode) {
 	reqAuthType := getRequestAuthType(r)
 
 	switch reqAuthType {
 	case authTypePresignedV2, authTypeSignedV2:
 		// Signature V2 validation.
-		s3Error := isReqAuthenticatedV2(r)
+		cred, s3Error = isReqAuthenticatedV2(r)
 		if s3Error != ErrNone {
 			errorIf(errSignatureMismatch, "%s", dumpRequest(r))
 		}
-		return s3Error
+		return
 	case authTypeSigned, authTypePresigned:
-		s3Error := isReqAuthenticated(r, region)
+		cred, s3Error = isReqAuthenticated(r, region)
 		if s3Error != ErrNone {
 			errorIf(errSignatureMismatch, "%s", dumpRequest(r))
 		}
-		return s3Error
+		return
 	}
 
 	if reqAuthType == authTypeAnonymous && policyAction != "" {
@@ -139,25 +139,28 @@ func checkRequestAuthType(r *http.Request, bucket, policyAction, region string) 
 		sourceIP := getSourceIPAddress(r)
 		resource, err := getResource(r.URL.Path, r.Host, globalDomainName)
 		if err != nil {
-			return ErrInternalError
+			s3Error = ErrInternalError
+			return
 		}
-		return enforceBucketPolicy(bucket, policyAction, resource,
+		s3Error = enforceBucketPolicy(bucket, policyAction, resource,
 			r.Referer(), sourceIP, r.URL.Query())
+		return
 	}
 
 	// By default return ErrAccessDenied
-	return ErrAccessDenied
+	s3Error = ErrAccessDenied
+	return
 }
 
 // Verify if request has valid AWS Signature Version '2'.
-func isReqAuthenticatedV2(r *http.Request) (s3Error APIErrorCode) {
+func isReqAuthenticatedV2(r *http.Request) (cred CustomCredentials, s3Error APIErrorCode) {
 	if isRequestSignatureV2(r) {
 		return doesSignV2Match(r)
 	}
 	return doesPresignV2SignatureMatch(r)
 }
 
-func reqSignatureV4Verify(r *http.Request, region string) (s3Error APIErrorCode) {
+func reqSignatureV4Verify(r *http.Request, region string) (cred CustomCredentials, s3Error APIErrorCode) {
 	sha256sum := getContentSha256Cksum(r)
 	switch {
 	case isRequestSignatureV4(r):
@@ -165,22 +168,25 @@ func reqSignatureV4Verify(r *http.Request, region string) (s3Error APIErrorCode)
 	case isRequestPresignedSignatureV4(r):
 		return doesPresignedSignatureMatch(sha256sum, r, region)
 	default:
-		return ErrAccessDenied
+		s3Error = ErrAccessDenied
+		return
 	}
 }
 
 // Verify if request has valid AWS Signature Version '4'.
-func isReqAuthenticated(r *http.Request, region string) (s3Error APIErrorCode) {
+func isReqAuthenticated(r *http.Request, region string) (cred CustomCredentials, s3Error APIErrorCode) {
 	if r == nil {
-		return ErrInternalError
+		s3Error = ErrInternalError
+		return
 	}
-	if errCode := reqSignatureV4Verify(r, region); errCode != ErrNone {
-		return errCode
+	if cred, s3Error = reqSignatureV4Verify(r, region); s3Error != ErrNone {
+		return
 	}
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		errorIf(err, "Unable to read request body for signature verification")
-		return ErrInternalError
+		s3Error = ErrInternalError
+		return
 	}
 
 	// Populate back the payload.
@@ -189,12 +195,13 @@ func isReqAuthenticated(r *http.Request, region string) (s3Error APIErrorCode) {
 	// Verify Content-Md5, if payload is set.
 	if r.Header.Get("Content-Md5") != "" {
 		if r.Header.Get("Content-Md5") != getMD5HashBase64(payload) {
-			return ErrBadDigest
+			s3Error = ErrBadDigest
+			return
 		}
 	}
 
 	if skipContentSha256Cksum(r) {
-		return ErrNone
+		return
 	}
 
 	// Verify that X-Amz-Content-Sha256 Header == sha256(payload)
@@ -204,9 +211,10 @@ func isReqAuthenticated(r *http.Request, region string) (s3Error APIErrorCode) {
 		sum = r.URL.Query().Get("X-Amz-Content-Sha256")
 	}
 	if sum != "" && sum != getSHA256Hash(payload) {
-		return ErrContentSHA256Mismatch
+		s3Error = ErrContentSHA256Mismatch
+		return
 	}
-	return ErrNone
+	return
 }
 
 // authHandler - handles all the incoming authorization headers and validates them if possible.

--- a/cmd/auth-handler_test.go
+++ b/cmd/auth-handler_test.go
@@ -353,7 +353,7 @@ func TestIsReqAuthenticated(t *testing.T) {
 
 	// Validates all testcases.
 	for _, testCase := range testCases {
-		if s3Error := isReqAuthenticated(testCase.req, globalServerConfig.GetRegion()); s3Error != testCase.s3Error {
+		if _, s3Error := isReqAuthenticated(testCase.req, globalServerConfig.GetRegion()); s3Error != testCase.s3Error {
 			t.Fatalf("Unexpected s3error returned wanted %d, got %d", testCase.s3Error, s3Error)
 		}
 	}
@@ -382,7 +382,7 @@ func TestCheckAdminRequestAuthType(t *testing.T) {
 		{Request: mustNewPresignedRequest("GET", "http://127.0.0.1:9000", 0, nil, t), ErrCode: ErrAccessDenied},
 	}
 	for i, testCase := range testCases {
-		if s3Error := checkAdminRequestAuthType(testCase.Request, globalServerConfig.GetRegion()); s3Error != testCase.ErrCode {
+		if _, s3Error := checkAdminRequestAuthType(testCase.Request, globalServerConfig.GetRegion()); s3Error != testCase.ErrCode {
 			t.Errorf("Test %d: Unexpected s3error returned wanted %d, got %d", i, testCase.ErrCode, s3Error)
 		}
 	}

--- a/cmd/bucket-handlers-listobjects.go
+++ b/cmd/bucket-handlers-listobjects.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 )
@@ -62,13 +63,19 @@ func (api objectAPIHandlers) ListObjectsV2Handler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if s3Error := checkRequestAuthType(r, bucket, "s3:ListBucket", globalServerConfig.GetRegion()); s3Error != ErrNone {
+	cred, s3Error := checkRequestAuthType(r, bucket, "s3:ListBucket", globalServerConfig.GetRegion())
+	if s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
 
 	// Extract all the listObjectsV2 query params to their native values.
 	prefix, token, startAfter, delimiter, fetchOwner, maxKeys, _ := getListObjectsV2Args(r.URL.Query())
+	restrictedPrefix, valid := cred.GetValidFilterPrefix(bucket, prefix)
+	if !valid {
+		writeErrorResponse(w, ErrAccessDenied, r.URL)
+		return
+	}
 
 	// In ListObjectsV2 'continuation-token' is the marker.
 	marker := token
@@ -94,6 +101,23 @@ func (api objectAPIHandlers) ListObjectsV2Handler(w http.ResponseWriter, r *http
 		return
 	}
 
+	if cred.Scope != "" {
+		var objects []ObjectInfo
+		for _, object := range listObjectsV2Info.Objects {
+			if strings.HasPrefix(object.Name, restrictedPrefix) {
+				objects = append(objects, object)
+			}
+		}
+		listObjectsV2Info.Objects = objects
+		var prefixes []string
+		for _, prefix := range listObjectsV2Info.Prefixes {
+			if strings.HasPrefix(prefix, restrictedPrefix) {
+				prefixes = append(prefixes, prefix)
+			}
+		}
+		listObjectsV2Info.Prefixes = prefixes
+	}
+
 	response := generateListObjectsV2Response(bucket, prefix, token, listObjectsV2Info.NextContinuationToken, startAfter, delimiter, fetchOwner, listObjectsV2Info.IsTruncated, maxKeys, listObjectsV2Info.Objects, listObjectsV2Info.Prefixes)
 
 	// Write success response.
@@ -116,13 +140,19 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if s3Error := checkRequestAuthType(r, bucket, "s3:ListBucket", globalServerConfig.GetRegion()); s3Error != ErrNone {
+	cred, s3Error := checkRequestAuthType(r, bucket, "s3:ListBucket", globalServerConfig.GetRegion())
+	if s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
 
 	// Extract all the litsObjectsV1 query params to their native values.
 	prefix, marker, delimiter, maxKeys, _ := getListObjectsV1Args(r.URL.Query())
+	restrictedPrefix, valid := cred.GetValidFilterPrefix(bucket, prefix)
+	if !valid {
+		writeErrorResponse(w, ErrAccessDenied, r.URL)
+		return
+	}
 
 	// Validate the maxKeys lowerbound. When maxKeys > 1000, S3 returns 1000 but
 	// does not throw an error.
@@ -142,6 +172,22 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
+	}
+	if cred.Scope != "" {
+		var objects []ObjectInfo
+		for _, object := range listObjectsInfo.Objects {
+			if strings.HasPrefix(object.Name, restrictedPrefix) {
+				objects = append(objects, object)
+			}
+		}
+		listObjectsInfo.Objects = objects
+		var prefixes []string
+		for _, prefix := range listObjectsInfo.Prefixes {
+			if strings.HasPrefix(prefix, restrictedPrefix) {
+				prefixes = append(prefixes, prefix)
+			}
+		}
+		listObjectsInfo.Prefixes = prefixes
 	}
 	response := generateListObjectsV1Response(bucket, prefix, marker, delimiter, maxKeys, listObjectsInfo)
 

--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -54,13 +54,19 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 		writeErrorResponse(w, ErrNotImplemented, r.URL)
 		return
 	}
-	if s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion()); s3Error != ErrNone {
+	cred, s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion())
+	if s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
 
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
+
+	if restrictedBkt := cred.Bucket(); restrictedBkt != "" && restrictedBkt != bucket {
+		writeErrorResponse(w, ErrAccessDenied, r.URL)
+		return
+	}
 
 	_, err := objAPI.GetBucketInfo(bucket)
 	if err != nil {
@@ -112,13 +118,19 @@ func (api objectAPIHandlers) PutBucketNotificationHandler(w http.ResponseWriter,
 		writeErrorResponse(w, ErrNotImplemented, r.URL)
 		return
 	}
-	if s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion()); s3Error != ErrNone {
+	cred, s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion())
+	if s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
 
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
+
+	if restrictedBkt := cred.Bucket(); restrictedBkt != "" && cred.Scope[1:] == restrictedBkt && restrictedBkt != bucket {
+		writeErrorResponse(w, ErrAccessDenied, r.URL)
+		return
+	}
 
 	_, err := objectAPI.GetBucketInfo(bucket)
 	if err != nil {
@@ -308,13 +320,19 @@ func (api objectAPIHandlers) ListenBucketNotificationHandler(w http.ResponseWrit
 		writeErrorResponse(w, ErrNotImplemented, r.URL)
 		return
 	}
-	if s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion()); s3Error != ErrNone {
+	cred, s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion())
+	if s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
 
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
+
+	if restrictedBkt := cred.Bucket(); restrictedBkt != "" && restrictedBkt != bucket {
+		writeErrorResponse(w, ErrAccessDenied, r.URL)
+		return
+	}
 
 	// Parse listen bucket notification resources.
 	prefixes, suffixes, events := getListenBucketNotificationResources(r.URL.Query())

--- a/cmd/bucket-policy-handlers.go
+++ b/cmd/bucket-policy-handlers.go
@@ -226,13 +226,19 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion()); s3Error != ErrNone {
+	cred, s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion())
+	if s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
 
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
+
+	if restrictedBkt := cred.Bucket(); restrictedBkt != "" && cred.Scope[1:] == restrictedBkt && restrictedBkt != bucket {
+		writeErrorResponse(w, ErrAccessDenied, r.URL)
+		return
+	}
 
 	// Before proceeding validate if bucket exists.
 	_, err := objAPI.GetBucketInfo(bucket)
@@ -300,13 +306,19 @@ func (api objectAPIHandlers) DeleteBucketPolicyHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	if s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion()); s3Error != ErrNone {
+	cred, s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion())
+	if s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
 
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
+
+	if restrictedBkt := cred.Bucket(); restrictedBkt != "" && cred.Scope[1:] == restrictedBkt && restrictedBkt != bucket {
+		writeErrorResponse(w, ErrAccessDenied, r.URL)
+		return
+	}
 
 	// Before proceeding validate if bucket exists.
 	_, err := objAPI.GetBucketInfo(bucket)
@@ -337,13 +349,19 @@ func (api objectAPIHandlers) GetBucketPolicyHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion()); s3Error != ErrNone {
+	cred, s3Error := checkRequestAuthType(r, "", "", globalServerConfig.GetRegion())
+	if s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
 
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
+
+	if restrictedBkt := cred.Bucket(); restrictedBkt != "" && restrictedBkt != bucket {
+		writeErrorResponse(w, ErrAccessDenied, r.URL)
+		return
+	}
 
 	// Before proceeding validate if bucket exists.
 	_, err := objAPI.GetBucketInfo(bucket)

--- a/cmd/custom-credentials.go
+++ b/cmd/custom-credentials.go
@@ -1,0 +1,128 @@
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/minio/minio/pkg/auth"
+)
+
+// CustomCredentials extends standard with scope
+type CustomCredentials struct {
+	auth.Credentials `json:",inline"`
+	Scope            string `json:"scope"`
+}
+
+// CredentialProvider indices credentials by keys
+type CredentialProvider interface {
+	Get(key string) (CustomCredentials, APIErrorCode)
+}
+
+// GlobalCredentialProvider is used to authenticate requests with custom provided credentials
+var GlobalCredentialProvider CredentialProvider
+
+// GetCredentials get current credentials.
+func (s *serverConfig) GetCredentialByKey(key string) (CustomCredentials, APIErrorCode) {
+	if GlobalCredentialProvider == nil || key == s.Credential.AccessKey {
+		return CustomCredentials{Credentials: s.Credential, Scope: ""}, ErrNone
+	}
+	return GlobalCredentialProvider.Get(key)
+}
+
+// CredentialsMapProvider is a simple map provider
+type CredentialsMapProvider map[string]CustomCredentials
+
+// Get implements the CredentialProvider interface
+func (cm CredentialsMapProvider) Get(key string) (cred CustomCredentials, err APIErrorCode) {
+	cred, ok := cm[key]
+	if !ok {
+		err = ErrInvalidAccessKeyID
+		return
+	}
+	return
+}
+
+// Bucket returns bucket component in Scope
+func (cc *CustomCredentials) Bucket() string {
+	if cc.Scope == "" {
+		return ""
+	}
+	return strings.SplitN(cc.Scope[1:], slashSeparator, 2)[0]
+}
+
+// ObjectPrefix returns object prefix part in scope
+func (cc *CustomCredentials) ObjectPrefix() string {
+	if cc.Scope == "" {
+		return ""
+	}
+	return strings.TrimLeft(cc.Scope[len(cc.Bucket())+1:], slashSeparator)
+}
+
+// Verified returns if /bucket/object has prefix of scope
+func (cc *CustomCredentials) Verified(bucket, object string) bool {
+	if cc.Scope == "" {
+		return true
+	}
+	return strings.HasPrefix(filepath.Join("/", bucket, object), cc.Scope)
+}
+
+// GetValidFilterPrefix returns a prefix for bucket to filter out objects
+func (cc *CustomCredentials) GetValidFilterPrefix(bucket, prefix string) (restrictedPrefix string, valid bool) {
+	if cc.Scope == "" {
+		return "", true
+	}
+	path := pathJoin("/", bucket, prefix)
+	if prefix == "" {
+		path += slashSeparator
+	}
+	if len(path) < len(cc.Scope) {
+		if cc.Scope[:len(path)] != path {
+			return "", false
+		}
+		// assume
+		// scope: /foo/barz/folder/prefix
+		// bucket: /foo
+		// 1. prefix is ""
+		//	first:    /foo/
+		//	last:     barz/folder/prefix
+		//	restrict: ""+barz/
+		// 2. prefix is "barz/"
+		//	first:    /foo/barz/
+		//	last:     folder/prefix
+		//	restrict: barz/folder/
+		// 3. prefix is "barz/folder/"
+		//	first:    /foo/barz/folder/
+		//	last:     prefix
+		//	restrict: barz/folder/prefix
+		// 3. prefix is "barz/fold"
+		//	first:    /foo/barz/fold
+		//	last:     er/prefix
+		//	restrict: barz/folder/
+		last := cc.Scope[len(path):]
+		if idx := strings.Index(last, "/"); idx >= 0 {
+			restrictedPrefix = prefix + last[:idx+1]
+		} else {
+			restrictedPrefix = prefix + last
+		}
+	} else if !strings.HasPrefix(path, cc.Scope) {
+		return "", false
+	}
+	valid = true
+	return
+}

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -417,7 +417,7 @@ func (fs *FSObjects) ListObjectParts(bucket, object, uploadID string, partNumber
 	for partNumber, etag := range partsMap {
 		parts = append(parts, PartInfo{PartNumber: partNumber, ETag: etag})
 	}
-	sort.SliceStable(parts, func(i int, j int) bool {
+	sort.Slice(parts, func(i int, j int) bool {
 		return parts[i].PartNumber < parts[j].PartNumber
 	})
 	i := 0

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -806,7 +806,7 @@ func (a *azureObjects) ListObjectParts(bucket, object, uploadID string, partNumb
 	for _, part := range partsMap {
 		parts = append(parts, part)
 	}
-	sort.SliceStable(parts, func(i int, j int) bool {
+	sort.Slice(parts, func(i int, j int) bool {
 		return parts[i].PartNumber < parts[j].PartNumber
 	})
 	partsCount := 0

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -53,8 +53,11 @@ func authenticateJWT(accessKey, secretKey string, expiry time.Duration) (string,
 		return "", err
 	}
 
-	serverCred := globalServerConfig.GetCredential()
-
+	// Access credentials.
+	serverCred, errCode := globalServerConfig.GetCredentialByKey(passedCredential.AccessKey)
+	if errCode != ErrNone {
+		return "", errInvalidAccessKeyID
+	}
 	if serverCred.AccessKey != passedCredential.AccessKey {
 		return "", errInvalidAccessKeyID
 	}
@@ -86,51 +89,63 @@ func keyFuncCallback(jwtToken *jwtgo.Token) (interface{}, error) {
 	if _, ok := jwtToken.Method.(*jwtgo.SigningMethodHMAC); !ok {
 		return nil, fmt.Errorf("Unexpected signing method: %v", jwtToken.Header["alg"])
 	}
+	if claims, ok := jwtToken.Claims.(*jwtgo.StandardClaims); ok {
+		accessKey := claims.Subject
+		cred, err := globalServerConfig.GetCredentialByKey(accessKey)
+		if err != ErrNone {
+			return nil, errors.New(getAPIError(err).Description)
+		}
+		return []byte(cred.SecretKey), nil
+	}
 
-	return []byte(globalServerConfig.GetCredential().SecretKey), nil
+	return nil, errors.New("Unknown token format")
 }
 
 func isAuthTokenValid(tokenString string) bool {
 	if tokenString == "" {
 		return false
 	}
-	var claims jwtgo.StandardClaims
-	jwtToken, err := jwtgo.ParseWithClaims(tokenString, &claims, keyFuncCallback)
-	if err != nil {
-		errorIf(err, "Unable to parse JWT token string")
-		return false
-	}
-	if err = claims.Valid(); err != nil {
-		errorIf(err, "Invalid claims in JWT token string")
-		return false
-	}
-	return jwtToken.Valid && claims.Subject == globalServerConfig.GetCredential().AccessKey
+	_, err := tokenAuthenticate(tokenString)
+	return err == nil
 }
 
 func isHTTPRequestValid(req *http.Request) bool {
-	return webRequestAuthenticate(req) == nil
+	_, err := webRequestAuthenticate(req)
+	return err == nil
 }
 
 // Check if the request is authenticated.
 // Returns nil if the request is authenticated. errNoAuthToken if token missing.
 // Returns errAuthentication for all other errors.
-func webRequestAuthenticate(req *http.Request) error {
+func webRequestAuthenticate(req *http.Request) (cred CustomCredentials, err error) {
 	var claims jwtgo.StandardClaims
-	jwtToken, err := jwtreq.ParseFromRequestWithClaims(req, jwtreq.AuthorizationHeaderExtractor, &claims, keyFuncCallback)
+	_, err = jwtreq.ParseFromRequestWithClaims(req, jwtreq.AuthorizationHeaderExtractor, &claims, keyFuncCallback)
 	if err != nil {
 		if err == jwtreq.ErrNoTokenInRequest {
-			return errNoAuthToken
+			err = errNoAuthToken
+			return
 		}
-		return errAuthentication
+		err = errAuthentication
+		return
 	}
-	if err = claims.Valid(); err != nil {
-		return errAuthentication
+	cred, errCode := globalServerConfig.GetCredentialByKey(claims.Subject)
+	if errCode != ErrNone {
+		err = errors.New(getAPIError(errCode).Description)
+		return
 	}
-	if claims.Subject != globalServerConfig.GetCredential().AccessKey {
-		return errInvalidAccessKeyID
+	return cred, nil
+}
+
+func tokenAuthenticate(tokenString string) (cred CustomCredentials, err error) {
+	var claims jwtgo.StandardClaims
+	_, err = jwtgo.ParseWithClaims(tokenString, &claims, keyFuncCallback)
+	if err != nil {
+		return
 	}
-	if !jwtToken.Valid {
-		return errAuthentication
+	cred, errCode := globalServerConfig.GetCredentialByKey(claims.Subject)
+	if errCode != ErrNone {
+		err = errors.New(getAPIError(errCode).Description)
+		return
 	}
-	return nil
+	return cred, nil
 }

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -95,6 +95,9 @@ func keyFuncCallback(jwtToken *jwtgo.Token) (interface{}, error) {
 		if err != ErrNone {
 			return nil, errors.New(getAPIError(err).Description)
 		}
+		if cred.AccessKey != accessKey {
+			return nil, errInvalidAccessKeyID
+		}
 		return []byte(cred.SecretKey), nil
 	}
 

--- a/cmd/jwt_test.go
+++ b/cmd/jwt_test.go
@@ -132,7 +132,7 @@ func TestWebRequestAuthenticate(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		gotErr := webRequestAuthenticate(testCase.req)
+		_, gotErr := webRequestAuthenticate(testCase.req)
 		if testCase.expectedErr != gotErr {
 			t.Errorf("Test %d, expected err %s, got %s", i+1, testCase.expectedErr, gotErr)
 		}

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -1284,7 +1284,7 @@ func TestPosixAppendFile(t *testing.T) {
 
 	for _, testCase := range testCases {
 		if err = posixStorage.AppendFile("success-vol", testCase.fileName, []byte("hello, world")); err != testCase.expectedErr {
-			t.Errorf("Case: %s, expected: %s, got: %s", testCase, testCase.expectedErr, err)
+			t.Errorf("Case: %s, expected: %s, got: %s", testCase.fileName, testCase.expectedErr, err)
 		}
 	}
 
@@ -1375,7 +1375,7 @@ func TestPosixPrepareFile(t *testing.T) {
 
 	for _, testCase := range testCases {
 		if err = posixStorage.PrepareFile("success-vol", testCase.fileName, 16); err != testCase.expectedErr {
-			t.Errorf("Case: %s, expected: %s, got: %s", testCase, testCase.expectedErr, err)
+			t.Errorf("Case: %s, expected: %s, got: %s", testCase.fileName, testCase.expectedErr, err)
 		}
 	}
 

--- a/cmd/signature-v2_test.go
+++ b/cmd/signature-v2_test.go
@@ -135,7 +135,7 @@ func TestDoesPresignedV2SignatureMatch(t *testing.T) {
 			// Should be set since we are simulating a http server.
 			req.RequestURI = req.URL.RequestURI()
 			// Check if it matches!
-			errCode := doesPresignV2SignatureMatch(req)
+			_, errCode := doesPresignV2SignatureMatch(req)
 			if errCode != testCase.expected {
 				t.Errorf("(%d) expected to get %s, instead got %s", i, niceError(testCase.expected), niceError(errCode))
 			}
@@ -146,7 +146,7 @@ func TestDoesPresignedV2SignatureMatch(t *testing.T) {
 			}
 			// Should be set since we are simulating a http server.
 			req.RequestURI = req.URL.RequestURI()
-			errCode := doesPresignV2SignatureMatch(req)
+			_, errCode := doesPresignV2SignatureMatch(req)
 			if errCode != testCase.expected {
 				t.Errorf("(%d) expected to get success, instead got %s", i, niceError(errCode))
 			}

--- a/cmd/signature-v4_test.go
+++ b/cmd/signature-v4_test.go
@@ -290,7 +290,7 @@ func TestDoesPresignedSignatureMatch(t *testing.T) {
 		}
 
 		// Check if it matches!
-		err := doesPresignedSignatureMatch(payloadSHA256, req, testCase.region)
+		_, err := doesPresignedSignatureMatch(payloadSHA256, req, testCase.region)
 		if err != testCase.expected {
 			t.Errorf("(%d) expected to get %s, instead got %s", i, niceError(testCase.expected), niceError(err))
 		}

--- a/embeded_example_main.go
+++ b/embeded_example_main.go
@@ -1,0 +1,86 @@
+// +build ignore
+
+/*
+ * Minio Cloud Storage, (C) 2016,2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Below main package has canonical imports for 'go get' and 'go build'
+ * to work with all other clones of github.com/minio/minio repository. For
+ * more information refer https://golang.org/doc/go1.4#canonicalimports
+ */
+
+//!builder ignore
+package main // import "github.com/minio/minio"
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/minio/mc/pkg/console"
+	minio "github.com/minio/minio/cmd"
+	"github.com/minio/minio/pkg/auth"
+
+	// Import gateway
+	_ "github.com/minio/minio/cmd/gateway"
+)
+
+const (
+	// Minio requires at least Go v1.9.4
+	minGoVersion        = "1.9.4"
+	goVersionConstraint = ">= " + minGoVersion
+)
+
+// Check if this binary is compiled with at least minimum Go version.
+func checkGoVersion(goVersionStr string) error {
+	constraint, err := version.NewConstraint(goVersionConstraint)
+	if err != nil {
+		return fmt.Errorf("'%s': %s", goVersionConstraint, err)
+	}
+
+	goVersion, err := version.NewVersion(goVersionStr)
+	if err != nil {
+		return err
+	}
+
+	if !constraint.Check(goVersion) {
+		return fmt.Errorf("Minio is not compiled by Go %s.  Please recompile accordingly",
+			goVersionConstraint)
+	}
+
+	return nil
+}
+
+func main() {
+	// When `go get` is used minimum Go version check is not triggered but it would have compiled it successfully.
+	// However such binary will fail at runtime, hence we also check Go version at runtime.
+	if err := checkGoVersion(runtime.Version()[2:]); err != nil {
+		console.Fatalln("Go runtime version check failed.", err)
+	}
+
+	minio.GlobalCredentialProvider = minio.CredentialsMapProvider(map[string]minio.CustomCredentials{
+		"guest": minio.CustomCredentials{
+			Credentials: auth.Credentials{
+				AccessKey: "guest",
+				SecretKey: "gueststorage",
+			},
+			Scope: "/restdata",
+		},
+	})
+
+	minio.Main(os.Args)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add a CredentialProvider to enable multiple credential pairs for embedded Minio server

## Description
<!--- Describe your changes in detail -->

In our internal FaaS, we need to assign different  credential pairs for each function and jail API access under certain prefix(we call scope), we embed Minio gateway in custom server sync credentials from controller.

I think may be this will help to solve #5305 or a PoC at least.

Interface `CredentialProvider` can be implemented for different backends, in [embeded_example_main.go](https://github.com/antmanler/minio/blob/1aabdd88075a1fe285706e2ea701d41a561f1580/embeded_example_main.go) it simple uses a dict to provides extra credentials.

```go
type CredentialProvider interface {
	Get(key string) (CustomCredentials, APIErrorCode)
}
```

`Secondary credentials` are indexed by accessKey in `CredentialProvider`,

 `AccessKey` , `SecretKey` in config or passed from Env is `master credentials`.

Secondary credentials can access most of S3 apis but admin and internal apis require master credentials.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#5305

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual, unit tests not ready yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.