### PR TITLE
Disable restarting server after setting a new config

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -787,8 +787,6 @@ func (a adminAPIHandlers) SetConfigHandler(w http.ResponseWriter, r *http.Reques
 
 	// Reply to the client before restarting minio server.
 	writeSuccessResponseHeadersOnly(w)
-
-	sendServiceCmd(globalAdminPeers, serviceRestart)
 }
 
 func convertValueType(elem []byte, jsonType gjson.Type) (interface{}, error) {
@@ -920,8 +918,6 @@ func (a adminAPIHandlers) SetConfigKeysHandler(w http.ResponseWriter, r *http.Re
 
 	// Send success response
 	writeSuccessResponseHeadersOnly(w)
-
-	sendServiceCmd(globalAdminPeers, serviceRestart)
 }
 
 // UpdateCredsHandler - POST /minio/admin/v1/config/credential

--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -713,16 +713,6 @@ func TestSetConfigHandler(t *testing.T) {
 	globalMinioAddr = "127.0.0.1:9000"
 	initGlobalAdminPeers(mustGetNewEndpointList("http://127.0.0.1:9000/d1"))
 
-	var wg sync.WaitGroup
-
-	// SetConfigHandler restarts minio setup - need to start a
-	// signal receiver to receive on globalServiceSignalCh.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		testServiceSignalReceiver(restartCmd, t)
-	}()
-
 	// Prepare query params for set-config mgmt REST API.
 	queryVal := url.Values{}
 	queryVal.Set("config", "")
@@ -782,9 +772,6 @@ func TestSetConfigHandler(t *testing.T) {
 			t.Errorf("Got unexpected response code or body %d - %s", rec.Code, respBody)
 		}
 	}
-
-	// Wait until testServiceSignalReceiver finishes its execution
-	wg.Wait()
 }
 
 func TestAdminServerInfo(t *testing.T) {

--- a/pkg/madmin/config-commands.go
+++ b/pkg/madmin/config-commands.go
@@ -94,11 +94,6 @@ func (adm *AdminClient) GetConfig() ([]byte, error) {
 
 // GetConfigKeys - returns partial json or json value from config.json of a minio setup.
 func (adm *AdminClient) GetConfigKeys(keys []string) ([]byte, error) {
-	// No TLS?
-	if !adm.secure {
-		// return nil, fmt.Errorf("credentials/configuration cannot be retrieved over an insecure connection")
-	}
-
 	queryVals := make(url.Values)
 	for _, k := range keys {
 		queryVals.Add(k, "")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In Admin API, we should not automatically restart the server after setting a new config file or keys 


## Motivation and Context
Fixes #6507 

## Regression
No

## How Has This Been Tested?
1. Run a Minio server
2. Set a new config file `mc admin config set myminio/</tmp/newconfig-file.json`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.