### PR TITLE
[WIP] Modify return code for GetObject Request

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -313,22 +313,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 		getObjectNInfo = api.CacheAPI().GetObjectNInfo
 	}
 
-	// Get request range.
 	var rs *HTTPRangeSpec
-	rangeHeader := r.Header.Get("Range")
-	if rangeHeader != "" {
-		if rs, err = parseRequestRangeSpec(rangeHeader); err != nil {
-			// Handle only errInvalidRange. Ignore other
-			// parse error and treat it as regular Get
-			// request like Amazon S3.
-			if err == errInvalidRange {
-				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidRange), r.URL, guessIsBrowserReq(r))
-				return
-			}
-
-			logger.LogIf(ctx, err)
-		}
-	}
 
 	gr, err := getObjectNInfo(ctx, bucket, object, rs, r.Header, readLock, opts)
 	if err != nil {
@@ -350,6 +335,22 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	// Validate pre-conditions if any.
 	if checkPreconditions(ctx, w, r, objInfo) {
 		return
+	}
+
+	// Get request range.
+	rangeHeader := r.Header.Get("Range")
+	if rangeHeader != "" {
+		if rs, err = parseRequestRangeSpec(rangeHeader); err != nil {
+			// Handle only errInvalidRange. Ignore other
+			// parse error and treat it as regular Get
+			// request like Amazon S3.
+			if err == errInvalidRange {
+				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidRange), r.URL, guessIsBrowserReq(r))
+				return
+			}
+
+			logger.LogIf(ctx, err)
+		}
 	}
 
 	// Set encryption response headers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Precondition checked before the range validation.

If you specify a GetObject-Request with the Range- and the If-Match-Header set but a "wrong" ETAG and a range value that is out of range then the server returns a http 416 status code (range not satisfiable) instead of a http 412 status code (precondition failed).

## Description
<!--- Describe your changes in detail -->
Earlier the validation for request range was done before the validation of precondition 
which resulted in http `416 status code (range not satisfiable)` . 
With this change preconditions validation is done before the range valdiation thus returning 
correct error code ` http 412 status code (precondition failed).` keeping in line with S3.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Return the correct erro code
<!--- If it fixes an open issue, please link to the issue here. -->
[Issue](https://github.com/minio/minio/issues/7292)

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
In order to replicate the issue use aws cli and run the command 
```
aws --endpoint-url <<endpoint-url>> s3api get-object --bucket <<my-bucket-name>> --key <<my-object-name>> --if-match <<etag>> --range bytes=<<range-of-bytes>> <<path-to-file-which-saves-the-content>>

Example : 
aws --endpoint-url http://192.168.0.103:9000  s3api get-object --bucket sinha-minio --key foo --if-match ab2aecac342f500bf6992093d67d63c9 --range bytes=10-21 /home/ashish/cli.txt
```

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [X] All new and existing tests passed.