### PR TITLE
Adds missing info to docs for credentials and domain env. vars.

### DIFF
--- a/docs/distributed/README.md
+++ b/docs/distributed/README.md
@@ -42,8 +42,9 @@ To start a distributed Minio instance, you just need to pass drive locations as 
 
 *Note*
 
-- All the nodes running distributed Minio need to have same access key and secret key for the nodes to connect. To achieve this, you need to export access key and secret key as environment variables on all the nodes before executing Minio server command.
+- All the nodes running distributed Minio need to have same access key and secret key for the nodes to connect. To achieve this, it is **mandatory** to export access key and secret key as environment variables, `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`, on all the nodes before executing Minio server command.
 - All the nodes running distributed Minio need to be on homogenous environments i.e same operating system, same number of disks and same interconnects.
+- `MINIO_DOMAIN` environment variable should be defined and exported if domain is needed to be set.
 - Minio distributed mode requires fresh directories. If required, the drives can be shared with other applications. You can do this by using a sub-directory exclusive to minio. For example, if you have mounted your volume under `/export`, pass `/export/data` as arguments to Minio server.
 - The IP addresses and drive paths below are for demonstration purposes only, you need to replace these with the actual IP addresses and drive paths/folders.
 - Servers running distributed Minio instances should be less than 3 seconds apart. You can use [NTP](http://www.ntp.org/) as a best practice to ensure consistent times across servers.

--- a/docs/multi-tenancy/README.md
+++ b/docs/multi-tenancy/README.md
@@ -49,7 +49,7 @@ minio --config-dir ~/tenant3 server --address :9003 http://192.168.10.11/data/te
 
 *Note*
 
-Please remember that defining and exporting credential environment variables, `MINIO_ACCESS_KEY` and  `MINIO_SECRET_KEY`, is **mandatory** on Distributed Deployments. It is also required to define and export domain environment variable, `MINIO_DOMAIN`, if domain information is needed to be set.
+Please remember that defining and exporting credential environment variables, `MINIO_ACCESS_KEY` and  `MINIO_SECRET_KEY`, is **mandatory** on distributed deployments. It is also required to define and export domain environment variable, `MINIO_DOMAIN`, if domain information is needed to be set.
 
 ## Cloud Scale Deployment
 

--- a/docs/multi-tenancy/README.md
+++ b/docs/multi-tenancy/README.md
@@ -47,7 +47,12 @@ minio --config-dir ~/tenant3 server --address :9003 http://192.168.10.11/data/te
 
 ![Example-3](https://github.com/minio/minio/blob/master/docs/screenshots/Example-3.jpg?raw=true)
 
+*Note*
+
+Please remember that defining and exporting credential environment variables, `MINIO_ACCESS_KEY` and  `MINIO_SECRET_KEY`, is **mandatory** on Distributed Deployments. It is also required to define and export domain environment variable, `MINIO_DOMAIN`, if domain information is needed to be set.
+
 ## Cloud Scale Deployment
+
 For large scale multi-tenant Minio deployments, we recommend using one of the popular container orchestration platforms, e.g. Kubernetes, DC/OS or Docker Swarm. Refer [this document](https://docs.minio.io/docs/minio-deployment-quickstart-guide) to get started with Minio on orchestration platforms.  
 
 


### PR DESCRIPTION
Fixes #6445
The fix adds missing information about **mandatory** definition of the credential environment variables for distributed minio servers. It also adds info about the necessity for the domain environment variable to be defined when domain info is needed to be set.

## Description
Adds info into distributed deployments.

## Motivation and Context
Not having information about the mandatory environment variables is confusing for the end-user.

## Regression
No

## How Has This Been Tested?
Manually made the changes and previewed them.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.