### PR TITLE
COUNT() function in select should return an int

### DIFF
--- a/pkg/s3select/sql/aggregation.go
+++ b/pkg/s3select/sql/aggregation.go
@@ -277,7 +277,7 @@ func (e *FuncExpr) aggregateRow(r Record) error {
 func (e *FuncExpr) getAggregate() (*Value, error) {
 	switch e.getFunctionName() {
 	case aggFnCount:
-		return FromFloat(float64(e.aggregate.runningCount)), nil
+		return FromInt(e.aggregate.runningCount), nil
 
 	case aggFnAvg:
 		if e.aggregate.runningCount == 0 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
S3Select's COUNT aggregation function should return an int.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently COUNT() returns its result as a float. This results in output like:

```
mc sql --query "select count(*) from s3object " myminio/sqlselectapi/big.csv.gz 
1e+06
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually. This now returns:

```
mc sql --query "select count(*) from s3object " myminio/sqlselectapi/big.csv.gz 
1000000
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
