### PR TITLE
s3: Encode continuation & next continuation tokens when asked

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -498,8 +498,8 @@ func generateListObjectsV2Response(bucket, prefix, token, nextToken, startAfter,
 	data.Delimiter = s3EncodeName(delimiter, encodingType)
 	data.Prefix = s3EncodeName(prefix, encodingType)
 	data.MaxKeys = maxKeys
-	data.ContinuationToken = token
-	data.NextContinuationToken = nextToken
+	data.ContinuationToken = s3EncodeName(token, encodingType)
+	data.NextContinuationToken = s3EncodeName(nextToken, encodingType)
 	data.IsTruncated = isTruncated
 	for _, prefix := range prefixes {
 		var prefixItem = CommonPrefix{}


### PR DESCRIPTION

## Description
When url encoding is passed in v2 listing handler, continuationToken
and nextContinuationToken needs to be encoded. The reason is that
both represents an object name/prefix in Minio server and it could
contain a character unsupported by XML specification.


## Motivation and Context
Avoid returning un-espaced next continuation token in listing object

## How to test this PR?
Upload more than 1000 objects which contains this character 0x17, and then try to list using https://github.com/minio/minio-go/pull/1165


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
