### PR TITLE
fs: Fix setting new deployment ID in format when not present

### DIFF
--- a/cmd/format-fs.go
+++ b/cmd/format-fs.go
@@ -350,27 +350,24 @@ func formatFSFixDeploymentID(fsFormatPath string) error {
 			logger.Info("Another minio process(es) might be holding a lock to the file %s. Please kill that minio process(es) (elapsed %s)\n", fsFormatPath, getElapsedTime())
 			continue
 		}
-		if err != nil {
-			break
-		}
-
-		if err = jsonLoad(wlk, format); err != nil {
-			break
-		}
-
-		// Check if format needs to be updated
-		if format.ID != "" {
-			err = nil
-			break
-		}
-
-		format.ID = mustGetUUID()
-		if err = jsonSave(wlk, format); err != nil {
-			break
-		}
+		break
 	}
-	if wlk != nil {
-		wlk.Close()
+	if err != nil {
+		return err
 	}
-	return err
+
+	defer wlk.Close()
+
+	if err = jsonLoad(wlk, format); err != nil {
+		return err
+	}
+
+	// Check if format needs to be updated
+	if format.ID != "" {
+		return nil
+	}
+
+	// Set new UUID to the format and save it
+	format.ID = mustGetUUID()
+	return jsonSave(wlk, format)
 }


### PR DESCRIPTION

## Description
The code does not properly set a new deployemnt ID when not present
in format.json: it loops twice without releasing write lock on format.json
causing an infinite locking error on the same file.

This commit fixes and simplifies a little the code.



## Motivation and Context
Fixes #8505 

## How to test this PR?
1. ./minio.RELEASE.2018-07-13T00-09-07Z server /tmp/fs/
2. Control-C
3. ./minio server /tmp/fs # use master version)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
