### PR TITLE
add testing for s3select

### DIFF
--- a/mint/Dockerfile.dev
+++ b/mint/Dockerfile.dev
@@ -74,6 +74,9 @@ RUN build/worm/install.sh
 COPY build/healthcheck /mint/build/healthcheck
 RUN build/healthcheck/install.sh
 
+COPY build/s3select /mint/build/s3select
+RUN build/s3select/install.sh
+
 COPY remove-packages.list /mint
 COPY postinstall.sh /mint
 RUN /mint/postinstall.sh

--- a/mint/README.md
+++ b/mint/README.md
@@ -15,6 +15,7 @@ Mint is a testing framework for Minio object server, available as a docker image
 - minio-dotnet
 - s3cmd
 - worm
+- s3select
 
 ## Running Mint
 

--- a/mint/build/s3select/install.sh
+++ b/mint/build/s3select/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+#
+#  Mint (C) 2017 Minio, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+test_run_dir="$MINT_RUN_CORE_DIR/s3select"
+GOPROXY=https://proxy.golang.org GO111MODULE=on go build -o "$test_run_dir/s3select" "$test_run_dir/s3select_testing.go" "$test_run_dir/access_log_testing.go" "$test_run_dir/csv_testing.go" "$test_run_dir/json_testing.go" "$test_run_dir/sql_functions_testing.go" "$test_run_dir/util.go"

--- a/mint/run/core/s3select/access_log_testing.go
+++ b/mint/run/core/s3select/access_log_testing.go
@@ -1,0 +1,152 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+func TestAccessLog_Normal() []TestItem {
+	return []TestItem{
+		{
+			Key: "hello.csv",
+			Content: `127.0.0.1 - - [17/Jun/2019:10:52:30 +0800] "GET / HTTP/1.1" 200 3700 "-" "curl/7.29.0" "-"
+203.205.141.46 - - [17/Jun/2019:10:52:54 +0800] "GET / HTTP/1.1" 200 3700 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.46 - - [17/Jun/2019:10:52:55 +0800] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.46 - - [17/Jun/2019:10:52:59 +0800] "GET /abc HTTP/1.1" 404 3650 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"`,
+			Expression: "Select s._1 from S3Object s",
+			Args: map[string]string{
+				"InputSerialization_CSV_FieldDelimiter": " ",
+				"InputSerialization_CSV_FileHeaderInfo": "NONE",
+			},
+			Expects: []Result{
+				{
+					Payload: "127.0.0.1\n203.205.141.46\n203.205.141.46\n203.205.141.46\n",
+				},
+			},
+			Comment: "",
+		},
+		{
+			Key: "hello.csv",
+			Content: `127.0.0.1 - - [17/Jun/2019:10:52:30 +0800] "GET / HTTP/1.1" 200 3700 "-" "curl/7.29.0" "-"
+203.205.141.45 - - [17/Jun/2019:10:52:54 +0800] "GET / HTTP/1.1" 200 3700 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.46 - - [17/Jun/2019:10:52:55 +0800] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.47 - - [17/Jun/2019:10:52:59 +0800] "GET /abc HTTP/1.1" 404 3650 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"`,
+			Expression: "Select s._1 from S3Object s where s._1 = '203.205.141.45'",
+			Args: map[string]string{
+				"InputSerialization_CSV_FieldDelimiter": " ",
+				"InputSerialization_CSV_FileHeaderInfo": "NONE",
+			},
+			Expects: []Result{
+				{
+					Payload: "203.205.141.45\n",
+				},
+			},
+			Comment: "filter by client ip",
+		},
+		{
+			Key: "hello.csv",
+			Content: `127.0.0.1 - - [17/Jun/2019:10:52:30 +0800] "GET / HTTP/1.1" 200 3700 "-" "curl/7.29.0" "-"
+203.205.141.45 - - [17/Jun/2019:10:52:54 +0800] "GET / HTTP/1.1" 200 3700 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.46 - - [17/Jun/2019:10:52:55 +0800] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.47 - - [17/Jun/2019:10:52:59 +0800] "GET /abc HTTP/1.1" 404 3650 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"`,
+			Expression: "Select * from S3Object s where s._1 = '203.205.141.45'",
+			Args: map[string]string{
+				"InputSerialization_CSV_FieldDelimiter": " ",
+				"InputSerialization_CSV_FileHeaderInfo": "NONE",
+			},
+			Expects: []Result{
+				{
+					Payload: `203.205.141.45,-,-,[17/Jun/2019:10:52:54,+0800],GET / HTTP/1.1,200,3700,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-` + "\n",
+				},
+			},
+			Comment: "filter by client ip",
+		},
+		{
+			Key: "hello.csv",
+			Content: `127.0.0.1 - - [17/Jun/2019:10:52:30 +0800] "GET / HTTP/1.1" 200 3700 "-" "curl/7.29.0" "-"
+203.205.141.45 - - [17/Jun/2019:10:52:54 +0800] "GET / HTTP/1.1" 200 3700 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.46 - - [17/Jun/2019:10:52:55 +0800] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.47 - - [17/Jun/2019:10:52:59 +0800] "GET /abc HTTP/1.1" 404 3650 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"`,
+			Expression: "Select * from S3Object s where s._1 = '203.205.141.45'",
+			Args: map[string]string{
+				"InputSerialization_CSV_FieldDelimiter":  " ",
+				"InputSerialization_CSV_FileHeaderInfo":  "NONE",
+				"OutputSerialization_CSV_FieldDelimiter": " ",
+			},
+			Expects: []Result{
+				{
+					Payload: `203.205.141.45 - - [17/Jun/2019:10:52:54 +0800] "GET / HTTP/1.1" 200 3700 - "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" -` + "\n",
+				},
+			},
+			Comment: "a white space as the output delimiter",
+		},
+		{
+			Key: "hello.csv",
+			Content: `127.0.0.1 - - [17/Jun/2019:10:52:30 +0800] "GET / HTTP/1.1" 200 3700 "-" "curl/7.29.0" "-"
+203.205.141.45 - - [17/Jun/2019:10:52:54 +0800] "GET / HTTP/1.1" 200 3700 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.46 - - [17/Jun/2019:10:52:55 +0800] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.47 - - [17/Jun/2019:10:52:59 +0800] "GET /abc HTTP/1.1" 404 3650 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"`,
+			Expression: "Select * from S3Object s where s._1 like '203.205.141.%'",
+			Args: map[string]string{
+				"InputSerialization_CSV_FieldDelimiter": " ",
+				"InputSerialization_CSV_FileHeaderInfo": "NONE",
+			},
+			Expects: []Result{
+				{
+					Payload: `203.205.141.45,-,-,[17/Jun/2019:10:52:54,+0800],GET / HTTP/1.1,200,3700,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-
+203.205.141.46,-,-,[17/Jun/2019:10:52:55,+0800],GET / HTTP/1.1,304,0,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-
+203.205.141.47,-,-,[17/Jun/2019:10:52:59,+0800],GET /abc HTTP/1.1,404,3650,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-` + "\n",
+				},
+			},
+			Comment: "filter by ip prefix",
+		},
+		{
+			Key: "hello.csv",
+			Content: `127.0.0.1 - - [17/Jun/2019:10:52:30 +0800] "GET / HTTP/1.1" 200 3700 "-" "curl/7.29.0" "-"
+203.205.141.45 - - [17/Jun/2019:10:52:54 +0800] "GET / HTTP/1.1" 200 3700 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.46 - - [17/Jun/2019:10:52:55 +0800] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.47 - - [17/Jun/2019:10:52:59 +0800] "GET /abc HTTP/1.1" 404 3650 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"`,
+			Expression: "Select * from S3Object s where s._10 like 'curl%'",
+			Args: map[string]string{
+				"InputSerialization_CSV_FieldDelimiter": " ",
+				"InputSerialization_CSV_FileHeaderInfo": "NONE",
+			},
+			Expects: []Result{
+				{
+					Payload: `127.0.0.1,-,-,[17/Jun/2019:10:52:30,+0800],GET / HTTP/1.1,200,3700,-,curl/7.29.0,-` + "\n",
+				},
+			},
+			Comment: "filter by user agent",
+		},
+		{
+			Key: "hello.csv",
+			Content: `127.0.0.1 - - [2019-06-17T11:57:49+08:00] "GET / HTTP/1.1" 200 3700 "-" "curl/7.29.0" "-"
+203.205.141.45 - - [2019-06-18T11:57:49+08:00] "GET / HTTP/1.1" 200 3700 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.46 - - [2019-06-18T11:57:49+08:00] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"
+203.205.141.47 - - [2019-06-19T11:57:49+08:00] "GET /abc HTTP/1.1" 404 3650 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36" "-"`,
+			Expression: "Select *  from S3Object s where CAST(TRIM(BOTH '[]' FROM s._4) AS TIMESTAMP ) >= CAST ('2019-06-18T00:00:00+08:00' AS TIMESTAMP) AND CAST(TRIM(BOTH '[]' FROM s._4) AS TIMESTAMP ) < CAST('2019-06-19T00:00:00+08:00' AS TIMESTAMP) ",
+			Args: map[string]string{
+				"InputSerialization_CSV_FieldDelimiter": " ",
+				"InputSerialization_CSV_FileHeaderInfo": "NONE",
+			},
+			Expects: []Result{
+				{
+					Payload: `203.205.141.45,-,-,[2019-06-18T11:57:49+08:00],GET / HTTP/1.1,200,3700,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-
+203.205.141.46,-,-,[2019-06-18T11:57:49+08:00],GET / HTTP/1.1,304,0,-,"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.90 Safari/537.36",-` + "\n",
+				},
+			},
+			Comment: "filter by time range",
+		},
+	}
+}

