### PR TITLE
call Close on error to release the read lock

### DIFF
--- a/pkg/s3select/select.go
+++ b/pkg/s3select/select.go
@@ -272,11 +272,13 @@ func (s3Select *S3Select) Open(getReader func(offset, length int64) (io.ReadClos
 
 		s3Select.progressReader, err = newProgressReader(rc, s3Select.Input.CompressionType)
 		if err != nil {
+			rc.Close()
 			return err
 		}
 
 		s3Select.recordReader, err = csv.NewReader(s3Select.progressReader, &s3Select.Input.CSVArgs)
 		if err != nil {
+			rc.Close()
 			return err
 		}
 
@@ -289,6 +291,7 @@ func (s3Select *S3Select) Open(getReader func(offset, length int64) (io.ReadClos
 
 		s3Select.progressReader, err = newProgressReader(rc, s3Select.Input.CompressionType)
 		if err != nil {
+			rc.Close()
 			return err
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
call `Close` on error to release the read lock

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

considering the following requests:

```bash
POST /testbucket/hello.csv?select=&select-type=2 HTTP/1.1
Host: 127.0.0.1:9000
User-Agent: aws-sdk-go/1.19.15 (go1.12.4; linux; amd64)
Content-Length: 490
Authorization: AWS4-HMAC-SHA256 Credential=MBX21LJAWC8A7ZF2LISL/20190625/us-east-1/s3/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=6cc29ed53063ef1705e92e927304d72b3085b8cf1d7697a558ff81d07ea454ac
X-Amz-Content-Sha256: 53ec9c7ace817289ba6ef4eb2f4f3d0da5ac0110eebd0f7ef2c88adc0c0b513f
X-Amz-Date: 20190625T095041Z
Accept-Encoding: gzip

<SelectObjectContentRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Expression>Select s._1 from S3Object s limit 1</Expression><ExpressionType>SQL</ExpressionType><InputSerialization><CSV><FileHeaderInfo>IGNORE</FileHeaderInfo><RecordDelimiter>
</RecordDelimiter><FieldDelimiter>,</FieldDelimiter></CSV><CompressionType>GZIP</CompressionType></InputSerialization><OutputSerialization><CSV><QuoteFields>ASNEEDED</QuoteFields></CSV></OutputSerialization></SelectObjectContentRequest>HTTP/1.1 400 Bad Request
Accept-Ranges: bytes
Content-Length: 405
Content-Security-Policy: block-all-mixed-content
Content-Type: application/xml
Server: MinIO/DEVELOPMENT.2019-06-25T09-50-02Z
Vary: Origin
X-Amz-Request-Id: 15AB682DC2B58B16
X-Minio-Deployment-Id: bdbdb029-e811-4d0b-87b7-648bbc9ee156
X-Xss-Protection: 1; mode=block
Date: Tue, 25 Jun 2019 09:50:41 GMT

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>TruncatedInput</Code><Message>Object decompression failed. Check that the object is properly compressed using the format specified in the request.</Message><Key>hello.csv</Key><BucketName>testbucket</BucketName><Resource>/testbucket/hello.csv</Resource><RequestId>15AB682DC2B58B16</RequestId><HostId>bdbdb029-e811-4d0b-87b7-648bbc9ee156</HostId></Error>
DELETE /testbucket/hello.csv HTTP/1.1
Host: 127.0.0.1:9000
User-Agent: aws-sdk-go/1.19.15 (go1.12.4; linux; amd64)
Authorization: AWS4-HMAC-SHA256 Credential=MBX21LJAWC8A7ZF2LISL/20190625/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=7456949e9e67a7bc2a337ff5d50eabdbf49a388e2e4fd8b8375e0d091f295d03
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20190625T095041Z
Accept-Encoding: gzip
```
the `DELETE` request is stucked because of the read lock is not released.


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes: resent the above requests and the DELETE request can be successfully completed.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.