### PR TITLE
AppVeyor's version scoped to go1.10.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ clone_folder: c:\gopath\src\github.com\minio\minio
 # Environment variables
 environment:
   GOPATH: c:\gopath
-  GOROOT: c:\go
+  GOROOT: c:\go110
 
 # scripts that run after cloning repository
 install:


### PR DESCRIPTION
`make build` will fail for go1.11 since formatting directives are made mandatory for `log.FatalIf` in go1.11+. 

![image](https://user-images.githubusercontent.com/5410427/44835317-7c261880-ac51-11e8-84c1-ba642fa07421.png)

So fixing the version to go1.10 ( Travis uses the same ) until decision is taken to migrate to go1.11

## Motivation and Context
AppVeyor build was failing for the PR's

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
