### PR TITLE
"admin user policy" Command is Wrong/Outdated

### DIFF
--- a/docs/multi-user/README.md
+++ b/docs/multi-user/README.md
@@ -59,7 +59,7 @@ mc admin user remove myminio newuser
 ### 5. Change user policy
 Change the policy for user `newuser` to `putonly` canned policy.
 ```
-mc admin user policy myminio newuser putonly
+mc admin user set-policy myminio newuser putonly
 ```
 
 ### 5. List all users


### PR DESCRIPTION
#7668  Description

Under "change user policy", the `mc admin user policy` command is wrong.  It should be `mc admin user set-policy`.

I don't know if this was a command rename at some point, or the docs here have always been wrong.

## Motivation and Context

Simple typo/documentation bug fix!
