### PR TITLE
Add a basic .dockerignore file to reduce docker context in `make docker`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ LDFLAGS := $(shell go run buildscripts/gen-ldflags.go)
 GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 
-TAG ?= $(USER)
+VERSION ?= $(shell git describe --tags)
+TAG ?= "minio/minio:$(VERSION)"
+
 BUILD_LDFLAGS := '$(LDFLAGS)'
 
 all: build


### PR DESCRIPTION

## Description
This PR reduces the size of docker context to Docker daemon during `make docker`.

## Motivation and Context
This reduces the time to build local docker images for testing.

## How to test this PR?
`make docker` with and without this PR and notice the difference in the docker context sizes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
