### PR TITLE
Appropriate error message is given if minio is not properly updated.

### DIFF
--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -456,32 +456,32 @@ func getUpdateInfo(timeout time.Duration, mode string) (updateMsg string, sha256
 	return prepareUpdateMessage(downloadURL, older), sha256Hex, currentReleaseTime, latestReleaseTime, nil
 }
 
-func doUpdate(sha256Hex string, latestReleaseTime time.Time, ok bool) (successMsg string, err error) {
+func doUpdate(sha256Hex string, latestReleaseTime time.Time, ok bool) (updateStatusMsg string, err error) {
 	if !ok {
-		successMsg = greenColorSprintf("Minio update to version RELEASE.%s canceled.",
+		updateStatusMsg = greenColorSprintf("Minio update to version RELEASE.%s canceled.",
 			latestReleaseTime.Format(minioReleaseTagTimeLayout))
-		return successMsg, nil
+		return updateStatusMsg, nil
 	}
 	var sha256Sum []byte
 	sha256Sum, err = hex.DecodeString(sha256Hex)
 	if err != nil {
-		return successMsg, err
+		return updateStatusMsg, err
 	}
 
 	resp, err := http.Get(getDownloadURL(releaseTimeToReleaseTag(latestReleaseTime)))
 	if err != nil {
-		return successMsg, err
+		return updateStatusMsg, err
 	}
 	defer resp.Body.Close()
 
 	// FIXME: add support for gpg verification as well.
-	if err = update.RollbackError(update.Apply(resp.Body,
+	if err = update.Apply(resp.Body,
 		update.Options{
 			Hash:     crypto.SHA256,
 			Checksum: sha256Sum,
 		},
-	)); err != nil {
-		return successMsg, err
+	); err != nil {
+		return updateStatusMsg, err
 	}
 
 	return greenColorSprintf("Minio updated to version RELEASE.%s successfully.",
@@ -497,6 +497,7 @@ func shouldUpdate(quiet bool, sha256Hex string, latestReleaseTime time.Time) (ok
 }
 
 var greenColorSprintf = color.New(color.FgGreen, color.Bold).SprintfFunc()
+var redColorSprintf = color.New(color.FgRed, color.Bold).SprintfFunc()
 
 func mainUpdate(ctx *cli.Context) {
 	if len(ctx.Args()) != 0 {
@@ -527,13 +528,14 @@ func mainUpdate(ctx *cli.Context) {
 	// if the in-place update is disabled then we shouldn't ask the
 	// user to update the binaries.
 	if strings.Contains(updateMsg, minioReleaseURL) && !globalInplaceUpdateDisabled {
-		var successMsg string
-		successMsg, err = doUpdate(sha256Hex, latestReleaseTime, shouldUpdate(quiet, sha256Hex, latestReleaseTime))
+		var updateStatusMsg string
+		updateStatusMsg, err = doUpdate(sha256Hex, latestReleaseTime, shouldUpdate(quiet, sha256Hex, latestReleaseTime))
 		if err != nil {
+			logger.Info(redColorSprintf("Unable to update ‘minio’."))
 			logger.Info(err.Error())
 			os.Exit(-1)
 		}
-		logger.Info(successMsg)
+		logger.Info(updateStatusMsg)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minio update was giving success message even if it was not updated. Added appropriate error message in case update fails.

## Motivation and Context
Fixes #6199 by giving error message if minio is not properly updated.

## How Has This Been Tested?
Run `minio update` from a folder which doesn't have write permissions. Appropriate error message is given. Then again, test it with `sudo`. You will be able to update and success message is given.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.