### PR TITLE
virtual host: Fix making new buckets

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -496,11 +496,6 @@ func (h resourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	// A put method on path "/" doesn't make sense, ignore it.
-	if r.Method == http.MethodPut && r.URL.Path == "/" {
-		writeErrorResponse(w, ErrNotImplemented, r.URL, guessIsBrowserReq(r))
-		return
-	}
 
 	// Serve HTTP.
 	h.handler.ServeHTTP(w, r)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit removes old code preventing PUT requests with '/' as a path,
but this is not needed anymore after the introduction of the virtual
host style in Minio server code.

'PUT /' when global domain is not configured already returns 405 Method
Not Allowed http error.

## Motivation and Context
Fix making buckets with virtual host style.

## Regression
No

## How Has This Been Tested?
1. `MINIO_DOMAIN=mydomain minio server /tmp/fs/`
2. Configure mc to connect with your Minio server
3. Configure alias to use dns style for S3 requests (edit ~/.mc/config.json > alias > lookup)
4. `mc mb alias/newbucket`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.