### PR TITLE
Fix CopyObject with  metadata for GCS gateway (#5800)

### DIFF
--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -758,13 +758,26 @@ func (l *gcsGateway) GetObject(ctx context.Context, bucket string, key string, s
 func fromGCSAttrsToObjectInfo(attrs *storage.ObjectAttrs) minio.ObjectInfo {
 	// All google cloud storage objects have a CRC32c hash, whereas composite objects may not have a MD5 hash
 	// Refer https://cloud.google.com/storage/docs/hashes-etags. Use CRC32C for ETag
+	metadata := make(map[string]string)
+	for k, v := range attrs.Metadata {
+		metadata[k] = v
+	}
+	if attrs.CacheControl != "" {
+		metadata["cache-control"] = attrs.CacheControl
+	}
+	if attrs.ContentDisposition != "" {
+		metadata["content-disposition"] = attrs.ContentDisposition
+	}
+	if attrs.ContentLanguage != "" {
+		metadata["content-language"] = attrs.ContentLanguage
+	}
 	return minio.ObjectInfo{
 		Name:            attrs.Name,
 		Bucket:          attrs.Bucket,
 		ModTime:         attrs.Updated,
 		Size:            attrs.Size,
 		ETag:            minio.ToS3ETag(fmt.Sprintf("%d", attrs.CRC32C)),
-		UserDefined:     attrs.Metadata,
+		UserDefined:     metadata,
 		ContentType:     attrs.ContentType,
 		ContentEncoding: attrs.ContentEncoding,
 	}


### PR DESCRIPTION
- Make sure to copy standard headers such as Content-Type, Content-Disposition
 and Content-Language from the source object during a CopyObject operation.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, standard headers like Content-Type,Cache-Control and Content-Language returned by gcs gateway are not being copied to metadata map. This PR fixes this bug.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#5800 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually with aws cli
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.