### PR TITLE
Support 1GB disk size

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -38,8 +38,8 @@ import (
 )
 
 const (
-	diskMinFreeSpace  = 1 * humanize.GiByte // Min 1GiB free space.
-	diskMinTotalSpace = diskMinFreeSpace    // Min 1GiB total space.
+	diskMinFreeSpace  = 900 * humanize.MiByte // Min 900MiB free space.
+	diskMinTotalSpace = diskMinFreeSpace      // Min 900MiB total space.
 	maxAllowedIOError = 5
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

PCF tile config by default sets disk size to 1GB. Because of this minio server fails to start.
i.e in 1GB, disk space will be allocated to the FS's metadata causing the space available to minio to be < 1G and hence minio server fails. Hence making minimum disk size needed = 900MB


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.