### PR TITLE
fix mysql config for native password authentication

### DIFF
--- a/pkg/event/target/mysql.go
+++ b/pkg/event/target/mysql.go
@@ -205,11 +205,12 @@ func (target *MySQLTarget) Close() error {
 func NewMySQLTarget(id string, args MySQLArgs) (*MySQLTarget, error) {
 	if args.DSN == "" {
 		config := mysql.Config{
-			User:   args.User,
-			Passwd: args.Password,
-			Net:    "tcp",
-			Addr:   args.Host.String() + ":" + args.Port,
-			DBName: args.Database,
+			User:                 args.User,
+			Passwd:               args.Password,
+			Net:                  "tcp",
+			Addr:                 args.Host.String() + ":" + args.Port,
+			DBName:               args.Database,
+			AllowNativePasswords: true,
 		}
 
 		args.DSN = config.FormatDSN()


### PR DESCRIPTION

fixes #7430

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set native password authentication allowed to true in mysql config
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See repro steps in the issue
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.