### PR TITLE
Remove double backtick that was breaking docs

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -62,7 +62,7 @@ minio server /data
 #### Region
 |Field|Type|Description|
 |:---|:---|:---|
-|``region``| _string_ | `region` describes the physical location of the server. By default it is set to ``. You may override this field with `MINIO_REGION` environment variable. If you are unsure leave it unset.|
+|``region``| _string_ | `region` describes the physical location of the server. By default it is blank. You may override this field with `MINIO_REGION` environment variable. If you are unsure leave it unset.|
 
 Example:
 


### PR DESCRIPTION
On the documentation site, the double backtick with nothing in between was breaking the page render and making the text itself look quite awkward!

![https://i.imgur.com/L1JcbGT.png](https://i.imgur.com/L1JcbGT.png)
