### PR TITLE
read LDAP authentication from the terminal

### DIFF
--- a/docs/sts/ldap.go
+++ b/docs/sts/ldap.go
@@ -20,6 +20,11 @@ package main
 import (
 	"fmt"
 	"log"
+        "bufio"
+        "os"
+        "strings"
+
+        "golang.org/x/crypto/ssh/terminal"
 
 	miniogo "github.com/minio/minio-go/v6"
 	cr "github.com/minio/minio-go/v6/pkg/credentials"
@@ -29,15 +34,25 @@ var (
 	// LDAP integrated Minio endpoint
 	stsEndpoint = "http://localhost:9000"
 
-	// LDAP credentials
-	ldapUsername = "ldapuser"
-	ldapPassword = "ldapsecret"
 )
 
 func main() {
 	// The credentials package in minio-go provides an interface to call the
 	// LDAP STS API.
+	
+	// read LDAP authenication from the terminal
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Enter LDAP Username: ")
+	username,_ := reader.ReadString('\n')
+	ldapUsername = strings.TrimSpace(username)
 
+	fmt.Print("LDAP Password: ")
+	bytePassword, err := terminal.ReadPassword(0)
+        if err != nil {
+                log.Fatalf("Need LDAP password from stdin", err)
+        }
+        ldapPassword = string(bytePassword)	
+	
 	// Initialize LDAP credentials
 	li, err := cr.NewLDAPIdentity(stsEndpoint, ldapUsername, ldapPassword)
 	if err != nil {


### PR DESCRIPTION
## Description
This patch is to read the LDAP credentials from the termal instead of hardcoding into a source file.

## Motivation and Context
Writing your authentication credentials in a source file is not safe and it seemed to be on the STS LDAP bucket list.

## How to test this PR?
go run ldap.go

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
