### PR TITLE
Return deploymentID in ServerInfo RPC call

### DIFF
--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -52,11 +52,12 @@ func getServerInfo() (*ServerInfoData, error) {
 		ConnStats:   globalConnStats.toServerConnStats(),
 		HTTPStats:   globalHTTPStats.toServerHTTPStats(),
 		Properties: ServerProperties{
-			Uptime:   UTCNow().Sub(globalBootTime),
-			Version:  Version,
-			CommitID: CommitID,
-			SQSARN:   globalNotificationSys.GetARNList(),
-			Region:   globalServerConfig.GetRegion(),
+			Uptime:       UTCNow().Sub(globalBootTime),
+			Version:      Version,
+			CommitID:     CommitID,
+			DeploymentID: globalDeploymentID,
+			SQSARN:       globalNotificationSys.GetARNList(),
+			Region:       globalServerConfig.GetRegion(),
 		},
 	}, nil
 }


### PR DESCRIPTION
Makes deploymentID information uniformly available in a distributed setup

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previous change didn't make deploymentID available via ServerInfo of all servers that are part of a cluster.  In this change, the inter-node serverInfo RPC returns the respective nodes deploymentID.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is part of making deploymentID available in `mc admin info ...` command.
## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by setting up a distributed minio setup and using a modified version of `mc admin info ...` (Since, mc admin changes are still under development)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.