### PR TITLE
Simplify custom format for s3 gateway encryption

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -325,7 +325,7 @@ func handleCommonEnvVars() {
 		if err != nil {
 			logger.Fatal(err, "Unable to initialize KMS")
 		}
-		globalKMS = kms
+		GlobalKMS = kms
 		globalKMSKeyID = kmsConf.Vault.Key.Name
 		globalKMSConfig = kmsConf
 	}

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -271,7 +271,7 @@ func (s *serverConfig) loadFromEnvs() {
 		s.SetCacheConfig(globalCacheDrives, globalCacheExcludes, globalCacheExpiry, globalCacheMaxUse)
 	}
 
-	if globalKMS != nil {
+	if GlobalKMS != nil {
 		s.KMS = globalKMSConfig
 	}
 
@@ -534,10 +534,10 @@ func (s *serverConfig) loadToCachedConfigs() {
 		globalCacheExpiry = cacheConf.Expiry
 		globalCacheMaxUse = cacheConf.MaxUse
 	}
-	if globalKMS == nil {
+	if GlobalKMS == nil {
 		globalKMSConfig = s.KMS
 		if kms, err := crypto.NewVault(globalKMSConfig); err == nil {
-			globalKMS = kms
+			GlobalKMS = kms
 			globalKMSKeyID = globalKMSConfig.Vault.Key.Name
 		}
 	}

--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -161,14 +161,14 @@ func rotateKey(oldKey []byte, newKey []byte, bucket, object string, metadata map
 		crypto.SSEC.CreateMetadata(metadata, sealedKey)
 		return nil
 	case crypto.S3.IsEncrypted(metadata):
-		if globalKMS == nil {
+		if GlobalKMS == nil {
 			return errKMSNotConfigured
 		}
 		keyID, kmsKey, sealedKey, err := crypto.S3.ParseMetadata(metadata)
 		if err != nil {
 			return err
 		}
-		oldKey, err := globalKMS.UnsealKey(keyID, kmsKey, crypto.Context{bucket: path.Join(bucket, object)})
+		oldKey, err := GlobalKMS.UnsealKey(keyID, kmsKey, crypto.Context{bucket: path.Join(bucket, object)})
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func rotateKey(oldKey []byte, newKey []byte, bucket, object string, metadata map
 			return err
 		}
 
-		newKey, encKey, err := globalKMS.GenerateKey(globalKMSKeyID, crypto.Context{bucket: path.Join(bucket, object)})
+		newKey, encKey, err := GlobalKMS.GenerateKey(globalKMSKeyID, crypto.Context{bucket: path.Join(bucket, object)})
 		if err != nil {
 			return err
 		}
@@ -190,10 +190,10 @@ func rotateKey(oldKey []byte, newKey []byte, bucket, object string, metadata map
 func newEncryptMetadata(key []byte, bucket, object string, metadata map[string]string, sseS3 bool) ([]byte, error) {
 	var sealedKey crypto.SealedKey
 	if sseS3 {
-		if globalKMS == nil {
+		if GlobalKMS == nil {
 			return nil, errKMSNotConfigured
 		}
-		key, encKey, err := globalKMS.GenerateKey(globalKMSKeyID, crypto.Context{bucket: path.Join(bucket, object)})
+		key, encKey, err := GlobalKMS.GenerateKey(globalKMSKeyID, crypto.Context{bucket: path.Join(bucket, object)})
 		if err != nil {
 			return nil, err
 		}
@@ -300,7 +300,7 @@ func decryptObjectInfo(key []byte, bucket, object string, metadata map[string]st
 	default:
 		return nil, errObjectTampered
 	case crypto.S3.IsEncrypted(metadata):
-		if globalKMS == nil {
+		if GlobalKMS == nil {
 			return nil, errKMSNotConfigured
 		}
 		keyID, kmsKey, sealedKey, err := crypto.S3.ParseMetadata(metadata)
@@ -308,7 +308,7 @@ func decryptObjectInfo(key []byte, bucket, object string, metadata map[string]st
 		if err != nil {
 			return nil, err
 		}
-		extKey, err := globalKMS.UnsealKey(keyID, kmsKey, crypto.Context{bucket: path.Join(bucket, object)})
+		extKey, err := GlobalKMS.UnsealKey(keyID, kmsKey, crypto.Context{bucket: path.Join(bucket, object)})
 		if err != nil {
 			return nil, err
 		}
@@ -416,7 +416,6 @@ func DecryptBlocksRequestR(inputReader io.Reader, h http.Header, offset,
 	io.Reader, error) {
 
 	bucket, object := oi.Bucket, oi.Name
-
 	// Single part case
 	if !isEncryptedMultipart(oi) {
 		var reader io.Reader

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -350,26 +350,11 @@ func parseGatewaySSE(s string) ([]string, error) {
 	gwSlice := make([]string, len(l))
 	for _, val := range l {
 		v := strings.ToUpper(val)
-		if v == GatewaySSES3 || v == GatewaySSEC || v == GatewaySSEKMS {
+		if v == GatewaySSES3 || v == GatewaySSEC {
 			gwSlice = append(gwSlice, v)
 			continue
 		}
 		return nil, uiErrInvalidGWSSEValue(nil).Msg("gateway SSE cannot be (%s) ", v)
-	}
-	return gwSlice, nil
-}
-
-// parse gateway sse mode env variable
-func parseGatewaySSEMode(s string) ([]string, error) {
-	l := strings.Split(s, ";")
-	gwSlice := make([]string, len(l))
-	for _, val := range l {
-		v := strings.ToLower(val)
-		if v == GatewaySSEBackendEncrypt || v == GatewaySSEGatewayEncrypt {
-			gwSlice = append(gwSlice, v)
-			continue
-		}
-		return nil, uiErrInvalidGWSSEModeValue(nil).Msg("gateway SSE mode cannot be (%s) ", v)
 	}
 	return gwSlice, nil
 }
@@ -384,18 +369,8 @@ func handleGatewayEnvVars() {
 		}
 		GlobalGatewaySSE = gwsseSlice
 	}
-	gwsseMode, ok := os.LookupEnv("MINIO_GW_SSE_MODE")
-	if ok {
-		gwsseModeSlice, err := parseGatewaySSEMode(gwsseMode)
-		if err != nil {
-			logger.Fatal(err, "Unable to parse MINIO_GW_SSE_MODE value (`%s`)", gwsseMode)
-		}
-		GlobalGatewaySSEMode = gwsseModeSlice
-	}
-	if len(gwsseMode) == 0 && len(gwsse) != 0 {
-		logger.Fatal(uiErrInvalidGWSSEEnvValue(nil).Msg("MINIO_GW_SSE_MODE not set"), "Unable to start gateway with sse")
-	}
-	if len(gwsse) == 0 && len(gwsseMode) != 0 {
-		logger.Fatal(uiErrInvalidGWSSEEnvValue(nil).Msg("MINIO_GW_SSE not set"), "Unable to start gateway with sse")
+
+	if len(gwsse) != 0 && GlobalKMS == nil {
+		logger.Fatal(uiErrInvalidGWSSEEnvValue(nil).Msg("MINIO_GW_SSE set but KMS not enabled"), "Unable to start gateway with sse")
 	}
 }

--- a/cmd/gateway-env.go
+++ b/cmd/gateway-env.go
@@ -21,10 +21,4 @@ const (
 	GatewaySSES3 = "S3"
 	// GatewaySSEC is set when SSE-C encryption needed on both gateway and backend
 	GatewaySSEC = "C"
-	// GatewaySSEKMS is set when SSE-KMS double encryption is needed
-	GatewaySSEKMS = "KMS"
-	// GatewaySSEBackendEncrypt is set when encryption is required at backend
-	GatewaySSEBackendEncrypt = "backend"
-	// GatewaySSEGatewayEncrypt is set when encryption is required at gateway
-	GatewaySSEGatewayEncrypt = "gateway"
 )

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -140,8 +140,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(pErr, "Unable to start gateway")
 	}
 
-	// Handle gateway specific env
-	handleGatewayEnvVars()
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
 	// (non-)minio process is listening on IPv4 of given port.
@@ -162,6 +160,9 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 
 	// Handle common env vars.
 	handleCommonEnvVars()
+
+	// Handle gateway specific env
+	handleGatewayEnvVars()
 
 	// Validate if we have access, secret set through environment.
 	if !globalIsEnvCreds {

--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -19,22 +19,18 @@ package s3
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"path"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/minio/minio-go/pkg/encrypt"
 	minio "github.com/minio/minio/cmd"
-	"github.com/minio/sio"
 
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/pkg/hash"
 )
 
 const (
@@ -57,44 +53,40 @@ type s3EncObjects struct {
 
 /*
  NOTE:
- Custom gateway encrypted objects uploaded with single PUT operation are stored on backend as follows:
+ Custom gateway encrypted objects are stored on backend as follows:
 	 obj/.minio/data   <= encrypted content
 	 obj/.minio/dare.meta  <= metadata
- Custom gateway encrypted objects uploaded with multipart upload operation are stored on backend as follows:
-		obj/.minio/dare.meta  <= metadata
-		obj/.minio/uploadId/1 <= encrypted part 1
-		obj/.minio/uploadId/2 ...
-		obj/.minio/uploadId/3
-	When a multipart upload is in progress, part metadata is stored in obj/.minio/uploadID/1/part-etag/part.meta
-	where part-etag is etag of the actual part content file on s3 backend. This metadata file will be cleaned up
-	after the upload completes.
+
+ When a multipart upload operation is in progress, the metadata set during
+ NewMultipartUpload is stored in obj/.minio/uploadID/dare.meta and each
+ UploadPart operation saves additional state of the part's encrypted ETag and
+ encrypted size in obj/.minio/uploadID/part1/part.meta
+
+ All the part metadata and temp dare.meta are cleaned up when upload completes
 */
 
 // ListObjects lists all blobs in S3 bucket filtered by prefix
 func (l *s3EncObjects) ListObjects(ctx context.Context, bucket string, prefix string, marker string, delimiter string, maxKeys int) (loi minio.ListObjectsInfo, e error) {
-	if len(minio.GlobalGatewaySSE) > 0 {
-		var continuationToken, startAfter string
-		res, err := l.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, false, startAfter)
-		if err != nil {
-			return loi, err
-		}
-		loi.IsTruncated = res.IsTruncated
-		loi.NextMarker = res.NextContinuationToken
-		loi.Objects = res.Objects
-		loi.Prefixes = res.Prefixes
-		return loi, nil
+	var continuationToken, startAfter string
+	res, err := l.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, false, startAfter)
+	if err != nil {
+		return loi, err
 	}
-	return l.s3Objects.ListObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)
+	loi.IsTruncated = res.IsTruncated
+	loi.NextMarker = res.NextContinuationToken
+	loi.Objects = res.Objects
+	loi.Prefixes = res.Prefixes
+	return loi, nil
+
 }
 
 // ListObjectsV2 lists all blobs in S3 bucket filtered by prefix
 func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (loi minio.ListObjectsV2Info, e error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, fetchOwner, startAfter)
-	}
+
 	var objects []minio.ObjectInfo
 	var prefixes []string
 	var isTruncated bool
+
 	// filter out objects that contain a .minio prefix, but is not a dare.meta metadata file.
 	for {
 		loi, e = l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, fetchOwner, startAfter)
@@ -105,10 +97,7 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 			startAfter = obj.Name
 			continuationToken = loi.NextContinuationToken
 			isTruncated = loi.IsTruncated
-			// skip parts objects from listing
-			if strings.Contains(obj.Name, defaultMinioGWPrefix) && !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
-				continue
-			}
+
 			if !isGWObject(obj.Name) {
 				continue
 			}
@@ -119,14 +108,11 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 				if e != nil {
 					continue
 				}
-				prefixSlice := strings.Split(obj.Name, slashSeparator+defaultMinioGWPrefix+slashSeparator)
-				if len(prefixSlice) >= 1 {
-					oInfo := gwMeta.ToObjectInfo(bucket, prefixSlice[0][:])
-					objects = append(objects, oInfo)
-				}
-				continue
+				oInfo := gwMeta.ToObjectInfo(bucket, objSlice[0])
+				objects = append(objects, oInfo)
+			} else {
+				objects = append(objects, obj)
 			}
-			objects = append(objects, obj)
 			if len(objects) > maxKeys {
 				break
 			}
@@ -172,6 +158,11 @@ func isGWObject(objName string) bool {
 	if !isEncrypted {
 		return true
 	}
+	// ignore temp part.meta files
+	if strings.Contains(objName, gwpartMetaJSON) {
+		return false
+	}
+
 	pfxSlice := strings.Split(objName, slashSeparator)
 	var i1, i2 int
 	for i := len(pfxSlice) - 1; i >= 0; i-- {
@@ -200,9 +191,6 @@ func (l *s3EncObjects) isPrefix(ctx context.Context, bucket, prefix string, fetc
 			return false
 		}
 		for _, obj := range loi.Objects {
-			if !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
-				continue
-			}
 			if isGWObject(obj.Name) {
 				return true
 			}
@@ -216,122 +204,16 @@ func (l *s3EncObjects) isPrefix(ctx context.Context, bucket, prefix string, fetc
 	return false
 }
 
-// shouldSetSSEHeaders returns true if sse mode specifies
-// backend encryption
+// shouldSetSSEHeaders returns true if backend encryption is specified
 func shouldSetSSEHeaders() bool {
-	for _, v := range minio.GlobalGatewaySSEMode {
-		if v == minio.GatewaySSEBackendEncrypt {
-			return true
-		}
-	}
-	return false
+	return len(minio.GlobalGatewaySSE) > 0
 }
 
 // GetObject reads an object from S3. Supports additional
 // parameters like offset and length which are synonymous with
 // HTTP Range requests.
-// In the case of multi-part uploads that were encrypted at the gateway, the objects
-// are stored in a custom format at the backend with each part as an individual object
-// and piped to the writer.
 func (l *s3EncObjects) GetObject(ctx context.Context, bucket string, key string, startOffset int64, length int64, writer io.Writer, etag string, opts minio.ObjectOptions) error {
-	var o minio.ObjectOptions
-	if shouldSetSSEHeaders() {
-		o = opts
-	}
-	// pass through encryption
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
-	}
-	dmeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(key))
-	if err != nil {
-		// unencrypted content
-		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
-	}
-
-	if len(dmeta.Parts) == 0 {
-		// custom gateway encrypted objects uploaded with single PUT operation
-		return l.s3Objects.GetObject(ctx, bucket, getGWContentPath(key), startOffset, length, writer, etag, o)
-	}
-
-	// handle custom multipart gateway encrypted objects
-	var partStartIndex int
-	var partStartOffset = startOffset
-
-	// Skip parts until final offset maps to a particular part offset.
-	for i, part := range dmeta.Parts {
-		decryptedSize, err := sio.DecryptedSize(uint64(part.Size))
-		if err != nil {
-			return err
-		}
-		partStartIndex = i
-
-		// Offset is smaller than size we have reached the
-		// proper part offset, break out we start from
-		// this part index.
-		if partStartOffset < int64(decryptedSize) {
-			break
-		}
-		// Continue to look for next part.
-		partStartOffset -= int64(decryptedSize)
-	}
-	startSeqNum := partStartOffset / minio.SSEDAREPackageBlockSize
-	partEncRelOffset := int64(startSeqNum) * (minio.SSEDAREPackageBlockSize + minio.SSEDAREPackageMetaSize)
-
-	var size int64
-	// concatenate parts stored as separate objects into writer
-	for i, part := range dmeta.Parts {
-		//skip parts before start offset
-		if i < partStartIndex {
-			continue
-		}
-		pInfo, err := l.s3Objects.GetObjectInfo(ctx, bucket, part.Name, o)
-		if err != nil {
-			logger.LogIf(ctx, err)
-			return minio.ObjectNotFound{
-				Bucket: bucket,
-				Object: key,
-			}
-		}
-		if o.GetDecryptedETagFn != nil && pInfo.ETag != o.GetDecryptedETagFn(part.ETag) {
-			logger.LogIf(ctx, err)
-			return minio.ObjectNotFound{
-				Bucket: bucket,
-				Object: key,
-			}
-		}
-
-		partLength := pInfo.Size - partEncRelOffset
-		size += partLength
-		if size > length {
-			partLength -= (size - length)
-		}
-
-		pipeReader, pipeWriter := io.Pipe()
-
-		var reader io.Reader = pipeReader
-		pInfo.Reader, err = hash.NewReader(reader, partLength, "", "", pInfo.Size)
-		pInfo.Writer = pipeWriter
-
-		go func(pInfo minio.ObjectInfo) {
-			if gerr := l.s3Objects.GetObject(ctx, bucket, pInfo.Name, partEncRelOffset, partLength, pInfo.Writer, pInfo.ETag, o); gerr != nil {
-				if gerr = pInfo.Writer.Close(); gerr != nil {
-					logger.LogIf(ctx, gerr)
-					return
-				}
-			}
-		}(pInfo)
-		if pInfo.Reader == nil {
-			return nil
-		}
-		_, err = io.Copy(writer, pInfo.Reader)
-		if err != nil {
-			logger.LogIf(ctx, err)
-			return minio.ErrorRespToObjectError(err)
-		}
-		partStartIndex++
-		partEncRelOffset = 0
-	}
-	return nil
+	return l.getObject(ctx, bucket, key, startOffset, length, writer, etag, opts)
 }
 
 func (l *s3EncObjects) isGWEncrypted(ctx context.Context, bucket, object string) bool {
@@ -363,19 +245,67 @@ func (l *s3EncObjects) writeGWMetadata(ctx context.Context, bucket, metaFileName
 	_, err = l.s3Objects.PutObject(ctx, bucket, metaFileName, minio.NewPutObjectReader(hashReader), map[string]string{}, o)
 	return err
 }
+
+// returns path of temporary metadata json file for the upload
 func getTmpDareMetaPath(object, uploadID string) string {
 	return path.Join(getGWMetaPath(object), uploadID, gwdareMetaJSON)
 }
+
+// returns path of metadata json file for encrypted objects
 func getDareMetaPath(object string) string {
 	return path.Join(getGWMetaPath(object), gwdareMetaJSON)
 }
-func getPartMetaPath(object, uploadID string, partID int, partETag string) string {
-	return path.Join(object, defaultMinioGWPrefix, uploadID, strconv.Itoa(partID), partETag, gwpartMetaJSON)
+
+// returns path of temporary part metadata file for multipart uploads
+func getPartMetaPath(object, uploadID string, partID int) string {
+	return path.Join(object, defaultMinioGWPrefix, uploadID, strconv.Itoa(partID), gwpartMetaJSON)
 }
 
 // deletes the custom dare metadata file saved at the backend
 func (l *s3EncObjects) deleteGWMetadata(ctx context.Context, bucket, metaFileName string) error {
 	return l.s3Objects.DeleteObject(ctx, bucket, metaFileName)
+}
+
+func (l *s3EncObjects) getObject(ctx context.Context, bucket string, key string, startOffset int64, length int64, writer io.Writer, etag string, opts minio.ObjectOptions) error {
+	var o minio.ObjectOptions
+	if shouldSetSSEHeaders() {
+		o = opts
+	}
+	dmeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(key))
+	if err != nil {
+		// unencrypted content
+		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
+	}
+	if startOffset < 0 {
+		logger.LogIf(ctx, minio.InvalidRange{})
+	}
+
+	// For negative length read everything.
+	if length < 0 {
+		length = dmeta.Stat.Size - startOffset
+	}
+	// Reply back invalid range if the input offset and length fall out of range.
+	if startOffset > dmeta.Stat.Size || startOffset+length > dmeta.Stat.Size {
+		logger.LogIf(ctx, minio.InvalidRange{OffsetBegin: startOffset, OffsetEnd: length, ResourceSize: dmeta.Stat.Size})
+		return minio.InvalidRange{OffsetBegin: startOffset, OffsetEnd: length, ResourceSize: dmeta.Stat.Size}
+	}
+	// Get start part index and offset.
+	_, partOffset, err := dmeta.ObjectToPartOffset(ctx, startOffset)
+	if err != nil {
+		return minio.InvalidRange{OffsetBegin: startOffset, OffsetEnd: length, ResourceSize: dmeta.Stat.Size}
+	}
+
+	// Calculate endOffset according to length
+	endOffset := startOffset
+	if length > 0 {
+		endOffset += length - 1
+	}
+
+	// Get last part index to read given length.
+	if _, _, err := dmeta.ObjectToPartOffset(ctx, endOffset); err != nil {
+		return minio.InvalidRange{OffsetBegin: startOffset, OffsetEnd: length, ResourceSize: dmeta.Stat.Size}
+	}
+	return l.s3Objects.GetObject(ctx, bucket, key, partOffset, endOffset, writer, dmeta.ETag, o)
 }
 
 // GetObjectNInfo - returns object info and locked object ReadCloser
@@ -384,22 +314,21 @@ func (l *s3EncObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	if shouldSetSSEHeaders() {
 		opts = o
 	}
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
-	}
-
 	objInfo, err := l.GetObjectInfo(ctx, bucket, object, opts)
 	if err != nil {
 		return l.s3Objects.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
 	}
+	objInfo.UserDefined = minio.CleanMinioInternalMetadataKeys(objInfo.UserDefined)
 	fn, off, length, err := minio.NewGetObjectReader(rs, objInfo)
 	if err != nil {
 		return nil, minio.ErrorRespToObjectError(err)
 	}
-
+	if l.isGWEncrypted(ctx, bucket, object) {
+		object = getGWContentPath(object)
+	}
 	pr, pw := io.Pipe()
 	go func() {
-		err := l.GetObject(ctx, bucket, object, off, length, pw, objInfo.ETag, opts)
+		err := l.getObject(ctx, bucket, object, off, length, pw, objInfo.ETag, opts)
 		pw.CloseWithError(err)
 	}()
 	// Setup cleanup function to cause the above go-routine to
@@ -415,9 +344,7 @@ func (l *s3EncObjects) GetObjectInfo(ctx context.Context, bucket string, object 
 	if shouldSetSSEHeaders() {
 		opts = o
 	}
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.GetObjectInfo(ctx, bucket, object, opts)
-	}
+
 	gwMeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(object))
 	if err != nil {
 		return l.s3Objects.GetObjectInfo(ctx, bucket, object, opts)
@@ -427,114 +354,36 @@ func (l *s3EncObjects) GetObjectInfo(ctx context.Context, bucket string, object 
 
 // CopyObject copies an object from source bucket to a destination bucket.
 func (l *s3EncObjects) CopyObject(ctx context.Context, srcBucket string, srcObject string, dstBucket string, dstObject string, srcInfo minio.ObjectInfo, s, d minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
-	var srcOpts, dstOpts minio.ObjectOptions
-	if shouldSetSSEHeaders() {
-		srcOpts = s
-		dstOpts = d
-	}
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.CopyObject(ctx, srcBucket, srcObject, dstBucket, dstObject, srcInfo, srcOpts, dstOpts)
-	}
 	return l.PutObject(ctx, dstBucket, dstObject, srcInfo.PutObjectReader, srcInfo.UserDefined, d)
 }
 
 // DeleteObject deletes a blob in bucket
-// For custom gateway encrypted large objects, cleans up individual parts and metadata files
+// For custom gateway encrypted large objects, cleans up encrypted content and metadata files
 // from the backend.
 func (l *s3EncObjects) DeleteObject(ctx context.Context, bucket string, object string) error {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.DeleteObject(ctx, bucket, object)
-	}
+
 	// Get dare meta json
 	if _, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(object)); err != nil {
 		return l.s3Objects.DeleteObject(ctx, bucket, object)
 	}
-	return l.deleteEncryptedObject(ctx, bucket, object)
-}
-
-func (l *s3EncObjects) deleteEncryptedObject(ctx context.Context, bucket string, object string) error {
-	// Get dare meta json
-	gwMeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(object))
-	if err != nil {
-		return err
-	}
-	if len(gwMeta.Parts) == 0 {
-		l.s3Objects.DeleteObject(ctx, bucket, getGWContentPath(object))
-	}
-	for _, part := range gwMeta.Parts {
-		if err = l.s3Objects.DeleteObject(ctx, bucket, part.Name); err != nil {
-			return err
-		}
-	}
+	// delete encrypted object
+	l.s3Objects.DeleteObject(ctx, bucket, getGWContentPath(object))
 	return l.deleteGWMetadata(ctx, bucket, getDareMetaPath(object))
 }
 
 // ListMultipartUploads lists all multipart uploads.
 func (l *s3EncObjects) ListMultipartUploads(ctx context.Context, bucket string, prefix string, keyMarker string, uploadIDMarker string, delimiter string, maxUploads int) (lmi minio.ListMultipartsInfo, e error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.ListMultipartUploads(ctx, bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
-	}
-	var uploadsMap map[string]string
-	var uploadIDs []string
-	var continuationToken, startAfter string
-	startAfter = keyMarker
 
-	lmi.MaxUploads = maxUploads
-	lmi.KeyMarker = keyMarker
-	lmi.Prefix = prefix
-	lmi.Delimiter = delimiter
-	lmi.NextKeyMarker = prefix
-	lmi.UploadIDMarker = uploadIDMarker
-	uploadsMap = make(map[string]string)
-	for {
-		loi, err := l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, false, startAfter)
-		if err != nil {
-			return lmi, minio.ErrorRespToObjectError(err, bucket)
-		}
-		for _, obj := range loi.Objects {
-			startAfter = obj.Name
-			if !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
-				continue
-			}
-			// skip completed uploads
-			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, gwdareMetaJSON)) {
-				continue
-			}
-			// identify uploadID from object name: obj/.minio/uploadID/..
-			pSlice := strings.Split(obj.Name, "/")
-			idx := -1
-			for i, p := range pSlice {
-				if p == defaultMinioGWPrefix {
-					idx = i + 1
-					break
-				}
-			}
-			if idx == -1 || (idx == len(pSlice)) {
-				continue
-			}
-			uploadID := pSlice[idx]
-			uploadsMap[uploadID] = ""
-			if len(uploadsMap)+len(lmi.Uploads) > maxUploads {
-				break
-			}
-		}
-		// get uploadID's without duplicates and sort them
-		for k := range uploadsMap {
-			uploadIDs = append(uploadIDs, k)
-		}
-		sort.Strings(uploadIDs)
-		for _, uploadID := range uploadIDs {
-			if len(lmi.Uploads) == maxUploads {
-				return lmi, nil
-			}
-			lmi.Uploads = append(lmi.Uploads, minio.MultipartInfo{Object: prefix, UploadID: uploadID})
-		}
-		continuationToken = loi.NextContinuationToken
-		if !loi.IsTruncated {
-			break
-		}
+	lmi, e = l.s3Objects.ListMultipartUploads(ctx, bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
+	if e != nil {
+		return
 	}
-	return lmi, nil
+	lmi.KeyMarker = strings.TrimSuffix(lmi.KeyMarker, getGWContentPath("/"))
+	lmi.NextKeyMarker = strings.TrimSuffix(lmi.NextKeyMarker, getGWContentPath("/"))
+	for i := range lmi.Uploads {
+		lmi.Uploads[i].Object = strings.TrimSuffix(lmi.Uploads[i].Object, getGWContentPath("/"))
+	}
+	return
 }
 
 // NewMultipartUpload uploads object in multiple parts
@@ -543,19 +392,22 @@ func (l *s3EncObjects) NewMultipartUpload(ctx context.Context, bucket string, ob
 	if shouldSetSSEHeaders() {
 		opts = o
 	}
-	// Create uploadID and write a temporary dare.meta object under object/uploadID prefix
-	if len(minio.GlobalGatewaySSE) > 0 {
-		uploadID := minio.MustGetUUID()
-		gwmeta := newGWMetaV1()
-		gwmeta.Meta = metadata
-		gwmeta.Stat.ModTime = time.Now().UTC()
-		err := l.writeGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID), gwmeta, minio.ObjectOptions{})
-		if err != nil {
-			return uploadID, minio.ErrorRespToObjectError(err)
-		}
-		return uploadID, nil
+	if o.ServerSideEncryption == nil {
+		return l.s3Objects.NewMultipartUpload(ctx, bucket, object, metadata, opts)
 	}
-	return l.s3Objects.NewMultipartUpload(ctx, bucket, object, metadata, opts)
+	uploadID, err = l.s3Objects.NewMultipartUpload(ctx, bucket, getGWContentPath(object), map[string]string{}, opts)
+	if err != nil {
+		return
+	}
+	// Create uploadID and write a temporary dare.meta object under object/uploadID prefix
+	gwmeta := newGWMetaV1()
+	gwmeta.Meta = metadata
+	gwmeta.Stat.ModTime = time.Now().UTC()
+	err = l.writeGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID), gwmeta, minio.ObjectOptions{})
+	if err != nil {
+		return uploadID, minio.ErrorRespToObjectError(err)
+	}
+	return uploadID, nil
 }
 
 // PutObject creates a new object with the incoming data,
@@ -564,22 +416,13 @@ func (l *s3EncObjects) PutObject(ctx context.Context, bucket string, object stri
 	if shouldSetSSEHeaders() {
 		s3Opts = opts
 	}
-	if len(minio.GlobalGatewaySSE) == 0 {
+
+	if opts.ServerSideEncryption == nil {
+		defer l.deleteGWMetadata(ctx, bucket, getDareMetaPath(object))
+		defer l.DeleteObject(ctx, bucket, getGWContentPath(object))
 		return l.s3Objects.PutObject(ctx, bucket, object, data, metadata, s3Opts)
 	}
-	if opts.ServerSideEncryption == nil {
-		wasEncrypted := l.isGWEncrypted(ctx, bucket, object)
-		oi, err := l.s3Objects.PutObject(ctx, bucket, object, data, metadata, s3Opts)
-		if err != nil {
-			return objInfo, minio.ErrorRespToObjectError(err)
-		}
-		if wasEncrypted {
-			l.deleteEncryptedObject(ctx, bucket, object)
-		}
-		return oi, nil
-	}
-	// overwrite any previous unencrypted object with same name
-	defer l.s3Objects.DeleteObject(ctx, bucket, object)
+
 	oi, err := l.s3Objects.PutObject(ctx, bucket, getGWContentPath(object), data, map[string]string{}, s3Opts)
 	if err != nil {
 		return objInfo, minio.ErrorRespToObjectError(err)
@@ -608,36 +451,40 @@ func (l *s3EncObjects) PutObject(ctx context.Context, bucket string, object stri
 		return objInfo, minio.ErrorRespToObjectError(err)
 	}
 	objInfo = gwMeta.ToObjectInfo(bucket, object)
-
+	// delete any unencrypted content of the same name created previously
+	l.s3Objects.DeleteObject(ctx, bucket, object)
 	return objInfo, nil
 }
 
 // PutObjectPart puts a part of object in bucket
 func (l *s3EncObjects) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *minio.PutObjectReader, opts minio.ObjectOptions) (pi minio.PartInfo, e error) {
+
+	if opts.ServerSideEncryption == nil {
+		return l.s3Objects.PutObjectPart(ctx, bucket, object, uploadID, partID, data, opts)
+	}
+
 	var s3Opts minio.ObjectOptions
 	// for sse-s3 encryption options should not be passed to backend
 	if opts.ServerSideEncryption != nil && opts.ServerSideEncryption.Type() == encrypt.SSEC && shouldSetSSEHeaders() {
 		s3Opts = opts
 	}
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.PutObjectPart(ctx, bucket, object, uploadID, partID, data, s3Opts)
-	}
+
 	uploadPath := getTmpGWMetaPath(object, uploadID)
 	tmpDareMeta := path.Join(uploadPath, gwdareMetaJSON)
 	_, err := l.s3Objects.GetObjectInfo(ctx, bucket, tmpDareMeta, minio.ObjectOptions{})
 	if err != nil {
 		return pi, minio.InvalidUploadID{UploadID: uploadID}
 	}
-	partUploadName := path.Join(uploadPath, strconv.Itoa(partID))
 
-	oi, err := l.s3Objects.PutObject(ctx, bucket, partUploadName, data, map[string]string{}, s3Opts)
-	if err != nil {
-		return pi, minio.ErrorRespToObjectError(err)
+	pi, e = l.s3Objects.PutObjectPart(ctx, bucket, getGWContentPath(object), uploadID, partID, data, s3Opts)
+	if e != nil {
+		return
 	}
+	var encMD5 string
 	gwMeta := newGWMetaV1()
 	gwMeta.Parts = make([]minio.ObjectPartInfo, 1)
 	if opts.CreateEncryptedETagFn != nil {
-		encMD5, _, err := opts.CreateEncryptedETagFn()
+		encMD5, _, err = opts.CreateEncryptedETagFn()
 		if err != nil {
 			return pi, minio.ErrorRespToObjectError(err)
 		}
@@ -645,18 +492,17 @@ func (l *s3EncObjects) PutObjectPart(ctx context.Context, bucket string, object 
 		// Add incoming part.
 		gwMeta.Parts[0] = minio.ObjectPartInfo{
 			Number: partID,
-			ETag:   encMD5,
-			Size:   oi.Size,
+			ETag:   pi.ETag,
+			Size:   pi.Size,
 			Name:   strconv.Itoa(partID),
 		}
 		gwMeta.ETag = encMD5
-		gwMeta.Stat.Size = oi.Size
-		gwMeta.Stat.ModTime = oi.ModTime
+		gwMeta.Stat.Size = pi.Size
+		gwMeta.Stat.ModTime = pi.LastModified
 	}
-	if err = l.writeGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, partID, oi.ETag), gwMeta, minio.ObjectOptions{}); err != nil {
+	if err = l.writeGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, partID), gwMeta, minio.ObjectOptions{}); err != nil {
 		return pi, minio.ErrorRespToObjectError(err)
 	}
-
 	return minio.PartInfo{
 		Size:         gwMeta.Stat.Size,
 		ETag:         minio.CanonicalizeETag(gwMeta.ETag),
@@ -668,16 +514,8 @@ func (l *s3EncObjects) PutObjectPart(ctx context.Context, bucket string, object 
 // CopyObjectPart creates a part in a multipart upload by copying
 // existing object or a part of it.
 func (l *s3EncObjects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject, uploadID string,
-	partID int, startOffset, length int64, srcInfo minio.ObjectInfo, s, d minio.ObjectOptions) (p minio.PartInfo, err error) {
-	var srcOpts, dstOpts minio.ObjectOptions
-	if shouldSetSSEHeaders() {
-		srcOpts = s
-		dstOpts = d
-	}
-	// pass through encryption
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
-	}
+	partID int, startOffset, length int64, srcInfo minio.ObjectInfo, srcOpts, dstOpts minio.ObjectOptions) (p minio.PartInfo, err error) {
+
 	return l.PutObjectPart(ctx, destBucket, destObject, uploadID, partID, srcInfo.PutObjectReader, dstOpts)
 }
 
@@ -687,86 +525,37 @@ func (l *s3EncObjects) ListObjectParts(ctx context.Context, bucket string, objec
 	if shouldSetSSEHeaders() {
 		opts = o
 	}
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts, opts)
-	}
 	// We do not store parts uploaded so far in the dare.meta. Only CompleteMultipartUpload finalizes the parts under upload prefix.Otherwise,
 	// there could be situations of dare.meta getting corrupted by competing upload parts.
-	uploadPrefix := getTmpGWMetaPath(object, uploadID)
 	dm, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID))
 	if err != nil {
 		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts, opts)
 	}
 
