### PR TITLE
Updated healthcheck file

### DIFF
--- a/dockerscripts/healthcheck.sh
+++ b/dockerscripts/healthcheck.sh
@@ -34,7 +34,7 @@ healthcheck_main () {
         exit 0
     else
         # Get the http response code
-        http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" ${scheme}${address}${resource})
+        http_response=$(curl -s -k -o /dev/null -w "%{http_code}" ${scheme}${address}${resource})
 
         # Get the http response body
         http_response_body=$(curl -k -s ${scheme}${address}${resource})
@@ -45,7 +45,7 @@ healthcheck_main () {
         if [ "$http_response" = "403" ] && \
         [ "$http_response_body" = "SSL required" ]; then
             scheme="https://"
-            http_response=$(curl -s -k -o /dev/null -I -w "%{http_code}" ${scheme}${address}${resource})
+            http_response=$(curl -s -k -o /dev/null -w "%{http_code}" ${scheme}${address}${resource})
         fi
 
         # If http_repsonse is 200 - server is up.


### PR DESCRIPTION
Healthcheck is no longer checking for a file so the -I in the curl check will fail.

## Description
PR #5543 added support for dedicated healthcheck endpoints and the URL was updated in the healthcheck script but utilizing the -I flag in curl when not downloading a file results in a 403 error. This causes the health checks reported to docker to fail. Removing the -I flag resolves this issue.

## Motivation and Context
In the current version the healthcheck for the container will fail.

## How Has This Been Tested?
Inside of the docker container I ran the following curl command to demonstrate the previous behaviour

```
/ # curl -s -o /dev/null -I -w %{http_code} http://127.0.0.1:9000/minio/health/live
403
```

Then I performed the same command removing the -I giving the expected behaviour

```
/ # curl -s -o /dev/null -w %{http_code} http://127.0.0.1:9000/minio/health/live
200
```

Prior to making the change the health status from a docker ps was 'unhealthy'
After updating the script the status was correctly changed to healthy.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.