### PR TITLE
xl: Fix verifying non streaming highway algo with dist. setup

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -446,9 +446,8 @@ func (client *storageRESTClient) VerifyFile(volume, path string, size int64, alg
 	values.Set(storageRESTBitrotAlgo, algo.String())
 	values.Set(storageRESTLength, strconv.FormatInt(size, 10))
 	values.Set(storageRESTShardSize, strconv.Itoa(int(shardSize)))
-	if len(sum) != 0 {
-		values.Set(storageRESTBitrotHash, hex.EncodeToString(sum))
-	}
+	values.Set(storageRESTBitrotHash, hex.EncodeToString(sum))
+
 	respBody, err := client.call(storageRESTMethodVerifyFile, values, nil, -1)
 	defer http.DrainBody(respBody)
 	if err != nil {

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -600,7 +600,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpoints EndpointList) {
 		subrouter.Methods(http.MethodPost).Path(SlashSeparator + storageRESTMethodRenameFile).HandlerFunc(httpTraceHdrs(server.RenameFileHandler)).
 			Queries(restQueries(storageRESTSrcVolume, storageRESTSrcPath, storageRESTDstVolume, storageRESTDstPath)...)
 		subrouter.Methods(http.MethodPost).Path(SlashSeparator + storageRESTMethodVerifyFile).HandlerFunc(httpTraceHdrs(server.VerifyFile)).
-			Queries(restQueries(storageRESTVolume, storageRESTFilePath, storageRESTBitrotAlgo, storageRESTLength, storageRESTShardSize)...)
+			Queries(restQueries(storageRESTVolume, storageRESTFilePath, storageRESTBitrotAlgo, storageRESTBitrotHash, storageRESTLength, storageRESTShardSize)...)
 		subrouter.Methods(http.MethodPost).Path(SlashSeparator + storageRESTMethodGetInstanceID).HandlerFunc(httpTraceAll(server.GetInstanceID))
 	}
 


### PR DESCRIPTION


## Description
VerifyFile in the distributed setup does not work with
the non streaming highway hash. The reason is that the
internode mux router did not expect `storageRESTBitrotHash`
parameter.

## Motivation and Context
Fix `mc admin heal` with an old Minio deployment

## How to test this PR?
Having a distributed setup with an object which the old highway hash algo (non streaming algo)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
