### PR TITLE
Fix New UX related bugs for Alerts, BucketList and Abort Upload modal

### DIFF
--- a/browser/app/js/uploads/AbortConfirmModal.js
+++ b/browser/app/js/uploads/AbortConfirmModal.js
@@ -50,7 +50,7 @@ export class AbortConfirmModal extends React.Component {
         sub="This cannot be undone!"
         okText="Abort"
         okIcon={okIcon}
-        cancelText="Upload"
+        cancelText="Continue"
         cancelIcon={cancelIcon}
         okHandler={this.abortUploads.bind(this)}
         cancelHandler={hideAbort}

--- a/browser/app/less/inc/alert.less
+++ b/browser/app/less/inc/alert.less
@@ -3,13 +3,15 @@
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     color: @white;
     width: 100%;
-    padding: 1.5rem 3rem 1.5rem 2rem;
+    padding: 1.5rem 4rem 1.5rem 2rem;
     z-index: 1000000;
     .animation-duration(800ms);
     .animation-fill-mode(both);
     font-size: @font-size-small;
+    word-wrap: break-word;
 
     &:not(.alert--upload) {
+        text-align: center;
         top: 1.5rem;
         max-width: 500px;
         border-radius: @border-radius-base;
@@ -22,7 +24,7 @@
 
     @media(max-width: (@screen-xs-max)) {
         left: 1.5rem;
-        width: ~"calc(100% - 3rem)";
+        width: ~"calc(100% - 4rem)";
         max-width: 100%;
     }
 

--- a/browser/app/less/inc/sidebar.less
+++ b/browser/app/less/inc/sidebar.less
@@ -88,10 +88,11 @@
 }
 
 .buckets__item {
-    padding: 0.8rem @sidebar-padding 0.8rem @sidebar-padding*2.2;
+    padding: 0.8rem @sidebar-padding*1.2 0.8rem @sidebar-padding*2.2;
     background: url(../../img/icons/bucket.svg) no-repeat left 2.2rem center;
     position: relative;
     cursor: pointer;
+    word-wrap: break-word;
 
     & > a {
         &, &:focus, &:hover {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Center text on Alert component appearing on top
- Change "Upload" to "Continue" on New UX Abort Upload modal
- Fix issue where long bucket names were overflowing instead of
continuing on the next line
- Fix word wrap issue similar to the last one for the alerts that appear
on top
- Help fix the cluttering issue on #5690 as the right margin has been
increased in alerts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #5689, #5691 and #5695

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.