### PR TITLE
Browser: Disable input validation styles on Firefox

### DIFF
--- a/browser/app/less/inc/form.less
+++ b/browser/app/less/inc/form.less
@@ -87,6 +87,7 @@ select.form-control {
     z-index: 1;
     border-bottom: 1px solid #eee;
     color: #32393F;
+    box-shadow: none;
     font-size: 13px;
 
 


### PR DESCRIPTION
## Description
Firefox adds a default red colored border-like box-shadow for all text/password inputs with a `required` attribute which need to be removed in order to maintain the overall Minio theming in form fields.  

This resolves: https://github.com/minio/minio/issues/5811

![ff-box-shadow](https://user-images.githubusercontent.com/13393018/38764574-4ba36d0a-3fcf-11e8-965c-981fce65aea4.jpg)


## Motivation and Context
https://github.com/minio/minio/issues/5811

## How Has This Been Tested?
Tested locally. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.