### PR TITLE
Skip non-bucket dns entry in federated bucket list

### DIFF
--- a/pkg/dns/etcd_dns.go
+++ b/pkg/dns/etcd_dns.go
@@ -101,6 +101,15 @@ func (c *coreDNS) list(key string) ([]SrvRecord, error) {
 		}
 		srvRecord.Key = strings.TrimPrefix(string(n.Key), key)
 		srvRecord.Key = strings.TrimSuffix(srvRecord.Key, srvRecord.Host)
+
+		// Skip non-bucket entry like for a key
+		// /skydns/net/miniocloud/10.0.0.1 that may exist as
+		// dns entry for the server (rather than the bucket
+		// itself).
+		if srvRecord.Key == "" {
+			continue
+		}
+
 		// SRV records are stored in the following form
 		// /skydns/net/miniocloud/bucket1, so this function serves multiple
 		// purposes basically when we do a Get(bucketName) this function


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In a federated setup, if there exists a DNS entry for the minio server in etcd, we need to skip it - otherwise a bucket with an empty name is returned in list buckets.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Did not test yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) - for a special setup.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
