### PR TITLE
profiling: Fix downloading tracing profiling data

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -218,18 +218,26 @@ func startProfiler(profilerType, dirPath string) (interface {
 		Stop()
 	}
 
-	// Enable profiler, supported types are [cpu, mem, block].
+	var profilerFileName string
+
+	// Enable profiler and set the name of the file that pkg/pprof
+	// library creates to store profiling data.
 	switch profilerType {
 	case "cpu":
 		profiler = profile.Start(profile.CPUProfile, profile.NoShutdownHook, profile.ProfilePath(dirPath))
+		profilerFileName = "cpu.pprof"
 	case "mem":
 		profiler = profile.Start(profile.MemProfile, profile.NoShutdownHook, profile.ProfilePath(dirPath))
+		profilerFileName = "mem.pprof"
 	case "block":
 		profiler = profile.Start(profile.BlockProfile, profile.NoShutdownHook, profile.ProfilePath(dirPath))
+		profilerFileName = "block.pprof"
 	case "mutex":
 		profiler = profile.Start(profile.MutexProfile, profile.NoShutdownHook, profile.ProfilePath(dirPath))
+		profilerFileName = "mutex.pprof"
 	case "trace":
 		profiler = profile.Start(profile.TraceProfile, profile.NoShutdownHook, profile.ProfilePath(dirPath))
+		profilerFileName = "trace.out"
 	default:
 		return nil, errors.New("profiler type unknown")
 	}
@@ -237,7 +245,7 @@ func startProfiler(profilerType, dirPath string) (interface {
 	return &profilerWrapper{
 		stopFn: profiler.Stop,
 		pathFn: func() string {
-			return filepath.Join(dirPath, profilerType+".pprof")
+			return filepath.Join(dirPath, profilerFileName)
 		},
 	}, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
pkg/pprof saves tracing profiling data in a different file name
(trace.out) in contrary to other profiling mode.


## Motivation and Context
Fix downloading tracing profiling data

## Regression
No

## How Has This Been Tested?
Test with mc profiling PR

```
$ mc admin profiling start --type="trace" myminio/
$ mc admin profiling stop myminio/
$ unzip profiling.zip
$ go tool trace profiling-0 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.