### PR TITLE
Errors in notification config should not crash the server

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -381,7 +381,7 @@ func serverMain(ctx *cli.Context) {
 
 	// Initialize notification system.
 	if err = globalNotificationSys.Init(newObject); err != nil {
-		logger.Fatal(err, "Unable to initialize notification system")
+		logger.LogIf(context.Background(), err)
 	}
 
 	globalObjLayerMutex.Lock()


### PR DESCRIPTION
Fixes #6870

<!--- Provide a general summary of your changes in the Title above -->

## Description
Minio server was crashing for errors in setConfig
Please refer #6870 for more info

## Motivation and Context
minio should fallback on such notification errors and continue serving

## Regression
No

## How Has This Been Tested?

1 - Start the minio server with bucket notification enabled
2 - Stop the notification server
3 - Try to restart the server by exiting and spawning again (or) `./mc admin service restart myminio`
4 - The server will emit logs but wont crash

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.