### PR TITLE
adding oauth support to MinIO browser

### DIFF
--- a/browser/app/js/App.js
+++ b/browser/app/js/App.js
@@ -18,11 +18,13 @@ import React from "react"
 import { Route, Switch, Redirect } from "react-router-dom"
 import Browser from "./browser/Browser"
 import Login from "./browser/Login"
+import OpenIDLogin from "./browser/OpenIDLogin"
 import web from "./web"
 
 export const App = () => {
   return (
     <Switch>
+      <Route path={"/login/openid"} component={OpenIDLogin} />
       <Route path={"/login"} component={Login} />
       <Route path={"/:bucket?/*"} component={Browser} />
     </Switch>

--- a/browser/app/js/browser/ChangePasswordModal.js
+++ b/browser/app/js/browser/ChangePasswordModal.js
@@ -93,10 +93,16 @@ export class ChangePasswordModal extends React.Component {
       return false
     }
 
+    // Password change is not allowed for temporary users(STS)
+    if(serverInfo.userInfo.isTempUser) {
+      return false
+    }
+
     // Password change is only allowed for regular users
     if (!serverInfo.userInfo.isIAMUser) {
       return false
     }
+
     return true
   }
 

--- a/browser/app/js/browser/Login.js
+++ b/browser/app/js/browser/Login.js
@@ -22,14 +22,18 @@ import Alert from "../alert/Alert"
 import * as actionsAlert from "../alert/actions"
 import InputGroup from "./InputGroup"
 import web from "../web"
-import { Redirect } from "react-router-dom"
+import { Redirect, Link } from "react-router-dom"
+import qs from "query-string"
+import storage from "local-storage-fallback"
+import history from "../history"
 
 export class Login extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
       accessKey: "",
-      secretKey: ""
+      secretKey: "",
+      OpenIDConfigURL: undefined
     }
   }
 
@@ -83,6 +87,14 @@ export class Login extends React.Component {
     document.body.classList.add("is-guest")
   }
 
+  componentDidMount() {
+    web.OpenIDConfig().then(({ OpenIDConfigURL }) => {
+      this.setState({
+        OpenIDConfigURL: OpenIDConfigURL
+      })
+    })
+  }
+
   componentWillUnmount() {
     document.body.classList.remove("is-guest")
   }
