### PR TITLE
Remove ppc64le support from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,6 @@ matrix:
         - make coverage
         - node --version
         - cd browser && yarn && yarn test && cd ..
-    - os: linux-ppc64le
-      env:
-        - ARCH=ppc64le
-      go: 1.10.1
-      script:
-        - make
-        - diff -au <(gofmt -s -d cmd) <(printf "")
-        - diff -au <(gofmt -s -d pkg) <(printf "")
-        - make test GOFLAGS="-timeout 15m -v"
-        - make coverage
-        - node --version
-        - cd browser && yarn && yarn test && cd ..
 
 before_install:
 - nvm install stable


### PR DESCRIPTION
## Description
Travis CI for ppc64le stays in queued state.
Removing the support for now.

## Motivation and Context
Travis CI build stays in queued state for a lot of time and does not even start execution. After some time it marks the build as failed. Restarting doesn't seem to help.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.