### PR TITLE
fix AllowQuotedRecordDelimiter arg check in s3select

### DIFF
--- a/pkg/s3select/csv/args.go
+++ b/pkg/s3select/csv/args.go
@@ -112,10 +112,6 @@ func (args *ReaderArgs) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 		return fmt.Errorf("unsupported Comments '%v'", parsedArgs.CommentCharacter)
 	}
 
-	if parsedArgs.AllowQuotedRecordDelimiter {
-		return fmt.Errorf("flag AllowQuotedRecordDelimiter is unsupported at the moment")
-	}
-
 	*args = ReaderArgs(parsedArgs)
 	args.unmarshaled = true
 	return nil


### PR DESCRIPTION
## Description

fix AllowQuotedRecordDelimiter arg check in s3select

## Motivation and Context

Actually, we support AllowQuotedRecordDelimiter already.

## How to test this PR?

run `SELECT * FROM S3Object` on hello.csv with the following content
```
Year,Make,Model
1997,"aaa
bbb",E350
2000,Mercury,Cougar
```

gives the correct result:

```
1997,"aaa
bbb",E350
2000,Mercury,Cougar
```

by the way, if AllowQuotedRecordDelimiter is false, we don't process it differently, no performance improved. (compared with s3, if AllowQuotedRecordDelimiter is false, performance may be improved according to the documents: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
