### PR TITLE
Prevent setting an invalid notification config

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1114,6 +1114,11 @@ func (a adminAPIHandlers) SetConfigHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if err = config.TestNotificationTargets(); err != nil {
+		writeCustomErrorResponseJSON(w, ErrAdminConfigBadJSON, err.Error(), r.URL)
+		return
+	}
+
 	if err = saveServerConfig(ctx, objectAPI, &config); err != nil {
 		writeErrorResponseJSON(w, toAdminAPIErrCode(err), r.URL)
 		return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Avoid setting an invalid notification config

## Description
This PR handles target errors. By checking the targets when a new config is set and error out.

## Motivation and Context
Fixes 
- #6642 - by avoid setting an invalid config.
- #6641 - this scenario is unreachable since we error out early while re-setting the config itself 

## Regression
No

## How Has This Been Tested?
- Set events notification per https://docs.minio.io/docs/minio-bucket-notification-guide.html (in this case I used mysql events)
- Get config file `mc admin config get myminio/ > /tmp/myconfig`
- Modify config file - pertinent snippet:

```
"mysql": {
                        "1": {
                                "enable": true,
                                "format": "namespace",
                                "dsnString": "",
                                "table": "minio_namespace",
                                "host": "127.0.0.1",
                                "port": "3306",
                                "user": "e",
                                "password": "password",
                                "database": "miniodb"
                             }
         }
```
- Reload config -`mc admin config set myminio < /tmp/myconfig`
- Copy an object into bucket to generate event and verify table got created in mysql database
- Edit config file and change format from namespace to access
- Minio errors out if we try to load the modified config. by `mc admin config set myminio < /tmp/myconfig`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.