### PR TITLE
Reload etcd users and policies properly

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -458,7 +458,7 @@ func reloadEtcdUsers(prefix string, usersMap map[string]auth.Credentials, policy
 		//  prefix := "config/iam/users/"
 		//  v := trim(trim(key, prefix), base(key)) == "newuser"
 		//
-		user := strings.TrimSuffix(strings.TrimSuffix(string(kv.Key), prefix), path.Base(string(kv.Key)))
+		user := path.Clean(strings.TrimSuffix(strings.TrimPrefix(string(kv.Key), prefix), path.Base(string(kv.Key))))
 		if !users.Contains(user) {
 			users.Add(user)
 		}
@@ -497,7 +497,7 @@ func reloadEtcdUsers(prefix string, usersMap map[string]auth.Credentials, policy
 			if err = json.Unmarshal(pdata, &policyName); err != nil {
 				return err
 			}
-			policyMap[path.Base(prefix)] = policyName
+			policyMap[user] = policyName
 		}
 	}
 	return nil
@@ -521,11 +521,11 @@ func reloadEtcdPolicies(prefix string, cannedPolicyMap map[string]iampolicy.Poli
 		// then strip off the remaining basename to obtain the prefix
 		// value, usually in the following form.
 		//
-		//  key := "config/iam/policys/newpolicy/identity.json"
-		//  prefix := "config/iam/policys/"
+		//  key := "config/iam/policies/newpolicy/identity.json"
+		//  prefix := "config/iam/policies/"
 		//  v := trim(trim(key, prefix), base(key)) == "newpolicy"
 		//
-		policyName := strings.TrimSuffix(strings.TrimSuffix(string(kv.Key), prefix), path.Base(string(kv.Key)))
+		policyName := path.Clean(strings.TrimSuffix(strings.TrimPrefix(string(kv.Key), prefix), path.Base(string(kv.Key))))
 		if !policies.Contains(policyName) {
 			policies.Add(policyName)
 		}
@@ -542,7 +542,7 @@ func reloadEtcdPolicies(prefix string, cannedPolicyMap map[string]iampolicy.Poli
 		if err = json.Unmarshal(pdata, &p); err != nil {
 			return err
 		}
-		cannedPolicyMap[path.Base(prefix)] = p
+		cannedPolicyMap[policyName] = p
 	}
 	return nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, there was a bug in how we reload users and policies
which leads to users/policies going missing due to the wrong path
construction.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #6693

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Following the steps documented under STS quickstart guide - https://docs.minio.io/docs/minio-sts-quickstart-guide.html
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.