### PR TITLE
Remove treewalk abort log message

### DIFF
--- a/cmd/tree-walk.go
+++ b/cmd/tree-walk.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"sort"
 	"strings"
-
-	"github.com/minio/minio/cmd/logger"
 )
 
 // Tree walk result carries results of tree walking.
@@ -147,7 +145,6 @@ func doTreeWalk(ctx context.Context, bucket, prefixDir, entryPrefixMatch, marker
 	if err != nil {
 		select {
 		case <-endWalkCh:
-			logger.LogIf(ctx, errWalkAbort)
 			return errWalkAbort
 		case resultCh <- treeWalkResult{err: err}:
 			return err
@@ -229,7 +226,6 @@ func doTreeWalk(ctx context.Context, bucket, prefixDir, entryPrefixMatch, marker
 		isEOF := ((i == len(entries)-1) && isEnd)
 		select {
 		case <-endWalkCh:
-			logger.LogIf(ctx, errWalkAbort)
 			return errWalkAbort
 		case resultCh <- treeWalkResult{entry: pathJoin(prefixDir, entry), end: isEOF}:
 		}


### PR DESCRIPTION
Log doesn't add any value and can be removed.

Fixes #5943


## Description
Ongoing cleanup of unwanted log messages in minio code.

## Motivation and Context
Removal of unwanted log messages in minio server.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.