### PR TITLE
Fix policy bugs Null conditions and canonical names

### DIFF
--- a/pkg/policy/condition/func_test.go
+++ b/pkg/policy/condition/func_test.go
@@ -53,12 +53,12 @@ func TestFunctionsEvaluate(t *testing.T) {
 		{case1Function, map[string][]string{
 			"x-amz-copy-source": {"mybucket/myobject"},
 			"SourceIp":          {"192.168.1.10"},
-		}, true},
+		}, false},
 		{case1Function, map[string][]string{
 			"x-amz-copy-source": {"mybucket/myobject"},
 			"SourceIp":          {"192.168.1.10"},
 			"Refer":             {"http://example.org/"},
-		}, true},
+		}, false},
 		{case1Function, map[string][]string{"x-amz-copy-source": {"mybucket/myobject"}}, false},
 		{case1Function, map[string][]string{"SourceIp": {"192.168.1.10"}}, false},
 		{case1Function, map[string][]string{
@@ -79,7 +79,7 @@ func TestFunctionsEvaluate(t *testing.T) {
 		result := testCase.functions.Evaluate(testCase.values)
 
 		if result != testCase.expectedResult {
-			t.Fatalf("case %v: expected: %v, got: %v\n", i+1, testCase.expectedResult, result)
+			t.Errorf("case %v: expected: %v, got: %v\n", i+1, testCase.expectedResult, result)
 		}
 	}
 }

--- a/pkg/policy/condition/ipaddressfunc.go
+++ b/pkg/policy/condition/ipaddressfunc.go
@@ -19,6 +19,7 @@ package condition
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"sort"
 )
 
