### PR TITLE
Doc Fix - Pika python package no longer accepts 'type' 

### DIFF
--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -99,7 +99,7 @@ connection = pika.BlockingConnection(pika.ConnectionParameters(
 channel = connection.channel()
 
 channel.exchange_declare(exchange='bucketevents',
-                         type='fanout')
+                         exchange_type='fanout')
 
 result = channel.queue_declare(exclusive=False)
 queue_name = result.method.queue

--- a/docs/zh_CN/bucket/notifications/README.md
+++ b/docs/zh_CN/bucket/notifications/README.md
@@ -95,7 +95,7 @@ connection = pika.BlockingConnection(pika.ConnectionParameters(
 channel = connection.channel()
 
 channel.exchange_declare(exchange='bucketevents',
-                         type='fanout')
+                         exchange_type='fanout')
 
 result = channel.queue_declare(exclusive=False)
 queue_name = result.method.queue


### PR DESCRIPTION
The pika python package used for listening to the rabbitMQ events has been updated. It no longer accepts 'type'. They have changed it to 'exchange_type'.

Doc Reference : http://pika.readthedocs.io/en/0.11.2/modules/channel.html (exchange_declare function) 

<!--- Provide a general summary of your changes in the Title above -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.