### PR TITLE
Correct link paths in Chinese documentation

### DIFF
--- a/docs/zh_CN/distributed/README.md
+++ b/docs/zh_CN/distributed/README.md
@@ -9,7 +9,7 @@
 ### 数据保护
 
 
-分布式Minio采用 [erasure code](https://github.com/minio/minio/tree/master/docs/zh_CN/erasure)来防范多个节点宕机和[位衰减`bit rot`](https://github.com/minio/minio/blob/master/docs/zh_CN/erasure/README.md#what-is-bit-rot-protection)。  
+分布式Minio采用 [erasure code](https://docs.minio.io/cn/minio-erasure-code-quickstart-guide)来防范多个节点宕机和[位衰减`bit rot`](https://github.com/minio/minio/blob/master/docs/zh_CN/erasure/README.md#what-is-bit-rot-protection)。  
 
 分布式Minio至少需要4个节点，使用分布式Minio自动引入了纠删码功能。
 
@@ -114,10 +114,10 @@ minio.exe server http://192.168.1.11/C:/data1 http://192.168.1.11/C:/data2 ^
 
 ## 了解更多
 
-- [Minio纠删码快速入门](https://github.com/minio/minio/tree/master/docs/zh_CN/erasure)
-- [使用 `mc`](https://docs.minio.io/docs/zh_CN/minio-client-quickstart-guide)
-- [使用 `aws-cli`](https://docs.minio.io/docs/zh_CN/aws-cli-with-minio)
-- [使用 `s3cmd](https://docs.minio.io/docs/zh_CN/s3cmd-with-minio)
-- [使用 `minio-go` SDK ](https://docs.minio.io/docs/zh_CN/golang-client-quickstart-guide)
+- [Minio纠删码快速入门](https://docs.minio.io/cn/minio-erasure-code-quickstart-guide)
+- [使用 `mc`](https://docs.minio.io/cn/minio-client-quickstart-guide)
+- [使用 `aws-cli`](https://docs.minio.io/cn/aws-cli-with-minio)
+- [使用 `s3cmd](https://docs.minio.io/cn/s3cmd-with-minio)
+- [使用 `minio-go` SDK ](https://docs.minio.io/cn/golang-client-quickstart-guide)
 
 - [minio官方文档](https://docs.minio.io)

--- a/docs/zh_CN/docker/README.md
+++ b/docs/zh_CN/docker/README.md
@@ -111,8 +111,8 @@ docker stats <container_id>
 ## 了解更多
 
 
-* [在Docker Compose上部署Minio](https://docs.minio.io/docs/zh_CN/deploy-minio-on-docker-compose)
-* [在Docker Swarm上部署Minio](https://docs.minio.io/docs/zh_CN/deploy-minio-on-docker-swarm)
-* [分布式Minio快速入门](https://docs.minio.io/docs/zh_CN/distributed-minio-quickstart-guide)
-* [Minio纠删码模式快速入门](https://github.com/minio/minio/tree/master/docs/zh_CN/erasure)
+* [在Docker Compose上部署Minio](https://docs.minio.io/cn/deploy-minio-on-docker-compose)
+* [在Docker Swarm上部署Minio](https://docs.minio.io/cn/deploy-minio-on-docker-swarm)
+* [分布式Minio快速入门](https://docs.minio.io/cn/distributed-minio-quickstart-guide)
+* [Minio纠删码模式快速入门](https://docs.minio.io/cn/minio-erasure-code-quickstart-guide)
 

--- a/docs/zh_CN/orchestration/dcos/README.md
+++ b/docs/zh_CN/orchestration/dcos/README.md
@@ -38,7 +38,7 @@ $ dcos package uninstall minio
 
 ### 了解更多
 
-- [Minio Erasure Code QuickStart Guide](https://github.com/minio/minio/tree/master/docs/zh_CN/erasure)
+- [Minio Erasure Code QuickStart Guide](https://docs.minio.io/cn/minio-erasure-code-quickstart-guide)
 
 - [DC/OS Project](https://docs.mesosphere.com/)
 

--- a/docs/zh_CN/orchestration/docker-compose/README.md
+++ b/docs/zh_CN/orchestration/docker-compose/README.md
@@ -44,7 +44,6 @@ docker-compose.exe up
 
 ### 了解更多
 - [Docker Compose概述](https://docs.docker.com/compose/overview/)
-- [Minio Docker快速入门](https://docs.minio.io/docs/zh_CN/minio-docker-quickstart-guide)
-- [使用Docker Swarm部署Minio](https://docs.minio.io/docs/zh_CN/deploy-minio-on-docker-swarm)
-- [Minio纠删码快速入门](https://github.com/minio/minio/tree/master/docs/zh_CN/erasure)
-
+- [Minio Docker快速入门](https://docs.minio.io/cn/minio-docker-quickstart-guide)
+- [使用Docker Swarm部署Minio](https://docs.minio.io/cn/deploy-minio-on-docker-swarm)
+- [Minio纠删码快速入门](https://docs.minio.io/cn/minio-erasure-code-quickstart-guide)

--- a/docs/zh_CN/orchestration/docker-swarm/README.md
+++ b/docs/zh_CN/orchestration/docker-swarm/README.md
@@ -81,6 +81,6 @@ docker volume rm volume_name
 
 ### 了解更多
 - [Docker Swarm mode概述](https://docs.docker.com/engine/swarm/)
-- [Minio Docker快速入门](https://docs.minio.io/docs/zh_CN/minio-docker-quickstart-guide)
-- [使用Docker Compose部署Minio](https://docs.minio.io/docs/zh_CN/deploy-minio-on-docker-compose)
-- [Minio纠删码快速入门](https://github.com/minio/minio/tree/master/docs/zh_CN/erasure)
+- [Minio Docker快速入门](https://docs.minio.io/cn/minio-docker-quickstart-guide)
+- [使用Docker Compose部署Minio](https://docs.minio.io/cn/deploy-minio-on-docker-compose)
+- [Minio纠删码快速入门](https://docs.minio.io/cn/minio-erasure-code-quickstart-guide)

--- a/docs/zh_CN/orchestration/kubernetes/README.md
+++ b/docs/zh_CN/orchestration/kubernetes/README.md
@@ -151,6 +151,6 @@ $ helm install --set accessKey=myaccesskey,secretKey=mysecretkey \
 
 ### 了解更多
 
-- [Minio纠删码快速入门](https://github.com/minio/minio/tree/master/docs/zh_CN/erasure)
+- [Minio纠删码快速入门](https://docs.minio.io/cn/minio-erasure-code-quickstart-guide)
 - [Kubernetes文档](https://kubernetes.io/docs/home/)
 - [Helm package manager for kubernetes](https://helm.sh/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit fixes the links pointing to incorrect paths in the updated Chinese documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The users who are referring to the Chinese documentation wouldn't have been able to navigate to the provided links for further reference.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The links have been visited to see if they are pointing to the correct paths.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.