### PR TITLE
Remove size query parameter from PerfInfo handler

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -64,7 +64,7 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 
 	}
 	// Performance command - return performance details based on input type
-	adminV1Router.Methods(http.MethodGet).Path("/performance").HandlerFunc(httpTraceAll(adminAPI.PerfInfoHandler)).Queries("perfType", "{perfType:.*}").Queries("size", "{size:.*}")
+	adminV1Router.Methods(http.MethodGet).Path("/performance").HandlerFunc(httpTraceAll(adminAPI.PerfInfoHandler)).Queries("perfType", "{perfType:.*}")
 
 	// Profiling operations
 	adminV1Router.Methods(http.MethodPost).Path("/profiling/start").HandlerFunc(httpTraceAll(adminAPI.StartProfilingHandler)).

--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -109,5 +109,6 @@ func getLocalDrivesPerf(endpoints EndpointList, size int64, r *http.Request) mad
 	return madmin.ServerDrivesPerfInfo{
 		Addr: addr,
 		Perf: dps,
+		Size: size,
 	}
 }


### PR DESCRIPTION
## Description
Fixes admin API router for PerfInfo handler

## Motivation and Context
`mc admin info server ALIAS` subcommand shares the PerfInfo handler with `mc admin speedtest {drive|net} ...` subcommands. The  `speedtest` subcommands require size parameter while the `info` subcommand doesn't. We need to modify the router rule to exclude the size query parameter and leave it to the handlers to take care of it.

## How to test this PR?
`mc admin info server ALIAS` should work as before

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression from 6ba323b009f3e89e40e8018fc0a63b69083bae05
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
