### PR TITLE
Add proper context based logging when bitrot stream calls fail

### DIFF
--- a/cmd/bitrot-streaming.go
+++ b/cmd/bitrot-streaming.go
@@ -84,9 +84,11 @@ func newStreamingBitrotWriter(disk StorageAPI, volume, filePath string, length i
 		totalFileSize := bitrotSumsTotalSize + length
 		err := disk.CreateFile(volume, filePath, totalFileSize, r)
 		if err != nil {
-			logger.LogIf(context.Background(), err)
-			r.CloseWithError(err)
+			reqInfo := (&logger.ReqInfo{}).AppendTags("storageDisk", disk.String())
+			ctx := logger.SetReqInfo(context.Background(), reqInfo)
+			logger.LogIf(ctx, err)
 		}
+		r.CloseWithError(err)
 		close(bw.canClose)
 	}()
 	return bw
@@ -125,7 +127,9 @@ func (b *streamingBitrotReader) ReadAt(buf []byte, offset int64) (int, error) {
 		streamOffset := (offset/b.shardSize)*int64(b.h.Size()) + offset
 		b.rc, err = b.disk.ReadFileStream(b.volume, b.filePath, streamOffset, b.tillOffset-streamOffset)
 		if err != nil {
-			logger.LogIf(context.Background(), err)
+			reqInfo := (&logger.ReqInfo{}).AppendTags("storageDisk", b.disk.String())
+			ctx := logger.SetReqInfo(context.Background(), reqInfo)
+			logger.LogIf(ctx, err)
 			return 0, err
 		}
 	}

--- a/cmd/bitrot.go
+++ b/cmd/bitrot.go
@@ -133,7 +133,7 @@ func newBitrotReader(disk StorageAPI, bucket string, filePath string, tillOffset
 // Close all the readers.
 func closeBitrotReaders(rs []io.ReaderAt) {
 	for _, r := range rs {
-		if br, ok := r.(*streamingBitrotReader); ok {
+		if br, ok := r.(io.Closer); ok {
 			br.Close()
 		}
 	}
@@ -142,7 +142,7 @@ func closeBitrotReaders(rs []io.ReaderAt) {
 // Close all the writers.
 func closeBitrotWriters(ws []io.Writer) {
 	for _, w := range ws {
-		if bw, ok := w.(*streamingBitrotWriter); ok {
+		if bw, ok := w.(io.Closer); ok {
 			bw.Close()
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add proper context based logging when bitrot stream calls fail
<!--- Describe your changes in detail -->

## Motivation and Context
Logging enhancements for debugging and also some behavior cleanup.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Just generating the error situations returned by CreateFile and ReadFileStream
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.