### PR TITLE
Distributed: Allow healing if all disks are on root partitions

### DIFF
--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -1010,9 +1010,6 @@ func (s *xlSets) ReloadFormat(ctx context.Context, dryRun bool) (err error) {
 // If it is a single node XL and all disks are root disks, it is most likely a test setup, else it is a production setup.
 // On a test setup we allow creation of format.json on root disks to help with dev/testing.
 func isTestSetup(infos []DiskInfo, errs []error) bool {
-	if globalIsDistXL {
-		return false
-	}
 	rootDiskCount := 0
 	for i := range errs {
 		if errs[i] != nil {


### PR DESCRIPTION
## Description
If all the disks are root devices in distributed mode, consider it
to be a test setup and allow healing to proceed.


## Motivation and Context
Issue #7346 

## Regression
Not Really. This is more like an enhancement to #7170

## How Has This Been Tested?
Using this docker compose file to reproduce the issue
```
version: '3'
services:
  minio1:
    image: minio/minio:RELEASE.2019-03-06T22-47-10Z
    ports:
      - "9001:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/lb{1...1}
  minio2:
    image: minio/minio:RELEASE.2019-03-06T22-47-10Z
    ports:
      - "9002:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/lb{1...1}
  minio3:
    image: minio/minio:RELEASE.2019-03-06T22-47-10Z
    ports:
      - "9003:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/lb{1...1}
  minio4:
    image: minio/minio:RELEASE.2019-03-06T22-47-10Z
    ports:
      - "9004:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/lb{1...1}
  ## By default this config uses default local driver,
  ## For custom volumes replace with volume driver configuration.
``` 
```
docker-compose -f compose_file_path up
```
Then use `mc` to connect to one of the nodes and issue the following command
```
mc admin heal -r myminio1
```
This will show that format.json is offline on all disks and show the object as Grey.

If you change the `docker-compose` file and to use the `minio` docker image built with this change and follow the steps again, `format.json` file will show as `Green` and there will not be any Grey objects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.