### PR TITLE
Modify fatalIf, startup and update message logging code

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -32,9 +32,9 @@ func checkUpdate(mode string) {
 	// Its OK to ignore any errors during doUpdate() here.
 	if updateMsg, _, currentReleaseTime, latestReleaseTime, err := getUpdateInfo(2*time.Second, mode); err == nil {
 		if globalInplaceUpdateDisabled {
-			log.Println(updateMsg)
+			LogInfoMessage(updateMsg)
 		} else {
-			log.Println(prepareUpdateMessage("Run `minio update`", latestReleaseTime.Sub(currentReleaseTime)))
+			LogInfoMessage(prepareUpdateMessage("Run `minio update`", latestReleaseTime.Sub(currentReleaseTime)))
 		}
 	}
 }
@@ -46,7 +46,7 @@ func initConfig() {
 		fatalIf(loadConfig(), "Unable to load config version: '%s'.", serverConfigVersion)
 	} else {
 		fatalIf(newConfig(), "Unable to initialize minio config for the first time.")
-		log.Println("Created minio configuration file successfully at " + getConfigDir())
+		LogInfoMessage("Created minio configuration file successfully at " + getConfigDir())
 	}
 }
 

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -26,7 +26,7 @@ import (
 )
 
 // DO NOT EDIT following message template, please open a github issue to discuss instead.
-var configMigrateMSGTemplate = "Configuration file %s migrated from version '%s' to '%s' successfully.\n"
+var configMigrateMSGTemplate = "Configuration file %s migrated from version '%s' to '%s' successfully."
 
 // Migrates all config versions from "1" to "18".
 func migrateConfig() error {
@@ -185,7 +185,7 @@ func purgeV1() error {
 	}
 
 	os.RemoveAll(configFile)
-	log.Println("Removed unsupported config version ‘1’.")
+	LogInfoMessage("Removed unsupported config version ‘1’.")
 	return nil
 }
 
@@ -243,7 +243,7 @@ func migrateV2ToV3() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv2.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv2.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv2.Version, srvConfig.Version)
 	return nil
 }
 
@@ -281,7 +281,7 @@ func migrateV3ToV4() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv3.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv3.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv3.Version, srvConfig.Version)
 	return nil
 }
 
@@ -322,7 +322,7 @@ func migrateV4ToV5() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv4.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv4.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv4.Version, srvConfig.Version)
 	return nil
 }
 
@@ -390,7 +390,7 @@ func migrateV5ToV6() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv5.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv5.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv5.Version, srvConfig.Version)
 	return nil
 }
 
@@ -446,7 +446,7 @@ func migrateV6ToV7() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv6.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv6.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv6.Version, srvConfig.Version)
 	return nil
 }
 
@@ -509,7 +509,7 @@ func migrateV7ToV8() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv7.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv7.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv7.Version, srvConfig.Version)
 	return nil
 }
 
@@ -579,7 +579,7 @@ func migrateV8ToV9() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv8.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv8.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv8.Version, srvConfig.Version)
 	return nil
 }
 
@@ -647,7 +647,7 @@ func migrateV9ToV10() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv9.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv9.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv9.Version, srvConfig.Version)
 	return nil
 }
 
@@ -718,7 +718,7 @@ func migrateV10ToV11() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv10.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv10.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv10.Version, srvConfig.Version)
 	return nil
 }
 
@@ -807,7 +807,7 @@ func migrateV11ToV12() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv11.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv11.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv11.Version, srvConfig.Version)
 	return nil
 }
 
@@ -887,7 +887,7 @@ func migrateV12ToV13() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv12.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv12.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv12.Version, srvConfig.Version)
 	return nil
 }
 
@@ -972,7 +972,7 @@ func migrateV13ToV14() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv13.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv13.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv13.Version, srvConfig.Version)
 	return nil
 }
 
@@ -1061,7 +1061,7 @@ func migrateV14ToV15() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv14.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv14.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv14.Version, srvConfig.Version)
 	return nil
 }
 
@@ -1151,7 +1151,7 @@ func migrateV15ToV16() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv15.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv15.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv15.Version, srvConfig.Version)
 	return nil
 }
 
@@ -1272,7 +1272,7 @@ func migrateV16ToV17() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv16.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv16.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv16.Version, srvConfig.Version)
 	return nil
 }
 
@@ -1376,7 +1376,7 @@ func migrateV17ToV18() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv17.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv17.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv17.Version, srvConfig.Version)
 	return nil
 }
 
