### PR TITLE
Improve disk usage thread CPU usage

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -187,14 +187,9 @@ func (fs *FSObjects) diskUsage(doneCh chan struct{}) {
 		case <-doneCh:
 			return errWalkAbort
 		default:
-			var fi os.FileInfo
-			var err error
-			if hasSuffix(entry, slashSeparator) {
-				fi, err = fsStatDir(ctx, entry)
-			} else {
-				fi, err = fsStatFile(ctx, entry)
-			}
+			fi, err := os.Stat(entry)
 			if err != nil {
+				err = osErrToFSFileErr(err)
 				return err
 			}
 			atomic.AddUint64(&fs.totalUsed, uint64(fi.Size()))
@@ -226,14 +221,9 @@ func (fs *FSObjects) diskUsage(doneCh chan struct{}) {
 					}
 				}
 
-				var fi os.FileInfo
-				var err error
-				if hasSuffix(entry, slashSeparator) {
-					fi, err = fsStatDir(ctx, entry)
-				} else {
-					fi, err = fsStatFile(ctx, entry)
-				}
+				fi, err := os.Stat(entry)
 				if err != nil {
+					err = osErrToFSFileErr(err)
 					return err
 				}
 				usage = usage + uint64(fi.Size())

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -83,8 +83,10 @@ func checkPathLength(pathName string) error {
 		return errFileNameTooLong
 	}
 
-	// Convert any '\' to '/'.
-	pathName = filepath.ToSlash(pathName)
+	if runtime.GOOS == "windows" {
+		// Convert any '\' to '/'.
+		pathName = filepath.ToSlash(pathName)
+	}
 
 	// Check each path segment length is > 255
 	for len(pathName) > 0 && pathName != "." && pathName != "/" {
@@ -374,6 +376,7 @@ func (s *posix) diskUsage(doneCh chan struct{}) {
 		default:
 			fi, err := os.Stat(entry)
 			if err != nil {
+				err = osErrToFSFileErr(err)
 				return err
 			}
 			atomic.AddUint64(&s.totalUsed, uint64(fi.Size()))
@@ -413,6 +416,7 @@ func (s *posix) diskUsage(doneCh chan struct{}) {
 				default:
 					fi, err := os.Stat(entry)
 					if err != nil {
+						err = osErrToFSFileErr(err)
 						return err
 					}
 					usage = usage + uint64(fi.Size())


### PR DESCRIPTION
## Description
Remove overhead while running the disk usage thread

## Motivation and Context
We have received complaints about `du` thread using high CPU, while the process itself is compute intensive (thread needs to walk down all the files in all the directories). Based on profiling results, removed the overhead in processing. Thanks to @harshavardhana for the pointers and patch.

## Regression
No

## How Has This Been Tested?
Using `go tool pprof`.Cumulative time taken by cmd.walk has come to 40s compared to 57s earlier (over the same sample rate and Minio running time). 

Load : 10M objects spread across 1000 buckets.

Previously
```
Showing top 10 nodes out of 67
      flat  flat%   sum%        cum   cum%
   28370ms 46.82% 46.82%    29660ms 48.94%  syscall.Syscall6
    7340ms 12.11% 58.93%     8740ms 14.42%  path.Clean
    4230ms  6.98% 65.91%     4230ms  6.98%  syscall.Syscall
    2510ms  4.14% 70.05%     4280ms  7.06%  runtime.mallocgc
    1380ms  2.28% 72.33%     1380ms  2.28%  strings.LastIndexByte
    1130ms  1.86% 74.19%     1830ms  3.02%  runtime.scanobject
     890ms  1.47% 75.66%     1850ms  3.05%  path.Base
     890ms  1.47% 77.13%     1640ms  2.71%  syscall.ByteSliceFromString
     730ms  1.20% 78.33%    57000ms 94.06%  github.com/minio/minio/cmd.walk
     680ms  1.12% 79.46%     2060ms  3.40%  strings.LastIndex
```

With this PR
```
Showing top 10 nodes out of 69
      flat  flat%   sum%        cum   cum%
   21910ms 50.00% 50.00%    23380ms 53.35%  syscall.Syscall6
    4500ms 10.27% 60.27%     4510ms 10.29%  syscall.Syscall
    2300ms  5.25% 65.52%     3730ms  8.51%  path.Clean
    2160ms  4.93% 70.45%     4010ms  9.15%  runtime.mallocgc
     940ms  2.15% 72.59%     1520ms  3.47%  runtime.scanobject
     850ms  1.94% 74.53%     1600ms  3.65%  syscall.ByteSliceFromString
     670ms  1.53% 76.06%    40400ms 92.20%  github.com/minio/minio/cmd.walk
     650ms  1.48% 77.54%      650ms  1.48%  runtime.memmove
     600ms  1.37% 78.91%      600ms  1.37%  runtime.memclrNoHeapPointers
     540ms  1.23% 80.15%      540ms  1.23%  runtime.heapBitsForObject
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.