### PR TITLE
s3: Encode StartAfter when encoding type is passed

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -414,7 +414,7 @@ func generateListObjectsV2Response(bucket, prefix, token, nextToken, startAfter,
 	data.Contents = contents
 
 	data.EncodingType = encodingType
-	data.StartAfter = startAfter
+	data.StartAfter = s3EncodeName(startAfter, encodingType)
 	data.Delimiter = s3EncodeName(delimiter, encodingType)
 	data.Prefix = s3EncodeName(prefix, encodingType)
 	data.MaxKeys = maxKeys


### PR DESCRIPTION
## Description
In ObjectList V2, StartAfter needs to be encoded when encoding-type
is specified.

## Motivation and Context
Fix issue after second s3 specification review

## Regression
No

## How Has This Been Tested?
Check `aws s3api list-objects-v2 --encoding-type url --start-after "something"` output between Minio & AWS server 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.