@@ -1482,7 +1482,7 @@ func migrateV18ToV19() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv18.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv18.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv18.Version, srvConfig.Version)
 	return nil
 }
 
@@ -1590,7 +1590,7 @@ func migrateV19ToV20() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv19.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv19.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv19.Version, srvConfig.Version)
 	return nil
 }
 
@@ -1697,7 +1697,7 @@ func migrateV20ToV21() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv20.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv20.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv20.Version, srvConfig.Version)
 	return nil
 }
 
@@ -1804,6 +1804,6 @@ func migrateV21ToV22() error {
 		return fmt.Errorf("Failed to migrate config from ‘%s’ to ‘%s’. %v", cv21.Version, srvConfig.Version, err)
 	}
 
-	log.Printf(configMigrateMSGTemplate, configFile, cv21.Version, srvConfig.Version)
+	LogInfoMessage(configMigrateMSGTemplate, configFile, cv21.Version, srvConfig.Version)
 	return nil
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -223,7 +223,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 
 		// Print a warning message if gateway is not ready for production before the startup banner.
 		if !gw.Production() {
-			log.Println(colorYellow("\n               *** Warning: Not Ready for Production ***"))
+			LogStartupMessage(colorYellow("\n               *** Warning: Not Ready for Production ***"))
 		}
 
 		// Print gateway startup message.

--- a/cmd/gateway-startup-msg.go
+++ b/cmd/gateway-startup-msg.go
@@ -49,12 +49,12 @@ func printGatewayCommonMsg(apiEndpoints []string) {
 
 	apiEndpointStr := strings.Join(apiEndpoints, "  ")
 	// Colorize the message and print.
-	log.Println(colorBlue("\nEndpoint: ") + colorBold(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 1), apiEndpointStr)))
-	log.Println(colorBlue("AccessKey: ") + colorBold(fmt.Sprintf("%s ", cred.AccessKey)))
-	log.Println(colorBlue("SecretKey: ") + colorBold(fmt.Sprintf("%s ", cred.SecretKey)))
+	LogStartupMessage(colorBlue("\nEndpoint: ") + colorBold(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 1), apiEndpointStr)))
+	LogStartupMessage(colorBlue("AccessKey: ") + colorBold(fmt.Sprintf("%s ", cred.AccessKey)))
+	LogStartupMessage(colorBlue("SecretKey: ") + colorBold(fmt.Sprintf("%s ", cred.SecretKey)))
 
 	if globalIsBrowserEnabled {
-		log.Println(colorBlue("\nBrowser Access:"))
-		log.Println(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 3), apiEndpointStr))
+		LogStartupMessage(colorBlue("\nBrowser Access:"))
+		LogStartupMessage(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 3), apiEndpointStr))
 	}
 }

--- a/cmd/gateway/sia/gateway-sia.go
+++ b/cmd/gateway/sia/gateway-sia.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -150,9 +149,9 @@ func (g *Sia) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error)
 	colorBlue := color.New(color.FgBlue).SprintfFunc()
 	colorBold := color.New(color.Bold).SprintFunc()
 
-	log.Println(colorBlue("\nSia Gateway Configuration:"))
-	log.Println(colorBlue("  Sia Daemon API Address:") + colorBold(fmt.Sprintf(" %s\n", sia.Address)))
-	log.Println(colorBlue("  Sia Temp Directory:") + colorBold(fmt.Sprintf(" %s\n", sia.TempDir)))
+	minio.LogStartupMessage(colorBlue("\nSia Gateway Configuration:"))
+	minio.LogStartupMessage(colorBlue("  Sia Daemon API Address:") + colorBold(fmt.Sprintf(" %s\n", sia.Address)))
+	minio.LogStartupMessage(colorBlue("  Sia Temp Directory:") + colorBold(fmt.Sprintf(" %s\n", sia.TempDir)))
 	return sia, nil
 }
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/errors"
 )
 
