### PR TITLE
Fix console logger crash in gateway mode

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,44 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package config
+
+import "testing"
+
+func TestValidRegion(t *testing.T) {
+	tests := []struct {
+		name    string
+		success bool
+	}{
+		{name: "us-east-1", success: true},
+		{name: "us_east", success: true},
+		{name: "helloWorld", success: true},
+		{name: "-fdslka", success: false},
+		{name: "^00[", success: false},
+		{name: "my region", success: false},
+		{name: "%%$#!", success: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ok := validRegionRegex.MatchString(test.name)
+			if test.success != ok {
+				t.Errorf("Expected %t, got %t", test.success, ok)
+			}
+		})
+	}
+}

--- a/cmd/config/legacy.go
+++ b/cmd/config/legacy.go
@@ -23,6 +23,13 @@ import "github.com/minio/minio/pkg/auth"
 
 // SetCredentials - One time migration code needed, for migrating from older config to new for server credentials.
 func SetCredentials(c Config, cred auth.Credentials) {
+	creds, err := auth.CreateCredentials(cred.AccessKey, cred.SecretKey)
+	if err != nil {
+		return
+	}
+	if !creds.IsValid() {
+		return
+	}
 	c[CredentialsSubSys][Default] = KVS{
 		State:     StateOn,
 		Comment:   "Settings for credentials, after migrating config",
@@ -33,6 +40,9 @@ func SetCredentials(c Config, cred auth.Credentials) {
 
 // SetRegion - One time migration code needed, for migrating from older config to new for server Region.
 func SetRegion(c Config, name string) {
+	if name == "" {
+		return
+	}
 	c[RegionSubSys][Default] = KVS{
 		RegionName: name,
 		State:      StateOn,

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -145,6 +145,9 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	// Set when gateway is enabled
 	globalIsGateway = true
 
+	// Initialize globalConsoleSys system
+	globalConsoleSys = NewConsoleLogger(context.Background(), globalEndpoints)
+
 	enableConfigOps := gatewayName == "nas"
 
 	// TODO: We need to move this code with globalConfigSys.Init()
@@ -171,8 +174,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		registerSTSRouter(router)
 	}
 
-	// Initialize globalConsoleSys system
-	globalConsoleSys = NewConsoleLogger(context.Background(), globalEndpoints)
 	enableIAMOps := globalEtcdClient != nil
 
 	// Enable IAM admin APIs if etcd is enabled, if not just enable basic

--- a/pkg/madmin/config-kv-commands.go
+++ b/pkg/madmin/config-kv-commands.go
@@ -55,16 +55,6 @@ func (adm *AdminClient) SetConfigKV(kv string) (err error) {
 	if err != nil {
 		return err
 	}
-	for subSys, targetKV := range targets {
-		for target := range targetKV {
-			_, ok := targets[subSys][target][stateKey]
-			if !ok {
-				// If client asked for state preserve.
-				// otherwise implicitly add state to "on"
-				targets[subSys][target][stateKey] = stateOn
-			}
-		}
-	}
 	econfigBytes, err := EncryptData(adm.secretAccessKey, []byte(targets.String()))
 	if err != nil {
 		return err


### PR DESCRIPTION

## Description
Fix console logger crash in gateway mode

## Motivation and Context
This PR also fixes config migration only
for credentials and region which are valid
and set.

## How to test this PR?
Try to set invalid region such as regions with invalid characters, also fixes a console logger crash in gateway mode

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
