### PR TITLE
Fix NAS Gateway Docker command example

### DIFF
--- a/docs/gateway/nas.md
+++ b/docs/gateway/nas.md
@@ -1,35 +1,47 @@
 # Minio NAS Gateway [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+
 Minio Gateway adds Amazon S3 compatibility to NAS storage. You may run multiple minio instances on the same shared NAS volume as a distributed object gateway.
 
 ## Run Minio Gateway for NAS Storage
+
 ### Using Docker
+
+Please ensure to replace `/shared/nasvol` with actual mount path.
+
 ```
 docker run -p 9000:9000 --name nas-s3 \
  -e "MINIO_ACCESS_KEY=minio" \
  -e "MINIO_SECRET_KEY=minio123" \
- minio/minio gateway nas /shared/nasvol
+ -v /shared/nasvol:/container/vol \
+ minio/minio gateway nas /container/vol
 ```
 
 ### Using Binary
+
 ```
-export MINIO_ACCESS_KEY=minioaccesskey
-export MINIO_SECRET_KEY=miniosecretkey
+export MINIO_ACCESS_KEY=minio
+export MINIO_SECRET_KEY=minio123
 minio gateway nas /shared/nasvol
 ```
+
 ## Test using Minio Browser
+
 Minio Gateway comes with an embedded web based object browser. Point your web browser to http://127.0.0.1:9000 to ensure that your server has started successfully.
 
 ![Screenshot](https://raw.githubusercontent.com/minio/minio/master/docs/screenshots/minio-browser-gateway.png)
 
 ## Test using Minio Client `mc`
+
 `mc` provides a modern alternative to UNIX commands such as ls, cat, cp, mirror, diff etc. It supports filesystems and Amazon S3 compatible cloud storage services.
 
 ### Configure `mc`
+
 ```
 mc config host add mynas http://gateway-ip:9000 access_key secret_key
 ```
 
 ### List buckets on nas
+
 ```
 mc ls mynas
 [2017-02-22 01:50:43 PST]     0B ferenginar/


### PR DESCRIPTION
## Description
Fix NAS gateway Docker run command to ensure external NFS mount is mapped to container path.

## Motivation and Context
Fixes #6965

## Regression
NA

## How Has This Been Tested?
Start NAS gateway using 

```
docker run -p 9000:9000 --name nas-s3 \
-e "MINIO_ACCESS_KEY=minio" \	 
-e "MINIO_ACCESS_KEY=minio" \
-v /shared/nasvol:/container/vol \
 minio/minio gateway nas /container/vol
```

an confirm files are accessible from outside the container in `/shared/nasvol` location.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.