### PR TITLE
Add support for session policies in STS APIs

### DIFF
--- a/docs/sts/assume-role.md
+++ b/docs/sts/assume-role.md
@@ -10,19 +10,28 @@ The temporary security credentials returned by this API consists of an access ke
 #### DurationSeconds
 The duration, in seconds. The value can range from 900 seconds (15 minutes) up to 12 hours. If value is higher than this setting, then operation fails. By default, the value is set to 3600 seconds.
 
-| Params | Value |
-| :-- | :-- |
-| *Type* | *Integer* |
+| Params        | Value                                           |
+| :--           | :--                                             |
+| *Type*        | *Integer*                                       |
 | *Valid Range* | *Minimum value of 900. Maximum value of 43200.* |
-| *Required* | *No* |
+| *Required*    | *No*                                            |
+
+#### Policy
+An IAM policy in JSON format that you want to use as an inline session policy. This parameter is optional. Passing policies to this operation returns new temporary credentials. The resulting session's permissions are the intersection of the canned policy name and the policy set here. You cannot use this policy to grant more permissions than those allowed by the canned policy name being assumed.
+
+| Params        | Value                                          |
+| :--           | :--                                            |
+| *Type*        | *String*                                       |
+| *Valid Range* | *Minimum length of 1. Maximum length of 2048.* |
+| *Required*    | *No*                                           |
 
 #### Version
 Indicates STS API version information, the only supported value is '2011-06-15'. This value is borrowed from AWS STS API documentation for compatibility reasons.
 
