### PR TITLE
gateway: Properly set globalMinioPort

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -135,7 +135,8 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	handleCommonCmdArgs(ctx)
 
 	// Get port to listen on from gateway address
-	_, gatewayPort, pErr := net.SplitHostPort(gatewayAddr)
+	var pErr error
+	_, globalMinioPort, pErr = net.SplitHostPort(gatewayAddr)
 	if pErr != nil {
 		logger.FatalIf(pErr, "Unable to start gateway")
 	}
@@ -144,7 +145,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
 	// (non-)minio process is listening on IPv4 of given port.
 	// To avoid this error situation we check for port availability.
-	logger.FatalIf(checkPortAvailability(gatewayPort), "Unable to start the gateway")
+	logger.FatalIf(checkPortAvailability(globalMinioPort), "Unable to start the gateway")
 
 	// Create certs path.
 	logger.FatalIf(createConfigDir(), "Unable to create configuration directories")


### PR DESCRIPTION

## Description
globalMinioPort is used in federation which stores the address
and the port number of the server hosting the specified bucket,
this latter uses globalMinioPort but this latter is not set in
startup of the gateway mode.

This commit fixes the behavior.

## Motivation and Context
Fixes #6858 

## Regression
Do not know

## How Has This Been Tested?
- Run two Minio clusters with a non standard port, such as 80.
- Create a bucket in cluster 1
- List buckets in cluster 2


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.