### PR TITLE
Add prometheus endpoint to support total Used storageInfo

### DIFF
--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -77,6 +77,13 @@ type cacheObjects struct {
 	DeleteBucketFn            func(ctx context.Context, bucket string) error
 }
 
+// CacheStorageInfo - represents total, free capacity of
+// underlying cache storage.
+type CacheStorageInfo struct {
+	Total uint64 // Total cache disk space.
+	Free  uint64 // Free cache available space.
+}
+
 // CacheObjectLayer implements primitives for cache object API layer.
 type CacheObjectLayer interface {
 	// Bucket operations.
@@ -98,7 +105,7 @@ type CacheObjectLayer interface {
 	CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart) (objInfo ObjectInfo, err error)
 
 	// Storage operations.
-	StorageInfo(ctx context.Context) StorageInfo
+	StorageInfo(ctx context.Context) CacheStorageInfo
 }
 
 // backendDownError returns true if err is due to backend failure or faulty disk if in server mode
@@ -771,7 +778,7 @@ func (c cacheObjects) CompleteMultipartUpload(ctx context.Context, bucket, objec
 }
 
 // StorageInfo - returns underlying storage statistics.
-func (c cacheObjects) StorageInfo(ctx context.Context) (storageInfo StorageInfo) {
+func (c cacheObjects) StorageInfo(ctx context.Context) (cInfo CacheStorageInfo) {
 	var total, free uint64
 	for _, cfs := range c.cache.cfs {
 		if cfs == nil {
@@ -783,12 +790,10 @@ func (c cacheObjects) StorageInfo(ctx context.Context) (storageInfo StorageInfo)
 		total += info.Total
 		free += info.Free
 	}
-	storageInfo = StorageInfo{
+	return CacheStorageInfo{
 		Total: total,
 		Free:  free,
 	}
-	storageInfo.Backend.Type = FS
-	return storageInfo
 }
 
 // DeleteBucket - marks bucket to be deleted from cache if bucket is deleted from backend.

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -39,9 +39,7 @@ const (
 
 // StorageInfo - represents total capacity of underlying storage.
 type StorageInfo struct {
-	Total uint64 // Total disk space.
-	Free  uint64 // Free available space.
-	Used  uint64 // Used total used per tenant.
+	Used uint64 // Used total used per tenant.
 
 	// Backend type.
 	Backend struct {

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -188,7 +188,7 @@ func printStorageInfo(storageInfo StorageInfo) {
 	}
 }
 
-func printCacheStorageInfo(storageInfo StorageInfo) {
+func printCacheStorageInfo(storageInfo CacheStorageInfo) {
 	msg := fmt.Sprintf("%s %s Free, %s Total", colorBlue("Cache Capacity:"),
 		humanize.IBytes(uint64(storageInfo.Free)),
 		humanize.IBytes(uint64(storageInfo.Total)))

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -1786,10 +1786,6 @@ func TestWebObjectLayerFaultyDisks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed %v", err)
 	}
-	// if Total size is 0 it indicates faulty disk.
-	if storageInfoReply.StorageInfo.Total != 0 {
-		t.Fatalf("Should get zero Total size since disks are faulty ")
-	}
 
 	// Test authorization of Web.Download
 	req, err = http.NewRequest("GET", "/minio/download/bucket/object?token="+authorization, nil)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add prometheus endpoint to support total Used storageInfo
<!--- Describe your changes in detail -->

## Motivation and Context
Since we deprecated Total/Free we don't need to update
prometheus with those metrics. This PR also adds support
for caching implementation.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.