### PR TITLE
Increase the maximum number of 1000 keys per list to 10000

### DIFF
--- a/cmd/api-resources_test.go
+++ b/cmd/api-resources_test.go
@@ -64,7 +64,7 @@ func TestListObjectsV2Resources(t *testing.T) {
 			startAfter:   "start-after",
 			delimiter:    SlashSeparator,
 			fetchOwner:   true,
-			maxKeys:      1000,
+			maxKeys:      maxObjectList,
 			encodingType: "gzip",
 			errCode:      ErrNone,
 		},
@@ -150,7 +150,7 @@ func TestListObjectsV1Resources(t *testing.T) {
 			prefix:       "photos/",
 			marker:       "test",
 			delimiter:    SlashSeparator,
-			maxKeys:      1000,
+			maxKeys:      maxObjectList,
 			encodingType: "gzip",
 		},
 	}

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -34,9 +34,9 @@ import (
 
 const (
 	timeFormatAMZLong = "2006-01-02T15:04:05.000Z" // Reply date format with nanosecond precision.
-	maxObjectList     = 1000                       // Limit number of objects in a listObjectsResponse.
-	maxUploadsList    = 1000                       // Limit number of uploads in a listUploadsResponse.
-	maxPartsList      = 1000                       // Limit number of parts in a listPartsResponse.
+	maxObjectList     = 10000                      // Limit number of objects in a listObjectsResponse.
+	maxUploadsList    = 10000                      // Limit number of uploads in a listUploadsResponse.
+	maxPartsList      = 10000                      // Limit number of parts in a listPartsResponse.
 )
 
 // LocationResponse - format for location response.

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -1231,14 +1231,14 @@ func TestPosixReadFile(t *testing.T) {
 			t.Fatalf("Unable to change permission to temporary directory %v. %v", permDeniedDir, err)
 		}
 
-		posixStorage, err = newPosix(permDeniedDir)
+		posixPermStorage, err := newPosix(permDeniedDir)
 		if err != nil {
 			t.Fatalf("Unable to initialize posix, %s", err)
 		}
 
 		// Common read buffer.
 		var buf = make([]byte, 10)
-		if _, err = posixStorage.ReadFile("mybucket", "myobject", 0, buf, v); err != errFileAccessDenied {
+		if _, err = posixPermStorage.ReadFile("mybucket", "myobject", 0, buf, v); err != errFileAccessDenied {
 			t.Errorf("expected: %s, got: %s", errFileAccessDenied, err)
 		}
 	}
@@ -1256,7 +1256,7 @@ func TestPosixReadFile(t *testing.T) {
 			t.Fatalf("Expected \"Faulty Disk\", got: \"%s\"", err)
 		}
 	} else {
-		t.Fatalf("Expected the StorageAPI to be of type *posix")
+		t.Fatalf("Expected the StorageAPI to be of type *posixDiskIDCheck")
 	}
 }
 


### PR DESCRIPTION
## Description
Increase the maximum number of 1000 keys per list to 10000

## Motivation and Context
Performance improvements, the time spent in 
tree-walk for 10000 keys is the same as 1000
so we better return a larger set of keys instead

## How to test this PR?
Use `mc ls` with 10,000 keys v/s 1000 keys 10 times. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
