### PR TITLE
Ignore "connection reset" errors when queueDir is configured

### DIFF
--- a/pkg/event/target/amqp.go
+++ b/pkg/event/target/amqp.go
@@ -231,7 +231,7 @@ func NewAMQPTarget(id string, args AMQPArgs, doneCh <-chan struct{}) (*AMQPTarge
 
 	conn, err = amqp.Dial(args.URL.String())
 	if err != nil {
-		if store == nil || !IsConnRefusedErr(err) {
+		if store == nil || !(IsConnRefusedErr(err) || IsConnResetErr(err)) {
 			return nil, err
 		}
 	}

--- a/pkg/event/target/mysql.go
+++ b/pkg/event/target/mysql.go
@@ -351,7 +351,7 @@ func NewMySQLTarget(id string, args MySQLArgs, doneCh <-chan struct{}) (*MySQLTa
 
 	err = target.db.Ping()
 	if err != nil {
-		if target.store == nil || !IsConnRefusedErr(err) {
+		if target.store == nil || !(IsConnRefusedErr(err) || IsConnResetErr(err)) {
 			return nil, err
 		}
 	} else {

--- a/pkg/event/target/nsq.go
+++ b/pkg/event/target/nsq.go
@@ -182,7 +182,7 @@ func NewNSQTarget(id string, args NSQArgs, doneCh <-chan struct{}) (*NSQTarget, 
 
 	if err := target.producer.Ping(); err != nil {
 		// To treat "connection refused" errors as errNotConnected.
-		if target.store == nil || !IsConnRefusedErr(err) {
+		if target.store == nil || !(IsConnRefusedErr(err) || IsConnResetErr(err)) {
 			return nil, err
 		}
 	}

--- a/pkg/event/target/postgresql.go
+++ b/pkg/event/target/postgresql.go
@@ -358,7 +358,7 @@ func NewPostgreSQLTarget(id string, args PostgreSQLArgs, doneCh <-chan struct{})
 
 	err = target.db.Ping()
 	if err != nil {
-		if target.store == nil || !IsConnRefusedErr(err) {
+		if target.store == nil || !(IsConnRefusedErr(err) || IsConnResetErr(err)) {
 			return nil, err
 		}
 	} else {

--- a/pkg/event/target/redis.go
+++ b/pkg/event/target/redis.go
@@ -276,7 +276,7 @@ func NewRedisTarget(id string, args RedisArgs, doneCh <-chan struct{}) (*RedisTa
 
 	_, pingErr := conn.Do("PING")
 	if pingErr != nil {
-		if target.store == nil || !IsConnRefusedErr(pingErr) {
+		if target.store == nil || !(IsConnRefusedErr(pingErr) || IsConnResetErr(pingErr)) {
 			return nil, pingErr
 		}
 	} else {

--- a/pkg/event/target/store.go
+++ b/pkg/event/target/store.go
@@ -93,8 +93,12 @@ func IsConnRefusedErr(err error) bool {
 	return false
 }
 
-// isConnResetErr - Checks for connection reset errors.
-func isConnResetErr(err error) bool {
+// IsConnResetErr - Checks for connection reset errors.
+func IsConnResetErr(err error) bool {
+	if strings.Contains(err.Error(), "connection reset by peer") {
+		return true
+	}
+	// incase if error message is wrapped.
 	if opErr, ok := err.(*net.OpError); ok {
 		if syscallErr, ok := opErr.Err.(*os.SyscallError); ok {
 			if syscallErr.Err == syscall.ECONNRESET {
@@ -117,7 +121,7 @@ func sendEvents(target event.Target, eventKeyCh <-chan string, doneCh <-chan str
 				break
 			}
 
-			if err != errNotConnected && !isConnResetErr(err) {
+			if err != errNotConnected && !IsConnResetErr(err) {
 				panic(fmt.Errorf("target.Send() failed with '%v'", err))
 			}
 


### PR DESCRIPTION


## Description
Connection related errors can be ignored while initializing the targets with queueDir active

## Motivation and Context
MinIO shouldn't panic on connection resets when queueDir is configured
Fixes #8178 

## How to test this PR?
As per steps provided in the issue 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
