### PR TITLE
Add admin API to send console log messages

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1818,3 +1818,68 @@ func (a adminAPIHandlers) TraceHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 }
+
+// The handler sends console logs to the connected HTTP client.
+func (a adminAPIHandlers) ConsoleLogHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := newContext(r, w, "ConsoleLog")
+
+	objectAPI := validateAdminReq(ctx, w, r)
+	if objectAPI == nil {
+		return
+	}
+	node := r.URL.Query().Get("node")
+	// limit buffered console entries if client requested it.
+	limitStr := r.URL.Query().Get("limit")
+	limitLines, err := strconv.Atoi(limitStr)
+	if err != nil {
+		limitLines = 10
+	}
+	// Avoid reusing tcp connection if read timeout is hit
+	// This is needed to make r.Context().Done() work as
+	// expected in case of read timeout
+	w.Header().Add("Connection", "close")
+	w.Header().Set(xhttp.ContentType, "text/event-stream")
+
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	logCh := make(chan interface{}, 4000)
+
+	remoteHosts := getRemoteHosts(globalEndpoints)
+	peers, err := getRestClients(remoteHosts)
+	if err != nil {
+		return
+	}
+
+	globalConsoleSys.Subscribe(logCh, doneCh, node, limitLines, nil)
+
+	for _, peer := range peers {
+		if node == "" || strings.ToLower(peer.host.Name) == strings.ToLower(node) {
+			peer.ConsoleLog(logCh, doneCh)
+		}
+	}
+
+	enc := json.NewEncoder(w)
+
+	keepAliveTicker := time.NewTicker(500 * time.Millisecond)
+	defer keepAliveTicker.Stop()
+
+	for {
+		select {
+		case entry := <-logCh:
+			log := entry.(madmin.LogInfo)
+			if log.SendLog(node) {
+				if err := enc.Encode(log); err != nil {
+					return
+				}
+				w.(http.Flusher).Flush()
+			}
+		case <-keepAliveTicker.C:
+			if _, err := w.Write([]byte(" ")); err != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
+		case <-GlobalServiceDoneCh:
+			return
+		}
+	}
+}

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -135,6 +135,9 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 
 	// HTTP Trace
 	adminV1Router.Methods(http.MethodGet).Path("/trace").HandlerFunc(adminAPI.TraceHandler)
+	// Console Logs
+	adminV1Router.Methods(http.MethodGet).Path("/log").HandlerFunc(httpTraceAll(adminAPI.ConsoleLogHandler))
+
 	// If none of the routes match, return error.
 	adminV1Router.NotFoundHandler = http.HandlerFunc(httpTraceHdrs(notFoundHandlerJSON))
 }

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/minio/cli"
 	"github.com/minio/minio-go/v6/pkg/set"
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/cmd/logger/target/console"
 	"github.com/minio/minio/cmd/logger/target/http"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/dns"
@@ -97,7 +96,7 @@ func loadLoggers() {
 
 	if globalServerConfig.Logger.Console.Enabled {
 		// Enable console logging
-		logger.AddTarget(console.New())
+		logger.AddTarget(globalConsoleSys.Console())
 	}
 
 }

