### PR TITLE
Replace proxy with forward in coredns file

### DIFF
--- a/docs/federation/lookup/Corefile.example
+++ b/docs/federation/lookup/Corefile.example
@@ -7,5 +7,5 @@
   prometheus
   cache 160 mydomain.com
   loadbalance
-  proxy . /etc/resolv.conf
+  forward . /etc/resolv.conf
 }


### PR DESCRIPTION
## Description
`Proxy` plugin has been removed in coredns from 1.5 thus replaced it with `forward` plugin.


## Motivation and Context
With core dns 1.5+ the `Corefile.example` was erroring out stating `Error during parsing: Unknown directive 'proxy'` . Upon investigating came to know that Proxy plugin is removed form coredns 1.5 onwards.  Refer https://coredns.io/2019/04/06/coredns-1.5.0-release/. 
This is replaced with `forward` plugin. [PR files](https://github.com/coredns/coredns/pull/2651/files) 
The `forward` plugin was introduced in version[ `1.06` ](https://coredns.io/2018/02/21/coredns-1.0.6-release/) thus IMO there is no need for two version of this file.

## How to test this PR?
Run core dns binary with the command below :
`./coredns  -dns.port=1053 -conf /home/ashish/Corefile.example` 


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
