### PR TITLE
Avoid ListBuckets() call instead rely on simple HTTP GET

### DIFF
--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -17,8 +17,10 @@
 package cmd
 
 import (
+	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/minio/minio/cmd/config"
 	xhttp "github.com/minio/minio/cmd/http"
@@ -285,6 +287,28 @@ func ToMinioClientCompleteParts(parts []CompletePart) []minio.CompletePart {
 		mparts[i] = ToMinioClientCompletePart(part)
 	}
 	return mparts
+}
+
+// IsBackendOnline - verifies if the backend is reachable
+// by performing a GET request on the URL. returns 'true'
+// if backend is reachable.
+func IsBackendOnline(ctx context.Context, clnt *http.Client, urlStr string) bool {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	// never follow redirects
+	clnt.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return false
+	}
+	if _, err = clnt.Do(req); err != nil {
+		return !xnet.IsNetworkOrHostDown(err)
+	}
+	return true
 }
 
 // ErrorRespToObjectError converts MinIO errors to minio object layer errors.

--- a/cmd/gateway/hdfs/gateway-hdfs.go
+++ b/cmd/gateway/hdfs/gateway-hdfs.go
@@ -227,7 +227,8 @@ func (n *hdfsObjects) StorageInfo(ctx context.Context) minio.StorageInfo {
 	}
 	sinfo := minio.StorageInfo{}
 	sinfo.Used = []uint64{fsInfo.Used}
-	sinfo.Backend.Type = minio.Unknown
+	sinfo.Backend.Type = minio.BackendGateway
+	sinfo.Backend.GatewayOnline = true
 	return sinfo
 }
 

--- a/cmd/gateway/nas/gateway-nas.go
+++ b/cmd/gateway/nas/gateway-nas.go
@@ -125,7 +125,8 @@ func (n *nasObjects) IsListenBucketSupported() bool {
 
 func (n *nasObjects) StorageInfo(ctx context.Context) minio.StorageInfo {
 	sinfo := n.ObjectLayer.StorageInfo(ctx)
-	sinfo.Backend.Type = minio.Unknown
+	sinfo.Backend.GatewayOnline = sinfo.Backend.Type == minio.BackendFS
+	sinfo.Backend.Type = minio.BackendGateway
 	return sinfo
 }
 

--- a/cmd/gateway/oss/gateway-oss.go
+++ b/cmd/gateway/oss/gateway-oss.go
@@ -145,7 +145,9 @@ func (g *OSS) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error)
 	if err != nil {
 		return nil, err
 	}
-
+	client.HTTPClient = &http.Client{
+		Transport: minio.NewCustomHTTPTransport(),
+	}
 	return &ossObjects{
 		Client: client,
 	}, nil
@@ -341,7 +343,9 @@ func (l *ossObjects) Shutdown(ctx context.Context) error {
 
 // StorageInfo is not relevant to OSS backend.
 func (l *ossObjects) StorageInfo(ctx context.Context) (si minio.StorageInfo) {
-	return
+	si.Backend.Type = minio.BackendGateway
+	si.Backend.GatewayOnline = minio.IsBackendOnline(ctx, l.Client.HTTPClient, l.Client.Config.Endpoint)
+	return si
 }
 
 // ossIsValidBucketName verifies whether a bucket name is valid.

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -59,18 +59,15 @@ func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 		// is able to start on orchestration platforms like Docker Swarm.
 		// Refer https://github.com/minio/minio/issues/8140 for more details.
 		// Make sure to add server not initialized status in header
-		w.Header().Set(xhttp.MinIOServerStatus, "Server-not-initialized")
+		w.Header().Set(xhttp.MinIOServerStatus, "server-not-initialized")
 		writeSuccessResponseHeadersOnly(w)
 		return
 	}
 
 	if !globalIsXL && !globalIsDistXL {
 		s := objLayer.StorageInfo(ctx)
-		// Gateways don't provide disk info.
-		if s.Backend.Type == Unknown {
-			// ListBuckets to confirm gateway backend is up
-			if _, err := objLayer.ListBuckets(ctx); err != nil {
-				logger.LogOnceIf(ctx, err, struct{}{})
+		if s.Backend.Type == BackendGateway {
+			if !s.Backend.GatewayOnline {
 				writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
 				return
 			}

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -34,6 +34,8 @@ const (
 	BackendFS
 	// Multi disk BackendErasure (single, distributed) backend.
 	BackendErasure
+	// Gateway backend.
+	BackendGateway
 	// Add your own backend.
 )
 
@@ -49,8 +51,11 @@ type StorageInfo struct {
 
 	// Backend type.
 	Backend struct {
-		// Represents various backend types, currently on FS and Erasure.
+		// Represents various backend types, currently on FS, Erasure and Gateway
 		Type BackendType
+
+		// Following fields are only meaningful if BackendType is Gateway.
+		GatewayOnline bool
 
 		// Following fields are only meaningful if BackendType is Erasure.
 		OnlineDisks      madmin.BackendDisks // Online disks during server startup.


### PR DESCRIPTION


## Description
Avoid ListBuckets() call instead rely on simple HTTP GET

## Motivation and Context
This is to avoid making calls to backend and requiring
gateways to allow permissions for ListBuckets() operation
just for Liveness checks, we can avoid this and make
our liveness checks to be more performant.

## How to test this PR?
Testing with AWS S3 gateway with restrictions on the backend access for access/secret keys

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
