### PR TITLE
Add support for deployment ID

### DIFF
--- a/cmd/format-meta.go
+++ b/cmd/format-meta.go
@@ -49,4 +49,6 @@ type formatMetaV1 struct {
 	Version string `json:"version"`
 	// Format indicates the backend format type, supports two values 'xl' and 'fs'.
 	Format string `json:"format"`
+	// ID is the identifier for the minio deployment
+	ID string `json:"id"`
 }

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -122,14 +122,15 @@ type api struct {
 }
 
 type logEntry struct {
-	Level      string      `json:"level"`
-	Time       string      `json:"time"`
-	API        *api        `json:"api,omitempty"`
-	RemoteHost string      `json:"remotehost,omitempty"`
-	RequestID  string      `json:"requestID,omitempty"`
-	UserAgent  string      `json:"userAgent,omitempty"`
-	Message    string      `json:"message,omitempty"`
-	Trace      *traceEntry `json:"error,omitempty"`
+	DeploymentID string      `json:"deploymentid,omitempty"`
+	Level        string      `json:"level"`
+	Time         string      `json:"time"`
+	API          *api        `json:"api,omitempty"`
+	RemoteHost   string      `json:"remotehost,omitempty"`
+	RequestID    string      `json:"requestID,omitempty"`
+	UserAgent    string      `json:"userAgent,omitempty"`
+	Message      string      `json:"message,omitempty"`
+	Trace        *traceEntry `json:"error,omitempty"`
 }
 
 // quiet: Hide startup messages if enabled
@@ -138,7 +139,14 @@ var (
 	quiet, jsonFlag bool
 	// Custom function to format error
 	errorFmtFunc func(string, error, bool) string
+
+	deploymentID string
 )
+
+// SetDeploymentID - Used to set the deployment ID, in XL and FS mode
+func SetDeploymentID(id string) {
+	deploymentID = id
+}
 
 // EnableQuiet - turns quiet option on.
 func EnableQuiet() {

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -186,6 +186,23 @@ func connectLoadInitFormats(firstDisk bool, endpoints EndpointList, setCount, dr
 		return nil, err
 	}
 
+	// Get the deploymentID if set.
+	format.ID, err = formatXLGetDeploymentID(format, formatConfigs)
+	if err != nil {
+		return nil, err
+	}
+
+	if format.ID == "" {
+		if err = formatXLFixDeploymentID(context.Background(), storageDisks, format); err != nil {
+			return nil, err
+		}
+	}
+
+	logger.SetDeploymentID(format.ID)
+
+	if err = formatXLFixLocalDeploymentID(context.Background(), storageDisks, format); err != nil {
+		return nil, err
+	}
 	return format, nil
 }
 


### PR DESCRIPTION
## Description
deployment ID helps in identifying a minio deployment in the case of remote
logging targets.

## Motivation and Context
This is part of the next set of logging improvements. Deployment ID will be useful while sending log messages to a remote target.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.