### PR TITLE
Fix gateway s3 cmd to run custom S3 endpoint

### DIFF
--- a/docs/gateway/s3.md
+++ b/docs/gateway/s3.md
@@ -33,7 +33,7 @@ As a prerequisite to run Minio S3 gateway on an AWS S3 compatible service, you n
 docker run -p 9000:9000 --name minio-s3 \
  -e "MINIO_ACCESS_KEY=access_key" \
  -e "MINIO_SECRET_KEY=secret_key" \
- minio/minio gateway s3 --address https://s3_compatible_service_endpoint:port
+ minio/minio gateway s3 https://s3_compatible_service_endpoint:port
 ```
 
 ### Using Binary
@@ -41,7 +41,7 @@ docker run -p 9000:9000 --name minio-s3 \
 ```
 export MINIO_ACCESS_KEY=access_key
 export MINIO_SECRET_KEY=secret_key
-minio gateway s3 --address https://s3_compatible_service_endpoint:port
+minio gateway s3 https://s3_compatible_service_endpoint:port
 ```
 
 ## Minio Caching


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
To pass a custom S3 endpoint in S3 gateway, the user needs
to specify it as an argument after 'minio gateway s3' and not
as '--address' option since this latter specifies the address
to which the gateway should listen.


## Motivation and Context
Fix documentation

## Regression
No

## How Has This Been Tested?
Nothing to change, it is a documentation change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.