### PR TITLE
Honor standard HTTP headers for sourceIP

### DIFF
--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/handlers"
 	trace "github.com/minio/minio/pkg/trace"
 )
 
@@ -200,7 +201,7 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 		Method:   r.Method,
 		Path:     r.URL.Path,
 		RawQuery: r.URL.RawQuery,
-		Client:   r.RemoteAddr,
+		Client:   handlers.GetSourceIP(r),
 		Headers:  reqHeaders,
 		Body:     reqBodyRecorder.Data(),
 	}


### PR DESCRIPTION

## Description
Honor standard HTTP headers for source IP

## Motivation and Context
Behind load balancers, we should be tracing source IP
preserved by load balancers.

## How to test this PR?
Just run `mc admin trace` behind haproxy config with multiple MinIO servers.

```

global
	log /dev/log	local0
	log /dev/log	local1 notice
	chroot /var/lib/haproxy
	stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
	stats timeout 30s
	user haproxy
	group haproxy
	daemon

	# Default SSL material locations
	ca-base /etc/ssl/certs
	crt-base /etc/ssl/private

	# Default ciphers to use on SSL-enabled listening sockets.
	# For more information, see ciphers(1SSL). This list is from:
	#  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
	# An alternative list with additional directives can be obtained from
	#  https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=haproxy
	ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
	ssl-default-bind-options no-sslv3

listen minio
        bind *:9000
        log global
        mode http
	timeout connect 5000
        timeout client  50000
        timeout server  50000
        balance roundrobin
        option forwardfor
        option httplog
        option httpchk GET /minio/health/ready HTTP/1.0
        http-check expect rstatus 200
        server minio1 localhost:9001 check cookie minio1 inter 30000
        server minio2 localhost:9002 check cookie minio2 inter 30000
        server minio3 localhost:9003 check cookie minio3 inter 30000
        server minio4 localhost:9004 check cookie minio4 inter 30000

defaults
	log	global
	mode	http
	option	httplog
	option	dontlognull
        timeout connect 5000
        timeout client  50000
        timeout server  50000
	errorfile 400 /etc/haproxy/errors/400.http
	errorfile 403 /etc/haproxy/errors/403.http
	errorfile 408 /etc/haproxy/errors/408.http
	errorfile 500 /etc/haproxy/errors/500.http
	errorfile 502 /etc/haproxy/errors/502.http
	errorfile 503 /etc/haproxy/errors/503.http
	errorfile 504 /etc/haproxy/errors/504.http
```

```
~ /usr/sbin/haproxy -Ws -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
```

```
#!/bin/bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
#rm -rf /tmp/{1..8}
for i in {01..04}; do
    minio server --address ":90${i}" http://127.0.0.1:9001/tmp/1 http://127.0.0.1:9002/tmp/2 http://127.0.0.1:9003/tmp/3 http://127.0.0.1:9004/tmp/4 http://127.0.0.1:9001/tmp/5 http://127.0.0.1:9002/tmp/6 http://127.0.0.1:9003/tmp/7 http://127.0.0.1:9004/tmp/8 &
done
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
