### PR TITLE
Fix DeleteObjects() to remove renamed objects inside tmp directory

### DIFF
--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -185,7 +185,7 @@ func cleanupObjectsBulk(ctx context.Context, storage StorageAPI, volume string, 
 		if errs[idx] != nil {
 			continue
 		}
-		output, err := traverse(objPath)
+		output, err := traverse(retainSlash(pathJoin(objPath)))
 		if err != nil {
 			errs[idx] = err
 			continue


### PR DESCRIPTION
## Description
After renaming erasure coded objects and moving 
them to tmp directory, DeleteObjects() failed to 
delete files from tmp directory. This is because 
objects are moved as is (i.e. as directories) and 
the moved directories are non-empty.

This PR adds "/" to temp objects (directories) 
created after rename, to ensure posix layer identifies 
these as directories and deletes inner content first 
before attempting to delete the directory.

## Motivation and Context
Reported by community user

## How to test this PR?
Issue `DeleteObjects` API (e.g. mc rm) on a MinIO Erasure 
Coded server. Check the backend `/.minio.sys/tmp`
directory to ensure there are no left over files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (Caused in #7607 )
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
