### PR TITLE
Fix LDAP responseXML to be named appropriately

### DIFF
--- a/cmd/sts-datatypes.go
+++ b/cmd/sts-datatypes.go
@@ -178,8 +178,8 @@ type ClientGrantsResult struct {
 // AssumeRoleWithLDAPResponse contains the result of successful
 // AssumeRoleWithLDAPIdentity request
 type AssumeRoleWithLDAPResponse struct {
-	XMLName          xml.Name           `xml:"https://sts.amazonaws.com/doc/2011-06-15/ AssumeRoleWithClientGrantsResponse" json:"-"`
-	Result           LDAPIdentityResult `xml:"AssumeRoleWithLDAPIdentity"`
+	XMLName          xml.Name           `xml:"https://sts.amazonaws.com/doc/2011-06-15/ AssumeRoleWithLDAPIdentityResponse" json:"-"`
+	Result           LDAPIdentityResult `xml:"AssumeRoleWithLDAPIdentityResult"`
 	ResponseMetadata struct {
 		RequestID string `xml:"RequestId,omitempty"`
 	} `xml:"ResponseMetadata,omitempty"`

--- a/docs/sts/assume-role.md
+++ b/docs/sts/assume-role.md
@@ -6,7 +6,18 @@ Returns a set of temporary security credentials that you can use to access MinIO
 
 The temporary security credentials returned by this API consists of an access key, a secret key, and a security token. Applications can use these temporary security credentials to sign calls to MinIO API operations. The policy applied to these temporary credentials is inherited from the MinIO user credentials. By default, the temporary security credentials created by AssumeRole last for one hour. However, use the optional DurationSeconds parameter to specify the duration of the credentials. This value varies from 900 seconds (15 minutes) up to the maximum session duration to 12 hours.
 
-### Request Parameters
+### API Request Parameters
+#### Version
+Indicates STS API version information, the only supported value is '2011-06-15'. This value is borrowed from AWS STS API documentation for compatibility reasons.
+
+| Params     | Value    |
+| :--        | :--      |
+| *Type*     | *String* |
+| *Required* | *Yes*    |
+
+#### AUTHPARAMS
+Indicates STS API Authorization information. If you are familiar with AWS Signature V4 Authorization header, this STS API supports signature V4 authorization as mentioned [here](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+
 #### DurationSeconds
 The duration, in seconds. The value can range from 900 seconds (15 minutes) up to 12 hours. If value is higher than this setting, then operation fails. By default, the value is set to 3600 seconds.
 
@@ -24,17 +35,6 @@ An IAM policy in JSON format that you want to use as an inline session policy. T
 | *Type*        | *String*                                       |
 | *Valid Range* | *Minimum length of 1. Maximum length of 2048.* |
 | *Required*    | *No*                                           |
-
-#### Version
-Indicates STS API version information, the only supported value is '2011-06-15'. This value is borrowed from AWS STS API documentation for compatibility reasons.
-
-| Params     | Value    |
-| :--        | :--      |
-| *Type*     | *String* |
-| *Required* | *Yes*    |
-
-#### AUTHPARAMS
-Indicates STS API Authorization information. If you are familiar with AWS Signature V4 Authorization header, this STS API supports signature V4 authorization as mentioned [here](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
 
 #### Response Elements
 XML response for this API is similar to [AWS STS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#API_AssumeRole_ResponseElements)

--- a/docs/sts/client-grants.go
+++ b/docs/sts/client-grants.go
@@ -99,7 +99,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Uncommend this to use MinIO API operations by initializing minio
+	// Uncomment this to use MinIO API operations by initializing minio
 	// client with obtained credentials.
 
 	opts := &minio.Options{

--- a/docs/sts/client-grants.md
+++ b/docs/sts/client-grants.md
@@ -5,7 +5,24 @@ Calling AssumeRoleWithClientGrants does not require the use of MinIO default cre
 
 By default, the temporary security credentials created by AssumeRoleWithClientGrants last for one hour. However, use the optional DurationSeconds parameter to specify the duration of the credentials. This value varies from 900 seconds (15 minutes) up to the maximum session duration to 12 hours.
 
-### Request Parameters
+### API Request Parameters
+#### Token
+The OAuth 2.0 access token that is provided by the identity provider. Application must get this token by authenticating the application using client credential grants before the application makes an AssumeRoleWithClientGrants call.
+
+| Params               | Value                                          |
+| :--                  | :--                                            |
+| *Type*               | *String*                                       |
+| *Length Constraints* | *Minimum length of 4. Maximum length of 2048.* |
+| *Required*           | *Yes*                                          |
+
+#### Version
+Indicates STS API version information, the only supported value is '2011-06-15'.  This value is borrowed from AWS STS API documentation for compatibility reasons.
+
+| Params     | Value    |
+| :--        | :--      |
+| *Type*     | *String* |
+| *Required* | *Yes*    |
+
 #### DurationSeconds
 The duration, in seconds. The value can range from 900 seconds (15 minutes) up to 12 hours. If value is higher than this setting, then operation fails. By default, the value is set to 3600 seconds.
 
@@ -23,23 +40,6 @@ An IAM policy in JSON format that you want to use as an inline session policy. T
 | *Type*        | *String*                                       |
 | *Valid Range* | *Minimum length of 1. Maximum length of 2048.* |
 | *Required*    | *No*                                           |
-
-#### Token
-The OAuth 2.0 access token that is provided by the identity provider. Application must get this token by authenticating the application using client credential grants before the application makes an AssumeRoleWithClientGrants call.
-
-| Params               | Value                                          |
-| :--                  | :--                                            |
-| *Type*               | *String*                                       |
-| *Length Constraints* | *Minimum length of 4. Maximum length of 2048.* |
-| *Required*           | *Yes*                                          |
-
-#### Version
-Indicates STS API version information, the only supported value is '2011-06-15'.  This value is borrowed from AWS STS API documentation for compatibility reasons.
-
-| Params     | Value    |
-| :--        | :--      |
-| *Type*     | *String* |
-| *Required* | *Yes*    |
 
 #### Response Elements
 XML response for this API is similar to [AWS STS AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_ResponseElements)

--- a/docs/sts/ldap.go
+++ b/docs/sts/ldap.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 
@@ -27,14 +28,26 @@ import (
 
 var (
 	// LDAP integrated Minio endpoint
-	stsEndpoint = "http://localhost:9000"
+	stsEndpoint string
 
 	// LDAP credentials
-	ldapUsername = "ldapuser"
-	ldapPassword = "ldapsecret"
+	ldapUsername string
+	ldapPassword string
 )
 
+func init() {
+	flag.StringVar(&stsEndpoint, "sts-ep", "http://localhost:9000", "STS endpoint")
+	flag.StringVar(&ldapUsername, "u", "", "AD/LDAP Username")
+	flag.StringVar(&ldapPassword, "p", "", "AD/LDAP Password")
+}
+
 func main() {
+	flag.Parse()
+	if ldapUsername == "" || ldapPassword == "" {
+		flag.PrintDefaults()
+		return
+	}
+
 	// The credentials package in minio-go provides an interface to call the
 	// LDAP STS API.
 

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -136,3 +136,95 @@ MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN='dc=minioad,dc=local'
 MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER='(&(objectclass=group)(member=${usernamedn}))'
 MINIO_IDENTITY_LDAP_GROUP_NAME_ATTRIBUTE='cn'
 ```
+
+### API Request Parameters
+#### LDAPUsername
+Is AD/LDAP username to login. Application must ask user for this value to successfully obtain rotating access credentials from AssumeRoleWithLDAPIdentity.
+
+| Params               | Value                                          |
+| :--                  | :--                                            |
+| *Type*               | *String*                                       |
+| *Length Constraints* | *Minimum length of 2. Maximum length of 2048.* |
+| *Required*           | *Yes*                                          |
+
+
+#### LDAPPassword
+Is AD/LDAP username password to login. Application must ask user for this value to successfully obtain rotating access credentials from AssumeRoleWithLDAPIdentity.
+
+| Params               | Value                                          |
+| :--                  | :--                                            |
+| *Type*               | *String*                                       |
+| *Length Constraints* | *Minimum length of 4. Maximum length of 2048.* |
+| *Required*           | *Yes*                                          |
+
+#### Version
+Indicates STS API version information, the only supported value is '2011-06-15'.  This value is borrowed from AWS STS API documentation for compatibility reasons.
+
+| Params     | Value    |
+| :--        | :--      |
+| *Type*     | *String* |
+| *Required* | *Yes*    |
+
+#### Policy
+An IAM policy in JSON format that you want to use as an inline session policy. This parameter is optional. Passing policies to this operation returns new temporary credentials. The resulting session's permissions are the intersection of the canned policy name and the policy set here. You cannot use this policy to grant more permissions than those allowed by the canned policy name being assumed.
+
+| Params        | Value                                          |
+| :--           | :--                                            |
+| *Type*        | *String*                                       |
+| *Valid Range* | *Minimum length of 1. Maximum length of 2048.* |
+| *Required*    | *No*                                           |
+
+#### Response Elements
+XML response for this API is similar to [AWS STS AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_ResponseElements)
+
+#### Errors
+XML error response for this API is similar to [AWS STS AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_Errors)
+
+#### Sample Request
+```
+http://minio.cluster:9000?Action=AssumeRoleWithLDAPIdentity&LDAPUsername=foouser&LDAPPassword=foouserpassword&Version=2011-06-15
+```
+
+#### Sample Response
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleWithLDAPIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithLDAPIdentityResult>
+    <AssumedRoleUser>
+      <Arn/>
+      <AssumeRoleId/>
+    </AssumedRoleUser>
+    <Credentials>
+      <AccessKeyId>Y4RJU1RNFGK48LGO9I2S</AccessKeyId>
+      <SecretAccessKey>sYLRKS1Z7hSjluf6gEbb9066hnx315wHTiACPAjg</SecretAccessKey>
+      <Expiration>2019-08-08T20:26:12Z</Expiration>
+      <SessionToken>eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiJZNFJKVTFSTkZHSzQ4TEdPOUkyUyIsImF1ZCI6IlBvRWdYUDZ1Vk80NUlzRU5SbmdEWGo1QXU1WWEiLCJhenAiOiJQb0VnWFA2dVZPNDVJc0VOUm5nRFhqNUF1NVlhIiwiZXhwIjoxNTQxODExMDcxLCJpYXQiOjE1NDE4MDc0NzEsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0Ojk0NDMvb2F1dGgyL3Rva2VuIiwianRpIjoiYTBiMjc2MjktZWUxYS00M2JmLTg3MzktZjMzNzRhNGNkYmMwIn0.ewHqKVFTaP-j_kgZrcOEKroNUjk10GEp8bqQjxBbYVovV0nHO985VnRESFbcT6XMDDKHZiWqN2vi_ETX_u3Q-w</SessionToken>
+    </Credentials>
+  </AssumeRoleWithLDAPIdentity>
+  <ResponseMetadata/>
+</AssumeRoleWithLDAPIdentityResponse>
+```
+
+#### Testing
+```
+$ export MINIO_ACCESS_KEY=minio
+$ export MINIO_SECRET_KEY=minio123
+$ export MINIO_IDENTITY_LDAP_SERVER_ADDR='ldaps://my.ldap-active-dir-server.com:636'
+$ export MINIO_IDENTITY_LDAP_USERNAME_FORMAT='cn=${username},cn=users,dc=minioad,dc=local'
+$ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN='dc=minioad,dc=local'
+$ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER='(&(objectclass=group)(member=${usernamedn}))'
+$ export MINIO_IDENTITY_LDAP_GROUP_NAME_ATTRIBUTE='cn'
+$ minio server ~/test
+```
+
+```
+$ go run ldap.go -u foouser -p foopassword
+
+##### Credentials
+{
+        "accessKey": "NUIBORZYTV2HG2BMRSXR",
+        "secretKey": "qQlP5O7CFPc5m5IXf1vYhuVTFj7BRVJqh0FqZ86S",
+        "expiration": "2018-08-21T17:10:29-07:00",
+        "sessionToken": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiJOVUlCT1JaWVRWMkhHMkJNUlNYUiIsImF1ZCI6IlBvRWdYUDZ1Vk80NUlzRU5SbmdEWGo1QXU1WWEiLCJhenAiOiJQb0VnWFA2dVZPNDVJc0VOUm5nRFhqNUF1NVlhIiwiZXhwIjoxNTM0ODk2NjI5LCJpYXQiOjE1MzQ4OTMwMjksImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0Ojk0NDMvb2F1dGgyL3Rva2VuIiwianRpIjoiNjY2OTZjZTctN2U1Ny00ZjU5LWI0MWQtM2E1YTMzZGZiNjA4In0.eJONnVaSVHypiXKEARSMnSKgr-2mlC2Sr4fEGJitLcJF_at3LeNdTHv0_oHsv6ZZA3zueVGgFlVXMlREgr9LXA"
+}
+```

--- a/docs/sts/web-identity.md
+++ b/docs/sts/web-identity.md
@@ -3,7 +3,24 @@ Calling AssumeRoleWithWebIdentity does not require the use of MinIO default cred
 
 By default, the temporary security credentials created by AssumeRoleWithWebIdentity last for one hour. However, use the optional DurationSeconds parameter to specify the duration of the credentials. This value varies from 900 seconds (15 minutes) up to the maximum session duration to 12 hours.
 
-### Request Parameters
+### API Request Parameters
+#### WebIdentityToken
+The OAuth 2.0 access token that is provided by the web identity provider. Application must get this token by authenticating the user who is using your application with a web identity provider before the application makes an AssumeRoleWithWebIdentity call.
+
+| Params               | Value                                          |
+| :--                  | :--                                            |
+| *Type*               | *String*                                       |
+| *Length Constraints* | *Minimum length of 4. Maximum length of 2048.* |
+| *Required*           | *Yes*                                          |
+
+#### Version
+Indicates STS API version information, the only supported value is '2011-06-15'. This value is borrowed from AWS STS API documentation for compatibility reasons.
+
+| Params     | Value    |
+| :--        | :--      |
+| *Type*     | *String* |
+| *Required* | *Yes*    |
+
 #### DurationSeconds
 The duration, in seconds. The value can range from 900 seconds (15 minutes) up to 12 hours. If value is higher than this setting, then operation fails. By default, the value is set to 3600 seconds.
 
@@ -21,23 +38,6 @@ An IAM policy in JSON format that you want to use as an inline session policy. T
 | *Type*        | *String*                                       |
 | *Valid Range* | *Minimum length of 1. Maximum length of 2048.* |
 | *Required*    | *No*                                           |
-
-#### WebIdentityToken
-The OAuth 2.0 access token that is provided by the web identity provider. Application must get this token by authenticating the user who is using your application with a web identity provider before the application makes an AssumeRoleWithWebIdentity call.
-
-| Params               | Value                                          |
-| :--                  | :--                                            |
-| *Type*               | *String*                                       |
-| *Length Constraints* | *Minimum length of 4. Maximum length of 2048.* |
-| *Required*           | *Yes*                                          |
-
-#### Version
-Indicates STS API version information, the only supported value is '2011-06-15'. This value is borrowed from AWS STS API documentation for compatibility reasons.
-
-| Params     | Value    |
-| :--        | :--      |
-| *Type*     | *String* |
-| *Required* | *Yes*    |
 
 #### Response Elements
 XML response for this API is similar to [AWS STS AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html#API_AssumeRoleWithWebIdentity_ResponseElements)


### PR DESCRIPTION
## Description
Fix LDAP responseXML to be named appropriately

## Motivation and Context
This PR additionally also adds support for missing

- Session policy support for AD/LDAP
- Add API request/response parameters detail
- Update example to take LDAP username,
  password input from the command line
- Fixes session policy handling for
  ClientGrants and WebIdentity STS handlers

## How to test this PR?
All the techniques used in testing the PR #8091 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
