### PR TITLE
Fix default quoteEscapeCharacter

### DIFF
--- a/pkg/s3select/csv/args.go
+++ b/pkg/s3select/csv/args.go
@@ -30,7 +30,7 @@ const (
 	defaultRecordDelimiter      = "\n"
 	defaultFieldDelimiter       = ","
 	defaultQuoteCharacter       = `"`
-	defaultQuoteEscapeCharacter = `"`
+	defaultQuoteEscapeCharacter = `\\`
 	defaultCommentCharacter     = "#"
 
 	always   = "always"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix default quoteEscapeCharacter
<!--- Describe your changes in detail -->

## Motivation and Context
QuoteEscapeCharacter is `\\` not `"` 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes perhaps during select refactoring.
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using spark-select project https://github.com/minio/spark-select/blob/master/examples/csv.scala
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.