### PR TITLE
WIP: add basic support for a secret key store

### DIFF
--- a/cmd/crypto/kms.go
+++ b/cmd/crypto/kms.go
@@ -67,7 +67,7 @@ func (c Context) WriteTo(w io.Writer) (n int64, err error) {
 	return n + int64(nn), err
 }
 
-// KMS represents an active and authenticted connection
+// KMS represents an active and authenticated connection
 // to a Key-Management-Service. It supports generating
 // data key generation and unsealing of KMS-generated
 // data keys.

--- a/cmd/crypto/kv.go
+++ b/cmd/crypto/kv.go
@@ -1,0 +1,36 @@
+// MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+// KeyStore represents an active and authenticated connection
+// to a Key-Value-Store that holds secret keys. It supports
+// loading, storing and deleting such secret keys.
+type KeyStore interface {
+
+	// Load fetches the 256 bit key from the key store
+	// that has been stored at the given path. It returns
+	// an error if fetching the key fails or if there is
+	// no key under the path.
+	Load(path string) (key [32]byte, err error)
+
+	// Store stores a 256 bit key at the key store
+	// under the given path. It returns an error if
+	// storing the key fails.
+	Store(path string, key [32]byte) error
+
+	// Delete deletes the key stored under the given
+	// path.
+	Delete(path string) error
+}

--- a/cmd/crypto/sse_test.go
+++ b/cmd/crypto/sse_test.go
@@ -219,7 +219,7 @@ var s3UnsealObjectKeyTests = []struct {
 
 func TestS3UnsealObjectKey(t *testing.T) {
 	for i, test := range s3UnsealObjectKeyTests {
-		if _, err := S3.UnsealObjectKey(test.KMS, test.Metadata, test.Bucket, test.Object); err != test.ExpectedErr {
+		if _, err := S3.UnsealObjectKeyWithKMS(test.KMS, test.Metadata, test.Bucket, test.Object); err != test.ExpectedErr {
 			t.Errorf("Test %d: got: %v - want: %v", i, err, test.ExpectedErr)
 		}
 	}

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -80,6 +80,11 @@ const (
 	EnvVaultKeyStore = "MINIO_SSE_VAULT_KEY_STORE"
 )
 
+// KeyStoreFeature is a feature flag that disables
+// the key store feature. Remove it as soon as we
+// officially support a key store.
+const KeyStoreFeature = false
+
 // Environment provides functions for accessing environment
 // variables.
 var Environment = environment{}
@@ -154,7 +159,7 @@ func (env environment) LookupKMSConfig(config crypto.KMSConfig) (err error) {
 				return err
 			}
 			globalKMSKeyID = config.Vault.Key.Name
-		case config.Vault.KeyStorePath != "":
+		case config.Vault.KeyStorePath != "" && KeyStoreFeature:
 			GlobalKeyStore, err = crypto.NewVaultKeyStore(config.Vault)
 			if err != nil {
 				return err

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -240,11 +240,19 @@ var (
 	// Usage check interval value.
 	globalUsageCheckInterval = globalDefaultUsageCheckInterval
 
-	// KMS key id
+	// KMS master key ID used to encrypt arriving objects.
 	globalKMSKeyID string
 
-	// GlobalKMS initialized KMS configuration
+	// GlobalKMS is the KMS to perform en/decryption
+	// operation. A deployment can either use a KMS
+	// or a KeyStore but not both at the same time.
 	GlobalKMS crypto.KMS
+
+	// GlobalKeyStore is the K/V store used to
+	// store encryption keys. A deployment can
+	// either use a KMS or a KeyStore but not both
+	// at the same time.
+	GlobalKeyStore crypto.KeyStore
 
 	// Auto-Encryption, if enabled, turns any non-SSE-C request
 	// into an SSE-S3 request. If enabled a valid, non-empty KMS

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -26,6 +26,7 @@ import (
 	goioutil "io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -2405,5 +2406,14 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		}
 		// Ignore delete object errors while replying to client, since we are suppposed to reply only 204.
 	}
+
+	// The delete succeeded - now try to delete the secret key if present.
+	if api.CacheAPI() == nil && objectAPI.IsEncryptionSupported() && GlobalKeyStore != nil {
+		if err := GlobalKeyStore.Delete(path.Join(bucket, object)); err != nil {
+			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+			return
+		}
+	}
+
 	writeSuccessNoContent(w)
 }


### PR DESCRIPTION
## Description
This commit adds basic support for fetching
and storing secret keys (for SSE-S3) at an
external key store.

Whenever a object is deleted we should try to
delete the secret key from the key store.
The current approach follows an eventual consistency
model where we delete the secret key after we have
deleted the object from the backend successfully.
However, it may be better to only delete the object
from the backend *if* we have deleted the secret key
from the key store.

## Motivation and Context
Follow up on #8259

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
