### PR TITLE
Avoid unsolicited response over idle http client

### DIFF
--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -35,9 +35,7 @@ import (
 
 var sslRequiredErrMsg = []byte("HTTP/1.0 403 Forbidden\r\n\r\nSSL required")
 
-var malformedErrMsgFn = func(data interface{}) string {
-	return fmt.Sprintf("HTTP/1.0 400 Bad Request\r\n\r\n%s", data)
-}
+var badRequestMsg = []byte("HTTP/1.0 400 Bad Request\r\n\r\n")
 
 // HTTP methods.
 var methods = []string{
@@ -97,7 +95,7 @@ func getPlainText(bufConn *BufConn) (bool, error) {
 	return false, nil
 }
 
-func getResourceHost(bufConn *BufConn, maxHeaderBytes int) (resource string, method string, host string, err error) {
+func getMethodResourceHost(bufConn *BufConn, maxHeaderBytes int) (method string, resource string, host string, err error) {
 	defer bufConn.setReadTimeout()
 
 	var data []byte
@@ -120,11 +118,15 @@ func getResourceHost(bufConn *BufConn, maxHeaderBytes int) (resource string, met
 
 		if method == "" && resource == "" {
 			if i := strings.IndexByte(tokens[0], ' '); i == -1 {
-				return "", "", "", fmt.Errorf("malformed HTTP request %s, from %s", tokens[0], bufConn.LocalAddr())
+				return "", "", "", fmt.Errorf("malformed HTTP request from '%s'", bufConn.LocalAddr())
 			}
 			httpTokens := strings.SplitN(tokens[0], " ", 3)
 			if len(httpTokens) < 3 {
-				return "", "", "", fmt.Errorf("malformed HTTP request %s, from %s", tokens[0], bufConn.LocalAddr())
+				return "", "", "", fmt.Errorf("malformed HTTP request from '%s'", bufConn.LocalAddr())
+			}
+			if !isHTTPMethod(httpTokens[0]) {
+				return "", "", "", fmt.Errorf("malformed HTTP request, invalid HTTP method '%s' from '%s'",
+					httpTokens[0], bufConn.LocalAddr())
 			}
 
 			method = httpTokens[0]
@@ -141,7 +143,7 @@ func getResourceHost(bufConn *BufConn, maxHeaderBytes int) (resource string, met
 			token = strings.ToLower(token)
 			if strings.HasPrefix(token, "host: ") {
 				host = strings.TrimPrefix(strings.TrimSuffix(token, "\r"), "host: ")
-				return resource, method, host, nil
+				return method, resource, host, nil
 			}
 		}
 
@@ -234,6 +236,7 @@ func (listener *httpListener) start() {
 				bufconn.Close()
 				return
 			}
+
 			if ok {
 				// As TLS is configured and we got plain text HTTP request,
 				// return 403 (forbidden) error.
@@ -241,8 +244,10 @@ func (listener *httpListener) start() {
 				bufconn.Close()
 				return
 			}
+
 			// As the listener is configured with TLS, try to do TLS handshake, drop the connection if it fails.
 			tlsConn := tls.Server(bufconn, listener.tlsConfig)
+
 			if err := tlsConn.Handshake(); err != nil {
 				reqInfo := (&logger.ReqInfo{}).AppendTags("remoteAddr", bufconn.RemoteAddr().String())
 				reqInfo.AppendTags("localAddr", bufconn.LocalAddr().String())
@@ -251,10 +256,11 @@ func (listener *httpListener) start() {
 				bufconn.Close()
 				return
 			}
+
 			bufconn = newBufConn(tlsConn, listener.readTimeout, listener.writeTimeout)
 		}
 
-		resource, method, host, err := getResourceHost(bufconn, listener.maxHeaderBytes)
+		method, resource, host, err := getMethodResourceHost(bufconn, listener.maxHeaderBytes)
 		if err != nil {
 			// Peek could fail legitimately when clients abruptly close
 			// connection. E.g. Chrome browser opens connections speculatively to
@@ -266,20 +272,8 @@ func (listener *httpListener) start() {
 				reqInfo.AppendTags("localAddr", bufconn.LocalAddr().String())
 				ctx := logger.SetReqInfo(context.Background(), reqInfo)
 				logger.LogIf(ctx, err)
+				bufconn.Write(badRequestMsg)
 			}
-			bufconn.Write([]byte(malformedErrMsgFn(err)))
-			bufconn.Close()
-			return
-		}
-
-		// Return bufconn if read data is a valid HTTP method.
-		if !isHTTPMethod(method) {
-			reqInfo := (&logger.ReqInfo{}).AppendTags("remoteAddr", bufconn.RemoteAddr().String())
-			reqInfo.AppendTags("localAddr", bufconn.LocalAddr().String())
-			ctx := logger.SetReqInfo(context.Background(), reqInfo)
-			err = fmt.Errorf("malformed HTTP invalid HTTP method %s", method)
-			logger.LogIf(ctx, err)
-			bufconn.Write([]byte(malformedErrMsgFn(err)))
 			bufconn.Close()
 			return
 		}

--- a/cmd/http/listener_test.go
+++ b/cmd/http/listener_test.go
@@ -657,11 +657,8 @@ func TestHTTPListenerAcceptError(t *testing.T) {
 				continue
 			}
 
-			s, err := bufio.NewReader(conn).ReadString('\n')
-			if err != nil {
-				t.Errorf("Test %d: reply read: expected = <nil>, got = %s", i+1, err)
-			} else if !strings.Contains(s, "HTTP/1.0 400 Bad Request") {
-				t.Errorf("Test %d: reply read: expected = 'HTTP/1.0 400 Bad Request' got = %s", i+1, s)
+			if _, err = bufio.NewReader(conn).ReadString('\n'); err != io.EOF {
+				t.Errorf("Test %d: reply read: expected = io.EOF, got = %s", i+1, err)
 			}
 
 			conn.Close()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Without this PR minio server is writing an erroneous
response to clients on an idle connection which ends
up printing following message

```
Unsolicited response received on idle HTTP channel
```
<!--- Describe your changes in detail -->

## Motivation and Context
This PR would avoid sending responses on idle connections
.i.e routine network errors.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
This issue is tricky to reproduce, requires quite a few runs and only in distributed setup 
```sh
#!/bin/bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
uuid1="export1"
uuid2="export2"
uuid3="export3"
uuid4="export4"
mkdir -p "/tmp/$uuid1" "/tmp/$uuid2" "/tmp/$uuid3" "/tmp/$uuid4"
minio server --config-dir /tmp/config --address :9001 "http://127.0.0.1:9001/tmp/${uuid1}" "http://127.0.0.1:9002/tmp/${uuid2}" "http://127.0.0.1:9003/tmp/${uuid3}" "http://127.0.0.1:9004/tmp/${uuid4}"&
minio server --config-dir /tmp/config --address :9002 "http://127.0.0.1:9001/tmp/${uuid1}" "http://127.0.0.1:9002/tmp/${uuid2}" "http://127.0.0.1:9003/tmp/${uuid3}" "http://127.0.0.1:9004/tmp/${uuid4}"&
minio server --config-dir /tmp/config --address :9003 "http://127.0.0.1:9001/tmp/${uuid1}" "http://127.0.0.1:9002/tmp/${uuid2}" "http://127.0.0.1:9003/tmp/${uuid3}" "http://127.0.0.1:9004/tmp/${uuid4}"&
minio server --config-dir /tmp/config --address :9004 "http://127.0.0.1:9001/tmp/${uuid1}" "http://127.0.0.1:9002/tmp/${uuid2}" "http://127.0.0.1:9003/tmp/${uuid3}" "http://127.0.0.1:9004/tmp/${uuid4}"
```

Repeatedly perform `mc admin heal` to reproduce this, @vadmeste suggested even mint tests would reproduce this problem.
```
mc admin heal -r myminio
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.