### PR TITLE
Add limitation to b2.md

### DIFF
--- a/docs/gateway/b2.md
+++ b/docs/gateway/b2.md
@@ -43,6 +43,7 @@ mc ls myb2
 ### Known limitations
 Gateway inherits the following B2 limitations:
 
+- PutObject() does not return an md5sum of the uploaded file as an etag response.  Apps that check vailidity will fail.
 - No support for CopyObject S3 API (There are no equivalent APIs available on Backblaze B2).
 - No support for CopyObjectPart S3 API (There are no equivalent APIs available on Backblaze B2).
 - Only read-only bucket policy supported at bucket level, all other variations will return API Notimplemented error.


### PR DESCRIPTION
The B2 gateway does not implement reporting md5sum as an etag response from PutObject.  Add to Known Limitations.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Update docs

## Motivation and Context
Good docs are good.

## Regression
N/A

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.