### PR TITLE
fix: close cacheReader before clearing cache

### DIFF
--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -200,6 +200,7 @@ func (c cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string,
 		return cacheReader, nil
 	} else if err != nil {
 		if _, ok := err.(ObjectNotFound); ok {
+			cacheReader.Close()
 			// Delete cached entry if backend object was deleted.
 			dcache.Delete(ctx, bucket, object)
 		}


### PR DESCRIPTION
entry if backend object was deleted

Fixes: #7549

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
GetObjectNInfo acquires a read lock on cache entry - if backend object is gone, this lock needs to be released before getting a write lock to delete cache entry.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes the hand issue referenced above
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see repro steps in issue
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.