--- a/mint/run/core/s3select/csv_testing.go
+++ b/mint/run/core/s3select/csv_testing.go
@@ -1,0 +1,570 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+func TestCsv_AllowQuotedRecordDelimiter() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,\"aaa\nbbb\",E350\n2000,Mercury,Cougar\n",
+			Expression: "SELECT * FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo":             "USE",
+				"InputSerialization_CSV_AllowQuotedRecordDelimiter": "TRUE",
+			},
+			Expects: []Result{
+				{
+					Payload: "1997,\"aaa\nbbb\",E350\n2000,Mercury,Cougar\n",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "MalformedXML",
+				},
+			},
+		},
+	}
+}
+
+func TestCsv_Unnormal() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "MissingRequiredParameter",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectFailure",
+				},
+			},
+			Comment: "empty sql",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "abc hahaha",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseUnexpectedToken",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectFailure",
+				},
+			},
+			Comment: "abnormal sql",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "select abc",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectMissingFrom",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectFailure",
+				},
+			},
+			Comment: "sql without where",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "select abc where",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectMissingFrom",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectFailure",
+				},
+			},
+			Comment: "sql without from",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "select abc where abc",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectMissingFrom",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectFailure",
+				},
+			},
+			Comment: "sql without from",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "select abc from",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseUnexpectedTerm",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectFailure",
+				},
+			},
+			Comment: "sql without table name",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "select abc from 123",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "InvalidDataSource",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectFailure",
+				},
+			},
+			Comment: "sql with wrong table name",
+		},
+	}
+}
+
+func TestCsv_EmptyRecord() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n",
+			Expression: "Select * from S3Object",
+			Expects: []Result{
+				{
+					Payload: "",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "\n",
+			Expression: "Select * from S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "NONE",
+			},
+			Expects: []Result{
+				{
+					Payload: "",
+				},
+			},
+		},
+	}
+}
+
+func TestCsv_SelectColumn_ColumnNumbers() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "SELECT s._1 FROM S3Object s",
+			Expects: []Result{
+				{
+					Payload: "1997\n2000\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "SELECT s._4 FROM S3Object s",
+			Expects: []Result{
+				{
+					Payload: "",
+				},
+				{
+					StatusCode: "200",
+					ErrorCode:  "InternalError: column _4 not found",
+				},
+			},
+			Comment: "select nonexisted column",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "SELECT s._0 FROM S3Object s",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "InvalidColumnIndex",
+				},
+				{
+					StatusCode: "200",
+					ErrorCode:  "InternalError: column _0 not found",
+				},
+			},
+			Comment: "select nonexisted column",
+		},
+	}
+}
+
+func TestCsv_SelectColumn_ColumnHeaders() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select name from S3Object",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "InvalidColumnIndex",
+				},
+				{
+					StatusCode: "200",
+					ErrorCode:  "InternalError: column name not found",
+				},
+			},
+		},
+	}
+}
+
+func TestCsv_SelectColumn_Where() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE s._1='zhangshan'",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE s._1!='zhangshan'",
+			Expects: []Result{
+				{
+					Payload: "lishi\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE s._1 >=  'zhangshan'",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE s._1 >=  'lishi'",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\nlishi\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE s._1 = 'abc'",
+			Expects: []Result{
+				{
+					Payload: "",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE s._1 = ''",
+			Expects: []Result{
+				{
+					Payload: "",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE cast(s._2 as int) < 29",
+			Expects: []Result{
+				{
+					Payload: "lishi\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE cast(s._2 as int) <= 28",
+			Expects: []Result{
+				{
+					Payload: "lishi\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE cast(s._2 as int) <= 100000",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\nlishi\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE cast(s._2 as int) >= 0",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\nlishi\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s WHERE cast(s._2 as int) != 28",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\n",
+				},
+			},
+		},
+	}
+}
+
+func TestCsv_SelectColumn_Limit() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\n",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s limit 0",
+			Expects: []Result{
+				{
+					Payload: "",
+				},
+			},
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s limit -1",
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "EvaluatorNegativeLimit",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "ParseSelectFailure",
+				},
+			},
+		},
+	}
+}
+
+func TestCsv_Quotes() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "\"name\",\"age\"\n\"zhangshan\",\"30\"\n\"lishi\",\"28\"\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\n",
+				},
+			},
+			Comment: "",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "\"name\",\"a ge\"\n\"zhangshan\",\"30\"\n\"lishi\",\"28\"\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\n",
+				},
+			},
+			Comment: "the column contains space",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "\"name\",\"age\"\n\"zhang shan\",\"30\"\n\"li shi\",\"28\"\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "zhang shan\n",
+				},
+			},
+			Comment: "record contatins space",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "'name','age'\n'zhangshan','30'\n'lishi','28'\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "'zhangshan'\n",
+				},
+			},
+			Comment: "single quote",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "'name','a ge'\n'zhangshan','30'\n'lishi','28'\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "'zhangshan'\n",
+				},
+			},
+			Comment: "single quote",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "'name','age'\n'zhang shan','30'\n'li shi','28'\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "'zhang shan'\n",
+				},
+			},
+			Comment: "single quote",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\n",
+				},
+			},
+			Comment: "",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,a ge\nzhangshan,30\nlishi,28\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "zhangshan\n",
+				},
+			},
+			Comment: "",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "name,age\nzhang shan,30\nli shi,28\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Expects: []Result{
+				{
+					Payload: "zhang shan\n",
+				},
+			},
+			Comment: "",
+		},
+	}
+}
+
+func TestCsv_Compression() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+			Expression: "Select s._1 from S3Object s limit 1",
+			Args: map[string]string{
+				"InputSerialization_CompressionType": "GZIP",
+			},
+			Expects: []Result{
+				{
+					StatusCode: "400",
+					ErrorCode:  "InvalidCompressionFormat",
+				},
+				{
+					StatusCode: "400",
+					ErrorCode:  "TruncatedInput",
+				},
+			},
+		},
+	}
+}
+
+func TestCsv_RecordDelimiter() []TestItem {
+	return []TestItem{
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\t1997,Ford,E350\t2000,Mercury,Cougar\t",
+			Expression: "Select s._1 from S3Object s",
+			Args: map[string]string{
+				"InputSerialization_CSV_RecordDelimiter": "\t",
+				"InputSerialization_CSV_FileHeaderInfo":  "NONE",
+			},
+			Expects: []Result{
+				{
+					Payload: "Year\n1997\n2000\n",
+				},
+			},
+			Comment: "RecordDelimiter为\t",
+		},
+		{
+			Key:        "hello.csv",
+			Content:    "Year,Make,Model\n1997,Ford,E350\t2000,Mercury,Cougar\t",
+			Expression: "Select s._1 from S3Object s",
+			Args: map[string]string{
+				"InputSerialization_CSV_RecordDelimiter": "\t",
+				"InputSerialization_CSV_FileHeaderInfo":  "IGNORE",
+			},
+			Expects: []Result{
+				{
+					Payload: "2000\n",
+				},
+				{
+					Payload: "1997\n2000\n",
+				},
+			},
+		},
+	}
+}

