### PR TITLE
fix: add integer code for Windows Subsystem for Linux filesystem

### DIFF
--- a/pkg/disk/type_linux.go
+++ b/pkg/disk/type_linux.go
@@ -37,6 +37,7 @@ var fsType2StringMap = map[string]string{
 	"794c7630": "overlayfs",
 	"2fc12fc1": "zfs",
 	"ff534d42": "cifs",
+	"53464846": "wslfs",
 }
 
 // getFSType returns the filesystem type of the underlying mounted filesystem


### PR DESCRIPTION
## Description

The `TestFree` test fails on Windows Subsystem for Linux because the filesystem type code is unknown.  This pull request augments the known file system types with the code used for `wslfs` as returned by `stat -f / --printf '%t %T'`

## Motivation and Context

Although MinIO run on Windows natively, if someone is within a WSL environment it would be nice to have MinIO run correctly.  This pull request fixes one of the unit tests that fail when running `make test` within WSL.

## How to test this PR?

Run `TestFree` on Windows Subsystem for Linux

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
