### PR TITLE
Fix unnecessary log messages to avoid flooding the logs

### DIFF
--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -225,6 +225,15 @@ func fsStatDir(ctx context.Context, statDir string) (os.FileInfo, error) {
 	return fi, nil
 }
 
+// Returns if the dirPath is a directory.
+func fsIsDir(ctx context.Context, dirPath string) bool {
+	fi, err := fsStat(ctx, dirPath)
+	if err != nil {
+		return false
+	}
+	return fi.IsDir()
+}
+
 // Lookup if file exists, returns file attributes upon success.
 func fsStatFile(ctx context.Context, statFile string) (os.FileInfo, error) {
 	fi, err := fsStat(ctx, statFile)
@@ -240,6 +249,15 @@ func fsStatFile(ctx context.Context, statFile string) (os.FileInfo, error) {
 		return nil, errFileAccessDenied
 	}
 	return fi, nil
+}
+
+// Returns if the filePath is a regular file.
+func fsIsFile(ctx context.Context, filePath string) bool {
+	fi, err := fsStat(ctx, filePath)
+	if err != nil {
+		return false
+	}
+	return fi.Mode().IsRegular()
 }
 
 // Opens the file at given path, optionally from an offset. Upon success returns
@@ -402,7 +420,9 @@ func fsDeleteFile(ctx context.Context, basePath, deletePath string) error {
 	}
 
 	if err := deleteFile(basePath, deletePath); err != nil {
-		logger.LogIf(ctx, err)
+		if err != errFileNotFound {
+			logger.LogIf(ctx, err)
+		}
 		return err
 	}
 	return nil

--- a/cmd/fs-v1-helpers_test.go
+++ b/cmd/fs-v1-helpers_test.go
@@ -547,3 +547,33 @@ func TestFSRemoveMeta(t *testing.T) {
 		t.Fatalf("`%s` parent directory found though it should have been deleted.", filePath)
 	}
 }
