### PR TITLE
[Doc] Change cmd `mc admin user *` to `mc admin users *`

### DIFF
--- a/docs/multi-user/README.md
+++ b/docs/multi-user/README.md
@@ -38,33 +38,33 @@ Create new canned policy by name `getonly` using `getonly.json` policy file.
 mc admin policy add myminio getonly getonly.json
 ```
 
-Create a new user `newuser` on Minio use `mc admin user`, specify `getonly` canned policy for this `newuser`.
+Create a new user `newuser` on Minio use `mc admin users`, specify `getonly` canned policy for this `newuser`.
 ```
-mc admin user add myminio newuser newuser123 getonly
+mc admin users add myminio newuser newuser123 getonly
 ```
 
 ### 3. Disable user
 Disable user `newuser`.
 ```
-mc admin user disable myminio newuser
+mc admin users disable myminio newuser
 ```
 
 ### 4. Remove user
 Remove the user `newuser`.
 ```
-mc admin user remove myminio newuser
+mc admin users remove myminio newuser
 ```
 
 ### 5. Change user policy
 Change the policy for user `newuser` to `putonly` canned policy.
 ```
-mc admin user policy myminio newuser putonly
+mc admin users policy myminio newuser putonly
 ```
 
 ### 5. List all users
 List all enabled and disabled users.
 ```
-mc admin user list myminio
+mc admin users list myminio
 ```
 
 ### 6. Configure `mc`


### PR DESCRIPTION
Change cmd `mc admin user *` to `mc admin users *`

## Motivation and Context
Documentation is wrong

## How Has This Been Tested?
Tested using cli

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
