### PR TITLE
madmin: Migrate to provable secure channel construction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/rjeczalik/notify v0.9.2
 	github.com/rs/cors v1.6.0
+	github.com/secure-io/sio-go v0.2.0
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	github.com/skyrings/skyring-common v0.0.0-20160929130248-d1c0bb1cbd5e

--- a/go.sum
+++ b/go.sum
@@ -583,6 +583,8 @@ github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec/go.mod h1:gi+0
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/secure-io/sio-go v0.2.0 h1:63Oy4FEiYUqUvn/pYX0q/eVB2rimmuK/j3WRpcK219s=
+github.com/secure-io/sio-go v0.2.0/go.mod h1:Np6qoCYRnuYMVrvizMS82+JbdOIT5ep43BJa5qGcT1Q=
 github.com/segmentio/go-prompt v0.0.0-20161017233205-f0d19b6901ad/go.mod h1:B3ehdD1xPoWDKgrQgUaGk+m8H1xb1J5TyYDfKpKNeEE=
 github.com/segmentio/go-prompt v1.2.1-0.20161017233205-f0d19b6901ad/go.mod h1:B3ehdD1xPoWDKgrQgUaGk+m8H1xb1J5TyYDfKpKNeEE=
 github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=

--- a/pkg/madmin/encrypt.go
+++ b/pkg/madmin/encrypt.go
@@ -19,50 +19,137 @@ package madmin
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/rand"
+	"errors"
 	"io"
 	"io/ioutil"
 
-	"github.com/minio/sio"
+	"github.com/secure-io/sio-go"
 	"golang.org/x/crypto/argon2"
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/sys/cpu"
 )
 
-// EncryptData - encrypts server config data.
+// EncryptData encrypts the data with an unique key
+// derived from password using the Argon2id PBKDF.
+//
+// The returned ciphertext data consists of:
+//    salt | AEAD ID | nonce | encrypted data
+//     32      1         8      ~ len(data)
 func EncryptData(password string, data []byte) ([]byte, error) {
 	salt := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
 		return nil, err
 	}
 
-	// derive an encryption key from the master key and the nonce
-	var key [32]byte
-	copy(key[:], argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32))
+	// Derive an unique 256 bit key from the password and the random salt.
+	key := argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32)
 
-	encrypted, err := sio.EncryptReader(bytes.NewReader(data), sio.Config{
-		Key: key[:]},
-	)
+	// Create a new AEAD instance - either AES-GCM if the CPU provides
+	// an AES hardware implementation or ChaCha20-Poly1305 otherwise.
+	id, cipher, err := newAEAD(key)
 	if err != nil {
 		return nil, err
 	}
-	edata, err := ioutil.ReadAll(encrypted)
-	return append(salt, edata...), err
+	stream := sio.NewStream(cipher, sio.BufSize)
+
+	nonce := make([]byte, stream.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	// ciphertext = salt || AEAD ID | nonce | encrypted data
+	cLen := int64(len(salt)+1+len(nonce)+len(data)) + stream.Overhead(int64(len(data)))
+	ciphertext := bytes.NewBuffer(make([]byte, 0, cLen)) // pre-alloc correct length
+
+	// Prefix the ciphertext with salt, AEAD ID and nonce
+	ciphertext.Write(salt)
+	ciphertext.WriteByte(id)
+	ciphertext.Write(nonce)
+
+	w := stream.EncryptWriter(ciphertext, nonce, nil)
+	if _, err = w.Write(data); err != nil {
+		return nil, err
+	}
+	if err = w.Close(); err != nil {
+		return nil, err
+	}
+	return ciphertext.Bytes(), nil
 }
 
