### PR TITLE
gateway: add single encryption at s3 gateway

### DIFF
--- a/cmd/gateway-env.go
+++ b/cmd/gateway-env.go
@@ -23,4 +23,8 @@ const (
 	GatewaySSEC = "C"
 	// GatewaySSEKMS is set when SSE-KMS double encryption is needed
 	GatewaySSEKMS = "KMS"
+	// GatewaySSEBackendEncrypt is set when encryption is required at backend
+	GatewaySSEBackendEncrypt = "backend"
+	// GatewaySSEGatewayEncrypt is set when encryption is required at gateway
+	GatewaySSEGatewayEncrypt = "gateway"
 )

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -257,6 +257,8 @@ var (
 
 	// GlobalGatewaySSE sse options
 	GlobalGatewaySSE []string
+	// GlobalGatewaySSEMode sse mode options
+	GlobalGatewaySSEMode []string
 	// Add new variable global values here.
 
 )

--- a/cmd/ui-errors.go
+++ b/cmd/ui-errors.go
@@ -209,4 +209,14 @@ Example 1:
 		"Please check the passed value",
 		"MINIO_GW_SSE: Gateway SSE accepts only S3, C and KMS as valid values. Delimit by `;` to set more than one value",
 	)
+	uiErrInvalidGWSSEModeValue = newUIErrFn(
+		"Invalid gateway sse mode value",
+		"Please check the passed value",
+		"MINIO_GW_SSE_MODE: Gateway SSE accepts only backend,gateway as valid values. Delimit by `;` to set more than one value",
+	)
+	uiErrInvalidGWSSEEnvValue = newUIErrFn(
+		"Invalid gateway sse configuration",
+		"",
+		"MINIO_GW_SSE and MINIO_GW_SSE_MODE environment variables need to be set",
+	)
 )

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -31,10 +31,18 @@ Optionally set `MINIO_SSE_VAULT_CAPATH` is the path to a directory of PEM-encode
 export MINIO_SSE_VAULT_CAPATH=/home/user/custom-pems
 ```
 
-To enable encryption at gateway MINIO_GW_SSE environment variable needs to be set to "s3" for sse-s3
+Gateway encryption options can be specified by setting MINIO_GW_SSE and MINI_GW_SSE_MODE.
+
+To specify encryption type at gateway MINIO_GW_SSE environment variable needs to be set to "s3" for sse-s3
 and "c" for sse-c encryption at gateway. More than one encryption option can be set, delimited by ";". If MINIO_GW_SSE is not set, any SSE headers will be passed to S3 backend.
+
+In gateway mode, encryption can be set to pass-through to backend, do encryption at the gateway or double encryption at both gateway and backend by setting environment variable MINIO_GW_SSE_MODE.  More than one encryption mode can be set, delimited by ";". If MINIO_GW_SSE_MODE is not set,SSE options will not be honored.
+Valid settings are "backend" to enable encryption at the backend, and "gateway" to enable encryption at the gateway. Both can be specified to turn on double
+encryption.
+
 ```sh
 export MINIO_GW_SSE="s3;c"
+export MINIO_GW_SSE_MODE="backend;gateway"
 export MINIO_SSE_VAULT_APPROLE_ID=9b56cc08-8258-45d5-24a3-679876769126
 export MINIO_SSE_VAULT_APPROLE_SECRET=4e30c52f-13e4-a6f5-0763-d50e8cb4321f
 export MINIO_SSE_VAULT_ENDPOINT=https://vault-endpoint-ip:8200


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently new feature #6423 adds double encryption at gateway or pass through encryption. Adding an option to turn on encryption at gateway without passing sse headers to backend. 

A new env variable MINIO_GW_SSE_MODE="backend;gateway" will allow setting encryption mode - "backend" will pass SSE headers to s3 backend, "gateway" to enable encryption at gateway and both can be specified delimited by ";" to turn on double encryption

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows flexibility in modes of operating.
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by setting MINIO_GW_SSE_MODE="gateway" and MINIO_GW_SSE="C;S3" and KMS settings enabled.
Run  MINIO_HTTP_TRACE=/dev/stdout ./minio gateway s3
  - all operations GET/PUT/Copy should be encrypted at the gateway only, and sse headers should not be forwarded to backend.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.