### PR TITLE
Update to Minio Storage Class Quickstart Guide

### DIFF
--- a/docs/erasure/storage-class/README.md
+++ b/docs/erasure/storage-class/README.md
@@ -1,28 +1,26 @@
 # Minio Storage Class Quickstart Guide [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
 
-Minio server supports storage class in erasure coding mode. This allows configurable data and parity disks per object.
+Minio Server supports two storage classes in erasure coding mode: `Reduced Redundancy` class and `Standard` class. These classes enable Minio Server to save an object across a configurable number of data and parity drives.
 
-## Overview
+These classes are defined by setting environment variables and specifying the data and parity hard drives before starting Minio Server. The storage class to use for an object is set by defining the `x-amz-storage-class` metadata field. 
 
-Minio supports two storage classes, Reduced Redundancy class and Standard class. These classes can be defined using environment variables
-set before starting Minio server. After the data and parity disks for each storage class are defined using environment variables,
-you can set the storage class of an object via request metadata field `x-amz-storage-class`. Minio server then honors the storage class by
-saving the object in specific number of data and parity disks.
+This guide describes how to prepare for and use a storage class.
 
-## Storage usage
+* [Calculate Drive Requirements and Usage](#calculate-drive-requirements-and-usage)
+* [Get Started with Storage Class](#get-started-with-storage-class)
 
-The selection of varying data and parity drives has a direct impact on the drive space usage. With storage class, you can optimize for high
-redundancy or better drive space utilization.
+## <a name="calculate-drive-requirements-and-usage"></a>1. Calculate Drive Requirements and Usage
 
-To get an idea of how various combinations of data and parity drives affect the storage usage, let’s take an example of a 100 MiB file stored
-on 16 drive Minio deployment. If you use eight data and eight parity drives, the file space usage will be approximately twice, i.e. 100 MiB
-file will take 200 MiB space. But, if you use ten data and six parity drives, same 100 MiB file takes around 160 MiB. If you use 14 data and
-two parity drives, 100 MiB file takes only approximately 114 MiB.
+The number of data and parity drives has a direct impact on the drive space usage. A storage class can be used to optimize for high redundancy or better drive space utilization.
 
-Below is a list of data/parity drives and corresponding _approximate_ storage space usage on a 16 drive Minio deployment. The field _storage
-usage ratio_ is simply the drive space used by the file after erasure-encoding, divided by actual file size.
+The following lists how different combinations of data and parity drives, affect storage usage for a 100 MB file stored on a 16-drive Minio deployment:
+* **8 data and 8 parity drives**: the file space usage is approximately twice the size of the file (i.e. the 100 MB file will consume 200 MB of space).
+* **8 data and 6 parity drives**: the file space usage for the 100 MB file is around 160 MB.
+* **14 data and 2 parity drives**: the file space usage for the 100 MB file is approximately 114 MB.
 
-| Total Drives (N) | Data Drives (D) | Parity Drives (P) | Storage Usage Ratio |
+Below is a list of data/parity drive configurations and the *approximate* storage space consumption on a 16-drive Minio deployment:
+
+| **Total Drives (N)** | **Data Drives (D)** | **Parity Drives (P)** | **Storage Usage Ratio** |
 |------------------|-----------------|-------------------|---------------------|
 |               16 |               8 |                 8 |                2.00 |
 |               16 |               9 |                 7 |                1.79 |
@@ -32,60 +30,56 @@ usage ratio_ is simply the drive space used by the file after erasure-encoding, 
 |               16 |              13 |                 3 |                1.23 |
 |               16 |              14 |                 2 |                1.14 |
 
-You can calculate _approximate_ storage usage ratio using the formula - total drives (N) / data drives (D).
 
-### Allowed values for STANDARD storage class
+The *storage usage* ratio is calculated as follows:
+* **Storage Usage = Drive Space Used by the File After Erasure-Encoding / Actual File Size**
 
-`STANDARD` storage class implies more parity than `REDUCED_REDUNDANCY` class. So, `STANDARD` parity disks should be
+The *approximate storage usage* ratio is calculated as follows:
+* **Approximate Storage Usage = Total Drives (N) / Data Drives (D)**
 
-- Greater than or equal to 2, if `REDUCED_REDUNDANCY` parity is not set.
-- Greater than `REDUCED_REDUNDANCY` parity, if it is set.
+### 1.1 Values for the STANDARD Storage Class
 
-Parity blocks can not be higher than data blocks, so `STANDARD` storage class parity can not be higher than N/2. (N being total number of disks)
+The usage of the `STANDARD` storage class implies more parity than the `REDUCED_REDUNDANCY` class. When using the `STANDARD` storage class, parity drives should be:
+* greater than or equal to 2, if `REDUCED_REDUNDANCY` parity is not set.
+* greater than `REDUCED_REDUNDANCY` parity, if `REDUCED_REDUNDANCY` parity is set.
 
-Default value for `STANDARD` storage class is `N/2` (N is the total number of drives).
+The number of parity blocks cannot be higher than data blocks, so the `STANDARD` storage class parity cannot be higher than N/2, where N is the total number of drives. The default value for `STANDARD` is N/2.
 
-### Allowed values for REDUCED_REDUNDANCY storage class
+### 1.2 Values for the REDUCED_REDUNDANCY Storage Class
 
-`REDUCED_REDUNDANCY` implies lesser parity than `STANDARD` class. So,`REDUCED_REDUNDANCY` parity disks should be
+`REDUCED_REDUNDANCY` implies less parity than the `STANDARD` class. When using the `REDUCED_REDUNDANCY` storage class, parity drives should be:
+* less than N/2, if `STANDARD` parity is not set.
+* less than `STANDARD` parity, if `STANDARD` parity is set.
 
-- Less than N/2, if `STANDARD` parity is not set.
-- Less than `STANDARD` Parity, if it is set.
+Since a parity of less than 2 is not recommended, the `REDUCED_REDUNDANCY` storage class does not support a 4-drive erasure coding configuration. The default value for the `REDUCED_REDUNDANCY` storage class is 2.
 
-As parity below 2 is not recommended, `REDUCED_REDUNDANCY` storage class is not supported for 4 disks erasure coding setup.
+## <a name="get-started-with-storage-class"></a>2. Get Started with Storage Class
 
-Default value for `REDUCED_REDUNDANCY` storage class is `2`.
+### 2.1 Set the Storage Class Using Environment Variables
 
-## Get started with Storage Class
-
-### Set storage class
-
-The format to set storage class environment variables is as follows
+Use the following format to set the storage class using environment variables:
 
 `MINIO_STORAGE_CLASS_STANDARD=EC:parity`
 `MINIO_STORAGE_CLASS_RRS=EC:parity`
 
-For example, set `MINIO_STORAGE_CLASS_RRS` parity 2 and `MINIO_STORAGE_CLASS_STANDARD` parity 3
+The following example sets `MINIO_STORAGE_CLASS_RRS` to parity 2 and `MINIO_STORAGE_CLASS_STANDARD` to parity 3:
 
 ```sh
 export MINIO_STORAGE_CLASS_STANDARD=EC:3
 export MINIO_STORAGE_CLASS_RRS=EC:2
 ```
 
-Storage class can also be set via `mc admin config` get/set commands to update the configuration. Refer [storage class](https://github.com/minio/minio/tree/master/docs/config#storage-class) for
-more details.
+### 2.2 Set the Storage Class Using Minio Client
 
-*Note*
+The storage class can also be set via `mc admin config` get/set commands to update the configuration. For more information see the [storage class](https://github.com/minio/minio/tree/master/docs/config#storage-class) documentation.
 
-- If `STANDARD` storage class is set via environment variables or `mc admin config` get/set commands, and `x-amz-storage-class` is not present in request metadata, Minio server will 
-apply `STANDARD` storage class to the object. This means the data and parity disks will be used as set in `STANDARD` storage class.
+**Note:**
+* If the `STANDARD` storage class is set via environment variables or `mc admin config` get/set commands, and `x-amz-storage-class` is not present in request metadata, Minio Server will apply the `STANDARD` storage class to the object. This means the data and parity drives will be used as set in the `STANDARD` storage class.
+* If the storage class is not defined before starting Minio Server, and a subsequent `PutObject` metadata field has `x-amz-storage-class` present with the values `REDUCED_REDUNDANCY` or `STANDARD`, Minio Server will use the default parity values.
 
-- If storage class is not defined before starting Minio server, and subsequent PutObject metadata field has `x-amz-storage-class` present
-with values `REDUCED_REDUNDANCY` or `STANDARD`, Minio server uses default parity values.
+### 2.2 Example in Go Using `REDUCED_REDUNDANCY`
 
-### Set metadata
-
-In below example `minio-go` is used to set the storage class to `REDUCED_REDUNDANCY`. This means this object will be split across 6 data disks and 2 parity disks (as per the storage class set in previous step).
+In the example below, `minio-go` is used to set the storage class to `REDUCED_REDUNDANCY` and split the object across 6 data drives and 2 parity drives:
 
 ```go
 s3Client, err := minio.New("localhost:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)

--- a/docs/erasure/storage-class/README.md
+++ b/docs/erasure/storage-class/README.md
@@ -2,12 +2,10 @@
 
 Minio Server supports two storage classes in erasure coding mode: `Reduced Redundancy` class and `Standard` class. These classes enable Minio Server to save an object across a configurable number of data and parity drives.
 
-These classes are defined by setting environment variables and specifying the data and parity hard drives before starting Minio Server. The storage class to use for an object is set by defining the `x-amz-storage-class` metadata field. 
-
 This guide describes how to prepare for and use a storage class.
 
-* [Calculate Drive Requirements and Usage](#calculate-drive-requirements-and-usage)
-* [Get Started with Storage Class](#get-started-with-storage-class)
+- [Calculate Drive Requirements and Usage](#calculate-drive-requirements-and-usage)
+- [Get Started with Storage Class](#get-started-with-storage-class)
 
 ## <a name="calculate-drive-requirements-and-usage"></a>1. Calculate Drive Requirements and Usage
 


### PR DESCRIPTION
1. Initial edits to this page which has, till now, rendered purely as a github page.
2. This page should become a hidden page that renders in gluegun. I propose adding these lines to the site.yml file:
      - Minio Storage Class Quickstart Guide:
        Link: ../minio/docs/erasure/storage-class/README.md
        Slug: minio-storage-class-quickstart-guide
        Options: hidden
3. This is referred to from https://docs.minio.io/docs/minio-erasure-code-quickstart-guide.html. Therefore, based on suggestion #2 above, the link to this page at line 20 in that file should be updated to:
[storage classes](./minio-storage-class-quickstart-guide.html)

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
