### PR TITLE
Fix divide by 0 error when directio.AlignSize is 0

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -45,6 +45,7 @@ const (
 	diskMinTotalSpace   = diskMinFreeSpace      // Min 900MiB total space.
 	maxAllowedIOError   = 5
 	posixWriteBlockSize = 4 * humanize.MiByte
+	directioAlignSize   = 4096 // DirectIO alignment needs to be 4K. Defined here as directio.AlignSize is defined as 0 in MacOS causing divide by 0 error.
 )
 
 // isValidVolname verifies a volname name in accordance with object
@@ -1142,7 +1143,7 @@ func (s *posix) CreateFile(volume, path string, fileSize int64, r io.Reader) (er
 		if err != nil {
 			return err
 		}
-		remainingAligned := (remaining / directio.AlignSize) * directio.AlignSize
+		remainingAligned := (remaining / directioAlignSize) * directioAlignSize
 		remainingAlignedBuf := buf[:remainingAligned]
 		remainingUnalignedBuf := buf[remainingAligned:]
 		if len(remainingAlignedBuf) > 0 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

```
remainingAligned := (remaining / directio.AlignSize) * directio.AlignSize
```

This was panicing because of divide by 0 on mac. This patch is to fix it.


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.