@@ -113,7 +112,7 @@ func waitForFormatXL(firstDisk bool, endpoints EndpointList, setCount, disksPerS
 
 			if shouldInitXLDisks(sErrs) {
 				if !firstDisk {
-					console.Println("Waiting for the first server to format the disks.")
+					LogInfoMessage("Waiting for the first server to format the disks.")
 					continue
 				}
 				return initFormatXL(endpoints, setCount, disksPerSet)
@@ -137,7 +136,7 @@ func waitForFormatXL(firstDisk bool, endpoints EndpointList, setCount, disksPerS
 				}
 				return format, nil
 			}
-			console.Printf("Waiting for a minimum of %d disks to come online (elapsed %s)\n", len(endpoints)/2, getElapsedTime())
+			LogInfoMessage("Waiting for a minimum of %d disks to come online (elapsed %s)", len(endpoints)/2, getElapsedTime())
 		case <-globalOSSignalCh:
 			return nil, fmt.Errorf("Initializing data volumes gracefully stopped")
 		}

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -109,17 +109,17 @@ func printServerCommonMsg(apiEndpoints []string) {
 	apiEndpointStr := strings.Join(apiEndpoints, "  ")
 
 	// Colorize the message and print.
-	log.Println(colorBlue("Endpoint: ") + colorBold(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 1), apiEndpointStr)))
-	log.Println(colorBlue("AccessKey: ") + colorBold(fmt.Sprintf("%s ", cred.AccessKey)))
-	log.Println(colorBlue("SecretKey: ") + colorBold(fmt.Sprintf("%s ", cred.SecretKey)))
+	LogStartupMessage(colorBlue("Endpoint: ") + colorBold(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 1), apiEndpointStr)))
+	LogStartupMessage(colorBlue("AccessKey: ") + colorBold(fmt.Sprintf("%s ", cred.AccessKey)))
+	LogStartupMessage(colorBlue("SecretKey: ") + colorBold(fmt.Sprintf("%s ", cred.SecretKey)))
 	if region != "" {
-		log.Println(colorBlue("Region: ") + colorBold(fmt.Sprintf(getFormatStr(len(region), 3), region)))
+		LogStartupMessage(colorBlue("Region: ") + colorBold(fmt.Sprintf(getFormatStr(len(region), 3), region)))
 	}
 	printEventNotifiers()
 
 	if globalIsBrowserEnabled {
-		log.Println(colorBlue("\nBrowser Access:"))
-		log.Println(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 3), apiEndpointStr))
+		LogStartupMessage(colorBlue("\nBrowser Access:"))
+		LogStartupMessage(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 3), apiEndpointStr))
 	}
 }
 
@@ -138,7 +138,7 @@ func printEventNotifiers() {
 	for queueArn := range externalTargets {
 		arnMsg += colorBold(fmt.Sprintf(getFormatStr(len(queueArn), 1), queueArn))
 	}
-	log.Println(arnMsg)
+	LogStartupMessage(arnMsg)
 }
 
 // Prints startup message for command line access. Prints link to our documentation
@@ -148,24 +148,24 @@ func printCLIAccessMsg(endPoint string, alias string) {
 	cred := globalServerConfig.GetCredential()
 
 	// Configure 'mc', following block prints platform specific information for minio client.
-	log.Println(colorBlue("\nCommand-line Access: ") + mcQuickStartGuide)
+	LogStartupMessage(colorBlue("\nCommand-line Access: ") + mcQuickStartGuide)
 	if runtime.GOOS == globalWindowsOSName {
 		mcMessage := fmt.Sprintf("$ mc.exe config host add %s %s %s %s", alias, endPoint, cred.AccessKey, cred.SecretKey)
-		log.Println(fmt.Sprintf(getFormatStr(len(mcMessage), 3), mcMessage))
+		LogStartupMessage(fmt.Sprintf(getFormatStr(len(mcMessage), 3), mcMessage))
 	} else {
 		mcMessage := fmt.Sprintf("$ mc config host add %s %s %s %s", alias, endPoint, cred.AccessKey, cred.SecretKey)
-		log.Println(fmt.Sprintf(getFormatStr(len(mcMessage), 3), mcMessage))
+		LogStartupMessage(fmt.Sprintf(getFormatStr(len(mcMessage), 3), mcMessage))
 	}
 }
 
 // Prints startup message for Object API acces, prints link to our SDK documentation.
 func printObjectAPIMsg() {
-	log.Println(colorBlue("\nObject API (Amazon S3 compatible):"))
-	log.Println(colorBlue("   Go: ") + fmt.Sprintf(getFormatStr(len(goQuickStartGuide), 8), goQuickStartGuide))
-	log.Println(colorBlue("   Java: ") + fmt.Sprintf(getFormatStr(len(javaQuickStartGuide), 6), javaQuickStartGuide))
-	log.Println(colorBlue("   Python: ") + fmt.Sprintf(getFormatStr(len(pyQuickStartGuide), 4), pyQuickStartGuide))
-	log.Println(colorBlue("   JavaScript: ") + jsQuickStartGuide)
-	log.Println(colorBlue("   .NET: ") + fmt.Sprintf(getFormatStr(len(dotnetQuickStartGuide), 6), dotnetQuickStartGuide))
+	LogStartupMessage(colorBlue("\nObject API (Amazon S3 compatible):"))
+	LogStartupMessage(colorBlue("   Go: ") + fmt.Sprintf(getFormatStr(len(goQuickStartGuide), 8), goQuickStartGuide))
+	LogStartupMessage(colorBlue("   Java: ") + fmt.Sprintf(getFormatStr(len(javaQuickStartGuide), 6), javaQuickStartGuide))
+	LogStartupMessage(colorBlue("   Python: ") + fmt.Sprintf(getFormatStr(len(pyQuickStartGuide), 4), pyQuickStartGuide))
+	LogStartupMessage(colorBlue("   JavaScript: ") + jsQuickStartGuide)
+	LogStartupMessage(colorBlue("   .NET: ") + fmt.Sprintf(getFormatStr(len(dotnetQuickStartGuide), 6), dotnetQuickStartGuide))
 }
 
 // Get formatted disk/storage info message.
