### PR TITLE
xl: Fix isObject() to consider not found disks

### DIFF
--- a/cmd/xl-v1-common.go
+++ b/cmd/xl-v1-common.go
@@ -58,12 +58,13 @@ func (xl xlObjects) isObject(bucket, prefix string) (ok bool) {
 
 	g := errgroup.WithNErrs(len(storageDisks))
 
-	for index, disk := range storageDisks {
-		if disk == nil {
-			continue
-		}
-		index := index
+	for i := range storageDisks {
+		// Initialize a new index variable before passing to the goroutine
+		index := i
 		g.Go(func() error {
+			if storageDisks[index] == nil {
+				return errDiskNotFound
+			}
 			// Check if 'prefix' is an object on this 'disk', else continue the check the next disk
 			fi, err := storageDisks[index].StatFile(bucket, pathJoin(prefix, xlMetaJSONFile))
 			if err != nil {
@@ -73,7 +74,7 @@ func (xl xlObjects) isObject(bucket, prefix string) (ok bool) {
 				return errCorruptedFormat
 			}
 			return nil
-		}, index)
+		}, i)
 	}
 
 	// NOTE: Observe we are not trying to read `xl.json` and figure out the actual


### PR DESCRIPTION


## Description
xl.isObject() returns 'nil' for not found disks when
calculating the existance of xl.json for a given object,
which what StatFile() is also doing (setting nil) if
xl.json exists.

This commit avoids this confusion by setting errDiskNotFound
error when the storage disk is not found.


## Motivation and Context
Fix a weird behavior during config migration

## How to test this PR?
Try Harsha new config PR with distributed setup, run the distributed setup one by one


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
