### PR TITLE
Remove DeploymentID from response headers

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -702,14 +702,14 @@ func (a adminAPIHandlers) HealHandler(w http.ResponseWriter, r *http.Request) {
 					if hr.errBody == "" {
 						errorRespJSON = encodeResponseJSON(getAPIErrorResponse(ctx, hr.apiErr,
 							r.URL.Path, w.Header().Get(responseRequestIDKey),
-							w.Header().Get(responseDeploymentIDKey)))
+							globalDeploymentID))
 					} else {
 						errorRespJSON = encodeResponseJSON(APIErrorResponse{
 							Code:      hr.apiErr.Code,
 							Message:   hr.errBody,
 							Resource:  r.URL.Path,
 							RequestID: w.Header().Get(responseRequestIDKey),
-							HostID:    w.Header().Get(responseDeploymentIDKey),
+							HostID:    globalDeploymentID,
 						})
 					}
 					if !started {

--- a/cmd/api-datatypes.go
+++ b/cmd/api-datatypes.go
@@ -23,8 +23,6 @@ import (
 const (
 	// Response request id.
 	responseRequestIDKey = "x-amz-request-id"
-	// Deployment id.
-	responseDeploymentIDKey = "x-minio-deployment-id"
 )
 
 // ObjectIdentifier carries key name for the object to delete.

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -590,7 +590,7 @@ func writeErrorResponse(ctx context.Context, w http.ResponseWriter, err APIError
 
 	// Generate error response.
 	errorResponse := getAPIErrorResponse(ctx, err, reqURL.Path,
-		w.Header().Get(responseRequestIDKey), w.Header().Get(responseDeploymentIDKey))
+		w.Header().Get(responseRequestIDKey), globalDeploymentID)
 	encodedErrorResponse := encodeResponse(errorResponse)
 	writeResponse(w, err.HTTPStatusCode, encodedErrorResponse, mimeXML)
 }
@@ -603,7 +603,7 @@ func writeErrorResponseHeadersOnly(w http.ResponseWriter, err APIError) {
 // useful for admin APIs.
 func writeErrorResponseJSON(ctx context.Context, w http.ResponseWriter, err APIError, reqURL *url.URL) {
 	// Generate error response.
-	errorResponse := getAPIErrorResponse(ctx, err, reqURL.Path, w.Header().Get(responseRequestIDKey), w.Header().Get(responseDeploymentIDKey))
+	errorResponse := getAPIErrorResponse(ctx, err, reqURL.Path, w.Header().Get(responseRequestIDKey), globalDeploymentID)
 	encodedErrorResponse := encodeResponseJSON(errorResponse)
 	writeResponse(w, err.HTTPStatusCode, encodedErrorResponse, mimeJSON)
 }
@@ -622,7 +622,7 @@ func writeCustomErrorResponseJSON(ctx context.Context, w http.ResponseWriter, er
 		BucketName: reqInfo.BucketName,
 		Key:        reqInfo.ObjectName,
 		RequestID:  w.Header().Get(responseRequestIDKey),
-		HostID:     w.Header().Get(responseDeploymentIDKey),
+		HostID:     globalDeploymentID,
 	}
 	encodedErrorResponse := encodeResponseJSON(errorResponse)
 	writeResponse(w, err.HTTPStatusCode, encodedErrorResponse, mimeJSON)
@@ -656,7 +656,7 @@ func writeCustomErrorResponseXML(ctx context.Context, w http.ResponseWriter, err
 		BucketName: reqInfo.BucketName,
 		Key:        reqInfo.ObjectName,
 		RequestID:  w.Header().Get(responseRequestIDKey),
-		HostID:     w.Header().Get(responseDeploymentIDKey),
+		HostID:     globalDeploymentID,
 	}
 
 	encodedErrorResponse := encodeResponse(errorResponse)

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -246,6 +246,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 
 	// This is only to uniquely identify each gateway deployments.
 	globalDeploymentID = os.Getenv("MINIO_GATEWAY_DEPLOYMENT_ID")
+	logger.SetDeploymentID(globalDeploymentID)
 
 	var cacheConfig = globalServerConfig.GetCacheConfig()
 	if len(cacheConfig.Drives) > 0 {

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -749,7 +749,7 @@ func setBucketForwardingHandler(h http.Handler) http.Handler {
 	return bucketForwardingHandler{fwd, h}
 }
 
-// customHeaderHandler sets x-amz-request-id, x-minio-deployment-id header.
+// customHeaderHandler sets x-amz-request-id header.
 // Previously, this value was set right before a response was sent to
 // the client. So, logger and Error response XML were not using this
 // value. This is set here so that this header can be logged as
@@ -763,12 +763,8 @@ func addCustomHeaders(h http.Handler) http.Handler {
 }
 
 func (s customHeaderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Set custom headers such as x-amz-request-id and x-minio-deployment-id
-	// for each request.
+	// Set custom headers such as x-amz-request-id for each request.
 	w.Header().Set(responseRequestIDKey, mustGetRequestID(UTCNow()))
-	if globalDeploymentID != "" {
-		w.Header().Set(responseDeploymentIDKey, globalDeploymentID)
-	}
 	s.handler.ServeHTTP(logger.NewResponseWriter(w), r)
 }
 

--- a/cmd/logger/audit.go
+++ b/cmd/logger/audit.go
@@ -63,6 +63,6 @@ func AuditLog(w http.ResponseWriter, r *http.Request, api string, reqClaims map[
 	}
 	// Send audit logs only to http targets.
 	for _, t := range AuditTargets {
-		_ = t.Send(audit.ToEntry(w, r, api, statusCode, reqClaims))
+		_ = t.Send(audit.ToEntry(w, r, api, statusCode, reqClaims, globalDeploymentID))
 	}
 }

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -55,6 +55,8 @@ const (
 
 var trimStrings []string
 
+var globalDeploymentID string
+
 // TimeFormat - logging time format.
 const TimeFormat string = "15:04:05 MST 01/02/2006"
 
@@ -152,6 +154,11 @@ func uniqueEntries(paths []string) []string {
 		}
 	}
 	return m.ToSlice()
+}
+
+// SetDeploymentID -- Deployment Id from the main package is set here
+func SetDeploymentID(deploymentID string) {
+	globalDeploymentID = deploymentID
 }
 
 // Init sets the trimStrings to possible GOPATHs
@@ -317,7 +324,9 @@ func logIf(ctx context.Context, err error) {
 
 	// Get the cause for the Error
 	message := err.Error()
-
+	if req.DeploymentID == "" {
+		req.DeploymentID = globalDeploymentID
+	}
 	entry := log.Entry{
 		DeploymentID: req.DeploymentID,
 		Level:        ErrorLvl.String(),

--- a/cmd/logger/message/audit/entry.go
+++ b/cmd/logger/message/audit/entry.go
@@ -50,7 +50,7 @@ type Entry struct {
 }
 
 // ToEntry - constructs an audit entry object.
-func ToEntry(w http.ResponseWriter, r *http.Request, api string, statusCode int, reqClaims map[string]interface{}) Entry {
+func ToEntry(w http.ResponseWriter, r *http.Request, api string, statusCode int, reqClaims map[string]interface{}, deploymentID string) Entry {
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 	object := vars["object"]
@@ -71,7 +71,7 @@ func ToEntry(w http.ResponseWriter, r *http.Request, api string, statusCode int,
 
 	entry := Entry{
 		Version:      Version,
-		DeploymentID: w.Header().Get("x-minio-deployment-id"),
+		DeploymentID: deploymentID,
 		RemoteHost:   handlers.GetSourceIP(r),
 		RequestID:    w.Header().Get("x-amz-request-id"),
 		UserAgent:    r.UserAgent(),

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -166,7 +166,7 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 				Key:        object,
 				Resource:   r.URL.Path,
 				RequestID:  w.Header().Get(responseRequestIDKey),
-				HostID:     w.Header().Get(responseDeploymentIDKey),
+				HostID:     globalDeploymentID,
 			})
 			writeResponse(w, serr.HTTPStatusCode(), encodedErrorResponse, mimeXML)
 		} else {
@@ -208,7 +208,7 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 				Key:        object,
 				Resource:   r.URL.Path,
 				RequestID:  w.Header().Get(responseRequestIDKey),
-				HostID:     w.Header().Get(responseDeploymentIDKey),
+				HostID:     globalDeploymentID,
 			})
 			writeResponse(w, serr.HTTPStatusCode(), encodedErrorResponse, mimeXML)
 		} else {
@@ -2269,7 +2269,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 
 		// Generate error response.
 		errorResponse := getAPIErrorResponse(ctx, err, reqURL.Path,
-			w.Header().Get(responseRequestIDKey), w.Header().Get(responseDeploymentIDKey))
+			w.Header().Get(responseRequestIDKey), globalDeploymentID)
 		encodedErrorResponse, _ := xml.Marshal(errorResponse)
 		setCommonHeaders(w)
 		w.Header().Set("Content-Type", string(mimeXML))

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -48,7 +48,7 @@ func registerDistXLRouters(router *mux.Router, endpoints EndpointList) {
 
 // List of some generic handlers which are applied for all incoming requests.
 var globalHandlers = []HandlerFunc{
-	// set x-amz-request-id, x-minio-deployment-id header.
+	// set x-amz-request-id header.
 	addCustomHeaders,
 	// set HTTP security headers such as Content-Security-Policy.
 	addSecurityHeaders,

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -317,6 +317,7 @@ func serverMain(ctx *cli.Context) {
 	}()
 
 	newObject, err := newObjectLayer(globalEndpoints)
+	logger.SetDeploymentID(globalDeploymentID)
 	if err != nil {
 		// Stop watching for any certificate changes.
 		globalTLSCerts.Stop()

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -413,7 +413,7 @@ func newContext(r *http.Request, w http.ResponseWriter, api string) context.Cont
 		object = prefix
 	}
 	reqInfo := &logger.ReqInfo{
-		DeploymentID: w.Header().Get(responseDeploymentIDKey),
+		DeploymentID: globalDeploymentID,
 		RequestID:    w.Header().Get(responseRequestIDKey),
 		RemoteHost:   handlers.GetSourceIP(r),
 		UserAgent:    r.UserAgent(),


### PR DESCRIPTION
Response headers need not contain deployment ID.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

MinIO responds with a header named `X-Minio-Deployment-ID`, so when we do a copy from a MinIO source to any other S3 server, the header `X-Minio-Deployment-ID` becomes `X-AMZ-X-Minio-Deployment-ID`. We need not send the header `X-Minio-Deployment-Id` as a response header.

## Motivation and Context
Desribed in the description. 

## Regression
No
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
mc cp /etc/issue myminio/bucket/object
mc stat play/test/object
```

The output should not contain a header called `X-Minio-deployment-Id` like in the following output
```
Name      : object
Date      : 2019-06-25 13:30:30 PDT 
Size      : 55 MiB 
ETag      : 4291fae1f746c6bafd4a9013da08d2f5 
Type      : file 
Metadata  :
  Content-Type         : application/x-executable 
  X-Minio-Deployment-Id: 41e39f4a-3b66-415b-9ddf-025d76a58668 
```



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.