### PR TITLE
Fix kernel tuning script to ignore write failures

### DIFF
--- a/docs/deployment/kernel-tuning/disk-tuning.sh
+++ b/docs/deployment/kernel-tuning/disk-tuning.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Minio Cloud Storage, (C) 2017 Minio, Inc.
+## Minio Cloud Storage, (C) 2017, 2018 Minio, Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 # This script changes protected files, and must be run as root
 
-for i in $(ls -d /sys/block/*/queue/iosched 2>/dev/null); do
-    iosched_dir=$(echo $i | awk '/iosched/ {print $1}')
-    [ -z $iosched_dir ] && {
+for i in $(echo /sys/block/*/queue/iosched 2>/dev/null); do
+    iosched_dir=$(echo "${i}" | awk '/iosched/ {print $1}')
+    [ -z "${iosched_dir}" ] && {
         continue
     }
     ## Change each disk ioscheduler to be "deadline"
@@ -29,22 +29,22 @@ for i in $(ls -d /sys/block/*/queue/iosched 2>/dev/null); do
     ## see whether write requests have been starved for too
     ## long, and then decides whether to start a new batch
     ## of reads or writes
-    path=$(dirname $iosched_dir)
-    [ -f $path/scheduler ] && {
-        echo "deadline" > $path/scheduler
+    path=$(dirname "${iosched_dir}")
+    [ -f "${path}/scheduler" ] && {
+        echo "deadline" > "${path}/scheduler" 2>/dev/null || true
     }
     ## This controls how many requests may be allocated
     ## in the block layer for read or write requests.
     ## Note that the total allocated number may be twice
     ## this amount, since it applies only to reads or
     ## writes (not the accumulate sum).
-    [ -f $path/nr_requests ] && {
-        echo "256" > $path/nr_requests
+    [ -f "${path}/nr_requests" ] && {
+        echo "256" > "${path}/nr_requests" 2>/dev/null || true
     }
     ## This is the maximum number of kilobytes
     ## supported in a single data transfer at
     ## block layer.
-    [ -f $path/max_sectors_kb ] && {
-        echo "1024" > $path/max_sectors_kb || true
+    [ -f "${path}/max_sectors_kb" ] && {
+        echo "1024" > "${path}/max_sectors_kb" 2>/dev/null || true
     }
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix kernel tuning script to ignore write failures

Fixes #6103
<!--- Describe your changes in detail -->

## Motivation and Context
Certain SCSI drivers do not allow certain tuning parameters
like nr_requests, max_sectors_kb to be changed, ignore these
errors silently as this script is simply a best effort.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.