### PR TITLE
Stops listing objects for write-only access

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -328,12 +328,16 @@ func (web *webAPIHandlers) ListObjects(r *http.Request, args *ListObjectsArgs, r
 			return toJSONError(authErr)
 		}
 
-		// Error out anonymous (non-owner) has no access download or upload objects.
-		if !readable && !writable {
-			return errAuthentication
+		reply.Writable = writable
+		if !readable {
+			// Error out if anonymous user (non-owner) has no access to download or upload objects
+			if !writable {
+				return errAuthentication
+			}
+			// return empty object list if access is write only
+			return nil
 		}
 
-		reply.Writable = writable
 	}
 
 	lo, err := listObjects(context.Background(), args.BucketName, args.Prefix, args.Marker, slashSeparator, 1000)


### PR DESCRIPTION
Fixes #6350 :  Minio Browser: Files inside a bucket with "Write Only" permission can be seen by guests 

## Description and Motivation
This was a regression due to [PR#5790](https://github.com/minio/minio/pull/5790) fix.

## Regression
Yes
 [PR#5790](https://github.com/minio/minio/pull/5790)

## How Has This Been Tested?
Manually with browser using anonymous access and all possible access policies

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.