### PR TITLE
Fix to only add SRV records that match the key exactly.

### DIFF
--- a/pkg/dns/etcd_dns.go
+++ b/pkg/dns/etcd_dns.go
@@ -84,7 +84,7 @@ func (c *coreDNS) Get(bucket string) ([]SrvRecord, error) {
 			if record.Key != "" {
 				continue
 			}
-			srvRecords = append(srvRecords, records...)
+			srvRecords = append(srvRecords, record)
 		}
 	}
 	if len(srvRecords) == 0 {


### PR DESCRIPTION
## Description
Fix to only add SRV records that match the key exactly.

## Motivation and Context
MinIO incorrectly appends DNS SRV records of buckets that have a prefix match with a given bucket. E.g bucket1 would incorrectly get bucket's DNS records too.

## How to test this PR?
```
ifconfig wlp59s0:1 10.0.0.2 netmask 255.255.255.0
ifconfig wlp59s0:2 10.0.0.3 netmask 255.255.255.0

docker run --rm  -p 2379:2379   -p 2380:2380  --name etcd-gcr-v3.3.9   gcr.io/etcd-development/etcd:v3.3.9   /usr/local/bin/etcd   --name s1   --data-dir /etcd-data   --listen-client-urls http://0.0.0.0:2379   --advertise-client-urls http://0.0.0.0:2379   --listen-peer-urls http://0.0.0.0:2380   --initial-advertise-peer-urls http://0.0.0.0:2380   --initial-cluster s1=http://0.0.0.0:2380   --initial-cluster-token tkn   --initial-cluster-state new

MINIO_PUBLIC_IPS=10.0.0.2 MINIO_DOMAIN=localhost MINIO_ETCD_ENDPOINTS=http://0.0.0.0:2379 minio server ~/test1 --address "10.0.0.2:9001"

MINIO_PUBLIC_IPS=10.0.0.3 MINIO_DOMAIN=localhost MINIO_ETCD_ENDPOINTS=http://0.0.0.0:2379 minio server ~/test2 --address "10.0.0.3:9002"

mc config host add myminio-local1 http://10.0.0.2:9001 minio minio123
mc config host add myminio-local2 http://10.0.0.3:9002 minio minio123

mc mb myminio-local1/ver-data-vsap-t003t
mc mb myminio-local2/ver-data-vsap-t003
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
