### PR TITLE
Fix mac build failure for healthcheck binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ coverage: build
 build: checks
 	@echo "Building minio binary to './minio'"
 	@GOFLAGS="" CGO_ENABLED=0 go build -tags kqueue --ldflags $(BUILD_LDFLAGS) -o $(PWD)/minio
-	@GOFLAGS="" CGO_ENABLED=0 go build --ldflags="-s -w" -o $(PWD)/dockerscripts/healthcheck $(PWD)/dockerscripts/healthcheck.go
+	@GOFLAGS="" CGO_ENABLED=0 go build -tags kqueue --ldflags="-s -w" -o $(PWD)/dockerscripts/healthcheck $(PWD)/dockerscripts/healthcheck.go
 
 docker: build
 	@docker build -t $(TAG) . -f Dockerfile.dev


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix mac build failure for healthcheck binary
<!--- Describe your changes in detail -->

## Motivation and Context
Mac build failure
```
$ go version
go version go1.11.5 darwin/amd64
$ make build
Checking dependencies
Checking for project in GOPATH
Building minio binary to './minio'
# github.com/minio/minio/vendor/github.com/rjeczalik/notify
vendor/github.com/rjeczalik/notify/watcher_fsevents.go:49:11: undefined: stream
make: *** [build] Error 2
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes in 1e82c4a7c4cae2771955f0e9b9dde5b5f1329da9

<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using a mac system
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.