### PR TITLE
Healing process should not heal root disk

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -303,9 +303,10 @@ func (s *posix) IsOnline() bool {
 // DiskInfo is an extended type which returns current
 // disk usage per path.
 type DiskInfo struct {
-	Total uint64
-	Free  uint64
-	Used  uint64
+	Total    uint64
+	Free     uint64
+	Used     uint64
+	RootDisk bool
 }
 
 // DiskInfo provides current information about disk space usage,
@@ -319,12 +320,17 @@ func (s *posix) DiskInfo() (info DiskInfo, err error) {
 	if !s.diskMount {
 		used = atomic.LoadUint64(&s.totalUsed)
 	}
-	return DiskInfo{
-		Total: di.Total,
-		Free:  di.Free,
-		Used:  used,
-	}, nil
 
+	rootDisk, err := disk.IsRootDisk(s.diskPath)
+	if err != nil {
+		return info, err
+	}
+	return DiskInfo{
+		Total:    di.Total,
+		Free:     di.Free,
+		Used:     used,
+		RootDisk: rootDisk,
+	}, nil
 }
 
 // getVolDir - will convert incoming volume names to

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -1029,6 +1029,18 @@ func (s *xlSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.HealRe
 		}
 	}(storageDisks)
 
+	for i, disk := range storageDisks {
+		info, err := disk.DiskInfo()
+		if err != nil {
+			storageDisks[i] = nil
+		}
+		if info.RootDisk {
+			// We should not heal on root disk. i.e in a situation where the minio-administrator has unmounted a
+			// defective drive we should not heal a path on the root disk.
+			storageDisks[i] = nil
+		}
+	}
+
 	formats, sErrs := loadFormatXLAll(storageDisks)
 	if err = checkFormatXLValues(formats); err != nil {
 		return madmin.HealResultItem{}, err

--- a/pkg/disk/root-disk-unix.go
+++ b/pkg/disk/root-disk-unix.go
@@ -1,0 +1,31 @@
+// +build !windows
+
+package disk
+
+import (
+	"os"
+	"syscall"
+)
+
+// IsRootDisk returns if diskPath belongs to root-disk, i.e the disk mounted at "/"
+func IsRootDisk(diskPath string) (bool, error) {
+	rootDisk := false
+	diskInfo, err := os.Stat(diskPath)
+	if err != nil {
+		return false, err
+	}
+	rootInfo, err := os.Stat("/")
+	if err != nil {
+		return false, err
+	}
+	diskStat, diskStatOK := diskInfo.Sys().(*syscall.Stat_t)
+	rootStat, rootStatOK := rootInfo.Sys().(*syscall.Stat_t)
+	if diskStatOK && rootStatOK {
+		if diskStat.Dev == rootStat.Dev {
+			// Indicate if the disk path is on root disk. This is used to indicate the healing
+			// process not to format the drive and end up healing it.
+			rootDisk = true
+		}
+	}
+	return rootDisk, nil
+}

--- a/pkg/disk/root-disk-windows.go
+++ b/pkg/disk/root-disk-windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package disk
+
+// IsRootDisk returns if diskPath belongs to root-disk, i.e the disk mounted at "/"
+func IsRootDisk(diskPath string) (bool, error) {
+	// On windows a disk can never be mounted on a subpath.
+	return false, nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Description
-----------
<!--- Describe your changes in detail -->
If an admin umounts a disk and runs heal, currently we endup healing a directory on the root FS. This PR ensures that when we heal, format healing is done only on non-root disks.


Motivation and Context
-------------
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If we heal a directory on root disk we will end up filling up the root disk

Regression
---
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No

How Has This Been Tested?
----
By using a loop mounted FS, I was able to simulate actualy disk mount to test this.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.