### PR TITLE
Fix OPA result response handling

### DIFF
--- a/docs/sts/docker-compose.yml
+++ b/docs/sts/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:0.9.1
+    image: openpolicyagent/opa:0.11.0
     ports:
       - 8181:8181
     command:

--- a/docs/sts/opa.md
+++ b/docs/sts/opa.md
@@ -15,7 +15,7 @@ cat >docker-compose.yml <<EOF
 version: '2'
 services:
   opa:
-    image: openpolicyagent/opa:0.9.1
+    image: openpolicyagent/opa:0.11.0
     ports:
       - 8181:8181
     command:
@@ -45,11 +45,12 @@ package httpapi.authz
 
 import input as http_api
 
-allow {
- input.action = "s3:PutObject"
- input.owner = false
-}
+default allow = false
 
+allow = true {
+ http_api.action = "s3:PutObject"
+ http_api.owner = false
+}
 EOF
 ```
 
@@ -62,7 +63,7 @@ curl -X PUT --data-binary @putobject.rego \
 ### 4. Setup MinIO with OPA
 MinIO server expects environment variable for OPA http API url as `MINIO_IAM_OPA_URL`, this environment variable takes a single entry.
 ```
-export MINIO_IAM_OPA_URL=http://localhost:8181/v1/data/httpapi/authz
+export MINIO_IAM_OPA_URL=http://localhost:8181/v1/data/httpapi/authz/allow
 minio server /mnt/data
 ```
 

--- a/docs/sts/putobject.rego
+++ b/docs/sts/putobject.rego
@@ -2,7 +2,9 @@ package httpapi.authz
 
 import input as http_api
 
-allow {
- input.action = "s3:PutObject"
- input.owner = false
+default allow = false
+
+allow = true {
+ http_api.action = "s3:PutObject"
+ http_api.owner = false
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix OPA result response handling
<!--- Describe your changes in detail -->

## Motivation and Context
Also update the document with updated rego policy
and updated OPA agent REST API.

This PR is to fix a regression caused by PR #7637

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
Yes in #7637 
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Follow the instructions in opa.md and use the following python program to observe the responses

```py
import requests

input_dict = {  # create input to hand to OPA
    "input": {
        "action": "s3:PutObject",
        "owner": False
    }
}
# ask OPA for a policy decision
# (in reality OPA URL would be constructed from environment)
rsp = requests.post("http://127.0.0.1:8181/v1/data/httpapi/authz", json=input_dict)
print(rsp.json())
if rsp.json()["result"]:
    print(rsp.json())
    # HTTP API allowed
else:
    print(rsp.json())
    # HTTP API denied
```

```py
import requests

input_dict = {  # create input to hand to OPA
    "input": {
        "action": "s3:PutObject",
        "owner": False
    }
}
# ask OPA for a policy decision
# (in reality OPA URL would be constructed from environment)
rsp = requests.post("http://127.0.0.1:8181/v1/data/httpapi/authz/allow", json=input_dict)
print(rsp.json())
if rsp.json()["result"]:
    print(rsp.json())
    # HTTP API allowed
else:
    print(rsp.json())
    # HTTP API denied
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.