### PR TITLE
crypto: add helper functions for unsealing object keys

### DIFF
--- a/cmd/crypto/sse_test.go
+++ b/cmd/crypto/sse_test.go
@@ -14,7 +14,10 @@
 
 package crypto
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
 func TestS3String(t *testing.T) {
 	const Domain = "SSE-S3"
@@ -27,5 +30,197 @@ func TestSSECString(t *testing.T) {
 	const Domain = "SSE-C"
 	if domain := SSEC.String(); domain != Domain {
 		t.Errorf("SSEC's string method returns wrong domain: got '%s' - want '%s'", domain, Domain)
+	}
+}
+
+var ssecUnsealObjectKeyTests = []struct {
+	Headers        http.Header
+	Bucket, Object string
+	Metadata       map[string]string
+
+	ExpectedErr error
+}{
+	{ // 0 - Valid HTTP headers and valid metadata entries for bucket/object
+		Headers: http.Header{
+			"X-Amz-Server-Side-Encryption-Customer-Algorithm": []string{"AES256"},
+			"X-Amz-Server-Side-Encryption-Customer-Key":       []string{"MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ="},
+			"X-Amz-Server-Side-Encryption-Customer-Key-Md5":   []string{"7PpPLAK26ONlVUGOWlusfg=="},
+		},
+		Bucket: "bucket",
+		Object: "object",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfAMBdYor5tf/UlVaQvwYlw5yKbPBeQqfygqsfHqhu1wHD9KDAP4bw38AhL12prFTS23JbbR9Re5Qv26ZnlQ==",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DAREv2-HMAC-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "coVfGS3I/CTrqexX5vUN+PQPoP9aUFiPYYrSzqTWfBA=",
+		},
+		ExpectedErr: nil,
+	},
+	{ // 1 - Valid HTTP headers but invalid metadata entries for bucket/object2
+		Headers: http.Header{
+			"X-Amz-Server-Side-Encryption-Customer-Algorithm": []string{"AES256"},
+			"X-Amz-Server-Side-Encryption-Customer-Key":       []string{"MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ="},
+			"X-Amz-Server-Side-Encryption-Customer-Key-Md5":   []string{"7PpPLAK26ONlVUGOWlusfg=="},
+		},
+		Bucket: "bucket",
+		Object: "object2",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfAMBdYor5tf/UlVaQvwYlw5yKbPBeQqfygqsfHqhu1wHD9KDAP4bw38AhL12prFTS23JbbR9Re5Qv26ZnlQ==",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DAREv2-HMAC-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "coVfGS3I/CTrqexX5vUN+PQPoP9aUFiPYYrSzqTWfBA=",
+		},
+		ExpectedErr: ErrSecretKeyMismatch,
+	},
+	{ // 2 - Valid HTTP headers but invalid metadata entries for bucket/object
+		Headers: http.Header{
+			"X-Amz-Server-Side-Encryption-Customer-Algorithm": []string{"AES256"},
+			"X-Amz-Server-Side-Encryption-Customer-Key":       []string{"MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ="},
+			"X-Amz-Server-Side-Encryption-Customer-Key-Md5":   []string{"7PpPLAK26ONlVUGOWlusfg=="},
+		},
+		Bucket: "bucket",
+		Object: "object",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key": "IAAfAMBdYor5tf/UlVaQvwYlw5yKbPBeQqfygqsfHqhu1wHD9KDAP4bw38AhL12prFTS23JbbR9Re5Qv26ZnlQ==",
+			"X-Minio-Internal-Server-Side-Encryption-Iv":         "coVfGS3I/CTrqexX5vUN+PQPoP9aUFiPYYrSzqTWfBA=",
+		},
+		ExpectedErr: errMissingInternalSealAlgorithm,
+	},
+	{ // 3 - Invalid HTTP headers for valid metadata entries for bucket/object
+		Headers: http.Header{
+			"X-Amz-Server-Side-Encryption-Customer-Algorithm": []string{"AES256"},
+			"X-Amz-Server-Side-Encryption-Customer-Key":       []string{"MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ="},
+		},
+		Bucket: "bucket",
+		Object: "object",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfAMBdYor5tf/UlVaQvwYlw5yKbPBeQqfygqsfHqhu1wHD9KDAP4bw38AhL12prFTS23JbbR9Re5Qv26ZnlQ==",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DAREv2-HMAC-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "coVfGS3I/CTrqexX5vUN+PQPoP9aUFiPYYrSzqTWfBA=",
+		},
+		ExpectedErr: ErrMissingCustomerKeyMD5,
+	},
+}
+
+func TestSSECUnsealObjectKey(t *testing.T) {
+	for i, test := range ssecUnsealObjectKeyTests {
+		if _, err := SSEC.UnsealObjectKey(test.Headers, test.Metadata, test.Bucket, test.Object); err != test.ExpectedErr {
+			t.Errorf("Test %d: got: %v - want: %v", i, err, test.ExpectedErr)
+		}
+	}
+}
+
+var sseCopyUnsealObjectKeyTests = []struct {
+	Headers        http.Header
+	Bucket, Object string
+	Metadata       map[string]string
+
+	ExpectedErr error
+}{
+	{ // 0 - Valid HTTP headers and valid metadata entries for bucket/object
+		Headers: http.Header{
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm": []string{"AES256"},
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key":       []string{"MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ="},
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-Md5":   []string{"7PpPLAK26ONlVUGOWlusfg=="},
+		},
+		Bucket: "bucket",
+		Object: "object",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfAMBdYor5tf/UlVaQvwYlw5yKbPBeQqfygqsfHqhu1wHD9KDAP4bw38AhL12prFTS23JbbR9Re5Qv26ZnlQ==",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DAREv2-HMAC-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "coVfGS3I/CTrqexX5vUN+PQPoP9aUFiPYYrSzqTWfBA=",
+		},
+		ExpectedErr: nil,
+	},
+	{ // 1 - Valid HTTP headers but invalid metadata entries for bucket/object2
+		Headers: http.Header{
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm": []string{"AES256"},
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key":       []string{"MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ="},
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-Md5":   []string{"7PpPLAK26ONlVUGOWlusfg=="},
+		},
+		Bucket: "bucket",
+		Object: "object2",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfAMBdYor5tf/UlVaQvwYlw5yKbPBeQqfygqsfHqhu1wHD9KDAP4bw38AhL12prFTS23JbbR9Re5Qv26ZnlQ==",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DAREv2-HMAC-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "coVfGS3I/CTrqexX5vUN+PQPoP9aUFiPYYrSzqTWfBA=",
+		},
+		ExpectedErr: ErrSecretKeyMismatch,
+	},
+	{ // 2 - Valid HTTP headers but invalid metadata entries for bucket/object
+		Headers: http.Header{
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm": []string{"AES256"},
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key":       []string{"MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ="},
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-Md5":   []string{"7PpPLAK26ONlVUGOWlusfg=="},
+		},
+		Bucket: "bucket",
+		Object: "object",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key": "IAAfAMBdYor5tf/UlVaQvwYlw5yKbPBeQqfygqsfHqhu1wHD9KDAP4bw38AhL12prFTS23JbbR9Re5Qv26ZnlQ==",
+			"X-Minio-Internal-Server-Side-Encryption-Iv":         "coVfGS3I/CTrqexX5vUN+PQPoP9aUFiPYYrSzqTWfBA=",
+		},
+		ExpectedErr: errMissingInternalSealAlgorithm,
+	},
+	{ // 3 - Invalid HTTP headers for valid metadata entries for bucket/object
+		Headers: http.Header{
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm": []string{"AES256"},
+			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key":       []string{"MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0cHJvdmlkZWQ="},
+		},
+		Bucket: "bucket",
+		Object: "object",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Sealed-Key":     "IAAfAMBdYor5tf/UlVaQvwYlw5yKbPBeQqfygqsfHqhu1wHD9KDAP4bw38AhL12prFTS23JbbR9Re5Qv26ZnlQ==",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm": "DAREv2-HMAC-SHA256",
+			"X-Minio-Internal-Server-Side-Encryption-Iv":             "coVfGS3I/CTrqexX5vUN+PQPoP9aUFiPYYrSzqTWfBA=",
+		},
+		ExpectedErr: ErrMissingCustomerKeyMD5,
+	},
+}
+
+func TestSSECopyUnsealObjectKey(t *testing.T) {
+	for i, test := range sseCopyUnsealObjectKeyTests {
+		if _, err := SSECopy.UnsealObjectKey(test.Headers, test.Metadata, test.Bucket, test.Object); err != test.ExpectedErr {
+			t.Errorf("Test %d: got: %v - want: %v", i, err, test.ExpectedErr)
+		}
+	}
+}
+
+var s3UnsealObjectKeyTests = []struct {
+	KMS            KMS
+	Bucket, Object string
+	Metadata       map[string]string
+
+	ExpectedErr error
+}{
+	{ // 0 - Valid KMS key-ID and valid metadata entries for bucket/object
+		KMS:    NewKMS([32]byte{}),
+		Bucket: "bucket",
+		Object: "object",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Iv":                "hhVY0LKR1YtZbzAKxTWUfZt5enDfYX6Fxz1ma8Kiudc=",
+			"X-Minio-Internal-Server-Side-Encryption-S3-Sealed-Key":     "IAAfALhsOeD5AE3s5Zgq3DZ5VFGsOa3B0ksVC86veDcaj+fXv2U0VadhPaOKYr9Emd5ssOsO0uIhIIrKiOy9rA==",
+			"X-Minio-Internal-Server-Side-Encryption-S3-Kms-Sealed-Key": "IAAfAMRS2iw45FsfiF3QXajSYVWj1lxMpQm6DxDGPtADCX6fJQQ4atHBtfpgqJFyeQmIHsm0FBI+UlHw1Lv4ug==",
+			"X-Minio-Internal-Server-Side-Encryption-S3-Kms-Key-Id":     "test-key-1",
+			"X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm":    "DAREv2-HMAC-SHA256",
+		},
+		ExpectedErr: nil,
+	},
+	{ // 1 - Valid KMS key-ID for invalid metadata entries for bucket/object
+		KMS:    NewKMS([32]byte{}),
+		Bucket: "bucket",
+		Object: "object",
+		Metadata: map[string]string{
+			"X-Minio-Internal-Server-Side-Encryption-Iv":                "hhVY0LKR1YtZbzAKxTWUfZt5enDfYX6Fxz1ma8Kiudc=",
+			"X-Minio-Internal-Server-Side-Encryption-S3-Sealed-Key":     "IAAfALhsOeD5AE3s5Zgq3DZ5VFGsOa3B0ksVC86veDcaj+fXv2U0VadhPaOKYr9Emd5ssOsO0uIhIIrKiOy9rA==",
+			"X-Minio-Internal-Server-Side-Encryption-S3-Kms-Sealed-Key": "IAAfAMRS2iw45FsfiF3QXajSYVWj1lxMpQm6DxDGPtADCX6fJQQ4atHBtfpgqJFyeQmIHsm0FBI+UlHw1Lv4ug==",
+			"X-Minio-Internal-Server-Side-Encryption-S3-Kms-Key-Id":     "test-key-1",
+		},
+		ExpectedErr: errMissingInternalSealAlgorithm,
+	},
+}
+
+func TestS3UnsealObjectKey(t *testing.T) {
+	for i, test := range s3UnsealObjectKeyTests {
+		if _, err := S3.UnsealObjectKey(test.KMS, test.Metadata, test.Bucket, test.Object); err != test.ExpectedErr {
+			t.Errorf("Test %d: got: %v - want: %v", i, err, test.ExpectedErr)
+		}
 	}
 }


### PR DESCRIPTION



## Description
This commit adds 2 helper functions for SSE-C and SSE-S3
to simplify object key unsealing in server code.

## Motivation and Context
See #6600

## Regression
no

## How Has This Been Tested?
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.