### PR TITLE
Avoid error modification during IAM migration

### DIFF
--- a/cmd/iam-etcd-store.go
+++ b/cmd/iam-etcd-store.go
@@ -213,7 +213,7 @@ func (ies *IAMEtcdStore) migrateToV1() error {
 		case errConfigNotFound:
 			// Need to migrate to V1.
 		default:
-			return errors.New("corrupt IAM format file")
+			return err
 		}
 	} else {
 		if iamFmt.Version >= iamFormatVersion1 {

--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -127,8 +127,8 @@ func (iamOS *IAMObjectStore) migrateUsersConfigToV1(isSTS bool) error {
 		identityPath := pathJoin(basePrefix, user, iamIdentityFile)
 		var cred auth.Credentials
 		if err := iamOS.loadIAMConfig(&cred, identityPath); err != nil {
-			switch err.(type) {
-			case ObjectNotFound:
+			switch err {
+			case errConfigNotFound:
 				// This should not happen.
 			default:
 				// File may be corrupt or network error
@@ -169,7 +169,7 @@ func (iamOS *IAMObjectStore) migrateToV1() error {
 		case errConfigNotFound:
 			// Need to migrate to V1.
 		default:
-			return errors.New("corrupt IAM format file")
+			return err
 		}
 	} else {
 		if iamFmt.Version >= iamFormatVersion1 {

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -101,6 +101,7 @@ func getDisksInfo(disks []StorageAPI) (disksInfo []DiskInfo, onlineDisks int, of
 	for _, err := range errs {
 		if err != nil {
 			offlineDisks++
+			continue
 		}
 		onlineDisks++
 	}


### PR DESCRIPTION

## Description
Avoid error modification during IAM migration

## Motivation and Context
The underlying errors are important, for IAM
requirements and should wait appropriately at
the caller level, this allows for distributed
setups to run properly and not fail prematurely
during startup.

Also additionally fix the onlineDisk counting


## How to test this PR?
To reproduce this issue, it requires a larger multi-disk setup where users are being
migrated from a previous format and previous releases. Easy to reproduce.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) In a way yes, has been there since 5d2b5ee6a9ddbd29cbc9175d9f842f4413a60594
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
