### PR TITLE
Fix broken healthcheck link

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -9,7 +9,7 @@ Minio server has two healthcheck related endpoints, a liveness probe to indicate
 - Liveness probe available at `/minio/health/live`
 - Readiness probe available at `/minio/health/ready`
 
-Read more on how to use these endpoints in [Minio healthcheck guide](./healthcheck/README.md).
+Read more on how to use these endpoints in [Minio healthcheck guide](https://github.com/minio/minio/blob/master/docs/metrics/healthcheck/README.md).
 
 ### Prometheus Probe
 


### PR DESCRIPTION
## Description
Fix broken link in metrics document

## Motivation and Context
The link to health check doc is broken in Doctor page (https://docs.minio.io/docs/minio-monitoring-guide). This PR fixes the link

## How Has This Been Tested?
NA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.