### PR TITLE
cache: remove cache space constraint

### DIFF
--- a/docs/disk-caching/DESIGN.md
+++ b/docs/disk-caching/DESIGN.md
@@ -31,7 +31,7 @@ minio server -h
 - The cache drives are required to be a filesystem mount point with [`atime`](http://kerolasa.github.io/filetimes.html) support to be enabled on the drive. Alternatively writable directories with atime support can be specified in MINIO_CACHE_DRIVES
 - Expiration of each cached entry takes user provided expiry as a hint, and defaults to 90 days if not provided.
 - Garbage collection sweep of the expired cache entries happens whenever cache usage is > 80% of drive capacity, GC continues until sufficient disk space is reclaimed.
-- An object is only cached when drive has sufficient disk space, upto 100 times the size of the object.
+- An object is only cached when drive has sufficient disk space.
 
 ## Behavior
 Disk caching caches objects for both **uploaded** and **downloaded** objects i.e


### PR DESCRIPTION
relax cache constraint of requiring 100 times size of object
being cached for better cache utilization.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #6603. Currently, disk cache has a heuristic in place to require 100 times size of object being uploaded to object storage. Relax this constraint,as it will facilitate better cache utilization.
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run minio in fs mode with cache enabled, i.e. set MINIO_CACHE_DRIVES and tweak the MINIO_CACHE_MAXUSE % based on available disk space on your system to test the edge case of cache space running out for a large enough upload.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.