### PR TITLE
Enable persistent event store in elasticsearch

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -92,7 +92,9 @@ var (
         "enable": false,
         "format": "namespace",
         "url": "",
-        "index": ""
+        "index": "",
+        "queueDir": "",
+        "queueLimit": 0
       }
     },
     "kafka": {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -314,7 +314,7 @@ func (s *serverConfig) TestNotificationTargets() error {
 		if !v.Enable {
 			continue
 		}
-		t, err := target.NewElasticsearchTarget(k, v)
+		t, err := target.NewElasticsearchTarget(k, v, GlobalServiceDoneCh)
 		if err != nil {
 			return fmt.Errorf("elasticsearch(%s): %s", k, err.Error())
 		}
@@ -651,7 +651,7 @@ func getNotificationTargets(config *serverConfig) *event.TargetList {
 
 	for id, args := range config.Notify.Elasticsearch {
 		if args.Enable {
-			newTarget, err := target.NewElasticsearchTarget(id, args)
+			newTarget, err := target.NewElasticsearchTarget(id, args, GlobalServiceDoneCh)
 			if err != nil {
 				logger.LogIf(context.Background(), err)
 				continue

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -224,7 +224,7 @@ func TestValidateConfig(t *testing.T) {
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "elasticsearch": { "1": { "enable": true, "format": "invalid", "url": "example.com", "index": "myindex" } }}}`, false},
 
 		// Test 24 - Test valid Format for ElasticSearch
-		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "elasticsearch": { "1": { "enable": true, "format": "namespace", "url": "example.com", "index": "myindex" } }}}`, true},
+		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "elasticsearch": { "1": { "enable": true, "format": "namespace", "url": "example.com", "index": "myindex", "queueDir": "", "queueLimit": 0 } }}}`, true},
 
 		// Test 25 - Test Format for Redis
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "invalid", "address": "example.com:80", "password": "xxx", "key": "key1" } }}}`, false},

--- a/cmd/config-versions.go
+++ b/cmd/config-versions.go
@@ -884,7 +884,8 @@ type serverConfigV32 struct {
 	} `json:"policy"`
 }
 
-// serverConfigV33 is just like version '32', removes clientID from NATS and MQTT, and adds queueDir, queueLimit with MQTT.
+// serverConfigV33 is just like version '32', removes clientID from NATS and MQTT, and adds queueDir, queueLimit in
+// MQTT and Elasticsearch.
 type serverConfigV33 struct {
 	quick.Config `json:"-"` // ignore interfaces
 

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -283,6 +283,8 @@ The MinIO server configuration file is stored on the backend in json format. The
 | `format` | _string_ | (Required) Either `namespace` or `access`. |
 | `url` | _string_ | (Required) The Elasticsearch server's address, with optional authentication info. For example: `http://localhost:9200` or with authentication info `http://elastic:MagicWord@127.0.0.1:9200`. |
 | `index` | _string_ | (Required) The name of an Elasticsearch index in which MinIO will store documents. |
+| `queueDir` | _string_ | Persistent store for events when Elasticsearch broker is offline |
+| `queueLimit` | _int_ | Set the maximum event limit for the persistent store. The default limit is 10000 |
 
 An example of Elasticsearch configuration is as follows:
 
@@ -292,10 +294,13 @@ An example of Elasticsearch configuration is as follows:
         "enable": true,
         "format": "namespace",
         "url": "http://127.0.0.1:9200",
-        "index": "minio_events"
+        "index": "minio_events",
+        "queueDir": "",
+        "queueLimit": 0
     }
 },
 ```
+Minio supports persistent event store. The persistent store will backup events when the Elasticsearch broker goes offline and replays it when the broker comes back online. The event store can be configured by setting the directory path in `queueDir` field and the maximum limit of events in the queueDir in `queueLimit` field. For eg, the `queueDir` can be `/home/events` and `queueLimit` can be `1000`. By default, the `queueLimit` is set to 10000.
 
 If Elasticsearch has authentication enabled, the credentials can be supplied to MinIO via the `url` parameter formatted as `PROTO://USERNAME:PASSWORD@ELASTICSEARCH_HOST:PORT`.
 

--- a/docs/config/config.sample.json
+++ b/docs/config/config.sample.json
@@ -56,7 +56,9 @@
 				"enable": false,
 				"format": "",
 				"url": "",
