### PR TITLE
Do not forbid listening on port 0

### DIFF
--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -297,7 +297,7 @@ func newHTTPListener(serverAddrs []string,
 	readTimeout time.Duration,
 	writeTimeout time.Duration,
 	updateBytesReadFunc func(int),
-	updateBytesWrittenFunc func(int)) (listener *httpListener, err error) {
+	updateBytesWrittenFunc func(int)) (listener *httpListener, listeningAddrs []string, err error) {
 
 	var tcpListeners []*net.TCPListener
 	// Close all opened listeners on error
@@ -315,15 +315,16 @@ func newHTTPListener(serverAddrs []string,
 	for _, serverAddr := range serverAddrs {
 		var l net.Listener
 		if l, err = net.Listen("tcp", serverAddr); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		tcpListener, ok := l.(*net.TCPListener)
 		if !ok {
-			return nil, fmt.Errorf("unexpected listener type found %v, expected net.TCPListener", l)
+			return nil, nil, fmt.Errorf("unexpected listener type found %v, expected net.TCPListener", l)
 		}
 
 		tcpListeners = append(tcpListeners, tcpListener)
+		listeningAddrs = append(listeningAddrs, tcpListener.Addr().String())
 	}
 
 	listener = &httpListener{
@@ -337,5 +338,5 @@ func newHTTPListener(serverAddrs []string,
 	}
 	listener.start()
 
-	return listener, nil
+	return listener, listeningAddrs, nil
 }

--- a/cmd/http/listener_test.go
+++ b/cmd/http/listener_test.go
@@ -228,7 +228,7 @@ func TestNewHTTPListener(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			testCase.tcpKeepAliveTimeout,
@@ -279,7 +279,7 @@ func TestHTTPListenerStartClose(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			time.Duration(0),
@@ -326,7 +326,7 @@ func TestHTTPListenerAddr(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			time.Duration(0),
@@ -370,7 +370,7 @@ func TestHTTPListenerAddrs(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			time.Duration(0),
@@ -416,7 +416,7 @@ func TestHTTPListenerAccept(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			time.Duration(0),
@@ -495,7 +495,7 @@ func TestHTTPListenerAcceptPeekError(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			time.Duration(0),
@@ -548,7 +548,7 @@ func TestHTTPListenerAcceptTLSError(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			time.Duration(0),
@@ -614,7 +614,7 @@ func TestHTTPListenerAcceptError(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			time.Duration(0),
@@ -739,7 +739,7 @@ func TestHTTPListenerAcceptParallel(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(
+		listener, _, err := newHTTPListener(
 			testCase.serverAddrs,
 			testCase.tlsConfig,
 			time.Duration(0),

--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -85,7 +85,7 @@ func (srv *Server) Start() (err error) {
 
 	// Create new HTTP listener.
 	var listener *httpListener
-	listener, err = newHTTPListener(
+	listener, addrs, err = newHTTPListener(
 		addrs,
 		tlsConfig,
 		tcpKeepAliveTimeout,
@@ -97,6 +97,7 @@ func (srv *Server) Start() (err error) {
 	if err != nil {
 		return err
 	}
+	srv.Addrs = addrs
 
 	// Wrap given handler to do additional
 	// * return 503 (service unavailable) if the server in shutdown.

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -359,8 +359,8 @@ func CheckLocalServerAddr(serverAddr string) error {
 	p, err := strconv.Atoi(port)
 	if err != nil {
 		return uiErrInvalidAddressFlag(err).Msg("invalid port number")
-	} else if p < 1 || p > 65535 {
-		return uiErrInvalidAddressFlag(nil).Msg("port number must be between 1 to 65535")
+	} else if p < 0 || p > 65535 {
+		return uiErrInvalidAddressFlag(nil).Msg("port number must be between 0 to 65535")
 	}
 
 	// 0.0.0.0 is a wildcard address and refers to local network

--- a/cmd/net_test.go
+++ b/cmd/net_test.go
@@ -235,11 +235,11 @@ func TestCheckLocalServerAddr(t *testing.T) {
 		{":54321", nil},
 		{"localhost:54321", nil},
 		{"0.0.0.0:9000", nil},
+		{":0", nil},
 		{"", fmt.Errorf("missing port in address")},
 		{"localhost", fmt.Errorf("address localhost: missing port in address")},
 		{"example.org:54321", fmt.Errorf("host in server address should be this server")},
-		{":0", fmt.Errorf("port number must be between 1 to 65535")},
-		{":-10", fmt.Errorf("port number must be between 1 to 65535")},
+		{":-10", fmt.Errorf("port number must be between 0 to 65535")},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -329,7 +329,7 @@ func serverMain(ctx *cli.Context) {
 	}
 
 	// Prints the formatted startup message once object layer is initialized.
-	apiEndpoints := getAPIEndpoints(globalMinioAddr)
+	apiEndpoints := getAPIEndpoints(globalHTTPServer.Addrs[0])
 	printStartupMessage(apiEndpoints)
 
 	// Set uptime time after object layer has initialized.


### PR DESCRIPTION
## Description

Allow a user to specify ":0" as a listening address.

## Motivation and Context

This is useful to bind on ":0" as it enables one to run minio on any
free port. This is convenient when running tests as it ensure the test
won't fail because a port is already in use.

## How Has This Been Tested?

Started minio with `./minio server --address 127.0.0.1:0`, checked we can connect to the provided endpoint.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes (well, modified an existing one).
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.