### PR TITLE
Fix #7995 federation same ip

### DIFF
--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -319,7 +319,7 @@ func isMinioReservedBucket(bucketName string) bool {
 func getHostsSlice(records []dns.SrvRecord) []string {
 	var hosts []string
 	for _, r := range records {
-		hosts = append(hosts, r.Host)
+		hosts = append(hosts, net.JoinHostPort(r.Host, fmt.Sprintf("%d", r.Port)))
 	}
 	return hosts
 }


### PR DESCRIPTION
## Description

This pull request fixes #7995 by always using both IP address and port as a pair when checking if a request needs to be federated.  In addition, after fixing this two other commits have been made separately and have not been squashed since they are semantically separate.

The first refactors some common code relating into a method `getRemoteBucketDNSRecords` to keep `globalDomainIPs` access centralized for maintainability.

The second, add unit tests for `updateDomainIPs` using IPv6 addresses.  In the process of testing these defects within `updateDomainIPs` and `getHostIP` were identified and fixed.  Some helper methods for these were added along with additional unittests.

If you would prefer these other commits to be in separate pull requests or removed entirely let me know.

## Motivation and Context

Supporting running multiple MinIO servers on the same IP address (i.e. same machine, NAT port-forwarding, etc.) in a federated environment.

## How to test this PR?

Follow test steps described in #7995 or run `make test`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
