### PR TITLE
Got rid of quotes for XSS Protection Header

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -661,7 +661,7 @@ func addSecurityHeaders(h http.Handler) http.Handler {
 
 func (s securityHeaderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	header := w.Header()
-	header.Set("X-XSS-Protection", "\"1; mode=block\"")              // Prevents against XSS attacks
+	header.Set("X-XSS-Protection", "1; mode=block")              // Prevents against XSS attacks
 	header.Set("Content-Security-Policy", "block-all-mixed-content") // prevent mixed (HTTP / HTTPS content)
 	s.handler.ServeHTTP(w, r)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Got rid of quotes for XSS Protection Header to resolve issue described here: https://github.com/minio/minio/issues/5972
XSS-Protection-Headers are supported in all browsers except Mozilla, the quotes are not needed as shown here:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.