### PR TITLE
Ignore permission errors on config-dir

### DIFF
--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -71,8 +71,12 @@ func getRootCAs(certsCAsDir string) (*x509.CertPool, error) {
 	// Get all CA file names.
 	var caFiles []string
 	fis, err := readDir(certsCAsDir)
-	if err != nil {
+	if err != nil && err != errFileNotFound {
 		return nil, err
+	}
+	// Return success if CA's directory is missing.
+	if err == errFileNotFound {
+		return nil, nil
 	}
 	for _, fi := range fis {
 		// Skip all directories.

--- a/cmd/certs_test.go
+++ b/cmd/certs_test.go
@@ -223,7 +223,8 @@ func TestGetRootCAs(t *testing.T) {
 		certCAsDir  string
 		expectedErr error
 	}{
-		{"nonexistent-dir", errFileNotFound},
+		// ignores non-existent directories.
+		{"nonexistent-dir", nil},
 		// Ignores directories.
 		{dir1, nil},
 		// Ignore empty directory.

--- a/cmd/config-dir.go
+++ b/cmd/config-dir.go
@@ -74,7 +74,15 @@ func (config *ConfigDir) GetCADir() string {
 
 // Create - creates configuration directory tree.
 func (config *ConfigDir) Create() error {
-	return os.MkdirAll(config.GetCADir(), 0700)
+	err := os.MkdirAll(config.GetCADir(), 0700)
+	// It is possible in kubernetes like deployments this directory
+	// is already mounted and is not writable, ignore any write errors.
+	if err != nil {
+		if os.IsPermission(err) {
+			err = nil
+		}
+	}
+	return err
 }
 
 // GetMinioConfigFile - returns absolute path of config.json file.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignore permission errors on config-dir
<!--- Describe your changes in detail -->

## Motivation and Context
Do not error out if we see permission errors on config directory.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
You would need to test this with Kubernetes or point `--config-dir` to a path where is not writable such as a user point to let's say `minio --config-dir /usr/share/config` 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.