### PR TITLE
Fix CopyObject regression calculating md5sum

### DIFF
--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -635,12 +635,13 @@ func (p *PutObjReader) MD5CurrentHexString() string {
 func NewPutObjReader(rawReader *hash.Reader, encReader *hash.Reader, encKey []byte) *PutObjReader {
 	p := PutObjReader{Reader: rawReader, rawReader: rawReader}
 
-	var objKey crypto.ObjectKey
-	copy(objKey[:], encKey)
-	p.sealMD5Fn = sealETagFn(objKey)
-	if encReader != nil {
+	if len(encKey) != 0 && encReader != nil {
+		var objKey crypto.ObjectKey
+		copy(objKey[:], encKey)
+		p.sealMD5Fn = sealETagFn(objKey)
 		p.Reader = encReader
 	}
+
 	return &p
 }
 
@@ -651,9 +652,10 @@ func sealETag(encKey crypto.ObjectKey, md5CurrSum []byte) []byte {
 	}
 	return encKey.SealETag(md5CurrSum)
 }
+
 func sealETagFn(key crypto.ObjectKey) SealMD5CurrFn {
-	fn1 := func(md5sumcurr []byte) []byte {
+	fn := func(md5sumcurr []byte) []byte {
 		return sealETag(key, md5sumcurr)
 	}
-	return fn1
+	return fn
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
CopyObject() failed to calculate proper md5sum
when without encryption headers. This is a regression
fix perhaps introduced in commit 5f6d717b7a

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes https://github.com/minio/minio-go/issues/1044

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes introduced in 5f6d717b7a
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using `minio-go` functional and unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.