### PR TITLE
Fix healthcheck handler to check errors in local disks only

### DIFF
--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -17,10 +17,12 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"runtime"
+
+	"github.com/minio/minio/cmd/logger"
 )
 
 const (
@@ -40,19 +42,38 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, http.StatusOK, nil, mimeNone)
 }
 
-// LivenessCheckHandler -- checks if server can ListBuckets internally. If not, server is
-// considered to have failed and needs to be restarted.
+// LivenessCheckHandler -- checks if server can reach its disks internally.
+// If not, server is considered to have failed and needs to be restarted.
 // Liveness probes are used to detect situations where application (minio)
 // has gone into a state where it can not recover except by being restarted.
 func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := newContext(r, w, "LivenessCheckHandler")
+
 	objLayer := newObjectLayerFn()
 	// Service not initialized yet
 	if objLayer == nil {
 		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
 		return
 	}
-	// List buckets is unsuccessful, means server is having issues, send 503 service unavailable
-	if _, err := objLayer.ListBuckets(context.Background()); err != nil {
+	var totalLocalDisks int
+	var erroredDisks int
+	for _, endpoint := range globalEndpoints {
+		// Check only if local disks are accessible, we do not have
+		// to reach to rest of the other servers in a distributed setup.
+		if endpoint.IsLocal {
+			totalLocalDisks++
+			// Attempt a stat to backend, any error resulting
+			// from this Stat() operation is considered as backend
+			// is not available, count them as errors.
+			if _, err := os.Stat(endpoint.Path); err != nil {
+				logger.LogIf(ctx, err)
+				erroredDisks++
+			}
+		}
+	}
+	// If all exported local disks have errored, we simply let kubernetes
+	// take us down.
+	if totalLocalDisks == erroredDisks {
 		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
 		return
 	}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix healthcheck handler to check errors in local disks only
<!--- Describe your changes in detail -->

## Motivation and Context
Healthcheck handler in current implementation was
performing ListBuckets() to check for liveness of Minio
service. ListBuckets() implementation on the other hand
doesn't do quorum based listing and if one of the disks
returned error, an I/O error it would be lead to kubernetes
taking the minio pod down prematurely even if the disk
is not local to that minio server.

The reason is ListBuckets() call cannot be trusted to
provide us the valid information that we need, Minio is a
clustered application which is designed to handle disk
failures. Error on one of the disks doesn't mean the pod
should become fully non-operational.

This PR attempts to fix this by only checking for alive
disks which are local to each setup and also by simply
performing a Stat() operation, if the Stat() returned
error on all disks local to a particular server then
we can let kubernetes safely take it down, until then
we should be operational.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.