### PR TITLE
fix type conversion in `UpdateKey` for Vault

### DIFF
--- a/cmd/crypto/vault.go
+++ b/cmd/crypto/vault.go
@@ -274,6 +274,6 @@ func (v *vaultService) UpdateKey(keyID string, sealedKey []byte, ctx Context) (r
 	if !ok {
 		return nil, errMissingUpdatedKey
 	}
-	rotatedKey = ciphertext.([]byte)
+	rotatedKey = []byte(ciphertext.(string))
 	return rotatedKey, nil
 }


### PR DESCRIPTION
## Description
This commit fixes a type conversion in the `UpdateKey`
implementation of Vault.

## Motivation and Context
Thanks to @sinhaashish

## How to test this PR?
Setup Vault: https://github.com/minio/minio/tree/master/docs/kms
Pull: https://github.com/minio/minio/pull/7955/
Start a MinIO server with Vault configuration and configure `/pkg/madmin/examples/key-status.go` with the correct access/secret key.
Run: `go run github.com/minio/minio/pkg/madmin/examples/key-status.go`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
