### PR TITLE
auto-heal: Use fast scan instead of the deep one

### DIFF
--- a/cmd/daily-heal-ops.go
+++ b/cmd/daily-heal-ops.go
@@ -39,7 +39,7 @@ func newBgHealSequence(numDisks int) *healSequence {
 	hs := madmin.HealOpts{
 		// Remove objects that do not have read-quorum
 		Remove:   true,
-		ScanMode: madmin.HealDeepScan,
+		ScanMode: madmin.HealNormalScan,
 	}
 
 	return &healSequence{


### PR DESCRIPTION
## Description
Deep scan is slow and consumes a lot of resources, disabling it for now. Users can still use mc admin to trigger the deep scan


## How to test this PR?
1. minio server /tmp/xl/{1..4}/
2. mc mb myminio/testbucket/
3. mc cp file myminio/testbucket/
4. rm /tmp/xl/1/testbucket/file/
5. Restart minio server to trigger auto healing and check the heal in the backend

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
