### PR TITLE
Implement lock.Open() to fix #5642

### DIFF
--- a/pkg/lock/lock_solaris.go
+++ b/pkg/lock/lock_solaris.go
@@ -98,3 +98,8 @@ func TryLockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, er
 func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
 	return lockedOpenFile(path, flag, perm, syscall.F_SETLKW)
 }
+
+// Open - Call os.OpenFile
+func Open(path string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, flag, perm)
+}


### PR DESCRIPTION
Fixes the issue of compiling minio on Smartos/Illumos. The fix was done by @ryumei, I did only create the pull request :)