### PR TITLE
Vendorize the packages to make go1.11rc1 build

### DIFF
--- a/vendor/github.com/minio/highwayhash/highwayhashAVX2_amd64.go
+++ b/vendor/github.com/minio/highwayhash/highwayhashAVX2_amd64.go
@@ -7,17 +7,13 @@
 
 package highwayhash
 
+import "golang.org/x/sys/cpu"
+
 var (
-	useSSE4 = supportsSSE4()
-	useAVX2 = supportsAVX2()
+	useSSE4 = cpu.X86.HasSSE41
+	useAVX2 = cpu.X86.HasAVX2
 	useNEON = false
 )
-
-//go:noescape
-func supportsSSE4() bool
-
-//go:noescape
-func supportsAVX2() bool
 
 //go:noescape
 func initializeSSE4(state *[16]uint64, key []byte)
@@ -38,31 +34,34 @@ func finalizeSSE4(out []byte, state *[16]uint64)
 func finalizeAVX2(out []byte, state *[16]uint64)
 
 func initialize(state *[16]uint64, key []byte) {
-	if useAVX2 {
+	switch {
+	case useAVX2:
 		initializeAVX2(state, key)
-	} else if useSSE4 {
+	case useSSE4:
 		initializeSSE4(state, key)
-	} else {
+	default:
 		initializeGeneric(state, key)
 	}
 }
 
 func update(state *[16]uint64, msg []byte) {
-	if useAVX2 {
+	switch {
+	case useAVX2:
 		updateAVX2(state, msg)
-	} else if useSSE4 {
+	case useSSE4:
 		updateSSE4(state, msg)
-	} else {
+	default:
 		updateGeneric(state, msg)
 	}
 }
 
 func finalize(out []byte, state *[16]uint64) {
-	if useAVX2 {
+	switch {
+	case useAVX2:
 		finalizeAVX2(out, state)
-	} else if useSSE4 {
+	case useSSE4:
 		finalizeSSE4(out, state)
-	} else {
+	default:
 		finalizeGeneric(out, state)
 	}
 }

--- a/vendor/github.com/minio/highwayhash/highwayhashAVX2_amd64.s
+++ b/vendor/github.com/minio/highwayhash/highwayhashAVX2_amd64.s
@@ -248,8 +248,3 @@ hash64:
 	MOVQ DX, 0(BX)
 	RET
 
-// func supportsAVX2() bool
-TEXT ·supportsAVX2(SB), 4, $0-1
-	MOVQ runtime·support_avx2(SB), AX
-	MOVB AX, ret+0(FP)
-	RET

--- a/vendor/github.com/minio/highwayhash/highwayhash_amd64.go
+++ b/vendor/github.com/minio/highwayhash/highwayhash_amd64.go
@@ -7,14 +7,13 @@
 
 package highwayhash
 
+import "golang.org/x/sys/cpu"
+
 var (
-	useSSE4 = supportsSSE4()
+	useSSE4 = cpu.X86.HasSSE41
 	useAVX2 = false
 	useNEON = false
 )
-
-//go:noescape
-func supportsSSE4() bool
 
 //go:noescape
 func initializeSSE4(state *[16]uint64, key []byte)

--- a/vendor/github.com/minio/highwayhash/highwayhash_amd64.s
+++ b/vendor/github.com/minio/highwayhash/highwayhash_amd64.s
@@ -292,12 +292,3 @@ hash64:
 	MOVQ  m10, DX
 	MOVQ  DX, 0(BX)
 	RET
-
-// func supportsSSE4() bool
-TEXT ·supportsSSE4(SB), 4, $0-1
-	MOVL $1, AX
-	CPUID
-	SHRL $19, CX       // Bit 19 indicates SSE4 support
-	ANDL $1, CX        // CX != 0 if support SSE4
-	MOVB CX, ret+0(FP)
-	RET

--- a/vendor/github.com/rjeczalik/notify/appveyor.yml
+++ b/vendor/github.com/rjeczalik/notify/appveyor.yml
@@ -7,16 +7,20 @@ clone_folder: c:\projects\src\github.com\rjeczalik\notify
 environment:
  PATH: c:\projects\bin;%PATH%
  GOPATH: c:\projects
- NOTIFY_TIMEOUT: 5s
+ NOTIFY_TIMEOUT: 10s
+ GOVERSION: 1.10.3
 
 install:
+ - rmdir c:\go /s /q
+ - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
+ - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
+
+ - cd %APPVEYOR_BUILD_FOLDER%
  - go version
- - go get -v -t ./...
 
 build_script:
- - go tool vet -all .
  - go build ./...
- - go test -v -timeout 60s -race ./...
+ - go test -v -timeout 120s -race ./...
 
 test: off
 

--- a/vendor/github.com/rjeczalik/notify/debug_nodebug.go
+++ b/vendor/github.com/rjeczalik/notify/debug_nodebug.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 The Notify Authors. All rights reserved.
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
@@ -6,4 +6,4 @@
 
 package notify
 
-var debugTag bool = false
+var debugTag = false

--- a/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go
@@ -48,7 +48,7 @@ var wg sync.WaitGroup      // used to wait until the runloop starts
 // started and is ready via the wg. It also serves purpose of a dummy source,
 // thanks to it the runloop does not return as it also has at least one source
 // registered.
-var source = C.CFRunLoopSourceCreate(nil, 0, &C.CFRunLoopSourceContext{
+var source = C.CFRunLoopSourceCreate(refZero, 0, &C.CFRunLoopSourceContext{
 	perform: (C.CFRunLoopPerformCallBack)(C.gosource),
 })
 
@@ -90,6 +90,10 @@ func gostream(_, info uintptr, n C.size_t, paths, flags, ids uintptr) {
 	if n == 0 {
 		return
 	}
+	fn := streamFuncs.get(info)
+	if fn == nil {
+		return
+	}
 	ev := make([]FSEvent, 0, int(n))
 	for i := uintptr(0); i < uintptr(n); i++ {
 		switch flags := *(*uint32)(unsafe.Pointer((flags + i*offflag))); {
@@ -104,7 +108,7 @@ func gostream(_, info uintptr, n C.size_t, paths, flags, ids uintptr) {
 		}
 
 	}
-	streamFuncs.get(info)(ev)
+	fn(ev)
 }
 
 // StreamFunc is a callback called when stream receives file events.
@@ -162,8 +166,8 @@ func (s *stream) Start() error {
 		return nil
 	}
 	wg.Wait()
-	p := C.CFStringCreateWithCStringNoCopy(nil, C.CString(s.path), C.kCFStringEncodingUTF8, nil)
-	path := C.CFArrayCreate(nil, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
+	p := C.CFStringCreateWithCStringNoCopy(refZero, C.CString(s.path), C.kCFStringEncodingUTF8, refZero)
+	path := C.CFArrayCreate(refZero, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
 	ctx := C.FSEventStreamContext{}
 	ref := C.EventStreamCreate(&ctx, C.uintptr_t(s.info), path, C.FSEventStreamEventId(atomic.LoadUint64(&since)), latency, flags)
 	if ref == nilstream {

--- a/vendor/github.com/rjeczalik/notify/watcher_fsevents_go1.10.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_fsevents_go1.10.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2018 The Notify Authors. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+// +build darwin,!kqueue,cgo,!go1.11
+
+package notify
+
+/*
+ #include <CoreServices/CoreServices.h>
+*/
+import "C"
+
+var refZero = (*C.struct___CFAllocator)(nil)

--- a/vendor/github.com/rjeczalik/notify/watcher_fsevents_go1.11.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_fsevents_go1.11.go
@@ -1,9 +1,9 @@
-// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
+// Copyright (c) 2018 The Notify Authors. All rights reserved.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build debug
+// +build darwin,!kqueue,go1.11
 
 package notify
 
-var debugTag = true
+const refZero = 0

--- a/vendor/github.com/rjeczalik/notify/watcher_notimplemented.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_notimplemented.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+// +build !darwin,!linux,!freebsd,!dragonfly,!netbsd,!openbsd,!windows
+// +build !kqueue,!solaris
+
+package notify
+
+import "errors"
+
+// newWatcher stub.
+func newWatcher(chan<- EventInfo) watcher {
+	return watcherStub{errors.New("notify: not implemented")}
+}

--- a/vendor/github.com/rjeczalik/notify/watcher_readdcw.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_readdcw.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 The Notify Authors. All rights reserved.
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
@@ -22,7 +22,7 @@ import (
 const readBufferSize = 4096
 
 // Since all operations which go through the Windows completion routine are done
-// asynchronously, filter may set one of the constants belor. They were defined
+// asynchronously, filter may set one of the constants below. They were defined
 // in order to distinguish whether current folder should be re-registered in
 // ReadDirectoryChangesW function or some control operations need to be executed.
 const (
@@ -109,8 +109,13 @@ func (g *grip) register(cph syscall.Handle) (err error) {
 // buffer. Directory changes that occur between calls to this function are added
 // to the buffer and then, returned with the next call.
 func (g *grip) readDirChanges() error {
+	handle := syscall.Handle(atomic.LoadUintptr((*uintptr)(&g.handle)))
+	if handle == syscall.InvalidHandle {
+		return nil // Handle was closed.
+	}
+
 	return syscall.ReadDirectoryChanges(
-		g.handle,
+		handle,
 		&g.buffer[0],
 		uint32(unsafe.Sizeof(g.buffer)),
 		g.recursive,
@@ -220,12 +225,27 @@ func (wd *watched) updateGrip(idx int, cph syscall.Handle, reset bool,
 // returned from the operating system kernel.
 func (wd *watched) closeHandle() (err error) {
 	for _, g := range wd.digrip {
-		if g != nil && g.handle != syscall.InvalidHandle {
-			switch suberr := syscall.CloseHandle(g.handle); {
-			case suberr == nil:
-				g.handle = syscall.InvalidHandle
-			case err == nil:
-				err = suberr
+		if g == nil {
+			continue
+		}
+
+		for {
+			handle := syscall.Handle(atomic.LoadUintptr((*uintptr)(&g.handle)))
+			if handle == syscall.InvalidHandle {
+				break // Already closed.
+			}
+
+			e := syscall.CloseHandle(handle)
+			if e != nil && err == nil {
+				err = e
+			}
+
+			// Set invalid handle even when CloseHandle fails. This will leak
+			// the handle but, since we can't close it anyway, there won't be
+			// any difference.
+			if atomic.CompareAndSwapUintptr((*uintptr)(&g.handle),
+				(uintptr)(handle), (uintptr)(syscall.InvalidHandle)) {
+				break
 			}
 		}
 	}
@@ -272,50 +292,49 @@ func (r *readdcw) RecursiveWatch(path string, event Event) error {
 // watch inserts a directory to the group of watched folders. If watched folder
 // already exists, function tries to rewatch it with new filters(NOT VALID). Moreover,
 // watch starts the main event loop goroutine when called for the first time.
-func (r *readdcw) watch(path string, event Event, recursive bool) (err error) {
+func (r *readdcw) watch(path string, event Event, recursive bool) error {
 	if event&^(All|fileNotifyChangeAll) != 0 {
 		return errors.New("notify: unknown event")
 	}
+
 	r.Lock()
-	wd, ok := r.m[path]
-	r.Unlock()
-	if !ok {
-		if err = r.lazyinit(); err != nil {
-			return
-		}
-		r.Lock()
-		defer r.Unlock()
-		if wd, ok = r.m[path]; ok {
-			dbgprint("watch: exists already")
-			return
-		}
-		if wd, err = newWatched(r.cph, uint32(event), recursive, path); err != nil {
-			return
-		}
-		r.m[path] = wd
-		dbgprint("watch: new watch added")
-	} else {
-		dbgprint("watch: exists already")
+	defer r.Unlock()
+
+	if wd, ok := r.m[path]; ok {
+		dbgprint("watch: already exists")
+		wd.filter &^= stateUnwatch
+		return nil
 	}
+
+	if err := r.lazyinit(); err != nil {
+		return err
+	}
+
+	wd, err := newWatched(r.cph, uint32(event), recursive, path)
+	if err != nil {
+		return err
+	}
+
+	r.m[path] = wd
+	dbgprint("watch: new watch added")
+
 	return nil
 }
 
-// lazyinit creates an I/O completion port and starts the main event processing
-// loop. This method uses Double-Checked Locking optimization.
+// lazyinit creates an I/O completion port and starts the main event loop.
 func (r *readdcw) lazyinit() (err error) {
 	invalid := uintptr(syscall.InvalidHandle)
+
 	if atomic.LoadUintptr((*uintptr)(&r.cph)) == invalid {
-		r.Lock()
-		defer r.Unlock()
-		if atomic.LoadUintptr((*uintptr)(&r.cph)) == invalid {
-			cph := syscall.InvalidHandle
-			if cph, err = syscall.CreateIoCompletionPort(cph, 0, 0, 0); err != nil {
-				return
-			}
-			r.cph, r.start = cph, true
-			go r.loop()
+		cph := syscall.InvalidHandle
+		if cph, err = syscall.CreateIoCompletionPort(cph, 0, 0, 0); err != nil {
+			return
 		}
+
+		r.cph, r.start = cph, true
+		go r.loop()
 	}
+
 	return
 }
 
@@ -364,6 +383,7 @@ func (r *readdcw) loopstate(overEx *overlappedEx) {
 			overEx.parent.parent.recreate(r.cph)
 		case stateUnwatch:
 			dbgprint("loopstate unwatch")
+			overEx.parent.parent.closeHandle()
 			delete(r.m, syscall.UTF16ToString(overEx.parent.pathw))
 		case stateCPClose:
 		default:
@@ -495,27 +515,30 @@ func (r *readdcw) RecursiveUnwatch(path string) error {
 // TODO : pknap
 func (r *readdcw) unwatch(path string) (err error) {
 	var wd *watched
+
 	r.Lock()
 	defer r.Unlock()
 	if wd, err = r.nonStateWatchedLocked(path); err != nil {
 		return
 	}
+
 	wd.filter |= stateUnwatch
-	if err = wd.closeHandle(); err != nil {
-		wd.filter &^= stateUnwatch
-		return
-	}
+	dbgprint("unwatch: set unwatch state")
+
 	if _, attrErr := syscall.GetFileAttributes(&wd.pathw[0]); attrErr != nil {
 		for _, g := range wd.digrip {
-			if g != nil {
-				dbgprint("unwatch: posting")
-				if err = syscall.PostQueuedCompletionStatus(r.cph, 0, 0, (*syscall.Overlapped)(unsafe.Pointer(g.ovlapped))); err != nil {
-					wd.filter &^= stateUnwatch
-					return
-				}
+			if g == nil {
+				continue
+			}
+
+			dbgprint("unwatch: posting")
+			if err = syscall.PostQueuedCompletionStatus(r.cph, 0, 0, (*syscall.Overlapped)(unsafe.Pointer(g.ovlapped))); err != nil {
+				wd.filter &^= stateUnwatch
+				return
 			}
 		}
 	}
+
 	return
 }
 

--- a/vendor/github.com/rjeczalik/notify/watcher_stub.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_stub.go
@@ -1,23 +1,13 @@
-// Copyright (c) 2014-2015 The Notify Authors. All rights reserved.
+// Copyright (c) 2014-2018 The Notify Authors. All rights reserved.
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-// +build !darwin,!linux,!freebsd,!dragonfly,!netbsd,!openbsd,!windows
-// +build !kqueue,!solaris
-
 package notify
 
-import "errors"
-
-type stub struct{ error }
-
-// newWatcher stub.
-func newWatcher(chan<- EventInfo) watcher {
-	return stub{errors.New("notify: not implemented")}
-}
+type watcherStub struct{ error }
 
 // Following methods implement notify.watcher interface.
-func (s stub) Watch(string, Event) error          { return s }
-func (s stub) Rewatch(string, Event, Event) error { return s }
-func (s stub) Unwatch(string) (err error)         { return s }
-func (s stub) Close() error                       { return s }
+func (s watcherStub) Watch(string, Event) error          { return s }
+func (s watcherStub) Rewatch(string, Event, Event) error { return s }
+func (s watcherStub) Unwatch(string) (err error)         { return s }
+func (s watcherStub) Close() error                       { return s }

--- a/vendor/github.com/rjeczalik/notify/watcher_trigger.go
+++ b/vendor/github.com/rjeczalik/notify/watcher_trigger.go
@@ -106,7 +106,8 @@ func newWatcher(c chan<- EventInfo) watcher {
 	}
 	t.t = newTrigger(t.pthLkp)
 	if err := t.t.Init(); err != nil {
-		panic(err)
+		t.Close()
+		return watcherStub{fmt.Errorf("failed setting up watcher: %v", err)}
 	}
 	go t.monitor()
 	return t

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -628,10 +628,10 @@
 			"revisionTime": "2018-01-23T12:12:34Z"
 		},
 		{
-			"checksumSHA1": "w7ykRf31om2J6832Py4Kz/PEnSI=",
+			"checksumSHA1": "2Fu1GmLwDo6FFdahjnlWnPkwJTE=",
 			"path": "github.com/minio/highwayhash",
-			"revision": "1ea1b5fce73b1d7abbd822a194b51f3736b1f23b",
-			"revisionTime": "2018-01-09T22:40:08Z"
+			"revision": "85fc8a2dacad36a6beb2865793cd81363a496696",
+			"revisionTime": "2018-05-01T08:09:13Z"
 		},
 		{
 			"checksumSHA1": "7/Hdd23/j4/yt4BXa+h0kqz1yjw=",
@@ -830,10 +830,10 @@
 			"revisionTime": "2018-04-08T09:29:02Z"
 		},
 		{
-			"checksumSHA1": "T2BgxGcsgrldYNFPQcmw46/K4qM=",
+			"checksumSHA1": "D8AVDI39CJ+jvw0HOotYU2gz54c=",
 			"path": "github.com/rjeczalik/notify",
-			"revision": "d152f3ce359a5464dc41e84a8919fc67e55bbbf0",
-			"revisionTime": "2018-03-12T21:30:58Z"
+			"revision": "4e54e7fd043e865c50bda93359fb78813a8d165b",
+			"revisionTime": "2018-08-08T20:39:25Z"
 		},
 		{
 			"path": "github.com/rs/cors",


### PR DESCRIPTION
Vendorized the following packages

- "github.com/rjeczalik/notify"
- "github.com/minio/highwayhash"

## Description
The `make` build was failing on go1.11rc1. Which is because of legacy versions of few packages. Vendorizing it solved the problem.

## Motivation and Context
To make a successful go build with latest versions go1.11+

## Regression
No

## How Has This Been Tested?
Ran current unit tests over it

Fixes #6315

