### PR TITLE
fix browser blank page on gateways

### DIFF
--- a/browser/app/js/browser/StorageInfo.js
+++ b/browser/app/js/browser/StorageInfo.js
@@ -26,7 +26,13 @@ export class StorageInfo extends React.Component {
   }
   render() {
     const { used } = this.props.storageInfo
-    var totalUsed = used.reduce((v1, v2) => v1 + v2, 0)
+
+    if (!used) {
+      return <noscript />
+    }
+
+    const totalUsed = used.reduce((v1, v2) => v1 + v2, 0)
+
     return (
       <div className="feh-used">
         <div className="fehu-chart">

--- a/browser/app/js/browser/__tests__/StorageInfo.test.js
+++ b/browser/app/js/browser/__tests__/StorageInfo.test.js
@@ -35,4 +35,15 @@ describe("StorageInfo", () => {
     )
     expect(fetchStorageInfo).toHaveBeenCalled()
   })
+
+  it("should not render anything if used is null", () => {
+    const fetchStorageInfo = jest.fn()
+    const wrapper = shallow(
+      <StorageInfo
+        storageInfo={{ used: null }}
+        fetchStorageInfo={fetchStorageInfo}
+      />
+    )
+    expect(wrapper.text()).toBe("")
+  })
 })


### PR DESCRIPTION
## Description
StorageInfo component will not be rendered if
Storage used is null.

Fixes the javascript error thrown here #8447 

## Motivation and Context
Storage info will not be available for gateway, so no need show this information on browser.

## How to test this PR?
Run `minio gateway s3` and open MinIO Browser, the page should render fine and storage info is not shown.
For `minio server` the storage info should be shown appropriately.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) PR #8003 
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
