### PR TITLE
Shouldn't require space in HTTP host header

### DIFF
--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -141,8 +141,8 @@ func getMethodResourceHost(bufConn *BufConn, maxHeaderBytes int) (method string,
 			// HTTP headers are case insensitive, so we should simply convert
 			// each tokens to their lower case form to match 'host' header.
 			token = strings.ToLower(token)
-			if strings.HasPrefix(token, "host: ") {
-				host = strings.TrimPrefix(strings.TrimSuffix(token, "\r"), "host: ")
+			if strings.HasPrefix(token, "host:") {
+				host = strings.TrimPrefix(strings.TrimSuffix(token, "\r"), "host:")
 				return method, resource, host, nil
 			}
 		}


### PR DESCRIPTION
Fixes #6741

<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, HTTP Host header in minio strictly requires a whitespace

## Motivation and Context
Issue #6741 

## Regression
Most probably Yes.

## How Has This Been Tested?
Using the steps explained in #6741

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.