### PR TITLE
Simplify erasure code by separating bitrot from erasure code

### DIFF
--- a/cmd/bitrot.go
+++ b/cmd/bitrot.go
@@ -1,0 +1,192 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"hash"
+
+	"github.com/minio/highwayhash"
+	"github.com/minio/minio/cmd/logger"
+	"golang.org/x/crypto/blake2b"
+)
+
+// magic HH-256 key as HH-256 hash of the first 100 decimals of π as utf-8 string with a zero key.
+var magicHighwayHash256Key = []byte("\x4b\xe7\x34\xfa\x8e\x23\x8a\xcd\x26\x3e\x83\xe6\xbb\x96\x85\x52\x04\x0f\x93\x5d\xa3\x9f\x44\x14\x97\xe0\x9d\x13\x22\xde\x36\xa0")
+
+// BitrotAlgorithm specifies a algorithm used for bitrot protection.
+type BitrotAlgorithm uint
+
+const (
+	// SHA256 represents the SHA-256 hash function
+	SHA256 BitrotAlgorithm = 1 + iota
+	// HighwayHash256 represents the HighwayHash-256 hash function
+	HighwayHash256
+	// BLAKE2b512 represents the BLAKE2b-512 hash function
+	BLAKE2b512
+)
+
+// DefaultBitrotAlgorithm is the default algorithm used for bitrot protection.
+const (
+	DefaultBitrotAlgorithm = HighwayHash256
+)
+
+var bitrotAlgorithms = map[BitrotAlgorithm]string{
+	SHA256:         "sha256",
+	BLAKE2b512:     "blake2b",
+	HighwayHash256: "highwayhash256",
+}
+
+// New returns a new hash.Hash calculating the given bitrot algorithm.
+func (a BitrotAlgorithm) New() hash.Hash {
+	switch a {
+	case SHA256:
+		return sha256.New()
+	case BLAKE2b512:
+		b2, _ := blake2b.New512(nil) // New512 never returns an error if the key is nil
+		return b2
+	case HighwayHash256:
+		hh, _ := highwayhash.New(magicHighwayHash256Key) // New will never return error since key is 256 bit
+		return hh
+	default:
+		logger.CriticalIf(context.Background(), errors.New("Unsupported bitrot algorithm"))
+		return nil
+	}
+}
+
+// Available reports whether the given algorihm is available.
+func (a BitrotAlgorithm) Available() bool {
+	_, ok := bitrotAlgorithms[a]
+	return ok
+}
+
+// String returns the string identifier for a given bitrot algorithm.
+// If the algorithm is not supported String panics.
+func (a BitrotAlgorithm) String() string {
+	name, ok := bitrotAlgorithms[a]
+	if !ok {
+		logger.CriticalIf(context.Background(), errors.New("Unsupported bitrot algorithm"))
+	}
+	return name
+}
+
+// NewBitrotVerifier returns a new BitrotVerifier implementing the given algorithm.
+func NewBitrotVerifier(algorithm BitrotAlgorithm, checksum []byte) *BitrotVerifier {
+	return &BitrotVerifier{algorithm, checksum}
+}
+
+// BitrotVerifier can be used to verify protected data.
+type BitrotVerifier struct {
+	algorithm BitrotAlgorithm
+	sum       []byte
+}
+
+// BitrotAlgorithmFromString returns a bitrot algorithm from the given string representation.
+// It returns 0 if the string representation does not match any supported algorithm.
+// The zero value of a bitrot algorithm is never supported.
+func BitrotAlgorithmFromString(s string) (a BitrotAlgorithm) {
+	for alg, name := range bitrotAlgorithms {
+		if name == s {
+			return alg
+		}
+	}
+	return
+}
+
+// To read bit-rot verified data.
+type bitrotReader struct {
+	disk      StorageAPI
+	volume    string
+	filePath  string
+	verifier  *BitrotVerifier // Holds the bit-rot info
+	endOffset int64           // Affects the length of data requested in disk.ReadFile depending on Read()'s offset
+	buf       []byte          // Holds bit-rot verified data
+}
+
+// newBitrotReader returns bitrotReader.
+// Note that the buffer is allocated later in Read(). This is because we will know the buffer length only
+// during the bitrotReader.Read(). Depending on when parallelReader fails-over, the buffer length can be different.
+func newBitrotReader(disk StorageAPI, volume, filePath string, algo BitrotAlgorithm, endOffset int64, sum []byte) *bitrotReader {
+	return &bitrotReader{
+		disk:      disk,
+		volume:    volume,
+		filePath:  filePath,
+		verifier:  &BitrotVerifier{algo, sum},
+		endOffset: endOffset,
+		buf:       nil,
+	}
+}
+
+// ReadChunk returns requested data.
+func (b *bitrotReader) ReadChunk(offset int64, length int64) ([]byte, error) {
+	if b.buf == nil {
+		b.buf = make([]byte, b.endOffset-offset)
+		if _, err := b.disk.ReadFile(b.volume, b.filePath, offset, b.buf, b.verifier); err != nil {
+			logger.LogIf(context.Background(), err)
+			return nil, err
+		}
+	}
+	if int64(len(b.buf)) < length {
+		logger.LogIf(context.Background(), errLessData)
+		return nil, errLessData
+	}
+	retBuf := b.buf[:length]
+	b.buf = b.buf[length:]
+	return retBuf, nil
+}
+
+// To calculate the bit-rot of the written data.
+type bitrotWriter struct {
+	disk     StorageAPI
+	volume   string
+	filePath string
+	h        hash.Hash
+}
+
+// newBitrotWriter returns bitrotWriter.
+func newBitrotWriter(disk StorageAPI, volume, filePath string, algo BitrotAlgorithm) *bitrotWriter {
+	return &bitrotWriter{
+		disk:     disk,
+		volume:   volume,
+		filePath: filePath,
+		h:        algo.New(),
+	}
+}
+
+// Append appends the data and while calculating the hash.
+func (b *bitrotWriter) Append(buf []byte) error {
+	n, err := b.h.Write(buf)
+	if err != nil {
+		return err
+	}
+	if n != len(buf) {
+		logger.LogIf(context.Background(), errUnexpected)
+		return errUnexpected
+	}
+	if err = b.disk.AppendFile(b.volume, b.filePath, buf); err != nil {
+		logger.LogIf(context.Background(), err)
+		return err
+	}
+	return nil
+}
+
+// Sum returns bit-rot sum.
+func (b *bitrotWriter) Sum() []byte {
+	return b.h.Sum(nil)
+}

