### PR TITLE
crypto: update SSE-S3 and SSE-C key derivation

### DIFF
--- a/cmd/crypto/error.go
+++ b/cmd/crypto/error.go
@@ -16,6 +16,13 @@ package crypto
 
 import "errors"
 
+// Error is the generic type for any error happening during decrypting
+// an object. It indicates that the object itself or its metadata was
+// modified accidentally or maliciously.
+type Error struct{ msg string }
+
+func (e Error) Error() string { return e.msg }
+
 var (
 	// ErrInvalidEncryptionMethod indicates that the specified SSE encryption method
 	// is not supported.

--- a/cmd/crypto/sse.go
+++ b/cmd/crypto/sse.go
@@ -35,6 +35,18 @@ const (
 	S3KMSSealedKey = "X-Minio-Internal-Server-Side-Encryption-S3-Kms-Sealed-Key"
 )
 
+const (
+	// SealAlgorithm is the encryption/sealing algorithm used to derive & seal
+	// the key-encryption-key and to en/decrypt the object data.
+	SealAlgorithm = "DAREv2-HMAC-SHA256"
+
+	// InsecureSealAlgorithm is the legacy encryption/sealing algorithm used
+	// to derive & seal the key-encryption-key and to en/decrypt the object data.
+	// This algorithm should not be used for new objects because its key derivation
+	// is not optimal. See: https://github.com/minio/minio/pull/6121
+	InsecureSealAlgorithm = "DARE-SHA256"
+)
+
 // EncryptSinglePart encrypts an io.Reader which must be the
 // the body of a single-part PUT request.
 func EncryptSinglePart(r io.Reader, key ObjectKey) io.Reader {


### PR DESCRIPTION
## Description
This commit updates the key derivation to reflect the
latest change of crypto/doc.go. This includes handling
the insecure legacy KDF.

Since #6064 is fixed the 3. test case for object key
generation is enabled again.

## Motivation and Context
SSE-C, SSE-S3, #6121 

## How Has This Been Tested?
unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.