### PR TITLE
[s3/extension] Introduce PutObjectChunked API

### DIFF
--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -64,7 +64,7 @@ func registerAPIRouter(router *mux.Router, encryptionEnabled, allowSSEKMS bool) 
 		bucket.Methods(http.MethodPut).Path("/{object:.+}").HeadersRegexp(xhttp.AmzCopySource, ".*?(\\/|%2F).*?").HandlerFunc(httpTraceAll(api.CopyObjectPartHandler)).Queries("partNumber", "{partNumber:[0-9]+}", "uploadId", "{uploadId:.*}")
 		// PutObjectPart
 		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(httpTraceHdrs(api.PutObjectPartHandler)).Queries("partNumber", "{partNumber:[0-9]+}", "uploadId", "{uploadId:.*}")
-		// ListObjectPxarts
+		// ListObjectParts
 		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(httpTraceAll(api.ListObjectPartsHandler)).Queries("uploadId", "{uploadId:.*}")
 		// CompleteMultipartUpload
 		bucket.Methods(http.MethodPost).Path("/{object:.+}").HandlerFunc(httpTraceAll(api.CompleteMultipartUploadHandler)).Queries("uploadId", "{uploadId:.*}")
@@ -82,6 +82,8 @@ func registerAPIRouter(router *mux.Router, encryptionEnabled, allowSSEKMS bool) 
 		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(httpTraceHdrs(api.GetObjectHandler))
 		// CopyObject
 		bucket.Methods(http.MethodPut).Path("/{object:.+}").HeadersRegexp(xhttp.AmzCopySource, ".*?(\\/|%2F).*?").HandlerFunc(httpTraceAll(api.CopyObjectHandler))
+		// PutObjectChunked
+		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(httpTraceHdrs(api.PutObjectChunkedHandler)).Queries("chunked", "")
 		// PutObject
 		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(httpTraceHdrs(api.PutObjectHandler))
 		// DeleteObject

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -43,6 +43,12 @@ func (a GatewayUnsupported) CopyObjectPart(ctx context.Context, srcBucket, srcOb
 	return pi, NotImplemented{}
 }
 
+// PutObjectChunked - stub append object API
+func (a GatewayUnsupported) PutObjectChunked(ctx context.Context, bucket string, object string, data *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+	logger.LogIf(ctx, NotImplemented{})
+	return objInfo, NotImplemented{}
+}
+
 // PutObjectPart puts a part of object in bucket
 func (a GatewayUnsupported) PutObjectPart(ctx context.Context, bucket string, object string, uploadID string, partID int, data *PutObjReader, opts ObjectOptions) (pi PartInfo, err error) {
 	logger.LogIf(ctx, NotImplemented{})

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -71,6 +71,7 @@ type ObjectLayer interface {
 	GetObjectNInfo(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (reader *GetObjectReader, err error)
 	GetObject(ctx context.Context, bucket, object string, startOffset int64, length int64, writer io.Writer, etag string, opts ObjectOptions) (err error)
 	GetObjectInfo(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error)
+	PutObjectChunked(ctx context.Context, bucket, object string, data *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error)
 	PutObject(ctx context.Context, bucket, object string, data *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error)
 	CopyObject(ctx context.Context, srcBucket, srcObject, destBucket, destObject string, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (objInfo ObjectInfo, err error)
 	DeleteObject(ctx context.Context, bucket, object string) error

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -1287,6 +1287,7 @@ func (s *posix) AppendFile(volume, path string, buf []byte) (err error) {
 	var w *os.File
 	// Create file if not found. Not doing O_DIRECT here to avoid the code that does buffer aligned writes.
 	// AppendFile() is only used by healing code to heal objects written in old format.
+	// and also by PutObjectChunked API.
 	w, err = s.openFile(volume, path, os.O_CREATE|os.O_SYNC|os.O_APPEND|os.O_WRONLY)
 	if err != nil {
 		return err

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -630,6 +630,11 @@ func (s *xlSets) GetObject(ctx context.Context, bucket, object string, startOffs
 	return s.getHashedSet(object).GetObject(ctx, bucket, object, startOffset, length, writer, etag, opts)
 }
 
+// PutObjectChunked - appends to an existing object at a hashedSet based on the object name.
+func (s *xlSets) PutObjectChunked(ctx context.Context, bucket string, object string, data *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+	return s.getHashedSet(object).PutObjectChunked(ctx, bucket, object, data, opts)
+}
+
 // PutObject - writes an object to hashedSet based on the object name.
 func (s *xlSets) PutObject(ctx context.Context, bucket string, object string, data *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	return s.getHashedSet(object).PutObject(ctx, bucket, object, data, opts)

--- a/pkg/event/name.go
+++ b/pkg/event/name.go
@@ -35,6 +35,7 @@ const (
 	ObjectCreatedCopy
 	ObjectCreatedPost
 	ObjectCreatedPut
+	ObjectCreatedPutChunked
 	ObjectRemovedAll
 	ObjectRemovedDelete
 )


### PR DESCRIPTION
## Description
[s3/extension] Introduce PutObjectChunked API

## Motivation and Context
This implementation is based on `Transfer-Encoding: chunked`
this allows clients to upload an unending stream of content
without a predefined `Content-Length`

Fixes #8015 

## How to test this PR?
```sh
#!/bin/bash
file=test1
bucket=testbucket
resource="/${bucket}/${file}"
contentType="application/octet-stream"
dateValue=$(date +'%a, %d %b %Y %H:%M:%S %z')
stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
s3Key=minio
s3Secret=minio123
signature=$(/bin/echo -en "$stringToSign" | openssl sha1 -hmac ${s3Secret} -binary | base64)

curl -v --upload-file "-" \
     -H "Date: ${dateValue}" \
     -H "Content-Type: ${contentType}" \
     -H "Authorization: AWS ${s3Key}:${signature}" \
     http://localhost:9000${resource}?chunked
```

```
cat `which emacs` | ./curl.sh
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
