### PR TITLE
Cleanup unnecessary logs

### DIFF
--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -30,25 +30,21 @@ type GatewayUnsupported struct{}
 
 // ListMultipartUploads lists all multipart uploads.
 func (a GatewayUnsupported) ListMultipartUploads(ctx context.Context, bucket string, prefix string, keyMarker string, uploadIDMarker string, delimiter string, maxUploads int) (lmi ListMultipartsInfo, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return lmi, NotImplemented{}
 }
 
 // NewMultipartUpload upload object in multiple parts
 func (a GatewayUnsupported) NewMultipartUpload(ctx context.Context, bucket string, object string, metadata map[string]string, opts ObjectOptions) (uploadID string, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return "", NotImplemented{}
 }
 
 // CopyObjectPart copy part of object to uploadID for another object
 func (a GatewayUnsupported) CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject, uploadID string, partID int, startOffset, length int64, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (pi PartInfo, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return pi, NotImplemented{}
 }
 
 // PutObjectPart puts a part of object in bucket
 func (a GatewayUnsupported) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *hash.Reader, opts ObjectOptions) (pi PartInfo, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return pi, NotImplemented{}
 }
 
@@ -60,13 +56,11 @@ func (a GatewayUnsupported) ListObjectParts(ctx context.Context, bucket string, 
 
 // AbortMultipartUpload aborts a ongoing multipart upload
 func (a GatewayUnsupported) AbortMultipartUpload(ctx context.Context, bucket string, object string, uploadID string) error {
-	logger.LogIf(ctx, NotImplemented{})
 	return NotImplemented{}
 }
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object
 func (a GatewayUnsupported) CompleteMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, uploadedParts []CompletePart) (oi ObjectInfo, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return oi, NotImplemented{}
 }
 
@@ -78,13 +72,11 @@ func (a GatewayUnsupported) SetBucketPolicy(ctx context.Context, bucket string, 
 
 // GetBucketPolicy will get policy on bucket
 func (a GatewayUnsupported) GetBucketPolicy(ctx context.Context, bucket string) (bucketPolicy *policy.Policy, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return nil, NotImplemented{}
 }
 
 // DeleteBucketPolicy deletes all policies on bucket
 func (a GatewayUnsupported) DeleteBucketPolicy(ctx context.Context, bucket string) error {
-	logger.LogIf(ctx, NotImplemented{})
 	return NotImplemented{}
 }
 
@@ -95,50 +87,42 @@ func (a GatewayUnsupported) ReloadFormat(ctx context.Context, dryRun bool) error
 
 // HealFormat - Not implemented stub
 func (a GatewayUnsupported) HealFormat(ctx context.Context, dryRun bool) (madmin.HealResultItem, error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return madmin.HealResultItem{}, NotImplemented{}
 }
 
 // HealBucket - Not implemented stub
 func (a GatewayUnsupported) HealBucket(ctx context.Context, bucket string, dryRun bool) ([]madmin.HealResultItem, error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return nil, NotImplemented{}
 }
 
 // ListBucketsHeal - Not implemented stub
 func (a GatewayUnsupported) ListBucketsHeal(ctx context.Context) (buckets []BucketInfo, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return nil, NotImplemented{}
 }
 
 // HealObject - Not implemented stub
 func (a GatewayUnsupported) HealObject(ctx context.Context, bucket, object string, dryRun bool) (h madmin.HealResultItem, e error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return h, NotImplemented{}
 }
 
 // ListObjectsV2 - Not implemented stub
 func (a GatewayUnsupported) ListObjectsV2(ctx context.Context, bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (result ListObjectsV2Info, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return result, NotImplemented{}
 }
 
 // ListObjectsHeal - Not implemented stub
 func (a GatewayUnsupported) ListObjectsHeal(ctx context.Context, bucket, prefix, marker, delimiter string, maxKeys int) (loi ListObjectsInfo, e error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return loi, NotImplemented{}
 }
 
 // CopyObject copies a blob from source container to destination container.
 func (a GatewayUnsupported) CopyObject(ctx context.Context, srcBucket string, srcObject string, destBucket string, destObject string,
 	srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (objInfo ObjectInfo, err error) {
-	logger.LogIf(ctx, NotImplemented{})
 	return objInfo, NotImplemented{}
 }
 
 // RefreshBucketPolicy refreshes cache policy with what's on disk.
 func (a GatewayUnsupported) RefreshBucketPolicy(ctx context.Context, bucket string) error {
-	logger.LogIf(ctx, NotImplemented{})
 	return NotImplemented{}
 }
 

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -672,7 +672,6 @@ func (a *azureObjects) GetObject(ctx context.Context, bucket, object string, sta
 	}
 	_, err = io.Copy(writer, rc)
 	rc.Close()
-	logger.LogIf(ctx, err)
 	return err
 }
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2094,7 +2094,6 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			writeErrorResponse(w, ErrNoSuchBucket, r.URL)
 			return
 		}
-		logger.LogIf(ctx, err)
 		// Ignore delete object errors while replying to client, since we are suppposed to reply only 204.
 	}
 	writeSuccessNoContent(w)


