### PR TITLE
KMS Admin-API: add route and handler for KMS key info

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -135,8 +135,13 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 
 	// HTTP Trace
 	adminV1Router.Methods(http.MethodGet).Path("/trace").HandlerFunc(adminAPI.TraceHandler)
+
 	// Console Logs
 	adminV1Router.Methods(http.MethodGet).Path("/log").HandlerFunc(httpTraceAll(adminAPI.ConsoleLogHandler))
+
+	// -- KMS APIs --
+	//
+	adminV1Router.Methods(http.MethodGet).Path("/kms/key/status").HandlerFunc(httpTraceAll(adminAPI.KMSKeyStatusHandler))
 
 	// If none of the routes match, return error.
 	adminV1Router.NotFoundHandler = http.HandlerFunc(httpTraceHdrs(notFoundHandlerJSON))

--- a/pkg/madmin/README.md
+++ b/pkg/madmin/README.md
@@ -42,14 +42,13 @@ func main() {
 }
 
 ```
-
-| Service operations                  | Info operations                                 | Healing operations | Config operations                 | Top operations          | IAM operations                        | Misc                                              |
-|:------------------------------------|:------------------------------------------------|:-------------------|:----------------------------------|:------------------------|:--------------------------------------|:--------------------------------------------------|
-| [`ServiceRestart`](#ServiceRestart) | [`ServerInfo`](#ServerInfo)                     | [`Heal`](#Heal)    | [`GetConfig`](#GetConfig)         | [`TopLocks`](#TopLocks) | [`AddUser`](#AddUser)                 |                                                   |
-| [`ServiceStop`](#ServiceStop)       | [`ServerCPULoadInfo`](#ServerCPULoadInfo)       |                    | [`SetConfig`](#SetConfig)         |                         | [`SetUserPolicy`](#SetUserPolicy)     | [`StartProfiling`](#StartProfiling)               |
-|                                     | [`ServerMemUsageInfo`](#ServerMemUsageInfo)     |                    | [`GetConfigKeys`](#GetConfigKeys) |                         | [`ListUsers`](#ListUsers)             | [`DownloadProfilingData`](#DownloadProfilingData) |
-| [`ServiceTrace`](#ServiceTrace)     | [`ServerDrivesPerfInfo`](#ServerDrivesPerfInfo) |                    | [`SetConfigKeys`](#SetConfigKeys) |                         | [`AddCannedPolicy`](#AddCannedPolicy) | [`ServerUpdate`](#ServerUpdate)                   |
-|                                     | [`NetPerfInfo`](#NetPerfInfo)                   |                    |                                   |                         |                                       |                                                   |
+| Service operations                  | Info operations                                 | Healing operations | Config operations                 | Top operations          | IAM operations                        | Misc                                              | KMS                               |
+|:------------------------------------|:------------------------------------------------|:-------------------|:----------------------------------|:------------------------|:--------------------------------------|:--------------------------------------------------|:----------------------------------|
+| [`ServiceRestart`](#ServiceRestart) | [`ServerInfo`](#ServerInfo)                     | [`Heal`](#Heal)    | [`GetConfig`](#GetConfig)         | [`TopLocks`](#TopLocks) | [`AddUser`](#AddUser)                 |                                                   | [`GetKeyStatus`](#GetKeyStatus)   | 
+| [`ServiceStop`](#ServiceStop)       | [`ServerCPULoadInfo`](#ServerCPULoadInfo)       |                    | [`SetConfig`](#SetConfig)         |                         | [`SetUserPolicy`](#SetUserPolicy)     | [`StartProfiling`](#StartProfiling)               |                                   |
+|                                     | [`ServerMemUsageInfo`](#ServerMemUsageInfo)     |                    | [`GetConfigKeys`](#GetConfigKeys) |                         | [`ListUsers`](#ListUsers)             | [`DownloadProfilingData`](#DownloadProfilingData) |                                   |
+| [`ServiceTrace`](#ServiceTrace)     | [`ServerDrivesPerfInfo`](#ServerDrivesPerfInfo) |                    | [`SetConfigKeys`](#SetConfigKeys) |                         | [`AddCannedPolicy`](#AddCannedPolicy) | [`ServerUpdate`](#ServerUpdate)                   |                                   |
+|                                     | [`NetPerfInfo`](#NetPerfInfo)                   |                    |                                   |                         |                                       |                                                   |                                   |
     
 ## 1. Constructor
 <a name="MinIO"></a>
@@ -579,4 +578,31 @@ __Example__
     }
 
     log.Println("Profiling data successfully downloaded.")
+```
+
+## 11. KMS
+
+<a name="GetKeyStatus"></a> 
+### GetKeyStatus(keyID string) (*KMSKeyStatus, error)
+Requests status information about one particular KMS master key
+from a MinIO server. The keyID is optional and the server will
+use the default master key (configured via `MINIO_SSE_VAULT_KEY_NAME`
+or `MINIO_SSE_MASTER_KEY`) if the keyID is empty.
+
+__Example__
+
+``` go
+    keyInfo, err := madmClnt.GetKeyStatus("my-minio-key")
+    if err != nil {
+       log.Fatalln(err)
+    }
+    if keyInfo.EncryptionErr != "" {
+       log.Fatalf("Failed to perform encryption operation using '%s': %v\n", keyInfo.KeyID, keyInfo.EncryptionErr)
+    }
+    if keyInfo.UpdateErr != "" {
+       log.Fatalf("Failed to perform key re-wrap operation using '%s': %v\n", keyInfo.KeyID, keyInfo.UpdateErr)
+    }
+    if keyInfo.DecryptionErr != "" {
+       log.Fatalf("Failed to perform decryption operation using '%s': %v\n", keyInfo.KeyID, keyInfo.DecryptionErr)
+    }
 ```

