### PR TITLE
Updating disk storage for FS/Erasure mode

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -201,6 +201,7 @@ func (fs *FSObjects) diskUsage(doneCh chan struct{}) {
 	if err := getDiskUsage(context.Background(), fs.fsPath, usageFn); err != nil {
 		return
 	}
+	atomic.StoreInt32(&fs.usageRunning, 0)
 
 	for {
 		select {

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -359,6 +359,7 @@ func (s *posix) diskUsage(doneCh chan struct{}) {
 	if err := getDiskUsage(context.Background(), s.diskPath, usageFn); err != nil {
 		return
 	}
+	atomic.StoreInt32(&s.usageRunning, 0)
 
 	for {
 		select {


### PR DESCRIPTION
Updating the disk storage stats for FS/Erasure coded backend

<!--- Provide a general summary of your changes in the Title above -->
disk usage routine is set to 0.


## Description
<!--- Describe your changes in detail -->
The disk usage routine was in running state, which has been changed to completed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
minio_disk_storage_used_bytes was not updated.
<!--- If it fixes an open issue, please link to the issue here. -->
#6072 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Prometheus metric `minio_disk_storage_used_bytes` is updated in FS and Erasure mode.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [X] All new and existing tests passed.