### PR TITLE
Validate user provided SSE-C key on Head Object API

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -552,6 +552,11 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 			case crypto.S3.IsEncrypted(objInfo.UserDefined):
 				w.Header().Set(crypto.SSEHeader, crypto.SSEAlgorithmAES256)
 			case crypto.SSEC.IsEncrypted(objInfo.UserDefined):
+				// Validate the SSE-C Key set in the header.
+				if _, err = crypto.SSEC.UnsealObjectKey(r.Header, objInfo.UserDefined, bucket, object); err != nil {
+					writeErrorResponseHeadersOnly(w, toAPIErrorCode(err))
+					return
+				}
 				w.Header().Set(crypto.SSECAlgorithm, r.Header.Get(crypto.SSECAlgorithm))
 				w.Header().Set(crypto.SSECKeyMD5, r.Header.Get(crypto.SSECKeyMD5))
 			}


### PR DESCRIPTION


## Description
User provided SSE-C key is not currently validated on a Head Object API. 
Because of which, the HEAD Object API returns 200 for an incorrect SSE-C key.

Fixes #6598

## Motivation and Context
Issue #6598 

## Regression
No.

## How Has This Been Tested?
```
mc cp --encrypt-key "x1minio/test-enc1=$(echo original-password | openssl dgst -sha256 -binary | xxd -p -c 32 -l 16)" /tmp/sourcedir/1.rand x1minio/test-enc1/
mc stat --debug --encrypt-key "x1minio/test-enc1=$(echo wrong-password | openssl dgst -sha256 -binary | xxd -p -c 32 -l 16)" x1minio/test-enc1/1.rand
```
Without the changes, `HEAD` call would return `200` and with the change, it will return `403` just like `AWS S3`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.