### PR TITLE
[Proposal] Reorder credential providers for gateway s3

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -181,21 +181,21 @@ func newS3(url string) (*miniogo.Core, error) {
 	}
 
 	// Chains all credential types, in the following order:
+	//  - Static credentials provided by user (i.e. MINIO_ACCESS_KEY)
 	//  - AWS env vars (i.e. AWS_ACCESS_KEY_ID)
+	//  - AWS creds file (i.e. AWS_SHARED_CREDENTIALS_FILE or ~/.aws/credentials)
 	//  - IAM profile based credentials. (performs an HTTP
 	//    call to a pre-defined endpoint, only valid inside
 	//    configured ec2 instances)
-	//  - AWS creds file (i.e. AWS_SHARED_CREDENTIALS_FILE or ~/.aws/credentials)
-	//  - Static credentials provided by user (i.e. MINIO_ACCESS_KEY)
 	creds := credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.EnvMinio{},
 		&credentials.EnvAWS{},
+		&credentials.FileAWSCredentials{},
 		&credentials.IAM{
 			Client: &http.Client{
 				Transport: minio.NewCustomHTTPTransport(),
 			},
 		},
-		&credentials.FileAWSCredentials{},
-		&credentials.EnvMinio{},
 	})
 
 	clnt, err := miniogo.NewWithCredentials(endpoint, creds, secure, "")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Reorder credential providers so that:

1. Minio env is always tried first.
2. Then AWS standard envs
3. Then AWS config file
4. And finally IAM

The current behaviour makes it weird to run minio gateway in EC2 as experienced by @wlan0 - it is necessary to set AWS env vars to get it to work in the existing ordering.

@harshavardhana  For discussion

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.