### PR TITLE
notification: use write lock when deleting an event

### DIFF
--- a/pkg/event/target/queuestore.go
+++ b/pkg/event/target/queuestore.go
@@ -115,8 +115,8 @@ func (store *QueueStore) Put(e event.Event) error {
 
 // Get - gets a event from the store.
 func (store *QueueStore) Get(key string) (event.Event, error) {
-	store.RLock()
-	defer store.RUnlock()
+	store.Lock() // A Write lock is required since we eventl. delete an entry
+	defer store.Unlock()
 
 	var event event.Event
 


### PR DESCRIPTION
## Description
This commit fixes a potential race condition that can
occur since `Get` eventually deletes (write operation)
and event from the event queue.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