-				"index": ""
+				"index": "",
+                                "queueDir": "",
+                                "queueLimit": 0
 			}
 		},
 		"kafka": {

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/nsqio/go-nsq v1.0.7
 	github.com/pascaldekloe/goe v0.1.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
@@ -93,11 +93,12 @@ require (
 	go.uber.org/atomic v1.3.2
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect
-	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5
-	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
-	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67
+	golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a
+	golang.org/x/lint v0.0.0-20190409202823-959b441ac422 // indirect
+	golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2
+	golang.org/x/sys v0.0.0-20190416152802-12500544f89f
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	golang.org/x/tools v0.0.0-20190408220357-e5b8258f4918 // indirect
+	golang.org/x/tools v0.0.0-20190417005754-4ca4b55e2050 // indirect
 	google.golang.org/api v0.3.0
 	gopkg.in/Shopify/sarama.v1 v1.20.0
 	gopkg.in/olivere/elastic.v5 v5.0.80

--- a/go.sum
+++ b/go.sum
@@ -588,6 +588,8 @@ golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0F
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5 h1:bselrhR0Or1vomJZC8ZIjWtbDmn9OYFLX5Ik9alpJpE=
 golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
+golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a h1:Igim7XhdOpBnWPuYJ70XcNpq8q3BCACtVgNfoJxOV7g=
+golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -596,6 +598,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190409202823-959b441ac422 h1:QzoH/1pFpZguR8NrRHLcO6jKqfv2zpuSqZLgdm7ZmjI=
+golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -619,6 +623,8 @@ golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b h1:/zjbcJPEGAyu6Is/VBOALsgdi
 golang.org/x/net v0.0.0-20190403144856-b630fd6fe46b/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2 h1:iC0Y6EDq+rhnAePxGvJs2kzUAYcwESqdcGRPzEUfzTU=
+golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180603041954-1e0a3fa8ba9a/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -659,6 +665,8 @@ golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e h1:nFYrTHrdrAOpShe27kaFHjsqY
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 h1:1Fzlr8kkDLQwqMP8GxrhptBLqZG/EDpiATneiZHY998=
 golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190416152802-12500544f89f h1:1ZH9RnjNgLzh6YrsRp/c6ddZ8Lq0fq9xztNOoWJ2sz4=
+golang.org/x/sys v0.0.0-20190416152802-12500544f89f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -680,6 +688,8 @@ golang.org/x/tools v0.0.0-20190404132500-923d25813098 h1:MtqjsZmyGRgMmLUgxnmMJ6R
 golang.org/x/tools v0.0.0-20190404132500-923d25813098/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190408220357-e5b8258f4918 h1:Nc6hX4GCe+yXisksIiO0/6ToNDV42upjoQwt2IwHKUM=
 golang.org/x/tools v0.0.0-20190408220357-e5b8258f4918/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190417005754-4ca4b55e2050 h1:F2v+dqex82KbcdFuJrgIWjWXfT48L8i0Qh8NFaZPNZg=
+golang.org/x/tools v0.0.0-20190417005754-4ca4b55e2050/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/api v0.0.0-20180603000442-8e296ef26005/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20180916000451-19ff8768a5c0/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/pkg/event/target/elasticsearch.go
+++ b/pkg/event/target/elasticsearch.go
@@ -18,23 +18,28 @@ package target
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"net"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/minio/minio/pkg/event"
 	xnet "github.com/minio/minio/pkg/net"
+	"github.com/pkg/errors"
 
 	"gopkg.in/olivere/elastic.v5"
 )
 
 // ElasticsearchArgs - Elasticsearch target arguments.
 type ElasticsearchArgs struct {
-	Enable bool     `json:"enable"`
-	Format string   `json:"format"`
-	URL    xnet.URL `json:"url"`
-	Index  string   `json:"index"`
+	Enable     bool     `json:"enable"`
+	Format     string   `json:"format"`
+	URL        xnet.URL `json:"url"`
+	Index      string   `json:"index"`
+	QueueDir   string   `json:"queueDir"`
+	QueueLimit uint16   `json:"queueLimit"`
 }
 
 // Validate ElasticsearchArgs fields
@@ -62,6 +67,7 @@ type ElasticsearchTarget struct {
 	id     event.TargetID
 	args   ElasticsearchArgs
 	client *elastic.Client
+	store  Store
 }
 
 // ID - returns target ID.
@@ -69,14 +75,37 @@ func (target *ElasticsearchTarget) ID() event.TargetID {
 	return target.id
 }
 
-// Save - Sends event directly without persisting.
+// Save - saves the events to the store which will be replayed when the elasticsearch connection is active.
 func (target *ElasticsearchTarget) Save(eventData event.Event) error {
-	return target.send(eventData)
+	return target.store.Put(eventData)
 }
 
-func (target *ElasticsearchTarget) send(eventData event.Event) error {
+// Send - sends event to Elasticsearch.
+func (target *ElasticsearchTarget) Send(eventKey string) error {
 
 	var key string
+	var err error
+
+	if target.client == nil {
+		target.client, err = newClient(target.args)
+		if err != nil {
+			return err
+		}
+	}
+
+	if _, err := net.Dial("tcp", target.args.URL.Host); err != nil {
+		return errNotConnected
+	}
+
+	eventData, eErr := target.store.Get(eventKey)
+	if eErr != nil {
+		// The last event key in a successful batch will be sent in the channel atmost once by the replayEvents()
+		// Such events will not exist and wouldve been already been sent successfully.
+		if os.IsNotExist(eErr) {
+			return nil
+		}
+		return eErr
+	}
 
 	remove := func() error {
 		_, err := target.client.Delete().Index(target.args.Index).Type("event").Id(key).Do(context.Background())
@@ -106,19 +135,21 @@ func (target *ElasticsearchTarget) send(eventData event.Event) error {
 			err = update()
 		}
 
+		if err == nil {
+			return target.store.Del(eventKey)
+		}
 		return err
 	}
 
 	if target.args.Format == event.AccessFormat {
-		return add()
+		if err := add(); err == nil {
+			return target.store.Del(eventKey)
+		}
+		return err
 	}
 
-	return nil
-}
-
-// Send - interface compatible method does no-op.
-func (target *ElasticsearchTarget) Send(eventKey string) error {
-	return nil
+	// Delete the event from store.
+	return target.store.Del(eventKey)
 }
 
 // Close - does nothing and available for interface compatibility.
@@ -126,32 +157,75 @@ func (target *ElasticsearchTarget) Close() error {
 	return nil
 }
 
-// NewElasticsearchTarget - creates new Elasticsearch target.
-func NewElasticsearchTarget(id string, args ElasticsearchArgs) (*ElasticsearchTarget, error) {
-	client, err := elastic.NewClient(elastic.SetURL(args.URL.String()), elastic.SetSniff(false), elastic.SetMaxRetries(10))
-	if err != nil {
-		return nil, err
-	}
-
+// createIndex - creates the index if it does not exist.
+func createIndex(client *elastic.Client, args ElasticsearchArgs) error {
 	exists, err := client.IndexExists(args.Index).Do(context.Background())
 	if err != nil {
-		return nil, err
+		return err
 	}
-
 	if !exists {
 		var createIndex *elastic.IndicesCreateResult
 		if createIndex, err = client.CreateIndex(args.Index).Do(context.Background()); err != nil {
-			return nil, err
+			return err
 		}
 
 		if !createIndex.Acknowledged {
-			return nil, fmt.Errorf("index %v not created", args.Index)
+			return fmt.Errorf("index %v not created", args.Index)
+		}
+	}
+	return nil
+}
+
+func newClient(args ElasticsearchArgs) (*elastic.Client, error) {
+	client, clientErr := elastic.NewClient(elastic.SetURL(args.URL.String()), elastic.SetSniff(false), elastic.SetMaxRetries(10))
+	if clientErr != nil {
+		if !(errors.Cause(clientErr) == elastic.ErrNoClient) {
+			return nil, clientErr
+		}
+	} else {
+		if err := createIndex(client, args); err != nil {
+			return nil, err
+		}
+	}
+	return client, nil
+}
+
+// NewElasticsearchTarget - creates new Elasticsearch target.
+func NewElasticsearchTarget(id string, args ElasticsearchArgs, doneCh <-chan struct{}) (*ElasticsearchTarget, error) {
+	var client *elastic.Client
+	var err error
+
+	if _, derr := net.Dial("tcp", args.URL.Host); derr == nil {
+		client, err = newClient(args)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	return &ElasticsearchTarget{
+	var store Store
+
+	if args.QueueDir != "" {
+		queueDir := filepath.Join(args.QueueDir, storePrefix+"-elasticsearch-"+id)
+		store = NewQueueStore(queueDir, args.QueueLimit)
+		if oErr := store.Open(); oErr != nil {
+			return nil, oErr
+		}
+	} else {
+		store = NewMemoryStore(args.QueueLimit)
+	}
+
+	target := &ElasticsearchTarget{
 		id:     event.TargetID{ID: id, Name: "elasticsearch"},
 		args:   args,
 		client: client,
-	}, nil
+		store:  store,
+	}
+
+	// Replays the events from the store.
+	eventKeyCh := replayEvents(target.store, doneCh)
+
+	// Start replaying events from the store.
+	go sendEvents(target, eventKeyCh, doneCh)
+
+	return target, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Elasticsearch events will be persisted in a queue dir if configured, else persisted in memory.

## Motivation and Context
To provide offline backup/persistence for events, so that no events are lost.

## Regression
it is a feature

## How Has This Been Tested?
- Start minio with/without an active elastic search broker with the following config 
```
"elasticsearch": {
    "1": {
        "enable": true,
        "format": "namespace",
        "url": "http://127.0.0.1:9200",
        "index": "minio_events",
        "queueDir": "/tmp/els",
        "queueLimit": 1000
    }
},
```
- Enable bucket notification using mc
- Start sending events
- The events will persist in `/tmp/els` and gets replayed when the broker is turned on. (/tmp/els - will be empty if the events are successfully sent)
- You can curl the elasticsearch broker to see the entries for the "minio_events" index - `curl  "http://localhost:9200/minio_events/_search?pretty=true"`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.