### PR TITLE
Extend further validation of config values

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -933,7 +933,7 @@ func (a adminAPIHandlers) BackgroundHealStatusHandler(w http.ResponseWriter, r *
 
 func validateAdminReq(ctx context.Context, w http.ResponseWriter, r *http.Request) ObjectLayer {
 	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil || globalNotificationSys == nil || globalIAMSys == nil {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrServerNotInitialized), r.URL)
 		return nil

--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -90,7 +90,11 @@ func prepareAdminXLTestBed() (*adminXLTestBed, error) {
 	globalPolicySys = NewPolicySys()
 	globalPolicySys.Init(buckets, objLayer)
 
-	globalNotificationSys = NewNotificationSys(globalServerConfig, globalEndpoints)
+	globalNotificationSys, err = NewNotificationSys(globalServerConfig, globalEndpoints)
+	if err != nil {
+		return nil, err
+	}
+
 	globalNotificationSys.Init(buckets, objLayer)
 
 	// Setup admin mgmt REST API handlers.

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -660,7 +660,7 @@ func (h *healSequence) traverseAndHeal() {
 func (h *healSequence) healMinioSysMeta(metaPrefix string) func() error {
 	return func() error {
 		// Get current object layer instance.
-		objectAPI := newObjectLayerFn()
+		objectAPI := globalObjectAPI
 		if objectAPI == nil {
 			return errServerNotInitialized
 		}
@@ -692,7 +692,7 @@ func (h *healSequence) healDiskFormat() error {
 	}
 
 	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -712,7 +712,7 @@ func (h *healSequence) healBuckets() error {
 	}
 
 	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -734,7 +734,7 @@ func (h *healSequence) healBuckets() error {
 // healBucket - traverses and heals given bucket
 func (h *healSequence) healBucket(bucket string) error {
 	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -771,7 +771,7 @@ func (h *healSequence) healObject(bucket, object string) error {
 	}
 
 	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -37,8 +37,18 @@ type objectAPIHandlers struct {
 func registerAPIRouter(router *mux.Router, encryptionEnabled, allowSSEKMS bool) {
 	// Initialize API.
 	api := objectAPIHandlers{
-		ObjectAPI: newObjectLayerFn,
-		CacheAPI:  newCacheObjectsFn,
+		ObjectAPI: func() ObjectLayer {
+			if !globalSafeMode {
+				return globalObjectAPI
+			}
+			return nil
+		},
+		CacheAPI: func() CacheObjectLayer {
+			if !globalSafeMode {
+				return globalCacheObjectAPI
+			}
+			return nil
+		},
 		EncryptionEnabled: func() bool {
 			return encryptionEnabled
 		},

--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -107,7 +107,7 @@ func startBackgroundHealing() {
 
 	var objAPI ObjectLayer
 	for {
-		objAPI = newObjectLayerFn()
+		objAPI = globalObjectAPI
 		if objAPI == nil {
 			time.Sleep(time.Second)
 			continue
@@ -135,7 +135,7 @@ func initBackgroundHealing() {
 // failure error occurred.
 func bgHealDiskFormat(ctx context.Context, opts madmin.HealOpts) (madmin.HealResultItem, error) {
 	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return madmin.HealResultItem{}, errServerNotInitialized
 	}
@@ -165,7 +165,7 @@ func bgHealDiskFormat(ctx context.Context, opts madmin.HealOpts) (madmin.HealRes
 // bghealBucket - traverses and heals given bucket
 func bgHealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem, error) {
 	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return madmin.HealResultItem{}, errServerNotInitialized
 	}
@@ -176,7 +176,7 @@ func bgHealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (mad
 // bgHealObject - heal the given object and record result
 func bgHealObject(ctx context.Context, bucket, object string, opts madmin.HealOpts) (madmin.HealResultItem, error) {
 	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return madmin.HealResultItem{}, errServerNotInitialized
 	}

--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -36,7 +36,7 @@ func monitorLocalDisksAndHeal() {
 	// Wait until the object layer is ready
 	var objAPI ObjectLayer
 	for {
-		objAPI = newObjectLayerFn()
+		objAPI = globalObjectAPI
 		if objAPI == nil {
 			time.Sleep(time.Second)
 			continue

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -162,8 +162,9 @@ func handleCommonEnvVars() {
 		logger.Fatal(config.ErrInvalidBrowserValue(err), "Invalid MINIO_BROWSER value in environment variable")
 	}
 
-	for _, domainName := range strings.Split(env.Get(config.EnvDomain, ""), config.ValueSeparator) {
-		if domainName != "" {
+	domains := env.Get(config.EnvDomain, "")
+	if len(domains) != 0 {
+		for _, domainName := range strings.Split(domains, config.ValueSeparator) {
 			if _, ok := dns2.IsDomainName(domainName); !ok {
 				logger.Fatal(config.ErrInvalidDomainValue(nil).Msg("Unknown value `%s`", domainName),
 					"Invalid MINIO_DOMAIN value in environment variable")
@@ -172,9 +173,9 @@ func handleCommonEnvVars() {
 		}
 	}
 
-	minioEndpointsEnv, ok := env.Lookup(config.EnvPublicIPs)
-	if ok {
-		minioEndpoints := strings.Split(minioEndpointsEnv, config.ValueSeparator)
+	publicIPs := env.Get(config.EnvPublicIPs, "")
+	if len(publicIPs) != 0 {
+		minioEndpoints := strings.Split(publicIPs, config.ValueSeparator)
 		var domainIPs = set.NewStringSet()
 		for _, endpoint := range minioEndpoints {
 			if net.ParseIP(endpoint) == nil {

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -445,7 +445,7 @@ func migrateV5ToV6() error {
 
 	if cv5.Logger.ElasticSearch.URL != "" {
 		var url *xnet.URL
-		url, err = xnet.ParseURL(cv5.Logger.ElasticSearch.URL)
+		url, err = xnet.ParseHTTPURL(cv5.Logger.ElasticSearch.URL)
 		if err != nil {
 			return err
 		}

--- a/cmd/config/cache/config.go
+++ b/cmd/config/cache/config.go
@@ -89,6 +89,9 @@ func parseCacheDrives(drives []string) ([]string, error) {
 	}
 
 	for _, d := range endpoints {
+		if len(d) == 0 {
+			return nil, config.ErrInvalidCacheDrivesValue(nil).Msg("cache dir cannot be an empty path")
+		}
 		if !filepath.IsAbs(d) {
 			return nil, config.ErrInvalidCacheDrivesValue(nil).Msg("cache dir should be absolute path: %s", d)
 		}

--- a/cmd/config/cache/config_test.go
+++ b/cmd/config/cache/config_test.go
@@ -30,11 +30,15 @@ func TestParseCacheDrives(t *testing.T) {
 		expectedPatterns []string
 		success          bool
 	}{
-		// valid input
+		// Invalid input
 
 		{"bucket1/*;*.png;images/trip/barcelona/*", []string{}, false},
 		{"bucket1", []string{}, false},
+		{";;;", []string{}, false},
+		{",;,;,;", []string{}, false},
 	}
+
+	// Valid inputs
 	if runtime.GOOS == "windows" {
 		testCases = append(testCases, struct {
 			driveStr         string
@@ -91,8 +95,12 @@ func TestParseCacheExclude(t *testing.T) {
 		expectedPatterns []string
 		success          bool
 	}{
-		// valid input
+		// Invalid input
 		{"/home/drive1;/home/drive2;/home/drive3", []string{}, false},
+		{"/", []string{}, false},
+		{";;;", []string{}, false},
+
+		// valid input
 		{"bucket1/*;*.png;images/trip/barcelona/*", []string{"bucket1/*", "*.png", "images/trip/barcelona/*"}, true},
 		{"bucket1", []string{"bucket1"}, true},
 	}

--- a/cmd/config/certs.go
+++ b/cmd/config/certs.go
@@ -119,8 +119,8 @@ func LoadX509KeyPair(certFile, keyFile string) (tls.Certificate, error) {
 		return tls.Certificate{}, ErrSSLUnexpectedData(nil).Msg("The private key contains additional data")
 	}
 	if x509.IsEncryptedPEMBlock(key) {
-		password, ok := env.Lookup(EnvCertPassword)
-		if !ok {
+		password := env.Get(EnvCertPassword, "")
+		if len(password) == 0 {
 			return tls.Certificate{}, ErrSSLNoPassword(nil)
 		}
 		decryptedKey, decErr := x509.DecryptPEMBlock(key, []byte(password))

--- a/cmd/config/compress/compress.go
+++ b/cmd/config/compress/compress.go
@@ -56,10 +56,14 @@ var (
 )
 
 // Parses the given compression exclude list `extensions` or `content-types`.
-func parseCompressIncludes(includes []string) ([]string, error) {
+func parseCompressIncludes(include string) ([]string, error) {
+	includes := strings.Split(include, config.ValueSeparator)
 	for _, e := range includes {
 		if len(e) == 0 {
 			return nil, config.ErrInvalidCompressionIncludesValue(nil).Msg("extension/mime-type cannot be empty")
+		}
+		if e == "/" {
+			return nil, config.ErrInvalidCompressionIncludesValue(nil).Msg("extension/mime-type cannot be '/'")
 		}
 	}
 	return includes, nil
@@ -90,22 +94,21 @@ func LookupConfig(kvs config.KVS) (Config, error) {
 	compressMimeTypesLegacy := env.Get(EnvCompressMimeTypesLegacy, kvs.Get(MimeTypes))
 	if compressExtensions != "" || compressMimeTypes != "" || compressMimeTypesLegacy != "" {
 		if compressExtensions != "" {
-			extensions, err := parseCompressIncludes(strings.Split(compressExtensions, config.ValueSeparator))
+			extensions, err := parseCompressIncludes(compressExtensions)
 			if err != nil {
 				return cfg, fmt.Errorf("%s: Invalid MINIO_COMPRESS_EXTENSIONS value (`%s`)", err, extensions)
 			}
 			cfg.Extensions = extensions
 		}
 		if compressMimeTypes != "" {
-			mimeTypes, err := parseCompressIncludes(strings.Split(compressMimeTypes, config.ValueSeparator))
+			mimeTypes, err := parseCompressIncludes(compressMimeTypes)
 			if err != nil {
 				return cfg, fmt.Errorf("%s: Invalid MINIO_COMPRESS_MIME_TYPES value (`%s`)", err, mimeTypes)
 			}
 			cfg.MimeTypes = mimeTypes
 		}
 		if compressMimeTypesLegacy != "" {
-			mimeTypes, err := parseCompressIncludes(strings.Split(compressMimeTypesLegacy,
-				config.ValueSeparator))
+			mimeTypes, err := parseCompressIncludes(compressMimeTypesLegacy)
 			if err != nil {
 				return cfg, fmt.Errorf("%s: Invalid MINIO_COMPRESS_MIME_TYPES value (`%s`)", err, mimeTypes)
 			}

--- a/cmd/config/compress/compress_test.go
+++ b/cmd/config/compress/compress_test.go
@@ -1,0 +1,57 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package compress
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCompressIncludes(t *testing.T) {
+	testCases := []struct {
+		str              string
+		expectedPatterns []string
+		success          bool
+	}{
+		// invalid input
+		{",,,", []string{}, false},
+		{"", []string{}, false},
+		{",", []string{}, false},
+		{"/", []string{}, false},
+		{"text/*,/", []string{}, false},
+
+		// valid input
+		{".txt,.log", []string{".txt", ".log"}, true},
+		{"text/*,application/json", []string{"text/*", "application/json"}, true},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.str, func(t *testing.T) {
+			gotPatterns, err := parseCompressIncludes(testCase.str)
+			if !testCase.success && err == nil {
+				t.Error("expected failure but success instead")
+			}
+			if testCase.success && err != nil {
+				t.Errorf("expected success but failed instead %s", err)
+			}
+			if testCase.success && !reflect.DeepEqual(testCase.expectedPatterns, gotPatterns) {
+				t.Errorf("expected patterns %s but got %s", testCase.expectedPatterns, gotPatterns)
+			}
+		})
+	}
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -29,6 +29,12 @@ import (
 // Error config error type
 type Error string
 
+// Errorf - formats according to a format specifier and returns
+// the string as a value that satisfies error of type config.Error
+func Errorf(format string, a ...interface{}) error {
+	return Error(fmt.Sprintf(format, a...))
+}
+
 func (e Error) Error() string {
 	return string(e)
 }
@@ -402,10 +408,6 @@ func (c Config) SetKVS(s string, defaultKVS map[string]KVS) error {
 		if len(kv) == 1 && prevK != "" {
 			kvs[prevK] = strings.Join([]string{kvs[prevK], sanitizeValue(kv[0])}, KvSpaceSeparator)
 			continue
-		}
-		if len(kv[1]) == 0 {
-			err := fmt.Sprintf("value for key '%s' cannot be empty", kv[0])
-			return Error(err)
 		}
 		prevK = kv[0]
 		kvs[kv[0]] = sanitizeValue(kv[1])

--- a/cmd/config/etcd/etcd_test.go
+++ b/cmd/config/etcd/etcd_test.go
@@ -1,0 +1,66 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package etcd
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseEndpoints - tests parseEndpoints function with valid and invalid inputs.
+func TestParseEndpoints(t *testing.T) {
+	testCases := []struct {
+		s         string
+		endpoints []string
+		secure    bool
+		success   bool
+	}{
+		// Invalid inputs
+		{"https://localhost:2379,http://localhost:2380", nil, false, false},
+		{",,,", nil, false, false},
+		{"", nil, false, false},
+		{"ftp://localhost:2379", nil, false, false},
+		{"http://localhost:2379000", nil, false, false},
+
+		// Valid inputs
+		{"https://localhost:2379,https://localhost:2380", []string{
+			"https://localhost:2379", "https://localhost:2380"},
+			true, true},
+		{"http://localhost:2379", []string{"http://localhost:2379"}, false, true},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.s, func(t *testing.T) {
+			endpoints, secure, err := parseEndpoints(testCase.s)
+			if err != nil && testCase.success {
+				t.Errorf("expected to succeed but failed with %s", err)
+			}
+			if !testCase.success && err == nil {
+				t.Error("expected failure but succeeded instead")
+			}
+			if testCase.success {
+				if !reflect.DeepEqual(endpoints, testCase.endpoints) {
+					t.Errorf("expected %s, got %s", testCase.endpoints, endpoints)
+				}
+				if secure != testCase.secure {
+					t.Errorf("expected %t, got %t", testCase.secure, secure)
+				}
+			}
+		})
+	}
+}

--- a/cmd/config/identity/openid/jwt.go
+++ b/cmd/config/identity/openid/jwt.go
@@ -284,7 +284,7 @@ func LookupConfig(kv config.KVS, transport *http.Transport, closeRespFn func(io.
 
 	configURL := env.Get(EnvIdentityOpenIDURL, kv.Get(ConfigURL))
 	if configURL != "" {
-		c.URL, err = xnet.ParseURL(configURL)
+		c.URL, err = xnet.ParseHTTPURL(configURL)
 		if err != nil {
 			return c, err
 		}
@@ -315,7 +315,7 @@ func LookupConfig(kv config.KVS, transport *http.Transport, closeRespFn func(io.
 		closeRespFn: closeRespFn,
 	}
 
-	c.JWKS.URL, err = xnet.ParseURL(jwksURL)
+	c.JWKS.URL, err = xnet.ParseHTTPURL(jwksURL)
 	if err != nil {
 		return c, err
 	}

--- a/cmd/config/identity/openid/jwt_test.go
+++ b/cmd/config/identity/openid/jwt_test.go
@@ -53,7 +53,7 @@ func TestJWT(t *testing.T) {
 		}
 	}
 
-	u1, err := xnet.ParseURL("http://localhost:8443")
+	u1, err := xnet.ParseHTTPURL("http://localhost:8443")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/config/identity/openid/validators_test.go
+++ b/cmd/config/identity/openid/validators_test.go
@@ -87,7 +87,7 @@ func TestValidators(t *testing.T) {
 		t.Fatalf("Unexpected number of vids %v", vids)
 	}
 
-	u, err := xnet.ParseURL(ts.URL)
+	u, err := xnet.ParseHTTPURL(ts.URL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/config/policy/opa/config.go
+++ b/cmd/config/policy/opa/config.go
@@ -124,7 +124,7 @@ func LookupConfig(kv config.KVS, transport *http.Transport, closeRespFn func(io.
 		authToken = env.Get(EnvPolicyOpaAuthToken, kv.Get(AuthToken))
 	}
 
-	u, err := xnet.ParseURL(opaURL)
+	u, err := xnet.ParseHTTPURL(opaURL)
 	if err != nil {
 		return args, err
 	}

--- a/cmd/daily-lifecycle-ops.go
+++ b/cmd/daily-lifecycle-ops.go
@@ -55,7 +55,7 @@ func startDailyLifecycle() {
 
 	// Wait until the object API is ready
 	for {
-		objAPI = newObjectLayerFn()
+		objAPI = globalObjectAPI
 		if objAPI == nil {
 			time.Sleep(time.Second)
 			continue

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -553,23 +553,23 @@ func newServerCacheObjects(ctx context.Context, config cache.Config) (CacheObjec
 		migrating: migrateSw,
 		migMutex:  sync.Mutex{},
 		GetObjectInfoFn: func(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
-			return newObjectLayerFn().GetObjectInfo(ctx, bucket, object, opts)
+			return globalObjectAPI.GetObjectInfo(ctx, bucket, object, opts)
 		},
 		GetObjectNInfoFn: func(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error) {
-			return newObjectLayerFn().GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
+			return globalObjectAPI.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
 		},
 		DeleteObjectFn: func(ctx context.Context, bucket, object string) error {
-			return newObjectLayerFn().DeleteObject(ctx, bucket, object)
+			return globalObjectAPI.DeleteObject(ctx, bucket, object)
 		},
 		DeleteObjectsFn: func(ctx context.Context, bucket string, objects []string) ([]error, error) {
 			errs := make([]error, len(objects))
 			for idx, object := range objects {
-				errs[idx] = newObjectLayerFn().DeleteObject(ctx, bucket, object)
+				errs[idx] = globalObjectAPI.DeleteObject(ctx, bucket, object)
 			}
 			return errs, nil
 		},
 		PutObjectFn: func(ctx context.Context, bucket, object string, data *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error) {
-			return newObjectLayerFn().PutObject(ctx, bucket, object, data, opts)
+			return globalObjectAPI.PutObject(ctx, bucket, object, data, opts)
 		},
 	}
 	if migrateSw {

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -32,7 +32,6 @@ import (
 	"github.com/minio/cli"
 	"github.com/minio/minio-go/v6/pkg/set"
 	"github.com/minio/minio/cmd/config"
-	"github.com/minio/minio/cmd/config/etcd"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/env"
 	"github.com/minio/minio/pkg/mountinfo"
@@ -590,10 +589,8 @@ func CreateEndpoints(serverAddr string, args ...[]string) (string, EndpointList,
 		return serverAddr, endpoints, setupType, err
 	}
 
-	_, dok := env.Lookup(config.EnvDomain)
-	_, eok := env.Lookup(etcd.EnvEtcdEndpoints)
-	_, iok := env.Lookup(config.EnvPublicIPs)
-	if dok && eok && !iok {
+	publicIPs := env.Get(config.EnvPublicIPs, "")
+	if len(publicIPs) == 0 {
 		updateDomainIPs(uniqueArgs)
 	}
 

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -374,15 +374,6 @@ func parseGatewaySSE(s string) (gatewaySSE, error) {
 
 // handle gateway env vars
 func handleGatewayEnvVars() {
-	gwsseVal, ok := env.Lookup("MINIO_GATEWAY_SSE")
-	if ok {
-		var err error
-		GlobalGatewaySSE, err = parseGatewaySSE(gwsseVal)
-		if err != nil {
-			logger.Fatal(err, "Unable to parse MINIO_GATEWAY_SSE value (`%s`)", gwsseVal)
-		}
-	}
-
 	accessKey := env.Get(config.EnvAccessKey, "")
 	secretKey := env.Get(config.EnvSecretKey, "")
 	cred, err := auth.CreateCredentials(accessKey, secretKey)
@@ -391,4 +382,13 @@ func handleGatewayEnvVars() {
 			"Unable to validate credentials inherited from the shell environment")
 	}
 	globalActiveCred = cred
+
+	gwsseVal := env.Get("MINIO_GATEWAY_SSE", "")
+	if len(gwsseVal) != 0 {
+		var err error
+		GlobalGatewaySSE, err = parseGatewaySSE(gwsseVal)
+		if err != nil {
+			logger.Fatal(err, "Unable to parse MINIO_GATEWAY_SSE value (`%s`)", gwsseVal)
+		}
+	}
 }

--- a/cmd/gateway-startup-msg.go
+++ b/cmd/gateway-startup-msg.go
@@ -28,9 +28,8 @@ import (
 func printGatewayStartupMessage(apiEndPoints []string, backendType string) {
 	strippedAPIEndpoints := stripStandardPorts(apiEndPoints)
 	// If cache layer is enabled, print cache capacity.
-	cacheObjectAPI := newCacheObjectsFn()
-	if cacheObjectAPI != nil {
-		printCacheStorageInfo(cacheObjectAPI.StorageInfo(context.Background()))
+	if globalCacheObjectAPI != nil {
+		printCacheStorageInfo(globalCacheObjectAPI.StorageInfo(context.Background()))
 	}
 	// Prints credential.
 	printGatewayCommonMsg(strippedAPIEndpoints)

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -156,7 +156,7 @@ func execLeaderTasks(sets *xlSets) {
 func startGlobalHeal() {
 	var objAPI ObjectLayer
 	for {
-		objAPI = newObjectLayerFn()
+		objAPI = globalObjectAPI
 		if objAPI == nil {
 			time.Sleep(time.Second)
 			continue

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -251,6 +251,11 @@ var (
 	globalBackgroundHealRoutine *healRoutine
 	globalBackgroundHealState   *allHealState
 
+	// Only enabled when one of the sub-systems fail
+	// to initialize, this allows for administrators to
+	// fix the system.
+	globalSafeMode bool
+
 	// Add new variable global values here.
 )
 

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -52,9 +52,9 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "LivenessCheckHandler")
 
-	objLayer := newObjectLayerFn()
+	objLayer := globalObjectAPI
 	// Service not initialized yet
-	if objLayer == nil {
+	if objLayer == nil || globalSafeMode {
 		// Respond with 200 OK while server initializes to ensure a distributed cluster
 		// is able to start on orchestration platforms like Docker Swarm.
 		// Refer https://github.com/minio/minio/issues/8140 for more details.

--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -47,7 +47,7 @@ func (iamOS *IAMObjectStore) getObjectAPI() ObjectLayer {
 	if iamOS.objAPI != nil {
 		return iamOS.objAPI
 	}
-	return newObjectLayerFn()
+	return globalObjectAPI
 }
 
 func (iamOS *IAMObjectStore) setObjectAPI(objAPI ObjectLayer) {

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -406,7 +406,7 @@ func (sys *IAMSys) Init(objAPI ObjectLayer) error {
 
 // DeletePolicy - deletes a canned policy from backend or etcd.
 func (sys *IAMSys) DeletePolicy(policyName string) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -431,7 +431,7 @@ func (sys *IAMSys) DeletePolicy(policyName string) error {
 
 // InfoPolicy - expands the canned policy into its JSON structure.
 func (sys *IAMSys) InfoPolicy(policyName string) ([]byte, error) {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return nil, errServerNotInitialized
 	}
@@ -448,7 +448,7 @@ func (sys *IAMSys) InfoPolicy(policyName string) ([]byte, error) {
 
 // ListPolicies - lists all canned policies.
 func (sys *IAMSys) ListPolicies() (map[string][]byte, error) {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return nil, errServerNotInitialized
 	}
@@ -471,7 +471,7 @@ func (sys *IAMSys) ListPolicies() (map[string][]byte, error) {
 
 // SetPolicy - sets a new name policy.
 func (sys *IAMSys) SetPolicy(policyName string, p iampolicy.Policy) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -492,7 +492,7 @@ func (sys *IAMSys) SetPolicy(policyName string, p iampolicy.Policy) error {
 
 // DeleteUser - delete user (only for long-term users not STS users).
 func (sys *IAMSys) DeleteUser(accessKey string) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -521,7 +521,7 @@ func (sys *IAMSys) DeleteUser(accessKey string) error {
 
 // SetTempUser - set temporary user credentials, these credentials have an expiry.
 func (sys *IAMSys) SetTempUser(accessKey string, cred auth.Credentials, policyName string) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -561,7 +561,7 @@ func (sys *IAMSys) SetTempUser(accessKey string, cred auth.Credentials, policyNa
 
 // ListUsers - list all users.
 func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return nil, errServerNotInitialized
 	}
@@ -587,7 +587,7 @@ func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
 
 // GetUserInfo - get info on a user.
 func (sys *IAMSys) GetUserInfo(name string) (u madmin.UserInfo, err error) {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return u, errServerNotInitialized
 	}
@@ -617,7 +617,7 @@ func (sys *IAMSys) GetUserInfo(name string) (u madmin.UserInfo, err error) {
 
 // SetUserStatus - sets current user status, supports disabled or enabled.
 func (sys *IAMSys) SetUserStatus(accessKey string, status madmin.AccountStatus) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -653,7 +653,7 @@ func (sys *IAMSys) SetUserStatus(accessKey string, status madmin.AccountStatus) 
 
 // SetUser - set user credentials and policy.
 func (sys *IAMSys) SetUser(accessKey string, uinfo madmin.UserInfo) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -685,7 +685,7 @@ func (sys *IAMSys) SetUser(accessKey string, uinfo madmin.UserInfo) error {
 
 // SetUserSecretKey - sets user secret key
 func (sys *IAMSys) SetUserSecretKey(accessKey string, secretKey string) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -724,7 +724,7 @@ func (sys *IAMSys) GetUser(accessKey string) (cred auth.Credentials, ok bool) {
 // AddUsersToGroup - adds users to a group, creating the group if
 // needed. No error if user(s) already are in the group.
 func (sys *IAMSys) AddUsersToGroup(group string, members []string) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -782,7 +782,7 @@ func (sys *IAMSys) AddUsersToGroup(group string, members []string) error {
 // RemoveUsersFromGroup - remove users from group. If no users are
 // given, and the group is empty, deletes the group as well.
 func (sys *IAMSys) RemoveUsersFromGroup(group string, members []string) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -863,7 +863,7 @@ func (sys *IAMSys) RemoveUsersFromGroup(group string, members []string) error {
 
 // SetGroupStatus - enable/disabled a group
 func (sys *IAMSys) SetGroupStatus(group string, enabled bool) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -952,7 +952,7 @@ func (sys *IAMSys) ListGroups() (r []string, err error) {
 // PolicyDB. This function applies only long-term users. For STS
 // users, policy is set directly by called sys.policyDBSet().
 func (sys *IAMSys) PolicyDBSet(name, policy string, isGroup bool) error {
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return errServerNotInitialized
 	}
@@ -1007,7 +1007,7 @@ func (sys *IAMSys) PolicyDBGet(name string, isGroup bool) ([]string, error) {
 		return nil, errInvalidArgument
 	}
 
-	objectAPI := newObjectLayerFn()
+	objectAPI := globalObjectAPI
 	if objectAPI == nil {
 		return nil, errServerNotInitialized
 	}

--- a/cmd/lifecycle.go
+++ b/cmd/lifecycle.go
@@ -59,7 +59,7 @@ func (sys *LifecycleSys) Get(bucketName string) (lifecycle lifecycle.Lifecycle, 
 	if globalIsGateway {
 		// When gateway is enabled, no cached value
 		// is used to validate life cycle policies.
-		objAPI := newObjectLayerFn()
+		objAPI := globalObjectAPI
 		if objAPI == nil {
 			return
 		}

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -83,9 +83,9 @@ func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
 	minioVersionInfo.WithLabelValues(Version, CommitID).Set(float64(1.0))
 
 	// Fetch disk space info
-	objLayer := newObjectLayerFn()
+	objLayer := globalObjectAPI
 	// Service not initialized yet
-	if objLayer == nil {
+	if objLayer == nil || globalSafeMode {
 		return
 	}
 

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1098,10 +1098,10 @@ func (sys *NotificationSys) NetworkInfo() []madmin.ServerNetworkHardwareInfo {
 }
 
 // NewNotificationSys - creates new notification system object.
-func NewNotificationSys(cfg config.Config, endpoints EndpointList) *NotificationSys {
+func NewNotificationSys(cfg config.Config, endpoints EndpointList) (*NotificationSys, error) {
 	targetList, err := notify.GetNotificationTargets(cfg, GlobalServiceDoneCh, globalRootCAs)
 	if err != nil {
-		logger.FatalIf(err, "Unable to start notification sub system")
+		return nil, config.Errorf("Unable to start notification sub system: %s", err)
 	}
 
 	remoteHosts := getRemoteHosts(endpoints)
@@ -1113,7 +1113,7 @@ func NewNotificationSys(cfg config.Config, endpoints EndpointList) *Notification
 		bucketRulesMap:             make(map[string]event.RulesMap),
 		bucketRemoteTargetRulesMap: make(map[string]map[event.TargetID]event.RulesMap),
 		peerClients:                remoteClients,
-	}
+	}, nil
 }
 
 type eventArgs struct {

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -44,7 +44,7 @@ const (
 // Global object layer mutex, used for safely updating object layer.
 var globalObjLayerMutex *sync.RWMutex
 
-// Global object layer, only accessed by newObjectLayerFn().
+// Global object layer, only accessed by globalObjectAPI.
 var globalObjectAPI ObjectLayer
 
 //Global cacheObjects, only accessed by newCacheObjectsFn().

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -46,8 +46,8 @@ func getServerInfo() (*ServerInfoData, error) {
 		return nil, errServerNotInitialized
 	}
 
-	objLayer := newObjectLayerFn()
-	if objLayer == nil {
+	objLayer := globalObjectAPI
+	if objLayer == nil || globalSafeMode {
 		return nil, errServerNotInitialized
 	}
 
@@ -166,7 +166,7 @@ func (s *peerRESTServer) DeletePolicyHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	objAPI := newObjectLayerFn()
+	objAPI := globalObjectAPI
 	if objAPI == nil {
 		s.writeErrorResponse(w, errServerNotInitialized)
 		return
@@ -194,7 +194,7 @@ func (s *peerRESTServer) LoadPolicyHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	objAPI := newObjectLayerFn()
+	objAPI := globalObjectAPI
 	if objAPI == nil {
 		s.writeErrorResponse(w, errServerNotInitialized)
 		return
@@ -222,7 +222,7 @@ func (s *peerRESTServer) LoadPolicyMappingHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	objAPI := newObjectLayerFn()
+	objAPI := globalObjectAPI
 	if objAPI == nil {
 		s.writeErrorResponse(w, errServerNotInitialized)
 		return
@@ -251,7 +251,7 @@ func (s *peerRESTServer) DeleteUserHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	objAPI := newObjectLayerFn()
+	objAPI := globalObjectAPI
 	if objAPI == nil {
 		s.writeErrorResponse(w, errServerNotInitialized)
 		return
@@ -279,7 +279,7 @@ func (s *peerRESTServer) LoadUserHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	objAPI := newObjectLayerFn()
+	objAPI := globalObjectAPI
 	if objAPI == nil {
 		s.writeErrorResponse(w, errServerNotInitialized)
 		return
@@ -329,7 +329,7 @@ func (s *peerRESTServer) LoadGroupHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	objAPI := newObjectLayerFn()
+	objAPI := globalObjectAPI
 	if objAPI == nil {
 		s.writeErrorResponse(w, errServerNotInitialized)
 		return
@@ -539,7 +539,7 @@ func (s *peerRESTServer) ReloadFormatHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	objAPI := newObjectLayerFn()
+	objAPI := globalObjectAPI
 	if objAPI == nil {
 		s.writeErrorResponse(w, errServerNotInitialized)
 		return

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -69,7 +69,7 @@ func (sys *PolicySys) IsAllowed(args policy.Args) bool {
 	if globalIsGateway {
 		// When gateway is enabled, no cached value
 		// is used to validate bucket policies.
-		objAPI := newObjectLayerFn()
+		objAPI := globalObjectAPI
 		if objAPI != nil {
 			config, err := objAPI.GetBucketPolicy(context.Background(), args.BucketName)
 			if err == nil {

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -22,17 +22,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func newObjectLayerFn() (layer ObjectLayer) {
-	globalObjLayerMutex.RLock()
-	layer = globalObjectAPI
-	globalObjLayerMutex.RUnlock()
-	return
-}
-
-func newCacheObjectsFn() CacheObjectLayer {
-	return globalCacheObjectAPI
-}
-
 // Composed function registering routers for only distributed XL setup.
 func registerDistXLRouters(router *mux.Router, endpoints EndpointList) {
 	// Register storage rpc router only if its a distributed setup.

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -50,12 +50,11 @@ func printStartupMessage(apiEndPoints []string) {
 
 	strippedAPIEndpoints := stripStandardPorts(apiEndPoints)
 	// If cache layer is enabled, print cache capacity.
-	cacheObjectAPI := newCacheObjectsFn()
-	if cacheObjectAPI != nil {
-		printCacheStorageInfo(cacheObjectAPI.StorageInfo(context.Background()))
+	if globalCacheObjectAPI != nil {
+		printCacheStorageInfo(globalCacheObjectAPI.StorageInfo(context.Background()))
 	}
 	// Object layer is initialized then print StorageInfo.
-	objAPI := newObjectLayerFn()
+	objAPI := globalObjectAPI
 	if objAPI != nil {
 		printStorageInfo(objAPI.StorageInfo(context.Background()))
 	}
@@ -97,7 +96,7 @@ func stripStandardPorts(apiEndpoints []string) (newAPIEndpoints []string) {
 	newAPIEndpoints = make([]string, len(apiEndpoints))
 	// Check all API endpoints for standard ports and strip them.
 	for i, apiEndpoint := range apiEndpoints {
-		u, err := xnet.ParseURL(apiEndpoint)
+		u, err := xnet.ParseHTTPURL(apiEndpoint)
 		if err != nil {
 			newAPIEndpoints[i] = apiEndpoint
 			continue

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -55,7 +55,7 @@ func handleSignals() {
 		// send signal to various go-routines that they need to quit.
 		close(GlobalServiceDoneCh)
 
-		if objAPI := newObjectLayerFn(); objAPI != nil {
+		if objAPI := globalObjectAPI; objAPI != nil {
 			oerr = objAPI.Shutdown(context.Background())
 			logger.LogIf(context.Background(), oerr)
 		}
@@ -66,7 +66,7 @@ func handleSignals() {
 	for {
 		select {
 		case err := <-globalHTTPServerErrorCh:
-			if objAPI := newObjectLayerFn(); objAPI != nil {
+			if objAPI := globalObjectAPI; objAPI != nil {
 				objAPI.Shutdown(context.Background())
 			}
 			if err != nil {

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -498,7 +498,7 @@ func newStorageRESTHTTPServerClient(t *testing.T) (*httptest.Server, *storageRES
 	router := mux.NewRouter()
 	httpServer := httptest.NewServer(router)
 
-	url, err := xnet.ParseURL(httpServer.URL)
+	url, err := xnet.ParseHTTPURL(httpServer.URL)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/cmd/web-router.go
+++ b/cmd/web-router.go
@@ -62,8 +62,18 @@ const specialAssets = "index_bundle.*.js|loader.css|logo.svg|firefox.png|safari.
 func registerWebRouter(router *mux.Router) error {
 	// Initialize Web.
 	web := &webAPIHandlers{
-		ObjectAPI: newObjectLayerFn,
-		CacheAPI:  newCacheObjectsFn,
+		ObjectAPI: func() ObjectLayer {
+			if !globalSafeMode {
+				return globalObjectAPI
+			}
+			return nil
+		},
+		CacheAPI: func() CacheObjectLayer {
+			if !globalSafeMode {
+				return globalCacheObjectAPI
+			}
+			return nil
+		},
 	}
 
 	// Initialize a new json2 codec.

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -3,25 +3,46 @@ package env
 import (
 	"os"
 	"strings"
+	"sync"
 )
+
+var (
+	privateMutex sync.RWMutex
+	envOff       bool
+)
+
+// SetEnvOff - turns off env lookup
+func SetEnvOff() {
+	privateMutex.Lock()
+	defer privateMutex.Unlock()
+
+	envOff = true
+}
+
+// SetEnvOn - turns on env lookup
+func SetEnvOn() {
+	privateMutex.Lock()
+	defer privateMutex.Unlock()
+
+	envOff = false
+}
 
 // Get retrieves the value of the environment variable named
 // by the key. If the variable is present in the environment the
 // value (which may be empty) is returned. Otherwise it returns
 // the specified default value.
 func Get(key, defaultValue string) string {
+	privateMutex.RLock()
+	ok := envOff
+	privateMutex.RUnlock()
+	if ok {
+		return defaultValue
+	}
 	if v, ok := os.LookupEnv(key); ok {
 		return v
 	}
 	return defaultValue
 }
-
-// Lookup retrieves the value of the environment variable named
-// by the key. If the variable is present in the environment the
-// value (which may be empty) is returned and the boolean is true.
-// Otherwise the returned value will be empty and the boolean will
-// be false.
-func Lookup(key string) (string, bool) { return os.LookupEnv(key) }
 
 // List all envs with a given prefix.
 func List(prefix string) (envs []string) {

--- a/pkg/event/target/webhook.go
+++ b/pkg/event/target/webhook.go
@@ -98,7 +98,7 @@ func (target *WebhookTarget) Save(eventData event.Event) error {
 	if target.store != nil {
 		return target.store.Put(eventData)
 	}
-	u, pErr := xnet.ParseURL(target.args.Endpoint.String())
+	u, pErr := xnet.ParseHTTPURL(target.args.Endpoint.String())
 	if pErr != nil {
 		return pErr
 	}
@@ -153,7 +153,7 @@ func (target *WebhookTarget) send(eventData event.Event) error {
 
 // Send - reads an event from store and sends it to webhook.
 func (target *WebhookTarget) Send(eventKey string) error {
-	u, pErr := xnet.ParseURL(target.args.Endpoint.String())
+	u, pErr := xnet.ParseHTTPURL(target.args.Endpoint.String())
 	if pErr != nil {
 		return pErr
 	}

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -19,6 +19,7 @@ package net
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -101,6 +102,21 @@ func (u URL) DialHTTP() error {
 	}
 	resp.Body.Close()
 	return nil
+}
+
+// ParseHTTPURL - parses a string into HTTP URL, string is
+// expected to be of form http:// or https://
+func ParseHTTPURL(s string) (u *URL, err error) {
+	u, err = ParseURL(s)
+	if err != nil {
+		return nil, err
+	}
+	switch u.Scheme {
+	default:
+		return nil, fmt.Errorf("unexpected scheme found %s", u.Scheme)
+	case "http", "https":
+		return u, nil
+	}
 }
 
 // ParseURL - parses string into URL.

--- a/pkg/net/url_test.go
+++ b/pkg/net/url_test.go
@@ -133,6 +133,42 @@ func TestURLUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestParseHTTPURL(t *testing.T) {
+	testCases := []struct {
+		s           string
+		expectedURL *URL
+		expectErr   bool
+	}{
+		{"http://play", &URL{Scheme: "http", Host: "play"}, false},
+		{"https://play.min.io:0", &URL{Scheme: "https", Host: "play.min.io:0"}, false},
+		{"https://147.75.201.93:9000/", &URL{Scheme: "https", Host: "147.75.201.93:9000", Path: "/"}, false},
+		{"https://s3.amazonaws.com/?location", &URL{Scheme: "https", Host: "s3.amazonaws.com", Path: "/", RawQuery: "location"}, false},
+		{"http://myminio:10000/mybucket//myobject/", &URL{Scheme: "http", Host: "myminio:10000", Path: "/mybucket/myobject/"}, false},
+		{"ftp://myftp.server:10000/myuser", nil, true},
+		{"https://my.server:10000000/myuser", nil, true},
+		{"myserver:1000", nil, true},
+		{"http://:1000/mybucket", nil, true},
+		{"https://147.75.201.93:90000/", nil, true},
+		{"http:/play", nil, true},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.s, func(t *testing.T) {
+			url, err := ParseHTTPURL(testCase.s)
+			expectErr := (err != nil)
+			if expectErr != testCase.expectErr {
+				t.Fatalf("error: expected: %v, got: %v", testCase.expectErr, expectErr)
+			}
+			if !testCase.expectErr {
+				if !reflect.DeepEqual(url, testCase.expectedURL) {
+					t.Fatalf("host: expected: %#v, got: %#v", testCase.expectedURL, url)
+				}
+			}
+		})
+	}
+}
+
 func TestParseURL(t *testing.T) {
 	testCases := []struct {
 		s           string


### PR DESCRIPTION
## Description
Extend further validation of config values

## Motivation and Context
- This PR allows config KVS to be validated properly
  without being affected by ENV overrides, rejects
  invalid values to be not set into config.

- Expands unit tests and refactors the error handling
  for notification targets, returns error instead of
  ignoring targets for invalid KVS

- Does all the prep-work for implementing safe-mode
  style operation for MinIO server, introduces a new
  global variable to toggling safe mode based operations
  NOTE: this PR itself doesn't provide safe mode operations

## How to test this PR?
Specifically, this PR fixes situations like this https://github.com/minio/minio/issues/8434#issuecomment-547759190

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
