### PR TITLE
ARM/select: fix int overflow of math.MaxInt64

### DIFF
--- a/pkg/s3select/select_test.go
+++ b/pkg/s3select/select_test.go
@@ -296,7 +296,7 @@ func TestMyParser(t *testing.T) {
 		if alias != table.alias {
 			t.Error()
 		}
-		if myLimit != table.myLimit {
+		if myLimit != int64(table.myLimit) {
 			t.Error()
 		}
 		if !reflect.DeepEqual(table.aggFuncs, aggFunctionNames) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix compiling for ARM compilation due to overflow-related compilation issue:

```
pkg/s3select/select.go:175:18: constant 9223372036854775807 overflows int
```

## Motivation and Context
The latest release introducing CSV handling broke compiling `minio` for ARM because of an overflow issue.

## How Has This Been Tested?

I've assuming existing tests cover this change, as it's a compilation issue on ARMv7 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.