### PR TITLE
remove `encryption key` section for certtool docs

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -237,11 +237,6 @@ ip_address = "127.0.0.1"
 
 # Whether this certificate will be used for a TLS server
 tls_www_server
-
-# Whether this certificate will be used to encrypt data (needed
-# in TLS RSA cipher suites). Note that it is preferred to use different
-# keys for encryption and signing.
-encryption_key
 ```
 
 Run `certtool.exe` and specify the configuration file to generate a certificate:


### PR DESCRIPTION
## Description
This commit removes the encryption key section from
the certool.exe docs because:
 - MinIO does not support any TLS cipher that encrypts
   something with the private key. We only support PFS
   ciphers.
 - The doc comment is not really accurate anyway.

## Motivation and Context
https://twitter.com/Minio/status/1142083690140512258?s=20 :wink: 

## Regression
no

## How Has This Been Tested?
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.