### PR TITLE
[WIP] Set permissions to support running on OpenShift

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,10 @@ FROM alpine:3.7
 
 LABEL maintainer="Minio Inc <dev@minio.io>"
 
+RUN \
+     addgroup -S minio && \
+     adduser -S -u 1001 -G minio minio
+
 COPY dockerscripts/docker-entrypoint.sh dockerscripts/healthcheck /usr/bin/
 COPY minio /usr/bin/
 
@@ -14,7 +18,11 @@ RUN \
      echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
      chmod +x /usr/bin/minio  && \
      chmod +x /usr/bin/docker-entrypoint.sh && \
-     chmod +x /usr/bin/healthcheck
+     chmod +x /usr/bin/healthcheck && \
+     chown -R minio:0 /root && \
+     chmod -R g=u /root
+
+USER minio
 
 EXPOSE 9000
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -15,6 +15,10 @@ FROM alpine:3.7
 
 LABEL maintainer="Minio Inc <dev@minio.io>"
 
+RUN \
+     addgroup -S minio && \
+     adduser -S -u 1001 -G minio minio
+
 COPY --from=0 /usr/bin/healthcheck /usr/bin/healthcheck
 COPY dockerscripts/docker-entrypoint.sh /usr/bin/
 
@@ -28,7 +32,11 @@ RUN \
      curl https://dl.minio.io/server/minio/release/linux-amd64/minio > /usr/bin/minio && \
      chmod +x /usr/bin/minio  && \
      chmod +x /usr/bin/docker-entrypoint.sh && \
-     chmod +x /usr/bin/healthcheck
+     chmod +x /usr/bin/healthcheck && \
+     chown -R minio:0 /root && \
+     chmod -R g=u /root
+
+USER minio
 
 EXPOSE 9000
 


### PR DESCRIPTION
## Description
When running containers on Redhat's OpenShift platform containers are run with an arbitrarily assigned user ID.  

## Motivation and Context
By default all user's are part of the root group.  By changing the group owner in the container to ID 0, whichever user ID is generated to run the container has access to config file in /root.

## Regression

## How Has This Been Tested?
Using the following software
minishift v1.31.0+cfc599c
oc v3.11.69
kubernetes v1.11.0+d4cacc0
helm chart version 2.4.5

Installed minio on openshift using minishift as a single instance deployment and 4 instance replicaset using the latest helm chart within our stack.  All services were able to connect to the minio api.  Was able to browse to the minio dashboard to verify, and add objects. 

Upgraded an existing install of minio RELEASE.2018-04-27T23-33-52Z in an existing kubernetes 1.8.3 stack with no issues.  

Clean installed using helm into kubernetes 1.8.3 and 1.11.0 environments, with no issues storing and retrieving objects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.