### PR TITLE
add timestamp compare support

### DIFF
--- a/pkg/s3select/sql/value.go
+++ b/pkg/s3select/sql/value.go
@@ -340,6 +340,12 @@ func (v *Value) compareOp(op string, a *Value) (res bool, err error) {
 		return boolCompare(op, boolV, boolA)
 	}
 
+	timestampV, ok1t := v.ToTimestamp()
+	timestampA, ok2t := a.ToTimestamp()
+	if ok1t && ok2t {
+		return timestampCompare(op, timestampV, timestampA), nil
+	}
+
 	return false, errCmpMismatchedTypes
 }
 
@@ -719,6 +725,25 @@ func boolCompare(op string, left, right bool) (bool, error) {
 	default:
 		return false, errCmpInvalidBoolOperator
 	}
+}
+
+func timestampCompare(op string, left, right time.Time) bool {
+	switch op {
+	case opLt:
+		return left.Before(right)
+	case opLte:
+		return left.Before(right) || left.Equal(right)
+	case opGt:
+		return left.After(right)
+	case opGte:
+		return left.After(right) || left.Equal(right)
+	case opEq:
+		return left.Equal(right)
+	case opIneq:
+		return !left.Equal(right)
+	}
+	// This case does not happen
+	return false
 }
 
 func isValidArithOperator(op string) bool {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for timestamp comparing


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
support the following case:

we have a access log with the following content:
```
127.0.0.1 - - [2019-06-17T11:57:49+08:00] "GET / HTTP/1.1" 200 3700 "-" "curl/7.29.0" "-"
203.205.141.45 - - [2019-06-18T11:57:49+08:00] "GET / HTTP/1.1" 200 3700 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
203.205.141.46 - - [2019-06-18T11:57:49+08:00] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
203.205.141.47 - - [2019-06-19T11:57:49+08:00] "GET /abc HTTP/1.1" 404 3650 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
```

suppose we want to filter by the time column

```bash
./mc sql  --csv-input "fh=NONE,fd= "  --query "Select *  from S3Object s where CAST(TRIM(BOTH '[]' FROM s._4) AS TIMESTAMP ) >= CAST ('2019-06-18T00:00:00+08:00' AS TIMESTAMP)  "  myminio/testbucket/access_log.csv
```

got the following error message:

```bash
mc: <ERROR> Unable to run sql InternalError:"cannot compare values of different types"
```

after this fix, we got the right answer:
```bash
$ ./mc sql  --csv-input "fh=NONE,fd= "  --query "Select *  from S3Object s where CAST(TRIM(BOTH '[]' FROM s._4) AS TIMESTAMP ) >= CAST ('2019-06-18T00:00:00+08:00' AS TIMESTAMP)  "  myminio/testbucket/access_log.csv
203.205.141.45,-,-,[2019-06-18T11:57:49+08:00],GET / HTTP/1.1,200,3700,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-
203.205.141.46,-,-,[2019-06-18T11:57:49+08:00],GET / HTTP/1.1,304,0,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-
203.205.141.47,-,-,[2019-06-19T11:57:49+08:00],GET /abc HTTP/1.1,404,3650,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-
```


## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.