### PR TITLE
fix DoS vulnerability in the content SHA-256 processing

### DIFF
--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"encoding/hex"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -61,7 +62,7 @@ func skipContentSha256Cksum(r *http.Request) bool {
 // Returns SHA256 for calculating canonical-request.
 func getContentSha256Cksum(r *http.Request, stype serviceType) string {
 	if stype == serviceSTS {
-		payload, err := ioutil.ReadAll(r.Body)
+		payload, err := ioutil.ReadAll(io.LimitReader(r.Body, stsRequestBodyLimit))
 		if err != nil {
 			logger.CriticalIf(context.Background(), err)
 		}

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -40,6 +40,8 @@ const (
 	clientGrants = "AssumeRoleWithClientGrants"
 	webIdentity  = "AssumeRoleWithWebIdentity"
 	assumeRole   = "AssumeRole"
+
+	stsRequestBodyLimit = 10 * (1 << 20) // 10 MiB
 )
 
 // stsAPIHandlers implements and provides http handlers for AWS STS API.


### PR DESCRIPTION
## Description
This commit fixes a DoS issue that is caused by an incorrect
SHA-256 content verification during STS requests.

Before that fix clients could write arbitrary many bytes
to the server memory. This commit fixes this by limiting the
request body size.

## Motivation and Context
Security fix

## How to test this PR?
manually (Details redacted)  

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
