### PR TITLE
LDAP STS API

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1260,7 +1260,12 @@ func (a adminAPIHandlers) ListGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	groups := globalIAMSys.ListGroups()
+	groups, err := globalIAMSys.ListGroups()
+	if err != nil {
+		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
+		return
+	}
+
 	body, err := json.Marshal(groups)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -203,6 +203,12 @@ func getClaimsFromToken(r *http.Request) (map[string]interface{}, error) {
 	}
 
 	if globalPolicyOPA == nil {
+		// If OPA is not set and if ldap claim key is set,
+		// allow the claim.
+		if _, ok := claims[ldapUser]; ok {
+			return claims, nil
+		}
+
 		// If OPA is not set, session token should
 		// have a policy and its mandatory, reject
 		// requests without policy claim.

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2016, 2017, 2018 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2016-2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -302,6 +302,12 @@ func (s *serverConfig) loadFromEnvs() {
 		logger.FatalIf(opaArgs.Validate(), "Unable to reach MINIO_IAM_OPA_URL %s", opaURL)
 		s.Policy.OPA.URL = opaArgs.URL
 		s.Policy.OPA.AuthToken = opaArgs.AuthToken
+	}
+
+	var err error
+	s.LDAPServerConfig, err = newLDAPConfigFromEnv()
+	if err != nil {
+		logger.FatalIf(err, "Unable to parse LDAP configuration from env")
 	}
 }
 

--- a/cmd/config-versions.go
+++ b/cmd/config-versions.go
@@ -926,4 +926,6 @@ type serverConfigV33 struct {
 
 		// Add new external policy enforcements here.
 	} `json:"policy"`
+
+	LDAPServerConfig ldapServerConfig `json:"ldapserverconfig"`
 }

