### PR TITLE
Fix help message to be uniform across env vars

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -73,15 +73,15 @@ ENVIRONMENT VARIABLES:
      MINIO_BROWSER: To disable web browser access, set this value to "off".
 
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 
   UPDATE:
      MINIO_UPDATE: To turn off in-place upgrades, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 
 EXAMPLES:
   1. Start minio gateway server for Azure Blob Storage backend.

--- a/cmd/gateway/b2/gateway-b2.go
+++ b/cmd/gateway/b2/gateway-b2.go
@@ -64,15 +64,15 @@ ENVIRONMENT VARIABLES:
      MINIO_BROWSER: To disable web browser access, set this value to "off".
 
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 
   UPDATE:
      MINIO_UPDATE: To turn off in-place upgrades, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 
 EXAMPLES:
   1. Start minio gateway server for B2 backend.

--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -110,15 +110,15 @@ ENVIRONMENT VARIABLES:
      MINIO_BROWSER: To disable web browser access, set this value to "off".
 
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 
   UPDATE:
      MINIO_UPDATE: To turn off in-place upgrades, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 
   GCS credentials file:
      GOOGLE_APPLICATION_CREDENTIALS: Path to credentials.json

--- a/cmd/gateway/manta/gateway-manta.go
+++ b/cmd/gateway/manta/gateway-manta.go
@@ -72,12 +72,12 @@ ENVIRONMENT VARIABLES:
      MINIO_BROWSER: To disable web browser access, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 
 EXAMPLES:
   1. Start minio gateway server for Manta Object Storage backend.

--- a/cmd/gateway/nas/gateway-nas.go
+++ b/cmd/gateway/nas/gateway-nas.go
@@ -51,15 +51,15 @@ ENVIRONMENT VARIABLES:
      MINIO_BROWSER: To disable web browser access, set this value to "off".
 
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 
   UPDATE:
      MINIO_UPDATE: To turn off in-place upgrades, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 
 EXAMPLES:
   1. Start minio gateway server for NAS backend.

--- a/cmd/gateway/oss/gateway-oss.go
+++ b/cmd/gateway/oss/gateway-oss.go
@@ -69,12 +69,12 @@ ENVIRONMENT VARIABLES:
      MINIO_UPDATE: To turn off in-place upgrades, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 	
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 
 EXAMPLES:
   1. Start minio gateway server for Aliyun OSS backend.

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -57,15 +57,15 @@ ENVIRONMENT VARIABLES:
      MINIO_BROWSER: To disable web browser access, set this value to "off".
 
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 
   UPDATE:
      MINIO_UPDATE: To turn off in-place upgrades, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 
 EXAMPLES:
   1. Start minio gateway server for AWS S3 backend.

--- a/cmd/gateway/sia/gateway-sia.go
+++ b/cmd/gateway/sia/gateway-sia.go
@@ -74,15 +74,15 @@ ENVIRONMENT VARIABLES: (Default values in parenthesis)
      MINIO_BROWSER: To disable web browser access, set this value to "off".
 
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 
   UPDATE:
      MINIO_UPDATE: To turn off in-place upgrades, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 
   SIA_TEMP_DIR:        The name of the local Sia temporary storage directory. (.sia_temp)
   SIA_API_PASSWORD:    API password for Sia daemon. (default is empty)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -68,9 +68,9 @@ ENVIRONMENT VARIABLES:
      MINIO_BROWSER: To disable web browser access, set this value to "off".
 
   CACHE:
-     MINIO_CACHE_DRIVES: List of cache drives delimited by ";"
-     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";"
-     MINIO_CACHE_EXPIRY: Cache expiry duration in days
+     MINIO_CACHE_DRIVES: List of cache drives delimited by ";".
+     MINIO_CACHE_EXCLUDE: List of cache exclusion patterns delimited by ";".
+     MINIO_CACHE_EXPIRY: Cache expiry duration in days.
 	
   REGION:
      MINIO_REGION: To set custom region. By default all regions are accepted.
@@ -79,7 +79,7 @@ ENVIRONMENT VARIABLES:
      MINIO_UPDATE: To turn off in-place upgrades, set this value to "off".
 
   DOMAIN:
-     MINIO_DOMAIN: To enable virtual-host-style requests. Set this value to Minio host domain name.
+     MINIO_DOMAIN: To enable virtual-host-style requests, set this value to Minio host domain name.
 
   WORM:
      MINIO_WORM: To turn on Write-Once-Read-Many in server, set this value to "on".


### PR DESCRIPTION
## Description
Update help message, so it is uniform for all environment variables.

## Motivation and Context
Found while code review. Uniform help messages account for better user experience.

## How Has This Been Tested?
`minio server -h`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.