### PR TITLE
Fix Kubernetes TLS doc to avoid creating CAs dir on read only mount

### DIFF
--- a/docs/tls/kubernetes/README.md
+++ b/docs/tls/kubernetes/README.md
@@ -50,21 +50,6 @@ If you're using certificates provided by a CA, add the below section in your yam
             path: public.crt
           - key: private.key
             path: private.key
-```
-
-In case you are using a self signed certificate, Minio server will not trust it by default. To add the certificate as a 
-trusted certificate, add the `public.crt` to the `.minio/certs/CAs` directory as well. This can be done by
-
-```yaml
-    volumes:
-      - name: secret-volume
-        secret:
-          secretName: tls-ssl-minio
-          items:
-          - key: public.crt
-            path: public.crt
-          - key: private.key
-            path: private.key
           - key: public.crt
             path: CAs/public.crt
 ```
@@ -80,5 +65,7 @@ Note that the `secretName` should be same as the secret name created in previous
 
 Here the name of `volumeMount` should match the name of `volume` created previously. Also `mountPath` must be set to the path of
 the Minio server's config sub-directory that is used to store certificates. By default, the location is
-`/user-running-minio/.minio/certs`. Tip: In a standard Kubernetes configuration, this will be `/root/.minio/certs`.
-Kubernetes will mount the secrets volume read-only, so avoid setting `mountPath` to a path that Minio server expects to write to.
+`/<user-running-minio>/.minio/certs`.
+
+*Tip*: In a standard Kubernetes configuration, this will be `/root/.minio/certs`. Kubernetes will mount the secrets volume read-only, 
+so avoid setting `mountPath` to a path that Minio server expects to write to.


### PR DESCRIPTION
## Description
When using Kubernetes secrets to mount TLS certs for Minio server,
Minio server tries to create the `<minio-user>/.minio/certs/CAs` directory, 
which fails as secrets are mounted as read only. 

To avoid this, we can mount `public.crt` to `CAs/public.crt`

## Motivation and Context
Based on community feedback on https://minio.slack.com/

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.