### PR TITLE
Use errgroups instead of sync.WaitGroup as needed

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -71,8 +71,8 @@ func initFederatorBackend(objLayer ObjectLayer) {
 	// Add buckets that are not registered with the DNS
 	g := errgroup.WithNErrs(len(b))
 	for index := range b {
-		index := index
 		bucketSet.Add(b[index].Name)
+		index := index
 		g.Go(func() error {
 			r, gerr := globalDNSConfig.Get(b[index].Name)
 			if gerr != nil {
@@ -99,7 +99,6 @@ func initFederatorBackend(objLayer ObjectLayer) {
 	// Remove buckets that are in DNS for this server, but aren't local
 	for index := range dnsBuckets {
 		index := index
-
 		g.Go(func() error {
 			// This is a local bucket that exists, so we can continue
 			if bucketSet.Contains(dnsBuckets[index].Key) {

--- a/cmd/posix-list-dir_test.go
+++ b/cmd/posix-list-dir_test.go
@@ -129,8 +129,8 @@ func setupTestReadDirGeneric(t *testing.T) (testResults []result) {
 
 // Test to read non-empty directory with symlinks.
 func setupTestReadDirSymlink(t *testing.T) (testResults []result) {
-	if runtime.GOOS != "Windows" {
-		t.Log("symlinks not available on windows")
+	if runtime.GOOS == globalWindowsOSName {
+		t.Skip("symlinks not available on windows")
 		return nil
 	}
 	dir := mustSetupDir(t)

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -306,19 +306,21 @@ func newXLSets(endpoints EndpointList, format *formatXLV3, setCount int, drivesP
 // StorageInfo - combines output of StorageInfo across all erasure coded object sets.
 func (s *xlSets) StorageInfo(ctx context.Context) StorageInfo {
 	var storageInfo StorageInfo
-	var wg sync.WaitGroup
 
 	storageInfos := make([]StorageInfo, len(s.sets))
 	storageInfo.Backend.Type = BackendErasure
-	for index, set := range s.sets {
-		wg.Add(1)
-		go func(id int, set *xlObjects) {
-			defer wg.Done()
-			storageInfos[id] = set.StorageInfo(ctx)
-		}(index, set)
+
+	g := errgroup.WithNErrs(len(s.sets))
+	for index := range s.sets {
+		index := index
+		g.Go(func() error {
+			storageInfos[index] = s.sets[index].StorageInfo(ctx)
+			return nil
+		}, index)
 	}
+
 	// Wait for the go routines.
-	wg.Wait()
+	g.Wait()
 
 	for _, lstorageInfo := range storageInfos {
 		storageInfo.Used += lstorageInfo.Used
@@ -458,11 +460,12 @@ func undoMakeBucketSets(bucket string, sets []*xlObjects, errs []error) {
 	// Undo previous make bucket entry on all underlying sets.
 	for index := range sets {
 		index := index
-		if errs[index] == nil {
-			g.Go(func() error {
+		g.Go(func() error {
+			if errs[index] == nil {
 				return sets[index].DeleteBucket(context.Background(), bucket)
-			}, index)
-		}
+			}
+			return nil
+		}, index)
 	}
 
 	// Wait for all delete bucket to finish.
@@ -618,11 +621,12 @@ func undoDeleteBucketSets(bucket string, sets []*xlObjects, errs []error) {
 	// Undo previous delete bucket on all underlying sets.
 	for index := range sets {
 		index := index
-		if errs[index] == nil {
-			g.Go(func() error {
+		g.Go(func() error {
+			if errs[index] == nil {
 				return sets[index].MakeBucketWithLocation(context.Background(), bucket, "")
-			}, index)
-		}
+			}
+			return nil
+		}, index)
 	}
 
 	g.Wait()
@@ -742,19 +746,24 @@ func (s *xlSets) CopyObject(ctx context.Context, srcBucket, srcObject, destBucke
 func listDirSetsFactory(ctx context.Context, sets ...*xlObjects) ListDirFunc {
 	listDirInternal := func(bucket, prefixDir, prefixEntry string, disks []StorageAPI) (mergedEntries []string) {
 		var diskEntries = make([][]string, len(disks))
-		var wg sync.WaitGroup
+		g := errgroup.WithNErrs(len(disks))
 		for index, disk := range disks {
 			if disk == nil {
 				continue
 			}
-			wg.Add(1)
-			go func(index int, disk StorageAPI) {
-				defer wg.Done()
-				diskEntries[index], _ = disk.ListDir(bucket, prefixDir, -1, xlMetaJSONFile)
-			}(index, disk)
+			index := index
+			g.Go(func() error {
+				var err error
+				diskEntries[index], err = disks[index].ListDir(bucket, prefixDir, -1, xlMetaJSONFile)
+				return err
+			}, index)
 		}
 
-		wg.Wait()
+		for _, err := range g.Wait() {
+			if err != nil {
+				logger.LogIf(ctx, err)
+			}
+		}
 
 		// Find elements in entries which are not in mergedEntries
 		for _, entries := range diskEntries {
@@ -1405,21 +1414,21 @@ func isTestSetup(infos []DiskInfo, errs []error) bool {
 
 func getAllDiskInfos(storageDisks []StorageAPI) ([]DiskInfo, []error) {
 	infos := make([]DiskInfo, len(storageDisks))
-	errs := make([]error, len(storageDisks))
-	var wg sync.WaitGroup
-	for i := range storageDisks {
-		if storageDisks[i] == nil {
-			errs[i] = errDiskNotFound
-			continue
-		}
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			infos[i], errs[i] = storageDisks[i].DiskInfo()
-		}(i)
+	g := errgroup.WithNErrs(len(storageDisks))
+	for index := range storageDisks {
+		index := index
+		g.Go(func() error {
+			var err error
+			if storageDisks[index] != nil {
+				infos[index], err = storageDisks[index].DiskInfo()
+			} else {
+				// Disk not found.
+				err = errDiskNotFound
+			}
+			return err
+		}, index)
 	}
-	wg.Wait()
-	return infos, errs
+	return infos, g.Wait()
 }
 
 // Mark root disks as down so as not to heal them.

--- a/cmd/xl-v1-common.go
+++ b/cmd/xl-v1-common.go
@@ -19,7 +19,8 @@ package cmd
 import (
 	"context"
 	"path"
-	"sync"
+
+	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
 // getLoadBalancedDisks - fetches load balanced (sufficiently randomized) disk slice.
@@ -53,35 +54,33 @@ func (xl xlObjects) parentDirIsObject(ctx context.Context, bucket, parent string
 // isObject - returns `true` if the prefix is an object i.e if
 // `xl.json` exists at the leaf, false otherwise.
 func (xl xlObjects) isObject(bucket, prefix string) (ok bool) {
-	var errs = make([]error, len(xl.getDisks()))
-	var wg sync.WaitGroup
-	for index, disk := range xl.getDisks() {
+	storageDisks := xl.getDisks()
+
+	g := errgroup.WithNErrs(len(storageDisks))
+
+	for index, disk := range storageDisks {
 		if disk == nil {
 			continue
 		}
-		wg.Add(1)
-		go func(index int, disk StorageAPI) {
-			defer wg.Done()
+		index := index
+		g.Go(func() error {
 			// Check if 'prefix' is an object on this 'disk', else continue the check the next disk
-			fi, err := disk.StatFile(bucket, path.Join(prefix, xlMetaJSONFile))
+			fi, err := storageDisks[index].StatFile(bucket, pathJoin(prefix, xlMetaJSONFile))
 			if err != nil {
-				errs[index] = err
-				return
+				return err
 			}
 			if fi.Size == 0 {
-				errs[index] = errCorruptedFormat
-				return
+				return errCorruptedFormat
 			}
-		}(index, disk)
+			return nil
+		}, index)
 	}
-
-	wg.Wait()
 
 	// NOTE: Observe we are not trying to read `xl.json` and figure out the actual
 	// quorum intentionally, but rely on the default case scenario. Actual quorum
 	// verification will happen by top layer by using getObjectInfo() and will be
 	// ignored if necessary.
-	readQuorum := len(xl.getDisks()) / 2
+	readQuorum := len(storageDisks) / 2
 
-	return reduceReadQuorumErrs(context.Background(), errs, objectOpIgnoredErrs, readQuorum) == nil
+	return reduceReadQuorumErrs(context.Background(), g.Wait(), objectOpIgnoredErrs, readQuorum) == nil
 }

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
 	"time"
 
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/madmin"
+	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
 func (xl xlObjects) ReloadFormat(ctx context.Context, dryRun bool) error {
@@ -57,40 +57,31 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 	dryRun bool) (res madmin.HealResultItem, err error) {
 
 	// Initialize sync waitgroup.
-	var wg sync.WaitGroup
-
-	// Initialize list of errors.
-	var dErrs = make([]error, len(storageDisks))
+	g := errgroup.WithNErrs(len(storageDisks))
 
 	// Disk states slices
 	beforeState := make([]string, len(storageDisks))
 	afterState := make([]string, len(storageDisks))
 
 	// Make a volume entry on all underlying storage disks.
-	for index, disk := range storageDisks {
-		if disk == nil {
-			dErrs[index] = errDiskNotFound
-			beforeState[index] = madmin.DriveStateOffline
-			afterState[index] = madmin.DriveStateOffline
-			continue
-		}
-		wg.Add(1)
-
-		// Make a volume inside a go-routine.
-		go func(index int, disk StorageAPI) {
-			defer wg.Done()
-			if _, serr := disk.StatVol(bucket); serr != nil {
+	for index := range storageDisks {
+		index := index
+		g.Go(func() error {
+			if storageDisks[index] == nil {
+				beforeState[index] = madmin.DriveStateOffline
+				afterState[index] = madmin.DriveStateOffline
+				return errDiskNotFound
+			}
+			if _, serr := storageDisks[index].StatVol(bucket); serr != nil {
 				if serr == errDiskNotFound {
 					beforeState[index] = madmin.DriveStateOffline
 					afterState[index] = madmin.DriveStateOffline
-					dErrs[index] = serr
-					return
+					return serr
 				}
 				if serr != errVolumeNotFound {
 					beforeState[index] = madmin.DriveStateCorrupt
 					afterState[index] = madmin.DriveStateCorrupt
-					dErrs[index] = serr
-					return
+					return serr
 				}
 
 				beforeState[index] = madmin.DriveStateMissing
@@ -98,23 +89,22 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 
 				// mutate only if not a dry-run
 				if dryRun {
-					return
+					return nil
 				}
 
-				makeErr := disk.MakeVol(bucket)
-				dErrs[index] = makeErr
+				makeErr := storageDisks[index].MakeVol(bucket)
 				if makeErr == nil {
 					afterState[index] = madmin.DriveStateOk
 				}
-				return
+				return makeErr
 			}
 			beforeState[index] = madmin.DriveStateOk
 			afterState[index] = madmin.DriveStateOk
-		}(index, disk)
+			return nil
+		}, index)
 	}
 
-	// Wait for all make vol to finish.
-	wg.Wait()
+	errs := g.Wait()
 
 	// Initialize heal result info
 	res = madmin.HealResultItem{
@@ -122,13 +112,13 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 		Bucket:    bucket,
 		DiskCount: len(storageDisks),
 	}
-	for i, before := range beforeState {
+	for i := range beforeState {
 		if storageDisks[i] != nil {
 			drive := storageDisks[i].String()
 			res.Before.Drives = append(res.Before.Drives, madmin.HealDriveInfo{
 				UUID:     "",
 				Endpoint: drive,
-				State:    before,
+				State:    beforeState[i],
 			})
 			res.After.Drives = append(res.After.Drives, madmin.HealDriveInfo{
 				UUID:     "",
@@ -138,7 +128,7 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 		}
 	}
 
-	reducedErr := reduceWriteQuorumErrs(ctx, dErrs, bucketOpIgnoredErrs, writeQuorum)
+	reducedErr := reduceWriteQuorumErrs(ctx, errs, bucketOpIgnoredErrs, writeQuorum)
 	if reducedErr == errXLWriteQuorum {
 		// Purge successfully created buckets if we don't have writeQuorum.
 		undoMakeBucket(storageDisks, bucket)
@@ -597,29 +587,25 @@ func defaultHealResult(latestXLMeta xlMetaV1, storageDisks []StorageAPI, errs []
 
 // Stat all directories.
 func statAllDirs(ctx context.Context, storageDisks []StorageAPI, bucket, prefix string) []error {
-	var errs = make([]error, len(storageDisks))
-	var wg sync.WaitGroup
+	g := errgroup.WithNErrs(len(storageDisks))
 	for index, disk := range storageDisks {
 		if disk == nil {
 			continue
 		}
-		wg.Add(1)
-		go func(index int, disk StorageAPI) {
-			defer wg.Done()
-			entries, err := disk.ListDir(bucket, prefix, 1, "")
+		index := index
+		g.Go(func() error {
+			entries, err := storageDisks[index].ListDir(bucket, prefix, 1, "")
 			if err != nil {
-				errs[index] = err
-				return
+				return err
 			}
 			if len(entries) > 0 {
-				errs[index] = errVolumeNotEmpty
-				return
+				return errVolumeNotEmpty
 			}
-		}(index, disk)
+			return nil
+		}, index)
 	}
 
-	wg.Wait()
-	return errs
+	return g.Wait()
 }
 
 // ObjectDir is considered dangling/corrupted if any only

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -22,11 +22,11 @@ import (
 	"io"
 	"net/http"
 	"path"
-	"sync"
 
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/mimedb"
+	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
 // list all errors which can be ignored in object operations.
@@ -34,25 +34,26 @@ var objectOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied)
 
 // putObjectDir hints the bottom layer to create a new directory.
 func (xl xlObjects) putObjectDir(ctx context.Context, bucket, object string, writeQuorum int) error {
-	var wg sync.WaitGroup
+	storageDisks := xl.getDisks()
 
-	errs := make([]error, len(xl.getDisks()))
+	g := errgroup.WithNErrs(len(storageDisks))
+
 	// Prepare object creation in all disks
-	for index, disk := range xl.getDisks() {
-		if disk == nil {
+	for index := range storageDisks {
+		if storageDisks[index] == nil {
 			continue
 		}
-		wg.Add(1)
-		go func(index int, disk StorageAPI) {
-			defer wg.Done()
-			if err := disk.MakeVol(pathJoin(bucket, object)); err != nil && err != errVolumeExists {
-				errs[index] = err
+		index := index
+		g.Go(func() error {
+			err := storageDisks[index].MakeVol(pathJoin(bucket, object))
+			if err != nil && err != errVolumeExists {
+				return err
 			}
-		}(index, disk)
+			return nil
+		}, index)
 	}
-	wg.Wait()
 
-	return reduceWriteQuorumErrs(ctx, errs, objectOpIgnoredErrs, writeQuorum)
+	return reduceWriteQuorumErrs(ctx, g.Wait(), objectOpIgnoredErrs, writeQuorum)
 }
 
 /// Object Operations
@@ -335,36 +336,34 @@ func (xl xlObjects) getObject(ctx context.Context, bucket, object string, startO
 }
 
 // getObjectInfoDir - This getObjectInfo is specific to object directory lookup.
-func (xl xlObjects) getObjectInfoDir(ctx context.Context, bucket, object string) (oi ObjectInfo, err error) {
-	var wg sync.WaitGroup
+func (xl xlObjects) getObjectInfoDir(ctx context.Context, bucket, object string) (ObjectInfo, error) {
+	storageDisks := xl.getDisks()
 
-	errs := make([]error, len(xl.getDisks()))
+	g := errgroup.WithNErrs(len(storageDisks))
+
 	// Prepare object creation in a all disks
-	for index, disk := range xl.getDisks() {
+	for index, disk := range storageDisks {
 		if disk == nil {
 			continue
 		}
-		wg.Add(1)
-		go func(index int, disk StorageAPI) {
-			defer wg.Done()
+		index := index
+		g.Go(func() error {
 			// Check if 'prefix' is an object on this 'disk'.
-			entries, err := disk.ListDir(bucket, object, 1, "")
+			entries, err := storageDisks[index].ListDir(bucket, object, 1, "")
 			if err != nil {
-				errs[index] = err
-				return
+				return err
 			}
 			if len(entries) > 0 {
 				// Not a directory if not empty.
-				errs[index] = errFileNotFound
-				return
+				return errFileNotFound
 			}
-		}(index, disk)
+			return nil
+		}, index)
 	}
 
-	wg.Wait()
-
-	readQuorum := len(xl.getDisks()) / 2
-	return dirObjectInfo(bucket, object, 0, map[string]string{}), reduceReadQuorumErrs(ctx, errs, objectOpIgnoredErrs, readQuorum)
+	readQuorum := len(storageDisks) / 2
+	err := reduceReadQuorumErrs(ctx, g.Wait(), objectOpIgnoredErrs, readQuorum)
+	return dirObjectInfo(bucket, object, 0, map[string]string{}), err
 }
 
 // GetObjectInfo - reads object metadata and replies back ObjectInfo.
@@ -424,7 +423,6 @@ func (xl xlObjects) getObjectInfo(ctx context.Context, bucket, object string) (o
 }
 
 func undoRename(disks []StorageAPI, srcBucket, srcEntry, dstBucket, dstEntry string, isDir bool, errs []error) {
-	var wg sync.WaitGroup
 	// Undo rename object on disks where RenameFile succeeded.
 
 	// If srcEntry/dstEntry are objects then add a trailing slash to copy
@@ -433,56 +431,51 @@ func undoRename(disks []StorageAPI, srcBucket, srcEntry, dstBucket, dstEntry str
 		srcEntry = retainSlash(srcEntry)
 		dstEntry = retainSlash(dstEntry)
 	}
+	g := errgroup.WithNErrs(len(disks))
 	for index, disk := range disks {
 		if disk == nil {
 			continue
 		}
-		// Undo rename object in parallel.
-		wg.Add(1)
-		go func(index int, disk StorageAPI) {
-			defer wg.Done()
-			if errs[index] != nil {
-				return
+		index := index
+		g.Go(func() error {
+			if errs[index] == nil {
+				_ = disks[index].RenameFile(dstBucket, dstEntry, srcBucket, srcEntry)
 			}
-			_ = disk.RenameFile(dstBucket, dstEntry, srcBucket, srcEntry)
-		}(index, disk)
+			return nil
+		}, index)
 	}
-	wg.Wait()
+	g.Wait()
 }
 
 // rename - common function that renamePart and renameObject use to rename
 // the respective underlying storage layer representations.
 func rename(ctx context.Context, disks []StorageAPI, srcBucket, srcEntry, dstBucket, dstEntry string, isDir bool, writeQuorum int, ignoredErr []error) ([]StorageAPI, error) {
-	// Initialize sync waitgroup.
-	var wg sync.WaitGroup
-
-	// Initialize list of errors.
-	var errs = make([]error, len(disks))
 
 	if isDir {
 		dstEntry = retainSlash(dstEntry)
 		srcEntry = retainSlash(srcEntry)
 	}
 
+	g := errgroup.WithNErrs(len(disks))
+
 	// Rename file on all underlying storage disks.
-	for index, disk := range disks {
-		if disk == nil {
-			errs[index] = errDiskNotFound
-			continue
-		}
-		wg.Add(1)
-		go func(index int, disk StorageAPI) {
-			defer wg.Done()
-			if err := disk.RenameFile(srcBucket, srcEntry, dstBucket, dstEntry); err != nil {
+	for index := range disks {
+		index := index
+		g.Go(func() error {
+			if disks[index] == nil {
+				return errDiskNotFound
+			}
+			if err := disks[index].RenameFile(srcBucket, srcEntry, dstBucket, dstEntry); err != nil {
 				if !IsErrIgnored(err, ignoredErr...) {
-					errs[index] = err
+					return err
 				}
 			}
-		}(index, disk)
+			return nil
+		}, index)
 	}
 
 	// Wait for all renames to finish.
-	wg.Wait()
+	errs := g.Wait()
 
 	// We can safely allow RenameFile errors up to len(xl.getDisks()) - writeQuorum
 	// otherwise return failure. Cleanup successful renames.
@@ -744,39 +737,31 @@ func (xl xlObjects) deleteObject(ctx context.Context, bucket, object string, wri
 		}
 	}
 
-	// Initialize sync waitgroup.
-	var wg sync.WaitGroup
+	g := errgroup.WithNErrs(len(disks))
 
-	// Initialize list of errors.
-	var dErrs = make([]error, len(disks))
-
-	for index, disk := range disks {
-		if disk == nil {
-			dErrs[index] = errDiskNotFound
-			continue
-		}
-		wg.Add(1)
-		go func(index int, disk StorageAPI, isDir bool) {
-			defer wg.Done()
-			var e error
+	for index := range disks {
+		index := index
+		g.Go(func() error {
+			if disks[index] == nil {
+				return errDiskNotFound
+			}
+			var err error
 			if isDir {
 				// DeleteFile() simply tries to remove a directory
 				// and will succeed only if that directory is empty.
-				e = disk.DeleteFile(minioMetaTmpBucket, tmpObj)
+				err = disks[index].DeleteFile(minioMetaTmpBucket, tmpObj)
 			} else {
-				e = cleanupDir(ctx, disk, minioMetaTmpBucket, tmpObj)
+				err = cleanupDir(ctx, disks[index], minioMetaTmpBucket, tmpObj)
 			}
-			if e != nil && e != errVolumeNotFound {
-				dErrs[index] = e
+			if err != nil && err != errVolumeNotFound {
+				return err
 			}
-		}(index, disk, isDir)
+			return nil
+		}, index)
 	}
 
-	// Wait for all routines to finish.
-	wg.Wait()
-
 	// return errors if any during deletion
-	return reduceWriteQuorumErrs(ctx, dErrs, objectOpIgnoredErrs, writeQuorum)
+	return reduceWriteQuorumErrs(ctx, g.Wait(), objectOpIgnoredErrs, writeQuorum)
 }
 
 // deleteObject - wrapper for delete object, deletes an object from

--- a/cmd/xl-v1-utils.go
+++ b/cmd/xl-v1-utils.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"hash/crc32"
 	"path"
-	"sync"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
 // Returns number of errors that occurred the most (incl. nil) and the
@@ -180,28 +180,23 @@ func readXLMeta(ctx context.Context, disk StorageAPI, bucket string, object stri
 // Reads all `xl.json` metadata as a xlMetaV1 slice.
 // Returns error slice indicating the failed metadata reads.
 func readAllXLMetadata(ctx context.Context, disks []StorageAPI, bucket, object string) ([]xlMetaV1, []error) {
-	errs := make([]error, len(disks))
 	metadataArray := make([]xlMetaV1, len(disks))
-	var wg sync.WaitGroup
+
+	g := errgroup.WithNErrs(len(disks))
 	// Read `xl.json` parallelly across disks.
-	for index, disk := range disks {
-		if disk == nil {
-			errs[index] = errDiskNotFound
-			continue
-		}
-		wg.Add(1)
-		// Read `xl.json` in routine.
-		go func(index int, disk StorageAPI) {
-			defer wg.Done()
-			metadataArray[index], errs[index] = readXLMeta(ctx, disk, bucket, object)
-		}(index, disk)
+	for index := range disks {
+		index := index
+		g.Go(func() (err error) {
+			if disks[index] == nil {
+				return errDiskNotFound
+			}
+			metadataArray[index], err = readXLMeta(ctx, disks[index], bucket, object)
+			return err
+		}, index)
 	}
 
-	// Wait for all the routines to finish.
-	wg.Wait()
-
 	// Return all the metadata.
-	return metadataArray, errs
+	return metadataArray, g.Wait()
 }
 
 // Return shuffled partsMetadata depending on distribution.


### PR DESCRIPTION
## Description
Use errgroups instead of sync.WaitGroup as needed

## Motivation and Context
Cleanup of legacy code.

## How to test this PR?
To test all the functionality is working as intended.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
