### PR TITLE
Fixes for multiplatform dev and testing from forks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOPATH := $(shell go env GOPATH)
 LDFLAGS := $(shell go run buildscripts/gen-ldflags.go)
 
 GOOS := $(shell go env GOOS)
-GOOSALT := $(shell if [[ ${GOOS} == 'darwin' ]]; then echo 'mac'; else echo ${GOOS}; fi;)
+GOOSALT := $(shell if [ ${GOOS} == 'darwin' ]; then echo 'mac'; else echo ${GOOS}; fi;)
 
 TAG ?= $(USER)
 BUILD_LDFLAGS := '$(LDFLAGS)'

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ PWD := $(shell pwd)
 GOPATH := $(shell go env GOPATH)
 LDFLAGS := $(shell go run buildscripts/gen-ldflags.go)
 
+GOOS := $(shell go env GOOS)
+GOOSALT := $(shell if [[ ${GOOS} == 'darwin' ]]; then echo 'mac'; else echo ${GOOS}; fi;)
+
 TAG ?= $(USER)
 BUILD_LDFLAGS := '$(LDFLAGS)'
 
@@ -14,8 +17,8 @@ checks:
 getdeps:
 	@mkdir -p ${GOPATH}/bin
 	@which golint 1>/dev/null || (echo "Installing golint" && go get -u golang.org/x/lint/golint)
-	@which staticcheck 1>/dev/null || (echo "Installing staticcheck" && wget --quiet -O ${GOPATH}/bin/staticcheck https://github.com/dominikh/go-tools/releases/download/2019.1/staticcheck_linux_amd64 && chmod +x ${GOPATH}/bin/staticcheck)
-	@which misspell 1>/dev/null || (echo "Installing misspell" && wget --quiet https://github.com/client9/misspell/releases/download/v0.3.4/misspell_0.3.4_linux_64bit.tar.gz && tar xf misspell_0.3.4_linux_64bit.tar.gz && mv misspell ${GOPATH}/bin/misspell && chmod +x ${GOPATH}/bin/misspell && rm -f misspell_0.3.4_linux_64bit.tar.gz)
+	@which staticcheck 1>/dev/null || (echo "Installing staticcheck" && wget --quiet -O ${GOPATH}/bin/staticcheck https://github.com/dominikh/go-tools/releases/download/2019.1/staticcheck_${GOOS}_amd64 && chmod +x ${GOPATH}/bin/staticcheck)
+	@which misspell 1>/dev/null || (echo "Installing misspell" && wget --quiet https://github.com/client9/misspell/releases/download/v0.3.4/misspell_0.3.4_${GOOSALT}_64bit.tar.gz && tar xf misspell_0.3.4_${GOOSALT}_64bit.tar.gz && mv misspell ${GOPATH}/bin/misspell && chmod +x ${GOPATH}/bin/misspell && rm -f misspell_0.3.4_${GOOSALT}_64bit.tar.gz)
 
 crosscompile:
 	@(env bash $(PWD)/buildscripts/cross-compile.sh)

--- a/pkg/mountinfo/mountinfo.go
+++ b/pkg/mountinfo/mountinfo.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
  * MinIO Cloud Storage, (C) 2017 MinIO, Inc.
  *

--- a/pkg/s3select/select_test.go
+++ b/pkg/s3select/select_test.go
@@ -174,7 +174,7 @@ func TestParquetInput(t *testing.T) {
 `)
 
 	getReader := func(offset int64, length int64) (io.ReadCloser, error) {
-		testdataFile := path.Join(build.Default.GOPATH, "src/github.com/minio/minio/pkg/s3select/testdata.parquet")
+		testdataFile := "testdata.parquet"
 		file, err := os.Open(testdataFile)
 		if err != nil {
 			return nil, err

--- a/pkg/s3select/select_test.go
+++ b/pkg/s3select/select_test.go
@@ -18,12 +18,10 @@ package s3select
 
 import (
 	"bytes"
-	"go/build"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 	"reflect"
 	"testing"
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There were three changes:

First, the makefile was modified to download staticcheck and misspell libraries from the correct paths for your OS rather than defaulting to linux.

Second, I added a build condition to mountinfo.go so it would only build on linux because it is unused in darwin, causing the staticcheck to fail.

Third, the path for the testdata.parquet file was modified to be relative to the test directory rather than the GOPATH, allowing builds from forked repos to pass without having to also clone the `minio/minio` repo.

## Motivation and Context
This addresses basic development workflow issues for contributors running non-linux machines and outside of the minio organization.

## Regression
It looks like the linux-specific links were added in #7354 
I'm not sure the other two issues would qualify as regressions, but the hardcoded path came from #7023

## How Has This Been Tested?
make verifiers
go test ./...
    go test -race ./... didn't work because of issues with this test:
```
--- FAIL: TestValidPairAfterWrite (0.21s)
    certs_test.go:94: certificate doesn't match expected certificate
FAIL
FAIL	github.com/minio/minio/pkg/certs	0.258s
```
go build

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.