### PR TITLE
Pre-checking the bucket existence in the RemoveObjectHandler

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 	"strconv"
 
+	etcd "github.com/coreos/etcd/client"
 	"github.com/gorilla/mux"
 	miniogo "github.com/minio/minio-go"
 	"github.com/minio/minio/cmd/logger"
@@ -1537,6 +1538,27 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		// DeleteObject is always successful irrespective of object existence.
 		writeErrorResponse(w, ErrMethodNotAllowed, r.URL)
 		return
+	}
+
+	if globalDNSConfig != nil {
+		_, err := globalDNSConfig.Get(bucket)
+		if err != nil {
+			if etcd.IsKeyNotFound(err) || err == dns.ErrNoEntriesFound {
+				writeErrorResponse(w, ErrNoSuchBucket, r.URL)
+			} else {
+				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+			}
+			return
+		}
+	} else {
+		getBucketInfo := objectAPI.GetBucketInfo
+		if api.CacheAPI() != nil {
+			getBucketInfo = api.CacheAPI().GetBucketInfo
+		}
+		if _, err := getBucketInfo(ctx, bucket); err != nil {
+			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+			return
+		}
 	}
 
 	// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html


### PR DESCRIPTION
Error out `NoSuchBucket` in RemoveObjectHandler,  similar to s3.
The problem persisted when checked in s3cmd.

## Description
<!--- Describe your changes in detail -->
Does a globalDNS check for the bucket existence , if it is enabled.
Else GetBucketInfo is called to check whether the bucket existed or not.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #6077 

## How Has This Been Tested?
1) Do a `s3cmd del` on a non-existent bucket
2) Will respond with `ERROR: S3 error: 404 (NoSuchBucket): The specified bucket does not exist` instead of `delete: 's3://testcompressionsd/test.py'`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.