### PR TITLE
Fix error handling in DeleteFileBulk storage handler

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -37,6 +37,7 @@ func init() {
 	logger.Init(GOPATH, GOROOT)
 	logger.RegisterUIError(fmtError)
 	gob.Register(HashMismatchError{})
+	gob.Register(DeleteFileError(""))
 }
 
 // ServerFlags - server command specific flags

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -375,7 +375,6 @@ func (client *storageRESTClient) DeleteFileBulk(volume string, paths []string) (
 	if len(paths) == 0 {
 		return errs, err
 	}
-	errs = make([]error, len(paths))
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)
 	for _, path := range paths {
@@ -388,14 +387,13 @@ func (client *storageRESTClient) DeleteFileBulk(volume string, paths []string) (
 		return nil, err
 	}
 
-	bulkErrs := bulkErrorsResponse{}
-	gob.NewDecoder(respBody).Decode(&bulkErrs)
-	if err != nil {
+	dErrResp := &DeleteFileBulkErrsResp{}
+	if err = gob.NewDecoder(respBody).Decode(dErrResp); err != nil {
 		return nil, err
 	}
 
-	for i, dErr := range bulkErrs.Errs {
-		errs[i] = toStorageErr(dErr)
+	for _, dErr := range dErrResp.Errs {
+		errs = append(errs, toStorageErr(dErr))
 	}
 
 	return errs, nil


### PR DESCRIPTION

## Description
Fix error handling in DeleteFileBulk storage handler

## Motivation and Context
errors.errorString() cannot be marshaled by gob
encoder, so using a slice of []error would fail
to be encoded. This leads to no errors being
generated instead of gob.Decoder on the storage-client
would see an io.EOF

To avoid such bugs introduce a typed error for
handling such translations and register this type
for gob encoding support.

## How to test this PR?
For the most part, DeleteFileBulk will not generate errors, you need to simulate this by making a few disks read-only. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
