### PR TITLE
 Return correct ETag for SSE-S3 encrypted objects on s3 gateway

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -298,7 +298,7 @@ func (atb *adminXLTestBed) GenerateHealTestData(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			objectName := fmt.Sprintf("%s-%d", objName, i)
 			_, err = atb.objLayer.PutObject(context.Background(), bucketName, objectName,
-				mustGetHashReader(t, bytes.NewReader([]byte("hello")),
+				mustGetPutObjectReader(t, bytes.NewReader([]byte("hello")),
 					int64(len("hello")), "", ""), nil, ObjectOptions{})
 			if err != nil {
 				t.Fatalf("Failed to create %s - %v", objectName,
@@ -317,7 +317,7 @@ func (atb *adminXLTestBed) GenerateHealTestData(t *testing.T) {
 		}
 
 		_, err = atb.objLayer.PutObjectPart(context.Background(), bucketName, objName,
-			uploadID, 3, mustGetHashReader(t, bytes.NewReader(
+			uploadID, 3, mustGetPutObjectReader(t, bytes.NewReader(
 				[]byte("hello")), int64(len("hello")), "", ""), ObjectOptions{})
 		if err != nil {
 			t.Fatalf("mp put error: %v", err)

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -210,7 +210,7 @@ func (ahs *allHealState) LaunchNewHealSequence(h *healSequence) (
 				delete(ahs.healSeqMap, h.path)
 				return
 
-			case <-globalServiceDoneCh:
+			case <-GlobalServiceDoneCh:
 				// server could be restarting - need
 				// to exit immediately
 				return

--- a/cmd/benchmark-utils_test.go
+++ b/cmd/benchmark-utils_test.go
@@ -61,7 +61,7 @@ func runPutObjectBenchmark(b *testing.B, obj ObjectLayer, objSize int) {
 	for i := 0; i < b.N; i++ {
 		// insert the object.
 		objInfo, err := obj.PutObject(context.Background(), bucket, "object"+strconv.Itoa(i),
-			mustGetHashReader(b, bytes.NewBuffer(textData), int64(len(textData)), md5hex, sha256hex), metadata, ObjectOptions{})
+			mustGetPutObjectReader(b, bytes.NewBuffer(textData), int64(len(textData)), md5hex, sha256hex), metadata, ObjectOptions{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -123,7 +123,7 @@ func runPutObjectPartBenchmark(b *testing.B, obj ObjectLayer, partSize int) {
 			md5hex = getMD5Hash([]byte(textPartData))
 			var partInfo PartInfo
 			partInfo, err = obj.PutObjectPart(context.Background(), bucket, object, uploadID, j,
-				mustGetHashReader(b, bytes.NewBuffer(textPartData), int64(len(textPartData)), md5hex, sha256hex), opts)
+				mustGetPutObjectReader(b, bytes.NewBuffer(textPartData), int64(len(textPartData)), md5hex, sha256hex), opts)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -204,7 +204,7 @@ func runGetObjectBenchmark(b *testing.B, obj ObjectLayer, objSize int) {
 		// insert the object.
 		var objInfo ObjectInfo
 		objInfo, err = obj.PutObject(context.Background(), bucket, "object"+strconv.Itoa(i),
-			mustGetHashReader(b, bytes.NewBuffer(textData), int64(len(textData)), md5hex, sha256hex), metadata, ObjectOptions{})
+			mustGetPutObjectReader(b, bytes.NewBuffer(textData), int64(len(textData)), md5hex, sha256hex), metadata, ObjectOptions{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -304,7 +304,7 @@ func runPutObjectBenchmarkParallel(b *testing.B, obj ObjectLayer, objSize int) {
 		for pb.Next() {
 			// insert the object.
 			objInfo, err := obj.PutObject(context.Background(), bucket, "object"+strconv.Itoa(i),
-				mustGetHashReader(b, bytes.NewBuffer(textData), int64(len(textData)), md5hex, sha256hex), metadata, ObjectOptions{})
+				mustGetPutObjectReader(b, bytes.NewBuffer(textData), int64(len(textData)), md5hex, sha256hex), metadata, ObjectOptions{})
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -344,7 +344,7 @@ func runGetObjectBenchmarkParallel(b *testing.B, obj ObjectLayer, objSize int) {
 		// insert the object.
 		var objInfo ObjectInfo
 		objInfo, err = obj.PutObject(context.Background(), bucket, "object"+strconv.Itoa(i),
-			mustGetHashReader(b, bytes.NewBuffer(textData), int64(len(textData)), md5hex, sha256hex), metadata, ObjectOptions{})
+			mustGetPutObjectReader(b, bytes.NewBuffer(textData), int64(len(textData)), md5hex, sha256hex), metadata, ObjectOptions{})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/cmd/bucket-handlers-listobjects.go
+++ b/cmd/bucket-handlers-listobjects.go
@@ -116,6 +116,7 @@ func (api objectAPIHandlers) ListObjectsV2Handler(w http.ResponseWriter, r *http
 			// Set the info.Size to the actualSize.
 			listObjectsV2Info.Objects[i].Size = actualSize
 		} else if crypto.IsEncrypted(listObjectsV2Info.Objects[i].UserDefined) {
+			listObjectsV2Info.Objects[i].ETag = getDecryptedETag(r.Header, listObjectsV2Info.Objects[i], false)
 			listObjectsV2Info.Objects[i].Size, err = listObjectsV2Info.Objects[i].DecryptedSize()
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -198,6 +199,7 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 			// Set the info.Size to the actualSize.
 			listObjectsInfo.Objects[i].Size = actualSize
 		} else if crypto.IsEncrypted(listObjectsInfo.Objects[i].UserDefined) {
+			listObjectsInfo.Objects[i].ETag = getDecryptedETag(r.Header, listObjectsInfo.Objects[i], false)
 			listObjectsInfo.Objects[i].Size, err = listObjectsInfo.Objects[i].DecryptedSize()
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -611,6 +611,8 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		return
 	}
 
+	pReader := NewPutObjectReader(hashReader)
+
 	if objectAPI.IsEncryptionSupported() {
 		if hasServerSideEncryptionHeader(formValues) && !hasSuffix(object, slashSeparator) { // handle SSE-C and SSE-S3 requests
 			var reader io.Reader
@@ -633,10 +635,11 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
+			pReader.DataReader = hashReader
 		}
 	}
 
-	objInfo, err := objectAPI.PutObject(ctx, bucket, object, hashReader, metadata, ObjectOptions{})
+	objInfo, err := objectAPI.PutObject(ctx, bucket, object, pReader, metadata, ObjectOptions{})
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return

--- a/cmd/bucket-handlers_test.go
+++ b/cmd/bucket-handlers_test.go
@@ -625,7 +625,7 @@ func testAPIDeleteMultipleObjectsHandler(obj ObjectLayer, instanceType, bucketNa
 	for i := 0; i < 10; i++ {
 		objectName := "test-object-" + strconv.Itoa(i)
 		// uploading the object.
-		_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewBuffer(contentBytes), int64(len(contentBytes)), "", sha256sum), nil, ObjectOptions{})
+		_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewBuffer(contentBytes), int64(len(contentBytes)), "", sha256sum), nil, ObjectOptions{})
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object %d:  Error uploading object: <ERROR> %v", i, err)

--- a/cmd/config-common.go
+++ b/cmd/config-common.go
@@ -70,7 +70,7 @@ func saveConfig(ctx context.Context, objAPI ObjectLayer, configFile string, data
 		return err
 	}
 
-	_, err = objAPI.PutObject(ctx, minioMetaBucket, configFile, hashReader, nil, ObjectOptions{})
+	_, err = objAPI.PutObject(ctx, minioMetaBucket, configFile, NewPutObjectReader(hashReader), nil, ObjectOptions{})
 	return err
 }
 

--- a/cmd/disk-cache-fs.go
+++ b/cmd/disk-cache-fs.go
@@ -92,7 +92,7 @@ func newCacheFSObjects(dir string, expiry int, maxDiskUsagePct int) (*cacheFSObj
 		appendFileMap: make(map[string]*fsAppendFile),
 	}
 
-	go fsObjects.cleanupStaleMultipartUploads(context.Background(), globalMultipartCleanupInterval, globalMultipartExpiry, globalServiceDoneCh)
+	go fsObjects.cleanupStaleMultipartUploads(context.Background(), GlobalMultipartCleanupInterval, GlobalMultipartExpiry, GlobalServiceDoneCh)
 
 	cacheFS := cacheFSObjects{
 		FSObjects:       fsObjects,
@@ -159,7 +159,7 @@ func (cfs *cacheFSObjects) purgeTrash() {
 
 	for {
 		select {
-		case <-globalServiceDoneCh:
+		case <-GlobalServiceDoneCh:
 			return
 		case <-ticker.C:
 			trashPath := path.Join(cfs.fsPath, minioMetaBucket, cacheTrashDir)

--- a/cmd/disk-cache-fs.go
+++ b/cmd/disk-cache-fs.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/disk"
-	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/lock"
 )
 
@@ -258,7 +257,7 @@ func (cfs *cacheFSObjects) IsOnline() bool {
 }
 
 // Caches the object to disk
-func (cfs *cacheFSObjects) Put(ctx context.Context, bucket, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) error {
+func (cfs *cacheFSObjects) Put(ctx context.Context, bucket, object string, data *PutObjectReader, metadata map[string]string, opts ObjectOptions) error {
 	if cfs.diskUsageHigh() {
 		select {
 		case cfs.purgeChan <- struct{}{}:
@@ -301,7 +300,8 @@ func (cfs *cacheFSObjects) Exists(ctx context.Context, bucket, object string) bo
 
 // Identical to fs PutObject operation except that it uses ETag in metadata
 // headers.
-func (cfs *cacheFSObjects) PutObject(ctx context.Context, bucket string, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, retErr error) {
+func (cfs *cacheFSObjects) PutObject(ctx context.Context, bucket string, object string, r *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, retErr error) {
+	data := r.DataReader
 	fs := cfs.FSObjects
 	// Lock the object.
 	objectLock := fs.nsMutex.NewNSLock(bucket, object)

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -60,16 +60,16 @@ type cacheObjects struct {
 	GetObjectNInfoFn          func(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error)
 	GetObjectFn               func(ctx context.Context, bucket, object string, startOffset int64, length int64, writer io.Writer, etag string, opts ObjectOptions) (err error)
 	GetObjectInfoFn           func(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error)
-	PutObjectFn               func(ctx context.Context, bucket, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error)
+	PutObjectFn               func(ctx context.Context, bucket, object string, data *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error)
 	DeleteObjectFn            func(ctx context.Context, bucket, object string) error
 	ListObjectsFn             func(ctx context.Context, bucket, prefix, marker, delimiter string, maxKeys int) (result ListObjectsInfo, err error)
 	ListObjectsV2Fn           func(ctx context.Context, bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (result ListObjectsV2Info, err error)
 	ListBucketsFn             func(ctx context.Context) (buckets []BucketInfo, err error)
 	GetBucketInfoFn           func(ctx context.Context, bucket string) (bucketInfo BucketInfo, err error)
 	NewMultipartUploadFn      func(ctx context.Context, bucket, object string, metadata map[string]string, opts ObjectOptions) (uploadID string, err error)
-	PutObjectPartFn           func(ctx context.Context, bucket, object, uploadID string, partID int, data *hash.Reader, opts ObjectOptions) (info PartInfo, err error)
+	PutObjectPartFn           func(ctx context.Context, bucket, object, uploadID string, partID int, data *PutObjectReader, opts ObjectOptions) (info PartInfo, err error)
 	AbortMultipartUploadFn    func(ctx context.Context, bucket, object, uploadID string) error
-	CompleteMultipartUploadFn func(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart) (objInfo ObjectInfo, err error)
+	CompleteMultipartUploadFn func(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (objInfo ObjectInfo, err error)
 	DeleteBucketFn            func(ctx context.Context, bucket string) error
 }
 
@@ -92,14 +92,14 @@ type CacheObjectLayer interface {
 	GetObjectNInfo(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error)
 	GetObject(ctx context.Context, bucket, object string, startOffset int64, length int64, writer io.Writer, etag string, opts ObjectOptions) (err error)
 	GetObjectInfo(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error)
-	PutObject(ctx context.Context, bucket, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error)
+	PutObject(ctx context.Context, bucket, object string, data *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error)
 	DeleteObject(ctx context.Context, bucket, object string) error
 
 	// Multipart operations.
 	NewMultipartUpload(ctx context.Context, bucket, object string, metadata map[string]string, opts ObjectOptions) (uploadID string, err error)
-	PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *hash.Reader, opts ObjectOptions) (info PartInfo, err error)
+	PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *PutObjectReader, opts ObjectOptions) (info PartInfo, err error)
 	AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string) error
-	CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart) (objInfo ObjectInfo, err error)
+	CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (objInfo ObjectInfo, err error)
 
 	// Storage operations.
 	StorageInfo(ctx context.Context) CacheStorageInfo
@@ -247,7 +247,7 @@ func (c cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string,
 
 	go func() {
 		opts := ObjectOptions{}
-		putErr := dcache.Put(ctx, bucket, object, hashReader, c.getMetadata(bkReader.ObjInfo), opts)
+		putErr := dcache.Put(ctx, bucket, object, NewPutObjectReader(hashReader), c.getMetadata(bkReader.ObjInfo), opts)
 		// close the write end of the pipe, so the error gets
 		// propagated to getObjReader
 		pipeWriter.CloseWithError(putErr)
@@ -320,7 +320,7 @@ func (c cacheObjects) GetObject(ctx context.Context, bucket, object string, star
 		gerr := GetObjectFn(ctx, bucket, object, 0, objInfo.Size, io.MultiWriter(writer, pipeWriter), etag, opts)
 		pipeWriter.CloseWithError(gerr) // Close writer explicitly signaling we wrote all data.
 	}()
-	err = dcache.Put(ctx, bucket, object, hashReader, c.getMetadata(objInfo), opts)
+	err = dcache.Put(ctx, bucket, object, NewPutObjectReader(hashReader), c.getMetadata(objInfo), opts)
 	if err != nil {
 		return err
 	}
@@ -644,8 +644,9 @@ func (c cacheObjects) isCacheExclude(bucket, object string) bool {
 }
 
 // PutObject - caches the uploaded object for single Put operations
-func (c cacheObjects) PutObject(ctx context.Context, bucket, object string, r *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+func (c cacheObjects) PutObject(ctx context.Context, bucket, object string, r *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	putObjectFn := c.PutObjectFn
+	data := r.DataReader
 	dcache, err := c.cache.getCacheFS(ctx, bucket, object)
 	if err != nil {
 		// disk cache could not be located,execute backend call.
@@ -666,20 +667,20 @@ func (c cacheObjects) PutObject(ctx context.Context, bucket, object string, r *h
 	objInfo = ObjectInfo{}
 	// Initialize pipe to stream data to backend
 	pipeReader, pipeWriter := io.Pipe()
-	hashReader, err := hash.NewReader(pipeReader, size, r.MD5HexString(), r.SHA256HexString(), r.ActualSize())
+	hashReader, err := hash.NewReader(pipeReader, size, data.MD5HexString(), data.SHA256HexString(), data.ActualSize())
 	if err != nil {
 		return ObjectInfo{}, err
 	}
 	// Initialize pipe to stream data to cache
 	rPipe, wPipe := io.Pipe()
-	cHashReader, err := hash.NewReader(rPipe, size, r.MD5HexString(), r.SHA256HexString(), r.ActualSize())
+	cHashReader, err := hash.NewReader(rPipe, size, data.MD5HexString(), data.SHA256HexString(), data.ActualSize())
 	if err != nil {
 		return ObjectInfo{}, err
 	}
 	oinfoCh := make(chan ObjectInfo)
 	errCh := make(chan error)
 	go func() {
-		oinfo, perr := putObjectFn(ctx, bucket, object, hashReader, metadata, opts)
+		oinfo, perr := putObjectFn(ctx, bucket, object, NewPutObjectReader(hashReader), metadata, opts)
 		if perr != nil {
 			pipeWriter.CloseWithError(perr)
 			wPipe.CloseWithError(perr)
@@ -692,14 +693,14 @@ func (c cacheObjects) PutObject(ctx context.Context, bucket, object string, r *h
 	}()
 
 	go func() {
-		if err = dcache.Put(ctx, bucket, object, cHashReader, metadata, opts); err != nil {
+		if err = dcache.Put(ctx, bucket, object, NewPutObjectReader(cHashReader), metadata, opts); err != nil {
 			wPipe.CloseWithError(err)
 			return
 		}
 	}()
 
 	mwriter := io.MultiWriter(pipeWriter, wPipe)
-	_, err = io.Copy(mwriter, r)
+	_, err = io.Copy(mwriter, data)
 	if err != nil {
 		err = <-errCh
 		return objInfo, err
@@ -734,16 +735,17 @@ func (c cacheObjects) NewMultipartUpload(ctx context.Context, bucket, object str
 }
 
 // PutObjectPart - uploads part to backend and cache simultaneously.
-func (c cacheObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *hash.Reader, opts ObjectOptions) (info PartInfo, err error) {
+func (c cacheObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, r *PutObjectReader, opts ObjectOptions) (info PartInfo, err error) {
+	data := r.DataReader
 	putObjectPartFn := c.PutObjectPartFn
 	dcache, err := c.cache.getCacheFS(ctx, bucket, object)
 	if err != nil {
 		// disk cache could not be located,execute backend call.
-		return putObjectPartFn(ctx, bucket, object, uploadID, partID, data, opts)
+		return putObjectPartFn(ctx, bucket, object, uploadID, partID, r, opts)
 	}
 
 	if c.isCacheExclude(bucket, object) {
-		return putObjectPartFn(ctx, bucket, object, uploadID, partID, data, opts)
+		return putObjectPartFn(ctx, bucket, object, uploadID, partID, r, opts)
 	}
 
 	// make sure cache has at least size space available
@@ -753,7 +755,7 @@ func (c cacheObjects) PutObjectPart(ctx context.Context, bucket, object, uploadI
 		case dcache.purgeChan <- struct{}{}:
 		default:
 		}
-		return putObjectPartFn(ctx, bucket, object, uploadID, partID, data, opts)
+		return putObjectPartFn(ctx, bucket, object, uploadID, partID, r, opts)
 	}
 
 	info = PartInfo{}
@@ -772,7 +774,7 @@ func (c cacheObjects) PutObjectPart(ctx context.Context, bucket, object, uploadI
 	pinfoCh := make(chan PartInfo)
 	errorCh := make(chan error)
 	go func() {
-		info, err = putObjectPartFn(ctx, bucket, object, uploadID, partID, hashReader, opts)
+		info, err = putObjectPartFn(ctx, bucket, object, uploadID, partID, NewPutObjectReader(hashReader), opts)
 		if err != nil {
 			close(pinfoCh)
 			pipeWriter.CloseWithError(err)
@@ -784,7 +786,7 @@ func (c cacheObjects) PutObjectPart(ctx context.Context, bucket, object, uploadI
 		pinfoCh <- info
 	}()
 	go func() {
-		if _, perr := dcache.PutObjectPart(ctx, bucket, object, uploadID, partID, cHashReader, opts); perr != nil {
+		if _, perr := dcache.PutObjectPart(ctx, bucket, object, uploadID, partID, NewPutObjectReader(cHashReader), opts); perr != nil {
 			wPipe.CloseWithError(perr)
 			return
 		}
@@ -826,25 +828,25 @@ func (c cacheObjects) AbortMultipartUpload(ctx context.Context, bucket, object, 
 }
 
 // CompleteMultipartUpload - completes multipart upload operation on backend and cache.
-func (c cacheObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart) (objInfo ObjectInfo, err error) {
+func (c cacheObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	completeMultipartUploadFn := c.CompleteMultipartUploadFn
 
 	if c.isCacheExclude(bucket, object) {
-		return completeMultipartUploadFn(ctx, bucket, object, uploadID, uploadedParts)
+		return completeMultipartUploadFn(ctx, bucket, object, uploadID, uploadedParts, opts)
 	}
 
 	dcache, err := c.cache.getCacheFS(ctx, bucket, object)
 	if err != nil {
 		// disk cache could not be located,execute backend call.
-		return completeMultipartUploadFn(ctx, bucket, object, uploadID, uploadedParts)
+		return completeMultipartUploadFn(ctx, bucket, object, uploadID, uploadedParts, opts)
 	}
 	// perform backend operation
-	objInfo, err = completeMultipartUploadFn(ctx, bucket, object, uploadID, uploadedParts)
+	objInfo, err = completeMultipartUploadFn(ctx, bucket, object, uploadID, uploadedParts, opts)
 	if err != nil {
 		return
 	}
 	// create new multipart upload in cache with same uploadID
-	dcache.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts)
+	dcache.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
 	return
 }
 
@@ -969,7 +971,7 @@ func newServerCacheObjects(config CacheConfig) (CacheObjectLayer, error) {
 		GetObjectNInfoFn: func(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error) {
 			return newObjectLayerFn().GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
 		},
-		PutObjectFn: func(ctx context.Context, bucket, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+		PutObjectFn: func(ctx context.Context, bucket, object string, data *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 			return newObjectLayerFn().PutObject(ctx, bucket, object, data, metadata, opts)
 		},
 		DeleteObjectFn: func(ctx context.Context, bucket, object string) error {
@@ -990,14 +992,14 @@ func newServerCacheObjects(config CacheConfig) (CacheObjectLayer, error) {
 		NewMultipartUploadFn: func(ctx context.Context, bucket, object string, metadata map[string]string, opts ObjectOptions) (uploadID string, err error) {
 			return newObjectLayerFn().NewMultipartUpload(ctx, bucket, object, metadata, opts)
 		},
-		PutObjectPartFn: func(ctx context.Context, bucket, object, uploadID string, partID int, data *hash.Reader, opts ObjectOptions) (info PartInfo, err error) {
+		PutObjectPartFn: func(ctx context.Context, bucket, object, uploadID string, partID int, data *PutObjectReader, opts ObjectOptions) (info PartInfo, err error) {
 			return newObjectLayerFn().PutObjectPart(ctx, bucket, object, uploadID, partID, data, opts)
 		},
 		AbortMultipartUploadFn: func(ctx context.Context, bucket, object, uploadID string) error {
 			return newObjectLayerFn().AbortMultipartUpload(ctx, bucket, object, uploadID)
 		},
-		CompleteMultipartUploadFn: func(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart) (objInfo ObjectInfo, err error) {
-			return newObjectLayerFn().CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts)
+		CompleteMultipartUploadFn: func(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+			return newObjectLayerFn().CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
 		},
 		DeleteBucketFn: func(ctx context.Context, bucket string) error {
 			return newObjectLayerFn().DeleteBucket(ctx, bucket)

--- a/cmd/disk-cache_test.go
+++ b/cmd/disk-cache_test.go
@@ -134,7 +134,7 @@ func TestCacheExclusion(t *testing.T) {
 		t.Fatal(err)
 	}
 	cobj := cobjects.(*cacheObjects)
-	globalServiceDoneCh <- struct{}{}
+	GlobalServiceDoneCh <- struct{}{}
 	testCases := []struct {
 		bucketName     string
 		objectName     string

--- a/cmd/disk-cache_test.go
+++ b/cmd/disk-cache_test.go
@@ -199,7 +199,7 @@ func TestDiskCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = cache.Put(ctx, bucketName, objectName, hashReader, httpMeta, opts)
+	err = cache.Put(ctx, bucketName, objectName, NewPutObjectReader(hashReader), httpMeta, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,12 +275,12 @@ func TestDiskCacheMaxUse(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !cache.diskAvailable(int64(size)) {
-		err = cache.Put(ctx, bucketName, objectName, hashReader, httpMeta, opts)
+		err = cache.Put(ctx, bucketName, objectName, NewPutObjectReader(hashReader), httpMeta, opts)
 		if err != errDiskFull {
 			t.Fatal("Cache max-use limit violated.")
 		}
 	} else {
-		err = cache.Put(ctx, bucketName, objectName, hashReader, httpMeta, opts)
+		err = cache.Put(ctx, bucketName, objectName, NewPutObjectReader(hashReader), httpMeta, opts)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/dummy-object-layer_test.go
+++ b/cmd/dummy-object-layer_test.go
@@ -99,7 +99,7 @@ func (api *DummyObjectLayer) PutObjectPart(ctx context.Context, bucket, object, 
 	return
 }
 
-func (api *DummyObjectLayer) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error) {
+func (api *DummyObjectLayer) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int, opts ObjectOptions) (result ListPartsInfo, err error) {
 	return
 }
 

--- a/cmd/dummy-object-layer_test.go
+++ b/cmd/dummy-object-layer_test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/policy"
 )
@@ -72,7 +71,7 @@ func (api *DummyObjectLayer) GetObjectInfo(ctx context.Context, bucket, object s
 	return
 }
 
-func (api *DummyObjectLayer) PutObject(ctx context.Context, bucket, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+func (api *DummyObjectLayer) PutObject(ctx context.Context, bucket, object string, data *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	return
 }
 
@@ -96,7 +95,7 @@ func (api *DummyObjectLayer) CopyObjectPart(ctx context.Context, srcBucket, srcO
 	return
 }
 
-func (api *DummyObjectLayer) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *hash.Reader, opts ObjectOptions) (info PartInfo, err error) {
+func (api *DummyObjectLayer) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *PutObjectReader, opts ObjectOptions) (info PartInfo, err error) {
 	return
 }
 
@@ -108,7 +107,7 @@ func (api *DummyObjectLayer) AbortMultipartUpload(ctx context.Context, bucket, o
 	return
 }
 
-func (api *DummyObjectLayer) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart) (objInfo ObjectInfo, err error) {
+func (api *DummyObjectLayer) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	return
 }
 

--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -21,6 +21,7 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -28,6 +29,7 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/minio/minio-go/pkg/encrypt"
 	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/ioutil"
@@ -54,11 +56,11 @@ const (
 	// SSEIVSize is the size of the IV data
 	SSEIVSize = 32 // 32 bytes
 
-	// SSE dare package block size.
-	sseDAREPackageBlockSize = 64 * 1024 // 64KiB bytes
+	// SSEDAREPackageBlockSize - SSE dare package block size.
+	SSEDAREPackageBlockSize = 64 * 1024 // 64KiB bytes
 
-	// SSE dare package meta padding bytes.
-	sseDAREPackageMetaSize = 32 // 32 bytes
+	// SSEDAREPackageMetaSize - SSE dare package meta padding bytes.
+	SSEDAREPackageMetaSize = 32 // 32 bytes
 
 )
 
@@ -388,8 +390,8 @@ func DecryptBlocksRequestR(inputReader io.Reader, h http.Header, offset,
 		return reader, nil
 	}
 
-	partDecRelOffset := int64(seqNumber) * sseDAREPackageBlockSize
-	partEncRelOffset := int64(seqNumber) * (sseDAREPackageBlockSize + sseDAREPackageMetaSize)
+	partDecRelOffset := int64(seqNumber) * SSEDAREPackageBlockSize
+	partEncRelOffset := int64(seqNumber) * (SSEDAREPackageBlockSize + SSEDAREPackageMetaSize)
 
 	w := &DecryptBlocksReader{
 		reader:            inputReader,
@@ -454,7 +456,7 @@ type DecryptBlocksReader struct {
 	// Current part index
 	partIndex int
 	// Parts information
-	parts          []objectPartInfo
+	parts          []ObjectPartInfo
 	header         http.Header
 	bucket, object string
 	metadata       map[string]string
@@ -570,7 +572,7 @@ type DecryptBlocksWriter struct {
 	// Current part index
 	partIndex int
 	// Parts information
-	parts          []objectPartInfo
+	parts          []ObjectPartInfo
 	req            *http.Request
 	bucket, object string
 	metadata       map[string]string
@@ -721,6 +723,7 @@ func DecryptBlocksRequest(client io.Writer, r *http.Request, bucket, object stri
 	}
 
 	seqNumber, encStartOffset, encLength = getEncryptedMultipartsOffsetLength(startOffset, length, objInfo)
+
 	var partStartIndex int
 	var partStartOffset = startOffset
 	// Skip parts until final offset maps to a particular part offset.
@@ -743,8 +746,8 @@ func DecryptBlocksRequest(client io.Writer, r *http.Request, bucket, object stri
 		partStartOffset -= int64(decryptedSize)
 	}
 
-	startSeqNum := partStartOffset / sseDAREPackageBlockSize
-	partEncRelOffset := int64(startSeqNum) * (sseDAREPackageBlockSize + sseDAREPackageMetaSize)
+	startSeqNum := partStartOffset / SSEDAREPackageBlockSize
+	partEncRelOffset := int64(startSeqNum) * (SSEDAREPackageBlockSize + SSEDAREPackageMetaSize)
 
 	w := &DecryptBlocksWriter{
 		writer:            client,
@@ -775,6 +778,7 @@ func DecryptBlocksRequest(client io.Writer, r *http.Request, bucket, object stri
 		delete(objInfo.UserDefined, crypto.S3SealedKey)
 		delete(objInfo.UserDefined, crypto.S3KMSKeyID)
 		delete(objInfo.UserDefined, crypto.S3KMSSealedKey)
+		delete(objInfo.UserDefined, crypto.SSEHeader)
 	}
 	if w.copySource {
 		w.customerKeyHeader = r.Header.Get(crypto.SSECopyKey)
@@ -836,9 +840,9 @@ func getEncryptedMultipartsOffsetLength(offset, length int64, obj ObjectInfo) (u
 
 // getEncryptedSinglePartOffsetLength - fetch sequence number, encrypted start offset and encrypted length.
 func getEncryptedSinglePartOffsetLength(offset, length int64, objInfo ObjectInfo) (seqNumber uint32, encOffset int64, encLength int64) {
-	onePkgSize := int64(sseDAREPackageBlockSize + sseDAREPackageMetaSize)
+	onePkgSize := int64(SSEDAREPackageBlockSize + SSEDAREPackageMetaSize)
 
-	seqNumber = uint32(offset / sseDAREPackageBlockSize)
+	seqNumber = uint32(offset / SSEDAREPackageBlockSize)
 	encOffset = int64(seqNumber) * onePkgSize
 	// The math to compute the encrypted length is always
 	// originalLength i.e (offset+length-1) to be divided under
@@ -846,10 +850,10 @@ func getEncryptedSinglePartOffsetLength(offset, length int64, objInfo ObjectInfo
 	// block. This is then multiplied by final package size which
 	// is basically 64KiB + 32. Finally negate the encrypted offset
 	// to get the final encrypted length on disk.
-	encLength = ((offset+length)/sseDAREPackageBlockSize)*onePkgSize - encOffset
+	encLength = ((offset+length)/SSEDAREPackageBlockSize)*onePkgSize - encOffset
 
 	// Check for the remainder, to figure if we need one extract package to read from.
-	if (offset+length)%sseDAREPackageBlockSize > 0 {
+	if (offset+length)%SSEDAREPackageBlockSize > 0 {
 		encLength += onePkgSize
 	}
 
@@ -959,11 +963,11 @@ func (o *ObjectInfo) GetDecryptedRange(rs *HTTPRangeSpec) (encOff, encLength, sk
 	// partStart is always found in the loop above,
 	// because off is validated.
 
-	sseDAREEncPackageBlockSize := int64(sseDAREPackageBlockSize + sseDAREPackageMetaSize)
-	startPkgNum := (off - cumulativeSum) / sseDAREPackageBlockSize
+	sseDAREEncPackageBlockSize := int64(SSEDAREPackageBlockSize + SSEDAREPackageMetaSize)
+	startPkgNum := (off - cumulativeSum) / SSEDAREPackageBlockSize
 
 	// Now we can calculate the number of bytes to skip
-	skipLen = (off - cumulativeSum) % sseDAREPackageBlockSize
+	skipLen = (off - cumulativeSum) % SSEDAREPackageBlockSize
 
 	encOff = encCumulativeSum + startPkgNum*sseDAREEncPackageBlockSize
 	// Locate the part containing the end of the required range
@@ -980,7 +984,7 @@ func (o *ObjectInfo) GetDecryptedRange(rs *HTTPRangeSpec) (encOff, encLength, sk
 	}
 	// partEnd is always found in the loop above, because off and
 	// length are validated.
-	endPkgNum := (endOffset - cumulativeSum) / sseDAREPackageBlockSize
+	endPkgNum := (endOffset - cumulativeSum) / SSEDAREPackageBlockSize
 	// Compute endEncOffset with one additional DARE package (so
 	// we read the package containing the last desired byte).
 	endEncOffset := encCumulativeSum + (endPkgNum+1)*sseDAREEncPackageBlockSize
@@ -1069,4 +1073,141 @@ func DecryptObjectInfo(info ObjectInfo, headers http.Header) (encrypted bool, er
 		_, err = info.DecryptedSize()
 	}
 	return
+}
+
+// The customer key in the header is used by the gateway for encryption in the case of
+// s3 gateway double encryption. A new client key is derived from the customer provided
+// key to be sent to the s3 backend for encryption at the backend.
+func deriveClientKey(header http.Header, headerName, bucket, object string) ([32]byte, error) {
+	var key [32]byte
+	clientKey, err := base64.StdEncoding.DecodeString(header.Get(headerName))
+	if err != nil || len(clientKey) != 32 { // The client key must be 256 bits long
+		return key, crypto.ErrInvalidCustomerKey
+	}
+	mac := hmac.New(sha256.New, clientKey)
+	mac.Write([]byte(crypto.SSEC.String()))
+	mac.Write([]byte(path.Join(bucket, object)))
+	mac.Sum(key[:0])
+	return key, nil
+}
+
+// extract encryption options for pass through to backend in the case of gateway
+func extractEncryptionOption(header http.Header, copySource bool) (opts ObjectOptions, err error) {
+	var clientKey []byte
+	var sse encrypt.ServerSide
+
+	if copySource {
+		if crypto.SSECopy.IsRequested(header) {
+			clientKey, err = base64.StdEncoding.DecodeString(header.Get(crypto.SSECopyKey))
+			if err != nil || len(clientKey) != 32 { // The client key must be 256 bits long
+				return opts, crypto.ErrInvalidCustomerKey
+			}
+			if sse, err = encrypt.NewSSEC(clientKey); err != nil {
+				return
+			}
+			return ObjectOptions{ServerSideEncryption: encrypt.SSECopy(sse)}, nil
+		}
+		return
+	}
+
+	if crypto.SSEC.IsRequested(header) {
+		clientKey, err = base64.StdEncoding.DecodeString(header.Get(crypto.SSECKey))
+		if err != nil || len(clientKey) != 32 { // The client key must be 256 bits long
+			return opts, crypto.ErrInvalidCustomerKey
+		}
+		if sse, err = encrypt.NewSSEC(clientKey); err != nil {
+			return
+		}
+		return ObjectOptions{ServerSideEncryption: sse}, nil
+	}
+	if crypto.S3.IsRequested(header) {
+		return ObjectOptions{ServerSideEncryption: encrypt.NewSSE()}, nil
+	}
+	return opts, nil
+}
+
+// get ObjectOptions for GET calls from encryption headers
+func getEncryptionOpts(r *http.Request, bucket, object string) (ObjectOptions, error) {
+	var (
+		encryption encrypt.ServerSide
+		opts       ObjectOptions
+	)
+	if GlobalGatewaySSE != nil {
+		for _, k := range GlobalGatewaySSE {
+			if k == GatewaySSEC && crypto.SSEC.IsRequested(r.Header) {
+				derivedKey, err := deriveClientKey(r.Header, crypto.SSECKey, bucket, object)
+				if err != nil {
+					return opts, err
+				}
+				encryption, err = encrypt.NewSSEC(derivedKey[:])
+				if err != nil {
+					return opts, err
+				}
+				return ObjectOptions{ServerSideEncryption: encryption}, nil
+			}
+		}
+	}
+	// default case of passing encryption headers to backend
+	return extractEncryptionOption(r.Header, false)
+}
+
+// get ObjectOptions for PUT calls from encryption headers
+func putEncryptionOpts(r *http.Request, bucket, object string, metadata map[string]string) (opts ObjectOptions, err error) {
+	if GlobalGatewaySSE != nil {
+		for _, k := range GlobalGatewaySSE {
+			// In the case of multipart custom format, the metadata needs to be checked in addition to header to see if it
+			// is SSE-S3 encrypted, primarily because S3 protocol does not require SSE-S3 headers in PutObjectPart calls
+			if k == GatewaySSES3 && (crypto.S3.IsRequested(r.Header) || crypto.S3.IsEncrypted(metadata)) {
+				opts = ObjectOptions{ServerSideEncryption: encrypt.ServerSide(encrypt.NewSSE())}
+			}
+			if k == GatewaySSEC && crypto.SSEC.IsRequested(r.Header) {
+				return getEncryptionOpts(r, bucket, object)
+			}
+		}
+	}
+	// default case of passing encryption headers to backend
+	return extractEncryptionOption(r.Header, false)
+}
+
+// get ObjectOptions for Copy calls for encryption headers provided on the target side
+func copyDstEncryptionOpts(r *http.Request, bucket, object string, metadata map[string]string) (opts ObjectOptions, err error) {
+	if GlobalGatewaySSE != nil {
+		for _, k := range GlobalGatewaySSE {
+			// In the case of multipart custom format, the metadata needs to be checked in addition to header to see if it
+			// is SSE-S3 encrypted, primarily because S3 protocol does not require SSE-S3 headers in CopyObjectPart calls
+			if k == GatewaySSES3 && (crypto.S3.IsRequested(r.Header) || crypto.S3.IsEncrypted(metadata)) {
+				opts = ObjectOptions{ServerSideEncryption: encrypt.ServerSide(encrypt.NewSSE())}
+			}
+			if k == GatewaySSEC && crypto.SSEC.IsRequested(r.Header) {
+				return getEncryptionOpts(r, bucket, object)
+			}
+		}
+	}
+	// default case of passing encryption headers to backend
+	return extractEncryptionOption(r.Header, false)
+}
+
+// get ObjectOptions for Copy calls for encryption headers provided on the source side
+func copySrcEncryptionOpts(r *http.Request, bucket, object string) (ObjectOptions, error) {
+	var (
+		ssec encrypt.ServerSide
+		opts ObjectOptions
+	)
+	if GlobalGatewaySSE != nil {
+		for _, k := range GlobalGatewaySSE {
+			if k == GatewaySSEC && crypto.SSECopy.IsRequested(r.Header) {
+				derivedKey, err := deriveClientKey(r.Header, crypto.SSECopyKey, bucket, object)
+				if err != nil {
+					return opts, err
+				}
+				ssec, err = encrypt.NewSSEC(derivedKey[:])
+				if err != nil {
+					return opts, err
+				}
+				return ObjectOptions{ServerSideEncryption: encrypt.SSECopy(ssec)}, nil
+			}
+		}
+	}
+	// default case of passing encryption headers to backend
+	return extractEncryptionOption(r.Header, true)
 }

--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -23,6 +23,7 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"io"
 	"net/http"
@@ -32,6 +33,7 @@ import (
 	"github.com/minio/minio-go/pkg/encrypt"
 	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/ioutil"
 	sha256 "github.com/minio/sha256-simd"
 	"github.com/minio/sio"
@@ -183,7 +185,20 @@ func newEncryptMetadata(key []byte, bucket, object string, metadata map[string]s
 	sealedKey = objectKey.Seal(extKey, crypto.GenerateIV(rand.Reader), crypto.SSEC.String(), bucket, object)
 	crypto.SSEC.CreateMetadata(metadata, sealedKey)
 	return objectKey[:], nil
+}
 
+// For SSE encrypted objects, original content's MD5Sum is encrypted with object encryption key. This is required for
+// compatibility with AWS S3 which returns MD5Sum of content in the response header as ETag for SSE-S3 encrypted objects.
+// Extend same behavior to SSE-C encrypted objects
+// https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
+func getEncryptedETag(etag string, key []byte) string {
+	md5Bytes, err := hex.DecodeString(etag)
+	if err != nil {
+		return etag
+	}
+	var objectKey crypto.ObjectKey
+	copy(objectKey[:], key)
+	return hex.EncodeToString(objectKey.SealETag(md5Bytes))
 }
 
 func newEncryptReader(content io.Reader, key []byte, bucket, object string, metadata map[string]string, sseS3 bool) (io.Reader, error) {
@@ -192,6 +207,9 @@ func newEncryptReader(content io.Reader, key []byte, bucket, object string, meta
 		return nil, err
 	}
 
+	if hReader, ok := content.(*hash.Reader); ok {
+		hReader.SetEncryptionKey(objectEncryptionKey)
+	}
 	reader, err := sio.EncryptReader(content, sio.Config{Key: objectEncryptionKey[:], MinVersion: sio.Version20})
 	if err != nil {
 		return nil, crypto.ErrInvalidCustomerKey
@@ -556,7 +574,6 @@ func (d *DecryptBlocksReader) Read(p []byte) (int, error) {
 
 		d.partDecRelOffset += int64(n1)
 	}
-
 	return len(p), nil
 }
 
@@ -793,7 +810,6 @@ func DecryptBlocksRequest(client io.Writer, r *http.Request, bucket, object stri
 
 // getEncryptedMultipartsOffsetLength - fetch sequence number, encrypted start offset and encrypted length.
 func getEncryptedMultipartsOffsetLength(offset, length int64, obj ObjectInfo) (uint32, int64, int64) {
-
 	// Calculate encrypted offset of a multipart object
 	computeEncOffset := func(off int64, obj ObjectInfo) (seqNumber uint32, encryptedOffset int64, err error) {
 		var curPartEndOffset uint64
@@ -887,6 +903,57 @@ func (o *ObjectInfo) DecryptedSize() (int64, error) {
 		size += int64(partSize)
 	}
 	return size, nil
+}
+
+// For encrypted objects, the ETag sent by client if available
+// is stored in encrypted form in the backend.Decrypt the ETag
+// if ETag was previously encrypted.
+func getDecryptedETag(headers http.Header, objInfo ObjectInfo, copySource bool) (decryptedETag string) {
+	var (
+		key [32]byte
+		err error
+	)
+	// If ETag is contentMD5Sum return it as is.
+	if len(objInfo.ETag) == 32 {
+		return objInfo.ETag
+	}
+
+	if crypto.IsMultiPart(objInfo.UserDefined) {
+		return objInfo.ETag
+	}
+	if crypto.SSECopy.IsRequested(headers) {
+		key, err = crypto.SSECopy.ParseHTTP(headers)
+		if err != nil {
+			return objInfo.ETag
+		}
+	}
+	if crypto.SSEC.IsEncrypted(objInfo.UserDefined) && !copySource {
+		return objInfo.ETag[len(objInfo.ETag)-32:]
+	}
+
+	objectEncryptionKey, err := decryptObjectInfo(key[:], objInfo.Bucket, objInfo.Name, objInfo.UserDefined)
+	if err != nil {
+		return objInfo.ETag
+	}
+	return tryDecryptETag(objectEncryptionKey, objInfo.ETag, false)
+}
+
+// helper to decrypt Etag given object encryption key and encrypted ETag
+func tryDecryptETag(key []byte, encryptedETag string, ssec bool) string {
+	if ssec {
+		return encryptedETag[len(encryptedETag)-32:]
+	}
+	var objectKey crypto.ObjectKey
+	copy(objectKey[:], key)
+	encBytes, err := hex.DecodeString(encryptedETag)
+	if err != nil {
+		return encryptedETag
+	}
+	etagBytes, err := objectKey.UnsealETag(encBytes)
+	if err != nil {
+		return encryptedETag
+	}
+	return hex.EncodeToString(etagBytes)
 }
 
 // GetDecryptedRange - To decrypt the range (off, length) of the
@@ -1052,7 +1119,7 @@ func DecryptCopyObjectInfo(info *ObjectInfo, headers http.Header) (apiErr APIErr
 // decryption succeeded.
 //
 // DecryptObjectInfo also returns whether the object is encrypted or not.
-func DecryptObjectInfo(info ObjectInfo, headers http.Header) (encrypted bool, err error) {
+func DecryptObjectInfo(info *ObjectInfo, headers http.Header) (encrypted bool, err error) {
 	// Directories are never encrypted.
 	if info.IsDir {
 		return false, nil
@@ -1071,6 +1138,11 @@ func DecryptObjectInfo(info ObjectInfo, headers http.Header) (encrypted bool, er
 			return
 		}
 		_, err = info.DecryptedSize()
+
+		if crypto.IsEncrypted(info.UserDefined) && !crypto.IsMultiPart(info.UserDefined) {
+			info.ETag = getDecryptedETag(headers, *info, false)
+		}
+
 	}
 	return
 }
@@ -1092,7 +1164,7 @@ func deriveClientKey(header http.Header, headerName, bucket, object string) ([32
 }
 
 // extract encryption options for pass through to backend in the case of gateway
-func extractEncryptionOption(header http.Header, copySource bool) (opts ObjectOptions, err error) {
+func extractEncryptionOption(header http.Header, copySource bool, metadata map[string]string) (opts ObjectOptions, err error) {
 	var clientKey []byte
 	var sse encrypt.ServerSide
 
@@ -1120,7 +1192,7 @@ func extractEncryptionOption(header http.Header, copySource bool) (opts ObjectOp
 		}
 		return ObjectOptions{ServerSideEncryption: sse}, nil
 	}
-	if crypto.S3.IsRequested(header) {
+	if crypto.S3.IsRequested(header) || (metadata != nil && crypto.S3.IsEncrypted(metadata)) {
 		return ObjectOptions{ServerSideEncryption: encrypt.NewSSE()}, nil
 	}
 	return opts, nil
@@ -1148,7 +1220,7 @@ func getEncryptionOpts(r *http.Request, bucket, object string) (ObjectOptions, e
 		}
 	}
 	// default case of passing encryption headers to backend
-	return extractEncryptionOption(r.Header, false)
+	return extractEncryptionOption(r.Header, false, nil)
 }
 
 // get ObjectOptions for PUT calls from encryption headers
@@ -1166,7 +1238,7 @@ func putEncryptionOpts(r *http.Request, bucket, object string, metadata map[stri
 		}
 	}
 	// default case of passing encryption headers to backend
-	return extractEncryptionOption(r.Header, false)
+	return extractEncryptionOption(r.Header, false, metadata)
 }
 
 // get ObjectOptions for Copy calls for encryption headers provided on the target side
@@ -1184,7 +1256,7 @@ func copyDstEncryptionOpts(r *http.Request, bucket, object string, metadata map[
 		}
 	}
 	// default case of passing encryption headers to backend
-	return extractEncryptionOption(r.Header, false)
+	return extractEncryptionOption(r.Header, false, nil)
 }
 
 // get ObjectOptions for Copy calls for encryption headers provided on the source side
@@ -1209,5 +1281,5 @@ func copySrcEncryptionOpts(r *http.Request, bucket, object string) (ObjectOption
 		}
 	}
 	// default case of passing encryption headers to backend
-	return extractEncryptionOption(r.Header, true)
+	return extractEncryptionOption(r.Header, true, nil)
 }

--- a/cmd/encryption-v1_test.go
+++ b/cmd/encryption-v1_test.go
@@ -324,7 +324,7 @@ var decryptObjectInfoTests = []struct {
 
 func TestDecryptObjectInfo(t *testing.T) {
 	for i, test := range decryptObjectInfoTests {
-		if encrypted, err := DecryptObjectInfo(test.info, test.headers); err != test.expErr {
+		if encrypted, err := DecryptObjectInfo(&test.info, test.headers); err != test.expErr {
 			t.Errorf("Test %d: Decryption returned wrong error code: got %d , want %d", i, err, test.expErr)
 		} else if enc := crypto.IsEncrypted(test.info.UserDefined); encrypted && enc != encrypted {
 			t.Errorf("Test %d: Decryption thinks object is encrypted but it is not", i)

--- a/cmd/encryption-v1_test.go
+++ b/cmd/encryption-v1_test.go
@@ -443,7 +443,7 @@ func TestGetDecryptedRange(t *testing.T) {
 	var (
 		// make a multipart object-info given part sizes
 		mkMPObj = func(sizes []int64) ObjectInfo {
-			r := make([]objectPartInfo, len(sizes))
+			r := make([]ObjectPartInfo, len(sizes))
 			sum := int64(0)
 			for i, s := range sizes {
 				r[i].Number = i

--- a/cmd/fs-v1-metadata.go
+++ b/cmd/fs-v1-metadata.go
@@ -113,7 +113,7 @@ type fsMetaV1 struct {
 	// Metadata map for current object.
 	Meta map[string]string `json:"meta,omitempty"`
 	// parts info for current object - used in encryption.
-	Parts []objectPartInfo `json:"parts,omitempty"`
+	Parts []ObjectPartInfo `json:"parts,omitempty"`
 }
 
 // IsValid - tells if the format is sane by validating the version
@@ -207,9 +207,9 @@ func parseFSMetaMap(fsMetaBuf []byte) map[string]string {
 	return metaMap
 }
 
-func parseFSPartsArray(fsMetaBuf []byte) []objectPartInfo {
+func parseFSPartsArray(fsMetaBuf []byte) []ObjectPartInfo {
 	// Get xlMetaV1.Parts array
-	var partsArray []objectPartInfo
+	var partsArray []ObjectPartInfo
 
 	partsArrayResult := gjson.GetBytes(fsMetaBuf, "parts")
 	partsArrayResult.ForEach(func(key, part gjson.Result) bool {
@@ -219,7 +219,7 @@ func parseFSPartsArray(fsMetaBuf []byte) []objectPartInfo {
 		etag := gjson.Get(partJSON, "etag").String()
 		size := gjson.Get(partJSON, "size").Int()
 		actualSize := gjson.Get(partJSON, "actualSize").Int()
-		partsArray = append(partsArray, objectPartInfo{
+		partsArray = append(partsArray, ObjectPartInfo{
 			Number:     int(number),
 			Name:       name,
 			ETag:       etag,

--- a/cmd/fs-v1-metadata_test.go
+++ b/cmd/fs-v1-metadata_test.go
@@ -54,7 +54,7 @@ func TestReadFSMetadata(t *testing.T) {
 	if err := obj.MakeBucketWithLocation(context.Background(), bucketName, ""); err != nil {
 		t.Fatal("Unexpected err: ", err)
 	}
-	if _, err := obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{}); err != nil {
+	if _, err := obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{}); err != nil {
 		t.Fatal("Unexpected err: ", err)
 	}
 
@@ -89,7 +89,7 @@ func TestWriteFSMetadata(t *testing.T) {
 	if err := obj.MakeBucketWithLocation(context.Background(), bucketName, ""); err != nil {
 		t.Fatal("Unexpected err: ", err)
 	}
-	if _, err := obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{}); err != nil {
+	if _, err := obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{}); err != nil {
 		t.Fatal("Unexpected err: ", err)
 	}
 

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -374,7 +374,7 @@ func (fs *FSObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID
 // Implements S3 compatible ListObjectParts API. The resulting
 // ListPartsInfo structure is unmarshalled directly into XML and
 // replied back to the client.
-func (fs *FSObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int) (result ListPartsInfo, e error) {
+func (fs *FSObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int, opts ObjectOptions) (result ListPartsInfo, e error) {
 	if err := checkListPartsArgs(ctx, bucket, object, fs); err != nil {
 		return result, toObjectErr(err)
 	}

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -516,7 +516,7 @@ func (fs *FSObjects) CompleteMultipartUpload(ctx context.Context, bucket string,
 	fsMeta := fsMetaV1{}
 
 	// Allocate parts similar to incoming slice.
-	fsMeta.Parts = make([]objectPartInfo, len(parts))
+	fsMeta.Parts = make([]ObjectPartInfo, len(parts))
 
 	entries, err := readDir(uploadIDDir)
 	if err != nil {
@@ -561,7 +561,7 @@ func (fs *FSObjects) CompleteMultipartUpload(ctx context.Context, bucket string,
 			partSize = actualSize
 		}
 
-		fsMeta.Parts[i] = objectPartInfo{
+		fsMeta.Parts[i] = ObjectPartInfo{
 			Number:     part.PartNumber,
 			ETag:       part.ETag,
 			Size:       fi.Size(),

--- a/cmd/fs-v1-multipart_test.go
+++ b/cmd/fs-v1-multipart_test.go
@@ -36,7 +36,7 @@ func TestFSCleanupMultipartUploadsInRoutine(t *testing.T) {
 
 	// Close the go-routine, we are going to
 	// manually start it and test in this test case.
-	globalServiceDoneCh <- struct{}{}
+	GlobalServiceDoneCh <- struct{}{}
 
 	bucketName := "bucket"
 	objectName := "object"
@@ -47,14 +47,14 @@ func TestFSCleanupMultipartUploadsInRoutine(t *testing.T) {
 		t.Fatal("Unexpected err: ", err)
 	}
 
-	go fs.cleanupStaleMultipartUploads(context.Background(), 20*time.Millisecond, 0, globalServiceDoneCh)
+	go fs.cleanupStaleMultipartUploads(context.Background(), 20*time.Millisecond, 0, GlobalServiceDoneCh)
 
 	// Wait for 40ms such that - we have given enough time for
 	// cleanup routine to kick in.
 	time.Sleep(40 * time.Millisecond)
 
 	// Close the routine we do not need it anymore.
-	globalServiceDoneCh <- struct{}{}
+	GlobalServiceDoneCh <- struct{}{}
 
 	// Check if upload id was already purged.
 	if err = obj.AbortMultipartUpload(context.Background(), bucketName, objectName, uploadID); err != nil {

--- a/cmd/fs-v1-multipart_test.go
+++ b/cmd/fs-v1-multipart_test.go
@@ -114,7 +114,7 @@ func TestPutObjectPartFaultyDisk(t *testing.T) {
 	sha256sum := ""
 
 	fs.fsPath = filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
-	_, err = fs.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1, mustGetHashReader(t, bytes.NewReader(data), dataLen, md5Hex, sha256sum), ObjectOptions{})
+	_, err = fs.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1, mustGetPutObjectReader(t, bytes.NewReader(data), dataLen, md5Hex, sha256sum), ObjectOptions{})
 	if !isSameType(err, BucketNotFound{}) {
 		t.Fatal("Unexpected error ", err)
 	}
@@ -145,7 +145,7 @@ func TestCompleteMultipartUploadFaultyDisk(t *testing.T) {
 
 	parts := []CompletePart{{PartNumber: 1, ETag: md5Hex}}
 	fs.fsPath = filepath.Join(globalTestTmpDir, "minio-"+nextSuffix())
-	if _, err := fs.CompleteMultipartUpload(context.Background(), bucketName, objectName, uploadID, parts); err != nil {
+	if _, err := fs.CompleteMultipartUpload(context.Background(), bucketName, objectName, uploadID, parts, ObjectOptions{}); err != nil {
 		if !isSameType(err, BucketNotFound{}) {
 			t.Fatal("Unexpected error ", err)
 		}
@@ -175,13 +175,13 @@ func TestCompleteMultipartUpload(t *testing.T) {
 
 	md5Hex := getMD5Hash(data)
 
-	if _, err := fs.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1, mustGetHashReader(t, bytes.NewReader(data), 5, md5Hex, ""), ObjectOptions{}); err != nil {
+	if _, err := fs.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1, mustGetPutObjectReader(t, bytes.NewReader(data), 5, md5Hex, ""), ObjectOptions{}); err != nil {
 		t.Fatal("Unexpected error ", err)
 	}
 
 	parts := []CompletePart{{PartNumber: 1, ETag: md5Hex}}
 
-	if _, err := fs.CompleteMultipartUpload(context.Background(), bucketName, objectName, uploadID, parts); err != nil {
+	if _, err := fs.CompleteMultipartUpload(context.Background(), bucketName, objectName, uploadID, parts, ObjectOptions{}); err != nil {
 		t.Fatal("Unexpected error ", err)
 	}
 }
@@ -209,7 +209,7 @@ func TestAbortMultipartUpload(t *testing.T) {
 
 	md5Hex := getMD5Hash(data)
 
-	if _, err := fs.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1, mustGetHashReader(t, bytes.NewReader(data), 5, md5Hex, ""), ObjectOptions{}); err != nil {
+	if _, err := fs.PutObjectPart(context.Background(), bucketName, objectName, uploadID, 1, mustGetPutObjectReader(t, bytes.NewReader(data), 5, md5Hex, ""), ObjectOptions{}); err != nil {
 		t.Fatal("Unexpected error ", err)
 	}
 	time.Sleep(time.Second) // Without Sleep on windows, the fs.AbortMultipartUpload() fails with "The process cannot access the file because it is being used by another process."

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -154,10 +154,10 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 	fs.fsFormatRlk = rlk
 
 	if !fs.diskMount {
-		go fs.diskUsage(globalServiceDoneCh)
+		go fs.diskUsage(GlobalServiceDoneCh)
 	}
 
-	go fs.cleanupStaleMultipartUploads(ctx, globalMultipartCleanupInterval, globalMultipartExpiry, globalServiceDoneCh)
+	go fs.cleanupStaleMultipartUploads(ctx, GlobalMultipartCleanupInterval, GlobalMultipartExpiry, GlobalServiceDoneCh)
 
 	// Return successfully initialized object layer.
 	return fs, nil

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/lock"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/mimedb"
@@ -461,8 +460,7 @@ func (fs *FSObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBu
 		// Return the new object info.
 		return fsMeta.ToObjectInfo(srcBucket, srcObject, fi), nil
 	}
-
-	objInfo, err := fs.putObject(ctx, dstBucket, dstObject, srcInfo.Reader, srcInfo.UserDefined)
+	objInfo, err := fs.putObject(ctx, dstBucket, dstObject, srcInfo.PutObjectReader, srcInfo.UserDefined, dstOpts)
 	if err != nil {
 		return oi, toObjectErr(err, dstBucket, dstObject)
 	}
@@ -813,8 +811,8 @@ func (fs *FSObjects) parentDirIsObject(ctx context.Context, bucket, parent strin
 // until EOF, writes data directly to configured filesystem path.
 // Additionally writes `fs.json` which carries the necessary metadata
 // for future object operations.
-func (fs *FSObjects) PutObject(ctx context.Context, bucket string, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, retErr error) {
-	if err := checkPutObjectArgs(ctx, bucket, object, fs, data.Size()); err != nil {
+func (fs *FSObjects) PutObject(ctx context.Context, bucket string, object string, r *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, retErr error) {
+	if err := checkPutObjectArgs(ctx, bucket, object, fs, r.Size()); err != nil {
 		return ObjectInfo{}, err
 	}
 	// Lock the object.
@@ -824,11 +822,13 @@ func (fs *FSObjects) PutObject(ctx context.Context, bucket string, object string
 		return objInfo, err
 	}
 	defer objectLock.Unlock()
-	return fs.putObject(ctx, bucket, object, data, metadata)
+	return fs.putObject(ctx, bucket, object, r, metadata, opts)
 }
 
 // putObject - wrapper for PutObject
-func (fs *FSObjects) putObject(ctx context.Context, bucket string, object string, data *hash.Reader, metadata map[string]string) (objInfo ObjectInfo, retErr error) {
+func (fs *FSObjects) putObject(ctx context.Context, bucket string, object string, r *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, retErr error) {
+	data := r.DataReader
+
 	// No metadata is set, allocate a new one.
 	meta := make(map[string]string)
 	for k, v := range metadata {
@@ -920,7 +920,14 @@ func (fs *FSObjects) putObject(ctx context.Context, bucket string, object string
 		return ObjectInfo{}, toObjectErr(err, bucket, object)
 	}
 
-	fsMeta.Meta["etag"] = hex.EncodeToString(data.MD5Current())
+	if opts.ServerSideEncryption != nil {
+		if encMD5Sum, _, err := r.OrigReader.EncryptedMD5Sum(); err == nil {
+			fsMeta.Meta["etag"] = encMD5Sum
+		}
+	}
+	if fsMeta.Meta["etag"] == "" {
+		fsMeta.Meta["etag"] = hex.EncodeToString(r.DataReader.MD5Current())
+	}
 
 	// Should return IncompleteBody{} error when reader has fewer
 	// bytes than specified in request header.

--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -354,7 +354,7 @@ func TestFSListBuckets(t *testing.T) {
 		t.Fatal("Unexpected error: ", err)
 	}
 
-	globalServiceDoneCh <- struct{}{}
+	GlobalServiceDoneCh <- struct{}{}
 
 	// Create a bucket with invalid name
 	if err := os.MkdirAll(pathJoin(fs.fsPath, "vo^"), 0777); err != nil {

--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -40,7 +40,7 @@ func TestFSParentDirIsObject(t *testing.T) {
 	}
 	objectContent := "12345"
 	objInfo, err := obj.PutObject(context.Background(), bucketName, objectName,
-		mustGetHashReader(t, bytes.NewReader([]byte(objectContent)), int64(len(objectContent)), "", ""), nil, ObjectOptions{})
+		mustGetPutObjectReader(t, bytes.NewReader([]byte(objectContent)), int64(len(objectContent)), "", ""), nil, ObjectOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestFSShutdown(t *testing.T) {
 
 		objectContent := "12345"
 		obj.MakeBucketWithLocation(context.Background(), bucketName, "")
-		obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader([]byte(objectContent)), int64(len(objectContent)), "", ""), nil, ObjectOptions{})
+		obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader([]byte(objectContent)), int64(len(objectContent)), "", ""), nil, ObjectOptions{})
 		return fs, disk
 	}
 
@@ -203,7 +203,7 @@ func TestFSPutObject(t *testing.T) {
 	}
 
 	// With a regular object.
-	_, err := obj.PutObject(context.Background(), bucketName+"non-existent", objectName, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
+	_, err := obj.PutObject(context.Background(), bucketName+"non-existent", objectName, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
 	if err == nil {
 		t.Fatal("Unexpected should fail here, bucket doesn't exist")
 	}
@@ -212,7 +212,7 @@ func TestFSPutObject(t *testing.T) {
 	}
 
 	// With a directory object.
-	_, err = obj.PutObject(context.Background(), bucketName+"non-existent", objectName+"/", mustGetHashReader(t, bytes.NewReader([]byte("abcd")), 0, "", ""), nil, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName+"non-existent", objectName+"/", mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), 0, "", ""), nil, ObjectOptions{})
 	if err == nil {
 		t.Fatal("Unexpected should fail here, bucket doesn't exist")
 	}
@@ -220,11 +220,11 @@ func TestFSPutObject(t *testing.T) {
 		t.Fatalf("Expected error type BucketNotFound, got %#v", err)
 	}
 
-	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = obj.PutObject(context.Background(), bucketName, objectName+"/1", mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName, objectName+"/1", mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
 	if err == nil {
 		t.Fatal("Unexpected should fail here, backend corruption occurred")
 	}
@@ -239,7 +239,7 @@ func TestFSPutObject(t *testing.T) {
 		}
 	}
 
-	_, err = obj.PutObject(context.Background(), bucketName, objectName+"/1/", mustGetHashReader(t, bytes.NewReader([]byte("abcd")), 0, "", ""), nil, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName, objectName+"/1/", mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), 0, "", ""), nil, ObjectOptions{})
 	if err == nil {
 		t.Fatal("Unexpected should fail here, backned corruption occurred")
 	}
@@ -267,7 +267,7 @@ func TestFSDeleteObject(t *testing.T) {
 	objectName := "object"
 
 	obj.MakeBucketWithLocation(context.Background(), bucketName, "")
-	obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
+	obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
 
 	// Test with invalid bucket name
 	if err := fs.DeleteObject(context.Background(), "fo", objectName); !isSameType(err, BucketNameInvalid{}) {

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -18,7 +18,10 @@ package cmd
 
 import (
 	"net/http"
+	"os"
+	"strings"
 
+	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/hash"
 
 	minio "github.com/minio/minio-go"
@@ -30,7 +33,26 @@ var (
 
 	// MustGetUUID function alias.
 	MustGetUUID = mustGetUUID
+
+	// IsMinAllowedPartSize function alias.
+	IsMinAllowedPartSize = isMinAllowedPartSize
+
+	// GetCompleteMultipartMD5 functon alias.
+	GetCompleteMultipartMD5 = getCompleteMultipartMD5
+
+	// Contains function alias.
+	Contains = contains
+
+	// ExtractETag provides extractETag function alias.
+	ExtractETag = extractETag
+	// CleanMetadataKeys provides cleanMetadataKeys function alias.
+	CleanMetadataKeys = cleanMetadataKeys
 )
+
+// StatInfo -  alias for statInfo
+type StatInfo struct {
+	statInfo
+}
 
 // AnonErrToObjectErr - converts standard http codes into meaningful object layer errors.
 func AnonErrToObjectErr(statusCode int, params ...string) error {
@@ -320,4 +342,30 @@ func ErrorRespToObjectError(err error, params ...string) error {
 	}
 
 	return err
+}
+
+// parse gateway sse env variable
+func parseGatewaySSE(s string) ([]string, error) {
+	l := strings.Split(s, ";")
+	gwSlice := make([]string, len(l))
+	for _, val := range l {
+		v := strings.ToUpper(val)
+		if v == GatewaySSES3 || v == GatewaySSEC || v == GatewaySSEKMS {
+			gwSlice = append(gwSlice, v)
+			continue
+		}
+		return nil, uiErrInvalidGWSSEValue(nil).Msg("gateway SSE cannot be (%s) ", v)
+	}
+	return gwSlice, nil
+}
+
+// handle gateway env vars
+func handleGatewayEnvVars() {
+	if gwsse, ok := os.LookupEnv("MINIO_GW_SSE"); ok {
+		gwsseSlice, err := parseGatewaySSE(gwsse)
+		if err != nil {
+			logger.Fatal(err, "Unable to parse MINIO_GW_SSE value (`%s`)", gwsse)
+		}
+		GlobalGatewaySSE = gwsseSlice
+	}
 }

--- a/cmd/gateway-env.go
+++ b/cmd/gateway-env.go
@@ -1,0 +1,26 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+const (
+	// GatewaySSES3 is set when SSE-S3 encryption needed on both gateway and backend
+	GatewaySSES3 = "S3"
+	// GatewaySSEC is set when SSE-C encryption needed on both gateway and backend
+	GatewaySSEC = "C"
+	// GatewaySSEKMS is set when SSE-KMS double encryption is needed
+	GatewaySSEKMS = "KMS"
+)

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -143,6 +143,8 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(pErr, "Unable to start gateway")
 	}
 
+	// Handle gateway specific env
+	handleGatewayEnvVars()
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
 	// (non-)minio process is listening on IPv4 of given port.

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -52,7 +52,7 @@ func (a GatewayUnsupported) PutObjectPart(ctx context.Context, bucket string, ob
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket
-func (a GatewayUnsupported) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi ListPartsInfo, err error) {
+func (a GatewayUnsupported) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int, opts ObjectOptions) (lpi ListPartsInfo, err error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return lpi, NotImplemented{}
 }

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/policy"
 )
@@ -47,7 +46,7 @@ func (a GatewayUnsupported) CopyObjectPart(ctx context.Context, srcBucket, srcOb
 }
 
 // PutObjectPart puts a part of object in bucket
-func (a GatewayUnsupported) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *hash.Reader, opts ObjectOptions) (pi PartInfo, err error) {
+func (a GatewayUnsupported) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *PutObjectReader, opts ObjectOptions) (pi PartInfo, err error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return pi, NotImplemented{}
 }
@@ -65,7 +64,7 @@ func (a GatewayUnsupported) AbortMultipartUpload(ctx context.Context, bucket str
 }
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object
-func (a GatewayUnsupported) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, uploadedParts []CompletePart) (oi ObjectInfo, err error) {
+func (a GatewayUnsupported) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (oi ObjectInfo, err error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return oi, NotImplemented{}
 }

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -37,7 +37,6 @@ import (
 	miniogopolicy "github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
-	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/policy"
 	"github.com/minio/minio/pkg/policy/condition"
 	sha256 "github.com/minio/sha256-simd"
@@ -722,7 +721,8 @@ func (a *azureObjects) GetObjectInfo(ctx context.Context, bucket, object string,
 
 // PutObject - Create a new blob with the incoming data,
 // uses Azure equivalent CreateBlockBlobFromReader.
-func (a *azureObjects) PutObject(ctx context.Context, bucket, object string, data *hash.Reader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+func (a *azureObjects) PutObject(ctx context.Context, bucket, object string, r *minio.PutObjectReader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	data := r.DataReader
 	if data.Size() < azureBlockSize/10 {
 		blob := a.client.GetContainerReference(bucket).GetBlobReference(object)
 		blob.Metadata, blob.Properties, err = s3MetaToAzureProperties(ctx, metadata)
@@ -923,7 +923,8 @@ func (a *azureObjects) NewMultipartUpload(ctx context.Context, bucket, object st
 }
 
 // PutObjectPart - Use Azure equivalent PutBlockWithLength.
-func (a *azureObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *hash.Reader, opts minio.ObjectOptions) (info minio.PartInfo, err error) {
+func (a *azureObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, r *minio.PutObjectReader, opts minio.ObjectOptions) (info minio.PartInfo, err error) {
+	data := r.DataReader
 	if err = a.checkUploadIDExists(ctx, bucket, object, uploadID); err != nil {
 		return info, err
 	}
@@ -1062,7 +1063,7 @@ func (a *azureObjects) AbortMultipartUpload(ctx context.Context, bucket, object,
 }
 
 // CompleteMultipartUpload - Use Azure equivalent PutBlockList.
-func (a *azureObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []minio.CompletePart) (objInfo minio.ObjectInfo, err error) {
+func (a *azureObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []minio.CompletePart, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
 	metadataObject := getAzureMetadataObjectName(object, uploadID)
 	if err = a.checkUploadIDExists(ctx, bucket, object, uploadID); err != nil {
 		return objInfo, err

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -966,7 +966,7 @@ func (a *azureObjects) PutObjectPart(ctx context.Context, bucket, object, upload
 }
 
 // ListObjectParts - Use Azure equivalent GetBlockList.
-func (a *azureObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int) (result minio.ListPartsInfo, err error) {
+func (a *azureObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int, opts minio.ObjectOptions) (result minio.ListPartsInfo, err error) {
 	if err = a.checkUploadIDExists(ctx, bucket, object, uploadID); err != nil {
 		return result, err
 	}

--- a/cmd/gateway/b2/gateway-b2.go
+++ b/cmd/gateway/b2/gateway-b2.go
@@ -684,7 +684,7 @@ func (l *b2Objects) PutObjectPart(ctx context.Context, bucket string, object str
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket, uses B2's LargeFile upload API.
-func (l *b2Objects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi minio.ListPartsInfo, err error) {
+func (l *b2Objects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int, opts minio.ObjectOptions) (lpi minio.ListPartsInfo, err error) {
 	bkt, err := l.Bucket(ctx, bucket)
 	if err != nil {
 		return lpi, err

--- a/cmd/gateway/b2/gateway-b2.go
+++ b/cmd/gateway/b2/gateway-b2.go
@@ -534,7 +534,9 @@ func (nb *Reader) Read(p []byte) (int, error) {
 }
 
 // PutObject uploads the single upload to B2 backend by using *b2_upload_file* API, uploads upto 5GiB.
-func (l *b2Objects) PutObject(ctx context.Context, bucket string, object string, data *h2.Reader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+func (l *b2Objects) PutObject(ctx context.Context, bucket string, object string, r *minio.PutObjectReader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	data := r.DataReader
+
 	bkt, err := l.Bucket(ctx, bucket)
 	if err != nil {
 		return objInfo, err
@@ -653,7 +655,8 @@ func (l *b2Objects) NewMultipartUpload(ctx context.Context, bucket string, objec
 }
 
 // PutObjectPart puts a part of object in bucket, uses B2's LargeFile upload API.
-func (l *b2Objects) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *h2.Reader, opts minio.ObjectOptions) (pi minio.PartInfo, err error) {
+func (l *b2Objects) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, r *minio.PutObjectReader, opts minio.ObjectOptions) (pi minio.PartInfo, err error) {
+	data := r.DataReader
 	bkt, err := l.Bucket(ctx, bucket)
 	if err != nil {
 		return pi, err
@@ -726,7 +729,7 @@ func (l *b2Objects) AbortMultipartUpload(ctx context.Context, bucket string, obj
 }
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object, uses B2's LargeFile upload API.
-func (l *b2Objects) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, uploadedParts []minio.CompletePart) (oi minio.ObjectInfo, err error) {
+func (l *b2Objects) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, uploadedParts []minio.CompletePart, opts minio.ObjectOptions) (oi minio.ObjectInfo, err error) {
 	bkt, err := l.Bucket(ctx, bucket)
 	if err != nil {
 		return oi, err

--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -1123,7 +1123,7 @@ func gcsGetPartInfo(ctx context.Context, attrs *storage.ObjectAttrs) (minio.Part
 }
 
 //  ListObjectParts returns all object parts for specified object in specified bucket
-func (l *gcsGateway) ListObjectParts(ctx context.Context, bucket string, key string, uploadID string, partNumberMarker int, maxParts int) (minio.ListPartsInfo, error) {
+func (l *gcsGateway) ListObjectParts(ctx context.Context, bucket string, key string, uploadID string, partNumberMarker int, maxParts int, opts minio.ObjectOptions) (minio.ListPartsInfo, error) {
 	it := l.client.Bucket(bucket).Objects(ctx, &storage.Query{
 		Prefix: path.Join(gcsMinioMultipartPathV1, uploadID),
 	})

--- a/cmd/gateway/manta/gateway-manta.go
+++ b/cmd/gateway/manta/gateway-manta.go
@@ -35,7 +35,6 @@ import (
 	minio "github.com/minio/minio/cmd"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
-	"github.com/minio/minio/pkg/hash"
 )
 
 // stor is a namespace within manta where you store any documents that are deemed as private
@@ -608,7 +607,8 @@ func (d dummySeeker) Seek(offset int64, whence int) (int64, error) {
 // CreateBlockBlobFromReader.
 //
 // https://apidocs.joyent.com/manta/api.html#PutObject
-func (t *tritonObjects) PutObject(ctx context.Context, bucket, object string, data *hash.Reader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+func (t *tritonObjects) PutObject(ctx context.Context, bucket, object string, r *minio.PutObjectReader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	data := r.DataReader
 	if err = t.client.Objects().Put(ctx, &storage.PutObjectInput{
 		ContentLength: uint64(data.Size()),
 		ObjectPath:    path.Join(mantaRoot, bucket, object),

--- a/cmd/gateway/oss/gateway-oss.go
+++ b/cmd/gateway/oss/gateway-oss.go
@@ -886,7 +886,7 @@ func (l *ossObjects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, d
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket
-func (l *ossObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int) (lpi minio.ListPartsInfo, err error) {
+func (l *ossObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int, opts minio.ObjectOptions) (lpi minio.ListPartsInfo, err error) {
 	lupr, err := ossListObjectParts(l.Client, bucket, object, uploadID, partNumberMarker, maxParts)
 	if err != nil {
 		logger.LogIf(ctx, err)

--- a/cmd/gateway/oss/gateway-oss.go
+++ b/cmd/gateway/oss/gateway-oss.go
@@ -655,7 +655,9 @@ func ossPutObject(ctx context.Context, client *oss.Client, bucket, object string
 }
 
 // PutObject creates a new object with the incoming data.
-func (l *ossObjects) PutObject(ctx context.Context, bucket, object string, data *hash.Reader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+func (l *ossObjects) PutObject(ctx context.Context, bucket, object string, r *minio.PutObjectReader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	data := r.DataReader
+
 	return ossPutObject(ctx, l.Client, bucket, object, data, metadata)
 }
 
@@ -773,7 +775,8 @@ func (l *ossObjects) NewMultipartUpload(ctx context.Context, bucket, object stri
 }
 
 // PutObjectPart puts a part of object in bucket.
-func (l *ossObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *hash.Reader, opts minio.ObjectOptions) (pi minio.PartInfo, err error) {
+func (l *ossObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, r *minio.PutObjectReader, opts minio.ObjectOptions) (pi minio.PartInfo, err error) {
+	data := r.DataReader
 	bkt, err := l.Client.Bucket(bucket)
 	if err != nil {
 		logger.LogIf(ctx, err)
@@ -914,7 +917,7 @@ func (l *ossObjects) AbortMultipartUpload(ctx context.Context, bucket, object, u
 }
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object.
-func (l *ossObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []minio.CompletePart) (oi minio.ObjectInfo, err error) {
+func (l *ossObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []minio.CompletePart, opts minio.ObjectOptions) (oi minio.ObjectInfo, err error) {
 	client := l.Client
 	bkt, err := client.Bucket(bucket)
 	if err != nil {

--- a/cmd/gateway/s3/gateway-s3-metadata.go
+++ b/cmd/gateway/s3/gateway-s3-metadata.go
@@ -1,0 +1,211 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	minio "github.com/minio/minio/cmd"
+	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/hash"
+	"github.com/tidwall/gjson"
+)
+
+var (
+	errGWMetaNotFound      = errors.New("dare.meta file not found")
+	errGWMetaInvalidFormat = errors.New("dare.meta format is invalid")
+)
+
+// A gwMetaV1 represents `gw.json` metadata header.
+type gwMetaV1 struct {
+	Version string         `json:"version"` // Version of the current `gw.json`.
+	Format  string         `json:"format"`  // Format of the current `gw.json`.
+	Stat    minio.StatInfo `json:"stat"`    // Stat of the current object `gw.json`.
+	//TODO: parse
+	ETag string `json:"etag"` // ETag of the current object
+
+	// Metadata map for current object `gw.json`.
+	Meta map[string]string `json:"meta,omitempty"`
+	// Captures all the individual object `gw.json`.
+	Parts []minio.ObjectPartInfo `json:"parts,omitempty"`
+}
+
+// Gateway metadata constants.
+const (
+	// Gateway meta version.
+	gwMetaVersion = "1.0.0"
+
+	// Gateway meta version.
+	gwMetaVersion100 = "1.0.0"
+
+	// Gateway meta format string.
+	gwMetaFormat = "gw"
+
+	// Add new constants here.
+)
+
+// newGWMetaV1 - initializes new gwMetaV1, adds version.
+func newGWMetaV1() (gwMeta gwMetaV1) {
+	gwMeta = gwMetaV1{}
+	gwMeta.Version = gwMetaVersion
+	gwMeta.Format = gwMetaFormat
+	return gwMeta
+}
+
+// IsValid - tells if the format is sane by validating the version
+// string, format fields.
+func (m gwMetaV1) IsValid() bool {
+	return ((m.Version == gwMetaVersion || m.Version == gwMetaVersion100) &&
+		m.Format == gwMetaFormat)
+}
+
+// Converts metadata to object info.
+func (m gwMetaV1) ToObjectInfo(bucket, object string) minio.ObjectInfo {
+	filterKeys := append([]string{
+		"ETag",
+		"Content-Length",
+		"Last-Modified",
+		"Content-Type",
+	}, defaultFilterKeys...)
+	objInfo := minio.ObjectInfo{
+		IsDir:           false,
+		Bucket:          bucket,
+		Name:            object,
+		Size:            m.Stat.Size,
+		ModTime:         m.Stat.ModTime,
+		ContentType:     m.Meta["content-type"],
+		ContentEncoding: m.Meta["content-encoding"],
+		ETag:            minio.ExtractETag(m.Meta),
+		UserDefined:     minio.CleanMetadataKeys(m.Meta, filterKeys...),
+		Parts:           m.Parts,
+	}
+
+	if sc, ok := m.Meta["x-amz-storage-class"]; ok {
+		objInfo.StorageClass = sc
+	}
+	// Success.
+	return objInfo
+}
+
+// parses gateway metadata stat info from metadata json
+func parseGWStat(gwMetaBuf []byte) (si minio.StatInfo, e error) {
+	// obtain stat info.
+	stat := minio.StatInfo{}
+	// fetching modTime.
+	modTime, err := time.Parse(time.RFC3339, gjson.GetBytes(gwMetaBuf, "stat.modTime").String())
+	if err != nil {
+		return si, err
+	}
+	stat.ModTime = modTime
+	// obtain Stat.Size .
+	stat.Size = gjson.GetBytes(gwMetaBuf, "stat.size").Int()
+	return stat, nil
+}
+
+// parses gateway metadata version from metadata json
+func parseGWVersion(gwMetaBuf []byte) string {
+	return gjson.GetBytes(gwMetaBuf, "version").String()
+}
+
+// parses gateway metadata format from metadata json
+func parseGWFormat(gwMetaBuf []byte) string {
+	return gjson.GetBytes(gwMetaBuf, "format").String()
+}
+
+// parses gateway metadata json to get list of ObjectPartInfo
+func parseGWParts(gwMetaBuf []byte) []minio.ObjectPartInfo {
+	// Parse the GW Parts.
+	partsResult := gjson.GetBytes(gwMetaBuf, "parts").Array()
+	partInfo := make([]minio.ObjectPartInfo, len(partsResult))
+	for i, p := range partsResult {
+		info := minio.ObjectPartInfo{}
+		info.Number = int(p.Get("number").Int())
+		info.Name = p.Get("name").String()
+		info.ETag = p.Get("etag").String()
+		info.Size = p.Get("size").Int()
+		partInfo[i] = info
+	}
+	return partInfo
+}
+
+// parses gateway metadata json to get the metadata map
+func parseGWMetaMap(gwMetaBuf []byte) map[string]string {
+	// Get gwMetaV1.Meta map.
+	metaMapResult := gjson.GetBytes(gwMetaBuf, "meta").Map()
+	metaMap := make(map[string]string)
+	for key, valResult := range metaMapResult {
+		metaMap[key] = valResult.String()
+	}
+	return metaMap
+}
+
+// Constructs GWMetaV1 using `gjson` lib to retrieve each field.
+func gwMetaUnmarshalJSON(ctx context.Context, gwMetaBuf []byte) (gwMeta gwMetaV1, e error) {
+	// obtain version.
+	gwMeta.Version = parseGWVersion(gwMetaBuf)
+	// obtain format.
+	gwMeta.Format = parseGWFormat(gwMetaBuf)
+	// Parse gwMetaV1.Stat .
+	stat, err := parseGWStat(gwMetaBuf)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return gwMeta, err
+	}
+
+	gwMeta.Stat = stat
+
+	// Parse the GW Parts.
+	gwMeta.Parts = parseGWParts(gwMetaBuf)
+	// parse gwMetaV1.
+	gwMeta.Meta = parseGWMetaMap(gwMetaBuf)
+
+	return gwMeta, nil
+}
+
+// readGWMeta reads `dare.meta` and returns back GW metadata structure.
+func readGWMetadata(ctx context.Context, buf bytes.Buffer) (gwMeta gwMetaV1, err error) {
+	if buf.Len() == 0 {
+		return gwMetaV1{}, errGWMetaNotFound
+	}
+	gwMeta, err = gwMetaUnmarshalJSON(ctx, buf.Bytes())
+	if err != nil {
+		return gwMetaV1{}, err
+	}
+	if !gwMeta.IsValid() {
+		return gwMetaV1{}, errGWMetaInvalidFormat
+	}
+	// Return structured `dare.meta`.
+	return gwMeta, nil
+}
+
+// getGWMetadata - unmarshals dare.meta into a *hash.Reader
+func getGWMetadata(ctx context.Context, bucket, prefix string, gwMeta gwMetaV1) (*hash.Reader, error) {
+	// Marshal json.
+	metadataBytes, err := json.Marshal(&gwMeta)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return nil, err
+	}
+	var r io.Reader
+	r = bytes.NewReader(metadataBytes)
+	return hash.NewReader(r, int64(len(metadataBytes)), "", "", int64(len(metadataBytes)))
+}

--- a/cmd/gateway/s3/gateway-s3-metadata.go
+++ b/cmd/gateway/s3/gateway-s3-metadata.go
@@ -94,7 +94,7 @@ func (m gwMetaV1) ToObjectInfo(bucket, object string) minio.ObjectInfo {
 		ModTime:         m.Stat.ModTime,
 		ContentType:     m.Meta["content-type"],
 		ContentEncoding: m.Meta["content-encoding"],
-		ETag:            minio.ExtractETag(m.Meta),
+		ETag:            m.ETag,
 		UserDefined:     minio.CleanMetadataKeys(m.Meta, filterKeys...),
 		Parts:           m.Parts,
 	}
@@ -124,6 +124,11 @@ func parseGWStat(gwMetaBuf []byte) (si minio.StatInfo, e error) {
 // parses gateway metadata version from metadata json
 func parseGWVersion(gwMetaBuf []byte) string {
 	return gjson.GetBytes(gwMetaBuf, "version").String()
+}
+
+// parses gateway ETag from metadata json
+func parseGWETag(gwMetaBuf []byte) string {
+	return gjson.GetBytes(gwMetaBuf, "etag").String()
 }
 
 // parses gateway metadata format from metadata json
@@ -170,7 +175,7 @@ func gwMetaUnmarshalJSON(ctx context.Context, gwMetaBuf []byte) (gwMeta gwMetaV1
 		logger.LogIf(ctx, err)
 		return gwMeta, err
 	}
-
+	gwMeta.ETag = parseGWETag(gwMetaBuf)
 	gwMeta.Stat = stat
 
 	// Parse the GW Parts.

--- a/cmd/gateway/s3/gateway-s3-metadata_test.go
+++ b/cmd/gateway/s3/gateway-s3-metadata_test.go
@@ -1,0 +1,74 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// Tests for GW metadata format validity.
+func TestGWMetaFormatValid(t *testing.T) {
+	tests := []struct {
+		name    int
+		version string
+		format  string
+		want    bool
+	}{
+		{1, "123", "fs", false},
+		{2, "123", gwMetaFormat, false},
+		{3, gwMetaVersion, "test", false},
+		{4, gwMetaVersion100, "hello", false},
+		{5, gwMetaVersion, gwMetaFormat, true},
+		{6, gwMetaVersion100, gwMetaFormat, true},
+	}
+	for _, tt := range tests {
+		m := newGWMetaV1()
+		m.Version = tt.version
+		m.Format = tt.format
+		if got := m.IsValid(); got != tt.want {
+			t.Errorf("Test %d: Expected %v but received %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+// Tests for reading GW metadata info.
+func TestReadGWMetadata(t *testing.T) {
+	tests := []struct {
+		metaStr string
+		pass    bool
+	}{
+		{`{"version": "` + gwMetaVersion + `", "format":"` + gwMetaFormat + `", {"stat": {"size": "132", "modTime": "2018-08-31T22:25:39.23626461Z" }}}`, true},
+		{`{"version": "` + gwMetaVersion + `", "format":"` + gwMetaFormat + `", {"stat": {"size": "132", "modTime": "0000-00-00T00:00:00.00000000Z" }}}`, false},
+		{`{"version": "` + gwMetaVersion + `", "format":"` + gwMetaFormat + `", {"stat": {"size": "5242880", "modTime": "2018-08-31T22:25:39.23626461Z" }},"meta":{"content-type":"application/octet-stream","etag":"57c743902b2fc8eea6ba3bb4fc58c8e8"},"parts":[{"number":1,"name":"part.1","etag":"","size":5242880}]}}`, true},
+		{`{"version": "` + gwMetaVersion + `", "format":"` + gwMetaFormat + `", {"stat": {"size": "68190720", "modTime": "2018-08-31T22:25:39.23626461Z" }},"meta":{"X-Minio-Internal-Encrypted-Multipart":"","X-Minio-Internal-Server-Side-Encryption-Iv":"kdbOcKdXD3Sew8tOiHe5eI9xkX1oQ2W9JURz0oslCZA=","X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm":"DAREv2-HMAC-SHA256","X-Minio-Internal-Server-Side-Encryption-Sealed-Key":"IAAfAMfqKrxMXC9LuiI7ENP+p0xArepzAiIeB/MftFp7Xmq2OzDkKlmNbj5RKI89RrjiAbOVLSSEMvqQsrIrTQ==","content-type":"text/plain; charset=utf-8","etag":"2b137fa4ab80126af54623b010c98de6-2"},"parts":[{"number":1,"name":"part.1","etag":"c5cac075eefdab801a5198812f51b36e","size":67141632},{"number":2,"name":"part.2","etag":"ccdf4b774bc3be8eef9a8987309e8171","size":1049088}]}`, true},
+		{`{"version": "` + gwMetaVersion + `", "format":"` + gwMetaFormat + `", {"stat": {"size": "68190720", "modTime": "2018-08-31T22:25:39.23626461Z" }},"meta":{"X-Minio-Internal-Encrypted-Multipart":"","X-Minio-Internal-Server-Side-Encryption-Iv":"kdbOcKdXD3Sew8tOiHe5eI9xkX1oQ2W9JURz0oslCZA=","X-Minio-Internal-Server-Side-Encryption-Seal-Algorithm":"DAREv2-HMAC-SHA256","X-Minio-Internal-Server-Side-Encryption-Sealed-Key":"IAAfAMfqKrxMXC9LuiI7ENP+p0xArepzAiIeB/MftFp7Xmq2OzDkKlmNbj5RKI89RrjiAbOVLSSEMvqQsrIrTQ==","content-type":"text/plain; charset=utf-8","etag":"2b137fa4ab80126af54623b010c98de6-2"},"parts":"123"}`, true},
+	}
+
+	for i, tt := range tests {
+		buf := bytes.NewBufferString(tt.metaStr)
+		m, err := readGWMetadata(context.Background(), *buf)
+		t.Log(m)
+		if err != nil && tt.pass {
+			t.Errorf("Test %d: Expected parse gw metadata to succeed, but failed", i)
+		}
+		if err == nil && !tt.pass {
+			t.Errorf("Test %d: Expected parse gw metadata to succeed, but failed", i)
+		}
+	}
+}

--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -1,0 +1,909 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/minio/minio-go/pkg/encrypt"
+	minio "github.com/minio/minio/cmd"
+	"github.com/minio/sio"
+
+	"github.com/minio/minio/cmd/crypto"
+	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/hash"
+)
+
+const (
+	// name of custom multipart metadata file for s3 backend.
+	gwdareMetaJSON string = "dare.meta"
+	// custom multipart files are stored under the defaultMinioGWPrefix
+	defaultMinioGWPrefix     = ".minio"
+	defaultGWContentFileName = "data"
+	slashSeparator           = "/"
+)
+
+// s3EncObjects is a wrapper around s3Objects and implements gateway calls for
+// custom large objects encrypted at the gateway
+type s3EncObjects struct {
+	s3Objects
+}
+
+/*
+ NOTE:
+ Custom gateway encrypted objects uploaded with single PUT operation are stored on backend as follows:
+	 obj/.minio/data   <= encrypted content
+	 obj/.minio/dare.meta  <= metadata
+ Custom gateway encrypted objects uploaded with multipart upload operation are stored on backend as follows:
+		obj/.minio/dare.meta  <= metadata
+		obj/.minio/uploadId/1 <= encrypted part 1
+		obj/.minio/uploadId/2 ...
+		obj/.minio/uploadId/3
+*/
+
+// ListObjects lists all blobs in S3 bucket filtered by prefix
+func (l *s3EncObjects) ListObjects(ctx context.Context, bucket string, prefix string, marker string, delimiter string, maxKeys int) (loi minio.ListObjectsInfo, e error) {
+	if len(minio.GlobalGatewaySSE) > 0 {
+		var continuationToken, startAfter string
+		res, err := l.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, false, startAfter)
+		if err != nil {
+			return loi, err
+		}
+		loi.IsTruncated = res.IsTruncated
+		loi.NextMarker = res.NextContinuationToken
+		loi.Objects = res.Objects
+		loi.Prefixes = res.Prefixes
+		return loi, nil
+	}
+	return l.s3Objects.ListObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)
+}
+
+// ListObjectsV2 lists all blobs in S3 bucket filtered by prefix
+func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (loi minio.ListObjectsV2Info, e error) {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, fetchOwner, startAfter)
+	}
+	var objects []minio.ObjectInfo
+	var prefixes []string
+	var isTruncated bool
+	// filter out objects that contain a .minio prefix, but is not a dare.meta metadata file.
+	for {
+		loi, e = l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, fetchOwner, startAfter)
+		if e != nil {
+			return loi, e
+		}
+		for _, obj := range loi.Objects {
+			startAfter = obj.Name
+			continuationToken = loi.NextContinuationToken
+			isTruncated = loi.IsTruncated
+			// skip parts objects from listing
+			if strings.Contains(obj.Name, defaultMinioGWPrefix) && !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
+				continue
+			}
+
+			// get objectname and ObjectInfo from the custom metadata file
+			if strings.HasSuffix(obj.Name, gwdareMetaJSON) {
+				objSlice := strings.Split(obj.Name, slashSeparator+defaultMinioGWPrefix)
+				gwMeta, e := l.getDareMetadata(ctx, bucket, getGWMetaPath(objSlice[0]))
+				if e != nil {
+					continue
+				}
+				prefixSlice := strings.Split(obj.Name, slashSeparator+defaultMinioGWPrefix+slashSeparator)
+				if len(prefixSlice) >= 1 {
+					oInfo := gwMeta.ToObjectInfo(bucket, prefixSlice[0][:])
+					objects = append(objects, oInfo)
+				}
+				continue
+			}
+			objects = append(objects, obj)
+			if len(objects) > maxKeys {
+				break
+			}
+		}
+		for _, p := range loi.Prefixes {
+			prefixSlice := strings.Split(p, defaultMinioGWPrefix+slashSeparator)
+			if len(prefixSlice) >= 1 {
+				objName := strings.TrimSuffix(prefixSlice[0], slashSeparator)
+				gm, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(objName))
+				// if prefix is actually a custom multi-part object, append it to objects
+				if err == nil {
+					objects = append(objects, gm.ToObjectInfo(bucket, objName))
+					continue
+				}
+				prefixes = append(prefixes, prefixSlice[0])
+				continue
+			}
+			prefixes = append(prefixes, p)
+		}
+		if (len(objects) > maxKeys) || !loi.IsTruncated {
+			break
+		}
+	}
+
+	loi.IsTruncated = isTruncated
+	loi.ContinuationToken = continuationToken
+	loi.Objects = make([]minio.ObjectInfo, 0)
+	loi.Prefixes = make([]string, 0)
+
+	for _, obj := range objects {
+		loi.NextContinuationToken = obj.Name
+		loi.Objects = append(loi.Objects, obj)
+	}
+	for _, pfx := range prefixes {
+		if pfx != prefix {
+			loi.Prefixes = append(loi.Prefixes, pfx)
+		}
+	}
+	return loi, nil
+}
+
+// GetObject reads an object from S3. Supports additional
+// parameters like offset and length which are synonymous with
+// HTTP Range requests.
+// In the case of multi-part uploads that were encrypted at the gateway, the objects
+// are stored in a custom format at the backend with each part as an individual object
+// and piped to the writer.
+func (l *s3EncObjects) GetObject(ctx context.Context, bucket string, key string, startOffset int64, length int64, writer io.Writer, etag string, o minio.ObjectOptions) error {
+	// pass through encryption
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
+	}
+	dmeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(key))
+	if err != nil {
+		// unencrypted content
+		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
+	}
+
+	if len(dmeta.Parts) == 0 {
+		// custom gateway encrypted objects uploaded with single PUT operation
+		return l.s3Objects.GetObject(ctx, bucket, getGWContentPath(key), startOffset, length, writer, etag, o)
+	}
+
+	// handle custom multipart gateway encrypted objects
+	var partStartIndex int
+	var partStartOffset = startOffset
+
+	// Skip parts until final offset maps to a particular part offset.
+	for i, part := range dmeta.Parts {
+		decryptedSize, err := sio.DecryptedSize(uint64(part.Size))
+		if err != nil {
+			return err
+		}
+		partStartIndex = i
+
+		// Offset is smaller than size we have reached the
+		// proper part offset, break out we start from
+		// this part index.
+		if partStartOffset < int64(decryptedSize) {
+			break
+		}
+		// Continue to look for next part.
+		partStartOffset -= int64(decryptedSize)
+	}
+	startSeqNum := partStartOffset / minio.SSEDAREPackageBlockSize
+	partEncRelOffset := int64(startSeqNum) * (minio.SSEDAREPackageBlockSize + minio.SSEDAREPackageMetaSize)
+
+	var size int64
+	// concatenate parts stored as separate objects into writer
+	for i, part := range dmeta.Parts {
+		//skip parts before start offset
+		if i < partStartIndex {
+			continue
+		}
+		pInfo, err := l.s3Objects.GetObjectInfo(ctx, bucket, part.Name, o)
+		if err != nil || pInfo.ETag != part.ETag {
+			logger.LogIf(ctx, err)
+			return minio.ObjectNotFound{
+				Bucket: bucket,
+				Object: key,
+			}
+		}
+
+		partLength := pInfo.Size - partEncRelOffset
+		size += partLength
+		if size > length {
+			partLength -= (size - length)
+		}
+
+		pipeReader, pipeWriter := io.Pipe()
+
+		var reader io.Reader = pipeReader
+		pInfo.Reader, err = hash.NewReader(reader, partLength, "", "", pInfo.Size)
+		pInfo.Writer = pipeWriter
+
+		go func(pInfo minio.ObjectInfo) {
+			if gerr := l.s3Objects.GetObject(ctx, bucket, pInfo.Name, partEncRelOffset, partLength, pInfo.Writer, pInfo.ETag, o); gerr != nil {
+				if gerr = pInfo.Writer.Close(); gerr != nil {
+					logger.LogIf(ctx, gerr)
+					return
+				}
+			}
+		}(pInfo)
+		if pInfo.Reader == nil {
+			return nil
+		}
+		_, err = io.Copy(writer, pInfo.Reader)
+		if err != nil {
+			logger.LogIf(ctx, err)
+			return err
+		}
+		partStartIndex++
+		partEncRelOffset = 0
+	}
+	return nil
+}
+
+// getDaremetadata fetches dare.meta from s3 backend and marshals into a structured format.
+func (l *s3EncObjects) getDareMetadata(ctx context.Context, bucket, objectPrefix string) (m gwMetaV1, err error) {
+	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
+	oi, err1 := l.s3Objects.GetObjectInfo(ctx, bucket, dareMetaFile, minio.ObjectOptions{})
+	if err1 != nil {
+		return m, err1
+	}
+	var buffer bytes.Buffer
+	err = l.s3Objects.GetObject(ctx, bucket, dareMetaFile, 0, oi.Size, &buffer, oi.ETag, minio.ObjectOptions{})
+	if err != nil {
+		return m, err
+	}
+	return readGWMetadata(ctx, buffer)
+}
+
+// writes dare metadata to the s3 backend
+func (l *s3EncObjects) writeDareMetadata(ctx context.Context, bucket, objectPrefix string, m gwMetaV1, o minio.ObjectOptions) error {
+	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
+	hashReader, err := getGWMetadata(ctx, bucket, dareMetaFile, m)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return err
+	}
+	_, err = l.s3Objects.PutObject(ctx, bucket, dareMetaFile, hashReader, map[string]string{}, o)
+	return err
+}
+
+// deletes the custom dare metadata file saved at the backend
+func (l *s3EncObjects) deleteDareMetadata(ctx context.Context, bucket, objectPrefix string) error {
+	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
+	return l.s3Objects.DeleteObject(ctx, bucket, dareMetaFile)
+}
+
+// GetObjectNInfo - returns object info and locked object ReadCloser
+func (l *s3EncObjects) GetObjectNInfo(ctx context.Context, bucket, object string, rs *minio.HTTPRangeSpec, h http.Header, lockType minio.LockType, opts minio.ObjectOptions) (gr *minio.GetObjectReader, err error) {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
+	}
+	var objInfo minio.ObjectInfo
+	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
+	if err != nil {
+		return l.s3Objects.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
+	}
+
+	objInfo = gwMeta.ToObjectInfo(bucket, object)
+	fn, off, length, err := minio.NewGetObjectReader(rs, objInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		err := l.GetObject(ctx, bucket, object, off, length, pw, objInfo.ETag, opts)
+		pw.CloseWithError(err)
+	}()
+	// Setup cleanup function to cause the above go-routine to
+	// exit in case of partial read
+	pipeCloser := func() { pr.Close() }
+	return fn(pr, h, pipeCloser)
+}
+
+// GetObjectInfo reads object info and replies back ObjectInfo
+// For custom gateway encrypted large objects, the ObjectInfo is retrieved from the dare.meta file.
+func (l *s3EncObjects) GetObjectInfo(ctx context.Context, bucket string, object string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.GetObjectInfo(ctx, bucket, object, opts)
+	}
+	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
+	if err != nil {
+		return l.s3Objects.GetObjectInfo(ctx, bucket, object, opts)
+	}
+	return gwMeta.ToObjectInfo(bucket, object), nil
+}
+
+// CopyObject copies an object from source bucket to a destination bucket.
+func (l *s3EncObjects) CopyObject(ctx context.Context, srcBucket string, srcObject string, dstBucket string, dstObject string, srcInfo minio.ObjectInfo, srcOpts, dstOpts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	// Set this header such that following CopyObject() always sets the right metadata on the destination.
+	// metadata input is already a trickled down value from interpreting x-amz-metadata-directive at
+	// handler layer. So what we have right now is supposed to be applied on the destination object anyways.
+	// So preserve it by adding "REPLACE" directive to save all the metadata set by CopyObject API.
+	srcInfo.UserDefined["x-amz-metadata-directive"] = "REPLACE"
+	srcInfo.UserDefined["x-amz-copy-source-if-match"] = srcInfo.ETag
+	// if gateway encryption is turned off, do a pass thru
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.CopyObject(ctx, srcBucket, srcObject, dstBucket, dstObject, srcInfo, srcOpts, dstOpts)
+	}
+	// Check if source is custom multipart Object. If not, Get source object, decrypt at gateway and
+	// upload with destination side encryption options
+	gwMeta, err := l.getDareMetadata(ctx, srcBucket, getGWMetaPath(srcObject))
+	if err != nil {
+		return l.PutObject(ctx, dstBucket, dstObject, srcInfo.Reader, srcInfo.UserDefined, dstOpts)
+	}
+
+	// src encrypted, but not target or custom encrypted without multipart
+	if dstOpts.ServerSideEncryption == nil || len(gwMeta.Parts) == 0 {
+		return l.PutObject(ctx, dstBucket, dstObject, srcInfo.Reader, srcInfo.UserDefined, dstOpts)
+	}
+
+	// convert copy src encryption options for GET calls
+	var getOpts minio.ObjectOptions
+	if srcOpts.ServerSideEncryption != nil {
+		getOpts.ServerSideEncryption = encrypt.SSE(srcOpts.ServerSideEncryption)
+	}
+
+	// overwrite any previous unencrypted object with same name
+	defer l.s3Objects.DeleteObject(ctx, dstBucket, dstObject)
+
+	dstUploadID, err := l.NewMultipartUpload(ctx, dstBucket, dstObject, srcInfo.UserDefined, dstOpts)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return
+	}
+	var uploadedParts = make([]minio.CompletePart, 0)
+	var partID = 1
+
+	partUploadName := path.Join(getTmpGWMetaPath(dstObject, dstUploadID), strconv.Itoa(partID))
+	bkendObjInfo, rerr := l.s3Objects.PutObject(ctx, dstBucket, partUploadName, srcInfo.Reader, srcInfo.UserDefined, dstOpts)
+	if rerr != nil {
+		return
+	}
+	uploadedParts = append(uploadedParts, minio.CompletePart{
+		ETag:       bkendObjInfo.ETag,
+		PartNumber: partID,
+	})
+
+	return l.CompleteMultipartUpload(ctx, dstBucket, dstObject, dstUploadID, uploadedParts)
+}
+
+// DeleteObject deletes a blob in bucket
+// For custom gateway encrypted large objects, cleans up individual parts and metadata files
+// from the backend.
+func (l *s3EncObjects) DeleteObject(ctx context.Context, bucket string, object string) error {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.DeleteObject(ctx, bucket, object)
+	}
+	// Get dare meta json
+	if _, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object)); err != nil {
+		return l.s3Objects.DeleteObject(ctx, bucket, object)
+	}
+	return l.deleteEncryptedObject(ctx, bucket, object)
+}
+
+func (l *s3EncObjects) deleteEncryptedObject(ctx context.Context, bucket string, object string) error {
+	// Get dare meta json
+	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
+	if err != nil {
+		return l.s3Objects.DeleteObject(ctx, bucket, object)
+	}
+	if len(gwMeta.Parts) == 0 {
+		l.s3Objects.DeleteObject(ctx, bucket, getGWContentPath(object))
+	}
+	for _, part := range gwMeta.Parts {
+		if err = l.s3Objects.DeleteObject(ctx, bucket, part.Name); err != nil {
+			return err
+		}
+	}
+	return l.deleteDareMetadata(ctx, bucket, getGWMetaPath(object))
+}
+
+// ListMultipartUploads lists all multipart uploads.
+func (l *s3EncObjects) ListMultipartUploads(ctx context.Context, bucket string, prefix string, keyMarker string, uploadIDMarker string, delimiter string, maxUploads int) (lmi minio.ListMultipartsInfo, e error) {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.ListMultipartUploads(ctx, bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
+	}
+	var uploadsMap map[string]string
+	var uploadIDs []string
+	var continuationToken, startAfter string
+	startAfter = keyMarker
+
+	lmi.MaxUploads = maxUploads
+	lmi.KeyMarker = keyMarker
+	lmi.Prefix = prefix
+	lmi.Delimiter = delimiter
+	lmi.NextKeyMarker = prefix
+	lmi.UploadIDMarker = uploadIDMarker
+	uploadsMap = make(map[string]string)
+	for {
+		loi, err := l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, false, startAfter)
+		if err != nil {
+			return lmi, err
+		}
+		for _, obj := range loi.Objects {
+			startAfter = obj.Name
+			if !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
+				continue
+			}
+			// skip completed uploads
+			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, gwdareMetaJSON)) {
+				continue
+			}
+			// identify uploadID from object name: obj/.minio/uploadID/..
+			pSlice := strings.Split(obj.Name, "/")
+			idx := -1
+			for i, p := range pSlice {
+				if p == defaultMinioGWPrefix {
+					idx = i + 1
+					break
+				}
+			}
+			if idx == -1 || (idx == len(pSlice)) {
+				continue
+			}
+			uploadID := pSlice[idx]
+			uploadsMap[uploadID] = ""
+			if len(uploadsMap)+len(lmi.Uploads) > maxUploads {
+				break
+			}
+		}
+		// get uploadID's without duplicates and sort them
+		for k := range uploadsMap {
+			uploadIDs = append(uploadIDs, k)
+		}
+		sort.Strings(uploadIDs)
+		for _, uploadID := range uploadIDs {
+			if len(lmi.Uploads) == maxUploads {
+				return lmi, nil
+			}
+			lmi.Uploads = append(lmi.Uploads, minio.MultipartInfo{Object: prefix, UploadID: uploadID})
+		}
+		continuationToken = loi.NextContinuationToken
+		if !loi.IsTruncated {
+			break
+		}
+	}
+	return lmi, nil
+}
+
+// NewMultipartUpload uploads object in multiple parts
+func (l *s3EncObjects) NewMultipartUpload(ctx context.Context, bucket string, object string, metadata map[string]string, o minio.ObjectOptions) (uploadID string, err error) {
+	// Create uploadID and write a temporary dare.meta object under object/uploadID prefix
+	if (len(minio.GlobalGatewaySSE) > 0) && o.ServerSideEncryption != nil {
+		uploadID := minio.MustGetUUID()
+		tmpUploadPrefix := getTmpGWMetaPath(object, uploadID)
+		gwmeta := newGWMetaV1()
+		gwmeta.Meta = metadata
+		gwmeta.Stat.ModTime = time.Now().UTC()
+		err := l.writeDareMetadata(ctx, bucket, tmpUploadPrefix, gwmeta, minio.ObjectOptions{})
+		if err != nil {
+			return uploadID, err
+		}
+		return uploadID, nil
+	}
+	return l.s3Objects.NewMultipartUpload(ctx, bucket, object, metadata, o)
+}
+
+// PutObject creates a new object with the incoming data,
+func (l *s3EncObjects) PutObject(ctx context.Context, bucket string, object string, data *hash.Reader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.PutObject(ctx, bucket, object, data, metadata, opts)
+	}
+	if opts.ServerSideEncryption == nil {
+		oi, err := l.s3Objects.PutObject(ctx, bucket, object, data, metadata, opts)
+		if err != nil {
+			return objInfo, err
+		}
+		l.deleteEncryptedObject(ctx, bucket, object)
+		return oi, nil
+	}
+	// overwrite any previous unencrypted object with same name
+	defer l.s3Objects.DeleteObject(ctx, bucket, object)
+
+	oi, err := l.s3Objects.PutObject(ctx, bucket, getGWContentPath(object), data, metadata, opts)
+	if err != nil {
+		return objInfo, err
+	}
+	gwMeta := newGWMetaV1()
+	gwMeta.Meta = make(map[string]string)
+	for k, v := range oi.UserDefined {
+		gwMeta.Meta[k] = v
+	}
+	for k, v := range metadata {
+		gwMeta.Meta[k] = v
+	}
+	gwMeta.ETag = oi.ETag
+	gwMeta.Stat.Size = oi.Size
+	gwMeta.Stat.ModTime = oi.ModTime
+	if err = l.writeDareMetadata(ctx, bucket, getGWMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
+		return objInfo, err
+	}
+	return oi, nil
+}
+
+// PutObjectPart puts a part of object in bucket
+func (l *s3EncObjects) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *hash.Reader, opts minio.ObjectOptions) (pi minio.PartInfo, e error) {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.PutObjectPart(ctx, bucket, object, uploadID, partID, data, opts)
+	}
+	uploadPath := getTmpGWMetaPath(object, uploadID)
+	tmpDareMeta := path.Join(uploadPath, gwdareMetaJSON)
+	_, err := l.s3Objects.GetObjectInfo(ctx, bucket, tmpDareMeta, minio.ObjectOptions{})
+	if err != nil {
+		// it is a regular multipart,since dare.meta is missing.
+		return l.s3Objects.PutObjectPart(ctx, bucket, object, uploadID, partID, data, opts)
+	}
+	partUploadName := path.Join(uploadPath, strconv.Itoa(partID))
+	oi, err := l.s3Objects.PutObject(ctx, bucket, partUploadName, data, map[string]string{}, opts)
+	if err != nil {
+		return pi, err
+	}
+
+	return FromGatewayObjectPart(partID, oi), nil
+}
+
+// CopyObjectPart creates a part in a multipart upload by copying
+// existing object or a part of it.
+func (l *s3EncObjects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject, uploadID string,
+	partID int, startOffset, length int64, srcInfo minio.ObjectInfo, srcOpts, dstOpts minio.ObjectOptions) (p minio.PartInfo, err error) {
+	// pass through encryption
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
+	}
+	srcInfo.UserDefined = map[string]string{
+		"x-amz-copy-source-if-match": srcInfo.ETag,
+	}
+	// convert copy src and dst encryption options for GET/PUT calls
+	var getOpts minio.ObjectOptions
+	if srcOpts.ServerSideEncryption != nil {
+		getOpts.ServerSideEncryption = encrypt.SSE(srcOpts.ServerSideEncryption)
+	}
+
+	// Get dare meta json
+	gwMeta, err := l.getDareMetadata(ctx, destBucket, getTmpGWMetaPath(destObject, uploadID))
+	if err != nil {
+		// both src and dest are not encrypted - delegate to backend
+		if !crypto.IsEncrypted(srcInfo.UserDefined) {
+			return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
+		}
+		// src is encrypted
+		partName := path.Join(getTmpGWMetaPath(destObject, uploadID), strconv.Itoa(partID))
+		oi, oerr := l.PutObject(ctx, destBucket, partName, srcInfo.Reader, srcInfo.UserDefined, dstOpts)
+		if oerr != nil {
+			return minio.PartInfo{}, oerr
+		}
+		return minio.PartInfo{PartNumber: partID, ETag: oi.ETag, Size: oi.Size}, nil
+	}
+	if !crypto.IsEncrypted(gwMeta.ToObjectInfo(destBucket, destObject).UserDefined) {
+		return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
+	}
+	uploadPath := getTmpGWMetaPath(destObject, uploadID)
+	partUploadName := path.Join(uploadPath, strconv.Itoa(partID))
+	bkendObjInfo, rerr := l.s3Objects.PutObject(ctx, destBucket, partUploadName, srcInfo.Reader, srcInfo.UserDefined, dstOpts)
+	if rerr != nil {
+		return
+	}
+	return minio.PartInfo{PartNumber: partID, ETag: bkendObjInfo.ETag, Size: bkendObjInfo.Size}, nil
+}
+
+// ListObjectParts returns all object parts for specified object in specified bucket
+func (l *s3EncObjects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi minio.ListPartsInfo, e error) {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+	}
+	// We do not store parts uploaded so far in the dare.meta. Only CompleteMultipartUpload finalizes the parts under upload prefix.Otherwise,
+	// there could be situations of dare.meta getting corrupted by competing upload parts.
+	uploadPrefix := getTmpGWMetaPath(object, uploadID)
+	dm, err := l.getDareMetadata(ctx, bucket, uploadPrefix)
+	if err != nil {
+		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+	}
+	lpi.Parts = make([]minio.PartInfo, 0)
+	lpi.UserDefined = dm.Meta
+	lpi.Bucket = bucket
+	lpi.Object = object
+	lpi.UploadID = uploadID
+	lpi.MaxParts = maxParts
+	lpi.PartNumberMarker = partNumberMarker
+
+	if maxParts == 0 {
+		return lpi, nil
+	}
+
+	var continuationToken, startAfter, delimiter string
+	var loi minio.ListObjectsV2Info
+	if partNumberMarker > 0 {
+		startAfter = path.Join(uploadPrefix, strconv.Itoa(partNumberMarker))
+	}
+	for {
+		loi, err = l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
+		if err != nil {
+			return lpi, err
+		}
+		for _, obj := range loi.Objects {
+			startAfter = obj.Name
+			if !strings.HasPrefix(obj.Name, uploadPrefix) {
+				return lpi, nil
+			}
+			if strings.HasSuffix(obj.Name, gwdareMetaJSON) {
+				continue
+			}
+
+			partNumStr := strings.TrimLeft(obj.Name, path.Join(object, defaultMinioGWPrefix, uploadID, ""))
+			partNum, _ := strconv.Atoi(partNumStr)
+			if partNum < partNumberMarker {
+				continue
+			}
+			if partNum > 0 {
+				pi := minio.PartInfo{
+					PartNumber:   partNum,
+					Size:         obj.Size,
+					ETag:         obj.ETag,
+					LastModified: obj.ModTime,
+				}
+				lpi.Parts = append(lpi.Parts, pi)
+			}
+			if len(lpi.Parts) == maxParts {
+				break
+			}
+		}
+		continuationToken = loi.NextContinuationToken
+		if !loi.IsTruncated {
+			break
+		}
+	}
+	if len(loi.Objects) > len(lpi.Parts) && len(lpi.Parts) > 0 {
+		lpi.IsTruncated = true
+		lpi.NextPartNumberMarker = lpi.Parts[len(lpi.Parts)-1].PartNumber
+	}
+	return lpi, nil
+}
+
+// AbortMultipartUpload aborts a ongoing multipart upload
+func (l *s3EncObjects) AbortMultipartUpload(ctx context.Context, bucket string, object string, uploadID string) error {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.AbortMultipartUpload(ctx, bucket, object, uploadID)
+	}
+
+	uploadPrefix := getTmpGWMetaPath(object, uploadID)
+	var continuationToken, startAfter, delimiter string
+	for {
+		loi, err := l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
+		if err != nil {
+			return minio.InvalidUploadID{UploadID: uploadID}
+		}
+		for _, obj := range loi.Objects {
+			if !strings.HasPrefix(obj.Name, uploadPrefix) {
+				return nil
+			}
+			if err := l.s3Objects.DeleteObject(ctx, bucket, obj.Name); err != nil {
+				return err
+			}
+			startAfter = obj.Name
+		}
+		continuationToken = loi.NextContinuationToken
+		if !loi.IsTruncated {
+			break
+		}
+	}
+	return nil
+}
+
+// CompleteMultipartUpload completes ongoing multipart upload and finalizes object
+func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []minio.CompletePart) (oi minio.ObjectInfo, e error) {
+	if len(minio.GlobalGatewaySSE) == 0 {
+		return l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts)
+	}
+	uploadPrefix := getTmpGWMetaPath(object, uploadID)
+	dareMeta, err := l.getDareMetadata(ctx, bucket, uploadPrefix)
+	if err != nil {
+		return l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts)
+	}
+
+	// overwrite any previous unencrypted object with same name
+	defer l.s3Objects.DeleteObject(ctx, bucket, object)
+
+	// Calculate s3 compatible md5sum for complete multipart.
+	s3MD5, err := minio.GetCompleteMultipartMD5(ctx, uploadedParts)
+	if err != nil {
+		return oi, err
+	}
+	gwMeta := newGWMetaV1()
+	gwMeta.Meta = make(map[string]string)
+	for k, v := range dareMeta.Meta {
+		gwMeta.Meta[k] = v
+	}
+	// Allocate parts similar to incoming slice.
+	gwMeta.Parts = make([]minio.ObjectPartInfo, len(uploadedParts))
+
+	var objectSize int64
+	var marker, delimiter string
+	var partsMap = make(map[string]string)
+	// Validate each part and then commit to disk.
+	for i, part := range uploadedParts {
+		obj := fmt.Sprintf("%s/%d", uploadPrefix, part.PartNumber)
+		partsMap[obj] = ""
+		res, rerr := l.s3Objects.ListObjects(ctx, bucket, obj, marker, delimiter, 1)
+		if rerr != nil || len(res.Objects) == 0 {
+			return oi, minio.InvalidPart{}
+		}
+		partInfo := res.Objects[0]
+		// All parts should have same ETag as previously generated.
+		if partInfo.ETag != part.ETag {
+			invp := minio.InvalidPart{
+				PartNumber: part.PartNumber,
+				ExpETag:    partInfo.ETag,
+				GotETag:    part.ETag,
+			}
+			logger.LogIf(ctx, invp)
+			return oi, invp
+		}
+
+		// Last part could have been uploaded as 0bytes, do not need
+		// to save it in final `xl.json`.
+		if (i == len(uploadedParts)-1) && partInfo.Size == 0 {
+			gwMeta.Parts = gwMeta.Parts[:i] // Skip the part.
+			continue
+		}
+		// Save for total object size.
+		objectSize += partInfo.Size
+
+		// Add incoming parts.
+		gwMeta.Parts[i] = minio.ObjectPartInfo{
+			Number: part.PartNumber,
+			ETag:   part.ETag,
+			Size:   partInfo.Size,
+			Name:   partInfo.Name,
+		}
+	}
+
+	// Save the final object size and modtime.
+	gwMeta.Stat.Size = objectSize
+	gwMeta.Stat.ModTime = time.Now().UTC()
+
+	// Save successfully calculated md5sum.
+	gwMeta.Meta["etag"] = s3MD5
+
+	// Clean up any uploaded parts that are not being committed by this CompleteMultipart operation
+	var continuationToken, startAfter string
+	done := false
+	for {
+		loi, lerr := l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
+		if lerr != nil {
+			done = true
+			break
+		}
+		for _, obj := range loi.Objects {
+			if !strings.HasPrefix(obj.Name, uploadPrefix) {
+				done = true
+				break
+			}
+			startAfter = obj.Name
+			// delete parts not found in uploadedParts  map
+			if _, ok := partsMap[obj.Name]; !ok {
+				l.s3Objects.DeleteObject(ctx, bucket, obj.Name)
+			}
+		}
+		continuationToken = loi.NextContinuationToken
+		if !loi.IsTruncated || done {
+			break
+		}
+	}
+	if err = l.writeDareMetadata(ctx, bucket, getGWMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
+		return oi, err
+	}
+	// clean up temporary upload dare.meta file under uploadID prefix
+	if err = l.deleteDareMetadata(ctx, bucket, getTmpGWMetaPath(object, uploadID)); err != nil {
+		return oi, err
+	}
+	return gwMeta.ToObjectInfo(bucket, object), nil
+}
+
+// getTmpGWMetaPath returns the prefix under which uploads in progress are stored on backend
+func getTmpGWMetaPath(object, uploadID string) string {
+	return path.Join(object, defaultMinioGWPrefix, uploadID)
+}
+
+// getGWMetaPath returns the prefix under which custom large object is stored on backend after upload completes
+func getGWMetaPath(object string) string {
+	return path.Join(object, defaultMinioGWPrefix)
+}
+
+// getGWContentPath returns the prefix under which custom small object is stored on backend after upload completes
+func getGWContentPath(object string) string {
+	return path.Join(object, defaultMinioGWPrefix, defaultGWContentFileName)
+}
+
+// Clean-up the old multipart uploads. Should be run in a Go routine.
+func (l *s3EncObjects) cleanupStaleMultipartUploads(ctx context.Context, cleanupInterval, expiry time.Duration, doneCh chan struct{}) {
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-doneCh:
+			return
+		case <-ticker.C:
+			l.cleanupStaleMultipartUploadsOnGW(ctx, expiry)
+		}
+	}
+}
+
+// cleanupStaleMultipartUploads removes old custom encryption multipart uploads on backend
+func (l *s3EncObjects) cleanupStaleMultipartUploadsOnGW(ctx context.Context, expiry time.Duration) {
+	for {
+		buckets, err := l.s3Objects.ListBuckets(ctx)
+		if err != nil {
+			break
+		}
+		for _, b := range buckets {
+			allParts, expParts := l.getStalePartsForBucket(ctx, b.Name, expiry)
+			for k := range expParts {
+				if _, ok := allParts[k]; !ok {
+					l.s3Objects.DeleteObject(ctx, b.Name, k)
+				}
+			}
+		}
+	}
+}
+
+func (l *s3EncObjects) getStalePartsForBucket(ctx context.Context, bucket string, expiry time.Duration) (allParts, expParts map[string]string) {
+	var prefix, continuationToken, delimiter, startAfter string
+	allParts = make(map[string]string)
+	expParts = make(map[string]string)
+	now := time.Now()
+	for {
+		loi, err := l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, false, startAfter)
+		if err != nil {
+			break
+		}
+		for _, obj := range loi.Objects {
+			startAfter = obj.Name
+			if !strings.Contains(obj.Name, defaultMinioGWPrefix) {
+				continue
+			}
+			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, gwdareMetaJSON)) {
+				objSlice := strings.Split(obj.Name, path.Join(slashSeparator, defaultMinioGWPrefix))
+				meta, err := l.getDareMetadata(ctx, bucket, objSlice[0])
+				if err != nil {
+					continue
+				}
+				for _, p := range meta.Parts {
+					allParts[p.Name] = ""
+				}
+			}
+			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, defaultGWContentFileName)) {
+				objSlice := strings.Split(obj.Name, path.Join(slashSeparator, defaultMinioGWPrefix))
+				expParts[getGWContentPath(objSlice[0])] = ""
+			}
+			if now.Sub(obj.ModTime) > expiry {
+				// skip parts that are part of a completed upload
+				if _, ok := allParts[obj.Name]; !ok {
+					expParts[obj.Name] = ""
+				}
+			}
+		}
+		continuationToken = loi.NextContinuationToken
+		if !loi.IsTruncated {
+			break
+		}
+	}
+	return
+}

--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"path"
 	"sort"
@@ -32,7 +33,6 @@ import (
 	minio "github.com/minio/minio/cmd"
 	"github.com/minio/sio"
 
-	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/hash"
 )
@@ -40,6 +40,9 @@ import (
 const (
 	// name of custom multipart metadata file for s3 backend.
 	gwdareMetaJSON string = "dare.meta"
+
+	// name of temporary per part metadata file
+	gwpartMetaJSON string = "part.meta"
 	// custom multipart files are stored under the defaultMinioGWPrefix
 	defaultMinioGWPrefix     = ".minio"
 	defaultGWContentFileName = "data"
@@ -62,6 +65,9 @@ type s3EncObjects struct {
 		obj/.minio/uploadId/1 <= encrypted part 1
 		obj/.minio/uploadId/2 ...
 		obj/.minio/uploadId/3
+	When a multipart upload is in progress, part metadata is stored in obj/.minio/uploadID/1/part-etag/part.meta
+	where part-etag is etag of the actual part content file on s3 backend. This metadata file will be cleaned up
+	after the upload completes.
 */
 
 // ListObjects lists all blobs in S3 bucket filtered by prefix
@@ -93,7 +99,7 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 	for {
 		loi, e = l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, fetchOwner, startAfter)
 		if e != nil {
-			return loi, e
+			return loi, minio.ErrorRespToObjectError(e, bucket)
 		}
 		for _, obj := range loi.Objects {
 			startAfter = obj.Name
@@ -103,11 +109,13 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 			if strings.Contains(obj.Name, defaultMinioGWPrefix) && !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
 				continue
 			}
-
+			if !isGWObject(obj.Name) {
+				continue
+			}
 			// get objectname and ObjectInfo from the custom metadata file
 			if strings.HasSuffix(obj.Name, gwdareMetaJSON) {
 				objSlice := strings.Split(obj.Name, slashSeparator+defaultMinioGWPrefix)
-				gwMeta, e := l.getDareMetadata(ctx, bucket, getGWMetaPath(objSlice[0]))
+				gwMeta, e := l.getGWMetadata(ctx, bucket, getDareMetaPath(objSlice[0]))
 				if e != nil {
 					continue
 				}
@@ -124,19 +132,17 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 			}
 		}
 		for _, p := range loi.Prefixes {
-			prefixSlice := strings.Split(p, defaultMinioGWPrefix+slashSeparator)
-			if len(prefixSlice) >= 1 {
-				objName := strings.TrimSuffix(prefixSlice[0], slashSeparator)
-				gm, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(objName))
-				// if prefix is actually a custom multi-part object, append it to objects
-				if err == nil {
-					objects = append(objects, gm.ToObjectInfo(bucket, objName))
-					continue
-				}
-				prefixes = append(prefixes, prefixSlice[0])
+			objName := strings.TrimSuffix(p, slashSeparator)
+			gm, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(objName))
+			// if prefix is actually a custom multi-part object, append it to objects
+			if err == nil {
+				objects = append(objects, gm.ToObjectInfo(bucket, objName))
 				continue
 			}
-			prefixes = append(prefixes, p)
+			isPrefix := l.isPrefix(ctx, bucket, p, fetchOwner, startAfter)
+			if isPrefix {
+				prefixes = append(prefixes, p)
+			}
 		}
 		if (len(objects) > maxKeys) || !loi.IsTruncated {
 			break
@@ -160,6 +166,52 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 	return loi, nil
 }
 
+// isGWObject returns true if it is a custom object
+func isGWObject(objName string) bool {
+	pfxSlice := strings.Split(objName, slashSeparator)
+	var i1, i2 int
+	for i := len(pfxSlice) - 1; i >= 0; i-- {
+		p := pfxSlice[i]
+		if p == defaultMinioGWPrefix {
+			i1 = i
+		}
+		if p == gwdareMetaJSON {
+			i2 = i
+		}
+		if i1 > 0 && i2 > 0 {
+			break
+		}
+	}
+	// incomplete uploads would have a uploadID between defaultMinioGWPrefix and gwdareMetaJSON
+	return i2 > 0 && i1 > 0 && i2-i1 == 1
+}
+
+// isPrefix returns true if prefix exists and is not an incomplete multipart upload entry
+func (l *s3EncObjects) isPrefix(ctx context.Context, bucket, prefix string, fetchOwner bool, startAfter string) bool {
+	var continuationToken, delimiter string
+
+	for {
+		loi, e := l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, fetchOwner, startAfter)
+		if e != nil {
+			return false
+		}
+		for _, obj := range loi.Objects {
+			if !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
+				continue
+			}
+			if isGWObject(obj.Name) {
+				return true
+			}
+		}
+
+		continuationToken = loi.NextContinuationToken
+		if !loi.IsTruncated {
+			break
+		}
+	}
+	return false
+}
+
 // GetObject reads an object from S3. Supports additional
 // parameters like offset and length which are synonymous with
 // HTTP Range requests.
@@ -171,7 +223,7 @@ func (l *s3EncObjects) GetObject(ctx context.Context, bucket string, key string,
 	if len(minio.GlobalGatewaySSE) == 0 {
 		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
 	}
-	dmeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(key))
+	dmeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(key))
 	if err != nil {
 		// unencrypted content
 		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
@@ -214,7 +266,14 @@ func (l *s3EncObjects) GetObject(ctx context.Context, bucket string, key string,
 			continue
 		}
 		pInfo, err := l.s3Objects.GetObjectInfo(ctx, bucket, part.Name, o)
-		if err != nil || pInfo.ETag != part.ETag {
+		if err != nil {
+			logger.LogIf(ctx, err)
+			return minio.ObjectNotFound{
+				Bucket: bucket,
+				Object: key,
+			}
+		}
+		if o.GetDecryptedETagFn != nil && pInfo.ETag != o.GetDecryptedETagFn(part.ETag) {
 			logger.LogIf(ctx, err)
 			return minio.ObjectNotFound{
 				Bucket: bucket,
@@ -248,7 +307,7 @@ func (l *s3EncObjects) GetObject(ctx context.Context, bucket string, key string,
 		_, err = io.Copy(writer, pInfo.Reader)
 		if err != nil {
 			logger.LogIf(ctx, err)
-			return err
+			return minio.ErrorRespToObjectError(err)
 		}
 		partStartIndex++
 		partEncRelOffset = 0
@@ -256,15 +315,19 @@ func (l *s3EncObjects) GetObject(ctx context.Context, bucket string, key string,
 	return nil
 }
 
+func (l *s3EncObjects) isGWEncrypted(ctx context.Context, bucket, object string) bool {
+	_, err := l.s3Objects.GetObjectInfo(ctx, bucket, getDareMetaPath(object), minio.ObjectOptions{})
+	return err == nil
+}
+
 // getDaremetadata fetches dare.meta from s3 backend and marshals into a structured format.
-func (l *s3EncObjects) getDareMetadata(ctx context.Context, bucket, objectPrefix string) (m gwMetaV1, err error) {
-	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
-	oi, err1 := l.s3Objects.GetObjectInfo(ctx, bucket, dareMetaFile, minio.ObjectOptions{})
+func (l *s3EncObjects) getGWMetadata(ctx context.Context, bucket, metaFileName string) (m gwMetaV1, err error) {
+	oi, err1 := l.s3Objects.GetObjectInfo(ctx, bucket, metaFileName, minio.ObjectOptions{})
 	if err1 != nil {
 		return m, err1
 	}
 	var buffer bytes.Buffer
-	err = l.s3Objects.GetObject(ctx, bucket, dareMetaFile, 0, oi.Size, &buffer, oi.ETag, minio.ObjectOptions{})
+	err = l.s3Objects.GetObject(ctx, bucket, metaFileName, 0, oi.Size, &buffer, oi.ETag, minio.ObjectOptions{})
 	if err != nil {
 		return m, err
 	}
@@ -272,21 +335,28 @@ func (l *s3EncObjects) getDareMetadata(ctx context.Context, bucket, objectPrefix
 }
 
 // writes dare metadata to the s3 backend
-func (l *s3EncObjects) writeDareMetadata(ctx context.Context, bucket, objectPrefix string, m gwMetaV1, o minio.ObjectOptions) error {
-	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
-	hashReader, err := getGWMetadata(ctx, bucket, dareMetaFile, m)
+func (l *s3EncObjects) writeGWMetadata(ctx context.Context, bucket, metaFileName string, m gwMetaV1, o minio.ObjectOptions) error {
+	hashReader, err := getGWMetadata(ctx, bucket, metaFileName, m)
 	if err != nil {
 		logger.LogIf(ctx, err)
 		return err
 	}
-	_, err = l.s3Objects.PutObject(ctx, bucket, dareMetaFile, minio.NewPutObjectReader(hashReader), map[string]string{}, o)
+	_, err = l.s3Objects.PutObject(ctx, bucket, metaFileName, minio.NewPutObjectReader(hashReader), map[string]string{}, o)
 	return err
+}
+func getTmpDareMetaPath(object, uploadID string) string {
+	return path.Join(getGWMetaPath(object), uploadID, gwdareMetaJSON)
+}
+func getDareMetaPath(object string) string {
+	return path.Join(getGWMetaPath(object), gwdareMetaJSON)
+}
+func getPartMetaPath(object, uploadID string, partID int, partETag string) string {
+	return path.Join(object, defaultMinioGWPrefix, uploadID, strconv.Itoa(partID), partETag, gwpartMetaJSON)
 }
 
 // deletes the custom dare metadata file saved at the backend
-func (l *s3EncObjects) deleteDareMetadata(ctx context.Context, bucket, objectPrefix string) error {
-	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
-	return l.s3Objects.DeleteObject(ctx, bucket, dareMetaFile)
+func (l *s3EncObjects) deleteGWMetadata(ctx context.Context, bucket, metaFileName string) error {
+	return l.s3Objects.DeleteObject(ctx, bucket, metaFileName)
 }
 
 // GetObjectNInfo - returns object info and locked object ReadCloser
@@ -294,16 +364,14 @@ func (l *s3EncObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	if len(minio.GlobalGatewaySSE) == 0 {
 		return l.s3Objects.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
 	}
-	var objInfo minio.ObjectInfo
-	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
+
+	objInfo, err := l.GetObjectInfo(ctx, bucket, object, opts)
 	if err != nil {
 		return l.s3Objects.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
 	}
-
-	objInfo = gwMeta.ToObjectInfo(bucket, object)
 	fn, off, length, err := minio.NewGetObjectReader(rs, objInfo)
 	if err != nil {
-		return nil, err
+		return nil, minio.ErrorRespToObjectError(err)
 	}
 
 	pr, pw := io.Pipe()
@@ -323,7 +391,7 @@ func (l *s3EncObjects) GetObjectInfo(ctx context.Context, bucket string, object 
 	if len(minio.GlobalGatewaySSE) == 0 {
 		return l.s3Objects.GetObjectInfo(ctx, bucket, object, opts)
 	}
-	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
+	gwMeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(object))
 	if err != nil {
 		return l.s3Objects.GetObjectInfo(ctx, bucket, object, opts)
 	}
@@ -332,56 +400,10 @@ func (l *s3EncObjects) GetObjectInfo(ctx context.Context, bucket string, object 
 
 // CopyObject copies an object from source bucket to a destination bucket.
 func (l *s3EncObjects) CopyObject(ctx context.Context, srcBucket string, srcObject string, dstBucket string, dstObject string, srcInfo minio.ObjectInfo, srcOpts, dstOpts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
-	// Set this header such that following CopyObject() always sets the right metadata on the destination.
-	// metadata input is already a trickled down value from interpreting x-amz-metadata-directive at
-	// handler layer. So what we have right now is supposed to be applied on the destination object anyways.
-	// So preserve it by adding "REPLACE" directive to save all the metadata set by CopyObject API.
-	srcInfo.UserDefined["x-amz-metadata-directive"] = "REPLACE"
-	srcInfo.UserDefined["x-amz-copy-source-if-match"] = srcInfo.ETag
-	// if gateway encryption is turned off, do a pass thru
 	if len(minio.GlobalGatewaySSE) == 0 {
 		return l.s3Objects.CopyObject(ctx, srcBucket, srcObject, dstBucket, dstObject, srcInfo, srcOpts, dstOpts)
 	}
-	// Check if source is custom multipart Object. If not, Get source object, decrypt at gateway and
-	// upload with destination side encryption options
-	gwMeta, err := l.getDareMetadata(ctx, srcBucket, getGWMetaPath(srcObject))
-	if err != nil {
-		return l.PutObject(ctx, dstBucket, dstObject, srcInfo.PutObjectReader, srcInfo.UserDefined, dstOpts)
-	}
-
-	// src encrypted, but not target or custom encrypted without multipart
-	if dstOpts.ServerSideEncryption == nil || len(gwMeta.Parts) == 0 {
-		return l.PutObject(ctx, dstBucket, dstObject, srcInfo.PutObjectReader, srcInfo.UserDefined, dstOpts)
-	}
-
-	// convert copy src encryption options for GET calls
-	var getOpts minio.ObjectOptions
-	if srcOpts.ServerSideEncryption != nil {
-		getOpts.ServerSideEncryption = encrypt.SSE(srcOpts.ServerSideEncryption)
-	}
-
-	// overwrite any previous unencrypted object with same name
-	defer l.s3Objects.DeleteObject(ctx, dstBucket, dstObject)
-
-	dstUploadID, err := l.NewMultipartUpload(ctx, dstBucket, dstObject, srcInfo.UserDefined, dstOpts)
-	if err != nil {
-		logger.LogIf(ctx, err)
-		return
-	}
-	var uploadedParts = make([]minio.CompletePart, 0)
-	var partID = 1
-
-	partUploadName := path.Join(getTmpGWMetaPath(dstObject, dstUploadID), strconv.Itoa(partID))
-	bkendObjInfo, rerr := l.s3Objects.PutObject(ctx, dstBucket, partUploadName, srcInfo.PutObjectReader, srcInfo.UserDefined, dstOpts)
-	if rerr != nil {
-		return
-	}
-	uploadedParts = append(uploadedParts, minio.CompletePart{
-		ETag:       bkendObjInfo.ETag,
-		PartNumber: partID,
-	})
-
-	return l.CompleteMultipartUpload(ctx, dstBucket, dstObject, dstUploadID, uploadedParts, dstOpts)
+	return l.PutObject(ctx, dstBucket, dstObject, srcInfo.PutObjectReader, srcInfo.UserDefined, dstOpts)
 }
 
 // DeleteObject deletes a blob in bucket
@@ -392,7 +414,7 @@ func (l *s3EncObjects) DeleteObject(ctx context.Context, bucket string, object s
 		return l.s3Objects.DeleteObject(ctx, bucket, object)
 	}
 	// Get dare meta json
-	if _, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object)); err != nil {
+	if _, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(object)); err != nil {
 		return l.s3Objects.DeleteObject(ctx, bucket, object)
 	}
 	return l.deleteEncryptedObject(ctx, bucket, object)
@@ -400,9 +422,9 @@ func (l *s3EncObjects) DeleteObject(ctx context.Context, bucket string, object s
 
 func (l *s3EncObjects) deleteEncryptedObject(ctx context.Context, bucket string, object string) error {
 	// Get dare meta json
-	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
+	gwMeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(object))
 	if err != nil {
-		return l.s3Objects.DeleteObject(ctx, bucket, object)
+		return err
 	}
 	if len(gwMeta.Parts) == 0 {
 		l.s3Objects.DeleteObject(ctx, bucket, getGWContentPath(object))
@@ -412,7 +434,7 @@ func (l *s3EncObjects) deleteEncryptedObject(ctx context.Context, bucket string,
 			return err
 		}
 	}
-	return l.deleteDareMetadata(ctx, bucket, getGWMetaPath(object))
+	return l.deleteGWMetadata(ctx, bucket, getDareMetaPath(object))
 }
 
 // ListMultipartUploads lists all multipart uploads.
@@ -435,7 +457,7 @@ func (l *s3EncObjects) ListMultipartUploads(ctx context.Context, bucket string, 
 	for {
 		loi, err := l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, false, startAfter)
 		if err != nil {
-			return lmi, err
+			return lmi, minio.ErrorRespToObjectError(err, bucket)
 		}
 		for _, obj := range loi.Objects {
 			startAfter = obj.Name
@@ -486,15 +508,14 @@ func (l *s3EncObjects) ListMultipartUploads(ctx context.Context, bucket string, 
 // NewMultipartUpload uploads object in multiple parts
 func (l *s3EncObjects) NewMultipartUpload(ctx context.Context, bucket string, object string, metadata map[string]string, o minio.ObjectOptions) (uploadID string, err error) {
 	// Create uploadID and write a temporary dare.meta object under object/uploadID prefix
-	if (len(minio.GlobalGatewaySSE) > 0) && o.ServerSideEncryption != nil {
+	if len(minio.GlobalGatewaySSE) > 0 {
 		uploadID := minio.MustGetUUID()
-		tmpUploadPrefix := getTmpGWMetaPath(object, uploadID)
 		gwmeta := newGWMetaV1()
 		gwmeta.Meta = metadata
 		gwmeta.Stat.ModTime = time.Now().UTC()
-		err := l.writeDareMetadata(ctx, bucket, tmpUploadPrefix, gwmeta, minio.ObjectOptions{})
+		err := l.writeGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID), gwmeta, minio.ObjectOptions{})
 		if err != nil {
-			return uploadID, err
+			return uploadID, minio.ErrorRespToObjectError(err)
 		}
 		return uploadID, nil
 	}
@@ -507,20 +528,24 @@ func (l *s3EncObjects) PutObject(ctx context.Context, bucket string, object stri
 		return l.s3Objects.PutObject(ctx, bucket, object, data, metadata, opts)
 	}
 	if opts.ServerSideEncryption == nil {
+		wasEncrypted := l.isGWEncrypted(ctx, bucket, object)
 		oi, err := l.s3Objects.PutObject(ctx, bucket, object, data, metadata, opts)
 		if err != nil {
-			return objInfo, err
+			return objInfo, minio.ErrorRespToObjectError(err)
 		}
-		l.deleteEncryptedObject(ctx, bucket, object)
+		if wasEncrypted {
+			l.deleteEncryptedObject(ctx, bucket, object)
+		}
 		return oi, nil
 	}
 	// overwrite any previous unencrypted object with same name
 	defer l.s3Objects.DeleteObject(ctx, bucket, object)
 
-	oi, err := l.s3Objects.PutObject(ctx, bucket, getGWContentPath(object), data, metadata, opts)
+	oi, err := l.s3Objects.PutObject(ctx, bucket, getGWContentPath(object), data, map[string]string{}, opts)
 	if err != nil {
-		return objInfo, err
+		return objInfo, minio.ErrorRespToObjectError(err)
 	}
+
 	gwMeta := newGWMetaV1()
 	gwMeta.Meta = make(map[string]string)
 	for k, v := range oi.UserDefined {
@@ -529,20 +554,30 @@ func (l *s3EncObjects) PutObject(ctx context.Context, bucket string, object stri
 	for k, v := range metadata {
 		gwMeta.Meta[k] = v
 	}
-	gwMeta.ETag = oi.ETag
+	var encMD5 string
+	if opts.CreateEncryptedETagFn != nil {
+		encMD5, _, err = opts.CreateEncryptedETagFn()
+		if err != nil {
+			log.Fatal("shouldnt occur")
+		}
+	}
+
+	gwMeta.ETag = encMD5
 	gwMeta.Stat.Size = oi.Size
 	gwMeta.Stat.ModTime = oi.ModTime
-	if err = l.writeDareMetadata(ctx, bucket, getGWMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
-		return objInfo, err
+	if err = l.writeGWMetadata(ctx, bucket, getDareMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
+		return objInfo, minio.ErrorRespToObjectError(err)
 	}
-	return oi, nil
+	objInfo = gwMeta.ToObjectInfo(bucket, object)
+
+	return objInfo, nil
 }
 
 // PutObjectPart puts a part of object in bucket
 func (l *s3EncObjects) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *minio.PutObjectReader, opts minio.ObjectOptions) (pi minio.PartInfo, e error) {
 	var s3Opts minio.ObjectOptions
 	// for sse-s3 encryption options should not be passed to backend
-	if opts.ServerSideEncryption.Type() == encrypt.SSEC {
+	if opts.ServerSideEncryption != nil && opts.ServerSideEncryption.Type() == encrypt.SSEC {
 		s3Opts = opts
 	}
 	if len(minio.GlobalGatewaySSE) == 0 {
@@ -552,16 +587,43 @@ func (l *s3EncObjects) PutObjectPart(ctx context.Context, bucket string, object 
 	tmpDareMeta := path.Join(uploadPath, gwdareMetaJSON)
 	_, err := l.s3Objects.GetObjectInfo(ctx, bucket, tmpDareMeta, minio.ObjectOptions{})
 	if err != nil {
-		// it is a regular multipart,since dare.meta is missing.
-		return l.s3Objects.PutObjectPart(ctx, bucket, object, uploadID, partID, data, s3Opts)
+		return pi, minio.InvalidUploadID{UploadID: uploadID}
 	}
 	partUploadName := path.Join(uploadPath, strconv.Itoa(partID))
+
 	oi, err := l.s3Objects.PutObject(ctx, bucket, partUploadName, data, map[string]string{}, s3Opts)
 	if err != nil {
-		return pi, err
+		return pi, minio.ErrorRespToObjectError(err)
+	}
+	gwMeta := newGWMetaV1()
+	gwMeta.Parts = make([]minio.ObjectPartInfo, 1)
+	if opts.CreateEncryptedETagFn != nil {
+		encMD5, _, err := opts.CreateEncryptedETagFn()
+		if err != nil {
+			return pi, minio.ErrorRespToObjectError(err)
+		}
+
+		// Add incoming part.
+		gwMeta.Parts[0] = minio.ObjectPartInfo{
+			Number: partID,
+			ETag:   encMD5,
+			Size:   oi.Size,
+			Name:   strconv.Itoa(partID),
+		}
+		gwMeta.ETag = encMD5
+		gwMeta.Stat.Size = oi.Size
+		gwMeta.Stat.ModTime = oi.ModTime
+	}
+	if err = l.writeGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, partID, oi.ETag), gwMeta, minio.ObjectOptions{}); err != nil {
+		return pi, minio.ErrorRespToObjectError(err)
 	}
 
-	return FromGatewayObjectPart(partID, oi), nil
+	return minio.PartInfo{
+		Size:         gwMeta.Stat.Size,
+		ETag:         minio.CanonicalizeETag(gwMeta.ETag),
+		LastModified: gwMeta.Stat.ModTime,
+		PartNumber:   partID,
+	}, nil
 }
 
 // CopyObjectPart creates a part in a multipart upload by copying
@@ -572,54 +634,22 @@ func (l *s3EncObjects) CopyObjectPart(ctx context.Context, srcBucket, srcObject,
 	if len(minio.GlobalGatewaySSE) == 0 {
 		return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
 	}
-	srcInfo.UserDefined = map[string]string{
-		"x-amz-copy-source-if-match": srcInfo.ETag,
-	}
-	// convert copy src and dst encryption options for GET/PUT calls
-	var getOpts minio.ObjectOptions
-	if srcOpts.ServerSideEncryption != nil {
-		getOpts.ServerSideEncryption = encrypt.SSE(srcOpts.ServerSideEncryption)
-	}
-
-	// Get dare meta json
-	gwMeta, err := l.getDareMetadata(ctx, destBucket, getTmpGWMetaPath(destObject, uploadID))
-	if err != nil {
-		// both src and dest are not encrypted - delegate to backend
-		if !crypto.IsEncrypted(srcInfo.UserDefined) {
-			return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
-		}
-		// src is encrypted
-		partName := path.Join(getTmpGWMetaPath(destObject, uploadID), strconv.Itoa(partID))
-		oi, oerr := l.PutObject(ctx, destBucket, partName, srcInfo.PutObjectReader, srcInfo.UserDefined, dstOpts)
-		if oerr != nil {
-			return minio.PartInfo{}, oerr
-		}
-		return minio.PartInfo{PartNumber: partID, ETag: oi.ETag, Size: oi.Size}, nil
-	}
-	if !crypto.IsEncrypted(gwMeta.ToObjectInfo(destBucket, destObject).UserDefined) {
-		return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
-	}
-	uploadPath := getTmpGWMetaPath(destObject, uploadID)
-	partUploadName := path.Join(uploadPath, strconv.Itoa(partID))
-	bkendObjInfo, rerr := l.s3Objects.PutObject(ctx, destBucket, partUploadName, srcInfo.PutObjectReader, srcInfo.UserDefined, dstOpts)
-	if rerr != nil {
-		return
-	}
-	return minio.PartInfo{PartNumber: partID, ETag: bkendObjInfo.ETag, Size: bkendObjInfo.Size}, nil
+	return l.PutObjectPart(ctx, destBucket, destObject, uploadID, partID, srcInfo.PutObjectReader, dstOpts)
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket
-func (l *s3EncObjects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi minio.ListPartsInfo, e error) {
+func (l *s3EncObjects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int, opts minio.ObjectOptions) (lpi minio.ListPartsInfo, e error) {
 	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts, opts)
 	}
 	// We do not store parts uploaded so far in the dare.meta. Only CompleteMultipartUpload finalizes the parts under upload prefix.Otherwise,
 	// there could be situations of dare.meta getting corrupted by competing upload parts.
 	uploadPrefix := getTmpGWMetaPath(object, uploadID)
-	dm, err := l.getDareMetadata(ctx, bucket, uploadPrefix)
+	dm, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID))
 	if err != nil {
-		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts, opts)
 	}
+
 	lpi.Parts = make([]minio.PartInfo, 0)
 	lpi.UserDefined = dm.Meta
 	lpi.Bucket = bucket
@@ -640,28 +670,32 @@ func (l *s3EncObjects) ListObjectParts(ctx context.Context, bucket string, objec
 	for {
 		loi, err = l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
 		if err != nil {
-			return lpi, err
+			return lpi, minio.ErrorRespToObjectError(err, bucket)
 		}
 		for _, obj := range loi.Objects {
 			startAfter = obj.Name
 			if !strings.HasPrefix(obj.Name, uploadPrefix) {
 				return lpi, nil
 			}
-			if strings.HasSuffix(obj.Name, gwdareMetaJSON) {
+			if strings.HasSuffix(obj.Name, gwdareMetaJSON) || strings.HasSuffix(obj.Name, gwpartMetaJSON) {
 				continue
 			}
-
-			partNumStr := strings.TrimLeft(obj.Name, path.Join(object, defaultMinioGWPrefix, uploadID, ""))
+			partNumStr := strings.TrimPrefix(obj.Name, path.Join(object, defaultMinioGWPrefix, uploadID)+slashSeparator)
 			partNum, _ := strconv.Atoi(partNumStr)
+
 			if partNum < partNumberMarker {
 				continue
+			}
+			partMeta, err := l.getGWMetadata(ctx, bucket, path.Join(obj.Name, obj.ETag, gwpartMetaJSON))
+			if err != nil || len(partMeta.Parts) == 0 {
+				return lpi, minio.InvalidPart{}
 			}
 			if partNum > 0 {
 				pi := minio.PartInfo{
 					PartNumber:   partNum,
-					Size:         obj.Size,
-					ETag:         obj.ETag,
-					LastModified: obj.ModTime,
+					Size:         partMeta.Stat.Size,
+					ETag:         partMeta.ETag,
+					LastModified: partMeta.Stat.ModTime,
 				}
 				lpi.Parts = append(lpi.Parts, pi)
 			}
@@ -699,7 +733,7 @@ func (l *s3EncObjects) AbortMultipartUpload(ctx context.Context, bucket string, 
 				return nil
 			}
 			if err := l.s3Objects.DeleteObject(ctx, bucket, obj.Name); err != nil {
-				return err
+				return minio.ErrorRespToObjectError(err)
 			}
 			startAfter = obj.Name
 		}
@@ -717,7 +751,7 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 		return l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
 	}
 	uploadPrefix := getTmpGWMetaPath(object, uploadID)
-	dareMeta, err := l.getDareMetadata(ctx, bucket, uploadPrefix)
+	dareMeta, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID))
 	if err != nil {
 		return l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
 	}
@@ -728,7 +762,7 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 	// Calculate s3 compatible md5sum for complete multipart.
 	s3MD5, err := minio.GetCompleteMultipartMD5(ctx, uploadedParts)
 	if err != nil {
-		return oi, err
+		return oi, minio.ErrorRespToObjectError(err, bucket)
 	}
 	gwMeta := newGWMetaV1()
 	gwMeta.Meta = make(map[string]string)
@@ -740,18 +774,31 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 
 	var objectSize int64
 	var marker, delimiter string
+
 	var partsMap = make(map[string]string)
 	// Validate each part and then commit to disk.
 	for i, part := range uploadedParts {
 		obj := fmt.Sprintf("%s/%d", uploadPrefix, part.PartNumber)
 		partsMap[obj] = ""
+
 		res, rerr := l.s3Objects.ListObjects(ctx, bucket, obj, marker, delimiter, 1)
 		if rerr != nil || len(res.Objects) == 0 {
 			return oi, minio.InvalidPart{}
 		}
 		partInfo := res.Objects[0]
+		partMeta, err := l.getGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, part.PartNumber, partInfo.ETag))
+		if err != nil || len(partMeta.Parts) == 0 {
+			return oi, minio.InvalidPart{}
+		}
+
+		var partETag string
+		if opts.GetDecryptedETagFn != nil {
+			partETag = opts.GetDecryptedETagFn(partMeta.ETag)
+		}
+
 		// All parts should have same ETag as previously generated.
-		if partInfo.ETag != part.ETag {
+		// we are comparing encrypted etags here
+		if partETag != part.ETag {
 			invp := minio.InvalidPart{
 				PartNumber: part.PartNumber,
 				ExpETag:    partInfo.ETag,
@@ -773,7 +820,7 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 		// Add incoming parts.
 		gwMeta.Parts[i] = minio.ObjectPartInfo{
 			Number: part.PartNumber,
-			ETag:   part.ETag,
+			ETag:   partMeta.ETag, //save encrypted ETag
 			Size:   partInfo.Size,
 			Name:   partInfo.Name,
 		}
@@ -784,7 +831,7 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 	gwMeta.Stat.ModTime = time.Now().UTC()
 
 	// Save successfully calculated md5sum.
-	gwMeta.Meta["etag"] = s3MD5
+	gwMeta.ETag = s3MD5
 
 	// Clean up any uploaded parts that are not being committed by this CompleteMultipart operation
 	var continuationToken, startAfter string
@@ -805,18 +852,22 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 			if _, ok := partsMap[obj.Name]; !ok {
 				l.s3Objects.DeleteObject(ctx, bucket, obj.Name)
 			}
+			// delete temporary part metadata files
+			if strings.HasSuffix(obj.Name, gwpartMetaJSON) {
+				l.s3Objects.DeleteObject(ctx, bucket, obj.Name)
+			}
 		}
 		continuationToken = loi.NextContinuationToken
 		if !loi.IsTruncated || done {
 			break
 		}
 	}
-	if err = l.writeDareMetadata(ctx, bucket, getGWMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
-		return oi, err
+	if err = l.writeGWMetadata(ctx, bucket, getDareMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
+		return oi, minio.ErrorRespToObjectError(err)
 	}
 	// clean up temporary upload dare.meta file under uploadID prefix
-	if err = l.deleteDareMetadata(ctx, bucket, getTmpGWMetaPath(object, uploadID)); err != nil {
-		return oi, err
+	if err = l.deleteGWMetadata(ctx, bucket, getTmpGWMetaPath(object, uploadID)); err != nil {
+		return oi, minio.ErrorRespToObjectError(err)
 	}
 	return gwMeta.ToObjectInfo(bucket, object), nil
 }
@@ -886,7 +937,7 @@ func (l *s3EncObjects) getStalePartsForBucket(ctx context.Context, bucket string
 			}
 			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, gwdareMetaJSON)) {
 				objSlice := strings.Split(obj.Name, path.Join(slashSeparator, defaultMinioGWPrefix))
-				meta, err := l.getDareMetadata(ctx, bucket, objSlice[0])
+				meta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(objSlice[0]))
 				if err != nil {
 					continue
 				}

--- a/cmd/gateway/s3/gateway-s3-utils.go
+++ b/cmd/gateway/s3/gateway-s3-utils.go
@@ -1,0 +1,47 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3
+
+import minio "github.com/minio/minio/cmd"
+
+// List of header keys to be filtered, usually
+// from all S3 API http responses.
+var defaultFilterKeys = []string{
+	"Connection",
+	"Transfer-Encoding",
+	"Accept-Ranges",
+	"Date",
+	"Server",
+	"Vary",
+	"x-amz-bucket-region",
+	"x-amz-request-id",
+	"x-amz-id-2",
+	"Content-Security-Policy",
+	"X-Xss-Protection",
+
+	// Add new headers to be ignored.
+}
+
+// FromGatewayObjectPart converts ObjectInfo for custom part stored as object to PartInfo
+func FromGatewayObjectPart(partID int, oi minio.ObjectInfo) (pi minio.PartInfo) {
+	return minio.PartInfo{
+		Size:         oi.Size,
+		ETag:         minio.CanonicalizeETag(oi.ETag),
+		LastModified: oi.ModTime,
+		PartNumber:   partID,
+	}
+}

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -28,13 +28,14 @@ import (
 	"github.com/minio/cli"
 	miniogo "github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/credentials"
+	minio "github.com/minio/minio/cmd"
+
+	"github.com/minio/minio-go/pkg/encrypt"
 	"github.com/minio/minio-go/pkg/s3utils"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/policy"
-
-	minio "github.com/minio/minio/cmd"
 )
 
 const (
@@ -221,9 +222,15 @@ func (g *S3) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) 
 		return nil, err
 	}
 
-	return &s3Objects{
+	s := s3Objects{
 		Client: clnt,
-	}, nil
+	}
+	if len(minio.GlobalGatewaySSE) > 0 {
+		encS := s3EncObjects{s}
+		go encS.cleanupStaleMultipartUploads(context.Background(), minio.GlobalMultipartCleanupInterval, minio.GlobalMultipartExpiry, minio.GlobalServiceDoneCh)
+		return &encS, nil
+	}
+	return &s, nil
 }
 
 // Production - s3 gateway is production ready.
@@ -328,6 +335,7 @@ func (l *s3Objects) ListObjects(ctx context.Context, bucket string, prefix strin
 
 // ListObjectsV2 lists all blobs in S3 bucket filtered by prefix
 func (l *s3Objects) ListObjectsV2(ctx context.Context, bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (loi minio.ListObjectsV2Info, e error) {
+
 	result, err := l.Client.ListObjectsV2(bucket, prefix, continuationToken, fetchOwner, delimiter, maxKeys, startAfter)
 	if err != nil {
 		return loi, minio.ErrorRespToObjectError(err, bucket)
@@ -385,7 +393,6 @@ func (l *s3Objects) GetObject(ctx context.Context, bucket string, key string, st
 		return minio.ErrorRespToObjectError(err, bucket, key)
 	}
 	defer object.Close()
-
 	if _, err := io.Copy(writer, object); err != nil {
 		return minio.ErrorRespToObjectError(err, bucket, key)
 	}
@@ -394,7 +401,15 @@ func (l *s3Objects) GetObject(ctx context.Context, bucket string, key string, st
 
 // GetObjectInfo reads object info and replies back ObjectInfo
 func (l *s3Objects) GetObjectInfo(ctx context.Context, bucket string, object string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
-	oi, err := l.Client.StatObject(bucket, object, miniogo.StatObjectOptions{miniogo.GetObjectOptions{ServerSideEncryption: opts.ServerSideEncryption}})
+	// statOpts := miniogo.StatObjectOptions{}
+	// if opts.ServerSideEncryption != nil {
+	// 	statOpts.ServerSideEncryption = opts.ServerSideEncryption
+	// }
+	statOptions := miniogo.StatObjectOptions{miniogo.GetObjectOptions{
+		ServerSideEncryption: opts.ServerSideEncryption,
+	}}
+
+	oi, err := l.Client.StatObject(bucket, object, statOptions)
 	if err != nil {
 		return minio.ObjectInfo{}, minio.ErrorRespToObjectError(err, bucket, object)
 	}
@@ -423,6 +438,17 @@ func (l *s3Objects) CopyObject(ctx context.Context, srcBucket string, srcObject 
 	// So preserve it by adding "REPLACE" directive to save all the metadata set by CopyObject API.
 	srcInfo.UserDefined["x-amz-metadata-directive"] = "REPLACE"
 	srcInfo.UserDefined["x-amz-copy-source-if-match"] = srcInfo.ETag
+	header := make(http.Header)
+	if srcOpts.ServerSideEncryption != nil {
+		encrypt.SSECopy(srcOpts.ServerSideEncryption).Marshal(header)
+	}
+
+	if dstOpts.ServerSideEncryption != nil {
+		dstOpts.ServerSideEncryption.Marshal(header)
+	}
+	for k, v := range header {
+		srcInfo.UserDefined[k] = v[0]
+	}
 	if _, err = l.Client.CopyObject(srcBucket, srcObject, dstBucket, dstObject, srcInfo.UserDefined); err != nil {
 		return objInfo, minio.ErrorRespToObjectError(err, srcBucket, srcObject)
 	}
@@ -474,10 +500,21 @@ func (l *s3Objects) PutObjectPart(ctx context.Context, bucket string, object str
 // existing object or a part of it.
 func (l *s3Objects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject, uploadID string,
 	partID int, startOffset, length int64, srcInfo minio.ObjectInfo, srcOpts, dstOpts minio.ObjectOptions) (p minio.PartInfo, err error) {
-
 	srcInfo.UserDefined = map[string]string{
 		"x-amz-copy-source-if-match": srcInfo.ETag,
 	}
+	header := make(http.Header)
+	if srcOpts.ServerSideEncryption != nil {
+		encrypt.SSECopy(srcOpts.ServerSideEncryption).Marshal(header)
+	}
+
+	if dstOpts.ServerSideEncryption != nil {
+		dstOpts.ServerSideEncryption.Marshal(header)
+	}
+	for k, v := range header {
+		srcInfo.UserDefined[k] = v[0]
+	}
+
 	completePart, err := l.Client.CopyObjectPart(srcBucket, srcObject, destBucket, destObject,
 		uploadID, partID, startOffset, length, srcInfo.UserDefined)
 	if err != nil {
@@ -506,12 +543,11 @@ func (l *s3Objects) AbortMultipartUpload(ctx context.Context, bucket string, obj
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object
 func (l *s3Objects) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, uploadedParts []minio.CompletePart) (oi minio.ObjectInfo, e error) {
-	err := l.Client.CompleteMultipartUpload(bucket, object, uploadID, minio.ToMinioClientCompleteParts(uploadedParts))
+	etag, err := l.Client.CompleteMultipartUpload(bucket, object, uploadID, minio.ToMinioClientCompleteParts(uploadedParts))
 	if err != nil {
 		return oi, minio.ErrorRespToObjectError(err, bucket, object)
 	}
-
-	return l.GetObjectInfo(ctx, bucket, object, minio.ObjectOptions{})
+	return minio.ObjectInfo{ETag: etag}, nil
 }
 
 // SetBucketPolicy sets policy on bucket
@@ -552,4 +588,9 @@ func (l *s3Objects) DeleteBucketPolicy(ctx context.Context, bucket string) error
 // IsCompressionSupported returns whether compression is applicable for this layer.
 func (l *s3Objects) IsCompressionSupported() bool {
 	return false
+}
+
+// IsEncryptionSupported returns whether server side encryption is applicable for this layer.
+func (l *s3Objects) IsEncryptionSupported() bool {
+	return len(minio.GlobalGatewaySSE) > 0
 }

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -34,7 +34,6 @@ import (
 	"github.com/minio/minio-go/pkg/s3utils"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
-	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/policy"
 )
 
@@ -418,7 +417,8 @@ func (l *s3Objects) GetObjectInfo(ctx context.Context, bucket string, object str
 }
 
 // PutObject creates a new object with the incoming data,
-func (l *s3Objects) PutObject(ctx context.Context, bucket string, object string, data *hash.Reader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+func (l *s3Objects) PutObject(ctx context.Context, bucket string, object string, r *minio.PutObjectReader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	data := r.DataReader
 	oi, err := l.Client.PutObject(bucket, object, data, data.Size(), data.MD5Base64String(), data.SHA256HexString(), minio.ToMinioClientMetadata(metadata), opts.ServerSideEncryption)
 	if err != nil {
 		return objInfo, minio.ErrorRespToObjectError(err, bucket, object)
@@ -487,7 +487,8 @@ func (l *s3Objects) NewMultipartUpload(ctx context.Context, bucket string, objec
 }
 
 // PutObjectPart puts a part of object in bucket
-func (l *s3Objects) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *hash.Reader, opts minio.ObjectOptions) (pi minio.PartInfo, e error) {
+func (l *s3Objects) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, r *minio.PutObjectReader, opts minio.ObjectOptions) (pi minio.PartInfo, e error) {
+	data := r.DataReader
 	info, err := l.Client.PutObjectPart(bucket, object, uploadID, partID, data, data.Size(), data.MD5Base64String(), data.SHA256HexString(), opts.ServerSideEncryption)
 	if err != nil {
 		return pi, minio.ErrorRespToObjectError(err, bucket, object)
@@ -542,7 +543,7 @@ func (l *s3Objects) AbortMultipartUpload(ctx context.Context, bucket string, obj
 }
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object
-func (l *s3Objects) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, uploadedParts []minio.CompletePart) (oi minio.ObjectInfo, e error) {
+func (l *s3Objects) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, uploadedParts []minio.CompletePart, opts minio.ObjectOptions) (oi minio.ObjectInfo, e error) {
 	etag, err := l.Client.CompleteMultipartUpload(bucket, object, uploadID, minio.ToMinioClientCompleteParts(uploadedParts))
 	if err != nil {
 		return oi, minio.ErrorRespToObjectError(err, bucket, object)

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -527,10 +527,10 @@ func (l *s3Objects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, de
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket
-func (l *s3Objects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi minio.ListPartsInfo, e error) {
+func (l *s3Objects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int, opts minio.ObjectOptions) (lpi minio.ListPartsInfo, e error) {
 	result, err := l.Client.ListObjectParts(bucket, object, uploadID, partNumberMarker, maxParts)
 	if err != nil {
-		return lpi, err
+		return lpi, minio.ErrorRespToObjectError(err)
 	}
 
 	return minio.FromMinioClientListPartsInfo(result), nil

--- a/cmd/gateway/s3/gateway-s3_test.go
+++ b/cmd/gateway/s3/gateway-s3_test.go
@@ -110,8 +110,8 @@ func TestS3ToObjectError(t *testing.T) {
 		// Special test case for error that is not of type
 		// miniogo.ErrorResponse
 		{
-			inputErr:    fmt.Errorf("not a minio.ErrorResponse"),
-			expectedErr: fmt.Errorf("not a minio.ErrorResponse"),
+			inputErr:    fmt.Errorf("not a ErrorResponse"),
+			expectedErr: fmt.Errorf("not a ErrorResponse"),
 		},
 	}
 

--- a/cmd/gateway/sia/gateway-sia.go
+++ b/cmd/gateway/sia/gateway-sia.go
@@ -38,7 +38,6 @@ import (
 	minio "github.com/minio/minio/cmd"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
-	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/sha256-simd"
 )
 
@@ -554,7 +553,8 @@ func (s *siaObjects) GetObjectInfo(ctx context.Context, bucket string, object st
 }
 
 // PutObject creates a new object with the incoming data,
-func (s *siaObjects) PutObject(ctx context.Context, bucket string, object string, data *hash.Reader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+func (s *siaObjects) PutObject(ctx context.Context, bucket string, object string, r *minio.PutObjectReader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	data := r.DataReader
 	srcFile := path.Join(s.TempDir, minio.MustGetUUID())
 	writer, err := os.Create(srcFile)
 	if err != nil {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -78,9 +78,9 @@ const (
 	globalMaxSkewTime = 15 * time.Minute // 15 minutes skew allowed.
 
 	// Expiry duration after which the multipart uploads are deemed stale.
-	globalMultipartExpiry = time.Hour * 24 * 14 // 2 weeks.
+	GlobalMultipartExpiry = time.Hour * 24 * 14 // 2 weeks.
 	// Cleanup interval when the stale multipart cleanup is initiated.
-	globalMultipartCleanupInterval = time.Hour * 24 // 24 hrs.
+	GlobalMultipartCleanupInterval = time.Hour * 24 // 24 hrs.
 	// Refresh interval to update in-memory bucket policy cache.
 	globalRefreshBucketPolicyInterval = 5 * time.Minute
 	// Refresh interval to update in-memory iam config cache.
@@ -255,7 +255,10 @@ var (
 	// OPA policy system.
 	globalPolicyOPA *iampolicy.Opa
 
+	// GlobalGatewaySSE sse options
+	GlobalGatewaySSE []string
 	// Add new variable global values here.
+
 )
 
 // global colors.

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -78,7 +78,7 @@ func (sys *IAMSys) Init(objAPI ObjectLayer) error {
 			defer ticker.Stop()
 			for {
 				select {
-				case <-globalServiceDoneCh:
+				case <-GlobalServiceDoneCh:
 					return
 				case <-ticker.C:
 					sys.refresh(objAPI)

--- a/cmd/lock-rpc-server.go
+++ b/cmd/lock-rpc-server.go
@@ -166,7 +166,7 @@ func startLockMaintenance(lkSrv *lockRPCReceiver) {
 	for {
 		// Verifies every minute for locks held more than 2minutes.
 		select {
-		case <-globalServiceDoneCh:
+		case <-GlobalServiceDoneCh:
 			return
 		case <-ticker.C:
 			lkSrv.lockMaintenance(lockValidityCheckInterval)

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -103,7 +103,7 @@ type ObjectInfo struct {
 	UserDefined map[string]string
 
 	// List of individual parts, maximum size of upto 10,000
-	Parts []objectPartInfo `json:"-"`
+	Parts []ObjectPartInfo `json:"-"`
 
 	// Implements writer and reader used by CopyObject API
 	Writer       io.WriteCloser `json:"-"`

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -106,8 +106,10 @@ type ObjectInfo struct {
 	Parts []ObjectPartInfo `json:"-"`
 
 	// Implements writer and reader used by CopyObject API
-	Writer       io.WriteCloser `json:"-"`
-	Reader       *hash.Reader   `json:"-"`
+	Writer          io.WriteCloser   `json:"-"`
+	Reader          *hash.Reader     `json:"-"`
+	PutObjectReader *PutObjectReader `json:"-"`
+
 	metadataOnly bool
 
 	// Date and time when the object was last accessed.

--- a/cmd/object-api-deleteobject_test.go
+++ b/cmd/object-api-deleteobject_test.go
@@ -92,7 +92,7 @@ func testDeleteObject(obj ObjectLayer, instanceType string, t TestErrHandler) {
 
 		for _, object := range testCase.objectToUploads {
 			md5Bytes := md5.Sum([]byte(object.content))
-			_, err = obj.PutObject(context.Background(), testCase.bucketName, object.name, mustGetHashReader(t, bytes.NewBufferString(object.content),
+			_, err = obj.PutObject(context.Background(), testCase.bucketName, object.name, mustGetPutObjectReader(t, bytes.NewBufferString(object.content),
 				int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), nil, ObjectOptions{})
 			if err != nil {
 				t.Fatalf("%s : %s", instanceType, err.Error())

--- a/cmd/object-api-getobject_test.go
+++ b/cmd/object-api-getobject_test.go
@@ -75,7 +75,7 @@ func testGetObject(obj ObjectLayer, instanceType string, t TestErrHandler) {
 	// iterate through the above set of inputs and upkoad the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData["etag"], ""), input.metaData, ObjectOptions{})
+		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData["etag"], ""), input.metaData, ObjectOptions{})
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -220,7 +220,7 @@ func testGetObjectPermissionDenied(obj ObjectLayer, instanceType string, disks [
 	// iterate through the above set of inputs and upkoad the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData["etag"], ""), input.metaData, ObjectOptions{})
+		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData["etag"], ""), input.metaData, ObjectOptions{})
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -333,7 +333,7 @@ func testGetObjectDiskNotFound(obj ObjectLayer, instanceType string, disks []str
 	// iterate through the above set of inputs and upkoad the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData["etag"], ""), input.metaData, ObjectOptions{})
+		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData["etag"], ""), input.metaData, ObjectOptions{})
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)

--- a/cmd/object-api-getobjectinfo_test.go
+++ b/cmd/object-api-getobjectinfo_test.go
@@ -35,13 +35,13 @@ func testGetObjectInfo(obj ObjectLayer, instanceType string, t TestErrHandler) {
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}
 	opts := ObjectOptions{}
-	_, err = obj.PutObject(context.Background(), "test-getobjectinfo", "Asia/asiapics.jpg", mustGetHashReader(t, bytes.NewBufferString("asiapics"), int64(len("asiapics")), "", ""), nil, opts)
+	_, err = obj.PutObject(context.Background(), "test-getobjectinfo", "Asia/asiapics.jpg", mustGetPutObjectReader(t, bytes.NewBufferString("asiapics"), int64(len("asiapics")), "", ""), nil, opts)
 	if err != nil {
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}
 
 	// Put an empty directory
-	_, err = obj.PutObject(context.Background(), "test-getobjectinfo", "Asia/empty-dir/", mustGetHashReader(t, bytes.NewBufferString(""), int64(len("")), "", ""), nil, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), "test-getobjectinfo", "Asia/empty-dir/", mustGetPutObjectReader(t, bytes.NewBufferString(""), int64(len("")), "", ""), nil, opts)
 	if err != nil {
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}

--- a/cmd/object-api-getobjectinfo_test.go
+++ b/cmd/object-api-getobjectinfo_test.go
@@ -41,7 +41,7 @@ func testGetObjectInfo(obj ObjectLayer, instanceType string, t TestErrHandler) {
 	}
 
 	// Put an empty directory
-	_, err = obj.PutObject(context.Background(), "test-getobjectinfo", "Asia/empty-dir/", mustGetHashReader(t, bytes.NewBufferString(""), int64(len("")), "", ""), nil, opts)
+	_, err = obj.PutObject(context.Background(), "test-getobjectinfo", "Asia/empty-dir/", mustGetHashReader(t, bytes.NewBufferString(""), int64(len("")), "", ""), nil, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -28,9 +28,11 @@ import (
 
 // ObjectOptions represents object options for ObjectLayer operations
 type ObjectOptions struct {
-	ServerSideEncryption encrypt.ServerSide
-	ValidateETagsFn      ValidateETagsFn
-	GetEncryptedETagFn   GetEncryptedETagFn
+	ServerSideEncryption  encrypt.ServerSide
+	ValidateETagsFn       ValidateETagsFn
+	CreateEncryptedETagFn CreateEncryptedETagFn
+	GetEncryptedETagFn    GetEncryptedETagFn
+	GetDecryptedETagFn    GetDecryptedETagFn
 }
 
 // LockType represents required locking for ObjectLayer operations
@@ -47,6 +49,12 @@ type ValidateETagsFn func(string, string) bool
 
 // GetEncryptedETagFn type gets encrypted ETag
 type GetEncryptedETagFn func(string) string
+
+// CreateEncryptedETagFn type creates encrypted MD5Sum of content MD5Sum
+type CreateEncryptedETagFn func() (string, string, error)
+
+// GetDecryptedETagFn type gets decrypted ETag from encrypted ETag
+type GetDecryptedETagFn func(string) string
 
 // ObjectLayer implements primitives for object API layer.
 type ObjectLayer interface {
@@ -83,7 +91,7 @@ type ObjectLayer interface {
 	CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject string, uploadID string, partID int,
 		startOffset int64, length int64, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (info PartInfo, err error)
 	PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *PutObjectReader, opts ObjectOptions) (info PartInfo, err error)
-	ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error)
+	ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int, opts ObjectOptions) (result ListPartsInfo, err error)
 	AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string) error
 	CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (objInfo ObjectInfo, err error)
 

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -70,7 +70,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t TestErrHandler) {
 	}
 	for _, object := range testObjects {
 		md5Bytes := md5.Sum([]byte(object.content))
-		_, err = obj.PutObject(context.Background(), testBuckets[0], object.name, mustGetHashReader(t, bytes.NewBufferString(object.content),
+		_, err = obj.PutObject(context.Background(), testBuckets[0], object.name, mustGetPutObjectReader(t, bytes.NewBufferString(object.content),
 			int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), object.meta, ObjectOptions{})
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err.Error())
@@ -617,7 +617,7 @@ func BenchmarkListObjects(b *testing.B) {
 	// Insert objects to be listed and benchmarked later.
 	for i := 0; i < 20000; i++ {
 		key := "obj" + strconv.Itoa(i)
-		_, err = obj.PutObject(context.Background(), bucket, key, mustGetHashReader(b, bytes.NewBufferString(key), int64(len(key)), "", ""), nil, ObjectOptions{})
+		_, err = obj.PutObject(context.Background(), bucket, key, mustGetPutObjectReader(b, bytes.NewBufferString(key), int64(len(key)), "", ""), nil, ObjectOptions{})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1429,7 +1429,7 @@ func testListObjectPartsDiskNotFound(obj ObjectLayer, instanceType string, disks
 	}
 
 	for i, testCase := range testCases {
-		actualResult, actualErr := obj.ListObjectParts(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.partNumberMarker, testCase.maxParts)
+		actualResult, actualErr := obj.ListObjectParts(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.partNumberMarker, testCase.maxParts, ObjectOptions{})
 		if actualErr != nil && testCase.shouldPass {
 			t.Errorf("Test %d: %s: Expected to pass, but failed with: <ERROR> %s", i+1, instanceType, actualErr.Error())
 		}
@@ -1667,7 +1667,7 @@ func testListObjectParts(obj ObjectLayer, instanceType string, t TestErrHandler)
 	}
 
 	for i, testCase := range testCases {
-		actualResult, actualErr := obj.ListObjectParts(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.partNumberMarker, testCase.maxParts)
+		actualResult, actualErr := obj.ListObjectParts(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.partNumberMarker, testCase.maxParts, ObjectOptions{})
 		if actualErr != nil && testCase.shouldPass {
 			t.Errorf("Test %d: %s: Expected to pass, but failed with: <ERROR> %s", i+1, instanceType, actualErr.Error())
 		}

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -221,7 +221,7 @@ func testPutObjectPartDiskNotFound(obj ObjectLayer, instanceType string, disks [
 	sha256sum := ""
 	// Iterating over creatPartCases to generate multipart chunks.
 	for _, testCase := range createPartCases {
-		_, err = obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetHashReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), ObjectOptions{})
+		_, err = obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetPutObjectReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), ObjectOptions{})
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err.Error())
 		}
@@ -235,7 +235,7 @@ func testPutObjectPartDiskNotFound(obj ObjectLayer, instanceType string, disks [
 
 	// Object part upload should fail with quorum not available.
 	testCase := createPartCases[len(createPartCases)-1]
-	_, err = obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetHashReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), ObjectOptions{})
+	_, err = obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetPutObjectReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), ObjectOptions{})
 	if err == nil {
 		t.Fatalf("Test %s: expected to fail but passed instead", instanceType)
 	}
@@ -354,7 +354,7 @@ func testObjectAPIPutObjectPart(obj ObjectLayer, instanceType string, t TestErrH
 
 	// Validate all the test cases.
 	for i, testCase := range testCases {
-		actualInfo, actualErr := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetHashReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, testCase.inputSHA256), opts)
+		actualInfo, actualErr := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetPutObjectReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, testCase.inputSHA256), opts)
 		// All are test cases above are expected to fail.
 		if actualErr != nil && testCase.shouldPass {
 			t.Errorf("Test %d: %s: Expected to pass, but failed with: <ERROR> %s.", i+1, instanceType, actualErr.Error())
@@ -488,7 +488,7 @@ func testListMultipartUploads(obj ObjectLayer, instanceType string, t TestErrHan
 	sha256sum := ""
 	// Iterating over creatPartCases to generate multipart chunks.
 	for _, testCase := range createPartCases {
-		_, err := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetHashReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), opts)
+		_, err := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetPutObjectReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), opts)
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err.Error())
 		}
@@ -1309,7 +1309,7 @@ func testListObjectPartsDiskNotFound(obj ObjectLayer, instanceType string, disks
 	sha256sum := ""
 	// Iterating over creatPartCases to generate multipart chunks.
 	for _, testCase := range createPartCases {
-		_, err := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetHashReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), opts)
+		_, err := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetPutObjectReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), opts)
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err.Error())
 		}
@@ -1550,7 +1550,7 @@ func testListObjectParts(obj ObjectLayer, instanceType string, t TestErrHandler)
 	sha256sum := ""
 	// Iterating over creatPartCases to generate multipart chunks.
 	for _, testCase := range createPartCases {
-		_, err := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetHashReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), opts)
+		_, err := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetPutObjectReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), opts)
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err.Error())
 		}
@@ -1801,7 +1801,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 	sha256sum := ""
 	// Iterating over creatPartCases to generate multipart chunks.
 	for _, part := range parts {
-		_, err = obj.PutObjectPart(context.Background(), part.bucketName, part.objName, part.uploadID, part.PartID, mustGetHashReader(t, bytes.NewBufferString(part.inputReaderData), part.intputDataSize, part.inputMd5, sha256sum), opts)
+		_, err = obj.PutObjectPart(context.Background(), part.bucketName, part.objName, part.uploadID, part.PartID, mustGetPutObjectReader(t, bytes.NewBufferString(part.inputReaderData), part.intputDataSize, part.inputMd5, sha256sum), opts)
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err)
 		}
@@ -1904,7 +1904,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 	}
 
 	for i, testCase := range testCases {
-		actualResult, actualErr := obj.CompleteMultipartUpload(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.parts)
+		actualResult, actualErr := obj.CompleteMultipartUpload(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.parts, ObjectOptions{})
 		if actualErr != nil && testCase.shouldPass {
 			t.Errorf("Test %d: %s: Expected to pass, but failed with: <ERROR> %s", i+1, instanceType, actualErr)
 		}

--- a/cmd/object-api-putobject_test.go
+++ b/cmd/object-api-putobject_test.go
@@ -172,7 +172,7 @@ func testObjectAPIPutObject(obj ObjectLayer, instanceType string, t TestErrHandl
 	}
 
 	for i, testCase := range testCases {
-		objInfo, actualErr := obj.PutObject(context.Background(), testCase.bucketName, testCase.objName, mustGetHashReader(t, bytes.NewReader(testCase.inputData), testCase.intputDataSize, testCase.inputMeta["etag"], testCase.inputSHA256), testCase.inputMeta, ObjectOptions{})
+		objInfo, actualErr := obj.PutObject(context.Background(), testCase.bucketName, testCase.objName, mustGetPutObjectReader(t, bytes.NewReader(testCase.inputData), testCase.intputDataSize, testCase.inputMeta["etag"], testCase.inputSHA256), testCase.inputMeta, ObjectOptions{})
 		if actualErr != nil && testCase.expectedError == nil {
 			t.Errorf("Test %d: %s: Expected to pass, but failed with: error %s.", i+1, instanceType, actualErr.Error())
 		}
@@ -245,7 +245,7 @@ func testObjectAPIPutObjectDiskNotFound(obj ObjectLayer, instanceType string, di
 
 	sha256sum := ""
 	for i, testCase := range testCases {
-		objInfo, actualErr := obj.PutObject(context.Background(), testCase.bucketName, testCase.objName, mustGetHashReader(t, bytes.NewReader(testCase.inputData), testCase.intputDataSize, testCase.inputMeta["etag"], sha256sum), testCase.inputMeta, ObjectOptions{})
+		objInfo, actualErr := obj.PutObject(context.Background(), testCase.bucketName, testCase.objName, mustGetPutObjectReader(t, bytes.NewReader(testCase.inputData), testCase.intputDataSize, testCase.inputMeta["etag"], sha256sum), testCase.inputMeta, ObjectOptions{})
 		if actualErr != nil && testCase.shouldPass {
 			t.Errorf("Test %d: %s: Expected to pass, but failed with: <ERROR> %s.", i+1, instanceType, actualErr.Error())
 		}
@@ -294,7 +294,7 @@ func testObjectAPIPutObjectDiskNotFound(obj ObjectLayer, instanceType string, di
 		InsufficientWriteQuorum{},
 	}
 
-	_, actualErr := obj.PutObject(context.Background(), testCase.bucketName, testCase.objName, mustGetHashReader(t, bytes.NewReader(testCase.inputData), testCase.intputDataSize, testCase.inputMeta["etag"], sha256sum), testCase.inputMeta, ObjectOptions{})
+	_, actualErr := obj.PutObject(context.Background(), testCase.bucketName, testCase.objName, mustGetPutObjectReader(t, bytes.NewReader(testCase.inputData), testCase.intputDataSize, testCase.inputMeta["etag"], sha256sum), testCase.inputMeta, ObjectOptions{})
 	if actualErr != nil && testCase.shouldPass {
 		t.Errorf("Test %d: %s: Expected to pass, but failed with: <ERROR> %s.", len(testCases)+1, instanceType, actualErr.Error())
 	}
@@ -326,7 +326,7 @@ func testObjectAPIPutObjectStaleFiles(obj ObjectLayer, instanceType string, disk
 
 	data := []byte("hello, world")
 	// Create object.
-	_, err = obj.PutObject(context.Background(), bucket, object, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), nil, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucket, object, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), nil, ObjectOptions{})
 	if err != nil {
 		// Failed to create object, abort.
 		t.Fatalf("%s : %s", instanceType, err.Error())
@@ -371,7 +371,7 @@ func testObjectAPIMultipartPutObjectStaleFiles(obj ObjectLayer, instanceType str
 	md5Writer.Write(fiveMBBytes)
 	etag1 := hex.EncodeToString(md5Writer.Sum(nil))
 	sha256sum := ""
-	_, err = obj.PutObjectPart(context.Background(), bucket, object, uploadID, 1, mustGetHashReader(t, bytes.NewReader(fiveMBBytes), int64(len(fiveMBBytes)), etag1, sha256sum), opts)
+	_, err = obj.PutObjectPart(context.Background(), bucket, object, uploadID, 1, mustGetPutObjectReader(t, bytes.NewReader(fiveMBBytes), int64(len(fiveMBBytes)), etag1, sha256sum), opts)
 	if err != nil {
 		// Failed to upload object part, abort.
 		t.Fatalf("%s : %s", instanceType, err.Error())
@@ -382,7 +382,7 @@ func testObjectAPIMultipartPutObjectStaleFiles(obj ObjectLayer, instanceType str
 	md5Writer = md5.New()
 	md5Writer.Write(data)
 	etag2 := hex.EncodeToString(md5Writer.Sum(nil))
-	_, err = obj.PutObjectPart(context.Background(), bucket, object, uploadID, 2, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), etag2, sha256sum), opts)
+	_, err = obj.PutObjectPart(context.Background(), bucket, object, uploadID, 2, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), etag2, sha256sum), opts)
 	if err != nil {
 		// Failed to upload object part, abort.
 		t.Fatalf("%s : %s", instanceType, err.Error())
@@ -393,7 +393,7 @@ func testObjectAPIMultipartPutObjectStaleFiles(obj ObjectLayer, instanceType str
 		{ETag: etag1, PartNumber: 1},
 		{ETag: etag2, PartNumber: 2},
 	}
-	_, err = obj.CompleteMultipartUpload(context.Background(), bucket, object, uploadID, parts)
+	_, err = obj.CompleteMultipartUpload(context.Background(), bucket, object, uploadID, parts, ObjectOptions{})
 	if err != nil {
 		// Failed to complete multipart upload, abort.
 		t.Fatalf("%s : %s", instanceType, err.Error())

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -597,3 +597,17 @@ func (g *GetObjectReader) Read(p []byte) (n int, err error) {
 	}
 	return
 }
+
+// CleanMinioInternalMetadataKeys removes X-Amz-Meta- prefix from minio internal
+// encryption metadata that was sent by minio gateway
+func CleanMinioInternalMetadataKeys(metadata map[string]string) map[string]string {
+	var newMeta = make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		if strings.HasPrefix(k, "X-Amz-Meta-X-Minio-Internal-") {
+			newMeta[strings.TrimPrefix(k, "X-Amz-Meta-")] = v
+		} else {
+			newMeta[k] = v
+		}
+	}
+	return newMeta
+}

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -431,7 +431,7 @@ func TestGetActualSize(t *testing.T) {
 					"X-Minio-Internal-actual-size": "100000001",
 					"content-type":                 "application/octet-stream",
 					"etag":                         "b3ff3ef3789147152fbfbc50efba4bfd-2"},
-				Parts: []objectPartInfo{
+				Parts: []ObjectPartInfo{
 					{
 						Size:       39235668,
 						ActualSize: 67108864,
@@ -450,7 +450,7 @@ func TestGetActualSize(t *testing.T) {
 					"X-Minio-Internal-actual-size": "841",
 					"content-type":                 "application/octet-stream",
 					"etag":                         "b3ff3ef3789147152fbfbc50efba4bfd-2"},
-				Parts: []objectPartInfo{},
+				Parts: []ObjectPartInfo{},
 			},
 			result: 841,
 		},
@@ -459,7 +459,7 @@ func TestGetActualSize(t *testing.T) {
 				UserDefined: map[string]string{"X-Minio-Internal-compression": "golang/snappy/LZ77",
 					"content-type": "application/octet-stream",
 					"etag":         "b3ff3ef3789147152fbfbc50efba4bfd-2"},
-				Parts: []objectPartInfo{},
+				Parts: []ObjectPartInfo{},
 			},
 			result: -1,
 		},
@@ -482,7 +482,7 @@ func TestGetCompressedOffsets(t *testing.T) {
 	}{
 		{
 			objInfo: ObjectInfo{
-				Parts: []objectPartInfo{
+				Parts: []ObjectPartInfo{
 					{
 						Size:       39235668,
 						ActualSize: 67108864,
@@ -499,7 +499,7 @@ func TestGetCompressedOffsets(t *testing.T) {
 		},
 		{
 			objInfo: ObjectInfo{
-				Parts: []objectPartInfo{
+				Parts: []ObjectPartInfo{
 					{
 						Size:       39235668,
 						ActualSize: 67108864,
@@ -516,7 +516,7 @@ func TestGetCompressedOffsets(t *testing.T) {
 		},
 		{
 			objInfo: ObjectInfo{
-				Parts: []objectPartInfo{
+				Parts: []ObjectPartInfo{
 					{
 						Size:       39235668,
 						ActualSize: 67108864,

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -31,10 +31,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/minio/minio-go/pkg/encrypt"
+
 	snappy "github.com/golang/snappy"
 	"github.com/gorilla/mux"
 	miniogo "github.com/minio/minio-go"
-	"github.com/minio/minio-go/pkg/encrypt"
 	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/dns"
@@ -169,6 +170,12 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 	getObjectNInfo := objectAPI.GetObjectNInfo
 	if api.CacheAPI() != nil {
 		getObjectNInfo = api.CacheAPI().GetObjectNInfo
+	}
+
+	opts, err = getEncryptionOpts(r, bucket, object)
+	if err != nil {
+		writeErrorResponseHeadersOnly(w, toAPIErrorCode(err))
+		return
 	}
 
 	gr, err := getObjectNInfo(ctx, bucket, object, nil, r.Header, readLock, opts)
@@ -308,7 +315,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 	object := vars["object"]
-	// get gateway encryption options
+	// get encryption options
 	opts, err := getEncryptionOpts(r, bucket, object)
 	if err != nil {
 		writeErrorResponseHeadersOnly(w, toAPIErrorCode(err))
@@ -384,7 +391,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 
 	if objectAPI.IsEncryptionSupported() {
 		objInfo.UserDefined = CleanMinioInternalMetadataKeys(objInfo.UserDefined)
-		if _, err = DecryptObjectInfo(objInfo, r.Header); err != nil {
+		if _, err = DecryptObjectInfo(&objInfo, r.Header); err != nil {
 			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 			return
 		}
@@ -551,7 +558,7 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 
 	if objectAPI.IsEncryptionSupported() {
 		objInfo.UserDefined = CleanMinioInternalMetadataKeys(objInfo.UserDefined)
-		if _, err = DecryptObjectInfo(objInfo, r.Header); err != nil {
+		if _, err = DecryptObjectInfo(&objInfo, r.Header); err != nil {
 			writeErrorResponseHeadersOnly(w, toAPIErrorCode(err))
 			return
 		}
@@ -833,6 +840,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
 	}
+	pReader := NewPutObjectReader(srcInfo.Reader)
 
 	var encMetadata = make(map[string]string)
 	if objectAPI.IsEncryptionSupported() && !isCompressed {
@@ -904,9 +912,8 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 			case isSourceEncrypted && !isTargetEncrypted:
 				targetSize, _ = srcInfo.DecryptedSize()
 			}
-
 			if isTargetEncrypted {
-				reader, err = newEncryptReader(reader, newKey, dstBucket, dstObject, encMetadata, sseS3)
+				reader, err = newEncryptReader(srcInfo.Reader, newKey, dstBucket, dstObject, encMetadata, sseS3)
 				if err != nil {
 					writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 					return
@@ -924,6 +931,8 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
+			pReader.DataReader = srcInfo.Reader
+			srcInfo.PutObjectReader = pReader
 		}
 	}
 	srcInfo.UserDefined, err = getCpObjMetadataFromHeader(ctx, r, srcInfo.UserDefined)
@@ -998,7 +1007,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	response := generateCopyObjectResponse(objInfo.ETag, objInfo.ModTime)
+	response := generateCopyObjectResponse(getDecryptedETag(r.Header, objInfo, false), objInfo.ModTime)
 	encodedSuccessResponse := encodeResponse(response)
 
 	// Write success response.
@@ -1029,7 +1038,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		logger.GetReqInfo(ctx).SetTags(k, v)
 	}
 
-	logger.GetReqInfo(ctx).SetTags("etag", objInfo.ETag)
+	logger.GetReqInfo(ctx).SetTags("etag", getDecryptedETag(r.Header, objInfo, false))
 }
 
 // PutObjectHandler - PUT Object
@@ -1079,7 +1088,6 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		writeErrorResponse(w, ErrInvalidDigest, r.URL)
 		return
 	}
-
 	/// if Content-Length is unknown/missing, deny the request
 	size := r.ContentLength
 	rAuthType := getRequestAuthType(r)
@@ -1216,6 +1224,8 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		writeErrorResponseHeadersOnly(w, toAPIErrorCode(err))
 		return
 	}
+	pReader := NewPutObjectReader(hashReader)
+
 	// Deny if WORM is enabled
 	if globalWORMEnabled {
 		if _, err = objectAPI.GetObjectInfo(ctx, bucket, object, opts); err == nil {
@@ -1237,6 +1247,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
+			pReader.DataReader = hashReader
 		}
 	}
 
@@ -1248,7 +1259,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	// Create the object..
-	objInfo, err := putObject(ctx, bucket, object, hashReader, metadata, opts)
+	objInfo, err := putObject(ctx, bucket, object, pReader, metadata, opts)
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
@@ -1258,8 +1269,11 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		// Ignore compressed ETag.
 		objInfo.ETag = objInfo.ETag + "-1"
 	}
-
-	w.Header().Set("ETag", "\""+objInfo.ETag+"\"")
+	if hasServerSideEncryptionHeader(r.Header) {
+		w.Header().Set("ETag", "\""+getDecryptedETag(r.Header, objInfo, false)+"\"")
+	} else {
+		w.Header().Set("ETag", "\""+objInfo.ETag+"\"")
+	}
 	if objectAPI.IsEncryptionSupported() {
 		if crypto.IsEncrypted(objInfo.UserDefined) {
 			switch {
@@ -1324,11 +1338,8 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 	object := vars["object"]
-	// get gateway encryption options
-	var opts ObjectOptions
-	var err error
-
-	opts, err = putEncryptionOpts(r, bucket, object, nil)
+	// get encryption options
+	opts, err := putEncryptionOpts(r, bucket, object, nil)
 	if err != nil {
 		writeErrorResponseHeadersOnly(w, toAPIErrorCode(err))
 		return
@@ -1751,7 +1762,6 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		s3Error   APIErrorCode
 	)
 	reader = r.Body
-
 	if s3Error = isPutAllowed(rAuthType, bucket, object, r); s3Error != ErrNone {
 		writeErrorResponse(w, s3Error, r.URL)
 		return
@@ -1827,7 +1837,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	// get gateway encryption options
+	// get encryption options
 	var opts ObjectOptions
 	if crypto.SSEC.IsRequested(r.Header) {
 		opts, err = putEncryptionOpts(r, bucket, object, nil)
@@ -1836,6 +1846,8 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 			return
 		}
 	}
+	pReader := NewPutObjectReader(hashReader)
+
 	// Deny if WORM is enabled
 	if globalWORMEnabled {
 		if _, err = objectAPI.GetObjectInfo(ctx, bucket, object, opts); err == nil {
@@ -1845,6 +1857,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	}
 
 	isEncrypted := false
+	var objectEncryptionKey []byte
 	if objectAPI.IsEncryptionSupported() && !isCompressed {
 		var li ListPartsInfo
 		li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1)
@@ -1854,7 +1867,6 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		}
 		li.UserDefined = CleanMinioInternalMetadataKeys(li.UserDefined)
 		if crypto.IsEncrypted(li.UserDefined) {
-			isEncrypted = true
 			if !crypto.SSEC.IsRequested(r.Header) && crypto.SSEC.IsEncrypted(li.UserDefined) {
 				writeErrorResponse(w, ErrSSEMultipartEncrypted, r.URL)
 				return
@@ -1864,6 +1876,8 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
+			isEncrypted = true // to detect SSE-S3 encryption
+
 			var key []byte
 			if crypto.SSEC.IsRequested(r.Header) {
 				key, err = ParseSSECustomerRequest(r)
@@ -1874,7 +1888,6 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 			}
 
 			// Calculating object encryption key
-			var objectEncryptionKey []byte
 			objectEncryptionKey, err = decryptObjectInfo(key, bucket, object, li.UserDefined)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -1893,13 +1906,14 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
-
+			pReader.OrigReader.SetEncryptionKey(objectEncryptionKey)
 			info := ObjectInfo{Size: size}
 			hashReader, err = hash.NewReader(reader, info.EncryptedSize(), "", "", size) // do not try to verify encrypted content
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
+			pReader.DataReader = hashReader
 		}
 	}
 
@@ -1907,7 +1921,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	if api.CacheAPI() != nil && !isEncrypted {
 		putObjectPart = api.CacheAPI().PutObjectPart
 	}
-	partInfo, err := putObjectPart(ctx, bucket, object, uploadID, partID, hashReader, opts)
+	partInfo, err := putObjectPart(ctx, bucket, object, uploadID, partID, pReader, opts)
 	if err != nil {
 		// Verify if the underlying error is signature mismatch.
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -1918,8 +1932,13 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		// Suppress compressed ETag.
 		partInfo.ETag = partInfo.ETag + "-1"
 	}
+
 	if partInfo.ETag != "" {
-		w.Header().Set("ETag", "\""+partInfo.ETag+"\"")
+		if isEncrypted {
+			w.Header().Set("ETag", "\""+tryDecryptETag(objectEncryptionKey, partInfo.ETag, crypto.SSEC.IsRequested(r.Header))+"\"")
+		} else {
+			w.Header().Set("ETag", "\""+partInfo.ETag+"\"")
+		}
 	}
 
 	writeSuccessResponseHeadersOnly(w)
@@ -2009,6 +2028,39 @@ func (api objectAPIHandlers) ListObjectPartsHandler(w http.ResponseWriter, r *ht
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
 	}
+
+	var ssec bool
+	if objectAPI.IsEncryptionSupported() {
+		var li ListPartsInfo
+		li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1)
+		if err != nil {
+			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+			return
+		}
+		if crypto.IsEncrypted(li.UserDefined) {
+			var key []byte
+			if crypto.SSEC.IsEncrypted(li.UserDefined) {
+				ssec = true
+			}
+			var objectEncryptionKey []byte
+			if crypto.S3.IsEncrypted(li.UserDefined) {
+				// Calculating object encryption key
+				objectEncryptionKey, err = decryptObjectInfo(key, bucket, object, li.UserDefined)
+				if err != nil {
+					writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+					return
+				}
+			}
+			parts := make([]PartInfo, len(listPartsInfo.Parts))
+			for _, p := range listPartsInfo.Parts {
+				part := p
+				part.ETag = tryDecryptETag(objectEncryptionKey, p.ETag, ssec)
+				parts = append(parts, part)
+			}
+			listPartsInfo.Parts = parts
+		}
+	}
+
 	response := generateListPartsResponse(listPartsInfo)
 	encodedSuccessResponse := encodeResponse(response)
 
@@ -2070,6 +2122,29 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 		writeErrorResponse(w, ErrInvalidPartOrder, r.URL)
 		return
 	}
+	var objectEncryptionKey []byte
+	var opts ObjectOptions
+	if objectAPI.IsEncryptionSupported() {
+		var li ListPartsInfo
+		li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1)
+		if err != nil {
+			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+			return
+		}
+		if crypto.IsEncrypted(li.UserDefined) {
+			var key []byte
+
+			if crypto.S3.IsEncrypted(li.UserDefined) {
+				// Calculating object encryption key
+				objectEncryptionKey, err = decryptObjectInfo(key, bucket, object, li.UserDefined)
+				if err != nil {
+					writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+					return
+				}
+			}
+			opts = UnsealETagFn(objectEncryptionKey, crypto.SSEC.IsEncrypted(li.UserDefined))
+		}
+	}
 
 	// Complete parts.
 	var completeParts []CompletePart
@@ -2087,7 +2162,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 	if api.CacheAPI() != nil {
 		completeMultiPartUpload = api.CacheAPI().CompleteMultipartUpload
 	}
-	objInfo, err := completeMultiPartUpload(ctx, bucket, object, uploadID, completeParts)
+	objInfo, err := completeMultiPartUpload(ctx, bucket, object, uploadID, completeParts, opts)
 	if err != nil {
 		switch oErr := err.(type) {
 		case PartTooSmall:

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -395,6 +395,21 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 			return
 		}
+		if crypto.IsEncrypted(objInfo.UserDefined) {
+			var key, objectEncryptionKey []byte
+
+			if crypto.S3.IsEncrypted(objInfo.UserDefined) {
+				// Calculating object encryption key
+				objectEncryptionKey, err = decryptObjectInfo(key, bucket, object, objInfo.UserDefined)
+				if err != nil {
+					writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+					return
+				}
+			}
+			// needed for gateway decryption of part ETag
+			opts.UnsealETagFn(objectEncryptionKey, crypto.SSEC.IsEncrypted(objInfo.UserDefined))
+			opts.SetETagEncryptionOpts(nil)
+		}
 	}
 
 	// Validate pre-conditions if any.
@@ -754,7 +769,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	var rs *HTTPRangeSpec
-	gr, err := getObjectNInfo(ctx, srcBucket, srcObject, rs, r.Header, lock, srcOpts)
+	gr, err := getObjectNInfo(ctx, srcBucket, srcObject, rs, r.Header, lock, getOpts)
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
@@ -933,6 +948,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 			}
 			pReader.DataReader = srcInfo.Reader
 			srcInfo.PutObjectReader = pReader
+			dstOpts.SetETagEncryptionOpts(srcInfo.PutObjectReader)
 		}
 	}
 	srcInfo.UserDefined, err = getCpObjMetadataFromHeader(ctx, r, srcInfo.UserDefined)
@@ -1248,6 +1264,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 				return
 			}
 			pReader.DataReader = hashReader
+			opts.SetETagEncryptionOpts(pReader)
 		}
 	}
 
@@ -1264,7 +1281,6 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
 	}
-
 	if objInfo.IsCompressed() {
 		// Ignore compressed ETag.
 		objInfo.ETag = objInfo.ETag + "-1"
@@ -1493,12 +1509,6 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	srcInfo, err := objectAPI.GetObjectInfo(ctx, srcBucket, srcObject, getOpts)
-	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
-
 	// Deny if WORM is enabled
 	if globalWORMEnabled {
 		if _, err = objectAPI.GetObjectInfo(ctx, dstBucket, dstObject, dstOpts); err == nil {
@@ -1534,7 +1544,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	defer gr.Close()
-	srcInfo = gr.ObjInfo
+	srcInfo := gr.ObjInfo
 
 	actualPartSize := srcInfo.Size
 	if crypto.IsEncrypted(srcInfo.UserDefined) {
@@ -1573,7 +1583,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 	var reader io.Reader
 
 	var li ListPartsInfo
-	li, err = objectAPI.ListObjectParts(ctx, dstBucket, dstObject, uploadID, 0, 1)
+	li, err = objectAPI.ListObjectParts(ctx, dstBucket, dstObject, uploadID, 0, 1, dstOpts)
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
@@ -1608,9 +1618,11 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
 	}
-
-	if objectAPI.IsEncryptionSupported() && !isCompressed {
-		li, lerr := objectAPI.ListObjectParts(ctx, dstBucket, dstObject, uploadID, 0, 1)
+	pReader := NewPutObjectReader(srcInfo.Reader)
+	isEncrypted := false
+	var objectEncryptionKey []byte
+	if objectAPI.IsEncryptionSupported() && !srcInfo.IsCompressed() {
+		li, lerr := objectAPI.ListObjectParts(ctx, dstBucket, dstObject, uploadID, 0, 1, dstOpts)
 		if lerr != nil {
 			writeErrorResponse(w, toAPIErrorCode(lerr), r.URL)
 			return
@@ -1622,8 +1634,13 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 			return
 		}
 		if crypto.IsEncrypted(li.UserDefined) {
+			isEncrypted = true
 			if !crypto.SSEC.IsRequested(r.Header) && crypto.SSEC.IsEncrypted(li.UserDefined) {
 				writeErrorResponse(w, ErrSSEMultipartEncrypted, r.URL)
+				return
+			}
+			if crypto.S3.IsEncrypted(li.UserDefined) && crypto.SSEC.IsRequested(r.Header) {
+				writeErrorResponse(w, ErrIncompatibleEncryptionMethod, r.URL)
 				return
 			}
 			var key []byte
@@ -1634,7 +1651,6 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 					return
 				}
 			}
-			var objectEncryptionKey []byte
 			objectEncryptionKey, err = decryptObjectInfo(key, dstBucket, dstObject, li.UserDefined)
 			if err != nil {
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
@@ -1659,8 +1675,12 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
+			pReader.OrigReader.SetEncryptionKey(objectEncryptionKey)
+			pReader.DataReader = srcInfo.Reader
+			dstOpts.SetETagEncryptionOpts(pReader)
 		}
 	}
+	srcInfo.PutObjectReader = pReader
 
 	// Copy source object to destination, if source and destination
 	// object is same then only metadata is updated.
@@ -1669,6 +1689,9 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
+	}
+	if isEncrypted {
+		partInfo.ETag = tryDecryptETag(objectEncryptionKey, partInfo.ETag, crypto.SSEC.IsRequested(r.Header))
 	}
 
 	response := generateCopyObjectPartResponse(partInfo.ETag, partInfo.LastModified)
@@ -1795,8 +1818,17 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	var pipeReader *io.PipeReader
 	var pipeWriter *io.PipeWriter
 
+	// get encryption options
+	var opts ObjectOptions
+	if crypto.SSEC.IsRequested(r.Header) {
+		opts, err = putEncryptionOpts(r, bucket, object, nil)
+		if err != nil {
+			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
+			return
+		}
+	}
 	var li ListPartsInfo
-	li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1)
+	li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1, opts)
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
@@ -1836,9 +1868,9 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
 	}
+	pReader := NewPutObjectReader(hashReader)
 
-	// get encryption options
-	var opts ObjectOptions
+	// set encryption options
 	if crypto.SSEC.IsRequested(r.Header) {
 		opts, err = putEncryptionOpts(r, bucket, object, nil)
 		if err != nil {
@@ -1846,8 +1878,6 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 			return
 		}
 	}
-	pReader := NewPutObjectReader(hashReader)
-
 	// Deny if WORM is enabled
 	if globalWORMEnabled {
 		if _, err = objectAPI.GetObjectInfo(ctx, bucket, object, opts); err == nil {
@@ -1859,12 +1889,6 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	isEncrypted := false
 	var objectEncryptionKey []byte
 	if objectAPI.IsEncryptionSupported() && !isCompressed {
-		var li ListPartsInfo
-		li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1)
-		if err != nil {
-			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-			return
-		}
 		li.UserDefined = CleanMinioInternalMetadataKeys(li.UserDefined)
 		if crypto.IsEncrypted(li.UserDefined) {
 			if !crypto.SSEC.IsRequested(r.Header) && crypto.SSEC.IsEncrypted(li.UserDefined) {
@@ -1893,7 +1917,6 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
-
 			var partIDbin [4]byte
 			binary.LittleEndian.PutUint32(partIDbin[:], uint32(partID)) // marshal part ID
 
@@ -1906,6 +1929,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 				writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 				return
 			}
+
 			pReader.OrigReader.SetEncryptionKey(objectEncryptionKey)
 			info := ObjectInfo{Size: size}
 			hashReader, err = hash.NewReader(reader, info.EncryptedSize(), "", "", size) // do not try to verify encrypted content
@@ -1914,6 +1938,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 				return
 			}
 			pReader.DataReader = hashReader
+			opts.SetETagEncryptionOpts(pReader)
 		}
 	}
 
@@ -2023,16 +2048,17 @@ func (api objectAPIHandlers) ListObjectPartsHandler(w http.ResponseWriter, r *ht
 		writeErrorResponse(w, ErrInvalidMaxParts, r.URL)
 		return
 	}
-	listPartsInfo, err := objectAPI.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+	var opts ObjectOptions
+	opts.SetETagEncryptionOpts(nil)
+	listPartsInfo, err := objectAPI.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts, opts)
 	if err != nil {
 		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 		return
 	}
-
 	var ssec bool
 	if objectAPI.IsEncryptionSupported() {
 		var li ListPartsInfo
-		li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1)
+		li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1, opts)
 		if err != nil {
 			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 			return
@@ -2052,10 +2078,10 @@ func (api objectAPIHandlers) ListObjectPartsHandler(w http.ResponseWriter, r *ht
 				}
 			}
 			parts := make([]PartInfo, len(listPartsInfo.Parts))
-			for _, p := range listPartsInfo.Parts {
+			for i, p := range listPartsInfo.Parts {
 				part := p
 				part.ETag = tryDecryptETag(objectEncryptionKey, p.ETag, ssec)
-				parts = append(parts, part)
+				parts[i] = part
 			}
 			listPartsInfo.Parts = parts
 		}
@@ -2126,7 +2152,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 	var opts ObjectOptions
 	if objectAPI.IsEncryptionSupported() {
 		var li ListPartsInfo
-		li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1)
+		li, err = objectAPI.ListObjectParts(ctx, bucket, object, uploadID, 0, 1, opts)
 		if err != nil {
 			writeErrorResponse(w, toAPIErrorCode(err), r.URL)
 			return
@@ -2142,7 +2168,8 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 					return
 				}
 			}
-			opts = UnsealETagFn(objectEncryptionKey, crypto.SSEC.IsEncrypted(li.UserDefined))
+			opts.UnsealETagFn(objectEncryptionKey, crypto.SSEC.IsEncrypted(li.UserDefined))
+			opts.SetETagEncryptionOpts(nil)
 		}
 	}
 

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -1730,7 +1730,7 @@ func testAPICopyObjectPartHandler(obj ObjectLayer, instanceType, bucketName stri
 			// See if the new part has been uploaded.
 			// testing whether the copy was successful.
 			var results ListPartsInfo
-			results, err = obj.ListObjectParts(context.Background(), testCase.bucketName, testObject, testCase.uploadID, 0, 1)
+			results, err = obj.ListObjectParts(context.Background(), testCase.bucketName, testObject, testCase.uploadID, 0, 1, ObjectOptions{})
 			if err != nil {
 				t.Fatalf("Test %d: %s: Failed to look for copied object part: <ERROR> %s", i+1, instanceType, err)
 			}
@@ -2224,7 +2224,7 @@ func testAPINewMultipartHandler(obj ObjectLayer, instanceType, bucketName string
 		t.Fatalf("Error decoding the recorded response Body")
 	}
 	// verify the uploadID my making an attempt to list parts.
-	_, err = obj.ListObjectParts(context.Background(), bucketName, objectName, multipartResponse.UploadID, 0, 1)
+	_, err = obj.ListObjectParts(context.Background(), bucketName, objectName, multipartResponse.UploadID, 0, 1, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Invalid UploadID: <ERROR> %s", err)
 	}
@@ -2276,7 +2276,7 @@ func testAPINewMultipartHandler(obj ObjectLayer, instanceType, bucketName string
 		t.Fatalf("Error decoding the recorded response Body")
 	}
 	// verify the uploadID my making an attempt to list parts.
-	_, err = obj.ListObjectParts(context.Background(), bucketName, objectName, multipartResponse.UploadID, 0, 1)
+	_, err = obj.ListObjectParts(context.Background(), bucketName, objectName, multipartResponse.UploadID, 0, 1, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Invalid UploadID: <ERROR> %s", err)
 	}
@@ -2391,7 +2391,7 @@ func testAPINewMultipartHandlerParallel(obj ObjectLayer, instanceType, bucketNam
 	wg.Wait()
 	// Validate the upload ID by an attempt to list parts using it.
 	for _, uploadID := range testUploads.uploads {
-		_, err := obj.ListObjectParts(context.Background(), bucketName, objectName, uploadID, 0, 1)
+		_, err := obj.ListObjectParts(context.Background(), bucketName, objectName, uploadID, 0, 1, ObjectOptions{})
 		if err != nil {
 			t.Fatalf("Invalid UploadID: <ERROR> %s", err)
 		}

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -83,7 +83,7 @@ func testAPIHeadObjectHandler(obj ObjectLayer, instanceType, bucketName string, 
 	// iterate through the above set of inputs and upload the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err := obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, ObjectOptions{})
+		_, err := obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, ObjectOptions{})
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -355,7 +355,7 @@ func testAPIGetObjectHandler(obj ObjectLayer, instanceType, bucketName string, a
 	// iterate through the above set of inputs and upload the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err := obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, ObjectOptions{})
+		_, err := obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, ObjectOptions{})
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -1391,7 +1391,7 @@ func testAPICopyObjectPartHandlerSanity(obj ObjectLayer, instanceType, bucketNam
 	for i, input := range putObjectInputs {
 		// uploading the object.
 		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName,
-			mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, opts)
+			mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, opts)
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -1449,7 +1449,7 @@ func testAPICopyObjectPartHandlerSanity(obj ObjectLayer, instanceType, bucketNam
 		})
 	}
 
-	result, err := obj.CompleteMultipartUpload(context.Background(), bucketName, testObject, uploadID, parts)
+	result, err := obj.CompleteMultipartUpload(context.Background(), bucketName, testObject, uploadID, parts, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Test: %s complete multipart upload failed: <ERROR> %v", instanceType, err)
 	}
@@ -1501,7 +1501,7 @@ func testAPICopyObjectPartHandler(obj ObjectLayer, instanceType, bucketName stri
 	// iterate through the above set of inputs and upload the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, opts)
+		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, opts)
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -1838,7 +1838,7 @@ func testAPICopyObjectHandler(obj ObjectLayer, instanceType, bucketName string, 
 	// iterate through the above set of inputs and upload the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, opts)
+		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, opts)
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -2462,7 +2462,7 @@ func testAPICompleteMultipartHandler(obj ObjectLayer, instanceType, bucketName s
 	// Iterating over creatPartCases to generate multipart chunks.
 	for _, part := range parts {
 		_, err = obj.PutObjectPart(context.Background(), part.bucketName, part.objName, part.uploadID, part.PartID,
-			mustGetHashReader(t, bytes.NewBufferString(part.inputReaderData), part.intputDataSize, part.inputMd5, ""), opts)
+			mustGetPutObjectReader(t, bytes.NewBufferString(part.inputReaderData), part.intputDataSize, part.inputMd5, ""), opts)
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err)
 		}
@@ -2811,7 +2811,7 @@ func testAPIAbortMultipartHandler(obj ObjectLayer, instanceType, bucketName stri
 	// Iterating over createPartCases to generate multipart chunks.
 	for _, part := range parts {
 		_, err = obj.PutObjectPart(context.Background(), part.bucketName, part.objName, part.uploadID, part.PartID,
-			mustGetHashReader(t, bytes.NewBufferString(part.inputReaderData), part.intputDataSize, part.inputMd5, ""), opts)
+			mustGetPutObjectReader(t, bytes.NewBufferString(part.inputReaderData), part.intputDataSize, part.inputMd5, ""), opts)
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err)
 		}
@@ -2949,7 +2949,7 @@ func testAPIDeleteObjectHandler(obj ObjectLayer, instanceType, bucketName string
 	// iterate through the above set of inputs and upload the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, opts)
+		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData[""], ""), input.metaData, opts)
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -3655,7 +3655,7 @@ func testAPIListObjectPartsHandler(obj ObjectLayer, instanceType, bucketName str
 	uploadIDCopy := uploadID
 
 	// create an object Part, will be used to test list object parts.
-	_, err = obj.PutObjectPart(context.Background(), bucketName, testObject, uploadID, 1, mustGetHashReader(t, bytes.NewReader([]byte("hello")), int64(len("hello")), "5d41402abc4b2a76b9719d911017c592", ""), opts)
+	_, err = obj.PutObjectPart(context.Background(), bucketName, testObject, uploadID, 1, mustGetPutObjectReader(t, bytes.NewReader([]byte("hello")), int64(len("hello")), "5d41402abc4b2a76b9719d911017c592", ""), opts)
 	if err != nil {
 		t.Fatalf("Minio %s : %s.", instanceType, err)
 	}

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -140,7 +140,7 @@ func (sys *PolicySys) Init(objAPI ObjectLayer) error {
 			defer ticker.Stop()
 			for {
 				select {
-				case <-globalServiceDoneCh:
+				case <-GlobalServiceDoneCh:
 					return
 				case <-ticker.C:
 					sys.refresh(objAPI)

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -190,7 +190,7 @@ func newPosix(path string) (*posix, error) {
 	}
 
 	if !p.diskMount {
-		go p.diskUsage(globalServiceDoneCh)
+		go p.diskUsage(GlobalServiceDoneCh)
 	}
 
 	// Success.

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -35,11 +35,11 @@ const (
 var globalServiceSignalCh chan serviceSignal
 
 // Global service done channel.
-var globalServiceDoneCh chan struct{}
+var GlobalServiceDoneCh chan struct{}
 
 // Initialize service mutex once.
 func init() {
-	globalServiceDoneCh = make(chan struct{}, 1)
+	GlobalServiceDoneCh = make(chan struct{}, 1)
 	globalServiceSignalCh = make(chan serviceSignal)
 }
 

--- a/cmd/storage-class_test.go
+++ b/cmd/storage-class_test.go
@@ -189,7 +189,7 @@ func testObjectQuorumFromMeta(obj ObjectLayer, instanceType string, dirs []strin
 
 	// Object for test case 1 - No StorageClass defined, no MetaData in PutObject
 	object1 := "object1"
-	_, err = obj.PutObject(context.Background(), bucket, object1, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), nil, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object1, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), nil, opts)
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}
@@ -200,7 +200,7 @@ func testObjectQuorumFromMeta(obj ObjectLayer, instanceType string, dirs []strin
 	object2 := "object2"
 	metadata2 := make(map[string]string)
 	metadata2["x-amz-storage-class"] = reducedRedundancyStorageClass
-	_, err = obj.PutObject(context.Background(), bucket, object2, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata2, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object2, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata2, opts)
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}
@@ -211,7 +211,7 @@ func testObjectQuorumFromMeta(obj ObjectLayer, instanceType string, dirs []strin
 	object3 := "object3"
 	metadata3 := make(map[string]string)
 	metadata3["x-amz-storage-class"] = standardStorageClass
-	_, err = obj.PutObject(context.Background(), bucket, object3, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata3, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object3, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata3, opts)
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}
@@ -227,7 +227,7 @@ func testObjectQuorumFromMeta(obj ObjectLayer, instanceType string, dirs []strin
 		Scheme: "EC",
 	}
 
-	_, err = obj.PutObject(context.Background(), bucket, object4, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata4, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object4, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata4, opts)
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}
@@ -245,7 +245,7 @@ func testObjectQuorumFromMeta(obj ObjectLayer, instanceType string, dirs []strin
 		Scheme: "EC",
 	}
 
-	_, err = obj.PutObject(context.Background(), bucket, object5, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata5, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object5, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata5, opts)
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}
@@ -263,7 +263,7 @@ func testObjectQuorumFromMeta(obj ObjectLayer, instanceType string, dirs []strin
 		Scheme: "EC",
 	}
 
-	_, err = obj.PutObject(context.Background(), bucket, object6, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata6, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object6, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata6, opts)
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}
@@ -281,7 +281,7 @@ func testObjectQuorumFromMeta(obj ObjectLayer, instanceType string, dirs []strin
 		Scheme: "EC",
 	}
 
-	_, err = obj.PutObject(context.Background(), bucket, object7, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata7, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object7, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), metadata7, opts)
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -136,12 +136,12 @@ func calculateSignedChunkLength(chunkDataSize int64) int64 {
 		2 // CRLF
 }
 
-func mustGetHashReader(t TestErrHandler, data io.Reader, size int64, md5hex, sha256hex string) *hash.Reader {
+func mustGetPutObjectReader(t TestErrHandler, data io.Reader, size int64, md5hex, sha256hex string) *PutObjectReader {
 	hr, err := hash.NewReader(data, size, md5hex, sha256hex, size)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return hr
+	return NewPutObjectReader(hr)
 }
 
 // calculateSignedChunkLength - calculates the length of the overall stream (data + metadata)

--- a/cmd/ui-errors.go
+++ b/cmd/ui-errors.go
@@ -203,4 +203,10 @@ Example 1:
 		"Please check the passed value",
 		"Compress extensions/mime-types are delimited by `,`. For eg, MINIO_COMPRESS_ATTR=\"A,B,C\"",
 	)
+
+	uiErrInvalidGWSSEValue = newUIErrFn(
+		"Invalid gateway sse value",
+		"Please check the passed value",
+		"MINIO_GW_SSE: Gateway SSE accepts only S3, C and KMS as valid values. Delimit by `;` to set more than one value",
+	)
 )

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -807,7 +807,11 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 		writeWebErrorResponse(w, err)
 		return
 	}
-	opts := ObjectOptions{}
+	opts, err := getEncryptionOpts(r, bucket, object)
+	if err != nil {
+		writeWebErrorResponse(w, err)
+		return
+	}
 	// Deny if WORM is enabled
 	if globalWORMEnabled {
 		if _, err = objectAPI.GetObjectInfo(ctx, bucket, object, opts); err == nil {
@@ -816,7 +820,7 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	objInfo, err := putObject(ctx, bucket, object, hashReader, metadata, opts)
+	objInfo, err := putObject(ctx, bucket, object, NewPutObjectReader(hashReader), metadata, opts)
 	if err != nil {
 		writeWebErrorResponse(w, err)
 		return
@@ -921,7 +925,7 @@ func (web *webAPIHandlers) Download(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if objectAPI.IsEncryptionSupported() {
-		if _, err = DecryptObjectInfo(objInfo, r.Header); err != nil {
+		if _, err = DecryptObjectInfo(&objInfo, r.Header); err != nil {
 			writeWebErrorResponse(w, err)
 			return
 		}
@@ -1125,7 +1129,7 @@ func (web *webAPIHandlers) DownloadZip(w http.ResponseWriter, r *http.Request) {
 			}
 			length = info.Size
 			if objectAPI.IsEncryptionSupported() {
-				if _, err = DecryptObjectInfo(info, r.Header); err != nil {
+				if _, err = DecryptObjectInfo(&info, r.Header); err != nil {
 					writeWebErrorResponse(w, err)
 					return err
 				}

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -349,7 +349,7 @@ func testDeleteBucketWebHandler(obj ObjectLayer, instanceType string, t TestErrH
 	for _, test := range testCases {
 		if test.initWithObject {
 			data := bytes.NewBufferString("hello")
-			_, err = obj.PutObject(context.Background(), test.bucketName, "object", mustGetHashReader(t, data, int64(data.Len()), "", ""), nil, opts)
+			_, err = obj.PutObject(context.Background(), test.bucketName, "object", mustGetPutObjectReader(t, data, int64(data.Len()), "", ""), nil, opts)
 			// _, err = obj.PutObject(test.bucketName, "object", int64(data.Len()), data, nil, "")
 			if err != nil {
 				t.Fatalf("could not put object to %s, %s", test.bucketName, err.Error())
@@ -485,7 +485,7 @@ func testListObjectsWebHandler(obj ObjectLayer, instanceType string, t TestErrHa
 
 	data := bytes.Repeat([]byte("a"), objectSize)
 	metadata := map[string]string{"etag": "c9a34cfc85d982698c6ac89f76071abd"}
-	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), metadata["etag"], ""), metadata, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), metadata["etag"], ""), metadata, ObjectOptions{})
 
 	if err != nil {
 		t.Fatalf("Was not able to upload an object, %v", err)
@@ -589,14 +589,14 @@ func testRemoveObjectWebHandler(obj ObjectLayer, instanceType string, t TestErrH
 
 	data := bytes.Repeat([]byte("a"), objectSize)
 	metadata := map[string]string{"etag": "c9a34cfc85d982698c6ac89f76071abd"}
-	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), metadata["etag"], ""), metadata, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), metadata["etag"], ""), metadata, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Was not able to upload an object, %v", err)
 	}
 
 	objectName = "a/object"
 	metadata = map[string]string{"etag": "c9a34cfc85d982698c6ac89f76071abd"}
-	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), metadata["etag"], ""), metadata, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), metadata["etag"], ""), metadata, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Was not able to upload an object, %v", err)
 	}
@@ -987,7 +987,7 @@ func testDownloadWebHandler(obj ObjectLayer, instanceType string, t TestErrHandl
 
 	content := []byte("temporary file's content")
 	metadata := map[string]string{"etag": "01ce59706106fe5e02e7f55fffda7f34"}
-	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader(content), int64(len(content)), metadata["etag"], ""), metadata, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader(content), int64(len(content)), metadata["etag"], ""), metadata, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Was not able to upload an object, %v", err)
 	}
@@ -1090,9 +1090,9 @@ func testWebHandlerDownloadZip(obj ObjectLayer, instanceType string, t TestErrHa
 		t.Fatalf("%s : %s", instanceType, err)
 	}
 
-	obj.PutObject(context.Background(), bucket, "a/one", mustGetHashReader(t, strings.NewReader(fileOne), int64(len(fileOne)), "", ""), nil, opts)
-	obj.PutObject(context.Background(), bucket, "a/b/two", mustGetHashReader(t, strings.NewReader(fileTwo), int64(len(fileTwo)), "", ""), nil, opts)
-	obj.PutObject(context.Background(), bucket, "a/c/three", mustGetHashReader(t, strings.NewReader(fileThree), int64(len(fileThree)), "", ""), nil, opts)
+	obj.PutObject(context.Background(), bucket, "a/one", mustGetPutObjectReader(t, strings.NewReader(fileOne), int64(len(fileOne)), "", ""), nil, opts)
+	obj.PutObject(context.Background(), bucket, "a/b/two", mustGetPutObjectReader(t, strings.NewReader(fileTwo), int64(len(fileTwo)), "", ""), nil, opts)
+	obj.PutObject(context.Background(), bucket, "a/c/three", mustGetPutObjectReader(t, strings.NewReader(fileThree), int64(len(fileThree)), "", ""), nil, opts)
 
 	test := func(token string) (int, []byte) {
 		rec := httptest.NewRecorder()
@@ -1177,7 +1177,7 @@ func testWebPresignedGetHandler(obj ObjectLayer, instanceType string, t TestErrH
 
 	data := bytes.Repeat([]byte("a"), objectSize)
 	metadata := map[string]string{"etag": "c9a34cfc85d982698c6ac89f76071abd"}
-	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), metadata["etag"], ""), metadata, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucketName, objectName, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), metadata["etag"], ""), metadata, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Was not able to upload an object, %v", err)
 	}

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -235,7 +235,7 @@ func (s *xlSets) monitorAndConnectEndpoints(monitorInterval time.Duration) {
 
 	for {
 		select {
-		case <-globalServiceDoneCh:
+		case <-GlobalServiceDoneCh:
 			return
 		case <-s.disksConnectDoneCh:
 			return
@@ -289,7 +289,7 @@ func newXLSets(endpoints EndpointList, format *formatXLV3, setCount int, drivesP
 			nsMutex:  mutex,
 			bp:       bp,
 		}
-		go s.sets[i].cleanupStaleMultipartUploads(context.Background(), globalMultipartCleanupInterval, globalMultipartExpiry, globalServiceDoneCh)
+		go s.sets[i].cleanupStaleMultipartUploads(context.Background(), GlobalMultipartCleanupInterval, GlobalMultipartExpiry, GlobalServiceDoneCh)
 	}
 
 	// Connect disks right away, but wait until we have `format.json` quorum.

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -835,8 +835,8 @@ func (s *xlSets) PutObjectPart(ctx context.Context, bucket, object, uploadID str
 }
 
 // ListObjectParts - lists all uploaded parts to an object in hashedSet.
-func (s *xlSets) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error) {
-	return s.getHashedSet(object).ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+func (s *xlSets) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int, opts ObjectOptions) (result ListPartsInfo, err error) {
+	return s.getHashedSet(object).ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts, opts)
 }
 
 // Aborts an in-progress multipart operation on hashedSet based on the object name.

--- a/cmd/xl-v1-common_test.go
+++ b/cmd/xl-v1-common_test.go
@@ -43,7 +43,7 @@ func TestXLParentDirIsObject(t *testing.T) {
 	}
 	objectContent := "12345"
 	objInfo, err := obj.PutObject(context.Background(), bucketName, objectName,
-		mustGetHashReader(t, bytes.NewReader([]byte(objectContent)), int64(len(objectContent)), "", ""), nil, ObjectOptions{})
+		mustGetPutObjectReader(t, bytes.NewReader([]byte(objectContent)), int64(len(objectContent)), "", ""), nil, ObjectOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/xl-v1-healing-common_test.go
+++ b/cmd/xl-v1-healing-common_test.go
@@ -97,7 +97,7 @@ func partsMetaFromModTimes(modTimes []time.Time, algorithm BitrotAlgorithm, chec
 			Stat: statInfo{
 				ModTime: modTime,
 			},
-			Parts: []objectPartInfo{
+			Parts: []ObjectPartInfo{
 				{
 					Name: "part.1",
 				},

--- a/cmd/xl-v1-healing-common_test.go
+++ b/cmd/xl-v1-healing-common_test.go
@@ -200,7 +200,7 @@ func TestListOnlineDisks(t *testing.T) {
 			t.Fatalf("Failed to make a bucket %v", err)
 		}
 
-		_, err = obj.PutObject(context.Background(), bucket, object, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), nil, ObjectOptions{})
+		_, err = obj.PutObject(context.Background(), bucket, object, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), nil, ObjectOptions{})
 		if err != nil {
 			t.Fatalf("Failed to putObject %v", err)
 		}
@@ -292,7 +292,7 @@ func TestDisksWithAllParts(t *testing.T) {
 		t.Fatalf("Failed to make a bucket %v", err)
 	}
 
-	_, err = obj.PutObject(ctx, bucket, object, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), nil, ObjectOptions{})
+	_, err = obj.PutObject(ctx, bucket, object, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), nil, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Failed to putObject %v", err)
 	}

--- a/cmd/xl-v1-healing_test.go
+++ b/cmd/xl-v1-healing_test.go
@@ -91,7 +91,7 @@ func TestHealObjectXL(t *testing.T) {
 
 	var uploadedParts []CompletePart
 	for _, partID := range []int{2, 1} {
-		pInfo, err1 := obj.PutObjectPart(context.Background(), bucket, object, uploadID, partID, mustGetHashReader(t, bytes.NewReader(data), int64(len(data)), "", ""), opts)
+		pInfo, err1 := obj.PutObjectPart(context.Background(), bucket, object, uploadID, partID, mustGetPutObjectReader(t, bytes.NewReader(data), int64(len(data)), "", ""), opts)
 		if err1 != nil {
 			t.Fatalf("Failed to upload a part - %v", err1)
 		}
@@ -101,7 +101,7 @@ func TestHealObjectXL(t *testing.T) {
 		})
 	}
 
-	_, err = obj.CompleteMultipartUpload(context.Background(), bucket, object, uploadID, uploadedParts)
+	_, err = obj.CompleteMultipartUpload(context.Background(), bucket, object, uploadID, uploadedParts, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Failed to complete multipart upload - %v", err)
 	}

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -31,9 +31,9 @@ import (
 
 const erasureAlgorithmKlauspost = "klauspost/reedsolomon/vandermonde"
 
-// objectPartInfo Info of each part kept in the multipart metadata
+// ObjectPartInfo Info of each part kept in the multipart metadata
 // file after CompleteMultipartUpload() is called.
-type objectPartInfo struct {
+type ObjectPartInfo struct {
 	Number     int    `json:"number"`
 	Name       string `json:"name"`
 	ETag       string `json:"etag"`
@@ -42,7 +42,7 @@ type objectPartInfo struct {
 }
 
 // byObjectPartNumber is a collection satisfying sort.Interface.
-type byObjectPartNumber []objectPartInfo
+type byObjectPartNumber []ObjectPartInfo
 
 func (t byObjectPartNumber) Len() int           { return len(t) }
 func (t byObjectPartNumber) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
@@ -153,7 +153,7 @@ type xlMetaV1 struct {
 	// Metadata map for current object `xl.json`.
 	Meta map[string]string `json:"meta,omitempty"`
 	// Captures all the individual object `xl.json`.
-	Parts []objectPartInfo `json:"parts,omitempty"`
+	Parts []ObjectPartInfo `json:"parts,omitempty"`
 }
 
 // XL metadata constants.
@@ -243,7 +243,7 @@ func (m xlMetaV1) ToObjectInfo(bucket, object string) ObjectInfo {
 }
 
 // objectPartIndex - returns the index of matching object part number.
-func objectPartIndex(parts []objectPartInfo, partNumber int) int {
+func objectPartIndex(parts []ObjectPartInfo, partNumber int) int {
 	for i, part := range parts {
 		if partNumber == part.Number {
 			return i
@@ -254,7 +254,7 @@ func objectPartIndex(parts []objectPartInfo, partNumber int) int {
 
 // AddObjectPart - add a new object part in order.
 func (m *xlMetaV1) AddObjectPart(partNumber int, partName string, partETag string, partSize int64, actualSize int64) {
-	partInfo := objectPartInfo{
+	partInfo := ObjectPartInfo{
 		Number:     partNumber,
 		Name:       partName,
 		ETag:       partETag,
@@ -351,7 +351,7 @@ func pickValidXLMeta(ctx context.Context, metaArr []xlMetaV1, modTime time.Time,
 var objMetadataOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errVolumeNotFound, errFileNotFound, errFileAccessDenied, errCorruptedFormat)
 
 // readXLMetaParts - returns the XL Metadata Parts from xl.json of one of the disks picked at random.
-func (xl xlObjects) readXLMetaParts(ctx context.Context, bucket, object string) (xlMetaParts []objectPartInfo, xlMeta map[string]string, err error) {
+func (xl xlObjects) readXLMetaParts(ctx context.Context, bucket, object string) (xlMetaParts []ObjectPartInfo, xlMeta map[string]string, err error) {
 	var ignoredErrs []error
 	for _, disk := range xl.getLoadBalancedDisks() {
 		if disk == nil {

--- a/cmd/xl-v1-metadata_test.go
+++ b/cmd/xl-v1-metadata_test.go
@@ -69,7 +69,7 @@ func testXLReadStat(obj ObjectLayer, instanceType string, disks []string, t *tes
 	// iterate through the above set of inputs and upkoad the object.
 	for i, input := range putObjectInputs {
 		// uploading the object.
-		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetHashReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData["etag"], ""), input.metaData, ObjectOptions{})
+		_, err = obj.PutObject(context.Background(), input.bucketName, input.objectName, mustGetPutObjectReader(t, bytes.NewBuffer(input.textData), input.contentLength, input.metaData["etag"], ""), input.metaData, ObjectOptions{})
 		// if object upload fails stop the test.
 		if err != nil {
 			t.Fatalf("Put Object case %d:  Error uploading object: <ERROR> %v", i+1, err)
@@ -153,7 +153,7 @@ func testXLReadMetaParts(obj ObjectLayer, instanceType string, disks []string, t
 	sha256sum := ""
 	// Iterating over creatPartCases to generate multipart chunks.
 	for _, testCase := range createPartCases {
-		_, perr := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetHashReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), opts)
+		_, perr := obj.PutObjectPart(context.Background(), testCase.bucketName, testCase.objName, testCase.uploadID, testCase.PartID, mustGetPutObjectReader(t, bytes.NewBufferString(testCase.inputReaderData), testCase.intputDataSize, testCase.inputMd5, sha256sum), opts)
 		if perr != nil {
 			t.Fatalf("%s : %s", instanceType, perr)
 		}

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -643,7 +643,7 @@ func (xl xlObjects) CompleteMultipartUpload(ctx context.Context, bucket string, 
 	var currentXLMeta = xlMeta
 
 	// Allocate parts similar to incoming slice.
-	xlMeta.Parts = make([]objectPartInfo, len(parts))
+	xlMeta.Parts = make([]ObjectPartInfo, len(parts))
 
 	// Validate each part and then commit to disk.
 	for i, part := range parts {
@@ -690,7 +690,7 @@ func (xl xlObjects) CompleteMultipartUpload(ctx context.Context, bucket string, 
 		objectActualSize += currentXLMeta.Parts[partIdx].ActualSize
 
 		// Add incoming parts.
-		xlMeta.Parts[i] = objectPartInfo{
+		xlMeta.Parts[i] = ObjectPartInfo{
 			Number:     part.PartNumber,
 			ETag:       part.ETag,
 			Size:       currentXLMeta.Parts[partIdx].Size,

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -490,7 +490,7 @@ func (xl xlObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID 
 // Implements S3 compatible ListObjectParts API. The resulting
 // ListPartsInfo structure is marshaled directly into XML and
 // replied back to the client.
-func (xl xlObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int) (result ListPartsInfo, e error) {
+func (xl xlObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int, opts ObjectOptions) (result ListPartsInfo, e error) {
 	if err := checkListPartsArgs(ctx, bucket, object, xl); err != nil {
 		return result, err
 	}

--- a/cmd/xl-v1-multipart_test.go
+++ b/cmd/xl-v1-multipart_test.go
@@ -36,7 +36,7 @@ func TestXLCleanupStaleMultipartUploads(t *testing.T) {
 
 	// Close the go-routine, we are going to
 	// manually start it and test in this test case.
-	globalServiceDoneCh <- struct{}{}
+	GlobalServiceDoneCh <- struct{}{}
 
 	bucketName := "bucket"
 	objectName := "object"
@@ -48,14 +48,14 @@ func TestXLCleanupStaleMultipartUploads(t *testing.T) {
 		t.Fatal("Unexpected err: ", err)
 	}
 
-	go xl.cleanupStaleMultipartUploads(context.Background(), 20*time.Millisecond, 0, globalServiceDoneCh)
+	go xl.cleanupStaleMultipartUploads(context.Background(), 20*time.Millisecond, 0, GlobalServiceDoneCh)
 
 	// Wait for 40ms such that - we have given enough time for
 	// cleanup routine to kick in.
 	time.Sleep(40 * time.Millisecond)
 
 	// Close the routine we do not need it anymore.
-	globalServiceDoneCh <- struct{}{}
+	GlobalServiceDoneCh <- struct{}{}
 
 	// Check if upload id was already purged.
 	if err = obj.AbortMultipartUpload(context.Background(), bucketName, objectName, uploadID); err != nil {

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -507,7 +507,7 @@ func renameCorruptedObject(ctx context.Context, bucket, object string, validMeta
 			Algorithm: validMeta.Erasure.Checksums[0].Algorithm,
 			Hash:      alg.Sum(nil),
 		}
-		validMeta.Parts[0] = objectPartInfo{
+		validMeta.Parts[0] = ObjectPartInfo{
 			Number: 1,
 			Name:   "part.1",
 		}

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -153,7 +153,7 @@ func (xl xlObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBuc
 		return oi, toObjectErr(err, dstBucket, dstObject)
 	}
 
-	objInfo, err := xl.putObject(ctx, dstBucket, dstObject, hashReader, srcInfo.UserDefined, dstOpts)
+	objInfo, err := xl.putObject(ctx, dstBucket, dstObject, NewPutObjectReader(hashReader), srcInfo.UserDefined, dstOpts)
 	if err != nil {
 		return oi, toObjectErr(err, dstBucket, dstObject)
 	}
@@ -639,7 +639,7 @@ func rename(ctx context.Context, disks []StorageAPI, srcBucket, srcEntry, dstBuc
 // until EOF, erasure codes the data across all disk and additionally
 // writes `xl.json` which carries the necessary metadata for future
 // object operations.
-func (xl xlObjects) PutObject(ctx context.Context, bucket string, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+func (xl xlObjects) PutObject(ctx context.Context, bucket string, object string, data *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	// Validate put object input args.
 	if err = checkPutObjectArgs(ctx, bucket, object, xl, data.Size()); err != nil {
 		return ObjectInfo{}, err
@@ -655,7 +655,9 @@ func (xl xlObjects) PutObject(ctx context.Context, bucket string, object string,
 }
 
 // putObject wrapper for xl PutObject
-func (xl xlObjects) putObject(ctx context.Context, bucket string, object string, data *hash.Reader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+func (xl xlObjects) putObject(ctx context.Context, bucket string, object string, r *PutObjectReader, metadata map[string]string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+	data := r.DataReader
+
 	uniqueID := mustGetUUID()
 	tempObj := uniqueID
 
@@ -841,7 +843,14 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 
 	// Save additional erasureMetadata.
 	modTime := UTCNow()
-	metadata["etag"] = hex.EncodeToString(data.MD5Current())
+	if opts.ServerSideEncryption != nil {
+		if encMD5Sum, _, err := r.OrigReader.EncryptedMD5Sum(); err == nil {
+			metadata["etag"] = encMD5Sum
+		}
+	}
+	if metadata["etag"] == "" {
+		metadata["etag"] = hex.EncodeToString(data.MD5Current())
+	}
 
 	// Guess content-type from the extension if possible.
 	if metadata["content-type"] == "" {

--- a/cmd/xl-v1-object_test.go
+++ b/cmd/xl-v1-object_test.go
@@ -55,12 +55,12 @@ func TestRepeatPutObjectPart(t *testing.T) {
 	}
 	fiveMBBytes := bytes.Repeat([]byte("a"), 5*humanize.MiByte)
 	md5Hex := getMD5Hash(fiveMBBytes)
-	_, err = objLayer.PutObjectPart(context.Background(), "bucket1", "mpartObj1", uploadID, 1, mustGetHashReader(t, bytes.NewReader(fiveMBBytes), 5*humanize.MiByte, md5Hex, ""), opts)
+	_, err = objLayer.PutObjectPart(context.Background(), "bucket1", "mpartObj1", uploadID, 1, mustGetPutObjectReader(t, bytes.NewReader(fiveMBBytes), 5*humanize.MiByte, md5Hex, ""), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// PutObjectPart should succeed even if part already exists. ref: https://github.com/minio/minio/issues/1930
-	_, err = objLayer.PutObjectPart(context.Background(), "bucket1", "mpartObj1", uploadID, 1, mustGetHashReader(t, bytes.NewReader(fiveMBBytes), 5*humanize.MiByte, md5Hex, ""), opts)
+	_, err = objLayer.PutObjectPart(context.Background(), "bucket1", "mpartObj1", uploadID, 1, mustGetPutObjectReader(t, bytes.NewReader(fiveMBBytes), 5*humanize.MiByte, md5Hex, ""), opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestXLDeleteObjectBasic(t *testing.T) {
 	}
 
 	// Create object "dir/obj" under bucket "bucket" for Test 7 to pass
-	_, err = xl.PutObject(context.Background(), "bucket", "dir/obj", mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
+	_, err = xl.PutObject(context.Background(), "bucket", "dir/obj", mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("XL Object upload failed: <ERROR> %s", err)
 	}
@@ -131,7 +131,7 @@ func TestXLDeleteObjectDiskNotFound(t *testing.T) {
 	object := "object"
 	opts := ObjectOptions{}
 	// Create object "obj" under bucket "bucket".
-	_, err = obj.PutObject(context.Background(), bucket, object, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestXLDeleteObjectDiskNotFound(t *testing.T) {
 	}
 
 	// Create "obj" under "bucket".
-	_, err = obj.PutObject(context.Background(), bucket, object, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestGetObjectNoQuorum(t *testing.T) {
 	object := "object"
 	opts := ObjectOptions{}
 	// Create "object" under "bucket".
-	_, err = obj.PutObject(context.Background(), bucket, object, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestPutObjectNoQuorum(t *testing.T) {
 	object := "object"
 	opts := ObjectOptions{}
 	// Create "object" under "bucket".
-	_, err = obj.PutObject(context.Background(), bucket, object, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
+	_, err = obj.PutObject(context.Background(), bucket, object, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func TestPutObjectNoQuorum(t *testing.T) {
 			}
 		}
 		// Upload new content to same object "object"
-		_, err = obj.PutObject(context.Background(), bucket, object, mustGetHashReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
+		_, err = obj.PutObject(context.Background(), bucket, object, mustGetPutObjectReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), nil, opts)
 		if err != toObjectErr(errXLWriteQuorum, bucket, object) {
 			t.Errorf("Expected putObject to fail with %v, but failed with %v", toObjectErr(errXLWriteQuorum, bucket, object), err)
 		}
@@ -290,7 +290,7 @@ func TestHealing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = obj.PutObject(context.Background(), bucket, object, mustGetHashReader(t, bytes.NewReader(data), length, "", ""), nil, ObjectOptions{})
+	_, err = obj.PutObject(context.Background(), bucket, object, mustGetPutObjectReader(t, bytes.NewReader(data), length, "", ""), nil, ObjectOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -192,12 +192,12 @@ func parseXLErasureInfo(ctx context.Context, xlMetaBuf []byte) (ErasureInfo, err
 	return erasure, nil
 }
 
-func parseXLParts(xlMetaBuf []byte) []objectPartInfo {
+func parseXLParts(xlMetaBuf []byte) []ObjectPartInfo {
 	// Parse the XL Parts.
 	partsResult := gjson.GetBytes(xlMetaBuf, "parts").Array()
-	partInfo := make([]objectPartInfo, len(partsResult))
+	partInfo := make([]ObjectPartInfo, len(partsResult))
 	for i, p := range partsResult {
-		info := objectPartInfo{}
+		info := ObjectPartInfo{}
 		info.Number = int(p.Get("number").Int())
 		info.Name = p.Get("name").String()
 		info.ETag = p.Get("etag").String()
@@ -249,7 +249,7 @@ func xlMetaV1UnmarshalJSON(ctx context.Context, xlMetaBuf []byte) (xlMeta xlMeta
 }
 
 // read xl.json from the given disk, parse and return xlV1MetaV1.Parts.
-func readXLMetaParts(ctx context.Context, disk StorageAPI, bucket string, object string) ([]objectPartInfo, map[string]string, error) {
+func readXLMetaParts(ctx context.Context, disk StorageAPI, bucket string, object string) ([]ObjectPartInfo, map[string]string, error) {
 	// Reads entire `xl.json`.
 	xlMetaBuf, err := disk.ReadAll(bucket, path.Join(object, xlMetaJSONFile))
 	if err != nil {

--- a/cmd/xl-v1-utils_test.go
+++ b/cmd/xl-v1-utils_test.go
@@ -174,7 +174,7 @@ func (m *xlMetaV1) AddTestObjectCheckSum(checkSumNum int, name string, algorithm
 
 // AddTestObjectPart - add a new object part in order.
 func (m *xlMetaV1) AddTestObjectPart(partNumber int, partName string, partETag string, partSize int64) {
-	partInfo := objectPartInfo{
+	partInfo := ObjectPartInfo{
 		Number: partNumber,
 		Name:   partName,
 		ETag:   partETag,
@@ -201,7 +201,7 @@ func getSampleXLMeta(totalParts int) xlMetaV1 {
 	// Number of checksum info == total parts.
 	xlMeta.Erasure.Checksums = make([]ChecksumInfo, totalParts)
 	// total number of parts.
-	xlMeta.Parts = make([]objectPartInfo, totalParts)
+	xlMeta.Parts = make([]ObjectPartInfo, totalParts)
 	for i := 0; i < totalParts; i++ {
 		partName := "part." + strconv.Itoa(i+1)
 		// hard coding hash and algo value for the checksum, Since we are benchmarking the parsing of xl.json the magnitude doesn't affect the test,

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -31,6 +31,16 @@ Optionally set `MINIO_SSE_VAULT_CAPATH` is the path to a directory of PEM-encode
 export MINIO_SSE_VAULT_CAPATH=/home/user/custom-pems
 ```
 
+To enable encryption at gateway MINIO_GW_SSE environment variable needs to be set to "s3" for sse-s3
+and "c" for sse-c encryption at gateway. More than one encryption option can be set, delimited by ";". If MINIO_GW_SSE is not set, any SSE headers will be passed to S3 backend.
+```sh
+export MINIO_GW_SSE="s3;c"
+export MINIO_SSE_VAULT_APPROLE_ID=9b56cc08-8258-45d5-24a3-679876769126
+export MINIO_SSE_VAULT_APPROLE_SECRET=4e30c52f-13e4-a6f5-0763-d50e8cb4321f
+export MINIO_SSE_VAULT_ENDPOINT=https://vault-endpoint-ip:8200
+export MINIO_SSE_VAULT_KEY_NAME=my-minio-key
+minio gateway s3
+```
 ### 4. Test your setup
 
 To test this setup, access the Minio server via browser or [`mc`](https://docs.minio.io/docs/minio-client-quickstart-guide). You’ll see the uploaded files are accessible from the all the Minio endpoints.

--- a/docs/zh_CN/backend/fs/README.md
+++ b/docs/zh_CN/backend/fs/README.md
@@ -1,9 +1,9 @@
 ### Backend format `fs.json`
 
 ```go
-// objectPartInfo Info of each part kept in the multipart metadata
+// ObjectPartInfo Info of each part kept in the multipart metadata
 // file after CompleteMultipartUpload() is called.
-type objectPartInfo struct {
+type ObjectPartInfo struct {
 	Number int    `json:"number"`
 	Name   string `json:"name"`
 	ETag   string `json:"etag"`
@@ -19,6 +19,6 @@ type fsMetaV1 struct {
 	} `json:"minio"`
 	// Metadata map for current object `fs.json`.
 	Meta  map[string]string `json:"meta,omitempty"`
-	Parts []objectPartInfo  `json:"parts,omitempty"`
+	Parts []ObjectPartInfo  `json:"parts,omitempty"`
 }
 ```

--- a/docs/zh_CN/backend/xl/README.md
+++ b/docs/zh_CN/backend/xl/README.md
@@ -1,9 +1,9 @@
 ### Backend format `xl.json`
 
 ```go
-// objectPartInfo Info of each part kept in the multipart metadata
+// ObjectPartInfo Info of each part kept in the multipart metadata
 // file after CompleteMultipartUpload() is called.
-type objectPartInfo struct {
+type ObjectPartInfo struct {
 	Number int    `json:"number"`
 	Name   string `json:"name"`
 	ETag   string `json:"etag"`
@@ -49,6 +49,6 @@ type xlMetaV1 struct {
 	// Metadata map for current object `xl.json`.
 	Meta map[string]string `json:"meta,omitempty"`
 	// Captures all the individual object `xl.json`.
-	Parts []objectPartInfo `json:"parts,omitempty"`
+	Parts []ObjectPartInfo `json:"parts,omitempty"`
 }
 ```

--- a/vendor/github.com/minio/minio-go/core.go
+++ b/vendor/github.com/minio/minio-go/core.go
@@ -117,11 +117,11 @@ func (c Core) ListObjectParts(bucket, object, uploadID string, partNumberMarker 
 }
 
 // CompleteMultipartUpload - Concatenate uploaded parts and commit to an object.
-func (c Core) CompleteMultipartUpload(bucket, object, uploadID string, parts []CompletePart) error {
-	_, err := c.completeMultipartUpload(context.Background(), bucket, object, uploadID, completeMultipartUpload{
+func (c Core) CompleteMultipartUpload(bucket, object, uploadID string, parts []CompletePart) (string, error) {
+	res, err := c.completeMultipartUpload(context.Background(), bucket, object, uploadID, completeMultipartUpload{
 		Parts: parts,
 	})
-	return err
+	return res.ETag, err
 }
 
 // AbortMultipartUpload - Abort an incomplete upload.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes https://github.com/minio/minio/issues/
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Content MD5Sum needs to be returned as ETag for requests with SSE-S3 Headers. This is as per S3 spec.
The PR open for new feature to support encryption at the gateway and backend (PR #6423) doesn't currently provide original ETag, but computes MD5Sum on encrypted object.
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
With awscli, s3cmd and minio-go
Run minio s3 gateway with KMS enabled and MINIO_GW_SSE set to "S3;C"
Any put or copy-object would fail because of ETag mismatch, whereas these operations would succeed with this change.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.