### PR TITLE
Fix of staticcheck warning

### DIFF
--- a/cmd/gateway/oss/gateway-oss.go
+++ b/cmd/gateway/oss/gateway-oss.go
@@ -182,7 +182,7 @@ func appendS3MetaToOSSOptions(ctx context.Context, opts []oss.Option, s3Metadata
 		case k == "X-Amz-Acl":
 			// Valid values: public-read, private, and public-read-write
 			opts = append(opts, oss.ObjectACL(oss.ACLType(v)))
-		case k == "X-Amz-Server-Side​-Encryption":
+		case k == "X-Amz-Server-Side-Encryption":
 			opts = append(opts, oss.ServerSideEncryption(v))
 		case k == "X-Amz-Copy-Source-If-Match":
 			opts = append(opts, oss.CopySourceIfMatch(v))


### PR DESCRIPTION
## Description
I just followed the instructions in `CONTRIBUTING.md` and get warning after running of
```make verifiers``` command:
```bash
$ make verifiers                                                                                                                                                    patch-1  22:16:18
Installing golint
Installing staticcheck
Installing misspell
Running vet
Running fmt
Running lint
Running staticcheck
cmd/gateway/oss/gateway-oss.go:185:13: string literal contains the Unicode format character U+200B, consider using the '\u200b' escape sequence (ST1018)
make: *** [Makefile:41: staticcheck] Ошибка 1
```
I just retyped ```X-Amz-Server-Side-Encryption``` text and now it is ok.