### PR TITLE
Manta gateway fixes for subuser and private manta support

### DIFF
--- a/cmd/gateway/manta/gateway-manta.go
+++ b/cmd/gateway/manta/gateway-manta.go
@@ -144,7 +144,7 @@ func (g *Manta) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, erro
 	ctx := context.Background()
 
 	if g.host != "" {
-		endpoint, _, err = minio.ParseGatewayEndpoint(g.host)
+		endpoint, secure, err = minio.ParseGatewayEndpoint(g.host)
 		if err != nil {
 			return nil, err
 		}
@@ -233,6 +233,7 @@ func (g *Manta) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, erro
 
 	return &tritonObjects{
 		client: tc,
+    ctx: ctx,
 	}, nil
 }
 
@@ -245,6 +246,7 @@ func (g *Manta) Production() bool {
 type tritonObjects struct {
 	minio.GatewayUnsupported
 	client *storage.StorageClient
+  ctx context.Context
 }
 
 // Shutdown - save any gateway metadata to disk
@@ -631,7 +633,7 @@ func (t *tritonObjects) CopyObject(ctx context.Context, srcBucket, srcObject, de
 //
 // https://apidocs.joyent.com/manta/api.html#DeleteObject
 func (t *tritonObjects) DeleteObject(ctx context.Context, bucket, object string) error {
-	if err := t.client.Objects().Delete(ctx, &storage.DeleteObjectInput{
+	if err := t.client.Objects().Delete(t.ctx, &storage.DeleteObjectInput{
 		ObjectPath: path.Join(mantaRoot, bucket, object),
 	}); err != nil {
 		logger.LogIf(ctx, err)

--- a/vendor/github.com/joyent/triton-go/CHANGELOG.md
+++ b/vendor/github.com/joyent/triton-go/CHANGELOG.md
@@ -1,39 +1,68 @@
 ## Unreleased
 
-- Add support for managing columes in Triton [#100]
+- identity/roles: Add support for SetRoleTags [#112]
+
+## 1.2.0 (March 20 2018)
+
+- compute/instance: Instance Deletion status now included in the GET instance response [#138]
+
+## 1.1.1 (March 13 2018)
+
+- client: Adding the rbac user support to the SSHAgentSigner [BUG!]
+
+## 1.1.0 (March 13 2018)
+
+- client: Add support for Manta RBAC http signatures
+
+## 1.0.0 (February 28 2018)
+
+- client: Add support for querystring in client/ExecuteRequestRaw [#121]
+- client: Introduce SetHeader for overriding API request header [#125]
+- compute/instances: Add support for passing a list of tags to filter List instances [#116]
+- compute/instances: Add support for getting a count of current instances from the CloudAPI [#119]
+- compute/instances: Add ability to support name-prefix [#129]
+- compute/instances: Add support for Instance Deletion Protection [#131]
+- identity/user: Add support for ChangeUserPassword [#111]
+- expose GetTritonEnv as a root level func [#126]
+
+## 0.9.0 (January 23 2018)
+
+**Please Note:** This is a precursor release to marking triton-go as 1.0.0. We are going to wait and fix any bugs that occur from this large set of changes that has happened since 0.5.2
+
+- Add support for managing volumes in Triton [#100]
 - identity/policies: Add support for managing policies in Triton [#86]
-- addition of triton-go errors package to expose unwraping of internal errors
+- addition of triton-go errors package to expose unwrapping of internal errors
 - Migration from hashicorp/errwrap to pkg/errors
 - Using path.Join() for URL structures rather than fmt.Sprintf()
 
-## 0.5.2 (December 28)
+## 0.5.2 (December 28 2017)
 
 - Standardise the API SSH Signers input casing and naming
 
-## 0.5.1 (December 28)
+## 0.5.1 (December 28 2017)
 
 - Include leading '/' when working with SSH Agent signers
 
-## 0.5.0 (December 28)
+## 0.5.0 (December 28 2017)
 
 - Add support for RBAC in triton-go [#82]
 This is a breaking change. No longer do we pass individual parameters to the SSH Signer funcs, but we now pass an input Struct. This will guard from from additional parameter changes in the future. 
 We also now add support for using `SDC_*` and `TRITON_*` env vars when working with the Default agent signer
 
-## 0.4.2 (December 22)
+## 0.4.2 (December 22 2017)
 
 - Fixing a panic when the user loses network connectivity when making a GET request to instance [#81]
 
-## 0.4.1 (December 15)
+## 0.4.1 (December 15 2017)
 
 - Clean up the handling of directory sanitization. Use abs paths everywhere [#79]
 
-## 0.4.0 (December 15)
+## 0.4.0 (December 15 2017)
 
 - Fix an issue where Manta HEAD requests do not return an error resp body [#77]
 - Add support for recursively creating child directories [#78]
 
-## 0.3.0 (December 14)
+## 0.3.0 (December 14 2017)
 
 - Introduce CloudAPI's ListRulesMachines under networking
 - Enable HTTP KeepAlives by default in the client.  15s idle timeout, 2x
@@ -46,11 +75,11 @@ We also now add support for using `SDC_*` and `TRITON_*` env vars when working w
 - Add support for ForceDelete of all children of a directory [#71](https://github.com/joyent/issues/71)
 - storage: Introduce `Objects.GetInfo` and `Objects.IsDir` using HEAD requests [#74](https://github.com/joyent/triton-go/issues/74)
 
-## 0.2.1 (November 8)
+## 0.2.1 (November 8 2017)
 
 - Fixing a bug where CreateUser and UpdateUser didn't return the UserID
 
-## 0.2.0 (November 7)
+## 0.2.0 (November 7 2017)
 
 - Introduce CloudAPI's Ping under compute
 - Introduce CloudAPI's RebootMachine under compute instances
@@ -59,6 +88,6 @@ We also now add support for using `SDC_*` and `TRITON_*` env vars when working w
 - tools: Introduce unit testing and scripts for linting, etc.
 - bug: Fix the `compute.ListMachineRules` endpoint
 
-## 0.1.0 (November 2)
+## 0.1.0 (November 2 2017)
 
 - Initial release of a versioned SDK

--- a/vendor/github.com/joyent/triton-go/GNUmakefile
+++ b/vendor/github.com/joyent/triton-go/GNUmakefile
@@ -1,15 +1,13 @@
 TEST?=$$(go list ./... |grep -Ev 'vendor|examples|testutils')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 
-default: vet errcheck test
+default: check test
 
 tools:: ## Download and install all dev/code tools
 	@echo "==> Installing dev tools"
 	go get -u github.com/golang/dep/cmd/dep
-	go get -u github.com/golang/lint/golint
-	go get -u github.com/kisielk/errcheck
-	@echo "==> Installing test package dependencies"
-	go test -i $(TEST) || exit 1
+	go get -u github.com/alecthomas/gometalinter
+	gometalinter --install
 
 test:: ## Run unit tests
 	@echo "==> Running unit test with coverage"
@@ -19,26 +17,22 @@ testacc:: ## Run acceptance tests
 	@echo "==> Running acceptance tests"
 	TRITON_TEST=1 go test $(TEST) -v $(TESTARGS) -run -timeout 120m
 
-vet:: ## Check for unwanted code constructs
-	@echo "go vet ."
-	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \
-		echo ""; \
-		echo "Vet found suspicious constructs. Please check the reported constructs"; \
-		echo "and fix them if necessary before submitting the code for review."; \
-		exit 1; \
-	fi
-
-lint:: ## Lint and vet code by common Go standards
-	@bash $(CURDIR)/scripts/lint.sh
-
-fmt:: ## Format as canonical Go code
-	gofmt -w $(GOFMT_FILES)
-
-fmtcheck:: ## Check if code format is canonical Go
-	@bash $(CURDIR)/scripts/gofmtcheck.sh
-
-errcheck:: ## Check for unhandled errors
-	@bash $(CURDIR)/scripts/errcheck.sh
+check::
+	gometalinter \
+    		--deadline 10m \
+    		--vendor \
+    		--sort="path" \
+    		--aggregate \
+    		--enable-gc \
+    		--disable-all \
+    		--enable goimports \
+    		--enable misspell \
+    		--enable vet \
+    		--enable deadcode \
+    		--enable varcheck \
+    		--enable ineffassign \
+    		--enable gofmt \
+    		./...
 
 .PHONY: help
 help:: ## Display this help message

--- a/vendor/github.com/joyent/triton-go/README.md
+++ b/vendor/github.com/joyent/triton-go/README.md
@@ -5,6 +5,15 @@ using Joyent's Triton Compute and Storage (Manta) APIs.
 
 [![Build Status](https://travis-ci.org/joyent/triton-go.svg?branch=master)](https://travis-ci.org/joyent/triton-go) [![Go Report Card](https://goreportcard.com/badge/github.com/joyent/triton-go)](https://goreportcard.com/report/github.com/joyent/triton-go)
 
+The Triton Go SDK is used in the following open source projects.
+
+- [Packer](http://github.com/hashicorp/packer)
+- [Vault](http://github.com/hashicorp/vault)
+- [Terraform](http://github.com/hashicorp/terraform)
+- [Terraform Triton Provider](https://github.com/terraform-providers/terraform-provider-triton)
+- [Docker Machine](https://github.com/joyent/docker-machine-driver-triton)
+- [Triton Kubernetes](https://github.com/joyent/triton-kubernetes)
+
 ## Usage
 
 Triton uses [HTTP Signature][4] to sign the Date header in each HTTP request
@@ -38,7 +47,7 @@ ssh-keygen -Emd5 -lf ~/.ssh/id_rsa.pub | cut -d " " -f 2 | sed 's/MD5://'
 ```
 
 Each top level package, `account`, `compute`, `identity`, `network`, all have
-their own seperate client. In order to initialize a package client, simply pass
+their own separate client. In order to initialize a package client, simply pass
 the global `triton.ClientConfig` struct into the client's constructor function.
 
 ```go
@@ -73,8 +82,8 @@ if err != nil {
 ## Error Handling
 
 If an error is returned by the HTTP API, the `error` returned from the function
-will contain an instance of `compute.TritonError` in the chain. Error wrapping
-is performed using the [errwrap][7] library from HashiCorp.
+will contain an instance of `errors.APIError` in the chain. Error wrapping
+is performed using the [pkg/errors][7] library.
 
 ## Acceptance Tests
 
@@ -235,4 +244,4 @@ func main() {
 [4]: https://github.com/joyent/node-http-signature/blob/master/http_signing.md
 [5]: https://godoc.org/github.com/joyent/triton-go/authentication
 [6]: https://godoc.org/github.com/joyent/triton-go/authentication
-[7]: https://github.com/hashicorp/go-errwrap
+[7]: https://github.com/pkg/errors

--- a/vendor/github.com/joyent/triton-go/authentication/agent_key_identifier.go
+++ b/vendor/github.com/joyent/triton-go/authentication/agent_key_identifier.go
@@ -1,0 +1,25 @@
+package authentication
+
+import "path"
+
+type KeyID struct {
+	UserName    string
+	AccountName string
+	Fingerprint string
+	IsManta     bool
+}
+
+func (input *KeyID) generate() string {
+	var keyID string
+	if input.UserName != "" {
+		if input.IsManta {
+			keyID = path.Join("/", input.AccountName, input.UserName, "keys", input.Fingerprint)
+		} else {
+			keyID = path.Join("/", input.AccountName, "users", input.UserName, "keys", input.Fingerprint)
+		}
+	} else {
+		keyID = path.Join("/", input.AccountName, "keys", input.Fingerprint)
+	}
+
+	return keyID
+}

--- a/vendor/github.com/joyent/triton-go/authentication/signer.go
+++ b/vendor/github.com/joyent/triton-go/authentication/signer.go
@@ -13,6 +13,6 @@ const authorizationHeaderFormat = `Signature keyId="%s",algorithm="%s",headers="
 type Signer interface {
 	DefaultAlgorithm() string
 	KeyFingerprint() string
-	Sign(dateHeader string) (string, error)
+	Sign(dateHeader string, isManta bool) (string, error)
 	SignRaw(toSign string) (string, string, error)
 }

--- a/vendor/github.com/joyent/triton-go/authentication/test_signer.go
+++ b/vendor/github.com/joyent/triton-go/authentication/test_signer.go
@@ -26,7 +26,7 @@ func (s *TestSigner) KeyFingerprint() string {
 	return ""
 }
 
-func (s *TestSigner) Sign(dateHeader string) (string, error) {
+func (s *TestSigner) Sign(dateHeader string, isManta bool) (string, error) {
 	return "", nil
 }
 

--- a/vendor/github.com/joyent/triton-go/storage/client.go
+++ b/vendor/github.com/joyent/triton-go/storage/client.go
@@ -9,6 +9,8 @@
 package storage
 
 import (
+	"net/http"
+
 	triton "github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/client"
 )
@@ -32,6 +34,12 @@ func NewClient(config *triton.ClientConfig) (*StorageClient, error) {
 		return nil, err
 	}
 	return newStorageClient(client), nil
+}
+
+// SetHeader allows a consumer of the current client to set a custom header for
+// the next backend HTTP request sent to CloudAPI.
+func (c *StorageClient) SetHeader(header *http.Header) {
+	c.Client.RequestHeader = header
 }
 
 // Dir returns a DirectoryClient used for accessing functions pertaining to

--- a/vendor/github.com/joyent/triton-go/storage/directory.go
+++ b/vendor/github.com/joyent/triton-go/storage/directory.go
@@ -102,7 +102,7 @@ type PutDirectoryInput struct {
 	DirectoryName string
 }
 
-// Put puts a directoy into the Triton Object Storage service is an idempotent
+// Put puts a director into the Triton Object Storage service is an idempotent
 // create-or-update operation. Your private namespace starts at /:login, and you
 // can create any nested set of directories or objects within it.
 func (s *DirectoryClient) Put(ctx context.Context, input *PutDirectoryInput) error {

--- a/vendor/github.com/joyent/triton-go/triton.go
+++ b/vendor/github.com/joyent/triton-go/triton.go
@@ -9,6 +9,8 @@
 package triton
 
 import (
+	"os"
+
 	"github.com/joyent/triton-go/authentication"
 )
 
@@ -24,4 +26,21 @@ type ClientConfig struct {
 	AccountName string
 	Username    string
 	Signers     []authentication.Signer
+}
+
+var envPrefixes = []string{"TRITON", "SDC"}
+
+// GetEnv looks up environment variables using the preferred "TRITON" prefix,
+// but falls back to the retired "SDC" prefix.  For example, looking up "USER"
+// will search for "TRITON_USER" followed by "SDC_USER".  If the environment
+// variable is not set, an empty string is returned.  GetEnv() is used to aid in
+// the transition and deprecation of the "SDC_*" environment variables.
+func GetEnv(name string) string {
+	for _, prefix := range envPrefixes {
+		if val, found := os.LookupEnv(prefix + "_" + name); found {
+			return val
+		}
+	}
+
+	return ""
 }

--- a/vendor/github.com/joyent/triton-go/version.go
+++ b/vendor/github.com/joyent/triton-go/version.go
@@ -13,20 +13,30 @@ import (
 	"runtime"
 )
 
-// The main version number of the current released Triton-go SDK.
-const Version = "0.9.0"
+// Version represents main version number of the current release
+// of the Triton-go SDK.
+const Version = "1.3.0"
 
-// A pre-release marker for the version. If this is "" (empty string)
-// then it means that it is a final release. Otherwise, this is a pre-release
-// such as "dev" (in development), "beta", "rc1", etc.
-var Prerelease = ""
+// Prerelease adds a pre-release marker to the version.
+//
+// If this is "" (empty string) then it means that it is a final release.
+// Otherwise, this is a pre-release such as "dev" (in development), "beta",
+// "rc1", etc.
+var Prerelease = "dev"
 
+// UserAgent returns a Triton-go characteristic string that allows the
+// network protocol peers to identify the version, release and runtime
+// of the Triton-go client from which the requests originate.
 func UserAgent() string {
 	if Prerelease != "" {
-		return fmt.Sprintf("triton-go/%s-%s (%s-%s; %s)", Version, Prerelease, runtime.GOARCH, runtime.GOOS, runtime.Version())
-	} else {
-		return fmt.Sprintf("triton-go/%s (%s-%s; %s)", Version, runtime.GOARCH, runtime.GOOS, runtime.Version())
+		return fmt.Sprintf("triton-go/%s-%s (%s-%s; %s)", Version, Prerelease,
+			runtime.GOARCH, runtime.GOOS, runtime.Version())
 	}
+
+	return fmt.Sprintf("triton-go/%s (%s-%s; %s)", Version, runtime.GOARCH,
+		runtime.GOOS, runtime.Version())
 }
 
+// CloudAPIMajorVersion specifies the CloudAPI version compatibility
+// for current release of the Triton-go SDK.
 const CloudAPIMajorVersion = "8"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -293,22 +293,22 @@
 			"revisionTime": "2016-01-12T19:33:35Z"
 		},
 		{
-			"checksumSHA1": "Lg8OHK87XRGCaipG+5+zFyN8OMw=",
+			"checksumSHA1": "5VzjxB0GrAjzNsfz1DhLc+uPs7c=",
 			"path": "github.com/joyent/triton-go",
-			"revision": "7e6a47b300b10be9449610a6ff4fbae17d6e95b6",
-			"revisionTime": "2018-01-16T16:19:11Z"
+			"revision": "b83a06f9648d350e2540ce3b382e0e9308381ac0",
+			"revisionTime": "2018-03-20T19:41:30Z"
 		},
 		{
-			"checksumSHA1": "Y03+L+I0FVZ2bMGWt1MHTDEyWM4=",
+			"checksumSHA1": "yNrArK8kjkVkU0bunKlemd6dFkE=",
 			"path": "github.com/joyent/triton-go/authentication",
-			"revision": "7e6a47b300b10be9449610a6ff4fbae17d6e95b6",
-			"revisionTime": "2018-01-16T16:19:11Z"
+			"revision": "b83a06f9648d350e2540ce3b382e0e9308381ac0",
+			"revisionTime": "2018-03-20T19:41:30Z"
 		},
 		{
-			"checksumSHA1": "MuJsGBr6HlXQYxZY9cM5rBk+Lns=",
+			"checksumSHA1": "QzmY6NT9K3EeHuV01wRPL/33/4o=",
 			"path": "github.com/joyent/triton-go/client",
-			"revision": "7e6a47b300b10be9449610a6ff4fbae17d6e95b6",
-			"revisionTime": "2018-01-16T16:19:11Z"
+			"revision": "b83a06f9648d350e2540ce3b382e0e9308381ac0",
+			"revisionTime": "2018-03-20T19:41:30Z"
 		},
 		{
 			"checksumSHA1": "d/Py6j/uMgOAFNFGpsQrNnSsO+k=",
@@ -317,10 +317,10 @@
 			"revisionTime": "2018-01-16T16:19:11Z"
 		},
 		{
-			"checksumSHA1": "5v533ELM047YOiwHsyMaVzITpR0=",
+			"checksumSHA1": "MAjG3M0OLUJ3hdNZLHHpXdl1THQ=",
 			"path": "github.com/joyent/triton-go/storage",
-			"revision": "7e6a47b300b10be9449610a6ff4fbae17d6e95b6",
-			"revisionTime": "2018-01-16T16:19:11Z"
+			"revision": "b83a06f9648d350e2540ce3b382e0e9308381ac0",
+			"revisionTime": "2018-03-20T19:41:30Z"
 		},
 		{
 			"path": "github.com/klauspost/cpuid",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The parsing on custom manta url was incorrect and would strip 'https://'. In order to support subuser authentication, the subuser needed to be passed in with the client config. The referenced triton-go branch needs to be rebased to a newer version. 

I'm waiting on multipart upload to hit public manta before merging the metadata and minio multipart upload code as well.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Manta gateway has always been broken for private and subuser.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested against public joyent endpoint (https://us-east.manta.joyent.com) as well as against a private endpoint, both with and without subuser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.