### PR TITLE
fix admin info peer to point to first endpoint

### DIFF
--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -256,7 +256,9 @@ type adminPeers []adminPeer
 func makeAdminPeers(endpoints EndpointList) (adminPeerList adminPeers) {
 	thisPeer := globalMinioAddr
 	if globalMinioHost == "" {
-		thisPeer = net.JoinHostPort("localhost", globalMinioPort)
+		// When host is not explicitly provided simply
+		// use the first IPv4.
+		thisPeer = net.JoinHostPort(sortIPs(localIP4.ToSlice())[0], globalMinioPort)
 	}
 	adminPeerList = append(adminPeerList, adminPeer{
 		thisPeer,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
fix admin info peer to point to first endpoint
<!--- Describe your changes in detail -->

## Motivation and Context
The current problem is that when you invoke

```
mc admin info play | head -1
●  localhost:9000
```

This output is incorrect as the expected output should be
```
mc admin info play | head -1
●  play.minio.io:9000
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using `mc admin info`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.