### PR TITLE
mint: turn off progress for awscli sync test

### DIFF
--- a/mint/build/awscli/install.sh
+++ b/mint/build/awscli/install.sh
@@ -15,6 +15,6 @@
 #  limitations under the License.
 #
 
-AWS_CLI_VERSION="1.11.112"
+AWS_CLI_VERSION="1.11.177"
 
 python -m pip install awscli==$AWS_CLI_VERSION

--- a/mint/run/core/awscli/test.sh
+++ b/mint/run/core/awscli/test.sh
@@ -863,7 +863,7 @@ function test_aws_s3_sync() {
 
     # if make bucket succeeds sync all the files in a directory
     if [ $rv -eq 0 ]; then
-        function="${AWS} s3 sync $MINT_DATA_DIR s3://${bucket_name}/"
+        function="${AWS} s3 sync --no-progress $MINT_DATA_DIR s3://${bucket_name}/"
         test_function=${function}
         out=$($function 2>&1)
         rv=$?


### PR DESCRIPTION
## Description


## Motivation and Context

Mint test output on travis can be more readable if aws s3 sync runs with --no-progress 
## How to test this PR?

see travis output of this PR
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
