### PR TITLE
aggregation functions' argument may already has been cast to numeric

### DIFF
--- a/pkg/s3select/sql/aggregation.go
+++ b/pkg/s3select/sql/aggregation.go
@@ -103,12 +103,14 @@ func (e *FuncExpr) evalAggregationNode(r Record) error {
 
 		// Here, we diverge from Amazon S3 behavior by
 		// inferring untyped values are numbers.
-		if i, ok := argVal.bytesToInt(); ok {
-			argVal.setInt(i)
-		} else if f, ok := argVal.bytesToFloat(); ok {
-			argVal.setFloat(f)
-		} else {
-			return errNonNumericArg(funcName)
+		if !argVal.isNumeric() {
+			if i, ok := argVal.bytesToInt(); ok {
+				argVal.setInt(i)
+			} else if f, ok := argVal.bytesToFloat(); ok {
+				argVal.setFloat(f)
+			} else {
+				return errNonNumericArg(funcName)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
suppose we have an object hello.csv with the following content:
```
Name,Score
alice,80
bob,81
```

the query `SELECT SUM(Score) FROM S3Object` succeed, but the query `SELECT SUM(CAST (Score as int)) FROM S3Object` failed with the error message:
```
InternalError: SUM() requires a numeric argument
```

compared with s3:
the query `SELECT SUM(Score) FROM S3Object` on s3 failed with `400:ExternalEvalException` and
the query `SELECT SUM(CAST (Score as int)) FROM S3Object` succeed.

by the way, my test bucket on s3 is in region us-west-1, maybe different region has little tiny different behavior.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