-	lpi.Parts = make([]minio.PartInfo, 0)
+	lpi, err = l.s3Objects.ListObjectParts(ctx, bucket, getGWContentPath(object), uploadID, partNumberMarker, maxParts, opts)
+	if err != nil {
+		return lpi, err
+	}
+	for i, part := range lpi.Parts {
+		partMeta, err := l.getGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, part.PartNumber))
+		if err != nil || len(partMeta.Parts) == 0 {
+			return lpi, minio.InvalidPart{}
+		}
+		lpi.Parts[i].ETag = partMeta.ETag
+	}
 	lpi.UserDefined = dm.Meta
-	lpi.Bucket = bucket
 	lpi.Object = object
-	lpi.UploadID = uploadID
-	lpi.MaxParts = maxParts
-	lpi.PartNumberMarker = partNumberMarker
-
-	if maxParts == 0 {
-		return lpi, nil
-	}
-
-	var continuationToken, startAfter, delimiter string
-	var loi minio.ListObjectsV2Info
-	if partNumberMarker > 0 {
-		startAfter = path.Join(uploadPrefix, strconv.Itoa(partNumberMarker))
-	}
-	for {
-		loi, err = l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
-		if err != nil {
-			return lpi, minio.ErrorRespToObjectError(err, bucket)
-		}
-		for _, obj := range loi.Objects {
-			startAfter = obj.Name
-			if !strings.HasPrefix(obj.Name, uploadPrefix) {
-				return lpi, nil
-			}
-			if strings.HasSuffix(obj.Name, gwdareMetaJSON) || strings.HasSuffix(obj.Name, gwpartMetaJSON) {
-				continue
-			}
-			partNumStr := strings.TrimPrefix(obj.Name, path.Join(object, defaultMinioGWPrefix, uploadID)+slashSeparator)
-			partNum, _ := strconv.Atoi(partNumStr)
-
-			if partNum < partNumberMarker {
-				continue
-			}
-			partMeta, err := l.getGWMetadata(ctx, bucket, path.Join(obj.Name, obj.ETag, gwpartMetaJSON))
-			if err != nil || len(partMeta.Parts) == 0 {
-				return lpi, minio.InvalidPart{}
-			}
-			if partNum > 0 {
-				pi := minio.PartInfo{
-					PartNumber:   partNum,
-					Size:         partMeta.Stat.Size,
-					ETag:         partMeta.ETag,
-					LastModified: partMeta.Stat.ModTime,
-				}
-				lpi.Parts = append(lpi.Parts, pi)
-			}
-			if len(lpi.Parts) == maxParts {
-				break
-			}
-		}
-		continuationToken = loi.NextContinuationToken
-		if !loi.IsTruncated {
-			break
-		}
-	}
-	if len(loi.Objects) > len(lpi.Parts) && len(lpi.Parts) > 0 {
-		lpi.IsTruncated = true
-		lpi.NextPartNumberMarker = lpi.Parts[len(lpi.Parts)-1].PartNumber
-	}
 	return lpi, nil
 }
 
 // AbortMultipartUpload aborts a ongoing multipart upload
 func (l *s3EncObjects) AbortMultipartUpload(ctx context.Context, bucket string, object string, uploadID string) error {
-	if len(minio.GlobalGatewaySSE) == 0 {
+	if _, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID)); err != nil {
 		return l.s3Objects.AbortMultipartUpload(ctx, bucket, object, uploadID)
+	}
+
+	if err := l.s3Objects.AbortMultipartUpload(ctx, bucket, getGWContentPath(object), uploadID); err != nil {
+		return err
 	}
 
 	uploadPrefix := getTmpGWMetaPath(object, uploadID)
