### PR TITLE
Add Minio TLS configuration doc for Kubernetes deployment

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -173,6 +173,7 @@ certtool.exe --generate-self-signed --load-privkey private.key --template cert.c
 Minio can be configured to connect to other servers, whether Minio nodes or servers like NATs, Redis. If these servers use certificates that are not registered in one of the known certificates authorities, you can make Minio server trust these CAs by dropping these certificates under Minio config path (`~/.minio/certs/CAs/` on Linux or `C:\Users\<Username>\.minio\certs\CAs` on Windows).
 
 # Explore Further
+* [TLS Configuration for Minio server on Kubernetes](https://github.com/minio/minio/tree/master/docs/tls/kubernetes)
 * [Minio Client Complete Guide](https://docs.minio.io/docs/minio-client-complete-guide)
 * [Generate Let's Encrypt Certificate](https://docs.minio.io/docs/generate-let-s-encypt-certificate-using-concert-for-minio)
 * [Setup Nginx Proxy with Minio Server](https://docs.minio.io/docs/setup-nginx-proxy-with-minio)

--- a/docs/tls/kubernetes/README.md
+++ b/docs/tls/kubernetes/README.md
@@ -1,0 +1,80 @@
+# How to secure access to Minio on Kubernetes with TLS [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+
+This document explains how to configure Minio server with TLS certificates on Kubernetes.
+
+## 1. Prerequisites
+
+- Familiarity with [Minio deployment process on Kubernetes](https://docs.minio.io/docs/deploy-minio-on-kubernetes).
+
+- Kubernetes cluster with `kubectl` configured.
+
+- Acquire TLS certificates, either from a CA or [create self-signed certificates](https://docs.minio.io/docs/how-to-secure-access-to-minio-server-with-tls).
+
+## 2. Create Kubernetes secret
+
+[Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret) are intended to hold sensitive information. 
+We'll use secrets to hold the TLS certificate and key. To create a secret, update the paths to `private.key` and `public.crt` 
+below.
+
+Then type
+
+```sh
+kubectl create secret generic tls-ssl-minio --from-file=path/to/private.key --from-file=path/to/public.crt
+```
+
+Cross check if the secret is created successfully using 
+
+```sh
+kubectl get secrets
+```
+
+You should see a secret named `tls-ssl-minio`.
+
+## 3. Update deployment yaml file
+
+Whether you are planning to use Kubernetes StatefulSet or Kubernetes Deployment, the steps remain the same.
+
+If you're using certificates provided by a CA, add the below section in your yaml file under `spec.volumes[]`
+
+```yaml
+    volumes:
+      - name: secret-volume
+        secret:
+          secretName: tls-ssl-minio
+          items:
+          - key: public.crt
+            path: .minio/certs/public.crt
+          - key: private.key
+            path: .minio/certs/private.key
+```
+
+In case you are using a self signed certificate, Minio server will not trust it by default. To add the certificate as a 
+trusted certificate, add the `public.crt` to the `.minio/certs/CAs` directory as well. This can be done by
+
+```yaml
+    volumes:
+      - name: secret-volume
+        secret:
+          secretName: tls-ssl-minio
+          items:
+          - key: public.crt
+            path: .minio/certs/public.crt
+          - key: private.key
+            path: .minio/certs/private.key
+          - key: public.crt
+            path: .minio/certs/CAs/public.crt
+```
+
+Note that the `secretName` should be same as the secret name created in previous step. Then add the below section under
+`spec.containers[].volumeMounts[]`
+
+```yaml
+    volumeMounts:
+        - name: secret-volume
+          mountPath: /<user-running-minio>/
+```
+
+Here the name of `volumeMount` should match the name of `volume` created previously. Also `mountPath` is the path of 
+Minio server's config directory, (used to store the certificates). By default the location is 
+`/user-running-minio/.minio/certs`. Update the `mountPath` to appropriate parent directory for Minio server config 
+directory. (Tip: In default Kubernetes configuration this will be `/root`).


### PR DESCRIPTION
## Description
This PR adds documentation on how to setup TLS for Minio deployments on Kubernetes

## Motivation and Context
Based on user feedback and questions.

## How Has This Been Tested?
Manually on a Minikube setup, with self-signed certs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.