### PR TITLE
Fix format migration regression

### DIFF
--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -147,6 +147,20 @@ func waitForFormatXL(firstDisk bool, endpoints EndpointList, setCount, disksPerS
 				return initFormatXL(endpoints, setCount, disksPerSet)
 			}
 
+			// Following function is added to fix a regressions which was introduced
+			// in release RELEASE.2018-03-16T22-52-12Z after migrating v1 to v2 to v3.
+			// This migration failed to capture '.This' field properly which indicates
+			// the disk UUID association. Below function is called to handle and fix
+			// this regression, for more info refer https://github.com/minio/minio/issues/5667
+			if err = fixFormatXLV3(endpoints, formatConfigs); err != nil {
+				return nil, err
+			}
+
+			// If any of the .This field is still empty we wait them to be fixed.
+			if formatXLV3ThisEmpty(formatConfigs) {
+				continue
+			}
+
 			format, err = getFormatXLInQuorum(formatConfigs)
 			if err == nil {
 				for i := range formatConfigs {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Migration regression got introduced in 9083bc152e798026f348357d68623444b098d174
adding more unit tests to catch this scenario, we need to fix this by
re-writing the formats after the migration to 'V3'.

This bug only happens when a user is migrating directly from V1 to V3,
not from V1 to V2 and V2 to V3.

Added additional unit tests to cover these situations as well.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #5667

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually and unit tested.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.