### PR TITLE
Update Kubernetes TLS doc with info for distributed setups

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -70,8 +70,16 @@ openssl rsa -in private-pkcs8-key.key -aes256 -passout pass:PASSWORD -out privat
 
 **Generate the self-signed certificate**:
 
+Generate self-signed certificate using the below command (remember to replace `<domain.com>` with your actual domain name)
+
 ```sh
-openssl req -new -x509 -days 3650 -key private.key -out public.crt -subj "/C=US/ST=state/L=location/O=organization/CN=domain"
+openssl req -new -x509 -days 3650 -key private.key -out public.crt -subj "/C=US/ST=state/L=location/O=organization/CN=<domain.com>"
+```
+
+Generate self-signed wildcard certificate using the below command. This certificate will be valid for all the sub-domains under `domain.com`. Wildcard certificates come in handy while deploying distributed Minio instances where there may be multiple sub-domains under a single domain, with each one running a separate Minio instance.
+
+```sh
+openssl req -new -x509 -days 3650 -key private.key -out public.crt -subj "/C=US/ST=state/L=location/O=organization/CN=<*.domain.com>"
 ```
 
 ### Using OpenSSL (with IP address)

--- a/docs/tls/kubernetes/README.md
+++ b/docs/tls/kubernetes/README.md
@@ -10,6 +10,10 @@ This document explains how to configure Minio server with TLS certificates on Ku
 
 - Acquire TLS certificates, either from a CA or [create self-signed certificates](https://docs.minio.io/docs/how-to-secure-access-to-minio-server-with-tls).
 
+For a [distributed Minio setup](https://docs.minio.io/docs/distributed-minio-quickstart-guide), where there are multiple pods with different domain names expected to run, you will either need wildcard certificates valid for all the domains or have specific certificates for each domain. If you are going to use specific certificates, make sure to create Kubernetes secrets accordingly.
+
+For testing purposes, here is [how to create self-signed certificates](https://github.com/minio/minio/tree/master/docs/tls#3-generate-self-signed-certificates).
+
 ## 2. Create Kubernetes secret
 
 [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret) are intended to hold sensitive information. 


### PR DESCRIPTION
## Description
When deploying distributed Minio with TLS on Kubernetes, users need to have either wildcard certificates valid for all the subdomains or multiple certificates corresponding to each domain that is going to be created. 

This PR adds this info to the Kubernetes TLS doc.

## Motivation and Context
Based on discussion with users

## How Has This Been Tested?
Manually on minishift Minio setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.