### PR TITLE
Docs fix for restart issue with orchestrated minio stack (#6606)

### DIFF
--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -34,6 +34,19 @@ echo "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" | docker secret create secret_ke
 
 ## 4. Deploy distributed Minio services
 
+The example Minio stack uses 4 Docker volumes, which are created automatically by deploying the stack. We have to make sure that the services in the stack are always (re)started on the same node, where the service is deployed the first time. 
+Otherwise Docker will create a new volume upon restart of the service on another Docker node, which is not in sync with the other volumes and the stack will fail to start healthy. 
+Before deploying the stack, add labels to the Docker nodes where you want the minio services to run:
+
+```
+docker node update --label-add minio1=true <DOCKER-NODE1>
+docker node update --label-add minio2=true <DOCKER-NODE2>
+docker node update --label-add minio3=true <DOCKER-NODE3>
+docker node update --label-add minio4=true <DOCKER-NODE4>
+```
+
+It is possible to run more than one minio service on one Docker Node. Set the labels accordingly.
+
 Download the [Docker Compose file](https://github.com/minio/minio/blob/master/docs/orchestration/docker-swarm/docker-compose-secrets.yaml?raw=true) on your Swarm master. Then execute the command
 
 ```shell

--- a/docs/orchestration/docker-swarm/docker-compose-secrets.yaml
+++ b/docs/orchestration/docker-swarm/docker-compose-secrets.yaml
@@ -3,6 +3,7 @@ version: '3.1'
 services:
   minio1:
     image: minio/minio:RELEASE.2018-10-06T00-15-16Z
+    hostname: minio1
     volumes:
       - minio1-data:/export
     ports:
@@ -14,6 +15,9 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      placement:
+        constraints:
+          - node.labels.minio1==true
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
     secrets:
       - secret_key
@@ -21,6 +25,7 @@ services:
 
   minio2:
     image: minio/minio:RELEASE.2018-10-06T00-15-16Z
+    hostname: minio2
     volumes:
       - minio2-data:/export
     ports:
@@ -32,6 +37,9 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      placement:
+        constraints:
+          - node.labels.minio2==true
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
     secrets:
       - secret_key
@@ -39,6 +47,7 @@ services:
 
   minio3:
     image: minio/minio:RELEASE.2018-10-06T00-15-16Z
+    hostname: minio3
     volumes:
       - minio3-data:/export
     ports:
@@ -50,6 +59,9 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      placement:
+        constraints:
+          - node.labels.minio3==true
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
     secrets:
       - secret_key
@@ -57,6 +69,7 @@ services:
 
   minio4:
     image: minio/minio:RELEASE.2018-10-06T00-15-16Z
+    hostname: minio4
     volumes:
       - minio4-data:/export
     ports:
@@ -68,6 +81,9 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      placement:
+        constraints:
+          - node.labels.minio4==true
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
     secrets:
       - secret_key

--- a/docs/orchestration/docker-swarm/docker-compose.yaml
+++ b/docs/orchestration/docker-swarm/docker-compose.yaml
@@ -3,6 +3,7 @@ version: '3'
 services:
   minio1:
     image: minio/minio:RELEASE.2018-10-06T00-15-16Z
+    hostname: minio1
     volumes:
       - minio1-data:/export
     ports:
@@ -17,10 +18,14 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      placement:
+        constraints:
+          - node.labels.minio1==true
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
 
   minio2:
     image: minio/minio:RELEASE.2018-10-06T00-15-16Z
+    hostname: minio2
     volumes:
       - minio2-data:/export
     ports:
@@ -35,10 +40,14 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      placement:
+        constraints:
+          - node.labels.minio2==true
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
 
   minio3:
     image: minio/minio:RELEASE.2018-10-06T00-15-16Z
+    hostname: minio3
     volumes:
       - minio3-data:/export
     ports:
@@ -53,10 +62,14 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      placement:
+        constraints:
+          - node.labels.minio3==true
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
 
   minio4:
     image: minio/minio:RELEASE.2018-10-06T00-15-16Z
+    hostname: minio4
     volumes:
       - minio4-data:/export
     ports:
@@ -71,6 +84,9 @@ services:
         delay: 10s
         max_attempts: 10
         window: 60s
+      placement:
+        constraints:
+          - node.labels.minio4==true
     command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
 
 volumes:


### PR DESCRIPTION
Documentation and example orchestration files for deploying in Docker Swarm improved.

## Description
Documentation and example docker-compose.yaml files are improved to start an orchestrated Docker swarm stack which can be restarted successfully without issues with the Docker Volumes (#6606). This fix also contains a fix for issue #6240. 

## Motivation and Context
Fixes #6606 
Fixes #6240 

## Regression
No

## How Has This Been Tested?
This fix is tested within a Docker Swarm environment with 2 nodes both running Docker 18.06.1-ce running on ubuntu 16.04 LTS.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.