### PR TITLE
listV2: Continuation and NextContinuation tokens are encoded with base64

### DIFF
--- a/cmd/api-resources.go
+++ b/cmd/api-resources.go
@@ -96,6 +96,7 @@ func getListObjectsV2Args(values url.Values) (prefix, token, startAfter, delimit
 		decodedToken, err := base64.StdEncoding.DecodeString(token)
 		if err != nil {
 			errCode = ErrIncorrectContinuationToken
+			return
 		}
 		token = string(decodedToken)
 	}

--- a/cmd/api-resources.go
+++ b/cmd/api-resources.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"net/url"
 	"strconv"
 )
@@ -86,11 +87,18 @@ func getListObjectsV2Args(values url.Values) (prefix, token, startAfter, delimit
 	}
 
 	prefix = values.Get("prefix")
-	token = values.Get("continuation-token")
 	startAfter = values.Get("start-after")
 	delimiter = values.Get("delimiter")
 	fetchOwner = values.Get("fetch-owner") == "true"
 	encodingType = values.Get("encoding-type")
+
+	if token = values.Get("continuation-token"); token != "" {
+		decodedToken, err := base64.StdEncoding.DecodeString(token)
+		if err != nil {
+			errCode = ErrIncorrectContinuationToken
+		}
+		token = string(decodedToken)
+	}
 	return
 }
 

--- a/cmd/api-resources_test.go
+++ b/cmd/api-resources_test.go
@@ -34,7 +34,7 @@ func TestListObjectsV2Resources(t *testing.T) {
 		{
 			values: url.Values{
 				"prefix":             []string{"photos/"},
-				"continuation-token": []string{"token"},
+				"continuation-token": []string{"dG9rZW4="},
 				"start-after":        []string{"start-after"},
 				"delimiter":          []string{SlashSeparator},
 				"fetch-owner":        []string{"true"},
@@ -53,7 +53,7 @@ func TestListObjectsV2Resources(t *testing.T) {
 		{
 			values: url.Values{
 				"prefix":             []string{"photos/"},
-				"continuation-token": []string{"token"},
+				"continuation-token": []string{"dG9rZW4="},
 				"start-after":        []string{"start-after"},
 				"delimiter":          []string{SlashSeparator},
 				"fetch-owner":        []string{"true"},

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/xml"
 	"net/http"
 	"net/url"
@@ -498,8 +499,8 @@ func generateListObjectsV2Response(bucket, prefix, token, nextToken, startAfter,
 	data.Delimiter = s3EncodeName(delimiter, encodingType)
 	data.Prefix = s3EncodeName(prefix, encodingType)
 	data.MaxKeys = maxKeys
-	data.ContinuationToken = s3EncodeName(token, encodingType)
-	data.NextContinuationToken = s3EncodeName(nextToken, encodingType)
+	data.ContinuationToken = base64.StdEncoding.EncodeToString([]byte(token))
+	data.NextContinuationToken = base64.StdEncoding.EncodeToString([]byte(nextToken))
 	data.IsTruncated = isTruncated
 	for _, prefix := range prefixes {
 		var prefixItem = CommonPrefix{}


### PR DESCRIPTION

## Description
Minio V2 listing uses object names/prefixes as continuation tokens. This
is problematic when object names contain some characters that are forbidden
in XML documents. This PR will use base64 encoded form of continuation
and next continuation tokens to address that corner case.


## Motivation and Context
Fixes https://github.com/minio/mc/issues/2913


## How to test this PR?
As described in the PR itself


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