--- a/mint/run/core/s3select/json_testing.go
+++ b/mint/run/core/s3select/json_testing.go
@@ -1,0 +1,95 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+func TestJson_Normal() []TestItem {
+	return []TestItem{
+		{
+			Format: "JSON",
+			Key:    "hello.json",
+			Content: jsonPretty(`
+{ 
+    "name": "Susan Smith", 
+    "org": "engineering",
+    "projects": [
+        {"project_name":"project1", "completed":false},
+        {"project_name":"project2", "completed":true}
+    ]
+}`),
+			Expression: "Select s.name from S3Object s",
+			Expects: []Result{
+				{
+					Payload: `{"name":"Susan Smith"}
+`,
+				},
+			},
+		},
+		{
+			Format: "JSON",
+			Key:    "hello.json",
+			Content: `{"Year":"1997","Make":"Ford","Model":"E350"}
+{"Year":"2000","Make":"Mercury","Model":"Cougar"}`,
+			Expression: "Select * from S3Object s",
+			Args: map[string]string{
+				"InputSerialization_JSON_Type": "LINES",
+			},
+			Expects: []Result{
+				{
+					Payload: `{"Year":"1997","Make":"Ford","Model":"E350"}
+{"Year":"2000","Make":"Mercury","Model":"Cougar"}
+`,
+				},
+			},
+		},
+		{
+			Format: "JSON",
+			Key:    "hello.json",
+			Content: `{"Year":"1997","Make":"Ford","Model":"E350"}
+{"Year":"2000","Make":"Mercury","Model":"Cougar"}`,
+			Expression: "Select * from S3Object s",
+			Args: map[string]string{
+				"InputSerialization_JSON_Type": "LINES",
+				"OutputSerialization_CSV":      "true",
+			},
+			Expects: []Result{
+				{
+					Payload: `1997,Ford,E350
+2000,Mercury,Cougar
+`,
+				},
+			},
+		},
+		{
+			Format: "JSON",
+			Key:    "hello.json",
+			Content: `{"Year":"1997","Make":"Ford","Model":"E350"}
+{"Year":"2000","Make":"Mercury","Model":"Cougar"}`,
+			Expression: "Select s.Make from S3Object s",
+			Args: map[string]string{
+				"InputSerialization_JSON_Type": "LINES",
+				"OutputSerialization_CSV":      "true",
+			},
+			Expects: []Result{
+				{
+					Payload: `Ford
+Mercury
+`,
+				},
+			},
+		},
+	}
+}

