### PR TITLE
cmd: remove duplicated switch case

### DIFF
--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -47,7 +47,7 @@ func toObjectErr(err error, params ...string) error {
 				Object: params[1],
 			}
 		}
-	case errIsNotRegular, errFileAccessDenied:
+	case errIsNotRegular,:
 		if len(params) >= 2 {
 			err = ObjectExistsAsDirectory{
 				Bucket: params[0],


### PR DESCRIPTION
The `errFileAccessDenied` case was repeated twice.
