### PR TITLE
S3 Select: Detect full object

### DIFF
--- a/pkg/s3select/select_test.go
+++ b/pkg/s3select/select_test.go
@@ -166,6 +166,16 @@ func TestJSONQueries(t *testing.T) {
 			wantResult: `{"id":3,"title":"Second Record","desc":"another text","nested":[[2,3,4],[7,8.5,9]]}`,
 		},
 		{
+			name:       "indexed-list-match-equals-s-star",
+			query:      `SELECT s.* from s3object s WHERE (7,8.5,9) = s.nested[1]`,
+			wantResult: `{"id":3,"title":"Second Record","desc":"another text","nested":[[2,3,4],[7,8.5,9]]}`,
+		},
+		{
+			name:       "indexed-list-match-equals-s-index",
+			query:      `SELECT s.nested[1], s.nested[0] from s3object s WHERE (7,8.5,9) = s.nested[1]`,
+			wantResult: `{"_1":[7,8.5,9],"_2":[2,3,4]}`,
+		},
+		{
 			name:  "indexed-list-match-not-equals",
 			query: `SELECT * from s3object s WHERE (7,8.5,9) != s.nested[1]`,
 			wantResult: `{"id":0,"title":"Test Record","desc":"Some text","synonyms":["foo","bar","whatever"]}

--- a/pkg/s3select/sql/statement.go
+++ b/pkg/s3select/sql/statement.go
@@ -56,6 +56,21 @@ func ParseSelectStatement(s string) (stmt SelectStatement, err error) {
 		err = errQueryParseFailure(err)
 		return
 	}
+
+	// Check if select is "SELECT s.* from S3Object s"
+	if !selectAST.Expression.All &&
+		len(selectAST.Expression.Expressions) == 1 &&
+		len(selectAST.Expression.Expressions[0].Expression.And) == 1 &&
+		len(selectAST.Expression.Expressions[0].Expression.And[0].Condition) == 1 &&
+		selectAST.Expression.Expressions[0].Expression.And[0].Condition[0].Operand != nil &&
+		selectAST.Expression.Expressions[0].Expression.And[0].Condition[0].Operand.Operand.Left != nil &&
+		selectAST.Expression.Expressions[0].Expression.And[0].Condition[0].Operand.Operand.Left.Left != nil &&
+		selectAST.Expression.Expressions[0].Expression.And[0].Condition[0].Operand.Operand.Left.Left.Primary != nil &&
+		selectAST.Expression.Expressions[0].Expression.And[0].Condition[0].Operand.Operand.Left.Left.Primary.JPathExpr != nil {
+		if selectAST.Expression.Expressions[0].Expression.And[0].Condition[0].Operand.Operand.Left.Left.Primary.JPathExpr.String() == selectAST.From.As+".*" {
+			selectAST.Expression.All = true
+		}
+	}
 	stmt.selectAST = &selectAST
 
 	// Check the parsed limit value


### PR DESCRIPTION
## Description

Check if select is `SELECT s.* from S3Object s` and forward it to All

## Motivation and Context

Fixes #8371 and makes this case run significantly faster.

## How to test this PR?

Test case included.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
