### PR TITLE
Fixed tautological conditions

### DIFF
--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -1830,9 +1830,7 @@ func TestPosixVerifyFile(t *testing.T) {
 		if err == io.EOF {
 			break
 		}
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Fatal(err)
 	}
 	w.Close()
 	if err := posixStorage.VerifyFile(volName, fileName, false, algo, nil, shardSize); err != nil {

--- a/pkg/event/target/amqp.go
+++ b/pkg/event/target/amqp.go
@@ -163,13 +163,14 @@ func NewAMQPTarget(id string, args AMQPArgs) (*AMQPTarget, error) {
 	// Retry 5 times with time interval of 2 seconds.
 	for i := 1; i <= 5; i++ {
 		conn, err = amqp.Dial(args.URL.String())
-		if err == nil {
-			break
+		if err != nil {
+			if i == 5 {
+				return nil, err
+			}
+			time.Sleep(2 * time.Second)
+			continue
 		}
-		if err != nil && i == 5 {
-			return nil, err
-		}
-		time.Sleep(2 * time.Second)
+		break
 	}
 
 	return &AMQPTarget{


### PR DESCRIPTION
We already check for err being equal to nil above, no need
to check again.