### PR TITLE
Bucket Heal: Do not add empty endpoint entry

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -133,30 +133,19 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 		DiskCount: len(storageDisks),
 	}
 	for i, before := range beforeState {
-		if storageDisks[i] == nil {
+		if storageDisks[i] != nil {
+			drive := storageDisks[i].String()
 			res.Before.Drives = append(res.Before.Drives, madmin.HealDriveInfo{
 				UUID:     "",
-				Endpoint: "",
+				Endpoint: drive,
 				State:    before,
 			})
 			res.After.Drives = append(res.After.Drives, madmin.HealDriveInfo{
 				UUID:     "",
-				Endpoint: "",
+				Endpoint: drive,
 				State:    afterState[i],
 			})
-			continue
 		}
-		drive := storageDisks[i].String()
-		res.Before.Drives = append(res.Before.Drives, madmin.HealDriveInfo{
-			UUID:     "",
-			Endpoint: drive,
-			State:    before,
-		})
-		res.After.Drives = append(res.After.Drives, madmin.HealDriveInfo{
-			UUID:     "",
-			Endpoint: drive,
-			State:    afterState[i],
-		})
 	}
 
 	reducedErr := reduceWriteQuorumErrs(ctx, dErrs, bucketOpIgnoredErrs, writeQuorum)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Currently during a heal of a bucket, if one disk is offline an empty endpoint entry is added. 
Then another entry with the missing endpoint is also added.

This results in more entries than disks being added.

Code that adds empty endpoint has been removed.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
While verifying https://github.com/minio/minio/pull/7154 on a 4 disk distributed setup, saw that 
there were 5 entries when only 4 was expected.
```
{
  "status": "success",
  "type": "bucket",
  "name": "test/",
  "before": {
    "color": "red",
    "offline": 2,
    "online": 3,
    "missing": 0,
    "corrupted": 0,
    "drives": [
      {
        "uuid": "",
        "endpoint": "",
        "state": "offline"
      },
      {
        "uuid": "",
        "endpoint": "/tmp/12",
        "state": "ok"
      },
      {
        "uuid": "",
        "endpoint": "http://127.0.0.1:9002/tmp/13",
        "state": "ok"
      },
      {
        "uuid": "",
        "endpoint": "http://127.0.0.1:9003/tmp/14",
        "state": "ok"
      },
      {
        "uuid": "",
        "endpoint": "http://127.0.0.1:9000/tmp/11",
        "state": "offline"
      }
    ]
  },
  "after": {
    "color": "red",
    "offline": 2,
    "online": 3,
    "missing": 0,
    "corrupted": 0,
    "drives": [
      {
        "uuid": "",
        "endpoint": "",
        "state": "offline"
      },
      {
        "uuid": "",
        "endpoint": "/tmp/12",
        "state": "ok"
      },
      {
        "uuid": "",
        "endpoint": "http://127.0.0.1:9002/tmp/13",
        "state": "ok"
      },
      {
        "uuid": "",
        "endpoint": "http://127.0.0.1:9003/tmp/14",
        "state": "ok"
      },
      {
        "uuid": "",
        "endpoint": "http://127.0.0.1:9000/tmp/11",
        "state": "offline"
      }
    ]
  },
  "size": 0
}
```


## Regression
No

## How Has This Been Tested?
1. Started a 4 node, 4 disk Distributed setup
2. Created a bucket
3. Then kill one node that kills one disk
4. run `mc admin heal -r --json myminio/bucket`

Without the change, you will see 5 entries and with this change you will see only 4 entries.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.