### PR TITLE
Allow lazyQuotes for certain types of CSV

### DIFF
--- a/pkg/s3select/csv/reader.go
+++ b/pkg/s3select/csv/reader.go
@@ -138,6 +138,12 @@ func NewReader(readCloser io.ReadCloser, args *ReaderArgs) (*Reader, error) {
 	csvReader.Comma = []rune(args.FieldDelimiter)[0]
 	csvReader.Comment = []rune(args.CommentCharacter)[0]
 	csvReader.FieldsPerRecord = -1
+	// If LazyQuotes is true, a quote may appear in an unquoted field and a
+	// non-doubled quote may appear in a quoted field.
+	csvReader.LazyQuotes = true
+	// If TrimLeadingSpace is true, leading white space in a field is ignored.
+	// This is done even if the field delimiter, Comma, is white space.
+	csvReader.TrimLeadingSpace = true
 
 	r := &Reader{
 		args:       args,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow lazyQuotes for certain types of CSV
<!--- Describe your changes in detail -->

## Motivation and Context
Set lazyQuotes is true, a quote may appear in an
unquote field and a non-doubled quote may appear
in a quoted field.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using an unusual CSV type pick the 

```
~ mc ls s3/sqlselectapi/USvideos.csv
[2019-02-22 12:15:55 PST]  60MiB USvideos.csv
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.