### PR TITLE
Honor etcd legacy v/s new config settings properly

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -405,6 +405,9 @@ func (c Config) SetKVS(s string, defaultKVS map[string]KVS) error {
 			kvs[prevK] = strings.Join([]string{kvs[prevK], sanitizeValue(kv[0])}, KvSpaceSeparator)
 			continue
 		}
+		if len(kv) == 1 {
+			return Error(fmt.Sprintf("key '%s', cannot have empty value", kv[0]))
+		}
 		prevK = kv[0]
 		kvs[kv[0]] = sanitizeValue(kv[1])
 	}

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -578,7 +578,12 @@ func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
 	for k, v := range sys.iamUsersMap {
 		users[k] = madmin.UserInfo{
 			PolicyName: sys.iamUserPolicyMap[k].Policy,
-			Status:     madmin.AccountStatus(v.Status),
+			Status: func() madmin.AccountStatus {
+				if v.IsValid() {
+					return madmin.AccountEnabled
+				}
+				return madmin.AccountDisabled
+			}(),
 		}
 	}
 
@@ -609,8 +614,13 @@ func (sys *IAMSys) GetUserInfo(name string) (u madmin.UserInfo, err error) {
 
 	u = madmin.UserInfo{
 		PolicyName: sys.iamUserPolicyMap[name].Policy,
-		Status:     madmin.AccountStatus(creds.Status),
-		MemberOf:   sys.iamUserGroupMemberships[name].ToSlice(),
+		Status: func() madmin.AccountStatus {
+			if creds.IsValid() {
+				return madmin.AccountEnabled
+			}
+			return madmin.AccountDisabled
+		}(),
+		MemberOf: sys.iamUserGroupMemberships[name].ToSlice(),
 	}
 	return u, nil
 }

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -235,15 +235,6 @@ func initSafeModeInit(buckets []BucketInfo) (err error) {
 		return err
 	}
 
-	if globalEtcdClient != nil {
-		// ****  WARNING ****
-		// Migrating to encrypted backend on etcd should happen before initialization of
-		// IAM sub-systems, make sure that we do not move the above codeblock elsewhere.
-		if err = migrateIAMConfigsEtcdToEncrypted(globalEtcdClient); err != nil {
-			return fmt.Errorf("Unable to handle encrypted backend for iam and policies: %v", err)
-		}
-	}
-
 	return nil
 }
 
@@ -255,6 +246,15 @@ func initAllSubsystems(buckets []BucketInfo, newObject ObjectLayer) (err error) 
 
 	if err = globalNotificationSys.AddNotificationTargetsFromConfig(globalServerConfig); err != nil {
 		return fmt.Errorf("Unable to initialize notification target(s) from config: %w", err)
+	}
+
+	if globalEtcdClient != nil {
+		// ****  WARNING ****
+		// Migrating to encrypted backend on etcd should happen before initialization of
+		// IAM sub-systems, make sure that we do not move the above codeblock elsewhere.
+		if err = migrateIAMConfigsEtcdToEncrypted(globalEtcdClient); err != nil {
+			return fmt.Errorf("Unable to handle encrypted backend for iam and policies: %v", err)
+		}
 	}
 
 	if err = globalIAMSys.Init(newObject); err != nil {

--- a/pkg/madmin/parse-kv.go
+++ b/pkg/madmin/parse-kv.go
@@ -37,10 +37,23 @@ const (
 	commentKey = "comment"
 )
 
+// Count - returns total numbers of target
+func (t Targets) Count() int {
+	var count int
+	for _, targetKV := range t {
+		for range targetKV {
+			count++
+		}
+	}
+	return count
+}
+
 func (t Targets) String() string {
 	var s strings.Builder
+	count := t.Count()
 	for subSys, targetKV := range t {
 		for target, kv := range targetKV {
+			count--
 			c := kv[commentKey]
 			data, err := base64.RawStdEncoding.DecodeString(c)
 			if err == nil {
@@ -73,7 +86,7 @@ func (t Targets) String() string {
 				s.WriteString(KvDoubleQuote)
 				s.WriteString(KvSpaceSeparator)
 			}
-			if len(t) > 1 {
+			if (len(t) > 1 || len(targetKV) > 1) && count > 0 {
 				s.WriteString(KvNewline)
 				s.WriteString(KvNewline)
 			}
@@ -121,7 +134,7 @@ func convertTargets(s string, targets Targets) error {
 			kvs[prevK] = strings.Join([]string{kvs[prevK], sanitizeValue(kv[0])}, KvSpaceSeparator)
 			continue
 		}
-		if len(kv[1]) == 0 {
+		if len(kv) == 1 {
 			return fmt.Errorf("value for key '%s' cannot be empty", kv[0])
 		}
 		prevK = kv[0]


### PR DESCRIPTION


## Description
Honor etcd legacy v/s new config settings properly

## Motivation and Context
This PR also fixes issues related to

- Add proper newline for `mc admin config get` output
  for more than one targets
- Fixes issue of temporary user credentials to have
  consistent output
- Fixes a crash when setting a key with empty values
- Fixes a parsing issue with `mc admin config history`
## How to test this PR?
Fixes reported issues in #8434 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in PR #8478 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
