### PR TITLE
Bump RPC version after ReadFile RPC arguments change

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -206,8 +206,9 @@ var (
 	// RPC V1 - Initial version
 	// RPC V2 - format.json XL version changed to 2
 	// RPC V3 - format.json XL version changed to 3
+	// RPC V4 - ReadFile() arguments signature changed
 	// Current RPC version
-	globalRPCAPIVersion = RPCVersion{3, 0, 0}
+	globalRPCAPIVersion = RPCVersion{4, 0, 0}
 
 	// Allocated etcd endpoint for config and bucket DNS.
 	globalEtcdClient *etcd.Client


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ReadFile RPC input argument has been changed in commit a8f5939452959d27674560c6b803daa9,
however, RPC doesn't detect such a change when it calls other nodes with older versions.

Hence, bumping RPC version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/minio/minio/issues/6458

## Regression
Yes, a8f5939452959d27674560c6b803daa9

## How Has This Been Tested?
*) Initializing a fresh cluster using older version, like RELEASE.2018-07-31T02-11-47Z
*) Kill one node
*) Run the node again with newer version


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.