### PR TITLE
profiler: Download API returns error when all nodes fail

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -355,8 +355,7 @@ func (a adminAPIHandlers) DownloadProfilingHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Return 200 OK
-	w.WriteHeader(http.StatusOK)
+	profilingDataFound := false
 
 	// Initialize a zip writer which will provide a zipped content
 	// of profiling data of all nodes
@@ -370,6 +369,8 @@ func (a adminAPIHandlers) DownloadProfilingHandler(w http.ResponseWriter, r *htt
 			logger.LogIf(context.Background(), fmt.Errorf("Unable to download profiling data from node `%s`, reason: %s", peer.addr, err.Error()))
 			continue
 		}
+
+		profilingDataFound = true
 
 		// Send profiling data to zip as file
 		header, err := zip.FileInfoHeader(dummyFileInfo{
@@ -390,6 +391,11 @@ func (a adminAPIHandlers) DownloadProfilingHandler(w http.ResponseWriter, r *htt
 		if _, err = io.Copy(writer, bytes.NewBuffer(data)); err != nil {
 			return
 		}
+	}
+
+	if !profilingDataFound {
+		writeErrorResponseJSON(w, ErrAdminProfilerNotEnabled, r.URL)
+		return
 	}
 }
 

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -291,6 +291,7 @@ const (
 	ErrInvalidColumnIndex
 	ErrMissingHeaders
 	ErrAdminConfigNotificationTargetsFailed
+	ErrAdminProfilerNotEnabled
 )
 
 // error code to APIError structure, these fields carry respective
@@ -890,6 +891,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 	ErrAdminConfigNotificationTargetsFailed: {
 		Code:           "XMinioAdminNotificationTargetsTestFailed",
 		Description:    "Configuration update failed due an unsuccessful attempt to connect to one or more notification servers",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrAdminProfilerNotEnabled: {
+		Code:           "XMinioAdminProfilerNotEnabled",
+		Description:    "Unable to perform the requested operation because profiling is not enabled",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrAdminCredentialsMismatch: {


### PR DESCRIPTION
## Description
When download profiling data API fails to gather profiling data
from all nodes for any reason (including profiler not enabled),
return 400 http code with the appropriate json message.

## Motivation and Context
Fix one admin bug

## Regression
No

## How Has This Been Tested?
Using this PR https://github.com/minio/mc/pull/2557

`mc admin profiling --download /tmp/profiling myminio` without starting profiling.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.