### PR TITLE
Indicate backend encrypted only if encryption is requested

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -183,7 +183,9 @@ func (a adminAPIHandlers) SetConfigKVHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Make sure to write backend is encrypted
-	saveConfig(context.Background(), objectAPI, backendEncryptedFile, backendEncryptedMigrationComplete)
+	if globalConfigEncrypted {
+		saveConfig(context.Background(), objectAPI, backendEncryptedFile, backendEncryptedMigrationComplete)
+	}
 }
 
 // GetConfigKVHandler - GET /minio/admin/v2/get-config-kv?key={key}
@@ -447,7 +449,9 @@ func (a adminAPIHandlers) SetConfigHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Make sure to write backend is encrypted
-	saveConfig(context.Background(), objectAPI, backendEncryptedFile, backendEncryptedMigrationComplete)
+	if globalConfigEncrypted {
+		saveConfig(context.Background(), objectAPI, backendEncryptedFile, backendEncryptedMigrationComplete)
+	}
 
 	// Reply to the client before restarting minio server.
 	writeSuccessResponseHeadersOnly(w)

--- a/cmd/logger/config.go
+++ b/cmd/logger/config.go
@@ -193,7 +193,7 @@ func LookupConfig(scfg config.Config) (Config, error) {
 		if starget != config.Default {
 			authTokenEnv = EnvLoggerHTTPAuditAuthToken + config.Default + starget
 		}
-		cfg.HTTP[starget] = HTTP{
+		cfg.Audit[starget] = HTTP{
 			Enabled:   true,
 			Endpoint:  endpoint,
 			AuthToken: env.Get(authTokenEnv, kv.Get(AuthToken)),


### PR DESCRIPTION
## Description
Indicate backend encrypted only if encryption is requested

## Motivation and Context
Allow updating credentials in unencrypted mode

## How to test this PR?
As per mentioned steps in https://github.com/minio/minio/issues/8434#issuecomment-552630969

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in #8478 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
