### PR TITLE
Handle corrupted files correctly by fixing quorum

### DIFF
--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -448,38 +448,102 @@ func (xl xlObjects) GetObjectInfo(ctx context.Context, bucket, object string, op
 	return info, nil
 }
 
-// getObjectInfo - wrapper for reading object metadata and constructs ObjectInfo.
-func (xl xlObjects) getObjectInfo(ctx context.Context, bucket, object string) (objInfo ObjectInfo, err error) {
-	// Read metadata associated with the object from all disks.
-	metaArr, errs := readAllXLMetadata(ctx, xl.getDisks(), bucket, object)
-
-	// Get quorum for this object
-	readQuorum, _, err := objectQuorumFromMeta(ctx, xl, metaArr, errs)
-	if err != nil {
-		return objInfo, err
+func (xl xlObjects) isObjectCorrupted(metaArr []xlMetaV1, errs []error) (validMeta xlMetaV1, ok bool) {
+	// We can consider an object data not reliable
+	// when xl.json is not found in read quorum disks.
+	var notFoundXLJSON int
+	for _, readErr := range errs {
+		if readErr == errFileNotFound {
+			notFoundXLJSON++
+		}
 	}
 
-	const xlCorruptedSuffix = ".CORRUPTED"
+	for _, m := range metaArr {
+		if !m.IsValid() {
+			continue
+		}
+		validMeta = m
+		break
+	}
 
+	// Return if the object is indeed corrupted.
+	return validMeta, len(xl.getDisks())-notFoundXLJSON < validMeta.Erasure.DataBlocks
+}
+
+const xlCorruptedSuffix = ".CORRUPTED"
+
+// Renames the corrupted object and makes it visible.
+func renameCorruptedObject(ctx context.Context, bucket, object string, validMeta xlMetaV1, disks []StorageAPI, errs []error) {
+	writeQuorum := validMeta.Erasure.DataBlocks + 1
+
+	// Move all existing objects into corrupted suffix.
+	rename(ctx, disks, bucket, object, bucket, object+xlCorruptedSuffix, true, writeQuorum, []error{errFileNotFound})
+
+	tempObj := mustGetUUID()
+
+	// Get all the disks which do not have the file.
+	var cdisks = make([]StorageAPI, len(disks))
+	for i, merr := range errs {
+		if merr == errFileNotFound {
+			cdisks[i] = disks[i]
+		}
+	}
+
+	for _, disk := range cdisks {
+		if disk == nil {
+			continue
+		}
+
+		// Write empty part file on missing disks.
+		disk.AppendFile(minioMetaTmpBucket, pathJoin(tempObj, "part.1"), []byte{})
+
+		// Write algorithm hash for empty part file.
+		alg := validMeta.Erasure.Checksums[0].Algorithm.New()
+		alg.Write([]byte{})
+
+		// Update the checksums and part info.
+		validMeta.Erasure.Checksums[0] = ChecksumInfo{
+			Name:      validMeta.Erasure.Checksums[0].Name,
+			Algorithm: validMeta.Erasure.Checksums[0].Algorithm,
+			Hash:      alg.Sum(nil),
+		}
+		validMeta.Parts[0] = objectPartInfo{
+			Number: 1,
+			Name:   "part.1",
+		}
+
+		// Write the `xl.json` with the newly calculated metadata.
+		writeXLMetadata(ctx, disk, minioMetaTmpBucket, tempObj, validMeta)
+	}
+
+	// Finally rename all the parts into their respective locations.
+	rename(ctx, cdisks, minioMetaTmpBucket, tempObj, bucket, object+xlCorruptedSuffix, true, writeQuorum, []error{errFileNotFound})
+}
+
+// getObjectInfo - wrapper for reading object metadata and constructs ObjectInfo.
+func (xl xlObjects) getObjectInfo(ctx context.Context, bucket, object string) (objInfo ObjectInfo, err error) {
+	disks := xl.getDisks()
+
+	// Read metadata associated with the object from all disks.
+	metaArr, errs := readAllXLMetadata(ctx, disks, bucket, object)
+
+	var readQuorum int
 	// Having read quorum means we have xl.json in at least N/2 disks.
 	if !strings.HasSuffix(object, xlCorruptedSuffix) {
-		// We can consider an object data not reliable
-		// when xl.json is not found in read quorum disks.
-		var notFoundXLJSON int
-		for _, readErr := range errs {
-			if readErr == errFileNotFound {
-				notFoundXLJSON++
-			}
-		}
-		// If xl.json is not present in read quorum disks,
-		// add .CORRUPTED prefix to the current object.
-		if len(xl.getDisks())-notFoundXLJSON < readQuorum {
-			writeQuorum := readQuorum + 1
-			rename(ctx, xl.getDisks(), bucket, object, bucket, object+xlCorruptedSuffix, true, writeQuorum, []error{errFileNotFound})
+		if validMeta, ok := xl.isObjectCorrupted(metaArr, errs); ok {
+			renameCorruptedObject(ctx, bucket, object, validMeta, disks, errs)
 			// Return err file not found since we renamed now the corrupted object
 			return objInfo, errFileNotFound
 		}
+
+		// Not a corrupted object, attempt to get readquorum properly.
+		readQuorum, _, err = objectQuorumFromMeta(ctx, xl, metaArr, errs)
+		if err != nil {
+			return objInfo, err
+		}
+
 	} else {
+
 		// If this is a corrupted object, change read quorum to N/2 disks
 		// so it will be visible to users, so they can delete it.
 		readQuorum = len(xl.getDisks()) / 2


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Handle corrupted files correctly by fixing the quorum
<!--- Describe your changes in detail -->

## Motivation and Context
This PR completes the missing functionality from #6592

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Start minio server
```
~ MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123 minio server /tmp/export{1..12}
```

Download this file [object.txt](https://github.com/minio/minio/files/2493861/object.txt)
```
~ objs=$(cat object.txt)
~ mc mb myminio/id-platform-gamma/
~ for i in $(echo $objs); do mc cp --quiet /etc/issue myminio/${i}; done
```

Now delete the entries and create stale file scenario.
```
~ rm -rf /tmp/export{1..9}/id-platform-gamma/benchmark
```

This removes all the files on 1 to disk 9 under prefix benchmark.

```
~ mc ls myminio/id-platform-gamma/
[2018-10-18 16:13:45 PDT]     0B benchmark/
```

The first attempt will not list any stale files since it will rename at this phase 
```
~ mc ls -r myminio/id-platform-gamma/
```

The second attempt should show CORRUPTED files
```
~ mc ls myminio/id-platform-gamma/ -r 
[2018-10-18 16:13:41 PDT]    26B benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828130108_0038_m_000812_0/part-00812-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED
[2018-10-18 16:13:41 PDT]    26B benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828130108_0038_m_000832_0/part-00832-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED
[2018-10-18 16:13:41 PDT]    26B benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828130108_0038_m_000836_0/part-00836-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED
[2018-10-18 16:13:40 PDT]    26B benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828154647_0038_m_001062_3/part-01062-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED
[2018-10-18 16:13:40 PDT]    26B benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828154651_0038_m_000058_5/part-00058-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED
```

Now these can be cleanly removed
```
~ mc rm -r --force myminio/id-platform-gamma/benchmark/
Removing `myminio/id-platform-gamma/benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828130108_0038_m_000812_0/part-00812-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED`.
Removing `myminio/id-platform-gamma/benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828130108_0038_m_000832_0/part-00832-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED`.
Removing `myminio/id-platform-gamma/benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828130108_0038_m_000836_0/part-00836-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED`.
Removing `myminio/id-platform-gamma/benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828154647_0038_m_001062_3/part-01062-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED`.
Removing `myminio/id-platform-gamma/benchmark/v1/candidate/candidate_pins/_temporary/0/_temporary/attempt_20180828154651_0038_m_000058_5/part-00058-b4a74e65-4e0f-44fb-910c-60918653132a-c000.snappy.parquet.CORRUPTED`.
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.