### PR TITLE
Show 401 unauthorized msg when nodes are started with different creds

### DIFF
--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -66,7 +66,10 @@ func (c *Client) Call(method string, values url.Values, body io.Reader, length i
 		if err != nil {
 			return nil, err
 		}
-		return nil, errors.New(string(b))
+		if len(b) > 0 {
+			return nil, errors.New(string(b))
+		}
+		return nil, errors.New(resp.Status)
 	}
 	return resp.Body, nil
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -353,6 +353,14 @@ func (client *storageRESTClient) RenameFile(srcVolume, srcPath, dstVolume, dstPa
 
 // Gets peer storage server's instanceID - to be used with every REST call for validation.
 func (client *storageRESTClient) getInstanceID() (err error) {
+	// getInstanceID() does not use storageRESTClient.call()
+	// function so we need to update lastError field here.
+	defer func() {
+		if err != nil {
+			client.lastError = err
+		}
+	}()
+
 	respBody, err := client.restClient.Call(storageRESTMethodGetInstanceID, nil, nil, -1)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Before this commit, nodes wait indefinitely without showing any
indicate error message when a node is started with different access
and secret keys.

This PR will show '401 Unauthorized' in this case.

## Motivation and Context
Fixes #7410

## Regression
No

## How Has This Been Tested?
Running 4 nodes with different access & secret keys

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.