### PR TITLE
[gateway/gcs] Disable "chunked" uploading by the GCS client for objects smaller than the chunk size.

### DIFF
--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -800,6 +800,11 @@ func (l *gcsGateway) PutObject(ctx context.Context, bucket string, key string, d
 	object := l.client.Bucket(bucket).Object(key)
 
 	w := object.NewWriter(l.ctx)
+	// Disable "chunked" uploading in GCS client if the size of the data to be uploaded is below
+	// the current chunk-size of the writer. This avoids an unnecessary memory allocation.
+	if data.Size() < int64(w.ChunkSize) {
+		w.ChunkSize = 0
+	}
 
 	w.ContentType = metadata["content-type"]
 	w.ContentEncoding = metadata["content-encoding"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates the GCS PutObject implementation to disable "chunked" uploading when the size of the object is less than the ChunkSize set on the Writer. This prevents the GCS client from unnecessarily allocating a buffer for the purpose of performing a chunked upload before determining that the object's data is smaller than the chunk size and should be uploaded using a single request instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When running the mint tests against the GCS gateway, I saw that minio's memory usage would spike when many small objects were uploaded rapidly. ListObjects_Test5 in the minio-dotnet functional tests is a good test to use to reproduce this issue as it uploads 1050 small objects asynchronously.

This test alone would cause minios memory usage to spike to approximately 2GB. The issue appears to be caused by the GCS client which will by default allocate an 8MB buffer in preparation for carrying out a chunked upload.  This allocation occurs before it is able to determine that the data being uploaded is smaller than the chunk size and that the buffer isn't needed.  A GCS gateway with a high throughput of small objects could see a lot of memory allocated unnecessarily.

When running the above test again with chunked uploading disabled when not needed, minios memory consumption remained under 100MB.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran mint against the GCS gateway

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.