### PR TITLE
Provide configurable port for metrics scraping

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -355,4 +355,11 @@ func handleCommonEnvVars() {
 			globalCompressMimeTypes = contenttypes
 		}
 	}
+
+	extensionsPort := os.Getenv("MINIO_EXT_PORT")
+	if extensionsPort == globalMinioPort {
+		errorMsg := "Invalid MINIO_EXT_PORT value (:" + extensionsPort + ")"
+		logger.FatalIf(errors.New("port is already in use"), errorMsg)
+	}
+	globalExtensionsPort = ":" + extensionsPort
 }

--- a/cmd/extension-port-handlers.go
+++ b/cmd/extension-port-handlers.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"net/http"
+)
+
+const (
+	extPortReservedMetrics     = "metrics"
+	extPortReservedMetricsPath = "/" + extPortReservedMetrics
+)
+
+//
+// Metrics Routing
+//
+func isMetricsOnExtensionPort(path string, host string) bool {
+	_, requestPort := mustSplitHostPort(host)
+	requestPort = ":" + requestPort
+	return path == extPortReservedMetricsPath && globalExtensionsPort != "" && requestPort == globalExtensionsPort
+}
+
+func isSupportedPath(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	aType := getRequestAuthType(req)
+	return aType == authTypeAnonymous &&
+		isMetricsOnExtensionPort(req.URL.Path, req.Host)
+}
+
+type extPortReservedPathHandler struct {
+	handler http.Handler
+}
+
+func setExtPortReservedPathHandler(h http.Handler) http.Handler {
+	return extPortReservedPathHandler{h}
+}
+
+func (h extPortReservedPathHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if isSupportedPath(r) {
+		h.handler.ServeHTTP(w, r)
+	} else {
+		writeErrorResponse(w, ErrNotImplemented, r.URL, guessIsBrowserReq(r))
+		return
+	}
+}
+
+//
+// Cache Control
+//
+type extPortCacheControlHandler struct {
+	handler http.Handler
+}
+
+func setExtPortBrowserCacheControlHandler(h http.Handler) http.Handler {
+	return extPortCacheControlHandler{h}
+}
+
+func (h extPortCacheControlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet && guessIsBrowserReq(r) && globalIsBrowserEnabled {
+		if hasPrefix(r.URL.Path, extPortReservedMetricsPath) {
+			w.Header().Set("Cache-Control", "no-store")
+		}
+	}
+	h.handler.ServeHTTP(w, r)
+}

--- a/cmd/extensions-port-server.go
+++ b/cmd/extensions-port-server.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"github.com/gorilla/mux"
+	xhttp "github.com/minio/minio/cmd/http"
+	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/certs"
+)
+
+func initLogger() {
+	logger.Init(GOPATH, GOROOT)
+	logger.RegisterUIError(fmtError)
+}
+
+var extPortHandlers = []HandlerFunc{
+	setExtPortReservedPathHandler,
+	setExtPortBrowserCacheControlHandler,
+	// Add new extension port specific handlers here.
+}
+
+func startExtensionsPortServer(getCert certs.GetCertificateFunc) {
+	initLogger()
+	err := checkPortAvailability(globalExtensionsPort)
+	if err != nil {
+		logger.Fatal(err, "Unable to start the extensions port server")
+	}
+
+	router := mux.NewRouter().SkipClean(true)
+
+	// register all extensions port applicable routers
+	registerMetricsRouter(router, extPortReservedMetricsPath)
+	handler := registerHandlers(registerHandlers(router, globalHandlers...), extPortHandlers...)
+
+	extensionsPortServer := xhttp.NewServer([]string{globalMinioHost + globalExtensionsPort}, criticalErrorHandler{handler}, getCert)
+	extensionsPortServer.UpdateBytesReadFunc = globalConnStats.incInputBytes
+	extensionsPortServer.UpdateBytesWrittenFunc = globalConnStats.incOutputBytes
+	go func() {
+		globalHTTPServerErrorCh <- extensionsPortServer.Start()
+	}()
+}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -258,6 +258,9 @@ var (
 	// Deployment ID - unique per deployment
 	globalDeploymentID string
 
+	// Additional port to facilitate alternative path extensions e.g. /metrics
+	globalExtensionsPort string
+
 	// Add new variable global values here.
 )
 

--- a/cmd/metrics-router.go
+++ b/cmd/metrics-router.go
@@ -25,8 +25,12 @@ const (
 )
 
 // registerMetricsRouter - add handler functions for metrics.
-func registerMetricsRouter(router *mux.Router) {
-	// metrics router
-	metricsRouter := router.NewRoute().PathPrefix(minioReservedBucketPath).Subrouter()
-	metricsRouter.Handle(prometheusMetricsPath, metricsHandler())
+func registerMetricsRouter(router *mux.Router, path string) {
+	if path != "" {
+		metricsRouter := router.NewRoute().Subrouter()
+		metricsRouter.Handle(path, metricsHandler())
+	} else {
+		metricsRouter := router.NewRoute().PathPrefix(minioReservedBucketPath).Subrouter()
+		metricsRouter.Handle(prometheusMetricsPath, metricsHandler())
+	}
 }

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -325,6 +325,11 @@ func serverMain(ctx *cli.Context) {
 		globalHTTPServerErrorCh <- globalHTTPServer.Start()
 	}()
 
+	// if extensions port is set then enable server
+	if globalExtensionsPort != "" {
+		startExtensionsPortServer(getCert)
+	}
+
 	signal.Notify(globalOSSignalCh, os.Interrupt, syscall.SIGTERM)
 
 	newObject, err := newObjectLayer(globalEndpoints)

--- a/cmd/ui-errors.go
+++ b/cmd/ui-errors.go
@@ -203,4 +203,10 @@ Example 1:
 		"Please check the passed value",
 		"Compress extensions/mime-types are delimited by `,`. For eg, MINIO_COMPRESS_ATTR=\"A,B,C\"",
 	)
