### PR TITLE
Add ServerDrivesInfo() admin API

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -60,6 +60,11 @@ func registerAdminRouter(router *mux.Router, enableIAM bool) {
 		adminV1Router.Methods(http.MethodPost).Path("/heal/").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
 		adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
 		adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}/{prefix:.*}").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
+
+		/// Health operations
+
+		// Performance command - return performance details based on input type
+		adminV1Router.Methods(http.MethodGet).Path("/performance").HandlerFunc(httpTraceAll(adminAPI.PerfInfoHandler)).Queries("perfType", "{perfType:.*}")
 	}
 
 	// Profiling operations

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/minio/minio-go/pkg/set"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/disk"
 	"github.com/minio/minio/pkg/mountinfo"
 )
 
@@ -195,6 +196,34 @@ func (endpoints EndpointList) GetString(i int) string {
 		return ""
 	}
 	return endpoints[i].String()
+}
+
+// localEndpointsPerf - returns ServerDrivesPerfInfo for only the
+// local endpoints from given list of endpoints
+func localEndpointsPerf(endpoints EndpointList) ServerDrivesPerfInfo {
+	var dps []disk.Performance
+	var addr string
+	for _, endpoint := range endpoints {
+		// Only proceed for local endpoints
+		if endpoint.IsLocal {
+			addr = GetLocalPeer(endpoints)
+			if _, err := os.Stat(endpoint.Path); err != nil {
+				// Since this drive is not available, add relevant details and proceed
+				dps = append(dps, disk.Performance{Path: endpoint.Path, Error: err.Error()})
+				continue
+			}
+			tempObj := mustGetUUID()
+			fsPath := pathJoin(endpoint.Path, minioMetaTmpBucket, tempObj)
+			dp := disk.GetPerformance(fsPath)
+			dp.Path = endpoint.Path
+			dps = append(dps, dp)
+		}
+	}
+
+	return ServerDrivesPerfInfo{
+		Addr: addr,
+		Perf: dps,
+	}
 }
 
 // NewEndpointList - returns new endpoint list based on input args.

--- a/cmd/peer-rpc-client.go
+++ b/cmd/peer-rpc-client.go
@@ -141,6 +141,15 @@ func (rpcClient *PeerRPCClient) LoadCredentials() error {
 	return rpcClient.Call(peerServiceName+".LoadCredentials", &args, &reply)
 }
 
+// DrivePerfInfo - returns drive performance info for remote server.
+func (rpcClient *PeerRPCClient) DrivePerfInfo() (ServerDrivesPerfInfo, error) {
+	args := AuthArgs{}
+	var reply ServerDrivesPerfInfo
+
+	err := rpcClient.Call(peerServiceName+".DrivePerfInfo", &args, &reply)
+	return reply, err
+}
+
 // NewPeerRPCClient - returns new peer RPC client.
 func NewPeerRPCClient(host *xnet.Host) (*PeerRPCClient, error) {
 	scheme := "http"

--- a/cmd/peer-rpc-server.go
+++ b/cmd/peer-rpc-server.go
@@ -238,6 +238,17 @@ func (receiver *peerRPCReceiver) LoadCredentials(args *AuthArgs, reply *VoidRepl
 	return globalConfigSys.Load(newObjectLayerFn())
 }
 
+// DrivePerfInfo - handles drive performance RPC call
+func (receiver *peerRPCReceiver) DrivePerfInfo(args *AuthArgs, reply *ServerDrivesPerfInfo) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
+	*reply = localEndpointsPerf(globalEndpoints)
+	return nil
+}
+
 // NewPeerRPCServer - returns new peer RPC server.
 func NewPeerRPCServer() (*xrpc.Server, error) {
 	rpcServer := xrpc.NewServer()

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2015 Minio, Inc.
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,26 @@
 
 package disk
 
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"os"
+	"path"
+	"strconv"
+	"time"
+
+	humanize "github.com/dustin/go-humanize"
+)
+
+// file size for performance read and write checks
+const randBufSize = 1 * humanize.KiByte
+const randParts = 1024
+const fileSize = randParts * randBufSize
+
+// Total count of read / write iteration for performance measurement
+const iterations = 10
+
 // Info stat fs struct is container which holds following values
 // Total - total size of the volume / disk
 // Free - free size of the volume / disk
