### PR TITLE
Allow minio s3 gateway to use different AWS auth mechanisms

### DIFF
--- a/docs/gateway/s3.md
+++ b/docs/gateway/s3.md
@@ -3,11 +3,9 @@
 Minio S3 Gateway adds Minio features like Minio Browser and disk caching to AWS S3 or any other AWS S3 compatible service.
 
 ## Run Minio Gateway for AWS S3
-
-As a prerequisite to run Minio S3 gateway, you need valid AWS S3 access key and secret key.
+As a prerequisite to run Minio S3 gateway, you need valid AWS S3 access key and secret key by default. Optionally you can also set custom access/secret key, when you have rotating AWS IAM credentials or AWS credentials through environment variables (i.e. AWS_ACCESS_KEY_ID)
 
 ### Using Docker
-
 ```
 docker run -p 9000:9000 --name minio-s3 \
  -e "MINIO_ACCESS_KEY=aws_s3_access_key" \
@@ -16,19 +14,30 @@ docker run -p 9000:9000 --name minio-s3 \
 ```
 
 ### Using Binary
-
 ```
 export MINIO_ACCESS_KEY=aws_s3_access_key
 export MINIO_SECRET_KEY=aws_s3_secret_key
 minio gateway s3
 ```
 
-## Run Minio Gateway for AWS S3 compatible services
+### Using Binary in EC2
+Using IAM rotating credentials for AWS S3
+```
+export MINIO_ACCESS_KEY=custom_access_key
+export MINIO_SECRET_KEY=custom_secret_key
+minio gateway s3
+```
 
+Minio gateway will automatically look for list of credential styles in following order.
+
+- AWS env vars (i.e. AWS_ACCESS_KEY_ID)
+- IAM profile based credentials. (performs an HTTP call to a pre-defined endpoint, only valid inside configured ec2 instances)
+- AWS creds file (i.e. AWS_SHARED_CREDENTIALS_FILE or ~/.aws/credentials)
+
+## Run Minio Gateway for AWS S3 compatible services
 As a prerequisite to run Minio S3 gateway on an AWS S3 compatible service, you need valid access key, secret key and service endpoint.
 
 ### Using Docker
-
 ```
 docker run -p 9000:9000 --name minio-s3 \
  -e "MINIO_ACCESS_KEY=access_key" \
@@ -37,7 +46,6 @@ docker run -p 9000:9000 --name minio-s3 \
 ```
 
 ### Using Binary
-
 ```
 export MINIO_ACCESS_KEY=access_key
 export MINIO_SECRET_KEY=secret_key
@@ -45,7 +53,6 @@ minio gateway s3 https://s3_compatible_service_endpoint:port
 ```
 
 ## Minio Caching
-
 Minio edge caching allows storing content closer to the applications. Frequently accessed objects are stored in a local disk based cache. Edge caching with Minio gateway feature allows
 
 - Dramatic improvements for time to first byte for any object.
@@ -54,7 +61,6 @@ Minio edge caching allows storing content closer to the applications. Frequently
 Refer [this document](https://docs.minio.io/docs/minio-disk-cache-guide.html) to get started with Minio Caching.
 
 ## Minio Browser
-
 Minio Gateway comes with an embedded web based object browser. Point your web browser to http://127.0.0.1:9000 to ensure that your server has started successfully.
 
 ![Screenshot](https://github.com/minio/minio/blob/master/docs/screenshots/minio-browser-gateway.png?raw=true)


### PR DESCRIPTION
## Description
Allow minio s3 gateway to use aws environment credentials,
IAM instance credentials, or AWS file credentials.

If AWS_ACCESS_KEY_ID, AWS_SECRET_ACCSES_KEY are set, or minio
is running on an ec2 instance with IAM instance credentials, or
there is a file $HOME/.aws/credentials, minio running as an S3
gateway will authenticate with AWS S3 using those one of credentials.

The lookup order:
1. AWS environment varaibles
2. IAM instance credentials
3. $HOME/.aws/credentials
4. minio environment variables

To authenticate with the minio gateway, you will always use the
minio environment variables MINIO_ACCESS_KEY MINIO_SECRET_KEY.



## Motivation and Context
This is a solution to #6124, though it still requires credentials to minio to be explicitly set

## How Has This Been Tested?
I ran this change on an EC2 machine and attached an IAM profile that had access to read and write a bucket. I was able to use the minio browser to upload and download objects.

The role looked like this:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": [
                "s3:ListAllMyBuckets",
                "s3:ListBucket",
                "s3:HeadBucket"
            ],
            "Resource": "*"
        },
        {
            "Sid": "VisualEditor1",
            "Effect": "Allow",
            "Action": "s3:*",
            "Resource": "arn:aws:s3:::mybucket/*"
        }
    ]
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.