@@ -46,7 +47,12 @@ type ipAddressFunc struct {
 // falls in one of network or not.
 func (f ipAddressFunc) evaluate(values map[string][]string) bool {
 	IPs := []net.IP{}
-	for _, s := range values[f.k.Name()] {
+	requestValue, ok := values[http.CanonicalHeaderKey(f.k.Name())]
+	if !ok {
+		requestValue = values[f.k.Name()]
+	}
+
+	for _, s := range requestValue {
 		IP := net.ParseIP(s)
 		if IP == nil {
 			panic(fmt.Errorf("invalid IP address '%v'", s))

--- a/pkg/policy/condition/nullfunc_test.go
+++ b/pkg/policy/condition/nullfunc_test.go
@@ -37,23 +37,23 @@ func TestNullFuncEvaluate(t *testing.T) {
 		values         map[string][]string
 		expectedResult bool
 	}{
-		{case1Function, map[string][]string{"prefix": {"true"}}, true},
-		{case1Function, map[string][]string{"prefix": {"false"}}, true},
-		{case1Function, map[string][]string{"prefix": {"mybucket/foo"}}, true},
-		{case1Function, map[string][]string{}, false},
-		{case1Function, map[string][]string{"delimiter": {"/"}}, false},
-		{case2Function, map[string][]string{"prefix": {"true"}}, false},
-		{case2Function, map[string][]string{"prefix": {"false"}}, false},
-		{case2Function, map[string][]string{"prefix": {"mybucket/foo"}}, false},
-		{case2Function, map[string][]string{}, true},
-		{case2Function, map[string][]string{"delimiter": {"/"}}, true},
+		{case1Function, map[string][]string{"prefix": {"true"}}, false},
+		{case1Function, map[string][]string{"prefix": {"false"}}, false},
+		{case1Function, map[string][]string{"prefix": {"mybucket/foo"}}, false},
+		{case1Function, map[string][]string{}, true},
+		{case1Function, map[string][]string{"delimiter": {"/"}}, true},
+		{case2Function, map[string][]string{"prefix": {"true"}}, true},
+		{case2Function, map[string][]string{"prefix": {"false"}}, true},
+		{case2Function, map[string][]string{"prefix": {"mybucket/foo"}}, true},
+		{case2Function, map[string][]string{}, false},
+		{case2Function, map[string][]string{"delimiter": {"/"}}, false},
 	}
 
 	for i, testCase := range testCases {
 		result := testCase.function.evaluate(testCase.values)
 
 		if result != testCase.expectedResult {
-			t.Fatalf("case %v: expected: %v, got: %v\n", i+1, testCase.expectedResult, result)
+			t.Errorf("case %v: expected: %v, got: %v\n", i+1, testCase.expectedResult, result)
 		}
 	}
 }

--- a/pkg/policy/condition/stringequalsfunc.go
+++ b/pkg/policy/condition/stringequalsfunc.go
@@ -18,6 +18,7 @@ package condition
 
 import (
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -44,7 +45,11 @@ type stringEqualsFunc struct {
 // evaluate() - evaluates to check whether value by Key in given values is in
 // condition values.
 func (f stringEqualsFunc) evaluate(values map[string][]string) bool {
-	requestValue := values[f.k.Name()]
+	requestValue, ok := values[http.CanonicalHeaderKey(f.k.Name())]
+	if !ok {
+		requestValue = values[f.k.Name()]
+	}
+
 	return !f.values.Intersection(set.CreateStringSet(requestValue...)).IsEmpty()
 }
 

--- a/pkg/policy/condition/stringlikefunc.go
+++ b/pkg/policy/condition/stringlikefunc.go
@@ -18,6 +18,7 @@ package condition
 
 import (
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -45,7 +46,12 @@ type stringLikeFunc struct {
 // evaluate() - evaluates to check whether value by Key in given values is wildcard
 // matching in condition values.
 func (f stringLikeFunc) evaluate(values map[string][]string) bool {
-	for _, v := range values[f.k.Name()] {
+	requestValue, ok := values[http.CanonicalHeaderKey(f.k.Name())]
+	if !ok {
+		requestValue = values[f.k.Name()]
+	}
+
+	for _, v := range requestValue {
 		if !f.values.FuncMatch(wildcard.Match, v).IsEmpty() {
 			return true
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes two different issues

- Null condition implementation
- HTTP Canonical request value names

This PR fixes handling of null conditions and
handle HTTP canonical names in request values.

<!--- Describe your changes in detail -->

## Motivation and Context
This PR was tested with policies mentioned in the following blog
https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/

Fixes #6955
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
This PR was tested with policies mentioned in the following blog
https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/

```
~ aws --endpoint-url http://localhost:9000 s3api put-bucket-policy --bucket vadmeste --policy file:///tmp/policy.json
```

```
~ curl -i --upload /etc/hosts http://localhost:9000/vadmeste/prefix/1
HTTP/1.1 403 Forbidden
Accept-Ranges: bytes
Content-Security-Policy: block-all-mixed-content
Content-Type: application/xml
Server: Minio/DEVELOPMENT.2018-12-24T23-36-15Z (linux; amd64)
Vary: Origin
X-Amz-Request-Id: 15736BF7C984AB30
X-Minio-Deployment-Id: 7564a643-0505-4c84-87fc-5095d5389967
X-Xss-Protection: 1; mode=block
Date: Tue, 25 Dec 2018 00:30:10 GMT
Transfer-Encoding: chunked

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied.</Message><Resource>/vadmeste/prefix/1</Resource><RequestId>15736BF7C984AB30</RequestId><HostId>3L137</HostId></Error>
```

```
~ curl -i -H "x-amz-server-side-encryption: AES256" --upload /etc/hosts http://localhost:9000/vadmeste/prefix/1
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Security-Policy: block-all-mixed-content
Etag: "e84e95f216090f7bf153d92d1fb4f7fd"
Server: Minio/DEVELOPMENT.2018-12-24T23-36-15Z (linux; amd64)
Vary: Origin
X-Amz-Request-Id: 15736BF33F575F18
X-Amz-Server-Side-Encryption: AES256
X-Minio-Deployment-Id: 7564a643-0505-4c84-87fc-5095d5389967
X-Xss-Protection: 1; mode=block
Date: Tue, 25 Dec 2018 00:29:49 GMT
Content-Length: 0
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.