### PR TITLE
Avoid go-prompt to show colored prompt properly in Windows

### DIFF
--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -30,12 +30,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/inconshreveable/go-update"
 	"github.com/minio/cli"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	_ "github.com/minio/sha256-simd" // Needed for sha256 hash verifier.
-	"github.com/segmentio/go-prompt"
 )
 
 // Check for new software updates.
@@ -452,7 +452,7 @@ func getUpdateInfo(timeout time.Duration, mode string) (updateMsg string, sha256
 
 func doUpdate(sha256Hex string, latestReleaseTime time.Time, ok bool) (updateStatusMsg string, err error) {
 	if !ok {
-		updateStatusMsg = colorGreenBold("MinIO update to version RELEASE.%s canceled.",
+		updateStatusMsg = colorRedBold("MinIO update to version RELEASE.%s canceled.",
 			latestReleaseTime.Format(minioReleaseTagTimeLayout))
 		return updateStatusMsg, nil
 	}
@@ -482,10 +482,25 @@ func doUpdate(sha256Hex string, latestReleaseTime time.Time, ok bool) (updateSta
 		latestReleaseTime.Format(minioReleaseTagTimeLayout)), nil
 }
 
+// Confirm continues prompting until the input is boolean-ish.
+func confirm(prompt string, args ...interface{}) bool {
+	for {
+		var s string
+		fmt.Fprintf(color.Output, prompt+": ", args...)
+		fmt.Scanln(&s)
+		switch s {
+		case "Yes", "yes", "y", "Y":
+			return true
+		case "No", "no", "n", "N":
+			return false
+		}
+	}
+}
+
 func shouldUpdate(quiet bool, sha256Hex string, latestReleaseTime time.Time) (ok bool) {
 	ok = true
 	if !quiet {
-		ok = prompt.Confirm(colorGreenBold("Update to RELEASE.%s [%s]", latestReleaseTime.Format(minioReleaseTagTimeLayout), "yes"))
+		ok = confirm(colorGreenBold("Update to RELEASE.%s ? [%s]", latestReleaseTime.Format(minioReleaseTagTimeLayout), "y/n"))
 	}
 	return ok
 }


### PR DESCRIPTION
## Description
Update prompt shows some weird characters under Windows, the reason
is that go-prompt is used to show a yes/no prompt, since go-prompt
does not seem to have a way to support color/fatih, this PR will
implements its own yes/no prompt with the correct text coloration.


## Motivation and Context
Fixes https://github.com/minio/minio/issues/7881

## How to test this PR?
Hard to test without changing the code, contact me


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
