### PR TITLE
Validates Minio config.json file on the client side before it is set on the server side

### DIFF
--- a/pkg/madmin/config-commands.go
+++ b/pkg/madmin/config-commands.go
@@ -64,10 +64,10 @@ func (adm *AdminClient) GetConfig() ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
-var configMap map[string]interface{}
-
 // SetConfig - set config supplied as config.json for the setup.
 func (adm *AdminClient) SetConfig(config io.Reader) (r SetConfigResult, err error) {
+	var configMap map[string]interface{}
+
 	if !adm.secure { // No TLS?
 		return r, fmt.Errorf("credentials/configuration cannot be updated over an insecure connection")
 	}

--- a/pkg/madmin/config-commands.go
+++ b/pkg/madmin/config-commands.go
@@ -24,6 +24,8 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/minio/minio/pkg/quick"
 )
 
 // NodeSummary - represents the result of an operation part of
@@ -66,27 +68,40 @@ func (adm *AdminClient) GetConfig() ([]byte, error) {
 
 // SetConfig - set config supplied as config.json for the setup.
 func (adm *AdminClient) SetConfig(config io.Reader) (r SetConfigResult, err error) {
-	var configMap map[string]interface{}
+	const maxConfigJSONSize = 256 * 1024 // 256KiB
 
 	if !adm.secure { // No TLS?
 		return r, fmt.Errorf("credentials/configuration cannot be updated over an insecure connection")
 	}
 
-	// Read config bytes to calculate MD5, SHA256 and content length.
-	configBytes, err := ioutil.ReadAll(config)
-	if err != nil {
+	// Read configuration bytes
+	configBuf := make([]byte, maxConfigJSONSize+1)
+	n, err := io.ReadFull(config, configBuf)
+	if err == nil {
+		return r, fmt.Errorf("too large file")
+	}
+	if err != io.ErrUnexpectedEOF {
 		return r, err
 	}
+	configBytes := configBuf[:n]
 
-	// Check if read configBtyes is in json format
-	err = json.Unmarshal(configBytes, &configMap)
-	if err != nil {
+	type configVersion struct {
+		Version string `json:"version,omitempty"`
+	}
+	var cfg configVersion
+
+	// Check if read data is in json format
+	if err = json.Unmarshal(configBytes, &cfg); err != nil {
 		return r, errors.New("Invalid JSON format: " + err.Error())
 	}
 
-	// Make sure "version" key exists
-	if _, ok := configMap["version"]; !ok {
-		return r, errors.New("Missing \"version\" key in json file")
+	// Check if the provided json file has "version" key set
+	if cfg.Version == "" {
+		return r, errors.New("Missing or unset \"version\" key in json file")
+	}
+	// Validate there are no duplicate keys in the JSON
+	if err = quick.CheckDuplicateKeys(string(configBytes)); err != nil {
+		return r, errors.New("Duplicate key in json file: " + err.Error())
 	}
 
 	reqData := requestData{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Minio config.json file validation on the Minio Client side before it is sent to the server side
## Description
We wanted to validate if the Minio config.json file fed into `mc admin config set` command to udpate Minio configuration is in valid json format and the `"version"` key is always included as part of the new configuration information. The config file does not need to be complete.
## Motivation and Context
To provide an input validation logic for the end user to easily diagnose basic file setup problems before the configuration takes effect and the server restarted.
## How Has This Been Tested?
Tested with partial and full Minio config.json files on a local Minio fs server
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.