### PR TITLE
xl: Avoid healing a bucket in an unformatted disk

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -68,7 +68,17 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 
 	// Make a volume entry on all underlying storage disks.
 	for index, disk := range storageDisks {
+		// Check if the disk is formatted to
+		// avoid writing in it otherwise.
+		diskNotFound := false
 		if disk == nil {
+			diskNotFound = true
+		} else {
+			if _, dErr := disk.StatVol(pathJoin(minioMetaBucket, formatConfigFile)); dErr != nil {
+				diskNotFound = true
+			}
+		}
+		if diskNotFound {
 			dErrs[index] = errDiskNotFound
 			beforeState[index] = madmin.DriveStateOffline
 			afterState[index] = madmin.DriveStateOffline


### PR DESCRIPTION
## Description
Healing bucket will create a directory in a disk whether
it is formatted or not. An unformatted disk with data in
it is considered corrupted. This PR will check for
.minio.sys/format.json in each disk before creating the
bucket directory.

## Motivation and Context
Fixes #8188 

## How to test this PR?
1. Apply the following diff to accelerate healing cycle (each 1 minute)
```diff
diff --git a/cmd/daily-sweeper.go b/cmd/daily-sweeper.go
index f3237b9a..3ba50e7d 100644
--- a/cmd/daily-sweeper.go
+++ b/cmd/daily-sweeper.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
        "context"
-       "math/rand"
        "sync"
        "time"
 
@@ -131,12 +130,11 @@ func dailySweeper() {
                break
        }
 
-       // Start with random sleep time, so as to avoid "synchronous checks" between servers
-       time.Sleep(time.Duration(rand.Float64() * float64(time.Hour)))
+       time.Sleep(2 * time.Minute)
 
        for {
-               if time.Since(lastSweepTime) < 30*24*time.Hour {
-                       time.Sleep(time.Hour)
+               if time.Since(lastSweepTime) < time.Minute {
+                       time.Sleep(time.Second)
                        continue
                }
 
```


2. Start a standalone erasure with 4 fresh disks
3. Create a bucket and upload an object
4. Remove the content of one disk (along with its .minio.sys)
5. Wait one minute, you will see the bucket healed but .minio.sys
6. Stop Minio server and restart it, you will get a corrupted error message 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
