### PR TITLE
Support SSE-C multipart source objects in CopyObject

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -398,6 +398,10 @@ func (fs *FSObjects) CopyObject(srcBucket, srcObject, dstBucket, dstObject strin
 
 		// Save objects' metadata in `fs.json`.
 		fsMeta := newFSMetaV1()
+		if _, err = fsMeta.ReadFrom(wlk); err != nil {
+			return oi, toObjectErr(err, srcBucket, srcObject)
+		}
+
 		fsMeta.Meta = srcInfo.UserDefined
 		if _, err = fsMeta.WriteTo(wlk); err != nil {
 			return oi, toObjectErr(err, srcBucket, srcObject)

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -83,7 +83,9 @@ func (xl xlObjects) CopyObject(srcBucket, srcObject, dstBucket, dstObject string
 	cpSrcDstSame := isStringEqual(pathJoin(srcBucket, srcObject), pathJoin(dstBucket, dstObject))
 
 	// Read metadata associated with the object from all disks.
-	metaArr, errs := readAllXLMetadata(xl.getDisks(), srcBucket, srcObject)
+	storageDisks := xl.getDisks()
+
+	metaArr, errs := readAllXLMetadata(storageDisks, srcBucket, srcObject)
 
 	// get Quorum for this object
 	readQuorum, writeQuorum, err := objectQuorumFromMeta(xl, metaArr, errs)
@@ -96,7 +98,7 @@ func (xl xlObjects) CopyObject(srcBucket, srcObject, dstBucket, dstObject string
 	}
 
 	// List all online disks.
-	onlineDisks, modTime := listOnlineDisks(xl.getDisks(), metaArr, errs)
+	_, modTime := listOnlineDisks(storageDisks, metaArr, errs)
 
 	// Pick latest valid metadata.
 	xlMeta, err := pickValidXLMeta(metaArr, modTime)
@@ -104,25 +106,22 @@ func (xl xlObjects) CopyObject(srcBucket, srcObject, dstBucket, dstObject string
 		return oi, toObjectErr(err, srcBucket, srcObject)
 	}
 
-	// Reorder online disks based on erasure distribution order.
-	onlineDisks = shuffleDisks(onlineDisks, xlMeta.Erasure.Distribution)
-
 	// Length of the file to read.
 	length := xlMeta.Stat.Size
 
 	// Check if this request is only metadata update.
 	if cpSrcDstSame {
-		xlMeta.Meta = srcInfo.UserDefined
-		partsMetadata := make([]xlMetaV1, len(xl.getDisks()))
 		// Update `xl.json` content on each disks.
-		for index := range partsMetadata {
-			partsMetadata[index] = xlMeta
+		for index := range metaArr {
+			metaArr[index].Meta = srcInfo.UserDefined
 		}
+
+		var onlineDisks []StorageAPI
 
 		tempObj := mustGetUUID()
 
 		// Write unique `xl.json` for each disk.
-		if onlineDisks, err = writeUniqueXLMetadata(onlineDisks, minioMetaTmpBucket, tempObj, partsMetadata, writeQuorum); err != nil {
+		if onlineDisks, err = writeUniqueXLMetadata(storageDisks, minioMetaTmpBucket, tempObj, metaArr, writeQuorum); err != nil {
 			return oi, toObjectErr(err, srcBucket, srcObject)
 		}
 		// Rename atomically `xl.json` from tmp location to destination for each disk.

--- a/pkg/ioutil/ioutil.go
+++ b/pkg/ioutil/ioutil.go
@@ -114,3 +114,15 @@ func (w *LimitWriter) Close() error {
 func LimitedWriter(w io.Writer, skipBytes int64, limit int64) *LimitWriter {
 	return &LimitWriter{w, skipBytes, limit}
 }
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }
+
+// NopCloser returns a WriteCloser with a no-op Close method wrapping
+// the provided Writer w.
+func NopCloser(w io.Writer) io.WriteCloser {
+	return nopCloser{w}
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Support SSE-C multipart source objects in CopyObject
<!--- Describe your changes in detail -->

## Motivation and Context
Current code didn't implement the logic to support
decrypting encrypted multiple parts, this PR fixes
by supporting copying encrypted multipart objects.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.