### PR TITLE
Fix regression in peer clients in TLS setups

### DIFF
--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -410,7 +410,7 @@ func newPeerRESTClient(peer *xnet.Host) (*peerRESTClient, error) {
 	var tlsConfig *tls.Config
 	if globalIsSSL {
 		tlsConfig = &tls.Config{
-			ServerName: peer.String(),
+			ServerName: peer.Name,
 			RootCAs:    globalRootCAs,
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix regression in peer clients in TLS setups
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes regression was introduced in eb69c4f946ce10f5996566f9ee4c550a3119aeae

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes eb69c4f946ce10f5996566f9ee4c550a3119aeae
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using a distributed TLS setup

```
#!/bin/bash

uuid1="export1"
uuid2="export2"
uuid3="export3"
uuid4="export4"

MINIO=${GOPATH}/bin/minio
export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
#export MINIO_HTTP_TRACE="/dev/stdout"
mkdir -p "/tmp/$uuid1" "/tmp/$uuid2" "/tmp/$uuid3" "/tmp/$uuid4"
mkdir -p "/tmp/cfg-$uuid1/certs/CAs" "/tmp/cfg-$uuid2/certs/CAs" "/tmp/cfg-$uuid3/certs/CAs" "/tmp/cfg-$uuid4/certs/CAs"
mkdir -p "/tmp/certs-tmp"
(cd /tmp/certs-tmp && \
     openssl ecparam -genkey -name prime256v1 | openssl ec -out private.key && \
     openssl req -new -x509 -days 3650 -key private.key -out public.crt -subj "/C=US/ST=state/L=location/O=organization/CN=localhost" && \
     cp private.key public.crt /tmp/cfg-$uuid1/certs && \
     cp private.key public.crt /tmp/cfg-$uuid2/certs && \
     cp private.key public.crt /tmp/cfg-$uuid3/certs && \
     cp private.key public.crt /tmp/cfg-$uuid4/certs && \
     cp public.crt /tmp/cfg-$uuid1/certs/CAs && \
     cp public.crt /tmp/cfg-$uuid2/certs/CAs && \
     cp public.crt /tmp/cfg-$uuid3/certs/CAs && \
     cp public.crt /tmp/cfg-$uuid4/certs/CAs && \
     rm -rf ../certs-tmp
)

${MINIO} server -C /tmp/cfg-$uuid1 --address localhost:9001 "https://localhost:9001/tmp/${uuid1}" "https://localhost:9002/tmp/${uuid2}" "https://localhost:9003/tmp/${uuid3}" "https://localhost:9004/tmp/${uuid4}"&
${MINIO} server -C /tmp/cfg-$uuid2 --address localhost:9002 "https://localhost:9001/tmp/${uuid1}" "https://localhost:9002/tmp/${uuid2}" "https://localhost:9003/tmp/${uuid3}" "https://localhost:9004/tmp/${uuid4}"&
${MINIO} server -C /tmp/cfg-$uuid3 --address localhost:9003 "https://localhost:9001/tmp/${uuid1}" "https://localhost:9002/tmp/${uuid2}" "https://localhost:9003/tmp/${uuid3}" "https://localhost:9004/tmp/${uuid4}"&
${MINIO} server -C /tmp/cfg-$uuid4 --address localhost:9004 "https://localhost:9001/tmp/${uuid1}" "https://localhost:9002/tmp/${uuid2}" "https://localhost:9003/tmp/${uuid3}" "https://localhost:9004/tmp/${uuid4}"
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.