### PR TITLE
Better error message for the PartSizeUnequal error.

### DIFF
--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -324,7 +324,8 @@ func (e InvalidPart) Error() string {
 type PartsSizeUnequal struct{}
 
 func (e PartsSizeUnequal) Error() string {
-	return "All parts except the last part should be of the same size"
+	return "All parts except the last part should be of the same size. If you see this, you are probably using the standalone single directory mode. " +
+		"You can workaround this by specifying four data directories instead of one."
 }
 
 // PartTooSmall - error if part size is less than 5MB.


### PR DESCRIPTION
Only the standalone single directory mode emits the PartSizeUnequal error and is therefore incompatible with some client libraries (e.g. https://github.com/hubrick/vertx-s3-client).

The new error message makes this clearer and avoids deterring potential users because of perceived incompatibilities.