### PR TITLE
Replaces panic() with logger.FatalIf()

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/minio/minio/cmd/logger"
+
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/event/target"
@@ -167,9 +169,12 @@ func (s *serverConfig) ConfigDiff(t *serverConfig) string {
 }
 
 func newServerConfig() *serverConfig {
+	cred, err := auth.GetNewCredentials()
+	logger.FatalIf(err, "")
+
 	srvCfg := &serverConfig{
 		Version:    serverConfigVersion,
-		Credential: auth.MustGetNewCredentials(),
+		Credential: cred,
 		Region:     globalMinioDefaultRegion,
 		Browser:    true,
 		StorageClass: storageClassConfig{

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/sys"
 	"github.com/rs/cors"
 	"golang.org/x/time/rate"
@@ -591,9 +592,7 @@ func (h pathValidityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // cancelled immediately.
 func setRateLimitHandler(h http.Handler) http.Handler {
 	_, maxLimit, err := sys.GetMaxOpenFileLimit()
-	if err != nil {
-		panic(err)
-	}
+	logger.CriticalIf(context.Background(), err)
 	// Burst value is set to 1 to allow only maxOpenFileLimit
 	// requests to happen at once.
 	l := rate.NewLimiter(rate.Limit(maxLimit), 1)

--- a/cmd/jwt_test.go
+++ b/cmd/jwt_test.go
@@ -30,7 +30,10 @@ func testAuthenticate(authType string, t *testing.T) {
 		t.Fatalf("unable initialize config file, %s", err)
 	}
 	defer os.RemoveAll(testPath)
-	cred := auth.MustGetNewCredentials()
+	cred, err := auth.GetNewCredentials()
+	if err != nil {
+		t.Fatalf("Error getting new credentials: %s", err)
+	}
 	globalServerConfig.SetCredential(cred)
 
 	// Define test cases.

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -314,7 +314,19 @@ func LogIf(ctx context.Context, err error) {
 	fmt.Println(output)
 }
 
+// CriticalIf :
+// Like LogIf with exit
+// It'll be called for fatal error conditions during run-time
+func CriticalIf(ctx context.Context, err error) {
+	if err != nil {
+		LogIf(ctx, err)
+		os.Exit(1)
+	}
+}
+
 // FatalIf :
+// Just fatal error message, no stack trace
+// It'll be called for input validation failures
 func FatalIf(err error, msg string, data ...interface{}) {
 	if err != nil {
 		if msg != "" {

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -168,7 +168,7 @@ func pathJoin(elem ...string) string {
 func mustGetUUID() string {
 	uuid, err := uuid.New()
 	if err != nil {
-		panic(fmt.Sprintf("Random UUID generation failed. Error: %s", err))
+		logger.CriticalIf(context.Background(), err)
 	}
 
 	return uuid.String()

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -406,7 +406,8 @@ func (web webAPIHandlers) GenerateAuth(r *http.Request, args *WebGenericArgs, re
 	if !isHTTPRequestValid(r) {
 		return toJSONError(errAuthentication)
 	}
-	cred := auth.MustGetNewCredentials()
+	cred, err := auth.GetNewCredentials()
+	logger.CriticalIf(context.Background(), err)
 	reply.AccessKey = cred.AccessKey
 	reply.SecretKey = cred.SecretKey
 	reply.UIVersion = browser.UIVersion

--- a/pkg/auth/credentials_test.go
+++ b/pkg/auth/credentials_test.go
@@ -54,8 +54,11 @@ func TestIsSecretKeyValid(t *testing.T) {
 	}
 }
 
-func TestMustGetNewCredentials(t *testing.T) {
-	cred := MustGetNewCredentials()
+func TestGetNewCredentials(t *testing.T) {
+	cred, err := GetNewCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get a new credential")
+	}
 	if !cred.IsValid() {
 		t.Fatalf("Failed to get new valid credential")
 	}
@@ -106,7 +109,14 @@ func TestCreateCredentials(t *testing.T) {
 }
 
 func TestCredentialsEqual(t *testing.T) {
-	cred := MustGetNewCredentials()
+	cred, err := GetNewCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get a new credential")
+	}
+	cred2, err := GetNewCredentials()
+	if err != nil {
+		t.Fatalf("Failed to get a new credential")
+	}
 	testCases := []struct {
 		cred           Credentials
 		ccred          Credentials
@@ -119,7 +129,7 @@ func TestCredentialsEqual(t *testing.T) {
 		// Empty credentials.
 		{Credentials{}, cred, false},
 		// Two different credentialss
-		{cred, MustGetNewCredentials(), false},
+		{cred, cred2, false},
 		// Access key is different in credentials to compare.
 		{cred, Credentials{AccessKey: "myuser", SecretKey: cred.SecretKey}, false},
 		// Secret key is different in credentials to compare.

--- a/pkg/event/target/httpclient.go
+++ b/pkg/event/target/httpclient.go
@@ -19,7 +19,6 @@ package target
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -118,24 +117,28 @@ func (target *HTTPClientTarget) Close() error {
 	return nil
 }
 
-func mustGetNewUUID() string {
+func getNewUUID() (string, error) {
 	uuid, err := uuid.New()
 	if err != nil {
-		panic(fmt.Sprintf("%s. Unable to generate random UUID", err))
+		return "", err
 	}
 
-	return uuid.String()
+	return uuid.String(), nil
 }
 
 // NewHTTPClientTarget - creates new HTTP client target.
-func NewHTTPClientTarget(host xnet.Host, w http.ResponseWriter) *HTTPClientTarget {
+func NewHTTPClientTarget(host xnet.Host, w http.ResponseWriter) (*HTTPClientTarget, error) {
+	uuid, err := getNewUUID()
+	if err != nil {
+		return nil, err
+	}
 	c := &HTTPClientTarget{
-		id:      event.TargetID{"httpclient" + "+" + mustGetNewUUID() + "+" + host.Name, host.Port.String()},
+		id:      event.TargetID{"httpclient" + "+" + uuid + "+" + host.Name, host.Port.String()},
 		w:       w,
 		eventCh: make(chan []byte),
 		DoneCh:  make(chan struct{}),
 		stopCh:  make(chan struct{}),
 	}
 	c.start()
-	return c
+	return c, nil
 }

--- a/pkg/event/target/nats.go
+++ b/pkg/event/target/nats.go
@@ -112,7 +112,10 @@ func NewNATSTarget(id string, args NATSArgs) (*NATSTarget, error) {
 
 		clientID := args.Streaming.ClientID
 		if clientID == "" {
-			clientID = mustGetNewUUID()
+			clientID, err = getNewUUID()
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		connOpts := []stan.Option{stan.NatsURL(addressURL)}

--- a/pkg/net/host.go
+++ b/pkg/net/host.go
@@ -139,12 +139,3 @@ func ParseHost(s string) (*Host, error) {
 		IsPortSet: isPortSet,
 	}, nil
 }
-
-// MustParseHost - parses given string to Host, else panics.
-func MustParseHost(s string) *Host {
-	host, err := ParseHost(s)
-	if err != nil {
-		panic(err)
-	}
-	return host
-}

--- a/pkg/net/host_test.go
+++ b/pkg/net/host_test.go
@@ -207,30 +207,3 @@ func TestParseHost(t *testing.T) {
 		}
 	}
 }
-
-func TestMustParseHost(t *testing.T) {
-	testCases := []struct {
-		s            string
-		expectedHost *Host
-	}{
-		{"play", &Host{"play", 0, false}},
-		{"play:0", &Host{"play", 0, true}},
-		{"play:9000", &Host{"play", 9000, true}},
-		{"play.minio.io", &Host{"play.minio.io", 0, false}},
-		{"play.minio.io:9000", &Host{"play.minio.io", 9000, true}},
-		{"147.75.201.93", &Host{"147.75.201.93", 0, false}},
-		{"147.75.201.93:9000", &Host{"147.75.201.93", 9000, true}},
-		{"play12", &Host{"play12", 0, false}},
-		{"12play", &Host{"12play", 0, false}},
-		{"play-minio-io", &Host{"play-minio-io", 0, false}},
-		{"play--minio.io", &Host{"play--minio.io", 0, false}},
-	}
-
-	for i, testCase := range testCases {
-		host := MustParseHost(testCase.s)
-
-		if !reflect.DeepEqual(host, testCase.expectedHost) {
-			t.Fatalf("test %v: host: expected: %#v, got: %#v", i+1, testCase.expectedHost, host)
-		}
-	}
-}

--- a/pkg/net/port.go
+++ b/pkg/net/port.go
@@ -42,13 +42,3 @@ func ParsePort(s string) (p Port, err error) {
 
 	return Port(i), nil
 }
-
-// MustParsePort - parses string into Port, else panics
-func MustParsePort(s string) Port {
-	p, err := ParsePort(s)
-	if err != nil {
-		panic(err)
-	}
-
-	return p
-}

--- a/pkg/net/port_test.go
+++ b/pkg/net/port_test.go
@@ -71,22 +71,3 @@ func TestParsePort(t *testing.T) {
 		}
 	}
 }
-
-func TestMustParsePort(t *testing.T) {
-	testCases := []struct {
-		s            string
-		expectedPort Port
-	}{
-		{"0", Port(0)},
-		{"9000", Port(9000)},
-		{"65535", Port(65535)},
-	}
-
-	for i, testCase := range testCases {
-		port := MustParsePort(testCase.s)
-
-		if port != testCase.expectedPort {
-			t.Fatalf("test %v: error: port: %v, got: %v", i+1, testCase.expectedPort, port)
-		}
-	}
-}

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -35,7 +35,10 @@ func (u URL) IsEmpty() bool {
 func (u URL) String() string {
 	// if port number 80 and 443, remove for http and https scheme respectively
 	if u.Host != "" {
-		host := MustParseHost(u.Host)
+		host, err := ParseHost(u.Host)
+		if err != nil {
+			panic(err)
+		}
 		switch {
 		case u.Scheme == "http" && host.Port == 80:
 			fallthrough


### PR DESCRIPTION
Panic() calls are replaced with logger.FatalIf() calls to adhere our new logging standard.

## Motivation and Context
Fixes #5728 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.