### PR TITLE
add some security HTTP headers

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -625,3 +625,19 @@ func (l rateLimit) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	l.handler.ServeHTTP(w, r)
 }
+
+type securityHeaderHandler struct {
+	handler http.Handler
+}
+
+func addSecurityHeaders(h http.Handler) http.Handler {
+	return securityHeaderHandler{handler: h}
+}
+
+func (s securityHeaderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	header := w.Header()
+	header.Set("X-XSS-Protection", "\"1; mode=block\"")              // Prevents against XSS attacks
+	header.Set("X-Frame-Options", "SAMEORIGIN")                      // Prevents against Clickjacking
+	header.Set("Content-Security-Policy", "block-all-mixed-content") // prevent mixed (HTTP / HTTPS content)
+	s.handler.ServeHTTP(w, r)
+}

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -59,6 +59,8 @@ func registerDistXLRouters(mux *router.Router, endpoints EndpointList) error {
 
 // List of some generic handlers which are applied for all incoming requests.
 var globalHandlers = []HandlerFunc{
+	// set HTTP security headers such as Content-Security-Policy.
+	addSecurityHeaders,
 	// Ratelimit the incoming requests using a token bucket algorithm
 	setRateLimitHandler,
 	// Validate all the incoming paths.

--- a/vendor/github.com/gorilla/rpc/v2/server.go
+++ b/vendor/github.com/gorilla/rpc/v2/server.go
@@ -149,11 +149,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Prevents Internet Explorer from MIME-sniffing a response away
 	// from the declared content-type
 	w.Header().Set("x-content-type-options", "nosniff")
-	// Prevents against XSS Atacks
-	w.Header().Set("X-XSS-Protection", "\"1; mode=block\"")
-	// Prevents against Clickjacking
-	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
-	
+
 	// Encode the response.
 	if errResult == nil {
 		codecReq.WriteResponse(w, reply.Interface())


### PR DESCRIPTION
## Description
This change adds some security headers like Content-Security-Policy.
It does not set the HSTS header because Content-Security-Policy prevents
mixed HTTP and HTTPS content and the server does not use cookies.
However it is a header which could be added later on.

It also moves some headers added by #5805 from a vendored file
to a generic handler.

## Motivation and Context
Fixes #5813

## How Has This Been Tested?
manually 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.