### PR TITLE
Fix s3select TRIM function's nil pointer dereference bug

### DIFF
--- a/pkg/s3select/sql/analysis.go
+++ b/pkg/s3select/sql/analysis.go
@@ -274,6 +274,15 @@ func (e *FuncExpr) analyze(s *Select) (result qProp) {
 		}
 		return result
 
+	case sqlFnTrim:
+		if e.Trim.TrimChars != nil {
+			result.combine(e.Trim.TrimChars.analyze(s))
+		}
+		if e.Trim.TrimFrom != nil {
+			result.combine(e.Trim.TrimFrom.analyze(s))
+		}
+		return result
+
 	case sqlFnSubstring:
 		errVal := fmt.Errorf("Invalid argument(s) to %s", string(funcName))
 		result.combine(e.Substring.Expr.analyze(s))

--- a/pkg/s3select/sql/funceval.go
+++ b/pkg/s3select/sql/funceval.go
@@ -337,20 +337,25 @@ func handleSQLSubstring(r Record, e *SubstringFunc) (val *Value, err error) {
 }
 
 func handleSQLTrim(r Record, e *TrimFunc) (res *Value, err error) {
-	charsV, cerr := e.TrimChars.evalNode(r)
-	if cerr != nil {
-		return nil, cerr
-	}
-	inferTypeAsString(charsV)
-	chars, ok := charsV.ToString()
-	if !ok {
-		return nil, errNonStringTrimArg
+	chars := ""
+	ok := false
+	if e.TrimChars != nil {
+		charsV, cerr := e.TrimChars.evalNode(r)
+		if cerr != nil {
+			return nil, cerr
+		}
+		inferTypeAsString(charsV)
+		chars, ok = charsV.ToString()
+		if !ok {
+			return nil, errNonStringTrimArg
+		}
 	}
 
 	fromV, ferr := e.TrimFrom.evalNode(r)
 	if ferr != nil {
 		return nil, ferr
 	}
+	inferTypeAsString(fromV)
 	from, ok := fromV.ToString()
 	if !ok {
 		return nil, errNonStringTrimArg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix the following bug:
s3select query `Select trim(s.FirstName)  from S3Object s` on hello.csv with content:
```
FirstName,LastName
Zongyou,Yao
```
gives the following error:
```
mc: <ERROR> Unable to run sql Function is not yet implemented
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.