### PR TITLE
Increase the keep alive timeout to 30 secs

### DIFF
--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -178,6 +178,9 @@ type httpListener struct {
 // isRoutineNetErr returns true if error is due to a network timeout,
 // connect reset or io.EOF and false otherwise
 func isRoutineNetErr(err error) bool {
+	if err == nil {
+		return false
+	}
 	if nErr, ok := err.(*net.OpError); ok {
 		// Check if the error is a tcp connection reset
 		if syscallErr, ok := nErr.Err.(*os.SyscallError); ok {
@@ -188,7 +191,8 @@ func isRoutineNetErr(err error) bool {
 		// Check if the error is a timeout
 		return nErr.Timeout()
 	}
-	return err == io.EOF
+	// check for io.EOF and also some times io.EOF is wrapped is another error type.
+	return err == io.EOF || err.Error() == "EOF"
 }
 
 // start - starts separate goroutine for each TCP listener.  A valid insecure/TLS HTTP new connection is passed to httpListener.acceptCh.

--- a/cmd/http/listener_test.go
+++ b/cmd/http/listener_test.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -802,11 +803,19 @@ func TestIgnoreErr(t *testing.T) {
 			want: true,
 		},
 		{
+			err:  errors.New("EOF"),
+			want: true,
+		},
+		{
 			err:  &net.OpError{Err: &myTimeoutErr{timeout: false}},
 			want: false,
 		},
 		{
 			err:  io.ErrUnexpectedEOF,
+			want: false,
+		},
+		{
+			err:  nil,
 			want: false,
 		},
 	}

--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -36,7 +36,7 @@ const (
 	DefaultShutdownTimeout = 5 * time.Second
 
 	// DefaultTCPKeepAliveTimeout - default TCP keep alive timeout for accepted connection.
-	DefaultTCPKeepAliveTimeout = 10 * time.Second
+	DefaultTCPKeepAliveTimeout = 30 * time.Second
 
 	// DefaultReadTimeout - default timout to read data from accepted connection.
 	DefaultReadTimeout = 5 * time.Minute


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Increase the keep-alive timeout to 30 secs
<!--- Describe your changes in detail -->

## Motivation and Context
Go by default uses a 3 * minute, we should
at least use 30 secs as 10 secs is too aggressive.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Testing on this is harder but this is done to ensure that idle connections in client are kept for a longer period, allowing for greater re-use of the connections.  By default Go HTTP sets this value to 3 * minutes and our value of 10 seconds is just too small.  So moved it to 30 seconds.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.