### PR TITLE
Cleanup stack trace in error logs

### DIFF
--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -33,6 +33,7 @@ func genLDFlags(version string) string {
 	ldflagsStr += " -X github.com/minio/minio/cmd.CommitID=" + commitID()
 	ldflagsStr += " -X github.com/minio/minio/cmd.ShortCommitID=" + commitID()[:12]
 	ldflagsStr += " -X github.com/minio/minio/cmd.GOPATH=" + os.Getenv("GOPATH")
+	ldflagsStr += " -X github.com/minio/minio/cmd.GOROOT=" + os.Getenv("GOROOT")
 	return ldflagsStr
 }
 

--- a/cmd/build-constants.go
+++ b/cmd/build-constants.go
@@ -22,6 +22,9 @@ var (
 	// GOPATH - GOPATH value at the time of build.
 	GOPATH = ""
 
+	// GOROOT - GOROOT value at the time of build.
+	GOROOT = ""
+
 	// Go get development tag.
 	goGetTag = "DEVELOPMENT.GOGET"
 

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -34,7 +34,7 @@ import (
 )
 
 func init() {
-	logger.Init(GOPATH)
+	logger.Init(GOPATH, GOROOT)
 	logger.RegisterUIError(fmtError)
 }
 

--- a/cmd/logger/utils.go
+++ b/cmd/logger/utils.go
@@ -50,3 +50,16 @@ func ansiSaveAttributes() {
 func ansiRestoreAttributes() {
 	ansiEscape("8")
 }
+
+func uniqueEntries(paths []string) []string {
+	found := map[string]bool{}
+	unqiue := []string{}
+
+	for v := range paths {
+		if _, ok := found[paths[v]]; !ok {
+			found[paths[v]] = true
+			unqiue = append(unqiue, paths[v])
+		}
+	}
+	return unqiue
+}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -33,7 +33,7 @@ import (
 )
 
 func init() {
-	logger.Init(GOPATH)
+	logger.Init(GOPATH, GOROOT)
 	logger.RegisterUIError(fmtError)
 }
 


### PR DESCRIPTION
## Description
Add compile time GOROOT path to the list of prefix
of file paths to be removed.

Add webhandler function names to the slice that
stores function names to terminate logging.

## Motivation and Context
Cleanup GOROOT path from the file path displayed in a stack trace. Previously compiled GOROOT path was not included.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.