### PR TITLE
Trimming leading and tailing white spaces in crt file to avoid SSL issue

### DIFF
--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/tls"
@@ -38,6 +39,9 @@ func parsePublicCertFile(certFile string) (x509Certs []*x509.Certificate, err er
 	if data, err = ioutil.ReadFile(certFile); err != nil {
 		return nil, err
 	}
+
+	// Trimming leading and tailing white spaces.
+	data = bytes.TrimSpace(data)
 
 	// Parse all certs in the chain.
 	current := data


### PR DESCRIPTION
Issue Fix: SSL - **Invalid SSL certificate file #5632**

The spaces in the public.crt throws "Invalid SSL certificate file"

Changes Done: Removed the tailing/heading spaces in **parsePublicCertFile** function #