### PR TITLE
Provide actual size in events instead of compressed size.

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -537,6 +537,9 @@ func (args eventArgs) ToEvent() event.Event {
 	if args.EventName != event.ObjectRemovedDelete {
 		newEvent.S3.Object.ETag = args.Object.ETag
 		newEvent.S3.Object.Size = args.Object.Size
+		if args.Object.IsCompressed() {
+			newEvent.S3.Object.Size = args.Object.GetActualSize()
+		}
 		newEvent.S3.Object.ContentType = args.Object.ContentType
 		newEvent.S3.Object.UserMetadata = args.Object.UserDefined
 	}


### PR DESCRIPTION
## Description
Previous behavior did not check if the object was compressed when constructing events and incorrectly reported the stored size rather than the actual object size.

## Motivation and Context
I ran across this while mirroring between two minio servers with `mc mirror --watch`. Since the objects in the source are compressed, the events received by `mc` included an incorrect size, causing `mc` to provide and incorrect content-length to the destination minio server. This manifested as `mc` reporting an error like:

```
Put http://127.0.0.1:9000/bucket/object/name: Connection closed by foreign host http://127.0.0.1:9000/bucket/object/name. Retry again.
```

The destination server was returning a 400 response (below), but the `*http.Client` reports an "unexpected EOF".
```
HTTP/1.1 400 Bad Request
Accept-Ranges: bytes
Content-Security-Policy: block-all-mixed-content
Content-Type: application/xml
Server: Minio/RELEASE.2018-12-06T01-27-43Z (linux; amd64)
Vary: Origin
X-Amz-Request-Id: 156F237798F43EAA
X-Minio-Deployment-Id: 7b0215a1-7ab3-47a5-ae39-43b3fc416d8d
X-Xss-Protection: 1; mode=block
Date: Tue, 11 Dec 2018 01:36:33 GMT
Transfer-Encoding: chunked

18c
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>IncompleteBody</Code><Message>You did not provide the number of bytes specified by the Content-Length HTTP header.</Message><Resource>/bucket/object/name</Resource><RequestId>156F237798F43EAA</RequestId><HostId>3L137</HostId></Error>
```

## Regression
Not that I'm aware of.

## How Has This Been Tested?
Tested locally. Happy to add tests if someone can point me to the appropriate test file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.