### PR TITLE
Add Profiler Admin API

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -60,6 +60,10 @@ func registerAdminRouter(router *mux.Router) {
 	adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
 	adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}/{prefix:.*}").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
 
+	// Profiling operations
+	adminV1Router.Methods(http.MethodPost).Path("/profiling/start/{profiler}").HandlerFunc(httpTraceAll(adminAPI.StartProfilingHandler))
+	adminV1Router.Methods(http.MethodGet).Path("/profiling/download").HandlerFunc(httpTraceAll(adminAPI.DownloadProfilingHandler))
+
 	/// Config operations
 
 	// Update credentials

--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -68,6 +68,22 @@ func (rpcClient *AdminRPCClient) GetConfig() ([]byte, error) {
 	return reply, err
 }
 
+// StartProfiling - starts profiling in the remote server.
+func (rpcClient *AdminRPCClient) StartProfiling(profiler string) error {
+	args := StartProfilingArgs{Profiler: profiler}
+	reply := VoidReply{}
+	return rpcClient.Call(adminServiceName+".StartProfiling", &args, &reply)
+}
+
+// DownloadProfilingData - returns profiling data of the remote server.
+func (rpcClient *AdminRPCClient) DownloadProfilingData() ([]byte, error) {
+	args := AuthArgs{}
+	var reply []byte
+
+	err := rpcClient.Call(adminServiceName+".DownloadProfilingData", &args, &reply)
+	return reply, err
+}
+
 // NewAdminRPCClient - returns new admin RPC client.
 func NewAdminRPCClient(host *xnet.Host) (*AdminRPCClient, error) {
 	scheme := "http"
@@ -112,6 +128,8 @@ type adminCmdRunner interface {
 	ReInitFormat(dryRun bool) error
 	ServerInfo() (ServerInfoData, error)
 	GetConfig() ([]byte, error)
+	StartProfiling(string) error
+	DownloadProfilingData() ([]byte, error)
 }
 
 // adminPeer - represents an entity that implements admin API RPCs.

--- a/cmd/admin-rpc-server.go
+++ b/cmd/admin-rpc-server.go
@@ -52,6 +52,23 @@ func (receiver *adminRPCReceiver) ServerInfo(args *AuthArgs, reply *ServerInfoDa
 	return err
 }
 
+// StartProfilingArgs - holds the RPC argument for StartingProfiling RPC call
+type StartProfilingArgs struct {
+	AuthArgs
+	Profiler string
+}
+
+// StartProfiling - starts profiling of this server
+func (receiver *adminRPCReceiver) StartProfiling(args *StartProfilingArgs, reply *VoidReply) error {
+	return receiver.local.StartProfiling(args.Profiler)
+}
+
+// DownloadProfilingData - stops and returns profiling data of this server
+func (receiver *adminRPCReceiver) DownloadProfilingData(args *AuthArgs, reply *[]byte) (err error) {
+	*reply, err = receiver.local.DownloadProfilingData()
+	return
+}
+
 // GetConfig - returns the config.json of this server.
 func (receiver *adminRPCReceiver) GetConfig(args *AuthArgs, reply *[]byte) (err error) {
 	*reply, err = receiver.local.GetConfig()

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1727,7 +1727,10 @@ func toAPIErrorCode(err error) (apiErr APIErrorCode) {
 
 // getAPIError provides API Error for input API error code.
 func getAPIError(code APIErrorCode) APIError {
-	return errorCodeResponse[code]
+	if apiErr, ok := errorCodeResponse[code]; ok {
+		return apiErr
+	}
+	return errorCodeResponse[ErrInternalError]
 }
 
 // getErrorResponse gets in standard error and resource value and

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -98,7 +98,9 @@ func handleCommonCmdArgs(ctx *cli.Context) {
 func handleCommonEnvVars() {
 	// Start profiler if env is set.
 	if profiler := os.Getenv("_MINIO_PROFILER"); profiler != "" {
-		globalProfiler = startProfiler(profiler)
+		var err error
+		globalProfiler, err = startProfiler(profiler, "")
+		logger.FatalIf(err, "Unable to setup a profiler")
 	}
 
 	accessKey := os.Getenv("MINIO_ACCESS_KEY")

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -228,8 +228,9 @@ func TestURL2BucketObjectName(t *testing.T) {
 
 // Add tests for starting and stopping different profilers.
 func TestStartProfiler(t *testing.T) {
-	if startProfiler("") != nil {
-		t.Fatal("Expected nil, but non-nil value returned for invalid profiler.")
+	_, err := startProfiler("", "")
+	if err == nil {
+		t.Fatal("Expected a non nil error, but nil error returned for invalid profiler.")
 	}
 }
 

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -39,8 +39,8 @@ func main() {
 | Service operations         | Info operations  | Healing operations                    | Config operations         | Misc                                |
 |:----------------------------|:----------------------------|:--------------------------------------|:--------------------------|:------------------------------------|
 | [`ServiceStatus`](#ServiceStatus) | [`ServerInfo`](#ServerInfo) | [`Heal`](#Heal) | [`GetConfig`](#GetConfig) | [`SetCredentials`](#SetCredentials) |
-| [`ServiceSendAction`](#ServiceSendAction) | | | [`SetConfig`](#SetConfig) | |
-| | |            | [`GetConfigKeys`](#GetConfigKeys) |                                     |
+| [`ServiceSendAction`](#ServiceSendAction) | | | [`SetConfig`](#SetConfig) | [`StartProfiling`](#StartProfiling) |
+| | |            | [`GetConfigKeys`](#GetConfigKeys) | [`DownloadProfilingData`](#DownloadProfilingData) |
 | | |            | [`SetConfigKeys`](#SetConfigKeys) |                                     |
 
 
@@ -384,4 +384,57 @@ __Example__
     }
     log.Println("New credentials successfully set.")
 
+```
+
+<a name="StartProfiling"></a>
+### StartProfiling(profiler string) error
+Ask all nodes to start profiling using the specified profiler mode
+
+__Example__
+
+``` go
+    startProfilingResults, err = madmClnt.StartProfiling("cpu")
+    if err != nil {
+            log.Fatalln(err)
+    }
+    for _, result := range startProfilingResults {
+        if !result.Success {
+            log.Printf("Unable to start profiling on node `%s`, reason = `%s`\n", result.NodeName, result.Error)
+        } else {
+            log.Printf("Profiling successfully started on node `%s`\n", result.NodeName)
+        }
+    }
+
+```
+
+<a name="DownloadProfilingData"></a>
+### DownloadProfilingData() ([]byte, error)
+Download profiling data of all nodes in a zip format.
+
+__Example__
+
+``` go
+    profilingData, err := madmClnt.DownloadProfilingData()
+    if err != nil {
+            log.Fatalln(err)
+    }
+
+    profilingFile, err := os.Create("/tmp/profiling-data.zip")
+    if err != nil {
+            log.Fatal(err)
+    }
+
+    if _, err := io.Copy(profilingFile, profilingData); err != nil {
+            log.Fatal(err)
+    }
+
+    if err := profilingFile.Close(); err != nil {
+            log.Fatal(err)
+    }
+
+    if err := profilingData.Close(); err != nil {
+            log.Fatal(err)
+    }
+
+    log.Println("Profiling data successfully downloaded.")
 ```

--- a/pkg/madmin/examples/profiling.go
+++ b/pkg/madmin/examples/profiling.go
@@ -1,0 +1,89 @@
+// +build ignore
+
+/*
+ * Minio Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY are
+	// dummy values, please replace them with original values.
+
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTPS) otherwise.
+	// New returns an Minio Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	profiler := madmin.ProfilerCPU
+	log.Println("Starting " + profiler + " profiling..")
+
+	startResults, err := madmClnt.StartProfiling(profiler)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	for _, result := range startResults {
+		if !result.Success {
+			log.Printf("Unable to start profiling on node `%s`, reason = `%s`\n", result.NodeName, result.Error)
+			continue
+		}
+		log.Printf("Profiling successfully started on node `%s`\n", result.NodeName)
+	}
+
+	sleep := time.Duration(10)
+	time.Sleep(time.Second * sleep)
+
+	log.Println("Stopping profiling..")
+
+	profilingData, err := madmClnt.DownloadProfilingData()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	profilingFile, err := os.Create("/tmp/profiling-" + string(profiler) + ".zip")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := io.Copy(profilingFile, profilingData); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := profilingFile.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := profilingData.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Profiling files " + profilingFile.Name() + " successfully downloaded.")
+}

--- a/pkg/madmin/profiling-commands.go
+++ b/pkg/madmin/profiling-commands.go
@@ -1,0 +1,104 @@
+/*
+ * Minio Cloud Storage, (C) 2017, 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package madmin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// ProfilerType represents the profiler type
+// passed to the profiler subsystem, currently
+// it can be only "cpu", "mem" or "block"
+type ProfilerType string
+
+const (
+	// ProfilerCPU represents CPU profiler type
+	ProfilerCPU = ProfilerType("cpu")
+	// ProfilerMEM represents MEM profiler type
+	ProfilerMEM = ProfilerType("mem")
+	// ProfilerBlock represents Block profiler type
+	ProfilerBlock = ProfilerType("block")
+)
+
+// StartProfilingResult holds the result of starting
+// profiler result in a given node.
+type StartProfilingResult struct {
+	NodeName string `json:"nodeName"`
+	Success  bool   `json:"success"`
+	Error    string `json:"error"`
+}
+
+// StartProfiling makes an admin call to remotely start profiling on a standalone
+// server or the whole cluster in  case of a distributed setup.
+func (adm *AdminClient) StartProfiling(profiler ProfilerType) ([]StartProfilingResult, error) {
+	path := fmt.Sprintf("/v1/profiling/start/%s", profiler)
+	resp, err := adm.executeMethod("POST", requestData{
+		relPath: path,
+	})
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	jsonResult, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var startResults []StartProfilingResult
+	err = json.Unmarshal(jsonResult, &startResults)
+	if err != nil {
+		return nil, err
+	}
+
+	return startResults, nil
+}
+
+// DownloadProfilingData makes an admin call to download profiling data of a standalone
+// server or of the whole cluster in  case of a distributed setup.
+func (adm *AdminClient) DownloadProfilingData() (io.ReadCloser, error) {
+	path := fmt.Sprintf("/v1/profiling/download")
+	resp, err := adm.executeMethod("GET", requestData{
+		relPath: path,
+	})
+
+	if err != nil {
+		closeResponse(resp)
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		closeResponse(resp)
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	if resp.Body == nil {
+		return nil, errors.New("body is nil")
+	}
+
+	return resp.Body, nil
+}

--- a/vendor/github.com/pkg/profile/README.md
+++ b/vendor/github.com/pkg/profile/README.md
@@ -3,6 +3,9 @@ profile
 
 Simple profiling support package for Go
 
+[![Build Status](https://travis-ci.org/pkg/profile.svg?branch=master)](https://travis-ci.org/pkg/profile) [![GoDoc](http://godoc.org/github.com/pkg/profile?status.svg)](http://godoc.org/github.com/pkg/profile)
+
+
 installation
 ------------
 
@@ -42,3 +45,10 @@ func main() {
 Several convenience package level values are provided for cpu, memory, and block (contention) profiling.
 
 For more complex options, consult the [documentation](http://godoc.org/github.com/pkg/profile).
+
+contributing
+------------
+
+We welcome pull requests, bug fixes and issue reports.
+
+Before proposing a change, please discuss it first by raising an issue.

--- a/vendor/github.com/pkg/profile/mutex.go
+++ b/vendor/github.com/pkg/profile/mutex.go
@@ -1,0 +1,13 @@
+// +build go1.8
+
+package profile
+
+import "runtime"
+
+func enableMutexProfile() {
+	runtime.SetMutexProfileFraction(1)
+}
+
+func disableMutexProfile() {
+	runtime.SetMutexProfileFraction(0)
+}

--- a/vendor/github.com/pkg/profile/mutex17.go
+++ b/vendor/github.com/pkg/profile/mutex17.go
@@ -1,0 +1,9 @@
+// +build !go1.8
+
+package profile
+
+// mock mutex support for Go 1.7 and earlier.
+
+func enableMutexProfile() {}
+
+func disableMutexProfile() {}

--- a/vendor/github.com/pkg/profile/trace.go
+++ b/vendor/github.com/pkg/profile/trace.go
@@ -1,0 +1,8 @@
+// +build go1.7
+
+package profile
+
+import "runtime/trace"
+
+var startTrace = trace.Start
+var stopTrace = trace.Stop

--- a/vendor/github.com/pkg/profile/trace16.go
+++ b/vendor/github.com/pkg/profile/trace16.go
@@ -1,0 +1,10 @@
+// +build !go1.7
+
+package profile
+
+import "io"
+
+// mock trace support for Go 1.6 and earlier.
+
+func startTrace(w io.Writer) error { return nil }
+func stopTrace()                   {}

--- a/vendor/github.com/pkg/profile/wercker.yml
+++ b/vendor/github.com/pkg/profile/wercker.yml
@@ -1,1 +1,0 @@
-box: wercker/golang

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -765,9 +765,10 @@
 			"revisionTime": "2017-12-16T07:03:16Z"
 		},
 		{
+			"checksumSHA1": "C3yiSMdTQxSY3xqKJzMV9T+KnIc=",
 			"path": "github.com/pkg/profile",
-			"revision": "c78aac22bd43883fd2817833b982153dcac17b3b",
-			"revisionTime": "2016-05-18T16:56:57+10:00"
+			"revision": "057bc52a47ec3c79498dda63f4a6f8298725e976",
+			"revisionTime": "2018-08-09T11:22:05Z"
 		},
 		{
 			"checksumSHA1": "3NL4uu8RZhI2d+/SEmVOHPT390c=",


### PR DESCRIPTION
## Description
Two handlers are added to admin API to enable profiling and disable
profiling of a server in a standalone mode, or all nodes in the
distributed mode.

/minio/admin/profiling/start/{cpu,block,mem}:
  - Start profiling and return starting JSON results, e.g. one
    node is offline.

/minio/admin/profiling/download:
  - Stop the on-going profiling task
  - Stream a zip file which contains all profiling files that can
    be later inspected by go tool pprof

## Motivation and Context
Fixes https://github.com/minio/minio/issues/6462

## Regression
No

## How Has This Been Tested?
1. Checkout this PR
2. Go to $GOPATH/src/github.com/minio/minio/pkg/madmin/examples/
3. Edit Minio credentials in profiling.go
4. `go run profiling.go`
5. `unzip /tmp/profiling-cpu.zip`
6.  Generate pdf to the profiling data of the first server
`go tool pprof -pdf $(which minio) profiling-0 >/tmp/profiling.pdf`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.