### PR TITLE
Expand GCS project ID regex to allow for project IDs with a domain prefix

### DIFF
--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -331,7 +331,7 @@ func gcsToObjectError(err error, params ...string) error {
 }
 
 // gcsProjectIDRegex defines a valid gcs project id format
-var gcsProjectIDRegex = regexp.MustCompile("^[a-z][a-z0-9-]{5,29}$")
+var gcsProjectIDRegex = regexp.MustCompile(`^(?:(?:[-a-z0-9]{1,63}\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?))$`)
 
 // isValidGCSProjectIDFormat - checks if a given project id format is valid or not.
 // Project IDs must start with a lowercase letter and can have lowercase ASCII letters,


### PR DESCRIPTION
## Description

Expand GCS project ID regex to allow for project IDs with a domain prefix

## Motivation and Context

Google Cloud Project IDs can be prefixed with a domain, such as `google.com:project-123`. This is not documented very clearly (or at least I haven't been able to find it), but when trying out the Google APIs through [the reference documentation](https://cloud.google.com/compute/docs/reference/rest/v1/instances/list#try-it) I discovered that a wrongly formatted Project ID returned the following error:

```
project does not match pattern: /(?:(?:[-a-z0-9]{1,63}\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?))/
```

## How to test this PR?

```
minio gateway gcs "google.com:project-123"
```

^^ should be accepted as a valid Project ID.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