@@ -777,9 +566,6 @@ func (l *s3EncObjects) AbortMultipartUpload(ctx context.Context, bucket string, 
 			return minio.InvalidUploadID{UploadID: uploadID}
 		}
 		for _, obj := range loi.Objects {
-			if !strings.HasPrefix(obj.Name, uploadPrefix) {
-				return nil
-			}
 			if err := l.s3Objects.DeleteObject(ctx, bucket, obj.Name); err != nil {
 				return minio.ErrorRespToObjectError(err)
 			}
@@ -796,97 +582,62 @@ func (l *s3EncObjects) AbortMultipartUpload(ctx context.Context, bucket string, 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object
 func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []minio.CompletePart, opts minio.ObjectOptions) (oi minio.ObjectInfo, e error) {
 	var s3Opts minio.ObjectOptions
+
 	if shouldSetSSEHeaders() {
 		s3Opts = opts
 	}
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, s3Opts)
-	}
-	uploadPrefix := getTmpGWMetaPath(object, uploadID)
-	dareMeta, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID))
-	if err != nil {
-		return l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
-	}
 
-	// overwrite any previous unencrypted object with same name
-	defer l.s3Objects.DeleteObject(ctx, bucket, object)
-
-	// Calculate s3 compatible md5sum for complete multipart.
-	s3MD5, err := minio.GetCompleteMultipartMD5(ctx, uploadedParts)
+	tmpMeta, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID))
 	if err != nil {
-		return oi, minio.ErrorRespToObjectError(err, bucket)
+		oi, e = l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
+		if e == nil {
+			// delete any encrypted version of object that might exist
+			defer l.deleteGWMetadata(ctx, bucket, getDareMetaPath(object))
+			defer l.DeleteObject(ctx, bucket, getGWContentPath(object))
+		}
+		return oi, e
 	}
 	gwMeta := newGWMetaV1()
 	gwMeta.Meta = make(map[string]string)
