### PR TITLE
not return NextMarker if delimiter not specified

### DIFF
--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -315,6 +315,7 @@ func listObjectsNonSlash(ctx context.Context, bucket, prefix, marker, delimiter 
 
 	if !eof {
 		result.IsTruncated = true
+		// add NextMarker only if delimiter specified
 		if len(objInfos) > 0 && delimiter != "" {
 			result.NextMarker = objInfos[len(objInfos)-1].Name
 		}
@@ -442,6 +443,7 @@ func listObjects(ctx context.Context, obj ObjectLayer, bucket, prefix, marker, d
 
 	if !eof {
 		result.IsTruncated = true
+		// add NextMarker only if delimiter specified
 		if len(objInfos) > 0 && delimiter != "" {
 			result.NextMarker = objInfos[len(objInfos)-1].Name
 		}

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -315,7 +315,7 @@ func listObjectsNonSlash(ctx context.Context, bucket, prefix, marker, delimiter 
 
 	if !eof {
 		result.IsTruncated = true
-		if len(objInfos) > 0 {
+		if len(objInfos) > 0 && delimiter != "" {
 			result.NextMarker = objInfos[len(objInfos)-1].Name
 		}
 	}
@@ -442,7 +442,7 @@ func listObjects(ctx context.Context, obj ObjectLayer, bucket, prefix, marker, d
 
 	if !eof {
 		result.IsTruncated = true
-		if len(objInfos) > 0 {
+		if len(objInfos) > 0 && delimiter != "" {
 			result.NextMarker = objInfos[len(objInfos)-1].Name
 		}
 	}


### PR DESCRIPTION
## Description
listObject should not return NextMarker element if delimiter not specified

## Motivation and Context
https://docs.aws.amazon.com/en_pv/AmazonS3/latest/API/API_ListObjects.html  

This element(NextMarker) is returned only if you have delimiter request parameter specified

## How to test this PR?


## Types of changes
- [x ] S3 compatibility
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
