### PR TITLE
Correct startup with a random uid and without MINIO_USERNAME and MINIO_GROUPNAME

### DIFF
--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -52,7 +52,7 @@ docker_sse_encryption_env() {
 
 # su-exec to requested user, if service cannot run exec will fail.
 docker_switch_user() {
-    if [ -z "${MINIO_USERNAME}" ] || [ -z "${MINIO_GROUPNAME}" ]; then
+    if [ ! -z "${MINIO_USERNAME}" ] && [ ! -z "${MINIO_GROUPNAME}" ]; then
         addgroup -S "$MINIO_GROUPNAME" >/dev/null 2>&1 && \
             adduser -S -G "$MINIO_GROUPNAME" "$MINIO_USERNAME" >/dev/null 2>&1
 


### PR DESCRIPTION
## Description

This correction in `docker-entrypoint.sh` should fix startups, where no `MINIO_USERNAME` or `MINIO_GROUPNAME` are provided.

## Motivation and Context

It makes no sense to create a user or a group, when `MINIO_USERNAME` or `MINIO_GROUPNAME` parameter is empty.
Fixes #7943 

## How to test this PR?

Start docker image with a "random" user
```
docker run --user 123123 minio:local_image
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #7930
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed
