### PR TITLE
Add IAM groups support

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -110,6 +110,18 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 		// List users
 		adminV1Router.Methods(http.MethodGet).Path("/list-users").HandlerFunc(httpTraceHdrs(adminAPI.ListUsers))
 
+		// Add/Remove members from group
+		adminV1Router.Methods(http.MethodPut).Path("/update-group-members").HandlerFunc(httpTraceHdrs(adminAPI.UpdateGroupMembers))
+
+		// Get Group
+		adminV1Router.Methods(http.MethodGet).Path("/group").HandlerFunc(httpTraceHdrs(adminAPI.GetGroup)).Queries("group", "{group:.*}")
+
+		// List Groups
+		adminV1Router.Methods(http.MethodGet).Path("/groups").HandlerFunc(httpTraceHdrs(adminAPI.ListGroups))
+
+		// Set Group Status
+		adminV1Router.Methods(http.MethodPut).Path("/set-group-status").HandlerFunc(httpTraceHdrs(adminAPI.SetGroupStatus)).Queries("group", "{group:.*}").Queries("status", "{status:.*}")
+
 		// List policies
 		adminV1Router.Methods(http.MethodGet).Path("/list-canned-policies").HandlerFunc(httpTraceHdrs(adminAPI.ListCannedPolicies))
 	}

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -203,6 +203,8 @@ const (
 
 	ErrMalformedJSON
 	ErrAdminNoSuchUser
+	ErrAdminNoSuchGroup
+	ErrAdminGroupNotEmpty
 	ErrAdminNoSuchPolicy
 	ErrAdminInvalidArgument
 	ErrAdminInvalidAccessKey
@@ -923,6 +925,16 @@ var errorCodes = errorCodeMap{
 		Description:    "The specified user does not exist.",
 		HTTPStatusCode: http.StatusNotFound,
 	},
+	ErrAdminNoSuchGroup: {
+		Code:           "XMinioAdminNoSuchGroup",
+		Description:    "The specified group does not exist.",
+		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrAdminGroupNotEmpty: {
+		Code:           "XMinioAdminGroupNotEmpty",
+		Description:    "The specified group is not empty - cannot remove it.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
 	ErrAdminNoSuchPolicy: {
 		Code:           "XMinioAdminNoSuchPolicy",
 		Description:    "The canned policy does not exist.",
@@ -1500,6 +1512,10 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrAdminInvalidArgument
 	case errNoSuchUser:
 		apiErr = ErrAdminNoSuchUser
+	case errNoSuchGroup:
+		apiErr = ErrAdminNoSuchGroup
+	case errGroupNotEmpty:
+		apiErr = ErrAdminGroupNotEmpty
 	case errNoSuchPolicy:
 		apiErr = ErrAdminNoSuchPolicy
 	case errSignatureMismatch:

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1250,12 +1250,12 @@ func (sys *IAMSys) AddUsersToGroup(group string, members []string) error {
 		return errServerNotInitialized
 	}
 
-	sys.Lock()
-	defer sys.Unlock()
-
 	if group == "" {
 		return errInvalidArgument
 	}
+
+	sys.Lock()
+	defer sys.Unlock()
 
 	// Validate that all members exist.
 	for _, member := range members {
@@ -1310,12 +1310,12 @@ func (sys *IAMSys) RemoveUsersFromGroup(group string, members []string) error {
 		return errServerNotInitialized
 	}
 
-	sys.Lock()
-	defer sys.Unlock()
-
 	if group == "" {
 		return errInvalidArgument
 	}
+
+	sys.Lock()
+	defer sys.Unlock()
 
 	// Validate that all members exist.
 	for _, member := range members {

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -232,6 +232,19 @@ func (sys *NotificationSys) LoadUsers() []NotificationPeerErr {
 	return ng.Wait()
 }
 
+// LoadGroup - loads a specific group on all peers.
+func (sys *NotificationSys) LoadGroup(group string) []NotificationPeerErr {
+	ng := WithNPeers(len(sys.peerClients))
+	for idx, client := range sys.peerClients {
+		if client == nil {
+			continue
+		}
+		client := client
+		ng.Go(context.Background(), func() error { return client.LoadGroup(group) }, idx, *client.host)
+	}
+	return ng.Wait()
+}
+
 // BackgroundHealStatus - returns background heal status of all peers
 func (sys *NotificationSys) BackgroundHealStatus() []madmin.BgHealState {
 	states := make([]madmin.BgHealState, len(sys.peerClients))

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -443,6 +443,18 @@ func (client *peerRESTClient) LoadUsers() (err error) {
 	return nil
 }
 
+// LoadGroup - send load group command to peers.
+func (client *peerRESTClient) LoadGroup(group string) error {
+	values := make(url.Values)
+	values.Set(peerRESTGroup, group)
+	respBody, err := client.call(peerRESTMethodLoadGroup, values, nil, -1)
+	if err != nil {
+		return err
+	}
+	defer http.DrainBody(respBody)
+	return nil
+}
+
 // SignalService - sends signal to peer nodes.
 func (client *peerRESTClient) SignalService(sig serviceSignal) error {
 	values := make(url.Values)

--- a/cmd/peer-rest-common.go
+++ b/cmd/peer-rest-common.go
@@ -34,6 +34,7 @@ const (
 	peerRESTMethodLoadPolicy               = "loadpolicy"
 	peerRESTMethodDeletePolicy             = "deletepolicy"
 	peerRESTMethodLoadUsers                = "loadusers"
+	peerRESTMethodLoadGroup                = "loadgroup"
 	peerRESTMethodStartProfiling           = "startprofiling"
 	peerRESTMethodDownloadProfilingData    = "downloadprofilingdata"
 	peerRESTMethodBucketPolicySet          = "setbucketpolicy"
@@ -50,6 +51,7 @@ const (
 const (
 	peerRESTBucket   = "bucket"
 	peerRESTUser     = "user"
+	peerRESTGroup    = "group"
 	peerRESTUserTemp = "user-temp"
 	peerRESTPolicy   = "policy"
 	peerRESTSignal   = "signal"

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -260,6 +260,30 @@ func (s *peerRESTServer) LoadUsersHandler(w http.ResponseWriter, r *http.Request
 	w.(http.Flusher).Flush()
 }
 
+// LoadGroupHandler - reloads group along with members list.
+func (s *peerRESTServer) LoadGroupHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.IsValid(w, r) {
+		s.writeErrorResponse(w, errors.New("Invalid request"))
+		return
+	}
+
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		s.writeErrorResponse(w, errServerNotInitialized)
+		return
+	}
+
+	vars := mux.Vars(r)
+	group := vars[peerRESTGroup]
+	err := globalIAMSys.LoadGroup(objAPI, group)
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+
+	w.(http.Flusher).Flush()
+}
+
 // StartProfilingHandler - Issues the start profiling command.
 func (s *peerRESTServer) StartProfilingHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.IsValid(w, r) {
@@ -800,6 +824,7 @@ func registerPeerRESTHandlers(router *mux.Router) {
 	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodDeleteUser).HandlerFunc(httpTraceAll(server.LoadUserHandler)).Queries(restQueries(peerRESTUser)...)
 	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodLoadUser).HandlerFunc(httpTraceAll(server.LoadUserHandler)).Queries(restQueries(peerRESTUser, peerRESTUserTemp)...)
 	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodLoadUsers).HandlerFunc(httpTraceAll(server.LoadUsersHandler))
+	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodLoadGroup).HandlerFunc(httpTraceAll(server.LoadGroupHandler)).Queries(restQueries(peerRESTGroup)...)
 
 	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodStartProfiling).HandlerFunc(httpTraceAll(server.StartProfilingHandler)).Queries(restQueries(peerRESTProfiler)...)
 	subrouter.Methods(http.MethodPost).Path("/" + peerRESTMethodDownloadProfilingData).HandlerFunc(httpTraceHdrs(server.DownloadProflingDataHandler))

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -183,11 +183,16 @@ func (sts *stsAPIHandlers) AssumeRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	policyName, err := globalIAMSys.PolicyDBGet(user.AccessKey)
+	policies, err := globalIAMSys.PolicyDBGet(user.AccessKey, false)
 	if err != nil {
 		logger.LogIf(ctx, err)
 		writeSTSErrorResponse(w, stsErrCodes.ToSTSErr(ErrSTSInvalidParameterValue))
 		return
+	}
+
+	policyName := ""
+	if len(policies) > 0 {
+		policyName = policies[0]
 	}
 
 	// This policy is the policy associated with the user

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -80,6 +80,13 @@ var errInvalidDecompressedSize = errors.New("Invalid Decompressed Size")
 // error returned in IAM subsystem when user doesn't exist.
 var errNoSuchUser = errors.New("Specified user does not exist")
 
+// error returned in IAM subsystem when groups doesn't exist.
+var errNoSuchGroup = errors.New("Specified group does not exist")
+
+// error returned in IAM subsystem when a non-empty group needs to be
+// deleted.
+var errGroupNotEmpty = errors.New("Specified group is not empty - cannot remove it")
+
 // error returned in IAM subsystem when policy doesn't exist.
 var errNoSuchPolicy = errors.New("Specified canned policy does not exist")
 

--- a/pkg/madmin/group-commands.go
+++ b/pkg/madmin/group-commands.go
@@ -140,10 +140,10 @@ const (
 )
 
 // SetGroupStatus - sets the status of a group.
-func (adm *AdminClient) SetGroupStatus(group string, status string) error {
+func (adm *AdminClient) SetGroupStatus(group string, status GroupStatus) error {
 	v := url.Values{}
 	v.Set("group", group)
-	v.Set("status", status)
+	v.Set("status", string(status))
 
 	reqData := requestData{
 		relPath:     "/v1/set-group-status",

--- a/pkg/madmin/group-commands.go
+++ b/pkg/madmin/group-commands.go
@@ -1,0 +1,164 @@
+/*
+ * MinIO Cloud Storage, (C) 2018-2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package madmin
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// GroupAddRemove is type for adding/removing members to/from a group.
+type GroupAddRemove struct {
+	Group    string   `json:"group"`
+	Members  []string `json:"members"`
+	IsRemove bool     `json:"isRemove"`
+}
+
+// UpdateGroupMembers - adds/removes users to/from a group. Server
+// creates the group as needed. Group is removed if remove request is
+// made on empty group.
+func (adm *AdminClient) UpdateGroupMembers(g GroupAddRemove) error {
+	data, err := json.Marshal(g)
+	if err != nil {
+		return err
+	}
+
+	reqData := requestData{
+		relPath: "/v1/update-group-members",
+		content: data,
+	}
+
+	// Execute PUT on /minio/admin/v1/update-group-members
+	resp, err := adm.executeMethod("PUT", reqData)
+
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return httpRespToErrorResponse(resp)
+	}
+
+	return nil
+}
+
+// GroupDesc is a type that holds group info along with the policy
+// attached to it.
+type GroupDesc struct {
+	Name    string   `json:"name"`
+	Status  string   `json:"status"`
+	Members []string `json:"members"`
+	Policy  string   `json:"policy"`
+}
+
+// GetGroupDescription - fetches information on a group.
+func (adm *AdminClient) GetGroupDescription(group string) (*GroupDesc, error) {
+	v := url.Values{}
+	v.Set("group", group)
+	reqData := requestData{
+		relPath:     "/v1/group",
+		queryValues: v,
+	}
+
+	resp, err := adm.executeMethod("GET", reqData)
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	gd := GroupDesc{}
+	if err = json.Unmarshal(data, &gd); err != nil {
+		return nil, err
+	}
+
+	return &gd, nil
+}
+
+// ListGroups - lists all groups names present on the server.
+func (adm *AdminClient) ListGroups() ([]string, error) {
+	reqData := requestData{
+		relPath: "/v1/groups",
+	}
+
+	resp, err := adm.executeMethod("GET", reqData)
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	groups := []string{}
+	if err = json.Unmarshal(data, &groups); err != nil {
+		return nil, err
+	}
+
+	return groups, nil
+}
+
+// GroupStatus - group status.
+type GroupStatus string
+
+// GroupStatus values.
+const (
+	GroupEnabled  GroupStatus = "enabled"
+	GroupDisabled GroupStatus = "disabled"
+)
+
+// SetGroupStatus - sets the status of a group.
+func (adm *AdminClient) SetGroupStatus(group string, status string) error {
+	v := url.Values{}
+	v.Set("group", group)
+	v.Set("status", status)
+
+	reqData := requestData{
+		relPath:     "/v1/set-group-status",
+		queryValues: v,
+	}
+
+	resp, err := adm.executeMethod("PUT", reqData)
+	defer closeResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return httpRespToErrorResponse(resp)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

This change adds admin APIs and IAM subsystem APIs to:

- add or remove members to a group (group addition and deletion is
  implicit on add and remove)

- enable/disable a group

- list and fetch group info

## Motivation and Context

This change is in preparation to add user-groups support to MinIO.

## How to test this PR?

To test this PR use the companion mc PR: https://github.com/minio/mc/pull/2841

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
