### PR TITLE
Set Read/Write timeouts only for net.Conn not http.Server

### DIFF
--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -57,6 +57,8 @@ const (
 type Server struct {
 	http.Server
 	Addrs                  []string      // addresses on which the server listens for new connection.
+	ReadTimeout            time.Duration // timeout used for net.Conn.Read() deadlines.
+	WriteTimeout           time.Duration // timeout used for net.Conn.Write() deadlines.
 	ShutdownTimeout        time.Duration // timeout used for graceful server shutdown.
 	TCPKeepAliveTimeout    time.Duration // timeout used for underneath TCP connection.
 	UpdateBytesReadFunc    func(int)     // function to be called to update bytes read in bufConn.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Set Read/Write timeouts only for net.Conn not http.Server
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #7425

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes perhaps in the HTTP 2.0 PR
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using `curl` a bigfile to https://play.minio.io:9000 over http2, this is because 
of top-level timeout overrides in http.Server are carried over to http2.ConfigureServer()
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.