### PR TITLE
Do not join the peer endpoints for fs/xl disk paths in StorageInfo

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -252,12 +252,11 @@ func (fs *FSObjects) StorageInfo(ctx context.Context) StorageInfo {
 	if !fs.diskMount {
 		used = atomic.LoadUint64(&fs.totalUsed)
 	}
-	localPeer := GetLocalPeer(globalEndpoints)
 	storageInfo := StorageInfo{
 		Used:       []uint64{used},
 		Total:      []uint64{di.Total},
 		Available:  []uint64{di.Free},
-		MountPaths: []string{localPeer + fs.fsPath},
+		MountPaths: []string{fs.fsPath},
 	}
 	storageInfo.Backend.Type = BackendFS
 	return storageInfo

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -99,6 +99,10 @@ func getDisksInfo(disks []StorageAPI) (disksInfo []DiskInfo, onlineDisks, offlin
 
 	getPeerAddress := func(diskPath string) (string, error) {
 		hostPort := strings.Split(diskPath, SlashSeparator)[0]
+		// Host will be empty for xl/fs disk paths.
+		if hostPort == "" {
+			return "", nil
+		}
 		thisAddr, err := xnet.ParseHost(hostPort)
 		if err != nil {
 			return "", err
@@ -111,6 +115,7 @@ func getDisksInfo(disks []StorageAPI) (disksInfo []DiskInfo, onlineDisks, offlin
 	// Wait for the routines.
 	for i, err := range g.Wait() {
 		peerAddr, pErr := getPeerAddress(disksInfo[i].RelativePath)
+
 		if pErr != nil {
 			continue
 		}
@@ -122,6 +127,7 @@ func getDisksInfo(disks []StorageAPI) (disksInfo []DiskInfo, onlineDisks, offlin
 		}
 		if err != nil {
 			offlineDisks[peerAddr]++
+			continue
 		}
 		onlineDisks[peerAddr]++
 	}

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/klauspost/reedsolomon v1.9.3
 	github.com/kurin/blazer v0.5.4-0.20190613185654-cf2f27cc0be3
 	github.com/lib/pq v1.0.0
-	github.com/mattn/go-isatty v0.0.7
 	github.com/miekg/dns v1.1.8
 	github.com/minio/cli v1.22.0
 	github.com/minio/dsync/v2 v2.0.0


### PR DESCRIPTION
## Description
Append peer endpoints only for remote disks. 

## Motivation and Context
Fixes a bug introduced in StorageInfo changes - 7873

## How to test this PR?
`mc admin info server` will report `Storage: Used 0 B, Free 0 B` for XL/FS (Not for Dist XL)
The corresponding mc change is in https://github.com/minio/mc/pull/2947

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
