### PR TITLE
rpc: Avoid using Pool since it conflicts with http2

### DIFF
--- a/cmd/rpc/client.go
+++ b/cmd/rpc/client.go
@@ -17,6 +17,7 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/gob"
@@ -49,8 +50,7 @@ func (client *Client) Call(serviceMethod string, args, reply interface{}) error 
 		return fmt.Errorf("rpc reply must be a pointer type, but found %v", replyKind)
 	}
 
-	argBuf := bufPool.Get()
-	defer bufPool.Put(argBuf)
+	argBuf := bytes.NewBuffer(make([]byte, 0, 1024))
 
 	if err := gobEncodeBuf(args, argBuf); err != nil {
 		return err
@@ -61,8 +61,7 @@ func (client *Client) Call(serviceMethod string, args, reply interface{}) error 
 		ArgBytes: argBuf.Bytes(),
 	}
 
-	reqBuf := bufPool.Get()
-	defer bufPool.Put(reqBuf)
+	reqBuf := bytes.NewBuffer(make([]byte, 0, 1024))
 	if err := gob.NewEncoder(reqBuf).Encode(callRequest); err != nil {
 		return err
 	}

--- a/cmd/rpc/server.go
+++ b/cmd/rpc/server.go
@@ -40,8 +40,6 @@ var errorType = reflect.TypeOf((*error)(nil)).Elem()
 // reflect.Type of Authenticator interface.
 var authenticatorType = reflect.TypeOf((*Authenticator)(nil)).Elem()
 
-var bufPool = NewPool()
-
 func gobEncodeBuf(e interface{}, buf *bytes.Buffer) error {
 	return gob.NewEncoder(buf).Encode(e)
 }
@@ -239,8 +237,8 @@ func (server *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	callResponse := CallResponse{}
-	buf := bufPool.Get()
-	defer bufPool.Put(buf)
+
+	buf := bytes.NewBuffer(make([]byte, 0, 1024))
 
 	if err := server.call(callRequest.Method, callRequest.ArgBytes, buf); err != nil {
 		callResponse.Error = err.Error()

--- a/cmd/rpc/server_test.go
+++ b/cmd/rpc/server_test.go
@@ -253,8 +253,7 @@ func TestServerCall(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		buf := bufPool.Get()
-		defer bufPool.Put(buf)
+		buf := bytes.NewBuffer([]byte{})
 
 		err := testCase.server.call(testCase.serviceMethod, testCase.argBytes, buf)
 		expectErr := (err != nil)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
A race is detected between a bytes.Buffer generated with cmd/rpc.Pool
and http2 module. An issue is raised in golang (https://github.com/golang/go/issues/31192).

Meanwhile, this commit disables Pool in RPC code and it generates a
new 1kb of bytes.Buffer for each RPC call.

1kb is chosen as it doesn't exceed it generally

## Motivation and Context
Fix locking issue

## Regression
This started to happen after the introduction of http2 but this is most likely a golang bug.

## How Has This Been Tested?
1. Start a distributed Minio cluster of four nodes with TLS enabled.
2. Install the TLS certificate in the OS
2. Create a bucket.
3. Run the following code which does a parallel HEAD bucket continuously

```golang

package main

import (
	"fmt"
	"log"
	"sync"

	"github.com/minio/minio-go"
)

func main() {
	s3Client1, err := minio.New("minio:9000", "minio", "minio123", true)
	if err != nil {
		log.Fatalln(err)
	}

	s3Client2, err := minio.New("minio:9000", "minio", "minio123", true)
	if err != nil {
		log.Fatalln(err)
	}

	var clients = []*minio.Client{s3Client1, s3Client2}
	var wg sync.WaitGroup

	for {

		for i := 0; i < len(clients); i++ {
			wg.Add(1)
			go func(i int) {
				defer wg.Done()
				found, err := clients[i].BucketExists("testbucket")
				if err != nil {
					log.Fatalln(err)
				}

				if found {
					fmt.Printf(".")
				} else {
					log.Fatalln("Bucket not found.")
				}
			}(i)
		}

	}

	wg.Wait()
}
```


4. Check the locking status using `mc admin top locks alias/`

After few moments, you will notice having some unreleased read locks issued by HEAD buckets.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.