### PR TITLE
Close the writer cleanup in GetObjectNInfo

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -634,9 +634,13 @@ func (a *azureObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 		err := a.GetObject(ctx, bucket, object, startOffset, length, pw, objInfo.ETag, minio.ObjectOptions{})
 		pw.CloseWithError(err)
 	}()
-	// Setup cleanup function to cause the above go-routine to
-	// exit in case of partial read
-	pipeCloser := func() { pr.Close() }
+
+	// Cleanup function to cause the go routine above to exit, in case of incomplete read.
+	pipeCloser := func() {
+		pw.Close()
+		pr.Close()
+	}
+
 	return minio.NewGetObjectReaderFromReader(pr, objInfo, pipeCloser), nil
 }
 

--- a/cmd/gateway/b2/gateway-b2.go
+++ b/cmd/gateway/b2/gateway-b2.go
@@ -414,9 +414,13 @@ func (l *b2Objects) GetObjectNInfo(ctx context.Context, bucket, object string, r
 		err := l.GetObject(ctx, bucket, object, startOffset, length, pw, objInfo.ETag, minio.ObjectOptions{})
 		pw.CloseWithError(err)
 	}()
-	// Setup cleanup function to cause the above go-routine to
-	// exit in case of partial read
-	pipeCloser := func() { pr.Close() }
+
+	// Cleanup function to cause the go routine above to exit, in case of incomplete read.
+	pipeCloser := func() {
+		pw.Close()
+		pr.Close()
+	}
+
 	return minio.NewGetObjectReaderFromReader(pr, objInfo, pipeCloser), nil
 }
 

--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -755,9 +755,13 @@ func (l *gcsGateway) GetObjectNInfo(ctx context.Context, bucket, object string, 
 		err := l.GetObject(ctx, bucket, object, startOffset, length, pw, objInfo.ETag, minio.ObjectOptions{})
 		pw.CloseWithError(err)
 	}()
-	// Setup cleanup function to cause the above go-routine to
-	// exit in case of partial read
-	pipeCloser := func() { pr.Close() }
+
+	// Cleanup function to cause the go routine above to exit, in case of incomplete read.
+	pipeCloser := func() {
+		pw.Close()
+		pr.Close()
+	}
+
 	return minio.NewGetObjectReaderFromReader(pr, objInfo, pipeCloser), nil
 }
 

--- a/cmd/gateway/manta/gateway-manta.go
+++ b/cmd/gateway/manta/gateway-manta.go
@@ -525,9 +525,13 @@ func (t *tritonObjects) GetObjectNInfo(ctx context.Context, bucket, object strin
 		err := t.GetObject(ctx, bucket, object, startOffset, length, pw, objInfo.ETag, minio.ObjectOptions{})
 		pw.CloseWithError(err)
 	}()
-	// Setup cleanup function to cause the above go-routine to
-	// exit in case of partial read
-	pipeCloser := func() { pr.Close() }
+
+	// Cleanup function to cause the go routine above to exit, in case of incomplete read.
+	pipeCloser := func() {
+		pw.Close()
+		pr.Close()
+	}
+
 	return minio.NewGetObjectReaderFromReader(pr, objInfo, pipeCloser), nil
 }
 

--- a/cmd/gateway/oss/gateway-oss.go
+++ b/cmd/gateway/oss/gateway-oss.go
@@ -565,9 +565,13 @@ func (l *ossObjects) GetObjectNInfo(ctx context.Context, bucket, object string, 
 		err := l.GetObject(ctx, bucket, object, startOffset, length, pw, objInfo.ETag, minio.ObjectOptions{})
 		pw.CloseWithError(err)
 	}()
-	// Setup cleanup function to cause the above go-routine to
-	// exit in case of partial read
-	pipeCloser := func() { pr.Close() }
+
+	// Cleanup function to cause the go routine above to exit, in case of incomplete read.
+	pipeCloser := func() {
+		pw.Close()
+		pr.Close()
+	}
+
 	return minio.NewGetObjectReaderFromReader(pr, objInfo, pipeCloser), nil
 }
 

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -346,9 +346,13 @@ func (l *s3Objects) GetObjectNInfo(ctx context.Context, bucket, object string, r
 		err := l.GetObject(ctx, bucket, object, startOffset, length, pw, objInfo.ETag, minio.ObjectOptions{})
 		pw.CloseWithError(err)
 	}()
