### PR TITLE
Migrate all backend at .minio.sys/config to encrypted backend

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/minio/minio-go/v6/pkg/set"
 	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/certs"
 	"github.com/minio/minio/pkg/env"
 )
@@ -202,6 +203,18 @@ func handleCommonEnvVars() {
 	// or is not set to 'off', if MINIO_UPDATE is set to 'off' then
 	// in-place update is off.
 	globalInplaceUpdateDisabled = strings.EqualFold(env.Get(config.EnvUpdate, config.StateOn), config.StateOff)
+
+	accessKey := env.Get(config.EnvAccessKey, "")
+	secretKey := env.Get(config.EnvSecretKey, "")
+	if accessKey != "" && secretKey != "" {
+		cred, err := auth.CreateCredentials(accessKey, secretKey)
+		if err != nil {
+			logger.Fatal(config.ErrInvalidCredentials(err),
+				"Unable to validate credentials inherited from the shell environment")
+		}
+		globalActiveCred = cred
+		globalConfigEncrypted = true
+	}
 }
 
 func logStartupMessage(msg string) {

--- a/cmd/config-encrypted.go
+++ b/cmd/config-encrypted.go
@@ -1,0 +1,308 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	etcd "github.com/coreos/etcd/clientv3"
+	"github.com/minio/minio/cmd/config"
+	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/auth"
+	"github.com/minio/minio/pkg/env"
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func handleEncryptedConfigBackend(objAPI ObjectLayer, server bool) error {
+	if !server {
+		return nil
+	}
+
+	// If its server mode or nas gateway, migrate the backend.
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+
+	var encrypted bool
+	var err error
+
+	// Migrating Config backend needs a retry mechanism for
+	// the following reasons:
+	//  - Read quorum is lost just after the initialization
+	//    of the object layer.
+	for range newRetryTimerSimple(doneCh) {
+		if encrypted, err = checkBackendEncrypted(objAPI); err != nil {
+			if err == errDiskNotFound ||
+				strings.Contains(err.Error(), InsufficientReadQuorum{}.Error()) ||
+				strings.Contains(err.Error(), InsufficientWriteQuorum{}.Error()) {
+				logger.Info("Waiting for config backend to be encrypted..")
+				continue
+			}
+			return err
+		}
+		break
+	}
+
+	if encrypted {
+		// backend is encrypted, but credentials are not specified
+		// we shall fail right here. if not proceed forward.
+		if !globalConfigEncrypted || !globalActiveCred.IsValid() {
+			return config.ErrMissingCredentialsBackendEncrypted(nil)
+		}
+	} else {
+		// backend is not yet encrypted, check if encryption of
+		// backend is requested if not return nil and proceed
+		// forward.
+		if !globalConfigEncrypted {
+			return nil
+		}
+		if !globalActiveCred.IsValid() {
+			return errInvalidArgument
+		}
+	}
+
+	accessKeyOld := env.Get(config.EnvAccessKeyOld, "")
+	secretKeyOld := env.Get(config.EnvSecretKeyOld, "")
+	var activeCredOld auth.Credentials
+	if accessKeyOld != "" && secretKeyOld != "" {
+		activeCredOld, err = auth.CreateCredentials(accessKeyOld, secretKeyOld)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Migrating Config backend needs a retry mechanism for
+	// the following reasons:
+	//  - Read quorum is lost just after the initialization
+	//    of the object layer.
+	for range newRetryTimerSimple(doneCh) {
+		// Migrate IAM configuration
+		if err = migrateConfigPrefixToEncrypted(objAPI, activeCredOld, encrypted); err != nil {
+			if err == errDiskNotFound ||
+				strings.Contains(err.Error(), InsufficientReadQuorum{}.Error()) ||
+				strings.Contains(err.Error(), InsufficientWriteQuorum{}.Error()) {
+				logger.Info("Waiting for config backend to be encrypted..")
+				continue
+			}
+			return err
+		}
+		break
+	}
+	return nil
+}
+
+const (
+	backendEncryptedFile = "backend-encrypted"
+)
+
+var (
+	backendEncryptedFileValue = []byte("encrypted")
+)
+
+func checkBackendEtcdEncrypted(ctx context.Context, client *etcd.Client) (bool, error) {
+	data, err := readKeyEtcd(ctx, client, backendEncryptedFile)
+	if err != nil && err != errConfigNotFound {
+		return false, err
+	}
+	return err == nil && bytes.Equal(data, backendEncryptedFileValue), nil
+}
+
+func checkBackendEncrypted(objAPI ObjectLayer) (bool, error) {
+	data, err := readConfig(context.Background(), objAPI, backendEncryptedFile)
+	if err != nil && err != errConfigNotFound {
+		return false, err
+	}
+	return err == nil && bytes.Equal(data, backendEncryptedFileValue), nil
+}
+
+func migrateIAMConfigsEtcdToEncrypted(client *etcd.Client) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultContextTimeout)
+	defer cancel()
+
+	encrypted, err := checkBackendEtcdEncrypted(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	if encrypted {
+		// backend is encrypted, but credentials are not specified
+		// we shall fail right here. if not proceed forward.
+		if !globalConfigEncrypted || !globalActiveCred.IsValid() {
+			return config.ErrMissingCredentialsBackendEncrypted(nil)
+		}
+	} else {
+		// backend is not yet encrypted, check if encryption of
+		// backend is requested if not return nil and proceed
+		// forward.
+		if !globalConfigEncrypted {
+			return nil
+		}
+		if !globalActiveCred.IsValid() {
+			return errInvalidArgument
+		}
+	}
+
+	accessKeyOld := env.Get(config.EnvAccessKeyOld, "")
+	secretKeyOld := env.Get(config.EnvSecretKeyOld, "")
+	var activeCredOld auth.Credentials
+	if accessKeyOld != "" && secretKeyOld != "" {
+		activeCredOld, err = auth.CreateCredentials(accessKeyOld, secretKeyOld)
+		if err != nil {
+			return err
+		}
+	}
+
+	if encrypted {
+		// No key rotation requested, and backend is
+		// already encrypted. We proceed without migration.
+		if !activeCredOld.IsValid() {
+			return nil
+		}
+
+		// No real reason to rotate if old and new creds are same.
+		if activeCredOld.Equal(globalActiveCred) {
+			return nil
+		}
+	}
+
+	if !activeCredOld.IsValid() {
+		logger.Info("Attempting a one time encrypt of all IAM users and policies on etcd")
+	} else {
+		logger.Info("Attempting a rotation of encrypted IAM users and policies on etcd with newly supplied credentials")
+	}
+
+	r, err := client.Get(ctx, minioConfigPrefix, etcd.WithPrefix(), etcd.WithKeysOnly())
+	if err != nil {
+		return err
+	}
+	for _, kv := range r.Kvs {
+		var (
+			cdata    []byte
+			cencdata []byte
+		)
+		cdata, err = readKeyEtcd(ctx, client, string(kv.Key))
+		if err != nil {
+			switch err {
+			case errConfigNotFound:
+				// Perhaps not present or someone deleted it.
+				continue
+			}
+			return err
+		}
+		// Is rotating of creds requested?
+		if activeCredOld.IsValid() {
+			cdata, err = madmin.DecryptData(activeCredOld.String(), bytes.NewReader(cdata))
+			if err != nil {
+				if err == madmin.ErrMaliciousData {
+					return config.ErrInvalidRotatingCredentialsBackendEncrypted(nil)
+				}
+				return err
+			}
+		}
+
+		cencdata, err = madmin.EncryptData(globalActiveCred.String(), cdata)
+		if err != nil {
+			return err
+		}
+
+		if err = saveKeyEtcd(ctx, client, string(kv.Key), cencdata); err != nil {
+			return err
+		}
+	}
+	return saveKeyEtcd(ctx, client, backendEncryptedFile, backendEncryptedFileValue)
+}
+
+func migrateConfigPrefixToEncrypted(objAPI ObjectLayer, activeCredOld auth.Credentials, encrypted bool) error {
+	if encrypted {
+		// No key rotation requested, and backend is
+		// already encrypted. We proceed without migration.
+		if !activeCredOld.IsValid() {
+			return nil
+		}
+
+		// No real reason to rotate if old and new creds are same.
+		if activeCredOld.Equal(globalActiveCred) {
+			return nil
+		}
+	}
+
+	if !activeCredOld.IsValid() {
+		logger.Info("Attempting a one time encrypt of all config, IAM users and policies on MinIO backend")
+	} else {
+		logger.Info("Attempting a rotation of encrypted config, IAM users and policies on MinIO with newly supplied credentials")
+	}
+
+	// Construct path to config/transaction.lock for locking
+	transactionConfigPrefix := minioConfigPrefix + "/transaction.lock"
+
+	// As object layer's GetObject() and PutObject() take respective lock on minioMetaBucket
+	// and configFile, take a transaction lock to avoid data race between readConfig()
+	// and saveConfig().
+	objLock := globalNSMutex.NewNSLock(context.Background(), minioMetaBucket, transactionConfigPrefix)
+	if err := objLock.GetLock(globalOperationTimeout); err != nil {
+		return err
+	}
+	defer objLock.Unlock()
+
+	var marker string
+	for {
+		res, err := objAPI.ListObjects(context.Background(), minioMetaBucket, minioConfigPrefix, marker, "", maxObjectList)
+		if err != nil {
+			return err
+		}
+		for _, obj := range res.Objects {
+			var (
+				cdata    []byte
+				cencdata []byte
+			)
+
+			cdata, err = readConfig(context.Background(), objAPI, obj.Name)
+			if err != nil {
+				return err
+			}
+
+			// Is rotating of creds requested?
+			if activeCredOld.IsValid() {
+				cdata, err = madmin.DecryptData(activeCredOld.String(), bytes.NewReader(cdata))
+				if err != nil {
+					if err == madmin.ErrMaliciousData {
+						return config.ErrInvalidRotatingCredentialsBackendEncrypted(nil)
+					}
+					return err
+				}
+			}
+
+			cencdata, err = madmin.EncryptData(globalActiveCred.String(), cdata)
+			if err != nil {
+				return err
+			}
+
+			if err = saveConfig(context.Background(), objAPI, obj.Name, cencdata); err != nil {
+				return err
+			}
+		}
+
+		if !res.IsTruncated {
+			break
+		}
+
+		marker = res.NextMarker
+	}
+
+	return saveConfig(context.Background(), objAPI, backendEncryptedFile, backendEncryptedFileValue)
+}

--- a/cmd/config/constants.go
+++ b/cmd/config/constants.go
@@ -23,13 +23,15 @@ const (
 
 // Top level common ENVs
 const (
-	EnvAccessKey  = "MINIO_ACCESS_KEY"
-	EnvSecretKey  = "MINIO_SECRET_KEY"
-	EnvBrowser    = "MINIO_BROWSER"
-	EnvDomain     = "MINIO_DOMAIN"
-	EnvRegionName = "MINIO_REGION_NAME"
-	EnvPublicIPs  = "MINIO_PUBLIC_IPS"
-	EnvEndpoints  = "MINIO_ENDPOINTS"
+	EnvAccessKey    = "MINIO_ACCESS_KEY"
+	EnvSecretKey    = "MINIO_SECRET_KEY"
+	EnvAccessKeyOld = "MINIO_ACCESS_KEY_OLD"
+	EnvSecretKeyOld = "MINIO_SECRET_KEY_OLD"
+	EnvBrowser      = "MINIO_BROWSER"
+	EnvDomain       = "MINIO_DOMAIN"
+	EnvRegionName   = "MINIO_REGION_NAME"
+	EnvPublicIPs    = "MINIO_PUBLIC_IPS"
+	EnvEndpoints    = "MINIO_ENDPOINTS"
 
 	EnvUpdate    = "MINIO_UPDATE"
 	EnvWormState = "MINIO_WORM_STATE"

--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -72,6 +72,24 @@ var (
 		"MINIO_CACHE_ENCRYPTION_MASTER_KEY: For more information, please refer to https://docs.min.io/docs/minio-disk-cache-guide",
 	)
 
+	ErrInvalidRotatingCredentialsBackendEncrypted = newErrFn(
+		"Invalid rotating credentials",
+		"Please set correct rotating credentials in the environment for decryption",
+		`Detected encrypted config backend, correct old access and secret keys should be specified via environment variables MINIO_ACCESS_KEY_OLD and MINIO_SECRET_KEY_OLD to be able to re-encrypt the MinIO config, user IAM and policies with new credentials`,
+	)
+
+	ErrInvalidCredentialsBackendEncrypted = newErrFn(
+		"Invalid credentials",
+		"Please set correct credentials in the environment for decryption",
+		`Detected encrypted config backend, correct access and secret keys should be specified via environment variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY to be able to decrypt the MinIO config, user IAM and policies`,
+	)
+
+	ErrMissingCredentialsBackendEncrypted = newErrFn(
+		"Credentials missing",
+		"Please set your credentials in the environment",
+		`Detected encrypted config backend, access and secret keys should be specified via environment variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY to be able to decrypt the MinIO config, user IAM and policies`,
+	)
+
 	ErrInvalidCredentials = newErrFn(
 		"Invalid credentials",
 		"Please provide correct credentials",

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -23,7 +23,6 @@ import (
 	"github.com/minio/minio/cmd/config"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/env"
 	"github.com/minio/minio/pkg/hash"
 	xnet "github.com/minio/minio/pkg/net"
@@ -373,15 +372,14 @@ func parseGatewaySSE(s string) (gatewaySSE, error) {
 }
 
 // handle gateway env vars
-func handleGatewayEnvVars() {
-	accessKey := env.Get(config.EnvAccessKey, "")
-	secretKey := env.Get(config.EnvSecretKey, "")
-	cred, err := auth.CreateCredentials(accessKey, secretKey)
-	if err != nil {
-		logger.Fatal(config.ErrInvalidCredentials(err),
+func gatewayHandleEnvVars() {
+	// Handle common env vars.
+	handleCommonEnvVars()
+
+	if !globalActiveCred.IsValid() {
+		logger.Fatal(config.ErrInvalidCredentials(nil),
 			"Unable to validate credentials inherited from the shell environment")
 	}
-	globalActiveCred = cred
 
 	gwsseVal := env.Get("MINIO_GATEWAY_SSE", "")
 	if len(gwsseVal) != 0 {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -186,6 +186,9 @@ var (
 
 	globalActiveCred auth.Credentials
 
+	// Indicates if config is to be encrypted
+	globalConfigEncrypted bool
+
 	globalPublicCerts []*x509.Certificate
 
 	globalDomainNames []string      // Root domains for virtual host style requests

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -523,12 +523,12 @@ func newTestConfig(bucketLocation string, obj ObjectLayer) (err error) {
 		return err
 	}
 
-	logger.Disable = true
-
 	globalActiveCred = auth.Credentials{
 		AccessKey: auth.DefaultAccessKey,
 		SecretKey: auth.DefaultSecretKey,
 	}
+
+	globalConfigEncrypted = true
 
 	// Set a default region.
 	config.SetRegion(globalServerConfig, bucketLocation)

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -32,13 +32,29 @@ $ mc tree --files ~/.minio
 You can provide a custom certs directory using `--certs-dir` command line option.
 
 #### Credentials
-On MinIO admin credentials or root credentials are only allowed to be changed using ENVs `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`.
+On MinIO admin credentials or root credentials are only allowed to be changed using ENVs namely `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`. Using the combination of these two values MinIO encrypts the config stored at the backend.
 
 ```
 export MINIO_ACCESS_KEY=minio
 export MINIO_SECRET_KEY=minio13
 minio server /data
 ```
+
+##### Rotating encryption with new credentials
+
+Additionally if you wish to change the admin credentials, then MinIO will automatically detect this and re-encrypt with new credentials as shown below. For one time only special ENVs as shown below needs to be set for rotating the encryption config.
+
+> Old ENVs are never remembered in memory and are destroyed right after they are used to migrate your existing content with new credentials. You are safe to remove them after the server as successfully started, by restarting the services once again.
+
+```
+export MINIO_ACCESS_KEY=newminio
+export MINIO_SECRET_KEY=newminio123
+export MINIO_ACCESS_KEY_OLD=minio
+export MINIO_SECRET_KEY_OLD=minio123
+minio server /data
+```
+
+Once the migration is complete and server has started successfully remove `MINIO_ACCESS_KEY_OLD` and `MINIO_SECRET_KEY_OLD` environment variables, restart the server.
 
 #### Region
 | Field                     | Type     | Description                                                                                                                                                                             |


### PR DESCRIPTION

## Description
Migrate all backend at .minio.sys/config to encrypted backend

## Motivation and Context
- Supports migrating only when the credential ENVs are set,
  so any FS mode deployments which do not have ENVs set will
  continue to remain as is.
- Credential ENVs can be rotated using MINIO_ACCESS_KEY_OLD
  and MINIO_SECRET_KEY_OLD envs, in such scenarios it allowed
  to rotate the encrypted content to a new admin key.


## How to test this PR?
As documented in docs/config/README.md

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
