### PR TITLE
Handle port as json.Number for DNS records in etcd

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -103,7 +103,7 @@ func initFederatorBackend(buckets []BucketInfo, objLayer ObjectLayer) {
 			}
 
 			// This is not for our server, so we can continue
-			hostPort := net.JoinHostPort(dnsBuckets[index].Host, dnsBuckets[index].Port)
+			hostPort := net.JoinHostPort(dnsBuckets[index].Host, string(dnsBuckets[index].Port))
 			if globalDomainIPs.Intersection(set.CreateStringSet(hostPort)).IsEmpty() {
 				return nil
 			}

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -328,7 +328,7 @@ func isMinioReservedBucket(bucketName string) bool {
 func getHostsSlice(records []dns.SrvRecord) []string {
 	var hosts []string
 	for _, r := range records {
-		hosts = append(hosts, net.JoinHostPort(r.Host, r.Port))
+		hosts = append(hosts, net.JoinHostPort(r.Host, string(r.Port)))
 	}
 	return hosts
 }
@@ -337,7 +337,7 @@ func getHostsSlice(records []dns.SrvRecord) []string {
 func getHostFromSrv(records []dns.SrvRecord) string {
 	rand.Seed(time.Now().Unix())
 	srvRecord := records[rand.Intn(len(records))]
-	return net.JoinHostPort(srvRecord.Host, srvRecord.Port)
+	return net.JoinHostPort(srvRecord.Host, string(srvRecord.Port))
 }
 
 // IsCompressed returns true if the object is marked as compressed.

--- a/pkg/dns/etcd_dns.go
+++ b/pkg/dns/etcd_dns.go
@@ -41,7 +41,7 @@ const etcdPathSeparator = "/"
 func newCoreDNSMsg(ip string, port string, ttl uint32) ([]byte, error) {
 	return json.Marshal(&SrvRecord{
 		Host:         ip,
-		Port:         port,
+		Port:         json.Number(port),
 		TTL:          ttl,
 		CreationDate: time.Now().UTC(),
 	})

--- a/pkg/dns/types.go
+++ b/pkg/dns/types.go
@@ -17,6 +17,7 @@
 package dns
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -28,13 +29,13 @@ const (
 
 // SrvRecord - represents a DNS service record
 type SrvRecord struct {
-	Host     string `json:"host,omitempty"`
-	Port     string `json:"port,omitempty"`
-	Priority int    `json:"priority,omitempty"`
-	Weight   int    `json:"weight,omitempty"`
-	Text     string `json:"text,omitempty"`
-	Mail     bool   `json:"mail,omitempty"` // Be an MX record. Priority becomes Preference.
-	TTL      uint32 `json:"ttl,omitempty"`
+	Host     string      `json:"host,omitempty"`
+	Port     json.Number `json:"port,omitempty"`
+	Priority int         `json:"priority,omitempty"`
+	Weight   int         `json:"weight,omitempty"`
+	Text     string      `json:"text,omitempty"`
+	Mail     bool        `json:"mail,omitempty"` // Be an MX record. Priority becomes Preference.
+	TTL      uint32      `json:"ttl,omitempty"`
 
 	// Holds info about when the entry was created first.
 	CreationDate time.Time `json:"creationDate"`


### PR DESCRIPTION
## Description
Handle port as json.Number for DNS records in etcd

## Motivation and Context
Fix backward compatibility when upgrading from previous 
version of federation deployments

## How to test this PR?
Should be tested with federated deployments with the current release 
and then using the latest master which will not work. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes perhaps introduced in PR #8392 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
