### PR TITLE
posix: unify ReadFile storage API

### DIFF
--- a/cmd/bitrot-streaming.go
+++ b/cmd/bitrot-streaming.go
@@ -111,7 +111,7 @@ func (b *streamingBitrotReader) ReadAt(buf []byte, offset int64) (int, error) {
 		// For the first ReadAt() call we need to open the stream for reading.
 		b.currOffset = offset
 		streamOffset := (offset/b.shardSize)*int64(b.h.Size()) + offset
-		b.rc, err = b.disk.ReadFileStream(b.volume, b.filePath, streamOffset, b.tillOffset-streamOffset)
+		b.rc, err = b.disk.ReadFile(b.volume, b.filePath, streamOffset, b.tillOffset-streamOffset, NewBitrotVerifier(HighwayHash256S, nil, b.shardSize))
 		if err != nil {
 			return 0, err
 		}

--- a/cmd/bitrot-whole.go
+++ b/cmd/bitrot-whole.go
@@ -21,6 +21,7 @@ import (
 	"hash"
 	"io"
 
+	"github.com/minio/minio/cmd/ecc"
 	"github.com/minio/minio/cmd/logger"
 )
 
@@ -59,40 +60,36 @@ func newWholeBitrotWriter(disk StorageAPI, volume, filePath string, algo BitrotA
 // Implementation to verify bitrot for the whole file.
 type wholeBitrotReader struct {
 	disk       StorageAPI
+	rc         ecc.Verifier
 	volume     string
 	filePath   string
 	verifier   *BitrotVerifier // Holds the bit-rot info
 	tillOffset int64           // Affects the length of data requested in disk.ReadFile depending on Read()'s offset
-	buf        []byte          // Holds bit-rot verified data
 }
 
 func (b *wholeBitrotReader) ReadAt(buf []byte, offset int64) (n int, err error) {
-	if b.buf == nil {
-		b.buf = make([]byte, b.tillOffset-offset)
-		if _, err := b.disk.ReadFile(b.volume, b.filePath, offset, b.buf, b.verifier); err != nil {
-			ctx := context.Background()
-			logger.GetReqInfo(ctx).AppendTags("disk", b.disk.String())
-			logger.LogIf(ctx, err)
+	if b.rc == nil {
+		if b.rc, err = b.disk.ReadFile(b.volume, b.filePath, offset, b.tillOffset-offset, b.verifier); err != nil {
 			return 0, err
 		}
 	}
-	if len(b.buf) < len(buf) {
-		logger.LogIf(context.Background(), errLessData)
-		return 0, errLessData
+	return io.ReadFull(b.rc, buf)
+}
+
+func (b *wholeBitrotReader) Close() error {
+	if b.rc != nil {
+		return b.rc.Close()
 	}
-	n = copy(buf, b.buf)
-	b.buf = b.buf[n:]
-	return n, nil
+	return nil
 }
 
 // Returns whole-file bitrot reader.
-func newWholeBitrotReader(disk StorageAPI, volume, filePath string, algo BitrotAlgorithm, tillOffset int64, sum []byte) *wholeBitrotReader {
+func newWholeBitrotReader(disk StorageAPI, volume, filePath string, algo BitrotAlgorithm, tillOffset int64, sum []byte, shardSize int64) *wholeBitrotReader {
 	return &wholeBitrotReader{
 		disk:       disk,
 		volume:     volume,
 		filePath:   filePath,
-		verifier:   &BitrotVerifier{algo, sum},
+		verifier:   NewBitrotVerifier(algo, sum, shardSize),
 		tillOffset: tillOffset,
-		buf:        nil,
 	}
 }

--- a/cmd/bitrot.go
+++ b/cmd/bitrot.go
@@ -94,14 +94,15 @@ func (a BitrotAlgorithm) String() string {
 }
 
 // NewBitrotVerifier returns a new BitrotVerifier implementing the given algorithm.
-func NewBitrotVerifier(algorithm BitrotAlgorithm, checksum []byte) *BitrotVerifier {
-	return &BitrotVerifier{algorithm, checksum}
+func NewBitrotVerifier(algorithm BitrotAlgorithm, checksum []byte, shardSize int64) *BitrotVerifier {
+	return &BitrotVerifier{algorithm, checksum, shardSize}
 }
 
 // BitrotVerifier can be used to verify protected data.
 type BitrotVerifier struct {
 	algorithm BitrotAlgorithm
 	sum       []byte
+	shardSize int64
 }
 
 // BitrotAlgorithmFromString returns a bitrot algorithm from the given string representation.
@@ -127,7 +128,7 @@ func newBitrotReader(disk StorageAPI, bucket string, filePath string, tillOffset
 	if algo == HighwayHash256S {
 		return newStreamingBitrotReader(disk, bucket, filePath, tillOffset, algo, shardSize)
 	}
-	return newWholeBitrotReader(disk, bucket, filePath, algo, tillOffset, sum)
+	return newWholeBitrotReader(disk, bucket, filePath, algo, tillOffset, sum, shardSize)
 }
 
 // Close all the readers.

--- a/cmd/ecc/ecc.go
+++ b/cmd/ecc/ecc.go
@@ -1,0 +1,56 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package ecc implements the erasure coding and error correction
+// of the MinIO server.
+//
+//
+// Architecture
+//
+// Conceptually, MinIO implements S3, data collection, error detection and error correction
+// in different layers:
+//                       HTTP handler --------------------- S3, encryption, compression, ...
+//                            |
+//                            |
+//                        Object API ---------------------- Backend implementation (FS, XL, Gateway, ...)
+//                            |
+//                            |
+//                      Reconstruction -------------------- Reedsolomon Erasure-coding
+//                            |
+//                            |
+//                      spawn | join  --------------------- Concurrent read scheduling
+//                 +------+---+---+------+
+//                 |      |       |      |
+//                 |      |       |      |
+//                Detection      Detection ----------------- Content verification (HighwayHash, BLAKE2, ...)
+//                 |      |       |      |
+//                 |      |       |      |
+//               disk1  disk2   disk3  disk4 --------------- File / POSIX layer
+//                 |      |       |      |
+//                 |      |       |       \
+//         part.1 -+      |       +-part.1 +--- part.1
+//                 |      |       |         \
+//         part.2 -+      |       +-part.2   +--- part.2
+//                 |      |       |           \
+//         part.3 -+   offline    +-part.3     +--- part.3
+//
+// The ecc package implements primitives to build the reconstruction,
+// read scheduling and content verification layers.
+package ecc
+
+type errorType string
+
+func (e errorType) Error() string { return string(e) }

--- a/cmd/ecc/verify.go
+++ b/cmd/ecc/verify.go
@@ -1,0 +1,69 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecc
+
+import (
+	"bytes"
+	"hash"
+	"io"
+)
+
+// ErrContentMismatch is returned by Verify when
+// the content hash checksum does not match the
+// expected checksum computed when the data was
+// created.
+//
+// ErrContentMismatch indicates that some bits
+// of the content data got flipped.
+const ErrContentMismatch errorType = "ecc: bitrot: content checksum does not match"
+
+// Verify writes everything it reads from r to hash using the buffer and
+// compares the computed hash value to the provided checksum.
+// If the computed hash differs from checksum it returns ErrContentMismatch.
+func Verify(r io.Reader, buffer []byte, hash hash.Hash, checksum []byte) error {
+	if _, err := io.CopyBuffer(hash, r, buffer); err != nil {
+		return err
+	}
+	if computed := hash.Sum(nil); !bytes.Equal(computed, checksum) {
+		return ErrContentMismatch
+	}
+	return nil
+}
+
+// A Verifier verifies everything it reads from an underlying
+// data stream. It returns ErrContentMismatch if it detects that
+// the underlying data stream is invalid.
+type Verifier interface {
+	io.Reader
+	io.WriterTo
+	io.Closer
+}
+
+type nopVerifier struct{ io.ReadCloser }
+
+// NOPVerifier is a verifier that does not actually
+// verify whatever it reads. The verification step is
+// implemented as a NOP.
+//
+// A NOPVerifier should be used when the content has
+// been verified before but an API requires a Verifier.
+func NOPVerifier(src io.ReadCloser) Verifier { return &nopVerifier{src} }
+
+// WriteTo behaves as specified by the io.WriterTo interface.
+// In particular, it writes everything it reads from an
+// underlying data source to w.
+func (v *nopVerifier) WriteTo(w io.Writer) (int64, error) { return io.Copy(w, v.ReadCloser) }

--- a/cmd/erasure-decode_test.go
+++ b/cmd/erasure-decode_test.go
@@ -28,10 +28,6 @@ import (
 	humanize "github.com/dustin/go-humanize"
 )
 
-func (a badDisk) ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
-	return 0, errFaultyDisk
-}
-
 var erasureDecodeTests = []struct {
 	dataBlocks                   int
 	onDisks, offDisks            int

--- a/cmd/erasure-encode_test.go
+++ b/cmd/erasure-encode_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/minio/minio/cmd/ecc"
 )
 
 type badDisk struct{ StorageAPI }
@@ -36,7 +37,7 @@ func (a badDisk) AppendFile(volume string, path string, buf []byte) error {
 	return errFaultyDisk
 }
 
-func (a badDisk) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, error) {
+func (a badDisk) ReadFile(volume, path string, offset, length int64, verifier *BitrotVerifier) (ecc.Verifier, error) {
 	return nil, errFaultyDisk
 }
 

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -19,6 +19,8 @@ package cmd
 import (
 	"io"
 	"sync"
+
+	"github.com/minio/minio/cmd/ecc"
 )
 
 // naughtyDisk wraps a POSIX disk and returns programmed errors
@@ -128,18 +130,11 @@ func (d *naughtyDisk) ListDir(volume, path string, count int, leafFile string) (
 	return d.disk.ListDir(volume, path, count, leafFile)
 }
 
-func (d *naughtyDisk) ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
-	if err := d.calcError(); err != nil {
-		return 0, err
-	}
-	return d.disk.ReadFile(volume, path, offset, buf, verifier)
-}
-
-func (d *naughtyDisk) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, error) {
+func (d *naughtyDisk) ReadFile(volume string, path string, offset, length int64, verifier *BitrotVerifier) (ecc.Verifier, error) {
 	if err := d.calcError(); err != nil {
 		return nil, err
 	}
-	return d.disk.ReadFileStream(volume, path, offset, length)
+	return d.disk.ReadFile(volume, path, offset, length, verifier)
 }
 
 func (d *naughtyDisk) CreateFile(volume, path string, size int64, reader io.Reader) error {

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"io"
+
+	"github.com/minio/minio/cmd/ecc"
 )
 
 // Detects change in underlying disk.
@@ -112,11 +114,11 @@ func (p *posixDiskIDCheck) ListDir(volume, dirPath string, count int, leafFile s
 	return p.storage.ListDir(volume, dirPath, count, leafFile)
 }
 
-func (p *posixDiskIDCheck) ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
+func (p *posixDiskIDCheck) ReadFile(volume string, path string, offset, length int64, verifier *BitrotVerifier) (ecc.Verifier, error) {
 	if p.isDiskStale() {
-		return 0, errDiskNotFound
+		return nil, errDiskNotFound
 	}
-	return p.storage.ReadFile(volume, path, offset, buf, verifier)
+	return p.storage.ReadFile(volume, path, offset, length, verifier)
 }
 
 func (p *posixDiskIDCheck) AppendFile(volume string, path string, buf []byte) (err error) {
@@ -131,13 +133,6 @@ func (p *posixDiskIDCheck) CreateFile(volume, path string, size int64, reader io
 		return errDiskNotFound
 	}
 	return p.storage.CreateFile(volume, path, size, reader)
-}
-
-func (p *posixDiskIDCheck) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, error) {
-	if p.isDiskStale() {
-		return nil, errDiskNotFound
-	}
-	return p.storage.ReadFileStream(volume, path, offset, length)
 }
 
 func (p *posixDiskIDCheck) RenameFile(srcVolume, srcPath, dstVolume, dstPath string) error {

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -339,19 +339,18 @@ func testStorageAPIReadFile(t *testing.T, storage StorageAPI) {
 		volumeName     string
 		objectName     string
 		offset         int64
+		length         int64
 		expectedResult []byte
 		expectErr      bool
 	}{
-		{"foo", "myobject", 0, []byte("foo"), false},
-		{"foo", "myobject", 1, []byte("oo"), false},
+		{"foo", "myobject", 0, 3, []byte("foo"), false},
+		{"foo", "myobject", 1, 2, []byte("oo"), false},
 		// file not found error.
-		{"foo", "yourobject", 0, nil, true},
+		{"foo", "yourobject", 0, 3, nil, true},
 	}
 
-	result := make([]byte, 100)
 	for i, testCase := range testCases {
-		result = result[testCase.offset:3]
-		_, err := storage.ReadFile(testCase.volumeName, testCase.objectName, testCase.offset, result, nil)
+		r, err := storage.ReadFile(testCase.volumeName, testCase.objectName, testCase.offset, testCase.length, nil)
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {
@@ -359,6 +358,10 @@ func testStorageAPIReadFile(t *testing.T, storage StorageAPI) {
 		}
 
 		if !testCase.expectErr {
+			result, err := ioutil.ReadAll(r)
+			if err != nil {
+				t.Fatalf("case %v: error: %v", i+1, err)
+			}
 			if !reflect.DeepEqual(result, testCase.expectedResult) {
 				t.Fatalf("case %v: result: expected: %v, got: %v", i+1, string(testCase.expectedResult), string(result))
 			}


### PR DESCRIPTION
# Description
This commit unifies the ReadFile storage API
such that "legacy" and streaming bitrot uses
the same `ReadFile` API.

This is a refactoring that makes future changes
to bitrot verification and erasure coding easier.
In particular, it simplifies moving streaming
bitrot verification to the "server side" / posix
layer.

With the `ecc` package this commit tries to organize
and simplify the structure of the erasure coding and
content verification layers in the MinIO server.

## Motivation and Context
Bitrot

## How to test this PR?
unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
