### PR TITLE
Add anonymous flag to prevent logging sensitive information

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -80,6 +80,31 @@ func loadLoggers() {
 
 func handleCommonCmdArgs(ctx *cli.Context) {
 
+	// Get "json" flag from command line argument and
+	// enable json and quite modes if jason flag is turned on.
+	globalCLIContext.JSON = ctx.IsSet("json") || ctx.GlobalIsSet("json")
+	if globalCLIContext.JSON {
+		logger.EnableJSON()
+	}
+
+	// Get quiet flag from command line argument.
+	globalCLIContext.Quiet = ctx.IsSet("quiet") || ctx.GlobalIsSet("quiet")
+	if globalCLIContext.Quiet {
+		logger.EnableQuiet()
+	}
+
+	// Get anonymous flag from command line argument.
+	globalCLIContext.Anonymous = ctx.IsSet("anonymous") || ctx.GlobalIsSet("anonymous")
+	if globalCLIContext.Anonymous {
+		logger.EnableAnonymous()
+	}
+
+	// Fetch address option
+	globalCLIContext.Addr = ctx.GlobalString("address")
+	if globalCLIContext.Addr == "" || globalCLIContext.Addr == ":"+globalMinioDefaultPort {
+		globalCLIContext.Addr = ctx.String("address")
+	}
+
 	var configDir string
 
 	switch {

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -112,30 +112,11 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		cli.ShowCommandHelpAndExit(ctx, gatewayName, 1)
 	}
 
-	// Get "json" flag from command line argument and
-	// enable json and quite modes if jason flag is turned on.
-	jsonFlag := ctx.IsSet("json") || ctx.GlobalIsSet("json")
-	if jsonFlag {
-		logger.EnableJSON()
-	}
-
-	// Get quiet flag from command line argument.
-	quietFlag := ctx.IsSet("quiet") || ctx.GlobalIsSet("quiet")
-	if quietFlag {
-		logger.EnableQuiet()
-	}
-
-	// Fetch address option
-	gatewayAddr := ctx.GlobalString("address")
-	if gatewayAddr == ":"+globalMinioPort {
-		gatewayAddr = ctx.String("address")
-	}
-
 	// Handle common command args.
 	handleCommonCmdArgs(ctx)
 
 	// Get port to listen on from gateway address
-	globalMinioHost, globalMinioPort = mustSplitHostPort(gatewayAddr)
+	globalMinioHost, globalMinioPort = mustSplitHostPort(globalCLIContext.Addr)
 
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
@@ -206,7 +187,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		getCert = globalTLSCerts.GetCertificate
 	}
 
-	globalHTTPServer = xhttp.NewServer([]string{gatewayAddr}, criticalErrorHandler{registerHandlers(router, globalHandlers...)}, getCert)
+	globalHTTPServer = xhttp.NewServer([]string{globalCLIContext.Addr}, criticalErrorHandler{registerHandlers(router, globalHandlers...)}, getCert)
 	globalHTTPServer.UpdateBytesReadFunc = globalConnStats.incInputBytes
 	globalHTTPServer.UpdateBytesWrittenFunc = globalConnStats.incOutputBytes
 	go func() {
@@ -293,7 +274,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	globalObjLayerMutex.Unlock()
 
 	// Prints the formatted startup message once object layer is initialized.
-	if !quietFlag {
+	if !globalCLIContext.Quiet {
 		mode := globalMinioModeGatewayPrefix + gatewayName
 		// Check update mode.
 		checkUpdate(mode)

--- a/cmd/gateway-startup-msg.go
+++ b/cmd/gateway-startup-msg.go
@@ -58,7 +58,7 @@ func printGatewayCommonMsg(apiEndpoints []string) {
 
 	// Colorize the message and print.
 	logger.StartupMessage(colorBlue("Endpoint: ") + colorBold(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 1), apiEndpointStr)))
-	if isTerminal() {
+	if isTerminal() && !globalCLIContext.Anonymous {
 		logger.StartupMessage(colorBlue("AccessKey: ") + colorBold(fmt.Sprintf("%s ", cred.AccessKey)))
 		logger.StartupMessage(colorBlue("SecretKey: ") + colorBold(fmt.Sprintf("%s ", cred.SecretKey)))
 	}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -42,6 +42,8 @@ import (
 const (
 	globalMinioCertExpireWarnDays = time.Hour * 24 * 30 // 30 days.
 
+	globalMinioDefaultPort = "9000"
+
 	globalMinioDefaultRegion = ""
 	// This is a sha256 output of ``arn:aws:iam::minio:user/admin``,
 	// this is kept in present form to be compatible with S3 owner ID
@@ -90,6 +92,12 @@ const (
 	maxLocationConstraintSize = 3 * humanize.MiByte
 )
 
+var globalCLIContext = struct {
+	JSON, Quiet bool
+	Anonymous   bool
+	Addr        string
+}{}
+
 var (
 	// Indicates the total number of erasure coded sets configured.
 	globalXLSetCount int
@@ -127,7 +135,7 @@ var (
 	// Minio local server address (in `host:port` format)
 	globalMinioAddr = ""
 	// Minio default port, can be changed through command line.
-	globalMinioPort = "9000"
+	globalMinioPort = globalMinioDefaultPort
 	// Holds the host that was passed using --address
 	globalMinioHost = ""
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,10 @@ var globalFlags = []cli.Flag{
 		Usage: "Disable startup information.",
 	},
 	cli.BoolFlag{
+		Name:  "anonymous",
+		Usage: "Hide sensitive information from logging.",
+	},
+	cli.BoolFlag{
 		Name:  "json",
 		Usage: "Output server logs and startup information in json format.",
 	},

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -123,7 +123,7 @@ func printServerCommonMsg(apiEndpoints []string) {
 
 	// Colorize the message and print.
 	logger.StartupMessage(colorBlue("Endpoint: ") + colorBold(fmt.Sprintf(getFormatStr(len(apiEndpointStr), 1), apiEndpointStr)))
-	if isTerminal() {
+	if isTerminal() && !globalCLIContext.Anonymous {
 		logger.StartupMessage(colorBlue("AccessKey: ") + colorBold(fmt.Sprintf("%s ", cred.AccessKey)))
 		logger.StartupMessage(colorBlue("SecretKey: ") + colorBold(fmt.Sprintf("%s ", cred.SecretKey)))
 		if region != "" {


### PR DESCRIPTION
## Description
`minio --anonymous server /path` will prevent printing access & secret keys from the startup banner. It will also prevent printing bucket and object names from the logs and replace them with [REDACTED] if they can be found in any other field in logger.Entry{} field, such as the error message.

However this doesn't affect AUDIT as we need complete information for it.


## Motivation and Context
Add anonymous feature

## Regression
No

## How Has This Been Tested?
1. `$ minio --anonymous server /tmp/fs/`
2. `$ mc mb myminio/testbucket/`
    `$ mc cp file myminio/testbucket/file`
    `$ mc cp file myminio/testbucket/file/another-copy`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.