### PR TITLE
Return InvalidDigest when md5 sent by the client is invalid

### DIFF
--- a/cmd/hasher.go
+++ b/cmd/hasher.go
@@ -24,11 +24,16 @@ import (
 	"github.com/minio/sha256-simd"
 )
 
-// getSHA256Hash returns SHA-256 hash of given data.
+// getSHA256Hash returns SHA-256 hash in hex encoding of given data.
 func getSHA256Hash(data []byte) string {
+	return hex.EncodeToString(getSHA256Sum(data))
+}
+
+// getSHA256Hash returns SHA-256 sum of given data.
+func getSHA256Sum(data []byte) []byte {
 	hash := sha256.New()
 	hash.Write(data)
-	return hex.EncodeToString(hash.Sum(nil))
+	return hash.Sum(nil)
 }
 
 // getMD5Sum returns MD5 sum of given data.
@@ -38,7 +43,7 @@ func getMD5Sum(data []byte) []byte {
 	return hash.Sum(nil)
 }
 
-// getMD5Hash returns MD5 hash of given data.
+// getMD5Hash returns MD5 hash in hex encoding of given data.
 func getMD5Hash(data []byte) string {
 	return hex.EncodeToString(getMD5Sum(data))
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -98,8 +98,15 @@ func xmlDecoder(body io.Reader, v interface{}, size int64) error {
 }
 
 // checkValidMD5 - verify if valid md5, returns md5 in bytes.
-func checkValidMD5(md5 string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(strings.TrimSpace(md5))
+func checkValidMD5(h http.Header) ([]byte, error) {
+	md5B64, ok := h["Content-Md5"]
+	if ok {
+		if md5B64[0] == "" {
+			return nil, fmt.Errorf("Content-Md5 header set to empty value")
+		}
+		return base64.StdEncoding.DecodeString(md5B64[0])
+	}
+	return []byte{}, nil
 }
 
 /// http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Return InvalidDigest when md5 sent by the client is invalid
<!--- Describe your changes in detail -->

## Motivation and Context
This is to ensure proper compatibility with AWS S3, handle
special cases where

- Content-Md5 is set to empty
- Content-Md5 is set to invalid
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using `ceph` s3-tests. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.