### PR TITLE
Fix out-of-bound array access crash in select processing

### DIFF
--- a/pkg/s3select/select.go
+++ b/pkg/s3select/select.go
@@ -370,8 +370,9 @@ func aggregationFunctions(counter int, filtrCount int, myAggVals []float64, colu
 			// If column names are provided as an index it'll use this if statement instead of the else/
 			var convAggFloat float64
 			if representsInt(storeReqCols[i]) {
-				myIndex, _ := strconv.Atoi(storeReqCols[i])
-				convAggFloat, _ = strconv.ParseFloat(record[myIndex], 64)
+				colIndex, _ := strconv.Atoi(storeReqCols[i])
+				// colIndex is 1-based
+				convAggFloat, _ = strconv.ParseFloat(record[colIndex-1], 64)
 
 			} else {
 				// case that the columns are in the form of named columns rather than indices.

--- a/pkg/s3select/select_test.go
+++ b/pkg/s3select/select_test.go
@@ -331,7 +331,7 @@ func TestMyAggregationFunc(t *testing.T) {
 		{1, 1, []float64{10}, columnsMap, []string{"Col1"}, []string{"avg"}, []string{"1", "2"}, nil, 5.500},
 		{10, 5, []float64{0.000}, columnsMap, []string{"Col1"}, []string{"random"}, []string{"1", "2"}, ErrParseNonUnaryAgregateFunctionCall, 0},
 		{0, 5, []float64{0}, columnsMap, []string{"0"}, []string{"count"}, []string{"1", "2"}, nil, 1},
-		{10, 5, []float64{10}, columnsMap, []string{"1"}, []string{"min"}, []string{"1", "12"}, nil, 10},
+		{10, 5, []float64{10}, columnsMap, []string{"1"}, []string{"min"}, []string{"1", "12"}, nil, 1},
 	}
 	for _, table := range tables {
 		err := aggregationFunctions(table.counter, table.filtrCount, table.myAggVals, table.columnsMap, table.storeReqCols, table.storeFunctions, table.record)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix an array out of bound access crash. This happens in select processing when using array based column selection.

To reproduce the problem:

Sample Csv file `2.csv`
```
Name,Count
A,3
B,4
C,1
D,0
```

Commands:

```bash
mc cp 2.csv myminio/test
mc select --query "select sum(s._2) from S3Object" myminio/test/2.csv
```

On the server console we see a full crash (server process exits!):

```
$ MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123 ./minio server /tmp/disk

Endpoint:  http://192.168.1.176:9000  http://172.22.0.1:9000  http://172.17.0.1:9000  http://172.19.0.1:9000  http://172.20.0.1:9000  http://172.21.0.1:9000  http://172.23.0.1:9000  http://172.18.0.1:9000  http://192.168.122.1:9000  http://127.0.0.1:9000
AccessKey: minio 
SecretKey: minio123 

Browser Access:
   http://192.168.1.176:9000  http://172.22.0.1:9000  http://172.17.0.1:9000  http://172.19.0.1:9000  http://172.20.0.1:9000  http://172.21.0.1:9000  http://172.23.0.1:9000  http://172.18.0.1:9000  http://192.168.122.1:9000  http://127.0.0.1:9000

Command-line Access: https://docs.minio.io/docs/minio-client-quickstart-guide
   $ mc config host add myminio http://192.168.1.176:9000 minio minio123

Object API (Amazon S3 compatible):
   Go:         https://docs.minio.io/docs/golang-client-quickstart-guide
   Java:       https://docs.minio.io/docs/java-client-quickstart-guide
   Python:     https://docs.minio.io/docs/python-client-quickstart-guide
   JavaScript: https://docs.minio.io/docs/javascript-client-quickstart-guide
   .NET:       https://docs.minio.io/docs/dotnet-client-quickstart-guide
panic: runtime error: index out of range

goroutine 69 [running]:
github.com/minio/minio/pkg/s3select.aggregationFunctions(0xffffffffffffffff, 0x0, 0xc4205eee00, 0x1, 0x1, 0xc420015c38, 0xc4205c86f0, 0x1, 0x1, 0xc4205c86e0, ...)
	/home/aditya/Code/goenv-1.10.1/workspace/src/github.com/minio/minio/pkg/s3select/select.go:364 +0x51b
github.com/minio/minio/pkg/s3select.(*Input).processSelectReq(0xc4200b2280, 0xc4205c86f0, 0x1, 0x1, 0xc4205eeda0, 0x8, 0x0, 0x0, 0x7fffffffffffffff, 0xc4205c86e0, ...)
	/home/aditya/Code/goenv-1.10.1/workspace/src/github.com/minio/minio/pkg/s3select/select.go:236 +0x51b
github.com/minio/minio/pkg/s3select.(*Input).runSelectParser(0xc4200b2280, 0xc4205f0480, 0x1e, 0xc4200a9320)
	/home/aditya/Code/goenv-1.10.1/workspace/src/github.com/minio/minio/pkg/s3select/select.go:45 +0x19c
created by github.com/minio/minio/pkg/s3select.(*Input).Execute
	/home/aditya/Code/goenv-1.10.1/workspace/src/github.com/minio/minio/pkg/s3select/input.go:299 +0x1e4
```

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
Not sure, if this was working in an earlier version of select.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Repeat the steps to reproduce and the correct result is received without any crash.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.