--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -429,24 +429,33 @@ func (iamOS *IAMObjectStore) loadAll(sys *IAMSys, objectAPI ObjectLayer) error {
 	iamUserPolicyMap := make(map[string]MappedPolicy)
 	iamGroupPolicyMap := make(map[string]MappedPolicy)
 
+	isMinIOUsersSys := false
+	sys.RLock()
+	if sys.usersSysType == MinIOUsersSysType {
+		isMinIOUsersSys = true
+	}
+	sys.RUnlock()
+
 	if err := iamOS.loadPolicyDocs(iamPolicyDocsMap); err != nil {
 		return err
 	}
-	if err := iamOS.loadUsers(false, iamUsersMap); err != nil {
-		return err
-	}
-	// load STS temp users into the same map
+	// load STS temp users
 	if err := iamOS.loadUsers(true, iamUsersMap); err != nil {
 		return err
 	}
-	if err := iamOS.loadGroups(iamGroupsMap); err != nil {
-		return err
-	}
+	if isMinIOUsersSys {
+		if err := iamOS.loadUsers(false, iamUsersMap); err != nil {
+			return err
+		}
+		if err := iamOS.loadGroups(iamGroupsMap); err != nil {
+			return err
+		}
 
-	if err := iamOS.loadMappedPolicies(false, false, iamUserPolicyMap); err != nil {
-		return err
+		if err := iamOS.loadMappedPolicies(false, false, iamUserPolicyMap); err != nil {
+			return err
+		}
 	}
-	// load STS policy mappings into the same map
+	// load STS policy mappings
 	if err := iamOS.loadMappedPolicies(true, false, iamUserPolicyMap); err != nil {
 		return err
 	}

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -484,7 +484,7 @@ func (sys *IAMSys) DeleteUser(accessKey string) error {
 	defer sys.Unlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return errIAMActionNotPossible
+		return errIAMActionNotAllowed
 	}
 
 	// It is ok to ignore deletion error on the mapped policy
@@ -555,7 +555,7 @@ func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
 	defer sys.RUnlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return nil, errIAMActionNotPossible
+		return nil, errIAMActionNotAllowed
 	}
 
 	for k, v := range sys.iamUsersMap {
@@ -612,7 +612,7 @@ func (sys *IAMSys) SetUserStatus(accessKey string, status madmin.AccountStatus) 
 	defer sys.Unlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return errIAMActionNotPossible
+		return errIAMActionNotAllowed
 	}
 
 	cred, ok := sys.iamUsersMap[accessKey]
@@ -650,7 +650,7 @@ func (sys *IAMSys) SetUser(accessKey string, uinfo madmin.UserInfo) error {
 	defer sys.Unlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return errIAMActionNotPossible
+		return errIAMActionNotAllowed
 	}
 
 	if err := sys.store.saveUserIdentity(accessKey, false, u); err != nil {
@@ -676,7 +676,7 @@ func (sys *IAMSys) SetUserSecretKey(accessKey string, secretKey string) error {
 	defer sys.Unlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return errIAMActionNotPossible
+		return errIAMActionNotAllowed
 	}
 
 	cred, ok := sys.iamUsersMap[accessKey]
@@ -719,7 +719,7 @@ func (sys *IAMSys) AddUsersToGroup(group string, members []string) error {
 	defer sys.Unlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return errIAMActionNotPossible
+		return errIAMActionNotAllowed
 	}
 
 	// Validate that all members exist.
@@ -777,7 +777,7 @@ func (sys *IAMSys) RemoveUsersFromGroup(group string, members []string) error {
 	defer sys.Unlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return errIAMActionNotPossible
+		return errIAMActionNotAllowed
 	}
 
 	// Validate that all members exist.
@@ -854,7 +854,7 @@ func (sys *IAMSys) SetGroupStatus(group string, enabled bool) error {
 	defer sys.Unlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return errIAMActionNotPossible
+		return errIAMActionNotAllowed
 	}
 
 	if group == "" {
@@ -921,7 +921,7 @@ func (sys *IAMSys) ListGroups() (r []string, err error) {
 	defer sys.RUnlock()
 
 	if sys.usersSysType != MinIOUsersSysType {
-		return nil, errIAMActionNotPossible
+		return nil, errIAMActionNotAllowed
 	}
 
 	for k := range sys.iamGroupsMap {

--- a/cmd/ldap-ops.go
+++ b/cmd/ldap-ops.go
@@ -1,0 +1,178 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"time"
+
+	ldap "gopkg.in/ldap.v3"
+)
+
+const (
+	defaultLDAPExpiry = time.Hour * 1
+)
+
+// ldapServerConfig contains server connectivity information.
+type ldapServerConfig struct {
+	IsEnabled bool `json:"enabled"`
+
+	// E.g. "ldap.minio.io:636"
+	ServerAddr string `json:"serverAddr"`
+
+	// STS credentials expiry duration
+	STSExpiryDuration string        `json:"stsExpiryDuration"`
+	stsExpiryDuration time.Duration // contains converted value
+
+	// Skips TLS verification (for testing, not
+	// recommended in production).
+	SkipTLSVerify bool `json:"skipTLSverify"`
+
+	// Format string for usernames
+	UsernameFormat string `json:"usernameFormat"`
+
+	GroupSearchBaseDN  string `json:"groupSearchBaseDN"`
+	GroupSearchFilter  string `json:"groupSearchFilter"`
+	GroupNameAttribute string `json:"groupNameAttribute"`
+}
+
+func (l *ldapServerConfig) Connect() (ldapConn *ldap.Conn, err error) {
+	if l == nil {
+		// Happens when LDAP is not configured.
+		return
+	}
+	if l.SkipTLSVerify {
+		ldapConn, err = ldap.DialTLS("tcp", l.ServerAddr, &tls.Config{InsecureSkipVerify: true})
+	} else {
+		ldapConn, err = ldap.DialTLS("tcp", l.ServerAddr, &tls.Config{})
+	}
+	return
+}
+
+// newLDAPConfigFromEnv loads configuration from the environment
+func newLDAPConfigFromEnv() (l ldapServerConfig, err error) {
+	if ldapServer, ok := os.LookupEnv("MINIO_IDENTITY_LDAP_SERVER_ADDR"); ok {
+		l.IsEnabled = true
+		l.ServerAddr = ldapServer
+
+		if v := os.Getenv("MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY"); v == "true" {
+			l.SkipTLSVerify = true
+		}
+
+		if v := os.Getenv("MINIO_IDENTITY_LDAP_STS_EXPIRY"); v != "" {
+			expDur, err := time.ParseDuration(v)
+			if err != nil {
+				return l, errors.New("LDAP expiry time err:" + err.Error())
+			}
+			if expDur <= 0 {
+				return l, errors.New("LDAP expiry time has to be positive")
+			}
+			l.STSExpiryDuration = v
+			l.stsExpiryDuration = expDur
+		} else {
+			l.stsExpiryDuration = defaultLDAPExpiry
+		}
+
+		if v := os.Getenv("MINIO_IDENTITY_LDAP_USERNAME_FORMAT"); v != "" {
+			subs := newSubstituter("username", "test")
+			if _, err := subs.substitute(v); err != nil {
+				return l, errors.New("Only username may be substituted in the username format")
+			}
+			l.UsernameFormat = v
+		}
+
+		grpSearchFilter := os.Getenv("MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER")
+		grpSearchNameAttr := os.Getenv("MINIO_IDENTITY_LDAP_GROUP_NAME_ATTRIBUTE")
+		grpSearchBaseDN := os.Getenv("MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN")
+
+		// Either all group params must be set or none must be set.
+		allNotSet := grpSearchFilter == "" && grpSearchNameAttr == "" && grpSearchBaseDN == ""
+		allSet := grpSearchFilter != "" && grpSearchNameAttr != "" && grpSearchBaseDN != ""
+		if !allNotSet && !allSet {
+			return l, errors.New("All group related parameters must be set")
+		}
+
+		if allSet {
+			subs := newSubstituter("username", "test", "usernamedn", "test2")
+			if _, err := subs.substitute(grpSearchFilter); err != nil {
+				return l, errors.New("Only username and usernamedn may be substituted in the group search filter string")
+			}
+			l.GroupSearchFilter = grpSearchFilter
+
+			l.GroupNameAttribute = grpSearchNameAttr
+
+			subs = newSubstituter("username", "test", "usernamedn", "test2")
+			if _, err := subs.substitute(grpSearchBaseDN); err != nil {
+				return l, errors.New("Only username and usernamedn may be substituted in the base DN string")
+			}
+			l.GroupSearchBaseDN = grpSearchBaseDN
+		}
+	}
+	return
+}
+
+// substituter - This type is to allow restricted runtime
+// substitutions of variables in LDAP configuration items during
+// runtime.
+type substituter struct {
+	vals map[string]string
+}
+
+// newSubstituter - sets up the substituter for usage, for e.g.:
+//
+//  subber := newSubstituter("username", "john")
+func newSubstituter(v ...string) substituter {
+	if len(v)%2 != 0 {
+		log.Fatal("Need an even number of arguments")
+	}
+	vals := make(map[string]string)
+	for i := 0; i < len(v); i += 2 {
+		vals[v[i]] = v[i+1]
+	}
+	return substituter{vals: vals}
+}
+
+// substitute - performs substitution on the given string `t`. Returns
+// an error if there are any variables in the input that do not have
+// values in the substituter. E.g.:
+//
+// subber.substitute("uid=${username},cn=users,dc=example,dc=com")
+//
+// returns "uid=john,cn=users,dc=example,dc=com"
+//
+// whereas:
+//
+// subber.substitute("uid=${usernamedn}")
+//
+// returns an error.
+func (s *substituter) substitute(t string) (string, error) {
+	for k, v := range s.vals {
+		re := regexp.MustCompile(fmt.Sprintf(`\$\{%s\}`, k))
+		t = re.ReplaceAllLiteralString(t, v)
+	}
+	// Check if all requested substitutions have been made.
+	re := regexp.MustCompile(`\$\{.*\}`)
+	if re.MatchString(t) {
+		return "", errors.New("unsupported substitution requested")
+	}
+	return t, nil
+}

--- a/cmd/sts-datatypes.go
+++ b/cmd/sts-datatypes.go
@@ -174,3 +174,19 @@ type ClientGrantsResult struct {
 	// provider as the token's sub (Subject) claim.
 	SubjectFromToken string `xml:",omitempty"`
 }
+
+// AssumeRoleWithLDAPResponse contains the result of successful
+// AssumeRoleWithLDAPIdentity request
+type AssumeRoleWithLDAPResponse struct {
+	XMLName          xml.Name           `xml:"https://sts.amazonaws.com/doc/2011-06-15/ AssumeRoleWithClientGrantsResponse" json:"-"`
+	Result           LDAPIdentityResult `xml:"AssumeRoleWithLDAPIdentity"`
+	ResponseMetadata struct {
+		RequestID string `xml:"RequestId,omitempty"`
+	} `xml:"ResponseMetadata,omitempty"`
+}
+
+// LDAPIdentityResult - contains credentials for a successful
+// AssumeRoleWithLDAPIdentity request.
+type LDAPIdentityResult struct {
+	Credentials auth.Credentials `xml:",omitempty"`
+}

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1932,17 +1932,17 @@ func ExecObjectLayerAPITest(t *testing.T, objAPITest objAPITestType, endpoints [
 		t.Fatalf("Initialization of API handler tests failed: <ERROR> %s", err)
 	}
 
-	globalIAMSys = NewIAMSys()
-	globalIAMSys.Init(objLayer)
-
-	globalPolicySys = NewPolicySys()
-	globalPolicySys.Init(objLayer)
-
 	// initialize the server and obtain the credentials and root.
 	// credentials are necessary to sign the HTTP request.
 	if err = newTestConfig(globalMinioDefaultRegion, objLayer); err != nil {
 		t.Fatalf("Unable to initialize server config. %s", err)
 	}
+
+	globalIAMSys = NewIAMSys()
+	globalIAMSys.Init(objLayer)
+
+	globalPolicySys = NewPolicySys()
+	globalPolicySys.Init(objLayer)
 
 	credentials := globalServerConfig.GetCredential()
 

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -91,7 +91,7 @@ var errGroupNotEmpty = errors.New("Specified group is not empty - cannot remove 
 var errNoSuchPolicy = errors.New("Specified canned policy does not exist")
 
 // error returned in IAM subsystem when an external users systems is configured.
-var errIAMActionNotPossible = errors.New("Specified IAM action is not possible under the current configuration")
+var errIAMActionNotAllowed = errors.New("Specified IAM action is not allowed under the current configuration")
 
 // error returned when access is denied.
 var errAccessDenied = errors.New("Do not have enough permissions to access this resource")

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -90,5 +90,8 @@ var errGroupNotEmpty = errors.New("Specified group is not empty - cannot remove 
 // error returned in IAM subsystem when policy doesn't exist.
 var errNoSuchPolicy = errors.New("Specified canned policy does not exist")
 
+// error returned in IAM subsystem when an external users systems is configured.
+var errIAMActionNotPossible = errors.New("Specified IAM action is not possible under the current configuration")
+
 // error returned when access is denied.
 var errAccessDenied = errors.New("Do not have enough permissions to access this resource")

--- a/docs/sts/ldap.go
+++ b/docs/sts/ldap.go
@@ -1,0 +1,63 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main
+
+import (
+	"fmt"
+	"log"
+
+	miniogo "github.com/minio/minio-go"
+	cr "github.com/minio/minio-go/pkg/credentials"
+)
+
+var (
+	// LDAP integrated Minio endpoint
+	stsEndpoint = "http://localhost:9000"
+
+	// LDAP credentials
+	ldapUsername = "ldapuser"
+	ldapPassword = "ldapsecret"
+)
+
+func main() {
+
+	// If client machine is configured as a Kerberos client, just
+	// pass nil instead of `getKrbConfig()` below.
+	li, err := cr.NewLDAPIdentity(stsEndpoint, ldapUsername, ldapPassword)
+	if err != nil {
+		log.Fatalf("INIT Err: %v", err)
+	}
+
+	v, err := li.Get()
+	if err != nil {
+		log.Fatalf("GET Err: %v", err)
+	}
+	fmt.Printf("%#v\n", v)
+
+	minioClient, err := miniogo.NewWithCredentials("localhost:9000", li, false, "")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println("Calling list buckets with temp creds:")
+	b, err := minioClient.ListBuckets()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	fmt.Println(b)
+}

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -1,0 +1,92 @@
+# MinIO LDAP Integration
+
+MinIO provides a custom STS API that allows integration with LDAP
+based corporate environments. The flow is as follows:
+
+1. User provides their LDAP username and password to the STS API.
+2. MinIO logs-in to the LDAP server as the user - if the login
+   succeeds the user is authenticated.
+3. MinIO then queries the LDAP server for a list of groups that the
+   user is a member of.
+   - This is done via a customizable LDAP search query.
+4. MinIO then generates temporary credentials for the user storing the
+   list of groups in a cryptographically secure session token. The
+   temporary access key, secret key and session token are returned to
+   the user.
+5. The user can now use these credentials to make requests to the
+   MinIO server.
+
+The administrator will associate IAM access policies with each group
+and if required with the user too. The MinIO server then evaluates
+applicable policies on a user (these are the policies associated with
+the groups along with the policy on the user if any) to check if the
+request should be allowed or denied.
+
+## Configuring LDAP on MinIO
+
+LDAP configuration is designed to be simple for the MinIO
+administrator.
+
+The full path of a user DN (Distinguished Name)
+(e.g. `uid=johnwick,cn=users,cn=accounts,dc=minio,dc=io`) is
+configured as a format string in the
+**MINIO_IDENTITY_LDAP_USERNAME_FORMAT** environment variable. This
+allows an LDAP user to not specify this whole string in the LDAP STS
+API. Instead the user only needs to specify the username portion
+(i.e. `johnwick` in this example) that will be substituted into the
+format string configured on the server.
+
+MinIO can be configured to find the groups of a user from LDAP by
+specifying the **MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER** and
+**MINIO_IDENTITY_LDAP_GROUP_NAME_ATTRIBUTE** environment
+variables. When a user logs in via the STS API, the MinIO server
+queries the LDAP server with the given search filter and extracts the
+given attribute from the search results. These values represent the
+groups that the user is a member of. On each access MinIO applies the
+IAM policies attached to these groups in MinIO.
+
+LDAP is configured via the following environment variables:
+
+| Variable                                     | Required?                 | Purpose                                             |
+|----------------------------------------------|---------------------------|-----------------------------------------------------|
+| **MINIO_IDENTITY_LDAP_SERVER_ADDR**               | **YES**                   | LDAP server address                                 |
+| **MINIO_IDENTITY_LDAP_USERNAME_FORMAT**      | **YES**                   | Format of full username DN                          |
+| **MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN** | **NO**                    | Base DN in LDAP hierarchy to use in search requests |
+| **MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER**  | **NO**                    | Search filter to find groups of a user              |
+| **MINIO_IDENTITY_LDAP_GROUP_NAME_ATTRIBUTE** | **NO**                    | Attribute of search results to use as group name    |
+| **MINIO_IDENTITY_LDAP_STS_EXPIRY_DURATION**  | **NO** (default: "1h")    | STS credentials validity duration                   |
+| **MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY**      | **NO** (default: "false") | Disable TLS certificate verification                |
+
+Please note that MinIO will only access the LDAP server over TLS.
+
+An example setup for development or experimentation:
+
+``` shell
+export MINIO_IDENTITY_LDAP_SERVER_ADDR=myldapserver.com:636
+export MINIO_IDENTITY_LDAP_USERNAME_FORMAT="uid=${username},cn=accounts,dc=myldapserver,dc=com"
+export MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN="dc=myldapserver,dc=com"
+export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER="(&(objectclass=groupOfNames)(member=${usernamedn}))"
+export MINIO_IDENTITY_LDAP_GROUP_NAME_ATTRIBUTE="cn"
+export MINIO_IDENTITY_LDAP_STS_EXPIRY_DURATION=60
+export MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY=true
+```
+
+### Variable substitution in LDAP configuration strings
+
+In the configuration values described above, some values support
+runtime substitutions. The substitution syntax is simply
+`${variable}` - this substring is replaced with the (string) value of
+`variable`. The following substitutions will be available:
+
+| Variable     | Example Runtime Value                          | Description                                                                                                                                  |
+|--------------|------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| *username*   | "james"                                        | The LDAP username of a user.                                                                                                                 |
+| *usernamedn* | "uid=james,cn=accounts,dc=myldapserver,dc=com" | The LDAP username DN of a user. This is constructed from the LDAP user DN format string provided to the server and the actual LDAP username. |
+
+The **MINIO_IDENTITY_LDAP_USERNAME_FORMAT** environment variable
+supports substitution of the *username* variable only.
+
+The **MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER** and
+**MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN** environment variables
+support substitution of the *username* and *usernamedn* variables
+only.

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,8 @@ require (
 	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd
 	google.golang.org/api v0.4.0
 	gopkg.in/Shopify/sarama.v1 v1.20.0
+	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
+	gopkg.in/ldap.v3 v3.0.3
 	gopkg.in/olivere/elastic.v5 v5.0.80
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,6 @@ require (
 	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd
 	google.golang.org/api v0.4.0
 	gopkg.in/Shopify/sarama.v1 v1.20.0
-	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/ldap.v3 v3.0.3
 	gopkg.in/olivere/elastic.v5 v5.0.80
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -782,6 +782,7 @@ gopkg.in/Shopify/sarama.v1 v1.20.0 h1:DrCuMOhmuaUwb5o4aL9JJnW+whbEnuuL6AZ99ySMoQ
 gopkg.in/Shopify/sarama.v1 v1.20.0/go.mod h1:AxnvoaevB2nBjNK17cG61A3LleFcWFwVBHBt+cot4Oc=
 gopkg.in/VividCortex/ewma.v1 v1.1.1/go.mod h1:TekXuFipeiHWiAlO1+wSS23vTcyFau5u3rxXUSXj710=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d h1:TxyelI5cVkbREznMhfzycHdkp5cLA7DpE+GKjSslYhM=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
@@ -811,6 +812,8 @@ gopkg.in/jcmturner/gokrb5.v5 v5.3.0/go.mod h1:oQz8Wc5GsctOTgCVyKad1Vw4TCWz5G6gfI
 gopkg.in/jcmturner/rpc.v0 v0.0.2/go.mod h1:NzMq6cRzR9lipgw7WxRBHNx5N8SifBuaCQsOT1kWY/E=
 gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gopkg.in/ldap.v3 v3.0.3 h1:YKRHW/2sIl05JsCtx/5ZuUueFuJyoj/6+DGXe3wp6ro=
+gopkg.in/ldap.v3 v3.0.3/go.mod h1:oxD7NyBuxchC+SgJDE1Q5Od05eGt29SDQVBmV+HYbzw=
 gopkg.in/mattn/go-colorable.v0 v0.1.0/go.mod h1:BVJlBXzARQxdi3nZo6f6bnl5yR20/tOL6p+V0KejgSY=
 gopkg.in/mattn/go-isatty.v0 v0.0.4/go.mod h1:wt691ab7g0X4ilKZNmMII3egK0bTxl37fEn/Fwbd8gc=
 gopkg.in/mattn/go-runewidth.v0 v0.0.4/go.mod h1:BmXejnxvhwdaATwiJbB1vZ2dtXkQKZGu9yLFCZb4msQ=


### PR DESCRIPTION
## Description

Add LDAP based users-groups system

This change adds support to integrate an LDAP server for user
authentication. This works via a custom STS API for LDAP. Each user
accessing the MinIO who can be authenticated via LDAP receives
temporary credentials to access the MinIO server.

LDAP is enabled only over TLS.

User groups are also supported via LDAP. The administrator may
configure an LDAP search query to find the group attribute of a user -
this may correspond to any attribute in the LDAP tree (that the user
has access to view). One or more groups may be returned by such a
query.

A group is mapped to an IAM policy in the usual way, and the server
enforces a policy corresponding to all the groups and the user's own
mapped policy.

When LDAP is configured, the internal MinIO users system is disabled.


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
