### PR TITLE
Add method to fetch Vault info

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -696,7 +696,7 @@ func TestAdminServerInfo(t *testing.T) {
 
 	// Prepare query params for set-config mgmt REST API.
 	queryVal := url.Values{}
-	queryVal.Set("info", "")
+	queryVal.Set("infoType", "server")
 
 	req, err := buildAdminRequest(queryVal, http.MethodGet, "/info", 0, nil)
 	if err != nil {

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -50,8 +50,8 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 	// Service restart and stop - TODO
 	adminV1Router.Methods(http.MethodPost).Path("/service").HandlerFunc(httpTraceAll(adminAPI.ServiceStopNRestartHandler))
 
-	// Info operations
-	adminV1Router.Methods(http.MethodGet).Path("/info").HandlerFunc(httpTraceAll(adminAPI.ServerInfoHandler))
+	// Info operations - return details based on input type
+	adminV1Router.Methods(http.MethodGet).Path("/info").HandlerFunc(httpTraceAll(adminAPI.ServerInfoHandler)).Queries("infoType", "{infoType:.*}")
 
 	if globalIsDistXL || globalIsXL {
 		/// Heal operations
@@ -66,9 +66,6 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 		/// Health operations
 
 	}
-	// Performance command - return performance details based on input type
-	adminV1Router.Methods(http.MethodGet).Path("/performance").HandlerFunc(httpTraceAll(adminAPI.PerfInfoHandler)).Queries("perfType", "{perfType:.*}")
-
 	// Profiling operations
 	adminV1Router.Methods(http.MethodPost).Path("/profiling/start").HandlerFunc(httpTraceAll(adminAPI.StartProfilingHandler)).
 		Queries("profilerType", "{profilerType:.*}")

--- a/pkg/madmin/README.md
+++ b/pkg/madmin/README.md
@@ -46,7 +46,7 @@ func main() {
 | [`ServiceStatus`](#ServiceStatus)         | [`ServerInfo`](#ServerInfo)                 | [`Heal`](#Heal)    | [`GetConfig`](#GetConfig)         | [`TopLocks`](#TopLocks) | [`AddUser`](#AddUser)                 |                                                   |
 | [`ServiceSendAction`](#ServiceSendAction) | [`ServerCPULoadInfo`](#ServerCPULoadInfo)   |                    | [`SetConfig`](#SetConfig)         |                         | [`SetUserPolicy`](#SetUserPolicy)     | [`StartProfiling`](#StartProfiling)               |
 | [`Trace`](#Trace)                                          | [`ServerMemUsageInfo`](#ServerMemUsageInfo) |                    | [`GetConfigKeys`](#GetConfigKeys) |                         | [`ListUsers`](#ListUsers)             | [`DownloadProfilingData`](#DownloadProfilingData) |
-|                                           |                                             |                    | [`SetConfigKeys`](#SetConfigKeys) |                         | [`AddCannedPolicy`](#AddCannedPolicy) |                                                   |
+|                                           |       [`ServerVaultInfo`](#ServerVaultInfo)                                      |                    | [`SetConfigKeys`](#SetConfigKeys) |                         | [`AddCannedPolicy`](#AddCannedPolicy) |                                                   |
 
 
 ## 1. Constructor
@@ -229,7 +229,7 @@ Fetches drive performance information for all cluster nodes. Returned value is i
 | `disk.Performance.ReadSpeed`  | _float64_ | Read speed on above path in Bytes/s.                   |
 
 <a name="ServerCPULoadInfo"></a>
-### ServerCPULoadInfo() ([]ServerCPULoadInfo, error)
+### ) ([]ServerCPULoadInfo, error)
 
 Fetches CPU utilization for all cluster nodes. Returned value is in Bytes.
 
@@ -261,6 +261,24 @@ Fetches Mem utilization for all cluster nodes. Returned value is in Bytes.
 |-------------------|----------|--------------------------------------------------------|
 | `mem.Usage.Mem`   | _uint64_ | The total number of bytes obtained from the OS         |
 | `mem.Usage.Error` | _string_ | Error (if any) encountered while accesing the CPU info |
+
+
+<a name="ServerVaultInfo"></a>
+### ServerVaultInfo() (ServerVaultInfo, error)
+
+Fetches Vault information. Returned value is in Bytes.
+
+| Param           | Type               | Description                                                         |
+|-----------------|--------------------|---------------------------------------------------------------------|
+| `vi.EndPoint`   | _string_           | Address of the vault server                                         |
+| `vi.Name`       | _string_           | The name of the encryption key-ring                                 |
+| `vi.Type`       | _string_           | The authentication type                                             |
+| `vi.Perm`       | _vi.Permission_    | The Permission for Encrypt and Decrypt                              |
+
+| Param                | Type     | Description                                            |
+|----------------------|----------|--------------------------------------------------------|
+| `vi.Perm.Encryption` | _string_ | Permission to Encrypt                                  |
+| `vi.Perm.Decryption` | _string_ | Permission to Decrypt                                  |
 
 ## 6. Heal operations
 

--- a/pkg/madmin/examples/server-info.go
+++ b/pkg/madmin/examples/server-info.go
@@ -31,7 +31,7 @@ func main() {
 
 	// API requests are secure (HTTPS) if secure=true and insecure (HTTPS) otherwise.
 	// New returns an MinIO Admin client object.
-	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	madmClnt, err := madmin.New("localhost:9000", "minio", "minio123", false)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/madmin/examples/vault-info.go
+++ b/pkg/madmin/examples/vault-info.go
@@ -20,9 +20,8 @@
 package main
 
 import (
-	"log"
-
 	"github.com/minio/minio/pkg/madmin"
+	"log"
 )
 
 func main() {
@@ -31,14 +30,14 @@ func main() {
 
 	// API requests are secure (HTTPS) if secure=true and insecure (HTTPS) otherwise.
 	// New returns an MinIO Admin client object.
-	madmClnt, err := madmin.New("localhost:9000", "minio", "minio123", false)
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	st, err := madmClnt.ServerMemUsageInfo()
+	vaultInfo, err := madmClnt.ServerVaultInfo()
 	if err != nil {
 		log.Fatalln(err)
 	}
-	log.Println(st)
+	log.Println(vaultInfo)
 }


### PR DESCRIPTION
## Description
1. Added a method `ServerVaultInfo` to fetch the vault info.
2. Removed `PerfInfoHandler` and merged performance parameters to `ServerInfoHandler` .

## Motivation and Context
`mc` will display the vault info.

## How to test this PR?
Run 
1. `vault-info.go`
2. `server-info.go`
3. `mem-usage-info.go`
4. `cpu-load-info.go`.


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [X] Documentation needed
- [X] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
