### PR TITLE
Remove s3:ListObjects policy action to be in sync with AWS-S3

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -183,24 +183,6 @@ func checkRequestAuthType(ctx context.Context, r *http.Request, action policy.Ac
 		return ErrNone
 	}
 
-	// As policy.ListBucketAction and policy.ListObjectsAction are same but different names,
-	// policy.ListBucketAction is used across the code but user may used policy.ListObjectsAction
-	// in bucket policy to denote the same. In below try again with policy.ListObjectsAction.
-	if action != policy.ListBucketAction {
-		return ErrAccessDenied
-	}
-
-	if globalPolicySys.IsAllowed(policy.Args{
-		AccountName:     accountName,
-		Action:          policy.ListObjectsAction,
-		BucketName:      bucketName,
-		ConditionValues: getConditionValues(r, locationConstraint),
-		IsOwner:         isOwner,
-		ObjectName:      objectName,
-	}) {
-		return ErrNone
-	}
-
 	return ErrAccessDenied
 }
 

--- a/pkg/policy/action.go
+++ b/pkg/policy/action.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Action - policy action.
-// Refer https://docs.aws.amazon.com/IAM/latest/UserGuide/list_s3.html
+// Refer https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html
 // for more information about available actions.
 type Action string
 
@@ -75,9 +75,6 @@ const (
 	// ListMultipartUploadPartsAction - ListParts Rest API action.
 	ListMultipartUploadPartsAction = "s3:ListMultipartUploadParts"
 
-	// ListObjectsAction - ListObjects Rest API action exactly same behavior as ListBucketAction.
-	ListObjectsAction = "s3:ListObjects"
-
 	// PutBucketNotificationAction - PutObjectNotification Rest API action.
 	PutBucketNotificationAction = "s3:PutBucketNotification"
 
@@ -113,7 +110,7 @@ func (action Action) IsValid() bool {
 		fallthrough
 	case ListBucketMultipartUploadsAction, ListenBucketNotificationAction:
 		fallthrough
-	case ListMultipartUploadPartsAction, ListObjectsAction, PutBucketNotificationAction:
+	case ListMultipartUploadPartsAction, PutBucketNotificationAction:
 		fallthrough
 	case PutBucketPolicyAction, PutObjectAction:
 		return true
@@ -233,14 +230,6 @@ var actionConditionKeyMap = map[Action]condition.KeySet{
 	),
 
 	ListMultipartUploadPartsAction: condition.NewKeySet(
-		condition.AWSReferer,
-		condition.AWSSourceIP,
-	),
-
-	ListObjectsAction: condition.NewKeySet(
-		condition.S3Prefix,
-		condition.S3Delimiter,
-		condition.S3MaxKeys,
 		condition.AWSReferer,
 		condition.AWSSourceIP,
 	),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
AWS-S3 doesn't support `s3:ListObjects` anymore https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html

We can also remove it.

(`s3:ListBucket` is supported though.)

<!--- Describe your changes in detail -->
```
krishna@escape:~$ cat policy1.json
{
  "Id": "Policy1525202156495",
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "Stmt1525201999262",
      "Action": [
        "s3:ListObjects"
      ],
      "Effect": "Allow",
      "Resource": "arn:aws:s3:::vadmeste",
      "Principal": "*"
    }
  ]
}
krishna@escape:~$ aws s3api put-bucket-policy --bucket vadmeste --policy file:///home/krishna/policy1.json

An error occurred (MalformedPolicy) when calling the PutBucketPolicy operation: Policy has invalid action
krishna@escape:~$
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.