### PR TITLE
Fix ListObjectsV2 for gateway encryption mode

### DIFF
--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -138,14 +138,17 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 	loi.ContinuationToken = continuationToken
 	loi.Objects = make([]minio.ObjectInfo, 0)
 	loi.Prefixes = make([]string, 0)
+	loi.Objects = append(loi.Objects, objects...)
 
-	for _, obj := range objects {
-		loi.NextContinuationToken = obj.Name
-		loi.Objects = append(loi.Objects, obj)
-	}
 	for _, pfx := range prefixes {
 		if pfx != prefix {
 			loi.Prefixes = append(loi.Prefixes, pfx)
+		}
+	}
+	// Set continuation token if s3 returned truncated list
+	if isTruncated {
+		if len(objects) > 0 {
+			loi.NextContinuationToken = objects[len(objects)-1].Name
 		}
 	}
 	return loi, nil


### PR DESCRIPTION
Fixes #7468 by setting NextContinuationToken only if list is
truncated

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NextContinuationToken was being set even when the end of list is reached. When end of list is reached IsTruncated should be false and NextContinuationToken ""
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Most clients decide whether to continue listing based on IsTruncated returning true. aws-sdk-php seems to be using the NextContinuationToken to decide whether to send ListObjectsV2 call for continuing to iterate through the list. This results in a infinite loop on Mint for aws-sdk-php when gateway double encryption mode is on.
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No ( incorrectly implemented)
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See issue description - rerun Mint for aws-sdk-php with this fix. Also, generic `mc ls` tests to ensure there are no side-effects
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.