### PR TITLE
fix loading config from openid config_url

### DIFF
--- a/cmd/config/identity/openid/jwt.go
+++ b/cmd/config/identity/openid/jwt.go
@@ -282,6 +282,13 @@ func LookupConfig(kv config.KVS, transport *http.Transport, closeRespFn func(io.
 		jwksURL = env.Get(EnvIdentityOpenIDJWKSURL, kv.Get(JwksURL))
 	}
 
+	c = Config{
+		ClaimPrefix: env.Get(EnvIdentityOpenIDClaimPrefix, kv.Get(ClaimPrefix)),
+		publicKeys:  make(map[string]crypto.PublicKey),
+		transport:   transport,
+		closeRespFn: closeRespFn,
+	}
+
 	configURL := env.Get(EnvIdentityOpenIDURL, kv.Get(ConfigURL))
 	if configURL != "" {
 		c.URL, err = xnet.ParseHTTPURL(configURL)
@@ -306,13 +313,6 @@ func LookupConfig(kv config.KVS, transport *http.Transport, closeRespFn func(io.
 	}
 	if jwksURL == "" {
 		return c, nil
-	}
-
-	c = Config{
-		ClaimPrefix: env.Get(EnvIdentityOpenIDClaimPrefix, kv.Get(ClaimPrefix)),
-		publicKeys:  make(map[string]crypto.PublicKey),
-		transport:   transport,
-		closeRespFn: closeRespFn,
 	}
 
 	c.JWKS.URL, err = xnet.ParseHTTPURL(jwksURL)


### PR DESCRIPTION
## Description
OpenID configuration is not loaded from config_url. This is now fixed.

## Motivation and Context
Users should be able to login using OpenID on browser. But this was not working due to the configuration not loaded form openid config_url

## How to test this PR?
Follow the steps mentioned here 
https://github.com/minio/minio/blob/master/docs/sts/keycloak.md

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
