### PR TITLE
Support etcd TLS certficates

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -134,9 +134,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	// Handle common command args.
 	handleCommonCmdArgs(ctx)
 
-	// Handle common env vars.
-	handleCommonEnvVars()
-
 	// Get port to listen on from gateway address
 	_, gatewayPort, pErr := net.SplitHostPort(gatewayAddr)
 	if pErr != nil {
@@ -149,11 +146,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	// To avoid this error situation we check for port availability.
 	logger.FatalIf(checkPortAvailability(gatewayPort), "Unable to start the gateway")
 
-	// Validate if we have access, secret set through environment.
-	if !globalIsEnvCreds {
-		logger.Fatal(uiErrEnvCredentialsMissingGateway(nil), "Unable to start gateway")
-	}
-
 	// Create certs path.
 	logger.FatalIf(createConfigDir(), "Unable to create configuration directories")
 
@@ -165,6 +157,14 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	// Check and load Root CAs.
 	globalRootCAs, err = getRootCAs(getCADir())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
+
+	// Handle common env vars.
+	handleCommonEnvVars()
+
+	// Validate if we have access, secret set through environment.
+	if !globalIsEnvCreds {
+		logger.Fatal(uiErrEnvCredentialsMissingGateway(nil), "Unable to start gateway")
+	}
 
 	// Set system resources to maximum.
 	logger.LogIf(context.Background(), setMaxResources())

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -203,6 +203,9 @@ func newS3(url string) (*miniogo.Core, error) {
 		return nil, err
 	}
 
+	// Set custom transport
+	clnt.SetCustomTransport(minio.NewCustomHTTPTransport())
+
 	probeBucketName := randString(60, rand.NewSource(time.Now().UnixNano()), "probe-bucket-sign-")
 	// Check if the provided keys are valid.
 	if _, err = clnt.BucketExists(probeBucketName); err != nil {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -218,12 +218,6 @@ func serverMain(ctx *cli.Context) {
 		logger.EnableQuiet()
 	}
 
-	// Handle all server command args.
-	serverHandleCmdArgs(ctx)
-
-	// Handle all server environment vars.
-	serverHandleEnvVars()
-
 	// Create certs path.
 	logger.FatalIf(createConfigDir(), "Unable to initialize configuration files")
 
@@ -235,6 +229,12 @@ func serverMain(ctx *cli.Context) {
 	// Check and load Root CAs.
 	globalRootCAs, err = getRootCAs(getCADir())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
+
+	// Handle all server command args.
+	serverHandleCmdArgs(ctx)
+
+	// Handle all server environment vars.
+	serverHandleEnvVars()
 
 	// Is distributed setup, error out if no certificates are found for HTTPS endpoints.
 	if globalIsDistXL {

--- a/docs/sts/etcd.md
+++ b/docs/sts/etcd.md
@@ -29,6 +29,8 @@ rm -rf /tmp/etcd-data.tmp && mkdir -p /tmp/etcd-data.tmp && \
   --initial-cluster-state new
 ```
 
+You may also setup etcd with TLS following this documentation [here](https://coreos.com/etcd/docs/latest/op-guide/security.html)
+
 ### 3. Setup Minio with etcd
 Minio server expects environment variable for etcd as `MINIO_ETCD_ENDPOINTS`, this environment variable takes many comma separated entries.
 ```
@@ -36,7 +38,9 @@ export MINIO_ETCD_ENDPOINTS=localhost:2379
 minio server /data
 ```
 
-### 5. Test with Minio STS API
+NOTE: If `etcd` is configured with `Client-to-server authentication with HTTPS client certificates` then you need to use additional envs such as `MINIO_ETCD_CLIENT_CERT` pointing to path to `etcd-client.crt` and `MINIO_ETCD_CLIENT_CERT_KEY` path to `etcd-client.key` .
+
+### 4. Test with Minio STS API
 Assuming that you have configured Minio server to support STS API by following the doc [Minio STS Quickstart Guide](https://docs.minio.io/docs/minio-sts-quickstart-guide) and once you have obtained the JWT from WSO2 as mentioned in [WSO2 Quickstart Guide](https://github.com/minio/minio/blob/master/docs/sts/wso2.md).
 ```
 go run full-example.go -cid PoEgXP6uVO45IsENRngDXj5Au5Ya -csec eKsw6z8CtOJVBtrOWvhRWL4TUCga


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support etcd TLS certficates
<!--- Describe your changes in detail -->

## Motivation and Context
This PR supports two models for etcd certs

- Client-to-server transport security with HTTPS
- Client-to-server authentication with HTTPS client certificates

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
By configuring etcd with TLS certs - follow the instructions here

- https://coreos.com/etcd/docs/latest/op-guide/security.html
- https://coreos.com/os/docs/latest/generate-self-signed-certificates.html#tldr

This is to generate Client-to-server transport security with HTTPS where client simply has access to `ca.pem` 
```
echo '{"CN":"CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
export ADDRESS=127.0.0.1
export NAME=server
echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
```
Make sure to copy `ca.pem` to `/.minio/certs/CAs` for proper connection. 

If you are testing for client certs based authentication then you need another step
```
export ADDRESS=
export NAME=client
echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
```

In this when starting Minio server along with `MINIO_ETCD_ENDPOINTS` you need to set `MINIO_ETCD_CLIENT_CERT` and `MINIO_ETCD_CLIENT_CERT_KEY` environment variables. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.