### PR TITLE
fix ListObjectV2 inconsistent behavior

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -913,12 +913,10 @@ func (fs *FSObjects) ListObjects(ctx context.Context, bucket, prefix, marker, de
 		return loi, nil
 	}
 
-	// For delimiter and prefix as '/' we do not list anything at all
-	// since according to s3 spec we stop at the 'delimiter'
-	// along // with the prefix. On a flat namespace with 'prefix'
+	// On a flat namespace with 'prefix'
 	// as '/' we don't have any entries, since all the keys are
 	// of form 'keyName/...'
-	if delimiter == slashSeparator && prefix == slashSeparator {
+	if hasPrefix(prefix, slashSeparator) {
 		return loi, nil
 	}
 

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1553,16 +1553,19 @@ func getBucketLocationURL(endPoint, bucketName string) string {
 }
 
 // return URL for listing objects in the bucket with V1 legacy API.
-func getListObjectsV1URL(endPoint, bucketName string, maxKeys string) string {
+func getListObjectsV1URL(endPoint, bucketName string, maxKeys string, prefix string) string {
 	queryValue := url.Values{}
 	if maxKeys != "" {
 		queryValue.Set("max-keys", maxKeys)
+	}
+	if prefix != "" {
+		queryValue.Set("prefix", prefix)
 	}
 	return makeTestTargetURL(endPoint, bucketName, "", queryValue)
 }
 
 // return URL for listing objects in the bucket with V2 API.
-func getListObjectsV2URL(endPoint, bucketName string, maxKeys string, fetchOwner string) string {
+func getListObjectsV2URL(endPoint, bucketName string, maxKeys string, fetchOwner string, prefix string) string {
 	queryValue := url.Values{}
 	queryValue.Set("list-type", "2") // Enables list objects V2 URL.
 	if maxKeys != "" {
@@ -1570,6 +1573,9 @@ func getListObjectsV2URL(endPoint, bucketName string, maxKeys string, fetchOwner
 	}
 	if fetchOwner != "" {
 		queryValue.Set("fetch-owner", fetchOwner)
+	}
+	if prefix != "" {
+		queryValue.Set("prefix", prefix)
 	}
 	return makeTestTargetURL(endPoint, bucketName, "", queryValue)
 }

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -679,6 +679,10 @@ func (s *xlSets) ListObjects(ctx context.Context, bucket, prefix, marker, delimi
 		return result, err
 	}
 
+	if hasPrefix(prefix, slashSeparator) {
+		return result, nil
+	}
+
 	var objInfos []ObjectInfo
 	var eof bool
 	var nextMarker string

--- a/cmd/xl-v1-list-objects.go
+++ b/cmd/xl-v1-list-objects.go
@@ -69,6 +69,9 @@ func listDirFactory(isLeaf isLeafFunc, treeWalkIgnoredErrs []error, disks ...Sto
 
 // listObjects - wrapper function implemented over file tree walk.
 func (xl xlObjects) listObjects(bucket, prefix, marker, delimiter string, maxKeys int) (loi ListObjectsInfo, e error) {
+	if hasPrefix(prefix, slashSeparator) {
+		return loi, nil
+	}
 	// Default is recursive, if delimiter is set then list non recursive.
 	recursive := true
 	if delimiter == slashSeparator {


### PR DESCRIPTION
For minio, if we send a rest api `/?list-type=2&prefix=/` minio returns
entries with the key name has a "/" prefix. But for s3, they return no
entries.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.