### PR TITLE
posix/readDir should populate name for DT_UKNOWN

### DIFF
--- a/cmd/posix-list-dir_unix.go
+++ b/cmd/posix-list-dir_unix.go
@@ -58,7 +58,6 @@ func parseDirEnt(buf []byte) (consumed int, name string, typ os.FileMode, err er
 		// to handle such files, MinIO is only interested in
 		// files and directories.
 		typ = unexpectedFileMode
-		return
 	}
 
 	nameBuf := (*[unsafe.Sizeof(dirent.Name)]byte)(unsafe.Pointer(&dirent.Name[0]))


### PR DESCRIPTION


## Description
posix/readDir should populate name for DT_UKNOWN

## Motivation and Context
In commit a8296445ad we changed the code to handle
some corner cases on ARM and other platforms, this
PR just avoids the return for unknown filetypes
prematurely and let the name be populated appropriately.

This fixes a bug for older XFS implementations such as
in Ubuntu 14.04

## How to test this PR?
Run Ubuntu 14.04 with XFS with latest release, upload a few objects you cannot list them at all. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression Yes introduced in a8296445ad
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
