### PR TITLE
Add example for IPv6 for address flag

### DIFF
--- a/cmd/ui-errors.go
+++ b/cmd/ui-errors.go
@@ -119,9 +119,10 @@ Refer to the link https://github.com/minio/minio/tree/master/docs/erasure/storag
 	uiErrInvalidAddressFlag = newUIErrFn(
 		"--address input is invalid",
 		"Please check --address parameter",
-		`--address binds to a specific ADDRESS:PORT, ADDRESS can be an  IP or hostname (default port is ':9000')
-    Examples: --address ':443'
-              --address '172.16.34.31:9000'`,
+		`--address binds to a specific ADDRESS:PORT, ADDRESS can be an IPv4/IPv6 address or hostname (default port is ':9000')
+	Examples: --address ':443'
+		  --address '172.16.34.31:9000'
+		  --address '[fe80::da00:a6c8:e3ae:ddd7]:9000'`,
 	)
 
 	uiErrInvalidFSEndpoint = newUIErrFn(


### PR DESCRIPTION
## Description
Add IPv6 example in `--address` flag.

## Motivation and Context
With IPv6 support added in the server, it will help users to show how to use IPv6 with `--address` flag

## Regression
No

## How Has This Been Tested?
Test it by passing incorrect `address` flag value, e.g. `./minio server --address "" /tmp/data`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.