### PR TITLE
[MQTT]  ClientID removed in the MQTT config

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -119,7 +119,6 @@ var (
         "broker": "",
         "topic": "",
         "qos": 0,
-        "clientId": "",
         "username": "",
         "password": "",
         "reconnectInterval": 0,

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -233,7 +233,7 @@ func TestValidateConfig(t *testing.T) {
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "namespace", "address": "example.com:80", "password": "xxx", "key": "key1" } }}}`, true},
 
 		// Test 27 - Test MQTT
-		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "mqtt": { "1": { "enable": true, "broker": "",  "topic": "", "qos": 0, "clientId": "", "username": "", "password": "", "queueDir": ""}}}}`, false},
+		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "mqtt": { "1": { "enable": true, "broker": "",  "topic": "", "qos": 0, "username": "", "password": "", "queueDir": ""}}}}`, false},
 
 		// Test 28 - Test NSQ
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "nsq": { "1": { "enable": true, "nsqdAddress": "", "topic": ""} }}}`, false},

--- a/cmd/config-versions.go
+++ b/cmd/config-versions.go
@@ -893,7 +893,7 @@ type serverConfigV32 struct {
 	} `json:"policy"`
 }
 
-// serverConfigV33 is just like version '32', removes clientID from NATS and adds queueDir with MQTT.
+// serverConfigV33 is just like version '32', removes clientID from NATS and MQTT, and adds queueDir with MQTT.
 type serverConfigV33 struct {
 	quick.Config `json:"-"` // ignore interfaces
 

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -160,7 +160,6 @@ The Minio server configuration file is stored on the backend in json format. The
 | `broker` | _string_ | (Required) MQTT server endpoint, e.g. `tcp://localhost:1883` |
 | `topic` | _string_ | (Required) Name of the MQTT topic to publish on, e.g. `minio` |
 | `qos` | _int_ | Set the Quality of Service Level |
-| `clientId` | _string_ | Unique ID for the MQTT broker to identify Minio |
 | `username` | _string_ | Username to connect to the MQTT server (if required) |
 | `password` | _string_ | Password to connect to the MQTT server (if required) |
 | `queueDir` | _string_ | Persistent store for events when MQTT broker is offline |
@@ -174,7 +173,6 @@ An example configuration for MQTT is shown below:
         "broker": "tcp://localhost:1883",
         "topic": "minio",
         "qos": 1,
-        "clientId": "minio",
         "username": "",
         "password": "",
         "queueDir": ""
@@ -222,12 +220,14 @@ import paho.mqtt.client as mqtt
 
 def on_connect(client, userdata, flags, rc):
   print("Connected with result code "+str(rc))
-  client.subscribe("minio")
+  # qos level is set to 1
+  client.subscribe("minio", 1)
 
 def on_message(client, userdata, msg):
     print(msg.payload)
 
-client = mqtt.Client()
+# client_id is a randomly generated unique ID for the mqtt broker to identify the connection.
+client = mqtt.Client(client_id="myclientid",clean_session=False)
 
 client.on_connect = on_connect
 client.on_message = on_message

--- a/docs/config/config.sample.json
+++ b/docs/config/config.sample.json
@@ -82,7 +82,6 @@
 				"broker": "",
 				"topic": "",
 				"qos": 0,
-				"clientId": "",
 				"username": "",
 				"password": "",
 				"reconnectInterval": 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This issue is similar to the one related to this PR #6391
 
## Description

The client id cannot be same for two or more concurrent/active connections. It may not be user-configurable because `clientID` can be any random unique ID which minio uses to establish a connection with MQTT broker.

The client ID generation is taken care by the mqtt library. Which randomly generates it if it is set to empty.

## Motivation and Context

Anyway this will not be a problem in a single node setup since it needs only one connection at a time.
But for distributed setup, this will cause problem in establishing the connections. as there are more than one client trying to connect to the broker with the `SAME` client ID. as shown below in mqtt -verbose mode.

![image](https://user-images.githubusercontent.com/5410427/51778164-4ca70980-2126-11e9-9655-7e34b4d99dba.png)


## Regression
maybe

## How Has This Been Tested?

Start mqtt in verbose mode `mosquitto -v` and try to spawn the distributed setup with the client ID set.

<b>To test the happy flow:</b>

1 - Start activeMQ (http://activemq.apache.org/) by `./activemq start`
2 - The mqtt will be running on `tcp://localhost:1884` 
3 - Configure the mqtt config as below

```
{
				"enable": true,
				"broker": "tcp://localhost:1883",
				"topic": "miniomqtt",
				"qos": 1,
				"username": "",
				"password": "",
				"reconnectInterval": 0,
				"keepAliveInterval": 0,
				"queueDir": "/tmp/events"
}
```
4 - Open the web console for activeMQ, which will be running on `http://localhost:8161/admin` with default username, password as `admin`,`admin`
5 - Kickstart the subscriber script
```#!/usr/bin/env python3
from __future__ import print_function
import paho.mqtt.client as mqtt
#import ssl

# This is the Subscriber

def on_connect(client, userdata, flags, rc):
  print("Connected with result code "+str(rc))
  client.subscribe("miniomqtt", 1)

def on_message(client, userdata, msg):
    print(msg.payload)

client = mqtt.Client(client_id="myclientid",clean_session=False)
#client = mqtt.Client(client_id="",clean_session=True)


client.on_connect = on_connect
client.on_message = on_message


#client.tls_set("/home/praveen/.minio/certs/CAs/m2mqtt_srv.crt", tls_version=ssl.PROTOCOL_TLSv1)
#client.tls_insecure_set(True)

client.connect("localhost",1883,60)
client.loop_forever()
```
6 - configure event notifications as per `https://docs.minio.io/docs/minio-bucket-notification-guide#MQTT` and start sending events

You can see the `messages enqued` , `messages dequeued` in topics page `http://localhost:8161/admin/topics.jsp`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.