### PR TITLE
Remove applying custom policies with STS access keys

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -305,18 +305,14 @@ func (sys *IAMSys) IsAllowed(args iampolicy.Args) bool {
 	sys.RLock()
 	defer sys.RUnlock()
 
-	// If policy is available for given user, check the policy.
-	if p, found := sys.iamPolicyMap[args.AccountName]; found {
-		// If opa is configured, use OPA in conjunction with IAM policies.
-		if globalPolicyOPA != nil {
-			return p.IsAllowed(args) && globalPolicyOPA.IsAllowed(args)
-		}
-		return p.IsAllowed(args)
-	}
-
-	// If no policies are set, let the policy arrive from OPA if any.
+	// If opa is configured, use OPA always.
 	if globalPolicyOPA != nil {
 		return globalPolicyOPA.IsAllowed(args)
+	}
+
+	// If policy is available for given user, check the policy.
+	if p, found := sys.iamPolicyMap[args.AccountName]; found {
+		return p.IsAllowed(args)
 	}
 
 	// As policy is not available and OPA is not configured, return the owner value.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove applying custom policies with STS access keys
<!--- Describe your changes in detail -->

## Motivation and Context
Move away from allowing custom policies, all policies in
STS come from OPA otherwise they fail.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Disallowing `Policy` string along with STS tokens to avoid providing full access to
backend without JWT based claims. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.