### PR TITLE
Log `disk not found error` only once

### DIFF
--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -47,6 +47,11 @@ const (
 
 const loggerTimeFormat string = "15:04:05 MST 01/02/2006"
 
+// List of error strings to be ignored by LogIf
+const (
+	diskNotFoundError = "disk not found"
+)
+
 var matchingFuncNames = [...]string{
 	"http.HandlerFunc.ServeHTTP",
 	"cmd.serverMain",
@@ -267,14 +272,33 @@ func getTrace(traceLevel int) []string {
 	return trace
 }
 
-// LogIf prints a detailed error message during
+// LogAlwaysIf prints a detailed error message during
 // the execution of the server.
-func LogIf(ctx context.Context, err error) {
-	if Disable {
+func LogAlwaysIf(ctx context.Context, err error) {
+	if err == nil {
 		return
 	}
 
+	logIf(ctx, err)
+}
+
+// LogIf prints a detailed error message during
+// the execution of the server, if it is not an
+// ignored error.
+func LogIf(ctx context.Context, err error) {
 	if err == nil {
+		return
+	}
+
+	if err.Error() != diskNotFoundError {
+		logIf(ctx, err)
+	}
+}
+
+// logIf prints a detailed error message during
+// the execution of the server.
+func logIf(ctx context.Context, err error) {
+	if Disable {
 		return
 	}
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -36,14 +36,14 @@ var printEndpointError = func() func(Endpoint, error) {
 			m = make(map[string]bool)
 			m[err.Error()] = true
 			printOnce[endpoint] = m
-			logger.LogIf(ctx, err)
+			logger.LogAlwaysIf(ctx, err)
 			return
 		}
 		if m[err.Error()] {
 			return
 		}
 		m[err.Error()] = true
-		logger.LogIf(ctx, err)
+		logger.LogAlwaysIf(ctx, err)
 	}
 }()
 

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -50,7 +50,6 @@ func (xl xlObjects) MakeBucketWithLocation(ctx context.Context, bucket, location
 	// Make a volume entry on all underlying storage disks.
 	for index, disk := range xl.getDisks() {
 		if disk == nil {
-			logger.LogIf(ctx, errDiskNotFound)
 			dErrs[index] = errDiskNotFound
 			continue
 		}
@@ -234,7 +233,6 @@ func (xl xlObjects) DeleteBucket(ctx context.Context, bucket string) error {
 	// Remove a volume entry on all underlying storage disks.
 	for index, disk := range xl.getDisks() {
 		if disk == nil {
-			logger.LogIf(ctx, errDiskNotFound)
 			dErrs[index] = errDiskNotFound
 			continue
 		}

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -108,7 +108,6 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 	// Make a volume entry on all underlying storage disks.
 	for index, disk := range storageDisks {
 		if disk == nil {
-			logger.LogIf(ctx, errDiskNotFound)
 			dErrs[index] = errDiskNotFound
 			beforeState[index] = madmin.DriveStateOffline
 			afterState[index] = madmin.DriveStateOffline

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -428,7 +428,6 @@ func writeUniqueXLMetadata(ctx context.Context, disks []StorageAPI, bucket, pref
 	// Start writing `xl.json` to all disks in parallel.
 	for index, disk := range disks {
 		if disk == nil {
-			logger.LogIf(ctx, errDiskNotFound)
 			mErrs[index] = errDiskNotFound
 			continue
 		}
@@ -467,7 +466,6 @@ func writeSameXLMetadata(ctx context.Context, disks []StorageAPI, bucket, prefix
 	// Start writing `xl.json` to all disks in parallel.
 	for index, disk := range disks {
 		if disk == nil {
-			logger.LogIf(ctx, errDiskNotFound)
 			mErrs[index] = errDiskNotFound
 			continue
 		}

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -103,7 +103,6 @@ func commitXLMetadata(ctx context.Context, disks []StorageAPI, srcBucket, srcPre
 	// Rename `xl.json` to all disks in parallel.
 	for index, disk := range disks {
 		if disk == nil {
-			logger.LogIf(ctx, errDiskNotFound)
 			mErrs[index] = errDiskNotFound
 			continue
 		}
@@ -791,7 +790,6 @@ func (xl xlObjects) cleanupUploadedParts(ctx context.Context, uploadIDPath strin
 	// Cleanup uploadID for all disks.
 	for index, disk := range xl.getDisks() {
 		if disk == nil {
-			logger.LogIf(ctx, errDiskNotFound)
 			errs[index] = errDiskNotFound
 			continue
 		}

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -807,7 +807,6 @@ func (xl xlObjects) deleteObject(ctx context.Context, bucket, object string) err
 
 	for index, disk := range xl.getDisks() {
 		if disk == nil {
-			logger.LogIf(ctx, errDiskNotFound)
 			dErrs[index] = errDiskNotFound
 			continue
 		}


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description
If a disk is offline, then the disk not found error is displayed continuously now.
This change is to fix that and display it only once. 
Modified the LogIf function to log only if the error passed is not on the
ignored errors list.
Currently only disk not found error is added to the list.
Added a new function in logger package called LogAlwaysIf, which
will print on any error.
The `monitorAndConnectEndpoints` goroutine will print only once if there is a disk not found error


Fixes #5997

## Motivation and Context
As described in #5997 when a disk is offline, we will see the same disk is not found error on all operations. This will flood the console with lots of logs.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.