### PR TITLE
Send length instead of empty buffer for ReadFile()

### DIFF
--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -227,7 +227,7 @@ func (client *StorageRPCClient) ReadFile(volume string, path string, offset int6
 		Vol:      volume,
 		Path:     path,
 		Offset:   offset,
-		Buffer:   buffer,
+		Length:   int64(len(buffer)),
 		Verified: true, // mark read as verified by default
 	}
 	if verifier != nil {

--- a/cmd/storage-rpc-server.go
+++ b/cmd/storage-rpc-server.go
@@ -127,7 +127,7 @@ type ReadFileArgs struct {
 	Vol          string
 	Path         string
 	Offset       int64
-	Buffer       []byte
+	Length       int64
 	Algo         BitrotAlgorithm
 	ExpectedHash []byte
 	Verified     bool
@@ -140,13 +140,14 @@ func (receiver *storageRPCReceiver) ReadFile(args *ReadFileArgs, reply *[]byte) 
 		verifier = NewBitrotVerifier(args.Algo, args.ExpectedHash)
 	}
 
-	n, err := receiver.local.ReadFile(args.Vol, args.Path, args.Offset, args.Buffer, verifier)
+	buf := make([]byte, args.Length)
+	n, err := receiver.local.ReadFile(args.Vol, args.Path, args.Offset, buf, verifier)
 	// Ignore io.ErrEnexpectedEOF for short reads i.e. less content available than requested.
 	if err == io.ErrUnexpectedEOF {
 		err = nil
 	}
 
-	*reply = args.Buffer[0:n]
+	*reply = buf[0:n]
 	return err
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

Currently we are sending empty buffer for ReadFile() call, we can avoid it by sending length instead.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.