--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -1,0 +1,128 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	ring "container/ring"
+	"context"
+
+	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/cmd/logger/message/log"
+	"github.com/minio/minio/cmd/logger/target/console"
+	"github.com/minio/minio/pkg/madmin"
+	xnet "github.com/minio/minio/pkg/net"
+	"github.com/minio/minio/pkg/pubsub"
+)
+
+// number of log messages to buffer
+const defaultLogBufferCount = 10000
+
+//HTTPConsoleLoggerSys holds global console logger state
+type HTTPConsoleLoggerSys struct {
+	pubsub   *pubsub.PubSub
+	console  *console.Target
+	nodeName string
+	logBuf   *ring.Ring
+}
+
+// NewConsoleLogger - creates new HTTPConsoleLoggerSys with all nodes subscribed to
+// the console logging pub sub system
+func NewConsoleLogger(ctx context.Context, endpoints EndpointList) *HTTPConsoleLoggerSys {
+	host, err := xnet.ParseHost(GetLocalPeer(globalEndpoints))
+	if err != nil {
+		logger.FatalIf(err, "Unable to start console logging subsystem")
+	}
+	var nodeName string
+	if globalIsDistXL {
+		nodeName = host.Name
+	}
+	ps := pubsub.New()
+	return &HTTPConsoleLoggerSys{
+		ps, nil, nodeName, ring.New(defaultLogBufferCount),
+	}
+}
+
+// HasLogListeners returns true if console log listeners are registered
+// for this node or peers
+func (sys *HTTPConsoleLoggerSys) HasLogListeners() bool {
+	return sys != nil && sys.pubsub.HasSubscribers()
+}
+
+// Subscribe starts console logging for this node.
+func (sys *HTTPConsoleLoggerSys) Subscribe(subCh chan interface{}, doneCh chan struct{}, node string, last int, filter func(entry interface{}) bool) {
+	// Enable console logging for remote client even if local console logging is disabled in the config.
+	if !globalServerConfig.Logger.Console.Enabled && !sys.pubsub.HasSubscribers() {
+		logger.AddTarget(globalConsoleSys.Console())
+	}
+
+	cnt := 0
+	// by default send all console logs in the ring buffer unless node or limit query parameters
+	// are set.
+	var lastN []madmin.LogInfo
+	if last > defaultLogBufferCount || last <= 0 {
+		last = defaultLogBufferCount
+	}
+
+	lastN = make([]madmin.LogInfo, last)
+	r := sys.logBuf
+	r.Do(func(p interface{}) {
+		if p != nil && (p.(madmin.LogInfo)).SendLog(node) {
+			lastN[cnt%last] = p.(madmin.LogInfo)
+			cnt++
+		}
+	})
+	// send last n console log messages in order filtered by node
+	if cnt > 0 {
+		for i := 0; i < last; i++ {
+			entry := lastN[(cnt+i)%last]
+			if (entry == madmin.LogInfo{}) {
+				continue
+			}
+			select {
+			case subCh <- entry:
+			case <-doneCh:
+				return
+			}
+		}
+	}
+	sys.pubsub.Subscribe(subCh, doneCh, filter)
+}
+
+// Console returns a  console target
+func (sys *HTTPConsoleLoggerSys) Console() *HTTPConsoleLoggerSys {
+	if sys.console == nil {
+		sys.console = console.New()
+	}
+	return sys
+}
+
+// Send log message 'e' to console and publish to console
+// log pubsub system
+func (sys *HTTPConsoleLoggerSys) Send(e interface{}) error {
+	lg := madmin.LogInfo{}
+	lg.Entry = e.(log.Entry)
+	lg.NodeName = sys.nodeName
+	sys.pubsub.Publish(lg)
+	// add log to ring buffer
+	sys.logBuf.Value = lg
+	sys.logBuf = sys.logBuf.Next()
+
+	if globalServerConfig.Logger.Console.Enabled {
+		return sys.console.Send(e)
+	}
+	return nil
+}

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -159,6 +159,9 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		registerSTSRouter(router)
 	}
 
