### PR TITLE
Fix regression in removing notification

### DIFF
--- a/pkg/event/config.go
+++ b/pkg/event/config.go
@@ -219,14 +219,13 @@ func (conf *Config) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return err
 	}
 
-	if len(parsedConfig.QueueList) == 0 {
-		return errors.New("missing queue configuration(s)")
-	}
-
-	for i, q1 := range parsedConfig.QueueList[:len(parsedConfig.QueueList)-1] {
-		for _, q2 := range parsedConfig.QueueList[i+1:] {
-			if reflect.DeepEqual(q1, q2) {
-				return &ErrDuplicateQueueConfiguration{q1}
+	// Empty queue list means user wants to delete the notification configuration.
+	if len(parsedConfig.QueueList) > 0 {
+		for i, q1 := range parsedConfig.QueueList[:len(parsedConfig.QueueList)-1] {
+			for _, q2 := range parsedConfig.QueueList[i+1:] {
+				if reflect.DeepEqual(q1, q2) {
+					return &ErrDuplicateQueueConfiguration{q1}
+				}
 			}
 		}
 	}
@@ -276,10 +275,6 @@ func ParseConfig(reader io.Reader, region string, targetList *TargetList) (*Conf
 	var config Config
 	if err := xml.NewDecoder(reader).Decode(&config); err != nil {
 		return nil, err
-	}
-
-	if len(config.QueueList) == 0 {
-		return nil, errors.New("missing queue configuration(s)")
 	}
 
 	if err := config.Validate(region, targetList); err != nil {

--- a/pkg/event/config_test.go
+++ b/pkg/event/config_test.go
@@ -494,6 +494,9 @@ func TestConfigUnmarshalXML(t *testing.T) {
   </TopicConfiguration>
 </NotificationConfiguration>
 `)
+
+	dataCase5 := []byte(`<NotificationConfiguration></NotificationConfiguration>`)
+
 	testCases := []struct {
 		data      []byte
 		expectErr bool
@@ -502,6 +505,8 @@ func TestConfigUnmarshalXML(t *testing.T) {
 		{dataCase2, false},
 		{dataCase3, false},
 		{dataCase4, true},
+		// make sure we don't fail when queue is empty.
+		{dataCase5, false},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix regression in removing notification
<!--- Describe your changes in detail -->

## Motivation and Context
fixes a regression introduced in 0e4431725cd85236d3d18643f8fc2506c7d88c66
when removing a previously applied notification configuration.

event.ParseConfig() was stricter in terms of handling notification
configuration, we need to allow when notification configuration is
sent empty, this is the way to remove notification configuration.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using `go test` and `mc`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.