### PR TITLE
for O_RDONLY mode hold shared locks on windows

### DIFF
--- a/pkg/lock/lock_windows.go
+++ b/pkg/lock/lock_windows.go
@@ -76,13 +76,25 @@ func lockedOpenFile(path string, flag int, perm os.FileMode, lockType uint32) (*
 // doesn't wait forever but instead returns if it cannot
 // acquire a write lock.
 func TryLockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
-	return lockedOpenFile(path, flag, perm, lockFileFailImmediately)
+	var lockType uint32 = lockFileFailImmediately | lockFileExclusiveLock
+	switch flag {
+	case syscall.O_RDONLY:
+		// https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-lockfileex
+		lockType = lockFileFailImmediately | 0 // Set this to enable shared lock and fail immediately.
+	}
+	return lockedOpenFile(path, flag, perm, lockType)
 }
 
 // LockedOpenFile - initializes a new lock and protects
 // the file from concurrent access.
 func LockedOpenFile(path string, flag int, perm os.FileMode) (*LockedFile, error) {
-	return lockedOpenFile(path, flag, perm, 0)
+	var lockType uint32 = lockFileExclusiveLock
+	switch flag {
+	case syscall.O_RDONLY:
+		// https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-lockfileex
+		lockType = 0 // Set this to enable shared lock.
+	}
+	return lockedOpenFile(path, flag, perm, lockType)
 }
 
 // fixLongPath returns the extended-length (\\?\-prefixed) form of
@@ -165,7 +177,7 @@ func fixLongPath(path string) string {
 	return string(pathbuf[:w])
 }
 
-// perm param is ignored, on windows file perms/NT acls
+// Open - perm param is ignored, on windows file perms/NT acls
 // are not octet combinations. Providing access to NT
 // acls is out of scope here.
 func Open(path string, flag int, perm os.FileMode) (*os.File, error) {
@@ -217,14 +229,11 @@ func Open(path string, flag int, perm os.FileMode) (*os.File, error) {
 
 func lockFile(fd syscall.Handle, flags uint32) error {
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
-	var flag uint32 = lockFileExclusiveLock // Lockfile exlusive.
-	flag |= flags
-
 	if fd == syscall.InvalidHandle {
 		return nil
 	}
 
-	err := lockFileEx(fd, flag, 1, 0, &syscall.Overlapped{})
+	err := lockFileEx(fd, flags, 1, 0, &syscall.Overlapped{})
 	if err == nil {
 		return nil
 	} else if err.Error() == "The process cannot access the file because another process has locked a portion of the file." {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
for O_RDONLY mode hold shared locks on windows
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #6401

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes, perhaps no idea when. 
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
This PR can only be validated on a windows box since the changes are windows specific. Please reach out directly on how to test and validate this PR can provide a system to test.

The test is successful when we are able to start multiple minio servers on a different port on the same path as `minio gateway nas ...` 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.