### PR TITLE
Enable event persistence in Redis

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -192,7 +192,9 @@ var (
         "format": "namespace",
         "address": "",
         "password": "",
-        "key": ""
+        "key": "",
+        "queueDir": "",
+        "queueLimit": 0
       }
     },
     "webhook": {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -391,7 +391,7 @@ func (s *serverConfig) TestNotificationTargets() error {
 		if !v.Enable {
 			continue
 		}
-		t, err := target.NewRedisTarget(k, v)
+		t, err := target.NewRedisTarget(k, v, GlobalServiceDoneCh)
 		if err != nil {
 			return fmt.Errorf("redis(%s): %s", k, err.Error())
 		}
@@ -752,7 +752,7 @@ func getNotificationTargets(config *serverConfig) *event.TargetList {
 
 	for id, args := range config.Notify.Redis {
 		if args.Enable {
-			newTarget, err := target.NewRedisTarget(id, args)
+			newTarget, err := target.NewRedisTarget(id, args, GlobalServiceDoneCh)
 			if err != nil {
 				logger.LogIf(context.Background(), err)
 				continue

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -227,7 +227,7 @@ func TestValidateConfig(t *testing.T) {
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "elasticsearch": { "1": { "enable": true, "format": "namespace", "url": "example.com", "index": "myindex", "queueDir": "", "queueLimit": 0 } }}}`, true},
 
 		// Test 25 - Test Format for Redis
-		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "invalid", "address": "example.com:80", "password": "xxx", "key": "key1" } }}}`, false},
+		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "invalid", "address": "example.com:80", "password": "xxx", "key": "key1", "queueDir": "", "queueLimit": 0 } }}}`, false},
 
 		// Test 26 - Test valid Format for Redis
 		{`{"version": "` + v + `", "credential": { "accessKey": "minio", "secretKey": "minio123" }, "region": "us-east-1", "browser": "on", "notify": { "redis": { "1": { "enable": true, "format": "namespace", "address": "example.com:80", "password": "xxx", "key": "key1" } }}}`, true},

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -460,10 +460,14 @@ An example of Redis configuration is as follows:
         "format": "namespace",
         "address": "127.0.0.1:6379",
         "password": "yoursecret",
-        "key": "bucketevents"
+        "key": "bucketevents",
+        "queueDir": "",
+        "queueLimit": 0
     }
 }
 ```
+
+MinIO supports persistent event store. The persistent store will backup events when the Redis broker goes offline and replays it when the broker comes back online. The event store can be configured by setting the directory path in `queueDir` field and the maximum limit of events in the queueDir in `queueLimit` field. For eg, the `queueDir` can be `/home/events` and `queueLimit` can be `1000`. By default, the `queueLimit` is set to 10000.
 
 To update the configuration, use `mc admin config get` command to get the current configuration file for the minio deployment in json format, and save it locally.
 

--- a/docs/config/config.sample.json
+++ b/docs/config/config.sample.json
@@ -157,7 +157,9 @@
 				"format": "",
 				"address": "",
 				"password": "",
-				"key": ""
+				"key": "",
+                                "queueDir": "",
+                                "queueLimit": 0                 
 			}
 		},
 		"webhook": {

--- a/pkg/event/target/nsq.go
+++ b/pkg/event/target/nsq.go
@@ -20,11 +20,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"net"
 	"net/url"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/nsqio/go-nsq"
 
@@ -90,26 +88,12 @@ func (target *NSQTarget) Save(eventData event.Event) error {
 	}
 	if err := target.producer.Ping(); err != nil {
 		// To treat "connection refused" errors as errNotConnected.
-		if isConnRefusedErr(err) {
+		if IsConnRefusedErr(err) {
 			return errNotConnected
 		}
 		return err
 	}
 	return target.send(eventData)
-}
-
-// isConnRefusedErr - To check fot "connection refused" error.
-func isConnRefusedErr(err error) bool {
-	if opErr, ok := err.(*net.OpError); ok {
-		if sysErr, ok := opErr.Err.(*os.SyscallError); ok {
-			if errno, ok := sysErr.Err.(syscall.Errno); ok {
-				if errno == syscall.ECONNREFUSED {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 // send - sends an event to the NSQ.
@@ -133,7 +117,7 @@ func (target *NSQTarget) Send(eventKey string) error {
 
 	if err := target.producer.Ping(); err != nil {
 		// To treat "connection refused" errors as errNotConnected.
-		if isConnRefusedErr(err) {
+		if IsConnRefusedErr(err) {
 			return errNotConnected
 		}
 		return err
@@ -198,7 +182,7 @@ func NewNSQTarget(id string, args NSQArgs, doneCh <-chan struct{}) (*NSQTarget, 
 
 	if err := target.producer.Ping(); err != nil {
 		// To treat "connection refused" errors as errNotConnected.
-		if target.store == nil || !isConnRefusedErr(err) {
+		if target.store == nil || !IsConnRefusedErr(err) {
 			return nil, err
 		}
 	}

--- a/pkg/event/target/store.go
+++ b/pkg/event/target/store.go
@@ -79,6 +79,20 @@ func replayEvents(store Store, doneCh <-chan struct{}) <-chan string {
 	return eventKeyCh
 }
 
+// IsConnRefusedErr - To check fot "connection refused" error.
+func IsConnRefusedErr(err error) bool {
+	if opErr, ok := err.(*net.OpError); ok {
+		if sysErr, ok := opErr.Err.(*os.SyscallError); ok {
+			if errno, ok := sysErr.Err.(syscall.Errno); ok {
+				if errno == syscall.ECONNREFUSED {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // isConnResetErr - Checks for connection reset errors.
 func isConnResetErr(err error) bool {
 	if opErr, ok := err.(*net.OpError); ok {

--- a/pkg/event/target/webhook.go
+++ b/pkg/event/target/webhook.go
@@ -30,7 +30,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/minio/minio/pkg/event"
@@ -132,20 +131,6 @@ func (target *WebhookTarget) send(eventData event.Event) error {
 	}
 
 	return nil
-}
-
-// IsConnRefusedErr - To check for "connection refused" errors.
-func IsConnRefusedErr(err error) bool {
-	if opErr, ok := err.(*net.OpError); ok {
-		if sysErr, ok := opErr.Err.(*os.SyscallError); ok {
-			if errno, ok := sysErr.Err.(syscall.Errno); ok {
-				if errno == syscall.ECONNREFUSED {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 // Send - reads an event from store and sends it to webhook.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Redis events will be persisted in a queue dir if configured, else persisted in memory.

## Motivation and Context
To provide offline backup/persistence for events, so that no events are lost.

## Regression
It is a feature

## How Has This Been Tested?
- Start MinIO without an active nsq broker with the following config
```
"redis": {
    "1": {
        "enable": true,
        "format": "namespace",
        "address": "127.0.0.1:6379",
        "password": "yoursecret",
        "key": "bucketevents",
        "queueDir": "/tmp/redis",
        "queueLimit": 1000
    }
}
```
- Enable bucket notification using mc
- Start sending events
-  The events will persist in /tmp/redis and gets replayed when the broker is turned on. (/tmp/redis - will be empty if the events are successfully sent)
- Start redis server using `redis-server --requirepass "yoursecret"`
- The events will be replayed to the server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.