### PR TITLE
Honor MINIO_REGION env in S3 gateway

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -182,6 +182,12 @@ func handleCommonEnvVars() {
 		globalActiveCred = cred
 	}
 
+	if region := os.Getenv("MINIO_REGION"); region != "" {
+		// region Envs are set globally.
+		globalIsEnvRegion = true
+		globalServerRegion = region
+	}
+
 	if browser := os.Getenv("MINIO_BROWSER"); browser != "" {
 		browserFlag, err := ParseBoolFlag(browser)
 		if err != nil {

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -98,7 +98,7 @@ func TestServerConfigWithEnvs(t *testing.T) {
 	globalObjectAPI = objLayer
 	globalObjLayerMutex.Unlock()
 
-	serverHandleEnvVars()
+	handleCommonEnvVars()
 
 	// Init config
 	initConfig(objLayer)

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -34,17 +34,6 @@ var (
 	// MustGetUUID function alias.
 	MustGetUUID = mustGetUUID
 
-	// IsMinAllowedPartSize function alias.
-	IsMinAllowedPartSize = isMinAllowedPartSize
-
-	// GetCompleteMultipartMD5 functon alias.
-	GetCompleteMultipartMD5 = getCompleteMultipartMD5
-
-	// Contains function alias.
-	Contains = contains
-
-	// ExtractETag provides extractETag function alias.
-	ExtractETag = extractETag
 	// CleanMetadataKeys provides cleanMetadataKeys function alias.
 	CleanMetadataKeys = cleanMetadataKeys
 )
@@ -361,6 +350,9 @@ func parseGatewaySSE(s string) (gatewaySSE, error) {
 
 // handle gateway env vars
 func handleGatewayEnvVars() {
+	// Handle common env vars.
+	handleCommonEnvVars()
+
 	gwsseVal, ok := os.LookupEnv("MINIO_GATEWAY_SSE")
 	if ok {
 		var err error

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -132,9 +132,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	globalRootCAs, err = getRootCAs(globalCertsCADir.Get())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
 
-	// Handle common env vars.
-	handleCommonEnvVars()
-
 	// Handle gateway specific env
 	handleGatewayEnvVars()
 

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -198,7 +199,10 @@ func newS3(url string) (*miniogo.Core, error) {
 		&credentials.EnvMinio{},
 	})
 
-	clnt, err := miniogo.NewWithCredentials(endpoint, creds, secure, "")
+	// Fetch region if set from ENV and use for all API operations.
+	region := os.Getenv("MINIO_REGION")
+
+	clnt, err := miniogo.NewWithCredentials(endpoint, creds, secure, region)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -182,18 +182,6 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	}
 }
 
-func serverHandleEnvVars() {
-	// Handle common environment variables.
-	handleCommonEnvVars()
-
-	if serverRegion := os.Getenv("MINIO_REGION"); serverRegion != "" {
-		// region Envs are set globally.
-		globalIsEnvRegion = true
-		globalServerRegion = serverRegion
-	}
-
-}
-
 // serverMain handler called for 'minio server' command.
 func serverMain(ctx *cli.Context) {
 	if ctx.Args().First() == "help" || !endpointsPresent(ctx) {
@@ -217,7 +205,7 @@ func serverMain(ctx *cli.Context) {
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
 
 	// Handle all server environment vars.
-	serverHandleEnvVars()
+	handleCommonEnvVars()
 
 	// Is distributed setup, error out if no certificates are found for HTTPS endpoints.
 	if globalIsDistXL {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Honor MINIO_REGION env in S3 gateway
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #7044

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using another Minio server as backend which has region configured. 

```
~ export MINIO_ACCESS_KEY=minio
~ export MINIO_SECRET_KEY=minio123
~ export MINIO_REGION=custom-region
~ minio server ~/data --address ":9001"
```

```
~ export MINIO_ACCESS_KEY=minio
~ export MINIO_SECRET_KEY=minio123
~ export MINIO_REGION=custom-region
~ minio gateway s3 http://localhost:9001
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.