### PR TITLE
Ensure to load only regular files for CAs

### DIFF
--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 )
 
 // TLSPrivateKeyPassword is the environment variable which contains the password used
@@ -64,14 +63,18 @@ func parsePublicCertFile(certFile string) (x509Certs []*x509.Certificate, err er
 func getRootCAs(certsCAsDir string) (*x509.CertPool, error) {
 	// Get all CA file names.
 	var caFiles []string
-	fis, err := ioutil.ReadDir(certsCAsDir)
+	fis, err := readDir(certsCAsDir)
 	if err != nil {
 		return nil, err
 	}
 	for _, fi := range fis {
-		caFiles = append(caFiles, filepath.Join(certsCAsDir, fi.Name()))
+		// Skip all directories.
+		if hasSuffix(fi, slashSeparator) {
+			continue
+		}
+		// We are only interested in regular files here.
+		caFiles = append(caFiles, pathJoin(certsCAsDir, fi))
 	}
-
 	if len(caFiles) == 0 {
 		return nil, nil
 	}

--- a/cmd/certs_test.go
+++ b/cmd/certs_test.go
@@ -219,27 +219,16 @@ func TestGetRootCAs(t *testing.T) {
 		t.Fatalf("Unable create test file. %v", err)
 	}
 
-	nonexistentErr := fmt.Errorf("open nonexistent-dir: no such file or directory")
-	if runtime.GOOS == "windows" {
-		// Below concatenation is done to get rid of goline error
-		// "error strings should not be capitalized or end with punctuation or a newline"
-		nonexistentErr = fmt.Errorf("open nonexistent-dir:" + " The system cannot find the file specified.")
-	}
-
-	err1 := fmt.Errorf("read %s: is a directory", filepath.Join(dir1, "empty-dir"))
-	if runtime.GOOS == "windows" {
-		// Below concatenation is done to get rid of goline error
-		// "error strings should not be capitalized or end with punctuation or a newline"
-		err1 = fmt.Errorf("read %s:"+" The handle is invalid.", filepath.Join(dir1, "empty-dir"))
-	}
-
 	testCases := []struct {
 		certCAsDir  string
 		expectedErr error
 	}{
-		{"nonexistent-dir", nonexistentErr},
-		{dir1, err1},
+		{"nonexistent-dir", errFileNotFound},
+		// Ignores directories.
+		{dir1, nil},
+		// Ignore empty directory.
 		{emptydir, nil},
+		// Loads the cert properly.
 		{dir2, nil},
 	}
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensure to load only regular files for CAs
<!--- Describe your changes in detail -->

## Motivation and Context
In kubernetes statefulset like environments when secrets
are mounted to pods they have sub-directories, we should
ideally be only looking for regular files here and skip
all others.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using kubernetes statefulset deployment.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.