### PR TITLE
Fix host address returned in admin API calls

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -240,8 +240,7 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 	if objectAPI == nil {
 		return
 	}
-
-	thisAddr, err := xnet.ParseHost(GetLocalPeer(globalEndpoints))
+	hostName, err := getHostName(r)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
@@ -251,7 +250,7 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 	// Once we have received all the ServerInfo from peers
 	// add the local peer server info as well.
 	serverInfo = append(serverInfo, ServerInfo{
-		Addr: thisAddr.String(),
+		Addr: hostName,
 		Data: &ServerInfoData{
 			StorageInfo: objectAPI.StorageInfo(ctx),
 			ConnStats:   globalConnStats.toServerConnStats(),
@@ -329,7 +328,7 @@ func (a adminAPIHandlers) PerfInfoHandler(w http.ResponseWriter, r *http.Request
 			return
 		}
 		// Get drive performance details from local server's drive(s)
-		dp := localEndpointsDrivePerf(globalEndpoints)
+		dp := localEndpointsDrivePerf(globalEndpoints, r)
 
 		// Notify all other MinIO peers to report drive performance numbers
 		dps := globalNotificationSys.DrivePerfInfo()
@@ -347,7 +346,7 @@ func (a adminAPIHandlers) PerfInfoHandler(w http.ResponseWriter, r *http.Request
 		writeSuccessResponseJSON(w, jsonBytes)
 	case "cpu":
 		// Get CPU load details from local server's cpu(s)
-		cpu := localEndpointsCPULoad(globalEndpoints)
+		cpu := localEndpointsCPULoad(globalEndpoints, r)
 		// Notify all other MinIO peers to report cpu load numbers
 		cpus := globalNotificationSys.CPULoadInfo()
 		cpus = append(cpus, cpu)
@@ -364,7 +363,7 @@ func (a adminAPIHandlers) PerfInfoHandler(w http.ResponseWriter, r *http.Request
 		writeSuccessResponseJSON(w, jsonBytes)
 	case "mem":
 		// Get mem usage details from local server(s)
-		m := localEndpointsMemUsage(globalEndpoints)
+		m := localEndpointsMemUsage(globalEndpoints, r)
 		// Notify all other MinIO peers to report mem usage numbers
 		mems := globalNotificationSys.MemUsageInfo()
 		mems = append(mems, m)
@@ -442,8 +441,7 @@ func (a adminAPIHandlers) TopLocksHandler(w http.ResponseWriter, r *http.Request
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL)
 		return
 	}
-
-	thisAddr, err := xnet.ParseHost(GetLocalPeer(globalEndpoints))
+	hostName, err := getHostName(r)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
@@ -454,7 +452,7 @@ func (a adminAPIHandlers) TopLocksHandler(w http.ResponseWriter, r *http.Request
 	// add the local peer locks list as well.
 	localLocks := globalLockServer.ll.DupLockMap()
 	peerLocks = append(peerLocks, &PeerLocks{
-		Addr:  thisAddr.String(),
+		Addr:  hostName,
 		Locks: localLocks,
 	})
 

--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -704,9 +704,6 @@ func TestAdminServerInfo(t *testing.T) {
 	}
 
 	for _, serverInfo := range results {
-		if len(serverInfo.Addr) == 0 {
-			t.Error("Expected server address to be non empty")
-		}
 		if serverInfo.Error != "" {
 			t.Errorf("Unexpected error = %v\n", serverInfo.Error)
 		}

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -288,7 +289,7 @@ func (endpoints EndpointList) UpdateIsLocal() error {
 
 // localEndpointsMemUsage - returns ServerMemUsageInfo for only the
 // local endpoints from given list of endpoints
-func localEndpointsMemUsage(endpoints EndpointList) ServerMemUsageInfo {
+func localEndpointsMemUsage(endpoints EndpointList, r *http.Request) ServerMemUsageInfo {
 	var memUsages []mem.Usage
 	var historicUsages []mem.Usage
 	scratchSpace := map[string]bool{}
@@ -303,8 +304,12 @@ func localEndpointsMemUsage(endpoints EndpointList) ServerMemUsageInfo {
 			scratchSpace[endpoint.Host] = true
 		}
 	}
+	addr := r.Host
+	if globalIsDistXL {
+		addr = GetLocalPeer(endpoints)
+	}
 	return ServerMemUsageInfo{
-		Addr:          GetLocalPeer(endpoints),
+		Addr:          addr,
 		Usage:         memUsages,
 		HistoricUsage: historicUsages,
 	}
@@ -312,7 +317,7 @@ func localEndpointsMemUsage(endpoints EndpointList) ServerMemUsageInfo {
 
 // localEndpointsCPULoad - returns ServerCPULoadInfo for only the
 // local endpoints from given list of endpoints
-func localEndpointsCPULoad(endpoints EndpointList) ServerCPULoadInfo {
+func localEndpointsCPULoad(endpoints EndpointList, r *http.Request) ServerCPULoadInfo {
 	var cpuLoads []cpu.Load
 	var historicLoads []cpu.Load
 	scratchSpace := map[string]bool{}
@@ -327,8 +332,12 @@ func localEndpointsCPULoad(endpoints EndpointList) ServerCPULoadInfo {
 			scratchSpace[endpoint.Host] = true
 		}
 	}
+	addr := r.Host
+	if globalIsDistXL {
+		addr = GetLocalPeer(endpoints)
+	}
 	return ServerCPULoadInfo{
-		Addr:         GetLocalPeer(endpoints),
+		Addr:         addr,
 		Load:         cpuLoads,
 		HistoricLoad: historicLoads,
 	}
@@ -336,7 +345,7 @@ func localEndpointsCPULoad(endpoints EndpointList) ServerCPULoadInfo {
 
 // localEndpointsDrivePerf - returns ServerDrivesPerfInfo for only the
 // local endpoints from given list of endpoints
-func localEndpointsDrivePerf(endpoints EndpointList) ServerDrivesPerfInfo {
+func localEndpointsDrivePerf(endpoints EndpointList, r *http.Request) ServerDrivesPerfInfo {
 	var dps []disk.Performance
 	for _, endpoint := range endpoints {
 		// Only proceed for local endpoints
@@ -351,9 +360,12 @@ func localEndpointsDrivePerf(endpoints EndpointList) ServerDrivesPerfInfo {
 			dps = append(dps, dp)
 		}
 	}
-
+	addr := r.Host
+	if globalIsDistXL {
+		addr = GetLocalPeer(endpoints)
+	}
 	return ServerDrivesPerfInfo{
-		Addr: GetLocalPeer(endpoints),
+		Addr: addr,
 		Perf: dps,
 	}
 }

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/handlers"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // Parses location constraint from the incoming reader.
@@ -382,4 +383,18 @@ func notFoundHandlerJSON(w http.ResponseWriter, r *http.Request) {
 // If none of the http routes match respond with MethodNotAllowed
 func notFoundHandler(w http.ResponseWriter, r *http.Request) {
 	writeErrorResponse(context.Background(), w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
+}
+
+// gets host name for current node
+func getHostName(r *http.Request) (hostName string, err error) {
+	var thisAddr *xnet.Host
+	hostName = r.Host
+	if globalIsDistXL {
+		thisAddr, err = xnet.ParseHost(GetLocalPeer(globalEndpoints))
+		if err != nil {
+			return
+		}
+		hostName = thisAddr.String()
+	}
+	return
 }

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -331,7 +331,7 @@ func (s *peerRESTServer) CPULoadInfoHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	ctx := newContext(r, w, "CPULoadInfo")
-	info := localEndpointsCPULoad(globalEndpoints)
+	info := localEndpointsCPULoad(globalEndpoints, r)
 
 	defer w.(http.Flusher).Flush()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
@@ -345,7 +345,7 @@ func (s *peerRESTServer) DrivePerfInfoHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	ctx := newContext(r, w, "DrivePerfInfo")
-	info := localEndpointsDrivePerf(globalEndpoints)
+	info := localEndpointsDrivePerf(globalEndpoints, r)
 
 	defer w.(http.Flusher).Flush()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
@@ -358,7 +358,7 @@ func (s *peerRESTServer) MemUsageInfoHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	ctx := newContext(r, w, "MemUsageInfo")
-	info := localEndpointsMemUsage(globalEndpoints)
+	info := localEndpointsMemUsage(globalEndpoints, r)
 
 	defer w.(http.Flusher).Flush()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))


### PR DESCRIPTION
## Description

`mc admin monitor` , `mc admin info` commands currently return loopback address instead
of public facing ip. This PR fixes the address returned in the admin API calls 

## Motivation and Context


## How to test this PR?
Run the mc commands above in erasure/fs/dist modes.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
