### PR TITLE
Select should return early errors as XML

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -161,8 +161,16 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 	s3Select, err := s3select.NewS3Select(r.Body)
 	if err != nil {
 		if serr, ok := err.(s3select.SelectError); ok {
-			w.WriteHeader(serr.HTTPStatusCode())
-			w.Write(s3select.NewErrorMessage(serr.ErrorCode(), serr.ErrorMessage()))
+			encodedErrorResponse := encodeResponse(APIErrorResponse{
+				Code:       serr.ErrorCode(),
+				Message:    serr.ErrorMessage(),
+				BucketName: bucket,
+				Key:        object,
+				Resource:   r.URL.Path,
+				RequestID:  w.Header().Get(responseRequestIDKey),
+				HostID:     w.Header().Get(responseDeploymentIDKey),
+			})
+			writeResponse(w, serr.HTTPStatusCode(), encodedErrorResponse, mimeXML)
 		} else {
 			writeErrorResponse(w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		}
@@ -195,8 +203,16 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 
 	if err = s3Select.Open(getObject); err != nil {
 		if serr, ok := err.(s3select.SelectError); ok {
-			w.WriteHeader(serr.HTTPStatusCode())
-			w.Write(s3select.NewErrorMessage(serr.ErrorCode(), serr.ErrorMessage()))
+			encodedErrorResponse := encodeResponse(APIErrorResponse{
+				Code:       serr.ErrorCode(),
+				Message:    serr.ErrorMessage(),
+				BucketName: bucket,
+				Key:        object,
+				Resource:   r.URL.Path,
+				RequestID:  w.Header().Get(responseRequestIDKey),
+				HostID:     w.Header().Get(responseDeploymentIDKey),
+			})
+			writeResponse(w, serr.HTTPStatusCode(), encodedErrorResponse, mimeXML)
 		} else {
 			writeErrorResponse(w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Select should return early errors as XML
<!--- Describe your changes in detail -->

## Motivation and Context
Currently, we were sending errors in Select binary API format, 
which is incompatible with S3 behavior, errors in binary are 
sent after HTTP status code is already 200 OK - i.e it happens 
during the evaluation in the middle.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes but this has happened with quite a few refactors
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using `mc` and aws client SDKs
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.