### PR TITLE
change `ReadPerf` into `ReadThroughput` in NetPerfInfo.

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -334,9 +334,9 @@ type ServerMemUsageInfo struct {
 
 // ServerNetReadPerfInfo network read performance information.
 type ServerNetReadPerfInfo struct {
-	Addr     string        `json:"addr"`
-	ReadPerf time.Duration `json:"readPerf"`
-	Error    string        `json:"error,omitempty"`
+	Addr           string `json:"addr"`
+	ReadThroughput uint64 `json:"readThroughput"`
+	Error          string `json:"error,omitempty"`
 }
 
 // PerfInfoHandler - GET /minio/admin/v1/performance?perfType={perfType}

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -106,9 +106,10 @@ func (s *peerRESTServer) NetReadPerfInfoHandler(w http.ResponseWriter, r *http.R
 		addr = GetLocalPeer(globalEndpoints)
 	}
 
+	d := end.Sub(start)
 	info := ServerNetReadPerfInfo{
-		Addr:     addr,
-		ReadPerf: end.Sub(start),
+		Addr:           addr,
+		ReadThroughput: uint64(int64(time.Second) * size / int64(d)),
 	}
 
 	ctx := newContext(r, w, "NetReadPerfInfo")

--- a/pkg/madmin/README.md
+++ b/pkg/madmin/README.md
@@ -280,11 +280,11 @@ Fetches Mem utilization for all cluster nodes.
 
 Fetches network performance of all cluster nodes using given sized payload. Returned value is a map containing each node indexed list of performance of other nodes.
 
-| Param      | Type             | Description                                                        |
-|------------|------------------|--------------------------------------------------------------------|
-| `Addr`     | _string_         | Address of the server the following information is retrieved from. |
-| `Error`    | _string_         | Errors (if any) encountered while reaching this node               |
-| `ReadPerf` | _time.Duration_  | Network read performance of the server                             |
+| Param            | Type      | Description                                                        |
+|------------------|-----------|--------------------------------------------------------------------|
+| `Addr`           | _string_  | Address of the server the following information is retrieved from. |
+| `Error`          | _string_  | Errors (if any) encountered while reaching this node               |
+| `ReadThroughput` | _uint64_  | Network read throughput of the server in bytes per second          |
 
 ## 5. Heal operations
 

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -305,9 +305,9 @@ func (adm *AdminClient) ServerMemUsageInfo() ([]ServerMemUsageInfo, error) {
 
 // NetPerfInfo network performance information.
 type NetPerfInfo struct {
-	Addr     string        `json:"addr"`
-	ReadPerf time.Duration `json:"readPerf"`
-	Error    string        `json:"error,omitempty"`
+	Addr           string `json:"addr"`
+	ReadThroughput uint64 `json:"readThroughput"`
+	Error          string `json:"error,omitempty"`
 }
 
 // NetPerfInfo - Returns network performance information of all cluster nodes.


### PR DESCRIPTION
Previously `ReadPerf` was in time.Duration is changed to `ReadThroughput` in uint64.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
