### PR TITLE
Update healthcheck related examples and add head support

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -200,7 +200,7 @@ func guessIsHealthCheckReq(req *http.Request) bool {
 		return false
 	}
 	aType := getRequestAuthType(req)
-	return req.Method == http.MethodGet && aType == authTypeAnonymous &&
+	return aType == authTypeAnonymous && (req.Method == http.MethodGet || req.Method == http.MethodHead) &&
 		(req.URL.Path == healthCheckPathPrefix+healthCheckLivenessPath ||
 			req.URL.Path == healthCheckPathPrefix+healthCheckReadinessPath)
 }

--- a/cmd/healthcheck-router.go
+++ b/cmd/healthcheck-router.go
@@ -37,7 +37,9 @@ func registerHealthCheckRouter(mux *router.Router) {
 
 	// Liveness handler
 	healthRouter.Methods(http.MethodGet).Path(healthCheckLivenessPath).HandlerFunc(LivenessCheckHandler)
+	healthRouter.Methods(http.MethodHead).Path(healthCheckLivenessPath).HandlerFunc(LivenessCheckHandler)
 
 	// Readiness handler
 	healthRouter.Methods(http.MethodGet).Path(healthCheckReadinessPath).HandlerFunc(ReadinessCheckHandler)
+	healthRouter.Methods(http.MethodHead).Path(healthCheckReadinessPath).HandlerFunc(ReadinessCheckHandler)
 }

--- a/docs/healthcheck/README.md
+++ b/docs/healthcheck/README.md
@@ -3,37 +3,21 @@
 Minio server exposes two un-authenticated, healthcheck endpoints - liveness probe and readiness probe at `/minio/health/live` and `/minio/health/ready` respectively.
 
 ### Liveness probe
+
 This probe is used to identify situations where the server is running but may not behave optimally, i.e. sluggish response or corrupt backend. Such problems can be *only* fixed by a restart.
 
 Internally, Minio liveness probe handler does a ListBuckets call. If successful, the server returns 200 OK, otherwise 503 Service Unavailable.
 
-When liveness probe fails, Kubernetes like platforms restart the container.
-
-Sample configuration in a Kubernetes `yaml` file.
-
-```yaml
-livenessProbe:
-  httpGet:
-    path: /minio/health/live
-    port: 9000
-  initialDelaySeconds: 10
-  periodSeconds: 20
-```
+When liveness probe fails, Kubernetes like platforms restart the container. 
 
 ### Readiness probe
+
 This probe is used to identify situations where the server is not ready to accept requests yet. In most cases, such conditions recover in some time.
 
 Internally, Minio readiness probe handler checks for total go-routines. If the number of go-routines is less than 1000 (threshold), the server returns 200 OK, otherwise 503 Service Unavailable.
 
-Platforms like Kubernetes *do not* forward traffic to a pod until its readiness probe is successful.
+Platforms like Kubernetes *do not* forward traffic to a pod until its readiness probe is successful. 
 
-Sample configuration in a Kubernetes `yaml` file.
+### Configuration example
 
-```yaml
-livenessProbe:
-  httpGet:
-    path: /minio/health/ready
-    port: 9000
-  initialDelaySeconds: 10
-  periodSeconds: 20
-```
+Sample `liveness` and `readiness` probe configuration in a Kubernetes `yaml` file can be found [here](https://github.com/minio/minio/blob/master/docs/orchestration/kubernetes-yaml/minio-standalone-deployment.yaml).

--- a/docs/orchestration/kubernetes-yaml/README.md
+++ b/docs/orchestration/kubernetes-yaml/README.md
@@ -135,6 +135,24 @@ spec:
           value: "minio123"
         ports:
         - containerPort: 9000
+        # Readiness probe detects situations when Minio server instance
+        # is not ready to accept traffic. Kubernetes doesn't forward
+        # traffic to the pod till readiness checks fail.
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+        # Liveness probe detects situations where Minio server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
 ```
 
 Create the Deployment
@@ -298,6 +316,15 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+        # Liveness probe detects situations where Minio server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
   # These are converted to volume claims by the controller
   # and mounted at the paths mentioned above.
   volumeClaimTemplates:

--- a/docs/orchestration/kubernetes-yaml/minio-distributed-statefulset.yaml
+++ b/docs/orchestration/kubernetes-yaml/minio-distributed-statefulset.yaml
@@ -35,6 +35,15 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+        # Liveness probe detects situations where Minio server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
   # These are converted to volume claims by the controller
   # and mounted at the paths mentioned above.
   volumeClaimTemplates:

--- a/docs/orchestration/kubernetes-yaml/minio-standalone-deployment.yaml
+++ b/docs/orchestration/kubernetes-yaml/minio-standalone-deployment.yaml
@@ -41,3 +41,21 @@ spec:
           value: "minio123"
         ports:
         - containerPort: 9000
+        # Readiness probe detects situations when Minio server instance
+        # is not ready to accept traffic. Kubernetes doesn't forward
+        # traffic to the pod while readiness checks fail.
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+        # Liveness probe detects situations where Minio server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20


### PR DESCRIPTION
## Description
- Add head method for healthcheck endpoint. Some platforms/users
may use the HTTP Head method to check for health status.

- Add liveness and readiness probe examples in Kubernetes yaml
example docs. Note that readiness probe not added to StatefulSet
example due to https://github.com/kubernetes/kubernetes/issues/27114

## Motivation and Context
Based on discussion after healthcheck support addition

## How Has This Been Tested?
Manually on Kubernetes (minikube deployment)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.