### PR TITLE
Avoid crash in PopulatePublicKey() by re-initializing the args

### DIFF
--- a/pkg/iam/openid/jwt.go
+++ b/pkg/iam/openid/jwt.go
@@ -62,14 +62,11 @@ func (r *JWKSArgs) PopulatePublicKey() error {
 		return err
 	}
 
-	r.publicKeys = make(map[string]crypto.PublicKey)
 	for _, key := range jwk.Keys {
-		var publicKey crypto.PublicKey
-		publicKey, err = key.DecodePublicKey()
+		r.publicKeys[key.Kid], err = key.DecodePublicKey()
 		if err != nil {
 			return err
 		}
-		r.publicKeys[key.Kid] = publicKey
 	}
 
 	return nil
@@ -215,10 +212,18 @@ func LookupConfig(args JWKSArgs, transport *http.Transport, closeRespFn func(io.
 	if err != nil {
 		return args, err
 	}
-	args.URL = u
-	if err := args.PopulatePublicKey(); err != nil {
+
+	args = JWKSArgs{
+		URL:         u,
+		publicKeys:  make(map[string]crypto.PublicKey),
+		transport:   transport,
+		closeRespFn: closeRespFn,
+	}
+
+	if err = args.PopulatePublicKey(); err != nil {
 		return args, err
 	}
+
 	return args, nil
 }
 


### PR DESCRIPTION


## Description
Avoid crash in PopulatePublicKey() by re-initializing the args

## Motivation and Context
This is to avoid nil pointer dereference when method by pointer
reference and method by value reference are implemented.

Fixes #8387

## How to test this PR?
Just run the following test and see the crash with the latest master

```
#!/bin/bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
export MINIO_IAM_JWKS_URL="https://www.googleapis.com/oauth2/v3/certs"
for i in {02..05}; do
    minio server --address ":90${i}" http://127.0.0.1:9002/tmp/1 http://127.0.0.1:9003/tmp/2 http://127.0.0.1:9004/tmp/3 http://127.0.0.1:9005/tmp/4 http://127.0.0.1:9002/tmp/5 http://127.0.0.1:9003/tmp/6 http://127.0.0.1:9004/tmp/7 http://127.0.0.1:9005/tmp/8 &
done
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
