### PR TITLE
Enhance config restore to carry previous set content as well

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -81,7 +81,7 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 		adminRouter.Methods(http.MethodPut).Path(adminAPIVersionPrefix + "/set-config-kv").HandlerFunc(httpTraceHdrs(adminAPI.SetConfigKVHandler))
 		adminRouter.Methods(http.MethodDelete).Path(adminAPIVersionPrefix + "/del-config-kv").HandlerFunc(httpTraceHdrs(adminAPI.DelConfigKVHandler))
 		adminRouter.Methods(http.MethodGet).Path(adminAPIVersionPrefix+"/help-config-kv").HandlerFunc(httpTraceAll(adminAPI.HelpConfigKVHandler)).Queries("subSys", "{subSys:.*}", "key", "{key:.*}")
-		adminRouter.Methods(http.MethodGet).Path(adminAPIVersionPrefix + "/list-config-history-kv").HandlerFunc(httpTraceAll(adminAPI.ListConfigHistoryKVHandler))
+		adminRouter.Methods(http.MethodGet).Path(adminAPIVersionPrefix+"/list-config-history-kv").HandlerFunc(httpTraceAll(adminAPI.ListConfigHistoryKVHandler)).Queries("count", "{count:[0-9]+}")
 		adminRouter.Methods(http.MethodDelete).Path(adminAPIVersionPrefix+"/clear-config-history-kv").HandlerFunc(httpTraceHdrs(adminAPI.ClearConfigHistoryKVHandler)).Queries("restoreId", "{restoreId:.*}")
 		adminRouter.Methods(http.MethodPut).Path(adminAPIVersionPrefix+"/restore-config-history-kv").HandlerFunc(httpTraceHdrs(adminAPI.RestoreConfigHistoryKVHandler)).Queries("restoreId", "{restoreId:.*}")
 	}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/minio/minio-go/pkg/set"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/env"
+	"github.com/minio/minio/pkg/madmin"
 )
 
 // Error config error type
