### PR TITLE
Use toAPIErrorCode in HeadObject handler when decrypting request fails

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -253,7 +253,7 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 			return
 		} else if encrypted {
 			if _, err = DecryptRequest(w, r, objInfo.UserDefined); err != nil {
-				writeErrorResponse(w, ErrSSEEncryptedObject, r.URL)
+				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
 			w.Header().Set(SSECustomerAlgorithm, r.Header.Get(SSECustomerAlgorithm))


### PR DESCRIPTION
## Description
HeadObject handler returns 400 error code when SSE-C key mismatch but it is supposed to return 403 Access denied instead. This PR uses toAPIErrorCode for better error handling.

## Motivation and Context
Fix a bug

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Hadoop AWS unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.