### PR TITLE
Cleanup orchestration documents

### DIFF
--- a/docs/orchestration/docker-compose/docker-compose.yaml
+++ b/docs/orchestration/docker-compose/docker-compose.yaml
@@ -5,7 +5,7 @@ version: '2'
 # 9001 through 9004.
 services:
  minio1:
-  image: minio/minio
+  image: minio/minio:RELEASE.2018-02-09T22-40-05Z
   volumes:
    - data1:/data
   ports:
@@ -15,7 +15,7 @@ services:
    MINIO_SECRET_KEY: minio123
   command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data 
  minio2:
-  image: minio/minio
+  image: minio/minio:RELEASE.2018-02-09T22-40-05Z
   volumes:
    - data2:/data
   ports:
@@ -25,7 +25,7 @@ services:
    MINIO_SECRET_KEY: minio123
   command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data 
  minio3:
-  image: minio/minio
+  image: minio/minio:RELEASE.2018-02-09T22-40-05Z
   volumes:
    - data3:/data
   ports:
@@ -35,7 +35,7 @@ services:
    MINIO_SECRET_KEY: minio123
   command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data 
  minio4:
-  image: minio/minio
+  image: minio/minio:RELEASE.2018-02-09T22-40-05Z
   volumes:
    - data4:/data
   ports:

--- a/docs/orchestration/kubernetes-yaml/README.md
+++ b/docs/orchestration/kubernetes-yaml/README.md
@@ -135,7 +135,6 @@ spec:
           value: "minio123"
         ports:
         - containerPort: 9000
-          hostPort: 9000
 ```
 
 Create the Deployment
@@ -294,7 +293,6 @@ spec:
         - http://minio-3.minio.default.svc.cluster.local/data
         ports:
         - containerPort: 9000
-          hostPort: 9000
         # These volume mounts are persistent. Each pod in the PetSet
         # gets a volume mounted based on this field.
         volumeMounts:
@@ -475,7 +473,6 @@ spec:
           value: "/etc/credentials/application_default_credentials.json"
         ports:
         - containerPort: 9000
-          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
         - name: gcs-credentials

--- a/docs/orchestration/kubernetes-yaml/minio-distributed-statefulset.yaml
+++ b/docs/orchestration/kubernetes-yaml/minio-distributed-statefulset.yaml
@@ -30,7 +30,6 @@ spec:
         - http://minio-3.minio.default.svc.cluster.local/data
         ports:
         - containerPort: 9000
-          hostPort: 9000
         # These volume mounts are persistent. Each pod in the PetSet
         # gets a volume mounted based on this field.
         volumeMounts:

--- a/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-deployment.yaml
+++ b/docs/orchestration/kubernetes-yaml/minio-gcs-gateway-deployment.yaml
@@ -37,7 +37,6 @@ spec:
           value: "/etc/credentials/application_default_credentials.json"
         ports:
         - containerPort: 9000
-          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
         - name: gcs-credentials

--- a/docs/orchestration/kubernetes-yaml/minio-standalone-deployment.yaml
+++ b/docs/orchestration/kubernetes-yaml/minio-standalone-deployment.yaml
@@ -41,4 +41,3 @@ spec:
           value: "minio123"
         ports:
         - containerPort: 9000
-          hostPort: 9000

--- a/docs/zh_CN/orchestration/kubernetes-yaml/README.md
+++ b/docs/zh_CN/orchestration/kubernetes-yaml/README.md
@@ -127,7 +127,6 @@ spec:
           value: "minio123"
         ports:
         - containerPort: 9000
-          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
         - name: data # must match the volume name, above
@@ -287,7 +286,6 @@ spec:
         - http://minio-3.minio.default.svc.cluster.local/data
         ports:
         - containerPort: 9000
-          hostPort: 9000
         # These volume mounts are persistent. Each pod in the PetSet
         # gets a volume mounted based on this field.
         volumeMounts:
@@ -470,7 +468,6 @@ spec:
           value: "/etc/credentials/application_default_credentials.json"
         ports:
         - containerPort: 9000
-          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
         - name: gcs-credentials


### PR DESCRIPTION
## Description

- Remove hostPort from Kubernetes deployment example docs. Initially
hostPort was added to ensure Minio pods are allocated to separate
machines, but as per latest Kubernetes documents this is not
recommended approach (ref: https://kubernetes.io/docs/concepts/
configuration/overview/#services). To define pod allocations,
Affinity and Anti-Affinity concepts are the recommended approach.
(ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node)

- Add Minio release tag to Docker-Compose example file.

## Motivation and Context
Doc cleanup

## How Has This Been Tested?
Locally on Minikube

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.