### PR TITLE
add KeyStore interface and Vault env. variable

### DIFF
--- a/cmd/crypto/kms.go
+++ b/cmd/crypto/kms.go
@@ -67,7 +67,7 @@ func (c Context) WriteTo(w io.Writer) (n int64, err error) {
 	return n + int64(nn), err
 }
 
-// KMS represents an active and authenticted connection
+// KMS represents an active and authenticated connection
 // to a Key-Management-Service. It supports generating
 // data key generation and unsealing of KMS-generated
 // data keys.

--- a/cmd/crypto/kv.go
+++ b/cmd/crypto/kv.go
@@ -1,0 +1,36 @@
+// MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+// KeyStore represents an active and authenticated connection
+// to a Key-Value-Store that holds secret keys. It supports
+// loading, storing and deleting such secret keys.
+type KeyStore interface {
+
+	// Load fetches the 256 bit key from the key store
+	// that has been stored at the given path. It returns
+	// an error if fetching the key fails or if there is
+	// no key under the path.
+	Load(path string) (key [32]byte, err error)
+
+	// Store stores a 256 bit key at the key store
+	// under the given path. It returns an error if
+	// storing the key fails.
+	Store(path string, key [32]byte) error
+
+	// Delete deletes the key stored under the given
+	// path.
+	Delete(path string) error
+}

