### PR TITLE
remove unnecessary buffer while discarding stream

### DIFF
--- a/cmd/http/close.go
+++ b/cmd/http/close.go
@@ -44,9 +44,7 @@ func DrainBody(respBody io.ReadCloser) {
 		// Without this closing connection would disallow re-using
 		// the same connection for future uses.
 		//  - http://stackoverflow.com/a/17961593/4465767
-		bufp := b512pool.Get().(*[]byte)
-		defer b512pool.Put(bufp)
-		io.CopyBuffer(ioutil.Discard, respBody, *bufp)
-		respBody.Close()
+		defer respBody.Close()
+		io.Copy(ioutil.Discard, respBody)
 	}
 }


### PR DESCRIPTION
Makes no sense to use a buffer while draining http body. We are choking a fast operation by putting a buffer in between. `ioutil.Discard` is not going to push back on the reader, if anything, it'll be the buffer that pushes back.