### PR TITLE
Add a function `TypeByExtension` under pkg `mimedb`

### DIFF
--- a/cmd/fs-v1-metadata.go
+++ b/cmd/fs-v1-metadata.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"os"
 	pathutil "path"
-	"strings"
 
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/lock"
@@ -137,11 +136,7 @@ func (m fsMetaV1) ToObjectInfo(bucket, object string, fi os.FileInfo) ObjectInfo
 
 	// Guess content-type from the extension if possible.
 	if m.Meta["content-type"] == "" {
-		if objectExt := pathutil.Ext(object); objectExt != "" {
-			if content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]; ok {
-				m.Meta["content-type"] = content.ContentType
-			}
-		}
+		m.Meta["content-type"] = mimedb.TypeByExtension(pathutil.Ext(object))
 	}
 
 	if hasSuffix(object, slashSeparator) {

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -674,13 +674,8 @@ func (fs *FSObjects) createFsJSON(object, fsMetaPath string) error {
 	fsMeta := newFSMetaV1()
 	fsMeta.Meta = make(map[string]string)
 	fsMeta.Meta["etag"] = GenETag()
-	if objectExt := path.Ext(object); objectExt != "" {
-		if content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]; ok {
-			fsMeta.Meta["content-type"] = content.ContentType
-		} else {
-			fsMeta.Meta["content-type"] = "application/octet-stream"
-		}
-	}
+	contentType := mimedb.TypeByExtension(path.Ext(object))
+	fsMeta.Meta["content-type"] = contentType
 	wlk, werr := fs.rwPool.Create(fsMetaPath)
 	if werr == nil {
 		_, err := fsMeta.WriteTo(wlk)
@@ -695,13 +690,8 @@ func (fs *FSObjects) defaultFsJSON(object string) fsMetaV1 {
 	fsMeta := newFSMetaV1()
 	fsMeta.Meta = make(map[string]string)
 	fsMeta.Meta["etag"] = defaultEtag
-	if objectExt := path.Ext(object); objectExt != "" {
-		if content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]; ok {
-			fsMeta.Meta["content-type"] = content.ContentType
-		} else {
-			fsMeta.Meta["content-type"] = "application/octet-stream"
-		}
-	}
+	contentType := mimedb.TypeByExtension(path.Ext(object))
+	fsMeta.Meta["content-type"] = contentType
 	return fsMeta
 }
 

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -198,15 +198,8 @@ func (xl xlObjects) newMultipartUpload(ctx context.Context, bucket string, objec
 	// establish the writeQuorum using this data
 	writeQuorum := dataBlocks + 1
 
-	// If not set default to "application/octet-stream"
 	if meta["content-type"] == "" {
-		contentType := "application/octet-stream"
-		if objectExt := path.Ext(object); objectExt != "" {
-			content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]
-			if ok {
-				contentType = content.ContentType
-			}
-		}
+		contentType := mimedb.TypeByExtension(path.Ext(object))
 		meta["content-type"] = contentType
 	}
 	xlMeta.Stat.ModTime = UTCNow()

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"path"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/minio/minio/cmd/logger"
@@ -785,11 +784,7 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 
 	// Guess content-type from the extension if possible.
 	if metadata["content-type"] == "" {
-		if objectExt := path.Ext(object); objectExt != "" {
-			if content, ok := mimedb.DB[strings.ToLower(strings.TrimPrefix(objectExt, "."))]; ok {
-				metadata["content-type"] = content.ContentType
-			}
-		}
+		metadata["content-type"] = mimedb.TypeByExtension(path.Ext(object))
 	}
 
 	if xl.isObject(bucket, object) {

--- a/pkg/mimedb/db_test.go
+++ b/pkg/mimedb/db_test.go
@@ -29,3 +29,17 @@ func TestMimeLookup(t *testing.T) {
 		t.Fatalf("Invalid content type are found expected \"false\", got %t", compressible)
 	}
 }
+
+func TestTypeByExtension(t *testing.T) {
+	var contentType string
+	// Test TypeByExtension.
+	contentType = TypeByExtension(".txt")
+	if contentType != "text/plain" {
+		t.Fatalf("Invalid content type are found expected \"text/plain\", got %s", contentType)
+	}
+	// Test non-existent type resolution
+	contentType = TypeByExtension(".abc")
+	if contentType != "application/octet-stream" {
+		t.Fatalf("Invalid content type are found expected \"application/octet-stream\", got %s", contentType)
+	}
+}

--- a/pkg/mimedb/resolve-db.go
+++ b/pkg/mimedb/resolve-db.go
@@ -1,0 +1,33 @@
+/*
+ * mime-db: Mime Database, (C) 2015, 2016, 2017, 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mimedb
+
+import (
+	"strings"
+)
+
+// TypeByExtension resolves the extension to its respective content-type.
+func TypeByExtension(ext string) string {
+	// Set default to "application/octet-stream".
+	var contentType = "application/octet-stream"
+	if ext != "" {
+		if content, ok := DB[strings.ToLower(strings.TrimPrefix(ext, "."))]; ok {
+			contentType = content.ContentType
+		}
+	}
+	return contentType
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`TypeByExtension(extension)` of package `mimedb` will now resolve extension to their respective content-type

## Motivation and Context
Simplifies the content-type resolution (This can also be used in `mc`)
There is a dependency for this in minio/mc#2563 (will reduce loc/modifications to be done in `mc select`)

## Regression
No

## How Has This Been Tested?
Current unit tests passed with the change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.