### PR TITLE
Convert errAuthentication as AccessDenied appropriately

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1526,6 +1526,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrEntityTooLarge
 	case errDataTooSmall:
 		apiErr = ErrEntityTooSmall
+	case errAuthentication:
+		apiErr = ErrAccessDenied
 	case auth.ErrInvalidAccessKeyLength:
 		apiErr = ErrAdminInvalidAccessKey
 	case auth.ErrInvalidSecretKeyLength:


### PR DESCRIPTION

## Description
Convert errAuthentication as AccessDenied appropriately

## Motivation and Context
Fixes #8062


## How to test this PR?
Just authenticate with wso2 using client_grants - without using OPA and use the generated tokens with `aws cli` - should generate the error as shown in #8062 

This PR simply converts that to `ErrAccessDenied` as an appropriate error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression It does look like one, but not sure when. 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
