### PR TITLE
disable elliptic curves P-384 and P-521 for TLS.

### DIFF
--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -172,6 +172,9 @@ var defaultCipherSuites = []uint16{
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 }
 
+// Go only provides constant-time implementations of Curve25519 and NIST P-256 curve.
+var secureCurves = []tls.CurveID{tls.X25519, tls.CurveP256}
+
 // NewServer - creates new HTTP server using given arguments.
 func NewServer(addrs []string, handler http.Handler, certificate *tls.Certificate) *Server {
 	var tlsConfig *tls.Config
@@ -179,6 +182,7 @@ func NewServer(addrs []string, handler http.Handler, certificate *tls.Certificat
 		tlsConfig = &tls.Config{
 			PreferServerCipherSuites: true,
 			CipherSuites:             defaultCipherSuites,
+			CurvePreferences:         secureCurves,
 			MinVersion:               tls.VersionTLS12,
 			NextProtos:               []string{"http/1.1", "h2"},
 		}

--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -43,6 +43,9 @@ or protect the private key additionally with a password:
 ```sh
 openssl ecparam -genkey -name prime256v1 | openssl ec -aes256 -out private.key -passout pass:PASSWORD
 ```
+
+Notice that the NIST curves P-384 and P-521 are not supported yet.
+
 2. **RSA:**
 ```sh
 openssl genrsa -out private.key 2048


### PR DESCRIPTION
## Description
This change disables the non-constant-time implementations of P-384 and P-521.
As a consequence a client using just these curves cannot connect to the server.
This should be no real issues because (all) clients at least support P-256.

Further this change also rejects ECDSA private keys of P-384 and P-521.
While non-constant-time implementations for the ECDHE exchange don't expose an
obvious vulnerability, using P-384 or P-521 keys for the ECDSA signature may allow
pratical timing attacks.

## Motivation and Context
Fixes #5844

## How Has This Been Tested?
manually - added mint test 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [x] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.