### PR TITLE
Remove redundant prometheus data points

### DIFF
--- a/cmd/http-stats.go
+++ b/cmd/http-stats.go
@@ -190,8 +190,6 @@ func (st *HTTPStats) updateStats(r *http.Request, w *httpResponseRecorder, durat
 			st.successDELETEs.Duration.Add(durationSecs)
 		}
 	}
-	// Increment the prometheus http request count with appropriate label
-	httpRequests.With(prometheus.Labels{"request_type": r.Method}).Inc()
 	// Increment the prometheus http request response histogram with appropriate label
 	httpRequestsDuration.With(prometheus.Labels{"request_type": r.Method}).Observe(durationSecs)
 }


### PR DESCRIPTION
## Description
Removed field minio_http_requests_total as it was redundant with
minio_http_requests_duration_seconds_count

Also removed field minio_server_start_time_seconds as it was
redundant with process_start_time_seconds

## Motivation and Context
This PR removes couple of redundant fields in Prometheus data exported by Minio server.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.