### PR TITLE
SignatureV4 validation with Metadata in the presignedUrl

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -601,7 +601,8 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	}
 
 	// Extract metadata to be saved from received Form.
-	metadata, err := extractMetadataFromHeader(ctx, formValues)
+	metadata := make(map[string]string)
+	err = extractMetadataFromMap(ctx, formValues, metadata)
 	if err != nil {
 		writeErrorResponse(w, ErrInternalError, r.URL)
 		return

--- a/cmd/handler-utils_test.go
+++ b/cmd/handler-utils_test.go
@@ -165,9 +165,9 @@ func TestExtractMetadataHeaders(t *testing.T) {
 				"x-amz-meta-appid": []string{"amz-meta"},
 			},
 			metadata: map[string]string{
-				"X-Amz-Meta-Appid": "amz-meta",
+				"x-amz-meta-appid": "amz-meta",
 			},
-			shouldFail: true,
+			shouldFail: false,
 		},
 		// Empty header input returns empty metadata.
 		{
@@ -179,7 +179,8 @@ func TestExtractMetadataHeaders(t *testing.T) {
 
 	// Validate if the extracting headers.
 	for i, testCase := range testCases {
-		metadata, err := extractMetadataFromHeader(context.Background(), testCase.header)
+		metadata := make(map[string]string)
+		err := extractMetadataFromMap(context.Background(), testCase.header, metadata)
 		if err != nil && !testCase.shouldFail {
 			t.Fatalf("Test %d failed to extract metadata: %v", i+1, err)
 		}

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -249,6 +249,12 @@ func doesPresignedSignatureMatch(hashedPayload string, r *http.Request, region s
 
 	// Save other headers available in the request parameters.
 	for k, v := range req.URL.Query() {
+
+		// Handle the metadata in presigned put query string
+		if strings.Contains(strings.ToLower(k), "x-amz-meta-") {
+			query.Set(k, v[0])
+		}
+
 		if strings.HasPrefix(strings.ToLower(k), "x-amz") {
 			continue
 		}

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -629,7 +629,7 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Extract incoming metadata if any.
-	metadata, err := extractMetadataFromHeader(context.Background(), r.Header)
+	metadata, err := extractMetadata(context.Background(), r)
 	if err != nil {
 		writeErrorResponse(w, ErrInternalError, r.URL)
 		return


### PR DESCRIPTION
- [x] - The presigned url generated by the sdk had the amz-metadata in the query string. The v4signature should have the metadata included,which was not happening before.
- [x] - The metadata was not handled when sent in as a query string parameter. Still was accepting it via headers.

**Changes Made:**
- Function doesPresignedSignatureMatch, metadata inclusion in signature validation

**Function Added:**
- Function extractMetadataFromQueryString, extracting metadata from query string

**Resolves:** #5857

**Changes committed:**
	modified:   cmd/handler-utils.go
	modified:   cmd/object-handlers.go
	modified:   cmd/signature-v4.go
