### PR TITLE
Support IPv6 in minio command line 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ matrix:
         - for d in $(go list ./... | grep -v browser); do go test -v -race --timeout 20m "$d"; done
         - bash buildscripts/go-coverage.sh
 
+before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'; fi
+
 before_install:
  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then nvm install stable ; fi
 

--- a/buildscripts/verify-build.sh
+++ b/buildscripts/verify-build.sh
@@ -68,6 +68,36 @@ function start_minio_erasure_sets()
     echo "$minio_pid"
 }
 
+function start_minio_dist_erasure_sets_ipv6()
+{
+    declare -a minio_pids
+    export MINIO_ACCESS_KEY=$ACCESS_KEY
+    export MINIO_SECRET_KEY=$SECRET_KEY
+    "${MINIO[@]}" server --address="[::1]:9000" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9000.log" 2>&1 &
+    minio_pids[0]=$!
+    "${MINIO[@]}" server --address="[::1]:9001" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9001.log" 2>&1 &
+    minio_pids[1]=$!
+    "${MINIO[@]}" server --address="[::1]:9002" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9002.log" 2>&1 &
+    minio_pids[2]=$!
+    "${MINIO[@]}" server --address="[::1]:9003" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9003.log" 2>&1 &
+    minio_pids[3]=$!
+    "${MINIO[@]}" server --address="[::1]:9004" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9004.log" 2>&1 &
+    minio_pids[4]=$!
+    "${MINIO[@]}" server --address="[::1]:9005" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9005.log" 2>&1 &
+    minio_pids[5]=$!
+    "${MINIO[@]}" server --address="[::1]:9006" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9006.log" 2>&1 &
+    minio_pids[6]=$!
+    "${MINIO[@]}" server --address="[::1]:9007" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9007.log" 2>&1 &
+    minio_pids[7]=$!
+    "${MINIO[@]}" server --address="[::1]:9008" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9008.log" 2>&1 &
+    minio_pids[8]=$!
+    "${MINIO[@]}" server --address="[::1]:9009" "http://[::1]:9000${WORK_DIR}/dist-disk-sets1" "http://[::1]:9001${WORK_DIR}/dist-disk-sets2" "http://[::1]:9002${WORK_DIR}/dist-disk-sets3" "http://[::1]:9003${WORK_DIR}/dist-disk-sets4" "http://[::1]:9004${WORK_DIR}/dist-disk-sets5" "http://[::1]:9005${WORK_DIR}/dist-disk-sets6" "http://[::1]:9006${WORK_DIR}/dist-disk-sets7" "http://[::1]:9007${WORK_DIR}/dist-disk-sets8" "http://[::1]:9008${WORK_DIR}/dist-disk-sets9" "http://[::1]:9009${WORK_DIR}/dist-disk-sets10" "http://[::1]:9000${WORK_DIR}/dist-disk-sets11" "http://[::1]:9001${WORK_DIR}/dist-disk-sets12" "http://[::1]:9002${WORK_DIR}/dist-disk-sets13" "http://[::1]:9003${WORK_DIR}/dist-disk-sets14" "http://[::1]:9004${WORK_DIR}/dist-disk-sets15" "http://[::1]:9005${WORK_DIR}/dist-disk-sets16" "http://[::1]:9006${WORK_DIR}/dist-disk-sets17" "http://[::1]:9007${WORK_DIR}/dist-disk-sets18" "http://[::1]:9008${WORK_DIR}/dist-disk-sets19" "http://[::1]:9009${WORK_DIR}/dist-disk-sets20" >"$WORK_DIR/dist-minio-v6-9009.log" 2>&1 &
+    minio_pids[9]=$!
+
+    sleep 35
+    echo "${minio_pids[@]}"
+}
+
 function start_minio_dist_erasure_sets()
 {
     declare -a minio_pids
@@ -161,6 +191,34 @@ function run_test_erasure_sets() {
     return "$rv"
 }
 
+function run_test_dist_erasure_sets_ipv6()
+{
+    minio_pids=( $(start_minio_dist_erasure_sets_ipv6) )
+
+    export SERVER_ENDPOINT="[::1]:9000"
+
+    (cd "$WORK_DIR" && "$FUNCTIONAL_TESTS")
+    rv=$?
+
+    for pid in "${minio_pids[@]}"; do
+        kill "$pid"
+    done
+    sleep 3
+
+    if [ "$rv" -ne 0 ]; then
+        for i in $(seq 0 9); do
+            echo "server$i log:"
+            cat "$WORK_DIR/dist-minio-v6-900$i.log"
+        done
+    fi
+
+    for i in $(seq 0 9); do
+        rm -f "$WORK_DIR/dist-minio-v6-900$i.log"
+    done
+
+    return "$rv"
+}
+
 function run_test_dist_erasure_sets()
 {
     minio_pids=( $(start_minio_dist_erasure_sets) )
@@ -237,6 +295,7 @@ function run_test_gateway_s3()
 {
     minio_pid="$(start_minio_gateway_s3)"
 
+    export SERVER_ENDPOINT="127.0.0.1:9000"
     export ACCESS_KEY=Q3AM3UQ867SPQQA43P2F
     export SECRET_KEY=zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
     (cd "$WORK_DIR" && "$FUNCTIONAL_TESTS")
@@ -279,6 +338,7 @@ function __init__()
         exit 1
     fi
 
+    sed -i 's|-sS|-sSg|g' "$FUNCTIONAL_TESTS"
     chmod a+x "$FUNCTIONAL_TESTS"
 }
 
@@ -314,6 +374,13 @@ function main()
 
     echo "Testing in Distributed Erasure setup as sets"
     if ! run_test_dist_erasure_sets; then
+        echo "FAILED"
+        rm -fr "$WORK_DIR"
+        exit 1
+    fi
+
+    echo "Testing in Distributed Erasure setup as sets with ipv6"
+    if ! run_test_dist_erasure_sets_ipv6; then
         echo "FAILED"
         rm -fr "$WORK_DIR"
         exit 1

--- a/cmd/admin-rpc-client.go
+++ b/cmd/admin-rpc-client.go
@@ -149,6 +149,11 @@ func makeAdminPeers(endpoints EndpointList) (adminPeerList adminPeers) {
 		// Use first IPv4 instead of loopback address.
 		localAddr = net.JoinHostPort(sortIPs(localIP4.ToSlice())[0], globalMinioPort)
 	}
+	if strings.HasPrefix(localAddr, "[::1]:") {
+		// Use first IPv4 instead of loopback address.
+		localAddr = net.JoinHostPort(localIP6.ToSlice()[0], globalMinioPort)
+	}
+
 	adminPeerList = append(adminPeerList, adminPeer{
 		addr:      localAddr,
 		cmdRunner: localAdminClient{},

--- a/cmd/endpoint-ellipses_test.go
+++ b/cmd/endpoint-ellipses_test.go
@@ -226,6 +226,17 @@ func TestGetSetIndexes(t *testing.T) {
 	}
 }
 
+func getHexSequences(start int, number int, paddinglen int) (seq []string) {
+	for i := start; i <= number; i++ {
+		if paddinglen == 0 {
+			seq = append(seq, fmt.Sprintf("%x", i))
+		} else {
+			seq = append(seq, fmt.Sprintf(fmt.Sprintf("%%0%dx", paddinglen), i))
+		}
+	}
+	return seq
+}
+
 func getSequences(start int, number int, paddinglen int) (seq []string) {
 	for i := start; i <= number; i++ {
 		if paddinglen == 0 {
@@ -464,6 +475,52 @@ func TestParseEndpointSet(t *testing.T) {
 							Prefix: "/export",
 							Suffix: "/disk",
 							Seq:    getSequences(1, 10, 0),
+						},
+					},
+				},
+				nil,
+				[][]uint64{{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}},
+			},
+			true,
+		},
+		// IPv6 ellipses with hexadecimal expansion
+		{
+			"http://[2001:3984:3989::{1...a}]/disk{1...10}",
+			endpointSet{
+				[]ellipses.ArgPattern{
+					[]ellipses.Pattern{
+						{
+							Prefix: "",
+							Suffix: "",
+							Seq:    getSequences(1, 10, 0),
+						},
+						{
+							Prefix: "http://[2001:3984:3989::",
+							Suffix: "]/disk",
+							Seq:    getHexSequences(1, 10, 0),
+						},
+					},
+				},
+				nil,
+				[][]uint64{{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}},
+			},
+			true,
+		},
+		// IPv6 ellipses with hexadecimal expansion with 3 position numerics.
+		{
+			"http://[2001:3984:3989::{001...00a}]/disk{1...10}",
+			endpointSet{
+				[]ellipses.ArgPattern{
+					[]ellipses.Pattern{
+						{
+							Prefix: "",
+							Suffix: "",
+							Seq:    getSequences(1, 10, 0),
+						},
+						{
+							Prefix: "http://[2001:3984:3989::",
+							Suffix: "]/disk",
+							Seq:    getHexSequences(1, 10, 3),
 						},
 					},
 				},

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -112,6 +112,9 @@ func NewEndpoint(arg string) (ep Endpoint, e error) {
 				return ep, fmt.Errorf("invalid URL endpoint format: port number must be between 1 to 65535")
 			}
 		}
+		if i := strings.Index(host, "%"); i > -1 {
+			host = host[:i]
+		}
 
 		if host == "" {
 			return ep, fmt.Errorf("invalid URL endpoint format: empty host name")
@@ -152,7 +155,7 @@ func NewEndpoint(arg string) (ep Endpoint, e error) {
 		// Only check if the arg is an ip address and ask for scheme since its absent.
 		// localhost, example.com, any FQDN cannot be disambiguated from a regular file path such as
 		// /mnt/export1. So we go ahead and start the minio server in FS modes in these cases.
-		if isHostIPv4(arg) {
+		if isHostIP(arg) {
 			return ep, fmt.Errorf("invalid URL endpoint format: missing scheme http or https")
 		}
 		u = &url.URL{Path: path.Clean(arg)}
@@ -224,7 +227,6 @@ func NewEndpointList(args ...string) (endpoints EndpointList, err error) {
 		uniqueArgs.Add(arg)
 		endpoints = append(endpoints, endpoint)
 	}
-
 	return endpoints, nil
 }
 
@@ -341,7 +343,7 @@ func CreateEndpoints(serverAddr string, args ...[]string) (string, EndpointList,
 			if err != nil {
 				host = endpoint.Host
 			}
-			hostIPSet, _ := getHostIP4(host)
+			hostIPSet, _ := getHostIP(host)
 			if IPSet, ok := pathIPMap[endpoint.Path]; ok {
 				if !IPSet.Intersection(hostIPSet).IsEmpty() {
 					return serverAddr, endpoints, setupType,
@@ -411,12 +413,12 @@ func CreateEndpoints(serverAddr string, args ...[]string) (string, EndpointList,
 				host = localServerAddr
 			}
 
-			ipList, err := getHostIP4(host)
+			ipList, err := getHostIP(host)
 			logger.FatalIf(err, "unexpected error when resolving host '%s'", host)
 
-			// Filter ipList by IPs those start with '127.'.
+			// Filter ipList by IPs those start with '127.' or '::1'
 			loopBackIPs := ipList.FuncMatch(func(ip string, matchString string) bool {
-				return strings.HasPrefix(ip, "127.")
+				return strings.HasPrefix(ip, "127.") || strings.HasPrefix(ip, "::1")
 			}, "")
 
 			// If loop back IP is found and ipList contains only loop back IPs, then error out.
@@ -485,10 +487,10 @@ func GetLocalPeer(endpoints EndpointList) (localPeer string) {
 		// Local peer can be empty in FS or Erasure coded mode.
 		// If so, return globalMinioHost + globalMinioPort value.
 		if globalMinioHost != "" {
-			return globalMinioHost + ":" + globalMinioPort
+			return net.JoinHostPort(globalMinioHost, globalMinioPort)
 		}
 
-		return "127.0.0.1:" + globalMinioPort
+		return net.JoinHostPort("127.0.0.1", globalMinioPort)
 	}
 	return peerSet.ToSlice()[0]
 }
@@ -525,10 +527,10 @@ func updateDomainIPs(endPoints set.StringSet) {
 				continue
 			}
 		}
-		IPs, _ := getHostIP4(host)
+		IPs, _ := getHostIP(host)
 		ipList = ipList.Union(IPs)
 	}
 	globalDomainIPs = ipList.FuncMatch(func(ip string, matchString string) bool {
-		return !strings.HasPrefix(ip, "127.")
+		return !strings.HasPrefix(ip, "127.") || strings.HasPrefix(ip, "::1")
 	}, "")
 }

--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -304,27 +304,27 @@ func TestCreateEndpoints(t *testing.T) {
 		}, DistXLSetupType, nil},
 	}
 
-	for _, testCase := range testCases {
+	for i, testCase := range testCases {
 		serverAddr, endpoints, setupType, err := CreateEndpoints(testCase.serverAddr, testCase.args...)
 
 		if err == nil {
 			if testCase.expectedErr != nil {
-				t.Fatalf("error: expected = %v, got = <nil>", testCase.expectedErr)
+				t.Fatalf("Test (%d) error: expected = %v, got = <nil>", i+1, testCase.expectedErr)
 			} else {
 				if serverAddr != testCase.expectedServerAddr {
-					t.Fatalf("serverAddr: expected = %v, got = %v", testCase.expectedServerAddr, serverAddr)
+					t.Fatalf("Test (%d) serverAddr: expected = %v, got = %v", i+1, testCase.expectedServerAddr, serverAddr)
 				}
 				if !reflect.DeepEqual(endpoints, testCase.expectedEndpoints) {
-					t.Fatalf("endpoints: expected = %v, got = %v", testCase.expectedEndpoints, endpoints)
+					t.Fatalf("Test (%d) endpoints: expected = %v, got = %v", i+1, testCase.expectedEndpoints, endpoints)
 				}
 				if setupType != testCase.expectedSetupType {
-					t.Fatalf("setupType: expected = %v, got = %v", testCase.expectedSetupType, setupType)
+					t.Fatalf("Test (%d) setupType: expected = %v, got = %v", i+1, testCase.expectedSetupType, setupType)
 				}
 			}
 		} else if testCase.expectedErr == nil {
-			t.Fatalf("error: expected = <nil>, got = %v", err)
+			t.Fatalf("Test (%d) error: expected = <nil>, got = %v", i+1, err)
 		} else if err.Error() != testCase.expectedErr.Error() {
-			t.Fatalf("error: expected = %v, got = %v", testCase.expectedErr, err)
+			t.Fatalf("Test (%d) error: expected = %v, got = %v", i+1, testCase.expectedErr, err)
 		}
 	}
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/url"
 	"os"
 	"os/signal"
@@ -135,11 +134,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	handleCommonCmdArgs(ctx)
 
 	// Get port to listen on from gateway address
-	var pErr error
-	_, globalMinioPort, pErr = net.SplitHostPort(gatewayAddr)
-	if pErr != nil {
-		logger.FatalIf(pErr, "Unable to start gateway")
-	}
+	globalMinioHost, globalMinioPort = mustSplitHostPort(gatewayAddr)
 
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
@@ -301,7 +296,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		}
 
 		// Print gateway startup message.
-		printGatewayStartupMessage(getAPIEndpoints(gatewayAddr), gatewayName)
+		printGatewayStartupMessage(getAPIEndpoints(), gatewayName)
 	}
 
 	handleSignals()

--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -399,8 +399,8 @@ func newHTTPListener(serverAddrs []string,
 
 	for _, serverAddr := range serverAddrs {
 		var l net.Listener
-		if l, err = listen("tcp4", serverAddr); err != nil {
-			if l, err = fallbackListen("tcp4", serverAddr); err != nil {
+		if l, err = listen("tcp", serverAddr); err != nil {
+			if l, err = fallbackListen("tcp", serverAddr); err != nil {
 				return nil, err
 			}
 		}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -389,8 +389,7 @@ func serverMain(ctx *cli.Context) {
 	globalObjLayerMutex.Unlock()
 
 	// Prints the formatted startup message once object layer is initialized.
-	apiEndpoints := getAPIEndpoints(globalMinioAddr)
-	printStartupMessage(apiEndpoints)
+	printStartupMessage(getAPIEndpoints())
 
 	// Set uptime time after object layer has initialized.
 	globalBootTime = UTCNow()

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"net/url"
 	"runtime"
 	"strings"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/minio/cmd/logger"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // Documentation links, these are part of message printing code.
@@ -83,23 +83,12 @@ func stripStandardPorts(apiEndpoints []string) (newAPIEndpoints []string) {
 	newAPIEndpoints = make([]string, len(apiEndpoints))
 	// Check all API endpoints for standard ports and strip them.
 	for i, apiEndpoint := range apiEndpoints {
-		url, err := url.Parse(apiEndpoint)
+		url, err := xnet.ParseURL(apiEndpoint)
 		if err != nil {
 			newAPIEndpoints[i] = apiEndpoint
 			continue
 		}
-		host, port := mustSplitHostPort(url.Host)
-		// For standard HTTP(s) ports such as "80" and "443"
-		// apiEndpoints should only be host without port.
-		switch {
-		case url.Scheme == "http" && port == "80":
-			fallthrough
-		case url.Scheme == "https" && port == "443":
-			url.Host = host
-			newAPIEndpoints[i] = url.String()
-		default:
-			newAPIEndpoints[i] = apiEndpoint
-		}
+		newAPIEndpoints[i] = url.String()
 	}
 	return newAPIEndpoints
 }

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -2319,7 +2319,7 @@ func getEndpointsLocalAddr(endpoints EndpointList) string {
 		}
 	}
 
-	return globalMinioHost + ":" + globalMinioPort
+	return net.JoinHostPort(globalMinioHost, globalMinioPort)
 }
 
 // fetches a random number between range min-max.

--- a/pkg/ellipses/ellipses.go
+++ b/pkg/ellipses/ellipses.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// Regex to extract ellipses syntax inputs.
-	regexpEllipses = regexp.MustCompile(`(.*)({[0-9]*\.\.\.[0-9]*})(.*)`)
+	regexpEllipses = regexp.MustCompile(`(.*)({[0-9a-z]*\.\.\.[0-9a-z]*})(.*)`)
 
 	// Ellipses constants
 	openBraces  = "{"
@@ -53,13 +53,24 @@ func parseEllipsesRange(pattern string) (seq []string, err error) {
 		return nil, errors.New("Invalid argument")
 	}
 
+	var hexadecimal bool
 	var start, end uint64
 	if start, err = strconv.ParseUint(ellipsesRange[0], 10, 64); err != nil {
-		return nil, err
+		// Look for hexadecimal conversions if any.
+		start, err = strconv.ParseUint(ellipsesRange[0], 16, 64)
+		if err != nil {
+			return nil, err
+		}
+		hexadecimal = true
 	}
 
 	if end, err = strconv.ParseUint(ellipsesRange[1], 10, 64); err != nil {
-		return nil, err
+		// Look for hexadecimal conversions if any.
+		end, err = strconv.ParseUint(ellipsesRange[1], 16, 64)
+		if err != nil {
+			return nil, err
+		}
+		hexadecimal = true
 	}
 
 	if start > end {
@@ -68,9 +79,17 @@ func parseEllipsesRange(pattern string) (seq []string, err error) {
 
 	for i := start; i <= end; i++ {
 		if strings.HasPrefix(ellipsesRange[0], "0") && len(ellipsesRange[0]) > 1 || strings.HasPrefix(ellipsesRange[1], "0") {
-			seq = append(seq, fmt.Sprintf(fmt.Sprintf("%%0%dd", len(ellipsesRange[1])), i))
+			if hexadecimal {
+				seq = append(seq, fmt.Sprintf(fmt.Sprintf("%%0%dx", len(ellipsesRange[1])), i))
+			} else {
+				seq = append(seq, fmt.Sprintf(fmt.Sprintf("%%0%dd", len(ellipsesRange[1])), i))
+			}
 		} else {
-			seq = append(seq, fmt.Sprintf("%d", i))
+			if hexadecimal {
+				seq = append(seq, fmt.Sprintf("%x", i))
+			} else {
+				seq = append(seq, fmt.Sprintf("%d", i))
+			}
 		}
 	}
 

--- a/pkg/ellipses/ellipses_test.go
+++ b/pkg/ellipses/ellipses_test.go
@@ -96,6 +96,7 @@ func TestHasEllipses(t *testing.T) {
 			true,
 		},
 		{
+
 			[]string{
 				"mydisk-{1...4}{1..2.}",
 			},
@@ -201,6 +202,11 @@ func TestFindEllipsesPatterns(t *testing.T) {
 			false,
 			0,
 		},
+		{
+			"{f...z}",
+			false,
+			0,
+		},
 		// Test for valid input.
 		{
 			"{1...64}",
@@ -221,6 +227,11 @@ func TestFindEllipsesPatterns(t *testing.T) {
 			"{001...036}",
 			true,
 			36,
+		},
+		{
+			"{1...a}",
+			true,
+			10,
 		},
 	}
 

--- a/pkg/net/host.go
+++ b/pkg/net/host.go
@@ -44,7 +44,7 @@ func (host Host) String() string {
 		return host.Name
 	}
 
-	return host.Name + ":" + host.Port.String()
+	return net.JoinHostPort(host.Name, host.Port.String())
 }
 
 // Equal - checks whether given host is equal or not.
@@ -127,6 +127,10 @@ func ParseHost(s string) (*Host, error) {
 		}
 
 		isPortSet = true
+	}
+
+	if i := strings.Index(host, "%"); i > -1 {
+		host = host[:i]
 	}
 
 	if !isValidHost(host) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Support IPv6 in minio command line 
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #6946

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using the following docker-compose.yml 

```yml
version: '2.1'

# starts 4 docker containers running minio server instances. Each
# minio server's web interface will be accessible on the host at port
# 9001 through 9004.
services:
 minio1:
  image: y4m4/minio:test
  volumes:
   - data1:/data
  ports:
   - "9001:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data
  networks:
    - app_net
 minio2:
  image: y4m4/minio:test
  volumes:
   - data2:/data
  ports:
   - "9002:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data
  networks:
    - app_net  
 minio3:
  image: y4m4/minio:test
  volumes:
   - data3:/data
  ports:
   - "9003:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data
  networks:
    - app_net  
 minio4:
  image: y4m4/minio:test
  volumes:
   - data4:/data
  ports:
   - "9004:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio1/data http://minio2/data http://minio3/data http://minio4/data 
  networks:
    - app_net

## By default this config uses default local driver,
## For custom volumes replace with volume driver configuration.
volumes:
  data1:
  data2:
  data3:
  data4:

networks:
  app_net:
    driver: bridge
    enable_ipv6: true
    ipam:
      driver: default
      config:
      -
        subnet: 172.16.238.0/24
      -
        subnet: 2001:3984:3989::/64    
```

Few other ways to test this

```
#!/bin/bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"

rm -rf /tmp/export{01..24}
for i in {01..24}; do
    minio server --address ":90${i}" http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9001/tmp/export01 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9002/tmp/export02 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9003/tmp/export03 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9004/tmp/export04 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9005/tmp/export05 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9006/tmp/export06 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9007/tmp/export07 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9008/tmp/export08 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9009/tmp/export09 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9010/tmp/export10 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9011/tmp/export11 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9012/tmp/export12 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9013/tmp/export13 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9014/tmp/export14 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9015/tmp/export15 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9016/tmp/export16 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9017/tmp/export17 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9018/tmp/export18 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9019/tmp/export19 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9020/tmp/export20 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9021/tmp/export21 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9022/tmp/export22 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9023/tmp/export23 http://[2601:646:c403:8df0:581e:2368:c22a:4a98]:9024/tmp/export24 &
done
```

Docker way to test this PR is `docker-compose -f /tmp/ipv6.txt up` - make sure to build docker locally using `TAG=y4m4/minio:test make docker`

```yml

version: '2.1'

services:
 minio:
  image: y4m4/minio:test
  volumes:
   - data1:/data
  ports:
   - "9001:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  entrypoint: |
    /bin/sh -c "
    while true; do sleep 1; done
    "

  networks:
    app_net:
      ipv6_address: 2001:3984:3989::20

## By default this config uses default local driver,
## For custom volumes replace with volume driver configuration.
volumes:
  data1:

networks:
  app_net:
    driver: bridge
    enable_ipv6: true
    ipam:
      driver: default
      config:
        -
          subnet: 2001:3984:3989::/64
          gateway: 2001:3984:3989::1
```

```
docker-compose -f /tmp/ipv6.txt up
Creating network "tmp_app_net" with driver "bridge"
Creating volume "tmp_data1" with default driver
Creating tmp_minio_1_1ceab28b2b18 ... done
Attaching to tmp_minio_1_17981cc9753a
minio_1_17981cc9753a | 
minio_1_17981cc9753a | Endpoint:  http://[2001:3984:3989::20]:9000
minio_1_17981cc9753a | 
minio_1_17981cc9753a | Browser Access:
minio_1_17981cc9753a |    http://[2001:3984:3989::20]:9000
minio_1_17981cc9753a | 
minio_1_17981cc9753a | Object API (Amazon S3 compatible):
minio_1_17981cc9753a |    Go:         https://docs.minio.io/docs/golang-client-quickstart-guide
minio_1_17981cc9753a |    Java:       https://docs.minio.io/docs/java-client-quickstart-guide
minio_1_17981cc9753a |    Python:     https://docs.minio.io/docs/python-client-quickstart-guide
minio_1_17981cc9753a |    JavaScript: https://docs.minio.io/docs/javascript-client-quickstart-guide
minio_1_17981cc9753a |    .NET:       https://docs.minio.io/docs/dotnet-client-quickstart-guide
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [x] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.