### PR TITLE
Fix etcd TLS handling

### DIFF
--- a/docs/sts/README.md
+++ b/docs/sts/README.md
@@ -42,7 +42,7 @@ export MINIO_ACCESS_KEY=aws_access_key
 export MINIO_SECRET_KEY=aws_secret_key
 export MINIO_IAM_JWKS_URL=https://localhost:9443/oauth2/jwks
 export MINIO_IAM_OPA_URL=http://localhost:8181/v1/data/httpapi/authz
-export MINIO_ETCD_ENDPOINTS=localhost:2379
+export MINIO_ETCD_ENDPOINTS=http://localhost:2379
 minio gateway s3
 ```
 

--- a/docs/sts/etcd.md
+++ b/docs/sts/etcd.md
@@ -34,7 +34,7 @@ You may also setup etcd with TLS following this documentation [here](https://cor
 ### 3. Setup Minio with etcd
 Minio server expects environment variable for etcd as `MINIO_ETCD_ENDPOINTS`, this environment variable takes many comma separated entries.
 ```
-export MINIO_ETCD_ENDPOINTS=localhost:2379
+export MINIO_ETCD_ENDPOINTS=http://localhost:2379
 minio server /data
 ```
 

--- a/docs/sts/sts.env
+++ b/docs/sts/sts.env
@@ -2,4 +2,4 @@ export MINIO_ACCESS_KEY=minio
 export MINIO_SECRET_KEY=minio123
 export MINIO_IAM_JWKS_URL=http://localhost:9763/oauth2/jwks
 export MINIO_IAM_OPA_URL=http://localhost:8181/v1/data/httpapi/authz
-export MINIO_ETCD_ENDPOINTS=localhost:2379
+export MINIO_ETCD_ENDPOINTS=http://localhost:2379


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix etcd TLS handling
<!--- Describe your changes in detail -->

## Motivation and Context
etcd fails to connect if TLS config is set, make TLS
conditional to input arguments instead

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes in 9fe51e392be56b9543216222e154893e2bff3537
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
By configuring etcd with TLS certs - follow the instructions here

- https://coreos.com/etcd/docs/latest/op-guide/security.html
- https://coreos.com/os/docs/latest/generate-self-signed-certificates.html#tldr

This is to generate Client-to-server transport security with HTTPS where client simply has access to `ca.pem` 
```
echo '{"CN":"CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare ca -
echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
export ADDRESS=127.0.0.1
export NAME=server
echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
```
Make sure to copy `ca.pem` to `/.minio/certs/CAs` for proper connection. 

If you are testing for client certs based authentication then you need another step
```
export ADDRESS=
export NAME=client
echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
```

In this when starting Minio server along with `MINIO_ETCD_ENDPOINTS` you need to set `MINIO_ETCD_CLIENT_CERT` and `MINIO_ETCD_CLIENT_CERT_KEY` environment variables. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.