### PR TITLE
Update comments regarding GCS component count and parts per multipart upload

### DIFF
--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -1015,12 +1015,8 @@ func (l *gcsGateway) AbortMultipartUpload(ctx context.Context, bucket string, ke
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object
 // Note that there is a limit (currently 32) to the number of components that can
-// be composed in a single operation. There is a limit (currently 1024) to the total
-// number of components for a given composite object. This means you can append to
-// each object at most 1023 times. There is a per-project rate limit (currently 200)
-// to the number of components you can compose per second. This rate counts both the
-// components being appended to a composite object as well as the components being
-// copied when the composite object of which they are a part is copied.
+// be composed in a single operation. There is a per-project rate limit (currently 200)
+// to the number of source objects you can compose per second.
 func (l *gcsGateway) CompleteMultipartUpload(ctx context.Context, bucket string, key string, uploadID string, uploadedParts []minio.CompletePart) (minio.ObjectInfo, error) {
 	meta := gcsMultipartMetaName(uploadID)
 	object := l.client.Bucket(bucket).Object(meta)

--- a/docs/gateway/gcs.md
+++ b/docs/gateway/gcs.md
@@ -55,7 +55,6 @@ mc ls mygcs
 ### Known limitations
 Gateway inherits the following GCS limitations:
 
-- Maximum number of multipart parts per upload is 1024.
 - Only read-only or write-only bucket policy supported at bucket level, all other variations will return API Notimplemented error.
 - _List Multipart Uploads_ and _List Object parts_ always returns empty list. i.e Client will need to remember all the parts that it has uploaded and use it for _Complete Multipart Upload_
 


### PR DESCRIPTION
## Description
GCS recently removed the 1024 limit for the number of components in a compose operation. Users can compose an arbitrary number of components now.
https://cloud.google.com/storage/docs/composite-objects

Since Minio implements the multipart upload API by uploading parts as objects then using the GCS compose API to combine them, this means that Minio users are no longer limited to how many parts can be included in a multipart upload.

## Types of changes
- Documentation change

## Checklist:.
- My change requires a change to the documentation.
- I have updated the documentation accordingly.