### PR TITLE
Errorring out an appropriate error message for insufficient disk volume

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -109,6 +109,9 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 
 	var err error
 	if fsPath, err = getValidPath(fsPath); err != nil {
+		if err == errMinDiskSize {
+			return nil, err
+		}
 		return nil, uiErrUnableToWriteInBackend(err)
 	}
 

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -218,7 +218,7 @@ func checkDiskMinTotal(di disk.Info) (err error) {
 	// used for journalling, inodes etc.
 	totalDiskSpace := float64(di.Total) * 0.95
 	if int64(totalDiskSpace) <= diskMinTotalSpace {
-		return errDiskFull
+		return errMinDiskSize
 	}
 	return nil
 }

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -1948,7 +1948,7 @@ func TestCheckDiskTotalMin(t *testing.T) {
 				FSType: "XFS",
 				Files:  9999,
 			},
-			err: errDiskFull,
+			err: errMinDiskSize,
 		},
 	}
 

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -76,6 +76,9 @@ var errBitrotHashAlgoInvalid = errors.New("bit-rot hash algorithm is invalid")
 // errCrossDeviceLink - rename across devices not allowed.
 var errCrossDeviceLink = errors.New("Rename across devices not allowed, please fix your backend configuration")
 
+// errMinDiskSize - cannot create volume or files when disk size is less than threshold.
+var errMinDiskSize = errors.New("The disk size is less than the minimum threshold")
+
 // hashMisMatchError - represents a bit-rot hash verification failure
 // error.
 type hashMismatchError struct {


### PR DESCRIPTION
Should reply with meaningful error message 

`ERROR Unable to initialize backend: The disk size is less than the minimum threshold.`

instead of

`ERROR Unable to initialize backend: Unable to write to the backend.
     > Please ensure Minio binary has write permissions for the backend.`

for an insufficient disk volume size while triggering the server.

## Motivation and Context
Fixes #5993

## How Has This Been Tested?
1) Partition a disk ( say `/dev/sdb` ) with volume < 1GiB
2) Mount the partition on a local dir
3) Start the server on the mounted partition

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.