+
+	uiErrInvalidExtPortValue = newUIErrFn(
+		"Invalid Extensions Port value",
+		"Please check the passed value",
+		"MINIO_EXT_PORT value must be available for use",
+	)
 )

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -153,6 +153,16 @@ export MINIO_DOMAIN=mydomain.com
 minio server /data
 ```
 
+### Metrics
+
+By default, Minio supports metrics scraping via /minio/prometheus/metrics on the server port.  By setting MINIO_EXT_PORT, metrics will also be available via the /metrics path on the specified port.
+Example:
+
+```sh
+export MINIO_EXT_PORT=9001
+minio server /data
+```
+
 ## Explore Further
 
 * [Minio Quickstart Guide](https://docs.minio.io/docs/minio-quickstart-guide)

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -13,8 +13,12 @@ Read more on how to use these endpoints in [Minio healthcheck guide](https://git
 
 ### Prometheus Probe
 
-Minio server exposes Prometheus compatible data on a single endpoint.
+Minio server exposes Prometheus compatible data on two possible endpoints. By default, metrics are available from:
 
-- Prometheus data available at `/minio/prometheus/metrics`
+* `:9000/minio/prometheus/metrics`
 
-To use this endpoint, setup Prometheus to scrape data from this endpoint. Read more on how to use Prometheues to monitor Minio server in [How to monitor Minio server with Prometheus](https://github.com/minio/cookbook/blob/master/docs/how-to-monitor-minio-with-prometheus.md).
+If MINIO_EXT_PORT is set, Prometheus data is available from here also:
+
+* `:<MINIO_EXT_PORT>/metrics`
+
+To use the desired endpoint, setup Prometheus to scrape data from the correct endpoint. Read more on how to use Prometheues to monitor Minio server in [How to monitor Minio server with Prometheus](https://github.com/minio/cookbook/blob/master/docs/how-to-monitor-minio-with-prometheus.md).


### PR DESCRIPTION
## Description
The metrics port can now be set via MINIO_EXT_PORT environment
variable, exposing metrics on path '/metrics'.  Where MINIO_EXT_PORT
has not been set, the default path of '/minio/prometheus/metrics' will
apply.

## Motivation and Context
Prometheus uses /metrics as the default path to scrape for metrics.
For multi-container Kubernetes PODs, this allows the path to be
consistent across all containers within the POD allowing for
auto-discovery of metrics.

## Regression
Is this PR fixing a regression? No

## How Has This Been Tested?
Local build of Minio Server and Gateway and verified with Prometheus.


## Prometheus
### values.yaml
```
- job_name: minio_metrics_9002
    scrape_interval: 10s
    metrics_path: /metrics
    static_configs:
    - targets:
      - 127.0.0.1:9002

  - job_name: minio_metrics_9000
    scrape_interval: 10s
    metrics_path: /minio/prometheus/metrics
    static_configs:
    - targets:
      - 127.0.0.1:9000
```
### Start Prometheus
```
./prometheus --config.file=values.yaml
```

## Server Behaviour
Running Minio Server on 127.0.0.1:9000 and also with a specific ip-address.

#### Start Server
```
export MINIO_EXT_PORT=<test-value>
./minio server /tmp

./minio server --address 192.168.0.13:9000 /tmp
```

| MINIO_EXT_PORT | Path                | Result |
|:---------------|:------------------- |:-------|
| 9000           | /metrics            | Fatal error, Invalid MINIO_EXT_PORT value (:9000): port is already in use. |
| 90000000       | /metrics            | Fatal error, Error: listen tcp4: address 900000000: invalid port |
| -1             | /metrics            | Fatal error, Error: listen tcp4: address -1: invalid port |
| Unset          | /metrics            | metrics available on /minio/prometheus/metrics port 9000 only, Prometheus displays 1 target |
| 9002           | /metrics            | metrics available on /metrics port 9002 and /minio/prometheus/metrics port 9000, Prometheus displays 2 targets |
| 9002           | /<any_other_path>   | 501 Not implemented, A header you provided implies functionality that is not implemented |

## Gateway Behaviour
Running Minio S3 Gateway and Server on 127.0.0.1:9000 and 127.0.0.1:9001 respectively and also with a specific ip-address.

#### Start Gateway
```
export MINIO_EXT_PORT=<test-value>
./minio gateway s3 http://127.0.0.1:9001

./minio gateway --address 192.168.0.13:9000 s3 http://127.0.0.1:9001

```

| MINIO_EXT_PORT | Path                | Result |
|:---------------|:------------------- |:-------|
| 9000           | /metrics            | Fatal error, Invalid MINIO_EXT_PORT value (:9000): port is already in use. |
| 9001           | /metrics            | Fatal error, Invalid MINIO_EXT_PORT value (:9001), port points to the local backend storage: Invalid Extensions Port value. |
| 90000000       | /metrics            | Fatal error, Error: listen tcp4: address 900000000: invalid port |
| -1             | /metrics            | Fatal error, Error: listen tcp4: address -1: invalid port |
| unset          | /metrics            | metrics available on /minio/prometheus/metrics port 9000 only, Prometheus displays 1 target |
| 9002           | /metrics            | metrics available on /metrics port 9002 and /minio/prometheus/metrics port 9000, Prometheus displays 2 targets |
| 9002           | /<any_other_path>   | 501 Not implemented, A header you provided implies functionality that is not implemented |


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.
- [x] Go Test passed.
- [x] Make Verifiers passed.