### PR TITLE
Add InfoCannedPolicy API to fetch only necessary policy

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1329,6 +1329,25 @@ func (a adminAPIHandlers) AddUser(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// InfoCannedPolicy - GET /minio/admin/v1/info-canned-policy?name={policyName}
+func (a adminAPIHandlers) InfoCannedPolicy(w http.ResponseWriter, r *http.Request) {
+	ctx := newContext(r, w, "InfoCannedPolicy")
+
+	objectAPI := validateAdminReq(ctx, w, r)
+	if objectAPI == nil {
+		return
+	}
+
+	data, err := globalIAMSys.InfoPolicy(mux.Vars(r)["name"])
+	if err != nil {
+		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
+		return
+	}
+
+	w.Write(data)
+	w.(http.Flusher).Flush()
+}
+
 // ListCannedPolicies - GET /minio/admin/v1/list-canned-policies
 func (a adminAPIHandlers) ListCannedPolicies(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "ListCannedPolicies")

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -91,6 +91,9 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 		adminV1Router.Methods(http.MethodPut).Path("/set-user-status").HandlerFunc(httpTraceHdrs(adminAPI.SetUserStatus)).
 			Queries("accessKey", "{accessKey:.*}").Queries("status", "{status:.*}")
 
+		// Info policy IAM
+		adminV1Router.Methods(http.MethodGet).Path("/info-canned-policy").HandlerFunc(httpTraceHdrs(adminAPI.InfoCannedPolicy)).Queries("name", "{name:.*}")
+
 		// Remove policy IAM
 		adminV1Router.Methods(http.MethodDelete).Path("/remove-canned-policy").HandlerFunc(httpTraceHdrs(adminAPI.RemoveCannedPolicy)).Queries("name", "{name:.*}")
 

--- a/pkg/madmin/policy-commands.go
+++ b/pkg/madmin/policy-commands.go
@@ -24,6 +24,31 @@ import (
 	"net/url"
 )
 
+// InfoCannedPolicy - expand canned policy into JSON structure.
+func (adm *AdminClient) InfoCannedPolicy(policyName string) ([]byte, error) {
+	queryValues := url.Values{}
+	queryValues.Set("name", policyName)
+
+	reqData := requestData{
+		relPath:     "/v1/info-canned-policy",
+		queryValues: queryValues,
+	}
+
+	// Execute GET on /minio/admin/v1/info-canned-policy
+	resp, err := adm.executeMethod("GET", reqData)
+
+	defer closeResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
+	return ioutil.ReadAll(resp.Body)
+}
+
 // ListCannedPolicies - list all configured canned policies.
 func (adm *AdminClient) ListCannedPolicies() (map[string][]byte, error) {
 	reqData := requestData{


### PR DESCRIPTION
## Description
Add InfoCannedPolicy API to fetch only necessary policy

## Motivation and Context
This PR adds
- InfoCannedPolicy() API for efficiency in fetching policies
- Send group memberships for LDAPUser if available

## How to test this PR?
You will have to use the example code in `pkg/madmin` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
