### PR TITLE
disable disk-usage when export is root mount path

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -34,6 +34,7 @@ import (
 	"github.com/minio/minio/pkg/lock"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/mimedb"
+	"github.com/minio/minio/pkg/mountinfo"
 	"github.com/minio/minio/pkg/policy"
 )
 
@@ -63,6 +64,8 @@ type FSObjects struct {
 
 	// ListObjects pool management.
 	listPool *treeWalkPool
+
+	diskMount bool
 
 	appendFileMap   map[string]*fsAppendFile
 	appendFileMapMu sync.Mutex
@@ -138,6 +141,7 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 		nsMutex:       newNSLock(false),
 		listPool:      newTreeWalkPool(globalLookupTimeout),
 		appendFileMap: make(map[string]*fsAppendFile),
+		diskMount:     mountinfo.IsLikelyMountPoint(fsPath),
 	}
 
 	// Once the filesystem has initialized hold the read lock for
@@ -156,7 +160,10 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 		return nil, uiErrUnableToReadFromBackend(err).Msg("Unable to initialize policy system")
 	}
 
-	go fs.diskUsage(globalServiceDoneCh)
+	if !fs.diskMount {
+		go fs.diskUsage(globalServiceDoneCh)
+	}
+
 	go fs.cleanupStaleMultipartUploads(ctx, globalMultipartCleanupInterval, globalMultipartExpiry, globalServiceDoneCh)
 
 	// Return successfully initialized object layer.
@@ -177,17 +184,29 @@ func (fs *FSObjects) diskUsage(doneCh chan struct{}) {
 	defer ticker.Stop()
 
 	usageFn := func(ctx context.Context, entry string) error {
-		var fi os.FileInfo
-		var err error
-		if hasSuffix(entry, slashSeparator) {
-			fi, err = fsStatDir(ctx, entry)
-		} else {
-			fi, err = fsStatFile(ctx, entry)
+		if globalHTTPServer != nil {
+			// Any requests in progress, delay the usage.
+			for globalHTTPServer.GetRequestCount() > 0 {
+				time.Sleep(1 * time.Second)
+			}
 		}
-		if err != nil {
-			return err
+
+		select {
+		case <-doneCh:
+			return errWalkAbort
+		default:
+			var fi os.FileInfo
+			var err error
+			if hasSuffix(entry, slashSeparator) {
+				fi, err = fsStatDir(ctx, entry)
+			} else {
+				fi, err = fsStatFile(ctx, entry)
+			}
+			if err != nil {
+				return err
+			}
+			atomic.AddUint64(&fs.totalUsed, uint64(fi.Size()))
 		}
-		atomic.AddUint64(&fs.totalUsed, uint64(fi.Size()))
 		return nil
 	}
 
@@ -216,6 +235,13 @@ func (fs *FSObjects) diskUsage(doneCh chan struct{}) {
 
 			var usage uint64
 			usageFn = func(ctx context.Context, entry string) error {
+				if globalHTTPServer != nil {
+					// Any requests in progress, delay the usage.
+					for globalHTTPServer.GetRequestCount() > 0 {
+						time.Sleep(1 * time.Second)
+					}
+				}
+
 				var fi os.FileInfo
 				var err error
 				if hasSuffix(entry, slashSeparator) {
@@ -243,8 +269,16 @@ func (fs *FSObjects) diskUsage(doneCh chan struct{}) {
 
 // StorageInfo - returns underlying storage statistics.
 func (fs *FSObjects) StorageInfo(ctx context.Context) StorageInfo {
+	di, err := getDiskInfo(fs.fsPath)
+	if err != nil {
+		return StorageInfo{}
+	}
+	used := di.Total - di.Free
+	if !fs.diskMount {
+		used = atomic.LoadUint64(&fs.totalUsed)
+	}
 	storageInfo := StorageInfo{
-		Used: atomic.LoadUint64(&fs.totalUsed),
+		Used: used,
 	}
 	storageInfo.Backend.Type = FS
 	return storageInfo

--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -59,7 +59,12 @@ type Server struct {
 	listenerMutex          *sync.Mutex   // to guard 'listener' field.
 	listener               *httpListener // HTTP listener for all 'Addrs' field.
 	inShutdown             uint32        // indicates whether the server is in shutdown or not
-	requestCount           int32         // counter holds no. of request in process.
+	requestCount           int32         // counter holds no. of request in progress.
+}
+
+// GetRequestCount - returns number of request in progress.
+func (srv *Server) GetRequestCount() int32 {
+	return atomic.LoadInt32(&srv.requestCount)
 }
 
 // Start - start HTTP server

--- a/pkg/mountinfo/mountinfo_windows.go
+++ b/pkg/mountinfo/mountinfo_windows.go
@@ -1,7 +1,7 @@
-// +build !linux,!windows
+// +build windows
 
 /*
- * Minio Cloud Storage, (C) 2017, 2018 Minio, Inc.
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,42 @@
 
 package mountinfo
 
+import (
+	"os"
+)
+
 // CheckCrossDevice - check if any input path has multiple sub-mounts.
 // this is a dummy function and returns nil for now.
 func CheckCrossDevice(paths []string) error {
 	return nil
 }
 
+// fileExists checks if specified file exists.
+func fileExists(filename string) (bool, error) {
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // IsLikelyMountPoint determines if a directory is a mountpoint.
 func IsLikelyMountPoint(file string) bool {
+	stat, err := os.Lstat(file)
+	if err != nil {
+		return false
+	}
+
+	// If current file is a symlink, then it is a mountpoint.
+	if stat.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(file)
+		if err != nil {
+			return false
+		}
+		exists, _ := fileExists(target)
+		return exists
+	}
+
 	return false
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
disable disk-usage when export is root mount path
<!--- Describe your changes in detail -->

## Motivation and Context
disk usage crawling is not needed when a tenant
is not sharing the same disk for multiple other
tenants. This PR adds an optimization when we
see a setup uses entire disk, we simply rely on
statvfs() to give us total usage.

This PR also additionally adds low priority
scheduling for usage check routine, such that
other go-routines blocked will be automatically
unblocked and prioritized before usage.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually in a customer deployment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.