### PR TITLE
Send actual size of object in event notifications

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1168,6 +1168,15 @@ func (args eventArgs) ToEvent() event.Event {
 func sendEvent(args eventArgs) {
 
 	// remove sensitive encryption entries in metadata.
+	switch {
+	case crypto.IsEncrypted(args.Object.UserDefined):
+		if totalObjectSize, err := args.Object.DecryptedSize(); err == nil {
+			args.Object.Size = totalObjectSize
+		}
+	case args.Object.IsCompressed():
+		args.Object.Size = args.Object.GetActualSize()
+	}
+
 	crypto.RemoveSensitiveEntries(args.Object.UserDefined)
 	crypto.RemoveInternalEntries(args.Object.UserDefined)
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1272,7 +1272,6 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 
 	if objectAPI.IsEncryptionSupported() {
 		if crypto.IsEncrypted(objInfo.UserDefined) {
-			objInfo.Size, _ = objInfo.DecryptedSize()
 			switch {
 			case crypto.S3.IsEncrypted(objInfo.UserDefined):
 				w.Header().Set(crypto.SSEHeader, crypto.SSEAlgorithmAES256)
@@ -2336,13 +2335,6 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 
 	// Write success response.
 	writeSuccessResponseXML(w, encodedSuccessResponse)
-
-	// Get host and port from Request.RemoteAddr.
-	if objectAPI.IsEncryptionSupported() {
-		if crypto.IsEncrypted(objInfo.UserDefined) {
-			objInfo.Size, _ = objInfo.DecryptedSize()
-		}
-	}
 
 	// Notify object created event.
 	sendEvent(eventArgs{


### PR DESCRIPTION
Fixes: #8407

## Description
The S3 layer receives encrypted size in ObjectInfo. The response headers decrypts the size correctly before sending the response in case of encrypted objects. This is not being done consistently for notification events. 

This change is needed for compressed objects also.

This PR fixes this by letting the notification.go  Send() and setObjectHeaders() in api-headers.go get the actual size before sending to client.

## Motivation and Context


## How to test this PR?
Set auto encryption on and start minio server with webhook setup to receive all notifications. 
Do `mc cp`, stat and cat operations.
The size of the object received by the webhook server should be actual size of object, not the encrypted size.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
