### PR TITLE
trace: Print either Transfer-Encoding or Content-Length

### DIFF
--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -100,8 +100,10 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 
 	// Setup a http request body recorder
 	reqHeaders := r.Header.Clone()
-	reqHeaders.Set("Content-Length", strconv.Itoa(int(r.ContentLength)))
 	reqHeaders.Set("Host", r.Host)
+	if len(r.TransferEncoding) == 0 {
+		reqHeaders.Set("Content-Length", strconv.Itoa(int(r.ContentLength)))
+	}
 	for _, enc := range r.TransferEncoding {
 		reqHeaders.Add("Transfer-Encoding", enc)
 	}


### PR DESCRIPTION
## Description
trace: Print either Transfer-Encoding or Content-Length

## Motivation and Context
If Transfer-Encoding is set client would have
never set Content-Length as its considered
malformed HTTP request

## How to test this PR?
Use the following program to upload an object to anonymous readwrite bucket

```go
package main

import (
	"fmt"
	"io"
	"log"
	"net/http"
	"net/http/httputil"
	"os"
)

type eofReader struct {
}

func (n eofReader) Close() error {
	return nil
}

func (n eofReader) Read([]byte) (int, error) {
	return 0, io.EOF
}

func testCase1(clnt *http.Client, debug bool) {
	req, err := http.NewRequest(http.MethodPut, "http://localhost:9001/testbucket/0byte", nil)
	if err != nil {
		log.Fatal(err)
	}
	req.Body = &eofReader{}
	req.ContentLength = 0

	if debug {
		reqBytes, err := httputil.DumpRequestOut(req, false)
		if err != nil {
			log.Fatal(err)
		}
		fmt.Println("############ REQUEST TestCase1")
		fmt.Println(string(reqBytes))
	}

	resp, err := clnt.Do(req)
	if err != nil {
		log.Fatal(err)
	}

	io.Copy(os.Stdout, resp.Body)
	resp.Body.Close()
}

func main() {
	debug := os.Getenv("DEBUG") == "1"
	clnt := &http.Client{}
	testCase1(clnt, debug)
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
