### PR TITLE
S3 Select: Support Square Bracket Lists

### DIFF
--- a/pkg/s3select/select_test.go
+++ b/pkg/s3select/select_test.go
@@ -173,6 +173,22 @@ func TestJSONQueries(t *testing.T) {
 {"id":2,"title":"Second Record","desc":"another text","numbers":[2,3,4]}`,
 		},
 		{
+			name:       "indexed-list-square-bracket",
+			query:      `SELECT * from s3object s WHERE [7,8.5,9] = s.nested[1]`,
+			wantResult: `{"id":3,"title":"Second Record","desc":"another text","nested":[[2,3,4],[7,8.5,9]]}`,
+		},
+		{
+			name:       "indexed-list-square-bracket",
+			query:      `SELECT * from s3object s WHERE [7,8.5,9] IN s.nested`,
+			wantResult: `{"id":3,"title":"Second Record","desc":"another text","nested":[[2,3,4],[7,8.5,9]]}`,
+		},
+		{
+			name:  "indexed-list-square-bracket",
+			query: `SELECT * from s3object s WHERE id IN [3,2]`,
+			wantResult: `{"id":2,"title":"Second Record","desc":"another text","numbers":[2,3,4]}
+{"id":3,"title":"Second Record","desc":"another text","nested":[[2,3,4],[7,8.5,9]]}`,
+		},
+		{
 			name:       "index-wildcard-in",
 			query:      `SELECT * from s3object s WHERE (8.5) IN s.nested[1][*]`,
 			wantResult: `{"id":3,"title":"Second Record","desc":"another text","nested":[[2,3,4],[7,8.5,9]]}`,

--- a/pkg/s3select/sql/parser.go
+++ b/pkg/s3select/sql/parser.go
@@ -149,7 +149,7 @@ type Expression struct {
 
 // ListExpr represents a literal list with elements as expressions.
 type ListExpr struct {
-	Elements []*Expression `parser:"\"(\" @@ ( \",\" @@ )* \")\""`
+	Elements []*Expression `parser:"\"(\" @@ ( \",\" @@ )* \")\" | \"[\" @@ ( \",\" @@ )* \"]\""`
 }
 
 // AndCondition represents logical conjunction of clauses


### PR DESCRIPTION
## Description

Allows for S3 compatible `SELECT * from s3object s WHERE id IN [3,2]`

## Motivation and Context

Fixes #8422

## How to test this PR?

Tests included

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
