### PR TITLE
Verify bitrot in ReadFile correctly when verifier is set

### DIFF
--- a/cmd/storage-rpc-client.go
+++ b/cmd/storage-rpc-client.go
@@ -242,7 +242,7 @@ func (client *StorageRPCClient) ReadFile(volume string, path string, offset int6
 		Path:     path,
 		Offset:   offset,
 		Length:   int64(len(buffer)),
-		Verified: true, // mark read as verified by default
+		Verified: verifier == nil, // Marked accordingly if verifier is set or not.
 	}
 	if verifier != nil {
 		args.Algo = verifier.algorithm


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Verify bitrot in ReadFile correctly when verifier is set
<!--- Describe your changes in detail -->

## Motivation and Context
This is a major regression introduced in this commit

ce02ab613d21bd777eeb35386d0eb6676c2499a2 is the first bad commit
commit ce02ab613d21bd777eeb35386d0eb6676c2499a2
Author: Krishna Srinivas <634494+krishnasrinivas@users.noreply.github.com>
Date:   Mon Aug 6 15:14:08 2018 -0700

    Simplify erasure code by separating bitrot from erasure code (#5959)

:040000 040000 794f58d82abb62bc02439e0118dc32825a45d255 d2201ebfc8df0b0f1d15347d50e9360541ddd7c9 M	cmd

This effects all distributed server deployments since this commit

All the following releases are affected

- RELEASE.2018-09-25T21-34-43Z
- RELEASE.2018-09-12T18-49-56Z
- RELEASE.2018-09-11T01-39-21Z
- RELEASE.2018-09-01T00-38-25Z
- RELEASE.2018-08-25T01-56-38Z
- RELEASE.2018-08-21T00-37-20Z
- RELEASE.2018-08-18T03-49-57Z
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes in ce02ab613d21bd777eeb35386d0eb6676c2499a2
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Run a 12 disk distributed setup
```
#!/bin/bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
set -x
for i in {01..12}; do
    minio server --address ":90${i}" http://127.0.0.1:9001/tmp/1 http://127.0.0.1:9002/tmp/2 http://127.0.0.1:9003/tmp/3 http://127.0.0.1:9004/tmp/4 http://127.0.0.1:9005/tmp/5 http://127.0.0.1:9006/tmp/6 http://127.0.0.1:9007/tmp/7 http://127.0.0.1:9008/tmp/8 http://127.0.0.1:9009/tmp/9 http://127.0.0.1:9010/tmp/10 http://127.0.0.1:9011/tmp/11 http://127.0.0.1:9012/tmp/12 &
done
```

Now run this script on another terminal
```
#!/bin/bash

mc mb myminio-local1/testbucket/ 2>/dev/null

mc cp -q "$(which emacs)" myminio-local1/testbucket/

for j in emacs; do
    for i in 1 11 12 5 2 3 4; do
        dd if=/dev/urandom of=/tmp/$i/testbucket/$j/part.1 bs=1024 count=1 seek=1024 conv=notrunc 2> /dev/null
    done
done

for j in emacs; do
    mc cat myminio-local1/testbucket/$j | md5sum
done
```

Expected
```
$ /tmp/test.sh 
`/usr/bin/emacs` -> `myminio-local1/testbucket/emacs`
Total: 13.85 MB, Transferred: 13.85 MB, Speed: 30.44 MB/s
mc: <ERROR> Unable to read from `myminio-local1/testbucket/emacs`. unexpected EOF
d41d8cd98f00b204e9800998ecf8427e
```

What we get in master is a bug, md5sum keeps changing indicating that we are trying to write corrupted data to client.
```
$ /tmp/test.sh 
`/usr/bin/emacs` -> `myminio-local1/testbucket/emacs`
Total: 13.85 MB, Transferred: 13.85 MB, Speed: 31.24 MB/s
1d33e205df8045af2c35cb0ee5060cb6  -

$ /tmp/test.sh 
`/usr/bin/emacs` -> `myminio-local1/testbucket/emacs`
Total: 13.85 MB, Transferred: 13.85 MB, Speed: 35.80 MB/s
0f4e96b7d27e593625aa2ffb033600d8  -
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.