### PR TITLE
canonicalize ETag correctly

### DIFF
--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -524,6 +524,11 @@ func (fs *FSObjects) CompleteMultipartUpload(ctx context.Context, bucket string,
 		return oi, err
 	}
 
+	// ensure that part ETag is canonicalized to strip off extraneous quotes
+	for i := range parts {
+		parts[i].ETag = canonicalizeETag(parts[i].ETag)
+	}
+
 	// Save consolidated actual size.
 	var objectActualSize int64
 	// Validate all parts and then commit to disk.

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1796,6 +1796,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 		// Part with size larger than 5Mb.
 		{bucketNames[0], objectNames[0], uploadIDs[0], 5, string(validPart), validPartMD5, int64(len(string(validPart)))},
 		{bucketNames[0], objectNames[0], uploadIDs[0], 6, string(validPart), validPartMD5, int64(len(string(validPart)))},
+		{bucketNames[0], objectNames[0], uploadIDs[0], 7, string(validPart), validPartMD5, int64(len(string(validPart)))},
 	}
 	sha256sum := ""
 	var opts ObjectOptions
@@ -1837,7 +1838,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 		// Part size greater than 5MB.
 		{
 			[]CompletePart{
-				{ETag: validPartMD5, PartNumber: 5},
+				{ETag: fmt.Sprintf("\"\"\"\"\"%s\"\"\"", validPartMD5), PartNumber: 5},
 			},
 		},
 		// inputParts - 4.

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -193,7 +193,7 @@ func mustGetUUID() string {
 func getCompleteMultipartMD5(ctx context.Context, parts []CompletePart) (string, error) {
 	var finalMD5Bytes []byte
 	for _, part := range parts {
-		md5Bytes, err := hex.DecodeString(part.ETag)
+		md5Bytes, err := hex.DecodeString(canonicalizeETag(part.ETag))
 		if err != nil {
 			logger.LogIf(ctx, err)
 			return "", err

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -19,12 +19,16 @@ package cmd
 import (
 	"context"
 	"net/http"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/handlers"
+)
+
+var (
+	etagRegex = regexp.MustCompile("\"*?([^\"]*?)\"*?$")
 )
 
 // Validates the preconditions for CopyObjectPart, returns true if CopyObjectPart
@@ -230,8 +234,7 @@ func ifModifiedSince(objTime time.Time, givenTime time.Time) bool {
 // canonicalizeETag returns ETag with leading and trailing double-quotes removed,
 // if any present
 func canonicalizeETag(etag string) string {
-	canonicalETag := strings.TrimPrefix(etag, "\"")
-	return strings.TrimSuffix(canonicalETag, "\"")
+	return etagRegex.ReplaceAllString(etag, "$1")
 }
 
 // isETagEqual return true if the canonical representations of two ETag strings

--- a/cmd/object-handlers-common_test.go
+++ b/cmd/object-handlers-common_test.go
@@ -1,0 +1,53 @@
+/*
+ * Minio Cloud Storage, (C) 2019 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+)
+
+// Tests - canonicalizeETag()
+func TestCanonicalizeETag(t *testing.T) {
+	testCases := []struct {
+		etag              string
+		canonicalizedETag string
+	}{
+		{
+			etag:              "\"\"\"",
+			canonicalizedETag: "",
+		},
+		{
+			etag:              "\"\"\"abc\"",
+			canonicalizedETag: "abc",
+		},
+		{
+			etag:              "abcd",
+			canonicalizedETag: "abcd",
+		},
+		{
+			etag:              "abcd\"\"",
+			canonicalizedETag: "abcd",
+		},
+	}
+	for _, test := range testCases {
+		etag := canonicalizeETag(test.etag)
+		if test.canonicalizedETag != etag {
+			t.Fatalf("Expected %s , got %s", test.canonicalizedETag, etag)
+
+		}
+	}
+}

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -675,6 +675,8 @@ func (xl xlObjects) CompleteMultipartUpload(ctx context.Context, bucket string, 
 
 	// Validate each part and then commit to disk.
 	for i, part := range parts {
+		// ensure that part ETag is canonicalized to strip off extraneous quotes
+		part.ETag = canonicalizeETag(part.ETag)
 		partIdx := objectPartIndex(currentXLMeta.Parts, part.PartNumber)
 		// All parts should have same part number.
 		if partIdx == -1 {


### PR DESCRIPTION
Fixes #7441 - Trim extra quotes prefixing/suffixing ETag in
CompleteMultipartUpload request and response

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Use  aws cli to do a multipart upload. In complete multipart upload, the upload should succeed even if redundant quotes prefix/suffix the part ETag. See example in PR thread.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.