+	// initialize globalConsoleSys system
+	globalConsoleSys = NewConsoleLogger(context.Background(), globalEndpoints)
+
 	enableConfigOps := gatewayName == "nas"
 	enableIAMOps := globalEtcdClient != nil
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -174,6 +174,10 @@ var (
 	// registered listeners
 	globalHTTPTrace = pubsub.New()
 
+	// global console system to send console logs to
+	// registered listeners
+	globalConsoleSys *HTTPConsoleLoggerSys
+
 	globalEndpoints EndpointList
 
 	// Global server's network statistics

--- a/cmd/peer-rest-common.go
+++ b/cmd/peer-rest-common.go
@@ -51,6 +51,7 @@ const (
 	peerRESTMethodTrace                    = "trace"
 	peerRESTMethodBucketLifecycleSet       = "setbucketlifecycle"
 	peerRESTMethodBucketLifecycleRemove    = "removebucketlifecycle"
+	peerRESTMethodLog                      = "log"
 )
 
 const (

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -289,6 +289,8 @@ func serverMain(ctx *cli.Context) {
 		globalSweepHealState = initHealState()
 	}
 
+	// initialize globalConsoleSys system
+	globalConsoleSys = NewConsoleLogger(context.Background(), globalEndpoints)
 	// Configure server.
 	var handler http.Handler
 	handler, err = configureServerHandler(globalEndpoints)

--- a/pkg/madmin/api-log.go
+++ b/pkg/madmin/api-log.go
@@ -1,0 +1,85 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package madmin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/minio/minio/cmd/logger/message/log"
+)
+
+// LogInfo holds console log messages
+type LogInfo struct {
+	log.Entry
+	NodeName string `json:"node"`
+	Err      error  `json:"-"`
+}
+
+// SendLog returns true if log pertains to node specified in args.
+func (l LogInfo) SendLog(node string) bool {
+	return node == "" || strings.ToLower(node) == strings.ToLower(l.NodeName)
+}
+
+// GetLogs - listen on console log messages.
+func (adm AdminClient) GetLogs(node string, lineCnt int, doneCh <-chan struct{}) <-chan LogInfo {
+	logCh := make(chan LogInfo, 1)
+
+	// Only success, start a routine to start reading line by line.
+	go func(logCh chan<- LogInfo) {
+		defer close(logCh)
+		urlValues := make(url.Values)
+		urlValues.Set("node", node)
+		urlValues.Set("limit", strconv.Itoa(lineCnt))
+		for {
+			reqData := requestData{
+				relPath:     "/v1/log",
+				queryValues: urlValues,
+			}
+			// Execute GET to call log handler
+			resp, err := adm.executeMethod("GET", reqData)
+			if err != nil {
+				closeResponse(resp)
+				return
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				logCh <- LogInfo{Err: httpRespToErrorResponse(resp)}
+				return
+			}
+			dec := json.NewDecoder(resp.Body)
+			for {
+				var info LogInfo
+				if err = dec.Decode(&info); err != nil {
+					break
+				}
+				select {
+				case <-doneCh:
+					return
+				case logCh <- info:
+				}
+			}
+
+		}
+	}(logCh)
+
+	// Returns the log info channel, for caller to start reading from.
+	return logCh
+}

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -40,7 +40,7 @@ func (ps *PubSub) Publish(item interface{}) {
 	defer ps.RUnlock()
 
 	for _, sub := range ps.subs {
-		if sub.filter(item) {
+		if sub.filter == nil || sub.filter(item) {
 			select {
 			case sub.ch <- item:
 			default:

--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -14,78 +14,77 @@
  * limitations under the License.
  */
 
- package pubsub
+package pubsub
 
- import (
-	 "fmt"
-	 "testing"
-	 "time"
- )
- 
- func TestSubscribe(t *testing.T) {
-	 ps := New()
-	 ch1 := make(chan interface{}, 1)
-	 ch2 := make(chan interface{}, 1)
-	 doneCh := make(chan struct{})
-	 defer close(doneCh)
-	 ps.Subscribe(ch1, doneCh, nil)
-	 ps.Subscribe(ch2, doneCh, nil)
-	 ps.Lock()
-	 defer ps.Unlock()
-	 if len(ps.subs) != 2 {
-		 t.Errorf("expected 2 subscribers")
-	 }
- }
- 
- func TestUnsubscribe(t *testing.T) {
-	 ps := New()
-	 ch1 := make(chan interface{}, 1)
-	 ch2 := make(chan interface{}, 1)
-	 doneCh1 := make(chan struct{})
-	 doneCh2 := make(chan struct{})
-	 ps.Subscribe(ch1, doneCh1, nil)
-	 ps.Subscribe(ch2, doneCh2, nil)
- 
-	 close(doneCh1)
-	 // Allow for the above statement to take effect.
-	 time.Sleep(100 * time.Millisecond)
-	 ps.Lock()
-	 if len(ps.subs) != 1 {
-		 t.Errorf("expected 1 subscriber")
-	 }
-	 ps.Unlock()
-	 close(doneCh2)
- }
- 
- func TestPubSub(t *testing.T) {
-	 ps := New()
-	 ch1 := make(chan interface{}, 1)
-	 doneCh1 := make(chan struct{})
-	 defer close(doneCh1)
-	 ps.Subscribe(ch1, doneCh1, func(entry interface{}) bool { return true })
-	 val := "hello"
-	 ps.Publish(val)
-	 msg := <-ch1
-	 if msg != "hello" {
-		 t.Errorf(fmt.Sprintf("expected %s , found %s", val, msg))
-	 }
- }
- 
- func TestMultiPubSub(t *testing.T) {
-	 ps := New()
-	 ch1 := make(chan interface{}, 1)
-	 ch2 := make(chan interface{}, 1)
-	 doneCh := make(chan struct{})
-	 defer close(doneCh)
-	 ps.Subscribe(ch1, doneCh, func(entry interface{}) bool { return true })
-	 ps.Subscribe(ch2, doneCh, func(entry interface{}) bool { return true })
-	 val := "hello"
-	 ps.Publish(val)
- 
-	 msg1 := <-ch1
-	 msg2 := <-ch2
-	 if msg1 != "hello" && msg2 != "hello" {
-		 t.Errorf(fmt.Sprintf("expected both subscribers to have%s , found %s and  %s", val, msg1, msg2))
-	 }
- }
- 
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestSubscribe(t *testing.T) {
+	ps := New()
+	ch1 := make(chan interface{}, 1)
+	ch2 := make(chan interface{}, 1)
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	ps.Subscribe(ch1, doneCh, nil)
+	ps.Subscribe(ch2, doneCh, nil)
+	ps.Lock()
+	defer ps.Unlock()
+	if len(ps.subs) != 2 {
+		t.Errorf("expected 2 subscribers")
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	ps := New()
+	ch1 := make(chan interface{}, 1)
+	ch2 := make(chan interface{}, 1)
+	doneCh1 := make(chan struct{})
+	doneCh2 := make(chan struct{})
+	ps.Subscribe(ch1, doneCh1, nil)
+	ps.Subscribe(ch2, doneCh2, nil)
+
+	close(doneCh1)
+	// Allow for the above statement to take effect.
+	time.Sleep(100 * time.Millisecond)
+	ps.Lock()
+	if len(ps.subs) != 1 {
+		t.Errorf("expected 1 subscriber")
+	}
+	ps.Unlock()
+	close(doneCh2)
+}
+
+func TestPubSub(t *testing.T) {
+	ps := New()
+	ch1 := make(chan interface{}, 1)
+	doneCh1 := make(chan struct{})
+	defer close(doneCh1)
+	ps.Subscribe(ch1, doneCh1, func(entry interface{}) bool { return true })
+	val := "hello"
+	ps.Publish(val)
+	msg := <-ch1
+	if msg != "hello" {
+		t.Errorf(fmt.Sprintf("expected %s , found %s", val, msg))
+	}
+}
+
+func TestMultiPubSub(t *testing.T) {
+	ps := New()
+	ch1 := make(chan interface{}, 1)
+	ch2 := make(chan interface{}, 1)
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	ps.Subscribe(ch1, doneCh, func(entry interface{}) bool { return true })
+	ps.Subscribe(ch2, doneCh, func(entry interface{}) bool { return true })
+	val := "hello"
+	ps.Publish(val)
+
+	msg1 := <-ch1
+	msg2 := <-ch2
+	if msg1 != "hello" && msg2 != "hello" {
+		t.Errorf(fmt.Sprintf("expected both subscribers to have%s , found %s and  %s", val, msg1, msg2))
+	}
+}

--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -14,77 +14,78 @@
  * limitations under the License.
  */
 
-package pubsub
+ package pubsub
 
-import (
-	"fmt"
-	"testing"
-	"time"
-)
-
-func TestSubscribe(t *testing.T) {
-	ps := New()
-	ch1 := make(chan interface{}, 1)
-	ch2 := make(chan interface{}, 1)
-	doneCh := make(chan struct{})
-	defer close(doneCh)
-	ps.Subscribe(ch1, doneCh, nil)
-	ps.Subscribe(ch2, doneCh, nil)
-	ps.Lock()
-	defer ps.Unlock()
-	if len(ps.subs) != 2 {
-		t.Errorf("expected 2 subscribers")
-	}
-}
-
-func TestUnsubscribe(t *testing.T) {
-	ps := New()
-	ch1 := make(chan interface{}, 1)
-	ch2 := make(chan interface{}, 1)
-	doneCh1 := make(chan struct{})
-	doneCh2 := make(chan struct{})
-	ps.Subscribe(ch1, doneCh1, nil)
-	ps.Subscribe(ch2, doneCh2, nil)
-
-	close(doneCh1)
-	// Allow for the above statement to take effect.
-	time.Sleep(100 * time.Millisecond)
-	ps.Lock()
-	if len(ps.subs) != 1 {
-		t.Errorf("expected 1 subscriber")
-	}
-	ps.Unlock()
-	close(doneCh2)
-}
-
-func TestPubSub(t *testing.T) {
-	ps := New()
-	ch1 := make(chan interface{}, 1)
-	doneCh1 := make(chan struct{})
-	defer close(doneCh1)
-	ps.Subscribe(ch1, doneCh1, func(entry interface{}) bool { return true })
-	val := "hello"
-	ps.Publish(val)
-	msg := <-ch1
-	if msg != "hello" {
-		t.Errorf(fmt.Sprintf("expected %s , found %s", val, msg))
-	}
-}
-
-func TestMultiPubSub(t *testing.T) {
-	ps := New()
-	ch1 := make(chan interface{}, 1)
-	ch2 := make(chan interface{}, 1)
-	doneCh := make(chan struct{})
-	defer close(doneCh)
-	ps.Subscribe(ch1, doneCh, func(entry interface{}) bool { return true })
-	ps.Subscribe(ch2, doneCh, func(entry interface{}) bool { return true })
-	val := "hello"
-	ps.Publish(val)
-
-	msg1 := <-ch1
-	msg2 := <-ch2
-	if msg1 != "hello" && msg2 != "hello" {
-		t.Errorf(fmt.Sprintf("expected both subscribers to have%s , found %s and  %s", val, msg1, msg2))
-	}
-}
+ import (
+	 "fmt"
+	 "testing"
+	 "time"
+ )
+ 
+ func TestSubscribe(t *testing.T) {
+	 ps := New()
+	 ch1 := make(chan interface{}, 1)
+	 ch2 := make(chan interface{}, 1)
+	 doneCh := make(chan struct{})
+	 defer close(doneCh)
+	 ps.Subscribe(ch1, doneCh, nil)
+	 ps.Subscribe(ch2, doneCh, nil)
+	 ps.Lock()
+	 defer ps.Unlock()
+	 if len(ps.subs) != 2 {
+		 t.Errorf("expected 2 subscribers")
+	 }
+ }
+ 
+ func TestUnsubscribe(t *testing.T) {
+	 ps := New()
+	 ch1 := make(chan interface{}, 1)
+	 ch2 := make(chan interface{}, 1)
+	 doneCh1 := make(chan struct{})
+	 doneCh2 := make(chan struct{})
+	 ps.Subscribe(ch1, doneCh1, nil)
+	 ps.Subscribe(ch2, doneCh2, nil)
+ 
+	 close(doneCh1)
+	 // Allow for the above statement to take effect.
+	 time.Sleep(100 * time.Millisecond)
+	 ps.Lock()
+	 if len(ps.subs) != 1 {
+		 t.Errorf("expected 1 subscriber")
+	 }
+	 ps.Unlock()
+	 close(doneCh2)
+ }
+ 
+ func TestPubSub(t *testing.T) {
+	 ps := New()
+	 ch1 := make(chan interface{}, 1)
+	 doneCh1 := make(chan struct{})
+	 defer close(doneCh1)
+	 ps.Subscribe(ch1, doneCh1, func(entry interface{}) bool { return true })
+	 val := "hello"
+	 ps.Publish(val)
+	 msg := <-ch1
+	 if msg != "hello" {
+		 t.Errorf(fmt.Sprintf("expected %s , found %s", val, msg))
+	 }
+ }
+ 
+ func TestMultiPubSub(t *testing.T) {
+	 ps := New()
+	 ch1 := make(chan interface{}, 1)
+	 ch2 := make(chan interface{}, 1)
+	 doneCh := make(chan struct{})
+	 defer close(doneCh)
+	 ps.Subscribe(ch1, doneCh, func(entry interface{}) bool { return true })
+	 ps.Subscribe(ch2, doneCh, func(entry interface{}) bool { return true })
+	 val := "hello"
+	 ps.Publish(val)
+ 
+	 msg1 := <-ch1
+	 msg2 := <-ch2
+	 if msg1 != "hello" && msg2 != "hello" {
+		 t.Errorf(fmt.Sprintf("expected both subscribers to have%s , found %s and  %s", val, msg1, msg2))
+	 }
+ }
+ 


### PR DESCRIPTION
to registered  listeners

Utilized by mc admin console command in mc

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
log messages printed on minio server console will also be sent to  listeners registering via the admin console api 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required for `mc admin console` command
## Regression
<!-- Is this PR fixing a regression? (Yes / No) --> No
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested? 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
using `mc admin console` - see companion PR
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.