### PR TITLE
handle exception InvalidPart

### DIFF
--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -294,6 +294,8 @@ func ErrorRespToObjectError(err error, params ...string) error {
 		err = BucketPolicyNotFound{}
 	case "InvalidBucketName":
 		err = BucketNameInvalid{Bucket: bucket}
+	case "InvalidPart":
+		err = InvalidPart{}
 	case "NoSuchBucket":
 		err = BucketNotFound{Bucket: bucket}
 	case "NoSuchKey":

--- a/cmd/gateway/s3/gateway-s3_test.go
+++ b/cmd/gateway/s3/gateway-s3_test.go
@@ -51,6 +51,10 @@ func TestS3ToObjectError(t *testing.T) {
 			expectedErr: minio.BucketNameInvalid{},
 		},
 		{
+			inputErr:    errResponse("InvalidPart"),
+			expectedErr: minio.InvalidPart{},
+		},
+		{
 			inputErr:    errResponse("NoSuchBucketPolicy"),
 			expectedErr: minio.BucketPolicyNotFound{},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
add switch case for exception `InvalidPart` at `ErrorRespToObjectError`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By default , minio will return 500(internal error) instead of 400(InvalidPart), which is vague for users to debug

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
import boto3
from botocore.exceptions import ClientError

access_key = '54EW6QBXPYGLTOBW7N04'
secret_key = 'u1337SiRgrdKOSmaM36YY4OmWgta4tBx5ZU7w50f'

host = 'http://s3.test.io'

s3client = boto3.client('s3', aws_secret_access_key = secret_key, aws_access_key_id = access_key, endpoint_url = host)

multipart_upload = s3client.create_multipart_upload(Bucket='multipart-test', Key='multipart1')

upload_id = multipart_upload['UploadId']


with open('boto3_multipart.py') as f:

    response = s3client.upload_part(Body=f, Bucket='multipart-test', Key='multipart1', PartNumber=1, UploadId=upload_id)
    etag = response['ETag']

parts = {'Parts':[{'ETag':etag, 'PartNumber':1}, {'ETag':'e8741c6d6349c1ed017fe7b7daa11966', 'PartNumber': 999}]}

try:
    response = s3client.complete_multipart_upload(Bucket='multipart-test', Key='multipart1', UploadId=upload_id, MultipartUpload=parts)
except ClientError as e:
    print e.response['Error']['Code']
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.