### PR TITLE
check that the server supports encryption for SSE-C requests

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -111,6 +111,10 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
+	if IsSSECustomerRequest(r.Header) && !objectAPI.IsEncryptionSupported() { // SSE-C request but backend does not support encryption
+		writeErrorResponse(w, ErrNotImplemented, r.URL)
+		return
+	}
 
 	objInfo, err := objectAPI.GetObjectInfo(bucket, object)
 	if err != nil {
@@ -236,6 +240,10 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 		writeErrorResponseHeadersOnly(w, s3Error)
 		return
 	}
+	if IsSSECustomerRequest(r.Header) && !objectAPI.IsEncryptionSupported() { // SSE-C request but backend does not support encryption
+		writeErrorResponse(w, ErrNotImplemented, r.URL)
+		return
+	}
 
 	objInfo, err := objectAPI.GetObjectInfo(bucket, object)
 	if err != nil {
@@ -334,6 +342,10 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 
 	if s3Error := checkRequestAuthType(r, dstBucket, "s3:PutObject", globalServerConfig.GetRegion()); s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
+		return
+	}
+	if (IsSSECustomerRequest(r.Header) || IsSSECopyCustomerRequest(r.Header)) && !objectAPI.IsEncryptionSupported() { // SSE-C request but backend does not support encryption
+		writeErrorResponse(w, ErrNotImplemented, r.URL)
 		return
 	}
 
@@ -558,6 +570,10 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 			return
 		}
 	}
+	if IsSSECustomerRequest(r.Header) && !objectAPI.IsEncryptionSupported() { // SSE-C request but backend does not support encryption
+		writeErrorResponse(w, ErrNotImplemented, r.URL)
+		return
+	}
 
 	// Get Content-Md5 sent by client and verify if valid
 	md5Bytes, err := checkValidMD5(r.Header.Get("Content-Md5"))
@@ -736,6 +752,10 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 		writeErrorResponse(w, s3Error, r.URL)
 		return
 	}
+	if IsSSECustomerRequest(r.Header) && !objectAPI.IsEncryptionSupported() { // SSE-C request but backend does not support encryption
+		writeErrorResponse(w, ErrNotImplemented, r.URL)
+		return
+	}
 
 	// Validate storage class metadata if present
 	if _, ok := r.Header[amzStorageClassCanonical]; ok {
@@ -807,6 +827,10 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 
 	if s3Error := checkRequestAuthType(r, dstBucket, "s3:PutObject", globalServerConfig.GetRegion()); s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
+		return
+	}
+	if (IsSSECustomerRequest(r.Header) || IsSSECopyCustomerRequest(r.Header)) && !objectAPI.IsEncryptionSupported() { // SSE-C request but backend does not support encryption
+		writeErrorResponse(w, ErrNotImplemented, r.URL)
 		return
 	}
 
@@ -977,6 +1001,10 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	objectAPI := api.ObjectAPI()
 	if objectAPI == nil {
 		writeErrorResponse(w, ErrServerNotInitialized, r.URL)
+		return
+	}
+	if IsSSECustomerRequest(r.Header) && !objectAPI.IsEncryptionSupported() { // SSE-C request but backend does not support encryption
+		writeErrorResponse(w, ErrNotImplemented, r.URL)
 		return
 	}
 


### PR DESCRIPTION
## Description

This change adds a check to verify that the server backend does support
encryption if a request contains SSE-C headers. If not the server
should fail - with Not Implemented - instead of given the impression
of e.g. encrypting the object while it actually stores the object in plaintext.

## Motivation and Context
Fixes #5511

## How Has This Been Tested?
manually - as described in the issue. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.