### PR TITLE
[SSE]: refactor SSE-C single part logic

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -601,7 +601,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	}
 
 	if objectAPI.IsEncryptionSupported() {
-		if hasSSECustomerHeader(formValues) && !hasSuffix(object, slashSeparator) { // handle SSE-C requests
+		if ContainsSSECustomerHeader(formValues) && !hasSuffix(object, slashSeparator) { // handle SSE-C requests
 			var reader io.Reader
 			var key []byte
 			key, err = ParseSSECustomerHeaders(formValues)

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -604,7 +604,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		if hasSSECustomerHeader(formValues) && !hasSuffix(object, slashSeparator) { // handle SSE-C requests
 			var reader io.Reader
 			var key []byte
-			key, err = ParseSSECustomerHeader(formValues)
+			key, err = ParseSSECustomerHeaders(formValues)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -601,10 +601,10 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	}
 
 	if objectAPI.IsEncryptionSupported() {
-		if ContainsSSECustomerHeader(formValues) && !hasSuffix(object, slashSeparator) { // handle SSE-C requests
+		if SSECustomerHeaders.Contains(formValues) && !hasSuffix(object, slashSeparator) { // handle SSE-C requests
 			var reader io.Reader
 			var key []byte
-			key, err = ParseSSECustomerHeaders(formValues)
+			key, err = SSECustomerHeaders.Parse(formValues)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return

--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -197,7 +197,7 @@ func (sse sseCustomerHeaders) Contains(header http.Header) bool {
 // Parse parses the SSE-C header fields of the provided HTTP headers.
 // It returns the client provided 256 bit key on success.
 func (sse sseCustomerHeaders) Parse(header http.Header) (key []byte, err error) {
-	defer func() { header.Del(sse.algorithm) }() // Remove SSE-C key from header
+	defer func() { header.Del(sse.key) }() // Remove SSE-C key from header
 
 	if !globalIsSSL { // minio only supports HTTP or HTTPS requests not both at the same time
 		// we cannot use r.TLS == nil here because Go's http implementation reflects on

--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -163,15 +163,15 @@ const (
 	SSESealAlgorithmDareSha256 = "DARE-SHA256"
 )
 
-// hasSSECustomerHeader returns true if the given HTTP header
+// ContainsSSECustomerHeader returns true if the given HTTP header
 // contains server-side-encryption with customer provided key fields.
-func hasSSECustomerHeader(header http.Header) bool {
+func ContainsSSECustomerHeader(header http.Header) bool {
 	return header.Get(SSECustomerAlgorithm) != "" || header.Get(SSECustomerKey) != "" || header.Get(SSECustomerKeyMD5) != ""
 }
 
-// hasSSECopyCustomerHeader returns true if the given HTTP header
+// ContainsSSECopyCustomerHeader returns true if the given HTTP header
 // contains copy source server-side-encryption with customer provided key fields.
-func hasSSECopyCustomerHeader(header http.Header) bool {
+func ContainsSSECopyCustomerHeader(header http.Header) bool {
 	return header.Get(SSECopyCustomerAlgorithm) != "" || header.Get(SSECopyCustomerKey) != "" || header.Get(SSECopyCustomerKeyMD5) != ""
 }
 
@@ -767,10 +767,10 @@ func DecryptCopyObjectInfo(info *ObjectInfo, headers http.Header) (apiErr APIErr
 	if info.IsDir {
 		return ErrNone, false
 	}
-	if apiErr, encrypted = ErrNone, info.IsEncrypted(); !encrypted && hasSSECopyCustomerHeader(headers) {
+	if apiErr, encrypted = ErrNone, info.IsEncrypted(); !encrypted && ContainsSSECopyCustomerHeader(headers) {
 		apiErr = ErrInvalidEncryptionParameters
 	} else if encrypted {
-		if !hasSSECopyCustomerHeader(headers) {
+		if !ContainsSSECopyCustomerHeader(headers) {
 			apiErr = ErrSSEEncryptedObject
 			return
 		}
@@ -794,10 +794,10 @@ func DecryptObjectInfo(info *ObjectInfo, headers http.Header) (apiErr APIErrorCo
 	if info.IsDir {
 		return ErrNone, false
 	}
-	if apiErr, encrypted = ErrNone, info.IsEncrypted(); !encrypted && hasSSECustomerHeader(headers) {
+	if apiErr, encrypted = ErrNone, info.IsEncrypted(); !encrypted && ContainsSSECustomerHeader(headers) {
 		apiErr = ErrInvalidEncryptionParameters
 	} else if encrypted {
-		if !hasSSECustomerHeader(headers) {
+		if !ContainsSSECustomerHeader(headers) {
 			apiErr = ErrSSEEncryptedObject
 			return
 		}

--- a/cmd/encryption-v1_test.go
+++ b/cmd/encryption-v1_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-var hasSSECopyCustomerHeaderTests = []struct {
+var containsSSECopyCustomerHeaderTests = []struct {
 	headers    map[string]string
 	sseRequest bool
 }{
@@ -35,19 +35,19 @@ var hasSSECopyCustomerHeaderTests = []struct {
 	{headers: map[string]string{SSECopyCustomerAlgorithm: "", SSECopyCustomerKey: "", SSECopyCustomerKeyMD5: ""}, sseRequest: false},                               // 6
 }
 
-func TestIsSSECopyCustomerRequest(t *testing.T) {
-	for i, test := range hasSSECopyCustomerHeaderTests {
+func TestContainsSSECopyCustomerHeader(t *testing.T) {
+	for i, test := range containsSSECopyCustomerHeaderTests {
 		headers := http.Header{}
 		for k, v := range test.headers {
 			headers.Set(k, v)
 		}
-		if hasSSECopyCustomerHeader(headers) != test.sseRequest {
+		if ContainsSSECopyCustomerHeader(headers) != test.sseRequest {
 			t.Errorf("Test %d: Expected hasSSECopyCustomerHeader to return %v", i, test.sseRequest)
 		}
 	}
 }
 
-var hasSSECustomerHeaderTests = []struct {
+var containsSSECustomerHeaderTests = []struct {
 	headers    map[string]string
 	sseRequest bool
 }{
@@ -60,13 +60,13 @@ var hasSSECustomerHeaderTests = []struct {
 	{headers: map[string]string{SSECustomerAlgorithm: "", SSECustomerKey: "", SSECustomerKeyMD5: ""}, sseRequest: false},                               // 6
 }
 
-func TesthasSSECustomerHeader(t *testing.T) {
-	for i, test := range hasSSECustomerHeaderTests {
+func TestContainsSSECustomerHeader(t *testing.T) {
+	for i, test := range containsSSECustomerHeaderTests {
 		headers := http.Header{}
 		for k, v := range test.headers {
 			headers.Set(k, v)
 		}
-		if hasSSECustomerHeader(headers) != test.sseRequest {
+		if ContainsSSECustomerHeader(headers) != test.sseRequest {
 			t.Errorf("Test %d: Expected hasSSECustomerHeader to return %v", i, test.sseRequest)
 		}
 	}

--- a/cmd/encryption-v1_test.go
+++ b/cmd/encryption-v1_test.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"net/http"
 	"testing"
 )
@@ -42,7 +44,7 @@ func TestContainsSSECopyCustomerHeader(t *testing.T) {
 			headers.Set(k, v)
 		}
 		if ContainsSSECopyCustomerHeader(headers) != test.sseRequest {
-			t.Errorf("Test %d: Expected hasSSECopyCustomerHeader to return %v", i, test.sseRequest)
+			t.Errorf("Test %d: Expected ContainsSSECopyCustomerHeader to return %v", i, test.sseRequest)
 		}
 	}
 }
@@ -67,7 +69,7 @@ func TestContainsSSECustomerHeader(t *testing.T) {
 			headers.Set(k, v)
 		}
 		if ContainsSSECustomerHeader(headers) != test.sseRequest {
-			t.Errorf("Test %d: Expected hasSSECustomerHeader to return %v", i, test.sseRequest)
+			t.Errorf("Test %d: Expected ContainsSSECustomerHeader to return %v", i, test.sseRequest)
 		}
 	}
 }
@@ -455,6 +457,187 @@ func TestDecryptObjectInfo(t *testing.T) {
 			t.Errorf("Test %d: Decryption thinks object is encrypted but it is not", i)
 		} else if !encrypted && enc != encrypted {
 			t.Errorf("Test %d: Decryption thinks object is not encrypted but it is", i)
+		}
+	}
+}
+
+var decryptCopyObjectInfoTests = []struct {
+	info    ObjectInfo
+	headers http.Header
+	expErr  APIErrorCode
+}{
+	{
+		info:    ObjectInfo{Size: 100},
+		headers: http.Header{},
+		expErr:  ErrNone,
+	},
+	{
+		info:    ObjectInfo{Size: 100, UserDefined: map[string]string{ServerSideEncryptionSealAlgorithm: SSESealAlgorithmDareSha256}},
+		headers: http.Header{SSECopyCustomerAlgorithm: []string{SSECustomerAlgorithmAES256}},
+		expErr:  ErrNone,
+	},
+	{
+		info:    ObjectInfo{Size: 0, UserDefined: map[string]string{ServerSideEncryptionSealAlgorithm: SSESealAlgorithmDareSha256}},
+		headers: http.Header{SSECopyCustomerAlgorithm: []string{SSECustomerAlgorithmAES256}},
+		expErr:  ErrNone,
+	},
+	{
+		info:    ObjectInfo{Size: 100, UserDefined: map[string]string{ServerSideEncryptionSealAlgorithm: SSESealAlgorithmDareSha256}},
+		headers: http.Header{},
+		expErr:  ErrSSEEncryptedObject,
+	},
+	{
+		info:    ObjectInfo{Size: 100, UserDefined: map[string]string{}},
+		headers: http.Header{SSECopyCustomerAlgorithm: []string{SSECustomerAlgorithmAES256}},
+		expErr:  ErrInvalidEncryptionParameters,
+	},
+	{
+		info:    ObjectInfo{Size: 31, UserDefined: map[string]string{ServerSideEncryptionSealAlgorithm: SSESealAlgorithmDareSha256}},
+		headers: http.Header{SSECopyCustomerAlgorithm: []string{SSECustomerAlgorithmAES256}},
+		expErr:  ErrObjectTampered,
+	},
+}
+
+func TestDecryptCopyObjectInfo(t *testing.T) {
+	for i, test := range decryptCopyObjectInfoTests {
+		if err, encrypted := DecryptCopyObjectInfo(&test.info, test.headers); err != test.expErr {
+			t.Errorf("Test %d: Decryption returned wrong error code: got %d , want %d", i, err, test.expErr)
+		} else if enc := test.info.IsEncrypted(); encrypted && enc != encrypted {
+			t.Errorf("Test %d: Decryption thinks object is encrypted but it is not", i)
+		} else if !encrypted && enc != encrypted {
+			t.Errorf("Test %d: Decryption thinks object is not encrypted but it is", i)
+		}
+	}
+}
+
+var unmarshalObjectEncryptionKeyTests = []struct {
+	key        []byte
+	metadata   map[string]string
+	shouldFail bool
+}{
+	{
+		key: make([]byte, 32),
+		metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "quG9piiYxLKEwPgTPpGAJSDX7dunXDtM9Rldtv6ks8A=",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DARE-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfALY6SRKZgLZ7fOj+bIkLKmORp10HC3CmdOLmHEBZJPjTYVcgp40z659/bbBlm6e/dsWiDRUQ/KASsL0J1w==",
+		},
+		shouldFail: false,
+	},
+	{
+		key: make([]byte, 33),
+		metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "2/mcHQdT9KMXGZTeQFKHYpaXXcN2XxkJ7ahRi+4oHNI=",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DARE-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfALpfVzXMQCpD8Uj8MTiq+X7DxlBRfhGw59GVivaHa+VsUdtA6kY1kdVXsFbf7f9gviA32tTDqQ8lTzwHAg==",
+		},
+		shouldFail: true,
+	},
+	{
+		key: append([]byte{1}, make([]byte, 31)...),
+		metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "2/mcHQdT9KMXGZTeQFKHYpaXXcN2XxkJ7ahRi+4oHNI=",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DARE-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfALpfVzXMQCpD8Uj8MTiq+X7DxlBRfhGw59GVivaHa+VsUdtA6kY1kdVXsFbf7f9gviA32tTDqQ8lTzwHAg==",
+		},
+		shouldFail: true,
+	},
+	{
+		key: make([]byte, 32),
+		metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "2/mcHQdT9KMXGZTeQAKHYpaXXcN2XxkJ7ahRi+4oHNI=", // modified IV
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DARE-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfALpfVzXMQCpD8Uj8MTiq+X7DxlBRfhGw59GVivaHa+VsUdtA6kY1kdVXsFbf7f9gviA32tTDqQ8lTzwHAg==",
+		},
+		shouldFail: true,
+	},
+	{
+		key: make([]byte, 32),
+		metadata: map[string]string{ // missing X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm
+			"X-Minio-Internal-Server-Side-Encryption-Iv":         "2/mcHQdT9KMXGZTeQFKHYpaXXcN2XxkJ7ahRi+4oHNI=",
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key": "IAAfALpfVzXMQCpD8Uj8MTiq+X7DxlBRfhGw59GVivaHa+VsUdtA6kY1kdVXsFbf7f9gviA32tTDqQ8lTzwHAg==",
+		},
+		shouldFail: true,
+	},
+	{
+		key: make([]byte, 32),
+		metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "2/mcHQdT9KMXGZTeQFKHYpaXXcN2XxkJ7ahRi+4oHNI=",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DARE-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfALpfVzXMQCpD8Uj8MTiq+X7DxlBRfhGw59GVivaHa+VsUdtA6kY1kdVXsFbf7f9gviA32tT0qQ8lTzwHAg==", // modified key
+		},
+		shouldFail: true,
+	},
+}
+
+func TestUnmarshalObjectEncryptionKey(t *testing.T) {
+	for i, test := range unmarshalObjectEncryptionKeyTests {
+		_, err := UnmarshalObjectEncryptionKey(test.key, test.metadata)
+		if err != nil && !test.shouldFail {
+			t.Errorf("Test %d: failed to unmarshal metadata: %v", i, err)
+		}
+		if err == nil && test.shouldFail {
+			t.Errorf("Test %d: should fail but passed successfully", i)
+		}
+	}
+}
+
+func TestMarshalObjectEncryptionKey(t *testing.T) {
+	key := make([]byte, 32)
+	metadata := map[string]string{
+		SSECustomerKey:     base64.StdEncoding.EncodeToString(key),
+		SSECopyCustomerKey: base64.StdEncoding.EncodeToString(key),
+	}
+
+	objectKey, err := DeriveObjectEncryptionKey(key)
+	if err != nil {
+		t.Errorf("Failed to derive object encryption key: %v", err)
+	}
+	kek, err := DeriveKeyEncryptionKey(key)
+	if err != nil {
+		t.Errorf("Failed to derive key encryption key: %v", err)
+	}
+	kek.Marshal(objectKey, metadata)
+
+	if _, ok := metadata[SSECustomerKey]; ok {
+		t.Errorf("%s survived in metadata", SSECustomerKey)
+	}
+	if _, ok := metadata[SSECopyCustomerKey]; ok {
+		t.Errorf("%s survived in metadata", SSECopyCustomerKey)
+	}
+
+	decryptedKey, err := UnmarshalObjectEncryptionKey(key, metadata)
+	if err != nil {
+		t.Errorf("Failed to unmarshal object encryption key: %v", err)
+	}
+	if objectKey != decryptedKey {
+		t.Error("Decrypted object encryption key does not match original key")
+	}
+}
+
+var derivePartKeyTests = []struct {
+	key    string
+	partID int
+}{
+	{partID: 1, key: "9325e77cbce096f91d55cb556a21e07c091cebe37b8d3c3223e9524836afe744"},
+	{partID: 2, key: "29a689195c35bb4f2687b3e0e92740456f7ae635bcd345302d5f001bd78197bc"},
+	{partID: 10000, key: "cdbd28833c1748e9fb6ebc3e3b548c662b0ad71584f596ba41df2e79346abcd0"},
+}
+
+func TestDerivePartKey(t *testing.T) {
+	var objKey ObjectEncryptionKey
+	key, _ := hex.DecodeString("b997f84afa94eb4482953512c98a5850d85dd5ad1cac483ad69ef073915ab3f5")
+	copy(objKey[:], key)
+
+	for i, test := range derivePartKeyTests {
+		key, err := hex.DecodeString(test.key)
+		if err != nil {
+			t.Errorf("Test %d: failed to decode key: %v", i, err)
+		}
+
+		partKey := objKey.DerivePartKey(test.partID)
+		if !bytes.Equal(key, partKey[:]) {
+			t.Errorf("Test %d: derived key does not match", i)
 		}
 	}
 }

--- a/cmd/encryption-v1_test.go
+++ b/cmd/encryption-v1_test.go
@@ -43,7 +43,7 @@ func TestContainsSSECopyCustomerHeader(t *testing.T) {
 		for k, v := range test.headers {
 			headers.Set(k, v)
 		}
-		if ContainsSSECopyCustomerHeader(headers) != test.sseRequest {
+		if SSECopyCustomerHeaders.Contains(headers) != test.sseRequest {
 			t.Errorf("Test %d: Expected ContainsSSECopyCustomerHeader to return %v", i, test.sseRequest)
 		}
 	}
@@ -68,7 +68,7 @@ func TestContainsSSECustomerHeader(t *testing.T) {
 		for k, v := range test.headers {
 			headers.Set(k, v)
 		}
-		if ContainsSSECustomerHeader(headers) != test.sseRequest {
+		if SSECustomerHeaders.Contains(headers) != test.sseRequest {
 			t.Errorf("Test %d: Expected ContainsSSECustomerHeader to return %v", i, test.sseRequest)
 		}
 	}
@@ -162,7 +162,7 @@ func TestParseSSECustomerRequest(t *testing.T) {
 		}
 		globalIsSSL = test.useTLS
 
-		_, err := ParseSSECustomerHeaders(headers)
+		_, err := SSECustomerHeaders.Parse(headers)
 		if err != test.err {
 			t.Errorf("Test %d: Parse returned: %v want: %v", i, err, test.err)
 		}
@@ -262,7 +262,7 @@ func TestParseSSECopyCustomerRequest(t *testing.T) {
 		}
 		globalIsSSL = test.useTLS
 
-		_, err := ParseSSECopyCustomerHeaders(headers)
+		_, err := SSECopyCustomerHeaders.Parse(headers)
 		if err != test.err {
 			t.Errorf("Test %d: Parse returned: %v want: %v", i, err, test.err)
 		}

--- a/cmd/encryption-v1_test.go
+++ b/cmd/encryption-v1_test.go
@@ -158,15 +158,13 @@ func TestParseSSECustomerRequest(t *testing.T) {
 		for k, v := range test.headers {
 			headers.Set(k, v)
 		}
-		request := &http.Request{}
-		request.Header = headers
 		globalIsSSL = test.useTLS
 
-		_, err := ParseSSECustomerRequest(request)
+		_, err := ParseSSECustomerHeaders(headers)
 		if err != test.err {
 			t.Errorf("Test %d: Parse returned: %v want: %v", i, err, test.err)
 		}
-		key := request.Header.Get(SSECustomerKey)
+		key := headers.Get(SSECustomerKey)
 		if (err == nil || err == errSSEKeyMD5Mismatch) && key != "" {
 			t.Errorf("Test %d: Client key survived parsing - found key: %v", i, key)
 		}
@@ -260,15 +258,13 @@ func TestParseSSECopyCustomerRequest(t *testing.T) {
 		for k, v := range test.headers {
 			headers.Set(k, v)
 		}
-		request := &http.Request{}
-		request.Header = headers
 		globalIsSSL = test.useTLS
 
-		_, err := ParseSSECopyCustomerRequest(request)
+		_, err := ParseSSECopyCustomerHeaders(headers)
 		if err != test.err {
 			t.Errorf("Test %d: Parse returned: %v want: %v", i, err, test.err)
 		}
-		key := request.Header.Get(SSECopyCustomerKey)
+		key := headers.Get(SSECopyCustomerKey)
 		if (err == nil || err == errSSEKeyMD5Mismatch) && key != "" {
 			t.Errorf("Test %d: Client key survived parsing - found key: %v", i, key)
 		}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -178,7 +178,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	httpWriter := ioutil.WriteOnClose(writer)
 
 	getObject := objectAPI.GetObject
-	if api.CacheAPI() != nil && !hasSSECustomerHeader(r.Header) {
+	if api.CacheAPI() != nil && !ContainsSSECustomerHeader(r.Header) {
 		getObject = api.CacheAPI().GetObject
 	}
 
@@ -451,7 +451,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 			for k, v := range srcInfo.UserDefined {
 				encMetadata[k] = v
 			}
-			if err = rotateKey(oldKey, newKey, encMetadata); err != nil {
+			if err = RotateKeys(oldKey, newKey, encMetadata); err != nil {
 				pipeWriter.CloseWithError(err)
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
@@ -727,7 +727,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	if api.CacheAPI() != nil && !hasSSECustomerHeader(r.Header) {
+	if api.CacheAPI() != nil && !ContainsSSECustomerHeader(r.Header) {
 		putObject = api.CacheAPI().PutObject
 	}
 	// Create the object..

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -157,7 +157,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	var writer io.Writer
 	writer = w
 	if objectAPI.IsEncryptionSupported() {
-		if ContainsSSECustomerHeader(r.Header) {
+		if SSECustomerHeaders.Contains(r.Header) {
 			// Response writer should be limited early on for decryption upto required length,
 			// additionally also skipping mod(offset)64KiB boundaries.
 			writer = ioutil.LimitedWriter(writer, startOffset%(64*1024), length)
@@ -178,7 +178,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	httpWriter := ioutil.WriteOnClose(writer)
 
 	getObject := objectAPI.GetObject
-	if api.CacheAPI() != nil && !ContainsSSECustomerHeader(r.Header) {
+	if api.CacheAPI() != nil && !SSECustomerHeaders.Contains(r.Header) {
 		getObject = api.CacheAPI().GetObject
 	}
 
@@ -427,10 +427,10 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	var encMetadata = make(map[string]string)
 	if objectAPI.IsEncryptionSupported() {
 		var oldKey, newKey []byte
-		sseCopyC := ContainsSSECopyCustomerHeader(r.Header)
-		sseC := ContainsSSECustomerHeader(r.Header)
+		sseCopyC := SSECopyCustomerHeaders.Contains(r.Header)
+		sseC := SSECustomerHeaders.Contains(r.Header)
 		if sseC {
-			newKey, err = ParseSSECustomerHeaders(r.Header)
+			newKey, err = SSECustomerHeaders.Parse(r.Header)
 			if err != nil {
 				pipeWriter.CloseWithError(err)
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -442,7 +442,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		// otherwise we proceed to encrypt/decrypt.
 		if sseCopyC && sseC && cpSrcDstSame {
 			// Get the old key which needs to be rotated.
-			oldKey, err = ParseSSECopyCustomerHeaders(r.Header)
+			oldKey, err = SSECopyCustomerHeaders.Parse(r.Header)
 			if err != nil {
 				pipeWriter.CloseWithError(err)
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -712,7 +712,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	if objectAPI.IsEncryptionSupported() {
-		if ContainsSSECustomerHeader(r.Header) && !hasSuffix(object, slashSeparator) { // handle SSE-C requests
+		if SSECustomerHeaders.Contains(r.Header) && !hasSuffix(object, slashSeparator) { // handle SSE-C requests
 			reader, err = EncryptRequest(hashReader, r, metadata)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -727,7 +727,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	if api.CacheAPI() != nil && !ContainsSSECustomerHeader(r.Header) {
+	if api.CacheAPI() != nil && !SSECustomerHeaders.Contains(r.Header) {
 		putObject = api.CacheAPI().PutObject
 	}
 	// Create the object..
@@ -739,7 +739,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 
 	w.Header().Set("ETag", "\""+objInfo.ETag+"\"")
 	if objectAPI.IsEncryptionSupported() {
-		if ContainsSSECustomerHeader(r.Header) {
+		if SSECustomerHeaders.Contains(r.Header) {
 			w.Header().Set(SSECustomerAlgorithm, r.Header.Get(SSECustomerAlgorithm))
 			w.Header().Set(SSECustomerKeyMD5, r.Header.Get(SSECustomerKeyMD5))
 		}
@@ -806,8 +806,8 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 	var encMetadata = map[string]string{}
 
 	if objectAPI.IsEncryptionSupported() {
-		if ContainsSSECustomerHeader(r.Header) {
-			key, err := ParseSSECustomerHeaders(r.Header)
+		if SSECustomerHeaders.Contains(r.Header) {
+			key, err := SSECustomerHeaders.Parse(r.Header)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
@@ -975,7 +975,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 			return
 		}
-		sseCopyC := ContainsSSECopyCustomerHeader(r.Header)
+		sseCopyC := SSECopyCustomerHeaders.Contains(r.Header)
 		if sseCopyC {
 			// Response writer should be limited early on for decryption upto required length,
 			// additionally also skipping mod(offset)64KiB boundaries.
@@ -988,12 +988,12 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 			}
 		}
 		if li.IsEncrypted() {
-			if !ContainsSSECustomerHeader(r.Header) {
+			if !SSECustomerHeaders.Contains(r.Header) {
 				writeErrorResponse(w, ErrSSEMultipartEncrypted, r.URL)
 				return
 			}
 			var key []byte
-			key, err = ParseSSECustomerHeaders(r.Header)
+			key, err = SSECustomerHeaders.Parse(r.Header)
 			if err != nil {
 				pipeWriter.CloseWithError(err)
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -1188,12 +1188,12 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 			return
 		}
 		if li.IsEncrypted() {
-			if !ContainsSSECustomerHeader(r.Header) {
+			if !SSECustomerHeaders.Contains(r.Header) {
 				writeErrorResponse(w, ErrSSEMultipartEncrypted, r.URL)
 				return
 			}
 			var key []byte
-			key, err = ParseSSECustomerHeaders(r.Header)
+			key, err = SSECustomerHeaders.Parse(r.Header)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -430,7 +430,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		sseCopyC := hasSSECopyCustomerHeader(r.Header)
 		sseC := hasSSECustomerHeader(r.Header)
 		if sseC {
-			newKey, err = ParseSSECustomerRequest(r)
+			newKey, err = ParseSSECustomerHeaders(r.Header)
 			if err != nil {
 				pipeWriter.CloseWithError(err)
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -442,7 +442,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		// otherwise we proceed to encrypt/decrypt.
 		if sseCopyC && sseC && cpSrcDstSame {
 			// Get the old key which needs to be rotated.
-			oldKey, err = ParseSSECopyCustomerRequest(r)
+			oldKey, err = ParseSSECopyCustomerHeaders(r.Header)
 			if err != nil {
 				pipeWriter.CloseWithError(err)
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -807,7 +807,7 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 
 	if objectAPI.IsEncryptionSupported() {
 		if hasSSECustomerHeader(r.Header) {
-			key, err := ParseSSECustomerRequest(r)
+			key, err := ParseSSECustomerHeaders(r.Header)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
@@ -993,7 +993,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 				return
 			}
 			var key []byte
-			key, err = ParseSSECustomerRequest(r)
+			key, err = ParseSSECustomerHeaders(r.Header)
 			if err != nil {
 				pipeWriter.CloseWithError(err)
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -1193,7 +1193,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 				return
 			}
 			var key []byte
-			key, err = ParseSSECustomerRequest(r)
+			key, err = ParseSSECustomerHeaders(r.Header)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return


### PR DESCRIPTION
## Description

This PR tries to simplify and reduce the code complexity of the SSE-C code.
The goal is to make the (SSE) security related code more explicit and easier to understand.

Therefore this PR breaks larger functions into smaller ones and combines functionality to mirror the SSE-C approach of the server.  

## Motivation and Context
Cleanup of grown code.

## How Has This Been Tested?
manually + https://github.com/aead/s3

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.