### PR TITLE
cache - fix corruption when client prematurely

### DIFF
--- a/cmd/disk-cache-backend.go
+++ b/cmd/disk-cache-backend.go
@@ -396,18 +396,19 @@ func (c *diskCache) bitrotWriteToCache(ctx context.Context, cachePath string, re
 	bufp := c.pool.Get().(*[]byte)
 	defer c.pool.Put(bufp)
 
+	var n int
 	for {
-		n, err := io.ReadFull(reader, *bufp)
-		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF && err != io.ErrClosedPipe {
+		n, err = io.ReadFull(reader, *bufp)
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 			return 0, err
 		}
-		eof := err == io.EOF || err == io.ErrUnexpectedEOF || err == io.ErrClosedPipe
+		eof := err == io.EOF || err == io.ErrUnexpectedEOF
 		if n == 0 && size != 0 {
 			// Reached EOF, nothing more to be done.
 			break
 		}
 		h.Reset()
-		if _, err := h.Write((*bufp)[:n]); err != nil {
+		if _, err = h.Write((*bufp)[:n]); err != nil {
 			return 0, err
 		}
 		hashBytes := h.Sum(nil)
@@ -500,7 +501,9 @@ func (c *diskCache) Put(ctx context.Context, bucket, object string, data io.Read
 	if err != nil {
 		return err
 	}
-
+	if actualSize != uint64(n) {
+		return IncompleteBody{}
+	}
 	return c.saveMetadata(ctx, bucket, object, metadata, n)
 }
 

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -237,7 +237,7 @@ func (c *cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 		pipeWriter.CloseWithError(putErr)
 	}()
 	cleanupBackend := func() { bkReader.Close() }
-	cleanupPipe := func() { pipeReader.Close() }
+	cleanupPipe := func() { pipeWriter.Close() }
 	return NewGetObjectReaderFromReader(teeReader, bkReader.ObjInfo, opts.CheckCopyPrecondFn, cleanupBackend, cleanupPipe)
 }
 


### PR DESCRIPTION
terminates request

Fixes #8130

## Description
err variable was being shadowed in cache bitrot write resulting in cache.json metadata creation even when the data was not fully written to cache. Make sure to cascade error correctly

## Motivation and Context


## How to test this PR?
see steps in the issue. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
