### PR TITLE
Support for ListObjectsV1 style marker for Azure gateway

### DIFF
--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -572,8 +572,8 @@ func (l *gcsGateway) ListObjects(ctx context.Context, bucket string, prefix stri
 	// supplied markers.
 	//
 	// - NextMarker in ListObjectsV1 response is constructed by
-	//   prefixing "##minio" to the GCS continuation token,
-	//   e.g, "##minioCgRvYmoz"
+	//   prefixing "{minio}" to the GCS continuation token,
+	//   e.g, "{minio}CgRvYmoz"
 	//
 	// - Application supplied markers are used as-is to list
 	//   object keys that appear after it in the lexicographical order.


### PR DESCRIPTION
fixes #4948

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Azure expects marker (https://docs.microsoft.com/en-us/rest/api/storageservices/List-Blobs?redirectedfrom=MSDN) in the ListBlobs request to be the nextmarker field of the previous ListBlobs result.

The marker is an opaque value.

Arq 5, does not use Azure's ListBlobs result for the marker and uses the object name directly (which is allowed in the S3 protocol)

To support such a List request:
```
        // To accommodate S3-compatible applications using
        // ListObjectsV1 to use object keys as markers to control the
        // listing of objects, we use the following encoding scheme to
        // distinguish between Azure continuation tokens and application
        // supplied markers.
        //
        // - NextMarker in ListObjectsV1 response is constructed by
        //   prefixing "{minio}" to the Azure continuation token,
        //   e.g, "{minio}CgRvYmoz"
        //
        // - Application supplied markers are used as-is to list
        //   object keys that appear after it in the lexicographical order.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.