### PR TITLE
[Bugfix] duplicating flag registration

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -48,7 +48,7 @@ var (
 
 // RegisterGatewayCommand registers a new command for gateway.
 func RegisterGatewayCommand(cmd cli.Command) error {
-	cmd.Flags = append(append(cmd.Flags, append(cmd.Flags, ServerFlags...)...), GlobalFlags...)
+	cmd.Flags = append(append(cmd.Flags, ServerFlags...), GlobalFlags...)
 	gatewayCmd.Subcommands = append(gatewayCmd.Subcommands, cmd)
 	return nil
 }

--- a/cmd/gateway-main_test.go
+++ b/cmd/gateway-main_test.go
@@ -60,7 +60,7 @@ func TestRunRegisteredGatewayCommand(t *testing.T) {
 
 	if err = newApp("minio").Run(
 		[]string{"minio", "gateway", "test", fmt.Sprintf("--%s", flagName), flagValue}); err != nil {
-		t.Errorf("Running registered gateway command got unexpected error: %s", err)
+		t.Errorf("running registered gateway command got unexpected error: %s", err)
 	}
 }
 

--- a/cmd/gateway-main_test.go
+++ b/cmd/gateway-main_test.go
@@ -43,7 +43,7 @@ func TestRunRegisteredGatewayCommand(t *testing.T) {
 	flagValue := "foo"
 
 	cmd := cli.Command{
-		Name: "test",
+		Name: "test-run-with-flag",
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: flagName},
 		},
@@ -54,14 +54,13 @@ func TestRunRegisteredGatewayCommand(t *testing.T) {
 		},
 	}
 
-	app := newApp("minio")
 	err = RegisterGatewayCommand(cmd)
 	if err != nil {
 		t.Errorf("RegisterGatewayCommand got unexpected error: %s", err)
 	}
 
-	if err = app.Run(
-		[]string{"minio", "gateway", "test", fmt.Sprintf("--%s", flagName), flagValue}); err != nil {
+	if err = newApp("minio").Run(
+		[]string{"minio", "gateway", cmd.Name, fmt.Sprintf("--%s", flagName), flagValue}); err != nil {
 		t.Errorf("running registered gateway command got unexpected error: %s", err)
 	}
 }

--- a/cmd/gateway-main_test.go
+++ b/cmd/gateway-main_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -31,6 +32,35 @@ func TestRegisterGatewayCommand(t *testing.T) {
 	err = RegisterGatewayCommand(cmd)
 	if err != nil {
 		t.Errorf("RegisterGatewayCommand got unexpected error: %s", err)
+	}
+}
+
+// Test running a registered gateway command with a flag
+func TestRunRegisteredGatewayCommand(t *testing.T) {
+	var err error
+
+	flagName := "test-flag"
+	flagValue := "foo"
+
+	cmd := cli.Command{
+		Name: "test",
+		Flags: []cli.Flag{
+			cli.StringFlag{Name: flagName},
+		},
+		Action: func(ctx *cli.Context) {
+			if actual := ctx.String(flagName); actual != flagValue {
+				t.Errorf("value of %s expects %s, but got %s", flagName, flagValue, actual)
+			}
+		},
+	}
+	err = RegisterGatewayCommand(cmd)
+	if err != nil {
+		t.Errorf("RegisterGatewayCommand got unexpected error: %s", err)
+	}
+
+	if err = newApp("minio").Run(
+		[]string{"minio", "gateway", "test", fmt.Sprintf("--%s", flagName), flagValue}); err != nil {
+		t.Errorf("Running registered gateway command got unexpected error: %s", err)
 	}
 }
 

--- a/cmd/gateway-main_test.go
+++ b/cmd/gateway-main_test.go
@@ -53,12 +53,14 @@ func TestRunRegisteredGatewayCommand(t *testing.T) {
 			}
 		},
 	}
+
+	app := newApp("minio")
 	err = RegisterGatewayCommand(cmd)
 	if err != nil {
 		t.Errorf("RegisterGatewayCommand got unexpected error: %s", err)
 	}
 
