### PR TITLE
heal: Preserve deployment ID from reference format.json

### DIFF
--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -896,6 +896,7 @@ func newHealFormatSets(refFormat *formatXLV3, setCount, disksPerSet int, formats
 			if errs[i*disksPerSet+j] == errUnformattedDisk || errs[i*disksPerSet+j] == nil {
 				newFormats[i][j] = &formatXLV3{}
 				newFormats[i][j].Version = refFormat.Version
+				newFormats[i][j].ID = refFormat.ID
 				newFormats[i][j].Format = refFormat.Format
 				newFormats[i][j].XL.Version = refFormat.XL.Version
 				newFormats[i][j].XL.DistributionAlgo = refFormat.XL.DistributionAlgo

--- a/cmd/format-xl_test.go
+++ b/cmd/format-xl_test.go
@@ -556,4 +556,13 @@ func TestNewFormatSets(t *testing.T) {
 	if newFormats == nil {
 		t.Fatal("Unexpected failure")
 	}
+
+	// Check if deployment IDs are preserved.
+	for i := range newFormats {
+		for j := range newFormats[i] {
+			if newFormats[i][j].ID != quorumFormat.ID {
+				t.Fatal("Deployment id in the new format is lost")
+			}
+		}
+	}
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Deployment ID is not copied into new formats after healing format. Although,
this is not critical since a new deployment ID will be generated and set in the
next cluster restart, it is still much better if we don't change the deployment
id of a cluster for a better tracking.


## Motivation and Context
Fixing a small bug

## Regression
No

## How Has This Been Tested?
1. Run a distributed setup (let's say 4 disks)
2. Check deployment id from format.json
2. Remove one disk content
3. mc admin heal -r alias/
4. Check again the deployement id

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.