### PR TITLE
Handle HEAD/GET requests for virtual DNS requests

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -294,7 +294,7 @@ func (h minioReservedBucketHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	default:
 		// For all other requests reject access to reserved
 		// buckets
-		bucketName, _ := urlPath2BucketObjectName(r.URL.Path)
+		bucketName, _ := request2BucketObjectName(r)
 		if isMinioReservedBucket(bucketName) || isMinioMetaBucket(bucketName) {
 			writeErrorResponse(context.Background(), w, errorCodes.ToAPIErr(ErrAllAccessDisabled), r.URL, guessIsBrowserReq(r))
 			return
@@ -494,7 +494,7 @@ var notimplementedObjectResourceNames = map[string]bool{
 
 // Resource handler ServeHTTP() wrapper
 func (h resourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	bucketName, objectName := urlPath2BucketObjectName(r.URL.Path)
+	bucketName, objectName := request2BucketObjectName(r)
 
 	// If bucketName is present and not objectName check for bucket level resource queries.
 	if bucketName != "" && objectName == "" {
@@ -696,7 +696,8 @@ func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	bucket, object := urlPath2BucketObjectName(r.URL.Path)
+	bucket, object := request2BucketObjectName(r)
+
 	// ListBucket requests should be handled at current endpoint as
 	// all buckets data can be fetched from here.
 	if r.Method == http.MethodGet && bucket == "" && object == "" {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -71,8 +71,20 @@ func cloneHeader(h http.Header) http.Header {
 	return h2
 }
 
+func request2BucketObjectName(r *http.Request) (bucketName, objectName string) {
+	path, err := getResource(r.URL.Path, r.Host, globalDomainNames)
+	if err != nil {
+		logger.CriticalIf(context.Background(), err)
+	}
+	return urlPath2BucketObjectName(path)
+}
+
 // Convert url path into bucket and object name.
 func urlPath2BucketObjectName(path string) (bucketName, objectName string) {
+	if path == "" || path == slashSeparator {
+		return "", ""
+	}
+
 	// Trim any preceding slash separator.
 	urlPath := strings.TrimPrefix(path, slashSeparator)
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Handle HEAD/GET requests for virtual DNS requests
<!--- Describe your changes in detail -->

## Motivation and Context
r.URL.Path is empty when HEAD bucket with virtual
DNS requests come in since bucket is now part of
r.Host, we should use our domain names and fetch
the right bucket/object names.

This fixes a really old issue in our federation
setups.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
No idea, it feels like it never really worked for this scenario
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
Using federation setup

```yaml
version: '3.7'

services:
  minio-bucket1:
    image: "minio/minio:latest"
    entrypoint: minio server /disk
    ports:
      - "9001:9000"
    environment:
      - MINIO_ACCESS_KEY=minio
      - MINIO_SECRET_KEY=minio123
      - MINIO_ETCD_ENDPOINTS=http://etcd:2379
      - MINIO_PUBLIC_IPS=minio-bucket1
      - MINIO_DOMAIN=load-balancer
    depends_on:
      - "etcd"
    networks:
      fed:
        aliases:
          - load-balancer

  minio-bucket2:
    image: "minio/minio:latest"
    entrypoint: minio server /disk
    ports:
      - "9002:9000"
    environment:
      - MINIO_ACCESS_KEY=minio
      - MINIO_SECRET_KEY=minio123
      - MINIO_ETCD_ENDPOINTS=http://etcd:2379
      - MINIO_PUBLIC_IPS=minio-bucket2
      - MINIO_DOMAIN=load-balancer
    depends_on:
      - "etcd"
    networks:
      fed:
        aliases:
          - load-balancer

  etcd:
    image: "quay.io/coreos/etcd"
    environment:
      - ETCD_NAME=node0
      - ETCDCTL_API=3
      - ETCD_INITIAL_ADVERTISE_PEER_URLS=http://etcd:2380
      - ETCD_INITIAL_CLUSTER=node0=http://etcd:2380
      - ETCD_INITIAL_CLUSTER_STATE=new
      - ETCD_INITIAL_CLUSTER_TOKEN=etcd-cluster
      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
      - ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380
      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
    networks:
      - fed

networks:
  fed:
    driver: bridge
```


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [x] All new and existing tests passed.