-	for k, v := range dareMeta.Meta {
+	for k, v := range tmpMeta.Meta {
 		gwMeta.Meta[k] = v
 	}
 	// Allocate parts similar to incoming slice.
 	gwMeta.Parts = make([]minio.ObjectPartInfo, len(uploadedParts))
 
+	bkUploadedParts := make([]minio.CompletePart, len(uploadedParts))
+	// Calculate full object size.
 	var objectSize int64
-	var marker, delimiter string
 
-	var partsMap = make(map[string]string)
 	// Validate each part and then commit to disk.
 	for i, part := range uploadedParts {
-		obj := fmt.Sprintf("%s/%d", uploadPrefix, part.PartNumber)
-		partsMap[obj] = ""
-
-		res, rerr := l.s3Objects.ListObjects(ctx, bucket, obj, marker, delimiter, 1)
-		if rerr != nil || len(res.Objects) == 0 {
-			return oi, minio.InvalidPart{}
-		}
-		partInfo := res.Objects[0]
-		partMeta, err := l.getGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, part.PartNumber, partInfo.ETag))
+		partMeta, err := l.getGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, part.PartNumber))
 		if err != nil || len(partMeta.Parts) == 0 {
 			return oi, minio.InvalidPart{}
 		}
-
-		var partETag string
-		if opts.GetDecryptedETagFn != nil {
-			partETag = opts.GetDecryptedETagFn(partMeta.ETag)
-		}
-
-		// All parts should have same ETag as previously generated.
-		// we are comparing decrypted etags here
-		if partETag != part.ETag {
-			invp := minio.InvalidPart{
-				PartNumber: part.PartNumber,
-				ExpETag:    partInfo.ETag,
-				GotETag:    part.ETag,
-			}
-			logger.LogIf(ctx, invp)
-			return oi, invp
-		}
-
-		// Last part could have been uploaded as 0bytes, do not need
-		// to save it in final `xl.json`.
-		if (i == len(uploadedParts)-1) && partInfo.Size == 0 {
-			gwMeta.Parts = gwMeta.Parts[:i] // Skip the part.
-			continue
-		}
-		// Save for total object size.
-		objectSize += partInfo.Size
-
-		// Add incoming parts.
-		gwMeta.Parts[i] = minio.ObjectPartInfo{
-			Number: part.PartNumber,
-			ETag:   partMeta.ETag, //save encrypted ETag
-			Size:   partInfo.Size,
-			Name:   partInfo.Name,
-		}
+		bkUploadedParts[i] = minio.CompletePart{PartNumber: part.PartNumber, ETag: partMeta.Parts[0].ETag}
+		gwMeta.Parts[i] = partMeta.Parts[0]
+		objectSize += partMeta.Parts[0].Size
 	}
