### PR TITLE
change credential chain order in s3 gateway to mimic official docs

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -182,19 +182,19 @@ func newS3(url string) (*miniogo.Core, error) {
 
 	// Chains all credential types, in the following order:
 	//  - AWS env vars (i.e. AWS_ACCESS_KEY_ID)
+	//  - AWS creds file (i.e. AWS_SHARED_CREDENTIALS_FILE or ~/.aws/credentials)
 	//  - IAM profile based credentials. (performs an HTTP
 	//    call to a pre-defined endpoint, only valid inside
 	//    configured ec2 instances)
-	//  - AWS creds file (i.e. AWS_SHARED_CREDENTIALS_FILE or ~/.aws/credentials)
 	//  - Static credentials provided by user (i.e. MINIO_ACCESS_KEY)
 	creds := credentials.NewChainCredentials([]credentials.Provider{
 		&credentials.EnvAWS{},
+		&credentials.FileAWSCredentials{},
 		&credentials.IAM{
 			Client: &http.Client{
 				Transport: minio.NewCustomHTTPTransport(),
 			},
 		},
-		&credentials.FileAWSCredentials{},
 		&credentials.EnvMinio{},
 	})
 

--- a/docs/gateway/s3.md
+++ b/docs/gateway/s3.md
@@ -31,8 +31,8 @@ minio gateway s3
 Minio gateway will automatically look for list of credential styles in following order.
 
 - AWS env vars (i.e. AWS_ACCESS_KEY_ID)
-- IAM profile based credentials. (performs an HTTP call to a pre-defined endpoint, only valid inside configured ec2 instances)
 - AWS creds file (i.e. AWS_SHARED_CREDENTIALS_FILE or ~/.aws/credentials)
+- IAM profile based credentials. (performs an HTTP call to a pre-defined endpoint, only valid inside configured ec2 instances)
 
 ## Run Minio Gateway for AWS S3 compatible services
 As a prerequisite to run Minio S3 gateway on an AWS S3 compatible service, you need valid access key, secret key and service endpoint.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

According to [official docs](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html), minio should try to load the credentials in the following order:

- AWS env variable
- AWS credential file
- IAM role
- Minio env variables

## Current Behavior

- AWS env variable
- **IAM role**
- AWS credential file
- Minio env variables

## Motivation and Context

It is not possible to use `AWS_SHARED_CREDENTIALS_FILE` when running inside `EC2` instance, because IAM role credentials takes precedence 

## Tests

We built a Docker image and published to dockerhub (`bringg/minio:PR-7091`). Currently runs on our  production environment. Works as expected!

## Types of changes
- [x] Bug fix (not really a bug, but a desired behavior as recommended by AWS)
- [x] Potentially Breaking change (if users rely on the order, this may affect them, users won't be affected if they follow the AWS recommendations)

