### PR TITLE
KMS Admin-API: add route and handler for KMS key listing

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1791,7 +1791,7 @@ func (a adminAPIHandlers) KMSListKeysHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Either check whether the requested bucket exists or
-	// of (no bucket is specified) list all buckets.
+ 	// if (no bucket is specified) list all buckets.
 	var bucketNames []string
 	if req.Bucket != "" {
 		if _, err := objectAPI.GetBucketInfo(ctx, req.Bucket); err != nil {

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -154,6 +154,7 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 	// -- KMS APIs --
 	//
 	adminRouter.Methods(http.MethodGet).Path("/kms/key/status").HandlerFunc(httpTraceAll(adminAPI.KMSKeyStatusHandler))
+	adminRouter.Methods(http.MethodPost).Path("/kms/key/list").HandlerFunc(httpTraceAll(adminAPI.KMSListKeysHandler))
 
 	// If none of the routes match, return error.
 	adminRouter.NotFoundHandler = http.HandlerFunc(httpTraceHdrs(notFoundHandler))

--- a/pkg/madmin/README.md
+++ b/pkg/madmin/README.md
@@ -45,7 +45,7 @@ func main() {
 | Service operations                  | Info operations                                   | Healing operations | Config operations         | Top operations          | IAM operations                        | Misc                                              | KMS                             |
 |:------------------------------------|:--------------------------------------------------|:-------------------|:--------------------------|:------------------------|:--------------------------------------|:--------------------------------------------------|:--------------------------------|
 | [`ServiceRestart`](#ServiceRestart) | [`ServerInfo`](#ServerInfo)                       | [`Heal`](#Heal)    | [`GetConfig`](#GetConfig) | [`TopLocks`](#TopLocks) | [`AddUser`](#AddUser)                 |                                                   | [`GetKeyStatus`](#GetKeyStatus) |
-| [`ServiceStop`](#ServiceStop)       | [`ServerCPULoadInfo`](#ServerCPULoadInfo)         |                    | [`SetConfig`](#SetConfig) |                         | [`SetUserPolicy`](#SetUserPolicy)     | [`StartProfiling`](#StartProfiling)               |                                 |
+| [`ServiceStop`](#ServiceStop)       | [`ServerCPULoadInfo`](#ServerCPULoadInfo)         |                    | [`SetConfig`](#SetConfig) |                         | [`SetUserPolicy`](#SetUserPolicy)     | [`StartProfiling`](#StartProfiling)               | [`ListKeys`](#ListKeys)         |
 |                                     | [`ServerMemUsageInfo`](#ServerMemUsageInfo)       |                    |                           |                         | [`ListUsers`](#ListUsers)             | [`DownloadProfilingData`](#DownloadProfilingData) |                                 |
 | [`ServiceTrace`](#ServiceTrace)     | [`ServerDrivesPerfInfo`](#ServerDrivesPerfInfo)   |                    |                           |                         | [`AddCannedPolicy`](#AddCannedPolicy) | [`ServerUpdate`](#ServerUpdate)                   |                                 |
 |                                     | [`NetPerfInfo`](#NetPerfInfo)                     |                    |                           |                         |                                       |                                                   |                                 |
@@ -636,4 +636,26 @@ __Example__
     if keyInfo.DecryptionErr != "" {
        log.Fatalf("Failed to perform decryption operation using '%s': %v\n", keyInfo.KeyID, keyInfo.DecryptionErr)
     }
+```
+
+
+<a name="ListKeys"></a>
+### ListKeys(bucket, prefix, keyID string, recursive bool) (io.ReadCloser, error)
+List all KMS master keys of all objects at the specified bucket that match the prefix.
+If the keyID is empty it lists all KMS master keys. If the recursive flag is true
+ListKeys performs a recursive list operations.
+
+__Example__
+
+``` go
+    // List all key-IDs that match "my-min" of all objects stored at the
+    // "my-bucket" bucket.
+    listing, err := madmClnt.ListKeys("my-bucket", "", "my-min", false)
+    if err != nil {
+            log.Fatalln(err)
+    }
+   	scanner := bufio.NewScanner(listing)
+	for scanner.Scan() {
+		log.Println(scanner.Text()) // Print JSON output
+	}
 ```

--- a/pkg/madmin/examples/kms-list-keys.go
+++ b/pkg/madmin/examples/kms-list-keys.go
@@ -1,0 +1,48 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"bufio"
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	resp, err := madmClnt.ListKeys("", "", "", true) // list all objects in all buckets encrypted with the default key
+	if err != nil {
+		log.Fatalln(err)
+	}
+	scanner := bufio.NewScanner(resp)
+	for scanner.Scan() {
+		log.Println(scanner.Text()) // Print JSON output
+	}
+}


### PR DESCRIPTION
## Description
This commit adds an admin API route and handler for
listing objects encrypted with master keys.

Therefore, the client specifies the KMS key ID (when
empty / not set the server takes the currently configured
default key-ID) and a bucket/object prefix and the server
tries to list all objects encrypted with that key. Therefore,
the server returns a (new-line separated) list of JSON encoded
values.


## Motivation and Context
KMS admin API

## How to test this PR?
1. `export MINIO_SSE_MASTER_KEY=my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574`
2. `export MINIO_SSE_AUTO_ENCRYPTION=on`
3. Start server
4. Create bucket and upload objects
5. `go run github.com/minio/minio/pkg/madmin/examples/kms-list-keys.go`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )

