### PR TITLE
Treat empty xl.json as file not found

### DIFF
--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -311,6 +311,9 @@ func readXLMeta(ctx context.Context, disk StorageAPI, bucket string, object stri
 		}
 		return xlMetaV1{}, err
 	}
+	if len(xlMetaBuf) == 0 {
+		return xlMetaV1{}, errFileNotFound
+	}
 	// obtain xlMetaV1{} using `github.com/tidwall/gjson`.
 	xlMeta, err = xlMetaV1UnmarshalJSON(ctx, xlMetaBuf)
 	if err != nil {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Treat empty xl.json as file not found
<!--- Describe your changes in detail -->

## Motivation and Context
If the buffer is empty we can avoid parsing
it and treat it essentially as `xl.json`
is effectively missing.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Recreating this situation by manually emptying the `xl.json` on the backend. 

1. Setup a distributed setup
```sh
#!/bin/bash

export MINIO_ERASURE_SET_DRIVE_COUNT=6
export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"

for i in {01..24}; do
    minio server --address ":90${i}" http://127.0.0.1:9001/tmp/export01 http://127.0.0.1:9002/tmp/export02 http://127.0.0.1:9003/tmp/export03 http://127.0.0.1:9004/tmp/export04 http://127.0.0.1:9005/tmp/export05 http://127.0.0.1:9006/tmp/export06 http://127.0.0.1:9007/tmp/export07 http://127.0.0.1:9008/tmp/export08 http://127.0.0.1:9009/tmp/export09 http://127.0.0.1:9010/tmp/export10 http://127.0.0.1:9011/tmp/export11 http://127.0.0.1:9012/tmp/export12 http://127.0.0.1:9013/tmp/export13 http://127.0.0.1:9014/tmp/export14 http://127.0.0.1:9015/tmp/export15 http://127.0.0.1:9016/tmp/export16 http://127.0.0.1:9017/tmp/export17 http://127.0.0.1:9018/tmp/export18 http://127.0.0.1:9019/tmp/export19 http://127.0.0.1:9020/tmp/export20 http://127.0.0.1:9021/tmp/export21 http://127.0.0.1:9022/tmp/export22 http://127.0.0.1:9023/tmp/export23 http://127.0.0.1:9024/tmp/export24 &
done
```

Skipping creating bucket, assuming you are already familiar with this process
```
~ mc cp /etc/issue myminio-local1/testbucket/1/2/3/issue
/etc/issue:                     26 B / 26 B ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 100.00% 149 B/s 0s
```

```
~ cd /tmp/export01/testbucket/1/2/3/issue
~ ls
[2018-11-12 23:25:08 PST]     9B part.1
[2018-11-12 23:25:08 PST]   592B xl.json
~ echo "" > xl.json
~ mc admin heal --recursive --debug myminio-local1/testbucket/1/2/3/
```

With this PR `mc admin heal` will heal the objects properly and would also avoid printing erroneous parsing issues.  

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.