### PR TITLE
Translate errInvalidEncryptionParameters to APIErrcode

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1441,6 +1441,8 @@ func toAPIErrorCode(err error) (apiErr APIErrorCode) {
 	case auth.ErrInvalidSecretKeyLength:
 		apiErr = ErrAdminInvalidSecretKey
 	// SSE errors
+	case errInvalidEncryptionParameters:
+		apiErr = ErrInvalidEncryptionParameters
 	case crypto.ErrInvalidEncryptionMethod:
 		apiErr = ErrInvalidEncryptionMethod
 	case errInsecureSSERequest:

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -565,7 +565,7 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 
 	// Set standard object headers.
 	if hErr := setObjectHeaders(w, objInfo, rs); hErr != nil {
-		writeErrorResponse(w, toAPIErrorCode(hErr), r.URL)
+		writeErrorResponseHeadersOnly(w, toAPIErrorCode(hErr))
 		return
 	}
 


### PR DESCRIPTION
Without this translation, errInvalidEncryptionParameters was being returned to the caller as Internal error with status code 500. Causing the client to unnecessarily retry.

In HeadObject Handler code, `writeErrorResponse` was incorrectly called in one place instead of `writeErrorResponseHeadersOnly`

Fixes #6623


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
#6623

## Regression
No

## How Has This Been Tested?
Please see instructions in #6623 to reproduce the issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.