### PR TITLE
  Add function to fetch etcd ,log and audit info

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -47,8 +47,11 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 	// Update MinIO servers.
 	adminV1Router.Methods(http.MethodPost).Path("/update").HandlerFunc(httpTraceAll(adminAPI.ServerUpdateHandler)).Queries("updateURL", "{updateURL:.*}")
 
-	// Info operations
+	// Info operations - return details based on input type
 	adminV1Router.Methods(http.MethodGet).Path("/info").HandlerFunc(httpTraceAll(adminAPI.ServerInfoHandler))
+
+	// Server Info operations - return details based on input type
+	adminV1Router.Methods(http.MethodGet).Path("/serviceinfo").HandlerFunc(httpTraceAll(adminAPI.ServiceInfoHandler)).Queries("info", "{info:.*}")
 
 	if globalIsDistXL || globalIsXL {
 		/// Heal operations

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -161,6 +161,10 @@ const (
 	ErrKMSNotConfigured
 	ErrKMSAuthFailure
 
+	ErrETCDNotConfigured
+	ErrHTTPLogNotConfigured
+	ErrAuditLogNotConfigured
+	ErrLambdaNotConfigured
 	ErrNoAccessKey
 	ErrInvalidToken
 
@@ -866,6 +870,26 @@ var errorCodes = errorCodeMap{
 		Code:           "InvalidTokenId",
 		Description:    "The security token included in the request is invalid",
 		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrETCDNotConfigured: {
+		Code:           "InvalidArgument",
+		Description:    "ETCD is not configured",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrHTTPLogNotConfigured: {
+		Code:           "InvalidArgument",
+		Description:    "HTTTP log endpoint not configured",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrAuditLogNotConfigured: {
+		Code:           "InvalidArgument",
+		Description:    "HTTP audit log is not configured",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrLambdaNotConfigured: {
+		Code:           "InvalidArgument",
+		Description:    "Notification target is not configured",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 
 	/// S3 extensions.

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -74,6 +74,17 @@ const (
 	// vault namespace. The vault namespace is used if the enterprise
 	// version of Hashicorp Vault is used.
 	EnvVaultNamespace = "MINIO_SSE_VAULT_NAMESPACE"
+
+	// EnvMinioDomain indicates the domain suffix for the bucket which
+	// will be used to resolve bucket through DNS.
+	EnvMinioDomain = "MINIO_DOMAIN"
+
+	// EnvLoggerHTTPEndpoint is the environment variable for HTTP target logging,
+	// this setting will override the endpoint settings in the MinIO server config.
+	EnvLoggerHTTPEndpoint = "MINIO_LOGGER_HTTP_ENDPOINT"
+
+	// EnvAuditLoggerHTTPEndpoint is the environment variable for Audit log.
+	EnvAuditLoggerHTTPEndpoint = "MINIO_AUDIT_LOGGER_HTTP_ENDPOINT"
 )
 
 // Environment provides functions for accessing environment

--- a/cmd/peer-rest-client-target.go
+++ b/cmd/peer-rest-client-target.go
@@ -31,6 +31,16 @@ func (target *PeerRESTClientTarget) ID() event.TargetID {
 	return target.id
 }
 
+// IsActive - does nothing and available for interface compatibility.
+func (target *PeerRESTClientTarget) IsActive() (bool, error) {
+	return true, nil
+}
+
+// MarshalJSON - interface compatible method does no-op.
+func (target *PeerRESTClientTarget) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
 // Save - Sends event directly without persisting.
 func (target *PeerRESTClientTarget) Save(eventData event.Event) error {
 	return target.send(eventData)

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/rjeczalik/notify v0.9.2
 	github.com/rs/cors v1.6.0
+	github.com/shirou/gopsutil v2.18.12+incompatible // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/skyrings/skyring-common v0.0.0-20160929130248-d1c0bb1cbd5e
 	github.com/streadway/amqp v0.0.0-20190402114354-16ed540749f6

--- a/go.sum
+++ b/go.sum
@@ -571,6 +571,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/go-prompt v0.0.0-20161017233205-f0d19b6901ad/go.mod h1:B3ehdD1xPoWDKgrQgUaGk+m8H1xb1J5TyYDfKpKNeEE=
 github.com/segmentio/go-prompt v1.2.1-0.20161017233205-f0d19b6901ad/go.mod h1:B3ehdD1xPoWDKgrQgUaGk+m8H1xb1J5TyYDfKpKNeEE=
+github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
+github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/event/target/amqp.go
+++ b/pkg/event/target/amqp.go
@@ -84,6 +84,23 @@ func (target *AMQPTarget) ID() event.TargetID {
 	return target.id
 }
 
+// IsActive - Return true if target is up and active
+func (target *AMQPTarget) IsActive() (bool, error) {
+	ch, err := target.channel()
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		ch.Close()
+	}()
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *AMQPTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
+}
+
 func (target *AMQPTarget) channel() (*amqp.Channel, error) {
 	var err error
 	var conn *amqp.Connection

--- a/pkg/event/target/elasticsearch.go
+++ b/pkg/event/target/elasticsearch.go
@@ -18,6 +18,7 @@ package target
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -75,6 +76,22 @@ type ElasticsearchTarget struct {
 // ID - returns target ID.
 func (target *ElasticsearchTarget) ID() event.TargetID {
 	return target.id
+}
+
+// IsActive - Return true if target is up and active
+func (target *ElasticsearchTarget) IsActive() (bool, error) {
+	if dErr := target.args.URL.DialHTTP(); dErr != nil {
+		if xnet.IsNetworkOrHostDown(dErr) {
+			return false, errNotConnected
+		}
+		return false, dErr
+	}
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *ElasticsearchTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
 }
 
 // Save - saves the events to the store if queuestore is configured, which will be replayed when the elasticsearch connection is active.

--- a/pkg/event/target/httpclient.go
+++ b/pkg/event/target/httpclient.go
@@ -44,6 +44,10 @@ func (target HTTPClientTarget) ID() event.TargetID {
 	return target.id
 }
 
+// MarshalJSON - interface compatible method does no-op.
+func (target *HTTPClientTarget) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
 func (target *HTTPClientTarget) start() {
 	go func() {
 		defer func() {

--- a/pkg/event/target/kafka.go
+++ b/pkg/event/target/kafka.go
@@ -90,6 +90,19 @@ func (target *KafkaTarget) ID() event.TargetID {
 	return target.id
 }
 
+// IsActive - Return true if target is up and active
+func (target *KafkaTarget) IsActive() (bool, error) {
+	if !target.args.pingBrokers() {
+		return false, errNotConnected
+	}
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *KafkaTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
+}
+
 // Save - saves the events to the store which will be replayed when the Kafka connection is active.
 func (target *KafkaTarget) Save(eventData event.Event) error {
 	if target.store != nil {

--- a/pkg/event/target/mqtt.go
+++ b/pkg/event/target/mqtt.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/minio/minio/pkg/event"
 	xnet "github.com/minio/minio/pkg/net"
 )
@@ -91,6 +91,20 @@ type MQTTTarget struct {
 // ID - returns target ID.
 func (target *MQTTTarget) ID() event.TargetID {
 	return target.id
+}
+
+// IsActive - Return true if target is up and active
+func (target *MQTTTarget) IsActive() (bool, error) {
+	// Do not send if the connection is not active.
+	if !target.client.IsConnectionOpen() {
+		return false, errNotConnected
+	}
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *MQTTTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
 }
 
 // send - sends an event to the mqtt.

--- a/pkg/event/target/mysql.go
+++ b/pkg/event/target/mysql.go
@@ -158,6 +158,22 @@ func (target *MySQLTarget) ID() event.TargetID {
 	return target.id
 }
 
+// IsActive - Return true if target is up and active
+func (target *MySQLTarget) IsActive() (bool, error) {
+	if err := target.db.Ping(); err != nil {
+		if IsConnErr(err) {
+			return false, errNotConnected
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *MySQLTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
+}
+
 // Save - saves the events to the store which will be replayed when the SQL connection is active.
 func (target *MySQLTarget) Save(eventData event.Event) error {
 	if target.store != nil {

--- a/pkg/event/target/nsq.go
+++ b/pkg/event/target/nsq.go
@@ -81,6 +81,23 @@ func (target *NSQTarget) ID() event.TargetID {
 	return target.id
 }
 
+// IsActive - Return true if target is up and active
+func (target *NSQTarget) IsActive() (bool, error) {
+	if err := target.producer.Ping(); err != nil {
+		// To treat "connection refused" errors as errNotConnected.
+		if IsConnRefusedErr(err) {
+			return false, errNotConnected
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *NSQTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
+}
+
 // Save - saves the events to the store which will be replayed when the nsq connection is active.
 func (target *NSQTarget) Save(eventData event.Event) error {
 	if target.store != nil {

--- a/pkg/event/target/postgresql.go
+++ b/pkg/event/target/postgresql.go
@@ -156,6 +156,27 @@ func (target *PostgreSQLTarget) ID() event.TargetID {
 	return target.id
 }
 
+// IsActive - Return true if target is up and active
+func (target *HTTPClientTarget) IsActive() (bool, error) {
+	return false, errNotConnected
+}
+
+// IsActive - Return true if target is up and active
+func (target *PostgreSQLTarget) IsActive() (bool, error) {
+	if err := target.db.Ping(); err != nil {
+		if IsConnErr(err) {
+			return false, errNotConnected
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *PostgreSQLTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
+}
+
 // Save - saves the events to the store if questore is configured, which will be replayed when the PostgreSQL connection is active.
 func (target *PostgreSQLTarget) Save(eventData event.Event) error {
 	if target.store != nil {

--- a/pkg/event/target/redis.go
+++ b/pkg/event/target/redis.go
@@ -107,6 +107,27 @@ func (target *RedisTarget) ID() event.TargetID {
 	return target.id
 }
 
+// IsActive - Return true if target is up and active
+func (target *RedisTarget) IsActive() (bool, error) {
+	conn := target.pool.Get()
+	defer func() {
+		conn.Close()
+	}()
+	_, pingErr := conn.Do("PING")
+	if pingErr != nil {
+		if IsConnRefusedErr(pingErr) {
+			return false, errNotConnected
+		}
+		return false, pingErr
+	}
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *RedisTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
+}
+
 // Save - saves the events to the store if questore is configured, which will be replayed when the redis connection is active.
 func (target *RedisTarget) Save(eventData event.Event) error {
 	if target.store != nil {

--- a/pkg/event/target/webhook.go
+++ b/pkg/event/target/webhook.go
@@ -77,6 +77,26 @@ func (target WebhookTarget) ID() event.TargetID {
 	return target.id
 }
 
+// IsActive - Return true if target is up and active
+func (target *WebhookTarget) IsActive() (bool, error) {
+	u, pErr := xnet.ParseURL(target.args.Endpoint.String())
+	if pErr != nil {
+		return false, pErr
+	}
+	if dErr := u.DialHTTP(); dErr != nil {
+		if xnet.IsNetworkOrHostDown(dErr) {
+			return false, errNotConnected
+		}
+		return false, dErr
+	}
+	return true, nil
+}
+
+// MarshalJSON - converts target arguments into JSON data.
+func (target *WebhookTarget) MarshalJSON() ([]byte, error) {
+	return json.Marshal(target.args)
+}
+
 // Save - saves the events to the store if queuestore is configured, which will be replayed when the wenhook connection is active.
 func (target *WebhookTarget) Save(eventData event.Event) error {
 	if target.store != nil {

--- a/pkg/event/targetlist.go
+++ b/pkg/event/targetlist.go
@@ -24,9 +24,11 @@ import (
 // Target - event target interface
 type Target interface {
 	ID() TargetID
+	IsActive() (bool, error)
 	Save(Event) error
 	Send(string) error
 	Close() error
+	MarshalJSON() ([]byte, error)
 }
 
 // TargetList - holds list of targets indexed by target ID.
@@ -149,4 +151,20 @@ func (list *TargetList) Send(event Event, targetIDs ...TargetID) <-chan TargetID
 // NewTargetList - creates TargetList.
 func NewTargetList() *TargetList {
 	return &TargetList{targets: make(map[TargetID]Target)}
+}
+
+// Status return status of target
+func (list *TargetList) Status(id TargetID) (bool, error) {
+	var status bool
+	var err error
+	target, ok := list.targets[id]
+	if ok {
+		status, err = target.IsActive()
+	}
+	return status, err
+}
+
+// TargetList list of target
+func (list *TargetList) TargetList() map[TargetID]Target {
+	return list.targets
 }

--- a/pkg/event/targetlist_test.go
+++ b/pkg/event/targetlist_test.go
@@ -39,6 +39,11 @@ func (target ExampleTarget) Save(eventData Event) error {
 	return target.send(eventData)
 }
 
+// MarshalJSON - interface compatible method does no-op.
+func (target ExampleTarget) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
 func (target ExampleTarget) send(eventData Event) error {
 	b := make([]byte, 1)
 	if _, err := rand.Read(b); err != nil {
@@ -67,6 +72,9 @@ func (target ExampleTarget) Close() error {
 	return nil
 }
 
+func (target ExampleTarget) IsActive() (bool, error) {
+	return false, errors.New("not connected to target server/service")
+}
 func TestTargetListAdd(t *testing.T) {
 	targetListCase1 := NewTargetList()
 

--- a/pkg/madmin/README.md
+++ b/pkg/madmin/README.md
@@ -49,6 +49,10 @@ func main() {
 |                                     | [`ServerMemUsageInfo`](#ServerMemUsageInfo)     |                    |                           |                         | [`ListUsers`](#ListUsers)             | [`DownloadProfilingData`](#DownloadProfilingData) |                                 |
 | [`ServiceTrace`](#ServiceTrace)     | [`ServerDrivesPerfInfo`](#ServerDrivesPerfInfo) |                    |                           |                         | [`AddCannedPolicy`](#AddCannedPolicy) | [`ServerUpdate`](#ServerUpdate)                   |                                 |
 |                                     | [`NetPerfInfo`](#NetPerfInfo)                   |                    |                           |                         |                                       |                                                   |                                 |
+|                                     | [`ServerETCDInfo`](#ServerETCDInfo)             |                    |                           |                         |                                       |                                                   |                                 |
+|                                     | [`ServerLoggerInfo`](#ServerLoggerInfo)         |                    |                           |                         |                                       |                                                   |                                 |
+|                                     | [`ServerAuditInfo`](#ServerAuditInfo)           |                    |                           |                         |                                       |                                                   |                                 |
+|                                     | [`ServerLambdaInfo`](#ServerLambdaInfo)         |                    |                           |                         |                                       |                                                   |                                 |
 
 ## 1. Constructor
 <a name="MinIO"></a>
@@ -286,7 +290,52 @@ Fetches network performance of all cluster nodes using given sized payload. Retu
 | `Error`    | _string_         | Errors (if any) encountered while reaching this node               |
 | `ReadPerf` | _time.Duration_  | Network read performance of the server                             |
 
-## 5. Heal operations
+<a name="ServerETCDInfo"></a>
+### ServerETCDInfo() (ServerETCDInfo, error)
+
+Fetches etcd info of the server.
+
+| Param             | Type        | Description                                                         |
+|-------------------|-------------|---------------------------------------------------------------------|
+| `ei.ETCDEndpoint` | _[]string_  | List of etcd servers that is used as the MinIO federation back-end. |
+| `ei.Domain`       | _string_    | Domain name used for the federated setup.                           |
+| `ei.PublicIPs`    | _string_    | The list of IP addresses to which buckets created on MinIO.         |
+| `ei.Error`        | _[]string_  | Error (if any) encountered while accesing etcd server.              |
+
+<a name="ServerLoggerInfo"></a>
+### ServerLoggerInfo() (ServerLoggerInfo, error)
+
+Fetches information of HTTP log endpoint of the server.
+
+| Param             | Type        | Description                                                         |
+|-------------------|-------------|---------------------------------------------------------------------|
+| `li.EndPoint`     | _string_    | Http log endpoint.                                                  |
+| `li.Success`      |  _bool_     | True, if HTTP log endpoint is up and active.                        |
+| `li.Error`        | _string_    | Error (if any) encountered while accesing log server.               |
+
+<a name="ServerAuditInfo"></a>
+### ServerAuditInfo() (ServerAuditInfo, error)
+
+Fetches information of HTTP audit log endpoint of server.
+
+| Param             | Type        | Description                                                         |
+|-------------------|-------------|---------------------------------------------------------------------|
+| `ai.EndPoint`     | _string_    | Http log endpoint for audit log.                                    |
+| `ai.Success`      |  _bool_     | True, if HTTP log endpoint for audit log is up and active.          |
+| `ai.Error`        | _string_    | Error (if any) encountered while accesing audit log server.         |
+
+<a name="ServerLambdaInfo"></a>
+### ServerLambdaInfo() ([]TargetInfo, error)
+
+Fetches lambda info of the server.
+
+| Param             | Type                       | Description                                          |
+|-------------------|----------------------|------------------------------------------------------------|
+| `sl.ID`           |  _event.TargetID_    | Identification and name of notification target.            |
+| `sl.Config`       |  _string_            | Target arguments.                                          |
+| `sl.Error`        |  _string_            | Error (if any) encountered while accesing lambda endpoint. |
+
+## 4. Heal operations
 
 <a name="Heal"></a>
 ### Heal(bucket, prefix string, healOpts HealOpts, clientToken string, forceStart bool, forceStop bool) (start HealStartSuccess, status HealTaskStatus, err error)
@@ -351,7 +400,7 @@ __Example__
 | `DiskInfo.AvailableOn` | _[]int_        | List of disks on which the healed entity is present and healthy |
 | `DiskInfo.HealedOn`    | _[]int_        | List of disks on which the healed entity was restored           |
 
-## 6. Config operations
+## 5. Config operations
 
 <a name="GetConfig"></a>
 ### GetConfig() ([]byte, error)
@@ -389,8 +438,7 @@ __Example__
     }
     log.Println("SetConfig was successful")
 ```
-
-## 7. Top operations
+## 6. Top operations
 
 <a name="TopLocks"></a>
 ### TopLocks() (LockEntries, error)
@@ -412,7 +460,7 @@ __Example__
     log.Println("TopLocks received successfully: ", string(out))
 ```
 
-## 8. IAM operations
+## 7. IAM operations
 
 <a name="AddCannedPolicy"></a>
 ### AddCannedPolicy(policyName string, policy string) error
@@ -468,7 +516,7 @@ __Example__
     }
 ```
 
-## 9. Misc operations
+## 8. Misc operations
 
 <a name="ServerUpdate"></a>
 ### ServerUpdate(updateURL string) (ServerUpdateStatus, error)

--- a/pkg/madmin/examples/audit-info.go
+++ b/pkg/madmin/examples/audit-info.go
@@ -1,0 +1,44 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	auditInfo, err := madmClnt.ServerAuditInfo()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(auditInfo)
+}

--- a/pkg/madmin/examples/etcd-info.go
+++ b/pkg/madmin/examples/etcd-info.go
@@ -1,0 +1,44 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	etcdInfo, err := madmClnt.ServerETCDInfo()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(etcdInfo)
+}

--- a/pkg/madmin/examples/lambda-info.go
+++ b/pkg/madmin/examples/lambda-info.go
@@ -1,0 +1,44 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	lambdaInfo, err := madmClnt.ServerLambdaInfo()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(lambdaInfo)
+}

--- a/pkg/madmin/examples/logger-info.go
+++ b/pkg/madmin/examples/logger-info.go
@@ -1,0 +1,44 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	logInfo, err := madmClnt.ServerLoggerInfo()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(logInfo)
+}


### PR DESCRIPTION
## Description
1. Added a method `ServerETCDInfo` to fetch the etcd info.
1. Added a method `ServerLoggerInfo` to fetch HTTP Log endpoint info.
1. Added a method `ServerAuditInfo` to fetch the audit endpoint info.


## Motivation and Context
`mc` will display the etcd info.

## How to test this PR?
Run 
1. `etcd-info.go`
2. `logger-info.go`
3. `audit-info.go`



## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [X] Documentation needed
- [X] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )