### PR TITLE
[web-router] update the white list for favicons

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -178,7 +178,9 @@ func getRedirectLocation(urlPath string) (rLocation string) {
 		"/",
 		"/webrpc",
 		"/login",
-		"/favicon.ico",
+		"/favicon-16x16.png",
+		"/favicon-32x32.png",
+		"/favicon-96x96.png",
 	}, urlPath) {
 		rLocation = minioReservedBucketPath + urlPath
 	}

--- a/cmd/generic-handlers_test.go
+++ b/cmd/generic-handlers_test.go
@@ -53,12 +53,22 @@ func TestRedirectLocation(t *testing.T) {
 			location: minioReservedBucketPath + "/login",
 		},
 		{
-			// 5. When urlPath is '/favicon.ico'
-			urlPath:  "/favicon.ico",
-			location: minioReservedBucketPath + "/favicon.ico",
+			// 5. When urlPath is '/favicon-16x16.png'
+			urlPath:  "/favicon-16x16.png",
+			location: minioReservedBucketPath + "/favicon-16x16.png",
 		},
 		{
-			// 6. When urlPath is '/unknown'
+			// 6. When urlPath is '/favicon-16x16.png'
+			urlPath:  "/favicon-32x32.png",
+			location: minioReservedBucketPath + "/favicon-32x32.png",
+		},
+		{
+			// 7. When urlPath is '/favicon-96x96.png'
+			urlPath:  "/favicon-96x96.png",
+			location: minioReservedBucketPath + "/favicon-96x96.png",
+		},
+		{
+			// 8. When urlPath is '/unknown'
 			urlPath:  "/unknown",
 			location: "",
 		},

--- a/cmd/web-router.go
+++ b/cmd/web-router.go
@@ -56,7 +56,7 @@ func assetFS() *assetfs.AssetFS {
 }
 
 // specialAssets are files which are unique files not embedded inside index_bundle.js.
-const specialAssets = "index_bundle.*.js|loader.css|logo.svg|firefox.png|safari.png|chrome.png|favicon.ico"
+const specialAssets = "index_bundle.*.js|loader.css|logo.svg|firefox.png|safari.png|chrome.png|favicon-16x16.png|favicon-32x32.png|favicon-96x96.png"
 
 // registerWebRouter - registers web router for serving minio browser.
 func registerWebRouter(router *mux.Router) error {


### PR DESCRIPTION
## Description
Complete #7408 in adding the new favicon routes to the white list.

## Motivation and Context
See #8023 

## How to test this PR?
Request `http://HOST:PORT/minio/favicon-32x32.png`, should return 200 with icon data.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #7408 22b4fe0a51bc58a63a11b3d5311b17bb5909f70c
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed

Closes #8023 