### PR TITLE
Fix runtime panic in BackendDisks.Merge()

### DIFF
--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -98,6 +98,9 @@ func (d1 BackendDisks) Sum() (sum int) {
 
 // Merge - Reduces two endpoint-disk maps.
 func (d1 BackendDisks) Merge(d2 BackendDisks) BackendDisks {
+	if len(d2) == 0 {
+		d2 = make(BackendDisks)
+	}
 	for i1, v1 := range d1 {
 		if v2, ok := d2[i1]; ok {
 			d2[i1] = v2 + v1


### PR DESCRIPTION
## Description
Fix `assignment to entry in nil map` panic which occurs in xlsets.StorageInfo (with setcount > 1) 

## Motivation and Context
Fixes a panic

## How to test this PR?
- Use ellipses expansion to construct more than one xl-set (OR) `minio server --address=localhost:9002  http://localhost:9002/tmp/path{1...4} http://localhost:9003/tmp/path{5...8}`
- Run mc admin info - You will see panic logs in server console

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
