### PR TITLE
Do not check for GOPATH env for builds

### DIFF
--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -128,12 +128,6 @@ assert_check_golang_env() {
         echo "Go runtime version '${installed_go_version}' is unsupported. Minimum supported version: ${GO_VERSION} to compile."
         exit 1
     fi
-
-    if [ -z "${GOPATH}" ]; then
-        echo "GOPATH environment variable missing, please refer to Go installation document at https://docs.minio.io/docs/how-to-install-golang"
-        exit 1
-    fi
-
 }
 
 assert_check_deps() {

--- a/buildscripts/checkgopath.sh
+++ b/buildscripts/checkgopath.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Minio Cloud Storage, (C) 2015, 2016 Minio, Inc.
+# Minio Cloud Storage, (C) 2015-2018 Minio, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 #
 
 main() {
-    IFS=':' read -r -a paths <<< "$GOPATH"
+    gopath=$(go env GOPATH)
+    IFS=':' read -r -a paths <<< "$gopath"
     for path in "${paths[@]}"; do
         minio_path="$path/src/github.com/minio/minio"
         if [ -d "$minio_path" ]; then
@@ -27,7 +28,7 @@ main() {
     done
 
     echo "ERROR"
-    echo "Project not found in ${GOPATH}."
+    echo "Project not found in ${gopath}."
     echo "Follow instructions at https://github.com/minio/minio/blob/master/CONTRIBUTING.md#setup-your-minio-github-repository"
     exit 1
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Do not check for GOPATH env for builds
<!--- Describe your changes in detail -->

## Motivation and Context
Since go1.8 GOPATH is not required to set prior, as
it defaults to "${HOME}/go" we only need to check if
go tool detected GOPATH correctly. If yes then we
proceed if not we fail.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.