### PR TITLE
Fix: Allow deleting multiple objects anonymously if policy supports it

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -559,7 +559,22 @@ func (web *webAPIHandlers) RemoveObject(r *http.Request, args *RemoveObjectArgs,
 
 	claims, owner, authErr := webRequestAuthenticate(r)
 	if authErr != nil {
-		return toJSONError(authErr)
+		if authErr == errNoAuthToken {
+			// Check if all objects are allowed to be deleted anonymously
+			for _, object := range args.Objects {
+				if !globalPolicySys.IsAllowed(policy.Args{
+					Action:          policy.DeleteObjectAction,
+					BucketName:      args.BucketName,
+					ConditionValues: getConditionValues(r, "", ""),
+					IsOwner:         false,
+					ObjectName:      object,
+				}) {
+					return toJSONError(errAuthentication)
+				}
+			}
+		} else {
+			return toJSONError(authErr)
+		}
 	}
 
 	if args.BucketName == "" || len(args.Objects) == 0 {
@@ -611,16 +626,20 @@ next:
 					return toJSONError(errMethodNotAllowed)
 				}
 			}
-
-			if !globalIAMSys.IsAllowed(iampolicy.Args{
-				AccountName:     claims.Subject,
-				Action:          iampolicy.DeleteObjectAction,
-				BucketName:      args.BucketName,
-				ConditionValues: getConditionValues(r, "", claims.Subject),
-				IsOwner:         owner,
-				ObjectName:      objectName,
-			}) {
-				return toJSONError(errAccessDenied)
+			// Check for permissions only in the case of
+			// non-anonymous login. For anonymous login, policy has already
+			// been checked.
+			if authErr != errNoAuthToken {
+				if !globalIAMSys.IsAllowed(iampolicy.Args{
+					AccountName:     claims.Subject,
+					Action:          iampolicy.DeleteObjectAction,
+					BucketName:      args.BucketName,
+					ConditionValues: getConditionValues(r, "", claims.Subject),
+					IsOwner:         owner,
+					ObjectName:      objectName,
+				}) {
+					return toJSONError(errAccessDenied)
+				}
 			}
 
 			if err = deleteObject(context.Background(), objectAPI, web.CacheAPI(), args.BucketName, objectName, r); err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Anonymous multiple objects deletion was not allowed before, even if the policy supported it.

This PR allows both Delete Multiple Objects S3 API and browser API to delete multiple obejcts if the API allows it.

Fixes #5683

## Description
<!--- Describe your changes in detail -->
Each object will be enumerated individually and if the policy doesn't allow in the case of S3 API, then access denied error is sent. 

In the case of browser, the browser will not delete any object if any of the object's policy does not allow anonymous deletion

## Motivation and Context
Issue #5683

## Regression
No

## How Has This Been Tested?
As described in issue #5683
and also using the following steps with mc

```
mc mb myminio/test
mc policy public myminio/test
mc cp /etc/issue myminio/test
mc config host add myminio-anon http://127.0.0.1:9000 "" "" --api "s3v4"
mc rm myminio/test/issue
```
Without the change, `mc rm` will fail

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.