-// DecryptData - decrypts server config data.
+// DecryptData decrypts the data with the key derived
+// from the salt (part of data) and the password using
+// the PBKDF used in EncryptData. DecryptData returns
+// the decrypted plaintext on success.
+//
+// The data must be a valid ciphertext produced by
+// EncryptData. Otherwise, the decryption will fail.
 func DecryptData(password string, data io.Reader) ([]byte, error) {
-	salt := make([]byte, 32)
-	if _, err := io.ReadFull(data, salt); err != nil {
+	var (
+		salt  [32]byte
+		id    [1]byte
+		nonce [8]byte // This depends on the AEAD but both used ciphers have the same nonce length.
+	)
+
+	if _, err := io.ReadFull(data, salt[:]); err != nil {
 		return nil, err
 	}
-	// derive an encryption key from the master key and the nonce
-	var key [32]byte
-	copy(key[:], argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32))
+	if _, err := io.ReadFull(data, id[:]); err != nil {
+		return nil, err
+	}
+	if _, err := io.ReadFull(data, nonce[:]); err != nil {
+		return nil, err
+	}
 
-	decrypted, err := sio.DecryptReader(data, sio.Config{
-		Key: key[:]},
-	)
+	key := argon2.IDKey([]byte(password), salt[:], 1, 64*1024, 4, 32)
+	cipher, err := parseAEAD(id[0], key)
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(decrypted)
+	stream := sio.NewStream(cipher, sio.BufSize)
+	return ioutil.ReadAll(stream.DecryptReader(data, nonce[:], nil))
+}
+
+const (
+	aesGcm   = 0x00
+	c20p1305 = 0x01
+)
+
+// newAEAD creates a new AEAD instance from the given key.
+// If the CPU provides an AES hardware implementation it
+// returns an AES-GCM instance. Otherwise it returns a
+// ChaCha20-Poly1305 instance.
+//
+// newAEAD also returns a byte as algorithm ID indicating
+// which AEAD scheme it has selected.
+func newAEAD(key []byte) (byte, cipher.AEAD, error) {
+	if (cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ) || cpu.S390X.HasAES || cpu.PPC64.IsPOWER8 || cpu.ARM64.HasAES {
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return 0, nil, err
+		}
+		c, err := cipher.NewGCM(block)
+		return aesGcm, c, err
+	}
+	c, err := chacha20poly1305.New(key)
+	return c20p1305, c, err
+}
+
+// parseAEAD creates a new AEAD instance from the id and key.
+// The id must be either 0 (AES-GCM) or 1 (ChaCha20-Poly1305).
+func parseAEAD(id byte, key []byte) (cipher.AEAD, error) {
+	switch id {
+	case aesGcm:
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return nil, err
+		}
+		return cipher.NewGCM(block)
+	case c20p1305:
+		return chacha20poly1305.New(key)
+	default:
+		return nil, errors.New("madmin: invalid AEAD algorithm ID")
+	}
 }