+
+func TestFSIsDir(t *testing.T) {
+	dirPath, err := ioutil.TempDir(globalTestTmpDir, "minio-")
+	if err != nil {
+		t.Fatalf("Unable to create tmp directory %s", err)
+	}
+	defer os.RemoveAll(dirPath)
+
+	if !fsIsDir(context.Background(), dirPath) {
+		t.Fatalf("Expected %s to be a directory", dirPath)
+	}
+}
+
+func TestFSIsFile(t *testing.T) {
+	dirPath, err := ioutil.TempDir(globalTestTmpDir, "minio-")
+	if err != nil {
+		t.Fatalf("Unable to create tmp directory %s", err)
+	}
+	defer os.RemoveAll(dirPath)
+
+	filePath := pathJoin(dirPath, "tmpfile")
+
+	if err = ioutil.WriteFile(filePath, nil, 0777); err != nil {
+		t.Fatalf("Unable to create file %s", filePath)
+	}
+
+	if !fsIsFile(context.Background(), filePath) {
+		t.Fatalf("Expected %s to be a file", filePath)
+	}
+}

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -563,17 +563,16 @@ func (fs *FSObjects) defaultFsJSON(object string) fsMetaV1 {
 // getObjectInfo - wrapper for reading object metadata and constructs ObjectInfo.
 func (fs *FSObjects) getObjectInfo(ctx context.Context, bucket, object string) (oi ObjectInfo, e error) {
 	fsMeta := fsMetaV1{}
-	fi, err := fsStatDir(ctx, pathJoin(fs.fsPath, bucket, object))
-	if err != nil && err != errFileAccessDenied {
-		return oi, err
-	}
-	if fi != nil {
-		// If file found and request was with object ending with "/", consider it
-		// as directory and return object info
-		if hasSuffix(object, slashSeparator) {
-			return fsMeta.ToObjectInfo(bucket, object, fi), nil
+	if hasSuffix(object, slashSeparator) {
+		// Since we support PUT of a "directory" object, we allow HEAD.
+		if !fsIsDir(ctx, pathJoin(fs.fsPath, bucket, object)) {
+			return oi, errFileNotFound
 		}
-		return oi, errFileNotFound
+		fi, err := fsStatDir(ctx, pathJoin(fs.fsPath, bucket, object))
+		if err != nil {
+			return oi, err
+		}
+		return fsMeta.ToObjectInfo(bucket, object, fi), nil
 	}
 
 	fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket, object, fs.metaJSONFile)
@@ -602,7 +601,7 @@ func (fs *FSObjects) getObjectInfo(ctx context.Context, bucket, object string) (
 	}
 
 	// Stat the file to get file size.
-	fi, err = fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
+	fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
 	if err != nil {
 		return oi, err
 	}
@@ -660,7 +659,7 @@ func (fs *FSObjects) parentDirIsObject(ctx context.Context, bucket, parent strin
 		if p == "." || p == "/" {
 			return false
 		}
-		if _, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, p)); err == nil {
+		if fsIsFile(ctx, pathJoin(fs.fsPath, bucket, p)) {
 			// If there is already a file at prefix "p", return true.
 			return true
 		}

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -137,7 +137,6 @@ func (xl xlObjects) getBucketInfo(ctx context.Context, bucketName string) (bucke
 			}
 			return bucketInfo, nil
 		}
-		logger.LogIf(ctx, serr)
 		err = serr
 		// For any reason disk went offline continue and pick the next one.
 		if IsErrIgnored(err, bucketMetadataOpIgnoredErrs...) {

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -829,7 +829,6 @@ func (xl xlObjects) DeleteObject(ctx context.Context, bucket, object string) (er
 
 	// Validate object exists.
 	if !xl.isObject(bucket, object) {
-		logger.LogIf(ctx, ObjectNotFound{bucket, object})
 		return ObjectNotFound{bucket, object}
 	} // else proceed to delete the object.
 

--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -66,7 +66,7 @@ func reduceErrs(errs []error, ignoredErrs []error) (maxCount int, maxErr error) 
 func reduceQuorumErrs(ctx context.Context, errs []error, ignoredErrs []error, quorum int, quorumErr error) error {
 	maxCount, maxErr := reduceErrs(errs, ignoredErrs)
 	if maxCount >= quorum {
-		if maxErr != errFileNotFound {
+		if maxErr != errFileNotFound && maxErr != errVolumeNotFound {
 			logger.LogIf(ctx, maxErr)
 		}
 		return maxErr


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
mc ls causes:
```
API: ListObjectsV1(bucket=test)
Time: 20:15:34 PDT 05/07/2018
RemoteHost: 127.0.0.1:39618
UserAgent: Minio (linux; amd64) minio-go/5.0.1 mc/DEVELOPMENT.GOGET
Error: file access denied
       1: cmd/fs-v1-helpers.go:222:cmd.fsStatDir()
       2: cmd/fs-v1.go:566:cmd.(*FSObjects).getObjectInfo()
       3: cmd/fs-v1.go:1009:cmd.(*FSObjects).ListObjects.func1()
       4: cmd/fs-v1.go:1046:cmd.(*FSObjects).ListObjects()
       5: cmd/bucket-handlers-listobjects.go:156:cmd.(ObjectLayer).ListObjects-fm()
       6: cmd/bucket-handlers-listobjects.go:163:cmd.objectAPIHandlers.ListObjectsV1Handler()
       7: cmd/api-router.go:95:cmd.(objectAPIHandlers).ListObjectsV1Handler-fm()
       8: net/http/server.go:1947:http.HandlerFunc.ServeHTTP()
```

mc rm -r --force myminio/test/a/b/ causes:
```
API: DeleteMultipleObjects(bucket=test)
Time: 20:39:16 PDT 05/07/2018
RemoteHost: 127.0.0.1:39676
UserAgent: Minio (linux; amd64) minio-go/5.0.1 mc/DEVELOPMENT.GOGET
Error: file not found
       1: cmd/fs-v1-helpers.go:421:cmd.fsDeleteFile()
       2: cmd/fs-v1.go:869:cmd.(*FSObjects).DeleteObject()
       3: cmd/bucket-handlers.go:256:cmd.(ObjectLayer).DeleteObject-fm()
       4: cmd/bucket-handlers.go:260:cmd.objectAPIHandlers.DeleteMultipleObjectsHandler.func1()

```

mc policy download  myminio/test/ causes:
```
API: SYSTEM()
Time: 20:15:54 PDT 05/07/2018
Error: file access denied
       1: cmd/fs-v1-helpers.go:239:cmd.fsStatFile()
       2: cmd/fs-v1.go:663:cmd.(*FSObjects).parentDirIsObject.func1()
       3: cmd/fs-v1.go:671:cmd.(*FSObjects).parentDirIsObject()
       4: cmd/fs-v1.go:734:cmd.(*FSObjects).putObject()
       5: cmd/fs-v1.go:689:cmd.(*FSObjects).PutObject()
       6: cmd/notification.go:502:cmd.saveConfig()
       7: cmd/policy.go:173:cmd.savePolicyConfig()
       8: cmd/fs-v1.go:1119:cmd.(*FSObjects).SetBucketPolicy()
       9: cmd/bucket-policy-handlers.go:88:cmd.objectAPIHandlers.PutBucketPolicyHandler()
      10: cmd/api-router.go:97:cmd.(objectAPIHandlers).PutBucketPolicyHandler-fm()
      11: net/http/server.go:1947:http.HandlerFunc.ServeHTTP()
```

fsStatDir is not at fault for printing error when it is not a dir, similarly fsStatFile is not at fault for printing when it is not a file. Hence callers should use fsIsDir/fsIsFile to detect if a path is a file or a directory.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove unnecessary logs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual and go test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.