### PR TITLE
Handle read/quorum errors when initializing all subsystems

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/minio/minio/cmd/logger"
@@ -234,7 +235,8 @@ func (sys *ConfigSys) Init(objAPI ObjectLayer) error {
 		case _ = <-retryTimerCh:
 			err := initConfig(objAPI)
 			if err != nil {
-				if isInsufficientReadQuorum(err) || isInsufficientWriteQuorum(err) {
+				if strings.Contains(err.Error(), InsufficientReadQuorum{}.Error()) ||
+					strings.Contains(err.Error(), InsufficientWriteQuorum{}.Error()) {
 					logger.Info("Waiting for configuration to be initialized..")
 					continue
 				}

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -345,7 +345,9 @@ func (sys *NotificationSys) Init(objAPI ObjectLayer) error {
 		select {
 		case _ = <-retryTimerCh:
 			if err := sys.refresh(objAPI); err != nil {
-				if err == errDiskNotFound || isInsufficientReadQuorum(err) || isInsufficientWriteQuorum(err) {
+				if err == errDiskNotFound ||
+					strings.Contains(err.Error(), InsufficientReadQuorum{}.Error()) ||
+					strings.Contains(err.Error(), InsufficientWriteQuorum{}.Error()) {
 					logger.Info("Waiting for notification subsystem to be initialized..")
 					continue
 				}

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -174,7 +174,7 @@ func (s *xlSets) reInitDisks(refFormat *formatXLV3, storageDisks []StorageAPI, f
 // any given sets.
 func (s *xlSets) connectDisksWithQuorum() {
 	var onlineDisks int
-	for onlineDisks < (len(s.endpoints)/2)+1 {
+	for onlineDisks < len(s.endpoints)/2 {
 		for _, endpoint := range s.endpoints {
 			if s.isConnected(endpoint) {
 				continue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Policy, notification and config subsystems can encounter some read/write quorums errors and we should not quit when that happens in a distributed mode since we need also to support rolling update (when not all nodes are started or ready at the same time)


## Motivation and Context

Fixes #6586 
Fixes #6584

## Regression
No

## How Has This Been Tested?
1. Run a cluster of 12 nodes.
2. Kill all nodes
3. Run only 6 nodes of that cluster

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.