### PR TITLE
Handle Range requests on empty objects

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1424,6 +1424,8 @@ func toAPIErrorCode(err error) (apiErr APIErrorCode) {
 	switch err {
 	case errSignatureMismatch:
 		apiErr = ErrSignatureDoesNotMatch
+	case errInvalidRange:
+		apiErr = ErrInvalidRange
 	case errDataTooLarge:
 		apiErr = ErrEntityTooLarge
 	case errDataTooSmall:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Handle Range requests on empty objects
<!--- Describe your changes in detail -->

## Motivation and Context
Return a proper error on empty objects, S3 returns
416 Invalid Range on objects which are empty.

We should return the same.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Not sure
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Follow these steps

```
touch empty
mc cp empty myminio/testbucket/
mc policy download myminio/testbucket

curl -v -H "Range: bytes=0-" http://localhost:9000/testbucket/empty
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9000 (#0)
> GET /testbucket/empty HTTP/1.1
> Host: localhost:9000
> User-Agent: curl/7.58.0
> Accept: */*
> Range: bytes=0-
> 
< HTTP/1.1 500 Internal Server Error
< Accept-Ranges: bytes
< Content-Security-Policy: block-all-mixed-content
< Content-Type: application/xml
< Server: Minio/DEVELOPMENT.2018-10-02T07-56-19Z (linux; amd64)
< Vary: Origin
< X-Amz-Request-Id: 1559BBFF93B53192
< X-Xss-Protection: 1; mode=block
< Date: Tue, 02 Oct 2018 08:04:14 GMT
< Transfer-Encoding: chunked
< 
<?xml version="1.0" encoding="UTF-8"?>
* Connection #0 to host localhost left intact
<Error><Code>InternalError</Code><Message>We encountered an internal error, please try again.</Message><Resource>/testbucket/empty</Resource><RequestId>1559BBFF93B53192</RequestId><HostId>3L137</HostId></Error>
```

Same commands with AWS S3
```
touch empty
mc cp empty s3/harshavardhana
mc policy download s3/harshavardhana

curl -v -H "Range: bytes=0-" http://s3.amazonaws.com/harshavardhana/empty
*   Trying 54.231.98.203...
* TCP_NODELAY set
* Connected to s3.amazonaws.com (54.231.98.203) port 80 (#0)
> GET /vadmeste/empty HTTP/1.1
> Host: s3.amazonaws.com
> User-Agent: curl/7.58.0
> Accept: */*
> Range: bytes=0-
> 
< HTTP/1.1 416 Requested Range Not Satisfiable
< x-amz-request-id: F8BCDEDAAA273B0A
< x-amz-id-2: z6ETN7+6GguwCWc4StTjWYtGB8qK5k1asyCNeSsvMxRY4rs17boq+vsv5Ng74YhB0DkEVawMj+4=
< Content-Type: application/xml
< Transfer-Encoding: chunked
< Date: Tue, 02 Oct 2018 08:32:33 GMT
< Server: AmazonS3
< 
<?xml version="1.0" encoding="UTF-8"?>
* Connection #0 to host s3.amazonaws.com left intact
<Error><Code>InvalidRange</Code><Message>The requested range is not satisfiable</Message><RangeRequested>bytes=0-</RangeRequested><ActualObjectSize>0</ActualObjectSize><RequestId>F8BCDEDAAA273B0A</RequestId><HostId>z6ETN7+6GguwCWc4StTjWYtGB8qK5k1asyCNeSsvMxRY4rs17boq+vsv5Ng74YhB0DkEVawMj+4=</HostId></Error>
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.