### PR TITLE
Return default ETag if fs.json is empty

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -719,8 +719,12 @@ func (fs *FSObjects) getObjectInfo(ctx context.Context, bucket, object string) (
 		// Read from fs metadata only if it exists.
 		_, rerr := fsMeta.ReadFrom(ctx, rlk.LockedFile)
 		fs.rwPool.Close(fsMetaPath)
-		if rerr != nil && rerr != io.EOF {
-			return oi, rerr
+		if rerr != nil {
+			if rerr != io.EOF {
+				return oi, rerr
+			}
+			// Set Default ETag, if fs.json is empty
+			fsMeta = fs.defaultFsJSON(object)
 		}
 	}
 


### PR DESCRIPTION
## Description
If fs.json is empty, then a default etag should be returned when a HeadObject command is issued.


## Regression
No

## How Has This Been Tested?
Start minio in `fs` mode
Create a bucket named `test`, if it doesn't exist already
`mc cp /etc/issue myminio/test`
Go to the backend and make `fs.json` empty. (`/data/dir/.minio.sys/buckets/test/issue/fs/json`)
Issue `mc stat myminio/test/issue`
This will not display the etag. With this fix, you will see the default etag displayed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.