### PR TITLE
remove errVolumeExists error

### DIFF
--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -648,24 +648,22 @@ func initFormatXL(ctx context.Context, storageDisks []StorageAPI, setCount, disk
 func makeFormatXLMetaVolumes(disk StorageAPI) error {
 	// Attempt to create `.minio.sys`.
 	if err := disk.MakeVol(minioMetaBucket); err != nil {
-		if !IsErrIgnored(err, initMetaVolIgnoredErrs...) {
+		if !IsErrIgnored(err, baseIgnoredErrs...) {
 			return err
 		}
 	}
 	if err := disk.MakeVol(minioMetaTmpBucket); err != nil {
-		if !IsErrIgnored(err, initMetaVolIgnoredErrs...) {
+		if !IsErrIgnored(err, baseIgnoredErrs...) {
 			return err
 		}
 	}
 	if err := disk.MakeVol(minioMetaMultipartBucket); err != nil {
-		if !IsErrIgnored(err, initMetaVolIgnoredErrs...) {
+		if !IsErrIgnored(err, baseIgnoredErrs...) {
 			return err
 		}
 	}
 	return nil
 }
-
-var initMetaVolIgnoredErrs = append(baseIgnoredErrs, errVolumeExists)
 
 // Initializes meta volume on all input storage disks.
 func initFormatXLMetaVolume(storageDisks []StorageAPI, formats []*formatXLV3) error {

--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/lock"
+	xos "github.com/minio/minio/pkg/os"
 )
 
 // Removes only the file at given path does not remove
@@ -120,10 +121,8 @@ func fsMkdir(ctx context.Context, dirPath string) (err error) {
 		return err
 	}
 
-	if err = os.Mkdir((dirPath), 0777); err != nil {
-		if os.IsExist(err) {
-			return errVolumeExists
-		} else if os.IsPermission(err) {
+	if err = xos.Mkdir(dirPath, 0777); err != nil {
+		if os.IsPermission(err) {
 			logger.LogIf(ctx, errDiskAccessDenied)
 			return errDiskAccessDenied
 		} else if isSysErrNotDir(err) {

--- a/cmd/fs-v1-helpers_test.go
+++ b/cmd/fs-v1-helpers_test.go
@@ -82,7 +82,7 @@ func TestFSStats(t *testing.T) {
 	// Seek back.
 	reader.Seek(0, 0)
 
-	if err = fsMkdir(context.Background(), pathJoin(path, "success-vol", "success-file")); err != errVolumeExists {
+	if err = fsMkdir(context.Background(), pathJoin(path, "success-vol", "success-file")); err != errDiskAccessDenied {
 		t.Fatal("Unexpected error", err)
 	}
 

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -228,6 +228,12 @@ func (fs *FSObjects) MakeBucketWithLocation(ctx context.Context, bucket, locatio
 		logger.LogIf(ctx, err)
 		return err
 	}
+
+	_, err := fs.statBucketDir(ctx, bucket)
+	if err == nil {
+		return BucketExists{Bucket: bucket}
+	}
+
 	bucketDir, err := fs.getBucketDir(ctx, bucket)
 	if err != nil {
 		return toObjectErr(err, bucket)

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -34,10 +34,6 @@ func toObjectErr(err error, params ...string) error {
 		if len(params) >= 1 {
 			err = BucketNotEmpty{Bucket: params[0]}
 		}
-	case errVolumeExists:
-		if len(params) >= 1 {
-			err = BucketExists{Bucket: params[0]}
-		}
 	case errDiskFull:
 		err = StorageFull{}
 	case errFileAccessDenied:

--- a/cmd/posix-errors.go
+++ b/cmd/posix-errors.go
@@ -55,6 +55,10 @@ func isSysErrIsDir(err error) bool {
 
 // Check if the given error corresponds to ENOTDIR (is not a directory).
 func isSysErrNotDir(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	if pathErr, ok := err.(*os.PathError); ok {
 		switch pathErr.Err {
 		case syscall.ENOTDIR:
@@ -95,6 +99,10 @@ func isSysErrNotEmpty(err error) bool {
 
 // Check if the given error corresponds to the specific ERROR_PATH_NOT_FOUND for windows
 func isSysErrPathNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	if runtime.GOOS != globalWindowsOSName {
 		return false
 	}

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -310,20 +310,13 @@ func (s *posix) MakeVol(volume string) (err error) {
 		return err
 	}
 
-	if _, err := os.Stat(volumeDir); err != nil {
-		// Volume does not exist we proceed to create.
-		if os.IsNotExist(err) {
-			// Make a volume entry, with mode 0777 mkdir honors system umask.
-			err = os.MkdirAll(volumeDir, 0777)
-		}
-		if os.IsPermission(err) {
-			return errDiskAccessDenied
-		}
-		return err
+	// Make a volume entry, with mode 0777 mkdir honors system umask.
+	err = os.MkdirAll(volumeDir, 0777)
+	if os.IsPermission(err) || isSysErrNotDir(err) || isSysErrPathNotFound(err) {
+		return errDiskAccessDenied
 	}
 
-	// Stat succeeds we return errVolumeExists.
-	return errVolumeExists
+	return err
 }
 
 // ListVols - list volumes.

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -343,13 +343,7 @@ func TestPosixMakeVol(t *testing.T) {
 		{
 			volName:     "vol-as-file",
 			ioErrCount:  0,
-			expectedErr: errVolumeExists,
-		},
-		// TestPosix case - 3.
-		{
-			volName:     "existing-vol",
-			ioErrCount:  0,
-			expectedErr: errVolumeExists,
+			expectedErr: errDiskAccessDenied,
 		},
 		// TestPosix case - 4.
 		// IO error > maxAllowedIOError, should fail with errFaultyDisk.

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -51,9 +51,6 @@ var errFileNotFound = errors.New("file not found")
 // errFileNameTooLong - given file name is too long than supported length.
 var errFileNameTooLong = errors.New("file name too long")
 
-// errVolumeExists - cannot create same volume again.
-var errVolumeExists = errors.New("volume already exists")
-
 // errIsNotRegular - not of regular file type.
 var errIsNotRegular = errors.New("not of regular file type")
 

--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -72,8 +72,6 @@ func toStorageErr(err error) error {
 		return errDiskFull
 	case errVolumeNotFound.Error():
 		return errVolumeNotFound
-	case errVolumeExists.Error():
-		return errVolumeExists
 	case errFileNotFound.Error():
 		return errFileNotFound
 	case errFileNameTooLong.Error():

--- a/cmd/storage-rpc-client_test.go
+++ b/cmd/storage-rpc-client_test.go
@@ -146,10 +146,6 @@ func TestStorageErr(t *testing.T) {
 			err:         fmt.Errorf("%s", errVolumeNotFound.Error()),
 		},
 		{
-			expectedErr: errVolumeExists,
-			err:         fmt.Errorf("%s", errVolumeExists.Error()),
-		},
-		{
 			expectedErr: errFileNotFound,
 			err:         fmt.Errorf("%s", errFileNotFound.Error()),
 		},

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -582,7 +582,7 @@ func (xl xlObjects) healObjectDir(ctx context.Context, bucket, object string, dr
 		})
 
 		if !dryRun {
-			if err := disk.MakeVol(pathJoin(bucket, object)); err != nil && err != errVolumeExists {
+			if err := disk.MakeVol(pathJoin(bucket, object)); err != nil {
 				return hr, toObjectErr(err, bucket, object)
 			}
 

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -46,7 +46,7 @@ func (xl xlObjects) putObjectDir(ctx context.Context, bucket, object string, wri
 		wg.Add(1)
 		go func(index int, disk StorageAPI) {
 			defer wg.Done()
-			if err := disk.MakeVol(pathJoin(bucket, object)); err != nil && err != errVolumeExists {
+			if err := disk.MakeVol(pathJoin(bucket, object)); err != nil {
 				errs[index] = err
 			}
 		}(index, disk)

--- a/pkg/os/os.go
+++ b/pkg/os/os.go
@@ -1,0 +1,42 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package os
+
+import (
+	"os"
+	"syscall"
+)
+
+// Mkdir creates a new directory as similar as os.Mkdir() except it ignores
+// already exists error.
+func Mkdir(name string, perm os.FileMode) error {
+	info, err := os.Stat(name)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		// As directory does not exist, create it.
+		return os.Mkdir(name, perm)
+	}
+
+	if !info.IsDir() {
+		return &os.PathError{Op: "mkdir", Path: name, Err: syscall.ENOTDIR}
+	}
+
+	return isDirWritable(name, info)
+}

--- a/pkg/os/os_nix.go
+++ b/pkg/os/os_nix.go
@@ -1,0 +1,59 @@
+// +build !windows
+
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package os
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	ownerWritable  = 0700 // 111 000 000
+	groupWritable  = 0070 // 000 111 000
+	othersWritable = 0007 // 000 000 111
+)
+
+func isDirWritable(name string, info os.FileInfo) error {
+	var stat syscall.Stat_t
+	if err := syscall.Stat(name, &stat); err != nil {
+		return err
+	}
+
+	if uint32(os.Geteuid()) == stat.Uid {
+		if info.Mode().Perm()&ownerWritable != ownerWritable {
+			return os.ErrPermission
+		}
+
+		return nil
+	}
+
+	if uint32(os.Getegid()) == stat.Gid {
+		if info.Mode().Perm()&groupWritable != groupWritable {
+			return os.ErrPermission
+		}
+
+		return nil
+	}
+
+	if info.Mode().Perm()&othersWritable != othersWritable {
+		return os.ErrPermission
+	}
+
+	return nil
+}

--- a/pkg/os/os_test.go
+++ b/pkg/os/os_test.go
@@ -1,0 +1,99 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package os
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMkdir(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", ".TestMkdir.")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	case1Name := filepath.Join(tempDir, "name1")
+
+	case2Name := filepath.Join(tempDir, "name2")
+	if err = ioutil.WriteFile(case2Name, []byte{}, os.ModePerm); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	testCases := []struct {
+		name      string
+		expectErr bool
+	}{
+		{case1Name, false},
+		{case1Name, false}, // no error on already existing directory.
+		{case2Name, true},
+	}
+
+	if runtime.GOOS != "windows" {
+		case3Name := filepath.Join(tempDir, "name3")
+		if err = os.Mkdir(case3Name, os.ModePerm); err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		if err = os.Chmod(case3Name, 0755); err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+
+		case4Name := filepath.Join(tempDir, "name4")
+		if err = os.Mkdir(case4Name, os.ModePerm); err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		if err = os.Chmod(case4Name, 0575); err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+
+		case5Name := filepath.Join(tempDir, "name5")
+		if err = os.Mkdir(case5Name, os.ModePerm); err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		if err = os.Chmod(case5Name, 0557); err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+
+		testCases = append(testCases,
+			struct {
+				name      string
+				expectErr bool
+			}{case3Name, false},
+			struct {
+				name      string
+				expectErr bool
+			}{case4Name, true},
+			struct {
+				name      string
+				expectErr bool
+			}{case5Name, true},
+		)
+	}
+
+	for i, testCase := range testCases {
+		err := Mkdir(testCase.name, os.ModePerm)
+		expectErr := (err != nil)
+
+		if expectErr != testCase.expectErr {
+			t.Fatalf("case %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+		}
+	}
+}

--- a/pkg/os/os_windows.go
+++ b/pkg/os/os_windows.go
@@ -1,0 +1,29 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package os
+
+import (
+	"os"
+)
+
+func isDirWritable(name string, info os.FileInfo) error {
+	if info.Mode() != os.ModePerm {
+		return os.ErrPermission
+	}
+
+	return nil
+}


### PR DESCRIPTION
`errVolumeExists` error is removed because it is ignored all the time except in method `MakeBucketWithLocation()` of FSObjects/xlObjects. Now `MakeBucketWithLocation()` returns `BucketExists` error by checking bucket existent before making bucket than finding it from `Mkdir()`.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.