### PR TITLE
Azure gateway complete multipart ETag

### DIFF
--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"strings"
@@ -332,6 +333,11 @@ func ErrorRespToObjectError(err error, params ...string) error {
 	}
 
 	return err
+}
+
+// ComputeCompleteMultipartMD5 calculates MD5 ETag for complete multipart responses
+func ComputeCompleteMultipartMD5(parts []CompletePart) (string, error) {
+	return getCompleteMultipartMD5(context.Background(), parts)
 }
 
 // parse gateway sse env variable

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -19,6 +19,7 @@ package azure
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
@@ -1167,6 +1168,7 @@ func (a *azureObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 	}
 
 	objBlob := a.client.GetContainerReference(bucket).GetBlobReference(object)
+	hasher := md5.New()
 
 	var allBlocks []storage.Block
 	for i, part := range uploadedParts {
@@ -1186,6 +1188,13 @@ func (a *azureObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 		if partMetadata.ETag != part.ETag {
 			return objInfo, minio.InvalidPart{}
 		}
+		checksum, err := hex.DecodeString(partMetadata.ETag)
+		if err != nil {
+			return objInfo, minio.InvalidPart{}
+		}
+		if _, err := hasher.Write(checksum); err != nil {
+			return objInfo, minio.InvalidPart{}
+		}
 		for _, blockID := range partMetadata.BlockIDs {
 			allBlocks = append(allBlocks, storage.Block{ID: blockID, Status: storage.BlockStatusUncommitted})
 		}
@@ -1202,19 +1211,18 @@ func (a *azureObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 	if err != nil {
 		return objInfo, azureToObjectError(err, bucket, object)
 	}
-	if len(metadata.Metadata) > 0 {
-		objBlob.Metadata, objBlob.Properties, err = s3MetaToAzureProperties(ctx, metadata.Metadata)
-		if err != nil {
-			return objInfo, azureToObjectError(err, bucket, object)
-		}
-		err = objBlob.SetProperties(nil)
-		if err != nil {
-			return objInfo, azureToObjectError(err, bucket, object)
-		}
-		err = objBlob.SetMetadata(nil)
-		if err != nil {
-			return objInfo, azureToObjectError(err, bucket, object)
-		}
+	objBlob.Metadata, objBlob.Properties, err = s3MetaToAzureProperties(ctx, metadata.Metadata)
+	objBlob.Metadata["md5sum"] = fmt.Sprintf("%s-%d", hex.EncodeToString(hasher.Sum(nil)), len(uploadedParts))
+	if err != nil {
+		return objInfo, azureToObjectError(err, bucket, object)
+	}
+	err = objBlob.SetProperties(nil)
+	if err != nil {
+		return objInfo, azureToObjectError(err, bucket, object)
+	}
+	err = objBlob.SetMetadata(nil)
+	if err != nil {
+		return objInfo, azureToObjectError(err, bucket, object)
 	}
 	var partNumberMarker int
 	for {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Computes the ETag for complete multipart upload in Azure gateway from the md5sum of the part md5sums.

## Motivation and Context

The ETag used for multipart upload complete in Azure is the ETag that comes from Azure. This doesn't match exactly with what S3 does and this causes problems with some clients. Specifically this breaks gitlab workhorse when using minio in Azure gateway. Relevant [issue on that project](https://gitlab.com/gitlab-org/gitlab-workhorse/issues/210).

## Regression
No

## How Has This Been Tested?
This has been tested with workhorse and previously failed upload are now successful.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.