### PR TITLE
crypto: implement Stringer for S3 and SSEC

### DIFF
--- a/cmd/crypto/sse.go
+++ b/cmd/crypto/sse.go
@@ -65,6 +65,14 @@ const (
 	InsecureSealAlgorithm = "DARE-SHA256"
 )
 
+// String returns the SSE domain as string. For SSE-S3 the
+// domain is "SSE-S3".
+func (s3) String() string { return "SSE-S3" }
+
+// String returns the SSE domain as string. For SSE-C the
+// domain is "SSE-C".
+func (ssec) String() string { return "SSE-C" }
+
 // EncryptSinglePart encrypts an io.Reader which must be the
 // the body of a single-part PUT request.
 func EncryptSinglePart(r io.Reader, key ObjectKey) io.Reader {

--- a/cmd/crypto/sse_test.go
+++ b/cmd/crypto/sse_test.go
@@ -1,0 +1,31 @@
+// Minio Cloud Storage, (C) 2015, 2016, 2017, 2018 Minio, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import "testing"
+
+func TestS3String(t *testing.T) {
+	const Domain = "SSE-S3"
+	if domain := S3.String(); domain != Domain {
+		t.Errorf("S3's string method returns wrong domain: got '%s' - want '%s'", domain, Domain)
+	}
+}
+
+func TestSSECString(t *testing.T) {
+	const Domain = "SSE-C"
+	if domain := SSEC.String(); domain != Domain {
+		t.Errorf("SSEC's string method returns wrong domain: got '%s' - want '%s'", domain, Domain)
+	}
+}


### PR DESCRIPTION
## Description

This commit adds a `fmt.Stringer` implementation for
SSE-S3 and SSE-C. The string representation is the
domain used for object key sealing.
See: `ObjectKey.Seal(...)` and `ObjectKey.Unseal(...)`


## Motivation and Context
SSE-C, SSE-S3

## How Has This Been Tested?
unit tests: `go test -v github.com/minio/minio/cmd/crypto`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.