### PR TITLE
Simplify custom format for s3 gateway encryption

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -327,7 +327,7 @@ func handleCommonEnvVars() {
 		if err != nil {
 			logger.Fatal(err, "Unable to initialize KMS")
 		}
-		globalKMS = kms
+		GlobalKMS = kms
 		globalKMSKeyID = kmsConf.Vault.Key.Name
 		globalKMSConfig = kmsConf
 	}

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -271,7 +271,7 @@ func (s *serverConfig) loadFromEnvs() {
 		s.SetCacheConfig(globalCacheDrives, globalCacheExcludes, globalCacheExpiry, globalCacheMaxUse)
 	}
 
-	if globalKMS != nil {
+	if GlobalKMS != nil {
 		s.KMS = globalKMSConfig
 	}
 
@@ -534,10 +534,10 @@ func (s *serverConfig) loadToCachedConfigs() {
 		globalCacheExpiry = cacheConf.Expiry
 		globalCacheMaxUse = cacheConf.MaxUse
 	}
-	if globalKMS == nil {
+	if GlobalKMS == nil {
 		globalKMSConfig = s.KMS
 		if kms, err := crypto.NewVault(globalKMSConfig); err == nil {
-			globalKMS = kms
+			GlobalKMS = kms
 			globalKMSKeyID = globalKMSConfig.Vault.Key.Name
 		}
 	}

--- a/cmd/dummy-object-layer_test.go
+++ b/cmd/dummy-object-layer_test.go
@@ -99,7 +99,7 @@ func (api *DummyObjectLayer) PutObjectPart(ctx context.Context, bucket, object, 
 	return
 }
 
-func (api *DummyObjectLayer) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error) {
+func (api *DummyObjectLayer) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int, opts ObjectOptions) (result ListPartsInfo, err error) {
 	return
 }
 

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -353,7 +353,7 @@ func (fs *FSObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID
 // Implements S3 compatible ListObjectParts API. The resulting
 // ListPartsInfo structure is unmarshalled directly into XML and
 // replied back to the client.
-func (fs *FSObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int) (result ListPartsInfo, e error) {
+func (fs *FSObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int, opts ObjectOptions) (result ListPartsInfo, e error) {
 	if err := checkListPartsArgs(ctx, bucket, object, fs); err != nil {
 		return result, toObjectErr(err)
 	}

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -350,7 +350,7 @@ func parseGatewaySSE(s string) ([]string, error) {
 	gwSlice := make([]string, len(l))
 	for _, val := range l {
 		v := strings.ToUpper(val)
-		if v == GatewaySSES3 || v == GatewaySSEC || v == GatewaySSEKMS {
+		if v == GatewaySSES3 || v == GatewaySSEC {
 			gwSlice = append(gwSlice, v)
 			continue
 		}
@@ -361,11 +361,16 @@ func parseGatewaySSE(s string) ([]string, error) {
 
 // handle gateway env vars
 func handleGatewayEnvVars() {
-	if gwsse, ok := os.LookupEnv("MINIO_GW_SSE"); ok {
+	gwsse, ok := os.LookupEnv("MINIO_GW_SSE")
+	if ok {
 		gwsseSlice, err := parseGatewaySSE(gwsse)
 		if err != nil {
 			logger.Fatal(err, "Unable to parse MINIO_GW_SSE value (`%s`)", gwsse)
 		}
 		GlobalGatewaySSE = gwsseSlice
+	}
+
+	if len(gwsse) != 0 && GlobalKMS == nil {
+		logger.Fatal(uiErrInvalidGWSSEEnvValue(nil).Msg("MINIO_GW_SSE set but KMS not enabled"), "Unable to start gateway with sse")
 	}
 }

--- a/cmd/gateway-env.go
+++ b/cmd/gateway-env.go
@@ -21,6 +21,4 @@ const (
 	GatewaySSES3 = "S3"
 	// GatewaySSEC is set when SSE-C encryption needed on both gateway and backend
 	GatewaySSEC = "C"
-	// GatewaySSEKMS is set when SSE-KMS double encryption is needed
-	GatewaySSEKMS = "KMS"
 )

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -140,8 +140,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(pErr, "Unable to start gateway")
 	}
 
-	// Handle gateway specific env
-	handleGatewayEnvVars()
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
 	// (non-)minio process is listening on IPv4 of given port.
@@ -162,6 +160,9 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 
 	// Handle common env vars.
 	handleCommonEnvVars()
+
+	// Handle gateway specific env
+	handleGatewayEnvVars()
 
 	// Validate if we have access, secret set through environment.
 	if !globalIsEnvCreds {

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -49,7 +49,7 @@ func (a GatewayUnsupported) PutObjectPart(ctx context.Context, bucket string, ob
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket
-func (a GatewayUnsupported) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi ListPartsInfo, err error) {
+func (a GatewayUnsupported) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int, opts ObjectOptions) (lpi ListPartsInfo, err error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return lpi, NotImplemented{}
 }

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -981,7 +981,7 @@ func (a *azureObjects) PutObjectPart(ctx context.Context, bucket, object, upload
 }
 
 // ListObjectParts - Use Azure equivalent GetBlockList.
-func (a *azureObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int) (result minio.ListPartsInfo, err error) {
+func (a *azureObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int, opts minio.ObjectOptions) (result minio.ListPartsInfo, err error) {
 	if err = a.checkUploadIDExists(ctx, bucket, object, uploadID); err != nil {
 		return result, err
 	}

--- a/cmd/gateway/b2/gateway-b2.go
+++ b/cmd/gateway/b2/gateway-b2.go
@@ -684,7 +684,7 @@ func (l *b2Objects) PutObjectPart(ctx context.Context, bucket string, object str
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket, uses B2's LargeFile upload API.
-func (l *b2Objects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi minio.ListPartsInfo, err error) {
+func (l *b2Objects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int, opts minio.ObjectOptions) (lpi minio.ListPartsInfo, err error) {
 	bkt, err := l.Bucket(ctx, bucket)
 	if err != nil {
 		return lpi, err

--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -1123,7 +1123,7 @@ func gcsGetPartInfo(ctx context.Context, attrs *storage.ObjectAttrs) (minio.Part
 }
 
 //  ListObjectParts returns all object parts for specified object in specified bucket
-func (l *gcsGateway) ListObjectParts(ctx context.Context, bucket string, key string, uploadID string, partNumberMarker int, maxParts int) (minio.ListPartsInfo, error) {
+func (l *gcsGateway) ListObjectParts(ctx context.Context, bucket string, key string, uploadID string, partNumberMarker int, maxParts int, opts minio.ObjectOptions) (minio.ListPartsInfo, error) {
 	it := l.client.Bucket(bucket).Objects(ctx, &storage.Query{
 		Prefix: path.Join(gcsMinioMultipartPathV1, uploadID),
 	})

--- a/cmd/gateway/oss/gateway-oss.go
+++ b/cmd/gateway/oss/gateway-oss.go
@@ -886,7 +886,7 @@ func (l *ossObjects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, d
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket
-func (l *ossObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int) (lpi minio.ListPartsInfo, err error) {
+func (l *ossObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int, opts minio.ObjectOptions) (lpi minio.ListPartsInfo, err error) {
 	lupr, err := ossListObjectParts(l.Client, bucket, object, uploadID, partNumberMarker, maxParts)
 	if err != nil {
 		logger.LogIf(ctx, err)

--- a/cmd/gateway/s3/gateway-s3-metadata.go
+++ b/cmd/gateway/s3/gateway-s3-metadata.go
@@ -39,8 +39,7 @@ type gwMetaV1 struct {
 	Version string         `json:"version"` // Version of the current `gw.json`.
 	Format  string         `json:"format"`  // Format of the current `gw.json`.
 	Stat    minio.StatInfo `json:"stat"`    // Stat of the current object `gw.json`.
-	//TODO: parse
-	ETag string `json:"etag"` // ETag of the current object
+	ETag    string         `json:"etag"`    // ETag of the current object
 
 	// Metadata map for current object `gw.json`.
 	Meta map[string]string `json:"meta,omitempty"`
@@ -93,7 +92,7 @@ func (m gwMetaV1) ToObjectInfo(bucket, object string) minio.ObjectInfo {
 		ModTime:         m.Stat.ModTime,
 		ContentType:     m.Meta["content-type"],
 		ContentEncoding: m.Meta["content-encoding"],
-		ETag:            minio.ExtractETag(m.Meta),
+		ETag:            m.ETag,
 		UserDefined:     minio.CleanMetadataKeys(m.Meta, filterKeys...),
 		Parts:           m.Parts,
 	}
@@ -103,6 +102,28 @@ func (m gwMetaV1) ToObjectInfo(bucket, object string) minio.ObjectInfo {
 	}
 	// Success.
 	return objInfo
+}
+
+// ObjectToPartOffset - translate offset of an object to offset of its individual part.
+func (m gwMetaV1) ObjectToPartOffset(ctx context.Context, offset int64) (partIndex int, partOffset int64, err error) {
+	if offset == 0 {
+		// Special case - if offset is 0, then partIndex and partOffset are always 0.
+		return 0, 0, nil
+	}
+	partOffset = offset
+	// Seek until object offset maps to a particular part offset.
+	for i, part := range m.Parts {
+		partIndex = i
+		// Offset is smaller than size we have reached the proper part offset.
+		if partOffset < part.Size {
+			return partIndex, partOffset, nil
+		}
+		// Continue to towards the next part.
+		partOffset -= part.Size
+	}
+	logger.LogIf(ctx, minio.InvalidRange{})
+	// Offset beyond the size of the object return InvalidRange.
+	return 0, 0, minio.InvalidRange{}
 }
 
 // parses gateway metadata stat info from metadata json
@@ -123,6 +144,11 @@ func parseGWStat(gwMetaBuf []byte) (si minio.StatInfo, e error) {
 // parses gateway metadata version from metadata json
 func parseGWVersion(gwMetaBuf []byte) string {
 	return gjson.GetBytes(gwMetaBuf, "version").String()
+}
+
+// parses gateway ETag from metadata json
+func parseGWETag(gwMetaBuf []byte) string {
+	return gjson.GetBytes(gwMetaBuf, "etag").String()
 }
 
 // parses gateway metadata format from metadata json
@@ -169,7 +195,7 @@ func gwMetaUnmarshalJSON(ctx context.Context, gwMetaBuf []byte) (gwMeta gwMetaV1
 		logger.LogIf(ctx, err)
 		return gwMeta, err
 	}
-
+	gwMeta.ETag = parseGWETag(gwMetaBuf)
 	gwMeta.Stat = stat
 
 	// Parse the GW Parts.

--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -19,27 +19,25 @@ package s3
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"path"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/minio/minio-go/pkg/encrypt"
 	minio "github.com/minio/minio/cmd"
-	"github.com/minio/sio"
 
-	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/pkg/hash"
 )
 
 const (
 	// name of custom multipart metadata file for s3 backend.
 	gwdareMetaJSON string = "dare.meta"
+
+	// name of temporary per part metadata file
+	gwpartMetaJSON string = "part.meta"
 	// custom multipart files are stored under the defaultMinioGWPrefix
 	defaultMinioGWPrefix     = ".minio"
 	defaultGWContentFileName = "data"
@@ -54,89 +52,82 @@ type s3EncObjects struct {
 
 /*
  NOTE:
- Custom gateway encrypted objects uploaded with single PUT operation are stored on backend as follows:
+ Custom gateway encrypted objects are stored on backend as follows:
 	 obj/.minio/data   <= encrypted content
 	 obj/.minio/dare.meta  <= metadata
- Custom gateway encrypted objects uploaded with multipart upload operation are stored on backend as follows:
-		obj/.minio/dare.meta  <= metadata
-		obj/.minio/uploadId/1 <= encrypted part 1
-		obj/.minio/uploadId/2 ...
-		obj/.minio/uploadId/3
+
+ When a multipart upload operation is in progress, the metadata set during
+ NewMultipartUpload is stored in obj/.minio/uploadID/dare.meta and each
+ UploadPart operation saves additional state of the part's encrypted ETag and
+ encrypted size in obj/.minio/uploadID/part1/part.meta
+
+ All the part metadata and temp dare.meta are cleaned up when upload completes
 */
 
 // ListObjects lists all blobs in S3 bucket filtered by prefix
 func (l *s3EncObjects) ListObjects(ctx context.Context, bucket string, prefix string, marker string, delimiter string, maxKeys int) (loi minio.ListObjectsInfo, e error) {
-	if len(minio.GlobalGatewaySSE) > 0 {
-		var continuationToken, startAfter string
-		res, err := l.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, false, startAfter)
-		if err != nil {
-			return loi, err
-		}
-		loi.IsTruncated = res.IsTruncated
-		loi.NextMarker = res.NextContinuationToken
-		loi.Objects = res.Objects
-		loi.Prefixes = res.Prefixes
-		return loi, nil
+	var continuationToken, startAfter string
+	res, err := l.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, false, startAfter)
+	if err != nil {
+		return loi, err
 	}
-	return l.s3Objects.ListObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)
+	loi.IsTruncated = res.IsTruncated
+	loi.NextMarker = res.NextContinuationToken
+	loi.Objects = res.Objects
+	loi.Prefixes = res.Prefixes
+	return loi, nil
+
 }
 
 // ListObjectsV2 lists all blobs in S3 bucket filtered by prefix
 func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (loi minio.ListObjectsV2Info, e error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, fetchOwner, startAfter)
-	}
+
 	var objects []minio.ObjectInfo
 	var prefixes []string
 	var isTruncated bool
+
 	// filter out objects that contain a .minio prefix, but is not a dare.meta metadata file.
 	for {
 		loi, e = l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, fetchOwner, startAfter)
 		if e != nil {
-			return loi, e
+			return loi, minio.ErrorRespToObjectError(e, bucket)
 		}
 		for _, obj := range loi.Objects {
 			startAfter = obj.Name
 			continuationToken = loi.NextContinuationToken
 			isTruncated = loi.IsTruncated
-			// skip parts objects from listing
-			if strings.Contains(obj.Name, defaultMinioGWPrefix) && !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
+
+			if !isGWObject(obj.Name) {
 				continue
 			}
-
 			// get objectname and ObjectInfo from the custom metadata file
 			if strings.HasSuffix(obj.Name, gwdareMetaJSON) {
 				objSlice := strings.Split(obj.Name, slashSeparator+defaultMinioGWPrefix)
-				gwMeta, e := l.getDareMetadata(ctx, bucket, getGWMetaPath(objSlice[0]))
+				gwMeta, e := l.getGWMetadata(ctx, bucket, getDareMetaPath(objSlice[0]))
 				if e != nil {
 					continue
 				}
-				prefixSlice := strings.Split(obj.Name, slashSeparator+defaultMinioGWPrefix+slashSeparator)
-				if len(prefixSlice) >= 1 {
-					oInfo := gwMeta.ToObjectInfo(bucket, prefixSlice[0][:])
-					objects = append(objects, oInfo)
-				}
-				continue
+				oInfo := gwMeta.ToObjectInfo(bucket, objSlice[0])
+				objects = append(objects, oInfo)
+			} else {
+				objects = append(objects, obj)
 			}
-			objects = append(objects, obj)
 			if len(objects) > maxKeys {
 				break
 			}
 		}
 		for _, p := range loi.Prefixes {
-			prefixSlice := strings.Split(p, defaultMinioGWPrefix+slashSeparator)
-			if len(prefixSlice) >= 1 {
-				objName := strings.TrimSuffix(prefixSlice[0], slashSeparator)
-				gm, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(objName))
-				// if prefix is actually a custom multi-part object, append it to objects
-				if err == nil {
-					objects = append(objects, gm.ToObjectInfo(bucket, objName))
-					continue
-				}
-				prefixes = append(prefixes, prefixSlice[0])
+			objName := strings.TrimSuffix(p, slashSeparator)
+			gm, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(objName))
+			// if prefix is actually a custom multi-part object, append it to objects
+			if err == nil {
+				objects = append(objects, gm.ToObjectInfo(bucket, objName))
 				continue
 			}
-			prefixes = append(prefixes, p)
+			isPrefix := l.isPrefix(ctx, bucket, p, fetchOwner, startAfter)
+			if isPrefix {
+				prefixes = append(prefixes, p)
+			}
 		}
 		if (len(objects) > maxKeys) || !loi.IsTruncated {
 			break
@@ -160,111 +151,83 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 	return loi, nil
 }
 
+// isGWObject returns true if it is a custom object
+func isGWObject(objName string) bool {
+	isEncrypted := strings.Contains(objName, defaultMinioGWPrefix)
+	if !isEncrypted {
+		return true
+	}
+	// ignore temp part.meta files
+	if strings.Contains(objName, gwpartMetaJSON) {
+		return false
+	}
+
+	pfxSlice := strings.Split(objName, slashSeparator)
+	var i1, i2 int
+	for i := len(pfxSlice) - 1; i >= 0; i-- {
+		p := pfxSlice[i]
+		if p == defaultMinioGWPrefix {
+			i1 = i
+		}
+		if p == gwdareMetaJSON {
+			i2 = i
+		}
+		if i1 > 0 && i2 > 0 {
+			break
+		}
+	}
+	// incomplete uploads would have a uploadID between defaultMinioGWPrefix and gwdareMetaJSON
+	return i2 > 0 && i1 > 0 && i2-i1 == 1
+}
+
+// isPrefix returns true if prefix exists and is not an incomplete multipart upload entry
+func (l *s3EncObjects) isPrefix(ctx context.Context, bucket, prefix string, fetchOwner bool, startAfter string) bool {
+	var continuationToken, delimiter string
+
+	for {
+		loi, e := l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, fetchOwner, startAfter)
+		if e != nil {
+			return false
+		}
+		for _, obj := range loi.Objects {
+			if isGWObject(obj.Name) {
+				return true
+			}
+		}
+
+		continuationToken = loi.NextContinuationToken
+		if !loi.IsTruncated {
+			break
+		}
+	}
+	return false
+}
+
+// shouldSetSSEHeaders returns true if backend encryption is specified
+func shouldSetSSEHeaders() bool {
+	return len(minio.GlobalGatewaySSE) > 0
+}
+
 // GetObject reads an object from S3. Supports additional
 // parameters like offset and length which are synonymous with
 // HTTP Range requests.
-// In the case of multi-part uploads that were encrypted at the gateway, the objects
-// are stored in a custom format at the backend with each part as an individual object
-// and piped to the writer.
-func (l *s3EncObjects) GetObject(ctx context.Context, bucket string, key string, startOffset int64, length int64, writer io.Writer, etag string, o minio.ObjectOptions) error {
-	// pass through encryption
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
-	}
-	dmeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(key))
-	if err != nil {
-		// unencrypted content
-		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
-	}
+func (l *s3EncObjects) GetObject(ctx context.Context, bucket string, key string, startOffset int64, length int64, writer io.Writer, etag string, opts minio.ObjectOptions) error {
+	return l.getObject(ctx, bucket, key, startOffset, length, writer, etag, opts)
+}
 
-	if len(dmeta.Parts) == 0 {
-		// custom gateway encrypted objects uploaded with single PUT operation
-		return l.s3Objects.GetObject(ctx, bucket, getGWContentPath(key), startOffset, length, writer, etag, o)
-	}
-
-	// handle custom multipart gateway encrypted objects
-	var partStartIndex int
-	var partStartOffset = startOffset
-
-	// Skip parts until final offset maps to a particular part offset.
-	for i, part := range dmeta.Parts {
-		decryptedSize, err := sio.DecryptedSize(uint64(part.Size))
-		if err != nil {
-			return err
-		}
-		partStartIndex = i
-
-		// Offset is smaller than size we have reached the
-		// proper part offset, break out we start from
-		// this part index.
-		if partStartOffset < int64(decryptedSize) {
-			break
-		}
-		// Continue to look for next part.
-		partStartOffset -= int64(decryptedSize)
-	}
-	startSeqNum := partStartOffset / minio.SSEDAREPackageBlockSize
-	partEncRelOffset := int64(startSeqNum) * (minio.SSEDAREPackageBlockSize + minio.SSEDAREPackageMetaSize)
-
-	var size int64
-	// concatenate parts stored as separate objects into writer
-	for i, part := range dmeta.Parts {
-		//skip parts before start offset
-		if i < partStartIndex {
-			continue
-		}
-		pInfo, err := l.s3Objects.GetObjectInfo(ctx, bucket, part.Name, o)
-		if err != nil || pInfo.ETag != part.ETag {
-			logger.LogIf(ctx, err)
-			return minio.ObjectNotFound{
-				Bucket: bucket,
-				Object: key,
-			}
-		}
-
-		partLength := pInfo.Size - partEncRelOffset
-		size += partLength
-		if size > length {
-			partLength -= (size - length)
-		}
-
-		pipeReader, pipeWriter := io.Pipe()
-
-		var reader io.Reader = pipeReader
-		pInfo.Reader, err = hash.NewReader(reader, partLength, "", "", pInfo.Size)
-		pInfo.Writer = pipeWriter
-
-		go func(pInfo minio.ObjectInfo) {
-			if gerr := l.s3Objects.GetObject(ctx, bucket, pInfo.Name, partEncRelOffset, partLength, pInfo.Writer, pInfo.ETag, o); gerr != nil {
-				if gerr = pInfo.Writer.Close(); gerr != nil {
-					logger.LogIf(ctx, gerr)
-					return
-				}
-			}
-		}(pInfo)
-		if pInfo.Reader == nil {
-			return nil
-		}
-		_, err = io.Copy(writer, pInfo.Reader)
-		if err != nil {
-			logger.LogIf(ctx, err)
-			return err
-		}
-		partStartIndex++
-		partEncRelOffset = 0
-	}
-	return nil
+func (l *s3EncObjects) isGWEncrypted(ctx context.Context, bucket, object string) bool {
+	_, err := l.s3Objects.GetObjectInfo(ctx, bucket, getDareMetaPath(object), minio.ObjectOptions{})
+	return err == nil
 }
 
 // getDaremetadata fetches dare.meta from s3 backend and marshals into a structured format.
-func (l *s3EncObjects) getDareMetadata(ctx context.Context, bucket, objectPrefix string) (m gwMetaV1, err error) {
-	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
-	oi, err1 := l.s3Objects.GetObjectInfo(ctx, bucket, dareMetaFile, minio.ObjectOptions{})
+func (l *s3EncObjects) getGWMetadata(ctx context.Context, bucket, metaFileName string) (m gwMetaV1, err error) {
+	oi, err1 := l.s3Objects.GetObjectInfo(ctx, bucket, metaFileName, minio.ObjectOptions{})
 	if err1 != nil {
 		return m, err1
 	}
 	var buffer bytes.Buffer
-	err = l.s3Objects.GetObject(ctx, bucket, dareMetaFile, 0, oi.Size, &buffer, oi.ETag, minio.ObjectOptions{})
+	err = l.s3Objects.GetObject(ctx, bucket, metaFileName, 0, oi.Size, &buffer, oi.ETag, minio.ObjectOptions{})
 	if err != nil {
 		return m, err
 	}
@@ -272,43 +235,99 @@ func (l *s3EncObjects) getDareMetadata(ctx context.Context, bucket, objectPrefix
 }
 
 // writes dare metadata to the s3 backend
-func (l *s3EncObjects) writeDareMetadata(ctx context.Context, bucket, objectPrefix string, m gwMetaV1, o minio.ObjectOptions) error {
-	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
-	reader, err := getGWMetadata(ctx, bucket, dareMetaFile, m)
+func (l *s3EncObjects) writeGWMetadata(ctx context.Context, bucket, metaFileName string, m gwMetaV1, o minio.ObjectOptions) error {
+	reader, err := getGWMetadata(ctx, bucket, metaFileName, m)
 	if err != nil {
 		logger.LogIf(ctx, err)
 		return err
 	}
-	_, err = l.s3Objects.PutObject(ctx, bucket, dareMetaFile, reader, map[string]string{}, o)
+	_, err = l.s3Objects.PutObject(ctx, bucket, metaFileName, reader, map[string]string{}, o)
 	return err
 }
 
+// returns path of temporary metadata json file for the upload
+func getTmpDareMetaPath(object, uploadID string) string {
+	return path.Join(getGWMetaPath(object), uploadID, gwdareMetaJSON)
+}
+
+// returns path of metadata json file for encrypted objects
+func getDareMetaPath(object string) string {
+	return path.Join(getGWMetaPath(object), gwdareMetaJSON)
+}
+
+// returns path of temporary part metadata file for multipart uploads
+func getPartMetaPath(object, uploadID string, partID int) string {
+	return path.Join(object, defaultMinioGWPrefix, uploadID, strconv.Itoa(partID), gwpartMetaJSON)
+}
+
 // deletes the custom dare metadata file saved at the backend
-func (l *s3EncObjects) deleteDareMetadata(ctx context.Context, bucket, objectPrefix string) error {
-	dareMetaFile := path.Join(objectPrefix, gwdareMetaJSON)
-	return l.s3Objects.DeleteObject(ctx, bucket, dareMetaFile)
+func (l *s3EncObjects) deleteGWMetadata(ctx context.Context, bucket, metaFileName string) error {
+	return l.s3Objects.DeleteObject(ctx, bucket, metaFileName)
+}
+
+func (l *s3EncObjects) getObject(ctx context.Context, bucket string, key string, startOffset int64, length int64, writer io.Writer, etag string, opts minio.ObjectOptions) error {
+	var o minio.ObjectOptions
+	if shouldSetSSEHeaders() {
+		o = opts
+	}
+	dmeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(key))
+	if err != nil {
+		// unencrypted content
+		return l.s3Objects.GetObject(ctx, bucket, key, startOffset, length, writer, etag, o)
+	}
+	if startOffset < 0 {
+		logger.LogIf(ctx, minio.InvalidRange{})
+	}
+
+	// For negative length read everything.
+	if length < 0 {
+		length = dmeta.Stat.Size - startOffset
+	}
+	// Reply back invalid range if the input offset and length fall out of range.
+	if startOffset > dmeta.Stat.Size || startOffset+length > dmeta.Stat.Size {
+		logger.LogIf(ctx, minio.InvalidRange{OffsetBegin: startOffset, OffsetEnd: length, ResourceSize: dmeta.Stat.Size})
+		return minio.InvalidRange{OffsetBegin: startOffset, OffsetEnd: length, ResourceSize: dmeta.Stat.Size}
+	}
+	// Get start part index and offset.
+	_, partOffset, err := dmeta.ObjectToPartOffset(ctx, startOffset)
+	if err != nil {
+		return minio.InvalidRange{OffsetBegin: startOffset, OffsetEnd: length, ResourceSize: dmeta.Stat.Size}
+	}
+
+	// Calculate endOffset according to length
+	endOffset := startOffset
+	if length > 0 {
+		endOffset += length - 1
+	}
+
+	// Get last part index to read given length.
+	if _, _, err := dmeta.ObjectToPartOffset(ctx, endOffset); err != nil {
+		return minio.InvalidRange{OffsetBegin: startOffset, OffsetEnd: length, ResourceSize: dmeta.Stat.Size}
+	}
+	return l.s3Objects.GetObject(ctx, bucket, key, partOffset, endOffset, writer, dmeta.ETag, o)
 }
 
 // GetObjectNInfo - returns object info and locked object ReadCloser
-func (l *s3EncObjects) GetObjectNInfo(ctx context.Context, bucket, object string, rs *minio.HTTPRangeSpec, h http.Header, lockType minio.LockType, opts minio.ObjectOptions) (gr *minio.GetObjectReader, err error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
+func (l *s3EncObjects) GetObjectNInfo(ctx context.Context, bucket, object string, rs *minio.HTTPRangeSpec, h http.Header, lockType minio.LockType, o minio.ObjectOptions) (gr *minio.GetObjectReader, err error) {
+	var opts minio.ObjectOptions
+	if shouldSetSSEHeaders() {
+		opts = o
 	}
-	var objInfo minio.ObjectInfo
-	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
+	objInfo, err := l.GetObjectInfo(ctx, bucket, object, opts)
 	if err != nil {
 		return l.s3Objects.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
 	}
-
-	objInfo = gwMeta.ToObjectInfo(bucket, object)
+	objInfo.UserDefined = minio.CleanMinioInternalMetadataKeys(objInfo.UserDefined)
 	fn, off, length, err := minio.NewGetObjectReader(rs, objInfo)
 	if err != nil {
-		return nil, err
+		return nil, minio.ErrorRespToObjectError(err)
 	}
-
+	if l.isGWEncrypted(ctx, bucket, object) {
+		object = getGWContentPath(object)
+	}
 	pr, pw := io.Pipe()
 	go func() {
-		err := l.GetObject(ctx, bucket, object, off, length, pw, objInfo.ETag, opts)
+		err := l.getObject(ctx, bucket, object, off, length, pw, objInfo.ETag, opts)
 		pw.CloseWithError(err)
 	}()
 
@@ -320,11 +339,13 @@ func (l *s3EncObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 
 // GetObjectInfo reads object info and replies back ObjectInfo
 // For custom gateway encrypted large objects, the ObjectInfo is retrieved from the dare.meta file.
-func (l *s3EncObjects) GetObjectInfo(ctx context.Context, bucket string, object string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.GetObjectInfo(ctx, bucket, object, opts)
+func (l *s3EncObjects) GetObjectInfo(ctx context.Context, bucket string, object string, o minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	var opts minio.ObjectOptions
+	if shouldSetSSEHeaders() {
+		opts = o
 	}
-	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
+
+	gwMeta, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(object))
 	if err != nil {
 		return l.s3Objects.GetObjectInfo(ctx, bucket, object, opts)
 	}
@@ -332,196 +353,105 @@ func (l *s3EncObjects) GetObjectInfo(ctx context.Context, bucket string, object 
 }
 
 // CopyObject copies an object from source bucket to a destination bucket.
-func (l *s3EncObjects) CopyObject(ctx context.Context, srcBucket string, srcObject string, dstBucket string, dstObject string, srcInfo minio.ObjectInfo, srcOpts, dstOpts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
-	// Set this header such that following CopyObject() always sets the right metadata on the destination.
-	// metadata input is already a trickled down value from interpreting x-amz-metadata-directive at
-	// handler layer. So what we have right now is supposed to be applied on the destination object anyways.
-	// So preserve it by adding "REPLACE" directive to save all the metadata set by CopyObject API.
-	srcInfo.UserDefined["x-amz-metadata-directive"] = "REPLACE"
-	srcInfo.UserDefined["x-amz-copy-source-if-match"] = srcInfo.ETag
-	// if gateway encryption is turned off, do a pass thru
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.CopyObject(ctx, srcBucket, srcObject, dstBucket, dstObject, srcInfo, srcOpts, dstOpts)
+func (l *s3EncObjects) CopyObject(ctx context.Context, srcBucket string, srcObject string, dstBucket string, dstObject string, srcInfo minio.ObjectInfo, s, d minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
+	cpSrcDstSame := strings.EqualFold(path.Join(srcBucket, srcObject), path.Join(dstBucket, dstObject))
+	if cpSrcDstSame {
+		var gwMeta gwMetaV1
+		if s.ServerSideEncryption != nil && d.ServerSideEncryption != nil &&
+			((s.ServerSideEncryption.Type() == encrypt.SSEC && d.ServerSideEncryption.Type() == encrypt.SSEC) ||
+				(s.ServerSideEncryption.Type() == encrypt.S3 && d.ServerSideEncryption.Type() == encrypt.S3)) {
+			gwMeta, err = l.getGWMetadata(ctx, srcBucket, getDareMetaPath(srcObject))
+			if err != nil {
+				return
+			}
+			header := make(http.Header)
+			if d.ServerSideEncryption != nil {
+				d.ServerSideEncryption.Marshal(header)
+			}
+			for k, v := range header {
+				srcInfo.UserDefined[k] = v[0]
+			}
+			gwMeta.Meta = srcInfo.UserDefined
+			if err = l.writeGWMetadata(ctx, dstBucket, getDareMetaPath(dstObject), gwMeta, minio.ObjectOptions{}); err != nil {
+				return objInfo, minio.ErrorRespToObjectError(err)
+			}
+			return gwMeta.ToObjectInfo(dstBucket, dstObject), nil
+		}
 	}
-	// Check if source is custom multipart Object. If not, Get source object, decrypt at gateway and
-	// upload with destination side encryption options
-	gwMeta, err := l.getDareMetadata(ctx, srcBucket, getGWMetaPath(srcObject))
-	if err != nil {
-		return l.PutObject(ctx, dstBucket, dstObject, srcInfo.PutObjReader, srcInfo.UserDefined, dstOpts)
-	}
-
-	// src encrypted, but not target or custom encrypted without multipart
-	if dstOpts.ServerSideEncryption == nil || len(gwMeta.Parts) == 0 {
-		return l.PutObject(ctx, dstBucket, dstObject, srcInfo.PutObjReader, srcInfo.UserDefined, dstOpts)
-	}
-
-	// convert copy src encryption options for GET calls
-	var getOpts minio.ObjectOptions
-	if srcOpts.ServerSideEncryption != nil {
-		getOpts.ServerSideEncryption = encrypt.SSE(srcOpts.ServerSideEncryption)
-	}
-
-	// overwrite any previous unencrypted object with same name
-	defer l.s3Objects.DeleteObject(ctx, dstBucket, dstObject)
-
-	dstUploadID, err := l.NewMultipartUpload(ctx, dstBucket, dstObject, srcInfo.UserDefined, dstOpts)
-	if err != nil {
-		logger.LogIf(ctx, err)
-		return
-	}
-	var uploadedParts = make([]minio.CompletePart, 0)
-	var partID = 1
-
-	partUploadName := path.Join(getTmpGWMetaPath(dstObject, dstUploadID), strconv.Itoa(partID))
-	bkendObjInfo, rerr := l.s3Objects.PutObject(ctx, dstBucket, partUploadName, srcInfo.PutObjReader, srcInfo.UserDefined, dstOpts)
-	if rerr != nil {
-		return
-	}
-	uploadedParts = append(uploadedParts, minio.CompletePart{
-		ETag:       bkendObjInfo.ETag,
-		PartNumber: partID,
-	})
-
-	return l.CompleteMultipartUpload(ctx, dstBucket, dstObject, dstUploadID, uploadedParts, dstOpts)
+	return l.PutObject(ctx, dstBucket, dstObject, srcInfo.PutObjReader, srcInfo.UserDefined, d)
 }
 
 // DeleteObject deletes a blob in bucket
-// For custom gateway encrypted large objects, cleans up individual parts and metadata files
+// For custom gateway encrypted large objects, cleans up encrypted content and metadata files
 // from the backend.
 func (l *s3EncObjects) DeleteObject(ctx context.Context, bucket string, object string) error {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.DeleteObject(ctx, bucket, object)
-	}
-	// Get dare meta json
-	if _, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object)); err != nil {
-		return l.s3Objects.DeleteObject(ctx, bucket, object)
-	}
-	return l.deleteEncryptedObject(ctx, bucket, object)
-}
 
-func (l *s3EncObjects) deleteEncryptedObject(ctx context.Context, bucket string, object string) error {
 	// Get dare meta json
-	gwMeta, err := l.getDareMetadata(ctx, bucket, getGWMetaPath(object))
-	if err != nil {
+	if _, err := l.getGWMetadata(ctx, bucket, getDareMetaPath(object)); err != nil {
 		return l.s3Objects.DeleteObject(ctx, bucket, object)
 	}
-	if len(gwMeta.Parts) == 0 {
-		l.s3Objects.DeleteObject(ctx, bucket, getGWContentPath(object))
-	}
-	for _, part := range gwMeta.Parts {
-		if err = l.s3Objects.DeleteObject(ctx, bucket, part.Name); err != nil {
-			return err
-		}
-	}
-	return l.deleteDareMetadata(ctx, bucket, getGWMetaPath(object))
+	// delete encrypted object
+	l.s3Objects.DeleteObject(ctx, bucket, getGWContentPath(object))
+	return l.deleteGWMetadata(ctx, bucket, getDareMetaPath(object))
 }
 
 // ListMultipartUploads lists all multipart uploads.
 func (l *s3EncObjects) ListMultipartUploads(ctx context.Context, bucket string, prefix string, keyMarker string, uploadIDMarker string, delimiter string, maxUploads int) (lmi minio.ListMultipartsInfo, e error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.ListMultipartUploads(ctx, bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
-	}
-	var uploadsMap map[string]string
-	var uploadIDs []string
-	var continuationToken, startAfter string
-	startAfter = keyMarker
 
-	lmi.MaxUploads = maxUploads
-	lmi.KeyMarker = keyMarker
-	lmi.Prefix = prefix
-	lmi.Delimiter = delimiter
-	lmi.NextKeyMarker = prefix
-	lmi.UploadIDMarker = uploadIDMarker
-	uploadsMap = make(map[string]string)
-	for {
-		loi, err := l.s3Objects.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, 1000, false, startAfter)
-		if err != nil {
-			return lmi, err
-		}
-		for _, obj := range loi.Objects {
-			startAfter = obj.Name
-			if !strings.HasSuffix(obj.Name, gwdareMetaJSON) {
-				continue
-			}
-			// skip completed uploads
-			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, gwdareMetaJSON)) {
-				continue
-			}
-			// identify uploadID from object name: obj/.minio/uploadID/..
-			pSlice := strings.Split(obj.Name, "/")
-			idx := -1
-			for i, p := range pSlice {
-				if p == defaultMinioGWPrefix {
-					idx = i + 1
-					break
-				}
-			}
-			if idx == -1 || (idx == len(pSlice)) {
-				continue
-			}
-			uploadID := pSlice[idx]
-			uploadsMap[uploadID] = ""
-			if len(uploadsMap)+len(lmi.Uploads) > maxUploads {
-				break
-			}
-		}
-		// get uploadID's without duplicates and sort them
-		for k := range uploadsMap {
-			uploadIDs = append(uploadIDs, k)
-		}
-		sort.Strings(uploadIDs)
-		for _, uploadID := range uploadIDs {
-			if len(lmi.Uploads) == maxUploads {
-				return lmi, nil
-			}
-			lmi.Uploads = append(lmi.Uploads, minio.MultipartInfo{Object: prefix, UploadID: uploadID})
-		}
-		continuationToken = loi.NextContinuationToken
-		if !loi.IsTruncated {
-			break
-		}
+	lmi, e = l.s3Objects.ListMultipartUploads(ctx, bucket, prefix, keyMarker, uploadIDMarker, delimiter, maxUploads)
+	if e != nil {
+		return
 	}
-	return lmi, nil
+	lmi.KeyMarker = strings.TrimSuffix(lmi.KeyMarker, getGWContentPath("/"))
+	lmi.NextKeyMarker = strings.TrimSuffix(lmi.NextKeyMarker, getGWContentPath("/"))
+	for i := range lmi.Uploads {
+		lmi.Uploads[i].Object = strings.TrimSuffix(lmi.Uploads[i].Object, getGWContentPath("/"))
+	}
+	return
 }
 
 // NewMultipartUpload uploads object in multiple parts
 func (l *s3EncObjects) NewMultipartUpload(ctx context.Context, bucket string, object string, metadata map[string]string, o minio.ObjectOptions) (uploadID string, err error) {
-	// Create uploadID and write a temporary dare.meta object under object/uploadID prefix
-	if (len(minio.GlobalGatewaySSE) > 0) && o.ServerSideEncryption != nil {
-		uploadID := minio.MustGetUUID()
-		tmpUploadPrefix := getTmpGWMetaPath(object, uploadID)
-		gwmeta := newGWMetaV1()
-		gwmeta.Meta = metadata
-		gwmeta.Stat.ModTime = time.Now().UTC()
-		err := l.writeDareMetadata(ctx, bucket, tmpUploadPrefix, gwmeta, minio.ObjectOptions{})
-		if err != nil {
-			return uploadID, err
-		}
-		return uploadID, nil
+	var opts minio.ObjectOptions
+	if shouldSetSSEHeaders() {
+		opts = o
 	}
-	return l.s3Objects.NewMultipartUpload(ctx, bucket, object, metadata, o)
+	if o.ServerSideEncryption == nil {
+		return l.s3Objects.NewMultipartUpload(ctx, bucket, object, metadata, opts)
+	}
+	uploadID, err = l.s3Objects.NewMultipartUpload(ctx, bucket, getGWContentPath(object), map[string]string{}, opts)
+	if err != nil {
+		return
+	}
+	// Create uploadID and write a temporary dare.meta object under object/uploadID prefix
+	gwmeta := newGWMetaV1()
+	gwmeta.Meta = metadata
+	gwmeta.Stat.ModTime = time.Now().UTC()
+	err = l.writeGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID), gwmeta, minio.ObjectOptions{})
+	if err != nil {
+		return uploadID, minio.ErrorRespToObjectError(err)
+	}
+	return uploadID, nil
 }
 
 // PutObject creates a new object with the incoming data,
 func (l *s3EncObjects) PutObject(ctx context.Context, bucket string, object string, data *minio.PutObjReader, metadata map[string]string, opts minio.ObjectOptions) (objInfo minio.ObjectInfo, err error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.PutObject(ctx, bucket, object, data, metadata, opts)
+	var s3Opts minio.ObjectOptions
+	if shouldSetSSEHeaders() {
+		s3Opts = opts
 	}
-	if opts.ServerSideEncryption == nil {
-		oi, err := l.s3Objects.PutObject(ctx, bucket, object, data, metadata, opts)
-		if err != nil {
-			return objInfo, err
-		}
-		l.deleteEncryptedObject(ctx, bucket, object)
-		return oi, nil
-	}
-	// overwrite any previous unencrypted object with same name
-	defer l.s3Objects.DeleteObject(ctx, bucket, object)
 
-	oi, err := l.s3Objects.PutObject(ctx, bucket, getGWContentPath(object), data, metadata, opts)
-	if err != nil {
-		return objInfo, err
+	if opts.ServerSideEncryption == nil {
+		defer l.deleteGWMetadata(ctx, bucket, getDareMetaPath(object))
+		defer l.DeleteObject(ctx, bucket, getGWContentPath(object))
+		return l.s3Objects.PutObject(ctx, bucket, object, data, metadata, s3Opts)
 	}
+
+	oi, err := l.s3Objects.PutObject(ctx, bucket, getGWContentPath(object), data, map[string]string{}, s3Opts)
+	if err != nil {
+		return objInfo, minio.ErrorRespToObjectError(err)
+	}
+
 	gwMeta := newGWMetaV1()
 	gwMeta.Meta = make(map[string]string)
 	for k, v := range oi.UserDefined {
@@ -530,157 +460,112 @@ func (l *s3EncObjects) PutObject(ctx context.Context, bucket string, object stri
 	for k, v := range metadata {
 		gwMeta.Meta[k] = v
 	}
-	gwMeta.ETag = oi.ETag
+	encMD5 := data.MD5CurrentHexString()
+
+	gwMeta.ETag = encMD5
 	gwMeta.Stat.Size = oi.Size
 	gwMeta.Stat.ModTime = oi.ModTime
-	if err = l.writeDareMetadata(ctx, bucket, getGWMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
-		return objInfo, err
+	if err = l.writeGWMetadata(ctx, bucket, getDareMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
+		return objInfo, minio.ErrorRespToObjectError(err)
 	}
-	return oi, nil
+	objInfo = gwMeta.ToObjectInfo(bucket, object)
+	// delete any unencrypted content of the same name created previously
+	l.s3Objects.DeleteObject(ctx, bucket, object)
+	return objInfo, nil
 }
 
 // PutObjectPart puts a part of object in bucket
 func (l *s3EncObjects) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *minio.PutObjReader, opts minio.ObjectOptions) (pi minio.PartInfo, e error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
+
+	if opts.ServerSideEncryption == nil {
 		return l.s3Objects.PutObjectPart(ctx, bucket, object, uploadID, partID, data, opts)
 	}
+
+	var s3Opts minio.ObjectOptions
+	// for sse-s3 encryption options should not be passed to backend
+	if opts.ServerSideEncryption != nil && opts.ServerSideEncryption.Type() == encrypt.SSEC && shouldSetSSEHeaders() {
+		s3Opts = opts
+	}
+
 	uploadPath := getTmpGWMetaPath(object, uploadID)
 	tmpDareMeta := path.Join(uploadPath, gwdareMetaJSON)
 	_, err := l.s3Objects.GetObjectInfo(ctx, bucket, tmpDareMeta, minio.ObjectOptions{})
 	if err != nil {
-		// it is a regular multipart,since dare.meta is missing.
-		return l.s3Objects.PutObjectPart(ctx, bucket, object, uploadID, partID, data, opts)
-	}
-	partUploadName := path.Join(uploadPath, strconv.Itoa(partID))
-	oi, err := l.s3Objects.PutObject(ctx, bucket, partUploadName, data, map[string]string{}, opts)
-	if err != nil {
-		return pi, err
+		return pi, minio.InvalidUploadID{UploadID: uploadID}
 	}
 
-	return FromGatewayObjectPart(partID, oi), nil
+	pi, e = l.s3Objects.PutObjectPart(ctx, bucket, getGWContentPath(object), uploadID, partID, data, s3Opts)
+	if e != nil {
+		return
+	}
+	gwMeta := newGWMetaV1()
+	gwMeta.Parts = make([]minio.ObjectPartInfo, 1)
+	// Add incoming part.
+	gwMeta.Parts[0] = minio.ObjectPartInfo{
+		Number: partID,
+		ETag:   pi.ETag,
+		Size:   pi.Size,
+		Name:   strconv.Itoa(partID),
+	}
+	gwMeta.ETag = data.MD5CurrentHexString() // encrypted ETag
+	gwMeta.Stat.Size = pi.Size
+	gwMeta.Stat.ModTime = pi.LastModified
+
+	if err = l.writeGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, partID), gwMeta, minio.ObjectOptions{}); err != nil {
+		return pi, minio.ErrorRespToObjectError(err)
+	}
+	return minio.PartInfo{
+		Size:         gwMeta.Stat.Size,
+		ETag:         minio.CanonicalizeETag(gwMeta.ETag),
+		LastModified: gwMeta.Stat.ModTime,
+		PartNumber:   partID,
+	}, nil
 }
 
 // CopyObjectPart creates a part in a multipart upload by copying
 // existing object or a part of it.
 func (l *s3EncObjects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject, uploadID string,
 	partID int, startOffset, length int64, srcInfo minio.ObjectInfo, srcOpts, dstOpts minio.ObjectOptions) (p minio.PartInfo, err error) {
-	// pass through encryption
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
-	}
-	srcInfo.UserDefined = map[string]string{
-		"x-amz-copy-source-if-match": srcInfo.ETag,
-	}
-	// convert copy src and dst encryption options for GET/PUT calls
-	var getOpts minio.ObjectOptions
-	if srcOpts.ServerSideEncryption != nil {
-		getOpts.ServerSideEncryption = encrypt.SSE(srcOpts.ServerSideEncryption)
-	}
-
-	// Get dare meta json
-	gwMeta, err := l.getDareMetadata(ctx, destBucket, getTmpGWMetaPath(destObject, uploadID))
-	if err != nil {
-		// both src and dest are not encrypted - delegate to backend
-		if !crypto.IsEncrypted(srcInfo.UserDefined) {
-			return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
-		}
-		// src is encrypted
-		partName := path.Join(getTmpGWMetaPath(destObject, uploadID), strconv.Itoa(partID))
-		oi, oerr := l.PutObject(ctx, destBucket, partName, srcInfo.PutObjReader, srcInfo.UserDefined, dstOpts)
-		if oerr != nil {
-			return minio.PartInfo{}, oerr
-		}
-		return minio.PartInfo{PartNumber: partID, ETag: oi.ETag, Size: oi.Size}, nil
-	}
-	if !crypto.IsEncrypted(gwMeta.ToObjectInfo(destBucket, destObject).UserDefined) {
-		return l.s3Objects.CopyObjectPart(ctx, srcBucket, srcObject, destBucket, destObject, uploadID, partID, startOffset, length, srcInfo, srcOpts, dstOpts)
-	}
-	uploadPath := getTmpGWMetaPath(destObject, uploadID)
-	partUploadName := path.Join(uploadPath, strconv.Itoa(partID))
-	bkendObjInfo, rerr := l.s3Objects.PutObject(ctx, destBucket, partUploadName, srcInfo.PutObjReader, srcInfo.UserDefined, dstOpts)
-	if rerr != nil {
-		return
-	}
-	return minio.PartInfo{PartNumber: partID, ETag: bkendObjInfo.ETag, Size: bkendObjInfo.Size}, nil
+	return l.PutObjectPart(ctx, destBucket, destObject, uploadID, partID, srcInfo.PutObjReader, dstOpts)
 }
 
 // ListObjectParts returns all object parts for specified object in specified bucket
-func (l *s3EncObjects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int) (lpi minio.ListPartsInfo, e error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+func (l *s3EncObjects) ListObjectParts(ctx context.Context, bucket string, object string, uploadID string, partNumberMarker int, maxParts int, o minio.ObjectOptions) (lpi minio.ListPartsInfo, e error) {
+	var opts minio.ObjectOptions
+	if shouldSetSSEHeaders() {
+		opts = o
 	}
 	// We do not store parts uploaded so far in the dare.meta. Only CompleteMultipartUpload finalizes the parts under upload prefix.Otherwise,
 	// there could be situations of dare.meta getting corrupted by competing upload parts.
-	uploadPrefix := getTmpGWMetaPath(object, uploadID)
-	dm, err := l.getDareMetadata(ctx, bucket, uploadPrefix)
+	dm, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID))
 	if err != nil {
-		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+		return l.s3Objects.ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts, opts)
 	}
-	lpi.Parts = make([]minio.PartInfo, 0)
+
+	lpi, err = l.s3Objects.ListObjectParts(ctx, bucket, getGWContentPath(object), uploadID, partNumberMarker, maxParts, opts)
+	if err != nil {
+		return lpi, err
+	}
+	for i, part := range lpi.Parts {
+		partMeta, err := l.getGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, part.PartNumber))
+		if err != nil || len(partMeta.Parts) == 0 {
+			return lpi, minio.InvalidPart{}
+		}
+		lpi.Parts[i].ETag = partMeta.ETag
+	}
 	lpi.UserDefined = dm.Meta
-	lpi.Bucket = bucket
 	lpi.Object = object
-	lpi.UploadID = uploadID
-	lpi.MaxParts = maxParts
-	lpi.PartNumberMarker = partNumberMarker
-
-	if maxParts == 0 {
-		return lpi, nil
-	}
-
-	var continuationToken, startAfter, delimiter string
-	var loi minio.ListObjectsV2Info
-	if partNumberMarker > 0 {
-		startAfter = path.Join(uploadPrefix, strconv.Itoa(partNumberMarker))
-	}
-	for {
-		loi, err = l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
-		if err != nil {
-			return lpi, err
-		}
-		for _, obj := range loi.Objects {
-			startAfter = obj.Name
-			if !strings.HasPrefix(obj.Name, uploadPrefix) {
-				return lpi, nil
-			}
-			if strings.HasSuffix(obj.Name, gwdareMetaJSON) {
-				continue
-			}
-
-			partNumStr := strings.TrimLeft(obj.Name, path.Join(object, defaultMinioGWPrefix, uploadID, ""))
-			partNum, _ := strconv.Atoi(partNumStr)
-			if partNum < partNumberMarker {
-				continue
-			}
-			if partNum > 0 {
-				pi := minio.PartInfo{
-					PartNumber:   partNum,
-					Size:         obj.Size,
-					ETag:         obj.ETag,
-					LastModified: obj.ModTime,
-				}
-				lpi.Parts = append(lpi.Parts, pi)
-			}
-			if len(lpi.Parts) == maxParts {
-				break
-			}
-		}
-		continuationToken = loi.NextContinuationToken
-		if !loi.IsTruncated {
-			break
-		}
-	}
-	if len(loi.Objects) > len(lpi.Parts) && len(lpi.Parts) > 0 {
-		lpi.IsTruncated = true
-		lpi.NextPartNumberMarker = lpi.Parts[len(lpi.Parts)-1].PartNumber
-	}
 	return lpi, nil
 }
 
 // AbortMultipartUpload aborts a ongoing multipart upload
 func (l *s3EncObjects) AbortMultipartUpload(ctx context.Context, bucket string, object string, uploadID string) error {
-	if len(minio.GlobalGatewaySSE) == 0 {
+	if _, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID)); err != nil {
 		return l.s3Objects.AbortMultipartUpload(ctx, bucket, object, uploadID)
+	}
+
+	if err := l.s3Objects.AbortMultipartUpload(ctx, bucket, getGWContentPath(object), uploadID); err != nil {
+		return err
 	}
 
 	uploadPrefix := getTmpGWMetaPath(object, uploadID)
@@ -691,11 +576,8 @@ func (l *s3EncObjects) AbortMultipartUpload(ctx context.Context, bucket string, 
 			return minio.InvalidUploadID{UploadID: uploadID}
 		}
 		for _, obj := range loi.Objects {
-			if !strings.HasPrefix(obj.Name, uploadPrefix) {
-				return nil
-			}
 			if err := l.s3Objects.DeleteObject(ctx, bucket, obj.Name); err != nil {
-				return err
+				return minio.ErrorRespToObjectError(err)
 			}
 			startAfter = obj.Name
 		}
@@ -709,81 +591,63 @@ func (l *s3EncObjects) AbortMultipartUpload(ctx context.Context, bucket string, 
 
 // CompleteMultipartUpload completes ongoing multipart upload and finalizes object
 func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []minio.CompletePart, opts minio.ObjectOptions) (oi minio.ObjectInfo, e error) {
-	if len(minio.GlobalGatewaySSE) == 0 {
-		return l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
-	}
-	uploadPrefix := getTmpGWMetaPath(object, uploadID)
-	dareMeta, err := l.getDareMetadata(ctx, bucket, uploadPrefix)
-	if err != nil {
-		return l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
+	var s3Opts minio.ObjectOptions
+
+	if shouldSetSSEHeaders() {
+		s3Opts = opts
 	}
 
-	// overwrite any previous unencrypted object with same name
-	defer l.s3Objects.DeleteObject(ctx, bucket, object)
-
-	// Calculate s3 compatible md5sum for complete multipart.
-	s3MD5, err := minio.GetCompleteMultipartMD5(ctx, uploadedParts)
+	tmpMeta, err := l.getGWMetadata(ctx, bucket, getTmpDareMetaPath(object, uploadID))
 	if err != nil {
-		return oi, err
+		oi, e = l.s3Objects.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
+		if e == nil {
+			// delete any encrypted version of object that might exist
+			defer l.deleteGWMetadata(ctx, bucket, getDareMetaPath(object))
+			defer l.DeleteObject(ctx, bucket, getGWContentPath(object))
+		}
+		return oi, e
 	}
 	gwMeta := newGWMetaV1()
 	gwMeta.Meta = make(map[string]string)
-	for k, v := range dareMeta.Meta {
+	for k, v := range tmpMeta.Meta {
 		gwMeta.Meta[k] = v
 	}
 	// Allocate parts similar to incoming slice.
 	gwMeta.Parts = make([]minio.ObjectPartInfo, len(uploadedParts))
 
+	bkUploadedParts := make([]minio.CompletePart, len(uploadedParts))
+	// Calculate full object size.
 	var objectSize int64
-	var marker, delimiter string
-	var partsMap = make(map[string]string)
+
 	// Validate each part and then commit to disk.
 	for i, part := range uploadedParts {
-		obj := fmt.Sprintf("%s/%d", uploadPrefix, part.PartNumber)
-		partsMap[obj] = ""
-		res, rerr := l.s3Objects.ListObjects(ctx, bucket, obj, marker, delimiter, 1)
-		if rerr != nil || len(res.Objects) == 0 {
+		partMeta, err := l.getGWMetadata(ctx, bucket, getPartMetaPath(object, uploadID, part.PartNumber))
+		if err != nil || len(partMeta.Parts) == 0 {
 			return oi, minio.InvalidPart{}
 		}
-		partInfo := res.Objects[0]
-		// All parts should have same ETag as previously generated.
-		if partInfo.ETag != part.ETag {
-			invp := minio.InvalidPart{
-				PartNumber: part.PartNumber,
-				ExpETag:    partInfo.ETag,
-				GotETag:    part.ETag,
-			}
-			logger.LogIf(ctx, invp)
-			return oi, invp
-		}
-
-		// Last part could have been uploaded as 0bytes, do not need
-		// to save it in final `xl.json`.
-		if (i == len(uploadedParts)-1) && partInfo.Size == 0 {
-			gwMeta.Parts = gwMeta.Parts[:i] // Skip the part.
-			continue
-		}
-		// Save for total object size.
-		objectSize += partInfo.Size
-
-		// Add incoming parts.
-		gwMeta.Parts[i] = minio.ObjectPartInfo{
-			Number: part.PartNumber,
-			ETag:   part.ETag,
-			Size:   partInfo.Size,
-			Name:   partInfo.Name,
-		}
+		bkUploadedParts[i] = minio.CompletePart{PartNumber: part.PartNumber, ETag: partMeta.Parts[0].ETag}
+		gwMeta.Parts[i] = partMeta.Parts[0]
+		objectSize += partMeta.Parts[0].Size
 	}
+	oi, e = l.s3Objects.CompleteMultipartUpload(ctx, bucket, getGWContentPath(object), uploadID, bkUploadedParts, s3Opts)
+	if e != nil {
+		return oi, e
+	}
+
+	//delete any unencrypted version of object that might be on the backend
+	defer l.s3Objects.DeleteObject(ctx, bucket, object)
 
 	// Save the final object size and modtime.
 	gwMeta.Stat.Size = objectSize
-	gwMeta.Stat.ModTime = time.Now().UTC()
+	gwMeta.Stat.ModTime = oi.ModTime
+	gwMeta.ETag = oi.ETag
 
-	// Save successfully calculated md5sum.
-	gwMeta.Meta["etag"] = s3MD5
-
+	if err = l.writeGWMetadata(ctx, bucket, getDareMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
+		return oi, minio.ErrorRespToObjectError(err)
+	}
 	// Clean up any uploaded parts that are not being committed by this CompleteMultipart operation
-	var continuationToken, startAfter string
+	var continuationToken, startAfter, delimiter string
+	uploadPrefix := getTmpGWMetaPath(object, uploadID)
 	done := false
 	for {
 		loi, lerr := l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
@@ -797,23 +661,14 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 				break
 			}
 			startAfter = obj.Name
-			// delete parts not found in uploadedParts  map
-			if _, ok := partsMap[obj.Name]; !ok {
-				l.s3Objects.DeleteObject(ctx, bucket, obj.Name)
-			}
+			l.s3Objects.DeleteObject(ctx, bucket, obj.Name)
 		}
 		continuationToken = loi.NextContinuationToken
 		if !loi.IsTruncated || done {
 			break
 		}
 	}
-	if err = l.writeDareMetadata(ctx, bucket, getGWMetaPath(object), gwMeta, minio.ObjectOptions{}); err != nil {
-		return oi, err
-	}
-	// clean up temporary upload dare.meta file under uploadID prefix
-	if err = l.deleteDareMetadata(ctx, bucket, getTmpGWMetaPath(object, uploadID)); err != nil {
-		return oi, err
-	}
+
 	return gwMeta.ToObjectInfo(bucket, object), nil
 }
 
@@ -822,12 +677,12 @@ func getTmpGWMetaPath(object, uploadID string) string {
 	return path.Join(object, defaultMinioGWPrefix, uploadID)
 }
 
-// getGWMetaPath returns the prefix under which custom large object is stored on backend after upload completes
+// getGWMetaPath returns the prefix under which custom object metadata and object are stored on backend after upload completes
 func getGWMetaPath(object string) string {
 	return path.Join(object, defaultMinioGWPrefix)
 }
 
-// getGWContentPath returns the prefix under which custom small object is stored on backend after upload completes
+// getGWContentPath returns the prefix under which custom object is stored on backend after upload completes
 func getGWContentPath(object string) string {
 	return path.Join(object, defaultMinioGWPrefix, defaultGWContentFileName)
 }
@@ -855,19 +710,16 @@ func (l *s3EncObjects) cleanupStaleMultipartUploadsOnGW(ctx context.Context, exp
 			break
 		}
 		for _, b := range buckets {
-			allParts, expParts := l.getStalePartsForBucket(ctx, b.Name, expiry)
+			expParts := l.getStalePartsForBucket(ctx, b.Name, expiry)
 			for k := range expParts {
-				if _, ok := allParts[k]; !ok {
-					l.s3Objects.DeleteObject(ctx, b.Name, k)
-				}
+				l.s3Objects.DeleteObject(ctx, b.Name, k)
 			}
 		}
 	}
 }
 
-func (l *s3EncObjects) getStalePartsForBucket(ctx context.Context, bucket string, expiry time.Duration) (allParts, expParts map[string]string) {
+func (l *s3EncObjects) getStalePartsForBucket(ctx context.Context, bucket string, expiry time.Duration) (expParts map[string]string) {
 	var prefix, continuationToken, delimiter, startAfter string
-	allParts = make(map[string]string)
 	expParts = make(map[string]string)
 	now := time.Now()
 	for {
@@ -880,25 +732,9 @@ func (l *s3EncObjects) getStalePartsForBucket(ctx context.Context, bucket string
 			if !strings.Contains(obj.Name, defaultMinioGWPrefix) {
 				continue
 			}
-			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, gwdareMetaJSON)) {
-				objSlice := strings.Split(obj.Name, path.Join(slashSeparator, defaultMinioGWPrefix))
-				meta, err := l.getDareMetadata(ctx, bucket, objSlice[0])
-				if err != nil {
-					continue
-				}
-				for _, p := range meta.Parts {
-					allParts[p.Name] = ""
-				}
-			}
-			if strings.HasSuffix(obj.Name, path.Join(defaultMinioGWPrefix, defaultGWContentFileName)) {
-				objSlice := strings.Split(obj.Name, path.Join(slashSeparator, defaultMinioGWPrefix))
-				expParts[getGWContentPath(objSlice[0])] = ""
-			}
-			if now.Sub(obj.ModTime) > expiry {
-				// skip parts that are part of a completed upload
-				if _, ok := allParts[obj.Name]; !ok {
-					expParts[obj.Name] = ""
-				}
+
+			if strings.HasSuffix(obj.Name, gwpartMetaJSON) && now.Sub(obj.ModTime) > expiry {
+				expParts[obj.Name] = ""
 			}
 		}
 		continuationToken = loi.NextContinuationToken

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -229,8 +229,8 @@ var (
 
 	// KMS key id
 	globalKMSKeyID string
-	// Allocated KMS
-	globalKMS crypto.KMS
+	// GlobalKMS - Allocated KMS
+	GlobalKMS crypto.KMS
 	// KMS config
 	globalKMSConfig crypto.KMSConfig
 

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -75,7 +75,7 @@ type ObjectLayer interface {
 	CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject string, uploadID string, partID int,
 		startOffset int64, length int64, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (info PartInfo, err error)
 	PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, data *PutObjReader, opts ObjectOptions) (info PartInfo, err error)
-	ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error)
+	ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int, opts ObjectOptions) (result ListPartsInfo, err error)
 	AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string) error
 	CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (objInfo ObjectInfo, err error)
 

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1429,7 +1429,7 @@ func testListObjectPartsDiskNotFound(obj ObjectLayer, instanceType string, disks
 	}
 
 	for i, testCase := range testCases {
-		actualResult, actualErr := obj.ListObjectParts(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.partNumberMarker, testCase.maxParts)
+		actualResult, actualErr := obj.ListObjectParts(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.partNumberMarker, testCase.maxParts, ObjectOptions{})
 		if actualErr != nil && testCase.shouldPass {
 			t.Errorf("Test %d: %s: Expected to pass, but failed with: <ERROR> %s", i+1, instanceType, actualErr.Error())
 		}
@@ -1667,7 +1667,7 @@ func testListObjectParts(obj ObjectLayer, instanceType string, t TestErrHandler)
 	}
 
 	for i, testCase := range testCases {
-		actualResult, actualErr := obj.ListObjectParts(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.partNumberMarker, testCase.maxParts)
+		actualResult, actualErr := obj.ListObjectParts(context.Background(), testCase.bucket, testCase.object, testCase.uploadID, testCase.partNumberMarker, testCase.maxParts, ObjectOptions{})
 		if actualErr != nil && testCase.shouldPass {
 			t.Errorf("Test %d: %s: Expected to pass, but failed with: <ERROR> %s", i+1, instanceType, actualErr.Error())
 		}

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -486,7 +486,6 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, cleanUpFns ...func()) 
 		// encrypted bytes. The header parameter is used to
 		// provide encryption parameters.
 		fn = func(inputReader io.Reader, h http.Header, cFns ...func()) (r *GetObjectReader, err error) {
-
 			copySource := h.Get(crypto.SSECopyAlgorithm) != ""
 
 			cFns = append(cleanUpFns, cFns...)
@@ -573,7 +572,6 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, cleanUpFns ...func()) 
 			return r, nil
 		}
 	}
-
 	return fn, off, length, nil
 }
 
@@ -651,6 +649,7 @@ func sealETag(encKey crypto.ObjectKey, md5CurrSum []byte) []byte {
 	}
 	return encKey.SealETag(md5CurrSum)
 }
+
 func sealETagFn(key crypto.ObjectKey) SealMD5CurrFn {
 	fn1 := func(md5sumcurr []byte) []byte {
 		return sealETag(key, md5sumcurr)

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -1730,7 +1730,7 @@ func testAPICopyObjectPartHandler(obj ObjectLayer, instanceType, bucketName stri
 			// See if the new part has been uploaded.
 			// testing whether the copy was successful.
 			var results ListPartsInfo
-			results, err = obj.ListObjectParts(context.Background(), testCase.bucketName, testObject, testCase.uploadID, 0, 1)
+			results, err = obj.ListObjectParts(context.Background(), testCase.bucketName, testObject, testCase.uploadID, 0, 1, ObjectOptions{})
 			if err != nil {
 				t.Fatalf("Test %d: %s: Failed to look for copied object part: <ERROR> %s", i+1, instanceType, err)
 			}
@@ -2224,7 +2224,7 @@ func testAPINewMultipartHandler(obj ObjectLayer, instanceType, bucketName string
 		t.Fatalf("Error decoding the recorded response Body")
 	}
 	// verify the uploadID my making an attempt to list parts.
-	_, err = obj.ListObjectParts(context.Background(), bucketName, objectName, multipartResponse.UploadID, 0, 1)
+	_, err = obj.ListObjectParts(context.Background(), bucketName, objectName, multipartResponse.UploadID, 0, 1, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Invalid UploadID: <ERROR> %s", err)
 	}
@@ -2276,7 +2276,7 @@ func testAPINewMultipartHandler(obj ObjectLayer, instanceType, bucketName string
 		t.Fatalf("Error decoding the recorded response Body")
 	}
 	// verify the uploadID my making an attempt to list parts.
-	_, err = obj.ListObjectParts(context.Background(), bucketName, objectName, multipartResponse.UploadID, 0, 1)
+	_, err = obj.ListObjectParts(context.Background(), bucketName, objectName, multipartResponse.UploadID, 0, 1, ObjectOptions{})
 	if err != nil {
 		t.Fatalf("Invalid UploadID: <ERROR> %s", err)
 	}
@@ -2391,7 +2391,7 @@ func testAPINewMultipartHandlerParallel(obj ObjectLayer, instanceType, bucketNam
 	wg.Wait()
 	// Validate the upload ID by an attempt to list parts using it.
 	for _, uploadID := range testUploads.uploads {
-		_, err := obj.ListObjectParts(context.Background(), bucketName, objectName, uploadID, 0, 1)
+		_, err := obj.ListObjectParts(context.Background(), bucketName, objectName, uploadID, 0, 1, ObjectOptions{})
 		if err != nil {
 			t.Fatalf("Invalid UploadID: <ERROR> %s", err)
 		}

--- a/cmd/ui-errors.go
+++ b/cmd/ui-errors.go
@@ -207,6 +207,12 @@ Example 1:
 	uiErrInvalidGWSSEValue = newUIErrFn(
 		"Invalid gateway sse value",
 		"Please check the passed value",
-		"MINIO_GW_SSE: Gateway SSE accepts only S3, C and KMS as valid values. Delimit by `;` to set more than one value",
+		"MINIO_GW_SSE: Gateway SSE accepts only C and S3 as valid values. Delimit by `;` to set more than one value",
+	)
+
+	uiErrInvalidGWSSEEnvValue = newUIErrFn(
+		"Invalid gateway sse configuration",
+		"",
+		"Refer to https://docs.minio.io/docs/minio-kms-quickstart-guide.html for setting up sse with s3 gateway",
 	)
 )

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -835,8 +835,8 @@ func (s *xlSets) PutObjectPart(ctx context.Context, bucket, object, uploadID str
 }
 
 // ListObjectParts - lists all uploaded parts to an object in hashedSet.
-func (s *xlSets) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListPartsInfo, err error) {
-	return s.getHashedSet(object).ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts)
+func (s *xlSets) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker int, maxParts int, opts ObjectOptions) (result ListPartsInfo, err error) {
+	return s.getHashedSet(object).ListObjectParts(ctx, bucket, object, uploadID, partNumberMarker, maxParts, opts)
 }
 
 // Aborts an in-progress multipart operation on hashedSet based on the object name.

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -480,7 +480,7 @@ func (xl xlObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID 
 // Implements S3 compatible ListObjectParts API. The resulting
 // ListPartsInfo structure is marshaled directly into XML and
 // replied back to the client.
-func (xl xlObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int) (result ListPartsInfo, e error) {
+func (xl xlObjects) ListObjectParts(ctx context.Context, bucket, object, uploadID string, partNumberMarker, maxParts int, opts ObjectOptions) (result ListPartsInfo, e error) {
 	if err := checkListPartsArgs(ctx, bucket, object, xl); err != nil {
 		return result, err
 	}

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -67,8 +67,13 @@ Optionally set `MINIO_SSE_VAULT_CAPATH` as the path to a directory of PEM-encode
 export MINIO_SSE_VAULT_CAPATH=/home/user/custom-pems
 ```
 
-To enable encryption at gateway MINIO_GW_SSE environment variable needs to be set to "s3" for sse-s3
-and "c" for sse-c encryption at gateway. More than one encryption option can be set, delimited by ";". If MINIO_GW_SSE is not set, any SSE headers will be passed to S3 backend.
+For S3 gateway, three encryption modes are possible. Encryption can be set to ``pass-through`` to backend, ``single encryption`` (at the gateway) or ``double encryption`` (single encryption at gateway and pass through to backend). This can be specified by setting MINIO_GW_SSE and KMS environment variables set in Step #3.
+
+If MINIO_GW_SSE and KMS are not setup, all encryption headers are passed through to the backend. If KMS environment variables are set up, ``single encryption`` is automatically performed at the gateway and encrypted object is saved at the backend.
+
+To specify ``double encryption``, MINIO_GW_SSE environment variable needs to be set to "s3" for sse-s3
+and "c" for sse-c encryption. More than one encryption option can be set, delimited by ";". Objects are encrypted at the gateway and the gateway also does a pass-through to backend. Note that in the case of SSE-C encryption, gateway derives a unique SSE-C key for pass through from the SSE-C client key using a KDF.
+
 ```sh
 export MINIO_GW_SSE="s3;c"
 export MINIO_SSE_VAULT_APPROLE_ID=9b56cc08-8258-45d5-24a3-679876769126


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Simplify the custom backend format for s3 gateway encrypted objects to leverage s3 multipart API. At the end of upload, the gateway backend will only have 2 objects - an encrypted object with data, and an additional metadata object for storing metadata attributes. This applies to both single and multipart objects

 

- Simplify environment variables for managing gateway encryption modes.
     If Vault is set up as KMS, s3 gateway will automatically perform single encryption
     If MINIO_GW_SSE is set up in addition to Vault KMS, double encryption is performed
     when neither KMS or MINIO_GW_SSE is set, do a pass through to backend.


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR brings in simplification to the custom format for encrypted objects in PR #6423, which is necessitated by need to maintain metadata and encrypted md5sum as state for multipart uploads.
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With aws cli, s3cmd and minio-go sdk
for e.g. to test single encryption at gateway
 - Start minio s3 gateway with [KMS settings](https://docs.minio.io/docs/minio-kms-quickstart-guide.html) 
 - ``` aws s3api put-object --bucket testbucket --key foo --no-verify-ssl --body /tmp/data --endpoint-url https://localhost:9000 --server-side-encryption AES256 ```
- object on the backend should be stored as foo/.minio/data (content)  and foo/.minio/dare.meta (metadata). If accessed directly on the backend, only encrypted content should be seen, but ``` mc cat myminio-ssl/testbucket/foo``` should show decrypted content.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.