### PR TITLE
Remove brittle TestServerTLSCiphers unit test

### DIFF
--- a/cmd/http/server_test.go
+++ b/cmd/http/server_test.go
@@ -17,12 +17,10 @@
 package http
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/minio/minio/pkg/certs"
 )
@@ -94,80 +92,5 @@ func TestNewServer(t *testing.T) {
 		if server.MaxHeaderBytes != DefaultMaxHeaderBytes {
 			t.Fatalf("Case %v: server.MaxHeaderBytes: expected: %v, got: %v", (i + 1), DefaultMaxHeaderBytes, server.MaxHeaderBytes)
 		}
-	}
-}
-
-func TestServerTLSCiphers(t *testing.T) {
-	var unsupportedCipherSuites = []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,    // Go stack contains (some) countermeasures against timing attacks (Lucky13)
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, // No countermeasures against timing attacks
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,    // Go stack contains (some) countermeasures against timing attacks (Lucky13)
-		tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,        // Broken cipher
-		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,     // Sweet32
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,      // Go stack contains (some) countermeasures against timing attacks (Lucky13)
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,   // No countermeasures against timing attacks
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,      // Go stack contains (some) countermeasures against timing attacks (Lucky13)
-		tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,          // Broken cipher
-
-		// all RSA-PKCS1-v1.5 ciphers are disabled - danger of Bleichenbacher attack variants
-		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,   // Sweet32
-		tls.TLS_RSA_WITH_AES_128_CBC_SHA,    // Go stack contains (some) countermeasures against timing attacks (Lucky13)
-		tls.TLS_RSA_WITH_AES_128_CBC_SHA256, // No countermeasures against timing attacks
-		tls.TLS_RSA_WITH_AES_256_CBC_SHA,    // Go stack contains (some) countermeasures against timing attacks (Lucky13)
-		tls.TLS_RSA_WITH_RC4_128_SHA,        // Broken cipher
-
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256, // Disabled because of RSA-PKCS1-v1.5 - AES-GCM is considered secure.
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384, // Disabled because of RSA-PKCS1-v1.5 - AES-GCM is considered secure.
-	}
-
-	testCases := []struct {
-		ciphers            []uint16
-		resetServerCiphers bool
-		expectErr          bool
-	}{
-		{nil, false, false},
-		{defaultCipherSuites, false, false},
-		{unsupportedCipherSuites, false, true},
-		{nil, true, false},
-	}
-
-	for i, testCase := range testCases {
-		func() {
-			addr := "127.0.0.1:" + getNextPort()
-
-			server := NewServer([]string{addr},
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fmt.Fprintf(w, "Hello, world")
-				}), getCert)
-			if testCase.resetServerCiphers {
-				// Use Go default ciphers.
-				server.TLSConfig.CipherSuites = nil
-			}
-
-			go func() {
-				server.Start()
-			}()
-			defer server.Shutdown()
-
-			client := http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-						CipherSuites:       testCase.ciphers,
-					},
-				},
-			}
-
-			// There is no guaranteed way to know whether the HTTP server is started successfully.
-			// The only option is to connect and check.  Hence below sleep is used as workaround.
-			time.Sleep(1 * time.Second)
-
-			_, err := client.Get("https://" + addr)
-			expectErr := (err != nil)
-
-			if expectErr != testCase.expectErr {
-				t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
-			}
-		}()
 	}
 }


### PR DESCRIPTION
## Description
The test TestServerTLSCiphers seems to fail sometimes for
no obvious reason. Actually the test is not needed
(as unit test) since minio/mint tests the server's TLS ciphers
as part of its security tests.

## Motivation and Context
Fixes #5977

## How Has This Been Tested?
manually (+ CI / mint)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.