### PR TITLE
federation: Avoid printing context canceled error

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -746,6 +746,9 @@ func setBucketForwardingHandler(h http.Handler) http.Handler {
 	fwd := handlers.NewForwarder(&handlers.Forwarder{
 		PassHost:     true,
 		RoundTripper: NewCustomHTTPTransport(),
+		Logger: func(err error) {
+			logger.LogIf(context.Background(), err)
+		},
 	})
 	return bucketForwardingHandler{fwd, h}
 }

--- a/pkg/handlers/forwarder.go
+++ b/pkg/handlers/forwarder.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2018 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2018-2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ const defaultFlushInterval = time.Duration(100) * time.Millisecond
 type Forwarder struct {
 	RoundTripper http.RoundTripper
 	PassHost     bool
+	Logger       func(error)
 
 	// internal variables
 	rewriter *headerRewriter
@@ -58,8 +59,18 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, inReq *http.Request) {
 		},
 		Transport:     f.RoundTripper,
 		FlushInterval: defaultFlushInterval,
+		ErrorHandler:  f.customErrHandler,
 	}
 	revproxy.ServeHTTP(w, outReq)
+}
+
+// customErrHandler is originally implemented to avoid having the following error
+//    `http: proxy error: context canceled` printed by Golang
+func (f *Forwarder) customErrHandler(w http.ResponseWriter, r *http.Request, err error) {
+	if f.Logger != nil && err != context.Canceled {
+		f.Logger(err)
+	}
+	w.WriteHeader(http.StatusBadGateway)
 }
 
 func (f *Forwarder) getURLFromRequest(req *http.Request) *url.URL {


### PR DESCRIPTION

## Description
Golang proactively prints this error
        `http: proxy error: context canceled`

when a request arrived to the current deployment and
redirected to another deployment in a federated setup.

Since this error can confuse users, this commit will
just hide it.


## Motivation and Context
Hide a useless log error seen by a user 

## How to test this PR?
It is hard to reproduce this error, however the following code is a minimal code which reproduces and fix the issue

```go
package main

import (
	"context"
	"fmt"
	"io/ioutil"
	"log"
	"net/http"
	"net/http/httptest"
	"net/http/httputil"
	"net/url"
	"path"
	"time"
)

func main() {
	backendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		w.WriteHeader(http.StatusOK)
		time.Sleep(100 * time.Millisecond)
		fmt.Fprintln(w, "this call was relayed by the reverse proxy")
	}))
	defer backendServer.Close()

	rpURL, err := url.Parse(backendServer.URL)
	if err != nil {
		log.Fatal(err)
	}

	director := func(req *http.Request) {
		req.URL.Scheme = rpURL.Scheme
		req.URL.Host = rpURL.Host
		req.URL.Path = path.Join(rpURL.Path, req.URL.Path)
	}

	// forwarderCustomErrHandler is originally implemented to avoid having
	// the following log `http: proxy error: context canceled` printed by Golang
	forwarderCustomErrHandler := func(w http.ResponseWriter, r *http.Request, err error) {
		w.WriteHeader(http.StatusBadGateway)
		if err != context.Canceled {
			log.Println(err)
		}
	}

	rvProxy := &httputil.ReverseProxy{
		Director:     director,
		ErrorHandler: forwarderCustomErrHandler,
	}

	frontendProxy := httptest.NewServer(rvProxy)
	defer frontendProxy.Close()

	httpClient := http.Client{
		Timeout: time.Duration(90 * time.Millisecond),
	}

	resp, err := httpClient.Get(frontendProxy.URL)
	if err != nil {
		log.Fatal(err)
	}

	b, err := ioutil.ReadAll(resp.Body)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("%s", b)

}
```



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
