### PR TITLE
fix csv read bug

### DIFF
--- a/pkg/s3select/csv/reader.go
+++ b/pkg/s3select/csv/reader.go
@@ -59,10 +59,10 @@ func (rr *recordReader) Read(p []byte) (n int, err error) {
 		p[i] = '\n'
 		if len(rr.recordDelimiter) > 1 {
 			p = append(p[:i+1], p[i+len(rr.recordDelimiter):]...)
+			n--
 		}
 	}
 
-	n = len(p)
 	if len(rr.recordDelimiter) == 1 || p[n-1] != rr.recordDelimiter[0] {
 		return n, nil
 	}

--- a/pkg/s3select/csv/reader_test.go
+++ b/pkg/s3select/csv/reader_test.go
@@ -1,0 +1,72 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package csv
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/minio/minio/pkg/s3select/sql"
+)
+
+func TestRead(t *testing.T) {
+	cases := []struct {
+		content         string
+		recordDelimiter string
+		fieldDelimiter  string
+	}{
+		{"1,2,3\na,b,c\n", "\n", ","},
+		{"1,2,3\ta,b,c\t", "\t", ","},
+		{"1,2,3\r\na,b,c\r\n", "\r\n", ","},
+	}
+
+	for i, c := range cases {
+		var err error
+		var record sql.Record
+
+		r, _ := NewReader(ioutil.NopCloser(strings.NewReader(c.content)), &ReaderArgs{
+			FileHeaderInfo:             none,
+			RecordDelimiter:            c.recordDelimiter,
+			FieldDelimiter:             c.fieldDelimiter,
+			QuoteCharacter:             defaultQuoteCharacter,
+			QuoteEscapeCharacter:       defaultQuoteEscapeCharacter,
+			CommentCharacter:           defaultCommentCharacter,
+			AllowQuotedRecordDelimiter: true,
+			unmarshaled:                true,
+		})
+
+		result := ""
+		for {
+			record, err = r.Read()
+			if err != nil {
+				break
+			}
+			s, _ := record.MarshalCSV([]rune(c.fieldDelimiter)[0])
+			result += string(s) + c.recordDelimiter
+		}
+		r.Close()
+		if err != io.EOF {
+			t.Fatalf("Case %d failed with %s", i, err)
+		}
+
+		if result != c.content {
+			t.Errorf("Case %d failed: expected %v result %v", i, c.content, result)
+		}
+	}
+}


### PR DESCRIPTION
## Description

currently failed to parse the following csv with record delimiter "\t"
"1,2,3\ta,b,c\t"
with a third record with trailing a lot of '\0' returned.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
