### PR TITLE
Use AWS S3 compliant error code

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -91,7 +91,7 @@ const (
 	ErrMissingContentMD5
 	ErrMissingRequestBodyError
 	ErrNoSuchBucket
-	ErrNoSuchBucketPolicy
+	ErrNoSuchLifecycleConfiguration
 	ErrNoSuchBucketLifecycle
 	ErrNoSuchKey
 	ErrNoSuchUpload
@@ -466,8 +466,8 @@ var errorCodes = errorCodeMap{
 		Description:    "The specified bucket does not exist",
 		HTTPStatusCode: http.StatusNotFound,
 	},
-	ErrNoSuchBucketPolicy: {
-		Code:           "NoSuchBucketPolicy",
+	ErrNoSuchLifecycleConfiguration: {
+		Code:           "NoSuchLifecycleConfiguration",
 		Description:    "The bucket policy does not exist",
 		HTTPStatusCode: http.StatusNotFound,
 	},
@@ -1656,7 +1656,7 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 	case UnsupportedMetadata:
 		apiErr = ErrUnsupportedMetadata
 	case BucketPolicyNotFound:
-		apiErr = ErrNoSuchBucketPolicy
+		apiErr = ErrNoSuchLifecycleConfiguration
 	case BucketLifecycleNotFound:
 		apiErr = ErrNoSuchBucketLifecycle
 	case *event.ErrInvalidEventName:

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -341,7 +341,7 @@ func ErrorRespToObjectError(err error, params ...string) error {
 		err = BucketAlreadyOwnedByYou{}
 	case "BucketNotEmpty":
 		err = BucketNotEmpty{}
-	case "NoSuchBucketPolicy":
+	case "NoSuchLifecycleConfiguration":
 		err = BucketPolicyNotFound{}
 	case "NoSuchBucketLifecycle":
 		err = BucketLifecycleNotFound{}

--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -1449,7 +1449,7 @@ func (l *gcsGateway) GetBucketPolicy(ctx context.Context, bucket string) (*polic
 		actionSet.Add(policy.PutObjectAction)
 	}
 
-	// Return NoSuchBucketPolicy error, when policy is not set
+	// Return NoSuchLifecycleConfiguration error, when policy is not set
 	if len(actionSet) == 0 {
 		return nil, gcsToObjectError(minio.BucketPolicyNotFound{}, bucket)
 	}

--- a/cmd/gateway/s3/gateway-s3_test.go
+++ b/cmd/gateway/s3/gateway-s3_test.go
@@ -55,7 +55,7 @@ func TestS3ToObjectError(t *testing.T) {
 			expectedErr: minio.InvalidPart{},
 		},
 		{
-			inputErr:    errResponse("NoSuchBucketPolicy"),
+			inputErr:    errResponse("NoSuchLifecycleConfiguration"),
 			expectedErr: minio.BucketPolicyNotFound{},
 		},
 		{

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -1637,7 +1637,7 @@ func (web *webAPIHandlers) SetBucketPolicy(r *http.Request, args *SetBucketPolic
 		}
 		var policyStr string
 		// Use the abstracted API instead of core, such that
-		// NoSuchBucketPolicy errors are automatically handled.
+		// NoSuchLifecycleConfiguration errors are automatically handled.
 		policyStr, err = core.Client.GetBucketPolicy(args.BucketName)
 		if err != nil {
 			return toJSONError(ctx, err, args.BucketName)


### PR DESCRIPTION
## Description
This fixes #8489. But the change might be breaking for some users.

Renames the error returned when a bucket policy for a bucket does not exist/is not found.
The new error matches the one returned by S3 in the same circumstances, specified [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html)

## Motivation and Context
Explained in more detail in #8489

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
