### PR TITLE
Fix CloudBerry rename object failed

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -427,7 +427,7 @@ func setIgnoreResourcesHandler(h http.Handler) http.Handler {
 func ignoreNotImplementedBucketResources(req *http.Request) bool {
 	for name := range req.URL.Query() {
 		// Enable GetBucketACL dummy call specifically.
-		if name == "acl" && req.Method == http.MethodGet {
+		if name == "acl" && (req.Method == http.MethodGet || req.Method == http.MethodPut) {
 			return false
 		}
 
@@ -442,7 +442,7 @@ func ignoreNotImplementedBucketResources(req *http.Request) bool {
 func ignoreNotImplementedObjectResources(req *http.Request) bool {
 	for name := range req.URL.Query() {
 		// Enable GetObjectACL dummy call specifically.
-		if name == "acl" && req.Method == http.MethodGet {
+		if name == "acl" && (req.Method == http.MethodGet || req.Method == http.MethodPut) {
 			return false
 		}
 		if notimplementedObjectResourceNames[name] {


### PR DESCRIPTION
CloudBerry rename object does PUT request and query acl key. Server  responses not implement causing rename failed.

<!--- Provide a general summary of your changes in the Title above -->
1. Make acl query pass through dummy api.
2. Create putObject/Bucket dummy api.

## Description
CloudBerry rename object does PUT request in the last step.
1. Add put method when generic-handler checking queries with acl key.
2. Create putObject/Bucket dummy api.

## Motivation and Context
Cloud berry explorer show failed when renaming objects(Actually it did rename). But server still return "Not implement" response.

## Regression
 No

## How Has This Been Tested?
Rename an object by Cloud berry explorer. And make sure no failed msg popup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x ] All new and existing tests passed.