### PR TITLE
docs: add link to s3 gateway

### DIFF
--- a/docs/gateway/README.md
+++ b/docs/gateway/README.md
@@ -4,6 +4,6 @@ Minio Gateway adds Amazon S3 compatibility to third party cloud storage provider
 - [Microsoft Azure Blob Storage](https://github.com/minio/minio/blob/master/docs/gateway/azure.md)
 - [Google Cloud Storage](https://github.com/minio/minio/blob/master/docs/gateway/gcs.md)
 - [Backblaze B2](https://github.com/minio/minio/blob/master/docs/gateway/b2.md)
+- [S3](https://github.com/minio/minio/blob/master/docs/gateway/s3.md)
 - [Sia Decentralized Cloud Storage](https://github.com/minio/minio/blob/master/docs/gateway/sia.md) _Alpha release_
 - [Manta Object Storage](https://github.com/minio/minio/blob/master/docs/gateway/manta.md) _Alpha release_
-


### PR DESCRIPTION
Minor change: Add a link to S3 gateway to make it easier to find that info.

## Description
It's hard to find the docs for `minio gateway s3`. I've added a link to the readme that contains the summary of available options.

## Regression
No

## How Has This Been Tested?
Previewed the markdown, looks good
