### PR TITLE
trace api: add call stats to trace

### DIFF
--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -24,10 +24,18 @@ import (
 // Info - represents a trace record, additionally
 // also reports errors if any while listening on trace.
 type Info struct {
-	NodeName string       `json:"nodename"`
-	FuncName string       `json:"funcname"`
-	ReqInfo  RequestInfo  `json:"request"`
-	RespInfo ResponseInfo `json:"response"`
+	NodeName  string       `json:"nodename"`
+	FuncName  string       `json:"funcname"`
+	ReqInfo   RequestInfo  `json:"request"`
+	RespInfo  ResponseInfo `json:"response"`
+	CallStats CallStats    `json:"stats"`
+}
+
+// CallStats records request stats
+type CallStats struct {
+	InputBytes  int           `json:"inputbytes"`
+	OutputBytes int           `json:"outputbytes"`
+	Latency     time.Duration `json:"latency"`
 }
 
 // RequestInfo represents trace of http request


### PR DESCRIPTION
## Description
Add call latency, input and output bytes in req/resp to trace for use by `mc admin trace` command.

## Motivation and Context


## How to test this PR?

see companion PR for mc 
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
