### PR TITLE
Enable event persistence in NSQ

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -168,7 +168,9 @@ var (
         "tls": {
 			"enable": false,
 			"skipVerify": false
-		}
+		},
+        "queueDir": "",
+        "queueLimit": 0
       }
     },
     "postgresql": {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -369,7 +369,7 @@ func (s *serverConfig) TestNotificationTargets() error {
 		if !v.Enable {
 			continue
 		}
-		t, err := target.NewNSQTarget(k, v)
+		t, err := target.NewNSQTarget(k, v, GlobalServiceDoneCh)
 		if err != nil {
 			return fmt.Errorf("nsq(%s): %s", k, err.Error())
 		}
@@ -724,7 +724,7 @@ func getNotificationTargets(config *serverConfig) *event.TargetList {
 
 	for id, args := range config.Notify.NSQ {
 		if args.Enable {
-			newTarget, err := target.NewNSQTarget(id, args)
+			newTarget, err := target.NewNSQTarget(id, args, GlobalServiceDoneCh)
 			if err != nil {
 				logger.LogIf(context.Background(), err)
 				continue

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -236,7 +236,7 @@ func TestValidateConfig(t *testing.T) {
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "mqtt": { "1": { "enable": true, "broker": "",  "topic": "", "qos": 0, "username": "", "password": "", "queueDir": "", "queueLimit": 0}}}}`, false},
 
 		// Test 28 - Test NSQ
-		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "nsq": { "1": { "enable": true, "nsqdAddress": "", "topic": ""} }}}`, false},
+		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "nsq": { "1": { "enable": true, "nsqdAddress": "", "topic": "", "queueDir": "", "queueLimit": 0} }}}`, false},
 	}
 
 	for i, testCase := range testCases {

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -1110,12 +1110,17 @@ An example configuration for NSQ is shown below:
         "tls": {
             "enable": false,
             "skipVerify": true
-        }
+        },
+        "queueDir": "",
+        "queueLimit": 0
     }
 }
+
+MinIO supports persistent event store. The persistent store will backup events when the NSQ broker goes offline and replays it when the broker comes back online. The event store can be configured by setting the directory path in `queueDir` field and the maximum limit of events in the queueDir in `queueLimit` field. For eg, the `queueDir` can be `/home/events` and `queueLimit` can be `1000`. By default, the `queueLimit` is set to 10000.
+
 ```
 
-To update the configuration, use `mc admin config get` command to get the current configuration file for the minio deployment in json format, and save it locally.
+To update the configuration, use `mc admin config get` command to get the current configuration file for the MinIO deployment in json format, and save it locally.
 
 ```sh
 $ mc admin config get myminio/ > /tmp/myconfig

--- a/docs/config/config.sample.json
+++ b/docs/config/config.sample.json
@@ -133,7 +133,9 @@
 				"tls": {
 					"enable": false,
 					"skipVerify": true
-				}
+				},
+                                "queueDir": "",
+                                "queueLimit": 0                 
 			}
 		},
 		"postgresql": {

--- a/pkg/event/target/nsq_test.go
+++ b/pkg/event/target/nsq_test.go
@@ -17,70 +17,9 @@
 package target
 
 import (
-	"reflect"
-	"testing"
-
-	"github.com/minio/minio/pkg/event"
-	"github.com/minio/minio/pkg/net"
 	xnet "github.com/minio/minio/pkg/net"
-	"github.com/nsqio/go-nsq"
+	"testing"
 )
-
-func TestNewNSQTarget(t *testing.T) {
-	type args struct {
-		id   string
-		args NSQArgs
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    *NSQTarget
-		wantErr bool
-	}{
-		{
-			name: "test1",
-			args: args{
-				id: "id",
-				args: NSQArgs{
-					Enable: true,
-					Topic:  "",
-					TLS: struct {
-						Enable     bool `json:"enable"`
-						SkipVerify bool `json:"skipVerify"`
-					}{true, true},
-				},
-			},
-			want: &NSQTarget{
-				id: event.TargetID{ID: "id", Name: "nsq"},
-				args: NSQArgs{
-					Enable:      true,
-					NSQDAddress: net.Host{},
-					Topic:       "",
-					TLS: struct {
-						Enable     bool `json:"enable"`
-						SkipVerify bool `json:"skipVerify"`
-					}{true, true},
-				},
-				producer: &nsq.Producer{},
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewNSQTarget(tt.args.id, tt.args.args)
-			// dirty hack, otherwhise cannot compare the pointers:
-			tt.want.producer = got.producer
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewNSQTarget() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewNSQTarget() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestNSQArgs_Validate(t *testing.T) {
 	type fields struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
NSQ events will be persisted in a queue dir if configured, else persisted in memory.

## Motivation and Context
To provide offline backup/persistence for events, so that no events are lost.

## Regression
It is a feature

## How Has This Been Tested?
- Start MinIO without an active nsq broker with the following config 
```
"nsq": {
    "1": {
        "enable": true,
        "nsqdAddress": "127.0.0.1:4150",
        "topic": "minio",
        "tls": {
            "enable": false,
            "skipVerify": true
        },
        "queueDir": "/tmp/nsq",
        "queueLimit": 1000
    }
}
```
- Enable bucket notification using mc
- Start sending events
- The events will persist in /tmp/nsq and gets replayed when the broker is turned on. (/tmp/nsq - will be empty if the events are successfully sent)
- Download nsq tail and listen on the topic "minio" 
`./nsq_tail -nsqd-tcp-address 127.0.0.1:4150 -topic minio`
- You can see the events in the consumer end.
- The persisted events will still survive the server restarts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.