--- a/cmd/bitrot_test.go
+++ b/cmd/bitrot_test.go
@@ -1,0 +1,71 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestBitrotReaderWriter(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	volume := "testvol"
+	filePath := "testfile"
+
+	disk, err := newPosix(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	disk.MakeVol(volume)
+
+	writer := newBitrotWriter(disk, volume, filePath, HighwayHash256)
+
+	err = writer.Append([]byte("aaaaaaaaa"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = writer.Append([]byte("a"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = writer.Append([]byte("aaaaaaaaaa"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = writer.Append([]byte("aaaaa"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = writer.Append([]byte("aaaaaaaaaa"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	reader := newBitrotReader(disk, volume, filePath, HighwayHash256, 35, writer.Sum())
+
+	if _, err = reader.ReadChunk(0, 35); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/erasure-healfile.go
+++ b/cmd/erasure-healfile.go
@@ -18,171 +18,31 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"hash"
-	"strings"
+	"io"
 
 	"github.com/minio/minio/cmd/logger"
 )
 
-// HealFile tries to reconstruct an erasure-coded file spread over all
-// available disks. HealFile will read the valid parts of the file,
-// reconstruct the missing data and write the reconstructed parts back
-// to `staleDisks` at the destination `dstVol/dstPath/`. Parts are
-// verified against the given BitrotAlgorithm and checksums.
-//
-// `staleDisks` is a slice of disks where each non-nil entry has stale
-// or no data, and so will be healed.
-//
-// It is required that `s.disks` have a (read-quorum) majority of
-// disks with valid data for healing to work.
-//
-// In addition, `staleDisks` and `s.disks` must have the same ordering
-// of disks w.r.t. erasure coding of the object.
-//
-// Errors when writing to `staleDisks` are not propagated as long as
-// writes succeed for at least one disk. This allows partial healing
-// despite stale disks being faulty.
-//
-// It returns bitrot checksums for the non-nil staleDisks on which
-// healing succeeded.
-func (s ErasureStorage) HealFile(ctx context.Context, staleDisks []StorageAPI, volume, path string, blocksize int64,
-	dstVol, dstPath string, size int64, alg BitrotAlgorithm, checksums [][]byte) (
-	f ErasureFileInfo, err error) {
-
-	if !alg.Available() {
-		logger.LogIf(ctx, errBitrotHashAlgoInvalid)
-		return f, errBitrotHashAlgoInvalid
-	}
-
-	// Initialization
-	f.Checksums = make([][]byte, len(s.disks))
-	hashers := make([]hash.Hash, len(s.disks))
-	verifiers := make([]*BitrotVerifier, len(s.disks))
-	for i, disk := range s.disks {
-		switch {
-		case staleDisks[i] != nil:
-			hashers[i] = alg.New()
-		case disk == nil:
-			// disregard unavailable disk
-			continue
-		default:
-			verifiers[i] = NewBitrotVerifier(alg, checksums[i])
+// HealFile heals the shard files on non-nil writers. Note that the quorum passed is 1
+// as healing should continue even if it has been successful healing only one shard file.
+func (s ErasureStorage) HealFile(ctx context.Context, readers []*bitrotReader, writers []*bitrotWriter, size int64) error {
+	r, w := io.Pipe()
+	go func() {
+		if err := s.ReadFile(ctx, w, readers, 0, size, size); err != nil {
+			w.CloseWithError(err)
+			return
 		}
-	}
-	writeErrors := make([]error, len(s.disks))
-
-	// Read part file data on each disk
-	chunksize := ceilFrac(blocksize, int64(s.dataBlocks))
-	numBlocks := ceilFrac(size, blocksize)
-
-	readLen := chunksize * (numBlocks - 1)
-
-	lastChunkSize := chunksize
-	hasSmallerLastBlock := size%blocksize != 0
-	if hasSmallerLastBlock {
-		lastBlockLen := size % blocksize
-		lastChunkSize = ceilFrac(lastBlockLen, int64(s.dataBlocks))
-	}
-	readLen += lastChunkSize
-	var buffers [][]byte
-	buffers, _, err = s.readConcurrent(ctx, volume, path, 0, readLen, verifiers)
+		w.Close()
+	}()
+	buf := make([]byte, s.blockSize)
+	// quorum is 1 because CreateFile should continue writing as long as we are writing to even 1 disk.
+	n, err := s.CreateFile(ctx, r, writers, buf, 1)
 	if err != nil {
-		return f, err
+		return err
 	}
-
-	// Scan part files on disk, block-by-block reconstruct it and
-	// write to stale disks.
-	blocks := make([][]byte, len(s.disks))
-
-	if numBlocks > 1 {
-		// Allocate once for all the equal length blocks. The
-		// last block may have a different length - allocation
-		// for this happens inside the for loop below.
-		for i := range blocks {
-			if len(buffers[i]) == 0 {
-				blocks[i] = make([]byte, chunksize)
-			}
-		}
+	if n != size {
+		logger.LogIf(ctx, errLessData)
+		return errLessData
 	}
-
-	var buffOffset int64
-	for blockNumber := int64(0); blockNumber < numBlocks; blockNumber++ {
-		if blockNumber == numBlocks-1 && lastChunkSize != chunksize {
-			for i := range blocks {
-				if len(buffers[i]) == 0 {
-					blocks[i] = make([]byte, lastChunkSize)
-				}
-			}
-		}
-
-		for i := range blocks {
-			if len(buffers[i]) == 0 {
-				blocks[i] = blocks[i][0:0]
-			}
-		}
-
-		csize := chunksize
-		if blockNumber == numBlocks-1 {
-			csize = lastChunkSize
-		}
-		for i := range blocks {
-			if len(buffers[i]) != 0 {
-				blocks[i] = buffers[i][buffOffset : buffOffset+csize]
-			}
-		}
-		buffOffset += csize
-
-		if err = s.ErasureDecodeDataAndParityBlocks(ctx, blocks); err != nil {
-			return f, err
-		}
-
-		// write computed shards as chunks on file in each
-		// stale disk
-		writeSucceeded := false
-		for i, disk := range staleDisks {
-			// skip nil disk or disk that had error on
-			// previous write
-			if disk == nil || writeErrors[i] != nil {
-				continue
-			}
-
-			writeErrors[i] = disk.AppendFile(dstVol, dstPath, blocks[i])
-			if writeErrors[i] == nil {
-				hashers[i].Write(blocks[i])
-				writeSucceeded = true
-			}
-		}
-
-		// If all disks had write errors we quit.
-		if !writeSucceeded {
-			// build error from all write errors
-			err := joinWriteErrors(writeErrors)
-			logger.LogIf(ctx, err)
-			return f, err
-		}
-	}
-
-	// copy computed file hashes into output variable
-	f.Size = size
-	f.Algorithm = alg
-	for i, disk := range staleDisks {
-		if disk == nil || writeErrors[i] != nil {
-			continue
-		}
-		f.Checksums[i] = hashers[i].Sum(nil)
-	}
-	return f, nil
-}
-
-func joinWriteErrors(errs []error) error {
-	msgs := []string{}
-	for i, err := range errs {
-		if err == nil {
-			continue
-		}
-		msgs = append(msgs, fmt.Sprintf("disk %d: %v", i+1, err))
-	}
-	return fmt.Errorf("all stale disks had write errors during healing: %s",
-		strings.Join(msgs, ", "))
+	return nil
 }

--- a/cmd/erasure-readfile_test.go
+++ b/cmd/erasure-readfile_test.go
@@ -19,10 +19,11 @@ package cmd
 import (
 	"bytes"
 	"context"
-	crand "crypto/rand"
 	"io"
 	"math/rand"
 	"testing"
+
+	crand "crypto/rand"
 
 	humanize "github.com/dustin/go-humanize"
 )
@@ -66,19 +67,18 @@ var erasureReadFileTests = []struct {
 	{dataBlocks: 8, onDisks: 16, offDisks: 7, blocksize: int64(blockSizeV1), data: oneMiByte, offset: 0, length: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},                                            // 23
 	{dataBlocks: 2, onDisks: 4, offDisks: 1, blocksize: int64(blockSizeV1), data: oneMiByte, offset: 0, length: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},                                             // 24
 	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: oneMiByte, offset: 0, length: oneMiByte, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},                                             // 25
-	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: oneMiByte, offset: 0, length: oneMiByte, algorithm: 0, shouldFail: true, shouldFailQuorum: false},                                                                   // 26
-	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(blockSizeV1) + 1, offset: 0, length: int64(blockSizeV1) + 1, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},                               // 27
-	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 12, length: int64(blockSizeV1) + 17, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},                             // 28
-	{dataBlocks: 3, onDisks: 6, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 1023, length: int64(blockSizeV1) + 1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},             // 29
-	{dataBlocks: 4, onDisks: 8, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 11, length: int64(blockSizeV1) + 2*1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},             // 30
-	{dataBlocks: 6, onDisks: 12, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 512, length: int64(blockSizeV1) + 8*1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},           // 31
-	{dataBlocks: 8, onDisks: 16, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: int64(blockSizeV1), length: int64(blockSizeV1) - 1, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false}, // 32
-	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(oneMiByte), offset: -1, length: 3, algorithm: DefaultBitrotAlgorithm, shouldFail: true, shouldFailQuorum: false},                                              // 33
-	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(oneMiByte), offset: 1024, length: -1, algorithm: DefaultBitrotAlgorithm, shouldFail: true, shouldFailQuorum: false},                                           // 34
-	{dataBlocks: 4, onDisks: 6, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(blockSizeV1), offset: 0, length: int64(blockSizeV1), algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},                                       // 35
-	{dataBlocks: 4, onDisks: 6, offDisks: 1, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 12, length: int64(blockSizeV1) + 17, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},                             // 36
-	{dataBlocks: 4, onDisks: 6, offDisks: 3, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 1023, length: int64(blockSizeV1) + 1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: true},              // 37
-	{dataBlocks: 8, onDisks: 12, offDisks: 4, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 11, length: int64(blockSizeV1) + 2*1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},            // 38
+	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(blockSizeV1) + 1, offset: 0, length: int64(blockSizeV1) + 1, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},                               // 26
+	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 12, length: int64(blockSizeV1) + 17, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},                             // 27
+	{dataBlocks: 3, onDisks: 6, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 1023, length: int64(blockSizeV1) + 1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},             // 28
+	{dataBlocks: 4, onDisks: 8, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 11, length: int64(blockSizeV1) + 2*1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},             // 29
+	{dataBlocks: 6, onDisks: 12, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 512, length: int64(blockSizeV1) + 8*1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},           // 30
+	{dataBlocks: 8, onDisks: 16, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: int64(blockSizeV1), length: int64(blockSizeV1) - 1, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false}, // 31
+	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(oneMiByte), offset: -1, length: 3, algorithm: DefaultBitrotAlgorithm, shouldFail: true, shouldFailQuorum: false},                                              // 32
+	{dataBlocks: 2, onDisks: 4, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(oneMiByte), offset: 1024, length: -1, algorithm: DefaultBitrotAlgorithm, shouldFail: true, shouldFailQuorum: false},                                           // 33
+	{dataBlocks: 4, onDisks: 6, offDisks: 0, blocksize: int64(blockSizeV1), data: int64(blockSizeV1), offset: 0, length: int64(blockSizeV1), algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},                                       // 34
+	{dataBlocks: 4, onDisks: 6, offDisks: 1, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 12, length: int64(blockSizeV1) + 17, algorithm: BLAKE2b512, shouldFail: false, shouldFailQuorum: false},                             // 35
+	{dataBlocks: 4, onDisks: 6, offDisks: 3, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 1023, length: int64(blockSizeV1) + 1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: true},              // 36
+	{dataBlocks: 8, onDisks: 12, offDisks: 4, blocksize: int64(blockSizeV1), data: int64(2 * blockSizeV1), offset: 11, length: int64(blockSizeV1) + 2*1024, algorithm: DefaultBitrotAlgorithm, shouldFail: false, shouldFailQuorum: false},            // 37
 }
 
 func TestErasureReadFile(t *testing.T) {
@@ -87,29 +87,54 @@ func TestErasureReadFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test %d: failed to create test setup: %v", i, err)
 		}
-		storage, err := NewErasureStorage(context.Background(), setup.disks, test.dataBlocks, test.onDisks-test.dataBlocks, test.blocksize)
+		storage, err := NewErasureStorage(context.Background(), test.dataBlocks, test.onDisks-test.dataBlocks, test.blocksize)
 		if err != nil {
 			setup.Remove()
 			t.Fatalf("Test %d: failed to create ErasureStorage: %v", i, err)
 		}
-
+		disks := setup.disks
 		data := make([]byte, test.data)
 		if _, err = io.ReadFull(crand.Reader, data); err != nil {
 			setup.Remove()
 			t.Fatalf("Test %d: failed to generate random test data: %v", i, err)
 		}
+
 		writeAlgorithm := test.algorithm
 		if !test.algorithm.Available() {
 			writeAlgorithm = DefaultBitrotAlgorithm
 		}
 		buffer := make([]byte, test.blocksize, 2*test.blocksize)
-		file, err := storage.CreateFile(context.Background(), bytes.NewReader(data[:]), "testbucket", "object", buffer, writeAlgorithm, test.dataBlocks+1)
+		writers := make([]*bitrotWriter, len(disks))
+		for i, disk := range disks {
+			writers[i] = newBitrotWriter(disk, "testbucket", "object", writeAlgorithm)
+		}
+		n, err := storage.CreateFile(context.Background(), bytes.NewReader(data[:]), writers, buffer, storage.dataBlocks+1)
 		if err != nil {
 			setup.Remove()
 			t.Fatalf("Test %d: failed to create erasure test file: %v", i, err)
 		}
+		if n != test.data {
+			setup.Remove()
+			t.Fatalf("Test %d: failed to create erasure test file", i)
+		}
+		for i, w := range writers {
+			if w == nil {
+				disks[i] = nil
+			}
+		}
+
+		// Get the checksums of the current part.
+		bitrotReaders := make([]*bitrotReader, len(disks))
+		for index, disk := range disks {
+			if disk == OfflineDisk {
+				continue
+			}
+			endOffset := getErasureShardFileEndOffset(test.offset, test.length, test.data, test.blocksize, storage.dataBlocks)
+			bitrotReaders[index] = newBitrotReader(disk, "testbucket", "object", writeAlgorithm, endOffset, writers[index].Sum())
+		}
+
 		writer := bytes.NewBuffer(nil)
-		readInfo, err := storage.ReadFile(context.Background(), writer, "testbucket", "object", test.offset, test.length, test.data, file.Checksums, test.algorithm, test.blocksize)
+		err = storage.ReadFile(context.Background(), writer, bitrotReaders, test.offset, test.length, test.data)
 		if err != nil && !test.shouldFail {
 			t.Errorf("Test %d: should pass but failed with: %v", i, err)
 		}
@@ -117,25 +142,32 @@ func TestErasureReadFile(t *testing.T) {
 			t.Errorf("Test %d: should fail but it passed", i)
 		}
 		if err == nil {
-			if readInfo.Size != test.length {
-				t.Errorf("Test %d: read returns wrong number of bytes: got: #%d want: #%d", i, readInfo.Size, test.length)
-			}
-			if readInfo.Algorithm != test.algorithm {
-				t.Errorf("Test %d: read returns wrong algorithm: got: %v want: %v", i, readInfo.Algorithm, test.algorithm)
-			}
 			if content := writer.Bytes(); !bytes.Equal(content, data[test.offset:test.offset+test.length]) {
 				t.Errorf("Test %d: read retruns wrong file content", i)
 			}
 		}
+		for i, r := range bitrotReaders {
+			if r == nil {
+				disks[i] = OfflineDisk
+			}
+		}
 		if err == nil && !test.shouldFail {
-			writer.Reset()
-			for j := range storage.disks[:test.offDisks] {
-				storage.disks[j] = badDisk{nil}
+			bitrotReaders = make([]*bitrotReader, len(disks))
+			for index, disk := range disks {
+				if disk == OfflineDisk {
+					continue
+				}
+				endOffset := getErasureShardFileEndOffset(test.offset, test.length, test.data, test.blocksize, storage.dataBlocks)
+				bitrotReaders[index] = newBitrotReader(disk, "testbucket", "object", writeAlgorithm, endOffset, writers[index].Sum())
+			}
+			for j := range disks[:test.offDisks] {
+				bitrotReaders[j].disk = badDisk{nil}
 			}
 			if test.offDisks > 0 {
-				storage.disks[0] = OfflineDisk
+				bitrotReaders[0] = nil
 			}
-			readInfo, err = storage.ReadFile(context.Background(), writer, "testbucket", "object", test.offset, test.length, test.data, file.Checksums, test.algorithm, test.blocksize)
+			writer.Reset()
+			err = storage.ReadFile(context.Background(), writer, bitrotReaders, test.offset, test.length, test.data)
 			if err != nil && !test.shouldFailQuorum {
 				t.Errorf("Test %d: should pass but failed with: %v", i, err)
 			}
@@ -143,12 +175,6 @@ func TestErasureReadFile(t *testing.T) {
 				t.Errorf("Test %d: should fail but it passed", i)
 			}
 			if !test.shouldFailQuorum {
-				if readInfo.Size != test.length {
-					t.Errorf("Test %d: read returns wrong number of bytes: got: #%d want: #%d", i, readInfo.Size, test.length)
-				}
-				if readInfo.Algorithm != test.algorithm {
-					t.Errorf("Test %d: read returns wrong algorithm: got: %v want: %v", i, readInfo.Algorithm, test.algorithm)
-				}
 				if content := writer.Bytes(); !bytes.Equal(content, data[test.offset:test.offset+test.length]) {
 					t.Errorf("Test %d: read retruns wrong file content", i)
 				}
@@ -174,8 +200,8 @@ func TestErasureReadFileRandomOffsetLength(t *testing.T) {
 		return
 	}
 	defer setup.Remove()
-
-	storage, err := NewErasureStorage(context.Background(), setup.disks, dataBlocks, parityBlocks, blockSize)
+	disks := setup.disks
+	storage, err := NewErasureStorage(context.Background(), dataBlocks, parityBlocks, blockSize)
 	if err != nil {
 		t.Fatalf("failed to create ErasureStorage: %v", err)
 	}
@@ -187,17 +213,25 @@ func TestErasureReadFileRandomOffsetLength(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	writers := make([]*bitrotWriter, len(disks))
+	for i, disk := range disks {
+		if disk == nil {
+			continue
+		}
+		writers[i] = newBitrotWriter(disk, "testbucket", "object", DefaultBitrotAlgorithm)
+	}
+
 	// 10000 iterations with random offsets and lengths.
 	iterations := 10000
 
 	// Create a test file to read from.
 	buffer := make([]byte, blockSize, 2*blockSize)
-	file, err := storage.CreateFile(context.Background(), bytes.NewReader(data), "testbucket", "testobject", buffer, DefaultBitrotAlgorithm, dataBlocks+1)
+	n, err := storage.CreateFile(context.Background(), bytes.NewReader(data), writers, buffer, storage.dataBlocks+1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file.Size != length {
-		t.Errorf("erasureCreateFile returned %d, expected %d", file.Size, length)
+	if n != length {
+		t.Errorf("erasureCreateFile returned %d, expected %d", n, length)
 	}
 
 	// To generate random offset/length.
@@ -212,7 +246,16 @@ func TestErasureReadFileRandomOffsetLength(t *testing.T) {
 
 		expected := data[offset : offset+readLen]
 
-		_, err = storage.ReadFile(context.Background(), buf, "testbucket", "testobject", offset, readLen, length, file.Checksums, DefaultBitrotAlgorithm, blockSize)
+		// Get the checksums of the current part.
+		bitrotReaders := make([]*bitrotReader, len(disks))
+		for index, disk := range disks {
+			if disk == OfflineDisk {
+				continue
+			}
+			endOffset := getErasureShardFileEndOffset(offset, readLen, length, blockSize, storage.dataBlocks)
+			bitrotReaders[index] = newBitrotReader(disk, "testbucket", "object", DefaultBitrotAlgorithm, endOffset, writers[index].Sum())
+		}
+		err = storage.ReadFile(context.Background(), buf, bitrotReaders, offset, readLen, length)
 		if err != nil {
 			t.Fatal(err, offset, readLen)
 		}
@@ -232,31 +275,47 @@ func benchmarkErasureRead(data, parity, dataDown, parityDown int, size int64, b 
 		b.Fatalf("failed to create test setup: %v", err)
 	}
 	defer setup.Remove()
-	storage, err := NewErasureStorage(context.Background(), setup.disks, data, parity, blockSizeV1)
+	disks := setup.disks
+	storage, err := NewErasureStorage(context.Background(), data, parity, blockSizeV1)
 	if err != nil {
 		b.Fatalf("failed to create ErasureStorage: %v", err)
 	}
 
+	writers := make([]*bitrotWriter, len(disks))
+	for i, disk := range disks {
+		if disk == nil {
+			continue
+		}
+		writers[i] = newBitrotWriter(disk, "testbucket", "object", DefaultBitrotAlgorithm)
+	}
+
 	content := make([]byte, size)
 	buffer := make([]byte, blockSizeV1, 2*blockSizeV1)
-	file, err := storage.CreateFile(context.Background(), bytes.NewReader(content), "testbucket", "object", buffer, DefaultBitrotAlgorithm, data+1)
+	_, err = storage.CreateFile(context.Background(), bytes.NewReader(content), writers, buffer, storage.dataBlocks+1)
 	if err != nil {
 		b.Fatalf("failed to create erasure test file: %v", err)
 	}
-	checksums := file.Checksums
 
 	for i := 0; i < dataDown; i++ {
-		storage.disks[i] = OfflineDisk
+		writers[i] = nil
 	}
 	for i := data; i < data+parityDown; i++ {
-		storage.disks[i] = OfflineDisk
+		writers[i] = nil
 	}
 
 	b.ResetTimer()
 	b.SetBytes(size)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if file, err = storage.ReadFile(context.Background(), bytes.NewBuffer(content[:0]), "testbucket", "object", 0, size, size, checksums, DefaultBitrotAlgorithm, blockSizeV1); err != nil {
+		bitrotReaders := make([]*bitrotReader, len(disks))
+		for index, disk := range disks {
+			if writers[index] == nil {
+				continue
+			}
+			endOffset := getErasureShardFileEndOffset(0, size, size, storage.blockSize, storage.dataBlocks)
+			bitrotReaders[index] = newBitrotReader(disk, "testbucket", "object", DefaultBitrotAlgorithm, endOffset, writers[index].Sum())
+		}
+		if err = storage.ReadFile(context.Background(), bytes.NewBuffer(content[:0]), bitrotReaders, 0, size, size); err != nil {
 			panic(err)
 		}
 	}

--- a/cmd/erasure-utils.go
+++ b/cmd/erasure-utils.go
@@ -104,3 +104,25 @@ func writeDataBlocks(ctx context.Context, dst io.Writer, enBlocks [][]byte, data
 	// Success.
 	return totalWritten, nil
 }
+
+// Returns shard-file size.
+func getErasureShardFileSize(blockSize int64, totalLength int64, dataBlocks int) int64 {
+	shardSize := ceilFrac(int64(blockSize), int64(dataBlocks))
+	numShards := totalLength / int64(blockSize)
+	lastBlockSize := totalLength % int64(blockSize)
+	lastShardSize := ceilFrac(lastBlockSize, int64(dataBlocks))
+	return shardSize*numShards + lastShardSize
+}
+
+// Returns the endOffset till which bitrotReader should read data using disk.ReadFile()
+// partOffset, partLength and partSize are values of the object's part file.
+func getErasureShardFileEndOffset(partOffset int64, partLength int64, partSize int64, erasureBlockSize int64, dataBlocks int) int64 {
+	shardSize := ceilFrac(erasureBlockSize, int64(dataBlocks))
+	shardFileSize := getErasureShardFileSize(erasureBlockSize, partSize, dataBlocks)
+	endShard := (partOffset + int64(partLength)) / erasureBlockSize
+	endOffset := endShard*shardSize + shardSize
+	if endOffset > shardFileSize {
+		endOffset = shardFileSize
+	}
+	return endOffset
+}

--- a/cmd/erasure_test.go
+++ b/cmd/erasure_test.go
@@ -52,8 +52,7 @@ func TestErasureDecode(t *testing.T) {
 		buffer := make([]byte, len(data), 2*len(data))
 		copy(buffer, data)
 
-		disks := make([]StorageAPI, test.dataBlocks+test.parityBlocks)
-		storage, err := NewErasureStorage(context.Background(), disks, test.dataBlocks, test.parityBlocks, blockSizeV1)
+		storage, err := NewErasureStorage(context.Background(), test.dataBlocks, test.parityBlocks, blockSizeV1)
 		if err != nil {
 			t.Fatalf("Test %d: failed to create erasure storage: %v", i, err)
 		}

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -79,6 +79,9 @@ var errCrossDeviceLink = errors.New("Rename across devices not allowed, please f
 // errMinDiskSize - cannot create volume or files when disk size is less than threshold.
 var errMinDiskSize = errors.New("The disk size is less than the minimum threshold")
 
+// errLessData - returned when less data available than what was requested.
+var errLessData = errors.New("less data available than what was requested")
+
 // hashMisMatchError - represents a bit-rot hash verification failure
 // error.
 type hashMismatchError struct {

--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -233,7 +233,6 @@ func (client *StorageRPCClient) ReadFile(volume string, path string, offset int6
 	if verifier != nil {
 		args.Algo = verifier.algorithm
 		args.ExpectedHash = verifier.sum
-		args.Verified = verifier.IsVerified()
 	}
 	var reply []byte
 

--- a/cmd/storage-rpc_test.go
+++ b/cmd/storage-rpc_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -347,13 +348,14 @@ func testStorageAPIReadFile(t *testing.T, storage StorageAPI) {
 		{"foo", "yourobject", 0, nil, true},
 	}
 
+	result := make([]byte, 100)
 	for i, testCase := range testCases {
-		result := make([]byte, 100)
-		n, err := storage.ReadFile(testCase.volumeName, testCase.objectName, testCase.offset, result, nil)
+		result = result[testCase.offset:3]
+		_, err := storage.ReadFile(testCase.volumeName, testCase.objectName, testCase.offset, result, nil)
 		expectErr := (err != nil)
-		result = result[:n]
 
 		if expectErr != testCase.expectErr {
+			fmt.Println(err)
 			t.Fatalf("case %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
 		}
 

--- a/cmd/xl-v1-common.go
+++ b/cmd/xl-v1-common.go
@@ -103,16 +103,3 @@ func (xl xlObjects) isObjectDir(bucket, prefix string) (ok bool) {
 	} // Exhausted all disks - return false.
 	return false
 }
-
-// Calculate the space occupied by an object in a single disk
-func (xl xlObjects) sizeOnDisk(fileSize int64, blockSize int64, dataBlocks int) int64 {
-	numBlocks := fileSize / blockSize
-	chunkSize := ceilFrac(blockSize, int64(dataBlocks))
-	sizeInDisk := numBlocks * chunkSize
-	remaining := fileSize % blockSize
-	if remaining > 0 {
-		sizeInDisk += ceilFrac(remaining, int64(dataBlocks))
-	}
-
-	return sizeInDisk
-}

--- a/cmd/xl-v1-healing-common.go
+++ b/cmd/xl-v1-healing-common.go
@@ -163,7 +163,6 @@ func getLatestXLMeta(ctx context.Context, partsMetadata []xlMetaV1, errs []error
 //   other than file not found and not a checksum error).
 func disksWithAllParts(ctx context.Context, onlineDisks []StorageAPI, partsMetadata []xlMetaV1, errs []error, bucket,
 	object string) ([]StorageAPI, []error, error) {
-
 	availableDisks := make([]StorageAPI, len(onlineDisks))
 	buffer := []byte{}
 	dataErrs := make([]error, len(onlineDisks))

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -369,7 +369,7 @@ func (xl xlObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID 
 		}
 	}
 
-	storage, err := NewErasureStorage(ctx, onlineDisks, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, xlMeta.Erasure.BlockSize)
+	storage, err := NewErasureStorage(ctx, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, xlMeta.Erasure.BlockSize)
 	if err != nil {
 		return pi, toObjectErr(err, bucket, object)
 	}
@@ -387,16 +387,32 @@ func (xl xlObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID 
 		defer xl.bp.Put(buffer)
 	}
 
-	file, err := storage.CreateFile(ctx, data, minioMetaTmpBucket, tmpPartPath, buffer, DefaultBitrotAlgorithm, writeQuorum)
+	if len(buffer) > int(xlMeta.Erasure.BlockSize) {
+		buffer = buffer[:xlMeta.Erasure.BlockSize]
+	}
+	writers := make([]*bitrotWriter, len(onlineDisks))
+	for i, disk := range onlineDisks {
+		if disk == nil {
+			continue
+		}
+		writers[i] = newBitrotWriter(disk, minioMetaTmpBucket, tmpPartPath, DefaultBitrotAlgorithm)
+	}
+	n, err := storage.CreateFile(ctx, data, writers, buffer, storage.dataBlocks+1)
 	if err != nil {
 		return pi, toObjectErr(err, bucket, object)
 	}
 
 	// Should return IncompleteBody{} error when reader has fewer bytes
 	// than specified in request header.
-	if file.Size < data.Size() {
+	if n < data.Size() {
 		logger.LogIf(ctx, IncompleteBody{})
 		return pi, IncompleteBody{}
+	}
+
+	for i := range writers {
+		if writers[i] == nil {
+			onlineDisks[i] = nil
+		}
 	}
 
 	// post-upload check (write) lock
@@ -440,14 +456,14 @@ func (xl xlObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID 
 	md5hex := hex.EncodeToString(data.MD5Current())
 
 	// Add the current part.
-	xlMeta.AddObjectPart(partID, partSuffix, md5hex, file.Size)
+	xlMeta.AddObjectPart(partID, partSuffix, md5hex, n)
 
 	for i, disk := range onlineDisks {
 		if disk == OfflineDisk {
 			continue
 		}
 		partsMetadata[i].Parts = xlMeta.Parts
-		partsMetadata[i].Erasure.AddChecksumInfo(ChecksumInfo{partSuffix, file.Algorithm, file.Checksums[i]})
+		partsMetadata[i].Erasure.AddChecksumInfo(ChecksumInfo{partSuffix, DefaultBitrotAlgorithm, writers[i].Sum()})
 	}
 
 	// Write all the checksum metadata.

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -60,7 +60,7 @@ func (xl xlObjects) putObjectDir(ctx context.Context, bucket, object string, wri
 func (xl xlObjects) prepareFile(ctx context.Context, bucket, object string, size int64, onlineDisks []StorageAPI, blockSize int64, dataBlocks, writeQuorum int) error {
 	pErrs := make([]error, len(onlineDisks))
 	// Calculate the real size of the part in one disk.
-	actualSize := xl.sizeOnDisk(size, blockSize, dataBlocks)
+	actualSize := getErasureShardFileSize(blockSize, size, dataBlocks)
 	// Prepare object creation in a all disks
 	for index, disk := range onlineDisks {
 		if disk != nil {
@@ -262,11 +262,11 @@ func (xl xlObjects) getObject(ctx context.Context, bucket, object string, startO
 	}
 
 	var totalBytesRead int64
-	storage, err := NewErasureStorage(ctx, onlineDisks, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, xlMeta.Erasure.BlockSize)
+	storage, err := NewErasureStorage(ctx, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, xlMeta.Erasure.BlockSize)
 	if err != nil {
 		return toObjectErr(err, bucket, object)
 	}
-	checksums := make([][]byte, len(storage.disks))
+
 	for ; partIndex <= lastPartIndex; partIndex++ {
 		if length == totalBytesRead {
 			break
@@ -275,30 +275,34 @@ func (xl xlObjects) getObject(ctx context.Context, bucket, object string, startO
 		partName := xlMeta.Parts[partIndex].Name
 		partSize := xlMeta.Parts[partIndex].Size
 
-		readSize := partSize - partOffset
-		// readSize should be adjusted so that we don't write more data than what was requested.
-		if readSize > (length - totalBytesRead) {
-			readSize = length - totalBytesRead
+		partLength := partSize - partOffset
+		// partLength should be adjusted so that we don't write more data than what was requested.
+		if partLength > (length - totalBytesRead) {
+			partLength = length - totalBytesRead
 		}
 
 		// Get the checksums of the current part.
-		var algorithm BitrotAlgorithm
-		for index, disk := range storage.disks {
+		bitrotReaders := make([]*bitrotReader, len(onlineDisks))
+		for index, disk := range onlineDisks {
 			if disk == OfflineDisk {
 				continue
 			}
 			checksumInfo := metaArr[index].Erasure.GetChecksumInfo(partName)
-			algorithm = checksumInfo.Algorithm
-			checksums[index] = checksumInfo.Hash
+			endOffset := getErasureShardFileEndOffset(partOffset, partLength, partSize, xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks)
+			bitrotReaders[index] = newBitrotReader(disk, bucket, pathJoin(object, partName), checksumInfo.Algorithm, endOffset, checksumInfo.Hash)
 		}
 
-		file, err := storage.ReadFile(ctx, writer, bucket, pathJoin(object, partName), partOffset, readSize, partSize, checksums, algorithm, xlMeta.Erasure.BlockSize)
+		err := storage.ReadFile(ctx, writer, bitrotReaders, partOffset, partLength, partSize)
 		if err != nil {
 			return toObjectErr(err, bucket, object)
 		}
-
+		for i, r := range bitrotReaders {
+			if r == nil {
+				onlineDisks[i] = OfflineDisk
+			}
+		}
 		// Track total bytes read from disk and written to the client.
-		totalBytesRead += file.Size
+		totalBytesRead += partLength
 
 		// partOffset will be valid only for the first part, hence reset it to 0 for
 		// the remaining parts.
@@ -605,7 +609,7 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 	// Total size of the written object
 	var sizeWritten int64
 
-	storage, err := NewErasureStorage(ctx, onlineDisks, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, xlMeta.Erasure.BlockSize)
+	storage, err := NewErasureStorage(ctx, xlMeta.Erasure.DataBlocks, xlMeta.Erasure.ParityBlocks, xlMeta.Erasure.BlockSize)
 	if err != nil {
 		return ObjectInfo{}, toObjectErr(err, bucket, object)
 	}
@@ -621,6 +625,10 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 	default:
 		buffer = xl.bp.Get()
 		defer xl.bp.Put(buffer)
+	}
+
+	if len(buffer) > int(xlMeta.Erasure.BlockSize) {
+		buffer = buffer[:xlMeta.Erasure.BlockSize]
 	}
 
 	// Read data and split into parts - similar to multipart mechanism
@@ -641,7 +649,7 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 		// This is only an optimization.
 		var curPartReader io.Reader
 		if curPartSize > 0 {
-			pErr := xl.prepareFile(ctx, minioMetaTmpBucket, tempErasureObj, curPartSize, storage.disks, xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks, writeQuorum)
+			pErr := xl.prepareFile(ctx, minioMetaTmpBucket, tempErasureObj, curPartSize, onlineDisks, xlMeta.Erasure.BlockSize, xlMeta.Erasure.DataBlocks, writeQuorum)
 			if pErr != nil {
 				return ObjectInfo{}, toObjectErr(pErr, bucket, object)
 			}
@@ -653,25 +661,35 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 			curPartReader = reader
 		}
 
-		file, erasureErr := storage.CreateFile(ctx, curPartReader, minioMetaTmpBucket,
-			tempErasureObj, buffer, DefaultBitrotAlgorithm, writeQuorum)
+		writers := make([]*bitrotWriter, len(onlineDisks))
+		for i, disk := range onlineDisks {
+			if disk == nil {
+				continue
+			}
+			writers[i] = newBitrotWriter(disk, minioMetaTmpBucket, tempErasureObj, DefaultBitrotAlgorithm)
+		}
+		n, erasureErr := storage.CreateFile(ctx, curPartReader, writers, buffer, storage.dataBlocks+1)
 		if erasureErr != nil {
 			return ObjectInfo{}, toObjectErr(erasureErr, minioMetaTmpBucket, tempErasureObj)
 		}
 
 		// Should return IncompleteBody{} error when reader has fewer bytes
 		// than specified in request header.
-		if file.Size < curPartSize {
+		if n < curPartSize {
 			logger.LogIf(ctx, IncompleteBody{})
 			return ObjectInfo{}, IncompleteBody{}
 		}
 
 		// Update the total written size
-		sizeWritten += file.Size
+		sizeWritten += n
 
-		for i := range partsMetadata {
-			partsMetadata[i].AddObjectPart(partIdx, partName, "", file.Size)
-			partsMetadata[i].Erasure.AddChecksumInfo(ChecksumInfo{partName, file.Algorithm, file.Checksums[i]})
+		for i, w := range writers {
+			if w == nil {
+				onlineDisks[i] = nil
+				continue
+			}
+			partsMetadata[i].AddObjectPart(partIdx, partName, "", n)
+			partsMetadata[i].Erasure.AddChecksumInfo(ChecksumInfo{partName, DefaultBitrotAlgorithm, w.Sum()})
 		}
 
 		// We wrote everything, break out.

--- a/cmd/xl-v1-utils_test.go
+++ b/cmd/xl-v1-utils_test.go
@@ -214,7 +214,6 @@ func getSampleXLMeta(totalParts int) xlMetaV1 {
 
 // Compare the unmarshaled XLMetaV1 with the one obtained from gjson parsing.
 func compareXLMetaV1(t *testing.T, unMarshalXLMeta, gjsonXLMeta xlMetaV1) {
-
 	// Start comparing the fields of xlMetaV1 obtained from gjson parsing with one parsed using json unmarshaling.
 	if unMarshalXLMeta.Version != gjsonXLMeta.Version {
 		t.Errorf("Expected the Version to be \"%s\", but got \"%s\".", unMarshalXLMeta.Version, gjsonXLMeta.Version)
@@ -268,6 +267,7 @@ func compareXLMetaV1(t *testing.T, unMarshalXLMeta, gjsonXLMeta xlMetaV1) {
 			}
 		}
 	}
+
 	if unMarshalXLMeta.Minio.Release != gjsonXLMeta.Minio.Release {
 		t.Errorf("Expected the Release string to be \"%s\", but got \"%s\".", unMarshalXLMeta.Minio.Release, gjsonXLMeta.Minio.Release)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR simplifies erasure related code by moving bitrot code out of erasure functions. It started out as a refactor needed to bring in chunked-bitrot feature (i.e instead of one hash for the entire file, have a slice of hashes - one hash per 32MB block), but that feature is on hold as of now. The refactor ended up making the erasure code flow much more straight forward (especially ReadFile)

benchmarks mostly show better performance and consistently less allocs/op
master branch erasure write:
```
goos: linux
goarch: amd64
pkg: github.com/minio/minio/cmd
BenchmarkErasureWriteQuick/_00|00_-4         	     100	  26186484 ns/op	 480.51 MB/s	   11250 B/op	     128 allocs/op
BenchmarkErasureWriteQuick/_00|X0_-4         	     100	  42183467 ns/op	 298.29 MB/s	    8736 B/op	     101 allocs/op
BenchmarkErasureWriteQuick/_X0|00_-4         	     100	  42699211 ns/op	 294.69 MB/s	    8730 B/op	     101 allocs/op
BenchmarkErasureWrite_4_64KB/_00|00_-4       	   10000	    140079 ns/op	 467.85 MB/s	    5895 B/op	      73 allocs/op
BenchmarkErasureWrite_4_64KB/_00|X0_-4       	   10000	    139937 ns/op	 468.32 MB/s	    4901 B/op	      60 allocs/op
BenchmarkErasureWrite_4_64KB/_X0|00_-4       	   10000	    268352 ns/op	 244.22 MB/s	    4902 B/op	      60 allocs/op
BenchmarkErasureWrite_8_20MB/_0000|0000_-4   	      50	 118549636 ns/op	 176.90 MB/s	   22587 B/op	     244 allocs/op
BenchmarkErasureWrite_8_20MB/_0000|X000_-4   	      50	  28331419 ns/op	 740.22 MB/s	   20330 B/op	     218 allocs/op
BenchmarkErasureWrite_8_20MB/_X000|0000_-4   	      50	  38442977 ns/op	 545.52 MB/s	   20345 B/op	     218 allocs/op
BenchmarkErasureWrite_8_20MB/_0000|XXX0_-4   	     100	  50881209 ns/op	 412.17 MB/s	   14981 B/op	     164 allocs/op
BenchmarkErasureWrite_8_20MB/_XXX0|0000_-4   	     100	  61528775 ns/op	 340.84 MB/s	   14976 B/op	     164 allocs/op
BenchmarkErasureWrite_12_30MB/_000000|000000_-4         	      20	 144020088 ns/op	 218.42 MB/s	78695067 B/op	     529 allocs/op
BenchmarkErasureWrite_12_30MB/_000000|X00000_-4         	      30	 122943909 ns/op	 255.87 MB/s	78688434 B/op	     483 allocs/op
BenchmarkErasureWrite_12_30MB/_X00000|000000_-4         	      30	 151870059 ns/op	 207.13 MB/s	78688432 B/op	     483 allocs/op
BenchmarkErasureWrite_12_30MB/_000000|XXXXX0_-4         	      30	 112631694 ns/op	 279.29 MB/s	78675626 B/op	     332 allocs/op
BenchmarkErasureWrite_12_30MB/_XXXXX0|000000_-4         	      30	  50500211 ns/op	 622.91 MB/s	78675625 B/op	     332 allocs/op
BenchmarkErasureWrite_16_40MB/_00000000|00000000_-4     	      30	 222538860 ns/op	 188.48 MB/s	   80554 B/op	     877 allocs/op
BenchmarkErasureWrite_16_40MB/_00000000|X0000000_-4     	      30	 206188438 ns/op	 203.42 MB/s	   76345 B/op	     826 allocs/op
BenchmarkErasureWrite_16_40MB/_X0000000|00000000_-4     	      30	 235677541 ns/op	 177.97 MB/s	   76381 B/op	     827 allocs/op
BenchmarkErasureWrite_16_40MB/_00000000|XXXXXXX0_-4     	      30	  52381580 ns/op	 800.72 MB/s	   51378 B/op	     528 allocs/op
BenchmarkErasureWrite_16_40MB/_XXXXXXX0|00000000_-4     	      30	 105537540 ns/op	 397.42 MB/s	   51386 B/op	     528 allocs/op
PASS
ok  	github.com/minio/minio/cmd	78.872s
```

simplify-erasure branch erasure write:
```
goos: linux
goarch: amd64
pkg: github.com/minio/minio/cmd
BenchmarkErasureWriteQuick/_00|00_-4         	     100	  24848093 ns/op	 506.39 MB/s	   10741 B/op	     120 allocs/op
BenchmarkErasureWriteQuick/_00|X0_-4         	     100	  24434015 ns/op	 514.98 MB/s	    7988 B/op	      92 allocs/op
BenchmarkErasureWriteQuick/_X0|00_-4         	     100	  38507709 ns/op	 326.76 MB/s	    7999 B/op	      92 allocs/op
BenchmarkErasureWrite_4_64KB/_00|00_-4       	   10000	    307006 ns/op	 213.47 MB/s	    5398 B/op	      64 allocs/op
BenchmarkErasureWrite_4_64KB/_00|X0_-4       	   10000	    129687 ns/op	 505.34 MB/s	    4165 B/op	      50 allocs/op
BenchmarkErasureWrite_4_64KB/_X0|00_-4       	   10000	    151819 ns/op	 431.67 MB/s	    4165 B/op	      50 allocs/op
BenchmarkErasureWrite_8_20MB/_0000|0000_-4   	      50	  90487069 ns/op	 231.76 MB/s	   21599 B/op	     228 allocs/op
BenchmarkErasureWrite_8_20MB/_0000|X000_-4   	      50	  52263000 ns/op	 401.27 MB/s	   19079 B/op	     201 allocs/op
BenchmarkErasureWrite_8_20MB/_X000|0000_-4   	      50	  88521639 ns/op	 236.91 MB/s	   19070 B/op	     201 allocs/op
BenchmarkErasureWrite_8_20MB/_0000|XXX0_-4   	      50	  60038124 ns/op	 349.30 MB/s	   14336 B/op	     148 allocs/op
BenchmarkErasureWrite_8_20MB/_XXX0|0000_-4   	     100	  57691554 ns/op	 363.51 MB/s	   13248 B/op	     146 allocs/op
BenchmarkErasureWrite_12_30MB/_000000|000000_-4         	      20	 133012663 ns/op	 236.50 MB/s	78693494 B/op	     506 allocs/op
BenchmarkErasureWrite_12_30MB/_000000|X00000_-4         	      30	 137967677 ns/op	 228.00 MB/s	78686690 B/op	     459 allocs/op
BenchmarkErasureWrite_12_30MB/_X00000|000000_-4         	      30	 115281025 ns/op	 272.87 MB/s	78686738 B/op	     459 allocs/op
BenchmarkErasureWrite_12_30MB/_000000|XXXXX0_-4         	      30	  52844453 ns/op	 595.28 MB/s	78672884 B/op	     304 allocs/op
BenchmarkErasureWrite_12_30MB/_XXXXX0|000000_-4         	      30	  84440031 ns/op	 372.54 MB/s	78672876 B/op	     304 allocs/op
BenchmarkErasureWrite_16_40MB/_00000000|00000000_-4     	      20	 213129602 ns/op	 196.80 MB/s	   82980 B/op	     858 allocs/op
BenchmarkErasureWrite_16_40MB/_00000000|X0000000_-4     	      30	 167005678 ns/op	 251.15 MB/s	   74038 B/op	     796 allocs/op
BenchmarkErasureWrite_16_40MB/_X0000000|00000000_-4     	      20	 227349659 ns/op	 184.49 MB/s	   78505 B/op	     808 allocs/op
BenchmarkErasureWrite_16_40MB/_00000000|XXXXXXX0_-4     	      30	 132088980 ns/op	 317.54 MB/s	   47618 B/op	     491 allocs/op
BenchmarkErasureWrite_16_40MB/_XXXXXXX0|00000000_-4     	      30	 130151638 ns/op	 322.26 MB/s	   47643 B/op	     491 allocs/op
PASS
ok  	github.com/minio/minio/cmd	72.189s
```

master branch erasure-read
```
goos: linux
goarch: amd64
pkg: github.com/minio/minio/cmd
BenchmarkErasureReadQuick/_00|00_-4         	     300	   5198303 ns/op	2420.58 MB/s	16499099 B/op	      57 allocs/op
BenchmarkErasureReadQuick/_00|X0_-4         	     300	   5083063 ns/op	2475.46 MB/s	16512776 B/op	      54 allocs/op
BenchmarkErasureReadQuick/_X0|00_-4         	     200	   8042600 ns/op	1564.53 MB/s	33455470 B/op	      74 allocs/op
BenchmarkErasureReadQuick/_X0|X0_-4         	     200	   8681753 ns/op	1449.35 MB/s	39678510 B/op	      74 allocs/op
BenchmarkErasureRead_4_64KB/_00|00_-4       	   10000	    157246 ns/op	 416.77 MB/s	  754868 B/op	      49 allocs/op
BenchmarkErasureRead_4_64KB/_00|X0_-4       	   10000	    154106 ns/op	 425.26 MB/s	  748092 B/op	      47 allocs/op
BenchmarkErasureRead_4_64KB/_X0|00_-4       	    5000	    205693 ns/op	 318.61 MB/s	  900783 B/op	      56 allocs/op
BenchmarkErasureRead_4_64KB/_X0|X0_-4       	   10000	    214145 ns/op	 306.03 MB/s	  951751 B/op	      56 allocs/op
BenchmarkErasureRead_4_64KB/_00|XX_-4       	   10000	    159268 ns/op	 411.48 MB/s	  756320 B/op	      45 allocs/op
BenchmarkErasureRead_4_64KB/_XX|00_-4       	   10000	    222836 ns/op	 294.10 MB/s	  962344 B/op	      56 allocs/op
BenchmarkErasureRead_8_20MB/_0000|0000_-4   	     200	   7768051 ns/op	2699.71 MB/s	24593491 B/op	     100 allocs/op
BenchmarkErasureRead_8_20MB/_0000|X000_-4   	     200	   7755506 ns/op	2704.08 MB/s	24692850 B/op	      98 allocs/op
BenchmarkErasureRead_8_20MB/_X000|0000_-4   	     100	  10958873 ns/op	1913.66 MB/s	40570543 B/op	     121 allocs/op
BenchmarkErasureRead_8_20MB/_X000|X000_-4   	     100	  11544365 ns/op	1816.60 MB/s	45886715 B/op	     123 allocs/op
BenchmarkErasureRead_8_20MB/_0000|XXXX_-4   	     200	   7721089 ns/op	2716.13 MB/s	24555732 B/op	      92 allocs/op
BenchmarkErasureRead_8_20MB/_XX00|XX00_-4   	     100	  12781197 ns/op	1640.81 MB/s	56225292 B/op	     123 allocs/op
BenchmarkErasureRead_8_20MB/_XXXX|0000_-4   	     100	  14237890 ns/op	1472.94 MB/s	56424589 B/op	     123 allocs/op
BenchmarkErasureRead_12_30MB/_000000|000000_-4         	     100	  11429498 ns/op	2752.29 MB/s	37089924 B/op	     155 allocs/op
BenchmarkErasureRead_12_30MB/_000000|X00000_-4         	     200	  11320750 ns/op	2778.73 MB/s	36988985 B/op	     150 allocs/op
BenchmarkErasureRead_12_30MB/_X00000|000000_-4         	     100	  15015384 ns/op	2095.00 MB/s	53239490 B/op	     184 allocs/op
BenchmarkErasureRead_12_30MB/_X00000|X00000_-4         	     100	  15597873 ns/op	2016.77 MB/s	58490500 B/op	     187 allocs/op
BenchmarkErasureRead_12_30MB/_000000|XXXXXX_-4         	     100	  11651602 ns/op	2699.82 MB/s	37067321 B/op	     143 allocs/op
BenchmarkErasureRead_12_30MB/_XXX000|XXX000_-4         	     100	  18075011 ns/op	1740.37 MB/s	79284403 B/op	     189 allocs/op
BenchmarkErasureRead_12_30MB/_XXXXXX|000000_-4         	      50	  21260468 ns/op	1479.61 MB/s	79569707 B/op	     195 allocs/op
BenchmarkErasureRead_16_40MB/_00000000|00000000_-4     	     100	  14991491 ns/op	2797.79 MB/s	49346079 B/op	     211 allocs/op
BenchmarkErasureRead_16_40MB/_00000000|X0000000_-4     	     100	  14977081 ns/op	2800.48 MB/s	49387808 B/op	     210 allocs/op
BenchmarkErasureRead_16_40MB/_X0000000|00000000_-4     	     100	  18895268 ns/op	2219.76 MB/s	65529347 B/op	     249 allocs/op
BenchmarkErasureRead_16_40MB/_X0000000|X0000000_-4     	     100	  19503575 ns/op	2150.53 MB/s	70709288 B/op	     253 allocs/op
BenchmarkErasureRead_16_40MB/_00000000|XXXXXXXX_-4     	     100	  14994205 ns/op	2797.28 MB/s	49343942 B/op	     195 allocs/op
BenchmarkErasureRead_16_40MB/_XXXX0000|XXXX0000_-4     	      50	  24973150 ns/op	1679.53 MB/s	102262809 B/op	     264 allocs/op
BenchmarkErasureRead_16_40MB/_XXXXXXXX|00000000_-4     	      50	  29751270 ns/op	1409.79 MB/s	102178819 B/op	     263 allocs/op
PASS
ok  	github.com/minio/minio/cmd	65.840s
```

simplify-erasure branch erasure read:
```
goos: linux
goarch: amd64
pkg: github.com/minio/minio/cmd
BenchmarkErasureReadQuick/_00|00_-4         	     300	   4666378 ns/op	2696.50 MB/s	12652586 B/op	      60 allocs/op
BenchmarkErasureReadQuick/_00|X0_-4         	     300	   4661863 ns/op	2699.12 MB/s	12652423 B/op	      57 allocs/op
BenchmarkErasureReadQuick/_X0|00_-4         	     200	   6491840 ns/op	1938.27 MB/s	18944729 B/op	      73 allocs/op
BenchmarkErasureReadQuick/_X0|X0_-4         	     200	   6435338 ns/op	1955.28 MB/s	18944541 B/op	      72 allocs/op
BenchmarkErasureRead_4_64KB/_00|00_-4       	   20000	     74979 ns/op	 874.05 MB/s	  134628 B/op	      54 allocs/op
BenchmarkErasureRead_4_64KB/_00|X0_-4       	   20000	     81826 ns/op	 800.92 MB/s	  134468 B/op	      51 allocs/op
BenchmarkErasureRead_4_64KB/_X0|00_-4       	   10000	    102550 ns/op	 639.06 MB/s	  167584 B/op	      59 allocs/op
BenchmarkErasureRead_4_64KB/_X0|X0_-4       	   10000	    103179 ns/op	 635.16 MB/s	  167440 B/op	      57 allocs/op
BenchmarkErasureRead_4_64KB/_00|XX_-4       	   20000	     74521 ns/op	 879.42 MB/s	  134308 B/op	      48 allocs/op
BenchmarkErasureRead_4_64KB/_XX|00_-4       	   10000	    112764 ns/op	 581.18 MB/s	  200208 B/op	      58 allocs/op
BenchmarkErasureRead_8_20MB/_0000|0000_-4   	     200	   7443535 ns/op	2817.41 MB/s	21110595 B/op	     110 allocs/op
BenchmarkErasureRead_8_20MB/_0000|X000_-4   	     200	   7500163 ns/op	2796.14 MB/s	21110439 B/op	     107 allocs/op
BenchmarkErasureRead_8_20MB/_X000|0000_-4   	     200	   9413000 ns/op	2227.93 MB/s	26354328 B/op	     123 allocs/op
BenchmarkErasureRead_8_20MB/_X000|X000_-4   	     200	   9380155 ns/op	2235.73 MB/s	26354205 B/op	     123 allocs/op
BenchmarkErasureRead_8_20MB/_0000|XXXX_-4   	     200	   7391263 ns/op	2837.34 MB/s	21109954 B/op	      98 allocs/op
BenchmarkErasureRead_8_20MB/_XX00|XX00_-4   	     100	  10476033 ns/op	2001.86 MB/s	31597514 B/op	     122 allocs/op
BenchmarkErasureRead_8_20MB/_XXXX|0000_-4   	     100	  12889754 ns/op	1626.99 MB/s	42083295 B/op	     127 allocs/op
BenchmarkErasureRead_12_30MB/_000000|000000_-4         	     200	  10903475 ns/op	2885.07 MB/s	31715521 B/op	     170 allocs/op
BenchmarkErasureRead_12_30MB/_000000|X00000_-4         	     100	  10937472 ns/op	2876.10 MB/s	31716377 B/op	     170 allocs/op
BenchmarkErasureRead_12_30MB/_X00000|000000_-4         	     100	  13577878 ns/op	2316.80 MB/s	36977670 B/op	     194 allocs/op
BenchmarkErasureRead_12_30MB/_X00000|X00000_-4         	     100	  13449705 ns/op	2338.88 MB/s	36977537 B/op	     194 allocs/op
BenchmarkErasureRead_12_30MB/_000000|XXXXXX_-4         	     100	  11031547 ns/op	2851.57 MB/s	31715563 B/op	     155 allocs/op
BenchmarkErasureRead_12_30MB/_XXX000|XXX000_-4         	     100	  15746882 ns/op	1997.68 MB/s	47495716 B/op	     194 allocs/op
BenchmarkErasureRead_12_30MB/_XXXXXX|000000_-4         	     100	  19749667 ns/op	1592.80 MB/s	63273546 B/op	     204 allocs/op
BenchmarkErasureRead_16_40MB/_00000000|00000000_-4     	     100	  14658585 ns/op	2861.33 MB/s	42223888 B/op	     238 allocs/op
BenchmarkErasureRead_16_40MB/_00000000|X0000000_-4     	     100	  14383188 ns/op	2916.12 MB/s	42223710 B/op	     234 allocs/op
BenchmarkErasureRead_16_40MB/_X0000000|00000000_-4     	     100	  17534808 ns/op	2391.99 MB/s	47469917 B/op	     267 allocs/op
BenchmarkErasureRead_16_40MB/_X0000000|X0000000_-4     	     100	  17492116 ns/op	2397.83 MB/s	47469809 B/op	     268 allocs/op
BenchmarkErasureRead_16_40MB/_00000000|XXXXXXXX_-4     	     100	  14723932 ns/op	2848.63 MB/s	42222593 B/op	     213 allocs/op
BenchmarkErasureRead_16_40MB/_XXXX0000|XXXX0000_-4     	      50	  21861108 ns/op	1918.61 MB/s	63200629 B/op	     277 allocs/op
BenchmarkErasureRead_16_40MB/_XXXXXXXX|00000000_-4     	      50	  28243035 ns/op	1485.08 MB/s	84172121 B/op	     293 allocs/op
PASS
ok  	github.com/minio/minio/cmd	65.308s
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.