### PR TITLE
Fix WORM and BROWSER status calculation

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -128,8 +128,8 @@ func (s *serverConfig) GetStorageClass() (storageClass, storageClass) {
 
 // GetBrowser get current credentials.
 func (s *serverConfig) GetBrowser() bool {
-	if globalIsEnvWORM {
-		return globalWORMEnabled
+	if globalIsEnvBrowser {
+		return globalIsBrowserEnabled
 	}
 	if s == nil {
 		return true
@@ -139,8 +139,8 @@ func (s *serverConfig) GetBrowser() bool {
 
 // GetWorm get current credentials.
 func (s *serverConfig) GetWorm() bool {
-	if globalIsEnvBrowser {
-		return globalIsBrowserEnabled
+	if globalIsEnvWORM {
+		return globalWORMEnabled
 	}
 	if s == nil {
 		return false

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -66,6 +66,9 @@ func TestServerConfigWithEnvs(t *testing.T) {
 	os.Setenv("MINIO_BROWSER", "off")
 	defer os.Unsetenv("MINIO_BROWSER")
 
+	os.Setenv("MINIO_WORM", "on")
+	defer os.Unsetenv("MINIO_WORM")
+
 	os.Setenv("MINIO_ACCESS_KEY", "minio")
 	defer os.Unsetenv("MINIO_ACCESS_KEY")
 
@@ -99,29 +102,35 @@ func TestServerConfigWithEnvs(t *testing.T) {
 	// Init config
 	initConfig(objLayer)
 
-	// Check if serverConfig has
+	// Check if serverConfig has browser disabled
 	if globalServerConfig.GetBrowser() {
-		t.Errorf("Expecting browser is set to false found %v", globalServerConfig.GetBrowser())
+		t.Error("Expected browser to be disabled but it is not")
 	}
 
-	// Check if serverConfig has
+	// Check if serverConfig returns WORM config from the env
+	if !globalServerConfig.GetWorm() {
+		t.Error("Expected WORM to be enabled but it is not")
+	}
+
+	// Check if serverConfig has region from the environment
 	if globalServerConfig.GetRegion() != "us-west-1" {
-		t.Errorf("Expecting region to be \"us-west-1\" found %v", globalServerConfig.GetRegion())
+		t.Errorf("Expected region to be \"us-west-1\", found %v", globalServerConfig.GetRegion())
 	}
 
-	// Check if serverConfig has
+	// Check if serverConfig has credentials from the environment
 	cred := globalServerConfig.GetCredential()
 
 	if cred.AccessKey != "minio" {
-		t.Errorf("Expecting access key to be `minio` found %s", cred.AccessKey)
+		t.Errorf("Expected access key to be `minio`, found %s", cred.AccessKey)
 	}
 
 	if cred.SecretKey != "minio123" {
-		t.Errorf("Expecting access key to be `minio123` found %s", cred.SecretKey)
+		t.Errorf("Expected access key to be `minio123`, found %s", cred.SecretKey)
 	}
 
+	// Check if serverConfig has the correct domain
 	if globalServerConfig.Domain != "domain.com" {
-		t.Errorf("Expecting Domain to be `domain.com` found " + globalServerConfig.Domain)
+		t.Errorf("Expected Domain to be `domain.com`, found " + globalServerConfig.Domain)
 	}
 }
 

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -434,6 +434,7 @@ func resetGlobalIsXL() {
 
 func resetGlobalIsEnvs() {
 	globalIsEnvCreds = false
+	globalIsEnvWORM = false
 	globalIsEnvBrowser = false
 	globalIsEnvRegion = false
 	globalIsStorageClass = false


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
One typo introduced in a recent commit miscalculates if worm and browser
are enabled or not. A simple test is also added to detect this issue
in the future if it ever happens again.


## Motivation and Context
Fixes #6355 

## Regression
Yes, caused by https://github.com/minio/minio/pull/6312

## How Has This Been Tested?
Added one test + Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.