### PR TITLE
Peer/rpc should never honor RPC calls without object-layer

### DIFF
--- a/cmd/peer-rpc-server.go
+++ b/cmd/peer-rpc-server.go
@@ -45,6 +45,11 @@ type DeleteBucketArgs struct {
 
 // DeleteBucket - handles delete bucket RPC call which removes all values of given bucket in global NotificationSys object.
 func (receiver *peerRPCReceiver) DeleteBucket(args *DeleteBucketArgs, reply *VoidReply) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	globalNotificationSys.RemoveNotification(args.BucketName)
 	globalPolicySys.Remove(args.BucketName)
 	return nil
@@ -59,6 +64,11 @@ type SetBucketPolicyArgs struct {
 
 // SetBucketPolicy - handles set bucket policy RPC call which adds bucket policy to globalPolicySys.
 func (receiver *peerRPCReceiver) SetBucketPolicy(args *SetBucketPolicyArgs, reply *VoidReply) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	globalPolicySys.Set(args.BucketName, args.Policy)
 	return nil
 }
@@ -71,6 +81,11 @@ type RemoveBucketPolicyArgs struct {
 
 // RemoveBucketPolicy - handles delete bucket policy RPC call which removes bucket policy to globalPolicySys.
 func (receiver *peerRPCReceiver) RemoveBucketPolicy(args *RemoveBucketPolicyArgs, reply *VoidReply) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	globalPolicySys.Remove(args.BucketName)
 	return nil
 }
@@ -84,6 +99,11 @@ type PutBucketNotificationArgs struct {
 
 // PutBucketNotification - handles put bucket notification RPC call which adds rules to given bucket to global NotificationSys object.
 func (receiver *peerRPCReceiver) PutBucketNotification(args *PutBucketNotificationArgs, reply *VoidReply) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	globalNotificationSys.AddRulesMap(args.BucketName, args.RulesMap)
 	return nil
 }
@@ -100,6 +120,11 @@ type ListenBucketNotificationArgs struct {
 
 // ListenBucketNotification - handles listen bucket notification RPC call. It creates PeerRPCClient target which pushes requested events to target in remote peer.
 func (receiver *peerRPCReceiver) ListenBucketNotification(args *ListenBucketNotificationArgs, reply *VoidReply) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	rpcClient := globalNotificationSys.GetPeerRPCClient(args.Addr)
 	if rpcClient == nil {
 		return fmt.Errorf("unable to find PeerRPCClient for provided address %v. This happens only if remote and this minio run with different set of endpoints", args.Addr)
@@ -126,6 +151,11 @@ type RemoteTargetExistArgs struct {
 
 // RemoteTargetExist - handles target ID exist RPC call which checks whether given target ID is a HTTP client target or not.
 func (receiver *peerRPCReceiver) RemoteTargetExist(args *RemoteTargetExistArgs, reply *bool) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	*reply = globalNotificationSys.RemoteTargetExist(args.BucketName, args.TargetID)
 	return nil
 }
@@ -140,6 +170,11 @@ type SendEventArgs struct {
 
 // SendEvent - handles send event RPC call which sends given event to target by given target ID.
 func (receiver *peerRPCReceiver) SendEvent(args *SendEventArgs, reply *bool) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	// Set default to true to keep the target.
 	*reply = true
 	errs := globalNotificationSys.send(args.BucketName, args.Event, args.TargetID)
@@ -159,6 +194,11 @@ func (receiver *peerRPCReceiver) SendEvent(args *SendEventArgs, reply *bool) err
 
 // LoadCredentials - handles load credentials RPC call.
 func (receiver *peerRPCReceiver) LoadCredentials(args *AuthArgs, reply *VoidReply) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
 	// Construct path to config.json for the given bucket.
 	configFile := path.Join(bucketConfigPrefix, minioConfigFile)
 	transactionConfigFile := configFile + ".transaction"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Peer/rpc should never honor RPC calls without object-layer
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #6484

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Not sure
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
- Couldn't reproduce it
- Theoretical fix with an actual possibility fixed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.