### PR TITLE
Return error response header only for HEAD method

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -783,7 +783,11 @@ type sseTLSHandler struct{ handler http.Handler }
 func (h sseTLSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Deny SSE-C requests if not made over TLS
 	if !globalIsSSL && (crypto.SSEC.IsRequested(r.Header) || crypto.SSECopy.IsRequested(r.Header)) {
-		writeErrorResponseHeadersOnly(w, ErrInsecureSSECustomerRequest)
+		if r.Method == http.MethodHead {
+			writeErrorResponseHeadersOnly(w, ErrInsecureSSECustomerRequest)
+		} else {
+			writeErrorResponse(w, ErrInsecureSSECustomerRequest, r.URL)
+		}
 		return
 	}
 	h.handler.ServeHTTP(w, r)

--- a/cmd/generic-handlers_test.go
+++ b/cmd/generic-handlers_test.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 
@@ -184,14 +185,15 @@ func TestContainsReservedMetadata(t *testing.T) {
 }
 
 var sseTLSHandlerTests = []struct {
+	URL               *url.URL
 	Header            http.Header
 	IsTLS, ShouldFail bool
 }{
-	{Header: http.Header{}, IsTLS: false, ShouldFail: false},                                        // 0
-	{Header: http.Header{crypto.SSECAlgorithm: []string{"AES256"}}, IsTLS: false, ShouldFail: true}, // 1
-	{Header: http.Header{crypto.SSECAlgorithm: []string{"AES256"}}, IsTLS: true, ShouldFail: false}, // 2
-	{Header: http.Header{crypto.SSECKey: []string{""}}, IsTLS: true, ShouldFail: false},             // 3
-	{Header: http.Header{crypto.SSECopyAlgorithm: []string{""}}, IsTLS: false, ShouldFail: true},    // 4
+	{URL: &url.URL{}, Header: http.Header{}, IsTLS: false, ShouldFail: false},                                        // 0
+	{URL: &url.URL{}, Header: http.Header{crypto.SSECAlgorithm: []string{"AES256"}}, IsTLS: false, ShouldFail: true}, // 1
+	{URL: &url.URL{}, Header: http.Header{crypto.SSECAlgorithm: []string{"AES256"}}, IsTLS: true, ShouldFail: false}, // 2
+	{URL: &url.URL{}, Header: http.Header{crypto.SSECKey: []string{""}}, IsTLS: true, ShouldFail: false},             // 3
+	{URL: &url.URL{}, Header: http.Header{crypto.SSECopyAlgorithm: []string{""}}, IsTLS: false, ShouldFail: true},    // 4
 }
 
 func TestSSETLSHandler(t *testing.T) {
@@ -206,6 +208,7 @@ func TestSSETLSHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := new(http.Request)
 		r.Header = test.Header
+		r.URL = test.URL
 
 		h := setSSETLSHandler(okHandler)
 		h.ServeHTTP(w, r)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Return error response header only for HEAD API. For the rest, body also should be returned.

## Motivation and Context


## Regression
No

## How Has This Been Tested?
Against `AWS` with insecure mode, 
```
MC_ENCRYPT_KEY="s3http/kannappan102/=01234567890123456789012345678901" mc cp /etc/issue s3http/kannappan102/issue --debug
```
it returns
```

mc: <DEBUG> PUT /issue HTTP/1.1
Host: kannappan102.s3.amazonaws.com
User-Agent: Minio (linux; amd64) minio-go/v6.0.8 mc/2018-10-25T21:58:44Z
Content-Length: 193
Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20181025/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-server-side-encryption-customer-algorithm;x-amz-server-side-encryption-customer-key;x-amz-server-side-encryption-customer-key-md5,Signature=**REDACTED**
Content-Type: application/octet-stream
X-Amz-Content-Sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD
X-Amz-Date: 20181025T224716Z
X-Amz-Decoded-Content-Length: 20
X-Amz-Server-Side-Encryption-Customer-Algorithm: AES256
X-Amz-Server-Side-Encryption-Customer-Key: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
X-Amz-Server-Side-Encryption-Customer-Key-Md5: KYvwGXoFFJ42a2u2GDWhwQ==
Accept-Encoding: gzip

mc: <DEBUG> HTTP/1.1 400 Bad Request
Connection: close
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Thu, 25 Oct 2018 22:47:15 GMT
Server: AmazonS3
X-Amz-Id-2: tEQMXDFXSTB+SZrUzlYihSdNheVFSTen3j8kUxCJU6IyWsFuQG1MSg6/1TZbXbzVyn8Sa02/f+M=
X-Amz-Request-Id: 14E9F2B5F5DF7893

1b2
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidArgument</Code><Message>Requests specifying Server Side Encryption with Customer provided keys must be made over a secure connection.</Message><ArgumentName>x-amz-server-side-encryption</ArgumentName><ArgumentValue>null</ArgumentValue><RequestId>14E9F2B5F5DF7893</RequestId><HostId>tEQMXDFXSTB+SZrUzlYihSdNheVFSTen3j8kUxCJU6IyWsFuQG1MSg6/1TZbXbzVyn8Sa02/f+M=</HostId></Error>
0
```

In the case of minio
```
MC_ENCRYPT_KEY="myminio/kannappan102/=01234567890123456789012345678901" mc cp /etc/issue myminio/kannappan102/issue --debug

```
returns
```
mc: <DEBUG> PUT /kannappan102/issue HTTP/1.1
Host: 127.0.0.1:9000
User-Agent: Minio (linux; amd64) minio-go/v6.0.8 mc/2018-10-25T21:58:44Z
Content-Length: 193
Authorization: AWS4-HMAC-SHA256 Credential=minio/20181025/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-server-side-encryption-customer-algorithm;x-amz-server-side-encryption-customer-key;x-amz-server-side-encryption-customer-key-md5,Signature=**REDACTED**
Content-Type: application/octet-stream
X-Amz-Content-Sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD
X-Amz-Date: 20181025T225157Z
X-Amz-Decoded-Content-Length: 20
X-Amz-Server-Side-Encryption-Customer-Algorithm: AES256
X-Amz-Server-Side-Encryption-Customer-Key: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
X-Amz-Server-Side-Encryption-Customer-Key-Md5: KYvwGXoFFJ42a2u2GDWhwQ==
Accept-Encoding: gzip

mc: <DEBUG> HTTP/1.1 400 Bad Request
Content-Length: 0
Accept-Ranges: bytes
Date: Thu, 25 Oct 2018 22:51:57 GMT
Server: Minio/DEVELOPMENT.2018-10-25T20-56-12Z (linux; amd64)

mc: <DEBUG> Response Time:  1.587365ms

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.