### PR TITLE
webhandler - display encryption errors properly

### DIFF
--- a/cmd/encryption-v1_test.go
+++ b/cmd/encryption-v1_test.go
@@ -521,43 +521,43 @@ func TestDecryptRequest(t *testing.T) {
 var decryptObjectInfoTests = []struct {
 	info    ObjectInfo
 	headers http.Header
-	expErr  APIErrorCode
+	expErr  error
 }{
 	{
 		info:    ObjectInfo{Size: 100},
 		headers: http.Header{},
-		expErr:  ErrNone,
+		expErr:  nil,
 	},
 	{
 		info:    ObjectInfo{Size: 100, UserDefined: map[string]string{crypto.SSESealAlgorithm: SSESealAlgorithmDareSha256}},
 		headers: http.Header{crypto.SSECAlgorithm: []string{crypto.SSEAlgorithmAES256}},
-		expErr:  ErrNone,
+		expErr:  nil,
 	},
 	{
 		info:    ObjectInfo{Size: 0, UserDefined: map[string]string{crypto.SSESealAlgorithm: SSESealAlgorithmDareSha256}},
 		headers: http.Header{crypto.SSECAlgorithm: []string{crypto.SSEAlgorithmAES256}},
-		expErr:  ErrNone,
+		expErr:  nil,
 	},
 	{
 		info:    ObjectInfo{Size: 100, UserDefined: map[string]string{crypto.SSECSealedKey: "EAAfAAAAAAD7v1hQq3PFRUHsItalxmrJqrOq6FwnbXNarxOOpb8jTWONPPKyM3Gfjkjyj6NCf+aB/VpHCLCTBA=="}},
 		headers: http.Header{},
-		expErr:  ErrSSEEncryptedObject,
+		expErr:  errEncryptedObject,
 	},
 	{
 		info:    ObjectInfo{Size: 100, UserDefined: map[string]string{}},
 		headers: http.Header{crypto.SSECAlgorithm: []string{crypto.SSEAlgorithmAES256}},
-		expErr:  ErrInvalidEncryptionParameters,
+		expErr:  errInvalidEncryptionParameters,
 	},
 	{
 		info:    ObjectInfo{Size: 31, UserDefined: map[string]string{crypto.SSESealAlgorithm: SSESealAlgorithmDareSha256}},
 		headers: http.Header{crypto.SSECAlgorithm: []string{crypto.SSEAlgorithmAES256}},
-		expErr:  ErrObjectTampered,
+		expErr:  errObjectTampered,
 	},
 }
 
 func TestDecryptObjectInfo(t *testing.T) {
 	for i, test := range decryptObjectInfoTests {
-		if err, encrypted := DecryptObjectInfo(&test.info, test.headers); err != test.expErr {
+		if encrypted, err := DecryptObjectInfo(&test.info, test.headers); err != test.expErr {
 			t.Errorf("Test %d: Decryption returned wrong error code: got %d , want %d", i, err, test.expErr)
 		} else if enc := crypto.IsEncrypted(test.info.UserDefined); encrypted && enc != encrypted {
 			t.Errorf("Test %d: Decryption thinks object is encrypted but it is not", i)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -306,8 +306,8 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	if objectAPI.IsEncryptionSupported() {
-		if apiErr, _ := DecryptObjectInfo(&objInfo, r.Header); apiErr != ErrNone {
-			writeErrorResponse(w, apiErr, r.URL)
+		if _, err = DecryptObjectInfo(&objInfo, r.Header); err != nil {
+			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 			return
 		}
 	}
@@ -467,10 +467,10 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 		writeErrorResponseHeadersOnly(w, toAPIErrorCode(err))
 		return
 	}
-
+	var encrypted bool
 	if objectAPI.IsEncryptionSupported() {
-		if apiErr, encrypted := DecryptObjectInfo(&objInfo, r.Header); apiErr != ErrNone {
-			writeErrorResponse(w, apiErr, r.URL)
+		if encrypted, err = DecryptObjectInfo(&objInfo, r.Header); err != nil {
+			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 			return
 		} else if encrypted {
 			s3Encrypted := crypto.S3.IsEncrypted(objInfo.UserDefined)

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -715,8 +715,8 @@ func (web *webAPIHandlers) Download(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if objectAPI.IsEncryptionSupported() {
-		if apiErr, _ := DecryptObjectInfo(&objInfo, r.Header); apiErr != ErrNone {
-			writeErrorResponse(w, apiErr, r.URL)
+		if _, err = DecryptObjectInfo(&objInfo, r.Header); err != nil {
+			writeWebErrorResponse(w, err)
 			return
 		}
 	}
@@ -818,8 +818,8 @@ func (web *webAPIHandlers) DownloadZip(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 			if objectAPI.IsEncryptionSupported() {
-				if apiErr, _ := DecryptObjectInfo(&info, r.Header); apiErr != ErrNone {
-					writeErrorResponse(w, apiErr, r.URL)
+				if _, err = DecryptObjectInfo(&info, r.Header); err != nil {
+					writeWebErrorResponse(w, err)
 					return err
 				}
 			}
@@ -1235,6 +1235,12 @@ func toWebAPIError(err error) APIError {
 			HTTPStatusCode: http.StatusBadRequest,
 			Description:    err.Error(),
 		}
+	} else if err == errEncryptedObject {
+		return getAPIError(ErrSSEEncryptedObject)
+	} else if err == errInvalidEncryptionParameters {
+		return getAPIError(ErrInvalidEncryptionParameters)
+	} else if err == errObjectTampered {
+		return getAPIError(ErrObjectTampered)
 	} else if err == errMethodNotAllowed {
 		return getAPIError(ErrMethodNotAllowed)
 	}


### PR DESCRIPTION
For encrypted objects, download errors need to be
displayed in web response format instead of xml format

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
DecryptObjectInfo needs to return error instead of ApiError so that web handler can translate error response into a browser friendly format. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #6327. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.