### PR TITLE
Fix IAM users migration regression

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -264,6 +264,7 @@ func loadUser(objectAPI ObjectLayer, user string, isSTS bool,
 		return nil
 	}
 
+	u.Credentials.AccessKey = user
 	m[user] = u.Credentials
 	return nil
 }
@@ -573,6 +574,7 @@ func migrateUsersConfigToV1(objAPI ObjectLayer, isSTS bool) error {
 
 		// Found a id file in old format. Copy value
 		// into new format and save it.
+		cred.AccessKey = user
 		u := newUserIdentity(cred)
 		if err := saveIAMConfigItem(objAPI, u, identityPath); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -799,6 +801,7 @@ func (sys *IAMSys) Init(objAPI ObjectLayer) error {
 		}
 		break
 	}
+
 	return nil
 }
 

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -264,6 +264,7 @@ func loadUser(objectAPI ObjectLayer, user string, isSTS bool,
 		return nil
 	}
 
+	// In some cases access key may not be set, so we set it explicitly.
 	u.Credentials.AccessKey = user
 	m[user] = u.Credentials
 	return nil


### PR DESCRIPTION
## Description

Fix a bug in IAM migration that causes existing users to not work after migration.

## Motivation and Context

Reported by community member.

Regression was introduced in https://github.com/minio/minio/commit/7bdaf9bc50eb49061e8a71b9cf471eae5db654ff

## How to test this PR?

Creates users in a previous release of minio https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2019-07-24T02-02-23Z and check that when moving to the version of the server in this PR it works fine


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