--- a/mint/run/core/s3select/run.sh
+++ b/mint/run/core/s3select/run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+#  Mint (C) 2017 Minio, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# handle command line arguments
+if [ $# -ne 2 ]; then
+    echo "usage: run.sh <OUTPUT-LOG-FILE> <ERROR-LOG-FILE>"
+    exit -1
+fi
+
+output_log_file="$1"
+error_log_file="$2"
+
+proto="http"
+if [[ ${ENABLE_HTTPS} -eq 1 ]]; then
+    proto="https"
+fi
+
+forcePathStyle="true"
+if [[ ${ENABLE_VIRTUAL_STYLE} -eq 1 ]]; then
+    forcePathStyle="false"
+fi
+
+# run tests
+/mint/run/core/s3select/s3select -endpoint="${proto}://${SERVER_ENDPOINT}" -access_key="${ACCESS_KEY}" -secret_key="${SECRET_KEY}" -force_path_style="${forcePathStyle}" | grep '^{' 1>>"$output_log_file" 2>"$error_log_file"

--- a/mint/run/core/s3select/s3select_testing.go
+++ b/mint/run/core/s3select/s3select_testing.go
@@ -1,0 +1,244 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	bucket = flag.String("bucket", "",
+		"bucket to test with if empty random bucket will be created")
+	accessKey      = flag.String("access_key", "AKIDZfbOAo7cllgPvF9cXFrJD0a1ICvR98JM", "access key")
+	secretKey      = flag.String("secret_key", "3yhFgx31rWzGKCuSq34yjLpBLRSHtIUU", "secret key")
+	region         = flag.String("region", "us-east-1", "region")
+	endpoint       = flag.String("endpoint", "http://127.0.0.1:9000", "endpoint")
+	forcePathStyle = flag.Bool("force_path_style", false, "force path style")
+)
+
+type T struct{}
+
+func (t *T) MatchString(pat, str string) (bool, error) {
+	re, err := regexp.Compile(pat)
+	if err != nil {
+		return false, err
+	}
+	return re.MatchString(str), nil
+}
+
+func (t *T) StartCPUProfile(w io.Writer) error           { return errors.New("not support") }
+func (t *T) StopCPUProfile()                             {}
+func (t *T) WriteProfileTo(string, io.Writer, int) error { return errors.New("not support") }
+func (t *T) ImportPath() string                          { return "" }
+func (t *T) StartTestLog(io.Writer)                      {}
+func (t *T) StopTestLog() error                          { return errors.New("not support") }
+
+type Result struct {
+	Payload    string // the payload we expect
+	StatusCode string // the http status code we expect, for example 200 or 400
+	ErrorCode  string // the error code we expect, for example EvaluatorNegativeLimit
+}
+
+type TestItem struct {
+	Format     string // the format of the object
+	Key        string // object key this test item will run on
+	Content    string // object content this test will select upon
+	Expression string // the sql expression to execute
+	Expects    []Result
+	Comment    string // comment for each test item
+
+	Args map[string]string
+}
+
+func runTestItem(testItem *TestItem) Result {
+	var result Result
+
+	if testItem.Format == "JSON" {
+		payload, statusCode, err := selectJsonObject(testItem.Key, testItem.Content, testItem.Expression, testItem.Args)
+		result.Payload = payload
+		result.StatusCode = strconv.Itoa(statusCode)
+		if err != nil {
+			result.ErrorCode = err.Error()
+		}
+	} else {
+		payload, statusCode, err := selectCsvObject(testItem.Key, testItem.Content, testItem.Expression, testItem.Args)
+		result.Payload = payload
+		result.StatusCode = strconv.Itoa(statusCode)
+		if err != nil {
+			result.ErrorCode = err.Error()
+		}
+	}
+
+	return result
+}
+
+func runTestCase(name string, f func() []TestItem) func(t *testing.T) {
+	return func(t *testing.T) {
+		testItems := f()
+
+		failed := false
+		for _, testItem := range testItems {
+			startTime := time.Now()
+			result := runTestItem(&testItem)
+			if !checkTestItemResult(testItem.Expects, result) {
+				//t.Logf("test item %v failed with result: %v", testItem, result)
+				failureLog(name, map[string]interface{}{
+					"format":     testItem.Format,
+					"key":        testItem.Key,
+					"content":    testItem.Content,
+					"expression": testItem.Expression,
+					"expects":    testItem.Expects,
+					"args":       testItem.Args,
+					"result":     result,
+				}, startTime).Fatal()
+				failed = true
+			} else {
+				successLogger(name, map[string]interface{}{
+					"format":     testItem.Format,
+					"key":        testItem.Key,
+					"content":    testItem.Content,
+					"expression": testItem.Expression,
+					"expects":    testItem.Expects,
+					"args":       testItem.Args,
+					"result":     result,
+				}, startTime).Info()
+			}
+		}
+
+		if failed {
+			t.Errorf("%s failed", name)
+		}
+	}
+}
+
+func checkTestItemResult(expects []Result, r Result) bool {
+	for _, expect := range expects {
+		if r.Payload == expect.Payload &&
+			r.ErrorCode == expect.ErrorCode &&
+			(expect.StatusCode == "" || r.StatusCode == expect.StatusCode) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// s3select_testing is a small program for testing s3select basic functions
+// and for testing compatibility between minio and aws s3.  It can run on
+// minio or run on aws s3, so we can compare the results.
+//
+// Example:
+//   run on aws s3:
+//   s3select_testing -endpoint="" -bucket="YOUR BUCKET NAME" -region="YOUR BUCKET REGION" -access_key="YOUR ACCESS KEY" -secret_key="YOUR SECRET KEY"
+//
+//   only run TestJson_Normal on aws s3:
+//   s3select_testing -endpoint="" -bucket="YOUR BUCKET NAME" -region="YOUR BUCKET REGION" -access_key="YOUR ACCESS KEY" -secret_key="YOUR SECRET KEY" -test.run="TestJson_Normal"
+//
+//   run on minio:
+//   s3select_testing -endpoint=http://127.0.0.1:9000 -access_key="YOUR ACCESS KEY" -secret_key="YOUR SECRET KEY" -force_path_style
+func main() {
+	testing.Init()
+	flag.Parse()
+
+	if *bucket == "" {
+		*bucket = randString(60, rand.NewSource(time.Now().UnixNano()), "s3select-testing-")
+		err := createBucket(*bucket)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create bucket: %v", err)
+			os.Exit(125)
+		}
+		defer deleteBucket(*bucket)
+	}
+
+	// Output to stdout instead of the default stderr
+	log.SetOutput(os.Stdout)
+	// create custom formatter
+	mintFormatter := mintJSONFormatter{}
+	// set custom formatter
+	log.SetFormatter(&mintFormatter)
+	// log Info or above -- success cases are Info level, failures are Fatal level
+	log.SetLevel(log.InfoLevel)
+
+	// See: https://stackoverflow.com/questions/46205923/how-do-i-use-the-testing-package-in-go-playground
+	testSuite := []testing.InternalTest{
+		{
+			Name: "TestCsv_AllowQuotedRecordDelimiter",
+			F:    runTestCase("TestCsv_AllowQuotedRecordDelimiter", TestCsv_AllowQuotedRecordDelimiter),
+		},
+		{
+			Name: "TestCsv_Unnormal",
+			F:    runTestCase("TestCsv_Unnormal", TestCsv_Unnormal),
+		},
+		{
+			Name: "TestCsv_EmptyRecord",
+			F:    runTestCase("TestCsv_EmptyRecord", TestCsv_EmptyRecord),
+		},
+		{
+			Name: "TestCsv_SelectColumn_ColumnHeaders",
+			F:    runTestCase("TestCsv_SelectColumn_ColumnHeaders", TestCsv_SelectColumn_ColumnHeaders),
+		},
+		{
+			Name: "TestCsv_SelectColumn_ColumnNumbers",
+			F:    runTestCase("TestCsv_SelectColumn_ColumnNumbers", TestCsv_SelectColumn_ColumnNumbers),
+		},
+		{
+			Name: "TestCsv_SelectColumn_Where",
+			F:    runTestCase("TestCsv_SelectColumn_Where", TestCsv_SelectColumn_Where),
+		},
+		{
+			Name: "TestCsv_SelectColumn_Limit",
+			F:    runTestCase("TestCsv_SelectColumn_Limit", TestCsv_SelectColumn_Limit),
+		},
+		{
+			Name: "TestCsv_Quotes",
+			F:    runTestCase("TestCsv_Quotes", TestCsv_Quotes),
+		},
+		{
+			Name: "TestCsv_Compression",
+			F:    runTestCase("TestCsv_Compression", TestCsv_Compression),
+		},
+		{
+			Name: "TestCsv_RecordDelimiter",
+			F:    runTestCase("TestCsv_RecordDelimiter", TestCsv_RecordDelimiter),
+		},
+		{
+			Name: "TestJson_Normal",
+			F:    runTestCase("TestJson_Normal", TestJson_Normal),
+		},
+		{
+			Name: "TestAccessLog_Normal",
+			F:    runTestCase("TestAccessLog_Normal", TestAccessLog_Normal),
+		},
+		{
+			Name: "TestSqlFunctions_Normal",
+			F:    runTestCase("TestSqlFunctions_Normal", TestSqlFunctions_Normal),
+		},
+	}
+
+	os.Exit(testing.MainStart(&T{}, testSuite, nil, nil).Run())
+}

--- a/mint/run/core/s3select/sql_functions_testing.go
+++ b/mint/run/core/s3select/sql_functions_testing.go
@@ -1,0 +1,363 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+func TestSqlFunctions_Normal() []TestItem {
+	return []TestItem{
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\nalice,80\nbob,81\n",
+			Expression: "SELECT AVG(Score) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload:    "",
+					StatusCode: "400",
+					ErrorCode:  "ExternalEvalException",
+				},
+				{
+					Payload: "80.5\n", // MinIO feature auto detect the type
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\nalice,80\nbob,81\n",
+			Expression: "SELECT AVG(CAST (Score as int)) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "80.5\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\nalice,80\nbob,81\n",
+			Expression: "SELECT SUM(CAST (Score as int)) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "161\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\nalice,80\nbob,81\n",
+			Expression: "SELECT MAX(CAST (Score as int)) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "81\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\nalice,80\nbob,81\n",
+			Expression: "SELECT MIN(CAST (Score as int)) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "80\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\nalice,80\nbob,81\n",
+			Expression: "SELECT COUNT(*) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "2\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\nalice,80\nbob,81\n",
+			Expression: "SELECT COUNT(Score) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "2\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\nbob,81\n",
+			Expression: "SELECT CHAR_LENGTH(Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "2\n3\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\nbob,81\n",
+			Expression: "SELECT CHARACTER_LENGTH(Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "2\n3\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\nBob,81\n",
+			Expression: "SELECT LOWER(Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "张三\nbob\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\nBob,81\n",
+			Expression: "SELECT SUBSTRING(Name, 0) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "张三\nBob\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\nBob,81\n",
+			Expression: "SELECT SUBSTRING(Name, 1) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "张三\nBob\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\nBob,81\n",
+			Expression: "SELECT SUBSTRING(Name, 2) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "三\nob\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\nBobbbbbbb,81\n",
+			Expression: "SELECT SUBSTRING(Name, 2, 3) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "三\nobb\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\nBobbbbbbb,81\n",
+			Expression: "SELECT SUBSTRING(Name, 100, 100) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n  ,80\n,81\n",
+			Expression: "SELECT SUBSTRING(Name, 1, 1) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "\" \"\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n  张三   ,80\n  Bobbbbbbb   ,81\n",
+			Expression: "SELECT trim(Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "张三\nBobbbbbbb\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n  张三   ,80\n  Bobbbbbbb   ,81\n",
+			Expression: "SELECT trim(LEADING FROM Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "张三   \nBobbbbbbb   \n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n  张三   ,80\n  Bobbbbbbb   ,81\n",
+			Expression: "SELECT trim(TRAILING  FROM Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "\"  张三\"\n\"  Bobbbbbbb\"\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n  张三   ,80\n  Bobbbbbbb   ,81\n",
+			Expression: "SELECT trim(BOTH  FROM Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "张三\nBobbbbbbb\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n   张三   ,80\n  Bobbbbbbb,81\n",
+			Expression: "SELECT trim(BOTH 'b' FROM Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "\"   张三   \"\n\"  Bo\"\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三张张,80\n  Bobbbbbbb,81\n",
+			Expression: "SELECT trim(BOTH '张' FROM Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "三\n\"  Bobbbbbbb\"\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三张张,80\n  Bobbbbbbb,81\n",
+			Expression: "SELECT trim(BOTH '张b' FROM Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "三\n\"  Bo\"\n",
+				},
+			},
+		},
+		{
+			Format:     "CSV",
+			Key:        "hello.csv",
+			Content:    "Name,Score\n张三,80\n  Bobbbbbbb,81\n",
+			Expression: "SELECT UPPER(Name) FROM S3Object",
+			Args: map[string]string{
+				"InputSerialization_CSV_FileHeaderInfo": "USE",
+			},
+			Expects: []Result{
+				{
+					Payload: "张三\n\"  BOBBBBBBB\"\n",
+				},
+			},
+		},
+	}
+}

