### PR TITLE
storage: Upgrade REST version after adding WriteAll API

### DIFF
--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -16,7 +16,7 @@
 
 package cmd
 
-const storageRESTVersion = "v1"
+const storageRESTVersion = "v2"
 const storageRESTPath = minioReservedBucketPath + "/storage/" + storageRESTVersion + "/"
 
 const (

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -378,5 +378,6 @@ func registerStorageRESTHandlers(router *mux.Router, endpoints EndpointList) {
 		subrouter.Methods(http.MethodPost).Path("/" + storageRESTMethodRenameFile).HandlerFunc(httpTraceHdrs(server.RenameFileHandler)).
 			Queries(restQueries(storageRESTSrcVolume, storageRESTSrcPath, storageRESTDstVolume, storageRESTDstPath)...)
 
+		subrouter.NotFoundHandler = http.HandlerFunc(httpTraceAll(notFoundHandler))
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Rolling update doesn't work properly because Storage REST API has
a new API WriteAll() but without API version number increase.

Also be sure to return 404 for unknown storage http paths.

## Motivation and Context
Fixing rolling update issue

## Regression
Yes, https://github.com/minio/minio/commit/f1f23f6f110071487b2b3fbf679ed3260fc73502

## How Has This Been Tested?
1. Run a distributed setup of 12 nodes with this release RELEASE.2018-11-06T01-01-02Z
 2. Kill one node, and run it again with this version RELEASE.2018-11-15T01-26-07Z


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.