### PR TITLE
fix: Propagate bucket policy update in a distributed setup

### DIFF
--- a/pkg/policy/condition/func.go
+++ b/pkg/policy/condition/func.go
@@ -162,6 +162,16 @@ func (functions *Functions) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// GobEncode - encodes Functions to gob data.
+func (functions Functions) GobEncode() ([]byte, error) {
+	return functions.MarshalJSON()
+}
+
+// GobDecode - decodes gob data to Functions.
+func (functions *Functions) GobDecode(data []byte) error {
+	return functions.UnmarshalJSON(data)
+}
+
 // NewFunctions - returns new Functions with given function list.
 func NewFunctions(functions ...Function) Functions {
 	return Functions(functions)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Commit 0d521260237ca69a89044f23f10a13b44e1f53c9 caused a regression in setting
a new bucket policy in a distributed setup. The reason is that gob is not able
to encode fields declared as interfaces unless we provide GobEncode() and GobDecode()
This PR adds them by using json marshaller and unmarshaller that are already
implemented for Functions interface.


## Motivation and Context
Fix a bug when updating a bucket policy in a distributed setup

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.