### PR TITLE
admin: Add Background heal status info API

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -61,7 +61,7 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 		adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
 		adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}/{prefix:.*}").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
 
-		adminV1Router.Methods(http.MethodPost).Path("/background-heal-status").HandlerFunc(httpTraceAll(adminAPI.BackgroundHealStatusHandler))
+		adminV1Router.Methods(http.MethodPost).Path("/background-heal/status").HandlerFunc(httpTraceAll(adminAPI.BackgroundHealStatusHandler))
 
 		/// Health operations
 

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -61,6 +61,8 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 		adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
 		adminV1Router.Methods(http.MethodPost).Path("/heal/{bucket}/{prefix:.*}").HandlerFunc(httpTraceAll(adminAPI.HealHandler))
 
+		adminV1Router.Methods(http.MethodPost).Path("/background-heal-status").HandlerFunc(httpTraceAll(adminAPI.BackgroundHealStatusHandler))
+
 		/// Health operations
 
 	}

--- a/cmd/daily-heal-ops.go
+++ b/cmd/daily-heal-ops.go
@@ -60,6 +60,18 @@ func newBgHealSequence(numDisks int) *healSequence {
 	}
 }
 
+func getLocalBackgroundHealStatus() madmin.BgHealState {
+	backgroundSequence, ok := globalSweepHealState.getHealSequenceByToken(bgHealingUUID)
+	if !ok {
+		return madmin.BgHealState{}
+	}
+
+	return madmin.BgHealState{
+		ScannedItemsCount: backgroundSequence.scannedItemsCount,
+		LastHealActivity:  backgroundSequence.lastHealActivity,
+	}
+}
+
 func initDailyHeal() {
 	go startDailyHeal()
 }

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -34,6 +34,7 @@ import (
 	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/event"
+	"github.com/minio/minio/pkg/madmin"
 	xnet "github.com/minio/minio/pkg/net"
 	"github.com/minio/minio/pkg/policy"
 )
@@ -228,6 +229,24 @@ func (sys *NotificationSys) LoadUsers() []NotificationPeerErr {
 		ng.Go(context.Background(), client.LoadUsers, idx, *client.host)
 	}
 	return ng.Wait()
+}
+
+// BackgroundHealStatus - returns background heal status of all peers
+func (sys *NotificationSys) BackgroundHealStatus() []madmin.BgHealState {
+	states := make([]madmin.BgHealState, len(sys.peerClients))
+	for idx, client := range sys.peerClients {
+		if client == nil {
+			continue
+		}
+		st, err := client.BackgroundHealStatus()
+		if err != nil {
+			logger.LogIf(context.Background(), err)
+		} else {
+			states[idx] = st
+		}
+	}
+
+	return states
 }
 
 // StartProfiling - start profiling on remote peers, by initiating a remote RPC.

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/cmd/rest"
 	"github.com/minio/minio/pkg/event"
+	"github.com/minio/minio/pkg/madmin"
 	xnet "github.com/minio/minio/pkg/net"
 	"github.com/minio/minio/pkg/policy"
 )
@@ -420,6 +421,18 @@ func (client *peerRESTClient) SignalService(sig serviceSignal) error {
 	}
 	defer http.DrainBody(respBody)
 	return nil
+}
+
+func (client *peerRESTClient) BackgroundHealStatus() (madmin.BgHealState, error) {
+	respBody, err := client.call(peerRESTMethodBackgroundHealStatus, nil, nil, -1)
+	if err != nil {
+		return madmin.BgHealState{}, err
+	}
+	defer http.DrainBody(respBody)
+
+	state := madmin.BgHealState{}
+	err = gob.NewDecoder(respBody).Decode(&state)
+	return state, err
 }
 
 // Trace - send http trace request to peer nodes

