### PR TITLE
Fix browser showing compressed instead of actual object size

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -540,6 +540,12 @@ func (web *webAPIHandlers) ListObjects(r *http.Request, args *ListObjectsArgs, r
 				if err != nil {
 					return toJSONError(ctx, err)
 				}
+			} else if lo.Objects[i].IsCompressed() {
+				var actualSize int64 = lo.Objects[i].GetActualSize()
+				if actualSize < 0 {
+					return toJSONError(ctx, errInvalidDecompressedSize)
+				}
+				lo.Objects[i].Size = actualSize
 			}
 		}
 


### PR DESCRIPTION
## Description
This commit fixes the MinIO browser showing the compressed size of a file instead of its actual size when compression is enabled.

## Motivation and Context
Fixes #8390

## How to test this PR?
1. Use the environment variables `MINIO_COMPRESS="true"` `MINIO_COMPRESS_EXTENSIONS=".pdf,.doc"` `MINIO_COMPRESS_MIMETYPES="text/html"` while starting the MinIO server
2. Upload a file conforming to the `MINIO_COMPRESS_EXTENSIONS` or `MINIO_COMPRESS_MIMETYPES` environment variables
3. Verify that the size displayed in the browser is equal to the actual file size

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
