### PR TITLE
Start lifecycle and background healing after object API init

### DIFF
--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -105,23 +105,13 @@ func initHealRoutine() *healRoutine {
 func startBackgroundHealing() {
 	ctx := context.Background()
 
-	var objAPI ObjectLayer
-	for {
-		objAPI = globalObjectAPI
-		if objAPI == nil {
-			time.Sleep(time.Second)
-			continue
-		}
-		break
-	}
-
 	// Run the background healer
 	globalBackgroundHealRoutine = initHealRoutine()
 	go globalBackgroundHealRoutine.run()
 
 	// Launch the background healer sequence to track
 	// background healing operations
-	info := objAPI.StorageInfo(ctx)
+	info := globalObjectAPI.StorageInfo(ctx)
 	numDisks := info.Backend.OnlineDisks.Sum() + info.Backend.OfflineDisks.Sum()
 	nh := newBgHealSequence(numDisks)
 	globalBackgroundHealState.LaunchNewHealSequence(nh)

--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -33,18 +33,7 @@ func initLocalDisksAutoHeal() {
 //  1. Only the concerned erasure set will be listed and healed
 //  2. Only the node hosting the disk is responsible to perform the heal
 func monitorLocalDisksAndHeal() {
-	// Wait until the object layer is ready
-	var objAPI ObjectLayer
-	for {
-		objAPI = globalObjectAPI
-		if objAPI == nil {
-			time.Sleep(time.Second)
-			continue
-		}
-		break
-	}
-
-	sets, ok := objAPI.(*xlSets)
+	sets, ok := globalObjectAPI.(*xlSets)
 	if !ok {
 		return
 	}

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -154,17 +154,7 @@ func execLeaderTasks(sets *xlSets) {
 }
 
 func startGlobalHeal() {
-	var objAPI ObjectLayer
-	for {
-		objAPI = globalObjectAPI
-		if objAPI == nil {
-			time.Sleep(time.Second)
-			continue
-		}
-		break
-	}
-
-	sets, ok := objAPI.(*xlSets)
+	sets, ok := globalObjectAPI.(*xlSets)
 	if !ok {
 		return
 	}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -365,6 +365,8 @@ func serverMain(ctx *cli.Context) {
 		logger.FatalIf(err, "Unable to initialize disk caching")
 	}
 
+	globalObjectAPI = newObject
+
 	initDailyLifecycle()
 
 	if globalIsXL {
@@ -372,8 +374,6 @@ func serverMain(ctx *cli.Context) {
 		initLocalDisksAutoHeal()
 		initGlobalHeal()
 	}
-
-	globalObjectAPI = newObject
 
 	// Prints the formatted startup message once object layer is initialized.
 	printStartupMessage(getAPIEndpoints())


### PR DESCRIPTION


## Description
This commit simplifies a little more the code and avoid having some
race morning due to a parallel read/write on globalObjectAPI.

## Motivation and Context
Fix #8484 

## How to test this PR?
`go build -race && ./minio server /tmp/xl/{1..4}`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
