### PR TITLE
Fix Gateway startup sequence to populate etcd with bucket info

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -221,6 +221,11 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(err, "Unable to initialize gateway backend")
 	}
 
+	// Populate existing buckets to the etcd backend
+	if globalDNSConfig != nil {
+		initFederatorBackend(newObject)
+	}
+
 	if enableConfigOps {
 		// Create a new config system.
 		globalConfigSys = NewConfigSys()


### PR DESCRIPTION
## Description
Fix Gateway startup sequence to populate etcd with bucket info

## Motivation and Context
When a existing gateway deployment starts up in Federated mode, it needs to 
import existing buckets to the etcd server.

## Regression
No

## How Has This Been Tested?
- Start MinIO Gateway mode
- Create multiple buckets
- Enable etcd and start a federated setup 
- You should be able to see the old buckets created before federated setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.