### PR TITLE
ecc: add new package and remove io.Pipe in object-API

### DIFF
--- a/cmd/bitrot-streaming.go
+++ b/cmd/bitrot-streaming.go
@@ -100,7 +100,7 @@ func (b *streamingBitrotReader) ReadAt(buf []byte, offset int64) (int, error) {
 	if b.rc == nil {
 		// For the first ReadAt() call we need to open the stream for reading.
 		streamOffset := (offset / b.shardSize) * (int64(b.hash.Size()) + offset)
-		b.rc, err = b.disk.ReadFileStream(b.volume, b.path, streamOffset, -1)
+		b.rc, _, err = b.disk.ReadFileStream(b.volume, b.path, streamOffset, -1)
 		if err != nil {
 			return 0, err
 		}

--- a/cmd/bitrot.go
+++ b/cmd/bitrot.go
@@ -125,7 +125,7 @@ func newBitrotWriter(disk StorageAPI, volume, filePath string, length int64, alg
 
 func newBitrotReader(disk StorageAPI, bucket string, filePath string, tillOffset int64, algo BitrotAlgorithm, sum []byte, shardSize int64) io.ReaderAt {
 	if algo == HighwayHash256S {
-		return newStreamingBitrotReader(disk, bucket, filePath, tillOffset, algo, shardSize)
+		return newStreamingBitrotReader(disk, bucket, filePath, algo, shardSize)
 	}
 	return newWholeBitrotReader(disk, bucket, filePath, algo, tillOffset, sum)
 }

--- a/cmd/ecc/buffer.go
+++ b/cmd/ecc/buffer.go
@@ -1,0 +1,167 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecc
+
+// The Buffer implementation below is tightly coupled to
+// the JoinedReaders implementation in this package.
+
+// Buffer contains a set of data and parity shards.
+// It translates between a flat memory and multi-dimensional
+// slices (shards).
+type Buffer struct {
+	shards [][]byte
+	data   [][]byte // view of shards containing actual data
+	parity [][]byte // view of shards containing parity data
+
+	buffer []byte
+	offset int
+}
+
+// NewBuffer creates a new buffer from the given shards.
+// It treats the first len(shards)-parity shards as
+// actual data shards and the remaining as parity
+// shards.
+//
+// NewBuffer assumes that each shards[i] has the
+// same length and capcacity. In particular:
+//  len(shards[i]) == cap(shards[i]) == len(shards[j]) == cap(shards[j])
+func NewBuffer(shards [][]byte, parity int) *Buffer {
+	if len(shards) > 0 {
+		for _, shard := range shards {
+			if len(shard) != cap(shard) {
+				panic("ecc: Buffer requires that each shard has equal len and cap")
+			}
+			if len(shards[0]) != len(shard) {
+				panic("ecc: Buffer requires that each shard has the same len")
+			}
+		}
+	}
+	return &Buffer{
+		shards: shards,
+		data:   shards[:len(shards)-parity],
+		parity: shards[len(shards)-parity:],
+	}
+}
+
+// IsDataMissing returns true if at least one
+// data shard is marked as missing. A data shard
+// is considered as not present if its length
+// len(shard) == 0.
+func (b *Buffer) IsDataMissing() bool {
+	dataShards := len(b.shards) - len(b.parity)
+	for _, shard := range b.shards[:dataShards] {
+		if len(shard) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Empty marks the buffer as empty such that
+// IsEmpty() returns true.
+func (b *Buffer) Empty() *Buffer {
+	b.offset = 0
+	b.data = b.data[:0]
+	return b
+}
+
+// IsEmpty returns true if the buffer does not
+// hold any actual data. In particular, copying
+// an empty buffer to a slice (using CopyTo)
+// copies no data.
+func (b *Buffer) IsEmpty() bool { return b.offset == 0 && len(b.data) == 0 }
+
+// Reset resets the buffer to its initial state.
+// In particular, a reseted buffer is not empty.
+func (b *Buffer) Reset() *Buffer {
+	for i := range b.shards {
+		b.shards[i] = b.shards[i][:cap(b.shards[i])]
+	}
+	b.data = b.shards[:len(b.shards)-len(b.parity)]
+	b.parity = b.shards[len(b.data):]
+
+	b.buffer = nil
+	b.offset = 0
+	return b
+}
+
+// Skip skips the next n (actual data) bytes hold
+// by the buffer. If n is greater than the number
+// of remaining data bytes hold by the buffer, Skip
+// will only skip as many (actual data) bytes as
+// available. In particular, trying to skip n > 0
+// bytes on an empty buffer is a NOP.
+func (b *Buffer) Skip(n int) *Buffer {
+	if n <= 0 || b.IsEmpty() {
+		return b
+	}
+	if b.offset > 0 {
+		remaining := len(b.buffer) - b.offset
+		if n < remaining {
+			b.offset += n
+			return b
+		}
+		n -= remaining
+		b.offset = 0
+	}
+
+	for len(b.data) > 0 {
+		b.buffer = b.data[0]
+		b.data = b.data[1:]
+		if n < len(b.buffer) {
+			b.offset += n
+			return b
+		}
+		n -= len(b.buffer)
+	}
+	return b
+}
+
+// CopyTo tries to copy len(p) (actual data)
+// bytes into p. It returns the number of bytes
+// copied to p. If the buffer holds less than
+// len(p) (actual data) bytes it copies as
+// many bytes as it holds until the buffer is
+// empty.
+func (b *Buffer) CopyTo(p []byte) int {
+	var n int
+	if b.offset > 0 {
+		n = copy(p, b.buffer[b.offset:])
+		if n == len(p) {
+			b.offset += n
+			return n
+		}
+		b.offset = 0
+		p = p[n:]
+	}
+
+	for len(b.data) > 0 {
+		b.buffer = b.data[0]
+		b.data = b.data[1:]
+
+		nn := copy(p, b.buffer)
+		n += nn
+		if nn == len(p) {
+			if nn != len(b.buffer) {
+				b.offset = nn
+			}
+			return n
+		}
+		p = p[nn:]
+	}
+	return n
+}

--- a/cmd/ecc/buffer.go
+++ b/cmd/ecc/buffer.go
@@ -86,7 +86,7 @@ func (b *Buffer) Empty() *Buffer {
 func (b *Buffer) IsEmpty() bool { return b.offset == 0 && len(b.data) == 0 }
 
 // Reset resets the buffer to its initial state.
-// In particular, a reseted buffer is not empty.
+// In particular, the buffer is not empty.
 func (b *Buffer) Reset() *Buffer {
 	for i := range b.shards {
 		b.shards[i] = b.shards[i][:cap(b.shards[i])]
@@ -99,9 +99,9 @@ func (b *Buffer) Reset() *Buffer {
 	return b
 }
 
-// Skip skips the next n (actual data) bytes hold
+// Skip skips the next n (actual data) bytes held
 // by the buffer. If n is greater than the number
-// of remaining data bytes hold by the buffer, Skip
+// of remaining data bytes held by the buffer, Skip
 // will only skip as many (actual data) bytes as
 // available. In particular, trying to skip n > 0
 // bytes on an empty buffer is a NOP.

--- a/cmd/ecc/buffer_test.go
+++ b/cmd/ecc/buffer_test.go
@@ -1,0 +1,280 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecc
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"testing"
+)
+
+var NewBufferTests = []struct {
+	Shards     [][]byte
+	Parity     int
+	ShouldFail bool
+}{
+	{Shards: [][]byte{}, Parity: 0, ShouldFail: false},                              // 0
+	{Shards: [][]byte{}, Parity: 1, ShouldFail: true},                               // 1
+	{Shards: [][]byte{{}, {}, {}, {}}, Parity: 2, ShouldFail: false},                // 2
+	{Shards: [][]byte{{0}, {}, {}, {}}, Parity: 2, ShouldFail: true},                // 3
+	{Shards: [][]byte{make([]byte, 0, 1), {}, {}, {}}, Parity: 2, ShouldFail: true}, // 4
+
+	{
+		Shards: [][]byte{
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+		},
+		Parity:     2,
+		ShouldFail: false,
+	}, // 5
+	{
+		Shards: [][]byte{
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024, 2048),
+		},
+		Parity:     2,
+		ShouldFail: true,
+	}, // 6
+
+}
+
+func TestNewBuffer(t *testing.T) {
+	for i := range NewBufferTests {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			test := NewBufferTests[i]
+
+			defer func(shouldFail bool, t *testing.T) {
+				err := recover()
+				if err == nil && shouldFail {
+					t.Fatal("Test should have panic'ed but it didn't")
+				}
+				if err != nil && !shouldFail {
+					t.Fatalf("Test should not panic but it did: %v", err)
+				}
+			}(test.ShouldFail, t)
+
+			_ = NewBuffer(test.Shards, test.Parity)
+		})
+	}
+}
+
+var IsDataMissingTests = []struct {
+	Shards    [][]byte
+	Parity    int
+	IsMissing bool
+}{
+	{
+		Shards: [][]byte{
+			{},
+			{},
+			{},
+			{},
+		},
+		Parity:    2,
+		IsMissing: true,
+	}, // 0
+	{
+		Shards: [][]byte{
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+		},
+		Parity:    2,
+		IsMissing: false,
+	}, // 1
+	{
+		Shards: [][]byte{
+			make([]byte, 512),
+			make([]byte, 512),
+			make([]byte, 512),
+			make([]byte, 512),
+			make([]byte, 512),
+			make([]byte, 512),
+		},
+		Parity:    3,
+		IsMissing: false,
+	}, // 2
+
+}
+
+func TestIsDataMissing(t *testing.T) {
+	for i := range IsDataMissingTests {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			test := IsDataMissingTests[i]
+			buffer := NewBuffer(test.Shards, test.Parity)
+
+			if missing := buffer.IsDataMissing(); missing != test.IsMissing {
+				t.Errorf("got %v - want %v", missing, test.IsMissing)
+			}
+
+			buffer.data[0] = buffer.data[0][:0]
+			if missing := buffer.IsDataMissing(); !missing {
+				t.Errorf("got %v - want %v", missing, true)
+			}
+
+			buffer.Reset()
+			if missing := buffer.IsDataMissing(); missing != test.IsMissing {
+				t.Errorf("got %v - want %v", missing, test.IsMissing)
+			}
+		})
+	}
+}
+
+var IsEmptyTests = []struct {
+	Shards  [][]byte
+	Parity  int
+	IsEmpty bool
+}{
+	{
+		Shards: [][]byte{
+			{},
+			{},
+			{},
+			{},
+		},
+		Parity:  2,
+		IsEmpty: false,
+	}, // 0
+	{
+		Shards: [][]byte{
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+			make([]byte, 1024),
+		},
+		Parity:  2,
+		IsEmpty: false,
+	}, // 1
+	{
+		Shards: [][]byte{
+			make([]byte, 512),
+			make([]byte, 512),
+			make([]byte, 512),
+			make([]byte, 512),
+			make([]byte, 512),
+			make([]byte, 512),
+		},
+		Parity:  3,
+		IsEmpty: false,
+	}, // 2
+
+}
+
+func TestIsEmpty(t *testing.T) {
+	const MaxInt = int(^uint(0) >> 1)
+	for i := range IsEmptyTests {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			test := IsEmptyTests[i]
+
+			buffer := NewBuffer(test.Shards, test.Parity)
+			if empty := buffer.IsEmpty(); empty != test.IsEmpty {
+				t.Errorf("got %v - want %v", empty, test.IsEmpty)
+			}
+
+			if !buffer.IsEmpty() && len(buffer.data[0]) > 0 {
+				buffer.Skip(1)
+				if empty := buffer.IsEmpty(); empty {
+					t.Errorf("got %v - want %v", empty, false)
+				}
+			}
+
+			buffer.Skip(MaxInt) // We skip everything
+			if empty := buffer.IsEmpty(); !empty {
+				t.Errorf("got %v - want %v", empty, true)
+			}
+
+			buffer.Reset()
+			if empty := buffer.IsEmpty(); empty != test.IsEmpty {
+				t.Errorf("got %v - want %v", empty, test.IsEmpty)
+			}
+
+			buffer.Empty()
+			if empty := buffer.IsEmpty(); !empty {
+				t.Errorf("got %v - want %v", empty, true)
+			}
+		})
+	}
+}
+
+var CopyToTests = []struct {
+	NShards   int
+	ShardSize int
+	Parity    int
+}{
+	{NShards: 4, ShardSize: 1024, Parity: 2},             // 0
+	{NShards: 6, ShardSize: 1024 * 1024, Parity: 3},      // 1
+	{NShards: 12, ShardSize: 512 * 1024, Parity: 4},      // 2
+	{NShards: 8, ShardSize: 64*1024 + 1, Parity: 4},      // 3
+	{NShards: 4, ShardSize: 17 * 1024 * 1024, Parity: 2}, // 4
+	{NShards: 32, ShardSize: 55 * 1024, Parity: 8},       // 5
+}
+
+func TestCopyTo(t *testing.T) {
+	for i := range CopyToTests {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			test := CopyToTests[i]
+
+			dst := make([]byte, test.ShardSize*(test.NShards-test.Parity))
+			src := make([][]byte, test.NShards)
+			for i := range src[:len(src)-test.Parity] {
+				src[i] = make([]byte, test.ShardSize)
+				if _, err := io.ReadFull(rand.Reader, src[i]); err != nil {
+					t.Fatalf("Failed to read random data: %v", err)
+				}
+				copy(dst[i*test.ShardSize:], src[i])
+			}
+			for i := len(src) - test.Parity; i < len(src); i++ {
+				src[i] = make([]byte, test.ShardSize)
+			}
+
+			buffer := NewBuffer(src, test.Parity)
+			if n := buffer.CopyTo(dst[:1]); n != 1 {
+				t.Fatalf("Copied the wrong number of bytes: got %d - want %d", n, 1)
+			}
+			if n := buffer.CopyTo(dst[1 : len(dst)/2]); n != (len(dst)/2 - 1) {
+				t.Fatalf("Copied the wrong number of bytes: got %d - want %d", n, (len(dst)/2 - 1))
+			}
+			if n := buffer.CopyTo(dst[len(dst)/2:]); n != (len(dst) - len(dst)/2) {
+				t.Fatalf("Copied the wrong number of bytes: got %d - want %d", n, (len(dst) - len(dst)/2))
+			}
+			if !buffer.IsEmpty() {
+				t.Fatal("Buffer is not empty after copying")
+			}
+
+			var data []byte
+			for _, src := range src[:len(src)-test.Parity] {
+				data = append(data, src...)
+			}
+			if !bytes.Equal(dst, data) {
+				t.Fatal("Copyied content does not match src data")
+			}
+		})
+	}
+}

