### PR TITLE
Fix: Handle regression caused by gorilla mux v1.7.0

### DIFF
--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"net"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -46,13 +45,8 @@ func registerAPIRouter(router *mux.Router, encryptionEnabled bool) {
 	apiRouter := router.PathPrefix("/").Subrouter()
 	var routers []*mux.Router
 	for _, domainName := range globalDomainNames {
-		var hostPort string
-		if globalMinioPort != "443" && globalMinioPort != "80" {
-			hostPort = net.JoinHostPort(domainName, globalMinioPort)
-		} else {
-			hostPort = domainName
-		}
-		routers = append(routers, apiRouter.Host("{bucket:.+}."+hostPort).Subrouter())
+		routers = append(routers, apiRouter.Host("{bucket:.+}."+domainName).Subrouter())
+		routers = append(routers, apiRouter.Host("{bucket:.+}."+domainName+":{port:.*}").Subrouter())
 	}
 	routers = append(routers, apiRouter.PathPrefix("/{bucket}").Subrouter())
 


### PR DESCRIPTION
## Description

PR #7595 fixed part of the regression, but did not handle the
scenario, where in docker, the internal port is different from
the port on the host.

This PR modifies the regular expression such that all the
scenarios are handled.

Fixes #7619

## Motivation and Context
Issues #7577 and #7619

## Regression
Yes

## How Has This Been Tested?
with steps mentioned in #7577

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.