### PR TITLE
Use paho configuration API instead in MQTT event.

### DIFF
--- a/pkg/event/target/mqtt.go
+++ b/pkg/event/target/mqtt.go
@@ -92,16 +92,15 @@ func (target *MQTTTarget) Close() error {
 
 // NewMQTTTarget - creates new MQTT target.
 func NewMQTTTarget(id string, args MQTTArgs) (*MQTTTarget, error) {
-	options := &mqtt.ClientOptions{
-		ClientID:             args.ClientID,
-		CleanSession:         true,
-		Username:             args.User,
-		Password:             args.Password,
-		MaxReconnectInterval: args.MaxReconnectInterval,
-		KeepAlive:            args.KeepAlive,
-		TLSConfig:            tls.Config{RootCAs: args.RootCAs},
-	}
-	options.AddBroker(args.Broker.String())
+	options := mqtt.NewClientOptions().
+		SetClientID(args.ClientID).
+		SetCleanSession(true).
+		SetUsername(args.User).
+		SetPassword(args.Password).
+		SetMaxReconnectInterval(args.MaxReconnectInterval).
+		SetKeepAlive(args.KeepAlive).
+		SetTLSConfig(&tls.Config{RootCAs: args.RootCAs}).
+		AddBroker(args.Broker.String())
 
 	client := mqtt.NewClient(options)
 	token := client.Connect()


### PR DESCRIPTION

## Description
Use [functions of paho](https://godoc.org/github.com/eclipse/paho.mqtt.golang#ClientOptions) instead of initializing struct directly.

## Motivation and Context
When I'm embedding minio to my test binary, `KeepAlive` field of MQTT client options causes compile error.
MQTT client library's `KeepAlive` field is now `int64` which is incompatible with `time.Duration`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Only checked build.
<!--- Include details of your testing environment, and the tests you ran to -->
CentOS 7
go 1.10
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.