### PR TITLE
storage: Increase the timeout of storage REST requests

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -31,6 +31,12 @@ import (
 // DefaultSkewTime - skew time is 15 minutes between minio peers.
 const DefaultSkewTime = 15 * time.Minute
 
+// defaultRPCTimeout - default RPC timeout is one minute.
+const defaultRPCTimeout = 5 * time.Minute
+
+// defaultRPCRetryTime - default RPC time to wait before retry after a network error
+const defaultRPCRetryTime = 1 * time.Minute
+
 var errRPCRetry = fmt.Errorf("rpc: retry error")
 
 func isNetError(err error) bool {
@@ -217,7 +223,7 @@ func (client *RPCClient) Call(serviceMethod string, args interface {
 		}
 
 		if isNetError(err) {
-			client.setRetryTicker(time.NewTicker(xrpc.DefaultRPCTimeout))
+			client.setRetryTicker(time.NewTicker(defaultRPCRetryTime))
 		} else {
 			client.setRetryTicker(nil)
 		}
@@ -265,6 +271,6 @@ func NewRPCClient(args RPCClientArgs) (*RPCClient, error) {
 	return &RPCClient{
 		args:      args,
 		authToken: args.NewAuthTokenFunc(),
-		rpcClient: xrpc.NewClient(args.ServiceURL, args.TLSConfig, xrpc.DefaultRPCTimeout),
+		rpcClient: xrpc.NewClient(args.ServiceURL, args.TLSConfig, defaultRPCTimeout),
 	}, nil
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"time"
 
 	"encoding/gob"
 	"encoding/hex"
@@ -37,6 +38,10 @@ import (
 	"github.com/minio/minio/cmd/rest"
 	xnet "github.com/minio/minio/pkg/net"
 )
+
+// The timeout of TCP connect and sending/receiving
+// data for all internode storage REST requests.
+const storageRESTTimeout = 5 * time.Minute
 
 func isNetworkDisconnectError(err error) bool {
 	if err == nil {
@@ -376,6 +381,6 @@ func newStorageRESTClient(endpoint Endpoint) *storageRESTClient {
 		}
 	}
 
-	restClient := rest.NewClient(serverURL, tlsConfig, rest.DefaultRESTTimeout, newAuthToken)
+	restClient := rest.NewClient(serverURL, tlsConfig, storageRESTTimeout, newAuthToken)
 	return &storageRESTClient{endpoint: endpoint, restClient: restClient, connected: true}
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit increases storage REST requests to 5 minutes, this includes
the opening TCP connection, and sending/receiving data. This will reduce
clients receiving errors when the server is under high load.


## Motivation and Context
Reduce the likewise of S3 clients having errors when the server is a bit of high load.

## Regression
No

## How Has This Been Tested?
1. Start a Minio cluster of 12 nodes
2. Run this following script

```
package main

import (
	"bytes"
	"fmt"
	"log"
	"math"
	"sync"
	"time"

	"github.com/minio/minio-go"
	"github.com/minio/minio-go/pkg/encrypt"
)

func main() {

	const parallelWorkers = 32
	const hostName = "minio"

	var wg sync.WaitGroup
	var totalTransfer int64

	objectContent := bytes.Repeat(bytes.Repeat([]byte("A"), int(math.Pow(2, 19))), 1)
	objectSize := int64(len(objectContent))


	for i := 1; i <= parallelWorkers; i++ {
		wg.Add(1)
		go func(i int) {
			defer wg.Done()

			hostAddr := fmt.Sprintf("%s:%d", hostName, 9001+i%12)

			s3Client, err := minio.New(hostAddr, "minio", "minio123", true)
			if err != nil {
				log.Fatalln(err)
			}

			bucketName := "testbucket"
			objectName := fmt.Sprintf("my-object-%d", i)

			password := "correct horse battery staple"
			encryption := encrypt.DefaultPBKDF([]byte(password),
				[]byte(bucketName+objectName))

			for {
				startTime := time.Now()
				_, err := s3Client.PutObject(bucketName,
					objectName,
					bytes.NewReader(objectContent),
					objectSize,
					minio.PutObjectOptions{
						ServerSideEncryption: encryption,
					},
				)
				if err != nil {
					log.Fatalln(err)
				} else {
					totalTransfer += objectSize
				}
				elapsed := time.Since(startTime)
				if elapsed > 3*time.Second {
					log.Println(elapsed)
				}
			}
		}(i)
	}

	wg.Wait()
}
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.