@@ -41,7 +42,7 @@ func (e Error) Error() string {
 
 // Default keys
 const (
-	Default = `_`
+	Default = madmin.Default
 	State   = "state"
 	Comment = "comment"
 
@@ -133,13 +134,13 @@ var SubSystemsSingleTargets = set.CreateStringSet([]string{
 
 // Constant separators
 const (
-	SubSystemSeparator = `:`
-	KvSeparator        = `=`
-	KvSpaceSeparator   = ` `
-	KvComment          = `#`
-	KvNewline          = "\n"
-	KvDoubleQuote      = `"`
-	KvSingleQuote      = `'`
+	SubSystemSeparator = madmin.SubSystemSeparator
+	KvSeparator        = madmin.KvSeparator
+	KvSpaceSeparator   = madmin.KvSpaceSeparator
+	KvComment          = madmin.KvComment
+	KvNewline          = madmin.KvNewline
+	KvDoubleQuote      = madmin.KvDoubleQuote
+	KvSingleQuote      = madmin.KvSingleQuote
 
 	// Env prefix used for all envs in MinIO
 	EnvPrefix        = "MINIO_"

--- a/pkg/madmin/config-help-commands.go
+++ b/pkg/madmin/config-help-commands.go
@@ -19,42 +19,12 @@ package madmin
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
-	"text/tabwriter"
-	"text/template"
-
-	"github.com/minio/minio/pkg/color"
 )
 
-// Help template used by all sub-systems
-const Help = `{{colorBlueBold "Key"}}{{"\t"}}{{colorBlueBold "Description"}}
-{{colorYellowBold "----"}}{{"\t"}}{{colorYellowBold "----"}}
-{{range $key, $value := .}}{{colorCyanBold $key}}{{ "\t" }}{{$value}}
-{{end}}`
-
-// HelpEnv template used by all sub-systems
-const HelpEnv = `{{colorBlueBold "KeyEnv"}}{{"\t"}}{{colorBlueBold "Description"}}
-{{colorYellowBold "----"}}{{"\t"}}{{colorYellowBold "----"}}
-{{range $key, $value := .}}{{colorCyanBold $key}}{{ "\t" }}{{$value}}
-{{end}}`
-
-var funcMap = template.FuncMap{
-	"colorBlueBold":   color.BlueBold,
-	"colorYellowBold": color.YellowBold,
-	"colorCyanBold":   color.CyanBold,
-}
-
-// HelpTemplate - captures config help template
-var HelpTemplate = template.Must(template.New("config-help").Funcs(funcMap).Parse(Help))
-
-// HelpEnvTemplate - captures config help template
-var HelpEnvTemplate = template.Must(template.New("config-help-env").Funcs(funcMap).Parse(HelpEnv))
-
 // HelpConfigKV - return help for a given sub-system.
-func (adm *AdminClient) HelpConfigKV(subSys, key string, envOnly bool) (io.Reader, error) {
+func (adm *AdminClient) HelpConfigKV(subSys, key string, envOnly bool) (map[string]string, error) {
 	v := url.Values{}
 	v.Set("subSys", subSys)
 	v.Set("key", key)
@@ -84,17 +54,5 @@ func (adm *AdminClient) HelpConfigKV(subSys, key string, envOnly bool) (io.Reade
 		return nil, err
 	}
 
-	var s strings.Builder
-	w := tabwriter.NewWriter(&s, 1, 8, 2, ' ', 0)
-	if !envOnly {
-		err = HelpTemplate.Execute(w, help)
-	} else {
-		err = HelpEnvTemplate.Execute(w, help)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	w.Flush()
-	return strings.NewReader(s.String()), nil
+	return help, nil
 }

--- a/pkg/madmin/config-kv-commands.go
+++ b/pkg/madmin/config-kv-commands.go
@@ -76,6 +76,7 @@ func (adm *AdminClient) SetConfigKV(kv string) (err error) {
 			s.WriteString(base64.RawStdEncoding.EncodeToString([]byte(comment)))
 			s.WriteString(KvDoubleQuote)
 		}
+		s.WriteString(KvNewline)
 		comment = ""
 	}
 
@@ -131,5 +132,5 @@ func (adm *AdminClient) GetConfigKV(key string) (Targets, error) {
 		return nil, err
 	}
 
-	return parseSubSysTarget(data)
+	return ParseSubSysTarget(data)
 }

--- a/pkg/madmin/parse-kv.go
+++ b/pkg/madmin/parse-kv.go
@@ -88,11 +88,11 @@ const (
 	KvSeparator        = `=`
 	KvSpaceSeparator   = ` `
 	KvComment          = `#`
+	KvNewline          = "\n"
 	KvDoubleQuote      = `"`
 	KvSingleQuote      = `'`
 
-	KvNewline = "\n"
-	Default   = `_`
+	Default = `_`
 )
 
 // This function is needed, to trim off single or double quotes, creeping into the values.
@@ -140,8 +140,8 @@ func convertTargets(s string, targets Targets) error {
 	return nil
 }
 
-// parseSubSysTarget - parse sub-system target
-func parseSubSysTarget(buf []byte) (Targets, error) {
+// ParseSubSysTarget - parse sub-system target
+func ParseSubSysTarget(buf []byte) (Targets, error) {
 	targets := make(map[string]map[string]KVS)
 	bio := bufio.NewScanner(bytes.NewReader(buf))
 	for bio.Scan() {


### PR DESCRIPTION

## Description
Enhance config restore to carry previous set content as well

## Motivation and Context
This PR brings support for `history` list to
list in the following agreed format

```
~ mc admin config history list -n 2 myminio
RestoreId: df0ebb1e-69b0-4043-b9dd-ab54508f2897
Date: Mon, 04 Nov 2019 17:27:27 GMT

region name="us-east-1" state="on"
region name="us-east-1" state="on"
region name="us-east-1" state="on"
region name="us-east-1" state="on"

RestoreId: ecc6873a-0ed3-41f9-b03e-a2a1bab48b5f
Date: Mon, 04 Nov 2019 17:28:23 GMT

region name=us-east-1 state=off
```

This PR also moves the help templating and coloring to
fully `mc` side instead of `madmin` API.


## How to test this PR?
Using the PR https://github.com/minio/mc/pull/2951

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