--- a/cmd/peer-rest-common.go
+++ b/cmd/peer-rest-common.go
@@ -26,6 +26,7 @@ const (
 	peerRESTMethodDrivePerfInfo            = "driveperfinfo"
 	peerRESTMethodDeleteBucket             = "deletebucket"
 	peerRESTMethodSignalService            = "signalservice"
+	peerRESTMethodBackgroundHealStatus     = "backgroundhealstatus"
 	peerRESTMethodGetLocks                 = "getlocks"
 	peerRESTMethodBucketPolicyRemove       = "removebucketpolicy"
 	peerRESTMethodLoadUser                 = "loaduser"

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -709,6 +709,20 @@ func (s *peerRESTServer) TraceHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *peerRESTServer) BackgroundHealStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.IsValid(w, r) {
+		s.writeErrorResponse(w, errors.New("invalid request"))
+		return
+	}
+
+	ctx := newContext(r, w, "BackgroundHealStatus")
+
+	state := getLocalBackgroundHealStatus()
+
+	defer w.(http.Flusher).Flush()
+	logger.LogIf(ctx, gob.NewEncoder(w).Encode(state))
+}
+
 func (s *peerRESTServer) writeErrorResponse(w http.ResponseWriter, err error) {
 	w.WriteHeader(http.StatusForbidden)
 	w.Write([]byte(err.Error()))
@@ -755,6 +769,7 @@ func registerPeerRESTHandlers(router *mux.Router) {
 	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodReloadFormat).HandlerFunc(httpTraceHdrs(server.ReloadFormatHandler)).Queries(restQueries(peerRESTDryRun)...)
 
 	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodTrace).HandlerFunc(server.TraceHandler)
+	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodBackgroundHealStatus).HandlerFunc(server.BackgroundHealStatusHandler)
 
 	router.NotFoundHandler = http.HandlerFunc(httpTraceAll(notFoundHandler))
 }

--- a/pkg/madmin/examples/heal-status.go
+++ b/pkg/madmin/examples/heal-status.go
@@ -41,5 +41,5 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	log.Printf("Heal status result: %#v\n", healStatusResult)
+	log.Printf("Heal status result: %+v\n", healStatusResult)
 }

--- a/pkg/madmin/examples/heal-status.go
+++ b/pkg/madmin/examples/heal-status.go
@@ -1,0 +1,45 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTPS) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	healStatusResult, err := madmClnt.BackgroundHealStatus()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Printf("Heal status result: %#v\n", healStatusResult)
+}

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -280,7 +280,7 @@ type BgHealState struct {
 // current server or cluster.
 func (adm *AdminClient) BackgroundHealStatus() (BgHealState, error) {
 	// Execute POST request to background heal status api
-	resp, err := adm.executeMethod("POST", requestData{relPath: "/v1/background-heal-status"})
+	resp, err := adm.executeMethod("POST", requestData{relPath: "/v1/background-heal/status"})
 	if err != nil {
 		return BgHealState{}, err
 	}

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -269,3 +269,37 @@ func (adm *AdminClient) Heal(bucket, prefix string, healOpts HealOpts,
 	}
 	return healStart, healTaskStatus, nil
 }
+
+// BgHealState represents the status of the background heal
+type BgHealState struct {
+	ScannedItemsCount int64
+	LastHealActivity  time.Time
+}
+
+// BackgroundHealStatus returns the background heal status of the
+// current server or cluster.
+func (adm *AdminClient) BackgroundHealStatus() (BgHealState, error) {
+	// Execute POST request to background heal status api
+	resp, err := adm.executeMethod("POST", requestData{relPath: "/v1/background-heal-status"})
+	if err != nil {
+		return BgHealState{}, err
+	}
+	defer closeResponse(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return BgHealState{}, httpRespToErrorResponse(resp)
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return BgHealState{}, err
+	}
+
+	var healState BgHealState
+
+	err = json.Unmarshal(respBytes, &healState)
+	if err != nil {
+		return BgHealState{}, err
+	}
+	return healState, nil
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This API returns the information related to the self healing routine.

For the moment, it returns:
- The total number of objects that are scanned
- The last time when an item was scanned


## Motivation and Context
Providing status of self healing

## Regression
No

## How Has This Been Tested?
The example in pkg/madmin/examples/heal-status.go can help to test this PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.