### PR TITLE
Use jstream to serialize records to JSON format in S3Select

### DIFF
--- a/pkg/s3select/csv/record.go
+++ b/pkg/s3select/csv/record.go
@@ -19,10 +19,11 @@ package csv
 import (
 	"bytes"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 
+	"github.com/bcicen/jstream"
 	"github.com/minio/minio/pkg/s3select/sql"
-	"github.com/tidwall/sjson"
 )
 
 // Record - is CSV record.
@@ -78,20 +79,11 @@ func (r *Record) MarshalCSV(fieldDelimiter rune) ([]byte, error) {
 
 // MarshalJSON - encodes to JSON data.
 func (r *Record) MarshalJSON() ([]byte, error) {
-	data := "{}"
-
-	var err error
-	for i := len(r.columnNames) - 1; i >= 0; i-- {
-		if i >= len(r.csvRecord) {
-			continue
-		}
-
-		if data, err = sjson.Set(data, r.columnNames[i], r.csvRecord[i]); err != nil {
-			return nil, err
-		}
+	var kvs jstream.KVS = make([]jstream.KV, len(r.columnNames))
+	for i := 0; i < len(r.columnNames); i++ {
+		kvs[i] = jstream.KV{Key: r.columnNames[i], Value: r.csvRecord[i]}
 	}
-
-	return []byte(data), nil
+	return json.Marshal(kvs)
 }
 
 // NewRecord - creates new CSV record.

--- a/pkg/s3select/json/reader.go
+++ b/pkg/s3select/json/reader.go
@@ -23,7 +23,6 @@ import (
 	"github.com/minio/minio/pkg/s3select/sql"
 
 	"github.com/bcicen/jstream"
-	"github.com/tidwall/sjson"
 )
 
 // Reader - JSON record reader for S3Select.
@@ -50,17 +49,18 @@ func (r *Reader) Read() (sql.Record, error) {
 	if v.ValueType == jstream.Object {
 		data, err = json.Marshal(v.Value)
 	} else {
-		// To be AWS S3 compatible
-		// Select for JSON needs to output non-object JSON as single column value
-		// i.e. a map with `_1` as key and value as the non-object.
-		data, err = sjson.SetBytes(data, "_1", v.Value)
+		// To be AWS S3 compatible Select for JSON needs to
+		// output non-object JSON as single column value
+		// i.e. a map with `_1` as key and value as the
+		// non-object.
+		data, err = json.Marshal(jstream.KVS{jstream.KV{Key: "_1", Value: v.Value}})
 	}
 	if err != nil {
 		return nil, errJSONParsingError(err)
 	}
 
 	return &Record{
-		data: data,
+		Data: data,
 	}, nil
 }
 


### PR DESCRIPTION
- Also, switch to jstream to generate internal record representation
  from CSV/JSON readers

- This fixes a bug in which JSON output objects have their keys
  reversed from the order they are specified in the Select columns.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In S3Select the ordering of keys in JSON object output is significant. The sjson library reverses the order of keys from their insertion order and leads to wrong results. This PR switches over to jstream with which the insertion order is preserved.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

WIth query like:

`mc sql -e "select s.Id, s.color from s3object s" myminio/sqlselectapi/1.json`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.