### PR TITLE
madmin: close http response when returning an error

### DIFF
--- a/pkg/madmin/api-error-response.go
+++ b/pkg/madmin/api-error-response.go
@@ -73,6 +73,7 @@ func httpRespToErrorResponse(resp *http.Response) error {
 			Message: "Failed to parse server response.",
 		}
 	}
+	closeResponse(resp)
 	return errResp
 }
 

--- a/pkg/madmin/profiling-commands.go
+++ b/pkg/madmin/profiling-commands.go
@@ -92,7 +92,6 @@ func (adm *AdminClient) DownloadProfilingData() (io.ReadCloser, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		closeResponse(resp)
 		return nil, httpRespToErrorResponse(resp)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
httpRespToErrorResponse() usually reads the http response when
the http error code is not expected to parse the json error
response in the http body, however it was never properly closing
the connection. This PR fixes the behavior.


## Motivation and Context
Better code

## Regression
No

## How Has This Been Tested?
No apparent bug for this, no testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.