### PR TITLE
Fix PUT bucket notification deadlocks

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -138,14 +138,6 @@ func (api objectAPIHandlers) PutBucketNotificationHandler(w http.ResponseWriter,
 		return
 	}
 
-	// Acquire a write lock on bucket before modifying its configuration.
-	bucketLock := globalNSMutex.NewNSLock(bucketName, "")
-	if err = bucketLock.GetLock(globalOperationTimeout); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-	defer bucketLock.Unlock()
-
 	if err = saveNotificationConfig(objectAPI, bucketName, config); err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -496,14 +496,6 @@ func readConfig(objAPI ObjectLayer, configFile string) (*bytes.Buffer, error) {
 func readNotificationConfig(objAPI ObjectLayer, bucketName string) (*event.Config, error) {
 	// Construct path to notification.xml for the given bucket.
 	configFile := path.Join(bucketConfigPrefix, bucketName, bucketNotificationConfig)
-
-	// Get read lock.
-	objLock := globalNSMutex.NewNSLock(minioMetaBucket, configFile)
-	if err := objLock.GetRLock(globalOperationTimeout); err != nil {
-		return nil, err
-	}
-	defer objLock.RUnlock()
-
 	reader, err := readConfig(objAPI, configFile)
 	if err != nil {
 		return nil, err
@@ -519,14 +511,6 @@ func saveNotificationConfig(objAPI ObjectLayer, bucketName string, config *event
 	}
 
 	configFile := path.Join(bucketConfigPrefix, bucketName, bucketNotificationConfig)
-
-	// Get write lock.
-	objLock := globalNSMutex.NewNSLock(minioMetaBucket, configFile)
-	if err := objLock.GetLock(globalOperationTimeout); err != nil {
-		return err
-	}
-	defer objLock.Unlock()
-
 	return saveConfig(objAPI, configFile, data)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes two different variants of deadlocks in
notification.

<!--- Describe your changes in detail -->

## Motivation and Context
- holding write lock on the bucket competing with read lock
- holding competing locks on read/save notification config
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.