### PR TITLE
Fix config subsystem to wait on quorum number of formatted disks

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -318,6 +318,9 @@ func serverMain(ctx *cli.Context) {
 		initFederatorBackend(newObject)
 	}
 
+	// Re-enable logging
+	logger.Disable = false
+
 	// Create a new config system.
 	globalConfigSys = NewConfigSys()
 
@@ -335,9 +338,6 @@ func serverMain(ctx *cli.Context) {
 		globalCacheObjectAPI, err = newServerCacheObjects(cacheConfig)
 		logger.FatalIf(err, "Unable to initialize disk caching")
 	}
-
-	// Re-enable logging
-	logger.Disable = false
 
 	// Create new policy system.
 	globalPolicySys = NewPolicySys()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix config subsystem to wait on quorum number of formatted disks
<!--- Describe your changes in detail -->

## Motivation and Context
During object-layer init, make sure at least quorum number of disks which are formatted at initialized. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.