-| Params | Value |
-| :-- | :-- |
-| *Type* | *String* |
-| *Required* | *Yes* |
+| Params     | Value    |
+| :--        | :--      |
+| *Type*     | *String* |
+| *Required* | *Yes*    |
 
 #### AUTHPARAMS
 Indicates STS API Authorization information. If you are familiar with AWS Signature V4 Authorization header, this STS API supports signature V4 authorization as mentioned [here](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
@@ -35,7 +44,7 @@ XML error response for this API is similar to [AWS STS AssumeRole](https://docs.
 
 #### Sample Request
 ```
-http://minio:9000/?Action=AssumeRole&DurationSeconds=3600&Version=2011-06-15&AUTHPARAMS
+http://minio:9000/?Action=AssumeRole&DurationSeconds=3600&Version=2011-06-15&Policy={"Version":"2012-10-17","Statement":[{"Sid":"Stmt1","Effect":"Allow","Action":"s3:*","Resource":"arn:aws:s3:::*"}]}&AUTHPARAMS
 ```
 
 #### Sample Response
@@ -82,7 +91,7 @@ aws_secret_access_key = foo12345
 > NOTE: In the following commands `--role-arn` and `--role-session-name` are not meaningful for MinIO and can be set to any value satisfying the command line requirements.
 
 ```
-$ aws --profile foobar --endpoint-url http://localhost:9000 sts assume-role --role-arn arn:xxx:xxx:xxx:xxx --role-session-name anything
+$ aws --profile foobar --endpoint-url http://localhost:9000 sts assume-role --policy '{"Version":"2012-10-17","Statement":[{"Sid":"Stmt1","Effect":"Allow","Action":"s3:*","Resource":"arn:aws:s3:::*"}]}' --role-arn arn:xxx:xxx:xxx:xxxx --role-session-name anything
 {
     "AssumedRoleUser": {
         "Arn": ""

--- a/docs/sts/client-grants.md
+++ b/docs/sts/client-grants.md
@@ -9,29 +9,37 @@ By default, the temporary security credentials created by AssumeRoleWithClientGr
 #### DurationSeconds
 The duration, in seconds. The value can range from 900 seconds (15 minutes) up to 12 hours. If value is higher than this setting, then operation fails. By default, the value is set to 3600 seconds.
 
-| Params | Value |
-| :-- | :-- |
-| *Type* | *Integer* |
+| Params        | Value                                           |
+| :--           | :--                                             |
+| *Type*        | *Integer*                                       |
 | *Valid Range* | *Minimum value of 900. Maximum value of 43200.* |
-| *Required* | *No* |
+| *Required*    | *No*                                            |
+
+#### Policy
+An IAM policy in JSON format that you want to use as an inline session policy. This parameter is optional. Passing policies to this operation returns new temporary credentials. The resulting session's permissions are the intersection of the canned policy name and the policy set here. You cannot use this policy to grant more permissions than those allowed by the canned policy name being assumed.
+
+| Params        | Value                                          |
+| :--           | :--                                            |
+| *Type*        | *String*                                       |
+| *Valid Range* | *Minimum length of 1. Maximum length of 2048.* |
+| *Required*    | *No*                                           |
 
 #### Token
 The OAuth 2.0 access token that is provided by the identity provider. Application must get this token by authenticating the application using client credential grants before the application makes an AssumeRoleWithClientGrants call.
 
-| Params | Value |
-| :-- | :-- |
-| *Type* | *String* |
+| Params               | Value                                          |
+| :--                  | :--                                            |
+| *Type*               | *String*                                       |
 | *Length Constraints* | *Minimum length of 4. Maximum length of 2048.* |
-| *Required* | *Yes* |
+| *Required*           | *Yes*                                          |
 
 #### Version
 Indicates STS API version information, the only supported value is '2011-06-15'.  This value is borrowed from AWS STS API documentation for compatibility reasons.
 
-
-| Params | Value |
-| :-- | :-- |
-| *Type* | *String* |
-| *Required* | *Yes* |
+| Params     | Value    |
+| :--        | :--      |
+| *Type*     | *String* |
+| *Required* | *Yes*    |
 
 #### Response Elements
 XML response for this API is similar to [AWS STS AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_ResponseElements)

--- a/docs/sts/web-identity.md
+++ b/docs/sts/web-identity.md
@@ -7,28 +7,37 @@ By default, the temporary security credentials created by AssumeRoleWithWebIdent
 #### DurationSeconds
 The duration, in seconds. The value can range from 900 seconds (15 minutes) up to 12 hours. If value is higher than this setting, then operation fails. By default, the value is set to 3600 seconds.
 
-| Params | Value |
-| :-- | :-- |
-| *Type* | *Integer* |
+| Params        | Value                                           |
+| :--           | :--                                             |
+| *Type*        | *Integer*                                       |
 | *Valid Range* | *Minimum value of 900. Maximum value of 43200.* |
-| *Required* | *No* |
+| *Required*    | *No*                                            |
+
+#### Policy
+An IAM policy in JSON format that you want to use as an inline session policy. This parameter is optional. Passing policies to this operation returns new temporary credentials. The resulting session's permissions are the intersection of the canned policy name and the policy set here. You cannot use this policy to grant more permissions than those allowed by the canned policy name being assumed.
+
+| Params        | Value                                          |
+| :--           | :--                                            |
+| *Type*        | *String*                                       |
+| *Valid Range* | *Minimum length of 1. Maximum length of 2048.* |
+| *Required*    | *No*                                           |
 
 #### WebIdentityToken
 The OAuth 2.0 access token that is provided by the web identity provider. Application must get this token by authenticating the user who is using your application with a web identity provider before the application makes an AssumeRoleWithWebIdentity call.
 
-| Params | Value |
-| :-- | :-- |
-| *Type* | *String* |
+| Params               | Value                                          |
+| :--                  | :--                                            |
+| *Type*               | *String*                                       |
 | *Length Constraints* | *Minimum length of 4. Maximum length of 2048.* |
-| *Required* | *Yes* |
+| *Required*           | *Yes*                                          |
 
 #### Version
 Indicates STS API version information, the only supported value is '2011-06-15'. This value is borrowed from AWS STS API documentation for compatibility reasons.
 
-| Params | Value |
-| :-- | :-- |
-| *Type* | *String* |
-| *Required* | *Yes* |
+| Params     | Value    |
+| :--        | :--      |
+| *Type*     | *String* |
+| *Required* | *Yes*    |
 
 #### Response Elements
 XML response for this API is similar to [AWS STS AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_ResponseElements)

--- a/pkg/iam/policy/constants.go
+++ b/pkg/iam/policy/constants.go
@@ -20,6 +20,12 @@ import (
 	"github.com/minio/minio/pkg/policy"
 )
 
+// Policy claim constants
+const (
+	PolicyName        = "policy"
+	SessionPolicyName = "sessionPolicy"
+)
+
 // ReadWrite - provides full access to all buckets and all objects
 var ReadWrite = Policy{
 	Version: DefaultVersion,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds support for adding session policies
for further restrictions on STS credentials, useful
in situations when applications want to generate
creds for multiple interested parties with different
set of policy restrictions.

This session policy is not mandatory, but optional.

<!--- Describe your changes in detail -->

## Motivation and Context
Fixes https://github.com/minio/minio/issues/7732
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using the update documents in docs/sts/assume-role.md
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.