### PR TITLE
Fix panic during trace requests

### DIFF
--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -130,7 +130,7 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 		Headers:  reqHeaders,
 		Body:     reqBodyRecorder.Data(),
 	}
-	rw, _ := w.(*logger.ResponseWriter)
+	rw := logger.NewResponseWriter(w)
 	rw.LogBody = logBody
 	f(rw, r)
 


### PR DESCRIPTION
## Description
While Tracing requests on server, type assertion on logger.ResponseWriter
caused nil pointer exception because of recordAPIStats{} being
used as ResponseWriter. This PR avoids the type assertion and
initializes a new logger.ResponseWriter.

## Motivation and Context
Fixes regression introduced in #8003

## How to test this PR?
Before this PR, Trace using `mc admin trace` panics, after this PR, 
Trace should work fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (#8003 )
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
