### PR TITLE
Allow S3 gateway credentials to be passed via AWS environment

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"io"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -180,8 +181,23 @@ func newS3(url, accessKey, secretKey string) (*miniogo.Core, error) {
 
 // NewGatewayLayer returns s3 ObjectLayer.
 func (g *S3) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) {
+	accessKey, ok := os.LookupEnv("AWS_ACCESS_KEY_ID")
+	if !ok {
+		accessKey, ok = os.LookupEnv("AWS_ACCESS_KEY")
+		if !ok {
+			accessKey = creds.AccessKey
+		}
+	}
+	secretKey, ok := os.LookupEnv("AWS_SECRET_ACCESS_KEY")
+	if !ok {
+		secretKey, ok = os.LookupEnv("AWS_SECRET_KEY")
+		if !ok {
+			secretKey = creds.SecretKey
+		}
+	}
+
 	// Probe S3 signature with input credentials.
-	clnt, err := newS3(g.host, creds.AccessKey, creds.SecretKey)
+	clnt, err := newS3(g.host, accessKey, secretKey)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/gateway/s3.md
+++ b/docs/gateway/s3.md
@@ -61,6 +61,31 @@ Minio Gateway comes with an embedded web based object browser. Point your web br
 
 With Minio S3 gateway, you can use Minio browser to explore AWS S3 based objects.
 
+## Different Credentials for AWS S3 and Gateway
+
+Minio Gateway allows to use different credentials for its provided service than to access the backend AWS S3 service.
+
+### Using Docker
+
+```
+docker run -p 9000:9000 --name minio-s3 \
+ -e "AWS_ACCESS_KEY_ID=aws_s3_access_key" \
+ -e "AWS_SECRET_ACCESS_KEY=aws_s3_secret_key" \
+ -e "MINIO_ACCESS_KEY=minio_access_key" \
+ -e "MINIO_SECRET_KEY=minio_secret_key" \
+ minio/minio gateway s3
+```
+
+### Using Binary
+
+```
+export AWS_ACCESS_KEY_ID=aws_s3_access_key
+export AWS_SECRET_ACCESS_KEY=aws_s3_secret_key
+export MINIO_ACCESS_KEY=minio_access_key
+export MINIO_SECRET_KEY=minio_secret_key
+minio gateway s3
+```
+
 ### Known limitations
 
 - Bucket notification APIs are not supported.


### PR DESCRIPTION
This allows the gateway to read the credentials for the backend S3 server
from the AWS environment variables so that one can have different
credentials for the backend and the gateway service.

## Description
Support reading the credentials for the backend S3 server from the environment variables documented in https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html.

## Motivation and Context
Be able to maintain different credentials for different gateway instances.

## How Has This Been Tested?
```
$ export MINIO_ACCESS_KEY=minio
$ export MINIO_SECRET_KEY=secret1234
$ export AWS_ACCESS_KEY_ID=user1
$ export AWS_SECRET_ACCESS_KEY=secret5678
$ ./minio gateway s3 http://minio:9000
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.