### PR TITLE
crypto: add unit test for vault config verification

### DIFF
--- a/cmd/crypto/vault_test.go
+++ b/cmd/crypto/vault_test.go
@@ -1,0 +1,97 @@
+// Minio Cloud Storage, (C) 2019 Minio, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"fmt"
+	"testing"
+)
+
+var verifyVaultConfigTests = []struct {
+	Config     VaultConfig
+	ShouldFail bool
+}{
+	{
+		ShouldFail: false, // 0
+		Config:     VaultConfig{},
+	},
+	{
+		ShouldFail: true,
+		Config:     VaultConfig{Endpoint: "https://127.0.0.1:8080"},
+	},
+	{
+		ShouldFail: true, // 1
+		Config: VaultConfig{
+			Endpoint: "https://127.0.0.1:8080",
+			Auth:     VaultAuth{Type: "unsupported"},
+		},
+	},
+	{
+		ShouldFail: true, // 2
+		Config: VaultConfig{
+			Endpoint: "https://127.0.0.1:8080",
+			Auth: VaultAuth{
+				Type:    "approle",
+				AppRole: VaultAppRole{},
+			},
+		},
+	},
+	{
+		ShouldFail: true, // 3
+		Config: VaultConfig{
+			Endpoint: "https://127.0.0.1:8080",
+			Auth: VaultAuth{
+				Type:    "approle",
+				AppRole: VaultAppRole{ID: "123456"},
+			},
+		},
+	},
+	{
+		ShouldFail: true, // 4
+		Config: VaultConfig{
+			Endpoint: "https://127.0.0.1:8080",
+			Auth: VaultAuth{
+				Type:    "approle",
+				AppRole: VaultAppRole{ID: "123456", Secret: "abcdef"},
+			},
+		},
+	},
+	{
+		ShouldFail: true, // 5
+		Config: VaultConfig{
+			Endpoint: "https://127.0.0.1:8080",
+			Auth: VaultAuth{
+				Type:    "approle",
+				AppRole: VaultAppRole{ID: "123456", Secret: "abcdef"},
+			},
+			Key: VaultKey{Name: "default-key", Version: -1},
+		},
+	},
+}
+
+func TestVerifyVaultConfig(t *testing.T) {
+	for i, test := range verifyVaultConfigTests {
+		test := test
+		t.Run(fmt.Sprintf("Test-%d", i), func(t *testing.T) {
+			err := test.Config.Verify()
+			if test.ShouldFail && err == nil {
+				t.Errorf("Verify should fail but returned 'err == nil'")
+			}
+			if !test.ShouldFail && err != nil {
+				t.Errorf("Verify should succeed but returned err: %s", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This commit adds a unit test for the vault
config verification (which covers also `IsEmpty()`).

Vault-related code is hard to test with unit tests
since a Vault service would be necessary. Therefore
this commit only adds tests for a fraction of the code.

## Motivation and Context
Fixes #7409 

## Regression
no

## How Has This Been Tested?
unit test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.