### PR TITLE
fix `DownloadZIP` for encrypted objects

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -1316,17 +1316,6 @@ func (web *webAPIHandlers) DownloadZip(w http.ResponseWriter, r *http.Request) {
 
 			info := gr.ObjInfo
 
-			length = info.Size
-			if objectAPI.IsEncryptionSupported() {
-				if _, err = DecryptObjectInfo(&info, r.Header); err != nil {
-					writeWebErrorResponse(w, err)
-					return err
-				}
-				if crypto.IsEncrypted(info.UserDefined) {
-					length, _ = info.DecryptedSize()
-				}
-			}
-			length = info.Size
 			var actualSize int64
 			if info.IsCompressed() {
 				// Read the decompressed size from the meta.json.
@@ -1345,21 +1334,16 @@ func (web *webAPIHandlers) DownloadZip(w http.ResponseWriter, r *http.Request) {
 				writeWebErrorResponse(w, errUnexpected)
 				return err
 			}
-			var startOffset int64
 			var writer io.Writer
 
 			if info.IsCompressed() {
-				// The decompress metrics are set.
-				snappyStartOffset := 0
-				snappyLength := actualSize
-
 				// Open a pipe for compression
 				// Where compressWriter is actually passed to the getObject
 				decompressReader, compressWriter := io.Pipe()
 				snappyReader := snappy.NewReader(decompressReader)
 
 				// The limit is set to the actual size.
-				responseWriter := ioutil.LimitedWriter(zipWriter, int64(snappyStartOffset), snappyLength)
+				responseWriter := ioutil.LimitedWriter(zipWriter, 0, actualSize)
 				wg.Add(1) //For closures.
 				go func() {
 					defer wg.Done()
@@ -1373,17 +1357,6 @@ func (web *webAPIHandlers) DownloadZip(w http.ResponseWriter, r *http.Request) {
 				writer = compressWriter
 			} else {
 				writer = zipWriter
-			}
-			if objectAPI.IsEncryptionSupported() && crypto.S3.IsEncrypted(info.UserDefined) {
-				// Response writer should be limited early on for decryption upto required length,
-				// additionally also skipping mod(offset)64KiB boundaries.
-				writer = ioutil.LimitedWriter(writer, startOffset%(64*1024), length)
-				writer, _, length, err = DecryptBlocksRequest(writer, r,
-					args.BucketName, objectName, startOffset, length, info, false)
-				if err != nil {
-					writeWebErrorResponse(w, err)
-					return err
-				}
 			}
 			httpWriter := ioutil.WriteOnClose(writer)
 


### PR DESCRIPTION
## Description
This commit fixes the web ZIP download handler for
encrypted objects. The decryption logic has moved into
`getObjectNInfo`. So trying to decrypt the (already decrypted)
content again in the ZIP handler obviously causes an error.

This commit fixes this by removing the decryption logic from the
the handler.

## Motivation and Context
Fixes #7965

## How to test this PR?
1. `export MINIO_ACCESS_KEY=minio`
2. `export MINIO_SECRET_KEY = minio123`
3. `export MINIO_SSE_MASTER_KEY=my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574`
4. `export MINIO_SSE_AUTO_ENCRYPTION=on`
5. `minio server /tmp/1`
6. `mc config host add local http://127.1:9000 minio minio123`
7. `mc mb local/test`
8. `mc cp ~/<some-dir>/* local/test/<some-dir>`
9. Open `http://127.1:9000` in the browser, go to the `test` bucket and download the entire
    object prefix `<some-dir>`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression: Introduced by `36e51d0ceef2c91e692637c54a266d3c0fad3130`.
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
