### PR TITLE
http: opt-in to TLS 1.3

### DIFF
--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net/http"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,6 +31,13 @@ import (
 	"github.com/minio/minio-go/pkg/set"
 	"github.com/minio/minio/pkg/certs"
 )
+
+func init() {
+	// Opt-in to TLS 1.3. See: https://golang.org/pkg/crypto/tls
+	// In future Go versions TLS 1.3 probably gets enabled by default.
+	// So, we can remove this line as soon as this is the case.
+	os.Setenv("GODEBUG", os.Getenv("GODEBUG")+",tls13=1")
+}
 
 const (
 	serverShutdownPoll = 500 * time.Millisecond


### PR DESCRIPTION
## Description
This commit enables TLS 1.3 on the server. For Go 1.12 TLS 1.3 is
enabled by an explicit opt-in.

## Motivation and Context
security

## Regression
no

## How Has This Been Tested?
manually, setup MinIO + TLS and access it e.g. via browser. The connection detail view of your browser should show you TLS 1.3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.