### PR TITLE
Initialize global object layer after all subsystems have initialized

### DIFF
--- a/cmd/config-migrate_test.go
+++ b/cmd/config-migrate_test.go
@@ -174,10 +174,6 @@ func TestServerConfigMigrateV2toV28(t *testing.T) {
 	}
 	defer os.RemoveAll(fsDir)
 
-	globalObjLayerMutex.Lock()
-	globalObjectAPI = objLayer
-	globalObjLayerMutex.Unlock()
-
 	configPath := rootPath + "/" + minioConfigFile
 
 	// Create a corrupted config file
@@ -203,12 +199,12 @@ func TestServerConfigMigrateV2toV28(t *testing.T) {
 		t.Fatal("Unexpected error: ", err)
 	}
 
-	if err := migrateConfigToMinioSys(); err != nil {
+	if err := migrateConfigToMinioSys(objLayer); err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}
 
 	// Initialize server config and check again if everything is fine
-	if err := loadConfig(newObjectLayerFn()); err != nil {
+	if err := loadConfig(objLayer); err != nil {
 		t.Fatalf("Unable to initialize from updated config file %s", err)
 	}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -202,9 +202,9 @@ func NewConfigSys() *ConfigSys {
 }
 
 // Migrates ${HOME}/.minio/config.json to '<export_path>/.minio.sys/config/config.json'
-func migrateConfigToMinioSys() error {
+func migrateConfigToMinioSys(objAPI ObjectLayer) error {
 	// Verify if backend already has the file.
-	if err := checkServerConfig(context.Background(), newObjectLayerFn()); err != errConfigNotFound {
+	if err := checkServerConfig(context.Background(), objAPI); err != errConfigNotFound {
 		return err
 	} // if errConfigNotFound proceed to migrate..
 
@@ -213,7 +213,7 @@ func migrateConfigToMinioSys() error {
 		return err
 	}
 
-	return saveServerConfig(newObjectLayerFn(), config)
+	return saveServerConfig(objAPI, config)
 }
 
 // Initialize and load config from remote etcd or local config directory
@@ -236,7 +236,7 @@ func initConfig(objAPI ObjectLayer) error {
 			}
 
 			// Migrates ${HOME}/.minio/config.json to '<export_path>/.minio.sys/config/config.json'
-			if err := migrateConfigToMinioSys(); err != nil {
+			if err := migrateConfigToMinioSys(objAPI); err != nil {
 				return err
 			}
 		}

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -77,10 +77,6 @@ func (sys *PolicySys) Remove(bucketName string) {
 
 // IsAllowed - checks given policy args is allowed to continue the Rest API.
 func (sys *PolicySys) IsAllowed(args policy.Args) bool {
-	if sys == nil {
-		return args.IsOwner
-	}
-
 	sys.RLock()
 	defer sys.RUnlock()
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -313,10 +313,6 @@ func serverMain(ctx *cli.Context) {
 		logger.FatalIf(err, "Unable to initialize backend")
 	}
 
-	globalObjLayerMutex.Lock()
-	globalObjectAPI = newObject
-	globalObjLayerMutex.Unlock()
-
 	// Populate existing buckets to the etcd backend
 	if globalDNSConfig != nil {
 		initFederatorBackend(newObject)
@@ -326,7 +322,7 @@ func serverMain(ctx *cli.Context) {
 	globalConfigSys = NewConfigSys()
 
 	// Initialize config system.
-	if err = globalConfigSys.Init(newObjectLayerFn()); err != nil {
+	if err = globalConfigSys.Init(newObject); err != nil {
 		logger.Fatal(err, "Unable to initialize config system")
 	}
 
@@ -347,7 +343,7 @@ func serverMain(ctx *cli.Context) {
 	globalPolicySys = NewPolicySys()
 
 	// Initialize policy system.
-	if err := globalPolicySys.Init(newObjectLayerFn()); err != nil {
+	if err := globalPolicySys.Init(newObject); err != nil {
 		logger.Fatal(err, "Unable to initialize policy system")
 	}
 
@@ -355,9 +351,13 @@ func serverMain(ctx *cli.Context) {
 	globalNotificationSys = NewNotificationSys(globalServerConfig, globalEndpoints)
 
 	// Initialize notification system.
-	if err := globalNotificationSys.Init(newObjectLayerFn()); err != nil {
+	if err := globalNotificationSys.Init(newObject); err != nil {
 		logger.Fatal(err, "Unable to initialize notification system")
 	}
+
+	globalObjLayerMutex.Lock()
+	globalObjectAPI = newObject
+	globalObjLayerMutex.Unlock()
 
 	// Prints the formatted startup message once object layer is initialized.
 	apiEndpoints := getAPIEndpoints(globalMinioAddr)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Initialize global object layer after all subsystems have initialized
<!--- Describe your changes in detail -->

## Motivation and Context
This is to ensure that object API operations are not performed
on a server on which subsystems are yet to be initialized.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.