### PR TITLE
Avoid network transfer for bitrot verification during healing

### DIFF
--- a/cmd/bitrot-streaming.go
+++ b/cmd/bitrot-streaming.go
@@ -131,7 +131,7 @@ func (b *streamingBitrotReader) ReadAt(buf []byte, offset int64) (int, error) {
 	b.h.Write(buf)
 
 	if !bytes.Equal(b.h.Sum(nil), b.hashBytes) {
-		err = hashMismatchError{hex.EncodeToString(b.hashBytes), hex.EncodeToString(b.h.Sum(nil))}
+		err = HashMismatchError{hex.EncodeToString(b.hashBytes), hex.EncodeToString(b.h.Sum(nil))}
 		logger.LogIf(context.Background(), err)
 		return 0, err
 	}

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -195,3 +195,10 @@ func (d *naughtyDisk) ReadAll(volume string, path string) (buf []byte, err error
 	}
 	return d.disk.ReadAll(volume, path)
 }
+
+func (d *naughtyDisk) VerifyFile(volume, path string, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
+	if err := d.calcError(); err != nil {
+		return err
+	}
+	return d.disk.VerifyFile(volume, path, algo, sum, shardSize)
+}

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -958,7 +958,7 @@ func (s *posix) ReadFile(volume, path string, offset int64, buffer []byte, verif
 	}
 
 	if !bytes.Equal(h.Sum(nil), verifier.sum) {
-		return 0, hashMismatchError{hex.EncodeToString(verifier.sum), hex.EncodeToString(h.Sum(nil))}
+		return 0, HashMismatchError{hex.EncodeToString(verifier.sum), hex.EncodeToString(h.Sum(nil))}
 	}
 
 	return int64(len(buffer)), nil
@@ -1589,7 +1589,7 @@ func (s *posix) VerifyFile(volume, path string, algo BitrotAlgorithm, sum []byte
 			return err
 		}
 		if !bytes.Equal(h.Sum(nil), sum) {
-			return hashMismatchError{hex.EncodeToString(sum), hex.EncodeToString(h.Sum(nil))}
+			return HashMismatchError{hex.EncodeToString(sum), hex.EncodeToString(h.Sum(nil))}
 		}
 		return nil
 	}
