### PR TITLE
formatMetaV1 should be "inherited" by disk format structs

### DIFF
--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -86,10 +86,11 @@ type formatXLV1 struct {
 // Represents the V2 backend disk structure version
 // under `.minio.sys` and actual data namespace.
 // formatXLV2 - structure holds format config version '2'.
+// The V2 format to support "large bucket" support where a bucket
+// can span multiple erasure sets.
 type formatXLV2 struct {
-	Version string `json:"version"`
-	Format  string `json:"format"`
-	XL      struct {
+	formatMetaV1
+	XL struct {
 		Version string `json:"version"` // Version of 'xl' format.
 		This    string `json:"this"`    // This field carries assigned disk uuid.
 		// Sets field carries the input disk order generated the first
@@ -107,9 +108,8 @@ type formatXLV2 struct {
 // In .minio.sys/multipart we have:
 // sha256(bucket/object)/uploadID/[xl.json, part.1, part.2 ....]
 type formatXLV3 struct {
-	Version string `json:"version"`
-	Format  string `json:"format"`
-	XL      struct {
+	formatMetaV1
+	XL struct {
 		Version string `json:"version"` // Version of 'xl' format.
 		This    string `json:"this"`    // This field carries assigned disk uuid.
 		// Sets field carries the input disk order generated the first

--- a/cmd/format-xl_test.go
+++ b/cmd/format-xl_test.go
@@ -345,8 +345,10 @@ func TestCheckFormatXLValue(t *testing.T) {
 		// Invalid XL format version "2".
 		{
 			&formatXLV3{
-				Version: "2",
-				Format:  "XL",
+				formatMetaV1: formatMetaV1{
+					Version: "2",
+					Format:  "XL",
+				},
 				XL: struct {
 					Version          string     `json:"version"`
 					This             string     `json:"this"`
@@ -361,8 +363,10 @@ func TestCheckFormatXLValue(t *testing.T) {
 		// Invalid XL format "Unknown".
 		{
 			&formatXLV3{
-				Version: "1",
-				Format:  "Unknown",
+				formatMetaV1: formatMetaV1{
+					Version: "1",
+					Format:  "Unknown",
+				},
 				XL: struct {
 					Version          string     `json:"version"`
 					This             string     `json:"this"`
@@ -377,8 +381,10 @@ func TestCheckFormatXLValue(t *testing.T) {
 		// Invalid XL format version "0".
 		{
 			&formatXLV3{
-				Version: "1",
-				Format:  "XL",
+				formatMetaV1: formatMetaV1{
+					Version: "1",
+					Format:  "XL",
+				},
 				XL: struct {
 					Version          string     `json:"version"`
 					This             string     `json:"this"`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During the design discussion of format related code we had decided to include formatMetaV1 at the top of the backend format files. It was missed in formatXLV2 and formatXLV3

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.