### PR TITLE
terminate disk-usage routine in tests

### DIFF
--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -191,6 +191,8 @@ func TestFSGetBucketInfo(t *testing.T) {
 		t.Fatal("BucketNotFound error not returned")
 	}
 
+	globalServiceDoneCh <- struct{}{}
+
 	// Check for buckets and should get disk not found.
 	fs.fsPath = filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 
@@ -301,6 +303,8 @@ func TestFSDeleteObject(t *testing.T) {
 		t.Fatal("Unexpected error: ", err)
 	}
 
+	globalServiceDoneCh <- struct{}{}
+
 	// Delete object should err disk not found.
 	fs.fsPath = filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	if err := fs.DeleteObject(context.Background(), bucketName, objectName); err != nil {
@@ -342,6 +346,8 @@ func TestFSDeleteBucket(t *testing.T) {
 
 	obj.MakeBucketWithLocation(context.Background(), bucketName, "")
 
+	globalServiceDoneCh <- struct{}{}
+
 	// Delete bucket should get error disk not found.
 	fs.fsPath = filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
 	if err = fs.DeleteBucket(context.Background(), bucketName); err != nil {
@@ -364,6 +370,8 @@ func TestFSListBuckets(t *testing.T) {
 	if err := obj.MakeBucketWithLocation(context.Background(), bucketName, ""); err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}
+
+	globalServiceDoneCh <- struct{}{}
 
 	// Create a bucket with invalid name
 	if err := os.MkdirAll(pathJoin(fs.fsPath, "vo^"), 0777); err != nil {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
terminate disk-usage routine in tests
<!--- Describe your changes in detail -->

## Motivation and Context
tests were written in the manner by editing internal
variables of fsObjects to mimic certain behavior from
APIs, but this is racy when an active go-routine is
reading from the same variable.

Make sure to terminate the go-routine if possible for
these tests.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually using `go test -race`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.