### PR TITLE
Add a note about the missing support of SSE-S3

### DIFF
--- a/docs/gateway/b2.md
+++ b/docs/gateway/b2.md
@@ -52,6 +52,7 @@ Gateway inherits the following B2 limitations:
 Other limitations:
 
 - Bucket notification APIs are not supported.
+- SSE-S3 encryption is not supported
 
 ## Explore Further
 - [`mc` command-line interface](https://docs.min.io/docs/minio-client-quickstart-guide)


### PR DESCRIPTION
## Description

I am testing minio encryption with B2 gateway and the gateway  raised an error : 

```
ERROR Encryption support is requested but 'gateway b2' does not support encryption: Invalid arguments specified
```

with the command

```
MINIO_SSE_MASTER_KEY=my-minio-key:0263b8bf32f0b9be1c07b2f6bcb42615bc6207ab94a10bebc2b1526d3f99ba2b MINIO_ACCESS_KEY=XXXX MINIO_SECRET_KEY=XXXX minio gateway b2
```

## Motivation and Context

My first understanding is that the encryption was a built in feature (ie: compression at the rest by the minio server) so there is no dependency with the backend gateway. Well, I was wrong, so I just amend the documentation for the B2 Gateway.

## How to test this PR?

No need to test