### PR TITLE
Reload users upon AddUser on peers

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -867,6 +867,14 @@ func (a adminAPIHandlers) SetUserStatus(w http.ResponseWriter, r *http.Request) 
 		writeErrorResponseJSON(w, toAdminAPIErrCode(ctx, err), r.URL)
 		return
 	}
+
+	// Notify all other Minio peers to reload users
+	for host, err := range globalNotificationSys.LoadUsers() {
+		if err != nil {
+			logger.GetReqInfo(ctx).SetTags("peerAddress", host.String())
+			logger.LogIf(ctx, err)
+		}
+	}
 }
 
 // AddUser - PUT /minio/admin/v1/add-user?accessKey=<access_key>
@@ -926,6 +934,14 @@ func (a adminAPIHandlers) AddUser(w http.ResponseWriter, r *http.Request) {
 	if err = globalIAMSys.SetUser(accessKey, uinfo); err != nil {
 		writeErrorResponseJSON(w, toAdminAPIErrCode(ctx, err), r.URL)
 		return
+	}
+
+	// Notify all other Minio peers to reload users
+	for host, err := range globalNotificationSys.LoadUsers() {
+		if err != nil {
+			logger.GetReqInfo(ctx).SetTags("peerAddress", host.String())
+			logger.LogIf(ctx, err)
+		}
 	}
 }
 
@@ -992,6 +1008,14 @@ func (a adminAPIHandlers) RemoveCannedPolicy(w http.ResponseWriter, r *http.Requ
 		writeErrorResponseJSON(w, toAdminAPIErrCode(ctx, err), r.URL)
 		return
 	}
+
+	// Notify all other Minio peers to reload users
+	for host, err := range globalNotificationSys.LoadUsers() {
+		if err != nil {
+			logger.GetReqInfo(ctx).SetTags("peerAddress", host.String())
+			logger.LogIf(ctx, err)
+		}
+	}
 }
 
 // AddCannedPolicy - PUT /minio/admin/v1/add-canned-policy?name=<policy_name>
@@ -1049,6 +1073,14 @@ func (a adminAPIHandlers) AddCannedPolicy(w http.ResponseWriter, r *http.Request
 		writeErrorResponseJSON(w, toAdminAPIErrCode(ctx, err), r.URL)
 		return
 	}
+
+	// Notify all other Minio peers to reload users
+	for host, err := range globalNotificationSys.LoadUsers() {
+		if err != nil {
+			logger.GetReqInfo(ctx).SetTags("peerAddress", host.String())
+			logger.LogIf(ctx, err)
+		}
+	}
 }
 
 // SetUserPolicy - PUT /minio/admin/v1/set-user-policy?accessKey=<access_key>&name=<policy_name>
