### PR TITLE
lifecycle: Send delete notification when deleting objects

### DIFF
--- a/cmd/daily-lifecycle-ops.go
+++ b/cmd/daily-lifecycle-ops.go
@@ -169,7 +169,7 @@ func lifecycleRound(ctx context.Context, objAPI ObjectLayer) error {
 						Object: ObjectInfo{
 							Name: objects[i],
 						},
-						Host: "[ILM-EXPIRY]",
+						Host: "Internal: [ILM-EXPIRY]",
 					})
 				}
 			}

--- a/cmd/daily-lifecycle-ops.go
+++ b/cmd/daily-lifecycle-ops.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/lifecycle"
 )
 
@@ -150,8 +151,29 @@ func lifecycleRound(ctx context.Context, objAPI ObjectLayer) error {
 					// Do nothing, for now.
 				}
 			}
+
 			// Deletes a list of objects.
-			objAPI.DeleteObjects(ctx, bucket.Name, objects)
+			deleteErrs, err := objAPI.DeleteObjects(ctx, bucket.Name, objects)
+			if err != nil {
+				logger.LogIf(ctx, err)
+			} else {
+				for i := range deleteErrs {
+					if deleteErrs[i] != nil {
+						logger.LogIf(ctx, deleteErrs[i])
+						continue
+					}
+					// Notify object deleted event.
+					sendEvent(eventArgs{
+						EventName:  event.ObjectRemovedDelete,
+						BucketName: bucket.Name,
+						Object: ObjectInfo{
+							Name: objects[i],
+						},
+						Host: "[ILM-EXPIRY]",
+					})
+				}
+			}
+
 			if !res.IsTruncated {
 				// We are done here, proceed to next bucket.
 				break


### PR DESCRIPTION
## Description
lifecycle: Send delete notification when deleting objects

## Motivation and Context
F.i.x.e.s one item in https://github.com/minio/minio/issues/8168

## How to test this PR?
Apply the following diff to accelerate lifecycle action

```diff
diff --git a/cmd/daily-lifecycle-ops.go b/cmd/daily-lifecycle-ops.go
index 7bf01d9d..1afd0112 100644
--- a/cmd/daily-lifecycle-ops.go
+++ b/cmd/daily-lifecycle-ops.go
@@ -26,8 +26,8 @@ import (
 )

 const (
-       bgLifecycleInterval = 24 * time.Hour
-       bgLifecycleTick     = time.Hour
+       bgLifecycleInterval = 1 * time.Minute
+       bgLifecycleTick     = time.Second
 )

 type lifecycleOps struct {
```
* Follow docs/lifecycle/README.me to apply a lifecycle config
* Run `mc watch your-alias/your-bucket` to see the object delete notification

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