-	// Setup cleanup function to cause the above go-routine to
-	// exit in case of partial read
-	pipeCloser := func() { pr.Close() }
+
+	// Cleanup function to cause the go routine above to exit, in case of incomplete read.
+	pipeCloser := func() {
+		pw.Close()
+		pr.Close()
+	}
+
 	return minio.NewGetObjectReaderFromReader(pr, objInfo, pipeCloser), nil
 }
 

--- a/cmd/gateway/sia/gateway-sia.go
+++ b/cmd/gateway/sia/gateway-sia.go
@@ -450,9 +450,13 @@ func (s *siaObjects) GetObjectNInfo(ctx context.Context, bucket, object string, 
 		err := s.GetObject(ctx, bucket, object, startOffset, length, pw, objInfo.ETag, minio.ObjectOptions{})
 		pw.CloseWithError(err)
 	}()
-	// Setup cleanup function to cause the above go-routine to
-	// exit in case of partial read
-	pipeCloser := func() { pr.Close() }
+
+	// Cleanup function to cause the go routine above to exit, in case of incomplete read.
+	pipeCloser := func() {
+		pw.Close()
+		pr.Close()
+	}
+
 	return minio.NewGetObjectReaderFromReader(pr, objInfo, pipeCloser), nil
 }
 

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -211,9 +211,12 @@ func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object string, r
 		err := xl.getObject(ctx, bucket, object, off, length, pw, "", ObjectOptions{})
 		pw.CloseWithError(err)
 	}()
-	// Cleanup function to cause the go routine above to exit, in
-	// case of incomplete read.
-	pipeCloser := func() { pr.Close() }
+
+	// Cleanup function to cause the go routine above to exit, in case of incomplete read.
+	pipeCloser := func() {
+		pw.Close()
+		pr.Close()
+	}
 
 	return fn(pr, h, pipeCloser)
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Close the writer cleanup in GetObjectNInfo
<!--- Describe your changes in detail -->

## Motivation and Context
This is to avoid memory build up, and quickly terminate
the writer end instead of the reader. Relinquishes the
writer end resources and reader receives an EOF.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using a spark test script against master v/s this PR

```sh
#!/bin/bash

export HADOOP_VERSION="3.1.1"
export JAVA_HOME=$(readlink -f /usr/bin/javac | sed "s:/bin/javac::")
export HADOOP_HOME=/home/minio/spark/hadoop-${HADOOP_VERSION}
export PATH=$PATH:$HADOOP_HOME/bin
export SPARK_DIST_CLASSPATH=$(hadoop classpath)


export PYTHONSTARTUP=test.py

./bin/pyspark --jars "./myjars/hadoop-aws-${HADOOP_VERSION}.jar,./myjars/httpclient-4.5.3.jar,./myjars/aws-java-sdk-dynamodb-1.11.283.jar,./myjars/aws-java-sdk-core-1.11.283.jar,./myjars/aws-java-sdk-kms-1.11.283.jar,./myjars/aws-java-sdk-1.11.283.jar,./myjars/aws-java-sdk-s3-1.11.283.jar,./myjars/joda-time-2.9.9.jar"  --conf spark.hadoop.fs.s3a.server-side-encryption-algorithm=SSE-C --conf spark.hadoop.fs.s3a.server-side-encryption-key='MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ=' --conf fs.s3a.path.style.access=true --conf fs.s3a.path.style.access=true --conf fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem
```

```py
from pyspark.sql import SparkSession
import random
from random import randint
import time


spark = SparkSession.builder.appName("repartition").getOrCreate()

df0 = spark.createDataFrame([("john-" + str(randint(0, 99999)), randint(0, 99999)) for _ in range(100)], ('name', 'age'))

while True:
    testfn = 'test-' + str(random.randint(1,10**10))
    start_time = time.time()
    df0.write.parquet('s3a://id-platform/benchmark/v1/'+testfn)
    df1 = spark.read.parquet("s3a://id-platform/benchmark/v1/"+testfn)
    df2 = df1.repartition(100)
    df2.write.mode("overwrite").partitionBy("name").parquet("s3a://id-platform/benchmark/v2/"+testfn)
    elapsed_time = time.time() - start_time
    print(elapsed_time)

spark.stop()
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.