### PR TITLE
Fix csv output delimiter bug for S3 Select

### DIFF
--- a/pkg/s3select/format/csv/csv.go
+++ b/pkg/s3select/format/csv/csv.go
@@ -205,7 +205,7 @@ func (reader *cinput) OutputFieldDelimiter() string {
 
 // OutputRecordDelimiter - returns the requested output record delimiter.
 func (reader *cinput) OutputRecordDelimiter() string {
-	return reader.options.OutputFieldDelimiter
+	return reader.options.OutputRecordDelimiter
 }
 
 // HasHeader - returns true or false depending upon the header.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a minor bug in csv output delimiter that uses field delimiter instead of record delimiter


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

Yes, possibly in #6910 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running a csv output query (e.g. `mc sql --query  'select * from s3object' myminio/sqlselectapi/5.csv`)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.