### PR TITLE
Make sure to handle FaultyDisks in listing ops

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -968,13 +968,15 @@ func (fs *FSObjects) DeleteObject(ctx context.Context, bucket, object string) er
 // is a leaf or non-leaf entry.
 func (fs *FSObjects) listDirFactory(isLeaf isLeafFunc) listDirFunc {
 	// listDir - lists all the entries at a given prefix and given entry in the prefix.
-	listDir := func(bucket, prefixDir, prefixEntry string) (entries []string, delayIsLeaf bool, err error) {
+	listDir := func(bucket, prefixDir, prefixEntry string) (entries []string, delayIsLeaf bool) {
+		var err error
 		entries, err = readDir(pathJoin(fs.fsPath, bucket, prefixDir))
 		if err != nil {
-			return nil, false, err
+			logger.LogIf(context.Background(), err)
+			return
 		}
 		entries, delayIsLeaf = filterListEntries(bucket, prefixDir, entries, prefixEntry, isLeaf)
-		return entries, delayIsLeaf, nil
+		return entries, delayIsLeaf
 	}
 
 	// Return list factory instance.

--- a/cmd/posix-errors.go
+++ b/cmd/posix-errors.go
@@ -24,22 +24,46 @@ import (
 
 // Function not implemented error
 func isSysErrNoSys(err error) bool {
-	return err == syscall.ENOSYS
+	if pathErr, ok := err.(*os.PathError); ok {
+		switch pathErr.Err {
+		case syscall.ENOSYS:
+			return true
+		}
+	}
+	return false
 }
 
 // Not supported error
 func isSysErrOpNotSupported(err error) bool {
-	return err == syscall.EOPNOTSUPP
+	if pathErr, ok := err.(*os.PathError); ok {
+		switch pathErr.Err {
+		case syscall.EOPNOTSUPP:
+			return true
+		}
+	}
+	return false
 }
 
 // No space left on device error
 func isSysErrNoSpace(err error) bool {
-	return err == syscall.ENOSPC
+	if pathErr, ok := err.(*os.PathError); ok {
+		switch pathErr.Err {
+		case syscall.ENOSPC:
+			return true
+		}
+	}
+	return false
 }
 
 // Input/output error
 func isSysErrIO(err error) bool {
-	return err == syscall.EIO
+	if pathErr, ok := err.(*os.PathError); ok {
+		switch pathErr.Err {
+		case syscall.EIO:
+			return true
+		}
+	}
+	return false
 }
 
 // Check if the given error corresponds to EISDIR (is a directory).

--- a/cmd/tree-walk.go
+++ b/cmd/tree-walk.go
@@ -86,7 +86,7 @@ func filterMatchingPrefix(entries []string, prefixEntry string) []string {
 }
 
 // "listDir" function of type listDirFunc returned by listDirFactory() - explained below.
-type listDirFunc func(bucket, prefixDir, prefixEntry string) (entries []string, delayIsLeaf bool, err error)
+type listDirFunc func(bucket, prefixDir, prefixEntry string) (entries []string, delayIsLeaf bool)
 
 // A function isLeaf of type isLeafFunc is used to detect if an entry is a leaf entry. There are four scenarios
 // where isLeaf should behave differently:
@@ -141,16 +141,8 @@ func doTreeWalk(ctx context.Context, bucket, prefixDir, entryPrefixMatch, marker
 			markerBase = markerSplit[1]
 		}
 	}
-	entries, delayIsLeaf, err := listDir(bucket, prefixDir, entryPrefixMatch)
-	if err != nil {
-		select {
-		case <-endWalkCh:
-			return errWalkAbort
-		case resultCh <- treeWalkResult{err: err}:
-			return err
-		}
-	}
 
+	entries, delayIsLeaf := listDir(bucket, prefixDir, entryPrefixMatch)
 	// When isleaf check is delayed, make sure that it is set correctly here.
 	if delayIsLeaf && isLeaf == nil {
 		return errInvalidArgument

--- a/cmd/tree-walk_test.go
+++ b/cmd/tree-walk_test.go
@@ -196,7 +196,7 @@ func TestTreeWalk(t *testing.T) {
 		return len(entries) == 0
 	}
 
-	listDir := listDirFactory(context.Background(), isLeaf, xlTreeWalkIgnoredErrs, disk)
+	listDir := listDirFactory(context.Background(), isLeaf, disk)
 	// Simple test for prefix based walk.
 	testTreeWalkPrefix(t, listDir, isLeaf, isLeafDir)
 	// Simple test when marker is set.
@@ -240,7 +240,7 @@ func TestTreeWalkTimeout(t *testing.T) {
 		return len(entries) == 0
 	}
 
-	listDir := listDirFactory(context.Background(), isLeaf, xlTreeWalkIgnoredErrs, disk)
+	listDir := listDirFactory(context.Background(), isLeaf, disk)
 
 	// TreeWalk pool with 2 seconds timeout for tree-walk go routines.
 	pool := newTreeWalkPool(2 * time.Second)
@@ -315,7 +315,7 @@ func TestListDir(t *testing.T) {
 	// create listDir function.
 	listDir := listDirFactory(context.Background(), func(volume, prefix string) bool {
 		return !hasSuffix(prefix, slashSeparator)
-	}, xlTreeWalkIgnoredErrs, disk1, disk2)
+	}, disk1, disk2)
 
 	// Create file1 in fsDir1 and file2 in fsDir2.
 	disks := []StorageAPI{disk1, disk2}
@@ -327,10 +327,7 @@ func TestListDir(t *testing.T) {
 	}
 
 	// Should list "file1" from fsDir1.
-	entries, _, err := listDir(volume, "", "")
-	if err != nil {
-		t.Error(err)
-	}
+	entries, _ := listDir(volume, "", "")
 	if len(entries) != 2 {
 		t.Fatal("Expected the number of entries to be 2")
 	}
@@ -348,10 +345,7 @@ func TestListDir(t *testing.T) {
 	}
 
 	// Should list "file2" from fsDir2.
-	entries, _, err = listDir(volume, "", "")
-	if err != nil {
-		t.Error(err)
-	}
+	entries, _ = listDir(volume, "", "")
 	if len(entries) != 1 {
 		t.Fatal("Expected the number of entries to be 1")
 	}
@@ -361,13 +355,6 @@ func TestListDir(t *testing.T) {
 	err = os.RemoveAll(fsDir2)
 	if err != nil {
 		t.Error(err)
-	}
-	// None of the disks are available, should get
-	// errDiskNotFound. Since errDiskNotFound is an ignored error,
-	// we should get nil.
-	_, _, err = listDir(volume, "", "")
-	if err != nil {
-		t.Errorf("expected nil error but found %v.", err)
 	}
 }
 
@@ -400,7 +387,7 @@ func TestRecursiveTreeWalk(t *testing.T) {
 	}
 
 	// Create listDir function.
-	listDir := listDirFactory(context.Background(), isLeaf, xlTreeWalkIgnoredErrs, disk1)
+	listDir := listDirFactory(context.Background(), isLeaf, disk1)
 
 	// Create the namespace.
 	var files = []string{
@@ -515,7 +502,7 @@ func TestSortedness(t *testing.T) {
 	}
 
 	// Create listDir function.
-	listDir := listDirFactory(context.Background(), isLeaf, xlTreeWalkIgnoredErrs, disk1)
+	listDir := listDirFactory(context.Background(), isLeaf, disk1)
 
 	// Create the namespace.
 	var files = []string{
@@ -598,7 +585,7 @@ func TestTreeWalkIsEnd(t *testing.T) {
 	}
 
 	// Create listDir function.
-	listDir := listDirFactory(context.Background(), isLeaf, xlTreeWalkIgnoredErrs, disk1)
+	listDir := listDirFactory(context.Background(), isLeaf, disk1)
 
 	// Create the namespace.
 	var files = []string{

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -445,6 +445,7 @@ func TestCeilFrac(t *testing.T) {
 // Test if isErrIgnored works correctly.
 func TestIsErrIgnored(t *testing.T) {
 	var errIgnored = fmt.Errorf("ignored error")
+	ignoredErrs := append(baseIgnoredErrs, errIgnored)
 	var testCases = []struct {
 		err     error
 		ignored bool
@@ -457,9 +458,13 @@ func TestIsErrIgnored(t *testing.T) {
 			err:     errIgnored,
 			ignored: true,
 		},
+		{
+			err:     errFaultyDisk,
+			ignored: true,
+		},
 	}
 	for i, testCase := range testCases {
-		if ok := IsErrIgnored(testCase.err, errIgnored); ok != testCase.ignored {
+		if ok := IsErrIgnored(testCase.err, ignoredErrs...); ok != testCase.ignored {
 			t.Errorf("Test: %d, Expected %t, got %t", i+1, testCase.ignored, ok)
 		}
 	}

--- a/cmd/xl-v1-common.go
+++ b/cmd/xl-v1-common.go
@@ -51,6 +51,8 @@ func (xl xlObjects) parentDirIsObject(ctx context.Context, bucket, parent string
 	return isParentDirObject(parent)
 }
 
+var xlTreeWalkIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errVolumeNotFound, errFileNotFound)
+
 // isObject - returns `true` if the prefix is an object i.e if
 // `xl.json` exists at the leaf, false otherwise.
 func (xl xlObjects) isObject(bucket, prefix string) (ok bool) {

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -49,9 +49,6 @@ type xlObjects struct {
 	listPool *treeWalkPool
 }
 
-// list of all errors that can be ignored in tree walk operation in XL
-var xlTreeWalkIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errVolumeNotFound, errFileNotFound)
-
 // Shutdown function for object storage interface.
 func (xl xlObjects) Shutdown(ctx context.Context) error {
 	// Add any object layer shutdown activities here.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make sure to handle FaultyDisks in listing ops
<!--- Describe your changes in detail -->

## Motivation and Context
Continuing from PR 157ed65c352e40c71fe6ab91738321d95bd19b34

Our posix.go implementation did not handle the I/O errors
properly on the disks, this led to situations where
top-level callers such as ListObjects might return early
without even verifying all the available disks.
    
This commit tries to address this in Kubernetes, drbd/nbd based
persistent volumes which can disconnect under load and
result in the situations with disks return I/O errors.
    
This commit also simplifies listing operation, listing
never returns any error. We can avoid this since we pretty
much ignore most of the errors anyways. When objects are
accessed directly we return proper errors.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
On a live k8s + drbd setup
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.