### PR TITLE
Fix config migration regressions - longer locks on conflicting resources, honor cache config in gateway mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ dist: trusty
 
 language: go
 
+# this ensures PRs based on a local branch are not built twice
+# the downside is that a PR targeting a different branch is not built
+# but as a workaround you can add the branch to this list
+branches:
+  only:
+    - master
+
 matrix:
   include:
     - os: linux

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -64,6 +64,12 @@ func (s *serverConfig) SetRegion(region string) {
 
 // GetRegion get current region.
 func (s *serverConfig) GetRegion() string {
+	if globalIsEnvRegion {
+		return globalServerRegion
+	}
+	if s == nil {
+		return ""
+	}
 	return s.Region
 }
 
@@ -111,16 +117,34 @@ func (s *serverConfig) SetStorageClass(standardClass, rrsClass storageClass) {
 // GetStorageClass reads storage class fields from current config.
 // It returns the standard and reduced redundancy storage class struct
 func (s *serverConfig) GetStorageClass() (storageClass, storageClass) {
+	if globalIsStorageClass {
+		return globalStandardStorageClass, globalRRStorageClass
+	}
+	if s == nil {
+		return storageClass{}, storageClass{}
+	}
 	return s.StorageClass.Standard, s.StorageClass.RRS
 }
 
 // GetBrowser get current credentials.
 func (s *serverConfig) GetBrowser() bool {
+	if globalIsEnvWORM {
+		return globalWORMEnabled
+	}
+	if s == nil {
+		return true
+	}
 	return bool(s.Browser)
 }
 
 // GetWorm get current credentials.
 func (s *serverConfig) GetWorm() bool {
+	if globalIsEnvBrowser {
+		return globalIsBrowserEnabled
+	}
+	if s == nil {
+		return false
+	}
 	return bool(s.Worm)
 }
 
@@ -134,10 +158,24 @@ func (s *serverConfig) SetCacheConfig(drives, exclude []string, expiry int, maxu
 
 // GetCacheConfig gets the current cache config
 func (s *serverConfig) GetCacheConfig() CacheConfig {
+	if globalIsDiskCacheEnabled {
+		return CacheConfig{
+			Drives:  globalCacheDrives,
+			Exclude: globalCacheExcludes,
+			Expiry:  globalCacheExpiry,
+			MaxUse:  globalCacheMaxUse,
+		}
+	}
+	if s == nil {
+		return CacheConfig{}
+	}
 	return s.Cache
 }
 
 func (s *serverConfig) Validate() error {
+	if s == nil {
+		return nil
+	}
 	if s.Version != serverConfigVersion {
 		return fmt.Errorf("configuration version mismatch. Expected: ‘%s’, Got: ‘%s’", serverConfigVersion, s.Version)
 	}

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -97,7 +97,7 @@ func TestServerConfigWithEnvs(t *testing.T) {
 	serverHandleEnvVars()
 
 	// Init config
-	initConfig()
+	initConfig(objLayer)
 
 	// Check if serverConfig has
 	if globalServerConfig.GetBrowser() {

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -2411,18 +2411,6 @@ func migrateV27ToV28() error {
 
 // Migrates '.minio.sys/config.json' v27 to v28.
 func migrateMinioSysConfig(objAPI ObjectLayer) error {
-	// Construct path to config.json for the given bucket.
-	configFile := path.Join(bucketConfigPrefix, minioConfigFile)
-	transactionConfigFile := configFile + ".transaction"
-
-	// As object layer's GetObject() and PutObject() take respective lock on minioMetaBucket
-	// and configFile, take a transaction lock to avoid race.
-	objLock := globalNSMutex.NewNSLock(minioMetaBucket, transactionConfigFile)
-	if err := objLock.GetLock(globalOperationTimeout); err != nil {
-		return err
-	}
-	defer objLock.Unlock()
-
 	return migrateV27ToV28MinioSys(objAPI)
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -193,7 +193,7 @@ func (sys *ConfigSys) Init(objAPI ObjectLayer) error {
 	if objAPI == nil {
 		return errInvalidArgument
 	}
-	return loadConfig(objAPI)
+	return initConfig(objAPI)
 }
 
 // NewConfigSys - creates new config system object.
@@ -201,20 +201,8 @@ func NewConfigSys() *ConfigSys {
 	return &ConfigSys{}
 }
 
-// Migrates ${HOME}/.minio/config.json to '<export_path>/.minio.sys/config/minio.json'
+// Migrates ${HOME}/.minio/config.json to '<export_path>/.minio.sys/config/config.json'
 func migrateConfigToMinioSys() error {
-	// Construct path to config.json for the given bucket.
-	configFile := path.Join(bucketConfigPrefix, minioConfigFile)
-	transactionConfigFile := configFile + ".transaction"
-
-	// As object layer's GetObject() and PutObject() take respective lock on minioMetaBucket
-	// and configFile, take a transaction lock to avoid race.
-	objLock := globalNSMutex.NewNSLock(minioMetaBucket, transactionConfigFile)
-	if err := objLock.GetLock(globalOperationTimeout); err != nil {
-		return err
-	}
-	defer objLock.Unlock()
-
 	// Verify if backend already has the file.
 	if err := checkServerConfig(context.Background(), newObjectLayerFn()); err != errConfigNotFound {
 		return err
@@ -229,39 +217,45 @@ func migrateConfigToMinioSys() error {
 }
 
 // Initialize and load config from remote etcd or local config directory
-func initConfig() {
+func initConfig(objAPI ObjectLayer) error {
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	if globalEtcdClient != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		resp, err := globalEtcdClient.Get(ctx, getConfigFile())
 		cancel()
 		if err == nil && resp.Count > 0 {
-			logger.FatalIf(migrateConfig(), "Config migration failed")
+			return migrateConfig()
 		}
 	} else {
 		if isFile(getConfigFile()) {
-			logger.FatalIf(migrateConfig(), "Config migration failed")
+			if err := migrateConfig(); err != nil {
+				return err
+			}
 
 			// Migrates ${HOME}/.minio/config.json to '<export_path>/.minio.sys/config/config.json'
 			if err := migrateConfigToMinioSys(); err != nil {
-				logger.Fatal(err, "Unable to migrate 'config.json' to '.minio.sys/config/config.json'")
+				return err
 			}
 		}
 	}
-	objAPI := newObjectLayerFn()
-	if objAPI == nil {
-		logger.FatalIf(errServerNotInitialized, "Server is not initialized yet unable to proceed")
-	}
+
 	if err := checkServerConfig(context.Background(), objAPI); err != nil {
 		if err == errConfigNotFound {
 			// Config file does not exist, we create it fresh and return upon success.
-			logger.FatalIf(newConfig(objAPI), "Unable to initialize minio config for the first time")
-			logger.Info("Created minio configuration file successfully at " + getConfigDir())
+			if err = newConfig(objAPI); err != nil {
+				return err
+			}
 		} else {
-			logger.FatalIf(err, "Unable to load the configuration file")
+			return err
 		}
 	}
 
-	logger.FatalIf(migrateMinioSysConfig(objAPI), "Config migration failed for minio.sys config")
+	if err := migrateMinioSysConfig(objAPI); err != nil {
+		return err
+	}
 
-	logger.FatalIf(loadConfig(objAPI), "Unable to load the configuration file")
+	return loadConfig(objAPI)
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -164,6 +164,14 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	globalServerConfig = srvCfg
 	globalServerConfigMu.Unlock()
 
+	var cacheConfig = globalServerConfig.GetCacheConfig()
+	if len(cacheConfig.Drives) > 0 {
+		var err error
+		// initialize the new disk cache objects.
+		globalCacheObjectAPI, err = newServerCacheObjects(cacheConfig)
+		logger.FatalIf(err, "Unable to initialize disk caching")
+	}
+
 	// Check and load SSL certificates.
 	var err error
 	globalPublicCerts, globalRootCAs, globalTLSCerts, globalIsSSL, err = getSSLConfig()

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -91,7 +91,7 @@ ENVIRONMENT VARIABLES:
      MINIO_DOMAIN:    To enable bucket DNS requests, set this value to Minio host domain name.
      MINIO_PUBLIC_IPS: To enable bucket DNS requests, set this value to list of Minio host public IP(s) delimited by ",".
      MINIO_ETCD_ENDPOINTS: To enable bucket DNS requests, set this value to list of etcd endpoints delimited by ",".
-	
+
    KMS:
      MINIO_SSE_VAULT_ENDPOINT: To enable Vault as KMS,set this value to Vault endpoint.
      MINIO_SSE_VAULT_APPROLE_ID: To enable Vault as KMS,set this value to Vault AppRole ID.
@@ -123,7 +123,7 @@ EXAMPLES:
      $ export MINIO_CACHE_EXPIRY=40
      $ export MINIO_CACHE_MAXUSE=80
      $ {{.HelpName}} /home/shared
-	
+
   7. Start minio server with KMS enabled.
      $ export MINIO_SSE_VAULT_APPROLE_ID=9b56cc08-8258-45d5-24a3-679876769126
      $ export MINIO_SSE_VAULT_APPROLE_SECRET=4e30c52f-13e4-a6f5-0763-d50e8cb4321f
@@ -322,8 +322,13 @@ func serverMain(ctx *cli.Context) {
 		initFederatorBackend(newObject)
 	}
 
-	// Initialize server config.
-	initConfig()
+	// Create a new config system.
+	globalConfigSys = NewConfigSys()
+
+	// Initialize config system.
+	if err = globalConfigSys.Init(newObjectLayerFn()); err != nil {
+		logger.Fatal(err, "Unable to initialize config system")
+	}
 
 	// Load logger subsystem
 	loadLoggers()
@@ -337,14 +342,6 @@ func serverMain(ctx *cli.Context) {
 
 	// Re-enable logging
 	logger.Disable = false
-
-	// Create a new config system.
-	globalConfigSys = NewConfigSys()
-
-	// Initialize config system.
-	if err := globalConfigSys.Init(newObjectLayerFn()); err != nil {
-		logger.Fatal(err, "Unable to initialize config system")
-	}
 
 	// Create new policy system.
 	globalPolicySys = NewPolicySys()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Merge initConfig logic to ConfigSys
<!--- Describe your changes in detail -->

## Motivation and Context
simplify config migration
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.