### PR TITLE
[WIP] add .rancher-pipeline.yml

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -2,14 +2,19 @@ stages:
 - name: Build
   steps:
   - runScriptConfig:
-      image: golang:1.10-stretch
+      image: golang:1.10.4
       shellScript: |-
-        apt-get update
-        apt-get install -y gcc
         mkdir -p /go/src/github.com/minio
         ln -s `pwd` /go/src/github.com/minio/minio
         cd /go/src/github.com/minio/minio
-        go build -o bin/minio github.com/minio/minio
+        make
+        diff -au <(gofmt -s -d cmd) <(printf "")
+        make test GOFLAGS="-timeout 15m -race -v"
+        make verify
+        make coverage
+        cd browser
+        yarn
+        yarn test
 - name: Test
   steps:
   - runScriptConfig:

--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -1,0 +1,39 @@
+stages:
+- name: Build
+  steps:
+  - runScriptConfig:
+      image: golang:1.10-stretch
+      shellScript: |-
+        apt-get update
+        apt-get install -y gcc
+        mkdir -p /go/src/github.com/minio
+        ln -s `pwd` /go/src/github.com/minio/minio
+        cd /go/src/github.com/minio/minio
+        go build -o bin/minio github.com/minio/minio
+- name: Test
+  steps:
+  - runScriptConfig:
+      image: wlan0/minio-gateway-test-2
+      shellScript: |-
+        export SERVER_ENDPOINT=127.0.0.1:9000
+        export ENABLE_HTTPS=0
+        export MC_VERSION=RELEASE.2018-12-19T22-58-03Z
+        export AWS_CLI_VERSION=1.11.112
+        export GOPATH=/go
+        ./bin/minio gateway s3 &
+        cd /mint
+        /mint/release.sh
+        /mint/entrypoint.sh
+    envFrom:
+    - sourceName: s3-gateway-tests
+      sourceKey: ACCESS_KEY
+      targetKey: ACCESS_KEY
+    - sourceName: s3-gateway-tests
+      sourceKey: MINIO_ACCESS_KEY
+      targetKey: MINIO_ACCESS_KEY
+    - sourceName: s3-gateway-tests
+      sourceKey: SECRET_KEY
+      targetKey: SECRET_KEY
+    - sourceName: s3-gateway-tests
+      sourceKey: MINIO_SECRET_KEY
+      targetKey: MINIO_SECRET_KEY


### PR DESCRIPTION
This PR introduces the configuration file for running s3 gateway-tests on every push to this repository. The tests run in our datacenter inside a kubernetes cluster. 

This PR is not quite ready to be merged yet. The following must be done before merging this PR

 - Create container image hosted in the minio official repository for the gateway-test container
 - Update the image name with the official image in `.rancher-pipeline.yml` 
  - Update the minio-java tests to pick up the patch that prevents infinite looping
  - Update minio/mint with changes required for this pipeline to function correctly
  - Review and finalize the versions of different SDKs (MC_CLIENT, AWS_CLI etc.) 

Once it is merged, the following must be done

 - Transfer the existing GithubApp for minio-ci to the minio repository
 - Activate builds for each pull request 

In the meantime, I'll work with @harshavardhana to get access to Github, Docker registry, and make the PRs for the other repositories.   