### PR TITLE
Allow sdk to use space character in access key

### DIFF
--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -250,6 +250,8 @@ func parsePreSignV4(query url.Values, region string, stype serviceType) (psv pre
 //            SignedHeaders=signedHeaders, Signature=signature
 //
 func parseSignV4(v4Auth string, region string, stype serviceType) (sv signValues, aec APIErrorCode) {
+	// credElement is fetched first to skip replacing the space in access key.
+	credElement := strings.TrimPrefix(strings.Split(strings.TrimSpace(v4Auth), ",")[0], signV4Algorithm)
 	// Replace all spaced strings, some clients can send spaced
 	// parameters and some won't. So we pro-actively remove any spaces
 	// to make parsing easier.
@@ -275,7 +277,7 @@ func parseSignV4(v4Auth string, region string, stype serviceType) (sv signValues
 
 	var err APIErrorCode
 	// Save credentail values.
-	signV4Values.Credential, err = parseCredentialHeader(authFields[0], region, stype)
+	signV4Values.Credential, err = parseCredentialHeader(strings.TrimSpace(credElement), region, stype)
 	if err != ErrNone {
 		return sv, err
 	}

--- a/cmd/signature-v4-parser_test.go
+++ b/cmd/signature-v4-parser_test.go
@@ -462,6 +462,36 @@ func TestParseSignV4(t *testing.T) {
 			},
 			expectedErrCode: ErrNone,
 		},
+		// Test case - 8.
+		{
+			inputV4AuthStr: signV4Algorithm +
+				strings.Join([]string{
+					// generating a valid credential.
+					generateCredentialStr(
+						"access key",
+						sampleTimeStr,
+						"us-west-1",
+						"s3",
+						"aws4_request"),
+					// valid SignedHeader.
+					"SignedHeaders=host;x-amz-content-sha256;x-amz-date",
+					// valid Signature field.
+					// a valid signature is of form "Signature="
+					"Signature=abcd",
+				}, ","),
+			expectedAuthField: signValues{
+				Credential: generateCredentials(
+					t,
+					"access key",
+					sampleTimeStr,
+					"us-west-1",
+					"s3",
+					"aws4_request"),
+				SignedHeaders: []string{"host", "x-amz-content-sha256", "x-amz-date"},
+				Signature:     "abcd",
+			},
+			expectedErrCode: ErrNone,
+		},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
## Description
Access key can contain spaces and be used by sdk.
Closes #8300 



## Motivation and Context
Since the server console prints the access key and secret key . They must be used by web interface and the sdk. Right now the request from sdk hits `parseSignV4`  where all the white space are removed.  Example : Access key passed by sdk is `minio object` . This on server side gets converted to `minioobject`  This leads to the error `Unable to initialize new config from the provided credentials. The access key ID you provided does not exist in our records.`  Solution to this is fetching the access key before removing the spaces to keep the access key intact.


## How to test this PR?

Run 
1. MC:  `./mc config host add myminio http://192.168.86.176:9000 "access key" "secretkey"`
2. JAVA: Initialise client `MinioClient minioClient = new MinioClient("http://localhost:9000", "access key", "secretkey");`
3. minio-py `client = Minio('localhost:9000',
               access_key='access key',
               secret_key='secretkey',
               secure=False)` 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
