### PR TITLE
Fix healthcheck script to wait for netstat command output

### DIFF
--- a/dockerscripts/healthcheck.go
+++ b/dockerscripts/healthcheck.go
@@ -83,6 +83,11 @@ func findEndpoint() string {
 			if strings.Count(addr, ":") > 0 {
 				addr = strings.Join([]string{"[", addr, "]"}, "")
 			}
+			// wait for cmd to complete before return
+			if err = cmd.Wait(); err != nil {
+				// command failed to run
+				log.Fatal(err.Error())
+			}
 			// return joint address and port
 			return strings.Join([]string{addr, port}, ":")
 		}


### PR DESCRIPTION
## Description
This commit fixes the issue with Docker healthcheck script, where the script
did not wait for command (`netstat`) output before exiting.

## Motivation and Context
Fixes #7272

## Regression
Yes, caused by #7105 

## How Has This Been Tested?
- Build Docker image using `TAG=custom-minio make docker`
- Use doc [here](https://github.com/minio/minio/tree/master/docs/orchestration/docker-compose) to create a compose setup (don't forget to change the image tag to `custom-minio`)
- Docker exec into one of the containers and observe for any zombie netstat processes. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.