### PR TITLE
remove TLS 1.3 opt-in code

### DIFF
--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"net/http"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,13 +29,6 @@ import (
 	"github.com/minio/minio-go/v6/pkg/set"
 	"github.com/minio/minio/pkg/certs"
 )
-
-func init() {
-	// Opt-in to TLS 1.3. See: https://golang.org/pkg/crypto/tls
-	// In future Go versions TLS 1.3 probably gets enabled by default.
-	// So, we can remove this line as soon as this is the case.
-	os.Setenv("GODEBUG", os.Getenv("GODEBUG")+",tls13=1")
-}
 
 const (
 	serverShutdownPoll = 500 * time.Millisecond


### PR DESCRIPTION
## Description
This commit removes the TLS 1.3 opt-in code.
Since TLS 1.3 is opt-out for >= Go 1.13 this
code is not needed anymore.

See: https://golang.org/pkg/crypto/tls/

## Motivation and Context
TLS

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
