### PR TITLE
Add sync mode for 'xl.json'

### DIFF
--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -159,6 +159,13 @@ func (d *naughtyDisk) DeleteFile(volume string, path string) (err error) {
 	return d.disk.DeleteFile(volume, path)
 }
 
+func (d *naughtyDisk) WriteAll(volume string, path string, buf []byte) (err error) {
+	if err := d.calcError(); err != nil {
+		return err
+	}
+	return d.disk.WriteAll(volume, path, buf)
+}
+
 func (d *naughtyDisk) ReadAll(volume string, path string) (buf []byte, err error) {
 	if err := d.calcError(); err != nil {
 		return nil, err

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -47,6 +47,9 @@ type StorageAPI interface {
 	StatFile(volume string, path string) (file FileInfo, err error)
 	DeleteFile(volume string, path string) (err error)
 
+	// Write all data, syncs the data to disk.
+	WriteAll(volume string, path string, buf []byte) (err error)
+
 	// Read all.
 	ReadAll(volume string, path string) (buf []byte, err error)
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -221,6 +221,17 @@ func (client *storageRESTClient) AppendFile(volume, path string, buffer []byte) 
 	return err
 }
 
+// WriteAll - write all data to a file.
+func (client *storageRESTClient) WriteAll(volume, path string, buffer []byte) error {
+	values := make(url.Values)
+	values.Set(storageRESTVolume, volume)
+	values.Set(storageRESTFilePath, path)
+	reader := bytes.NewBuffer(buffer)
+	respBody, err := client.call(storageRESTMethodWriteAll, values, reader)
+	defer CloseResponse(respBody)
+	return err
+}
+
 // StatFile - stat a file.
 func (client *storageRESTClient) StatFile(volume, path string) (info FileInfo, err error) {
 	values := make(url.Values)

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -28,6 +28,7 @@ const (
 
 	storageRESTMethodPrepareFile = "preparefile"
 	storageRESTMethodAppendFile  = "appendfile"
+	storageRESTMethodWriteAll    = "writeall"
 	storageRESTMethodStatFile    = "statfile"
 	storageRESTMethodReadAll     = "readall"
 	storageRESTMethodReadFile    = "readfile"

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -179,6 +179,33 @@ func (s *storageRESTServer) AppendFileHandler(w http.ResponseWriter, r *http.Req
 	}
 }
 
+// WriteAllHandler - write to file all content.
+func (s *storageRESTServer) WriteAllHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.IsValid(w, r) {
+		return
+	}
+	vars := mux.Vars(r)
+	volume := vars[storageRESTVolume]
+	filePath := vars[storageRESTFilePath]
+
+	if r.ContentLength < 0 {
+		s.writeErrorResponse(w, errInvalidArgument)
+		return
+	}
+
+	buf := make([]byte, r.ContentLength)
+	_, err := io.ReadFull(r.Body, buf)
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+
+	err = s.storage.WriteAll(volume, filePath, buf)
+	if err != nil {
+		s.writeErrorResponse(w, err)
+	}
+}
+
 // StatFileHandler - stat a file.
 func (s *storageRESTServer) StatFileHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.IsValid(w, r) {
@@ -335,6 +362,8 @@ func registerStorageRESTHandlers(router *mux.Router, endpoints EndpointList) {
 		subrouter.Methods(http.MethodPost).Path("/" + storageRESTMethodPrepareFile).HandlerFunc(httpTraceHdrs(server.PrepareFileHandler)).
 			Queries(restQueries(storageRESTVolume, storageRESTFilePath, storageRESTLength)...)
 		subrouter.Methods(http.MethodPost).Path("/" + storageRESTMethodAppendFile).HandlerFunc(httpTraceHdrs(server.AppendFileHandler)).
+			Queries(restQueries(storageRESTVolume, storageRESTFilePath)...)
+		subrouter.Methods(http.MethodPost).Path("/" + storageRESTMethodWriteAll).HandlerFunc(httpTraceHdrs(server.WriteAllHandler)).
 			Queries(restQueries(storageRESTVolume, storageRESTFilePath)...)
 		subrouter.Methods(http.MethodPost).Path("/" + storageRESTMethodStatFile).HandlerFunc(httpTraceHdrs(server.StatFileHandler)).
 			Queries(restQueries(storageRESTVolume, storageRESTFilePath)...)

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -423,8 +423,9 @@ func writeXLMetadata(ctx context.Context, disk StorageAPI, bucket, prefix string
 		logger.LogIf(ctx, err)
 		return err
 	}
+
 	// Persist marshaled data.
-	err = disk.AppendFile(bucket, jsonFile, metadataBytes)
+	err = disk.WriteAll(bucket, jsonFile, metadataBytes)
 	logger.LogIf(ctx, err)
 	return err
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add sync mode for 'xl.json'
<!--- Describe your changes in detail -->

## Motivation and Context
xl.json is the source of truth for all erasure
coded objects, without which we won't be able to
read the objects properly. This PR enables sync
mode for writing `xl.json` such all writes go hit
the disk and are persistent under situations such
as abrupt power failures on servers running Minio.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Harder to test and requires setting up a set of VMs and create abrupt power shutdowns without using ACPI shutdown on VMs, also a continuous set of PutObject()'s should be in progress. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.