### PR TITLE
Fix azure list-objects not to list minio.sys.tmp/

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -551,7 +551,7 @@ func (a *azureObjects) ListObjects(ctx context.Context, bucket, prefix, marker, 
 		}
 
 		for _, blob := range resp.Blobs {
-			if strings.HasPrefix(blob.Name, minio.GatewayMinioSysTmp) {
+			if delimiter == "" && strings.HasPrefix(blob.Name, minio.GatewayMinioSysTmp) {
 				// We filter out minio.GatewayMinioSysTmp entries in the recursive listing.
 				continue
 			}
@@ -572,7 +572,7 @@ func (a *azureObjects) ListObjects(ctx context.Context, bucket, prefix, marker, 
 		}
 
 		for _, blobPrefix := range resp.BlobPrefixes {
-			if prefix == minio.GatewayMinioSysTmp {
+			if blobPrefix == minio.GatewayMinioSysTmp {
 				// We don't do strings.HasPrefix(blob.Name, minio.GatewayMinioSysTmp) here so that
 				// we can use tools like mc to inspect the contents of minio.sys.tmp/
 				// It is OK to allow listing of minio.sys.tmp/ in non-recursive mode as it aids in debugging.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Because of incorrect comparison, we were listing `minio.sys.tmp/` in non-recursive listing output

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual and functional tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.