### PR TITLE
Add node address information to logs

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -241,17 +241,12 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 	if objectAPI == nil {
 		return
 	}
-	hostName, err := getHostName(r)
-	if err != nil {
-		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
-		return
-	}
 
 	serverInfo := globalNotificationSys.ServerInfo(ctx)
 	// Once we have received all the ServerInfo from peers
 	// add the local peer server info as well.
 	serverInfo = append(serverInfo, ServerInfo{
-		Addr: hostName,
+		Addr: getHostName(r),
 		Data: &ServerInfoData{
 			StorageInfo: objectAPI.StorageInfo(ctx),
 			ConnStats:   globalConnStats.toServerConnStats(),
@@ -442,18 +437,13 @@ func (a adminAPIHandlers) TopLocksHandler(w http.ResponseWriter, r *http.Request
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL)
 		return
 	}
-	hostName, err := getHostName(r)
-	if err != nil {
-		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
-		return
-	}
 
 	peerLocks := globalNotificationSys.GetLocks(ctx)
 	// Once we have received all the locks currently used from peers
 	// add the local peer locks list as well.
 	localLocks := globalLockServer.ll.DupLockMap()
 	peerLocks = append(peerLocks, &PeerLocks{
-		Addr:  hostName,
+		Addr:  getHostName(r),
 		Locks: localLocks,
 	})
 

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -31,7 +31,6 @@ import (
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/handlers"
-	xnet "github.com/minio/minio/pkg/net"
 )
 
 // Parses location constraint from the incoming reader.
@@ -387,15 +386,11 @@ func notFoundHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // gets host name for current node
-func getHostName(r *http.Request) (hostName string, err error) {
-	var thisAddr *xnet.Host
-	hostName = r.Host
+func getHostName(r *http.Request) (hostName string) {
 	if globalIsDistXL {
-		thisAddr, err = xnet.ParseHost(GetLocalPeer(globalEndpoints))
-		if err != nil {
-			return
-		}
-		hostName = thisAddr.String()
+		hostName = GetLocalPeer(globalEndpoints)
+	} else {
+		hostName = r.Host
 	}
 	return
 }

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -331,6 +331,7 @@ func logIf(ctx context.Context, err error) {
 		DeploymentID: req.DeploymentID,
 		Level:        ErrorLvl.String(),
 		RemoteHost:   req.RemoteHost,
+		Host:         req.Host,
 		RequestID:    req.RequestID,
 		UserAgent:    req.UserAgent,
 		Time:         time.Now().UTC().Format(time.RFC3339Nano),

--- a/cmd/logger/message/log/entry.go
+++ b/cmd/logger/message/log/entry.go
@@ -43,6 +43,7 @@ type Entry struct {
 	Time         string `json:"time"`
 	API          *API   `json:"api,omitempty"`
 	RemoteHost   string `json:"remotehost,omitempty"`
+	Host         string `json:"host,omitempty"`
 	RequestID    string `json:"requestID,omitempty"`
 	UserAgent    string `json:"userAgent,omitempty"`
 	Message      string `json:"message,omitempty"`

--- a/cmd/logger/reqinfo.go
+++ b/cmd/logger/reqinfo.go
@@ -36,6 +36,7 @@ type KeyVal struct {
 // ReqInfo stores the request info.
 type ReqInfo struct {
 	RemoteHost   string   // Client Host/IP
+	Host         string   // Node Host/IP
 	UserAgent    string   // User Agent
 	DeploymentID string   // x-minio-deployment-id
 	RequestID    string   // x-amz-request-id

--- a/cmd/logger/target/console/console.go
+++ b/cmd/logger/target/console/console.go
@@ -89,6 +89,11 @@ func (c *Target) Send(e interface{}) error {
 		remoteHost = "\nRemoteHost: " + entry.RemoteHost
 	}
 
+	var host string
+	if entry.Host != "" {
+		host = "\nHost: " + entry.Host
+	}
+
 	var userAgent string
 	if entry.UserAgent != "" {
 		userAgent = "\nUserAgent: " + entry.UserAgent
@@ -99,8 +104,8 @@ func (c *Target) Send(e interface{}) error {
 	}
 
 	var msg = logger.ColorFgRed(logger.ColorBold(entry.Trace.Message))
-	var output = fmt.Sprintf("\n%s\n%s%s%s%s%s\nError: %s%s\n%s",
-		apiString, timeString, deploymentID, requestID, remoteHost, userAgent,
+	var output = fmt.Sprintf("\n%s\n%s%s%s%s%s%s\nError: %s%s\n%s",
+		apiString, timeString, deploymentID, requestID, remoteHost, host, userAgent,
 		msg, tagString, strings.Join(trace, "\n"))
 
 	fmt.Println(output)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -429,6 +429,7 @@ func newContext(r *http.Request, w http.ResponseWriter, api string) context.Cont
 		DeploymentID: globalDeploymentID,
 		RequestID:    w.Header().Get(xhttp.AmzRequestID),
 		RemoteHost:   handlers.GetSourceIP(r),
+		Host:         getHostName(r),
 		UserAgent:    r.UserAgent(),
 		API:          api,
 		BucketName:   bucket,

--- a/cmd/web-handler-context.go
+++ b/cmd/web-handler-context.go
@@ -235,6 +235,7 @@ func newWebContext(r *http.Request, args ToKeyValuer, api string) context.Contex
 	reqInfo := &logger.ReqInfo{
 		DeploymentID: globalDeploymentID,
 		RemoteHost:   handlers.GetSourceIP(r),
+		Host:         getHostName(r),
 		UserAgent:    r.UserAgent(),
 		API:          api,
 		BucketName:   bucket,


### PR DESCRIPTION
## Description
Adds node address to MinIO console/http logs

## Motivation and Context
The ability to identify the node logging the error message would help in debugging issues, especially in distributed MinIO deployments.

## How to test this PR?
1. Start a MinIO server
2. Try to delete a bucket that has objects in it
3. Verify that the log message on console or http target contains
    node address information

E.g
```
API: webDeleteBucket(bucket=test)
Time: 14:48:34 PDT 07/17/2019
DeploymentID: 96f39533-866e-431a-8724-0004e9485729
RemoteHost: 127.0.0.1
Host: localhost:9000
UserAgent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0
Error: Bucket not empty: test
       3: cmd/web-handlers.go:2013:cmd.toWebAPIError()
       2: cmd/web-handlers.go:1893:cmd.toJSONError()
       1: cmd/web-handlers.go:265:cmd.(*webAPIHandlers).DeleteBucket()
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
