### PR TITLE
Adds fix to not error on empty fs.json when listing objects

### DIFF
--- a/cmd/fs-v1-metadata.go
+++ b/cmd/fs-v1-metadata.go
@@ -249,8 +249,7 @@ func (m *fsMetaV1) ReadFrom(ctx context.Context, lk *lock.LockedFile) (n int64, 
 	}
 
 	if len(fsMetaBuf) == 0 {
-		logger.LogIf(ctx, io.EOF)
-		return 0, io.EOF
+        return 0, nil
 	}
 
 	// obtain version.

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -656,9 +656,11 @@ func (fs *FSObjects) getObjectInfo(ctx context.Context, bucket, object string) (
 	// parallel Put() operations.
 
 	rlk, err := fs.rwPool.Open(fsMetaPath)
+	var n int64
 	if err == nil {
 		// Read from fs metadata only if it exists.
-		_, rerr := fsMeta.ReadFrom(ctx, rlk.LockedFile)
+		var rerr error
+		n, rerr = fsMeta.ReadFrom(ctx, rlk.LockedFile)
 		fs.rwPool.Close(fsMetaPath)
 		if rerr != nil {
 			return oi, rerr
@@ -666,7 +668,7 @@ func (fs *FSObjects) getObjectInfo(ctx context.Context, bucket, object string) (
 	}
 
 	// Return a default etag and content-type based on the object's extension.
-	if err == errFileNotFound {
+	if (err == errFileNotFound) || (n == 0) {
 		fsMeta = fs.defaultFsJSON(object)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In FS mode, if fs.json is empty we will return default etags and not error out
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue Number #6256

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.