### PR TITLE
Quick support to server level WORM

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -911,6 +911,8 @@ func toAPIErrorCode(err error) (apiErr APIErrorCode) {
 		apiErr = ErrBucketAlreadyOwnedByYou
 	case ObjectNotFound:
 		apiErr = ErrNoSuchKey
+	case ObjectAlreadyExists:
+		apiErr = ErrMethodNotAllowed
 	case ObjectNameInvalid:
 		apiErr = ErrInvalidObjectName
 	case InvalidUploadID:

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -300,6 +300,14 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 		return
 	}
 
+	// Deny if WORM is enabled
+	if globalWORMEnabled {
+		// Not required to check whether given objects exist or not, because
+		// DeleteMultipleObject is always successful irrespective of object existence.
+		writeErrorResponse(w, ErrMethodNotAllowed, r.URL)
+		return
+	}
+
 	var wg = &sync.WaitGroup{} // Allocate a new wait group.
 	var dErrs = make([]error, len(deleteObjects.Objects))
 

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -158,4 +158,7 @@ func handleCommonEnvVars() {
 			globalIsStorageClass = true
 		}
 	}
+
+	// Get WORM environment variable.
+	globalWORMEnabled = strings.EqualFold(os.Getenv("MINIO_WORM"), "on")
 }

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -745,6 +745,12 @@ func (fs *FSObjects) putObject(bucket string, object string, data *hash.Reader, 
 
 	// Entire object was written to the temp location, now it's safe to rename it to the actual location.
 	fsNSObjPath := pathJoin(fs.fsPath, bucket, object)
+	// Deny if WORM is enabled
+	if globalWORMEnabled {
+		if _, err = fsStatFile(fsNSObjPath); err == nil {
+			return ObjectInfo{}, errors.Trace(ObjectAlreadyExists{Bucket: bucket, Object: object})
+		}
+	}
 	if err = fsRenameFile(fsTmpObjPath, fsNSObjPath); err != nil {
 		return ObjectInfo{}, toObjectErr(err, bucket, object)
 	}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -172,6 +172,8 @@ var (
 	// Set to store standard storage class
 	globalStandardStorageClass storageClass
 
+	globalWORMEnabled bool
+
 	// Add new variable global values here.
 )
 

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2015 Minio, Inc.
+ * Minio Cloud Storage, (C) 2015, 2016, 2017, 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,6 +170,13 @@ type ObjectNotFound GenericError
 
 func (e ObjectNotFound) Error() string {
 	return "Object not found: " + e.Bucket + "#" + e.Object
+}
+
+// ObjectAlreadyExists object already exists.
+type ObjectAlreadyExists GenericError
+
+func (e ObjectAlreadyExists) Error() string {
+	return "Object: " + e.Bucket + "#" + e.Object + " already exists"
 }
 
 // ObjectExistsAsDirectory object already exists as a directory.

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -76,6 +76,9 @@ ENVIRONMENT VARIABLES:
   DOMAIN:
      MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
 
+  WORM:
+     MINIO_WORM: To turn on Write-Once-Read-Many in server, set this value to "on".
+
 EXAMPLES:
   1. Start minio server on "/home/shared" directory.
       $ {{.HelpName}} /home/shared

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2016, 2017 Minio, Inc.
+ * Minio Cloud Storage, (C) 2016, 2017, 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -725,6 +725,13 @@ func (xl xlObjects) CompleteMultipartUpload(ctx context.Context, bucket string, 
 			// Request 4: CompleteMultipartUpload --part 2
 			// N.B. 1st part is not present. This part should be removed from the storage.
 			xl.removeObjectPart(bucket, object, uploadID, curpart.Name)
+		}
+	}
+
+	// Deny if WORM is enabled
+	if globalWORMEnabled {
+		if xl.isObject(bucket, object) {
+			return ObjectInfo{}, errors.Trace(ObjectAlreadyExists{Bucket: bucket, Object: object})
 		}
 	}
 

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2016, 2017 Minio, Inc.
+ * Minio Cloud Storage, (C) 2016, 2017, 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -691,6 +691,13 @@ func (xl xlObjects) putObject(bucket string, object string, data *hash.Reader, m
 	// Write unique `xl.json` for each disk.
 	if onlineDisks, err = writeUniqueXLMetadata(onlineDisks, minioMetaTmpBucket, tempObj, partsMetadata, writeQuorum); err != nil {
 		return ObjectInfo{}, toObjectErr(err, bucket, object)
+	}
+
+	// Deny if WORM is enabled
+	if globalWORMEnabled {
+		if xl.isObject(bucket, object) {
+			return ObjectInfo{}, errors.Trace(ObjectAlreadyExists{Bucket: bucket, Object: object})
+		}
 	}
 
 	// Rename the successfully written temporary object to final location.


### PR DESCRIPTION
This is a trival fix to support server level WORM.  The feature comes
with an environment variable `MINIO_WORM`.

Usage:
```
$ export MINIO_WORM=on
$ minio server endpoint
```

Limitations:
When parallel fresh multiple uploads of an object may succeed because
of WORM awareness is not available in object layer.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.