--- a/cmd/ecc/buffer_test.go
+++ b/cmd/ecc/buffer_test.go
@@ -255,14 +255,14 @@ func TestCopyTo(t *testing.T) {
 			}
 
 			buffer := NewBuffer(src, test.Parity)
-			if n := buffer.CopyTo(dst[:1]); n != 1 {
-				t.Fatalf("Copied the wrong number of bytes: got %d - want %d", n, 1)
+			if n, err := buffer.Read(dst[:1]); err != nil || n != 1 {
+				t.Fatalf("Copied the wrong number of bytes: got %d - want %d: %v", n, 1, err)
 			}
-			if n := buffer.CopyTo(dst[1 : len(dst)/2]); n != (len(dst)/2 - 1) {
-				t.Fatalf("Copied the wrong number of bytes: got %d - want %d", n, (len(dst)/2 - 1))
+			if n, err := buffer.Read(dst[1 : len(dst)/2]); n != (len(dst)/2 - 1) {
+				t.Fatalf("Copied the wrong number of bytes: got %d - want %d: %v", n, (len(dst)/2 - 1), err)
 			}
-			if n := buffer.CopyTo(dst[len(dst)/2:]); n != (len(dst) - len(dst)/2) {
-				t.Fatalf("Copied the wrong number of bytes: got %d - want %d", n, (len(dst) - len(dst)/2))
+			if n, err := buffer.Read(dst[len(dst)/2:]); n != (len(dst) - len(dst)/2) {
+				t.Fatalf("Copied the wrong number of bytes: got %d - want %d: %v", n, (len(dst) - len(dst)/2), err)
 			}
 			if !buffer.IsEmpty() {
 				t.Fatal("Buffer is not empty after copying")

--- a/cmd/ecc/decoder.go
+++ b/cmd/ecc/decoder.go
@@ -1,0 +1,107 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecc
+
+import (
+	"github.com/klauspost/reedsolomon"
+)
+
+// Decoder implements reedsolomon erasure decoding of
+// a continuous data stream. Whenever some content data
+// is missing, it tries to reconstruct it on the fly.
+type Decoder struct {
+	src    *JoinedReaders
+	ecc    reedsolomon.Encoder
+	buffer *Buffer
+	err    error
+
+	firstRead bool
+}
+
+// NewDecoder returns a new Decoder that reads from a set
+// of data sources combined to JoinedReaders. Whenever,
+// the JoinedReaders report that some data shards are missing
+// it reconstructs the data using the reedsolomon encoder.
+//
+// The blockSize is the size of one erasure-coded block. The
+// reedsolomon encoder en/decodes data in blocks (e.g 10 MB).
+// Therefore, it splits a blockSize large buffer into N shards
+// where N is the number of data disks. For more information
+// refer to: https://godoc.org/github.com/klauspost/reedsolomon
+//
+// The parity is the number of parity shards. The total number
+// of shards = the number of data sources = data shards + parity
+// shards. The Decoder can recover data only if at most n = parity
+// shards of all shards are missing.
+func NewDecoder(src *JoinedReaders, enc reedsolomon.Encoder, blockSize, parity int) (*Decoder, error) {
+	// Split the buffer into data and parity shards.
+	// Using a buffer with a capacity of 2*blockSize
+	// is a small optimization to avoid reallocations
+	// during spliting.
+	// TODO(aead): measure impact
+	shards, err := enc.Split(make([]byte, blockSize, 2*blockSize))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Decoder{
+		src:    src,
+		ecc:    enc,
+		buffer: NewBuffer(shards, parity).Empty(),
+	}, nil
+}
+
+// Read behaves as specified by the io.Reader
+// interface and reads up to len(p) into p.
+func (d *Decoder) Read(p []byte) (int, error) {
+	if d.err != nil {
+		return 0, d.err
+	}
+
+	// This is only valid since we created an empty
+	// buffer during NewDecoder. On the first read
+	// the buffer must be "marked" as empty to
+	// avoid copying before reading anything.
+	// Alternatively, we could use a first-read flag
+	// and only copy if we have read at least once from
+	// src.
+	if !d.buffer.IsEmpty() {
+		return d.buffer.CopyTo(p), nil
+	}
+
+	// The JoinedReaders will reset the buffer before
+	// reading data into it.
+	if err := d.src.Read(d.buffer); err != nil {
+		d.err = err
+		return 0, err
+	}
+
+	// Only reconstruct (data, no parity shards) if one or more
+	// data shards are missing. If a parity shard is missing we
+	// don't care.
+	if d.buffer.IsDataMissing() {
+		if err := d.ecc.ReconstructData(d.buffer.shards); err != nil {
+			d.err = err
+			return 0, err
+		}
+	}
+	return d.buffer.CopyTo(p), nil
+}
+
+// Close closes all underlying data sources and behaves
+// as specified by the io.Closer interface.
+func (d *Decoder) Close() error { return d.src.Close() }

--- a/cmd/ecc/ecc.go
+++ b/cmd/ecc/ecc.go
@@ -1,0 +1,78 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package ecc implements the erasure coding and error correction
+// of the MinIO server.
+//
+//
+// Architecture
+//
+// Conceptually, MinIO implements S3, data collection, error detection and error correction
+// in different layers:
+//                       HTTP handler --------------------- S3, encryption, compression, ...
+//                            |
+//                            |
+//                        Object API ---------------------- Backend implementation (FS, XL, Gateway, ...)
+//                            |
+//                            |
+//                      Reconstruction -------------------- Reedsolomon Erasure-coding
+//                            |
+//                            |
+//                      spawn | join  --------------------- Concurrent read scheduling
+//                 +------+---+---+------+
+//                 |      |       |      |
+//                 |      |       |      |
+//                Detection      Detection ----------------- Content verification (HighwayHash, BLAKE2, ...)
+//                 |      |       |      |
+//                 |      |       |      |
+//               disk1  disk2   disk3  disk4 --------------- File / POSIX layer
+//                 |      |       |      |
+//                 |      |       |       \
+//         part.1 -+      |       +-part.1 +--- part.1
+//                 |      |       |         \
+//         part.2 -+      |       +-part.2   +--- part.2
+//                 |      |       |           \
+//         part.3 -+   offline    +-part.3     +--- part.3
+//
+// The ecc package implements primitives to build the reconstruction,
+// read scheduling and content verification layers.
+//
+//
+// Reconstruction
+//
+// The data reconstruction is implemented using reedsolomon erasure coding.
+// See:
+//    - https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction
+//    - https://godoc.org/github.com/klauspost/reedsolomon
+//
+// The ecc package provides the `Decoder` type that implements the io.ReadCloser
+// interface and reconstructs data (if necessary) on the fly during reading.
+// Therefore, it keeps a `Buffer` and uses `JoinedReaders` to read from the
+// underlying file / posix layer.
+//
+//
+// Read scheduling
+//
+// The `JoinedReaders` type is responsible for reading concurrently from
+// the data sources (posix layer) in an efficient way. In this case efficient
+// means that no unnecessary I/O operations should be performed and that
+// actual data (not parity) should be read if available - to avoid unnecessary
+// data reconstruction.
+package ecc
+
+type errorType string
+
+func (e errorType) Error() string { return string(e) }

--- a/cmd/ecc/join.go
+++ b/cmd/ecc/join.go
@@ -82,7 +82,7 @@ type JoinedReaders struct {
 // Let d be the number of data shards. Read spawns
 // d go routines - each tries to read one complete
 // shard from its data source. Whenever a go routine
-// completes but returns an error this data source
+// completes but returns an error, this data source
 // is considered unavailable and another go routine
 // is spawned. This new go routine tries to read from
 // the next data source. If no more data sources are
@@ -144,7 +144,7 @@ func (r *JoinedReaders) spawn(b *Buffer) (results chan readResult, next int, err
 		}
 		next++
 	}
-	// If we could not spwan a single go routine we should return an error
+	// If we could not spawn a single go routine we should return an error
 	// (or panic) since a join would block forever since the results channel
 	// would never receive a result. However, that error should never happen
 	// since there should be at least 1 (actually `len(b.data)`) non-nil data
@@ -208,7 +208,7 @@ func (r *JoinedReaders) join(b *Buffer, next int, results chan readResult) error
 	}
 
 	// If every read returns err == io.ErrUnexpected
-	// then we should not spwan go routines on the next
+	// then we should not spawn go routines on the next
 	// Read(b *Buffer) call. There won't be more data to
 	// read. However, n != 0 => so we only return io.EOF
 	// on the next Read call, not this time.
@@ -253,7 +253,7 @@ func (r *JoinedReaders) respawn(b *Buffer, next int, results chan<- readResult) 
 	for next < len(b.shards) {
 		if r.err[next] == nil { // Invariant: r.err[next] == nil => r.src[next] != nil
 			go readFrom(r.src[next], next, r.offset, b.shards[next], results)
-			next++
+			return next+1
 			break
 		}
 		next++

--- a/cmd/ecc/join.go
+++ b/cmd/ecc/join.go
@@ -1,0 +1,330 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecc
+
+import (
+	"io"
+)
+
+// This file contains a reader-like implementation that
+// combines a set of data sources and schedules and manages
+// concurrent reading from some/all data source in parallel.
+// The implementation is optimized for:
+// 1) Performing as few read operations as possible overall
+//    while doing as many reads in parallel as possible.
+// 2) Reading data shards first so that no erasure reconstruction
+//    is necessary if all data shards are available.
+//
+// Before changing the implementation make sure that you understand
+// the implications and take a look at the approaches [1] and [2]
+// at the end of the file - which are less optimal.
+
+const (
+	// ErrReadQuorum is the error returned by the JoinedReaders
+	// when too many read operations fail such that the erasure
+	// coding won't be able to reconstruct the content data.
+	ErrReadQuorum errorType = "ecc: no read quorum: too many data sources are unavailable"
+
+	// errOffline is the error used to mark a data source as offline.
+	// The MinIO server may has failed to fetch the metadata (XL.json)
+	// from certain data sources before. Such data sources are marked as
+	// offline by an io.ReaderAt that is nil.
+	errOffline errorType = "ecc: dat source is marked as offline"
+)
+
+// JoinReaders combines a set of data sources. It implements reading
+// from the sources concurrently. During a read it spawns and waits
+// for go routines that read from data sources until the all read
+// operations have accumulated enough data to reconstruct it.
+func JoinReaders(src []io.ReaderAt, offset int64) *JoinedReaders {
+	errors := make([]error, len(src))
+	for i := range src {
+		if src[i] == nil { // If a data source is nil...
+			errors[i] = errOffline // ...mark it as offline.
+		}
+	}
+	return &JoinedReaders{
+		src:    src,
+		err:    errors,
+		offset: offset,
+	}
+}
+
+// JoinedReaders groups a set of data sources
+// and manages reading from them concurrently.
+type JoinedReaders struct {
+	src    []io.ReaderAt
+	err    []error
+	offset int64
+
+	rErr error
+}
+
+// Read tries to read just as many shards
+// as necessary into the buffer such that the
+// erasure coding can reconstruct missing data
+// shards, if any.
+//
+// Let d be the number of data shards. Read spawns
+// d go routines - each tries to read one complete
+// shard from its data source. Whenever a go routine
+// completes but returns an error this data source
+// is considered unavailable and another go routine
+// is spawned. This new go routine tries to read from
+// the next data source. If no more data sources are
+// available it returns ErrNoReadQuorum.
+//
+// Read minimizes the total number of reads / connections
+// and tries to read as many data shards before
+// it tries to fetch any parity shards. Minimizing
+// the number of reads / connections is important to
+// avoid any unnecessary I/O or network load. Also, if
+// a data shard is available we should prefer fetching it
+// instead of reading a parity shard to avoid unnecessary
+// erasure coding reconstruction.
+func (r *JoinedReaders) Read(b *Buffer) error {
+	if len(r.src) != len(b.shards) {
+		panic("ecc: number of data sources does not match the number of shards")
+	}
+	if r.rErr != nil {
+		return r.rErr
+	}
+
+	b.Reset()
+	results, next, err := r.spawn(b)
+	if err != nil {
+		r.rErr = err
+		return r.rErr
+	}
+
+	// Mark all shards as missing.
+	// When a read from a data source succeeds
+	// the particular shard will get marked
+	// as available again.
+	for i := range b.shards {
+		b.shards[i] = b.shards[i][:0]
+	}
+
+	return r.join(b, next, results)
+}
+
+type readResult struct {
+	ID  int   // The ID / index of the shard / data source
+	N   int   // The number of bytes read from the data source
+	Err error // Any error that happened during reading
+}
+
+// spawn creates just as many concurrent go routines as necessary to read
+// enough shards to reconstruct the content data. If all data shards are
+// available each go routine tries to read a data shard.
+// It returns a channel which hold the read results once they are available.
+// The returned next index points to the next data source from which a go
+// routine should read if any of the spawned reads fails.
+func (r *JoinedReaders) spawn(b *Buffer) (results chan readResult, next int, err error) {
+	results = make(chan readResult, len(r.src))
+	var spawned int
+	for spawned < len(b.data) && next < len(b.shards) {
+		if r.err[next] == nil {
+			go readFrom(r.src[next], next, r.offset, b.shards[next], results)
+			spawned++
+		}
+		next++
+	}
+	// If we could not spwan a single go routine we should return an error
+	// (or panic) since a join would block forever since the results channel
+	// would never receive a result. However, that error should never happen
+	// since there should be at least 1 (actually `len(b.data)`) non-nil data
+	// sources. Otherwise, we never had read quorum in the first place and
+	// should have failed somewhere higher up the stack.
+	// TODO(aead): Consider a panic.
+	if spawned == 0 {
+		err = ErrReadQuorum
+	}
+	return
+}
+
+// join joins all go routines created by spawn(). Therefore, it reads
+// from the results channel until it has received enough shards. If
+// one read fails - i.e. returns an non-EOF error - it re-spawns another
+// go routine reading from the next data source.
+func (r *JoinedReaders) join(b *Buffer, next int, results chan readResult) error {
+	var (
+		n      int // Number of bytes read in total
+		nReads int // Number of reads that succeeded
+		nEOFs  int // Number of cases read returned an EOF error
+	)
+	for result := range results {
+		i, nn, err := result.ID, result.N, result.Err
+
+		// In case the i-th read fails we check whether
+		// performing another read "makes sense". (If we
+		// have encountered more the `N = parity` errors
+		// we won't be able to reconstruct the data - so
+		// we return ErrReadQuorum).
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+			r.err[i] = err
+			if next == len(b.shards) || countErrors(r.err) > len(b.parity) {
+				r.rErr = ErrReadQuorum
+				return r.rErr
+			}
+			next = r.respawn(b, next, results)
+			continue
+		}
+
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			nEOFs++
+		}
+		b.shards[i] = b.shards[i][:nn]
+		n += nn
+		nReads++
+
+		// As soon as we have read enough shards
+		// we exit the loop. The GC will take care
+		// of the channel and the remaining go routines.
+		if nReads >= len(b.data) {
+			break
+		}
+	}
+	// If we read no byte at all - i.e. every read
+	// returned err == io.EOF then there are no more
+	// erasure-encoded data blocks.
+	if n == 0 {
+		r.rErr = io.EOF
+		return r.rErr
+	}
+
+	// If every read returns err == io.ErrUnexpected
+	// then we should not spwan go routines on the next
+	// Read(b *Buffer) call. There won't be more data to
+	// read. However, n != 0 => so we only return io.EOF
+	// on the next Read call, not this time.
+	if nEOFs == nReads {
+		r.rErr = io.EOF
+	}
+
+	// Adjust the offset for the next Read. This assumes
+	// that every read from each data source returned the
+	// same number of bytes in case of success. In particular
+	// we assume that each `r.src[i].ReadAt(shard)` itself
+	// uses io.ReadFull or similar to actually read the data.
+	r.offset += int64(n / nReads)
+	return nil
+}
+
+// Close tries to close each data source if it implements
+// io.Closer. It returns the first error it encounters
+// during closing the data sources, if any.
+func (r *JoinedReaders) Close() error {
+	for _, src := range r.src {
+		if src != nil {
+			if closer, ok := src.(io.Closer); ok {
+				if err := closer.Close(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// respawn finds the next data source that is not marked as
+// unavailable, if any exists, and spawns a new go-routine that
+// tries to read from that source. The go routine sends its
+// result to the results channel.
+// respawn returns the (position of the) next data source that
+// should be tried when another go routine should be spawned.
+// If respawn(...) == len(r.src) then there are no more data
+// sources available.
+func (r *JoinedReaders) respawn(b *Buffer, next int, results chan<- readResult) int {
+	for next < len(b.shards) {
+		if r.err[next] == nil { // Invariant: r.err[next] == nil => r.src[next] != nil
+			go readFrom(r.src[next], next, r.offset, b.shards[next], results)
+			next++
+			break
+		}
+		next++
+	}
+	return next
+}
+
+// readFrom reads from the src at the given offset into the
+// shard buffer and writes the result to the channel.
+func readFrom(src io.ReaderAt, id int, offset int64, shard []byte, results chan<- readResult) {
+	nn, err := src.ReadAt(shard[:cap(shard)], offset)
+	results <- readResult{ID: id, N: nn, Err: err}
+}
+
+// countErrors returns the number of non-nil
+// errors in the errors slice.
+func countErrors(errors []error) (n int) {
+	for _, err := range errors {
+		if err != nil {
+			n++
+		}
+	}
+	return
+}
+
+// Footnotes:
+//
+// Approaches that don't work / are less optimal than the current
+// implementation:
+//
+// [1]: Reading sequentially
+// While reading sequentially from one data source after the other
+// is much easier to implement it would cause a significant performance
+// hit when the data is fetched over the network. Even with fast network
+// connections the round-trip times (a.o.) accumulate.
+//
+// [2]: Reading from all data sources in parallel
+// It might be tempting to just read from all data source in
+// parallel and wait for "just enough" results to reconstruct.
+// Even though this approach seems easier/less complex at the
+// beginning it has some drawbacks and ends up being actually
+// more complicated:
+//
+//    a) Performing N = len(r.src) parallel reads causes
+//       unnecessary I/O / network load on the system.
+//       Nevertheless, in situations with one or two slow
+//       data shard sources this maybe reduces the time-to-first
+//       byte slightly. But this does not reflect the avg. case.
+//
+//    b) Actual complexity. Let's assume there are N = 8 (4/4)
+//       data sources and you spawn 8 go routines to read
+//       from all in parallel. Now, 5 (3 data, 2 parity) returned
+//       successfully and 1 (parity) reported an error while 2 (1 data,
+//       1 parity) are still reading and havn't reported any result,
+//       yet.
+//       Now, you could wait for the 1 go routine with the data shard
+//       but if you always wait for the "slowest" data shard you just
+//       end up with the implementation from above but with more I/O
+//       load due to the extra parity shard reads. Also, you have enough
+//       shards to reconstruct the missing one (5 >= 4).
+//       However, doing so may lead to the following bug:
+//       1. The reconstruction starts while one go routine (data shard)
+//          has not finished reading yet.
+//       2. During reconstruction the erasure coding may use the data
+//          shard as some temporial scratch space.
+//       3. The go routine still reads from the data source and may
+//          overwrite some of the data written by the erasure coding
+//          or vice versa.
+//
+//          => The still reading go routine causes data corruption
+//             due to concurrent writes to the shard buffer.
+//       To avoid this you either need to have separate read and
+//       erasure coding buffers (requires copying = inefficient) or
+//       very sophisticated mutex locking (complex).

--- a/cmd/ecc/join_test.go
+++ b/cmd/ecc/join_test.go
@@ -1,0 +1,46 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecc
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+var CountErrorTests = []struct {
+	Err []error
+	N   int
+}{
+	{Err: make([]error, 4), N: 0},                                             // 0
+	{Err: make([]error, 16), N: 0},                                            // 1
+	{Err: []error{errOffline, errOffline, nil, nil}, N: 2},                    // 2
+	{Err: []error{errOffline, errOffline, errOffline, errOffline}, N: 4},      // 3
+	{Err: []error{errOffline, errOffline, errors.New("an error"), nil}, N: 3}, // 4
+}
+
+func TestCountErrors(t *testing.T) {
+	for i := range CountErrorTests {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			test := CountErrorTests[i]
+
+			if n := countErrors(test.Err); n != test.N {
+				t.Errorf("got %d - want %d", n, test.N)
+			}
+		})
+	}
+}

--- a/cmd/erasure-decode_test.go
+++ b/cmd/erasure-decode_test.go
@@ -268,8 +268,7 @@ func TestErasureDecodeRandomOffsetLength(t *testing.T) {
 			if disk == OfflineDisk {
 				continue
 			}
-			tillOffset := erasure.ShardFileTillOffset(offset, readLen, length)
-			bitrotReaders[index] = newStreamingBitrotReader(disk, "testbucket", "object", tillOffset, DefaultBitrotAlgorithm, erasure.ShardSize())
+			bitrotReaders[index] = newStreamingBitrotReader(disk, "testbucket", "object", DefaultBitrotAlgorithm, erasure.ShardSize())
 		}
 		err = erasure.Decode(context.Background(), buf, bitrotReaders, offset, readLen, length)
 		closeBitrotReaders(bitrotReaders)
@@ -330,8 +329,7 @@ func benchmarkErasureDecode(data, parity, dataDown, parityDown int, size int64, 
 			if writers[index] == nil {
 				continue
 			}
-			tillOffset := erasure.ShardFileTillOffset(0, size, size)
-			bitrotReaders[index] = newStreamingBitrotReader(disk, "testbucket", "object", tillOffset, DefaultBitrotAlgorithm, erasure.ShardSize())
+			bitrotReaders[index] = newStreamingBitrotReader(disk, "testbucket", "object", DefaultBitrotAlgorithm, erasure.ShardSize())
 		}
 		if err = erasure.Decode(context.Background(), bytes.NewBuffer(content[:0]), bitrotReaders, 0, size, size); err != nil {
 			panic(err)

--- a/cmd/erasure-encode_test.go
+++ b/cmd/erasure-encode_test.go
@@ -36,8 +36,8 @@ func (a badDisk) AppendFile(volume string, path string, buf []byte) error {
 	return errFaultyDisk
 }
 
-func (a badDisk) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, error) {
-	return nil, errFaultyDisk
+func (a badDisk) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, int64, error) {
+	return nil, -1, errFaultyDisk
 }
 
 func (a badDisk) CreateFile(volume, path string, size int64, reader io.Reader) error {

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -132,9 +132,9 @@ func (d *naughtyDisk) ReadFile(volume string, path string, offset int64, buf []b
 	return d.disk.ReadFile(volume, path, offset, buf, verifier)
 }
 
-func (d *naughtyDisk) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, error) {
+func (d *naughtyDisk) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, int64, error) {
 	if err := d.calcError(); err != nil {
-		return nil, err
+		return nil, length, err
 	}
 	return d.disk.ReadFileStream(volume, path, offset, length)
 }

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"path"
+
+	"github.com/minio/minio/cmd/ecc"
 )
 
 // Converts underlying storage error. Convenience function written to
@@ -99,7 +101,7 @@ func toObjectErr(err error, params ...string) error {
 				Object: params[1],
 			}
 		}
-	case errXLReadQuorum:
+	case errXLReadQuorum, ecc.ErrReadQuorum:
 		err = InsufficientReadQuorum{}
 	case errXLWriteQuorum:
 		err = InsufficientWriteQuorum{}

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -1126,6 +1126,9 @@ func (s *posix) ReadFileStream(volume, path string, offset, length int64) (io.Re
 	if _, err = file.Seek(offset, io.SeekStart); err != nil {
 		return nil, err
 	}
+	if length == -1 {
+		length = st.Size()
+	}
 
 	r := struct {
 		io.Reader

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -47,7 +47,7 @@ type StorageAPI interface {
 	ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error)
 	AppendFile(volume string, path string, buf []byte) (err error)
 	CreateFile(volume, path string, size int64, reader io.Reader) error
-	ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, error)
+	ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, int64, error)
 	RenameFile(srcVolume, srcPath, dstVolume, dstPath string) error
 	StatFile(volume string, path string) (file FileInfo, err error)
 	DeleteFile(volume string, path string) (err error)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -262,7 +262,7 @@ func (client *storageRESTClient) ReadAll(volume, path string) ([]byte, error) {
 }
 
 // ReadFileStream - returns a reader for the requested file.
-func (client *storageRESTClient) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, error) {
+func (client *storageRESTClient) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, int64, error) {
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)
 	values.Set(storageRESTFilePath, path)
@@ -270,9 +270,9 @@ func (client *storageRESTClient) ReadFileStream(volume, path string, offset, len
 	values.Set(storageRESTLength, strconv.Itoa(int(length)))
 	respBody, err := client.call(storageRESTMethodReadFileStream, values, nil, -1)
 	if err != nil {
-		return nil, err
+		return nil, length, err
 	}
-	return respBody, nil
+	return respBody, length, nil
 }
 
 // ReadFile - reads section of a file.

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -336,14 +336,14 @@ func (s *storageRESTServer) ReadFileStreamHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	rc, err := s.storage.ReadFileStream(volume, filePath, int64(offset), int64(length))
+	rc, fileLen, err := s.storage.ReadFileStream(volume, filePath, int64(offset), int64(length))
 	if err != nil {
 		s.writeErrorResponse(w, err)
 		return
 	}
 	defer rc.Close()
 
-	w.Header().Set(xhttp.ContentLength, strconv.Itoa(length))
+	w.Header().Set(xhttp.ContentLength, strconv.FormatInt(fileLen, 10))
 
 	io.Copy(w, rc)
 	w.(http.Flusher).Flush()

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -202,7 +202,6 @@ func (r *getObjectReader) Close() error {
 // which are synonymous with HTTP Range requests.
 //
 // startOffset indicates the starting read location of the object.
-
 // length indicates the total length of the object.
 func (xl xlObjects) GetObject(ctx context.Context, bucket, object string, startOffset int64, length int64, writer io.Writer, etag string, opts ObjectOptions) error {
 	// Lock the object before reading.

--- a/go.mod
+++ b/go.mod
@@ -65,11 +65,9 @@ require (
 	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a
 	go.uber.org/atomic v1.3.2
 	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
-	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
 	golang.org/x/sys v0.0.0-20190922100055-0a153f010e69
 	google.golang.org/api v0.4.0
 	gopkg.in/Shopify/sarama.v1 v1.20.0
-	gopkg.in/ini.v1 v1.48.0 // indirect
 	gopkg.in/ldap.v3 v3.0.3
 	gopkg.in/olivere/elastic.v5 v5.0.80
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -707,8 +707,6 @@ golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 h1:k7pJ2yAPLPgbskkFdhRCsA77k2fySZ1zf2zCjvQCiIM=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180603041954-1e0a3fa8ba9a/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -828,8 +826,6 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.41.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.42.0 h1:7N3gPTt50s8GuLortA00n8AqRTk75qOP98+mTPpgzRk=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.48.0 h1:URjZc+8ugRY5mL5uUeQH/a63JcHwdX9xZaWvmNWD7z8=
-gopkg.in/ini.v1 v1.48.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hrEw=
 gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1 h1:cIuC1OLRGZrld+16ZJvvZxVJeKPsvd5eUIvxfoN5hSM=


### PR DESCRIPTION
## Description
This commit adds the new `ecc` (error correction code) package
that implements primitives for MinIO's erasure coding and bitrot
protection. The main purpose of `ecc` is to provide a simpler
and well-documented implementation of erasure-coding and bitrot
protection primitives to reduce the overall code complexity.

This commit does not remove any previous code since it is still
used by e.g. healing. However, the plan is to move / re-implement
encoding and healing to/in `ecc`in the future.

Further, this PR removes the `io.Pipe` used by the Object-API.
Now, `GetObjectNInfo` returns an `io.ReadCloser` instead of
writing to a pipe.

The `ecc`package documentation can be viewed via:
  1. `godoc -http=":8080" -goroot=<your-go-root-path>`
  2. http://localhost:8080/pkg/github.com/minio/minio/cmd/ecc

## Motivation and Context
Refactor and performance

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
