### PR TITLE
Detect underlying disk mount/unmount

### DIFF
--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -77,6 +77,9 @@ func (d *naughtyDisk) calcError() (err error) {
 	return nil
 }
 
+func (d *naughtyDisk) SetDiskID(id string) {
+}
+
 func (d *naughtyDisk) DiskInfo() (info DiskInfo, err error) {
 	if err := d.calcError(); err != nil {
 		return info, err

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -99,7 +99,11 @@ func deleteBucketMetadata(ctx context.Context, bucket string, objAPI ObjectLayer
 // Depending on the disk type network or local, initialize storage API.
 func newStorageAPI(endpoint Endpoint) (storage StorageAPI, err error) {
 	if endpoint.IsLocal {
-		return newPosix(endpoint.Path)
+		storage, err := newPosix(endpoint.Path)
+		if err != nil {
+			return nil, err
+		}
+		return &posixDiskIDCheck{storage: storage}, nil
 	}
 
 	return newStorageRESTClient(endpoint)

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -1,0 +1,190 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"io"
+)
+
+// Detects change in underlying disk.
+type posixDiskIDCheck struct {
+	storage *posix
+	diskID  string
+}
+
+func (p *posixDiskIDCheck) String() string {
+	return p.storage.String()
+}
+
+func (p *posixDiskIDCheck) IsOnline() bool {
+	storedDiskID, err := p.storage.getDiskID()
+	if err != nil {
+		return false
+	}
+	return storedDiskID == p.diskID
+}
+
+func (p *posixDiskIDCheck) LastError() error {
+	return p.storage.LastError()
+}
+
+func (p *posixDiskIDCheck) Close() error {
+	return p.storage.Close()
+}
+
+func (p *posixDiskIDCheck) SetDiskID(id string) {
+	p.diskID = id
+}
+
+func (p *posixDiskIDCheck) isDiskStale() bool {
+	if p.diskID == "" {
+		// For empty disk-id we allow the call as the server might be coming up and trying to read format.json
+		// or create format.json
+		return false
+	}
+	storedDiskID, err := p.storage.getDiskID()
+	if err == nil && p.diskID == storedDiskID {
+		return false
+	}
+	return true
+}
+
+func (p *posixDiskIDCheck) DiskInfo() (info DiskInfo, err error) {
+	if p.isDiskStale() {
+		return info, errDiskNotFound
+	}
+	return p.storage.DiskInfo()
+}
+
+func (p *posixDiskIDCheck) MakeVol(volume string) (err error) {
+	if p.isDiskStale() {
+		return errDiskNotFound
+	}
+	return p.storage.MakeVol(volume)
+}
+
+func (p *posixDiskIDCheck) ListVols() ([]VolInfo, error) {
+	if p.isDiskStale() {
+		return nil, errDiskNotFound
+	}
+	return p.storage.ListVols()
+}
+
+func (p *posixDiskIDCheck) StatVol(volume string) (vol VolInfo, err error) {
+	if p.isDiskStale() {
+		return vol, errDiskNotFound
+	}
+	return p.storage.StatVol(volume)
+}
+
+func (p *posixDiskIDCheck) DeleteVol(volume string) (err error) {
+	if p.isDiskStale() {
+		return errDiskNotFound
+	}
+	return p.storage.DeleteVol(volume)
+}
+
+func (p *posixDiskIDCheck) Walk(volume, dirPath string, marker string, recursive bool, leafFile string, readMetadataFn readMetadataFunc, endWalkCh chan struct{}) (chan FileInfo, error) {
+	if p.isDiskStale() {
+		return nil, errDiskNotFound
+	}
+	return p.storage.Walk(volume, dirPath, marker, recursive, leafFile, readMetadataFn, endWalkCh)
+}
+
+func (p *posixDiskIDCheck) ListDir(volume, dirPath string, count int, leafFile string) ([]string, error) {
+	if p.isDiskStale() {
+		return nil, errDiskNotFound
+	}
+	return p.storage.ListDir(volume, dirPath, count, leafFile)
+}
+
+func (p *posixDiskIDCheck) ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
+	if p.isDiskStale() {
+		return 0, errDiskNotFound
+	}
+	return p.storage.ReadFile(volume, path, offset, buf, verifier)
+}
+
+func (p *posixDiskIDCheck) AppendFile(volume string, path string, buf []byte) (err error) {
+	if p.isDiskStale() {
+		return errDiskNotFound
+	}
+	return p.storage.AppendFile(volume, path, buf)
+}
+
+func (p *posixDiskIDCheck) CreateFile(volume, path string, size int64, reader io.Reader) error {
+	if p.isDiskStale() {
+		return errDiskNotFound
+	}
+	return p.storage.CreateFile(volume, path, size, reader)
+}
+
+func (p *posixDiskIDCheck) ReadFileStream(volume, path string, offset, length int64) (io.ReadCloser, error) {
+	if p.isDiskStale() {
+		return nil, errDiskNotFound
+	}
+	return p.storage.ReadFileStream(volume, path, offset, length)
+}
+
+func (p *posixDiskIDCheck) RenameFile(srcVolume, srcPath, dstVolume, dstPath string) error {
+	if p.isDiskStale() {
+		return errDiskNotFound
+	}
+	return p.storage.RenameFile(srcVolume, srcPath, dstVolume, dstPath)
+}
+
+func (p *posixDiskIDCheck) StatFile(volume string, path string) (file FileInfo, err error) {
+	if p.isDiskStale() {
+		return file, errDiskNotFound
+	}
+	return p.storage.StatFile(volume, path)
+}
+
+func (p *posixDiskIDCheck) DeleteFile(volume string, path string) (err error) {
+	if p.isDiskStale() {
+		return errDiskNotFound
+	}
+	return p.storage.DeleteFile(volume, path)
+}
+
+func (p *posixDiskIDCheck) DeleteFileBulk(volume string, paths []string) (errs []error, err error) {
+	if p.isDiskStale() {
+		return nil, errDiskNotFound
+	}
+	return p.storage.DeleteFileBulk(volume, paths)
+}
+
+func (p *posixDiskIDCheck) VerifyFile(volume, path string, size int64, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
+	if p.isDiskStale() {
+		return errDiskNotFound
+	}
+	return p.storage.VerifyFile(volume, path, size, algo, sum, shardSize)
+}
+
+func (p *posixDiskIDCheck) WriteAll(volume string, path string, reader io.Reader) (err error) {
+	if p.isDiskStale() {
+		return errDiskNotFound
+	}
+	return p.storage.WriteAll(volume, path, reader)
+}
+
+func (p *posixDiskIDCheck) ReadAll(volume string, path string) (buf []byte, err error) {
+	if p.isDiskStale() {
+		return nil, errDiskNotFound
+	}
+	return p.storage.ReadAll(volume, path)
+}

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -29,6 +29,7 @@ type StorageAPI interface {
 	IsOnline() bool // Returns true if disk is online.
 	LastError() error
 	Close() error
+	SetDiskID(id string)
 
 	DiskInfo() (info DiskInfo, err error)
 

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -17,7 +17,7 @@
 package cmd
 
 const (
-	storageRESTVersion = "v9"
+	storageRESTVersion = "v10"
 	storageRESTPath    = minioReservedBucketPath + "/storage/" + storageRESTVersion + SlashSeparator
 )
 
@@ -41,7 +41,6 @@ const (
 	storageRESTMethodDeleteFileBulk = "deletefilebulk"
 	storageRESTMethodRenameFile     = "renamefile"
 	storageRESTMethodVerifyFile     = "verifyfile"
-	storageRESTMethodGetInstanceID  = "getinstanceid"
 )
 
 const (
@@ -61,5 +60,5 @@ const (
 	storageRESTRecursive  = "recursive"
 	storageRESTBitrotAlgo = "bitrot-algo"
 	storageRESTBitrotHash = "bitrot-hash"
-	storageRESTInstanceID = "instance-id"
+	storageRESTDiskID     = "disk-id"
 )

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1599,7 +1599,7 @@ func newTestObjectLayer(endpoints EndpointList) (newObject ObjectLayer, err erro
 		return NewFSObjectLayer(endpoints[0].Path)
 	}
 
-	_, err = waitForFormatXL(endpoints[0].IsLocal, endpoints, 1, 16)
+	format, err := waitForFormatXL(endpoints[0].IsLocal, endpoints, 1, 16)
 	if err != nil {
 		return nil, err
 	}
@@ -1609,6 +1609,10 @@ func newTestObjectLayer(endpoints EndpointList) (newObject ObjectLayer, err erro
 		if err != nil && err != errDiskNotFound {
 			return nil, err
 		}
+	}
+
+	for i, disk := range storageDisks {
+		disk.SetDiskID(format.XL.Sets[0][i])
 	}
 
 	// Initialize list pool.

--- a/pkg/ioutil/ioutil.go
+++ b/pkg/ioutil/ioutil.go
@@ -160,6 +160,23 @@ func NewSkipReader(r io.Reader, n int64) io.Reader {
 	return &SkipReader{r, n}
 }
 
+// SameFile returns if the files are same.
+func SameFile(fi1, fi2 os.FileInfo) bool {
+	if !os.SameFile(fi1, fi2) {
+		return false
+	}
+	if !fi1.ModTime().Equal(fi2.ModTime()) {
+		return false
+	}
+	if fi1.Mode() != fi2.Mode() {
+		return false
+	}
+	if fi1.Size() != fi2.Size() {
+		return false
+	}
+	return true
+}
+
 // DirectIO alignment needs to be 4K. Defined here as
 // directio.AlignSize is defined as 0 in MacOS causing divide by 0 error.
 const directioAlignSize = 4096

--- a/pkg/ioutil/ioutil_test.go
+++ b/pkg/ioutil/ioutil_test.go
@@ -101,3 +101,34 @@ func TestSkipReader(t *testing.T) {
 		}
 	}
 }
+
+func TestSameFile(t *testing.T) {
+	f, err := goioutil.TempFile("", "")
+	if err != nil {
+		t.Errorf("Error creating tmp file: %v", err)
+	}
+	tmpFile := f.Name()
+	f.Close()
+	defer os.Remove(f.Name())
+	fi1, err := os.Stat(tmpFile)
+	if err != nil {
+		t.Fatalf("Error Stat(): %v", err)
+	}
+	fi2, err := os.Stat(tmpFile)
+	if err != nil {
+		t.Fatalf("Error Stat(): %v", err)
+	}
+	if !SameFile(fi1, fi2) {
+		t.Fatal("Expected the files to be same")
+	}
+	if err = goioutil.WriteFile(tmpFile, []byte("aaa"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fi2, err = os.Stat(tmpFile)
+	if err != nil {
+		t.Fatalf("Error Stat(): %v", err)
+	}
+	if SameFile(fi1, fi2) {
+		t.Fatal("Expected the files not to be same")
+	}
+}


### PR DESCRIPTION
## Description
If the underlying disk changes during anytime, we detect it and take suitable action. i.e if the disk is unmounted then we don't continue any operations on it, if a different disk is mounted we include the disk in the right place in `xlSets.xlDisks[i][j]`

## How to test this PR?
I have tested local disk setup by, moving the underlying disk around and making sure `mc cat` works as expected.

Reviewers please test distributed setup and ensure that disk changes are detected as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
