### PR TITLE
Fix healthcheck script to check for BadRequest Status

### DIFF
--- a/dockerscripts/healthcheck.go
+++ b/dockerscripts/healthcheck.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -142,18 +141,10 @@ func main() {
 			// exit with success
 			os.Exit(0)
 		}
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			// Drain any response.
-			xhttp.DrainBody(resp.Body)
-			// GET failed exit
-			log.Fatalln(err)
-		}
-		bodyString := string(bodyBytes)
 		// Drain any response.
 		xhttp.DrainBody(resp.Body)
-		// This means sever is configured with https
-		if resp.StatusCode == http.StatusForbidden && bodyString == "SSL required" {
+		// 400 response may mean sever is configured with https
+		if resp.StatusCode == http.StatusBadRequest {
 			// Try with https
 			u.Scheme = "https"
 			resp, err = client.Get(u.String())


### PR DESCRIPTION
## Description
This PR removes the check for `SSL Required` message in healthcheck script.

## Motivation and Context
As a part of #7302, MinIO server's (configured with https) response when it
encounters http request has changed from 403 to 400 and the custom message
"SSL Required" is removed.

Accordingly healthcheck script is updated to check for status 400 before
trying https request.

Fixes #7517

## Regression
Yes, after #7302 

## How Has This Been Tested?
- Start MinIO Docker container with https.
- Monitor the health status for 4-5 minutes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.