@@ -127,6 +139,14 @@ export class Login extends React.Component {
               <i className="fas fa-sign-in-alt" />
             </button>
           </form>
+          {this.state.OpenIDConfigURL && (
+            <div className="openid-login">
+              <div className="or">or</div>
+              <Link to={"/login/openid"} className="btn openid-btn">
+                Log in with OpenID
+              </Link>
+            </div>
+          )}
         </div>
         <div className="l-footer">
           <a className="lf-logo" href="">

--- a/browser/app/js/browser/OpenIDLogin.js
+++ b/browser/app/js/browser/OpenIDLogin.js
@@ -1,0 +1,173 @@
+/*
+ * MinIO Cloud Storage (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { connect } from "react-redux"
+import logo from "../../img/logo.svg"
+import Alert from "../alert/Alert"
+import * as actionsAlert from "../alert/actions"
+import InputGroup from "./InputGroup"
+import web from "../web"
+import { Redirect } from "react-router-dom"
+import qs from "query-string"
+import SuperAgent from "superagent-es6-promise"
+import { getRandomString } from "../utils"
+import storage from "local-storage-fallback"
+import jwtDecode from "jwt-decode"
+
+export class OpenIDLogin extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      clientID: "",
+      OpenIDConfigURL: undefined
+    }
+    this.clientIDChange = this.clientIDChange.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
+  }
+
+  clientIDChange(e) {
+    this.setState({
+      clientID: e.target.value
+    })
+  }
+
+  handleSubmit(event) {
+    event.preventDefault()
+    const { showAlert } = this.props
+    let message = ""
+    if (this.state.clientID === "") {
+      message = "Client ID cannot be empty"
+    }
+    if (message) {
+      showAlert("danger", message)
+      return
+    }
+    if (this.state.OpenIDConfigURL) {
+      let req = SuperAgent.get(this.state.OpenIDConfigURL)
+      req.send().then(res => {
+        const redirectURI = window.location.href.split("#")[0]
+        var params = new URLSearchParams()
+        params.set("response_type", "id_token")
+        params.set("scope", "openid")
+        params.set("client_id", this.state.clientID)
+        params.set("redirect_uri", redirectURI)
+
+        // Store nonce in localstorage to check again after the redirect
+        const nonce = getRandomString(16)
+        params.set("nonce", nonce)
+        storage.setItem("openIDKey", nonce)
+
+        const authURL = `${
+          res.body.authorization_endpoint
+        }?${params.toString()}`
+        window.location = authURL
+      })
+    }
+  }
+
+  componentWillMount() {
+    const { clearAlert } = this.props
+    // Clear out any stale message in the alert of previous page
+    clearAlert()
+    document.body.classList.add("is-guest")
+
+    web.OpenIDConfig().then(({ OpenIDConfigURL }) => {
+      this.setState({
+        OpenIDConfigURL: OpenIDConfigURL
+      })
+    })
+  }
+
+  componentDidMount() {
+    const values = qs.parse(this.props.location.hash)
+    if (values.error) {
+      this.props.showAlert("danger", values.error_description)
+      return
+    }
+
+    if (values.id_token) {
+      // Check nonce on the token to prevent replay attacks
+      const tokenJSON = jwtDecode(values.id_token)
+      if (storage.getItem("openIDKey") !== tokenJSON.nonce) {
+        this.props.showAlert("danger", "Invalid auth token")
+        return
+      }
+
+      web.LoginSTS({ token: values.id_token }).then(() => {
+        storage.removeItem("openIDKey")
+        this.forceUpdate()
+        return
+      })
+    }
+  }
+
+  componentWillUnmount() {
+    document.body.classList.remove("is-guest")
+  }
+
+  render() {
+    const { clearAlert, alert } = this.props
+    if (web.LoggedIn()) {
+      return <Redirect to={"/"} />
+    }
+    let alertBox = <Alert {...alert} onDismiss={clearAlert} />
+    // Make sure you don't show a fading out alert box on the initial web-page load.
+    if (!alert.message) alertBox = ""
+    return (
+      <div className="login">
+        {alertBox}
+        <div className="l-wrap">
+          <form onSubmit={this.handleSubmit}>
+            <InputGroup
+              value={this.state.clientID}
+              onChange={this.clientIDChange}
+              className="ig-dark"
+              label="Client ID"
+              id="clientID"
+              name="clientID"
+              type="text"
+              spellCheck="false"
+              required="required"
+            />
+            <button className="lw-btn" type="submit">
+              <i className="fas fa-sign-in-alt" />
+            </button>
+          </form>
+        </div>
+        <div className="l-footer">
+          <a className="lf-logo" href="">
+            <img src={logo} alt="" />
+          </a>
+          <div className="lf-server">{window.location.host}</div>
+        </div>
+      </div>
+    )
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    showAlert: (type, message) =>
+      dispatch(actionsAlert.set({ type: type, message: message })),
+    clearAlert: () => dispatch(actionsAlert.clear())
+  }
+}
+
+export default connect(
+  state => state,
+  mapDispatchToProps
+)(OpenIDLogin)

--- a/browser/app/js/browser/__tests__/ChangePasswordModal.test.js
+++ b/browser/app/js/browser/__tests__/ChangePasswordModal.test.js
@@ -90,6 +90,20 @@ describe("ChangePasswordModal", () => {
     ).toBe("Credentials of this user cannot be updated through MinIO Browser.")
   })
 
+  it("should not allow changing password for STS user", () => {
+    const newServerInfo = {
+      ...serverInfo,
+      userInfo: { isTempUser: true }
+    }
+    const wrapper = shallow(<ChangePasswordModal serverInfo={newServerInfo} />)
+    expect(
+      wrapper
+        .find("ModalBody")
+        .childAt(0)
+        .text()
+    ).toBe("Credentials of this user cannot be updated through MinIO Browser.")
+  })
+
   it("should not generate accessKey for IAM User", () => {
     const wrapper = shallow(<ChangePasswordModal serverInfo={serverInfo} />)
     wrapper.find("#generate-keys").simulate("click")

--- a/browser/app/js/browser/__tests__/Login.test.js
+++ b/browser/app/js/browser/__tests__/Login.test.js
@@ -19,11 +19,14 @@ import { shallow, mount } from "enzyme"
 import { Login } from "../Login"
 import web from "../../web"
 
-jest.mock('../../web', () => ({
+jest.mock("../../web", () => ({
   Login: jest.fn(() => {
     return Promise.resolve({ token: "test", uiVersion: "2018-02-01T01:17:47Z" })
   }),
-  LoggedIn: jest.fn()
+  LoggedIn: jest.fn(),
+  OpenIDConfig: jest.fn(() => {
+    return Promise.resolve({ OpenIDConfigURL: "test" })
+  })
 }))
 
 describe("Login", () => {

--- a/browser/app/js/utils.js
+++ b/browser/app/js/utils.js
@@ -107,3 +107,13 @@ export const getRandomSecretKey = () => {
   const base64Str = btoa(binStr)
   return base64Str.replace(/\//g, "+").substr(0, 40)
 }
+
+export const getRandomString = length => {
+  var text = ""
+  var possible =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+  for (var i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length))
+  }
+  return text
+}

--- a/browser/app/js/web.js
+++ b/browser/app/js/web.js
@@ -75,6 +75,16 @@ class Web {
   GetToken() {
     return storage.getItem('token')
   }
+  OpenIDConfig() {
+    return this.makeCall("OpenIDConfig")
+  }
+  LoginSTS(args) {
+    return this.makeCall('LoginSTS', args)
+      .then(res => {
+        storage.setItem('token', `${res.token}`)
+        return res
+      })
+  }
   ServerInfo() {
     return this.makeCall('ServerInfo')
   }

--- a/browser/app/less/inc/login.less
+++ b/browser/app/less/inc/login.less
@@ -95,6 +95,40 @@
     }
 }
 
+.openid-login {
+    margin-top: 30px;
+}
+
+.openid-btn {
+    display: inline-block;
+    margin-top: 30px;
+    border-width: 1px;
+    border-style: solid;
+    opacity: 0.6;
+    font-size: 14px;
+    &:hover {
+        color: @link-color;
+        opacity: 1;
+    }
+}
+
+.or {
+    display:flex;
+    justify-content:center;
+    align-items: center;
+    color:grey;
+  }
+  
+.or:after,
+.or:before {
+    content: "";
+    display: block;
+    background: grey;
+    width: 10px;
+    height: 1px;
+    margin: 0 10px;
+}
+
 /*------------------------------
     Chrome autofill fix
 -------------------------------*/

--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -8459,6 +8459,24 @@
         "prepend-http": "^1.0.0",
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true
+        }
       }
     },
     "npm-path": {
@@ -10287,13 +10305,13 @@
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+      "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -12142,6 +12160,11 @@
         }
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -12312,10 +12335,9 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",

