### PR TITLE
Return if paths are empty in DeleteFileBulk

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -374,6 +374,9 @@ func (client *storageRESTClient) DeleteFile(volume, path string) error {
 
 // DeleteFileBulk - deletes files in bulk.
 func (client *storageRESTClient) DeleteFileBulk(volume string, paths []string) (errs []error, err error) {
+	if len(paths) == 0 {
+		return errs, err
+	}
 	errs = make([]error, len(paths))
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)


### PR DESCRIPTION

## Description
Return if paths are empty in DeleteFileBulk

## Motivation and Context
This avoids a network call, also fixes an issue
when empty paths are passed the underlying call
fails with "405 Method Not Allowed".

This is reproducible when you are deleting a
non-existent object.

Fixes #8083

## How to test this PR?
Just run minio-js functional tests against MinIO. 

```
docker run --rm --network=minio_distribute ACCESS_KEY=minio -e SECRET_KEY=minio123 -e SERVER_ENDPOINT=minio-distributed:9000 -e ENABLE_HTTPS=0 -e MINT_MODE=full minio/mint:edge minio-js
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression but it is a side affect of 1cd801b2e9736224415b8a673d2386f25ddc0dc2 this change
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
