### PR TITLE
Honor header only when requested for use

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -297,6 +297,8 @@ const (
 	ErrEvaluatorInvalidTimestampFormatPatternSymbol
 	ErrEvaluatorBindingDoesNotExist
 	ErrMissingHeaders
+	ErrInvalidColumnIndex
+
 	ErrAdminConfigNotificationTargetsFailed
 	ErrAdminProfilerNotEnabled
 	ErrInvalidDecompressedSize
@@ -1431,6 +1433,11 @@ var errorCodeResponse = map[APIErrorCode]APIError{
 		Description:    "Some headers in the query are missing from the file. Check the file and try again.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
+	ErrInvalidColumnIndex: {
+		Code:           "InvalidColumnIndex",
+		Description:    "The column index is invalid. Please check the service documentation and try again.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
 	ErrInvalidDecompressedSize: {
 		Code:           "XMinioInvalidDecompressedSize",
 		Description:    "The data provided is unfit for decompression",
@@ -1658,6 +1665,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrMissingHeaders
 	case format.ErrParseInvalidPathComponent:
 		apiErr = ErrMissingHeaders
+	case format.ErrInvalidColumnIndex:
+		apiErr = ErrInvalidColumnIndex
 	}
 
 	// Compression errors

--- a/pkg/s3select/input.go
+++ b/pkg/s3select/input.go
@@ -75,7 +75,7 @@ func New(reader io.Reader, size int64, req ObjectSelectRequest) (s3s format.Sele
 			req.InputSerialization.CSV.RecordDelimiter = "\n"
 		}
 		s3s, err = csv.New(&csv.Options{
-			HasHeader:            req.InputSerialization.CSV.FileHeaderInfo != CSVFileHeaderInfoNone,
+			HasHeader:            req.InputSerialization.CSV.FileHeaderInfo == CSVFileHeaderInfoUse,
 			RecordDelimiter:      req.InputSerialization.CSV.RecordDelimiter,
 			FieldDelimiter:       req.InputSerialization.CSV.FieldDelimiter,
 			Comments:             req.InputSerialization.CSV.Comments,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Honor header only when requested for use
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes bugs reproduced
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using the following example code

```go
// +build ignore

package main

import (
    "context"
    "fmt"
    "io"
    "log"
    "os"

    minio "github.com/minio/minio-go"
)

func getMinioClient() *minio.Client {
    s3Client, err := minio.New("localhost:9000", "minio", "minio123", false)
    if err != nil {
        log.Fatalln(err)
    }
    return s3Client
}

var (
    jsonOpts = minio.SelectObjectOptions{
        ExpressionType: minio.QueryExpressionTypeSQL,
        InputSerialization: minio.SelectObjectInputSerialization{
            CompressionType: minio.SelectCompressionNONE,
            JSON:            &minio.JSONInputOptions{"LINES"},
        },
        OutputSerialization: minio.SelectObjectOutputSerialization{
            JSON: &minio.JSONOutputOptions{
                RecordDelimiter: "\n",
            },
        },
    }
    csvOpts = minio.SelectObjectOptions{
        ExpressionType: minio.QueryExpressionTypeSQL,
        InputSerialization: minio.SelectObjectInputSerialization{
            CompressionType: minio.SelectCompressionNONE,
            CSV: &minio.CSVInputOptions{
                FileHeaderInfo:  "IGNORE",
                RecordDelimiter: "\n",
                FieldDelimiter:  ",",
            },
        },
        OutputSerialization: minio.SelectObjectOutputSerialization{
            CSV: &minio.CSVOutputOptions{
                RecordDelimiter: "\n",
                FieldDelimiter:  ",",
            },
        },
    }
)

func runSelectQ(c *minio.Client, bucket, object string, opts minio.SelectObjectOptions) {
    fmt.Printf("Running `%s` on %s/%s...\n", opts.Expression, bucket, object)
    reader, err := c.SelectObjectContent(context.Background(), bucket, object, opts)
    if err != nil {
        log.Fatalln(err)
    }
    defer reader.Close()
    if _, err := io.Copy(os.Stdout, reader); err != nil {
        log.Fatalln(err)
    }
}

func main() {
    s3Client := getMinioClient()

    opts := csvOpts
    // opts.Expression = "select * from s3object s where 4 < cast(Exp as int)"
    // opts.Expression = "select * from s3object s where 4 < Exp"
    // opts.Expression = "select * from s3object s where cast(Exp as int) > 4"
    opts.Expression = "select s._2 from s3object s"

    bucket := "sqlselectapi"
    object := "4.csv"

    runSelectQ(s3Client, bucket, object, opts)
}
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.