### PR TITLE
Print storage errors during distributed initialization

### DIFF
--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -52,6 +52,10 @@ func (d *naughtyDisk) IsOnline() bool {
 	return d.disk.IsOnline()
 }
 
+func (d *naughtyDisk) LastError() (err error) {
+	return nil
+}
+
 func (d *naughtyDisk) Close() (err error) {
 	if err = d.calcError(); err != nil {
 		return err

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -274,6 +274,10 @@ func (s *posix) String() string {
 	return s.diskPath
 }
 
+func (s *posix) LastError() error {
+	return nil
+}
+
 func (s *posix) Close() error {
 	close(s.stopUsageCh)
 	s.connected = false

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -120,12 +120,24 @@ var errXLV3ThisEmpty = fmt.Errorf("XL format version 3 has This field empty")
 // connect to list of endpoints and load all XL disk formats, validate the formats are correct
 // and are in quorum, if no formats are found attempt to initialize all of them for the first
 // time. additionally make sure to close all the disks used in this attempt.
-func connectLoadInitFormats(firstDisk bool, endpoints EndpointList, setCount, drivesPerSet int) (*formatXLV3, error) {
+func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints EndpointList, setCount, drivesPerSet int) (*formatXLV3, error) {
+	// Initialize all storage disks
 	storageDisks, err := initStorageDisks(endpoints)
 	if err != nil {
 		return nil, err
 	}
 	defer closeStorageDisks(storageDisks)
+
+	// Connect to all storage disks, a connection failure will be
+	// only logged after some retries.
+	for _, disk := range storageDisks {
+		if disk != nil {
+			connectErr := disk.LastError()
+			if connectErr != nil && retryCount >= 5 {
+				logger.Info("Unable to connect to %s: %v\n", disk.String(), connectErr.Error())
+			}
+		}
+	}
 
 	// Attempt to load all `format.json` from all disks.
 	formatConfigs, sErrs := loadFormatXLAll(storageDisks)
@@ -238,8 +250,8 @@ func waitForFormatXL(ctx context.Context, firstDisk bool, endpoints EndpointList
 	retryTimerCh := newRetryTimerSimple(doneCh)
 	for {
 		select {
-		case _ = <-retryTimerCh:
-			format, err := connectLoadInitFormats(firstDisk, endpoints, setCount, disksPerSet)
+		case retryCount := <-retryTimerCh:
+			format, err := connectLoadInitFormats(retryCount, firstDisk, endpoints, setCount, disksPerSet)
 			if err != nil {
 				switch err {
 				case errNotFirstDisk:

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -27,7 +27,9 @@ type StorageAPI interface {
 
 	// Storage operations.
 	IsOnline() bool // Returns true if disk is online.
+	LastError() error
 	Close() error
+
 	DiskInfo() (info DiskInfo, err error)
 
 	// Volume operations.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit will print connection failures to other disks in other nodes
after 5 retries. It is useful for users to understand why the
distribued cluster fails to boot up.

## Motivation and Context
Printing errors during distributed mode initialization, such as certificate not trusted

Fixes #6202 

## Regression
No

## How Has This Been Tested?

Generate 4 pairs of private & public keys with domain name minio{1..4} and put them under  /tmp/minio-config-{1..4}

Run the following docker-compose file (docker-compose up)

```
version: '3'

services:
 minio1:
  image: vadmeste/minio
  volumes:
   - minio1:/export
   - /tmp/minio-config-1:/root/.minio/
  ports:
   - "9001:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server https://minio{1...4}/export
 minio2:
  image: vadmeste/minio
  volumes:
   - minio2:/export
   - /tmp/minio-config-2:/root/.minio/
  ports:
   - "9002:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server https://minio{1...4}/export
 minio3:
  image: vadmeste/minio
  volumes:
   - minio3:/export
   - /tmp/minio-config-3:/root/.minio/
  ports:
   - "9003:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server https://minio{1...4}/export
 minio4:
  image: vadmeste/minio
  volumes:
   - minio4:/export
   - /tmp/minio-config-4:/root/.minio/
  ports:
   - "9004:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server https://minio{1...4}/export

volumes:
  minio1:
  minio2:
  minio3:
  minio4:
```





## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.