### PR TITLE
fs/xl: Log warning if cache config specified

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -346,6 +346,9 @@ func serverMain(ctx *cli.Context) {
 		logger.Fatal(err, "Unable to initialize policy system")
 	}
 
+	if globalIsDiskCacheEnabled {
+		logger.StartupMessage(colorRed(colorBold("Disk caching is allowed only for gateway deployments")))
+	}
 	// Create new lifecycle system.
 	globalLifecycleSys = NewLifecycleSys()
 


### PR DESCRIPTION
in non-gateway mode.

## Description


## Motivation and Context

Since #8232 introduced a breaking change, add a warning message for server mode.
## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
