### PR TITLE
Return always a default heal item upon unexpected error

### DIFF
--- a/cmd/xl-v1-healing-common_test.go
+++ b/cmd/xl-v1-healing-common_test.go
@@ -258,7 +258,7 @@ func TestListOnlineDisks(t *testing.T) {
 				i+1, test.expectedTime, modTime)
 		}
 
-		availableDisks, newErrs, _ := disksWithAllParts(context.Background(), onlineDisks, partsMetadata, test.errs, bucket, object)
+		availableDisks, newErrs := disksWithAllParts(context.Background(), onlineDisks, partsMetadata, test.errs, bucket, object)
 		test.errs = newErrs
 
 		if test._tamperBackend != noTamper {
@@ -318,10 +318,7 @@ func TestDisksWithAllParts(t *testing.T) {
 	}
 
 	errs = make([]error, len(xlDisks))
-	filteredDisks, errs, err := disksWithAllParts(ctx, xlDisks, partsMetadata, errs, bucket, object)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
+	filteredDisks, errs := disksWithAllParts(ctx, xlDisks, partsMetadata, errs, bucket, object)
 
 	if len(filteredDisks) != len(xlDisks) {
 		t.Errorf("Unexpected number of disks: %d", len(filteredDisks))
@@ -353,10 +350,7 @@ func TestDisksWithAllParts(t *testing.T) {
 		t.Fatalf("Failed to read xl meta data %v", err)
 	}
 
-	filteredDisks, errs, err = disksWithAllParts(ctx, xlDisks, partsMetadata, errs, bucket, object)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
+	filteredDisks, errs = disksWithAllParts(ctx, xlDisks, partsMetadata, errs, bucket, object)
 
 	if len(filteredDisks) != len(xlDisks) {
 		t.Errorf("Unexpected number of disks: %d", len(filteredDisks))

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -295,7 +295,7 @@ func healObject(ctx context.Context, storageDisks []StorageAPI, bucket string, o
 		// continue to return filled madmin.HealResultItem struct which includes info
 		// on what disks the file is available etc.
 		if reducedErr := reduceReadQuorumErrs(ctx, errs, nil, quorum); reducedErr != nil {
-			return result, toObjectErr(reducedErr, bucket, object)
+			return defaultHealResult(storageDisks, errs, bucket, object), toObjectErr(reducedErr, bucket, object)
 		}
 	}
 
@@ -304,10 +304,7 @@ func healObject(ctx context.Context, storageDisks []StorageAPI, bucket string, o
 	latestDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
 	// List of disks having all parts as per latest xl.json.
-	availableDisks, dataErrs, aErr := disksWithAllParts(ctx, latestDisks, partsMetadata, errs, bucket, object)
-	if aErr != nil {
-		return result, toObjectErr(aErr, bucket, object)
-	}
+	availableDisks, dataErrs := disksWithAllParts(ctx, latestDisks, partsMetadata, errs, bucket, object)
 
 	// Initialize heal result object
 	result = madmin.HealResultItem{
@@ -338,7 +335,7 @@ func healObject(ctx context.Context, storageDisks []StorageAPI, bucket string, o
 			result.ObjectSize = partsMetadata[i].Stat.Size
 			result.ParityBlocks = partsMetadata[i].Erasure.ParityBlocks
 			result.DataBlocks = partsMetadata[i].Erasure.DataBlocks
-		case errs[i] == errDiskNotFound:
+		case errs[i] == errDiskNotFound, dataErrs[i] == errDiskNotFound:
 			driveState = madmin.DriveStateOffline
 		case errs[i] == errFileNotFound, errs[i] == errVolumeNotFound:
 			fallthrough
@@ -388,6 +385,10 @@ func healObject(ctx context.Context, storageDisks []StorageAPI, bucket string, o
 	// If less than read quorum number of disks have all the parts
 	// of the data, we can't reconstruct the erasure-coded data.
 	if numAvailableDisks < quorum {
+		// Default to most common configuration for erasure
+		// blocks upon returning quorum error.
+		result.ParityBlocks = len(storageDisks) / 2
+		result.DataBlocks = len(storageDisks) / 2
 		return result, toObjectErr(errXLReadQuorum, bucket, object)
 	}
 
@@ -512,7 +513,7 @@ func healObject(ctx context.Context, storageDisks []StorageAPI, bucket string, o
 	}
 
 	// Generate and write `xl.json` generated from other disks.
-	outDatedDisks, aErr = writeUniqueXLMetadata(ctx, outDatedDisks, minioMetaTmpBucket, tmpID,
+	outDatedDisks, aErr := writeUniqueXLMetadata(ctx, outDatedDisks, minioMetaTmpBucket, tmpID,
 		partsMetadata, diskCount(outDatedDisks))
 	if aErr != nil {
 		return result, toObjectErr(aErr, bucket, object)
@@ -602,6 +603,58 @@ func (xl xlObjects) healObjectDir(ctx context.Context, bucket, object string, dr
 	return hr, nil
 }
 
+// Populates default heal result item entries with possible values when we are returning prematurely.
+// This is to ensure that in any circumstance we are not returning empty arrays with wrong values.
+func defaultHealResult(storageDisks []StorageAPI, errs []error, bucket, object string) madmin.HealResultItem {
+	// Initialize heal result object
+	result := madmin.HealResultItem{
+		Type:      madmin.HealItemObject,
+		Bucket:    bucket,
+		Object:    object,
+		DiskCount: len(storageDisks),
+
+		// Initialize object size to -1, so we can detect if we are
+		// unable to reliably find the object size.
+		ObjectSize: -1,
+	}
+
+	for index, disk := range storageDisks {
+		if disk == nil {
+			result.Before.Drives = append(result.Before.Drives, madmin.HealDriveInfo{
+				UUID:  "",
+				State: madmin.DriveStateOffline,
+			})
+			result.After.Drives = append(result.After.Drives, madmin.HealDriveInfo{
+				UUID:  "",
+				State: madmin.DriveStateOffline,
+			})
+			continue
+		}
+		drive := disk.String()
+		driveState := madmin.DriveStateCorrupt
+		switch errs[index] {
+		case errFileNotFound, errVolumeNotFound:
+			driveState = madmin.DriveStateMissing
+		}
+		result.Before.Drives = append(result.Before.Drives, madmin.HealDriveInfo{
+			UUID:     "",
+			Endpoint: drive,
+			State:    driveState,
+		})
+		result.After.Drives = append(result.After.Drives, madmin.HealDriveInfo{
+			UUID:     "",
+			Endpoint: drive,
+			State:    driveState,
+		})
+	}
+
+	// Default to most common configuration for erasure blocks.
+	result.ParityBlocks = len(storageDisks) / 2
+	result.DataBlocks = len(storageDisks) / 2
+
+	return result
+}
+
 // HealObject - heal the given object.
 //
 // FIXME: If an object object was deleted and one disk was down,
@@ -624,19 +677,21 @@ func (xl xlObjects) HealObject(ctx context.Context, bucket, object string, dryRu
 		return xl.healObjectDir(healCtx, bucket, object, dryRun)
 	}
 
+	storageDisks := xl.getDisks()
+
 	// FIXME: Metadata is read again in the healObject() call below.
 	// Read metadata files from all the disks
-	partsMetadata, errs := readAllXLMetadata(healCtx, xl.getDisks(), bucket, object)
+	partsMetadata, errs := readAllXLMetadata(healCtx, storageDisks, bucket, object)
 
 	latestXLMeta, err := getLatestXLMeta(healCtx, partsMetadata, errs)
 	if err != nil {
-		return hr, toObjectErr(err, bucket, object)
+		return defaultHealResult(storageDisks, errs, bucket, object), toObjectErr(err, bucket, object)
 	}
 
 	// Lock the object before healing.
 	objectLock := xl.nsMutex.NewNSLock(bucket, object)
 	if lerr := objectLock.GetRLock(globalHealingTimeout); lerr != nil {
-		return hr, lerr
+		return defaultHealResult(storageDisks, errs, bucket, object), lerr
 	}
 	defer objectLock.RUnlock()
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Never return an empty result item even upon error,
choose all the default values and based on the errors
make sure to send right result reply.

<!--- Describe your changes in detail -->

## Motivation and Context
Return always a default heal item upon unexpected error
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
This issue needs some manual simulation, start with a 4 disk setup 

```
minio server /tmp/{1..4}
``` 

Create a bucket and upload an object.
```
mc mb myminio/testbucket
mc cp /etc/issue myminio/testbucket/
```

Remove read/write permissions 
```
sudo chmod -R 004 /tmp/{1..4}/testbucket/issue/part.1
```

```
 mc admin heal --json -r myminio/testbucket/issue
{"status":"success","type":"system","name":"disk-format","before":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"e1578c00-fcdc-402d-a2fc-10d7e90fab64","endpoint":"/tmp/1","state":"ok"},{"uuid":"5fb4a908-35a2-4873-aef9-43fa6d8a8bed","endpoint":"/tmp/2","state":"ok"},{"uuid":"b5903736-cb35-47d8-adfc-48f57ff45c94","endpoint":"/tmp/3","state":"ok"},{"uuid":"aa171d6f-33cd-4886-a64c-b5977855f25b","endpoint":"/tmp/4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"e1578c00-fcdc-402d-a2fc-10d7e90fab64","endpoint":"/tmp/1","state":"ok"},{"uuid":"5fb4a908-35a2-4873-aef9-43fa6d8a8bed","endpoint":"/tmp/2","state":"ok"},{"uuid":"b5903736-cb35-47d8-adfc-48f57ff45c94","endpoint":"/tmp/3","state":"ok"},{"uuid":"aa171d6f-33cd-4886-a64c-b5977855f25b","endpoint":"/tmp/4","state":"ok"}]},"size":0}
{"status":"success","type":"system","name":"bucket-metadata:.minio.sys/config/config.json","before":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"size":0}
{"status":"success","type":"system","name":"bucket-metadata:.minio.sys/config/config.json.backup","before":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"size":0}
{"status":"success","type":"bucket","name":"testbucket/","before":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"size":0}
{"status":"error","error":{"message":"Unable to display follow heal status.","cause":{"message":"Invalid parity shard count/surplus shard count given","error":{}},"type":"error","sysinfo":{"host.arch":"amd64","host.cpus":"4","host.lang":"go1.10.4","host.name":"prtsc","host.os":"linux","mem.heap.total":"5.8MB","mem.heap.used":"2.0MB","mem.total":"9.5MB","mem.used":"2.0MB"}}}
Invalid parity shard count/surplus shard count given
```

With --debug we see more
```{"status":"success","type":"system","name":"bucket-metadata:.minio.sys/config/config.json","before":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"size":0}
{"status":"success","type":"system","name":"bucket-metadata:.minio.sys/config/config.json.backup","before":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"size":0}
{"status":"success","type":"bucket","name":"testbucket/","before":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"/tmp/1","state":"ok"},{"uuid":"","endpoint":"/tmp/2","state":"ok"},{"uuid":"","endpoint":"/tmp/3","state":"ok"},{"uuid":"","endpoint":"/tmp/4","state":"ok"}]},"size":0}
{"status":"error","error":{"message":"Unable to display follow heal status.","cause":{"message":"Invalid parity shard count/surplus shard count given","error":{}},"type":"error","trace":[{"line":134,"file":"admin-heal.go","func":"cmd.mainAdminHeal"},{"line":134,"file":"admin-heal.go","func":"cmd.mainAdminHeal","env":{"Tags":["{\"summary\":\"finished\",\"detail\":\"\",\"startTime\":\"2018-10-02T07:19:48.822496954Z\",\"settings\":{\"recursive\":true,\"dryRun\":false},\"numDisks\":4,\"items\":[{\"resultId\":2,\"type\":\"bucket-metadata\",\"bucket\":\".minio.sys\",\"object\":\"config/config.json\",\"detail\":\"\",\"parityBlocks\":2,\"dataBlocks\":2,\"diskCount\":4,\"setCount\":0,\"before\":{\"drives\":[{\"uuid\":\"\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]},\"after\":{\"drives\":[{\"uuid\":\"\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]},\"objectSize\":2999},{\"resultId\":3,\"type\":\"bucket-metadata\",\"bucket\":\".minio.sys\",\"object\":\"config/config.json.backup\",\"detail\":\"\",\"parityBlocks\":2,\"dataBlocks\":2,\"diskCount\":4,\"setCount\":0,\"before\":{\"drives\":[{\"uuid\":\"\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]},\"after\":{\"drives\":[{\"uuid\":\"\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]},\"objectSize\":2899},{\"resultId\":4,\"type\":\"bucket\",\"bucket\":\"testbucket\",\"object\":\"\",\"detail\":\"\",\"diskCount\":4,\"setCount\":1,\"before\":{\"drives\":[{\"uuid\":\"\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]},\"after\":{\"drives\":[{\"uuid\":\"\",\"endpoint\":\"/tmp/1\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/2\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/3\",\"state\":\"ok\"},{\"uuid\":\"\",\"endpoint\":\"/tmp/4\",\"state\":\"ok\"}]},\"objectSize\":0},{\"resultId\":5,\"type\":\"\",\"bucket\":\"\",\"object\":\"\",\"detail\":\"Prefix access is denied: testbucket/issue\",\"diskCount\":0,\"setCount\":0,\"before\":{\"drives\":null},\"after\":{\"drives\":null},\"objectSize\":0}]}"]}}],"sysinfo":{"host.arch":"amd64","host.cpus":"4","host.lang":"go1.10.4","host.name":"prtsc","host.os":"linux","mem.heap.total":"5.8MB","mem.heap.used":"2.5MB","mem.total":"9.5MB","mem.used":"2.5MB"}}}
Invalid parity shard count/surplus shard count given
```

One can clearly see that is incorrect with all values zeroed out, this is incorrect and this PR fixes this issue.
```
{\"resultId\":5,\"type\":\"\",\"bucket\":\"\",\"object\":\"\",\"detail\":\"Prefix access is denied: testbucket/issue\",\"diskCount\":0,\"setCount\":0,\"before\":{\"drives\":null},\"after\":{\"drives\":null},\"objectSize\":0}]}"]}}
```

With this PR 
```json
{
  "status": "success",
  "type": "object",
  "name": "testbucket/issue",
  "before": {
    "color": "grey",
    "offline": 0,
    "online": 0,
    "missing": 0,
    "corrupted": 4,
    "drives": [
      {
        "uuid": "",
        "endpoint": "/tmp/1",
        "state": "corrupt"
      },
      {
        "uuid": "",
        "endpoint": "/tmp/2",
        "state": "corrupt"
      },
      {
        "uuid": "",
        "endpoint": "/tmp/3",
        "state": "corrupt"
      },
      {
        "uuid": "",
        "endpoint": "/tmp/4",
        "state": "corrupt"
      }
    ]
  },
  "after": {
    "color": "grey",
    "offline": 0,
    "online": 0,
    "missing": 0,
    "corrupted": 4,
    "drives": [
      {
        "uuid": "",
        "endpoint": "/tmp/1",
        "state": "corrupt"
      },
      {
        "uuid": "",
        "endpoint": "/tmp/2",
        "state": "corrupt"
      },
      {
        "uuid": "",
        "endpoint": "/tmp/3",
        "state": "corrupt"
      },
      {
        "uuid": "",
        "endpoint": "/tmp/4",
        "state": "corrupt"
      }
    ]
  },
  "size": -1
}
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.