### PR TITLE
Do not make multiple response.WriteHeader calls

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -265,10 +265,7 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 	}
 
 	// Executes the query on data-set
-	if err = s3select.Execute(w, s3s); err != nil {
-		writeErrorResponse(w, toAPIErrorCode(err), r.URL)
-		return
-	}
+	s3select.Execute(w, s3s)
 
 	for k, v := range objInfo.UserDefined {
 		logger.GetReqInfo(ctx).SetTags(k, v)


### PR DESCRIPTION
## Description
Execute method in s3Select package makes a response.WriteHeader call.

Not calling it again in SelectObjectContentHandler function in case of
error in s3Select.Execute call.

## Motivation and Context
When an s3 select command is executed
`mc select -e "select * from s3Object" s3/kannappan102/population.csv`
and it is killed midway while it is prinitng the output, you see something like
```
2018-10-29 20:47:56.179875 I | http: multiple response.WriteHeader calls
2018-10-29 21:01:23.170685 I | http: multiple response.WriteHeader calls
2018-10-29 21:03:58.870296 I | http: multiple response.WriteHeader calls
2018-10-29 21:04:14.778632 I | http: multiple response.WriteHeader calls
```
on the server console. This occurs when multiple WriteHeader calls are made.

## Regression
Yes. #6708 

## How Has This Been Tested?
Run the query before and after the fix
`mc select -e "select * from s3Object" s3/kannappan102/population.csv` and kill the process by entering `Ctrl + C` . It can be observed that the message is not displayed on the server console after the fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.