### PR TITLE
Add User-Agent header with MinIO release details in http logs

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -74,21 +74,23 @@ func checkUpdate(mode string) {
 
 // Load logger targets based on user's configuration
 func loadLoggers() {
+	loggerUserAgent := getUserAgent(getMinioMode())
+
 	auditEndpoint, ok := os.LookupEnv("MINIO_AUDIT_LOGGER_HTTP_ENDPOINT")
 	if ok {
 		// Enable audit HTTP logging through ENV.
-		logger.AddAuditTarget(http.New(auditEndpoint, NewCustomHTTPTransport()))
+		logger.AddAuditTarget(http.New(auditEndpoint, loggerUserAgent, NewCustomHTTPTransport()))
 	}
 
 	loggerEndpoint, ok := os.LookupEnv("MINIO_LOGGER_HTTP_ENDPOINT")
 	if ok {
 		// Enable HTTP logging through ENV.
-		logger.AddTarget(http.New(loggerEndpoint, NewCustomHTTPTransport()))
+		logger.AddTarget(http.New(loggerEndpoint, loggerUserAgent, NewCustomHTTPTransport()))
 	} else {
 		for _, l := range globalServerConfig.Logger.HTTP {
 			if l.Enabled {
 				// Enable http logging
-				logger.AddTarget(http.New(l.Endpoint, NewCustomHTTPTransport()))
+				logger.AddTarget(http.New(l.Endpoint, loggerUserAgent, NewCustomHTTPTransport()))
 			}
 		}
 	}

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -106,6 +106,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	logger.Disable = true
 
 	// Validate if we have access, secret set through environment.
+	globalGatewayName = gw.Name()
 	gatewayName := gw.Name()
 	if ctx.Args().First() == "help" {
 		cli.ShowCommandHelpAndExit(ctx, gatewayName, 1)

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -118,6 +118,9 @@ var (
 	// Indicates if the running minio is in gateway mode.
 	globalIsGateway = false
 
+	// Name of gateway server, e.g S3, GCS, Azure, etc
+	globalGatewayName = ""
+
 	// This flag is set to 'true' by default
 	globalIsBrowserEnabled = true
 

--- a/cmd/logger/target/http/http.go
+++ b/cmd/logger/target/http/http.go
@@ -37,7 +37,9 @@ type Target struct {
 
 	// HTTP(s) endpoint
 	endpoint string
-	client   gohttp.Client
+	// User-Agent to be set on each log request sent to the `endpoint`
+	userAgent string
+	client    gohttp.Client
 }
 
 func (h *Target) startHTTPLogger() {
@@ -56,6 +58,10 @@ func (h *Target) startHTTPLogger() {
 			}
 			req.Header.Set(xhttp.ContentType, "application/json")
 
+			// Set user-agent to indicate MinIO release
+			// version to the configured log endpoint
+			req.Header.Set("User-Agent", h.userAgent)
+
 			resp, err := h.client.Do(req)
 			if err != nil {
 				continue
@@ -69,9 +75,10 @@ func (h *Target) startHTTPLogger() {
 
 // New initializes a new logger target which
 // sends log over http to the specified endpoint
-func New(endpoint string, transport *gohttp.Transport) *Target {
+func New(endpoint, userAgent string, transport *gohttp.Transport) *Target {
 	h := Target{
-		endpoint: endpoint,
+		endpoint:  endpoint,
+		userAgent: userAgent,
 		client: gohttp.Client{
 			Transport: transport,
 		},

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -237,13 +237,7 @@ func serverMain(ctx *cli.Context) {
 
 	if !globalCLIContext.Quiet {
 		// Check for new updates from dl.min.io.
-		mode := globalMinioModeFS
-		if globalIsDistXL {
-			mode = globalMinioModeDistXL
-		} else if globalIsXL {
-			mode = globalMinioModeXL
-		}
-		checkUpdate(mode)
+		checkUpdate(getMinioMode())
 	}
 
 	// FIXME: This code should be removed in future releases and we should have mandatory

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -508,3 +508,16 @@ func lcp(l []string) string {
 	// are equal, min is the answer ("foo" < "foobar").
 	return min
 }
+
+// Returns the mode in which MinIO is running
+func getMinioMode() string {
+	mode := globalMinioModeFS
+	if globalIsDistXL {
+		mode = globalMinioModeDistXL
+	} else if globalIsXL {
+		mode = globalMinioModeXL
+	} else if globalIsGateway {
+		mode = globalMinioModeGatewayPrefix + globalGatewayName
+	}
+	return mode
+}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -500,5 +500,25 @@ func TestLCP(t *testing.T) {
 			t.Fatalf("Test %d: Common prefix found: `%v`, expected: `%v`", i+1, foundPrefix, test.commonPrefix)
 		}
 	}
+}
+
+func TestGetMinioMode(t *testing.T) {
+	testMinioMode := func(expected string) {
+		if mode := getMinioMode(); mode != expected {
+			t.Fatalf("Expected %s got %s", expected, mode)
+		}
+	}
+	globalIsDistXL = true
+	testMinioMode(globalMinioModeDistXL)
+
+	globalIsDistXL = false
+	globalIsXL = true
+	testMinioMode(globalMinioModeXL)
+
+	globalIsDistXL, globalIsXL = false, false
+	testMinioMode(globalMinioModeFS)
+
+	globalIsGateway, globalGatewayName = true, "azure"
+	testMinioMode(globalMinioModeGatewayPrefix + globalGatewayName)
 
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Passes MinIO deployment version to http log targets via User-Agent headers.

## Description
<!--- Describe your changes in detail -->
This change uses the `getUserAgent` function, used by minio-update, to construct `User-Agent`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This would allow http log target server to distinguish between log
messages across different versions of MinIO deployments.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.