### PR TITLE
Fix mint hub.docker.com builds

### DIFF
--- a/Dockerfile.mint
+++ b/Dockerfile.mint
@@ -10,10 +10,13 @@ ENV GOPATH /usr/local
 
 ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
 
+ENV MINT_ROOT_DIR /mint
+
+COPY mint /mint
+
 RUN apt-get --yes update && apt-get --yes upgrade && \
     apt-get --yes --quiet install wget jq curl git dnsmasq && \
-    git clone https://github.com/minio/minio.git /minio && \
-    ln -sf /minio/mint /mint && /mint/release.sh
+    cd /mint && /mint/release.sh
 
 WORKDIR /mint
 

--- a/mint/postinstall.sh
+++ b/mint/postinstall.sh
@@ -15,9 +15,11 @@
 #  limitations under the License.
 #
 
+export APT="apt --quiet --yes"
+
 # remove all packages listed in remove-packages.list
-xargs --arg-file=remove-packages.list apt --quiet --yes purge
-apt --quiet --yes autoremove
+xargs --arg-file="${MINT_ROOT_DIR}/remove-packages.list" apt --quiet --yes purge
+${APT} autoremove
 
 # remove unwanted files
 rm -fr "$GOROOT" "$GOPATH/src" /var/lib/apt/lists/*

--- a/mint/preinstall.sh
+++ b/mint/preinstall.sh
@@ -29,7 +29,6 @@ $APT install apt-transport-https
 wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
 dpkg -i packages-microsoft-prod.deb
 rm -f packages-microsoft-prod.deb
-$APT install apt-transport-https
 $APT update
 
 # download and install golang
@@ -41,7 +40,7 @@ if ! $WGET --output-document=- "$download_url" | tar -C "${GO_INSTALL_PATH}" -zx
     exit 1
 fi
 
-xargs --arg-file=install-packages.list apt --quiet --yes install
+xargs --arg-file="${MINT_ROOT_DIR}/install-packages.list" apt --quiet --yes install
 
 # set python 3.5 as default
 update-alternatives --install /usr/bin/python python /usr/bin/python3.5 1

--- a/mint/release.sh
+++ b/mint/release.sh
@@ -20,8 +20,8 @@ export MINT_RUN_CORE_DIR="$MINT_ROOT_DIR/run/core"
 export MINT_RUN_SECURITY_DIR="$MINT_ROOT_DIR/run/security"
 export WGET="wget --quiet --no-check-certificate"
 
-./create-data-files.sh
-./preinstall.sh
+"${MINT_ROOT_DIR}"/create-data-files.sh
+"${MINT_ROOT_DIR}"/preinstall.sh
 
 # install mint app packages
 for pkg in "$MINT_ROOT_DIR/build"/*/install.sh; do
@@ -29,4 +29,4 @@ for pkg in "$MINT_ROOT_DIR/build"/*/install.sh; do
     $pkg
 done
 
-./postinstall.sh
+"${MINT_ROOT_DIR}"/postinstall.sh


### PR DESCRIPTION
## Description
Fix mint hub.docker.com builds

## Motivation and Context
Fix docker builds for mint by moving mint/Dockerfile to 
/Dockerfile.mint such that hub.docker.com builds
succeed properly. 

## How to test this PR?
Test this by building `docker build -f Dockerfile.mint . -t minio/mint`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
