### PR TITLE
friendly message for s3select MalformedXML error

### DIFF
--- a/pkg/s3select/errors.go
+++ b/pkg/s3select/errors.go
@@ -56,7 +56,7 @@ func (err *s3Error) Error() string {
 func errMalformedXML(err error) *s3Error {
 	return &s3Error{
 		code:       "MalformedXML",
-		message:    "The XML provided was not well-formed or did not validate against our published schema. Check the service documentation and try again.",
+		message:    "The XML provided was not well-formed or did not validate against our published schema. Check the service documentation and try again: " + err.Error(),
 		statusCode: 400,
 		cause:      err,
 	}


### PR DESCRIPTION
partly fix #7911

## Description

more friendly prompt for s3select MalformedXML  error

## Motivation and Context

more friendly prompt for s3select MalformedXML  error

## How to test this PR?

before:

```xml
<Message>The XML provided was not well-formed or did not validate against our published schema. Check the service documentation and try again.</Message>
```

after 
```xml
<Message>The XML provided was not well-formed or did not validate against our published schema. Check the service documentation and try again: flag AllowQuotedRecordDelimiter is unsupported at the moment</Message>
```




## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