+	oi, e = l.s3Objects.CompleteMultipartUpload(ctx, bucket, getGWContentPath(object), uploadID, bkUploadedParts, s3Opts)
+	if e != nil {
+		return oi, e
+	}
+
+	//delete any unencrypted version of object that might be on the backend
+	defer l.s3Objects.DeleteObject(ctx, bucket, object)
 
 	// Save the final object size and modtime.
 	gwMeta.Stat.Size = objectSize
-	gwMeta.Stat.ModTime = time.Now().UTC()
+	gwMeta.Stat.ModTime = oi.ModTime
+	gwMeta.ETag = oi.ETag
 
-	// Save successfully calculated md5sum.
-	gwMeta.ETag = s3MD5
-
+	if err = l.writeGWMetadata(ctx, bucket, getDareMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
+		return oi, minio.ErrorRespToObjectError(err)
+	}
 	// Clean up any uploaded parts that are not being committed by this CompleteMultipart operation
-	var continuationToken, startAfter string
+	var continuationToken, startAfter, delimiter string
+	uploadPrefix := getTmpGWMetaPath(object, uploadID)
 	done := false
 	for {
 		loi, lerr := l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
@@ -900,27 +651,14 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 				break
 			}
 			startAfter = obj.Name
-			// delete parts not found in uploadedParts  map
-			if _, ok := partsMap[obj.Name]; !ok {
-				l.s3Objects.DeleteObject(ctx, bucket, obj.Name)
-			}
-			// delete temporary part metadata files
-			if strings.HasSuffix(obj.Name, gwpartMetaJSON) {
-				l.s3Objects.DeleteObject(ctx, bucket, obj.Name)
-			}
+			l.s3Objects.DeleteObject(ctx, bucket, obj.Name)
 		}
 		continuationToken = loi.NextContinuationToken
 		if !loi.IsTruncated || done {
 			break
 		}
 	}
