### PR TITLE
Initial work for OPA-Minio integration

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -193,6 +193,9 @@ const (
 	ErrHealMissingBucket
 	ErrHealAlreadyRunning
 	ErrHealOverlappingPaths
+
+	// OPA policy decision related error
+	ErrOpaPolicyDecision
 )
 
 // error code to APIError structure, these fields carry respective
@@ -844,6 +847,12 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	},
 
 	// Add your error structure here.
+
+	ErrOpaPolicyDecision: {
+		Code:           "PolicyDecisionError",
+		Description:    "User not authorized to perform this operation",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
 }
 
 // toAPIErrorCode - Converts embedded errors. Convenience

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -213,6 +213,12 @@ var (
 	globalUsageCheckInterval = globalDefaultUsageCheckInterval
 
 	// Add new variable global values here.
+
+	// OPA
+	// OPA URL
+	globalOpaURL string
+	// Enable OPA
+	globalIsOPAEnabled bool
 )
 
 // global colors.

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -94,6 +94,10 @@ ENVIRONMENT VARIABLES:
      MINIO_PUBLIC_IPS: To enable bucket DNS requests, set this value to list of Minio host public IP(s) delimited by ",".
      MINIO_ETCD_ENDPOINTS: To enable bucket DNS requests, set this value to list of etcd endpoints delimited by ",".
 
+  OPA
+     ENABLE_OPA: To enable OPA, set this value to "on".
+     OPA_URL: URL for OPA server
+
 EXAMPLES:
   1. Start minio server on "/home/shared" directory.
      $ {{.HelpName}} /home/shared
@@ -119,6 +123,11 @@ EXAMPLES:
      $ export MINIO_CACHE_EXCLUDE="bucket1/*;*.png"
      $ export MINIO_CACHE_EXPIRY=40
      $ {{.HelpName}} /home/shared
+
+  7. Start minio server with OPA server.
+     $ export ENABLE_OPA=on
+     $ export OPA_URL=http://localhost:8181/v1/data/minio/authz/allow
+     $ {{.HelpName}}
 `,
 }
 
@@ -182,6 +191,10 @@ func serverHandleEnvVars() {
 		globalServerRegion = serverRegion
 	}
 
+	if enableOPA := os.Getenv("ENABLE_OPA"); enableOPA == "on" {
+		globalIsOPAEnabled = true
+		globalOpaURL = os.Getenv("OPA_URL")
+	}
 }
 
 // serverMain handler called for 'minio server' command.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Integrate the Open Policy Agent (OPA) with Minio

## Motivation and Context
OPA is a general-purpose policy engine. OPA allows decoupling policy decisions from enforcement. In this way, the Minio server can offload policy decisions to OPA by executing HTTP POST queries. OPA allows to write fine grained access control polices which can be used to check for example if a client can access a particular S3 bucket etc.

## How Has This Been Tested?
Tested by running Minio and OPA server locally and running Minio client commands to list, create and delete buckets.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.