### PR TITLE
encryption: Fix copy from encrypted multipart to single part

### DIFF
--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -80,6 +80,28 @@ func hasServerSideEncryptionHeader(header http.Header) bool {
 	return crypto.S3.IsRequested(header) || crypto.SSEC.IsRequested(header)
 }
 
+// isEncryptedMultipart returns true if the current object is
+// uploaded by the user using multipart mechanism:
+// initiate new multipart, upload part, complete upload
+func isEncryptedMultipart(objInfo ObjectInfo) bool {
+	if len(objInfo.Parts) == 0 {
+		return false
+	}
+	if !crypto.IsMultiPart(objInfo.UserDefined) {
+		return false
+	}
+	for _, part := range objInfo.Parts {
+		_, err := sio.DecryptedSize(uint64(part.Size))
+		if err != nil {
+			return false
+		}
+	}
+	// Further check if this object is uploaded using multipart mechanism
+	// by the user and it is not about XL internally splitting the
+	// object into parts in PutObject()
+	return !(objInfo.backendType == BackendErasure && len(objInfo.ETag) == 32)
+}
+
 // ParseSSECopyCustomerRequest parses the SSE-C header fields of the provided request.
 // It returns the client provided key on success.
 func ParseSSECopyCustomerRequest(h http.Header, metadata map[string]string) (key []byte, err error) {
@@ -361,7 +383,7 @@ func newDecryptReaderWithObjectKey(client io.Reader, objectEncryptionKey []byte,
 // GetEncryptedOffsetLength - returns encrypted offset and length
 // along with sequence number
 func GetEncryptedOffsetLength(startOffset, length int64, objInfo ObjectInfo) (seqNumber uint32, encStartOffset, encLength int64) {
-	if len(objInfo.Parts) == 0 || !crypto.IsMultiPart(objInfo.UserDefined) {
+	if !isEncryptedMultipart(objInfo) {
 		seqNumber, encStartOffset, encLength = getEncryptedSinglePartOffsetLength(startOffset, length, objInfo)
 		return
 	}
@@ -378,7 +400,7 @@ func DecryptBlocksRequestR(inputReader io.Reader, h http.Header, offset,
 	bucket, object := oi.Bucket, oi.Name
 
 	// Single part case
-	if len(oi.Parts) == 0 || !crypto.IsMultiPart(oi.UserDefined) {
+	if !isEncryptedMultipart(oi) {
 		var reader io.Reader
 		var err error
 		if copySource {
@@ -708,7 +730,7 @@ func DecryptBlocksRequest(client io.Writer, r *http.Request, bucket, object stri
 	var seqNumber uint32
 	var encStartOffset, encLength int64
 
-	if len(objInfo.Parts) == 0 || !crypto.IsMultiPart(objInfo.UserDefined) {
+	if !isEncryptedMultipart(objInfo) {
 		seqNumber, encStartOffset, encLength = getEncryptedSinglePartOffsetLength(startOffset, length, objInfo)
 
 		var writer io.WriteCloser
@@ -870,7 +892,7 @@ func (o *ObjectInfo) DecryptedSize() (int64, error) {
 	if !crypto.IsEncrypted(o.UserDefined) {
 		return 0, errors.New("Cannot compute decrypted size of an unencrypted object")
 	}
-	if len(o.Parts) == 0 || !crypto.IsMultiPart(o.UserDefined) {
+	if !isEncryptedMultipart(*o) {
 		size, err := sio.DecryptedSize(uint64(o.Size))
 		if err != nil {
 			err = errObjectTampered // assign correct error type
@@ -918,7 +940,7 @@ func (o *ObjectInfo) GetDecryptedRange(rs *HTTPRangeSpec) (encOff, encLength, sk
 	}
 	sizes := []int64{int64(partSize)}
 	decObjSize = sizes[0]
-	if crypto.IsMultiPart(o.UserDefined) {
+	if isEncryptedMultipart(*o) {
 		sizes = make([]int64, len(o.Parts))
 		decObjSize = 0
 		for i, part := range o.Parts {

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -109,8 +109,12 @@ type ObjectInfo struct {
 	Writer       io.WriteCloser `json:"-"`
 	Reader       *hash.Reader   `json:"-"`
 	metadataOnly bool
+
 	// Date and time when the object was last accessed.
 	AccTime time.Time
+
+	// backendType indicates which backend filled this structure
+	backendType BackendType
 }
 
 // ListPartsInfo - represents list of all parts.

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -218,6 +218,8 @@ func (m xlMetaV1) ToObjectInfo(bucket, object string) ObjectInfo {
 		ContentEncoding: m.Meta["content-encoding"],
 	}
 
+	objInfo.backendType = BackendErasure
+
 	// Extract etag from metadata.
 	objInfo.ETag = extractETag(m.Meta)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
CopyObject handler forgot to remove multipart encryption flag in metadata
when source is an encrypted multipart object and the target is also encrypted
but single part object.

This PR also simplifies the code to facilitate review.

## Motivation and Context
Fix copy bug

## Regression
Yes, https://github.com/minio/minio/tree/RELEASE.2018-09-25T21-34-43Z

## How Has This Been Tested?
1. Upload an encrypted object with a size of 65 mb using mc
2. Copy that object to a new location, the copied object will still be encrypted
3. Download the copied object & check content


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [x] I have added/updated functional tests in [mint](https://github.com/minio/mint).  https://github.com/minio/mint/pull/291
- [x] All new and existing tests passed.