-	if err = l.writeGWMetadata(ctx, bucket, getDareMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
-		return oi, minio.ErrorRespToObjectError(err)
-	}
-	// clean up temporary upload dare.meta file under uploadID prefix
-	if err = l.deleteGWMetadata(ctx, bucket, getTmpGWMetaPath(object, uploadID)); err != nil {
-		return oi, minio.ErrorRespToObjectError(err)
-	}
+
 	return gwMeta.ToObjectInfo(bucket, object), nil
 }
 
@@ -929,12 +667,12 @@ func getTmpGWMetaPath(object, uploadID string) string {
 	return path.Join(object, defaultMinioGWPrefix, uploadID)
 }
 
-// getGWMetaPath returns the prefix under which custom large object is stored on backend after upload completes
+// getGWMetaPath returns the prefix under which custom object metadata and object are stored on backend after upload completes
 func getGWMetaPath(object string) string {
 	return path.Join(object, defaultMinioGWPrefix)
 }
 
-// getGWContentPath returns the prefix under which custom small object is stored on backend after upload completes
+// getGWContentPath returns the prefix under which custom object is stored on backend after upload completes
 func getGWContentPath(object string) string {
 	return path.Join(object, defaultMinioGWPrefix, defaultGWContentFileName)
 }
@@ -962,19 +700,16 @@ func (l *s3EncObjects) cleanupStaleMultipartUploadsOnGW(ctx context.Context, exp
 			break
 		}
 		for _, b := range buckets {
-			allParts, expParts := l.getStalePartsForBucket(ctx, b.Name, expiry)
+			expParts := l.getStalePartsForBucket(ctx, b.Name, expiry)
 			for k := range expParts {
-				if _, ok := allParts[k]; !ok {
-					l.s3Objects.DeleteObject(ctx, b.Name, k)
-				}
+				l.s3Objects.DeleteObject(ctx, b.Name, k)
 			}
 		}
 	}
 }
 
