### PR TITLE
Add missing time import to counter_darwin.go

### DIFF
--- a/pkg/cpu/counter_darwin.go
+++ b/pkg/cpu/counter_darwin.go
@@ -18,6 +18,7 @@ package cpu
 
 import (
 	"errors"
+	"time"
 )
 
 func newCounter() (counter, error) {


### PR DESCRIPTION
Looks like someone didn't build their shim.. `go get github.com/minio/minio` fails on MacOS with:

```
$GOPATH/src/github.com/minio/minio/pkg/cpu/counter_darwin.go:27:24: undefined: time
```

## Description

Added a missing time import.

## Motivation and Context

This change is required for Minio to build on MacOS.

## Regression

This file was introduced in f3f47d8cd3fa09923f74294299b51a405d9da7c3.

## How Has This Been Tested?

`go get github.com/minio/minio` does not produce this error with the change on MacOS.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.