@@ -31,4 +51,88 @@ type Info struct {
 
 	// Usage is calculated per tenant.
 	Usage uint64
+}
+
+// Performance holds informantion about read and write speed of a disk
+type Performance struct {
+	Path       string  `json:"path"`
+	Error      string  `json:"error,omitempty"`
+	WriteSpeed float64 `json:"writeSpeed"`
+	ReadSpeed  float64 `json:"readSpeed"`
+}
+
+// GetPerformance returns given disk's read and write performance
+func GetPerformance(path string) Performance {
+	perf := Performance{}
+	write, read, err := doPerfMeasure(path)
+	if err != nil {
+		perf.Error = err.Error()
+		return perf
+	}
+	perf.WriteSpeed = write
+	perf.ReadSpeed = read
+	return perf
+}
+
+// Calculate the write and read performance - write and read 10 tmp (1 MiB)
+// files and find the average time taken (Bytes / Sec)
+func doPerfMeasure(fsPath string) (write, read float64, err error) {
+	var count int
+	var totalWriteElapsed time.Duration
+	var totalReadElapsed time.Duration
+
+	defer os.RemoveAll(fsPath)
+
+	randBuf := make([]byte, randBufSize)
+	rand.Read(randBuf)
+	buf := bytes.Repeat(randBuf, randParts)
+
+	// create the enclosing directory
+	err = os.MkdirAll(fsPath, 0777)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for count = 1; count <= iterations; count++ {
+		fsTempObjPath := path.Join(fsPath, strconv.Itoa(count))
+
+		// Write performance calculation
+		writeStart := time.Now()
+		n, err := writeFile(fsTempObjPath, buf)
+
+		if err != nil {
+			return 0, 0, err
+		}
+		if n != fileSize {
+			return 0, 0, errors.New("Could not write temporary data to disk")
+		}
+
+		writeElapsed := time.Since(writeStart)
+		totalWriteElapsed += writeElapsed
+
+		// Read performance calculation
+		readStart := time.Now()
+		n, err = readFile(fsTempObjPath, buf)
+
+		if err != nil {
+			return 0, 0, err
+		}
+		if n != fileSize {
+			return 0, 0, errors.New("Could not read temporary data from disk")
+		}
+
+		readElapsed := time.Since(readStart)
+		totalReadElapsed += readElapsed
+	}
+	// Average time spent = total time elapsed / number of writes
+	avgWriteTime := totalWriteElapsed.Seconds() / float64(count)
+	// Write perf = fileSize (in Bytes) / average time spent writing (in seconds)
+	write = fileSize / avgWriteTime
+
+	// Average time spent = total time elapsed / number of writes
+	avgReadTime := totalReadElapsed.Seconds() / float64(count)
+	// read perf = fileSize (in Bytes) / average time spent reading (in seconds)
+	read = fileSize / avgReadTime
+
+	return write, read, nil
 }

--- a/pkg/disk/helpers.go
+++ b/pkg/disk/helpers.go
@@ -1,0 +1,52 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package disk
+
+import (
+	"os"
+)
+
+func readFile(path string, buf []byte) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	n, err := f.Read(buf)
+	if err != nil {
+		return 0, err
+	}
+
+	return n, nil
+}
+
+func writeFile(path string, data []byte) (int, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	n, err := f.Write(data)
+	if err != nil {
+		return 0, err
+	}
+
+	f.Sync()
+	return n, nil
+}

--- a/pkg/madmin/API.md
+++ b/pkg/madmin/API.md
@@ -39,7 +39,7 @@ func main() {
 | Service operations         | Info operations  | Healing operations                    | Config operations        | IAM operations | Misc                                |
 |:----------------------------|:----------------------------|:--------------------------------------|:--------------------------|:------------------------------------|:------------------------------------|
 | [`ServiceStatus`](#ServiceStatus) | [`ServerInfo`](#ServerInfo) | [`Heal`](#Heal) | [`GetConfig`](#GetConfig) | [`AddUser`](#AddUser) | [`SetAdminCredentials`](#SetAdminCredentials) |
-| [`ServiceSendAction`](#ServiceSendAction) | | | [`SetConfig`](#SetConfig) | [`SetUserPolicy`](#SetUserPolicy) | [`StartProfiling`](#StartProfiling) |
+| [`ServiceSendAction`](#ServiceSendAction) | [`ServerDrivesPerfInfo`](#ServerDrivesPerfInfo) | [`SetConfig`](#SetConfig) | [`SetUserPolicy`](#SetUserPolicy) | [`StartProfiling`](#StartProfiling) |
 | | |            | [`GetConfigKeys`](#GetConfigKeys) | [`ListUsers`](#ListUsers) | [`DownloadProfilingData`](#DownloadProfilingData) |
 | | |            | [`SetConfigKeys`](#SetConfigKeys) | [`AddCannedPolicy`](#AddCannedPolicy) | |
 
@@ -204,6 +204,23 @@ Fetches information for all cluster nodes, such as server properties, storage in
 
  ```
 
+<a name="ServerDrivesPerfInfo"></a>
+### ServerDrivesPerfInfo() ([]ServerDrivesPerfInfo, error)
+
+Fetches drive performance information for all cluster nodes. Returned value is in Bytes/s.
+
+| Param | Type | Description |
+|---|---|---|
+|`di.Addr` | _string_ | Address of the server the following information is retrieved from. |
+|`di.Error` | _string _ | Errors (if any) encountered while reaching this node |
+|`di.DrivesPerf` | _disk.Performance_ | Path of the drive mount on above server and read, write speed. |
+
+| Param | Type | Description |
+|---|---|---|
+|`disk.Performance.Path` | _string_ | Path of drive mount. |
+|`disk.Performance.Error` | _string_ | Error (if any) encountered while accessing this drive. |
+|`disk.Performance.WriteSpeed` | _float64_ | Write speed on above path in Bytes/s. |
+|`disk.Performance.ReadSpeed` | _float64_ | Read speed on above path in Bytes/s. |
 
 ## 6. Heal operations
 

--- a/pkg/madmin/examples/drives-perf-info.go
+++ b/pkg/madmin/examples/drives-perf-info.go
@@ -1,0 +1,44 @@
+// +build ignore
+
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTPS) otherwise.
+	// New returns an Minio Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	st, err := madmClnt.ServerDrivesPerfInfo()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(st)
+}


### PR DESCRIPTION
## Description
This is a part of implementation of mc admin health command.
ServerDrivePerfInfo() exposes local and remote server drive mount path
and write speed information.

## Motivation and Context
Part of https://github.com/minio/mc/issues/2606

## Regression
No

## How Has This Been Tested?
Using the madmin package

```go
	// Initialize minio client object.
	mdmClnt, err := madmin.New("127.0.0.1:9000", "minio", "minio123", ssl)
	if err != nil {
		fmt.Println(err)
		return
	}
	si, err := mdmClnt.ServerDrivesPerfInfo()
	if err != nil {
		log.Fatalln(err)
	}
	b, err := json.Marshal(si)
	fmt.Printf("%s\n", string(b))
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.