### PR TITLE
fix typo and the string representation of the time.Time value

### DIFF
--- a/pkg/s3select/sql/value.go
+++ b/pkg/s3select/sql/value.go
@@ -335,7 +335,7 @@ func (v *Value) compareOp(op string, a *Value) (res bool, err error) {
 	}
 
 	boolV, ok1b := v.ToBool()
-	boolA, ok2b := v.ToBool()
+	boolA, ok2b := a.ToBool()
 	if ok1b && ok2b {
 		return boolCompare(op, boolV, boolA)
 	}

--- a/pkg/s3select/sql/value.go
+++ b/pkg/s3select/sql/value.go
@@ -97,7 +97,7 @@ func (v *Value) Repr() string {
 	case typeBool, typeInt, typeFloat:
 		return fmt.Sprintf("%v:%s", v.value, v.GetTypeString())
 	case typeTimestamp:
-		return fmt.Sprintf("%s:TIMESTAMP", v.value.(*time.Time))
+		return fmt.Sprintf("%s:TIMESTAMP", v.value.(time.Time))
 	case typeString:
 		return fmt.Sprintf("\"%s\":%s", v.value.(string), v.GetTypeString())
 	case typeBytes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix typo and the string representation of the time.Time value

the value type is time.Time not *time.Time

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.