### PR TITLE
Allow fallback listen if first listener fails

### DIFF
--- a/cmd/http/listen_nix.go
+++ b/cmd/http/listen_nix.go
@@ -18,7 +18,11 @@
 
 package http
 
-import "github.com/valyala/tcplisten"
+import (
+	"net"
+
+	"github.com/valyala/tcplisten"
+)
 
 var cfg = &tcplisten.Config{
 	DeferAccept: true,
@@ -27,3 +31,4 @@ var cfg = &tcplisten.Config{
 
 // Unix listener with special TCP options.
 var listen = cfg.NewListener
+var fallbackListen = net.Listen

--- a/cmd/http/listen_others.go
+++ b/cmd/http/listen_others.go
@@ -22,3 +22,4 @@ import "net"
 
 // Windows, plan9 specific listener.
 var listen = net.Listen
+var fallbackListen = net.Listen

--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -401,7 +401,9 @@ func newHTTPListener(serverAddrs []string,
 	for _, serverAddr := range serverAddrs {
 		var l net.Listener
 		if l, err = listen("tcp4", serverAddr); err != nil {
-			return nil, err
+			if l, err = fallbackListen("tcp4", serverAddr); err != nil {
+				return nil, err
+			}
 		}
 
 		tcpListener, ok := l.(*net.TCPListener)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
On linux listen() uses kernel features TCP_FASTOPEN, DEFER_ACCEPT

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #6379

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Manually on CentOS 6.x
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.