@@ -1087,6 +1119,14 @@ func (a adminAPIHandlers) SetUserPolicy(w http.ResponseWriter, r *http.Request) 
 
 	if err := globalIAMSys.SetUserPolicy(accessKey, policyName); err != nil {
 		writeErrorResponseJSON(w, toAdminAPIErrCode(ctx, err), r.URL)
+	}
+
+	// Notify all other Minio peers to reload users
+	for host, err := range globalNotificationSys.LoadUsers() {
+		if err != nil {
+			logger.GetReqInfo(ctx).SetTags("peerAddress", host.String())
+			logger.LogIf(ctx, err)
+		}
 	}
 }
 

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -641,7 +641,12 @@ func (h *healSequence) healDiskFormat() error {
 	// Healing succeeded notify the peers to reload format and re-initialize disks.
 	// We will not notify peers only if healing succeeded.
 	if err == nil {
-		peersReInitFormat(globalAdminPeers, h.settings.DryRun)
+		for host, rerr := range globalNotificationSys.ReloadFormat(h.settings.DryRun) {
+			if rerr != nil {
+				logger.GetReqInfo(h.ctx).SetTags("peerAddress", host.String())
+				logger.LogIf(h.ctx, rerr)
+			}
+		}
 	}
 
 	// Push format heal result

--- a/cmd/admin-rpc-server.go
+++ b/cmd/admin-rpc-server.go
@@ -68,23 +68,6 @@ func (receiver *adminRPCReceiver) DownloadProfilingData(args *AuthArgs, reply *[
 	return
 }
 
-// GetConfig - returns the config.json of this server.
-func (receiver *adminRPCReceiver) GetConfig(args *AuthArgs, reply *[]byte) (err error) {
-	*reply, err = receiver.local.GetConfig()
-	return err
-}
-
-// ReInitFormatArgs - provides dry-run information to re-initialize format.json
-type ReInitFormatArgs struct {
-	AuthArgs
-	DryRun bool
-}
-
-// ReInitFormat - re-init 'format.json'
-func (receiver *adminRPCReceiver) ReInitFormat(args *ReInitFormatArgs, reply *VoidReply) error {
-	return receiver.local.ReInitFormat(args.DryRun)
-}
-
 // NewAdminRPCServer - returns new admin RPC server.
 func NewAdminRPCServer() (*xrpc.Server, error) {
 	rpcServer := xrpc.NewServer()

--- a/cmd/admin-rpc_test.go
+++ b/cmd/admin-rpc_test.go
@@ -63,34 +63,6 @@ func testAdminCmdRunnerSignalService(t *testing.T, client adminCmdRunner) {
 	}
 }
 
-func testAdminCmdRunnerReInitFormat(t *testing.T, client adminCmdRunner) {
-	tmpGlobalObjectAPI := globalObjectAPI
-	defer func() {
-		globalObjectAPI = tmpGlobalObjectAPI
-	}()
-
-	testCases := []struct {
-		objectAPI ObjectLayer
-		dryRun    bool
-		expectErr bool
-	}{
-		{&DummyObjectLayer{}, true, false},
-		{&DummyObjectLayer{}, false, false},
-		{nil, true, true},
-		{nil, false, true},
-	}
-
-	for i, testCase := range testCases {
-		globalObjectAPI = testCase.objectAPI
-		err := client.ReInitFormat(testCase.dryRun)
-		expectErr := (err != nil)
-
-		if expectErr != testCase.expectErr {
-			t.Fatalf("case %v: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
-		}
-	}
-}
-
 func testAdminCmdRunnerServerInfo(t *testing.T, client adminCmdRunner) {
 	tmpGlobalBootTime := globalBootTime
 	tmpGlobalObjectAPI := globalObjectAPI
@@ -129,33 +101,6 @@ func testAdminCmdRunnerServerInfo(t *testing.T, client adminCmdRunner) {
 		globalHTTPStats = testCase.httpStats
 		globalNotificationSys = testCase.notificationSys
 		_, err := client.ServerInfo()
-		expectErr := (err != nil)
-
-		if expectErr != testCase.expectErr {
-			t.Fatalf("case %v: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
-		}
-	}
-}
-
-func testAdminCmdRunnerGetConfig(t *testing.T, client adminCmdRunner) {
-	tmpGlobalServerConfig := globalServerConfig
-	defer func() {
-		globalServerConfig = tmpGlobalServerConfig
-	}()
-
-	config := newServerConfig()
-
-	testCases := []struct {
-		config    *serverConfig
-		expectErr bool
-	}{
-		{globalServerConfig, false},
-		{config, false},
-	}
-
-	for i, testCase := range testCases {
-		globalServerConfig = testCase.config
-		_, err := client.GetConfig()
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {
@@ -205,16 +150,6 @@ func TestAdminRPCClientSignalService(t *testing.T) {
 	testAdminCmdRunnerSignalService(t, rpcClient)
 }
 
-func TestAdminRPCClientReInitFormat(t *testing.T) {
-	httpServer, rpcClient, prevGlobalServerConfig := newAdminRPCHTTPServerClient(t)
-	defer httpServer.Close()
-	defer func() {
-		globalServerConfig = prevGlobalServerConfig
-	}()
-
-	testAdminCmdRunnerReInitFormat(t, rpcClient)
-}
-
 func TestAdminRPCClientServerInfo(t *testing.T) {
 	httpServer, rpcClient, prevGlobalServerConfig := newAdminRPCHTTPServerClient(t)
 	defer httpServer.Close()
@@ -223,14 +158,4 @@ func TestAdminRPCClientServerInfo(t *testing.T) {
 	}()
 
 	testAdminCmdRunnerServerInfo(t, rpcClient)
-}
-
-func TestAdminRPCClientGetConfig(t *testing.T) {
-	httpServer, rpcClient, prevGlobalServerConfig := newAdminRPCHTTPServerClient(t)
-	defer httpServer.Close()
-	defer func() {
-		globalServerConfig = prevGlobalServerConfig
-	}()
-
-	testAdminCmdRunnerGetConfig(t, rpcClient)
 }

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -60,9 +60,9 @@ type IAMSys struct {
 	iamCannedPolicyMap map[string]iampolicy.Policy
 }
 
-// Load - load iam.json
+// Load - loads iam subsystem
 func (sys *IAMSys) Load(objAPI ObjectLayer) error {
-	return sys.Init(objAPI)
+	return sys.refresh(objAPI)
 }
 
 // Init - initializes config system from iam.json

--- a/cmd/local-admin-client.go
+++ b/cmd/local-admin-client.go
@@ -18,9 +18,7 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 
 	"io/ioutil"
@@ -74,15 +72,6 @@ func (lc localAdminClient) ServerInfo() (sid ServerInfoData, e error) {
 			Region:   globalServerConfig.GetRegion(),
 		},
 	}, nil
-}
-
-// GetConfig - returns config.json of the local server.
-func (lc localAdminClient) GetConfig() ([]byte, error) {
-	if globalServerConfig == nil {
-		return nil, fmt.Errorf("config not present")
-	}
-
-	return json.Marshal(globalServerConfig)
 }
 
 // StartProfiling - starts profiling on the local server.

--- a/cmd/local-admin-client_test.go
+++ b/cmd/local-admin-client_test.go
@@ -24,14 +24,6 @@ func TestLocalAdminClientSignalService(t *testing.T) {
 	testAdminCmdRunnerSignalService(t, &localAdminClient{})
 }
 
-func TestLocalAdminClientReInitFormat(t *testing.T) {
-	testAdminCmdRunnerReInitFormat(t, &localAdminClient{})
-}
-
 func TestLocalAdminClientServerInfo(t *testing.T) {
 	testAdminCmdRunnerServerInfo(t, &localAdminClient{})
-}
-
-func TestLocalAdminClientGetConfig(t *testing.T) {
-	testAdminCmdRunnerGetConfig(t, &localAdminClient{})
 }

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -89,6 +89,60 @@ func (sys *NotificationSys) DeleteBucket(ctx context.Context, bucketName string)
 	}()
 }
 
+// ReloadFormat - calls ReloadFormat RPC call on all peers.
+func (sys *NotificationSys) ReloadFormat(dryRun bool) map[xnet.Host]error {
+	errors := make(map[xnet.Host]error)
+	var wg sync.WaitGroup
+	for addr, client := range sys.peerRPCClientMap {
+		wg.Add(1)
+		go func(addr xnet.Host, client *PeerRPCClient) {
+			defer wg.Done()
+			// Try to load format in three attempts, before giving up.
+			for i := 0; i < 3; i++ {
+				err := client.ReloadFormat(dryRun)
+				if err == nil {
+					break
+				}
+				errors[addr] = err
+				// Wait for one second and no need wait after last attempt.
+				if i < 2 {
+					time.Sleep(1 * time.Second)
+				}
+			}
+		}(addr, client)
+	}
+	wg.Wait()
+
+	return errors
+}
+
+// LoadUsers - calls LoadUsers RPC call on all peers.
+func (sys *NotificationSys) LoadUsers() map[xnet.Host]error {
+	errors := make(map[xnet.Host]error)
+	var wg sync.WaitGroup
+	for addr, client := range sys.peerRPCClientMap {
+		wg.Add(1)
+		go func(addr xnet.Host, client *PeerRPCClient) {
+			defer wg.Done()
+			// Try to load users in three attempts.
+			for i := 0; i < 3; i++ {
+				err := client.LoadUsers()
+				if err == nil {
+					break
+				}
+				errors[addr] = err
+				// Wait for one second and no need wait after last attempt.
+				if i < 2 {
+					time.Sleep(1 * time.Second)
+				}
+			}
+		}(addr, client)
+	}
+	wg.Wait()
+
+	return errors
+}
+
 // LoadCredentials - calls LoadCredentials RPC call on all peers.
 func (sys *NotificationSys) LoadCredentials() map[xnet.Host]error {
 	errors := make(map[xnet.Host]error)
@@ -97,7 +151,7 @@ func (sys *NotificationSys) LoadCredentials() map[xnet.Host]error {
 		wg.Add(1)
 		go func(addr xnet.Host, client *PeerRPCClient) {
 			defer wg.Done()
-			// Try to set credentials in three attempts.
+			// Try to load credentials in three attempts.
 			for i := 0; i < 3; i++ {
 				err := client.LoadCredentials()
 				if err == nil {

--- a/cmd/peer-rpc-client.go
+++ b/cmd/peer-rpc-client.go
@@ -115,12 +115,30 @@ func (rpcClient *PeerRPCClient) SendEvent(bucketName string, targetID, remoteTar
 	return err
 }
 
+// ReloadFormat - calls reload format RPC.
+func (rpcClient *PeerRPCClient) ReloadFormat(dryRun bool) error {
+	args := ReloadFormatArgs{
+		DryRun: dryRun,
+	}
+	reply := VoidReply{}
+
+	return rpcClient.Call(peerServiceName+".ReloadFormat", &args, &reply)
+}
+
+// LoadUsers - calls load users RPC.
+func (rpcClient *PeerRPCClient) LoadUsers() error {
+	args := AuthArgs{}
+	reply := VoidReply{}
+
+	return rpcClient.Call(peerServiceName+".LoadUsers", &args, &reply)
+}
+
 // LoadCredentials - calls load credentials RPC.
 func (rpcClient *PeerRPCClient) LoadCredentials() error {
 	args := AuthArgs{}
 	reply := VoidReply{}
 
-	return rpcClient.Call(peerServiceName+".SetCredentials", &args, &reply)
+	return rpcClient.Call(peerServiceName+".LoadCredentials", &args, &reply)
 }
 
 // NewPeerRPCClient - returns new peer RPC client.

--- a/cmd/peer-rpc-server.go
+++ b/cmd/peer-rpc-server.go
@@ -192,6 +192,30 @@ func (receiver *peerRPCReceiver) SendEvent(args *SendEventArgs, reply *bool) err
 	return nil
 }
 
+// ReloadFormatArgs - send event RPC arguments.
+type ReloadFormatArgs struct {
+	AuthArgs
+	DryRun bool
+}
+
+// ReloadFormat - handles reload format RPC call, reloads latest `format.json`
+func (receiver *peerRPCReceiver) ReloadFormat(args *ReloadFormatArgs, reply *VoidReply) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+	return objAPI.ReloadFormat(context.Background(), args.DryRun)
+}
+
+// LoadUsers - handles load users RPC call.
+func (receiver *peerRPCReceiver) LoadUsers(args *AuthArgs, reply *VoidReply) error {
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+	return globalIAMSys.Load(objAPI)
+}
+
 // LoadCredentials - handles load credentials RPC call.
 func (receiver *peerRPCReceiver) LoadCredentials(args *AuthArgs, reply *VoidReply) error {
 	objAPI := newObjectLayerFn()


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Reload users upon AddUser on peers
<!--- Describe your changes in detail -->

## Motivation and Context
Also, migrate ReloadFormat to notification subsystem,
remove GetConfig() we do not use this API anymore
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Run a distributed setup with a load balancer in front just running

```
./mc admin user add minio newuser newuser123 customPolicy 
mc: <ERROR> Cannot set user policy for new user The specified user does not exist.
```

Shouldn't result in an issue for subsequent operations when the calls reach peers.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.