### PR TITLE
Swap max_hw_sectors_kb for max_sectors_kb. Fixes #5633.

### DIFF
--- a/docs/deployment/kernel-tuning/disk-tuning.sh
+++ b/docs/deployment/kernel-tuning/disk-tuning.sh
@@ -14,6 +14,8 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
+# This script changes protected files, and must be run as root
+
 for i in $(ls -d /sys/block/*/queue/iosched 2>/dev/null); do
     iosched_dir=$(echo $i | awk '/iosched/ {print $1}')
     [ -z $iosched_dir ] && {

--- a/docs/deployment/kernel-tuning/disk-tuning.sh
+++ b/docs/deployment/kernel-tuning/disk-tuning.sh
@@ -42,7 +42,7 @@ for i in $(ls -d /sys/block/*/queue/iosched 2>/dev/null); do
     ## This is the maximum number of kilobytes
     ## supported in a single data transfer at
     ## block layer.
-    [ -f $path/max_hw_sectors_kb ] && {
-        echo "1024" > $path/max_hw_sectors_kb
+    [ -f $path/max_sectors_kb ] && {
+        echo "1024" > $path/max_sectors_kb || true
     }
 done


### PR DESCRIPTION
## Description
To fix #5633, the value of `max_sectors_kb` needs to be tuned, as opposed to `max_hw_sectors_kb`. Per feedback from @kannappanr, I have also added graceful handling of failure to tune this value. I'm keen to discuss any other changes or approaches that people would prefer to take.

## Motivation and Context
#5633 

## How Has This Been Tested?
This change was tested on a CentOS 7.4 test setup I have. The script was copied to the server and run manually before observing that the value had been changed as expected, and that the error was not occurring.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

No Go code has been modified, therefore the tests have not been run.
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.