--- a/mint/run/core/s3select/util.go
+++ b/mint/run/core/s3select/util.go
@@ -1,0 +1,395 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	log "github.com/sirupsen/logrus"
+)
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyz01234569"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+const (
+	PASS = "PASS" // Indicate that a test passed
+	FAIL = "FAIL" // Indicate that a test failed
+	NA   = "NA"   // Indicate that a test is not applicable
+)
+
+type mintJSONFormatter struct {
+}
+
+func (f *mintJSONFormatter) Format(entry *log.Entry) ([]byte, error) {
+	data := make(log.Fields, len(entry.Data))
+	for k, v := range entry.Data {
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/sirupsen/logrus/issues/137
+			data[k] = v.Error()
+		default:
+			data[k] = v
+		}
+	}
+
+	serialized, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+	return append(serialized, '\n'), nil
+}
+
+// log successful test runs
+func successLogger(function string, args map[string]interface{}, startTime time.Time) *log.Entry {
+	// calculate the test case duration
+	duration := time.Since(startTime)
+	// log with the fields as per mint
+	fields := log.Fields{"name": "aws-sdk-go", "function": function, "args": args, "duration": duration.Nanoseconds() / 1000000, "status": PASS}
+	return log.WithFields(fields)
+}
+
+// log failed test runs
+func failureLog(function string, args map[string]interface{}, startTime time.Time) *log.Entry {
+	// calculate the test case duration
+	duration := time.Since(startTime)
+	var fields log.Fields
+	// log with the fields as per mint
+	fields = log.Fields{"name": "aws-sdk-go", "function": function, "args": args,
+		"duration": duration.Nanoseconds() / 1000000, "status": FAIL}
+	return log.WithFields(fields)
+}
+
+func randString(n int, src rand.Source, prefix string) string {
+	b := make([]byte, n)
+	// A rand.Int63() generates 63 random bits, enough for letterIdxMax letters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+	return prefix + string(b[0:30-len(prefix)])
+}
+
+func createBucket(bucket string) error {
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region:           aws.String(*region),
+		Endpoint:         aws.String(*endpoint),
+		Credentials:      credentials.NewStaticCredentials(*accessKey, *secretKey, ""),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(*forcePathStyle),
+	}))
+
+	svc := s3.New(sess)
+
+	_, err := svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteBucket(bucket string) error {
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region:           aws.String(*region),
+		Endpoint:         aws.String(*endpoint),
+		Credentials:      credentials.NewStaticCredentials(*accessKey, *secretKey, ""),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(*forcePathStyle),
+	}))
+
+	svc := s3.New(sess)
+
+	_, err := svc.DeleteBucket(&s3.DeleteBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func putObject(key string, content string) error {
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region:           aws.String(*region),
+		Endpoint:         aws.String(*endpoint),
+		Credentials:      credentials.NewStaticCredentials(*accessKey, *secretKey, ""),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(*forcePathStyle),
+	}))
+
+	svc := s3.New(sess)
+	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+		Body:          aws.ReadSeekCloser(strings.NewReader(content)),
+		Bucket:        aws.String(*bucket),
+		Key:           aws.String(key),
+		ContentLength: aws.Int64(int64(len(content))),
+	})
+	err := req.Send()
+	return err
+}
+
+func deleteObject(key string) error {
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region:           aws.String(*region),
+		Endpoint:         aws.String(*endpoint),
+		Credentials:      credentials.NewStaticCredentials(*accessKey, *secretKey, ""),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(*forcePathStyle),
+	}))
+
+	svc := s3.New(sess)
+	_, err := svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(*bucket),
+		Key:    aws.String(key),
+	})
+	return err
+}
+
+// Return result, http status code, error code.
+func selectCsvObject(key string, content string, expression string, args map[string]string) (string, int, error) {
+	err := putObject(key, content)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to putObject: %v", err)
+	}
+	defer deleteObject(key)
+
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region:           aws.String(*region),
+		Endpoint:         aws.String(*endpoint),
+		Credentials:      credentials.NewStaticCredentials(*accessKey, *secretKey, ""),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(*forcePathStyle),
+	}))
+
+	svc := s3.New(sess)
+	params := &s3.SelectObjectContentInput{
+		Bucket:         aws.String(*bucket),
+		Key:            aws.String(key),
+		ExpressionType: aws.String(s3.ExpressionTypeSql),
+		Expression:     aws.String(expression),
+		InputSerialization: &s3.InputSerialization{
+			CSV: &s3.CSVInput{
+				FileHeaderInfo:  aws.String(s3.FileHeaderInfoIgnore),
+				RecordDelimiter: aws.String("\n"),
+				FieldDelimiter:  aws.String(","),
+			},
+		},
+		OutputSerialization: &s3.OutputSerialization{
+			CSV: &s3.CSVOutput{
+				QuoteFields: aws.String("ASNEEDED"),
+			},
+		},
+	}
+
+	if args != nil {
+		if compression, ok := args["InputSerialization_CompressionType"]; ok {
+			params.InputSerialization.CompressionType = aws.String(compression)
+		}
+		if recordDelimiter, ok := args["InputSerialization_CSV_RecordDelimiter"]; ok {
+			params.InputSerialization.CSV.RecordDelimiter = aws.String(recordDelimiter)
+		}
+		if fieldDelimiter, ok := args["InputSerialization_CSV_FieldDelimiter"]; ok {
+			params.InputSerialization.CSV.FieldDelimiter = aws.String(fieldDelimiter)
+		}
+		if fileHeaderInfo, ok := args["InputSerialization_CSV_FileHeaderInfo"]; ok {
+			params.InputSerialization.CSV.FileHeaderInfo = aws.String(fileHeaderInfo)
+		}
+		if allowQuotedRecordDelimiter, ok := args["InputSerialization_CSV_AllowQuotedRecordDelimiter"]; ok {
+			if allowQuotedRecordDelimiter == "TRUE" {
+				params.InputSerialization.CSV.AllowQuotedRecordDelimiter = aws.Bool(true)
+			} else {
+				params.InputSerialization.CSV.AllowQuotedRecordDelimiter = aws.Bool(false)
+			}
+		}
+		if fieldDelimiter, ok := args["OutputSerialization_CSV_FieldDelimiter"]; ok {
+			params.OutputSerialization.CSV.FieldDelimiter = aws.String(fieldDelimiter)
+		}
+	}
+
+	resp, err := svc.SelectObjectContent(params)
+	if err != nil {
+		if requestFailure, ok := err.(awserr.RequestFailure); ok {
+			return "", requestFailure.StatusCode(), errors.New(requestFailure.Code())
+		}
+		if awsErr, ok := err.(awserr.Error); ok {
+			return "", 0, errors.New(awsErr.Code())
+		}
+		return "", 0, fmt.Errorf("failed to SelectObjectContent: %v", err)
+	}
+	defer resp.EventStream.Close()
+
+	results, resultWriter := io.Pipe()
+	go func() {
+		defer resultWriter.Close()
+		for event := range resp.EventStream.Events() {
+			switch e := event.(type) {
+			case *s3.RecordsEvent:
+				resultWriter.Write(e.Payload)
+			}
+		}
+	}()
+
+	// Printout the results
+	resReader := csv.NewReader(results)
+	if args != nil {
+		if fieldDelimiter, ok := args["OutputSerialization_CSV_FieldDelimiter"]; ok {
+			resReader.Comma = []rune(fieldDelimiter)[0]
+		}
+	}
+	records, err := resReader.ReadAll()
+	if err != nil {
+		fmt.Printf("failed to ReadAll: %v\n", err)
+		return "", 200, err
+	}
+
+	if err := resp.EventStream.Err(); err != nil {
+		return "", 200, err
+	}
+
+	var s strings.Builder
+	csvWriter := csv.NewWriter(&s)
+	if args != nil {
+		if fieldDelimiter, ok := args["OutputSerialization_CSV_FieldDelimiter"]; ok {
+			csvWriter.Comma = []rune(fieldDelimiter)[0]
+		}
+	}
+	csvWriter.WriteAll(records)
+	if err := csvWriter.Error(); err != nil {
+		return "", 200, err
+	}
+
+	return s.String(), 200, nil
+}
+
+func selectJsonObject(key string, content string, expression string, args map[string]string) (string, int, error) {
+	err := putObject(key, content)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to putObject: %v", err)
+	}
+	defer deleteObject(key)
+
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region:           aws.String(*region),
+		Endpoint:         aws.String(*endpoint),
+		Credentials:      credentials.NewStaticCredentials(*accessKey, *secretKey, ""),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(*forcePathStyle),
+	}))
+
+	svc := s3.New(sess)
+	params := &s3.SelectObjectContentInput{
+		Bucket:         aws.String(*bucket),
+		Key:            aws.String(key),
+		ExpressionType: aws.String(s3.ExpressionTypeSql),
+		Expression:     aws.String(expression),
+		InputSerialization: &s3.InputSerialization{
+			JSON: &s3.JSONInput{
+				Type: aws.String("DOCUMENT"),
+			},
+		},
+		OutputSerialization: &s3.OutputSerialization{
+			JSON: &s3.JSONOutput{},
+		},
+	}
+
+	if args != nil {
+		if compression, ok := args["InputSerialization_CompressionType"]; ok {
+			params.InputSerialization.CompressionType = aws.String(compression)
+		}
+
+		if jsonType, ok := args["InputSerialization_JSON_Type"]; ok {
+			params.InputSerialization.JSON.Type = aws.String(jsonType)
+		}
+
+		if _, ok := args["OutputSerialization_CSV"]; ok {
+			params.OutputSerialization.JSON = nil
+			params.OutputSerialization.CSV = &s3.CSVOutput{
+				QuoteFields: aws.String("ASNEEDED"),
+			}
+		}
+	}
+
+	resp, err := svc.SelectObjectContent(params)
+	if err != nil {
+		if requestFailure, ok := err.(awserr.RequestFailure); ok {
+			return "", requestFailure.StatusCode(), errors.New(requestFailure.Code())
+		}
+		if awsErr, ok := err.(awserr.Error); ok {
+			return "", 0, errors.New(awsErr.Code())
+		}
+		return "", 0, fmt.Errorf("failed to SelectObjectContent: %v", err)
+	}
+	defer resp.EventStream.Close()
+
+	results, resultWriter := io.Pipe()
+	go func() {
+		defer resultWriter.Close()
+		for event := range resp.EventStream.Events() {
+			switch e := event.(type) {
+			case *s3.RecordsEvent:
+				resultWriter.Write(e.Payload)
+			}
+		}
+	}()
+
+	b, err := ioutil.ReadAll(results)
+	if err != nil {
+		return "", 200, err
+	}
+
+	if err := resp.EventStream.Err(); err != nil {
+		return "", 200, err
+	}
+
+	return string(b), 200, nil
+}
+
+func jsonPretty(raw string) string {
+	var buffer bytes.Buffer
+	err := json.Indent(&buffer, []byte(raw), "", "    ")
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.TrimSpace(buffer.String())
+}


### PR DESCRIPTION
## Description

add testing for s3select, try to fix #7901 
work in progress, any advice is appreciated

## Motivation and Context

add testing for s3select, for each test case, it is runnned roughly as below:
1. upload the Key with the Content for testing;
2. run s3select Expression on this object using Args;
3. check the result;
4. delete the object.

## How to test this PR?

Currently, to run this s3select testing, the steps are as below:
1. start minio server:  `minio server /data/`
2. `docker build -t minio/mint . -f Dockerfile.dev`
3. `docker run -e SERVER_ENDPOINT=10.144.118.219:9000 -e ACCESS_KEY=7V8TB1O3BOV11GHQLP55 -e SECRET_KEY="y+x+E1VaSizlMY1f7Zh8MKsQP1nTn14Scd2Nsj7J" -e ENABLE_HTTPS=0 -e MINT_MODE=full minio/mint:latest s3select`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
