### PR TITLE
Adding Notes on Swarm Network Aliases

### DIFF
--- a/docs/orchestration/docker-swarm/README.md
+++ b/docs/orchestration/docker-swarm/README.md
@@ -71,6 +71,12 @@ docker volume prune
 ```
 This will remove all the volumes not associated with any container.
 
+## 5. Accessing MinIO services
+
+The services are exposed, by default, on the internal overlay network by their services names (minio1, minio2, ...).
+The docker-compose.yml file also exposes the MinIO services behind a single alias on the minio_distributed network.
+
+Services in the Swarm which are attached to that network can interact with the host "minio-cluster" instead of individual services' hostnames.  This provides a simple way to loosely load balance across all the MinIO services in the Swarm as well as simplifies configuration and management.
 
 ### Notes
 

--- a/docs/orchestration/docker-swarm/docker-compose.yaml
+++ b/docs/orchestration/docker-swarm/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 
 services:
   minio1:
@@ -9,7 +9,11 @@ services:
     ports:
       - "9001:9000"
     networks:
-      - minio_distributed
+      # On the internal you are exposed as minio1/2/3/4 by default
+      internal:  {}
+      minio_distributed:
+        aliases:
+          - minio-cluster
     environment:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -31,7 +35,11 @@ services:
     ports:
       - "9002:9000"
     networks:
-      - minio_distributed
+      # On the internal you are exposed as minio1/2/3/4 by default
+      internal:  {}
+      minio_distributed:
+        aliases:
+          - minio-cluster
     environment:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -53,7 +61,11 @@ services:
     ports:
       - "9003:9000"
     networks:
-      - minio_distributed
+      # On the internal you are exposed as minio1/2/3/4 by default
+      internal:  {}
+      minio_distributed:
+        aliases:
+          - minio-cluster
     environment:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -75,7 +87,11 @@ services:
     ports:
       - "9004:9000"
     networks:
-      - minio_distributed
+      # On the internal you are exposed as minio1/2/3/4 by default
+      internal:  {}
+      minio_distributed:
+        aliases:
+          - minio-cluster
     environment:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -101,3 +117,4 @@ volumes:
 networks:
   minio_distributed:
     driver: overlay
+  internal: {}


### PR DESCRIPTION
## Description
Adds some notes for docker-compose files to expose all MinIO services behind a single overlay network hostname. This can simplify some things.

## Motivation and Context
Asked to provide via Slack

## How to test this PR?
Run the docker-compose file locally.

## Types of changes
Documentation

## Checklist:
