### PR TITLE
xl: ListObjectParts uses the latest valid xl meta

### DIFF
--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -505,8 +505,10 @@ func (xl xlObjects) ListObjectParts(ctx context.Context, bucket, object, uploadI
 
 	uploadIDPath := xl.getUploadIDDir(bucket, object, uploadID)
 
+	storageDisks := xl.getDisks()
+
 	// Read metadata associated with the object from all disks.
-	partsMetadata, errs := readAllXLMetadata(ctx, xl.getDisks(), minioMetaMultipartBucket, uploadIDPath)
+	partsMetadata, errs := readAllXLMetadata(ctx, storageDisks, minioMetaMultipartBucket, uploadIDPath)
 
 	// get Quorum for this object
 	_, writeQuorum, err := objectQuorumFromMeta(ctx, xl, partsMetadata, errs)
@@ -519,7 +521,7 @@ func (xl xlObjects) ListObjectParts(ctx context.Context, bucket, object, uploadI
 		return result, toObjectErr(err, minioMetaMultipartBucket, uploadIDPath)
 	}
 
-	_, modTime := listOnlineDisks(xl.getDisks(), partsMetadata, errs)
+	_, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
 	// Pick one from the first valid metadata.
 	xlValidMeta, err := pickValidXLMeta(ctx, partsMetadata, modTime, writeQuorum)

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -505,10 +505,30 @@ func (xl xlObjects) ListObjectParts(ctx context.Context, bucket, object, uploadI
 
 	uploadIDPath := xl.getUploadIDDir(bucket, object, uploadID)
 
-	xlParts, xlMeta, err := xl.readXLMetaParts(ctx, minioMetaMultipartBucket, uploadIDPath)
+	// Read metadata associated with the object from all disks.
+	partsMetadata, errs := readAllXLMetadata(ctx, xl.getDisks(), minioMetaMultipartBucket, uploadIDPath)
+
+	// get Quorum for this object
+	_, writeQuorum, err := objectQuorumFromMeta(ctx, xl, partsMetadata, errs)
 	if err != nil {
 		return result, toObjectErr(err, minioMetaMultipartBucket, uploadIDPath)
 	}
+
+	reducedErr := reduceWriteQuorumErrs(ctx, errs, objectOpIgnoredErrs, writeQuorum)
+	if reducedErr == errXLWriteQuorum {
+		return result, toObjectErr(err, minioMetaMultipartBucket, uploadIDPath)
+	}
+
+	_, modTime := listOnlineDisks(xl.getDisks(), partsMetadata, errs)
+
+	// Pick one from the first valid metadata.
+	xlValidMeta, err := pickValidXLMeta(ctx, partsMetadata, modTime, writeQuorum)
+	if err != nil {
+		return result, err
+	}
+
+	var xlMeta = xlValidMeta.Meta
+	var xlParts = xlValidMeta.Parts
 
 	// Populate the result stub.
 	result.Bucket = bucket


### PR DESCRIPTION

## Description
ListObjectParts is using xl.readXLMetaParts which picks the first
xl meta found in any disk, which is an inconsistent information.

E.g.: In a middle of a multipart upload, one node can go offline
and get back later with an outdated multipart information.

## Motivation and Context
Fix the following mc error during mirroring a large bucket

```
One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.
```

## Regression
No

## How Has This Been Tested?
- Run 4 nodes with 4 disks with a round robin load balancer.
- Create testbucket bucket
- Parallel upload of multiple encrypted objects (see code above)
- Kill one node and get it back sporadically.

```go
package main

import (
	"bytes"
	"fmt"
	"log"
	"strings"
	"sync"

	"github.com/minio/minio-go"
	"github.com/minio/minio-go/pkg/encrypt"
)

func main() {
	s3Client, err := minio.New("minio:9121", "minio", "minio123", true)
	if err != nil {
		log.Fatalln(err)
	}

	var wg sync.WaitGroup

	for i := 1; i <= 20; i++ {
		wg.Add(1)
		go func(i int) {
			defer wg.Done()
			content := bytes.Repeat([]byte("A"), 1024*1024*6)
			size := int64(len(content))

			bucketname := "testbucket"                 // Specify a bucket name - the bucket must already exist
			objectName := "testfile"                   // Specify a object name
			password := "correct horse battery staple" // Specify your password. DO NOT USE THIS ONE - USE YOUR OWN.

			// New SSE-C where the cryptographic key is derived from a password and the objectname + bucketname as salt
			encryption := encrypt.DefaultPBKDF([]byte(password), []byte(bucketname+objectName))

			index := fmt.Sprintf("%v", i)
			objName := fmt.Sprintf("%s-%v", objectName, index)

			for {
				// Encrypt file content and upload to the server
				_, err := s3Client.PutObject(bucketname, objName, bytes.NewReader(content), size, minio.PutObjectOptions{ServerSideEncryption: encryption})
				if err != nil {
					if !strings.Contains(err.Error(), "internal error") &&
						!strings.Contains(err.Error(), "Server not initialized") &&
						!strings.Contains(err.Error(), "Bad Gateway") {
						log.Fatalf(err.Error())
					}
				}
			}
		}(i)
	}

	wg.Wait()
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.