@@ -182,8 +182,8 @@ func getStorageInfoMsg(storageInfo StorageInfo) string {
 
 // Prints startup message of storage capacity and erasure information.
 func printStorageInfo(storageInfo StorageInfo) {
-	log.Println(getStorageInfoMsg(storageInfo))
-	log.Println()
+	LogStartupMessage(getStorageInfoMsg(storageInfo))
+	LogStartupMessage("\n")
 }
 
 // Prints certificate expiry date warning
@@ -206,5 +206,5 @@ func getCertificateChainMsg(certs []*x509.Certificate) string {
 
 // Prints the certificate expiry message.
 func printCertificateMsg(certs []*x509.Certificate) {
-	log.Println(getCertificateChainMsg(certs))
+	LogStartupMessage(getCertificateChainMsg(certs))
 }

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -62,14 +62,14 @@ func handleSignals() {
 			exit(err == nil && oerr == nil)
 		case osSignal := <-globalOSSignalCh:
 			stopHTTPTrace()
-			log.Printf("Exiting on signal %v\n", osSignal)
+			LogInfoMessage("Exiting on signal %v", osSignal)
 			exit(stopProcess())
 		case signal := <-globalServiceSignalCh:
 			switch signal {
 			case serviceStatus:
 				// Ignore this at the moment.
 			case serviceRestart:
-				log.Println("Restarting on service signal")
+				LogInfoMessage("Restarting on service signal")
 				err := globalHTTPServer.Shutdown()
 				errorIf(err, "Unable to shutdown http server")
 				stopHTTPTrace()
@@ -78,7 +78,7 @@ func handleSignals() {
 
 				exit(err == nil && rerr == nil)
 			case serviceStop:
-				log.Println("Stopping on service signal")
+				LogInfoMessage("Stopping on service signal")
 				stopHTTPTrace()
 				exit(stopProcess())
 			}

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -491,27 +491,27 @@ func mainUpdate(ctx *cli.Context) {
 	minioMode := ""
 	updateMsg, sha256Hex, _, latestReleaseTime, err := getUpdateInfo(10*time.Second, minioMode)
 	if err != nil {
-		log.Println(err)
+		LogInfoMessage(err.Error())
 		os.Exit(-1)
 	}
 
 	// Nothing to update running the latest release.
 	if updateMsg == "" {
-		log.Println(greenColorSprintf("You are already running the most recent version of ‘minio’."))
+		LogInfoMessage(greenColorSprintf("You are already running the most recent version of ‘minio’."))
 		os.Exit(0)
 	}
 
-	log.Println(updateMsg)
+	LogInfoMessage(updateMsg)
 	// if the in-place update is disabled then we shouldn't ask the
 	// user to update the binaries.
 	if strings.Contains(updateMsg, minioReleaseURL) && !globalInplaceUpdateDisabled {
 		var successMsg string
 		successMsg, err = doUpdate(sha256Hex, latestReleaseTime, shouldUpdate(quiet, sha256Hex, latestReleaseTime))
 		if err != nil {
-			log.Println(err)
+			LogInfoMessage(err.Error())
 			os.Exit(-1)
 		}
-		log.Println(successMsg)
+		LogInfoMessage(successMsg)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Description
Change fatalIf implementation in logger.go. Do not log trace, as all
of the fatalIf calls are made during startup.

Use new functions to and a common logging framework to make sure that
startup and update messages get logged in both console and json mode.

## Motivation and Context
These changes are part of error logging pod.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.