### PR TITLE
Honor connection pooling while tracing

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -394,20 +394,3 @@ func getHostName(r *http.Request) (hostName string) {
 	}
 	return
 }
-
-func isHTTPStatusOK(statusCode int) bool {
-	// List of success status.
-	var successStatus = []int{
-		http.StatusOK,
-		http.StatusCreated,
-		http.StatusAccepted,
-		http.StatusNoContent,
-		http.StatusPartialContent,
-	}
-	for _, okstatus := range successStatus {
-		if statusCode == okstatus {
-			return true
-		}
-	}
-	return false
-}

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -499,10 +499,12 @@ func (client *peerRESTClient) doTrace(traceCh chan interface{}, doneCh chan stru
 		if err = dec.Decode(&info); err != nil {
 			return
 		}
-		select {
-		case traceCh <- info:
-		default:
-			// Do not block on slow receivers.
+		if len(info.NodeName) > 0 {
+			select {
+			case traceCh <- info:
+			default:
+				// Do not block on slow receivers.
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description
Honor connection pooling while tracing

## Motivation and Context
This PR fixes relying on r.Context().Done()
by setting

```
Connection: "close"
```

HTTP Header, this has detrimental issues for
client-side connection pooling. Since this
header explicitly tells clients to turn-off
connection pooling. This causing pro-active
connections to be closed leaving many conn's
in TIME_WAIT state. This can be observed with
`mc admin trace -a` when running distributed
setup.

This PR also fixes tracing filtering issue
when bucket names have `minio` as prefixes,
trace was erroneously ignoring them.

## How to test this PR?
In a distributed setup `mc admin trace -a` to observe TIME_WAIT build up when you are performing lot's of I/O such as `mc cp -r` on another terminal. 

Another bug fix related to filtering can be tested with the master branch when running mint tests, `mc admin trace` doesn't print anything. This PR fixes this issue. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression - This is a regression in a way because we should avoid forcibly closing connections between servers, this came in as part of the Tracing feature PR. 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