--- a/pkg/madmin/encrypt_test.go
+++ b/pkg/madmin/encrypt_test.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2018 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/madmin/encrypt_test.go
+++ b/pkg/madmin/encrypt_test.go
@@ -1,0 +1,96 @@
+/*
+ * MinIO Cloud Storage, (C) 2018 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package madmin
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+var encryptDataTests = []struct {
+	Password string
+	Data     []byte
+}{
+	{Password: "", Data: nil},
+	{Password: "", Data: make([]byte, 256)},
+	{Password: `xPl.8/rhR"Q_1xLt`, Data: make([]byte, 32)},
+	{Password: "m69?yz4W-!k+7p0", Data: make([]byte, 1024*1024)},
+	{Password: `7h5oU4$te{;K}fgqlI^]`, Data: make([]byte, 256)},
+}
+
+func TestEncryptData(t *testing.T) {
+	for i, test := range encryptDataTests {
+		i, test := i, test
+		t.Run(fmt.Sprintf("Test-%d", i), func(t *testing.T) {
+			ciphertext, err := EncryptData(test.Password, test.Data)
+			if err != nil {
+				t.Fatalf("Failed to encrypt data: %v", err)
+			}
+			plaintext, err := DecryptData(test.Password, bytes.NewReader(ciphertext))
+			if err != nil {
+				t.Fatalf("Failed to decrypt data: %v", err)
+			}
+			if !bytes.Equal(plaintext, test.Data) {
+				t.Fatal("Decrypt plaintext does not match origin data")
+			}
+		})
+	}
+}
+
+var decryptDataTests = []struct {
+	Password string
+	Data     string
+}{
+	{Password: "", Data: "828aa81599df0651c0461adb82283e8b89956baee9f6e719947ef9cddc849028001dc9d3ac0938f66b07bacc9751437e1985f8a9763c240e81"},
+
+	{Password: "", Data: "1793c71df6647860437134073c15688cbb15961dc0758c7ee1225e66e79c724c00d790dba9c671eae89da2c736d858286ac9bd027abacc6443" +
+		"0375cd41b63b67c070c7fba475a8dd66ae65ba905176c48cbe6f734fc74df87343d8ccff54bada4aeb0a04bd021633ebe6c4768e23f5dea142" +
+		"561d4fe3f90ed59d13dc5fb3a585dadec1742325291b9c81692bdd3420b2428127f8195e0ecd9a1c9237712ed67af7339fbbf7ff3ee1c516e1" +
+		"f81e69d933e057b30997e7274a2c9698e07c39f0e8d6818858f34c8191871b5a52bea9061806bd029024bfc1d9c1f230904968d6c9e10fddcb" +
+		"c006ba97356ff243570fd96df07dd6894e215a6b24c4ed730369519289ebd877aff6ccbd2265985e4ab1a2b7930bab9cfb767b97348a639ddf" +
+		"8db81bf5151da7e8f3d9638a1b86eb1dd78cc6a526f10a414c78638f"},
+
+	{Password: `xPl.8/rhR"Q_1xLt`, Data: "b5c016e93b84b473fc8a37af94936563630c36d6df1841d23a86ee51ca161f9e00ac19116b32f643ff6a56a212b265d8c56" +
+		"195bb0d12ce199e13dfdc5272f80c1564da2c6fc2fa18da91d8062de02af5cdafea491c6f3cae1f"},
+
+	{Password: `7h5oU4$te{;K}fgqlI^]`, Data: "c58edf7cfd557b6b655de6f48b1a3049d8d049dadb3a7bfa9ac9ccbb5baf37ec00f83086a26f43b7d6bc9075ad0" +
+		"38bf5741f118d502ebe94165e4072ba7f98535d6b1e3b6ae67a98115d146d9b4d90e4df4ae82df9cfa17ed7cd42" +
+		"465181559f7ddf09c98beec521bb4478e0cb73c4e0827af8688ff4e7a07327a10d5a180035e6ddb16d974a85257" +
+		"981cd9e0360a20f7b4d653190267dfb241148f018ae180568042e864b9e1b5bc05425a3abc2b0324f50c72d5679" +
+		"8f924405dfc0f8523f4bb564ed65af8e1b1c82a7a0640552ecf81985d95d0993d99172592ddc1393dfa63e8f0b3" +
+		"d744b2cc4b73384ca4693f0c1aec0e9b00e85f2937e891105d67da8f59c14ca96608e0425c42f9c1e7c2a8b3413" +
+		"e1381784f9cfe01de7c47cea1f8d7a7d88f5d4aca783cf55332b47f957a6b9a65269d7eb606b877b"},
+}
+
+func TestDecryptData(t *testing.T) {
+	for i, test := range decryptDataTests {
+		i, test := i, test
+		t.Run(fmt.Sprintf("Test-%d", i), func(t *testing.T) {
+			ciphertext, err := hex.DecodeString(test.Data)
+			if err != nil {
+				t.Fatalf("Failed to decode ciphertext data: %v", err)
+			}
+			_, err = DecryptData(test.Password, bytes.NewReader(ciphertext))
+			if err != nil {
+				t.Fatalf("Failed to decrypt data: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This commit replaces the currently used channel construction
for en/decrypting config data with a provable secure scheme.

See: [code](https://github.com/secure-io/sio-go) and [doc](https://godoc.org/github.com/secure-io/sio-go)  for more information.

## Motivation and Context
Config K/V changes. 
This commit must be merged before #8392 since there would be no clean way to replace scheme in the future.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
