### PR TITLE
Fix healthcheck for NAS gateway

### DIFF
--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -57,8 +57,8 @@ func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s := objLayer.StorageInfo(ctx)
-	// Gateways don't provide disk info
-	if s.Backend.Type == Unknown {
+	// Gateways don't provide disk info, also handle special case for NAS gateway.
+	if s.Backend.Type == Unknown || s.Backend.Type == BackendFS {
 		// ListBuckets to confirm gateway backend is up
 		if _, err := objLayer.ListBuckets(ctx); err != nil {
 			writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
@@ -84,6 +84,7 @@ func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
 	// If all exported local disks have errored, we simply let kubernetes
 	// take us down.
 	if totalLocalDisks == erroredDisks {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix healthcheck for NAS gateway
<!--- Describe your changes in detail -->

## Motivation and Context
It was expected that in gateway mode, we do not know
the backend types whereas in NAS gateway since its
an extension of FS mode (standalone) this leads to
an issue in LivenessCheckHandler() which would perpetually
return 503, this would affect all kubernetes, openshift
deployments of NAS gateway.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Maybe do not know.
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
With minio master you can reproduce this issue simply by running the latest release 

```
$ minio gateway nas /tmp/data
$ curl -v http://localhost:9000/minio/health/live
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9000 (#0)
> GET /minio/health/live HTTP/1.1
> Host: localhost:9000
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 503 Service Unavailable
< Accept-Ranges: bytes
< Content-Security-Policy: block-all-mixed-content
< Server: Minio/DEVELOPMENT.2018-09-11T18-29-42Z (linux; amd64)
< Vary: Origin
< X-Amz-Request-Id: 15536BF5257C0583
< X-Xss-Protection: 1; mode=block
< Date: Tue, 11 Sep 2018 18:29:58 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
```

This has repercussions on our k8s deployments which actively use this endpoint to verify the liveness of any deployed service.

With this fix and building it locally you can see that now the curl output is correct and consistent
```
curl -v http://localhost:9000/minio/health/live
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9000 (#0)
> GET /minio/health/live HTTP/1.1
> Host: localhost:9000
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Security-Policy: block-all-mixed-content
< Server: Minio/DEVELOPMENT.2018-09-11T18-31-33Z (linux; amd64)
< Vary: Origin
< X-Amz-Request-Id: 15536C10D0BC6B45
< X-Xss-Protection: 1; mode=block
< Date: Tue, 11 Sep 2018 18:31:57 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.