### PR TITLE
Replace snappy.Writer/io.Pipe with snappyCompressReader.

### DIFF
--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -17,10 +17,14 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/golang/snappy"
 )
 
 // Tests validate bucket name.
@@ -542,5 +546,60 @@ func TestGetCompressedOffsets(t *testing.T) {
 			t.Errorf("Test %d - expected snappyOffset %d but received %d",
 				i+1, test.snappyStartOffset, snappyStartOffset)
 		}
+	}
+}
+
+func TestSnappyCompressReader(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: nil},
+		{name: "small", data: []byte("hello, world")},
+		{name: "large", data: bytes.Repeat([]byte("hello, world"), 1000)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := make([]byte, 100) // make small buffer to ensure multiple reads are required for large case
+
+			r := newSnappyCompressReader(bytes.NewReader(tt.data))
+
+			var rdrBuf bytes.Buffer
+			_, err := io.CopyBuffer(&rdrBuf, r, buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var stdBuf bytes.Buffer
+			w := snappy.NewBufferedWriter(&stdBuf)
+			_, err = io.CopyBuffer(w, bytes.NewReader(tt.data), buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = w.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var (
+				got  = rdrBuf.Bytes()
+				want = stdBuf.Bytes()
+			)
+			if !bytes.Equal(got, want) {
+				t.Errorf("encoded data does not match\n\t%q\n\t%q", got, want)
+			}
+
+			var decBuf bytes.Buffer
+			decRdr := snappy.NewReader(&rdrBuf)
+			_, err = io.Copy(&decBuf, decRdr)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(tt.data, decBuf.Bytes()) {
+				t.Errorf("roundtrip failed\n\t%q\n\t%q", tt.data, decBuf.Bytes())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Prevents deferred close functions from being called while still attempting to copy reader to `snappy.Writer`.

## Motivation and Context

I'm working on a fork with support for [SQLite as an `ObjectLayer`](https://github.com/vcabbage/minio/tree/sqlite) (which I'm interested in discussing upstreaming once it's more complete). While working on this I found that it was possible for `cleanUpFns` of a `GetObjectReader` to be called while the original reader is still being copied to the `snappy.Writer` when compression is enabled and the reader isn't read completely. This can potentially cause a data race, depending on the reader/`cleanUpFns` implementation.

This PR introduces a `snappyCompressReader` which adapts the `snappy.Writer` into an `io.Reader`, allowing the compression to happen synchronously instead of in a separate goroutine. This avoids the described problem and reduces some code duplication.

## Regression

No

## How Has This Been Tested?

Added `TestSnappyCompressReader` to ensure the encoding is identical to a plain `snappy.Writer`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.