### PR TITLE
Enable event persistence in AMQP

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -84,7 +84,9 @@ var (
         "durable": false,
         "internal": false,
         "noWait": false,
-        "autoDeleted": false
+        "autoDeleted": false,
+        "queueDir": "",
+        "queueLimit": 0
       }
     },
     "elasticsearch": {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -303,7 +303,7 @@ func (s *serverConfig) TestNotificationTargets() error {
 		if !v.Enable {
 			continue
 		}
-		t, err := target.NewAMQPTarget(k, v)
+		t, err := target.NewAMQPTarget(k, v, GlobalServiceDoneCh)
 		if err != nil {
 			return fmt.Errorf("amqp(%s): %s", k, err.Error())
 		}
@@ -637,7 +637,7 @@ func getNotificationTargets(config *serverConfig) *event.TargetList {
 	}
 	for id, args := range config.Notify.AMQP {
 		if args.Enable {
-			newTarget, err := target.NewAMQPTarget(id, args)
+			newTarget, err := target.NewAMQPTarget(id, args, GlobalServiceDoneCh)
 			if err != nil {
 				logger.LogIf(context.Background(), err)
 				continue

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -185,7 +185,7 @@ func TestValidateConfig(t *testing.T) {
 		{`{"version": "` + v + `", "browser": "on", "browser": "on", "region":"us-east-1", "credential" : {"accessKey":"minio", "secretKey":"minio123"}}`, false},
 
 		// Test 11 - Test AMQP
-		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "amqp": { "1": { "enable": true, "url": "", "exchange": "", "routingKey": "", "exchangeType": "", "mandatory": false, "immediate": false, "durable": false, "internal": false, "noWait": false, "autoDeleted": false }}}}`, false},
+		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "amqp": { "1": { "enable": true, "url": "", "exchange": "", "routingKey": "", "exchangeType": "", "mandatory": false, "immediate": false, "durable": false, "internal": false, "noWait": false, "autoDeleted": false, "queueDir": "", "queueLimit": 0}}}}`, false},
 
 		// Test 12 - Test NATS
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "nats": { "1": { "enable": true, "address": "", "subject": "", "username": "", "password": "", "token": "", "secure": false, "pingInterval": 0, "streaming": { "enable": false, "clusterID": "", "async": false, "maxPubAcksInflight": 0 } } }}}`, false},

--- a/cmd/config-versions.go
+++ b/cmd/config-versions.go
@@ -884,7 +884,7 @@ type serverConfigV32 struct {
 	} `json:"policy"`
 }
 
-// serverConfigV33 is just like version '32', removes clientID from NATS and MQTT, and adds queueDir, queueLimit with MQTT.
+// serverConfigV33 is just like version '32', removes clientID from NATS and MQTT, and adds queueDir, queueLimit in MQTT and AMQP.
 type serverConfigV33 struct {
 	quick.Config `json:"-"` // ignore interfaces
 

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -47,6 +47,9 @@ The MinIO server configuration file is stored on the backend in json format. The
 | `internal` | _bool_ | Exchange declaration related bool. |
 | `noWait` | _bool_ | Exchange declaration related bool. |
 | `autoDeleted` | _bool_ | Exchange declaration related bool. |
+| `queueDir` | _string_ | Persistent store for events when AMQP broker is offline |
+| `queueLimit` | _int_ | Set the maximum event limit for the persistent store. The default limit is 10000 |
+
 
 An example configuration for RabbitMQ is shown below:
 
@@ -64,7 +67,9 @@ An example configuration for RabbitMQ is shown below:
         "durable": false,
         "internal": false,
         "noWait": false,
-        "autoDeleted": false
+        "autoDeleted": false,
+        "queueDir": "",
+        "queueLimit": 0
     }
 }
 ```
@@ -296,6 +301,8 @@ An example of Elasticsearch configuration is as follows:
     }
 },
 ```
+
+MinIO supports persistent event store. The persistent store will backup events when the AMQP broker goes offline and replays it when the broker comes back online. The event store can be configured by setting the directory path in `queueDir` field and the maximum limit of events in the queueDir in `queueLimit` field. For eg, the `queueDir` can be `/home/events` and `queueLimit` can be `1000`. By default, the `queueLimit` is set to 10000.
 
 If Elasticsearch has authentication enabled, the credentials can be supplied to MinIO via the `url` parameter formatted as `PROTO://USERNAME:PASSWORD@ELASTICSEARCH_HOST:PORT`.
 

--- a/docs/config/config.sample.json
+++ b/docs/config/config.sample.json
@@ -48,7 +48,9 @@
 				"durable": false,
 				"internal": false,
 				"noWait": false,
-				"autoDeleted": false
+				"autoDeleted": false,
+                                "queueDir": "",
+                                "queueLimit": 0
 			}
 		},
 		"elasticsearch": {


### PR DESCRIPTION


## Description
AMQP events will be persisted in a queue dir if configured, else persisted in memory.

<!--- Describe your changes in detail -->
 
## Motivation and Context
To provide offline backup/persistence for events, so that no events are lost.

## Regression
It is a feature

## How Has This Been Tested?
- Start minio with/without an active amqp broker with the following config 
  ```"amqp": {
    "1": {
        "enable": true,
        "url": "amqp://guest:guest@localhost:5672",
        "exchange": "bucketevents",
        "routingKey": "bucketlogs",
        "exchangeType": "fanout",
        "deliveryMode": 0,
        "mandatory": false,
        "immediate": false,
        "durable": false,
        "internal": false,
        "noWait": false,
        "autoDeleted": false,
        "queueDir": "/tmp/amqp",
        "queueLimit": 1000
    } 
- Run the following consumer script

```
#!/usr/bin/env python
import pika
import time

def callback(ch, method, properties, body):
        print(" [xxx->] %r" % body)

        
while True:
    try:
        connection = pika.BlockingConnection(pika.ConnectionParameters(
            host='localhost'))
        channel = connection.channel()
    
        channel.exchange_declare(exchange='bucketevents',
                                exchange_type='fanout')
    
        result = channel.queue_declare("bucketlogs", exclusive=False)
        queue_name = result.method.queue
        
        channel.queue_bind(exchange='bucketevents',
                    queue=queue_name)
        
        print(' [*] Waiting for logs. To exit press CTRL+C')
        
        channel.basic_consume(queue=queue_name,on_message_callback=callback,auto_ack=True)

        channel.start_consuming()

    # Don't recover if connection was closed by broker
    except pika.exceptions.ConnectionClosedByBroker:
        continue
    # Don't recover on channel errors
    except pika.exceptions.AMQPChannelError:
        break
    # Recover on all other connection errors
    except pika.exceptions.AMQPConnectionError:
        continue
```
- Enable bucket notification using mc
- Start sending events
- The events will persist in `/tmp/amqp` and gets replayed when the broker is turned on. (/tmp/amqp - will be empty if the events are successfully sent)
- You can see the events in the consumer end.
- The persisted events will still survive the server restarts.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.