### PR TITLE
Add security HTTP Headers

### DIFF
--- a/vendor/github.com/gorilla/rpc/v2/server.go
+++ b/vendor/github.com/gorilla/rpc/v2/server.go
@@ -149,6 +149,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Prevents Internet Explorer from MIME-sniffing a response away
 	// from the declared content-type
 	w.Header().Set("x-content-type-options", "nosniff")
+	// Prevents against XSS Atacks
+	w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
+	//Prevents against Clickjacking
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+	
 	// Encode the response.
 	if errResult == nil {
 		codecReq.WriteResponse(w, reply.Interface())

--- a/vendor/github.com/gorilla/rpc/v2/server.go
+++ b/vendor/github.com/gorilla/rpc/v2/server.go
@@ -151,7 +151,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("x-content-type-options", "nosniff")
 	// Prevents against XSS Atacks
 	w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
-	//Prevents against Clickjacking
+	// Prevents against Clickjacking
 	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	
 	// Encode the response.


### PR DESCRIPTION
Add some HTTP security headers in Minio, 
To protect the aplication of some attacks, like XSS and Clickjacking attacks.

[X-Frame-Options](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#xxxsp)
X-Frame-Options response header improve the protection of web applications against Clickjacking. It declares a policy communicated from a host to the client browser on whether the browser must not display the transmitted content in frames of other web pages.

[X-XSS-Protection](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#xxxsp)
This header enables the Cross-site scripting (XSS) filter in your browser.

Some fonts:
https://www.owasp.org/index.php/Clickjacking
https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet

