### PR TITLE
[gateway] enable to restrict shown buckets 

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -44,7 +44,7 @@ const (
 var gatewayFlags = []cli.Flag{
 	cli.StringSliceFlag{
 		Name:   gatewayBucketFilterFlag,
-		Usage:  "whitelist patterns of exposed buckets which can include wildcard *",
+		Usage:  "whitelist patterns of buckets to expose which can include wildcard *",
 		EnvVar: "BUCKET_FILTER",
 	},
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -49,9 +49,10 @@ var gatewayFlags = []cli.Flag{
 	},
 }
 
-func gatewayBucketFilter(ctx *cli.Context) []string {
-	return ctx.StringSlice(gatewayBucketFilterFlag)
-}
+var globalGatewayContext = struct {
+	bucketFilter []string
+}{}
+
 
 var (
 	gatewayCmd = cli.Command{
@@ -111,6 +112,11 @@ func ValidateGatewayArguments(serverAddr, endpointAddr string) error {
 	return nil
 }
 
+// handle gateway sub command specific arguments
+func handleGatewayArgs(ctx *cli.Context) {
+	globalGatewayContext.bucketFilter = ctx.StringSlice(gatewayBucketFilterFlag)
+}
+
 // StartGateway - handler for 'minio gateway <name>'.
 func StartGateway(ctx *cli.Context, gw Gateway) {
 	if gw == nil {
@@ -129,6 +135,9 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 
 	// Handle common command args.
 	handleCommonCmdArgs(ctx)
+
+	// Handle gateway command specific args.
+	handleGatewayArgs(ctx)
 
 	// Get port to listen on from gateway address
 	globalMinioHost, globalMinioPort = mustSplitHostPort(globalCLIContext.Addr)

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -37,18 +37,34 @@ func init() {
 	logger.RegisterUIError(fmtError)
 }
 
+const (
+	gatewayBucketFilterFlag = "bucket-filter"
+)
+
+var gatewayFlags = []cli.Flag{
+	cli.StringSliceFlag{
+		Name:   gatewayBucketFilterFlag,
+		Usage:  "whitelist patterns of visible buckets which can include wildcard *",
+		EnvVar: "BUCKET_FILTER",
+	},
+}
+
+func gatewayBucketFilter(ctx *cli.Context) []string {
+	return ctx.StringSlice(gatewayBucketFilterFlag)
+}
+
 var (
 	gatewayCmd = cli.Command{
 		Name:            "gateway",
 		Usage:           "start object storage gateway",
-		Flags:           append(ServerFlags, GlobalFlags...),
+		Flags:           append(gatewayFlags, append(ServerFlags, GlobalFlags...)...),
 		HideHelpCommand: true,
 	}
 )
 
 // RegisterGatewayCommand registers a new command for gateway.
 func RegisterGatewayCommand(cmd cli.Command) error {
-	cmd.Flags = append(append(cmd.Flags, append(cmd.Flags, ServerFlags...)...), GlobalFlags...)
+	cmd.Flags = append(cmd.Flags, gatewayCmd.Flags...)
 	gatewayCmd.Subcommands = append(gatewayCmd.Subcommands, cmd)
 	return nil
 }

--- a/cmd/gateway-main_test.go
+++ b/cmd/gateway-main_test.go
@@ -27,7 +27,14 @@ import (
 func TestRegisterGatewayCommand(t *testing.T) {
 	var err error
 
-	cmd := cli.Command{Name: "test"}
+	cmd := cli.Command{
+		Name: "test",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name: "flag",
+			},
+		},
+	}
 	err = RegisterGatewayCommand(cmd)
 	if err != nil {
 		t.Errorf("RegisterGatewayCommand got unexpected error: %s", err)

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -160,6 +160,20 @@ func IsValidObjectPrefix(object string) bool {
 	return true
 }
 
+// Extract buckets whose name matches any of the given wildcard patterns
+// Returns all buckets if no pattern is specified
+func filterBuckets(buckets []BucketInfo, patterns []string) (filtered []BucketInfo) {
+	if patterns == nil || len(patterns) == 0 {
+		return buckets
+	}
+	for _, bucket := range buckets {
+		if hasPattern(patterns, bucket.Name) {
+			filtered = append(filtered, bucket)
+		}
+	}
+	return filtered
+}
+
 // Slash separator.
 const slashSeparator = "/"
 

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -135,6 +135,56 @@ func TestIsValidObjectName(t *testing.T) {
 	}
 }
 
+// Tests for filter bucket.
+func TestFilterBucket(t *testing.T) {
+	testCases := []struct {
+		buckets []string
+		filters []string
+		expected []string
+	}{
+		{
+			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters: nil,
+			expected: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+		},
+		{
+			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters: []string{},
+			expected: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+		},
+		{
+			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters: []string{"BBB", "BCC"},
+			expected: []string{"BBB", "BCC"},
+		},
+		{
+			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters: []string{"A*"},
+			expected: []string{"AAA", "ABB"},
+		},
+		{
+			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters: []string{"A*", "B*"},
+			expected: []string{"AAA", "ABB", "BBB", "BCC"},
+		},
+	}
+
+	for i, testCase := range testCases {
+		var buckets []BucketInfo
+		var expected []BucketInfo
+		for _, name := range testCase.buckets {
+			buckets = append(buckets, BucketInfo{Name: name})
+		}
+		for _, name := range testCase.expected {
+			expected = append(expected, BucketInfo{Name: name})
+		}
+
+		if actual := filterBuckets(buckets, testCase.filters); !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("test %d failed: expected: result=%v, got=%v", i+1, expected, actual)
+		}
+	}
+}
+
 // Tests getCompleteMultipartMD5
 func TestGetCompleteMultipartMD5(t *testing.T) {
 	testCases := []struct {

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -138,33 +138,33 @@ func TestIsValidObjectName(t *testing.T) {
 // Tests for filter bucket.
 func TestFilterBucket(t *testing.T) {
 	testCases := []struct {
-		buckets []string
-		filters []string
+		buckets  []string
+		filters  []string
 		expected []string
 	}{
 		{
-			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
-			filters: nil,
+			buckets:  []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters:  nil,
 			expected: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
 		},
 		{
-			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
-			filters: []string{},
+			buckets:  []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters:  []string{},
 			expected: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
 		},
 		{
-			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
-			filters: []string{"BBB", "BCC"},
+			buckets:  []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters:  []string{"BBB", "BCC"},
 			expected: []string{"BBB", "BCC"},
 		},
 		{
-			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
-			filters: []string{"A*"},
+			buckets:  []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters:  []string{"A*"},
 			expected: []string{"AAA", "ABB"},
 		},
 		{
-			buckets: []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
-			filters: []string{"A*", "B*"},
+			buckets:  []string{"AAA", "ABB", "BBB", "BCC", "CCC"},
+			filters:  []string{"A*", "B*"},
 			expected: []string{"AAA", "ABB", "BBB", "BCC"},
 		},
 	}

--- a/docs/gateway/gcs.md
+++ b/docs/gateway/gcs.md
@@ -19,7 +19,7 @@ MinIO GCS Gateway allows you to access Google Cloud Storage (GCS) with Amazon S3
 
 **Note:** For alternate ways to set up *Application Default Credentials*, see [Setting Up Authentication for Server to Server Production Applications](https://developers.google.com/identity/protocols/application-default-credentials).
 
-### 1.1 Run MinIO GCS Gateway Using Docker
+### 1.2 Run MinIO GCS Gateway Using Docker
 ```sh
 docker run -p 9000:9000 --name gcs-s3 \
  -v /path/to/credentials.json:/credentials.json \
@@ -29,7 +29,7 @@ docker run -p 9000:9000 --name gcs-s3 \
  minio/minio gateway gcs yourprojectid
 ```
 
-### 1.2 Run MinIO GCS Gateway Using the MinIO Binary
+### 1.3 Run MinIO GCS Gateway Using the MinIO Binary
 
 ```sh
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/minio/minio
 go 1.12
 
 require (
-	cloud.google.com/go v0.37.2
+	cloud.google.com/go v0.39.0
 	contrib.go.opencensus.io/exporter/ocagent v0.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go v27.0.0+incompatible
 	github.com/Azure/go-autorest v11.7.0+incompatible
@@ -89,12 +89,13 @@ require (
 	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a
 	go.etcd.io/bbolt v1.3.3 // indirect
 	go.uber.org/atomic v1.3.2
+	golang.org/x/build v0.0.0-20190314133821-5284462c4bec // indirect
 	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422 // indirect
-	golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b // indirect
+	golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b
 	golang.org/x/sys v0.0.0-20190618155005-516e3c20635f
 	golang.org/x/tools v0.0.0-20190619181801-b76e30ffa0aa // indirect
-	google.golang.org/api v0.4.0
+	google.golang.org/api v0.5.0
 	gopkg.in/Shopify/sarama.v1 v1.20.0
 	gopkg.in/olivere/elastic.v5 v5.0.80
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.2 h1:4y4L7BdHenTfZL0HervofNTHh9Ad6mNX72cQvl+5eH0=
 cloud.google.com/go v0.37.2/go.mod h1:H8IAquKe2L30IxoupDgqTaQvKSwF/c8prYHynGIWQbA=
+cloud.google.com/go v0.39.0 h1:UgQP9na6OTfp4dsAiz/eFpFA1C6tPdH5wiRdi19tuMw=
+cloud.google.com/go v0.39.0/go.mod h1:rVLT6fkc8chs9sfPtFc1SBH6em7n+ZoXaG+87tDISts=
 contrib.go.opencensus.io/exporter/ocagent v0.4.7/go.mod h1:+KkYrcvvEN0E5ls626sqMv8PdMx2931feKtzIwP01qI=
 contrib.go.opencensus.io/exporter/ocagent v0.4.10 h1:Trr4zF3bbDxrde1svPSW0PkGwCzoHY7f3JL8g5Gl+hM=
 contrib.go.opencensus.io/exporter/ocagent v0.4.10/go.mod h1:ueLzZcP7LPhPulEBukGn4aLh7Mx9YJwpVJ9nL2FYltw=
@@ -679,6 +681,7 @@ golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPlt9tHXFfw5kvc0yqlxRPWo=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXTqk7U7zPQCb+T4rbU9ZEoU=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443 h1:IcSOAf4PyMp3U3XbIEj1/xJ2BjNN2jWv7JoyOsMxXUU=
@@ -715,6 +718,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190611141213-3f473d35a33a h1:+KkCgOMgnKSgenxTBoiwkMqTiouMIy/3o8RLdmSbGoY=
 golang.org/x/net v0.0.0-20190611141213-3f473d35a33a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
@@ -761,6 +765,7 @@ golang.org/x/sys v0.0.0-20190322080309-f49334f85ddc/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190610200419-93c9922d18ae h1:xiXzMMEQdQcric9hXtr1QU98MHunKK7OTtsoU6bYWs4=
 golang.org/x/sys v0.0.0-20190610200419-93c9922d18ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190614160838-b47fdc937951 h1:ZUgGZ7PSkne6oY+VgAvayrB16owfm9/DKAtgWubzgzU=
@@ -787,6 +792,7 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190318200714-bb1270c20edf/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1P+/ZFC/IKythI5RzrnRg=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190603231351-8aaa1484dc10/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59 h1:QjA/9ArTfVTLfEhClDCG7SGrZkZixxWpwNCDiwJfh88=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190619181801-b76e30ffa0aa h1:OKbX3LR+DrC3Oj0rhniAcIbi43SoQW6ennRcN9MTxpE=
@@ -801,6 +807,8 @@ google.golang.org/api v0.3.0 h1:UIJY20OEo3+tK5MBlcdx37kmdH6EnRjGkW78mc6+EeA=
 google.golang.org/api v0.3.0/go.mod h1:IuvZyQh8jgscv8qWfQ4ABd8m7hEudgBFM/EdhA3BnXw=
 google.golang.org/api v0.4.0 h1:KKgc1aqhV8wDPbDzlDtpvyjZFY3vjz85FP7p4wcQUyI=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
+google.golang.org/api v0.5.0 h1:lj9SyhMzyoa38fgFF0oO2T6pjs5IzkLPKfVtxpyCRMM=
+google.golang.org/api v0.5.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -815,6 +823,8 @@ google.golang.org/genproto v0.0.0-20181029155118-b69ba1387ce2/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20181219182458-5a97ab628bfb/go.mod h1:7Ep/1NZk928CDR8SjdVbjWNpdIf6nzjE3BTgJDr2Atg=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19 h1:Lj2SnHtxkRGJDqnGaSjo+CCdIieEnwVazbOXILwQemk=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
+google.golang.org/genproto v0.0.0-20190508193815-b515fa19cec8 h1:x913Lq/RebkvUmRSdQ8MNb0GZKn+SR1ESfoetcQSeak=
+google.golang.org/genproto v0.0.0-20190508193815-b515fa19cec8/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.15.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=


### PR DESCRIPTION
## Description

- Added a `--bucket-filter` option to  gateway sub command that restricts shown buckets on the object browser.
- Fixed a bug that gateway command flag registration runs into an error .
    - the same flags are registered multiple times.


## Motivation and Context

Allow users who can access MinIO browser to see and download subset of objects on the GCS without authentication to a Google Cloud.

## Regression
No

## How Has This Been Tested?

- Added a unit test against bucket filtering.
- Run GCS gateway with bucket-filter option and checked that only buckets whose name matches the given pattern are shown on a browser.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. - Applied `gofmt`
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.