### PR TITLE
Improve ListObjects performance by listing in parallel

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1693,7 +1693,7 @@ func (s *TestSuiteCommon) TestListObjectsHandler(c *check) {
 		{getListObjectsV2URL(s.endPoint, bucketName, "", "1000", "", "url"), []string{"<Key>foo+bar+1</Key>", "<Key>foo+bar+2</Key>"}},
 	}
 
-	for i, testCase := range testCases {
+	for _, testCase := range testCases {
 		// create listObjectsV1 request with valid parameters
 		request, err = newTestSignedRequest("GET", testCase.getURL, 0, nil, s.accessKey, s.secretKey, s.signer)
 		c.Assert(err, nil)
@@ -1706,7 +1706,6 @@ func (s *TestSuiteCommon) TestListObjectsHandler(c *check) {
 		getContent, err := ioutil.ReadAll(response.Body)
 		c.Assert(err, nil)
 
-		fmt.Printf("Test %d: %+v vs %+v\n", i+1, string(getContent), testCase.expectedStrings)
 		for _, expectedStr := range testCase.expectedStrings {
 			c.Assert(strings.Contains(string(getContent), expectedStr), true)
 		}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Improve ListObjects performance by listing per set
<!--- Describe your changes in detail -->

## Motivation and Context
The side effect of this change is the
memory increase, but this is a trade-off
between performance and actual memory usage.

For all practical scenarios, this should be
an adequate change.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Requires a good amount of local setup with lots of files. Will post the results soon.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.