### PR TITLE
Reword missing credentials error msg

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -271,7 +271,7 @@ func serverMain(ctx *cli.Context) {
 				logger.Info(`Supplying credentials from your 'config.json' is **DEPRECATED**, Access key and Secret key in distributed server mode is expected to be specified with environment variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY. This approach will become mandatory in future releases, please migrate to this approach soon.`)
 			} else {
 				// Credential is not available anywhere by both means, we cannot start distributed setup anymore, fail eagerly.
-				logger.Fatal(uiErrEnvCredentialsMissingServer(nil), "Unable to initialize distributed Minio server.")
+				logger.Fatal(uiErrEnvCredentialsMissingDistributed(nil), "Unable to initialize the server in distributed mode")
 			}
 		}
 	}

--- a/cmd/ui-errors.go
+++ b/cmd/ui-errors.go
@@ -74,14 +74,14 @@ Secret key should be in between 8 and 40 characters.`,
 
 	uiErrEnvCredentialsMissingGateway = newUIErrFn(
 		"Credentials missing",
-		"Please provide correct credentials",
-		`Access key and Secret key should be specified in Gateway mode from environment variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY respectively.`,
+		"Please set your credentials in the environment",
+		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY respectively.`,
 	)
 
-	uiErrEnvCredentialsMissingServer = newUIErrFn(
+	uiErrEnvCredentialsMissingDistributed = newUIErrFn(
 		"Credentials missing",
-		"Please provide correct credentials",
-		`Access key and Secret key should be specified in distributed server mode from environment variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY respectively.`,
+		"Please set your credentials in the environment",
+		`In distributed server mode, access and secret keys should be specified via environment variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY respectively.`,
 	)
 
 	uiErrInvalidErasureEndpoints = newUIErrFn(


### PR DESCRIPTION
## Description
Enhance a little bit the error message that is showing
when access & secret keys are not specified in the
environment when running Minio in gateway and server mode.

This commit also removes a redundant check for access/secret keys.

## Motivation and Context
Enhancing an error message

## Regression
No

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.