### PR TITLE
Redirect to browser only if browser is enabled

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -582,7 +582,7 @@ func writeErrorResponse(ctx context.Context, w http.ResponseWriter, err APIError
 	case "AccessDenied":
 		// The request is from browser and also if browser
 		// is enabled we need to redirect.
-		if browser {
+		if browser && globalIsBrowserEnabled {
 			w.Header().Set(xhttp.Location, minioReservedBucketPath+reqURL.Path)
 			w.WriteHeader(http.StatusTemporaryRedirect)
 			return


### PR DESCRIPTION
## Description
Redirect to the browser only if the browser is enabled

## Motivation and Context
Redirect to the browser only if the browser is enabled

## How to test this PR?
Just disable `MINIO_BROWSER=off` when starting MinIO any access to non-public bucket should redirect. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in #7476
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
