### PR TITLE
gateway/hdfs: Fix isObjectDir to behave correctly

### DIFF
--- a/cmd/gateway/hdfs/gateway-hdfs.go
+++ b/cmd/gateway/hdfs/gateway-hdfs.go
@@ -509,10 +509,11 @@ func (n *hdfsObjects) isObjectDir(ctx context.Context, bucket, object string) bo
 	}
 	defer f.Close()
 	fis, err := f.Readdir(1)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		logger.LogIf(ctx, err)
 		return false
 	}
+	// Readdir returns an io.EOF when len(fis) == 0.
 	return len(fis) == 0
 }
 


### PR DESCRIPTION
## Description
gateway/hdfs: Fix isObjectDir to behave correctly

## Motivation and Context
Currently, directories with no-entry HDFS gateway is returning 404.

## How to test this PR?
Set up HDFS gateway and try to `mc stat` a prefix with no files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
