### PR TITLE
Fix gateway crash when using certain object stores

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -488,7 +488,7 @@ next:
 				return toJSONError(errAccessDenied)
 			}
 
-			if err = deleteObject(nil, objectAPI, web.CacheAPI(), args.BucketName, objectName, r); err != nil {
+			if err = deleteObject(context.Background(), objectAPI, web.CacheAPI(), args.BucketName, objectName, r); err != nil {
 				break next
 			}
 			continue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit replaces `nil` with `context.Background()` when deleting objects via the Gateway WebUI. The Gateway WebUI crashes with object stores like Manta which were written to expect a context to be passed in.

## Motivation and Context
This fixes a crash when deleting objects with certain gateway object stores through the WebUI

## Regression
Is this PR fixing a regression? **Yes**
I believe it was introduced in the following commit https://github.com/minio/minio/commit/e452377b247ca5f9155e780f4b9aac45266d3ea7#diff-a332614ad2487d48ea82260329c81b9a

## How Has This Been Tested?
I've loaded up the gateway using the manta object store, uploaded a file, and deleted a file. I'm using MacOS and Go 1.11.2

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.