### PR TITLE
xl: Heal empty parts

### DIFF
--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -196,9 +196,9 @@ func (d *naughtyDisk) ReadAll(volume string, path string) (buf []byte, err error
 	return d.disk.ReadAll(volume, path)
 }
 
-func (d *naughtyDisk) VerifyFile(volume, path string, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
+func (d *naughtyDisk) VerifyFile(volume, path string, empty bool, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
 	if err := d.calcError(); err != nil {
 		return err
 	}
-	return d.disk.VerifyFile(volume, path, algo, sum, shardSize)
+	return d.disk.VerifyFile(volume, path, empty, algo, sum, shardSize)
 }

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -1797,7 +1797,7 @@ func TestPosixVerifyFile(t *testing.T) {
 	if err := posixStorage.WriteAll(volName, fileName, bytes.NewBuffer(data)); err != nil {
 		t.Fatal(err)
 	}
-	if err := posixStorage.VerifyFile(volName, fileName, algo, hashBytes, 0); err != nil {
+	if err := posixStorage.VerifyFile(volName, fileName, false, algo, hashBytes, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1805,7 +1805,7 @@ func TestPosixVerifyFile(t *testing.T) {
 	if err := posixStorage.AppendFile(volName, fileName, []byte("a")); err != nil {
 		t.Fatal(err)
 	}
-	if err := posixStorage.VerifyFile(volName, fileName, algo, hashBytes, 0); err == nil {
+	if err := posixStorage.VerifyFile(volName, fileName, false, algo, hashBytes, 0); err == nil {
 		t.Fatal("expected to fail bitrot check")
 	}
 
@@ -1835,7 +1835,7 @@ func TestPosixVerifyFile(t *testing.T) {
 		}
 	}
 	w.Close()
-	if err := posixStorage.VerifyFile(volName, fileName, algo, nil, shardSize); err != nil {
+	if err := posixStorage.VerifyFile(volName, fileName, false, algo, nil, shardSize); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1849,7 +1849,7 @@ func TestPosixVerifyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.Close()
-	if err := posixStorage.VerifyFile(volName, fileName, algo, nil, shardSize); err == nil {
+	if err := posixStorage.VerifyFile(volName, fileName, false, algo, nil, shardSize); err == nil {
 		t.Fatal("expected to fail bitrot check")
 	}
 }

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -72,6 +72,9 @@ var errVolumeAccessDenied = errors.New("volume access denied")
 // errFileAccessDenied - cannot access file, insufficient permissions.
 var errFileAccessDenied = errors.New("file access denied")
 
+// errFileUnexpectedSize - file has an unexpected size
+var errFileUnexpectedSize = errors.New("file has unexpected size")
+
 // errFileParentIsFile - cannot have overlapping objects, parent is already a file.
 var errFileParentIsFile = errors.New("parent is a file")
 

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -52,7 +52,7 @@ type StorageAPI interface {
 	StatFile(volume string, path string) (file FileInfo, err error)
 	DeleteFile(volume string, path string) (err error)
 	DeleteFileBulk(volume string, paths []string) (errs []error, err error)
-	VerifyFile(volume, path string, algo BitrotAlgorithm, sum []byte, shardSize int64) error
+	VerifyFile(volume, path string, empty bool, algo BitrotAlgorithm, sum []byte, shardSize int64) error
 
 	// Write all data, syncs the data to disk.
 	WriteAll(volume string, path string, reader io.Reader) (err error)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -67,6 +67,8 @@ func toStorageErr(err error) error {
 		return io.EOF
 	case io.ErrUnexpectedEOF.Error():
 		return io.ErrUnexpectedEOF
+	case errFileUnexpectedSize.Error():
+		return errFileUnexpectedSize
 	case errUnexpected.Error():
 		return errUnexpected
 	case errDiskFull.Error():
@@ -434,11 +436,12 @@ func (client *storageRESTClient) getInstanceID() (err error) {
 	return nil
 }
 
-func (client *storageRESTClient) VerifyFile(volume, path string, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
+func (client *storageRESTClient) VerifyFile(volume, path string, empty bool, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)
 	values.Set(storageRESTFilePath, path)
 	values.Set(storageRESTBitrotAlgo, algo.String())
+	values.Set(storageRESTEmpty, strconv.FormatBool(empty))
 	values.Set(storageRESTLength, strconv.Itoa(int(shardSize)))
 	if len(sum) != 0 {
 		values.Set(storageRESTBitrotHash, hex.EncodeToString(sum))

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -16,7 +16,7 @@
 
 package cmd
 
-const storageRESTVersion = "v7"
+const storageRESTVersion = "v8"
 const storageRESTPath = minioReservedBucketPath + "/storage/" + storageRESTVersion + "/"
 
 const (
@@ -52,6 +52,7 @@ const (
 	storageRESTDstPath    = "destination-path"
 	storageRESTOffset     = "offset"
 	storageRESTLength     = "length"
+	storageRESTEmpty      = "empty"
 	storageRESTCount      = "count"
 	storageRESTMarkerPath = "marker"
 	storageRESTLeafFile   = "leaf-file"

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -520,6 +520,11 @@ func (s *storageRESTServer) VerifyFile(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	volume := vars[storageRESTVolume]
 	filePath := vars[storageRESTFilePath]
+	empty, err := strconv.ParseBool(vars[storageRESTEmpty])
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
 	shardSize, err := strconv.Atoi(vars[storageRESTLength])
 	if err != nil {
 		s.writeErrorResponse(w, err)
@@ -542,7 +547,7 @@ func (s *storageRESTServer) VerifyFile(w http.ResponseWriter, r *http.Request) {
 	algo := BitrotAlgorithmFromString(algoStr)
 	w.Header().Set(xhttp.ContentType, "text/event-stream")
 	doneCh := sendWhiteSpaceVerifyFile(w)
-	err = s.storage.VerifyFile(volume, filePath, algo, hash, int64(shardSize))
+	err = s.storage.VerifyFile(volume, filePath, empty, algo, hash, int64(shardSize))
 	<-doneCh
 	gob.NewEncoder(w).Encode(VerifyFileResp{err})
 }

--- a/cmd/xl-v1-healing-common.go
+++ b/cmd/xl-v1-healing-common.go
@@ -183,10 +183,10 @@ func disksWithAllParts(ctx context.Context, onlineDisks []StorageAPI, partsMetad
 			// it needs healing too.
 			for _, part := range partsMetadata[i].Parts {
 				checksumInfo := erasureInfo.GetChecksumInfo(part.Name)
-				err = onlineDisk.VerifyFile(bucket, pathJoin(object, part.Name), checksumInfo.Algorithm, checksumInfo.Hash, erasure.ShardSize())
+				err = onlineDisk.VerifyFile(bucket, pathJoin(object, part.Name), part.Size == 0, checksumInfo.Algorithm, checksumInfo.Hash, erasure.ShardSize())
 				if err != nil {
 					isCorrupt := strings.HasPrefix(err.Error(), "Bitrot verification mismatch - expected ")
-					if !isCorrupt && err != errFileNotFound && err != errVolumeNotFound {
+					if !isCorrupt && err != errFileNotFound && err != errVolumeNotFound && err != errFileUnexpectedSize {
 						logger.LogIf(ctx, err)
 					}
 					dataErrs[i] = err

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -195,6 +195,9 @@ func shouldHealObjectOnDisk(xlErr, dataErr error, meta xlMetaV1, quorumModTime t
 		if dataErr == errFileNotFound {
 			return true
 		}
+		if dataErr == errFileUnexpectedSize {
+			return true
+		}
 		if _, ok := dataErr.(HashMismatchError); ok {
 			return true
 		}


### PR DESCRIPTION

## Description
posix.VerifyFile() doesn't know how to check if a file
is corrupted if that file is empty. We do have the part
size in xl.json so we pass it to VerifyFile to return
an error so healing empty parts can work properly.

## Motivation and Context
Fixes #7366 


## How to test this PR?
Described here


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
