### PR TITLE
skip checking error also on Mac in TestCheckPortAvailability

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -58,6 +58,7 @@ const (
 	globalMinioDefaultStorageClass = "STANDARD"
 	globalWindowsOSName            = "windows"
 	globalNetBSDOSName             = "netbsd"
+	globalMacOSName                = "darwin"
 	globalMinioModeFS              = "mode-server-fs"
 	globalMinioModeXL              = "mode-server-xl"
 	globalMinioModeDistXL          = "mode-server-distributed-xl"

--- a/cmd/net_test.go
+++ b/cmd/net_test.go
@@ -216,8 +216,8 @@ func TestCheckPortAvailability(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		// On MS Windows, skip checking error case due to https://github.com/golang/go/issues/7598
-		if runtime.GOOS == globalWindowsOSName && testCase.expectedErr != nil {
+		// On MS Windows and Mac, skip checking error case due to https://github.com/golang/go/issues/7598
+		if (runtime.GOOS == globalWindowsOSName || runtime.GOOS == globalMacOSName) && testCase.expectedErr != nil {
 			continue
 		}
 


### PR DESCRIPTION
## Description

the TestCheckPortAvailability does not passed on my Mac:

```bash
$ go test -test.run "TestCheckPortAvailability" -test.v
=== RUN   TestCheckPortAvailability
--- FAIL: TestCheckPortAvailability (0.00s)
    net_test.go:230: error: expected = listen tcp 127.0.0.1:51737: bind: address already in use, got = <nil>
FAIL
exit status 1
FAIL	github.com/minio/minio/cmd	0.035s
```
maybe we need to skip checking error also on Mac


## Motivation and Context


## How to test this PR?

after this change, no failed test case:
```bash
$ go test -test.run "TestCheckPortAvailability" -test.v
=== RUN   TestCheckPortAvailability
--- PASS: TestCheckPortAvailability (0.00s)
PASS
ok  	github.com/minio/minio/cmd	0.035s
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
