### PR TITLE
Add go-mod cache for .travis to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ matrix:
         - ARCH=x86_64
         - CGO_ENABLED=0
         - GO111MODULE=on
+      # Enable build cache
+      # https://restic.net/blog/2018-09-02/travis-build-cache
+      cache:
+       directories:
+         - $HOME/.cache/go-build
+         - $HOME/gopath/pkg/mod
+         - $HOME/go/pkg/mod
+
       go: 1.12.1
       script:
         - make
@@ -37,7 +45,6 @@ matrix:
       go: 1.12.1
       script:
         - go build --ldflags="$(go run buildscripts/gen-ldflags.go)" -o %GOPATH%\bin\minio.exe
-        - for d in $(go list ./... | grep -v browser); do CGO_ENABLED=1 go test -v -race --timeout 20m "$d"; done
         - bash buildscripts/go-coverage.sh
 
 before_script:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add go-mod cache for .travis to speed up builds
<!--- Describe your changes in detail -->

## Motivation and Context
https://restic.net/blog/2018-09-02/travis-build-cache

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Just a build optimization
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.