### PR DESCRIPTION
## Description
Removing unnecessary logs

## Motivation and Context

Saw these errors while running mint against `gateway azure`
```
API: DeleteObject(bucket=minio-py-test-d360581e-1ad0-4c53-a814-50773eb4bdfe, object=bce2d1ab-4421-42fc-952a-62019d278fd5-copy)
Time: 15:54:25 PST 11/05/2018
RequestID: 15645F94E079CE89
RemoteHost: 192.168.1.161
UserAgent: Minio (Linux; x86_64) minio-py/4.0.6
Error: Object not found: minio-py-test-d360581e-1ad0-4c53-a814-50773eb4bdfe#bce2d1ab-4421-42fc-952a-62019d278fd5-copy
       1: cmd/object-handlers.go:2097:cmd.objectAPIHandlers.DeleteObjectHandler()
       2: cmd/api-router.go:74:cmd.(objectAPIHandlers).DeleteObjectHandler-fm()
       3: net/http/server.go:1947:http.HandlerFunc.ServeHTTP()

API: CopyObjectPart(bucket=aws-sdk-php-5be0e332ad41d, object=obj1-copy)
Time: 16:41:28 PST 11/05/2018
RequestID: 15646225FABAC20F
RemoteHost: 192.168.1.161
UserAgent: aws-sdk-php/3.69.16 GuzzleHttp/6.3.3 curl/7.47.0 PHP/7.0.32-0ubuntu0.16.04.1
Error: Not Implemented
       1: cmd/gateway-unsupported.go:45:cmd.GatewayUnsupported.CopyObjectPart()
       2: cmd/object-handlers.go:1577:cmd.objectAPIHandlers.CopyObjectPartHandler()
       3: cmd/api-router.go:52:cmd.(objectAPIHandlers).CopyObjectPartHandler-fm()
       4: cmd/api-router.go:52:cmd.(objectAPIHandlers).CopyObjectPartHandler-fm()
       5: net/http/server.go:1947:http.HandlerFunc.ServeHTTP()

API: CopyObjectPart(bucket=aws-sdk-php-5be0e332ad41d, object=obj1-copy)
Time: 16:41:28 PST 11/05/2018
RequestID: 15646225FABAC20F
RemoteHost: 192.168.1.161
UserAgent: aws-sdk-php/3.69.16 GuzzleHttp/6.3.3 curl/7.47.0 PHP/7.0.32-0ubuntu0.16.04.1
Error: io: read/write on closed pipe
       1: cmd/gateway/azure/gateway-azure.go:675:azure.(*azureObjects).GetObject()
       2: cmd/gateway/azure/gateway-azure.go:634:azure.(*azureObjects).GetObjectNInfo.func1()

API: CopyObject(bucket=aws-sdk-php-5be0e332ad41d, object=obj1-copy)
Time: 16:41:51 PST 11/05/2018
RequestID: 1564622B4FE4FFAD
RemoteHost: 192.168.1.161
UserAgent: aws-sdk-php/3.69.16 GuzzleHttp/6.3.3 curl/7.47.0 PHP/7.0.32-0ubuntu0.16.04.1
Error: io: read/write on closed pipe
       1: cmd/gateway/azure/gateway-azure.go:675:azure.(*azureObjects).GetObject()
       2: cmd/gateway/azure/gateway-azure.go:634:azure.(*azureObjects).GetObjectNInfo.func1()


API: GetObject(bucket=minio-java-test-3isffna, object=minio-java-test-2l8eisf)
Time: 16:31:06 PST 11/05/2018
RequestID: 156461955586074C
RemoteHost: 192.168.1.161
UserAgent: Minio (amd64; amd64) minio-java/dev
Error: io: read/write on closed pipe
       1: cmd/gateway/azure/gateway-azure.go:675:azure.(*azureObjects).GetObject()
       2: cmd/gateway/azure/gateway-azure.go:634:azure.(*azureObjects).GetObjectNInfo.func1()
```

## Regression
No

## How Has This Been Tested?
Run mint against `minio gateway azure` before and after the fix to see the difference

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.