### PR TITLE
Simplify OPA to use rootCAs custom transport

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -556,8 +556,10 @@ func (s *serverConfig) loadToCachedConfigs() {
 	if globalPolicyOPA == nil {
 		if s.Policy.OPA.URL != nil && s.Policy.OPA.URL.String() != "" {
 			globalPolicyOPA = iampolicy.NewOpa(iampolicy.OpaArgs{
-				URL:       s.Policy.OPA.URL,
-				AuthToken: s.Policy.OPA.AuthToken,
+				URL:         s.Policy.OPA.URL,
+				AuthToken:   s.Policy.OPA.AuthToken,
+				Transport:   NewCustomHTTPTransport(),
+				CloseRespFn: CloseResponse,
 			})
 		}
 	}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Simplify OPA to use rootCAs custom transport
<!--- Describe your changes in detail -->

## Motivation and Context
Also close the connections properly to use the
connection pooling properly for HTTP clients.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Testing OPA with TLS certs, also close the connections properly to avoid seeing lots of connections in TIME_WAIT. 

Configure OPA certs with https://www.openpolicyagent.org/docs/security.html#tls-and-https and then trust the `public.crt` by copying it into Minio `.minio/certs/CAs` folder. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.