-func (l *s3EncObjects) getStalePartsForBucket(ctx context.Context, bucket string, expiry time.Duration) (allParts, expParts map[string]string) {
+func (l *s3EncObjects) getStalePartsForBucket(ctx context.Context, bucket string, expiry time.Duration) (expParts map[string]string) {
 	var prefix, continuationToken, delimiter, startAfter string
-	allParts = make(map[string]string)
 	expParts = make(map[string]string)
 	now := time.Now()
 	for {
@@ -987,25 +722,9 @@ func (l *s3EncObjects) getStalePartsForBucket(ctx context.Context, bucket string
 			if !strings.Contains(obj.Name, defaultMinioGWPrefix) {
 				continue
 			}
-			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, gwdareMetaJSON)) {
-				objSlice := strings.Split(obj.Name, path.Join(slashSeparator, defaultMinioGWPrefix))
-				meta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(objSlice[0]))
-				if err != nil {
-					continue
-				}
-				for _, p := range meta.Parts {
-					allParts[p.Name] = ""
-				}
-			}
-			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, defaultGWContentFileName)) {
-				objSlice := strings.Split(obj.Name, path.Join(slashSeparator, defaultMinioGWPrefix))
-				expParts[getGWContentPath(objSlice[0])] = ""
-			}
-			if now.Sub(obj.ModTime) > expiry {
-				// skip parts that are part of a completed upload
-				if _, ok := allParts[obj.Name]; !ok {
-					expParts[obj.Name] = ""
-				}
+
+			if strings.HasSuffix(obj.Name, gwpartMetaJSON) && now.Sub(obj.ModTime) > expiry {
+				expParts[obj.Name] = ""
 			}
 		}
 		continuationToken = loi.NextContinuationToken

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -227,7 +227,7 @@ func (g *S3) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) 
 	s := s3Objects{
 		Client: clnt,
 	}
