### PR TITLE
xl: Fix typo in PutObject when uploading a 10Mb file

### DIFF
--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -686,7 +686,7 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 	switch size := data.Size(); {
 	case size == 0:
 		buffer = make([]byte, 1) // Allocate atleast a byte to reach EOF
-	case size == -1 || size > blockSizeV1:
+	case size == -1 || size >= blockSizeV1:
 		buffer = xl.bp.Get()
 		defer xl.bp.Put(buffer)
 	case size < blockSizeV1:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PutObject forgot to allocate memory when the size of the uploaded
file is exactly equal to blockSizeV1 = 10 Mb.

## Motivation and Context
Fix upload issue

## Regression
Yes, ce9d36d954ebb93db52e6055ec9e21594f746e33

## How Has This Been Tested?
mc cp 10mb.file myminio/testbucket/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.