### PR TITLE
Fix crash observed in OPA initialization

### DIFF
--- a/pkg/iam/policy/opa.go
+++ b/pkg/iam/policy/opa.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 
 	xnet "github.com/minio/minio/pkg/net"
 )
@@ -63,27 +62,14 @@ func (a *OpaArgs) UnmarshalJSON(data []byte) error {
 	type subOpaArgs OpaArgs
 	var so subOpaArgs
 
-	if opaURL, ok := os.LookupEnv("MINIO_IAM_OPA_URL"); ok {
-		u, err := xnet.ParseURL(opaURL)
-		if err != nil {
-			return err
-		}
-		so.URL = u
-		so.AuthToken = os.Getenv("MINIO_IAM_OPA_AUTHTOKEN")
-	} else {
-		if err := json.Unmarshal(data, &so); err != nil {
-			return err
-		}
+	if err := json.Unmarshal(data, &so); err != nil {
+		return err
 	}
 
 	oa := OpaArgs(so)
 	if oa.URL == nil || oa.URL.String() == "" {
 		*a = oa
 		return nil
-	}
-
-	if err := oa.Validate(); err != nil {
-		return err
 	}
 
 	*a = oa

--- a/pkg/iam/validator/jwt.go
+++ b/pkg/iam/validator/jwt.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -36,11 +35,6 @@ import (
 type JWKSArgs struct {
 	URL        *xnet.URL `json:"url"`
 	publicKeys map[string]crypto.PublicKey
-}
-
-// Validate JWT authentication target arguments
-func (r *JWKSArgs) Validate() error {
-	return nil
 }
 
 // PopulatePublicKey - populates a new publickey from the JWKS URL.
@@ -83,30 +77,14 @@ func (r *JWKSArgs) UnmarshalJSON(data []byte) error {
 	type subJWKSArgs JWKSArgs
 	var sr subJWKSArgs
 
-	// IAM related envs.
-	if jwksURL, ok := os.LookupEnv("MINIO_IAM_JWKS_URL"); ok {
-		u, err := xnet.ParseURL(jwksURL)
-		if err != nil {
-			return err
-		}
-		sr.URL = u
-	} else {
-		if err := json.Unmarshal(data, &sr); err != nil {
-			return err
-		}
+	if err := json.Unmarshal(data, &sr); err != nil {
+		return err
 	}
 
 	ar := JWKSArgs(sr)
 	if ar.URL == nil || ar.URL.String() == "" {
 		*r = ar
 		return nil
-	}
-	if err := ar.Validate(); err != nil {
-		return err
-	}
-
-	if err := ar.PopulatePublicKey(); err != nil {
-		return err
 	}
 
 	*r = ar


### PR DESCRIPTION


## Description
Fix crash observed in OPA initialization

## Motivation and Context
Related to #7982, this PR refactors the code
such that we validate the OPA or JWKS in a
commonplace.

This is also a refactor which is already done
in the new config migration change. Attempt
to avoid any network I/O during Unmarshal of
JSON from disk, instead of doing it later when
updating the in-memory data structure.

## How to test this PR?
Just run 
```
MINIO_IAM_OPA_URL=http://localhost:8181/ MINIO_IAM_JWKS_URL=https://localhost:9443/oauth2/jwks MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123 ./minio server ~/test
```
master code will crash

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression, yes introduced in #7982 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
