### PR TITLE
include ip address while doing checkPortAvailability

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -121,7 +121,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
 	// (non-)minio process is listening on IPv4 of given port.
 	// To avoid this error situation we check for port availability.
-	logger.FatalIf(checkPortAvailability(globalMinioPort), "Unable to start the gateway")
+	logger.FatalIf(checkPortAvailability(globalMinioHost, globalMinioPort), "Unable to start the gateway")
 
 	// Check and load TLS certificates.
 	var err error

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -190,10 +190,10 @@ func isHostIP(ipAddress string) bool {
 	return net.ParseIP(host) != nil
 }
 
-// checkPortAvailability - check if given port is already in use.
+// checkPortAvailability - check if given host and port is already in use.
 // Note: The check method tries to listen on given port and closes it.
 // It is possible to have a disconnected client in this tiny window of time.
-func checkPortAvailability(port string) (err error) {
+func checkPortAvailability(host, port string) (err error) {
 	// Return true if err is "address already in use" error.
 	isAddrInUseErr := func(err error) (b bool) {
 		if opErr, ok := err.(*net.OpError); ok {
@@ -209,7 +209,7 @@ func checkPortAvailability(port string) (err error) {
 
 	network := []string{"tcp", "tcp4", "tcp6"}
 	for _, n := range network {
-		l, err := net.Listen(n, net.JoinHostPort("", port))
+		l, err := net.Listen(n, net.JoinHostPort(host, port))
 		if err == nil {
 			// As we are able to listen on this network, the port is not in use.
 			// Close the listener and continue check other networks.

--- a/cmd/net_test.go
+++ b/cmd/net_test.go
@@ -206,11 +206,13 @@ func TestCheckPortAvailability(t *testing.T) {
 	defer listener.Close()
 
 	testCases := []struct {
+		host        string
 		port        string
 		expectedErr error
 	}{
-		{port, fmt.Errorf("listen tcp :%v: bind: address already in use", port)},
-		{getFreePort(), nil},
+		{"", port, fmt.Errorf("listen tcp :%v: bind: address already in use", port)},
+		{"127.0.0.1", port, fmt.Errorf("listen tcp 127.0.0.1:%v: bind: address already in use", port)},
+		{"", getFreePort(), nil},
 	}
 
 	for _, testCase := range testCases {
@@ -219,7 +221,7 @@ func TestCheckPortAvailability(t *testing.T) {
 			continue
 		}
 
-		err := checkPortAvailability(testCase.port)
+		err := checkPortAvailability(testCase.host, testCase.port)
 		if testCase.expectedErr == nil {
 			if err != nil {
 				t.Fatalf("error: expected = <nil>, got = %v", err)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -176,7 +176,7 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
 	// (non-)minio process is listening on IPv4 of given port.
 	// To avoid this error sutiation we check for port availability.
-	logger.FatalIf(checkPortAvailability(globalMinioPort), "Unable to start the server")
+	logger.FatalIf(checkPortAvailability(globalMinioHost, globalMinioPort), "Unable to start the server")
 
 	globalIsXL = (setupType == XLSetupType)
 	globalIsDistXL = (setupType == DistXLSetupType)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While checking for port availability, ip address should be included.
When a machine has multiple ip addresses, multiple minio instances
or some other applications can be run on the same port but different
ip address.

Fixes #7685

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When multiple minio instances needs to be run on a single host which has multiple ip addresses,
they can use same port but different ip addresses.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run minio on a particular ip:port (`./minio server ~/tmp/d1 --address localhost:9000`)
2. Run another minio instance on differnt ip same port (`./minio server ~/tmp/d2 --address 192.168.86.145:9000`)
3. Make both are accessible and working fine on their respective ip:port
4. Run minio on a particular port but all ip (`./minio server ~/tmp/d1 --address :9000`)
5. Run minio on a particular port but all ip (`./minio server ~/tmp/d2 --address :9000`)
6. The last one should fail
7. Run minio default (`./minio server ~/tmp/d1`)
8. Run another minio instance on a particular ip and same port (`./minio server ~/tmp/d2 --address 192.168.86.145:9000`)
9. The last one should fail

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [x] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.