--- a/pkg/madmin/examples/kms-status.go
+++ b/pkg/madmin/examples/kms-status.go
@@ -29,7 +29,7 @@ func main() {
 	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
 	// dummy values, please replace them with original values.
 
-	// API requests are secure (HTTPS) if secure=true and insecure (HTTPS) otherwise.
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
 	// New returns an MinIO Admin client object.
 	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
 	if err != nil {

--- a/pkg/madmin/examples/kms-status.go
+++ b/pkg/madmin/examples/kms-status.go
@@ -1,0 +1,60 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTPS) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	status, err := madmClnt.GetKeyStatus("") // empty string refers to the default master key
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Printf("Key: %s\n", status.KeyID)
+	if status.EncryptionErr == "" {
+		log.Println("\t • Encryption ✔")
+	} else {
+		log.Printf("\t • Encryption failed: %s\n", status.EncryptionErr)
+	}
+	if status.UpdateErr == "" {
+		log.Println("\t • Re-wrap ✔")
+	} else {
+		log.Printf("\t • Re-wrap failed: %s\n", status.UpdateErr)
+	}
+	if status.DecryptionErr == "" {
+		log.Println("\t • Decryption ✔")
+	} else {
+		log.Printf("\t •  Decryption failed: %s\n", status.DecryptionErr)
+	}
+}

--- a/pkg/madmin/kms-commands.go
+++ b/pkg/madmin/kms-commands.go
@@ -1,0 +1,62 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package madmin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// GetKeyStatus requests status information about the key referenced by keyID
+// from the KMS connected to a MinIO by performing a Admin-API request.
+// It basically hits the `/minio/admin/v1/kms/key/status` API endpoint.
+func (adm *AdminClient) GetKeyStatus(keyID string) (*KMSKeyStatus, error) {
+	// GET /minio/admin/v1/kms/key/status?key-id=<keyID>
+	qv := url.Values{}
+	qv.Set("key-id", keyID)
+	reqData := requestData{
+		relPath:     "/v1/kms/key/status",
+		queryValues: qv,
+	}
+
+	resp, err := adm.executeMethod("GET", reqData)
+	if err != nil {
+		return nil, err
+	}
+	defer closeResponse(resp)
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+	var keyInfo KMSKeyStatus
+	if err = json.NewDecoder(resp.Body).Decode(&keyInfo); err != nil {
+		return nil, err
+	}
+	return &keyInfo, nil
+}
+
+// KMSKeyStatus contains some status information about a KMS master key.
+// The MinIO server tries to access the KMS and perform encryption and
+// decryption operations. If the MinIO server can access the KMS and
+// all master key operations succeed it returns a status containing only
+// the master key ID but no error.
+type KMSKeyStatus struct {
+	KeyID         string `json:"key-id"`
+	EncryptionErr string `json:"encryption-error,omitempty"` // An empty error == success
+	UpdateErr     string `json:"update-error,omitempty"`     // An empty error == success
+	DecryptionErr string `json:"decryption-error,omitempty"` // An empty error == success
+}


### PR DESCRIPTION
## Description
This commit adds an admin API route and handler for
requesting status information about a KMS key.

Therefore, the client specifies the KMS key ID (when
empty / not set the server takes the currently configured
default key-ID) and the server tries to perform a dummy encryption,
re-wrap and decryption operation. If all three succeed we know that
the server can access the KMS and has permissions to generate, re-wrap
and decrypt data keys (policy is set correctly).

## Motivation and Context
KMS management

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
