### PR TITLE
Allow underscores in hostnames (fixes #5759)

### DIFF
--- a/pkg/net/host.go
+++ b/pkg/net/host.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-var hostLabelRegexp = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$")
+var hostLabelRegexp = regexp.MustCompile("^[a-zA-Z0-9_]([a-zA-Z0-9-_]*[a-zA-Z0-9_])?$")
 
 // Host - holds network host IP/name and its port.
 type Host struct {

--- a/pkg/net/host_test.go
+++ b/pkg/net/host_test.go
@@ -181,6 +181,7 @@ func TestParseHost(t *testing.T) {
 		{"12play", &Host{"12play", 0, false}, false},
 		{"play-minio-io", &Host{"play-minio-io", 0, false}, false},
 		{"play--minio.io", &Host{"play--minio.io", 0, false}, false},
+		{"play_minio", &Host{"play_minio", 0, false}, false},
 		{":9000", nil, true},
 		{"play:", nil, true},
 		{"play::", nil, true},


### PR DESCRIPTION
Allow underscores in hosts names

## Description
Allow underscores in hostnames

## Motivation and Context
Allow hostnames with underscores to be valid, as generated by Docker Swarm (form "stack_service").
Fixes #5759 

## How Has This Been Tested?
Added test, then `make test` fails.
```make test
[...]
--- FAIL: TestParseHost (0.00s)
	host_test.go:201: test 12: error: expected: false, got: true
FAIL
FAIL	github.com/minio/minio/pkg/net	0.018s
[...]
```

Fixed code. `make test` pass.
```make test
[...]
ok  	github.com/minio/minio/pkg/net	0.005s
[...]
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.