### PR TITLE
Fix SimpleCI to use different data directory for minio and mint

### DIFF
--- a/buildscripts/gateway-tests.sh
+++ b/buildscripts/gateway-tests.sh
@@ -22,7 +22,7 @@ set -o pipefail
 function start_minio_server()
 {
     MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123 \
-                    minio --quiet --json server data --address 127.0.0.1:24242 > server.log 2>&1 &
+                    minio --quiet --json server /data --address 127.0.0.1:24242 > server.log 2>&1 &
     server_pid=$!
     sleep 3
 


### PR DESCRIPTION
## Description
In SimpleCI, the backend minio server uses the same data directory
as the mint test itself, causing `s3 sync` to fail often.

Now `minio` backend will use a different data directory `/data`
instead of `/mint/data`

## Motivation and Context
SimpleCI fails often with this failure. Example http://ci.min.io:30004/view/01f4f833f6863ae32f5d75ec76e5860f5d0ab498

## Regression
No

## How Has This Been Tested?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.