### PR TITLE
Error log: Set error type correctly in anonymous mode

### DIFF
--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -343,7 +343,7 @@ func logIf(ctx context.Context, err error) {
 		entry.API.Args.Bucket = hashString(entry.API.Args.Bucket)
 		entry.API.Args.Object = hashString(entry.API.Args.Object)
 		entry.RemoteHost = hashString(entry.RemoteHost)
-		entry.Message = reflect.TypeOf(err).String()
+		entry.Trace.Message = reflect.TypeOf(err).String()
 		entry.Trace.Variables = make(map[string]string)
 	}
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently message is set to error type value.
Message field is not used in error logs. it is used only in the case of info logs.


This PR sets error message field to store error type.

## Motivation and Context
Discovered this when I was looking into anonymous logging mode.

## Regression
No

## How Has This Been Tested?
Start `minio` in distributed mode with anonymous logging flag turned on and make sure that one node/disk is down.

Then look at the minio console log. Without the fix, you will see two message fields, one that has the error text and one that has the error type. 

With the fix, it will be just the error type and it will be inside `trace` field.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.