### PR TITLE
Wait clearing the close channel

### DIFF
--- a/pkg/s3select/csv/reader.go
+++ b/pkg/s3select/csv/reader.go
@@ -106,8 +106,8 @@ func (r *Reader) Read(dst sql.Record) (sql.Record, error) {
 func (r *Reader) Close() error {
 	if r.close != nil {
 		close(r.close)
-		r.close = nil
 		r.readerWg.Wait()
+		r.close = nil
 	}
 	r.recordsRead = len(r.current)
 	if r.err == nil {


### PR DESCRIPTION
## Description

Close channel should not be nilled before goroutines have exited.

Fixes potential hang on closing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Fixes a regression from #8200 
