### PR TITLE
Avoid double bucket validation in DeleteObjectHandler

### DIFF
--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -984,12 +984,12 @@ func (xl xlObjects) DeleteObject(ctx context.Context, bucket, object string) (er
 		return err
 	}
 
-	if !xl.isObject(bucket, object) && !xl.isObjectDir(bucket, object) {
-		return ObjectNotFound{bucket, object}
-	}
-
 	var writeQuorum int
 	var isObjectDir = hasSuffix(object, slashSeparator)
+
+	if isObjectDir && !xl.isObjectDir(bucket, object) {
+		return toObjectErr(errFileNotFound, bucket, object)
+	}
 
 	if isObjectDir {
 		writeQuorum = len(xl.getDisks())/2 + 1

--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -305,7 +305,7 @@ func readXLMeta(ctx context.Context, disk StorageAPI, bucket string, object stri
 	// Reads entire `xl.json`.
 	xlMetaBuf, err := disk.ReadAll(bucket, path.Join(object, xlMetaJSONFile))
 	if err != nil {
-		if err != errFileNotFound {
+		if err != errFileNotFound && err != errVolumeNotFound {
 			logger.GetReqInfo(ctx).AppendTags("disk", disk.String())
 			logger.LogIf(ctx, err)
 		}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Avoid double bucket validation in DeleteObjectHandler
<!--- Describe your changes in detail -->

## Motivation and Context
On a heavily loaded server, getBucketInfo() becomes slow,
one can easily observe deleting an object causes many
additional network calls.

This PR is to let the underlying call return the actual
error and write it back to the client.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes perhaps introduced in #6085 
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Not tested, this is being validated at a customer site. We do have profiling output to indicate the slowness indicated here. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.