### PR TITLE
set vault namespace before getting accesstoken

### DIFF
--- a/cmd/crypto/vault.go
+++ b/cmd/crypto/vault.go
@@ -193,15 +193,16 @@ func NewVault(kmsConf KMSConfig) (KMS, error) {
 		return nil, err
 	}
 
+	if ns, ok := os.LookupEnv("VAULT_NAMESPACE"); ok {
+		c.SetNamespace(ns)
+	}
+
 	accessToken, leaseDuration, err := getVaultAccessToken(c, config.Auth.AppRole.ID, config.Auth.AppRole.Secret)
 	if err != nil {
 		return nil, err
 	}
 	// authenticate and get the access token
 	c.SetToken(accessToken)
-	if ns, ok := os.LookupEnv("VAULT_NAMESPACE"); ok {
-		c.SetNamespace(ns)
-	}
 	v := vaultService{client: c, config: &config, leaseDuration: time.Duration(leaseDuration)}
 	v.renewToken(c)
 	return &v, nil

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -720,7 +720,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	srcOpts, err = copySrcEncryptionOpts(r, srcBucket, srcObject)
 	if err != nil {
 		logger.LogIf(ctx, err)
-		writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL)
+		writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
 	// convert copy src encryption options for GET calls
@@ -732,7 +732,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	dstOpts, err = copyDstEncryptionOpts(r, dstBucket, dstObject, nil)
 	if err != nil {
 		logger.LogIf(ctx, err)
-		writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL)
+		writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
 
@@ -1490,7 +1490,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 	var srcOpts, dstOpts ObjectOptions
 	srcOpts, err = copySrcEncryptionOpts(r, srcBucket, srcObject)
 	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL)
+		writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
 	// convert copy src and dst encryption options for GET/PUT calls
@@ -1500,7 +1500,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 	}
 	dstOpts, err = copyDstEncryptionOpts(r, dstBucket, dstObject, nil)
 	if err != nil {
-		writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL)
+		writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
 
@@ -1622,13 +1622,13 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 	if objectAPI.IsEncryptionSupported() && !isCompressed {
 		li, lerr := objectAPI.ListObjectParts(ctx, dstBucket, dstObject, uploadID, 0, 1, dstOpts)
 		if lerr != nil {
-			writeErrorResponse(w, toAPIErrorCode(ctx, lerr), r.URL)
+			writeErrorResponse(w, toAPIErrorCode(ctx, lerr), r.URL, guessIsBrowserReq(r))
 			return
 		}
 		li.UserDefined = CleanMinioInternalMetadataKeys(li.UserDefined)
 		dstOpts, err = copyDstEncryptionOpts(r, dstBucket, dstObject, li.UserDefined)
 		if err != nil {
-			writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL)
+			writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
 			return
 		}
 		if crypto.IsEncrypted(li.UserDefined) {
@@ -1823,7 +1823,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	if crypto.SSEC.IsRequested(r.Header) {
 		opts, err = putEncryptionOpts(r, bucket, object, nil)
 		if err != nil {
-			writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL)
+			writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
 			return
 		}
 	}
@@ -1898,7 +1898,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 			isEncrypted = true // to detect SSE-S3 encryption
 			opts, err = putEncryptionOpts(r, bucket, object, li.UserDefined)
 			if err != nil {
-				writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL)
+				writeErrorResponse(w, toAPIErrorCode(ctx, err), r.URL, guessIsBrowserReq(r))
 				return
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set namespace before trying to get Vault access token as approle id and secret are scoped to namespace.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows kms to be initialized correctly when used with namespaces
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.