### PR TITLE
crypto: add `GenerateIV` from random IV generation

### DIFF
--- a/cmd/crypto/key.go
+++ b/cmd/crypto/key.go
@@ -35,8 +35,8 @@ import (
 type ObjectKey [32]byte
 
 // GenerateKey generates a unique ObjectKey from a 256 bit external key
-// and a source of randomness. If random is nil the default PRNG of system
-// (crypto/rand) is used.
+// and a source of randomness. If random is nil the default PRNG of the
+// system (crypto/rand) is used.
 func GenerateKey(extKey [32]byte, random io.Reader) (key ObjectKey) {
 	if random == nil {
 		random = rand.Reader
@@ -50,6 +50,19 @@ func GenerateKey(extKey [32]byte, random io.Reader) (key ObjectKey) {
 	sha.Write(nonce[:])
 	sha.Sum(key[:0])
 	return key
+}
+
+// GenerateIV generates a new random 256 bit IV from the provided source
+// of randomness. If random is nil the default PRNG of the system
+// (crypto/rand) is used.
+func GenerateIV(random io.Reader) (iv [32]byte) {
+	if random == nil {
+		random = rand.Reader
+	}
+	if _, err := io.ReadFull(random, iv[:]); err != nil {
+		logger.CriticalIf(context.Background(), errOutOfEntropy)
+	}
+	return iv
 }
 
 // SealedKey represents a sealed object key. It can be stored

--- a/cmd/crypto/key_test.go
+++ b/cmd/crypto/key_test.go
@@ -61,6 +61,32 @@ func TestGenerateKey(t *testing.T) {
 	}
 }
 
+var generateIVTests = []struct {
+	Random     io.Reader
+	ShouldPass bool
+}{
+	{Random: nil, ShouldPass: true},              // 0
+	{Random: rand.Reader, ShouldPass: true},      // 1
+	{Random: shortRandom(32), ShouldPass: true},  // 2
+	{Random: shortRandom(31), ShouldPass: false}, // 3
+}
+
+func TestGenerateIV(t *testing.T) {
+	defer func(disableLog bool) { logger.Disable = disableLog }(logger.Disable)
+	logger.Disable = true
+
+	for i, test := range generateIVTests {
+		i, test := i, test
+		func() {
+			defer recoverTest(i, test.ShouldPass, t)
+			iv := GenerateIV(test.Random)
+			if iv == [32]byte{} {
+				t.Errorf("Test %d: generated IV is zero IV", i) // check that we generate random and unique IV
+			}
+		}()
+	}
+}
+
 var sealUnsealKeyTests = []struct {
 	SealExtKey, SealIV                 [32]byte
 	SealDomain, SealBucket, SealObject string


### PR DESCRIPTION
## Description

This commit adds a `GenerateIV` function to simplify
the generation of random IVs.

It adds some unit tests for `GenerateIV` in key_test.go

## Motivation and Context
SSE-C, SSE-S3, refactoring

## How Has This Been Tested?
unit tests: `go test -v github.com/minio/minio/cmd/crypto`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.