### PR TITLE
Add noColor, jsonMode support for get/help commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ MinIO Server comes with an embedded web based object browser. Point your web bro
 ## Pre-existing data
 When deployed on a single drive, MinIO server lets clients access any pre-existing data in the data directory. For example, if MinIO is started with the command  `minio server /mnt/data`, any pre-existing data in the `/mnt/data` directory would be accessible to the clients.
 
-The above statement is also valid for all gateway backends.
+The above statement is also valid for all gateway backends, except `s3` gateway with encryption settings read more [here](https://github.com/minio/minio/blob/master/docs/gateway/s3.md#run-minio-gateway-with-double-encryption)
 
 ## Upgrading MinIO
 MinIO server supports rolling upgrades, i.e. you can update one MinIO instance at a time in a distributed cluster. This allows upgrades with no downtime. Upgrades can be done manually by replacing the binary with the latest release and restarting all servers in a rolling fashion. However, we recommend all our users to use [`mc admin update`](https://docs.min.io/docs/minio-admin-complete-guide.html#update) from the client. This will update all the nodes in the cluster and restart them, as shown in the following command from the MinIO client (mc):

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -982,22 +982,23 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 	if err == nil {
 		return noError
 	}
-	apiErr := errorCodes.ToAPIErr(toAdminAPIErrCode(ctx, err))
-	if apiErr.Code == "InternalError" {
-		switch e := err.(type) {
-		case config.Error:
-			apiErr = APIError{
-				Code:           "XMinioConfigError",
-				Description:    e.Error(),
-				HTTPStatusCode: http.StatusBadRequest,
-			}
-		case AdminError:
-			apiErr = APIError{
-				Code:           e.Code,
-				Description:    e.Message,
-				HTTPStatusCode: e.StatusCode,
-			}
+
+	var apiErr APIError
+	switch e := err.(type) {
+	case config.Error:
+		apiErr = APIError{
+			Code:           "XMinioConfigError",
+			Description:    e.Error(),
+			HTTPStatusCode: http.StatusBadRequest,
 		}
+	case AdminError:
+		apiErr = APIError{
+			Code:           e.Code,
+			Description:    e.Message,
+			HTTPStatusCode: e.StatusCode,
+		}
+	default:
+		apiErr = errorCodes.ToAPIErr(toAdminAPIErrCode(ctx, err))
 	}
 	return apiErr
 }

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -92,8 +92,7 @@ func lookupConfigs(s config.Config) {
 	var err error
 
 	if !globalActiveCred.IsValid() {
-		// Env doesn't seem to be set, we fallback to lookup
-		// creds from the config.
+		// Env doesn't seem to be set, we fallback to lookup creds from the config.
 		globalActiveCred, err = config.LookupCreds(s[config.CredentialsSubSys][config.Default])
 		if err != nil {
 			logger.Fatal(err, "Invalid credentials configuration")

--- a/cmd/config-encrypted.go
+++ b/cmd/config-encrypted.go
@@ -1,0 +1,250 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/minio/minio/cmd/config"
+	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/auth"
+	"github.com/minio/minio/pkg/env"
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func handleEncryptedConfigBackend(objAPI ObjectLayer, server bool) error {
+	if !globalConfigEncrypted {
+		return nil
+	}
+	if !globalActiveCred.IsValid() {
+		return errInvalidArgument
+	}
+
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+
+	accessKeyOld := env.Get(config.EnvAccessKeyOld, "")
+	secretKeyOld := env.Get(config.EnvSecretKeyOld, "")
+	var activeCredOld auth.Credentials
+	var err error
+	if accessKeyOld != "" && secretKeyOld != "" {
+		activeCredOld, err = auth.CreateCredentials(accessKeyOld, secretKeyOld)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If its server mode or nas gateway, migrate the backend.
+	if server {
+		// Migrating Config backend needs a retry mechanism for
+		// the following reasons:
+		//  - Read quorum is lost just after the initialization
+		//    of the object layer.
+		for range newRetryTimerSimple(doneCh) {
+			// Migrate IAM configuration
+			if err = migrateConfigPrefixToEncrypted(objAPI, activeCredOld); err != nil {
+				if err == errDiskNotFound ||
+					strings.Contains(err.Error(), InsufficientReadQuorum{}.Error()) ||
+					strings.Contains(err.Error(), InsufficientWriteQuorum{}.Error()) {
+					logger.Info("Waiting for config backend to be encrypted..")
+					continue
+				}
+				return err
+			}
+			break
+		}
+	}
+	if globalEtcdClient != nil {
+		return migrateIAMConfigsEtcdToEncrypted(globalEtcdClient, activeCredOld)
+	}
+	return nil
+}
+
+const (
+	backendEncryptedFile = "backend-encrypted"
+)
+
+var (
+	backendEncryptedFileValue = []byte("encrypted")
+)
+
+func checkBackendEtcdEncrypted(ctx context.Context, client *etcd.Client) (bool, error) {
+	data, err := readKeyEtcd(ctx, client, backendEncryptedFile)
+	if err != nil && err != errConfigNotFound {
+		return false, err
+	}
+	return err == nil && bytes.Equal(data, backendEncryptedFileValue), nil
+}
+
+func checkBackendEncrypted(objAPI ObjectLayer) (bool, error) {
+	data, err := readConfig(context.Background(), objAPI, backendEncryptedFile)
+	if err != nil && err != errConfigNotFound {
+		return false, err
+	}
+	return err == nil && bytes.Equal(data, backendEncryptedFileValue), nil
+}
+
+func migrateIAMConfigsEtcdToEncrypted(client *etcd.Client, activeCredOld auth.Credentials) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultContextTimeout)
+	defer cancel()
+
+	encrypted, err := checkBackendEtcdEncrypted(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	if encrypted {
+		// No key rotation requested, and backend is
+		// already encrypted. We proceed without migration.
+		if !activeCredOld.IsValid() {
+			return nil
+		}
+
+		// No real reason to rotate if old and new creds are same.
+		if activeCredOld.Equal(globalActiveCred) {
+			return nil
+		}
+	}
+
+	if !activeCredOld.IsValid() {
+		logger.Info("Attempting a one time encrypt all IAM users and policies on etcd")
+	} else {
+		logger.Info("Attempting a rotation of encrypted IAM users and policies on etcd with newly supplied credentials")
+	}
+
+	r, err := client.Get(ctx, minioConfigPrefix, etcd.WithPrefix(), etcd.WithKeysOnly())
+	if err != nil {
+		return err
+	}
+	for _, kv := range r.Kvs {
+		var (
+			cdata    []byte
+			cencdata []byte
+		)
+		cdata, err = readKeyEtcd(ctx, client, string(kv.Key))
+		if err != nil {
+			switch err {
+			case errConfigNotFound:
+				// Perhaps not present or someone deleted it.
+				continue
+			}
+			return err
+		}
+		// Is rotating of creds requested?
+		if activeCredOld.IsValid() {
+			cdata, err = madmin.DecryptData(activeCredOld.String(), bytes.NewReader(cdata))
+			if err != nil {
+				return err
+			}
+		}
+
+		cencdata, err = madmin.EncryptData(globalActiveCred.String(), cdata)
+		if err != nil {
+			return err
+		}
+
+		if err = saveKeyEtcd(ctx, client, string(kv.Key), cencdata); err != nil {
+			return err
+		}
+	}
+	return saveKeyEtcd(ctx, client, backendEncryptedFile, backendEncryptedFileValue)
+}
+
+func migrateConfigPrefixToEncrypted(objAPI ObjectLayer, activeCredOld auth.Credentials) error {
+	encrypted, err := checkBackendEncrypted(objAPI)
+	if err != nil {
+		return err
+	}
+
+	if encrypted {
+		// No key rotation requested, and backend is
+		// already encrypted. We proceed without migration.
+		if !activeCredOld.IsValid() {
+			return nil
+		}
+
+		// No real reason to rotate if old and new creds are same.
+		if activeCredOld.Equal(globalActiveCred) {
+			return nil
+		}
+	}
+
+	if !activeCredOld.IsValid() {
+		logger.Info("Attempting a one time encrypt of all config, IAM users and policies on MinIO backend")
+	} else {
+		logger.Info("Attempting a rotation of encrypted config, IAM users and policies on MinIO with newly supplied credentials")
+	}
+
+	// Construct path to config/.transaction for locking
+	transactionConfigPrefix := minioConfigPrefix + "/transaction.lock"
+
+	// As object layer's GetObject() and PutObject() take respective lock on minioMetaBucket
+	// and configFile, take a transaction lock to avoid data race between readConfig()
+	// and saveConfig().
+	objLock := globalNSMutex.NewNSLock(context.Background(), minioMetaBucket, transactionConfigPrefix)
+	if err := objLock.GetLock(globalOperationTimeout); err != nil {
+		return err
+	}
+	defer objLock.Unlock()
+
+	var marker string
+	for {
+		res, err := objAPI.ListObjects(context.Background(), minioMetaBucket, minioConfigPrefix, marker, "", 1000)
+		if err != nil {
+			return err
+		}
+		for _, obj := range res.Objects {
+			var (
+				cdata    []byte
+				cencdata []byte
+			)
+
+			cdata, err = readConfig(context.Background(), objAPI, obj.Name)
+			if err != nil {
+				return err
+			}
+
+			// Is rotating of creds requested?
+			if activeCredOld.IsValid() {
+				cdata, err = madmin.DecryptData(activeCredOld.String(), bytes.NewReader(cdata))
+				if err != nil {
+					return err
+				}
+			}
+
+			cencdata, err = madmin.EncryptData(globalActiveCred.String(), cdata)
+			if err != nil {
+				return err
+			}
+
+			if err = saveConfig(context.Background(), objAPI, obj.Name, cencdata); err != nil {
+				return err
+			}
+		}
+
+		if !res.IsTruncated {
+			break
+		}
+
+		marker = res.NextMarker
+	}
+
+	return saveConfig(context.Background(), objAPI, backendEncryptedFile, backendEncryptedFileValue)
+}

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -38,6 +39,7 @@ import (
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/event/target"
+	"github.com/minio/minio/pkg/madmin"
 	xnet "github.com/minio/minio/pkg/net"
 	"github.com/minio/minio/pkg/quick"
 )
@@ -2532,6 +2534,13 @@ func checkConfigVersion(objAPI ObjectLayer, configFile string, version string) (
 		return false, nil, err
 	}
 
+	if globalConfigEncrypted {
+		data, err = madmin.DecryptData(globalActiveCred.String(), bytes.NewReader(data))
+		if err != nil {
+			return false, nil, err
+		}
+	}
+
 	var versionConfig struct {
 		Version string `json:"version"`
 	}
@@ -2563,12 +2572,7 @@ func migrateV27ToV28MinioSys(objAPI ObjectLayer) error {
 	cfg.Version = "28"
 	cfg.KMS = crypto.KMSConfig{}
 
-	data, err = json.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-
-	if err = saveConfig(context.Background(), objAPI, configFile, data); err != nil {
+	if err = saveServerConfig(context.Background(), objAPI, cfg, nil); err != nil {
 		return fmt.Errorf("Failed to migrate config from ‘27’ to ‘28’. %v", err)
 	}
 
@@ -2595,12 +2599,7 @@ func migrateV28ToV29MinioSys(objAPI ObjectLayer) error {
 	}
 
 	cfg.Version = "29"
-	data, err = json.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-
-	if err = saveConfig(context.Background(), objAPI, configFile, data); err != nil {
+	if err = saveServerConfig(context.Background(), objAPI, cfg, nil); err != nil {
 		return fmt.Errorf("Failed to migrate config from ‘28’ to ‘29’. %v", err)
 	}
 
@@ -2632,12 +2631,7 @@ func migrateV29ToV30MinioSys(objAPI ObjectLayer) error {
 	cfg.Compression.Extensions = strings.Split(compress.DefaultExtensions, config.ValueSeparator)
 	cfg.Compression.MimeTypes = strings.Split(compress.DefaultMimeTypes, config.ValueSeparator)
 
-	data, err = json.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-
-	if err = saveConfig(context.Background(), objAPI, configFile, data); err != nil {
+	if err = saveServerConfig(context.Background(), objAPI, cfg, nil); err != nil {
 		return fmt.Errorf("Failed to migrate config from ‘29’ to ‘30’. %v", err)
 	}
 
@@ -2672,12 +2666,7 @@ func migrateV30ToV31MinioSys(objAPI ObjectLayer) error {
 		AuthToken: "",
 	}
 
-	data, err = json.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-
-	if err = saveConfig(context.Background(), objAPI, configFile, data); err != nil {
+	if err = saveServerConfig(context.Background(), objAPI, cfg, nil); err != nil {
 		return fmt.Errorf("Failed to migrate config from ‘30’ to ‘31’. %v", err)
 	}
 
@@ -2707,12 +2696,7 @@ func migrateV31ToV32MinioSys(objAPI ObjectLayer) error {
 	cfg.Notify.NSQ = make(map[string]target.NSQArgs)
 	cfg.Notify.NSQ["1"] = target.NSQArgs{}
 
-	data, err = json.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-
-	if err = saveConfig(context.Background(), objAPI, configFile, data); err != nil {
+	if err = saveServerConfig(context.Background(), objAPI, cfg, nil); err != nil {
 		return fmt.Errorf("Failed to migrate config from ‘31’ to ‘32’. %v", err)
 	}
 
@@ -2740,12 +2724,7 @@ func migrateV32ToV33MinioSys(objAPI ObjectLayer) error {
 
 	cfg.Version = "33"
 
-	data, err = json.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-
-	if err = saveConfig(context.Background(), objAPI, configFile, data); err != nil {
+	if err = saveServerConfig(context.Background(), objAPI, cfg, nil); err != nil {
 		return fmt.Errorf("Failed to migrate config from  32  to  33 . %v", err)
 	}
 

--- a/cmd/config/constants.go
+++ b/cmd/config/constants.go
@@ -23,13 +23,15 @@ const (
 
 // Top level common ENVs
 const (
-	EnvAccessKey  = "MINIO_ACCESS_KEY"
-	EnvSecretKey  = "MINIO_SECRET_KEY"
-	EnvBrowser    = "MINIO_BROWSER"
-	EnvDomain     = "MINIO_DOMAIN"
-	EnvRegionName = "MINIO_REGION_NAME"
-	EnvPublicIPs  = "MINIO_PUBLIC_IPS"
-	EnvEndpoints  = "MINIO_ENDPOINTS"
+	EnvAccessKey    = "MINIO_ACCESS_KEY"
+	EnvSecretKey    = "MINIO_SECRET_KEY"
+	EnvAccessKeyOld = "MINIO_ACCESS_KEY_OLD"
+	EnvSecretKeyOld = "MINIO_SECRET_KEY_OLD"
+	EnvBrowser      = "MINIO_BROWSER"
+	EnvDomain       = "MINIO_DOMAIN"
+	EnvRegionName   = "MINIO_REGION_NAME"
+	EnvPublicIPs    = "MINIO_PUBLIC_IPS"
+	EnvEndpoints    = "MINIO_ENDPOINTS"
 
 	EnvUpdate    = "MINIO_UPDATE"
 	EnvWormState = "MINIO_WORM_STATE"

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -228,6 +228,16 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		initFederatorBackend(newObject)
 	}
 
+	// Migrate all backend configs to encrypted backend, also handles rotation as well.
+	// For "nas" gateway we need to specially handle the backend migration as well.
+	// Internally code handles migrating etcd if enabled automatically.
+	logger.FatalIf(handleEncryptedConfigBackend(newObject, enableConfigOps),
+		"Unable to migrate config, iam, policies to an encrypted backend")
+
+	// ****  WARNING ****
+	// Migrating to encrypted backend should happen before initialization of any
+	// sub-systems, make sure that we do not move the above codeblock elsewhere.
+
 	if enableConfigOps {
 		// Create a new config system.
 		globalConfigSys = NewConfigSys()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -184,7 +184,11 @@ var (
 	// Time when object layer was initialized on start up.
 	globalBootTime time.Time
 
-	globalActiveCred  auth.Credentials
+	globalActiveCred auth.Credentials
+
+	// Indicates if config is to be encrypted
+	globalConfigEncrypted bool
+
 	globalPublicCerts []*x509.Certificate
 
 	globalDomainNames []string      // Root domains for virtual host style requests

--- a/cmd/iam-etcd-store.go
+++ b/cmd/iam-etcd-store.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -31,6 +32,7 @@ import (
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
 	iampolicy "github.com/minio/minio/pkg/iam/policy"
+	"github.com/minio/minio/pkg/madmin"
 )
 
 var defaultContextTimeout = 30 * time.Second
@@ -109,6 +111,12 @@ func (ies *IAMEtcdStore) saveIAMConfig(item interface{}, path string) error {
 	if err != nil {
 		return err
 	}
+	if globalConfigEncrypted {
+		data, err = madmin.EncryptData(globalActiveCred.String(), data)
+		if err != nil {
+			return err
+		}
+	}
 	return saveKeyEtcd(ies.getContext(), ies.client, path, data)
 }
 
@@ -117,6 +125,13 @@ func (ies *IAMEtcdStore) loadIAMConfig(item interface{}, path string) error {
 	if err != nil {
 		return err
 	}
+	if globalConfigEncrypted {
+		pdata, err = madmin.DecryptData(globalActiveCred.String(), bytes.NewReader(pdata))
+		if err != nil {
+			return err
+		}
+	}
+
 	return json.Unmarshal(pdata, item)
 }
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -191,7 +191,9 @@ func serverHandleEnvVars() {
 				"Unable to validate credentials inherited from the shell environment")
 		}
 		globalActiveCred = cred
+		globalConfigEncrypted = true
 	}
+
 }
 
 // serverMain handler called for 'minio server' command.
@@ -302,6 +304,14 @@ func serverMain(ctx *cli.Context) {
 
 	// Re-enable logging
 	logger.Disable = false
+
+	// Migrate all backend configs to encrypted backend, also handles rotation as well.
+	logger.FatalIf(handleEncryptedConfigBackend(newObject, true),
+		"Unable to migrate config, iam, policies to an encrypted backend")
+
+	// ****  WARNING ****
+	// Migrating to encrypted backend should happen before initialization of any
+	// sub-systems, make sure that we do not move the above codeblock elsewhere.
 
 	// Create a new config system.
 	globalConfigSys = NewConfigSys()

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2018 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2018-2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package cmd
 
 const (
-	storageRESTVersion = "v9"
+	storageRESTVersion = "v10"
 	storageRESTPath    = minioReservedBucketPath + "/storage/" + storageRESTVersion + SlashSeparator
 )
 

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -526,6 +526,8 @@ func newTestConfig(bucketLocation string, obj ObjectLayer) (err error) {
 		SecretKey: auth.DefaultSecretKey,
 	}
 
+	globalConfigEncrypted = true
+
 	// Set a default region.
 	config.SetRegion(globalServerConfig, bucketLocation)
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -12,6 +12,8 @@ Additionally `--config-dir` is now a legacy option which will is scheduled for r
 minio server /data
 ```
 
+MinIO also encrypts all the config, IAM and policies content with admin credentials.
+
 ### Certificate Directory
 
 TLS certificates by default are stored under ``${HOME}/.minio/certs`` directory. You need to place certificates here to enable `HTTPS` based access. Read more about [How to secure access to MinIO server with TLS](https://docs.min.io/docs/how-to-secure-access-to-minio-server-with-tls).
@@ -29,6 +31,30 @@ $ mc tree --files ~/.minio
 
 You can provide a custom certs directory using `--certs-dir` command line option.
 
+#### Credentials
+On MinIO admin credentials or root credentials are only allowed to be changed using ENVs namely `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`. Using the combination of these two values MinIO encrypts the config stored at the backend.
+
+```
+export MINIO_ACCESS_KEY=minio
+export MINIO_SECRET_KEY=minio13
+minio server /data
+```
+
+##### Rotating encryption with new credentials
+
+Additionally if you wish to change the admin credentials, then MinIO will automatically detect this and re-encrypt with new credentials as shown below. For one time only special ENVs as shown below needs to be set for rotating the encryption config.
+
+> Old ENVs are never remembered in memory and are destroyed right after they are used to migrate your existing content with new credentials. You are safe to remove them after the server as successfully started, by restarting the services once again.
+
+```
+export MINIO_ACCESS_KEY=newminio
+export MINIO_SECRET_KEY=newminio123
+export MINIO_ACCESS_KEY_OLD=minio
+export MINIO_SECRET_KEY_OLD=minio123
+minio server /data
+```
+
+Additional capabilities such as rotating credentials to newer admin credentials is also allowed by restarting the server with two additional ENVs
 #### Region
 | Field                     | Type     | Description                                                                                                                                                                             |
 |:--------------------------|:---------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/gateway/s3.md
+++ b/docs/gateway/s3.md
@@ -62,6 +62,29 @@ Minimum permissions required if you wish to provide restricted access with your 
 ## Run MinIO Gateway for AWS S3 compatible services
 As a prerequisite to run MinIO S3 gateway on an AWS S3 compatible service, you need valid access key, secret key and service endpoint.
 
+## Run MinIO Gateway with double-encryption
+MinIO gateway to S3 supports encryption of data at rest. Three types of encryption modes are supported
+
+- encryption can be set to ``pass-through`` to backend
+- ``single encryption`` (at the gateway)
+- ``double encryption`` (single encryption at gateway and pass through to backend).
+
+This can be specified by setting MINIO_GATEWAY_SSE environment variable. If MINIO_GATEWAY_SSE and KMS are not setup, all encryption headers are passed through to the backend. If KMS environment variables are set up, ``single encryption`` is automatically performed at the gateway and encrypted object is saved at the backend.
+
+To specify ``double encryption``, MINIO_GATEWAY_SSE environment variable needs to be set to "s3" for sse-s3
+and "c" for sse-c encryption. More than one encryption option can be set, delimited by ";". Objects are encrypted at the gateway and the gateway also does a pass-through to backend. Note that in the case of SSE-C encryption, gateway derives a unique SSE-C key for pass through from the SSE-C client key using a key derivation function (KDF).
+
+```sh
+export MINIO_GATEWAY_SSE="s3;c"
+export MINIO_KMS_VAULT_STATE=on
+export MINIO_KMS_VAULT_APPROLE_ID=9b56cc08-8258-45d5-24a3-679876769126
+export MINIO_KMS_VAULT_APPROLE_SECRET=4e30c52f-13e4-a6f5-0763-d50e8cb4321f
+export MINIO_KMS_VAULT_ENDPOINT=https://vault-endpoint-ip:8200
+export MINIO_KMS_VAULT_KEY_NAME=my-minio-key
+export MINIO_KMS_VAULT_AUTH_TYPE=approle
+minio gateway s3
+```
+
 ### Using Docker
 ```
 docker run -p 9000:9000 --name minio-s3 \

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -20,10 +20,7 @@ MinIO supports two different KMS concepts:
    Further if the MinIO server machine is ever compromised, then the master key must also be treated as compromised.
 
 **Important:**
-If multiple MinIO servers are configured as [gateways](https://github.com/minio/minio/blob/master/docs/gateway/README.md)
-pointing to the *same* backend - for example the same NAS storage - then the KMS configuration **must** be the same for
-all gateways. Otherwise one gateway may not be able to decrypt objects created by another gateway. It is the operators'
-responsibility to ensure consistency.
+If multiple MinIO servers are configured as [gateways](https://github.com/minio/minio/blob/master/docs/gateway/README.md) pointing to the *same* backend - for example the same NAS storage - then the KMS configuration **must** be the same for all gateways. Otherwise one gateway may not be able to decrypt objects created by another gateway. It is the operator responsibility to ensure consistency.
 
 ## Get started
 
@@ -196,24 +193,6 @@ export MINIO_KMS_VAULT_NAMESPACE=ns1
 ```
 
 Note: If [Vault Namespaces](https://learn.hashicorp.com/vault/operations/namespaces) are in use, MINIO_KMS_VAULT_VAULT_NAMESPACE variable needs to be set before setting approle and transit secrets engine.
-
-MinIO gateway to S3 supports encryption. Three encryption modes are possible - encryption can be set to ``pass-through`` to backend, ``single encryption`` (at the gateway) or ``double encryption`` (single encryption at gateway and pass through to backend). This can be specified by setting MINIO_GATEWAY_SSE and KMS environment variables set in Step 2.1.2.
-
-If MINIO_GATEWAY_SSE and KMS are not setup, all encryption headers are passed through to the backend. If KMS environment variables are set up, ``single encryption`` is automatically performed at the gateway and encrypted object is saved at the backend.
-
-To specify ``double encryption``, MINIO_GATEWAY_SSE environment variable needs to be set to "s3" for sse-s3
-and "c" for sse-c encryption. More than one encryption option can be set, delimited by ";". Objects are encrypted at the gateway and the gateway also does a pass-through to backend. Note that in the case of SSE-C encryption, gateway derives a unique SSE-C key for pass through from the SSE-C client key using a KDF.
-
-```sh
-export MINIO_GATEWAY_SSE="s3;c"
-export MINIO_KMS_VAULT_STATE=on
-export MINIO_KMS_VAULT_APPROLE_ID=9b56cc08-8258-45d5-24a3-679876769126
-export MINIO_KMS_VAULT_APPROLE_SECRET=4e30c52f-13e4-a6f5-0763-d50e8cb4321f
-export MINIO_KMS_VAULT_ENDPOINT=https://vault-endpoint-ip:8200
-export MINIO_KMS_VAULT_KEY_NAME=my-minio-key
-export MINIO_KMS_VAULT_AUTH_TYPE=approle
-minio gateway s3
-```
 
 #### 2.2 Specify a master key
 

--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -1,8 +1,25 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package color
 
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
@@ -101,3 +118,21 @@ var (
 		return fmt.Sprintf
 	}()
 )
+
+var privateMutex sync.Mutex
+
+// SetColorOff disables coloring for the entire session.
+func SetColorOff() {
+	privateMutex.Lock()
+	defer privateMutex.Unlock()
+	if !color.NoColor {
+		color.NoColor = true
+	}
+}
+
+// SetColorOn enables coloring for the entire session.
+func SetColorOn() {
+	privateMutex.Lock()
+	defer privateMutex.Unlock()
+	color.NoColor = false
+}

--- a/pkg/madmin/config-help-commands.go
+++ b/pkg/madmin/config-help-commands.go
@@ -24,10 +24,13 @@ import (
 )
 
 // HelpConfigKV - return help for a given sub-system.
-func (adm *AdminClient) HelpConfigKV(subSys, key string) (io.ReadCloser, error) {
+func (adm *AdminClient) HelpConfigKV(subSys, key string, noColor bool) (io.ReadCloser, error) {
 	v := url.Values{}
 	v.Set("subSys", subSys)
 	v.Set("key", key)
+	if noColor {
+		v.Set("noColor", "")
+	}
 	reqData := requestData{
 		relPath:     adminAPIPrefix + "/help-config-kv",
 		queryValues: v,

--- a/pkg/madmin/config-kv-commands.go
+++ b/pkg/madmin/config-kv-commands.go
@@ -77,9 +77,15 @@ func (adm *AdminClient) SetConfigKV(kv string) (err error) {
 }
 
 // GetConfigKV - returns the key, value of the requested key, incoming data is encrypted.
-func (adm *AdminClient) GetConfigKV(key string) ([]byte, error) {
+func (adm *AdminClient) GetConfigKV(key string, jsonMode bool, noColor bool) ([]byte, error) {
 	v := url.Values{}
 	v.Set("key", key)
+	if jsonMode {
+		v.Set("json", "")
+	}
+	if noColor {
+		v.Set("noColor", "")
+	}
 
 	// Execute GET on /minio/admin/v2/get-config-kv?key={key} to get value of key.
 	resp, err := adm.executeMethod(http.MethodGet,


### PR DESCRIPTION
## Description
Add noColor, jsonMode support for get/help commands

## Motivation and Context
This allows for saving config on the client-side for editing on dumb terminals.

## How to test this PR?
This is based on an existing PR #8439 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
