### PR TITLE
Disable ListenBucket notifications for NAS gateway

### DIFF
--- a/cmd/gateway/nas/gateway-nas.go
+++ b/cmd/gateway/nas/gateway-nas.go
@@ -117,7 +117,7 @@ func (g *NAS) Production() bool {
 }
 
 // IsListenBucketSupported returns whether listen bucket notification is applicable for this gateway.
-func (g *NAS) IsListenBucketSupported() bool {
+func (n *nasObjects) IsListenBucketSupported() bool {
 	return false
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
nas gateway should not have listen bucket notifications enabled. 
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> yes
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
PR  #6920 incorrectly implemented 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. ./minio gateway nas /tmp/data
2. mc mb myminio/images
3. mc watch myminio/images should return ```mc: <ERROR> Unable to watch for events. A header you provided implies functionality that is not implemented```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.