### PR TITLE
Use retry mechanism when initializing configuration

### DIFF
--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -395,3 +395,9 @@ func isInsufficientReadQuorum(err error) bool {
 	_, ok := err.(InsufficientReadQuorum)
 	return ok
 }
+
+// isInsufficientWriteQuorum - Check if error type is InsufficientWriteQuorum.
+func isInsufficientWriteQuorum(err error) bool {
+	_, ok := err.(InsufficientWriteQuorum)
+	return ok
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, one node in a cluster can fail to boot with the following error message:

```
ERROR Unable to initialize config system: Storage resources are insufficient for the write operation
```

This happens when disks are formatted, read quorum is met but write
quorum is not met. In checkServerConfig(), a insufficient read quorum
error is replaced by errConfigNotFound, the code will generate a
new config json and try to save it, but it will fail because write
quorum is not met.

Replacing read quorum with errConfigNotFound is also wrong because it
can lead, in rare cases, to overwrite the config set by the user.

So, this commit adds a retry mechanism in configuration initialization
to retry only with read or write quorum errors.

It will also fix the following cases:
 - Read quorum is lost just after the initialization of the object layer.
 - Write quorum not met when upgrading configuration version.

## Motivation and Context
Fix nodes starting issue.

Fixes #6474

## Regression
Yes https://github.com/minio/minio/commit/029f52880b5dc5086e2e39a7e0c2d19f511c1571



## How Has This Been Tested?
Hard to reproduce it locally but was able to reproduce in one k8s that I have access to

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.