### PR TITLE
[refactor] simplify en/decrypted size computation

### DIFF
--- a/vendor/github.com/minio/sio/writer-v1.go
+++ b/vendor/github.com/minio/sio/writer-v1.go
@@ -192,7 +192,7 @@ func flush(w io.Writer, p []byte) error {
 	if err != nil {
 		return err
 	}
-	if n != len(p) { // not neccasary if the w follows the io.Writer doc *precisly*
+	if n != len(p) { // not neccasary if the w follows the io.Writer doc *precisely*
 		return io.ErrShortWrite
 	}
 	return nil

--- a/vendor/github.com/minio/sio/writer-v2.go
+++ b/vendor/github.com/minio/sio/writer-v2.go
@@ -80,7 +80,7 @@ func (w *encWriterV20) Write(p []byte) (n int, err error) {
 }
 
 func (w *encWriterV20) Close() error {
-	if w.offset > 0 { // true if at least one Write call happend
+	if w.offset > 0 { // true if at least one Write call happened
 		w.SealFinal(w.buffer, w.buffer[headerSize:headerSize+w.offset])
 		if err := flush(w.dst, w.buffer[:headerSize+w.offset+tagSize]); err != nil { // write to underlying io.Writer
 			return err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -451,10 +451,10 @@
 			"revisionTime": "2017-08-28T17:39:33Z"
 		},
 		{
-			"checksumSHA1": "pvBHvHfubwxgvXNz35PDMbBWY9s=",
+			"checksumSHA1": "LLNO4saSnirHPhxJQ6nk2E0VMKs=",
 			"path": "github.com/minio/sio",
-			"revision": "83dd737d26dbcf4847f48ecec77c2c13f739eb25",
-			"revisionTime": "2018-03-01T21:58:29Z"
+			"revision": "b421622190be1ffb4569c7303ed1b7bef201a7c3",
+			"revisionTime": "2018-03-15T10:40:56Z"
 		},
 		{
 			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",


### PR DESCRIPTION
## Description

This commit replaces the en/decrypted size computation
with functions from the `sio` package.

## Motivation and Context
Fixes #5657

## How Has This Been Tested?
unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.