--- a/cmd/crypto/vault.go
+++ b/cmd/crypto/vault.go
@@ -51,11 +51,12 @@ type VaultAppRole struct {
 
 // VaultConfig represents vault configuration.
 type VaultConfig struct {
-	Endpoint  string    `json:"endpoint"` // The vault API endpoint as URL
-	CAPath    string    `json:"-"`        // The path to PEM-encoded certificate files used for mTLS. Currently not used in config file.
-	Auth      VaultAuth `json:"auth"`     // The vault authentication configuration
-	Key       VaultKey  `json:"key-id"`   // The named key used for key-generation / decryption.
-	Namespace string    `json:"-"`        // The vault namespace of enterprise vault instances
+	Endpoint     string    `json:"endpoint"` // The vault API endpoint as URL
+	CAPath       string    `json:"-"`        // The path to PEM-encoded certificate files used for mTLS. Currently not used in config file.
+	Auth         VaultAuth `json:"auth"`     // The vault authentication configuration
+	Key          VaultKey  `json:"key-id"`   // The named key used for key-generation / decryption.
+	Namespace    string    `json:"-"`        // The vault namespace of enterprise vault instances
+	KeyStorePath string    `json:"-"`
 }
 
 // vaultService represents a connection to a vault KMS.
@@ -66,7 +67,8 @@ type vaultService struct {
 	leaseDuration time.Duration
 }
 
-var _ KMS = (*vaultService)(nil) // compiler check that *vaultService implements KMS
+var _ KMS = (*vaultService)(nil)      // compiler check that *vaultService implements KMS
+var _ KeyStore = (*vaultService)(nil) // compiler check that *vaultService implements KeyStore
 
 // empty/default vault configuration used to check whether a particular is empty.
 var emptyVaultConfig = VaultConfig{}
@@ -75,12 +77,15 @@ var emptyVaultConfig = VaultConfig{}
 // empty configuration.
 func (v *VaultConfig) IsEmpty() bool { return *v == emptyVaultConfig }
 
-// Verify returns a nil error if the vault configuration
-// is valid. A valid configuration is either empty or
-// contains valid non-default values.
-func (v *VaultConfig) Verify() (err error) {
+// VerifyKMS returns a nil error if the vault configuration
+// is valid KMS configuration. A valid configuration is either
+// empty or contains valid non-default values.
+func (v *VaultConfig) VerifyKMS() (err error) {
 	if v.IsEmpty() {
 		return // an empty configuration is valid
+	}
+	if v.KeyStorePath != "" {
+		return errors.New("crypto: the key store path must not be present when using a KMS with master keys")
 	}
 	switch {
 	case v.Endpoint == "":
@@ -99,17 +104,71 @@ func (v *VaultConfig) Verify() (err error) {
 	return
 }
 
-// NewVault initializes Hashicorp Vault KMS by authenticating
+// VerifyKeyStore returns a nil error if the vault configuration
+// is a valid KeyStore configuration. A valid configuration is either
+// empty or contains valid non-default values.
+func (v *VaultConfig) VerifyKeyStore() (err error) {
+	if v.IsEmpty() {
+		return // an empty configuration is valid
+	}
+	if v.Key.Name != "" {
+		return errors.New("crypto: the master key name must not be present when using the key store")
+	}
+	switch {
+	case v.Endpoint == "":
+		err = errors.New("crypto: missing hashicorp vault endpoint")
+	case strings.ToLower(v.Auth.Type) != "approle":
+		err = fmt.Errorf("crypto: invalid hashicorp vault authentication type: %s is not supported", v.Auth.Type)
+	case v.Auth.AppRole.ID == "":
+		err = errors.New("crypto: missing hashicorp vault AppRole ID")
+	case v.Auth.AppRole.Secret == "":
+		err = errors.New("crypto: missing hashicorp vault AppSecret ID")
+	case v.KeyStorePath == "":
+		err = errors.New("crypto: missing hashicorp vault K/V path")
+	}
+	return
+}
+
+// NewVaultKMS initializes Hashicorp Vault KMS by authenticating
 // to Vault with the credentials in config and gets a client
-// token for future api calls.
-func NewVault(config VaultConfig) (KMS, error) {
+// token for future API calls.
+func NewVaultKMS(config VaultConfig) (KMS, error) {
 	if config.IsEmpty() {
 		return nil, errors.New("crypto: the hashicorp vault configuration must not be empty")
 	}
-	if err := config.Verify(); err != nil {
+	if err := config.VerifyKMS(); err != nil {
 		return nil, err
 	}
 
+	vaultCfg := vault.Config{Address: config.Endpoint}
+	if err := vaultCfg.ConfigureTLS(&vault.TLSConfig{CAPath: config.CAPath}); err != nil {
+		return nil, err
+	}
+	client, err := vault.NewClient(&vaultCfg)
+	if err != nil {
+		return nil, err
+	}
+	if config.Namespace != "" {
+		client.SetNamespace(config.Namespace)
+	}
+	v := &vaultService{client: client, config: &config}
+	if err := v.authenticate(); err != nil {
+		return nil, err
+	}
+	v.renewToken()
+	return v, nil
+}
+
+// NewVaultKeyStore initializes Hashicorp Vault K/V by authenticating
+// to Vault with the credentials in config and gets a client
+// token for future API calls.
+func NewVaultKeyStore(config VaultConfig) (KeyStore, error) {
+	if config.IsEmpty() {
+		return nil, errors.New("crypto: the hashicorp vault configuration must not be empty")
+	}
+	if err := config.VerifyKeyStore(); err != nil {
+		return nil, err
+	}
 	vaultCfg := vault.Config{Address: config.Endpoint}
 	if err := vaultCfg.ConfigureTLS(&vault.TLSConfig{CAPath: config.CAPath}); err != nil {
 		return nil, err
@@ -276,4 +335,43 @@ func (v *vaultService) UpdateKey(keyID string, sealedKey []byte, ctx Context) (r
 	}
 	rotatedKey = []byte(ciphertext.(string))
 	return rotatedKey, nil
+}
+
+// Load fetches the 256 bit key from the Vault K/V
+// that has been stored at the given path. It returns
+// an error if fetching the key fails or if there is
+// no key under the path.
+func (v *vaultService) Load(path string) (key [32]byte, err error) {
+	secret, err := v.client.Logical().Read(fmt.Sprintf("/%s/%s", v.config.KeyStorePath, path))
+	if err != nil {
+		return ObjectKey{}, err
+	}
+	base64Key := secret.Data["key"].(string)
+	decodedKey, err := base64.StdEncoding.DecodeString(base64Key)
+	if err != nil {
+		return key, err
+	}
+	if len(decodedKey) != len(key) {
+		return key, fmt.Errorf("crypto: KeyStore key has invalid size of %d bytes", len(decodedKey))
+	}
+	copy(key[:], decodedKey)
+	return key, nil
+}
+
+// Store stores a 256 bit key at the Vault K/V
+// under the given path. It returns an error if
+// storing the key fails.
+func (v *vaultService) Store(path string, key [32]byte) error {
+	payload := map[string]interface{}{
+		"key": base64.StdEncoding.EncodeToString(key[:]),
+	}
+	_, err := v.client.Logical().Write(fmt.Sprintf("/%s/%s", v.config.KeyStorePath, path), payload)
+	return err
+}
+
+// Delete deletes the key stored under the given
+// path.
+func (v *vaultService) Delete(path string) error {
+	_, err := v.client.Logical().Delete(fmt.Sprintf("/%s/%s", v.config.KeyStorePath, path))
+	return err
 }

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -74,6 +74,10 @@ const (
 	// vault namespace. The vault namespace is used if the enterprise
 	// version of Hashicorp Vault is used.
 	EnvVaultNamespace = "MINIO_SSE_VAULT_NAMESPACE"
+
+	// EnvVaultKeyStore is the environment variable used to specify
+	// the path to the vault K/V key store.
+	EnvVaultKeyStore = "MINIO_SSE_VAULT_KEY_STORE"
 )
 
 // Environment provides functions for accessing environment
@@ -122,12 +126,13 @@ func (env environment) LookupKMSConfig(config crypto.KMSConfig) (err error) {
 	config.Vault.Auth.AppRole.Secret = env.Get(EnvVaultAppSecretID, config.Vault.Auth.AppRole.Secret)
 	config.Vault.Key.Name = env.Get(EnvVaultKeyName, config.Vault.Key.Name)
 	config.Vault.Namespace = env.Get(EnvVaultNamespace, config.Vault.Namespace)
+	config.Vault.KeyStorePath = env.Get(EnvVaultKeyStore, config.Vault.KeyStorePath)
 	keyVersion := env.Get(EnvVaultKeyVersion, strconv.Itoa(config.Vault.Key.Version))
 	config.Vault.Key.Version, err = strconv.Atoi(keyVersion)
 	if err != nil {
 		return fmt.Errorf("Invalid ENV variable: Unable to parse %s value (`%s`)", EnvVaultKeyVersion, keyVersion)
 	}
-	if err = config.Vault.Verify(); err != nil {
+	if err = config.Vault.VerifyKMS(); err != nil {
 		return err
 	}
 
@@ -142,11 +147,20 @@ func (env environment) LookupKMSConfig(config crypto.KMSConfig) (err error) {
 		}
 	}
 	if !config.Vault.IsEmpty() {
-		GlobalKMS, err = crypto.NewVault(config.Vault)
-		if err != nil {
-			return err
+		switch {
+		case config.Vault.Key.Name != "":
+			GlobalKMS, err = crypto.NewVaultKMS(config.Vault)
+			if err != nil {
+				return err
+			}
+			globalKMSKeyID = config.Vault.Key.Name
+		case config.Vault.KeyStorePath != "":
+			GlobalKeyStore, err = crypto.NewVaultKeyStore(config.Vault)
+			if err != nil {
+				return err
+			}
+		default:
 		}
-		globalKMSKeyID = config.Vault.Key.Name
 	}
 
 	autoEncryption, err := ParseBoolFlag(env.Get(EnvAutoEncryption, "off"))
@@ -154,8 +168,8 @@ func (env environment) LookupKMSConfig(config crypto.KMSConfig) (err error) {
 		return err
 	}
 	globalAutoEncryption = bool(autoEncryption)
-	if globalAutoEncryption && GlobalKMS == nil { // auto-encryption enabled but no KMS
-		return errors.New("Invalid KMS configuration: auto-encryption is enabled but no valid KMS configuration is present")
+	if globalAutoEncryption && (GlobalKMS == nil && GlobalKeyStore == nil) { // auto-encryption enabled but no KMS
+		return errors.New("Invalid KMS configuration: auto-encryption is enabled but no valid KMS or Key Store configuration is present")
 	}
 	return nil
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -240,11 +240,19 @@ var (
 	// Usage check interval value.
 	globalUsageCheckInterval = globalDefaultUsageCheckInterval
 
-	// KMS key id
+	// KMS master key ID used to encrypt arriving objects.
 	globalKMSKeyID string
 
-	// GlobalKMS initialized KMS configuration
+	// GlobalKMS is the KMS to perform en/decryption
+	// operation. A deployment can either use a KMS
+	// or a KeyStore but not both at the same time.
 	GlobalKMS crypto.KMS
+
+	// GlobalKeyStore is the K/V store used to
+	// store encryption keys. A deployment can
+	// either use a KMS or a KeyStore but not both
+	// at the same time.
+	GlobalKeyStore crypto.KeyStore
 
 	// Auto-Encryption, if enabled, turns any non-SSE-C request
 	// into an SSE-S3 request. If enabled a valid, non-empty KMS


### PR DESCRIPTION
## Description
This commit adds the `KeyStore` interface
to load and store secret keys at an external
key-value store.

Further, it adds the `MINIO_SSE_VAULT_KEY_STORE`
env. var. to specify the path to the key store.

In general a MinIO cluster can use either a KMS
(with master keys) or a Key Store for key management - but
not both at the same time.

## Motivation and Context
Follow up on #8259

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
