### PR TITLE
Fix goroutine test fatalf

### DIFF
--- a/cmd/http/bufconn_test.go
+++ b/cmd/http/bufconn_test.go
@@ -47,6 +47,7 @@ func TestBuffConnReadTimeout(t *testing.T) {
 		tcpConn, terr := tcpListener.AcceptTCP()
 		if terr != nil {
 			t.Errorf("failed to accept new connection. %v", terr)
+			return
 		}
 		bufconn := newBufConn(tcpConn, 1*time.Second, 1*time.Second)
 		defer bufconn.Close()
@@ -56,10 +57,12 @@ func TestBuffConnReadTimeout(t *testing.T) {
 		_, terr = bufconn.Read(b)
 		if terr != nil {
 			t.Errorf("failed to read from client. %v", terr)
+			return
 		}
 		received := string(b)
 		if received != "message one\n" {
 			t.Errorf(`server: expected: "message one\n", got: %v`, received)
+			return
 		}
 
 		// Wait for more than read timeout to simulate processing.
@@ -68,16 +71,19 @@ func TestBuffConnReadTimeout(t *testing.T) {
 		_, terr = bufconn.Read(b)
 		if terr != nil {
 			t.Errorf("failed to read from client. %v", terr)
+			return
 		}
 		received = string(b)
 		if received != "message two\n" {
 			t.Errorf(`server: expected: "message two\n", got: %v`, received)
+			return
 		}
 
 		// Send a response.
 		_, terr = io.WriteString(bufconn, "messages received\n")
 		if terr != nil {
 			t.Errorf("failed to write to client. %v", terr)
+			return
 		}
 
 		// Removes all deadlines if any.

--- a/cmd/http/bufconn_test.go
+++ b/cmd/http/bufconn_test.go
@@ -46,7 +46,7 @@ func TestBuffConnReadTimeout(t *testing.T) {
 
 		tcpConn, terr := tcpListener.AcceptTCP()
 		if terr != nil {
-			t.Fatalf("failed to accept new connection. %v", terr)
+			t.Errorf("failed to accept new connection. %v", terr)
 		}
 		bufconn := newBufConn(tcpConn, 1*time.Second, 1*time.Second)
 		defer bufconn.Close()
@@ -55,11 +55,11 @@ func TestBuffConnReadTimeout(t *testing.T) {
 		var b = make([]byte, 12)
 		_, terr = bufconn.Read(b)
 		if terr != nil {
-			t.Fatalf("failed to read from client. %v", terr)
+			t.Errorf("failed to read from client. %v", terr)
 		}
 		received := string(b)
 		if received != "message one\n" {
-			t.Fatalf(`server: expected: "message one\n", got: %v`, received)
+			t.Errorf(`server: expected: "message one\n", got: %v`, received)
 		}
 
 		// Wait for more than read timeout to simulate processing.
@@ -67,17 +67,17 @@ func TestBuffConnReadTimeout(t *testing.T) {
 
 		_, terr = bufconn.Read(b)
 		if terr != nil {
-			t.Fatalf("failed to read from client. %v", terr)
+			t.Errorf("failed to read from client. %v", terr)
 		}
 		received = string(b)
 		if received != "message two\n" {
-			t.Fatalf(`server: expected: "message two\n", got: %v`, received)
+			t.Errorf(`server: expected: "message two\n", got: %v`, received)
 		}
 
 		// Send a response.
 		_, terr = io.WriteString(bufconn, "messages received\n")
 		if terr != nil {
-			t.Fatalf("failed to write to client. %v", terr)
+			t.Errorf("failed to write to client. %v", terr)
 		}
 
 		// Removes all deadlines if any.

--- a/cmd/namespace-lock_test.go
+++ b/cmd/namespace-lock_test.go
@@ -218,7 +218,7 @@ func TestNamespaceForceUnlockTest(t *testing.T) {
 		// Try to claim lock again.
 		anotherLock := globalNSMutex.NewNSLock("bucket", "object")
 		if anotherLock.GetLock(newDynamicTimeout(60*time.Second, time.Second)) != nil {
-			t.Fatalf("Failed to get lock")
+			t.Errorf("Failed to get lock")
 		}
 		// And signal success.
 		ch <- struct{}{}

--- a/cmd/namespace-lock_test.go
+++ b/cmd/namespace-lock_test.go
@@ -219,6 +219,7 @@ func TestNamespaceForceUnlockTest(t *testing.T) {
 		anotherLock := globalNSMutex.NewNSLock("bucket", "object")
 		if anotherLock.GetLock(newDynamicTimeout(60*time.Second, time.Second)) != nil {
 			t.Errorf("Failed to get lock")
+			return
 		}
 		// And signal success.
 		ch <- struct{}{}

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -2379,6 +2379,7 @@ func testAPINewMultipartHandlerParallel(obj ObjectLayer, instanceType, bucketNam
 
 			if err != nil {
 				t.Errorf("Failed to create HTTP request for NewMultipart request: <ERROR> %v", err)
+				return
 			}
 			// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 			// Call the ServeHTTP to executes the registered handler.
@@ -2386,6 +2387,7 @@ func testAPINewMultipartHandlerParallel(obj ObjectLayer, instanceType, bucketNam
 			// Assert the response code with the expected status.
 			if rec.Code != http.StatusOK {
 				t.Errorf("Minio %s:  Expected the response status to be `%d`, but instead found `%d`", instanceType, http.StatusOK, rec.Code)
+				return
 			}
 			// decode the response body.
 			decoder := xml.NewDecoder(rec.Body)
@@ -2394,6 +2396,7 @@ func testAPINewMultipartHandlerParallel(obj ObjectLayer, instanceType, bucketNam
 			err = decoder.Decode(multipartResponse)
 			if err != nil {
 				t.Errorf("Minio %s: Error decoding the recorded response Body", instanceType)
+				return
 			}
 			// push the obtained upload ID from the response into the array.
 			testUploads.Lock()

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -2378,14 +2378,14 @@ func testAPINewMultipartHandlerParallel(obj ObjectLayer, instanceType, bucketNam
 			req, err := newTestSignedRequestV4("POST", getNewMultipartURL("", bucketName, objectName), 0, nil, credentials.AccessKey, credentials.SecretKey, nil)
 
 			if err != nil {
-				t.Fatalf("Failed to create HTTP request for NewMultipart request: <ERROR> %v", err)
+				t.Errorf("Failed to create HTTP request for NewMultipart request: <ERROR> %v", err)
 			}
 			// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 			// Call the ServeHTTP to executes the registered handler.
 			apiRouter.ServeHTTP(rec, req)
 			// Assert the response code with the expected status.
 			if rec.Code != http.StatusOK {
-				t.Fatalf("Minio %s:  Expected the response status to be `%d`, but instead found `%d`", instanceType, http.StatusOK, rec.Code)
+				t.Errorf("Minio %s:  Expected the response status to be `%d`, but instead found `%d`", instanceType, http.StatusOK, rec.Code)
 			}
 			// decode the response body.
 			decoder := xml.NewDecoder(rec.Body)
@@ -2393,7 +2393,7 @@ func testAPINewMultipartHandlerParallel(obj ObjectLayer, instanceType, bucketNam
 
 			err = decoder.Decode(multipartResponse)
 			if err != nil {
-				t.Fatalf("Minio %s: Error decoding the recorded response Body", instanceType)
+				t.Errorf("Minio %s: Error decoding the recorded response Body", instanceType)
 			}
 			// push the obtained upload ID from the response into the array.
 			testUploads.Lock()

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1046,7 +1046,7 @@ func (s *TestSuiteCommon) TestPutBucket(c *check) {
 			client := http.Client{Transport: s.transport}
 			response, err := client.Do(request)
 			if err != nil {
-				c.Fatalf("Put bucket Failed: <ERROR> %s", err)
+				c.Errorf("Put bucket Failed: <ERROR> %s", err)
 			}
 			defer response.Body.Close()
 		}()

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1047,6 +1047,7 @@ func (s *TestSuiteCommon) TestPutBucket(c *check) {
 			response, err := client.Do(request)
 			if err != nil {
 				c.Errorf("Put bucket Failed: <ERROR> %s", err)
+				return
 			}
 			defer response.Body.Close()
 		}()

--- a/pkg/lock/lock_test.go
+++ b/pkg/lock/lock_test.go
@@ -161,11 +161,11 @@ func TestLockAndUnlock(t *testing.T) {
 	go func() {
 		bl, blerr := LockedOpenFile(f.Name(), os.O_WRONLY, 0600)
 		if blerr != nil {
-			t.Fatal(blerr)
+			t.Error(blerr)
 		}
 		locked <- struct{}{}
 		if blerr = bl.Close(); blerr != nil {
-			t.Fatal(blerr)
+			t.Error(blerr)
 		}
 	}()
 

--- a/pkg/lock/lock_test.go
+++ b/pkg/lock/lock_test.go
@@ -162,10 +162,12 @@ func TestLockAndUnlock(t *testing.T) {
 		bl, blerr := LockedOpenFile(f.Name(), os.O_WRONLY, 0600)
 		if blerr != nil {
 			t.Error(blerr)
+			return
 		}
 		locked <- struct{}{}
 		if blerr = bl.Close(); blerr != nil {
 			t.Error(blerr)
+			return
 		}
 	}()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR replaces `t.Fatal` and `t.Fatalf` with `t.Error` and `t.Errorf` when called from within a goroutine.

## Motivation and Context
`t.Fatal` and `t.Fatalf` must be called from the same goroutine running the Test function, see https://godoc.org/testing#T.

## How Has This Been Tested?
`make test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.