### PR TITLE
Add RPC counters for HTTP stats.

### DIFF
--- a/cmd/http/bufconn_test.go
+++ b/cmd/http/bufconn_test.go
@@ -48,7 +48,7 @@ func TestBuffConnReadTimeout(t *testing.T) {
 		if terr != nil {
 			t.Fatalf("failed to accept new connection. %v", terr)
 		}
-		bufconn := newBufConn(tcpConn, 1*time.Second, 1*time.Second, nil, nil)
+		bufconn := newBufConn(tcpConn, 1*time.Second, 1*time.Second)
 		defer bufconn.Close()
 
 		// Read a line

--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -72,6 +73,41 @@ func isHTTPMethod(s string) bool {
 	return false
 }
 
+func getResourceHost(bufConn *BufConn, maxHeaderBytes, methodLen int) (resource string, host string, err error) {
+	var data []byte
+	for dataLen := 0; methodLen+dataLen < maxHeaderBytes; dataLen += 8 {
+		if data, err = bufConn.Peek(methodLen + dataLen); err != nil {
+			return "", "", err
+		}
+
+		tokens := strings.Split(string(data), "\n")
+		if len(tokens) < 2 {
+			continue
+		}
+
+		if resource == "" {
+			resource = strings.SplitN(tokens[0][methodLen:], " ", 2)[0]
+		}
+
+		for _, token := range tokens[1:] {
+			if token == "" || !strings.HasSuffix(token, "\r") {
+				continue
+			}
+
+			if strings.HasPrefix(token, "Host: ") {
+				host = strings.TrimPrefix(strings.TrimSuffix(token, "\r"), "Host: ")
+				return resource, host, nil
+			}
+		}
+
+		if tokens[len(tokens)-1] == "\r" {
+			break
+		}
+	}
+
+	return resource, host, nil
+}
+
 type acceptResult struct {
 	conn net.Conn
 	err  error
@@ -87,8 +123,9 @@ type httpListener struct {
 	tcpKeepAliveTimeout    time.Duration
 	readTimeout            time.Duration
 	writeTimeout           time.Duration
-	updateBytesReadFunc    func(int) // function to be called to update bytes read in BufConn.
-	updateBytesWrittenFunc func(int) // function to be called to update bytes written in BufConn.
+	maxHeaderBytes         int
+	updateBytesReadFunc    func(*http.Request, int) // function to be called to update bytes read in BufConn.
+	updateBytesWrittenFunc func(*http.Request, int) // function to be called to update bytes written in BufConn.
 }
 
 // isRoutineNetErr returns true if error is due to a network timeout,
@@ -134,8 +171,7 @@ func (listener *httpListener) start() {
 		tcpConn.SetKeepAlive(true)
 		tcpConn.SetKeepAlivePeriod(listener.tcpKeepAliveTimeout)
 
-		bufconn := newBufConn(tcpConn, listener.readTimeout, listener.writeTimeout,
-			listener.updateBytesReadFunc, listener.updateBytesWrittenFunc)
+		bufconn := newBufConn(tcpConn, listener.readTimeout, listener.writeTimeout)
 
 		// Peek bytes of maximum length of all HTTP methods.
 		data, err := bufconn.Peek(methodMaxLen)
@@ -158,14 +194,39 @@ func (listener *httpListener) start() {
 		// Return bufconn if read data is a valid HTTP method.
 		tokens := strings.SplitN(string(data), " ", 2)
 		if isHTTPMethod(tokens[0]) {
-			if listener.tlsConfig == nil {
-				send(acceptResult{bufconn, nil}, doneCh)
-			} else {
+			if listener.tlsConfig != nil {
 				// As TLS is configured and we got plain text HTTP request,
 				// return 403 (forbidden) error.
 				bufconn.Write(sslRequiredErrMsg)
 				bufconn.Close()
+				return
 			}
+
+			var resource, host string
+			if resource, host, err = getResourceHost(bufconn, listener.maxHeaderBytes, len(tokens[0])+1); err != nil {
+				if !isRoutineNetErr(err) {
+					reqInfo := (&logger.ReqInfo{}).AppendTags("remoteAddr", bufconn.RemoteAddr().String())
+					reqInfo.AppendTags("localAddr", bufconn.LocalAddr().String())
+					ctx := logger.SetReqInfo(context.Background(), reqInfo)
+					logger.LogIf(ctx, err)
+				}
+				bufconn.Close()
+				return
+			}
+
+			header := make(http.Header)
+			if host != "" {
+				header.Add("Host", host)
+			}
+			bufconn.setRequest(&http.Request{
+				Method: tokens[0],
+				URL:    &url.URL{Path: resource},
+				Host:   bufconn.LocalAddr().String(),
+				Header: header,
+			})
+			bufconn.setUpdateFuncs(listener.updateBytesReadFunc, listener.updateBytesWrittenFunc)
+
+			send(acceptResult{bufconn, nil}, doneCh)
 			return
 		}
 
@@ -182,8 +243,7 @@ func (listener *httpListener) start() {
 			}
 
 			// Check whether the connection contains HTTP request or not.
-			bufconn = newBufConn(tlsConn, listener.readTimeout, listener.writeTimeout,
-				listener.updateBytesReadFunc, listener.updateBytesWrittenFunc)
+			bufconn = newBufConn(tlsConn, listener.readTimeout, listener.writeTimeout)
 
 			// Peek bytes of maximum length of all HTTP methods.
 			data, err = bufconn.Peek(methodMaxLen)
@@ -201,6 +261,30 @@ func (listener *httpListener) start() {
 			// Return bufconn if read data is a valid HTTP method.
 			tokens := strings.SplitN(string(data), " ", 2)
 			if isHTTPMethod(tokens[0]) {
+				var resource, host string
+				if resource, host, err = getResourceHost(bufconn, listener.maxHeaderBytes, len(tokens[0])+1); err != nil {
+					if !isRoutineNetErr(err) {
+						reqInfo := (&logger.ReqInfo{}).AppendTags("remoteAddr", bufconn.RemoteAddr().String())
+						reqInfo.AppendTags("localAddr", bufconn.LocalAddr().String())
+						ctx := logger.SetReqInfo(context.Background(), reqInfo)
+						logger.LogIf(ctx, err)
+					}
+					bufconn.Close()
+					return
+				}
+
+				header := make(http.Header)
+				if host != "" {
+					header.Add("Host", host)
+				}
+				bufconn.setRequest(&http.Request{
+					Method: tokens[0],
+					URL:    &url.URL{Path: resource},
+					Host:   bufconn.LocalAddr().String(),
+					Header: header,
+				})
+				bufconn.setUpdateFuncs(listener.updateBytesReadFunc, listener.updateBytesWrittenFunc)
+
 				send(acceptResult{bufconn, nil}, doneCh)
 				return
 			}
@@ -296,8 +380,9 @@ func newHTTPListener(serverAddrs []string,
 	tcpKeepAliveTimeout time.Duration,
 	readTimeout time.Duration,
 	writeTimeout time.Duration,
-	updateBytesReadFunc func(int),
-	updateBytesWrittenFunc func(int)) (listener *httpListener, err error) {
+	maxHeaderBytes int,
+	updateBytesReadFunc func(*http.Request, int),
+	updateBytesWrittenFunc func(*http.Request, int)) (listener *httpListener, err error) {
 
 	var tcpListeners []*net.TCPListener
 
@@ -333,6 +418,7 @@ func newHTTPListener(serverAddrs []string,
 		tcpKeepAliveTimeout:    tcpKeepAliveTimeout,
 		readTimeout:            readTimeout,
 		writeTimeout:           writeTimeout,
+		maxHeaderBytes:         maxHeaderBytes,
 		updateBytesReadFunc:    updateBytesReadFunc,
 		updateBytesWrittenFunc: updateBytesWrittenFunc,
 	}

--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -51,15 +51,15 @@ const (
 // Server - extended http.Server supports multiple addresses to serve and enhanced connection handling.
 type Server struct {
 	http.Server
-	Addrs                  []string      // addresses on which the server listens for new connection.
-	ShutdownTimeout        time.Duration // timeout used for graceful server shutdown.
-	TCPKeepAliveTimeout    time.Duration // timeout used for underneath TCP connection.
-	UpdateBytesReadFunc    func(int)     // function to be called to update bytes read in bufConn.
-	UpdateBytesWrittenFunc func(int)     // function to be called to update bytes written in bufConn.
-	listenerMutex          *sync.Mutex   // to guard 'listener' field.
-	listener               *httpListener // HTTP listener for all 'Addrs' field.
-	inShutdown             uint32        // indicates whether the server is in shutdown or not
-	requestCount           int32         // counter holds no. of request in progress.
+	Addrs                  []string                 // addresses on which the server listens for new connection.
+	ShutdownTimeout        time.Duration            // timeout used for graceful server shutdown.
+	TCPKeepAliveTimeout    time.Duration            // timeout used for underneath TCP connection.
+	UpdateBytesReadFunc    func(*http.Request, int) // function to be called to update bytes read in bufConn.
+	UpdateBytesWrittenFunc func(*http.Request, int) // function to be called to update bytes written in bufConn.
+	listenerMutex          *sync.Mutex              // to guard 'listener' field.
+	listener               *httpListener            // HTTP listener for all 'Addrs' field.
+	inShutdown             uint32                   // indicates whether the server is in shutdown or not
+	requestCount           int32                    // counter holds no. of request in progress.
 }
 
 // GetRequestCount - returns number of request in progress.
@@ -91,6 +91,7 @@ func (srv *Server) Start() (err error) {
 		tcpKeepAliveTimeout,
 		readTimeout,
 		writeTimeout,
+		srv.MaxHeaderBytes,
 		updateBytesReadFunc,
 		updateBytesWrittenFunc,
 	)


### PR DESCRIPTION
This patch introduces separate counters for HTTP stats for minio
reserved bucket.

Fixes #6158

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.