### PR TITLE
Buffconn should buffer upto maxHeaderBytes to avoid ErrBufferFull

### DIFF
--- a/cmd/http/bufconn.go
+++ b/cmd/http/bufconn.go
@@ -99,10 +99,10 @@ func (c *BufConn) Write(b []byte) (n int, err error) {
 }
 
 // newBufConn - creates a new connection object wrapping net.Conn.
-func newBufConn(c net.Conn, readTimeout, writeTimeout time.Duration) *BufConn {
+func newBufConn(c net.Conn, readTimeout, writeTimeout time.Duration, maxHeaderBytes int) *BufConn {
 	return &BufConn{
 		QuirkConn:    QuirkConn{Conn: c},
-		bufReader:    bufio.NewReader(c),
+		bufReader:    bufio.NewReaderSize(c, maxHeaderBytes),
 		readTimeout:  readTimeout,
 		writeTimeout: writeTimeout,
 	}

--- a/cmd/http/bufconn_test.go
+++ b/cmd/http/bufconn_test.go
@@ -49,7 +49,7 @@ func TestBuffConnReadTimeout(t *testing.T) {
 			t.Errorf("failed to accept new connection. %v", terr)
 			return
 		}
-		bufconn := newBufConn(tcpConn, 1*time.Second, 1*time.Second)
+		bufconn := newBufConn(tcpConn, 1*time.Second, 1*time.Second, 4096)
 		defer bufconn.Close()
 
 		// Read a line

--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -222,7 +222,7 @@ func (listener *httpListener) start() {
 		tcpConn.SetKeepAlive(true)
 		tcpConn.SetKeepAlivePeriod(listener.tcpKeepAliveTimeout)
 
-		bufconn := newBufConn(tcpConn, listener.readTimeout, listener.writeTimeout)
+		bufconn := newBufConn(tcpConn, listener.readTimeout, listener.writeTimeout, listener.maxHeaderBytes)
 		if listener.tlsConfig != nil {
 			ok, err := getPlainText(bufconn)
 			if err != nil {
@@ -261,7 +261,7 @@ func (listener *httpListener) start() {
 				return
 			}
 
-			bufconn = newBufConn(tlsConn, listener.readTimeout, listener.writeTimeout)
+			bufconn = newBufConn(tlsConn, listener.readTimeout, listener.writeTimeout, listener.maxHeaderBytes)
 		}
 
 		method, resource, host, err := getMethodResourceHost(bufconn, listener.maxHeaderBytes)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Buffconn should buffer up to maxHeaderBytes to avoid ErrBufferFull
<!--- Describe your changes in detail -->

## Motivation and Context
It can happen with erroneous clients which do not send `Host:`
header until 4k worth of header bytes has been read. This can lead
to Peek() method of bufio to fail with ErrBufferFull.

To avoid this we should make sure that Peek buffer is as large as
our maxHeaderBytes count.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
https://play.golang.org/p/COImHdhMj-J here is an example code to reproduce a version of this issue.
```go
package main

import (
	"bufio"
	"fmt"
	"strings"
)

// This is an example to show why getMethodResourceHost() might fail
// in certain situations when the Host header is sent by the client
// a few bytes later. https://github.com/minio/minio/blob/master/cmd/http/listener.go#L98
func main() {
	s := strings.NewReader(`
GET / HTTP/1.1
User-Agent: Minio (linux; amd64) minio-go/v6.0.8 mc/2018-12-18T08:29:42Z
Authorization: AWS4-HMAC-SHA256 Credential=minio/20181221/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=b5b57aa78845123d6b23d70b296920c784ef1b593de6ad9108011ba986764fb3
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20181221T211952Z
Host: localhost:9000`)

	// Buffer is only 16 bytes
	r := bufio.NewReaderSize(s, 16)

	// The looping up '512' max header bytes, so this means that if we Peek
	// beyond the buffer i.e '16' the following code will panic. It is possible
	// that "host:" header might actually arrive last upto 'maxHeaderBytes'
	for count := 1; count < 512; count++ {
		token, err := r.Peek(count)
		if err != nil {
			panic(err)
		}
		fmt.Printf("Token: %q\n", token)
	}
}
``` 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.