### PR TITLE
[gateway/azure] Support copying an object without copying its user-defined metadata

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -716,6 +716,17 @@ func (a *azureObjects) CopyObject(ctx context.Context, srcBucket, srcObject, des
 		logger.LogIf(ctx, err)
 		return objInfo, azureToObjectError(err, srcBucket, srcObject)
 	}
+	// Azure will copy metadata from the source object when an empty metadata map is provided.
+	// To handle the case where the source object should be copied without its metadata,
+	// the metadata must be removed from the dest. object after the copy completes
+	if len(azureMeta) == 0 && len(destBlob.Metadata) != 0 {
+		destBlob.Metadata = azureMeta
+		err = destBlob.SetMetadata(nil)
+		if err != nil {
+			logger.LogIf(ctx, err)
+			return objInfo, azureToObjectError(err, srcBucket, srcObject)
+		}
+	}
 	destBlob.Properties = props
 	err = destBlob.SetProperties(nil)
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a change to the Azure CopyObject implementation which handles the case where the user is copying an object which has existing metadata but would like to not have that metadata copied to the destination object.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Azure will copy the metadata from source object to the destination object if no user-defined metadata is specified on the copy object request ([See x-ms-meta description](https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob#request-headers)).  

Without this change a user is unable to remove all metadata from an object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the AWS CLI.  Steps to reproduce are as follows:

1) Upload an object with metadata
`aws --endpoint-url http://127.0.0.1:9000 s3api put-object --bucket testbucket --key test.txt --body testfile.txt --metadata test=123`

2) Copy the object over itself, specifying the metadata REPLACE directive while providing no metadata.
`aws --endpoint-url http://127.0.0.1:9000 s3api copy-object --copy-source testbucket/test.txt --bucket testbucket --key test.txt --metadata-directive REPLACE`

3) Perform a head object call against the copied object and observe that the user-defined metadata is still present on the object
`aws --endpoint-url http://127.0.0.1:9000 s3api head-object --bucket testbucket--key test.txt`

When repeating the above steps using the code in this PR, after performing step 3 you should observe that the user-defined metadata is no longer present on the object.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [x] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: minio/minio-java#677 )
- [x] All new and existing tests passed.