### PR TITLE
enforce authenticated request bodies for Admin-API

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -114,7 +114,7 @@ func getRequestAuthType(r *http.Request) authType {
 // It does not accept presigned or JWT or anonymous requests.
 func checkAdminRequestAuthType(r *http.Request, region string) APIErrorCode {
 	s3Err := ErrAccessDenied
-	if getRequestAuthType(r) == authTypeSigned { // we only support V4 (no presign)
+	if _, ok := r.Header["X-Amz-Content-Sha256"]; ok && getRequestAuthType(r) == authTypeSigned && !skipContentSha256Cksum(r) { // we only support V4 (no presign) with auth. body
 		s3Err = isReqAuthenticated(r, region)
 	}
 	if s3Err != ErrNone {

--- a/pkg/madmin/config-commands.go
+++ b/pkg/madmin/config-commands.go
@@ -18,7 +18,6 @@
 package madmin
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -66,8 +65,7 @@ func (adm *AdminClient) GetConfig() ([]byte, error) {
 
 // SetConfig - set config supplied as config.json for the setup.
 func (adm *AdminClient) SetConfig(config io.Reader) (r SetConfigResult, err error) {
-	// No TLS?
-	if !adm.secure {
+	if !adm.secure { // No TLS?
 		return r, fmt.Errorf("credentials/configuration cannot be updated over an insecure connection")
 	}
 
@@ -78,10 +76,8 @@ func (adm *AdminClient) SetConfig(config io.Reader) (r SetConfigResult, err erro
 	}
 
 	reqData := requestData{
-		relPath:            "/v1/config",
-		contentBody:        bytes.NewReader(configBytes),
-		contentMD5Bytes:    sumMD5(configBytes),
-		contentSHA256Bytes: sum256(configBytes),
+		relPath: "/v1/config",
+		content: configBytes,
 	}
 
 	// Execute PUT on /minio/admin/v1/config to set config.

--- a/pkg/madmin/generic-commands.go
+++ b/pkg/madmin/generic-commands.go
@@ -18,7 +18,6 @@
 package madmin
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -46,11 +45,8 @@ func (adm *AdminClient) SetCredentials(access, secret string) error {
 
 	// Setup new request
 	reqData := requestData{
-		relPath:            "/v1/config/credential",
-		contentBody:        bytes.NewReader(body),
-		contentLength:      int64(len(body)),
-		contentMD5Bytes:    sumMD5(body),
-		contentSHA256Bytes: sum256(body),
+		relPath: "/v1/config/credential",
+		content: body,
 	}
 
 	// Execute GET on bucket to list objects.

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -18,10 +18,8 @@
 package madmin
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -194,23 +192,18 @@ func (adm *AdminClient) Heal(bucket, prefix string, healOpts HealOpts,
 
 	// execute POST request to heal api
 	queryVals := make(url.Values)
-	var contentBody io.Reader
 	if clientToken != "" {
 		queryVals.Set("clientToken", clientToken)
 		body = []byte{}
-	} else {
-		// Set a body only if clientToken is not given
-		contentBody = bytes.NewReader(body)
 	}
 	if forceStart {
 		queryVals.Set("forceStart", "true")
 	}
 
 	resp, err := adm.executeMethod("POST", requestData{
-		relPath:            path,
-		contentBody:        contentBody,
-		contentSHA256Bytes: sum256(body),
-		queryValues:        queryVals,
+		relPath:     path,
+		content:     body,
+		queryValues: queryVals,
 	})
 	defer closeResponse(resp)
 	if err != nil {

--- a/pkg/madmin/service-commands.go
+++ b/pkg/madmin/service-commands.go
@@ -18,7 +18,6 @@
 package madmin
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -87,9 +86,8 @@ func (adm *AdminClient) ServiceSendAction(action ServiceActionValue) error {
 
 	// Request API to Restart server
 	resp, err := adm.executeMethod("POST", requestData{
-		relPath:            "/v1/service",
-		contentBody:        bytes.NewReader(body),
-		contentSHA256Bytes: sum256(body),
+		relPath: "/v1/service",
+		content: body,
 	})
 	defer closeResponse(resp)
 	if err != nil {


### PR DESCRIPTION
## Description
This commit adds a check to the server's admin-API such that it only
accepts Admin-API requests with authenticated bodies. Further this
commit updates the `madmin` package to always add the
`X-Amz-Content-Sha256` header.

This change improves the Admin-API security since the server does not
accept unauthenticated request bodies anymore.

After this commit `mc` must be updated to the new `madmin` api because
requests over TLS connections will fail.

## Motivation and Context
Security

## How Has This Been Tested?
manually

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.