### PR TITLE
add auto-encryption for SSE-S3 using a KMS

### DIFF
--- a/cmd/admin-rpc_test.go
+++ b/cmd/admin-rpc_test.go
@@ -40,11 +40,8 @@ import (
 ///////////////////////////////////////////////////////////////////////////////
 
 func testAdminCmdRunnerSignalService(t *testing.T, client adminCmdRunner) {
-	tmpGlobalServiceSignalCh := globalServiceSignalCh
+	defer func(sigChan chan serviceSignal) { globalServiceSignalCh = sigChan }(globalServiceSignalCh)
 	globalServiceSignalCh = make(chan serviceSignal, 10)
-	defer func() {
-		globalServiceSignalCh = tmpGlobalServiceSignalCh
-	}()
 
 	testCases := []struct {
 		signal    serviceSignal

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -619,6 +619,10 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	rawReader := hashReader
 	pReader := NewPutObjReader(rawReader, nil, nil)
 	var objectEncryptionKey []byte
+
+	if globalAutoEncryption && !crypto.SSEC.IsRequested(r.Header) {
+		r.Header.Add(crypto.SSEHeader, crypto.SSEAlgorithmAES256)
+	}
 	if objectAPI.IsEncryptionSupported() {
 		if hasServerSideEncryptionHeader(formValues) && !hasSuffix(object, slashSeparator) { // handle SSE-C and SSE-S3 requests
 			var reader io.Reader

--- a/cmd/crypto/config.go
+++ b/cmd/crypto/config.go
@@ -16,5 +16,6 @@ package crypto
 
 // KMSConfig has the KMS config for hashicorp vault
 type KMSConfig struct {
-	Vault VaultConfig `json:"vault"`
+	AutoEncryption bool        `json:"-"`
+	Vault          VaultConfig `json:"vault"`
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -227,7 +228,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		globalHTTPServer.Shutdown()
 		logger.FatalIf(err, "Unable to initialize gateway backend")
 	}
-
 	// Create a new config system.
 	globalConfigSys = NewConfigSys()
 	if globalEtcdClient != nil && gatewayName == "nas" {
@@ -284,6 +284,11 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	if globalEtcdClient != nil && newObject.IsNotificationSupported() {
 		_ = globalNotificationSys.Init(newObject)
 	}
+
+	if globalAutoEncryption && !newObject.IsEncryptionSupported() {
+		logger.Fatal(errors.New("Invalid KMS configuration"), "auto-encryption is enabled but gateway does not support encryption")
+	}
+
 	// Once endpoints are finalized, initialize the new object api.
 	globalObjLayerMutex.Lock()
 	globalObjectAPI = newObject

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -231,6 +231,11 @@ var (
 	// Allocated KMS
 	globalKMS crypto.KMS
 
+	// Auto-Encryption, if enabled, turns any non-SSE-C request
+	// into an SSE-S3 request. If enabled a valid, non-empty KMS
+	// configuration must be present.
+	globalAutoEncryption bool
+
 	// Is compression include extensions/content-types set.
 	globalIsEnvCompression bool
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -857,6 +857,9 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	rawReader := srcInfo.Reader
 	pReader := NewPutObjReader(srcInfo.Reader, nil, nil)
 
+	if globalAutoEncryption && !crypto.SSEC.IsRequested(r.Header) {
+		r.Header.Add(crypto.SSEHeader, crypto.SSEAlgorithmAES256)
+	}
 	var encMetadata = make(map[string]string)
 	if objectAPI.IsEncryptionSupported() && !isCompressed {
 		// Encryption parameters not applicable for this object.
@@ -1244,6 +1247,9 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 			return
 		}
 	}
+	if globalAutoEncryption && !crypto.SSEC.IsRequested(r.Header) {
+		r.Header.Add(crypto.SSEHeader, crypto.SSEAlgorithmAES256)
+	}
 	var objectEncryptionKey []byte
 	if objectAPI.IsEncryptionSupported() {
 		if hasServerSideEncryptionHeader(r.Header) && !hasSuffix(object, slashSeparator) { // handle SSE requests
@@ -1372,6 +1378,9 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 
 	var encMetadata = map[string]string{}
 
+	if globalAutoEncryption && !crypto.SSEC.IsRequested(r.Header) {
+		r.Header.Add(crypto.SSEHeader, crypto.SSEAlgorithmAES256)
+	}
 	if objectAPI.IsEncryptionSupported() {
 		if hasServerSideEncryptionHeader(r.Header) {
 			if err = setEncryptionMetadata(r, bucket, object, encMetadata); err != nil {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -382,6 +383,9 @@ func serverMain(ctx *cli.Context) {
 	// Initialize notification system.
 	if err = globalNotificationSys.Init(newObject); err != nil {
 		logger.LogIf(context.Background(), err)
+	}
+	if globalAutoEncryption && !newObject.IsEncryptionSupported() {
+		logger.Fatal(errors.New("Invalid KMS configuration"), "auto-encryption is enabled but server does not support encryption")
 	}
 
 	globalObjLayerMutex.Lock()

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -733,11 +733,6 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 		writeWebErrorResponse(w, errServerNotInitialized)
 		return
 	}
-
-	putObject := objectAPI.PutObject
-	if web.CacheAPI() != nil {
-		putObject = web.CacheAPI().PutObject
-	}
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 	object := vars["object"]
@@ -776,6 +771,9 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if globalAutoEncryption && !crypto.SSEC.IsRequested(r.Header) {
+		r.Header.Add(crypto.SSEHeader, crypto.SSEAlgorithmAES256)
+	}
 
 	// Require Content-Length to be set in the request
 	size := r.ContentLength
@@ -791,9 +789,15 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reader := r.Body
+	var pReader *PutObjReader
+	var reader io.Reader = r.Body
 	actualSize := size
 
+	hashReader, err := hash.NewReader(reader, size, "", "", actualSize)
+	if err != nil {
+		writeWebErrorResponse(w, err)
+		return
+	}
 	if objectAPI.IsCompressionSupported() && isCompressible(r.Header, object) && size > 0 {
 		// Storing the compression metadata.
 		metadata[ReservedMetadataPrefix+"compression"] = compressionAlgorithmV1
@@ -819,13 +823,35 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 		// Set compression metrics.
 		size = -1 // Since compressed size is un-predictable.
 		reader = pipeReader
+		hashReader, err = hash.NewReader(reader, size, "", "", actualSize)
+		if err != nil {
+			writeWebErrorResponse(w, err)
+			return
+		}
 	}
+	pReader = NewPutObjReader(hashReader, nil, nil)
 
-	hashReader, err := hash.NewReader(reader, size, "", "", actualSize)
-	if err != nil {
-		writeWebErrorResponse(w, err)
-		return
+	if objectAPI.IsEncryptionSupported() {
+		if hasServerSideEncryptionHeader(r.Header) && !hasSuffix(object, slashSeparator) { // handle SSE requests
+			rawReader := hashReader
+			var objectEncryptionKey []byte
+			reader, objectEncryptionKey, err = EncryptRequest(hashReader, r, bucket, object, metadata)
+			if err != nil {
+				writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
+				return
+			}
+			info := ObjectInfo{Size: size}
+			hashReader, err = hash.NewReader(reader, info.EncryptedSize(), "", "", size) // do not try to verify encrypted content
+			if err != nil {
+				writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
+				return
+			}
+			pReader = NewPutObjReader(rawReader, hashReader, objectEncryptionKey)
+		}
 	}
+	// Ensure that metadata does not contain sensitive information
+	crypto.RemoveSensitiveEntries(metadata)
+
 	var opts ObjectOptions
 	// Deny if WORM is enabled
 	if globalWORMEnabled {
@@ -835,10 +861,25 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	objInfo, err := putObject(ctx, bucket, object, NewPutObjReader(hashReader, nil, nil), metadata, opts)
+	putObject := objectAPI.PutObject
+	if !hasServerSideEncryptionHeader(r.Header) && web.CacheAPI() != nil {
+		putObject = web.CacheAPI().PutObject
+	}
+	objInfo, err := putObject(context.Background(), bucket, object, pReader, metadata, opts)
 	if err != nil {
 		writeWebErrorResponse(w, err)
 		return
+	}
+	if objectAPI.IsEncryptionSupported() {
+		if crypto.IsEncrypted(objInfo.UserDefined) {
+			switch {
+			case crypto.S3.IsEncrypted(objInfo.UserDefined):
+				w.Header().Set(crypto.SSEHeader, crypto.SSEAlgorithmAES256)
+			case crypto.SSEC.IsRequested(r.Header):
+				w.Header().Set(crypto.SSECAlgorithm, r.Header.Get(crypto.SSECAlgorithm))
+				w.Header().Set(crypto.SSECKeyMD5, r.Header.Get(crypto.SSECKeyMD5))
+			}
+		}
 	}
 
 	// Get host and port from Request.RemoteAddr.

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -18,6 +18,12 @@ Minio supports two different KMS concepts:
    Note: If the Minio server machine is ever compromised, then the master key must also be 
    treated as compromised.
 
+**Important:**  
+If multiple minio server are configured as [gateways](https://github.com/minio/minio/blob/master/docs/gateway/README.md)
+pointing to the *same* backend - for example the same NAS storage - than the KMS configuration **must** be equal for
+all gateways. Otherwise one gateway may not be able to decrypt objects created by another gateway. It's the operators 
+responsibility to ensure that.
+
 ## Get started
 
 ### 1. Prerequisites
@@ -85,6 +91,12 @@ export MINIO_SSE_VAULT_KEY_NAME=my-minio-key
 minio server ~/export
 ```
 
+Optionally set `MINIO_SSE_VAULT_CAPATH` to a directory of PEM-encoded CA cert files to use mTLS for client-server authentication.
+
+```
+export MINIO_SSE_VAULT_CAPATH=/home/user/custom-certs
+```
+
 Optionally set `MINIO_SSE_VAULT_NAMESPACE` if AppRole and Transit Secrets engine have been scoped to Vault Namespace
 
 ```
@@ -92,6 +104,8 @@ export MINIO_SSE_VAULT_NAMESPACE=ns1
 ```
 
 Note: If [Vault Namespaces](https://learn.hashicorp.com/vault/operations/namespaces) are in use, MINIO_SSE_VAULT_NAMESPACE variable needs to be set before setting approle and transit secrets engine.
+
+
 
 #### 2.2 Specify a master key
 
@@ -105,6 +119,25 @@ export MINIO_SSE_MASTER_KEY=my-minio-key:6368616e676520746869732070617373776f726
 ### 3. Test your setup
 
 To test this setup, start minio server with environment variables set in Step 3, and server is ready to handle SSE-S3 requests.
+
+### Auto-Encryption
+
+Minio can also enable auto-encryption **if** a valid KMS configuration is specified and the storage backend supports
+encrypted objects. Auto-Encryption, if enabled, ensures that all uploaded objects are encrypted using the specified
+KMS configuration.
+
+Auto-Encryption is useful especially if the Minio operator wants to ensure that objects are **never** stored in 
+plaintext - for example if sensitive data is stored on public cloud storage.
+
+To enable auto-encryption either set the ENV. variable: 
+
+```sh
+export MINIO_SSE_AUTO_ENCRYPTION=on
+```
+
+Note: Auto-Encryption only affects non-SSE-C requests since objects uploaded using SSE-C are already encrypted
+and S3 only allows either SSE-S3 or SSE-C but not both for the same object.   
+
 
 # Explore Further
 


### PR DESCRIPTION
## Description
This commit adds an auto-encryption feature which allows
the Minio operator to ensure that uploaded objects are
always encrypted.

This change adds  the ENV. variable `MINIO_SSE_AUTO_ENCRYPTION:{on,off}`.
It also updates the KMS documentation according to the
changes.

## Motivation and Context
Fixes #6502

## Regression
No

## How Has This Been Tested?
manually
 For reviewers:
 1. `export MINIO_SSE_AUTO_ENCRYPTION=on` should cause server to fail during startup (same for config file)
 2. After `export MINIO_SSE_MASTER_KEY=my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574` server should start for (fs / xl but not for e.g. azure b/c no encryption support) and any uploaded objects should be encrypted.
 
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.