### PR TITLE
 Remove duplicate cpu hardware info

### DIFF
--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -124,6 +124,8 @@ func getLocalCPUInfo(endpoints EndpointList, r *http.Request) madmin.ServerCPUHa
 		if seenHosts.Contains(endpoint.Host) {
 			continue
 		}
+		// Add to the list of visited hosts
+		seenHosts.Add(endpoint.Host)
 		// Only proceed for local endpoints
 		if endpoint.IsLocal {
 			cpuHardware, err := cpuhw.Info()


### PR DESCRIPTION
## Description

Function `getLocalCPUInfo` was fetching the cpu info for all the endpoint on host which resulted in duplicate information.
Added the code to skip the host if already visited .

```
// Add to the list of visited hosts
seenHosts.Add(endpoint.Host)
```




## Motivation and Context


## How to test this PR?
Run `hw-cpu-info.go`


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
