### PR TITLE
[Doc] Change cmd `mc admin policy *` to `...policies *`

### DIFF
--- a/docs/multi-user/README.md
+++ b/docs/multi-user/README.md
@@ -10,7 +10,7 @@ In this document we will explain in detail on how to configure multiple users.
 - Install Minio - [Minio Quickstart Guide](https://docs.minio.io/docs/minio-quickstart-guide)
 
 ### 2. Create a new user with canned policy
-Use [`mc admin policy`](https://docs.minio.io/docs/minio-admin-complete-guide.html#policies) to create canned policies. Server provides a default set of canned policies namely `writeonly`, `readonly` and `readwrite` *(these policies apply to all resources on the server)*. These can be overridden by custom policies using `mc admin policy` command.
+Use [`mc admin policies`](https://docs.minio.io/docs/minio-admin-complete-guide.html#policies) to create canned policies. Server provides a default set of canned policies namely `writeonly`, `readonly` and `readwrite` *(these policies apply to all resources on the server)*. These can be overridden by custom policies using `mc admin policies` command.
 
 Create new canned policy file `getonly.json`. This policy enables users to download all objects under `my-bucketname`.
 ```json
@@ -35,7 +35,7 @@ EOF
 
 Create new canned policy by name `getonly` using `getonly.json` policy file.
 ```
-mc admin policy add myminio getonly getonly.json
+mc admin policies add myminio getonly getonly.json
 ```
 
 Create a new user `newuser` on Minio use `mc admin user`, specify `getonly` canned policy for this `newuser`.


### PR DESCRIPTION
Change cmd `mc admin policy *` to `mc admin policies *`

## Motivation and Context
Documentation is wrong

## How Has This Been Tested?
Tested using cli

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