-	if err = newApp("minio").Run(
+	if err = app.Run(
 		[]string{"minio", "gateway", "test", fmt.Sprintf("--%s", flagName), flagValue}); err != nil {
 		t.Errorf("running registered gateway command got unexpected error: %s", err)
 	}

--- a/docs/gateway/gcs.md
+++ b/docs/gateway/gcs.md
@@ -19,7 +19,7 @@ MinIO GCS Gateway allows you to access Google Cloud Storage (GCS) with Amazon S3
 
 **Note:** For alternate ways to set up *Application Default Credentials*, see [Setting Up Authentication for Server to Server Production Applications](https://developers.google.com/identity/protocols/application-default-credentials).
 
-### 1.1 Run MinIO GCS Gateway Using Docker
+### 1.2 Run MinIO GCS Gateway Using Docker
 ```sh
 docker run -p 9000:9000 --name gcs-s3 \
  -v /path/to/credentials.json:/credentials.json \
@@ -29,7 +29,7 @@ docker run -p 9000:9000 --name gcs-s3 \
  minio/minio gateway gcs yourprojectid
 ```
 
-### 1.2 Run MinIO GCS Gateway Using the MinIO Binary
+### 1.3 Run MinIO GCS Gateway Using the MinIO Binary
 
 ```sh
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json


### PR DESCRIPTION
## Description
This PR fixes a bug that the same ` cmd.Flags` of gateway sub-command are registered twice.
Picked only bug fix part from #7819.

## Motivation and Context
Bug fix.

## How to test this PR?
Added a test case that runs registered gateway subcommand in the first commit and it runs into an error as follows:

```
test flag redefined: test-flag
--- FAIL: TestRunRegisteredGatewayCommand (0.00s)
panic: test flag redefined: test-flag [recovered]
        panic: test flag redefined: test-flag

goroutine 13 [running]:
testing.tRunner.func1(0xc00042a200)
        /home/saint1991/.goenv/versions/1.12.5/src/testing/testing.go:830 +0x392
panic(0x160b880, 0xc00040cc00)
        /home/saint1991/.goenv/versions/1.12.5/src/runtime/panic.go:522 +0x1b5
flag.(*FlagSet).Var(0xc0000d0660, 0x1bbc520, 0xc00040cbc0, 0x18bd576, 0x9, 0x0, 0x0)
        /home/saint1991/.goenv/versions/1.12.5/src/flag/flag.go:850 +0x4af
flag.(*FlagSet).StringVar(...)
        /home/saint1991/.goenv/versions/1.12.5/src/flag/flag.go:753
flag.(*FlagSet).String(0xc0000d0660, 0x18bd576, 0x9, 0x0, 0x0, 0x0, 0x0, 0x9)
        /home/saint1991/.goenv/versions/1.12.5/src/flag/flag.go:766 +0xa1
github.com/minio/cli.StringFlag.ApplyWithError.func1(0x18bd576, 0x9)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/flag.go:421 +0xda
github.com/minio/cli.eachName(0x18bd576, 0x9, 0xc0001ac438)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/flag.go:94 +0xdc
github.com/minio/cli.StringFlag.ApplyWithError(0x18bd576, 0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/flag.go:416 +0xcb
github.com/minio/cli.flagSet(0x18b5ef0, 0x4, 0xc00040b0e0, 0xa, 0x12, 0xc00040b0e0, 0x9, 0x12)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/flag.go:80 +0x125
github.com/minio/cli.Command.Run(0x18b5ef0, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/command.go:117 +0x106
github.com/minio/cli.(*App).RunAsSubcommand(0xc00000c3c0, 0xc000556a80, 0x0, 0x0)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/app.go:415 +0x815
github.com/minio/cli.Command.startApp(0x18b9f86, 0x7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x18e174d, 0x1c, 0x0, ...)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/command.go:308 +0x813
github.com/minio/cli.Command.Run(0x18b9f86, 0x7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x18e174d, 0x1c, 0x0, ...)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/command.go:106 +0x12a2
github.com/minio/cli.(*App).Run(0xc00000c1e0, 0xc000410190, 0x5, 0x5, 0x0, 0x0)
        /home/saint1991/go/1.12.5/pkg/mod/github.com/minio/cli@v1.20.0/app.go:289 +0x6af
github.com/minio/minio/cmd.TestRunRegisteredGatewayCommand(0xc00042a200)
        /mnt/c/Users/P218222/Desktop/projects/go/src/github.com/minio/minio/cmd/gateway-main_test.go:60 +0x5a9
testing.tRunner(0xc00042a200, 0x1943158)
        /home/saint1991/.goenv/versions/1.12.5/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
        /home/saint1991/.goenv/versions/1.12.5/src/testing/testing.go:916 +0x35a
FAIL    github.com/minio/minio/cmd      0.613s
```

It solved by the second commit.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
