### PR TITLE
Close GlobalServiceDoneCh when quitting

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -39,7 +39,7 @@ var GlobalServiceDoneCh chan struct{}
 
 // Initialize service mutex once.
 func init() {
-	GlobalServiceDoneCh = make(chan struct{}, 1)
+	GlobalServiceDoneCh = make(chan struct{})
 	globalServiceSignalCh = make(chan serviceSignal)
 }
 

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -52,6 +52,9 @@ func handleSignals() {
 		err = globalHTTPServer.Shutdown()
 		logger.LogIf(context.Background(), err)
 
+		// send signal to various go-routines that they need to quit.
+		close(GlobalServiceDoneCh)
+
 		if objAPI := newObjectLayerFn(); objAPI != nil {
 			oerr = objAPI.Shutdown(context.Background())
 			logger.LogIf(context.Background(), oerr)

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -407,6 +407,11 @@ func resetGlobalConfigPath() {
 	globalConfigDir = &ConfigDir{path: ""}
 }
 
+func resetGlobalServiceDoneCh() {
+	close(GlobalServiceDoneCh)
+	GlobalServiceDoneCh = make(chan struct{})
+}
+
 // sets globalObjectAPI to `nil`.
 func resetGlobalObjectAPI() {
 	globalObjLayerMutex.Lock()
@@ -479,6 +484,9 @@ func resetGlobalIAMSys() {
 // Resets all the globals used modified in tests.
 // Resetting ensures that the changes made to globals by one test doesn't affect others.
 func resetTestGlobals() {
+	// close any indefinitely running go-routines from previous
+	// tests.
+	resetGlobalServiceDoneCh()
 	// set globalObjectAPI to `nil`.
 	resetGlobalObjectAPI()
 	// Reset config path set.


### PR DESCRIPTION
This change allows indefinitely running go-routines to cleanup
gracefully.

This channel is now closed at the beginning of each test so that
long-running go-routines quit and a new one is assigned.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The change motivated due to weird test failures that happen because of interaction between long running go-routines started repeatedly in tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
