### PR TITLE
Return 200 OK for liveness checks while distributed cluster starts

### DIFF
--- a/cmd/http/headers.go
+++ b/cmd/http/headers.go
@@ -78,4 +78,7 @@ const (
 
 	// Deployment id.
 	MinioDeploymentID = "x-minio-deployment-id"
+
+	// Server-Status
+	MinIOServerStatus = "x-minio-server-status"
 )

--- a/docs/orchestration/docker-compose/docker-compose.yaml
+++ b/docs/orchestration/docker-compose/docker-compose.yaml
@@ -16,11 +16,10 @@ services:
       MINIO_SECRET_KEY: minio123
     command: server http://minio{1...4}/data{1...2}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio1:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio2:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -34,11 +33,10 @@ services:
       MINIO_SECRET_KEY: minio123
     command: server http://minio{1...4}/data{1...2}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio2:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio3:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -52,11 +50,10 @@ services:
       MINIO_SECRET_KEY: minio123
     command: server http://minio{1...4}/data{1...2}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio3:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio4:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -70,11 +67,10 @@ services:
       MINIO_SECRET_KEY: minio123
     command: server http://minio{1...4}/data{1...2}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio4:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
 ## By default this config uses default local driver,
 ## For custom volumes replace with volume driver configuration.

--- a/docs/orchestration/docker-swarm/docker-compose-secrets.yaml
+++ b/docs/orchestration/docker-swarm/docker-compose-secrets.yaml
@@ -18,16 +18,15 @@ services:
       placement:
         constraints:
           - node.labels.minio1==true
-    command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
+    command: server http://minio{1...4}/export
     secrets:
       - secret_key
       - access_key
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio1:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio2:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -46,16 +45,15 @@ services:
       placement:
         constraints:
           - node.labels.minio2==true
-    command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
+    command: server http://minio{1...4}/export
     secrets:
       - secret_key
       - access_key
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio2:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio3:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -74,16 +72,15 @@ services:
       placement:
         constraints:
           - node.labels.minio3==true
-    command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
+    command: server http://minio{1...4}/export
     secrets:
       - secret_key
       - access_key
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio3:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio4:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -102,16 +99,15 @@ services:
       placement:
         constraints:
           - node.labels.minio4==true
-    command: server http://minio1/export http://minio2/export http://minio3/export http://minio4/export
+    command: server http://minio{1...4}/export
     secrets:
       - secret_key
       - access_key
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio4:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
 volumes:
   minio1-data:

--- a/docs/orchestration/docker-swarm/docker-compose.yaml
+++ b/docs/orchestration/docker-swarm/docker-compose.yaml
@@ -27,11 +27,10 @@ services:
           - node.labels.minio1==true
     command: server http://minio{1...4}/export
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio1:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio2:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -59,11 +58,10 @@ services:
           - node.labels.minio2==true
     command: server http://minio{1...4}/export
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio2:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio3:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -91,11 +89,10 @@ services:
           - node.labels.minio3==true
     command: server http://minio{1...4}/export
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio3:9000/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 1m30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
   minio4:
     image: minio/minio:RELEASE.2019-08-29T00-25-01Z
@@ -123,11 +120,10 @@ services:
           - node.labels.minio4==true
     command: server http://minio{1...4}/export
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://minio4:9000/minio/health/live"]
-      interval: 1m30s
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
       timeout: 20s
       retries: 3
-      start_period: 3m
 
 volumes:
   minio1-data:


### PR DESCRIPTION
## Description
With this PR, liveness check responds with 200 OK with "server-not-
initialized" header while objectLayer gets initialized. The header
is removed as objectLayer is initialized. This is to allow
MinIO distributed cluster to get started when running on an
orchestration platform like Docker Swarm.
   
This PR also updates sample Swarm yaml files to use correct values
for healthcheck fields.

## Motivation and Context
Fixes #8140

## How to test this PR?
Deployed distributed MinIO cluster on Docker Swarm

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
