### PR TITLE
[doc]: fix openssl command for ECDSA key generation

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -37,7 +37,7 @@ go run generate_cert.go -ca --host "10.10.0.3"
 
 1. **ECDSA:**  
 ```sh
-openssl ecparam -genkey -name prime256v1 -out private.key
+openssl ecparam -genkey -name prime256v1 | openssl ec -out private.key
 ```
 or protect the private key additionally with a password:  
 ```sh


### PR DESCRIPTION
## Description
This change fixes the command for generating ECDSA private keys.
The current command produces private key files which cannot be parsed
by the server.


## Motivation and Context
Fixes #5614

## How Has This Been Tested?
manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.