-	if len(minio.GlobalGatewaySSE) > 0 {
+	if minio.GlobalKMS != nil {
 		encS := s3EncObjects{s}
 		go encS.cleanupStaleMultipartUploads(context.Background(), minio.GlobalMultipartCleanupInterval, minio.GlobalMultipartExpiry, minio.GlobalServiceDoneCh)
 		return &encS, nil
@@ -592,5 +592,5 @@ func (l *s3Objects) IsCompressionSupported() bool {
 
 // IsEncryptionSupported returns whether server side encryption is applicable for this layer.
 func (l *s3Objects) IsEncryptionSupported() bool {
-	return len(minio.GlobalGatewaySSE) > 0
+	return true
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -229,7 +229,7 @@ var (
 	// KMS key id
 	globalKMSKeyID string
 	// Allocated KMS
-	globalKMS crypto.KMS
+	GlobalKMS crypto.KMS
 	// KMS config
 	globalKMSConfig crypto.KMSConfig
 
@@ -257,8 +257,6 @@ var (
 
 	// GlobalGatewaySSE sse options
 	GlobalGatewaySSE []string
-	// GlobalGatewaySSEMode sse mode options
-	GlobalGatewaySSEMode []string
 	// Add new variable global values here.
 
 )

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -486,7 +486,6 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, cleanUpFns ...func()) 
 		// encrypted bytes. The header parameter is used to
 		// provide encryption parameters.
 		fn = func(inputReader io.Reader, h http.Header, cFns ...func()) (r *GetObjectReader, err error) {
-
 			copySource := h.Get(crypto.SSECopyAlgorithm) != ""
 
 			cFns = append(cleanUpFns, cFns...)
@@ -573,7 +572,6 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, cleanUpFns ...func()) 
 			return r, nil
 		}
 	}
-
 	return fn, off, length, nil
 }
 
@@ -661,14 +659,12 @@ func (o *ObjectOptions) UnsealETagFn(key []byte, ssec bool) {
 // SetETagEncryptionOpts sets opts to a function that creates encrypted
 // etag for gateway encryption
 func (o *ObjectOptions) SetETagEncryptionOpts(p *PutObjectReader) {
-	if GlobalGatewaySSE != nil {
-		var f3 CreateEncryptedETagFn
-		f3 = func() (string, string, error) {
-			if p != nil {
-				return p.OrigReader.EncryptedMD5Sum()
-			}
-			return "", "", errors.New("PutObjectReader not initialized")
+	var f3 CreateEncryptedETagFn
+	f3 = func() (string, string, error) {
+		if p != nil {
+			return p.OrigReader.EncryptedMD5Sum()
 		}
-		o.CreateEncryptedETagFn = f3
+		return "", "", errors.New("PutObjectReader not initialized")
 	}
+	o.CreateEncryptedETagFn = f3
 }

--- a/cmd/ui-errors.go
+++ b/cmd/ui-errors.go
@@ -207,16 +207,12 @@ Example 1:
 	uiErrInvalidGWSSEValue = newUIErrFn(
 		"Invalid gateway sse value",
 		"Please check the passed value",
-		"MINIO_GW_SSE: Gateway SSE accepts only S3, C and KMS as valid values. Delimit by `;` to set more than one value",
+		"MINIO_GW_SSE: Gateway SSE accepts only C and S3 as valid values. Delimit by `;` to set more than one value",
 	)
-	uiErrInvalidGWSSEModeValue = newUIErrFn(
-		"Invalid gateway sse mode value",
-		"Please check the passed value",
-		"MINIO_GW_SSE_MODE: Gateway SSE accepts only backend,gateway as valid values. Delimit by `;` to set more than one value",
-	)
+
 	uiErrInvalidGWSSEEnvValue = newUIErrFn(
 		"Invalid gateway sse configuration",
 		"",
-		"MINIO_GW_SSE and MINIO_GW_SSE_MODE environment variables need to be set",
+		"Refer to https://docs.minio.io/docs/minio-kms-quickstart-guide.html for setting up sse with s3 gateway",
 	)
 )

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -67,18 +67,15 @@ Optionally set `MINIO_SSE_VAULT_CAPATH` as the path to a directory of PEM-encode
 export MINIO_SSE_VAULT_CAPATH=/home/user/custom-pems
 ```
 
-Gateway encryption options can be specified by setting MINIO_GW_SSE and MINI_GW_SSE_MODE.
+For S3 gateway, three encryption modes are possible. Encryption can be set to ``pass-through`` to backend, ``single encryption`` (at the gateway) or ``double encryption`` (single encryption at gateway and pass through to backend). This can be specified by setting MINIO_GW_SSE and KMS environment variables set in Step #3.
 
-To specify encryption type at gateway MINIO_GW_SSE environment variable needs to be set to "s3" for sse-s3
-and "c" for sse-c encryption at gateway. More than one encryption option can be set, delimited by ";". If MINIO_GW_SSE is not set, any SSE headers will be passed to S3 backend.
+If MINIO_GW_SSE and KMS are not setup, all encryption headers are passed through to the backend. If KMS environment variables are set up, ``single encryption`` is automatically performed at the gateway and encrypted object is saved at the backend.
 
-In gateway mode, encryption can be set to pass-through to backend, do encryption at the gateway or double encryption at both gateway and backend by setting environment variable MINIO_GW_SSE_MODE.  More than one encryption mode can be set, delimited by ";". If MINIO_GW_SSE_MODE is not set,SSE options will not be honored.
-Valid settings are "backend" to enable encryption at the backend, and "gateway" to enable encryption at the gateway. Both can be specified to turn on double
-encryption.
+To specify ``double encryption``, MINIO_GW_SSE environment variable needs to be set to "s3" for sse-s3
+and "c" for sse-c encryption. More than one encryption option can be set, delimited by ";". Objects are encrypted at the gateway and the gateway also does a pass-through to backend. Note that in the case of SSE-C encryption, gateway derives a unique SSE-C key for pass through from the SSE-C client key using a KDF.
 
 ```sh
 export MINIO_GW_SSE="s3;c"
-export MINIO_GW_SSE_MODE="backend;gateway"
 export MINIO_SSE_VAULT_APPROLE_ID=9b56cc08-8258-45d5-24a3-679876769126
 export MINIO_SSE_VAULT_APPROLE_SECRET=4e30c52f-13e4-a6f5-0763-d50e8cb4321f
 export MINIO_SSE_VAULT_ENDPOINT=https://vault-endpoint-ip:8200


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- Simplify the custom backend format for s3 gateway encrypted objects to leverage s3 multipart API. At the end of upload, the gateway backend will only have 2 objects - an encrypted object with data, and an additional metadata object for storing metadata attributes. This applies to both single and multipart objects

 

- Simplify environment variables for managing gateway encryption modes.
     If Vault is set up as KMS, s3 gateway will automatically perform single encryption
     If MINIO_GW_SSE is set up in addition to Vault KMS, double encryption is performed
     when neither KMS or MINIO_GW_SSE is set, do a pass through to backend.


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR brings in simplification to the custom format for encrypted objects in PR #6423, which is necessitated by need to maintain metadata and encrypted md5sum as state for multipart uploads.
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With aws cli, s3cmd and minio-go sdk
for e.g. to test single encryption at gateway
 - Start minio s3 gateway with [KMS settings](https://docs.minio.io/docs/minio-kms-quickstart-guide.html) 
 - ``` aws s3api put-object --bucket testbucket --key foo --no-verify-ssl --body /tmp/data --endpoint-url https://localhost:9000 --server-side-encryption AES256 ```
- object on the backend should be stored as foo/.minio/data (content)  and foo/.minio/dare.meta (metadata). If accessed directly on the backend, only encrypted content should be seen, but ``` mc cat myminio-ssl/testbucket/foo``` should show decrypted content.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.