### PR TITLE
Use sanitized raw link for logo.svg in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MinIO Quickstart Guide
 [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io) [![Go Report Card](https://goreportcard.com/badge/minio/minio)](https://goreportcard.com/report/minio/minio) [![Docker Pulls](https://img.shields.io/docker/pulls/minio/minio.svg?maxAge=604800)](https://hub.docker.com/r/minio/minio/)
 
-[![MinIO](https://github.com/minio/minio/blob/master/.github/logo.svg)](https://min.io)
+[![MinIO](https://raw.githubusercontent.com/minio/minio/master/.github/logo.svg?sanitize=true)](https://min.io)
 
 MinIO is an object storage server released under Apache License v2.0. It is compatible with Amazon S3 cloud storage service. It is best suited for storing unstructured data such as photos, videos, log files, backups and container / VM images. Size of an object can range from a few KBs to a maximum of 5TB.
 


### PR DESCRIPTION
## Description
The .svg link for the MinIO logo has been replaced with the raw sanitized link.

## Motivation and Context
The MinIO logo wasn't being displayed on docs.min.io for the MinIO Quickstart Guide.

## How to test this PR?
Use [minio/gluegun](/minio/gluegun) to point to the README.md file in this branch, generate the documentation from there and check if the file is still there.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
