### PR TITLE
Browser: Fix the styling of upload abort button

### DIFF
--- a/browser/app/js/uploads/UploadModal.js
+++ b/browser/app/js/uploads/UploadModal.js
@@ -58,9 +58,7 @@ export class UploadModal extends React.Component {
 
     return (
       <div className="alert alert-info alert--upload animated fadeInUp ">
-        <button type="button" className="close" onClick={showAbortModal}>
-          <span>×</span>
-        </button>
+        <button type="button" className="close close--alt" onClick={showAbortModal}></button>
         <div>{text}</div>
         <ProgressBar now={percent} />
         <div>


### PR DESCRIPTION
## Description
This PR will fix the broken abort button on the upload modal. Issue occurred due to the incorrect HTML code used for close icon. 

After the fix, close icon should look like this:
![close](https://user-images.githubusercontent.com/13393018/37815652-c18111c6-2e95-11e8-9acf-79b88d561e5f.png)

## Motivation and Context
Fixes https://github.com/minio/minio/issues/5690

## How Has This Been Tested?
Tested locally

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.