### PR TITLE
Remove duplicate `checkPutObjectArgs` in PutObject

### DIFF
--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -116,7 +116,7 @@ func (xl xlObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBuc
 	}
 
 	putOpts := ObjectOptions{ServerSideEncryption: dstOpts.ServerSideEncryption, UserDefined: srcInfo.UserDefined}
-	return xl.putObject(ctx, dstBucket, dstObject, srcInfo.PutObjReader, putOpts)
+	return xl.PutObject(ctx, dstBucket, dstObject, srcInfo.PutObjReader, putOpts)
 }
 
 // GetObjectNInfo - returns object info and an object
@@ -510,6 +510,7 @@ func (xl xlObjects) PutObject(ctx context.Context, bucket string, object string,
 		return objInfo, err
 	}
 	defer objectLock.Unlock()
+
 	return xl.putObject(ctx, bucket, object, data, opts)
 }
 
@@ -558,11 +559,6 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 		}
 
 		return dirObjectInfo(bucket, object, data.Size(), opts.UserDefined), nil
-	}
-
-	// Validate put object input args.
-	if err = checkPutObjectArgs(ctx, bucket, object, xl, data.Size()); err != nil {
-		return ObjectInfo{}, err
 	}
 
 	// Validate input data size and it can never be less than zero.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We were double checking the input args in PutObject.

## Motivation and Context
Fixes  #7384

## Regression
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.