### PR TITLE
Remove "List Object Parts" from Azure Gateway limitations

### DIFF
--- a/docs/gateway/azure.md
+++ b/docs/gateway/azure.md
@@ -42,7 +42,7 @@ Gateway inherits the following Azure limitations:
 - Only read-only bucket policy supported at bucket level, all other variations will return API Notimplemented error.
 - Bucket names with "." in the bucket name are not supported.
 - Non-empty buckets get removed on a DeleteBucket() call.
-- _List Multipart Uploads_ and _List Object parts_ always returns empty list. i.e Client will need to remember all the parts that it has uploaded and use it for _Complete Multipart Upload_
+- _List Multipart Uploads_ always returns empty list.
 
 Other limitations:
 


### PR DESCRIPTION
Since https://github.com/minio/minio/pull/5198 has been implemented, my understanding is that "List Object Parts" is now implemented in the Azure Gateway, so this PR removes it from the "Known Limitations" section.