### PR TITLE
Minor TLS documentation improvements

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -22,7 +22,7 @@ Copy the existing private key and public certificate to the `certs` directory. T
 > NOTE: Location of custom certs directory can be specified using `--certs-dir` command line option.
 
 **Note:** 
-* The key and certificate files must be appended with `.key` and `.crt`, respectively.
+* Inside the `certs` directory, the private key must by named `private.key` and the public key must be named `public.crt`.
 * A certificate signed by a CA contains information about the issued identity (e.g. name, expiry, public key) and any intermediate certificates. The root CA is not included.
 
 ## <a name="generate-use-self-signed-keys-certificates"></a>3. Generate and use Self-signed Keys and Certificates with MinIO


### PR DESCRIPTION
## Description
From my limited understanding of the code, the server key/certificate file names are hardcoded [here](https://github.com/minio/minio/blob/b93ef73f9b82325599cadff980ab5e6da840f8d5/cmd/config-dir.go#L26) and cannot be changed. The user can only supply the path to the `certs` directory containing these two files.

But the TLS documentation isn't really clear on this:

> Copy the existing private key and public certificate to the `certs` directory

and:

> The key and certificate files must be appended with .key and .crt, respectively.

For clarity I've included in the second phrase to include the names `public.crt` and `private.key`. (I've lost way to much time trying to understand why minio wasn't picking up my `<hostname>.crt` and `hostname.key` files :D ).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.