### PR TITLE
Simplify putObject by not breaking the stream into parts

### DIFF
--- a/cmd/xl-v1-healing-common_test.go
+++ b/cmd/xl-v1-healing-common_test.go
@@ -311,9 +311,9 @@ func TestDisksWithAllParts(t *testing.T) {
 
 	diskFailures := make(map[int]string)
 	// key = disk index, value = part name with hash mismatch
-	diskFailures[0] = "part.3"
+	diskFailures[0] = "part.1"
 	diskFailures[3] = "part.1"
-	diskFailures[15] = "part.2"
+	diskFailures[15] = "part.1"
 
 	for diskIndex, partName := range diskFailures {
 		for _, info := range partsMetadata[diskIndex].Erasure.Checksums {
@@ -354,5 +354,4 @@ func TestDisksWithAllParts(t *testing.T) {
 
 		}
 	}
-
 }


### PR DESCRIPTION
Needs careful review (for encryption and compression's special needs on sizes)

## Description
<!--- Describe your changes in detail -->

We broke into parts previously as we had checksum for the entire file
to tax less on memory and to have better TTFB. We dont need to now
after the streaming-bitrot change.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Code simplification

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By creating the objects and making sure that the backend format for the object is as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.