### PR TITLE
Do not assume all HTTP errors as Network errors

### DIFF
--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -129,7 +129,7 @@ func cleanupDir(ctx context.Context, storage StorageAPI, volume, dirPath string)
 
 		// Entry path is empty, just delete it.
 		if len(entries) == 0 {
-			err = storage.DeleteFile(volume, path.Clean(entryPath))
+			err = storage.DeleteFile(volume, entryPath)
 			logger.LogIf(ctx, err)
 			return err
 		}

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -44,8 +44,8 @@ func isNetworkError(err error) bool {
 	if err.Error() == errConnectionStale.Error() {
 		return true
 	}
-	if _, ok := err.(*rest.NetworkError); ok {
-		return true
+	if nerr, ok := err.(*rest.NetworkError); ok {
+		return isNetworkOrHostDown(nerr.Err)
 	}
 	return false
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -29,7 +29,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -443,30 +442,21 @@ func isNetworkOrHostDown(err error) bool {
 	if err == nil {
 		return false
 	}
-	switch err.(type) {
-	case *net.DNSError, *net.OpError, net.UnknownNetworkError:
-		return true
-	case *url.Error:
-		// For a URL error, where it replies back "connection closed"
-		if strings.Contains(err.Error(), "Connection closed by foreign host") {
-			return true
-		}
-		return true
-	default:
-		if strings.Contains(err.Error(), "net/http: TLS handshake timeout") {
-			// If error is - tlsHandshakeTimeoutError,.
-			return true
-		} else if strings.Contains(err.Error(), "i/o timeout") {
-			// If error is - tcp timeoutError.
-			return true
-		} else if strings.Contains(err.Error(), "connection timed out") {
-			// If err is a net.Dial timeout.
-			return true
-		} else if strings.Contains(err.Error(), "net/http: HTTP/1.x transport connection broken") {
-			return true
-		}
+	// We need to figure if the error either a timeout
+	// or a non-temporary error.
+	e, ok := err.(net.Error)
+	if ok {
+		return e.Timeout()
 	}
-	return false
+	// Fallback to other mechanisms.
+	if strings.Contains(err.Error(), "i/o timeout") {
+		// If error is - tcp timeoutError.
+		ok = true
+	} else if strings.Contains(err.Error(), "connection timed out") {
+		// If err is a net.Dial timeout.
+		ok = true
+	}
+	return ok
 }
 
 // Used for registering with rest handlers (have a look at registerStorageRESTHandlers for usage example)


### PR DESCRIPTION


## Description
Do not assume all HTTP errors as Network errors

## Motivation and Context
In situations such as when client uploading data,
prematurely disconnects from the server such as 
pressing ctrl-c before uploading all the data. Under 
this situation in the distributed setup we prematurely
disconnect disks causing a reconnect loop. This has
an adverse effect we end up leaving a lot of files
in a temporary location which ideally should have been
cleaned up when Put() prematurely fails.

This is also a regression which got introduced in #7610

## How to test this PR?
Just run a distributed setup 

```
#!/bin/bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"

for i in {01..04}; do
    minio server --address ":90${i}" http://127.0.0.1:9001/tmp/1 http://127.0.0.1:9002/tmp/2 http://127.0.0.1:9003/tmp/3 http://127.0.0.1:9004/tmp/4 &
done
```

And then 
```
mc mb myminio-local1/testbucket
mc policy public myminio-local1/testbucket

curl --upload <bigfile> http://localhost:9001/testbucket/1.txt
<ctrl-c>
```

If you are using the latest release you will see that we 
leave /tmp/ temporary files behind. With this PR although
it is fixed properly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #7880 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression PR #7610 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
