### PR TITLE
Allow head requests for prefixes without trailing "/"

### DIFF
--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -199,7 +199,7 @@ func osErrToFSFileErr(err error) error {
 		return errFileAccessDenied
 	}
 	if isSysErrNotDir(err) {
-		return errFileAccessDenied
+		return errFileNotFound
 	}
 	if isSysErrPathNotFound(err) {
 		return errFileNotFound
@@ -218,8 +218,7 @@ func fsStatDir(ctx context.Context, statDir string) (os.FileInfo, error) {
 		return nil, err
 	}
 	if !fi.IsDir() {
-		logger.LogIf(ctx, errFileAccessDenied)
-		return nil, errFileAccessDenied
+		return nil, errFileNotFound
 	}
 	return fi, nil
 }
@@ -244,8 +243,7 @@ func fsStatFile(ctx context.Context, statFile string) (os.FileInfo, error) {
 		return nil, err
 	}
 	if fi.IsDir() {
-		logger.LogIf(ctx, errFileAccessDenied)
-		return nil, errFileAccessDenied
+		return nil, errFileNotFound
 	}
 	return fi, nil
 }

--- a/cmd/fs-v1-helpers_test.go
+++ b/cmd/fs-v1-helpers_test.go
@@ -136,7 +136,7 @@ func TestFSStats(t *testing.T) {
 			srcFSPath:   path,
 			srcVol:      "success-vol",
 			srcPath:     "path",
-			expectedErr: errFileAccessDenied,
+			expectedErr: errFileNotFound,
 		},
 		// Test case - 6.
 		// Test case with src path segment > 255.

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -696,7 +696,7 @@ func (fs *FSObjects) getObjectInfoWithLock(ctx context.Context, bucket, object s
 	}
 
 	if _, err := fs.statBucketDir(ctx, bucket); err != nil {
-		return oi, toObjectErr(err, bucket)
+		return oi, err
 	}
 
 	if strings.HasSuffix(object, slashSeparator) && !fs.isObjectDir(bucket, object) {


### PR DESCRIPTION
## Description
Reverted some of the changes from #5900 to allow Spark to work with Minio 
server in FS mode. 

## Motivation and Context
To ensure Spark runs with Minio server in FS mode.

## How Has This Been Tested?
Manually with Spark and Minio FS server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.