### PR TITLE
Add checks in DiskInfo() to protect against changing mounts

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -329,6 +329,10 @@ func (s *posix) DiskInfo() (info DiskInfo, err error) {
 		return info, errFaultyDisk
 	}
 
+	if err := s.checkDiskFound(); err != nil {
+		return info, err
+	}
+
 	di, err := getDiskInfo(s.diskPath)
 	if err != nil {
 		return info, err


### PR DESCRIPTION
## Description
Add checks in DiskInfo() to protect against changing mounts

## Motivation and Context
There is a possibility of DiskInfo() call returning incorrect
values if the disks are not mounted properly.

## How to test this PR?
The checks added in this PR are inline with other calls in posix layer.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
