### PR TITLE
Parallelize initialization of storageDisks

### DIFF
--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1615,9 +1615,11 @@ func newTestObjectLayer(endpoints EndpointList) (newObject ObjectLayer, err erro
 		return nil, err
 	}
 
-	storageDisks, err := initStorageDisks(endpoints)
-	if err != nil {
-		return nil, err
+	storageDisks, errs := initStorageDisksWithErrors(endpoints)
+	for _, err = range errs {
+		if err != nil && err != errDiskNotFound {
+			return nil, err
+		}
 	}
 
 	// Initialize list pool.

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -339,7 +339,7 @@ func (s *xlSets) StorageInfo(ctx context.Context) StorageInfo {
 		storageInfo.Backend.Sets[i] = make([]madmin.DriveInfo, s.drivesPerSet)
 	}
 
-	storageDisks, dErrs := initDisksWithErrors(s.endpoints)
+	storageDisks, dErrs := initStorageDisksWithErrors(s.endpoints)
 	defer closeStorageDisks(storageDisks)
 
 	formats, sErrs := loadFormatXLAll(storageDisks)
@@ -1324,9 +1324,11 @@ func (s *xlSets) ReloadFormat(ctx context.Context, dryRun bool) (err error) {
 	}
 	defer formatLock.RUnlock()
 
-	storageDisks, err := initStorageDisks(s.endpoints)
-	if err != nil {
-		return err
+	storageDisks, errs := initStorageDisksWithErrors(s.endpoints)
+	for i, err := range errs {
+		if err != nil && err != errDiskNotFound {
+			return fmt.Errorf("Disk %s: %w", s.endpoints[i], err)
+		}
 	}
 	defer func(storageDisks []StorageAPI) {
 		if err != nil {
@@ -1445,9 +1447,11 @@ func (s *xlSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.HealRe
 	}
 	defer formatLock.Unlock()
 
-	storageDisks, err := initStorageDisks(s.endpoints)
-	if err != nil {
-		return madmin.HealResultItem{}, err
+	storageDisks, errs := initStorageDisksWithErrors(s.endpoints)
+	for i, derr := range errs {
+		if derr != nil && derr != errDiskNotFound {
+			return madmin.HealResultItem{}, fmt.Errorf("Disk %s: %w", s.endpoints[i], derr)
+		}
 	}
 
 	defer func(storageDisks []StorageAPI) {


### PR DESCRIPTION
## Description
Parallelize initialization of storageDisks

## Motivation and Context
A higher number of endpoints should be initialized in parallel 

## How to test this PR?
```
~  benchcmp /tmp/prev /tmp/new 
benchmark                           old ns/op     new ns/op     delta
BenchmarkInitStorageDisks256-4      6868523       5633617       -17.98%
BenchmarkInitStorageDisks1024-4     31059490      26246112      -15.50%
BenchmarkInitStorageDisks2048-4     62277295      38179426      -38.69%
BenchmarkInitStorageDisksMax-4      193600127     178121000     -8.00%
```

```
~ benchstat /tmp/prev /tmp/new 
name                    old time/op    new time/op    delta
InitStorageDisks256-4     6.87ms ± 0%    5.63ms ± 0%   ~     (p=1.000 n=1+1)
InitStorageDisks1024-4    31.1ms ± 0%    26.2ms ± 0%   ~     (p=1.000 n=1+1)
InitStorageDisks2048-4    62.3ms ± 0%    38.2ms ± 0%   ~     (p=1.000 n=1+1)
InitStorageDisksMax-4      194ms ± 0%     178ms ± 0%   ~     (p=1.000 n=1+1)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
