### PR TITLE
rename vault namespace env variable to be more idiomatic

### DIFF
--- a/cmd/crypto/vault.go
+++ b/cmd/crypto/vault.go
@@ -193,7 +193,7 @@ func NewVault(kmsConf KMSConfig) (KMS, error) {
 		return nil, err
 	}
 
-	if ns, ok := os.LookupEnv("VAULT_NAMESPACE"); ok {
+	if ns, ok := os.LookupEnv("MINIO_SSE_VAULT_NAMESPACE"); ok {
 		c.SetNamespace(ns)
 	}
 

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -69,9 +69,9 @@ Optionally set `MINIO_SSE_VAULT_CAPATH` as the path to a directory of PEM-encode
 export MINIO_SSE_VAULT_CAPATH=/home/user/custom-pems
 ```
 
-Optionally set `VAULT_NAMESPACE` if AppRole and Transit Secrets engine have been scoped to Vault Namespace
+Optionally set `MINIO_SSE_VAULT_NAMESPACE` if AppRole and Transit Secrets engine have been scoped to Vault Namespace
 ```
-export VAULT_NAMESPACE=ns1
+export MINIO_SSE_VAULT_NAMESPACE=ns1
 ```
 ### 4. Test your setup
 


### PR DESCRIPTION
## Description
This commit renames the env variable for vault namespaces
such that it begins with `MINIO_SSE_`. This is the prefix
for all Minio SSE related env. variables (like KMS).

## Motivation and Context
Cleanup

## Regression
No

## How Has This Been Tested?
manually

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.