### PR TITLE
Remove go mod cache due to buggy travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,7 @@ matrix:
         - CGO_ENABLED=0
         - GO111MODULE=on
         - GOPROXY=https://proxy.golang.org
-      # Enable build cache
-      # https://restic.net/blog/2018-09-02/travis-build-cache
-      cache:
-       directories:
-         - $HOME/.cache/go-build
-         - $HOME/gopath/pkg/mod
-         - $HOME/go/pkg/mod
-
-      go: 1.12.5
+      go: 1.12.x
       script:
         - make
         - diff -au <(gofmt -s -d cmd) <(printf "")
@@ -54,7 +46,7 @@ matrix:
         - CGO_ENABLED=0
         - GO111MODULE=on
         - GOPROXY=https://proxy.golang.org
-      go: 1.12.5
+      go: 1.12.x
       script:
         - go build --ldflags="$(go run buildscripts/gen-ldflags.go)" -o %GOPATH%\bin\minio.exe
         - bash buildscripts/go-coverage.sh


### PR DESCRIPTION


## Description
Remove go mod cache due to buggy travis caching

## Motivation and Context
There are sporadic failures due to go-mod build
caches on travis, deprecate it since we moved to
using GOPROXY.

## How to test this PR?
Nothing to test really, just removing a feature which we used in travis

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
