### PR TITLE
Update doc with Object Tagging not supported

### DIFF
--- a/docs/minio-limits.md
+++ b/docs/minio-limits.md
@@ -52,6 +52,7 @@ We found the following APIs to be redundant or less useful outside of AWS S3. If
 - ObjectACL (Use [bucket policies](https://docs.min.io/docs/minio-client-complete-guide#policy) instead)
 - ObjectTorrent
 - ObjectVersions
+- ObjectTagging
 
 ### Object name restrictions on MinIO
 Object names that contain characters `^*|\/&";` are unsupported on Windows and other file systems which do not support filenames with these characters. Note that this list is not exhaustive, and depends on the maintainers of the filesystem itself.


### PR DESCRIPTION
## Description
Added Object Tagging to the list of Object Operations not supported.

## Motivation and Context
Customer requested this to be added to the documentation.

## How to test this PR?
Visually by looking at preview.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [X] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