--- a/browser/package.json
+++ b/browser/package.json
@@ -75,6 +75,7 @@
     "mime-db": "^1.25.0",
     "mime-types": "^2.1.13",
     "moment": "^2.24.0",
+    "query-string": "^6.8.2",
     "react": "^16.2.0",
     "react-addons-test-utils": "^0.14.8",
     "react-bootstrap": "^0.32.0",

--- a/browser/webpack.config.js
+++ b/browser/webpack.config.js
@@ -74,7 +74,8 @@ var exports = {
     proxy: {
       '/minio/webrpc': {
 	target: 'http://localhost:9000',
-	secure: false
+  secure: false,
+  headers: {'Host': "localhost:9000"}
       },
       '/minio/upload/*': {
 	target: 'http://localhost:9000',

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -212,7 +212,7 @@ func getClaimsFromToken(r *http.Request) (map[string]interface{}, error) {
 		// If OPA is not set, session token should
 		// have a policy and its mandatory, reject
 		// requests without policy claim.
-		p, pok := claims[iampolicy.PolicyName]
+		p, pok := claims[iamPolicyName()]
 		if !pok {
 			return nil, errAuthentication
 		}

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -111,7 +111,7 @@ func (s serverConfig) lookupConfigs() {
 		globalCompressMimeTypes = compCfg.MimeTypes
 	}
 
-	openidCfg, err := openid.LookupConfig(s[config.IdentityOpenIDSubSys][config.Default],
+	globalOpenidConfig, err = openid.LookupConfig(s[config.IdentityOpenIDSubSys][config.Default],
 		NewCustomHTTPTransport(), xhttp.DrainBody)
 	if err != nil {
 		logger.FatalIf(err, "Unable to initialize OpenID")
@@ -123,7 +123,7 @@ func (s serverConfig) lookupConfigs() {
 		logger.FatalIf(err, "Unable to initialize OPA")
 	}
 
-	globalOpenIDValidators = getOpenIDValidators(openidCfg)
+	globalOpenIDValidators = getOpenIDValidators(globalOpenidConfig.JWKS)
 	globalPolicyOPA = iampolicy.NewOpa(opaCfg)
 
 	globalLDAPConfig, err = xldap.Lookup(s[config.IdentityLDAPSubSys][config.Default],

--- a/cmd/config-versions.go
+++ b/cmd/config-versions.go
@@ -869,10 +869,7 @@ type serverConfigV33 struct {
 	Compression compress.Config `json:"compress"`
 
 	// OpenID configuration
-	OpenID struct {
-		// JWKS validator config.
-		JWKS openid.JWKSArgs `json:"jwks"`
-	} `json:"openid"`
+	OpenID openid.Config `json:"openid"`
 
 	// External policy enforcements.
 	Policy struct {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -152,6 +152,7 @@ var (
 
 	globalStorageClass storageclass.Config
 	globalLDAPConfig   xldap.Config
+	globalOpenidConfig openid.Config
 
 	// CA root certificates, a nil value means system certs pool will be used
 	globalRootCAs *x509.CertPool

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1125,7 +1125,7 @@ func (sys *IAMSys) IsAllowedSTS(args iampolicy.Args) bool {
 		return combinedPolicy.IsAllowed(args)
 	}
 
-	pname, ok := args.Claims[iampolicy.PolicyName]
+	pname, ok := args.Claims[iamPolicyName()]
 	if !ok {
 		// When claims are set, it should have a "policy" field.
 		return false

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -55,23 +55,27 @@ func authenticateJWTUsers(accessKey, secretKey string, expiry time.Duration) (st
 	if err != nil {
 		return "", err
 	}
+	expiresAt := UTCNow().Add(expiry)
+	return authenticateJWTUsersWithCredentials(passedCredential, expiresAt)
+}
 
+func authenticateJWTUsersWithCredentials(credentials auth.Credentials, expiresAt time.Time) (string, error) {
 	serverCred := globalActiveCred
-	if serverCred.AccessKey != passedCredential.AccessKey {
+	if serverCred.AccessKey != credentials.AccessKey {
 		var ok bool
-		serverCred, ok = globalIAMSys.GetUser(accessKey)
+		serverCred, ok = globalIAMSys.GetUser(credentials.AccessKey)
 		if !ok {
 			return "", errInvalidAccessKeyID
 		}
 	}
 
-	if !serverCred.Equal(passedCredential) {
+	if !serverCred.Equal(credentials) {
 		return "", errAuthentication
 	}
 
 	jwt := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, jwtgo.StandardClaims{
-		ExpiresAt: UTCNow().Add(expiry).Unix(),
-		Subject:   accessKey,
+		ExpiresAt: expiresAt.Unix(),
+		Subject:   credentials.AccessKey,
 	})
 	return jwt.SignedString([]byte(serverCred.SecretKey))
 }
@@ -105,6 +109,10 @@ func authenticateNode(accessKey, secretKey string) (string, error) {
 
 func authenticateWeb(accessKey, secretKey string) (string, error) {
 	return authenticateJWTUsers(accessKey, secretKey, defaultJWTExpiry)
+}
+
+func authenticateWebSTS(creds auth.Credentials) (string, error) {
+	return authenticateJWTUsersWithCredentials(creds, creds.Expiration)
 }
 
 func authenticateURL(accessKey, secretKey string) (string, error) {

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -202,7 +202,7 @@ func (sts *stsAPIHandlers) AssumeRole(w http.ResponseWriter, r *http.Request) {
 	// This policy is the policy associated with the user
 	// requesting for temporary credentials. The temporary
 	// credentials will inherit the same policy requirements.
-	m[iampolicy.PolicyName] = policyName
+	m[iamPolicyName()] = policyName
 
 	if len(sessionPolicyStr) > 0 {
 		m[iampolicy.SessionPolicyName] = base64.StdEncoding.EncodeToString([]byte(sessionPolicyStr))
@@ -338,7 +338,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithJWT(w http.ResponseWriter, r *http.Requ
 	// be set and configured on your identity provider as part of
 	// JWT custom claims.
 	var policyName string
-	if v, ok := m[iampolicy.PolicyName]; ok {
+	if v, ok := m[iamPolicyName()]; ok {
 		policyName, _ = v.(string)
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -38,6 +38,7 @@ import (
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/handlers"
+	iampolicy "github.com/minio/minio/pkg/iam/policy"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/gorilla/mux"
@@ -486,4 +487,8 @@ func getMinioMode() string {
 		mode = globalMinioModeGatewayPrefix + globalGatewayName
 	}
 	return mode
+}
+
+func iamPolicyName() string {
+	return globalOpenidConfig.PolicyClaimPrefix + iampolicy.PolicyName
 }

--- a/cmd/web-handler-context.go
+++ b/cmd/web-handler-context.go
@@ -179,6 +179,12 @@ func (args *LoginArgs) ToKeyValue() KeyValueMap {
 	return km
 }
 
+// ToKeyValue implementation for LoginSTSArgs
+func (args *LoginSTSArgs) ToKeyValue() KeyValueMap {
+	km := KeyValueMap{}
+	return km
+}
+
 // ToKeyValue implementation for GetBucketPolicyArgs
 func (args *GetBucketPolicyArgs) ToKeyValue() KeyValueMap {
 	km := KeyValueMap{}

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -172,6 +172,37 @@ func testLoginWebHandler(obj ObjectLayer, instanceType string, t TestErrHandler)
 	}
 }
 
+// Wrapper for calling OpenIDConfig Web Handler
+func TestWebHandlerOpenIDConfig(t *testing.T) {
+	ExecObjectLayerTest(t, testOpenIDConfigWebHandler)
+}
+
+// testServerInfoWebHandler - Test OpenIDConfig web handler
+func testOpenIDConfigWebHandler(obj ObjectLayer, instanceType string, t TestErrHandler) {
+	// Register the API end points with XL/FS object layer.
+	apiRouter := initTestWebRPCEndPoint(obj)
+	rec := httptest.NewRecorder()
+
+	openIDConfigRequest := &WebGenericArgs{}
+	openIDConfigReply := &OpenIDConfigResp{}
+	req, err := newTestWebRPCRequest("Web.OpenIDConfig", "", openIDConfigRequest)
+	if err != nil {
+		t.Fatalf("Failed to create HTTP request: <ERROR> %v", err)
+	}
+	apiRouter.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Expected the response status to be 200, but instead found `%d`", rec.Code)
+	}
+	err = getTestWebRPCResponse(rec, &openIDConfigReply)
+	if err != nil {
+		t.Fatalf("Failed, %v", err)
+	}
+
+	if openIDConfigReply.OpenIDConfigURL != globalOpenidConfig.ConfigURL {
+		t.Fatalf("OpenIDConfigURL did not match, got %#v, expected %#v", openIDConfigReply.OpenIDConfigURL, globalOpenidConfig.ConfigURL)
+	}
+}
+
 // Wrapper for calling StorageInfo Web Handler
 func TestWebHandlerStorageInfo(t *testing.T) {
 	ExecObjectLayerTest(t, testStorageInfoWebHandler)

--- a/cmd/web-router.go
+++ b/cmd/web-router.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/elazarl/go-bindata-assetfs"
+	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	jsonrpc "github.com/gorilla/rpc/v2"

--- a/docs/config/config.sample.json
+++ b/docs/config/config.sample.json
@@ -49,7 +49,9 @@
         "_": {
             "comment": "",
             "state": "off",
-            "jwks_url": ""
+            "jwks_url": "",
+            "config_url": "",
+            "policy_claim_prefix": ""
         }
     },
     "kms_vault": {

--- a/docs/sts/keycloak.md
+++ b/docs/sts/keycloak.md
@@ -1,0 +1,66 @@
+# Keycloak Quickstart Guide [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
+
+Keycloak is an open source Identity and Access Management solution aimed at modern applications and services, this document covers configuring Keycloak to be used as an identity provider for MinIO server STS API.
+
+## 1. Prerequisites
+
+- JAVA 1.8 and above installed
+- Download and start Keycloak server by following the [installation guide](https://www.keycloak.org/docs/latest/getting_started/index.html) (finish upto section 3.4)
+
+## 2. Configure Keycloak
+
+- Go to Users -> Click on the user -> Attribute, add a new attribute `Key` is `policy`, `Value` is name of the policy in minio (ex: `readwrite`). Click Add and then Save.
+- Go to Clients -> Click on `account` -> Settings, set `Valid Redirect URIs` to `*` and Save.
+- Go to Clients -> Client on `account` -> Mappers -> Create, `Mapper Type` is `User Attribute`, `User Attribute` is `policy`, `Token Claim Name` is `policy`, `Claim JSON Type` is `string`, then Save.
+- Open http://localhost:8080/auth/realms/demo/.well-known/openid-configuration and see if it has `authorization_endpoint` and `jwks_uri`
+
+## 3. Configure MinIO
+
+```
+$ export MINIO_ACCESS_KEY=minio
+$ export MINIO_SECRET_KEY=minio123
+$ minio server /mnt/export
+```
+
+Set `identity_openid` config and restart MinIO
+
+```
+mc admin config set myminio identity_openid jwks_url="http://localhost:8080/auth/realms/demo/protocol/openid-connect/certs" config_url="http://localhost:8080/auth/realms/demo/.well-known/openid-configuration"
+
+mc admin service restart myminio
+```
+
+## 4. Using WebIdentiy API
+
+Client ID and Client Secret can be found by clicking any of the clients listed [here](http://localhost:8080/auth/admin/master/console/#/realms/demo/clients). If you have followed the above steps docs, the default Client ID will be `account` and Client Secret can be found under `Credentials` tab.
+
+```
+$ go run web-identity.go -cid account -csec e61cb282-745b-4113-bece-29b921c735f0 -auth-ep http://localhost:8080/auth/realms/demo/protocol/openid-connect/auth -token-ep http://localhost:8080/auth/realms/demo/protocol/openid-connect/token -port 8888
+2018/12/26 17:49:36 listening on http://localhost:8888/
+```
+
+This will open the login page of keycloak, upon successful login, STS credentials will be printed on the screen, for example
+
+```
+##### Credentials
+{
+	"accessKey": "6N2BALX7ELO827DXS3GK",
+	"secretKey": "23JKqAD+um8ObHqzfIh+bfqwG9V8qs9tFY6MqeFR",
+	"expiration": "2019-10-01T07:22:34Z",
+	"sessionToken": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiI2TjJCQUxYN0VMTzgyN0RYUzNHSyIsImFjciI6IjAiLCJhdWQiOiJhY2NvdW50IiwiYXV0aF90aW1lIjoxNTY5OTEwNTUyLCJhenAiOiJhY2NvdW50IiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJleHAiOjE1Njk5MTQ1NTQsImlhdCI6MTU2OTkxMDk1NCwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgxL2F1dGgvcmVhbG1zL2RlbW8iLCJqdGkiOiJkOTk4YTBlZS01NDk2LTQ4OWYtYWJlMi00ZWE5MjJiZDlhYWYiLCJuYmYiOjAsInBvbGljeSI6InJlYWR3cml0ZSIsInByZWZlcnJlZF91c2VybmFtZSI6Im5ld3VzZXIxIiwic2Vzc2lvbl9zdGF0ZSI6IjJiYTAyYTI2LWE5MTUtNDUxNC04M2M1LWE0YjgwYjc4ZTgxNyIsInN1YiI6IjY4ZmMzODVhLTA5MjItNGQyMS04N2U5LTZkZTdhYjA3Njc2NSIsInR5cCI6IklEIn0._UG_-ZHgwdRnsp0gFdwChb7VlbPs-Gr_RNUz9EV7TggCD59qjCFAKjNrVHfOSVkKvYEMe0PvwfRKjnJl3A_mBA"
+}
+```
+
+These credentials can now be used to perform MinIO API operations.
+
+## 5. Using MinIO Browser
+
+- Open MinIO url on the browser, for example `http://localhost:9000`
+- Click on `Log in with OpenID`
+- Provide `Client ID` and press ENTER
+- Now the user will be redirected to the Keycloak login page, upon successful login the user will be redirected to MinIO page and logged in automatically
+
+## Explore Further
+
+- [MinIO STS Quickstart Guide](https://docs.min.io/docs/minio-sts-quickstart-guide)
+- [The MinIO documentation website](https://docs.min.io)

--- a/docs/sts/web-identity.go
+++ b/docs/sts/web-identity.go
@@ -78,6 +78,7 @@ var (
 	tokenEndpoint string
 	clientID      string
 	clientSecret  string
+	port					int
 )
 
 func init() {
@@ -86,6 +87,7 @@ func init() {
 	flag.StringVar(&tokenEndpoint, "token-ep", googleOAuth2.Endpoint.TokenURL, "Token endpoint")
 	flag.StringVar(&clientID, "cid", "", "Client ID")
 	flag.StringVar(&clientSecret, "csec", "", "Client secret")
+	flag.IntVar(&port, "port", 8080, "Port")
 }
 
 func main() {
@@ -104,7 +106,7 @@ func main() {
 			AuthURL:  authEndpoint,
 			TokenURL: tokenEndpoint,
 		},
-		RedirectURL: "http://localhost:8080/oauth2/callback",
+		RedirectURL: fmt.Sprintf("http://localhost:%v/oauth2/callback", port),
 		Scopes:      []string{"openid", "profile", "email"},
 	}
 
@@ -173,6 +175,7 @@ func main() {
 		}
 	})
 
-	log.Printf("listening on http://%s/", "localhost:8080")
-	log.Fatal(http.ListenAndServe("localhost:8080", nil))
+	address := fmt.Sprintf("localhost:%v", port)
+	log.Printf("listening on http://%s/", address)
+	log.Fatal(http.ListenAndServe(address, nil))
 }

--- a/docs/sts/web-identity.md
+++ b/docs/sts/web-identity.md
@@ -14,6 +14,7 @@
 - [Sample Response](#sample-response)
 - [Testing](#testing)
 - [Authorization Flow](#authorization-flow)
+- [MinIO Browser](#minio-browser)
 
 ## Introduction
 
@@ -114,3 +115,25 @@ $ go run web-identity.go -cid 204367807228-ok7601k6gj1pgge7m09h7d79co8p35xx.apps
 - Using the access token the callback handler further talks to Google OAuth2 Token URL to obtain an JWT id_token.
 - Once obtained the JWT id_token is further sent to STS endpoint i.e MinIO to retrive temporary credentials.
 - Temporary credentials are displayed on the browser upon successful retrieval.
+
+
+## MinIO Browser
+To support WebIdentity login on MinIO Browser
+
+1. Set openid configuration and restart MinIO
+  ```
+  mc admin config set myminio identity_openid jwks_url="<JWKS_URL>" config_url="<CONFIG_URL>"
+  
+  mc admin service restart myminio
+  ```
+  Sample URLs for Keycloak are
+  `config_url` - `http://localhost:8080/auth/realms/demo/.well-known/openid-configuration`,
+  `jwks_url` - `http://localhost:8080/auth/realms/demo/protocol/openid-connect/certs`
+
+  JWT token returned by the Identity Provider should include a custom claim for the policy, this is required to create a STS user in MinIO. The name of the custom claim could be either `policy` or `<NAMESPACE_PREFIX>policy`.
+  If there is no namespace then `policy_claim_prefix` can be ingored. For example if the custom claim name is `https://min.io/policy` then, `policy_claim_prefix` should be set as `https://min.io/`
+
+2. Open MinIO Browser and click `Log in with OpenID`
+3. Enter the `Client ID` obtained from Identity Provider and press ENTER
+4. The user will be redirected to the Identity Provider login page
+5. Upon successful login on Identity Provider page the user will be automatically logged into MinIO Browser


### PR DESCRIPTION
## Description
Adding OpenID login support to MinIO Browser.

## Motivation and Context
 Users will be able to login MinIO Browser through the configured Identity Provider.

## How to test this PR?
1. Setup an Identity Provider(wso2, keycloak, Auth0, etc)
2. Set openid configuration and restart MinIO
```
mc admin config set myminio identity_openid jwks_url="<JWKS_URL>" config_url="<CONFIG_URL>"
mc admin service restart myminio
```
 Sample URLs for Keycloak are
 config_url - http://localhost:8080/auth/realms/demo/.well-known/openid-configuration
 jwks_url - http://localhost:8080/auth/realms/demo/protocol/openid-connect/certs

JWT token should include a custom claim for the policy, this is required to create a STS user in MinIO. The name of the custom claim could be either `policy` or `<NAMESPACE_PREFIX>policy`.
If there is no namespace then `policy_claim_prefix` can be ignored. For example if the custom claim name is `https://min.io/policy` then, `policy_claim_prefix` should be set as `https://min.io/` 


3. Open MinIO Browser and click `Log in with OpenID`
4. Type in `Client ID` obtained from Identity Provider and ENTER
5. The user will be redirected the IdP login page
6. Upon successful login on IdP the user will be automatically logged into MinIO Browser



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
