### PR TITLE
do not set response header X-Frame-Options for S3 requests

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -648,7 +648,6 @@ func addSecurityHeaders(h http.Handler) http.Handler {
 func (s securityHeaderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	header := w.Header()
 	header.Set("X-XSS-Protection", "\"1; mode=block\"")              // Prevents against XSS attacks
-	header.Set("X-Frame-Options", "SAMEORIGIN")                      // Prevents against Clickjacking
 	header.Set("Content-Security-Policy", "block-all-mixed-content") // prevent mixed (HTTP / HTTPS content)
 	s.handler.ServeHTTP(w, r)
 }


### PR DESCRIPTION
## Description
This change removes the X-Frame-Options header - It should
not be set for S3 requests since it can break CORS.

## Motivation and Context
Fixes #5813

## How Has This Been Tested?
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.