### PR TITLE
Assume local endpoints appropriately in k8s deployments

### DIFF
--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -350,27 +350,29 @@ func TestCreateEndpoints(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		serverAddr, endpoints, setupType, err := CreateEndpoints(testCase.serverAddr, testCase.args...)
-
-		if err == nil {
-			if testCase.expectedErr != nil {
-				t.Fatalf("Test (%d) error: expected = %v, got = <nil>", i+1, testCase.expectedErr)
-			} else {
-				if serverAddr != testCase.expectedServerAddr {
-					t.Fatalf("Test (%d) serverAddr: expected = %v, got = %v", i+1, testCase.expectedServerAddr, serverAddr)
+		testCase := testCase
+		t.Run(fmt.Sprintf("Test%d", i+1), func(t *testing.T) {
+			serverAddr, endpoints, setupType, err := CreateEndpoints(testCase.serverAddr, testCase.args...)
+			if err == nil {
+				if testCase.expectedErr != nil {
+					t.Fatalf("error: expected = %v, got = <nil>", testCase.expectedErr)
+				} else {
+					if serverAddr != testCase.expectedServerAddr {
+						t.Fatalf("serverAddr: expected = %v, got = %v", testCase.expectedServerAddr, serverAddr)
+					}
+					if !reflect.DeepEqual(endpoints, testCase.expectedEndpoints) {
+						t.Fatalf("endpoints: expected = %v, got = %v", testCase.expectedEndpoints, endpoints)
+					}
+					if setupType != testCase.expectedSetupType {
+						t.Fatalf("setupType: expected = %v, got = %v", testCase.expectedSetupType, setupType)
+					}
 				}
-				if !reflect.DeepEqual(endpoints, testCase.expectedEndpoints) {
-					t.Fatalf("Test (%d) endpoints: expected = %v, got = %v", i+1, testCase.expectedEndpoints, endpoints)
-				}
-				if setupType != testCase.expectedSetupType {
-					t.Fatalf("Test (%d) setupType: expected = %v, got = %v", i+1, testCase.expectedSetupType, setupType)
-				}
+			} else if testCase.expectedErr == nil {
+				t.Fatalf("error: expected = <nil>, got = %v", err)
+			} else if err.Error() != testCase.expectedErr.Error() {
+				t.Fatalf("error: expected = %v, got = %v", testCase.expectedErr, err)
 			}
-		} else if testCase.expectedErr == nil {
-			t.Fatalf("Test (%d) error: expected = <nil>, got = %v", i+1, err)
-		} else if err.Error() != testCase.expectedErr.Error() {
-			t.Fatalf("Test (%d) error: expected = %v, got = %v", i+1, testCase.expectedErr, err)
-		}
+		})
 	}
 }
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -276,7 +276,11 @@ func serverMain(ctx *cli.Context) {
 
 	// Set nodes for dsync for distributed setup.
 	if globalIsDistXL {
-		globalDsync, err = dsync.New(newDsyncNodes(globalEndpoints))
+		clnts, myNode, err := newDsyncNodes(globalEndpoints)
+		if err != nil {
+			logger.Fatal(err, "Unable to initialize distributed locking on %s", globalEndpoints)
+		}
+		globalDsync, err = dsync.New(clnts, myNode)
 		if err != nil {
 			logger.Fatal(err, "Unable to initialize distributed locking on %s", globalEndpoints)
 		}


### PR DESCRIPTION

## Description
Assume local endpoints appropriately in k8s deployments

## Motivation and Context
On Kubernetes/Docker setups DNS resolves inappropriately
sometimes where there are situations same endpoints with
multiple disks come online indicating either one of them
is local and some of them are not local. This situation
can never happen and it's only a possibility in orchestrated
deployments with dynamic DNS. Following code ensures that we
treat if one of the endpoint says its local for a given host
it is true for all endpoints for the same host. Following code
ensures that this assumption is true and it works in all
scenarios and it is safe to assume for a given host.

This PR also adds validation such that we do not crash the
server if there are bugs in the endpoints list in dsync
initialization.

## How to test this PR?
Thanks to Daniel Valdivia <hola@danielvaldivia.com> for
reproducing this, this fix is needed as part of the
https://github.com/minio/m3 project.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
