### PR TITLE
Avoid terminating browser federation prematurely

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -658,7 +658,7 @@ func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	// For browser requests, when federation is setup we need to
-	// specifically handle download and upload for browser requests.
+	// specifically handle download and upload of objects.
 	if guessIsBrowserReq(r) && globalDNSConfig != nil && len(globalDomainNames) > 0 {
 		var bucket, _ string
 		switch r.Method {
@@ -697,6 +697,9 @@ func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			f.fwd.ServeHTTP(w, r)
 			return
 		}
+		// No conditions are valid, let the current server handle
+		// the request and fail appropriately if possible.
+		f.handler.ServeHTTP(w, r)
 		return
 	}
 


### PR DESCRIPTION


## Description
Avoid terminating browser federation prematurely

## Motivation and Context
Let the request be handled upwards when all checks
fail, rather than failing prematurely for a
browser-based federated setup.

## How to test this PR?
There is no easy way as it may not happen, but its a defensive code to
avoid silent bugs. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