@@ -1622,7 +1622,7 @@ func (s *posix) VerifyFile(volume, path string, algo BitrotAlgorithm, sum []byte
 		size -= int64(n)
 		h.Write(buf)
 		if !bytes.Equal(h.Sum(nil), hashBuf) {
-			return hashMismatchError{hex.EncodeToString(hashBuf), hex.EncodeToString(h.Sum(nil))}
+			return HashMismatchError{hex.EncodeToString(hashBuf), hex.EncodeToString(h.Sum(nil))}
 		}
 	}
 }

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -1251,13 +1251,13 @@ var posixReadFileWithVerifyTests = []struct {
 	{file: "myobject", offset: 25, length: 74, algorithm: SHA256, expError: nil},                     // 1
 	{file: "myobject", offset: 29, length: 70, algorithm: SHA256, expError: nil},                     // 2
 	{file: "myobject", offset: 100, length: 0, algorithm: SHA256, expError: nil},                     // 3
-	{file: "myobject", offset: 1, length: 120, algorithm: SHA256, expError: hashMismatchError{}},     // 4
+	{file: "myobject", offset: 1, length: 120, algorithm: SHA256, expError: HashMismatchError{}},     // 4
 	{file: "myobject", offset: 3, length: 1100, algorithm: SHA256, expError: nil},                    // 5
-	{file: "myobject", offset: 2, length: 100, algorithm: SHA256, expError: hashMismatchError{}},     // 6
+	{file: "myobject", offset: 2, length: 100, algorithm: SHA256, expError: HashMismatchError{}},     // 6
 	{file: "myobject", offset: 1000, length: 1001, algorithm: SHA256, expError: nil},                 // 7
-	{file: "myobject", offset: 0, length: 100, algorithm: BLAKE2b512, expError: hashMismatchError{}}, // 8
+	{file: "myobject", offset: 0, length: 100, algorithm: BLAKE2b512, expError: HashMismatchError{}}, // 8
 	{file: "myobject", offset: 25, length: 74, algorithm: BLAKE2b512, expError: nil},                 // 9
-	{file: "myobject", offset: 29, length: 70, algorithm: BLAKE2b512, expError: hashMismatchError{}}, // 10
+	{file: "myobject", offset: 29, length: 70, algorithm: BLAKE2b512, expError: HashMismatchError{}}, // 10
 	{file: "myobject", offset: 100, length: 0, algorithm: BLAKE2b512, expError: nil},                 // 11
 	{file: "myobject", offset: 1, length: 120, algorithm: BLAKE2b512, expError: nil},                 // 12
 	{file: "myobject", offset: 3, length: 1100, algorithm: BLAKE2b512, expError: nil},                // 13
@@ -1296,7 +1296,7 @@ func TestPosixReadFileWithVerify(t *testing.T) {
 		if test.expError != nil {
 			expected := h.Sum(nil)
 			h.Write([]byte{0})
-			test.expError = hashMismatchError{hex.EncodeToString(h.Sum(nil)), hex.EncodeToString(expected)}
+			test.expError = HashMismatchError{hex.EncodeToString(h.Sum(nil)), hex.EncodeToString(expected)}
 		}
 
 		buffer := make([]byte, test.length)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"net/http"
@@ -36,6 +37,7 @@ import (
 func init() {
 	logger.Init(GOPATH, GOROOT)
 	logger.RegisterUIError(fmtError)
+	gob.Register(HashMismatchError{})
 }
 
 // ServerFlags - server command specific flags

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -91,18 +91,17 @@ var errLessData = errors.New("less data available than what was requested")
 // errMoreData = returned when more data was sent by the caller than what it was supposed to.
 var errMoreData = errors.New("more data was sent than what was advertised")
 
-// hashMisMatchError - represents a bit-rot hash verification failure
-// error.
-type hashMismatchError struct {
-	expected string
-	computed string
+// HashMismatchError represents a bit-rot hash verification failure error.
+type HashMismatchError struct {
+	Expected string
+	Computed string
 }
 
-// error method for the hashMismatchError
-func (h hashMismatchError) Error() string {
+// Error method for the hashMismatchError
+func (h HashMismatchError) Error() string {
 	return fmt.Sprintf(
 		"Bitrot verification mismatch - expected %v, received %v",
-		h.expected, h.computed)
+		h.Expected, h.Computed)
 }
 
 // Collection of basic errors.

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -52,6 +52,7 @@ type StorageAPI interface {
 	StatFile(volume string, path string) (file FileInfo, err error)
 	DeleteFile(volume string, path string) (err error)
 	DeleteFileBulk(volume string, paths []string) (errs []error, err error)
+	VerifyFile(volume, path string, algo BitrotAlgorithm, sum []byte, shardSize int64) error
 
 	// Write all data, syncs the data to disk.
 	WriteAll(volume string, path string, reader io.Reader) (err error)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -106,7 +106,7 @@ func toStorageErr(err error) error {
 		fmt.Sscanf(err.Error(), "Bitrot verification mismatch - expected %s received %s", &expected, &received)
 		// Go's Sscanf %s scans "," that comes after the expected hash, hence remove it. Providing "," in the format string does not help.
 		expected = strings.TrimSuffix(expected, ",")
-		bitrotErr := hashMismatchError{expected, received}
+		bitrotErr := HashMismatchError{expected, received}
 		return bitrotErr
 	}
 	return err

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -16,7 +16,7 @@
 
 package cmd
 
-const storageRESTVersion = "v6"
+const storageRESTVersion = "v7"
 const storageRESTPath = minioReservedBucketPath + "/storage/" + storageRESTVersion + "/"
 
 const (
@@ -38,6 +38,7 @@ const (
 	storageRESTMethodDeleteFile     = "deletefile"
 	storageRESTMethodDeleteFileBulk = "deletefilebulk"
 	storageRESTMethodRenameFile     = "renamefile"
+	storageRESTMethodVerifyFile     = "verifyfile"
 	storageRESTMethodGetInstanceID  = "getinstanceid"
 )
 

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -487,6 +487,65 @@ func (s *storageRESTServer) RenameFileHandler(w http.ResponseWriter, r *http.Req
 	}
 }
 
+// Send whitespace to the client to avoid timeouts as bitrot verification can take time on spinning/slow disks.
+func sendWhiteSpaceVerifyFile(w http.ResponseWriter) <-chan struct{} {
+	doneCh := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(time.Second * 10)
+		for {
+			select {
+			case <-ticker.C:
+				w.Write([]byte(" "))
+				w.(http.Flusher).Flush()
+			case doneCh <- struct{}{}:
+				ticker.Stop()
+				return
+			}
+		}
+
+	}()
+	return doneCh
+}
+
+// VerifyFileResp - VerifyFile()'s response.
+type VerifyFileResp struct {
+	Err error
+}
+
+// VerifyFile - Verify the file for bitrot errors.
+func (s *storageRESTServer) VerifyFile(w http.ResponseWriter, r *http.Request) {
+	if !s.IsValid(w, r) {
+		return
+	}
+	vars := mux.Vars(r)
+	volume := vars[storageRESTVolume]
+	filePath := vars[storageRESTFilePath]
+	shardSize, err := strconv.Atoi(vars[storageRESTLength])
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+	hashStr := vars[storageRESTBitrotHash]
+	var hash []byte
+	if hashStr != "" {
+		hash, err = hex.DecodeString(hashStr)
+		if err != nil {
+			s.writeErrorResponse(w, err)
+			return
+		}
+	}
+	algoStr := vars[storageRESTBitrotAlgo]
+	if algoStr == "" {
+		s.writeErrorResponse(w, errInvalidArgument)
+		return
+	}
+	algo := BitrotAlgorithmFromString(algoStr)
+	doneCh := sendWhiteSpaceVerifyFile(w)
+	err = s.storage.VerifyFile(volume, filePath, algo, hash, int64(shardSize))
+	<-doneCh
+	gob.NewEncoder(w).Encode(VerifyFileResp{err})
+}
+
 // registerStorageRPCRouter - register storage rpc router.
 func registerStorageRESTHandlers(router *mux.Router, endpoints EndpointList) {
 	for _, endpoint := range endpoints {
@@ -534,6 +593,8 @@ func registerStorageRESTHandlers(router *mux.Router, endpoints EndpointList) {
 
 		subrouter.Methods(http.MethodPost).Path("/" + storageRESTMethodRenameFile).HandlerFunc(httpTraceHdrs(server.RenameFileHandler)).
 			Queries(restQueries(storageRESTSrcVolume, storageRESTSrcPath, storageRESTDstVolume, storageRESTDstPath)...)
+		subrouter.Methods(http.MethodPost).Path("/" + storageRESTMethodVerifyFile).HandlerFunc(httpTraceHdrs(server.VerifyFile)).
+			Queries(restQueries(storageRESTVolume, storageRESTFilePath, storageRESTBitrotAlgo, storageRESTLength)...)
 		subrouter.Methods(http.MethodPost).Path("/" + storageRESTMethodGetInstanceID).HandlerFunc(httpTraceAll(server.GetInstanceID))
 	}
 

--- a/cmd/xl-v1-healing-common.go
+++ b/cmd/xl-v1-healing-common.go
@@ -183,8 +183,7 @@ func disksWithAllParts(ctx context.Context, onlineDisks []StorageAPI, partsMetad
 			// it needs healing too.
 			for _, part := range partsMetadata[i].Parts {
 				checksumInfo := erasureInfo.GetChecksumInfo(part.Name)
-				tillOffset := erasure.ShardFileTillOffset(0, part.Size, part.Size)
-				err = bitrotCheckFile(onlineDisk, bucket, pathJoin(object, part.Name), tillOffset, checksumInfo.Algorithm, checksumInfo.Hash, erasure.ShardSize())
+				err = onlineDisk.VerifyFile(bucket, pathJoin(object, part.Name), checksumInfo.Algorithm, checksumInfo.Hash, erasure.ShardSize())
 				if err != nil {
 					isCorrupt := strings.HasPrefix(err.Error(), "Bitrot verification mismatch - expected ")
 					if !isCorrupt && err != errFileNotFound && err != errVolumeNotFound {

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -195,7 +195,7 @@ func shouldHealObjectOnDisk(xlErr, dataErr error, meta xlMetaV1, quorumModTime t
 		if dataErr == errFileNotFound {
 			return true
 		}
-		if _, ok := dataErr.(hashMismatchError); ok {
+		if _, ok := dataErr.(HashMismatchError); ok {
 			return true
 		}
 		if quorumModTime != meta.Stat.ModTime {

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -351,7 +351,7 @@ func (xl xlObjects) healObject(ctx context.Context, bucket string, object string
 	}
 
 	// Reorder so that we have data disks first and parity disks next.
-	latestDisks = shuffleDisks(latestDisks, latestMeta.Erasure.Distribution)
+	latestDisks = shuffleDisks(availableDisks, latestMeta.Erasure.Distribution)
 	outDatedDisks = shuffleDisks(outDatedDisks, latestMeta.Erasure.Distribution)
 	partsMetadata = shufflePartsMetadata(partsMetadata, latestMeta.Erasure.Distribution)
 	for i := range outDatedDisks {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To avoid network transfer for bitrot verification during healing (current code was not doing this for streaming bitrot verification during healing)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduce network usage

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There is a test case for posix.VerifyFile
Also verified manually by changing contents of the file and making sure that heal happens fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.