### PR TITLE
[RFC] Send all notifications to targetList when gateway

### DIFF
--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -224,7 +224,16 @@ func FromMinioClientListBucketResultToV2Info(bucket string, result minio.ListBuc
 	}
 }
 
-// ToMinioClientMetadata converts metadata to map[string][]string
+// ToMinioClientObjectInfoMetadata convertes metadata to map[string][]string
+func ToMinioClientObjectInfoMetadata(metadata map[string]string) map[string][]string {
+	mm := make(map[string][]string, len(metadata))
+	for k, v := range metadata {
+		mm[http.CanonicalHeaderKey(k)] = []string{v}
+	}
+	return mm
+}
+
+// ToMinioClientMetadata converts metadata to map[string]string
 func ToMinioClientMetadata(metadata map[string]string) map[string]string {
 	mm := make(map[string]string)
 	for k, v := range metadata {

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -71,6 +71,9 @@ ENVIRONMENT VARIABLES:
      MINIO_CACHE_EXPIRY: Cache expiry duration in days.
      MINIO_CACHE_MAXUSE: Maximum permitted usage of the cache in percentage (0-100).
 
+  NOTIFY:
+     MINIO_GATEWAY_NOTIFY: JSON config for adding notification targets to gateway
+
 EXAMPLES:
   1. Start minio gateway server for AWS S3 backend.
      $ export MINIO_ACCESS_KEY=accesskey
@@ -82,7 +85,14 @@ EXAMPLES:
      $ export MINIO_SECRET_KEY=zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
      $ {{.HelpName}} https://play.minio.io:9000
 
-  3. Start minio gateway server for AWS S3 backend with edge caching enabled.
+  3. Start minio gateway server for S3 backend on custom endpoint with notification
+     targets
+     $ export MINIO_ACCESS_KEY=Q3AM3UQ867SPQQA43P2F
+     $ export MINIO_SECRET_KEY=zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
+     $ export MINIO_GATEWAY_NOTIFY='{"notify":{"webhook":{"1":{"enable": true,"endpoint":"http://localhost:8000/"}}}}'
+     $ {{.HelpName}} https://play.minio.io:9000
+
+  4. Start minio gateway server for AWS S3 backend with edge caching enabled.
      $ export MINIO_ACCESS_KEY=accesskey
      $ export MINIO_SECRET_KEY=secretkey
      $ export MINIO_CACHE_DRIVES="/mnt/drive1;/mnt/drive2;/mnt/drive3;/mnt/drive4"
@@ -401,6 +411,9 @@ func (l *s3Objects) PutObject(ctx context.Context, bucket string, object string,
 	if err != nil {
 		return objInfo, minio.ErrorRespToObjectError(err, bucket, object)
 	}
+	// On success, populate the key & metadata so they are present in the notification
+	oi.Key = object
+	oi.Metadata = minio.ToMinioClientObjectInfoMetadata(metadata)
 
 	return minio.FromMinioClientObjectInfo(bucket, oi), nil
 }

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -370,7 +370,7 @@ func serverMain(ctx *cli.Context) {
 	globalNotificationSys = NewNotificationSys(globalServerConfig, globalEndpoints)
 
 	// Initialize notification system.
-	if err := globalNotificationSys.Init(newObject); err != nil {
+	if err := globalNotificationSys.Init(newObject, false); err != nil {
 		logger.Fatal(err, "Unable to initialize notification system")
 	}
 


### PR DESCRIPTION
When running as a gateway, send all bucket notifications to every
configured notification target. This enables administrative monitoring
of use of the gateway.

Control for whether notifications are sent or not is based on the
setting of the MINIO_GATEWAY_NOTIFY environment variable. This setting
is a mirror of the notify section of the old config.json file that is no
longer used when in gateway mode. All notification targets configured
will receive all object notifications. There is currently no event filter
mechanism for the gateway generated notifications.

## Description

To generate bucket notifications, the server configiguration
structure is populated with notification targets from the
MINIO_GATEWAY_NOTIFY environment variable. With this
configuration, the notification sub-system is flagged as being
in "gateway mode" so the configured targets are sent a
notification message in Send().

## Motivation and Context

While the server has the ability to configure bucket notification
events, there is no such facility for the gateway. This PR adds
the ability to enable (all or nothing) bucket notifications when
running as a gateway.  Such events can be used for collecting
administrative logs about the use of the gateway.

## How Has This Been Tested?

Use of webhook notifications has been manually tested with the
following steps.

Setup minio gateway:
```
$ export MINIO_ACCESS_KEY=Q3AM3UQ867SPQQA43P2F
$ export MINIO_SECRET_KEY=zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
$ export MINIO_GATEWAY_NOTIFY='{"notify":{"webhook":{"1":{"enable": true,"endpoint":"http://localhost:8000/"}}}}'
$ minio gateway s3 https://play.minio.io:9000
```

Using mc copy an object using the above gateway:
```
$ mc mb gwplay/ntfy
Bucket created successfully `gwplay/ntfy`.
$ mc cp LICENSE gwplay/ntfy/LICENSE
LICENSE:      11.09 KB / 11.09 KB  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00% 202.62 KB/s 0s
```

And with netcat listening, we can see the resulting notification:
```
$ nc -l 8000
POST / HTTP/1.1
Host: localhost:8000
User-Agent: Go-http-client/1.1
Content-Length: 856
Content-Type: application/json
Accept-Encoding: gzip

{"EventName":"s3:ObjectCreated:Put","Key":"ntfy/LICENSE","Records":[{"eventVersion":"2.0","eventSource":"minio:s3","awsRegion":"","eventTime":"2018-09-17T22:11:48Z","eventName":"s3:ObjectCreated:Put","userIdentity":{"principalId":"Q3AM3UQ867SPQQA43P2F"},"requestParameters":{"sourceIPAddress":"172.21.97.158"},"responseElements":{"x-amz-request-id":"15554F8B7B513F18","x-minio-origin-endpoint":"http://10.1.68.10:9000"},"s3":{"s3SchemaVersion":"1.0","configurationId":"Config","bucket":{"name":"ntfy","ownerIdentity":{"principalId":"Q3AM3UQ867SPQQA43P2F"},"arn":"arn:aws:s3:::ntfy"},"object":{"key":"LICENSE","size":11358,"eTag":"3b83ef96387f14655fc854ddc3c6bd57","userMetadata":{"Content-Type":""},"versionId":"1","sequencer":"15554F8B7B513F18"}},"source":{"host":"","port":"","userAgent":"Minio (darwin; amd64) minio-go/5.0.1 mc/2018-03-25T01:22:22Z"}}]}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [X] All new and existing gateway tests passed.
