### PR TITLE
Adding example on how to deploy minio without a backing store.

### DIFF
--- a/docs/orchestration/kubernetes-yaml/README.md
+++ b/docs/orchestration/kubernetes-yaml/README.md
@@ -17,6 +17,7 @@
     - [Create Minio Statefulset](#create-minio-statefulset)
     - [Create LoadBalancer Service](#create-minio-service)
   - [Update existing Minio StatefulSet](#update-existing-minio-statefulset)
+  - [Deploying on a cluster with no storageclass](#deploying-on-a-cluster-with-no-storageclass)
   - [Resource cleanup](#distributed-resource-cleanup)
 
 - [Minio GCS Gateway Deployment](#minio-gcs-gateway-deployment)
@@ -406,6 +407,35 @@ You can cleanup the cluster using
 kubectl delete statefulset minio \
 &&  kubectl delete svc minio \
 && kubectl delete svc minio-service
+```
+
+### Deploying on a cluster with no storageclass
+
+If your cluster does not have a storage solution or PV abstraction, you must explicitly define what nodes you wish to run Minio on, and define a homogeneous path to a local fast block device available on every host.
+
+This must be changed in the example daemonset: [minio-distributed-daemonset.yaml](minio-distributed-daemonset.yaml)
+
+Specifically the hostpath:
+```yaml
+        hostPath:
+          path: /data/minio/
+```
+
+And the list of hosts:
+```yaml
+        - http://hostname1:9000/data/minio
+        - http://hostname2:9000/data/minio
+        - http://hostname3:9000/data/minio
+        - http://hostname4:9000/data/minio
+```
+
+Once deployed, tag the defined host with the `minio-server=true` label:
+
+```bash
+kubectl label node hostname1  -l minio-server=true
+kubectl label node hostname2  -l minio-server=true
+kubectl label node hostname3  -l minio-server=true
+kubectl label node hostname4  -l minio-server=true
 ```
 
 ## Minio GCS Gateway Deployment

--- a/docs/orchestration/kubernetes-yaml/README.md
+++ b/docs/orchestration/kubernetes-yaml/README.md
@@ -409,7 +409,7 @@ kubectl delete statefulset minio \
 && kubectl delete svc minio-service
 ```
 
-### Deploying on a cluster with no storageclass
+### Deploying on cluster nodes with local host path
 
 If your cluster does not have a storage solution or PV abstraction, you must explicitly define what nodes you wish to run Minio on, and define a homogeneous path to a local fast block device available on every host.
 

--- a/docs/orchestration/kubernetes-yaml/README.md
+++ b/docs/orchestration/kubernetes-yaml/README.md
@@ -17,7 +17,7 @@
     - [Create Minio Statefulset](#create-minio-statefulset)
     - [Create LoadBalancer Service](#create-minio-service)
   - [Update existing Minio StatefulSet](#update-existing-minio-statefulset)
-  - [Deploying on a cluster with no storageclass](#deploying-on-a-cluster-with-no-storageclass)
+  - [Deploying on cluster nodes with local host path](#deploying-on-cluster-nodes-with-local-host-path)
   - [Resource cleanup](#distributed-resource-cleanup)
 
 - [Minio GCS Gateway Deployment](#minio-gcs-gateway-deployment)

--- a/docs/orchestration/kubernetes-yaml/minio-distributed-daemonset.yaml
+++ b/docs/orchestration/kubernetes-yaml/minio-distributed-daemonset.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      # We only deploy minio to the specified nodes. select your nodes by using `kubectl label node hostname1 -l minio-server=true`
+      nodeSelector:
+        minio-server: "true"
+      # This is to maximize network performance, the headless service can be used to connect to a random host.
+      hostNetwork: true
+      # We're just using a hostpath. This path must be the same on all servers, and should be the largest, fastest block device you can fit.
+      volumes:
+      - name: storage
+        hostPath:
+          path: /data/minio/
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2018-04-04T05-20-54Z
+        # Unfortunately you must manually define each server. Perhaps autodiscovery via DNS can be implemented in the future.
+        args:
+        - server
+        - http://hostname1:9000/data/minio
+        - http://hostname2:9000/data/minio
+        - http://hostname3:9000/data/minio
+        - http://hostname4:9000/data/minio
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - name: storage
+          mountPath: /data/minio/


### PR DESCRIPTION
Many on premise clusters do not have a PV abstraction, this example shows a way to deploy minio effectively in such environments.

This is intended to be adapted into a "Distributed, No PV" yaml generator for https://www.minio.io/kubernetes.html

The additional inputs should be a delimited list of hosts, and a hostpath.

However I also chose to add the example to the documentation.

## Description

This just extends the existing example to cover a situation where there is no block/shared storage solution on the cluster, just local disks.

The change consists of a daemonset and instructions on how to use the daemonset.

## Motivation and Context
The original motivation was a slack conversation with @harshavardhana.

## How Has This Been Tested?

This has been deployed in an internal lab.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.