### PR TITLE
Don't decrypt ETag in validation when source is SSEC multipart

### DIFF
--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -99,13 +99,14 @@ func checkCopyObjectPreconditions(ctx context.Context, w http.ResponseWriter, r 
 		}
 	}
 
-	ssec := crypto.SSECopy.IsRequested(r.Header)
+	shouldDecryptEtag := crypto.SSECopy.IsRequested(r.Header) && !crypto.IsMultiPart(objInfo.UserDefined)
+
 	// x-amz-copy-source-if-match : Return the object only if its entity tag (ETag) is the
 	// same as the one specified; otherwise return a 412 (precondition failed).
 	ifMatchETagHeader := r.Header.Get("x-amz-copy-source-if-match")
 	if ifMatchETagHeader != "" {
 		etag := objInfo.ETag
-		if ssec {
+		if shouldDecryptEtag {
 			etag = encETag[len(encETag)-32:]
 		}
 		if objInfo.ETag != "" && !isETagEqual(etag, ifMatchETagHeader) {
@@ -121,7 +122,7 @@ func checkCopyObjectPreconditions(ctx context.Context, w http.ResponseWriter, r 
 	ifNoneMatchETagHeader := r.Header.Get("x-amz-copy-source-if-none-match")
 	if ifNoneMatchETagHeader != "" {
 		etag := objInfo.ETag
-		if ssec {
+		if shouldDecryptEtag {
 			etag = encETag[len(encETag)-32:]
 		}
 		if objInfo.ETag != "" && isETagEqual(etag, ifNoneMatchETagHeader) {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Copying an encrypted SSEC object when this latter is uploaded using
multipart mechanism was failing because ETag in case of encrypted
multipart upload is not encrypted.

This PR fixes the behavior.

## Motivation and Context
Fixing an issue found by a user

## Regression
Yes (https://github.com/minio/minio/commit/b05825ffe825646dc075996d33c583f6cf456837)

## How Has This Been Tested?
Create a bucket, create a file of a size of 1 Gb, upload it with a SSEC key, then copy it in the same bucket using `mc cp` 



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes (https://github.com/minio/minio-go/pull/1092)
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.