### PR TITLE
Remote update should be on by default

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -235,7 +235,7 @@ func handleCommonEnvVars() {
 	// In place update is true by default if the MINIO_UPDATE is not set
 	// or is not set to 'off', if MINIO_UPDATE is set to 'off' then
 	// in-place update is off.
-	globalInplaceUpdateDisabled = strings.EqualFold(env.Get(config.EnvUpdate, "off"), "off")
+	globalInplaceUpdateDisabled = strings.EqualFold(env.Get(config.EnvUpdate, "on"), "off")
 
 	// Get WORM environment variable.
 	if worm := env.Get(config.EnvWorm, "off"); worm != "" {


### PR DESCRIPTION

## Description
Remote update should be on by default

## Motivation and Context
Fixes a regression introduced in PR #8351

## How to test this PR?
Just test `mc admin update` on the recent release

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in #8351
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
