### PR TITLE
Add object retention support

### DIFF
--- a/cmd/api-datatypes.go
+++ b/cmd/api-datatypes.go
@@ -26,7 +26,7 @@ type ObjectIdentifier struct {
 }
 
 // createBucketConfiguration container for bucket configuration request from client.
-// Used for parsing the location from the request body for MakeBucketbucket.
+// Used for parsing the location from the request body for Makebucket.
 type createBucketLocationConfiguration struct {
 	XMLName  xml.Name `xml:"CreateBucketConfiguration" json:"-"`
 	Location string   `xml:"LocationConstraint"`

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -141,6 +141,12 @@ const (
 	ErrInvalidPrefixMarker
 	ErrBadRequest
 	ErrKeyTooLongError
+	ErrInvalidBucketObjectLockConfiguration
+	ErrObjectLocked
+	ErrInvalidRetentionDate
+	ErrPastObjectLockRetainDate
+	ErrUnknownWORMModeDirective
+	ErrObjectLockInvalidHeaders
 	// Add new error codes here.
 
 	// SSE-S3 related API errors
@@ -720,7 +726,36 @@ var errorCodes = errorCodeMap{
 		Description:    "Duration provided in the request is invalid.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-
+	ErrInvalidBucketObjectLockConfiguration: {
+		Code:           "InvalidRequest",
+		Description:    "Bucket is missing ObjectLockConfiguration",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrObjectLocked: {
+		Code:           "InvalidRequest",
+		Description:    "Object is WORM protected and cannot be overwritten",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidRetentionDate: {
+		Code:           "InvalidRequest",
+		Description:    "Date must be provided in ISO 8601 format",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrPastObjectLockRetainDate: {
+		Code:           "InvalidRequest",
+		Description:    "the retain until date must be in the future",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrUnknownWORMModeDirective: {
+		Code:           "InvalidRequest",
+		Description:    "unknown wormMode directive",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrObjectLockInvalidHeaders: {
+		Code:           "InvalidRequest",
+		Description:    "x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
 	/// Bucket notification related errors.
 	ErrEventNotification: {
 		Code:           "InvalidArgument",
@@ -1569,6 +1604,14 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrOperationTimedOut
 	case errDiskNotFound:
 		apiErr = ErrSlowDown
+	case errInvalidRetentionDate:
+		apiErr = ErrInvalidRetentionDate
+	case errPastObjectLockRetainDate:
+		apiErr = ErrPastObjectLockRetainDate
+	case errUnknownWORMModeDirective:
+		apiErr = ErrUnknownWORMModeDirective
+	case errObjectLockInvalidHeaders:
+		apiErr = ErrObjectLockInvalidHeaders
 	}
 
 	// Compression errors

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -103,22 +103,22 @@ func registerAPIRouter(router *mux.Router, encryptionEnabled, allowSSEKMS bool) 
 		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(collectAPIStats("getobjecttagging", httpTraceHdrs(api.GetObjectTaggingHandler))).Queries("tagging", "")
 		// SelectObjectContent
 		bucket.Methods(http.MethodPost).Path("/{object:.+}").HandlerFunc(collectAPIStats("selectobjectcontent", httpTraceHdrs(api.SelectObjectContentHandler))).Queries("select", "").Queries("select-type", "2")
+		// GetObjectRetention
+		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(collectAPIStats("getobjectretention", httpTraceHdrs(api.GetObjectRetentionHandler))).Queries("retention", "")
 		// GetObject
 		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(collectAPIStats("getobject", httpTraceHdrs(api.GetObjectHandler)))
 		// CopyObject
 		bucket.Methods(http.MethodPut).Path("/{object:.+}").HeadersRegexp(xhttp.AmzCopySource, ".*?(\\/|%2F).*?").HandlerFunc(collectAPIStats("copyobject", httpTraceAll(api.CopyObjectHandler)))
+		// PutObjectRetention
+		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(collectAPIStats("putobjectretention", httpTraceHdrs(api.PutObjectRetentionHandler))).Queries("retention", "")
 		// PutObject
 		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(collectAPIStats("putobject", httpTraceHdrs(api.PutObjectHandler)))
 		// DeleteObject
 		bucket.Methods(http.MethodDelete).Path("/{object:.+}").HandlerFunc(collectAPIStats("deleteobject", httpTraceAll(api.DeleteObjectHandler)))
 		// PutObjectLegalHold
-		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(collectAPIStats("putobjectlegalhold", httpTraceHdrs(api.PutObjectLegalHoldHandler))).Queries("legal-hold", "").Queries("versionId", "")
+		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(collectAPIStats("putobjectlegalhold", httpTraceHdrs(api.PutObjectLegalHoldHandler))).Queries("legal-hold", "")
 		// GetObjectLegalHold
-		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(collectAPIStats("getobjectlegalhold", httpTraceHdrs(api.GetObjectLegalHoldHandler))).Queries("legal-hold", "").Queries("versionId", "")
-		// PutObjectRetention
-		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(collectAPIStats("putobjectretention", httpTraceHdrs(api.PutObjectRetentionHandler))).Queries("retention", "").Queries("versionId", "")
-		// GetObjectRetention
-		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(collectAPIStats("getobjectretention", httpTraceHdrs(api.GetObjectRetentionHandler))).Queries("retention", "").Queries("versionId", "")
+		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(collectAPIStats("getobjectlegalhold", httpTraceHdrs(api.GetObjectLegalHoldHandler))).Queries("legal-hold", "")
 
 		/// Bucket operations
 		// GetBucketLocation

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -357,7 +357,6 @@ func checkRequestAuthTypeToAccessKey(ctx context.Context, r *http.Request, actio
 		}
 		return accessKey, owner, ErrAccessDenied
 	}
-
 	if globalIAMSys.IsAllowed(iampolicy.Args{
 		AccountName:     cred.AccessKey,
 		Action:          iampolicy.Action(action),
@@ -487,10 +486,10 @@ func (a authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	writeErrorResponse(context.Background(), w, errorCodes.ToAPIErr(ErrSignatureVersionNotSupported), r.URL, guessIsBrowserReq(r))
 }
 
-// isPutAllowed - check if PUT operation is allowed on the resource, this
+// isPutActionAllowed - check if PUT operation is allowed on the resource, this
 // call verifies bucket policies and IAM policies, supports multi user
 // checks etc.
-func isPutAllowed(atype authType, bucketName, objectName string, r *http.Request) (s3Err APIErrorCode) {
+func isPutActionAllowed(atype authType, bucketName, objectName string, r *http.Request, action iampolicy.Action) (s3Err APIErrorCode) {
 	var cred auth.Credentials
 	var owner bool
 	switch atype {
@@ -527,7 +526,7 @@ func isPutAllowed(atype authType, bucketName, objectName string, r *http.Request
 
 	if globalIAMSys.IsAllowed(iampolicy.Args{
 		AccountName:     cred.AccessKey,
-		Action:          policy.PutObjectAction,
+		Action:          action,
 		BucketName:      bucketName,
 		ConditionValues: getConditionValues(r, "", cred.AccessKey, claims),
 		ObjectName:      objectName,

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -527,6 +527,13 @@ func (c *cacheObjects) PutObject(ctx context.Context, bucket, object string, r *
 	if opts.ServerSideEncryption != nil {
 		return putObjectFn(ctx, bucket, object, r, opts)
 	}
+
+	// skip cache for objects with locks
+	objRetention := getObjectRetentionMeta(opts.UserDefined)
+	if objRetention.Mode == Governance || objRetention.Mode == Compliance {
+		return putObjectFn(ctx, bucket, object, r, opts)
+	}
+
 	// fetch from backend if cache exclude pattern or cache-control
 	// directive set to exclude
 	if c.isCacheExclude(bucket, object) {

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -683,8 +683,8 @@ func (fs *FSObjects) CompleteMultipartUpload(ctx context.Context, bucket string,
 	}
 
 	// Deny if WORM is enabled
-	if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-		if fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object)); err == nil && retention.Retain(fi.ModTime()) {
+	if globalWORMEnabled {
+		if _, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object)); err == nil {
 			return ObjectInfo{}, ObjectAlreadyExists{Bucket: bucket, Object: object}
 		}
 	}

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -931,8 +931,8 @@ func (fs *FSObjects) putObject(ctx context.Context, bucket string, object string
 	// Entire object was written to the temp location, now it's safe to rename it to the actual location.
 	fsNSObjPath := pathJoin(fs.fsPath, bucket, object)
 	// Deny if WORM is enabled
-	if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-		if fi, err := fsStatFile(ctx, fsNSObjPath); err == nil && retention.Retain(fi.ModTime()) {
+	if globalWORMEnabled {
+		if _, err := fsStatFile(ctx, fsNSObjPath); err == nil {
 			return ObjectInfo{}, ObjectAlreadyExists{Bucket: bucket, Object: object}
 		}
 	}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -196,7 +196,7 @@ var (
 	// Is worm enabled
 	globalWORMEnabled bool
 
-	globalBucketRetentionConfig = newBucketRetentionConfig()
+	globalBucketObjectLockConfig = newBucketObjectLockConfig()
 
 	// Disk cache drives
 	globalCacheConfig cache.Config

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -141,7 +141,6 @@ func extractMetadata(ctx context.Context, r *http.Request) (metadata map[string]
 	if _, ok := metadata["content-type"]; !ok {
 		metadata["content-type"] = "application/octet-stream"
 	}
-
 	// Success.
 	return metadata, nil
 }

--- a/cmd/http/headers.go
+++ b/cmd/http/headers.go
@@ -57,10 +57,14 @@ const (
 	AmzCopySourceIfNoneMatch = "x-amz-copy-source-if-none-match"
 	AmzCopySourceIfMatch     = "x-amz-copy-source-if-match"
 
-	AmzCopySource          = "X-Amz-Copy-Source"
-	AmzCopySourceVersionID = "X-Amz-Copy-Source-Version-Id"
-	AmzCopySourceRange     = "X-Amz-Copy-Source-Range"
-	AmzMetadataDirective   = "X-Amz-Metadata-Directive"
+	AmzCopySource                 = "X-Amz-Copy-Source"
+	AmzCopySourceVersionID        = "X-Amz-Copy-Source-Version-Id"
+	AmzCopySourceRange            = "X-Amz-Copy-Source-Range"
+	AmzMetadataDirective          = "X-Amz-Metadata-Directive"
+	AmzObjectLockMode             = "X-Amz-Object-Lock-Mode"
+	AmzObjectLockRetainUntilDate  = "X-Amz-Object-Lock-Retain-Until-Date"
+	AmzObjectLockLegalHold        = "X-Amz-Object-Lock-Legal-Hold"
+	AmzObjectLockBypassGovernance = "X-Amz-Bypass-Governance-Retention"
 
 	// Signature V4 related contants.
 	AmzContentSha256        = "X-Amz-Content-Sha256"

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -30,6 +30,9 @@ import (
 // CheckCopyPreconditionFn returns true if copy precondition check failed.
 type CheckCopyPreconditionFn func(o ObjectInfo, encETag string) bool
 
+// GetObjectInfoFn is the signature of GetObjectInfo function.
+type GetObjectInfoFn func(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error)
+
 // ObjectOptions represents object options for ObjectLayer operations
 type ObjectOptions struct {
 	ServerSideEncryption encrypt.ServerSide

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -43,6 +43,7 @@ import (
 	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/handlers"
 	"github.com/minio/minio/pkg/hash"
+	iampolicy "github.com/minio/minio/pkg/iam/policy"
 	"github.com/minio/minio/pkg/ioutil"
 	"github.com/minio/minio/pkg/policy"
 	"github.com/minio/minio/pkg/s3select"
@@ -201,6 +202,9 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	getRetPerms := checkRequestAuthType(ctx, r, policy.GetObjectRetentionAction, bucket, object)
+	// filter object lock metadata if permission does not permit
+	objInfo.UserDefined = filterObjectLockMetadata(ctx, r, bucket, object, objInfo.UserDefined, false, getRetPerms)
 
 	if err = s3Select.Open(getObject); err != nil {
 		if serr, ok := err.(s3select.SelectError); ok {
@@ -340,6 +344,10 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	}
 	defer gr.Close()
 	objInfo := gr.ObjInfo
+
+	// filter object lock metadata if permission does not permit
+	getRetPerms := checkRequestAuthType(ctx, r, policy.GetObjectRetentionAction, bucket, object)
+	objInfo.UserDefined = filterObjectLockMetadata(ctx, r, bucket, object, objInfo.UserDefined, false, getRetPerms)
 
 	if objectAPI.IsEncryptionSupported() {
 		objInfo.UserDefined = CleanMinioInternalMetadataKeys(objInfo.UserDefined)
@@ -501,6 +509,11 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 		writeErrorResponseHeadersOnly(w, toAPIError(ctx, err))
 		return
 	}
+
+	// filter object lock metadata if permission does not permit
+	getRetPerms := checkRequestAuthType(ctx, r, policy.GetObjectRetentionAction, bucket, object)
+	objInfo.UserDefined = filterObjectLockMetadata(ctx, r, bucket, object, objInfo.UserDefined, false, getRetPerms)
+
 	if objectAPI.IsEncryptionSupported() {
 		if _, err = DecryptObjectInfo(&objInfo, r.Header); err != nil {
 			writeErrorResponseHeadersOnly(w, toAPIError(ctx, err))
@@ -737,14 +750,6 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 
 	cpSrcDstSame := isStringEqual(pathJoin(srcBucket, srcObject), pathJoin(dstBucket, dstObject))
 
-	// Deny if WORM is enabled.
-	if retention, isWORMBucket := isWORMEnabled(dstBucket); isWORMBucket {
-		if oi, err := objectAPI.GetObjectInfo(ctx, dstBucket, dstObject, dstOpts); err == nil && retention.Retain(oi.ModTime) {
-			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
-			return
-		}
-	}
-
 	getObjectNInfo := objectAPI.GetObjectNInfo
 	if api.CacheAPI() != nil {
 		getObjectNInfo = api.CacheAPI().GetObjectNInfo
@@ -944,7 +949,24 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
-
+	getObjectInfo := objectAPI.GetObjectInfo
+	if api.CacheAPI() != nil {
+		getObjectInfo = api.CacheAPI().GetObjectInfo
+	}
+	isCpy := true
+	getRetPerms := checkRequestAuthType(ctx, r, policy.GetObjectRetentionAction, srcBucket, srcObject)
+	srcInfo.UserDefined = filterObjectLockMetadata(ctx, r, srcBucket, srcObject, srcInfo.UserDefined, isCpy, getRetPerms)
+	retPerms := isPutActionAllowed(getRequestAuthType(r), dstBucket, dstObject, r, iampolicy.PutObjectRetentionAction)
+	// apply default bucket configuration/governance headers for dest side.
+	retentionMode, retentionDate, s3Err := checkPutObjectRetentionAllowed(ctx, r, dstBucket, dstObject, getObjectInfo, retPerms)
+	if s3Err == ErrNone && retentionMode != "" {
+		srcInfo.UserDefined[xhttp.AmzObjectLockMode] = string(retentionMode)
+		srcInfo.UserDefined[xhttp.AmzObjectLockRetainUntilDate] = retentionDate.UTC().Format(time.RFC3339)
+	}
+	if s3Err != ErrNone {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
+		return
+	}
 	// Store the preserved compression metadata.
 	for k, v := range compressMetadata {
 		srcInfo.UserDefined[k] = v
@@ -1036,7 +1058,6 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 //   - X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key
 func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "PutObject")
-
 	defer logger.AuditLog(w, r, "PutObject", mustGetClaimsFromToken(r))
 
 	objectAPI := api.ObjectAPI()
@@ -1142,7 +1163,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	reader = r.Body
 
 	// Check if put is allowed
-	if s3Err = isPutAllowed(rAuthType, bucket, object, r); s3Err != ErrNone {
+	if s3Err = isPutActionAllowed(rAuthType, bucket, object, r, iampolicy.PutObjectAction); s3Err != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
 		return
 	}
@@ -1220,12 +1241,15 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		getObjectInfo = api.CacheAPI().GetObjectInfo
 		putObject = api.CacheAPI().PutObject
 	}
-	// Deny if WORM is enabled
-	if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-		if oi, err := getObjectInfo(ctx, bucket, object, opts); err == nil && retention.Retain(oi.ModTime) {
-			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
-			return
-		}
+	retPerms := isPutActionAllowed(rAuthType, bucket, object, r, iampolicy.PutObjectRetentionAction)
+	retentionMode, retentionDate, s3Err := checkPutObjectRetentionAllowed(ctx, r, bucket, object, getObjectInfo, retPerms)
+	if s3Err == ErrNone && retentionMode != "" {
+		metadata[strings.ToLower(xhttp.AmzObjectLockMode)] = string(retentionMode)
+		metadata[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)] = retentionDate.UTC().Format(time.RFC3339)
+	}
+	if s3Err != ErrNone {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
+		return
 	}
 
 	var objectEncryptionKey []byte
@@ -1347,14 +1371,6 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	// Deny if WORM is enabled
-	if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-		if oi, err := objectAPI.GetObjectInfo(ctx, bucket, object, opts); err == nil && retention.Retain(oi.ModTime) {
-			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
-			return
-		}
-	}
-
 	// Validate storage class metadata if present
 	if sc := r.Header.Get(xhttp.AmzStorageClass); sc != "" {
 		if !storageclass.IsValid(sc) {
@@ -1383,7 +1399,16 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
-
+	retPerms := isPutActionAllowed(getRequestAuthType(r), bucket, object, r, iampolicy.PutObjectRetentionAction)
+	retentionMode, retentionDate, s3Err := checkPutObjectRetentionAllowed(ctx, r, bucket, object, objectAPI.GetObjectInfo, retPerms)
+	if s3Err == ErrNone && retentionMode != "" {
+		metadata[strings.ToLower(xhttp.AmzObjectLockMode)] = string(retentionMode)
+		metadata[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)] = retentionDate.UTC().Format(time.RFC3339)
+	}
+	if s3Err != ErrNone {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
+		return
+	}
 	// We need to preserve the encryption headers set in EncryptRequest,
 	// so we do not want to override them, copy them instead.
 	for k, v := range encMetadata {
@@ -1520,9 +1545,9 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Deny if WORM is enabled
-	if retention, isWORMBucket := isWORMEnabled(dstBucket); isWORMBucket {
-		if oi, err := objectAPI.GetObjectInfo(ctx, dstBucket, dstObject, dstOpts); err == nil && retention.Retain(oi.ModTime) {
+	// Deny if global WORM is enabled
+	if globalWORMEnabled {
+		if _, err := objectAPI.GetObjectInfo(ctx, dstBucket, dstObject, dstOpts); err == nil {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
 			return
 		}
@@ -1822,7 +1847,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		s3Error   APIErrorCode
 	)
 	reader = r.Body
-	if s3Error = isPutAllowed(rAuthType, bucket, object, r); s3Error != ErrNone {
+	if s3Error = isPutActionAllowed(rAuthType, bucket, object, r, iampolicy.PutObjectAction); s3Error != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL, guessIsBrowserReq(r))
 		return
 	}
@@ -1898,8 +1923,8 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	pReader := NewPutObjReader(rawReader, nil, nil)
 
 	// Deny if WORM is enabled
-	if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-		if oi, err := objectAPI.GetObjectInfo(ctx, bucket, object, opts); err == nil && retention.Retain(oi.ModTime) {
+	if globalWORMEnabled {
+		if _, err := objectAPI.GetObjectInfo(ctx, bucket, object, opts); err == nil {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
 			return
 		}
@@ -2004,14 +2029,6 @@ func (api objectAPIHandlers) AbortMultipartUploadHandler(w http.ResponseWriter, 
 	if s3Error := checkRequestAuthType(ctx, r, policy.AbortMultipartUploadAction, bucket, object); s3Error != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL, guessIsBrowserReq(r))
 		return
-	}
-
-	// Deny if WORM is enabled
-	if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-		if oi, err := objectAPI.GetObjectInfo(ctx, bucket, object, ObjectOptions{}); err == nil && retention.Retain(oi.ModTime) {
-			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
-			return
-		}
 	}
 
 	uploadID, _, _, _, s3Error := getObjectResources(r.URL.Query())
@@ -2182,12 +2199,17 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 		return
 	}
 
-	// Deny if WORM is enabled
-	if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-		if oi, err := objectAPI.GetObjectInfo(ctx, bucket, object, ObjectOptions{}); err == nil && retention.Retain(oi.ModTime) {
-			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
-			return
-		}
+	// Reject retention or governance headers if set, CompleteMultipartUpload spec
+	// does not use these headers, and should not be passed down to checkPutObjectRetentionAllowed
+	if isObjectLockRequested(r.Header) || isObjectLockGovernanceBypassSet(r.Header) {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidRequest), r.URL, guessIsBrowserReq(r))
+		return
+	}
+	// Enforce object lock governance in case a competing upload finalized first.
+	retPerms := isPutActionAllowed(getRequestAuthType(r), bucket, object, r, iampolicy.PutObjectRetentionAction)
+	if _, _, s3Err := checkPutObjectRetentionAllowed(ctx, r, bucket, object, objectAPI.GetObjectInfo, retPerms); s3Err != ErrNone {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
+		return
 	}
 
 	// Get upload id.
@@ -2377,14 +2399,16 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	// Deny if WORM is enabled
-	if _, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-		// Not required to check whether given object exists or not, because
-		// DeleteObject is always successful irrespective of object existence.
-		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMethodNotAllowed), r.URL, guessIsBrowserReq(r))
-		return
+	getObjectInfo := objectAPI.GetObjectInfo
+	if api.CacheAPI() != nil {
+		getObjectInfo = api.CacheAPI().GetObjectInfo
 	}
 
+	govBypassPerms := checkRequestAuthType(ctx, r, policy.BypassGovernanceRetentionAction, bucket, object)
+	if _, err := checkGovernanceBypassAllowed(ctx, r, bucket, object, getObjectInfo, govBypassPerms); err != ErrNone {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(err), r.URL, guessIsBrowserReq(r))
+		return
+	}
 	if globalDNSConfig != nil {
 		_, err := globalDNSConfig.Get(bucket)
 		if err != nil {
@@ -2486,7 +2510,7 @@ func (api objectAPIHandlers) GetObjectLegalHoldHandler(w http.ResponseWriter, r 
 	writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL, guessIsBrowserReq(r))
 }
 
-// PutObjectRetentionHandler - set legal hold configuration to object,
+// PutObjectRetentionHandler - set object hold configuration to object,
 func (api objectAPIHandlers) PutObjectRetentionHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "PutObjectRetention")
 
@@ -2506,30 +2530,78 @@ func (api objectAPIHandlers) PutObjectRetentionHandler(w http.ResponseWriter, r 
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrServerNotInitialized), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	// Check permissions to perform this governance operation
+	if s3Err := isPutActionAllowed(getRequestAuthType(r), bucket, object, r, policy.PutObjectRetentionAction); s3Err != ErrNone {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
+		return
+	}
+
+	// Get Content-Md5 sent by client and verify if valid
+	md5Bytes, err := checkValidMD5(r.Header)
+	if err != nil {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDigest), r.URL, guessIsBrowserReq(r))
+		return
+	}
+	if _, isWORMBucket := isWORMEnabled(bucket); !isWORMBucket {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidBucketObjectLockConfiguration), r.URL, guessIsBrowserReq(r))
+		return
+	}
 
 	getObjectInfo := objectAPI.GetObjectInfo
 	if api.CacheAPI() != nil {
 		getObjectInfo = api.CacheAPI().GetObjectInfo
 	}
 
-	opts, err := getOpts(ctx, r, bucket, object)
+	govBypassPerms := checkRequestAuthType(ctx, r, policy.BypassGovernanceRetentionAction, bucket, object)
+	objInfo, s3Err := checkGovernanceBypassAllowed(ctx, r, bucket, object, getObjectInfo, govBypassPerms)
+	if s3Err != ErrNone {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
+		return
+	}
+
+	objRetention, err := parseObjectRetention(r.Body)
 	if err != nil {
+		apiErr := errorCodes.ToAPIErr(ErrMalformedXML)
+		apiErr.Description = err.Error()
+		writeErrorResponse(ctx, w, apiErr, r.URL, guessIsBrowserReq(r))
+		return
+	}
+	// verify Content-MD5 sum of request body if this header set
+	if len(md5Bytes) > 0 {
+		data, err := xml.Marshal(objRetention)
+		if err != nil {
+			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+			return
+		}
+		if hex.EncodeToString(md5Bytes) != getMD5Hash(data) {
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDigest), r.URL, guessIsBrowserReq(r))
+			return
+		}
+	}
+	objInfo.UserDefined[strings.ToLower(xhttp.AmzObjectLockMode)] = string(objRetention.Mode)
+	objInfo.UserDefined[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)] = objRetention.RetainUntilDate.UTC().Format(time.RFC3339)
+	objInfo.metadataOnly = true
+	if _, err = objectAPI.CopyObject(ctx, bucket, object, bucket, object, objInfo, ObjectOptions{}, ObjectOptions{}); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
 
-	if _, err = getObjectInfo(ctx, bucket, object, opts); err != nil {
-		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
-		return
-	}
-
-	writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL, guessIsBrowserReq(r))
+	writeSuccessNoContent(w)
+	// Notify object  event.
+	sendEvent(eventArgs{
+		EventName:    event.ObjectCreatedPutRetention,
+		BucketName:   bucket,
+		Object:       objInfo,
+		ReqParams:    extractReqParams(r),
+		RespElements: extractRespElements(w),
+		UserAgent:    r.UserAgent(),
+		Host:         handlers.GetSourceIP(r),
+	})
 }
 
-// GetObjectRetentionHandler - get legal hold configuration to object,
+// GetObjectRetentionHandler - get object retention configuration of object,
 func (api objectAPIHandlers) GetObjectRetentionHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "GetObjectRetention")
-
 	defer logger.AuditLog(w, r, "GetObjectRetention", mustGetClaimsFromToken(r))
 
 	vars := mux.Vars(r)
@@ -2546,6 +2618,10 @@ func (api objectAPIHandlers) GetObjectRetentionHandler(w http.ResponseWriter, r 
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrServerNotInitialized), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	if s3Error := checkRequestAuthType(ctx, r, policy.GetObjectRetentionAction, bucket, object); s3Error != ErrNone {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL, guessIsBrowserReq(r))
+		return
+	}
 
 	getObjectInfo := objectAPI.GetObjectInfo
 	if api.CacheAPI() != nil {
@@ -2558,10 +2634,23 @@ func (api objectAPIHandlers) GetObjectRetentionHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	if _, err = getObjectInfo(ctx, bucket, object, opts); err != nil {
+	objInfo, err := getObjectInfo(ctx, bucket, object, opts)
+	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
 
-	writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL, guessIsBrowserReq(r))
+	retention := getObjectRetentionMeta(objInfo.UserDefined)
+
+	writeSuccessResponseXML(w, encodeResponse(retention))
+	// Notify object retention accessed via a GET request.
+	sendEvent(eventArgs{
+		EventName:    event.ObjectAccessedGetRetention,
+		BucketName:   bucket,
+		Object:       objInfo,
+		ReqParams:    extractReqParams(r),
+		RespElements: extractRespElements(w),
+		UserAgent:    r.UserAgent(),
+		Host:         handlers.GetSourceIP(r),
+	})
 }

--- a/cmd/object-lock.go
+++ b/cmd/object-lock.go
@@ -17,11 +17,17 @@
 package cmd
 
 import (
+	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"strings"
 	"sync"
 	"time"
+
+	xhttp "github.com/minio/minio/cmd/http"
 )
 
 // RetentionMode - object retention mode.
@@ -33,6 +39,30 @@ const (
 
 	// Compliance - compliance mode.
 	Compliance RetentionMode = "COMPLIANCE"
+
+	// Invalid - invalid retention mode.
+	Invalid RetentionMode = "Invalid"
+)
+
+func parseRetentionMode(modeStr string) (mode RetentionMode) {
+	switch strings.ToUpper(modeStr) {
+	case "GOVERNANCE":
+		mode = Governance
+	case "COMPLIANCE":
+		mode = Compliance
+	default:
+		mode = Invalid
+	}
+	return mode
+}
+
+var (
+	errMalformedBucketObjectConfig = errors.New("Invalid bucket object lock config")
+	errInvalidRetentionDate        = errors.New("Date must be provided in ISO 8601 format")
+	errPastObjectLockRetainDate    = errors.New("the retain until date must be in the future")
+	errUnknownWORMModeDirective    = errors.New("unknown WORM mode directive")
+	errObjectLockMissingContentMD5 = errors.New("Content-MD5 HTTP header is required for Put Object requests with Object Lock parameters")
+	errObjectLockInvalidHeaders    = errors.New("x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied")
 )
 
 // Retention - bucket level retention configuration.
@@ -51,37 +81,36 @@ func (r Retention) Retain(created time.Time) bool {
 	return globalWORMEnabled || created.Add(r.Validity).After(time.Now())
 }
 
-// BucketRetentionConfig - map of bucket and retention configuration.
-type BucketRetentionConfig struct {
+// BucketObjectLockConfig - map of bucket and retention configuration.
+type BucketObjectLockConfig struct {
 	sync.RWMutex
 	retentionMap map[string]Retention
 }
 
 // Set - set retention configuration.
-func (config *BucketRetentionConfig) Set(bucketName string, retention Retention) {
+func (config *BucketObjectLockConfig) Set(bucketName string, retention Retention) {
 	config.Lock()
 	config.retentionMap[bucketName] = retention
 	config.Unlock()
 }
 
 // Get - Get retention configuration.
-func (config *BucketRetentionConfig) Get(bucketName string) (r Retention, ok bool) {
+func (config *BucketObjectLockConfig) Get(bucketName string) (r Retention, ok bool) {
 	config.RLock()
 	defer config.RUnlock()
-
 	r, ok = config.retentionMap[bucketName]
 	return r, ok
 }
 
 // Delete - delete retention configuration.
-func (config *BucketRetentionConfig) Delete(bucketName string) {
+func (config *BucketObjectLockConfig) Delete(bucketName string) {
 	config.Lock()
 	delete(config.retentionMap, bucketName)
 	config.Unlock()
 }
 
-func newBucketRetentionConfig() *BucketRetentionConfig {
-	return &BucketRetentionConfig{
+func newBucketObjectLockConfig() *BucketObjectLockConfig {
+	return &BucketObjectLockConfig{
 		retentionMap: map[string]Retention{},
 	}
 }
@@ -130,12 +159,12 @@ func (dr *DefaultRetention) UnmarshalXML(d *xml.Decoder, start xml.StartElement)
 			return fmt.Errorf("Default retention period must be a positive integer value for 'Days'")
 		}
 		if *retention.Days > maximumRetentionDays {
-			return fmt.Errorf("Default retention period too large for 'Days' %w", *retention.Days)
+			return fmt.Errorf("Default retention period too large for 'Days' %d", *retention.Days)
 		}
 	} else if *retention.Years == 0 {
 		return fmt.Errorf("Default retention period must be a positive integer value for 'Years'")
 	} else if *retention.Years > maximumRetentionYears {
-		return fmt.Errorf("Default retention period too large for 'Years' %w", *retention.Years)
+		return fmt.Errorf("Default retention period too large for 'Years' %d", *retention.Years)
 	}
 
 	*dr = DefaultRetention(retention)
@@ -200,4 +229,254 @@ func newObjectLockConfig() *ObjectLockConfig {
 	return &ObjectLockConfig{
 		ObjectLockEnabled: "Enabled",
 	}
+}
+
+// RetentionDate is a embedded type containing time.Time to unmarshal
+// Date in Retention
+type RetentionDate struct {
+	time.Time
+}
+
+// UnmarshalXML parses date from Expiration and validates date format
+func (rDate *RetentionDate) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
+	var dateStr string
+	err := d.DecodeElement(&dateStr, &startElement)
+	if err != nil {
+		return err
+	}
+	// While AWS documentation mentions that the date specified
+	// must be present in ISO 8601 format, in reality they allow
+	// users to provide RFC 3339 compliant dates.
+	retDate, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		return errInvalidRetentionDate
+	}
+
+	*rDate = RetentionDate{retDate}
+	return nil
+}
+
+// MarshalXML encodes expiration date if it is non-zero and encodes
+// empty string otherwise
+func (rDate *RetentionDate) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+	if *rDate == (RetentionDate{time.Time{}}) {
+		return nil
+	}
+	return e.EncodeElement(rDate.Format(time.RFC3339), startElement)
+}
+
+// ObjectRetention specified in
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html
+type ObjectRetention struct {
+	XMLNS           string        `xml:"xmlns,attr,omitempty"`
+	XMLName         xml.Name      `xml:"Retention"`
+	Mode            RetentionMode `xml:"Mode,omitempty"`
+	RetainUntilDate RetentionDate `xml:"RetainUntilDate,omitempty"`
+}
+
+func parseObjectRetention(reader io.Reader) (*ObjectRetention, error) {
+	ret := ObjectRetention{}
+	if err := xml.NewDecoder(reader).Decode(&ret); err != nil {
+		return nil, err
+	}
+	if ret.Mode != Compliance && ret.Mode != Governance {
+		return &ret, errUnknownWORMModeDirective
+	}
+	if ret.RetainUntilDate.Before(time.Now()) {
+		return &ret, errPastObjectLockRetainDate
+	}
+	return &ret, nil
+}
+
+func isObjectLockRetentionRequested(h http.Header) bool {
+	if _, ok := h[xhttp.AmzObjectLockMode]; ok {
+		return true
+	}
+	if _, ok := h[xhttp.AmzObjectLockRetainUntilDate]; ok {
+		return true
+	}
+	return false
+}
+
+func isObjectLockLegalHoldRequested(h http.Header) bool {
+	_, ok := h[xhttp.AmzObjectLockLegalHold]
+	return ok
+}
+
+func isObjectLockGovernanceBypassSet(h http.Header) bool {
+	v, ok := h[xhttp.AmzObjectLockBypassGovernance]
+	if !ok {
+		return false
+	}
+	val := strings.Join(v, "")
+	return strings.ToLower(val) == "true"
+}
+
+func isObjectLockRequested(h http.Header) bool {
+	return isObjectLockLegalHoldRequested(h) || isObjectLockRetentionRequested(h)
+}
+
+func parseObjectLockRetentionHeaders(h http.Header) (rmode RetentionMode, r RetentionDate, err error) {
+	retMode, ok := h[xhttp.AmzObjectLockMode]
+	if ok {
+		rmode = parseRetentionMode(strings.Join(retMode, ""))
+		if rmode == Invalid {
+			return rmode, r, errUnknownWORMModeDirective
+		}
+	}
+	var retDate time.Time
+	dateStr, ok := h[xhttp.AmzObjectLockRetainUntilDate]
+	if ok {
+		// While AWS documentation mentions that the date specified
+		// must be present in ISO 8601 format, in reality they allow
+		// users to provide RFC 3339 compliant dates.
+		retDate, err = time.Parse(time.RFC3339, strings.Join(dateStr, ""))
+		if err != nil {
+			return rmode, r, errInvalidRetentionDate
+		}
+		if retDate.Before(time.Now()) {
+			return rmode, r, errPastObjectLockRetainDate
+		}
+	}
+	if len(retMode) == 0 || len(dateStr) == 0 {
+		return rmode, r, errObjectLockInvalidHeaders
+	}
+	return rmode, RetentionDate{retDate}, nil
+
+}
+
+func getObjectRetentionMeta(meta map[string]string) ObjectRetention {
+	var mode RetentionMode
+	var retainTill RetentionDate
+	if modeStr, ok := meta[strings.ToLower(xhttp.AmzObjectLockMode)]; ok {
+		mode = parseRetentionMode(modeStr)
+	}
+	if tillStr, ok := meta[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)]; ok {
+		if t, e := time.Parse(time.RFC3339, tillStr); e == nil {
+			retainTill = RetentionDate{t.UTC()}
+		}
+	}
+	return ObjectRetention{Mode: mode, RetainUntilDate: retainTill}
+}
+
+// checkGovernanceBypassAllowed enforces whether an existing object under governance can be overwritten
+// with governance bypass headers set in the request.
+// Objects under site wide WORM or those in "Compliance" mode can never be overwritten.
+// For objects in "Governance" mode, overwrite is allowed if a) object retention date is past OR
+// governance bypass headers are set and user has governance bypass permissions.
+func checkGovernanceBypassAllowed(ctx context.Context, r *http.Request, bucket, object string, getObjectInfoFn GetObjectInfoFn, govBypassPerm APIErrorCode) (oi ObjectInfo, s3Err APIErrorCode) {
+	var err error
+	var opts ObjectOptions
+	opts, err = getOpts(ctx, r, bucket, object)
+	if err != nil {
+		return oi, toAPIErrorCode(ctx, err)
+	}
+	oi, err = getObjectInfoFn(ctx, bucket, object, opts)
+	if err != nil {
+		// ignore case where object no longer exists
+		if toAPIError(ctx, err).Code == "NoSuchKey" {
+			return oi, ErrNone
+		}
+		return oi, toAPIErrorCode(ctx, err)
+	}
+	ret := getObjectRetentionMeta(oi.UserDefined)
+	if globalWORMEnabled || ret.Mode == Compliance {
+		return oi, ErrObjectLocked
+	}
+	// Here bucket does not support object lock
+	if ret.Mode == Invalid && isObjectLockGovernanceBypassSet(r.Header) {
+		return oi, ErrInvalidBucketObjectLockConfiguration
+	}
+	if ret.Mode == Compliance {
+		return oi, ErrObjectLocked
+	}
+	if ret.Mode == Governance {
+		if !isObjectLockGovernanceBypassSet(r.Header) {
+			if ret.RetainUntilDate.After(UTCNow()) {
+				return oi, ErrObjectLocked
+			}
+			return oi, ErrNone
+		}
+		if govBypassPerm != ErrNone {
+			return oi, ErrAccessDenied
+		}
+	}
+	return oi, ErrNone
+}
+
+// checkPutObjectRetentionAllowed enforces object retention policy for requests with WORM headers
+// See https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-managing.html for the spec.
+// For non-existing objects with object retention headers set, this method returns ErrNone if bucket has
+// locking enabled and user has requisite permissions (s3:PutObjectRetention)
+// If object exists on object store, if retention mode is "Compliance" or site wide WORM enabled -this method
+// returns an error. For objects in "Governance" mode, overwrite is allowed if the retention date has expired.
+func checkPutObjectRetentionAllowed(ctx context.Context, r *http.Request, bucket, object string, getObjectInfoFn GetObjectInfoFn, retentionPermErr APIErrorCode) (RetentionMode, RetentionDate, APIErrorCode) {
+	var mode RetentionMode
+	var retainDate RetentionDate
+	retention, isWORMBucket := isWORMEnabled(bucket)
+
+	retentionRequested := isObjectLockRequested(r.Header)
+
+	var objExists bool
+	opts, err := getOpts(ctx, r, bucket, object)
+	if err != nil {
+		return mode, retainDate, toAPIErrorCode(ctx, err)
+	}
+	if objInfo, err := getObjectInfoFn(ctx, bucket, object, opts); err == nil {
+		objExists = true
+		r := getObjectRetentionMeta(objInfo.UserDefined)
+		if globalWORMEnabled || r.Mode == Compliance {
+			return mode, retainDate, ErrObjectLocked
+		}
+		mode = r.Mode
+		retainDate = r.RetainUntilDate
+	}
+	if retentionRequested {
+		if !isWORMBucket {
+			return mode, retainDate, ErrInvalidBucketObjectLockConfiguration
+		}
+		rMode, rDate, err := parseObjectLockRetentionHeaders(r.Header)
+		if err != nil {
+			return mode, retainDate, toAPIErrorCode(ctx, err)
+		}
+		// AWS S3 just creates a new version of object when an object is being overwritten.
+		if objExists && retainDate.After(UTCNow()) {
+			return mode, retainDate, ErrObjectLocked
+		}
+		if rMode == Invalid {
+			return mode, retainDate, toAPIErrorCode(ctx, errObjectLockInvalidHeaders)
+		}
+		if retentionPermErr != ErrNone {
+			return mode, retainDate, retentionPermErr
+		}
+		return rMode, rDate, ErrNone
+	}
+	if !retentionRequested && isWORMBucket && !retention.IsEmpty() {
+		if retentionPermErr != ErrNone {
+			return mode, retainDate, retentionPermErr
+		}
+		// AWS S3 just creates a new version of object when an object is being overwritten.
+		if objExists && retainDate.After(UTCNow()) {
+			return mode, retainDate, ErrObjectLocked
+		}
+		// inherit retention from bucket configuration
+		return retention.Mode, RetentionDate{UTCNow().Add(retention.Validity)}, ErrNone
+	}
+	return mode, retainDate, ErrNone
+}
+
+// filter object lock metadata if s3:GetObjectRetention permission is denied or if isCopy flag set.
+func filterObjectLockMetadata(ctx context.Context, r *http.Request, bucket, object string, metadata map[string]string, isCopy bool, getRetPerms APIErrorCode) map[string]string {
+	ret := getObjectRetentionMeta(metadata)
+	if ret.Mode == Invalid || isCopy {
+		delete(metadata, xhttp.AmzObjectLockMode)
+		delete(metadata, xhttp.AmzObjectLockRetainUntilDate)
+		return metadata
+	}
+	if getRetPerms == ErrNone {
+		return metadata
+	}
+	delete(metadata, xhttp.AmzObjectLockMode)
+	delete(metadata, xhttp.AmzObjectLockRetainUntilDate)
+	return metadata
 }

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -510,7 +510,7 @@ func (s *peerRESTServer) DeleteBucketHandler(w http.ResponseWriter, r *http.Requ
 
 	globalNotificationSys.RemoveNotification(bucketName)
 	globalPolicySys.Remove(bucketName)
-	globalBucketRetentionConfig.Delete(bucketName)
+	globalBucketObjectLockConfig.Delete(bucketName)
 
 	w.(http.Flusher).Flush()
 }
@@ -787,7 +787,7 @@ func (s *peerRESTServer) PutBucketObjectLockConfigHandler(w http.ResponseWriter,
 		return
 	}
 
-	globalBucketRetentionConfig.Set(bucketName, retention)
+	globalBucketObjectLockConfig.Set(bucketName, retention)
 	w.(http.Flusher).Flush()
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -521,6 +521,5 @@ func isWORMEnabled(bucket string) (Retention, bool) {
 	if globalWORMEnabled {
 		return Retention{}, true
 	}
-
-	return globalBucketRetentionConfig.Get(bucket)
+	return globalBucketObjectLockConfig.Get(bucket)
 }

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -708,8 +708,8 @@ func (xl xlObjects) CompleteMultipartUpload(ctx context.Context, bucket string, 
 
 	if xl.isObject(bucket, object) {
 		// Deny if WORM is enabled
-		if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-			if oi, err := xl.getObjectInfo(ctx, bucket, object); err == nil && retention.Retain(oi.ModTime) {
+		if globalWORMEnabled {
+			if _, err := xl.getObjectInfo(ctx, bucket, object); err == nil {
 				return ObjectInfo{}, ObjectAlreadyExists{Bucket: bucket, Object: object}
 			}
 		}

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -611,8 +611,8 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 
 	if xl.isObject(bucket, object) {
 		// Deny if WORM is enabled
-		if retention, isWORMBucket := isWORMEnabled(bucket); isWORMBucket {
-			if oi, err := xl.getObjectInfo(ctx, bucket, object); err == nil && retention.Retain(oi.ModTime) {
+		if globalWORMEnabled {
+			if _, err := xl.getObjectInfo(ctx, bucket, object); err == nil {
 				return ObjectInfo{}, ObjectAlreadyExists{Bucket: bucket, Object: object}
 			}
 		}

--- a/docs/retention/README.md
+++ b/docs/retention/README.md
@@ -1,6 +1,9 @@
 # Object Lock and Immutablity [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-MinIO server allows to set bucket level WORM which makes objects in the bucket immutable i.e. delete and overwrite are not allowed till stipulated time specified in the bucket's object lock configuration.
+MinIO server allows selectively specify WORM for specific objects or configuring a bucket with default object lock configuration that applies default retention mode and retention duration to all incoming objects. Essentially, this makes objects in the bucket immutable i.e. delete and overwrite are not allowed till stipulated time specified in the bucket's object lock configuration or object retention.
+
+Object locking requires locking to be enabled on a bucket at the time of bucket creation. In addition, a default retention period and retention mode can be configured on a bucket to be
+applied to objects created in that bucket.
 
 ## Get Started
 
@@ -8,19 +11,33 @@ MinIO server allows to set bucket level WORM which makes objects in the bucket i
 
 Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/docs/minio-quickstart-guide).
 
-### 2. Set per bucket WORM
+### 2. Set bucket WORM configuration
 
 WORM on a bucket is enabled by setting object lock configuration. This configuration is applied to existing and new objects in the bucket. Below is an example sets `Governance` mode and one day retention time from object creation time of all objects in `mybucket`.
 
 ```sh
 $ awscli s3api put-object-lock-configuration --bucket mybucket --object-lock-configuration 'ObjectLockEnabled=\"Enabled\",Rule={DefaultRetention={Mode=\"GOVERNANCE\",Days=1}}'
 ```
+### Set object lock
+
+PutObject API allows setting per object retention mode and retention duration using `x-amz-object-lock-mode` and `x-amz-object-lock-retain-until-date` headers. This takes precedence over any bucket object lock configuration w.r.t retention.
+
+```sh
+aws s3api put-object --bucket testbucket --key lockme --object-lock-mode GOVERNANCE --object-lock-retain-until-date "2019-11-20"  --body /etc/issue
+```
+
+See https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html for AWS S3 spec on
+object locking and permissions required for object retention and governance bypass overrides.
 
 ### 3. Note
 
 - When global WORM is enabled by `MINIO_WORM` environment variable or `worm` field in configuration file supersedes bucket level WORM and `PUT object lock configuration` REST API is disabled.
-- Currently Governance mode is treated as Compliance mode.
-- Once object lock configuration is set to a bucket, existing and new objects are put in WORM mode.
+- global WORM and objects in `Compliance` mode can never be overwritten
+- Currently `Governance` mode does not allow overwriting an existing object as versioning is not
+available in MinIO. To that extent `Governance` mode is similar to `Compliance`. However,
+if user has requisite `Governance` bypass permissions, an object in `Governance` mode can be overwritten.
+- Once object lock configuration is set to a bucket, new objects inherit the retention settings of the bucket object lock configuration (if set) or the retention headers set in the PUT request
+or set with PutObjectRetention API call
 
 ## Explore Further
 

--- a/pkg/event/name.go
+++ b/pkg/event/name.go
@@ -29,12 +29,14 @@ type Name int
 const (
 	ObjectAccessedAll Name = 1 + iota
 	ObjectAccessedGet
+	ObjectAccessedGetRetention
 	ObjectAccessedHead
 	ObjectCreatedAll
 	ObjectCreatedCompleteMultipartUpload
 	ObjectCreatedCopy
 	ObjectCreatedPost
 	ObjectCreatedPut
+	ObjectCreatedPutRetention
 	ObjectRemovedAll
 	ObjectRemovedDelete
 )
@@ -43,9 +45,9 @@ const (
 func (name Name) Expand() []Name {
 	switch name {
 	case ObjectAccessedAll:
-		return []Name{ObjectAccessedGet, ObjectAccessedHead}
+		return []Name{ObjectAccessedGet, ObjectAccessedHead, ObjectAccessedGetRetention}
 	case ObjectCreatedAll:
-		return []Name{ObjectCreatedCompleteMultipartUpload, ObjectCreatedCopy, ObjectCreatedPost, ObjectCreatedPut}
+		return []Name{ObjectCreatedCompleteMultipartUpload, ObjectCreatedCopy, ObjectCreatedPost, ObjectCreatedPut, ObjectCreatedPutRetention}
 	case ObjectRemovedAll:
 		return []Name{ObjectRemovedDelete}
 	default:
@@ -60,6 +62,8 @@ func (name Name) String() string {
 		return "s3:ObjectAccessed:*"
 	case ObjectAccessedGet:
 		return "s3:ObjectAccessed:Get"
+	case ObjectAccessedGetRetention:
+		return "s3:ObjectAccessed:GetRetention"
 	case ObjectAccessedHead:
 		return "s3:ObjectAccessed:Head"
 	case ObjectCreatedAll:
@@ -72,6 +76,8 @@ func (name Name) String() string {
 		return "s3:ObjectCreated:Post"
 	case ObjectCreatedPut:
 		return "s3:ObjectCreated:Put"
+	case ObjectCreatedPutRetention:
+		return "s3:ObjectAccessed:PutRetention"
 	case ObjectRemovedAll:
 		return "s3:ObjectRemoved:*"
 	case ObjectRemovedDelete:
@@ -130,6 +136,8 @@ func ParseName(s string) (Name, error) {
 		return ObjectAccessedAll, nil
 	case "s3:ObjectAccessed:Get":
 		return ObjectAccessedGet, nil
+	case "s3:ObjectAccessed:GetRetention":
+		return ObjectAccessedGetRetention, nil
 	case "s3:ObjectAccessed:Head":
 		return ObjectAccessedHead, nil
 	case "s3:ObjectCreated:*":
@@ -142,6 +150,8 @@ func ParseName(s string) (Name, error) {
 		return ObjectCreatedPost, nil
 	case "s3:ObjectCreated:Put":
 		return ObjectCreatedPut, nil
+	case "s3:ObjectCreated:PutRetention":
+		return ObjectCreatedPutRetention, nil
 	case "s3:ObjectRemoved:*":
 		return ObjectRemovedAll, nil
 	case "s3:ObjectRemoved:Delete":

--- a/pkg/event/target/elasticsearch.go
+++ b/pkg/event/target/elasticsearch.go
@@ -146,7 +146,6 @@ func (target *ElasticsearchTarget) send(eventData event.Event) error {
 		} else {
 			err = update()
 		}
-
 		return err
 	}
 

--- a/pkg/iam/policy/action.go
+++ b/pkg/iam/policy/action.go
@@ -91,33 +91,57 @@ const (
 	// PutObjectAction - PutObject Rest API action.
 	PutObjectAction = "s3:PutObject"
 
+	// BypassGovernanceModeAction - bypass governance mode for DeleteObject Rest API action.
+	BypassGovernanceModeAction = "s3:BypassGovernanceMode"
+
+	// BypassGovernanceRetentionAction - bypass governance retention for PutObjectRetention, PutObject and DeleteObject Rest API action.
+	BypassGovernanceRetentionAction = "s3:BypassGovernanceRetention"
+
+	// PutObjectRetentionAction - PutObjectRetention Rest API action.
+	PutObjectRetentionAction = "s3:PutObjectRetention"
+
+	// GetObjectRetentionAction - GetObjectRetention, GetObject, HeadObject Rest API action.
+	GetObjectRetentionAction = "s3:GetObjectRetention"
+
+	// GetBucketObjectLockConfigurationAction - GetBucketObjectLockConfiguration Rest API action
+	GetBucketObjectLockConfigurationAction = "s3:GetBucketObjectLockConfiguration"
+
+	// PutBucketObjectLockConfigurationAction - PutBucketObjectLockConfiguration Rest API action
+	PutBucketObjectLockConfigurationAction = "s3:PutBucketObjectLockConfiguration"
+
 	// AllActions - all API actions
 	AllActions = "s3:*"
 )
 
 // List of all supported actions.
 var supportedActions = map[Action]struct{}{
-	AllActions:                       {},
-	AbortMultipartUploadAction:       {},
-	CreateBucketAction:               {},
-	DeleteBucketAction:               {},
-	DeleteBucketPolicyAction:         {},
-	DeleteObjectAction:               {},
-	GetBucketLocationAction:          {},
-	GetBucketNotificationAction:      {},
-	GetBucketPolicyAction:            {},
-	GetObjectAction:                  {},
-	HeadBucketAction:                 {},
-	ListAllMyBucketsAction:           {},
-	ListBucketAction:                 {},
-	ListBucketMultipartUploadsAction: {},
-	ListenBucketNotificationAction:   {},
-	ListMultipartUploadPartsAction:   {},
-	PutBucketNotificationAction:      {},
-	PutBucketPolicyAction:            {},
-	PutObjectAction:                  {},
-	GetBucketLifecycleAction:         {},
-	PutBucketLifecycleAction:         {},
+	AllActions:                             {},
+	AbortMultipartUploadAction:             {},
+	CreateBucketAction:                     {},
+	DeleteBucketAction:                     {},
+	DeleteBucketPolicyAction:               {},
+	DeleteObjectAction:                     {},
+	GetBucketLocationAction:                {},
+	GetBucketNotificationAction:            {},
+	GetBucketPolicyAction:                  {},
+	GetObjectAction:                        {},
+	HeadBucketAction:                       {},
+	ListAllMyBucketsAction:                 {},
+	ListBucketAction:                       {},
+	ListBucketMultipartUploadsAction:       {},
+	ListenBucketNotificationAction:         {},
+	ListMultipartUploadPartsAction:         {},
+	PutBucketNotificationAction:            {},
+	PutBucketPolicyAction:                  {},
+	PutObjectAction:                        {},
+	GetBucketLifecycleAction:               {},
+	PutBucketLifecycleAction:               {},
+	PutObjectRetentionAction:               {},
+	GetObjectRetentionAction:               {},
+	PutBucketObjectLockConfigurationAction: {},
+	GetBucketObjectLockConfigurationAction: {},
+	BypassGovernanceModeAction:             {},
+	BypassGovernanceRetentionAction:        {},
 }
 
 // isObjectAction - returns whether action is object type or not.
@@ -126,6 +150,10 @@ func (action Action) isObjectAction() bool {
 	case AbortMultipartUploadAction, DeleteObjectAction, GetObjectAction:
 		fallthrough
 	case ListMultipartUploadPartsAction, PutObjectAction, AllActions:
+		return true
+	case BypassGovernanceModeAction, BypassGovernanceRetentionAction:
+		return true
+	case PutObjectRetentionAction, GetObjectRetentionAction:
 		return true
 	}
 
@@ -238,4 +266,10 @@ var actionConditionKeyMap = map[Action]condition.KeySet{
 			condition.S3XAmzMetadataDirective,
 			condition.S3XAmzStorageClass,
 		}, condition.CommonKeys...)...),
+	PutObjectRetentionAction:               condition.NewKeySet(condition.CommonKeys...),
+	GetObjectRetentionAction:               condition.NewKeySet(condition.CommonKeys...),
+	BypassGovernanceModeAction:             condition.NewKeySet(condition.CommonKeys...),
+	BypassGovernanceRetentionAction:        condition.NewKeySet(condition.CommonKeys...),
+	GetBucketObjectLockConfigurationAction: condition.NewKeySet(condition.CommonKeys...),
+	PutBucketObjectLockConfigurationAction: condition.NewKeySet(condition.CommonKeys...),
 }

--- a/pkg/policy/action.go
+++ b/pkg/policy/action.go
@@ -89,6 +89,20 @@ const (
 
 	// GetBucketLifecycleAction - GetBucketLifecycle Rest API action.
 	GetBucketLifecycleAction = "s3:GetBucketLifecycle"
+
+	// BypassGovernanceModeAction - bypass governance mode for DeleteObject Rest API action.
+	BypassGovernanceModeAction = "s3:BypassGovernanceMode"
+	// BypassGovernanceRetentionAction - bypass governance retention for PutObjectRetention, PutObject and DeleteObject Rest API action.
+	BypassGovernanceRetentionAction = "s3:BypassGovernanceRetention"
+	// PutObjectRetentionAction - PutObjectRetention Rest API action.
+	PutObjectRetentionAction = "s3:PutObjectRetention"
+
+	// GetObjectRetentionAction - GetObjectRetention, GetObject, HeadObject Rest API action.
+	GetObjectRetentionAction = "s3:GetObjectRetention"
+	// GetBucketObjectLockConfigurationAction - GetObjectLockConfiguration Rest API action
+	GetBucketObjectLockConfigurationAction = "s3:GetBucketObjectLockConfiguration"
+	// PutBucketObjectLockConfigurationAction - PutObjectLockConfiguration Rest API action
+	PutBucketObjectLockConfigurationAction = "s3:PutBucketObjectLockConfiguration"
 )
 
 // isObjectAction - returns whether action is object type or not.
@@ -97,6 +111,10 @@ func (action Action) isObjectAction() bool {
 	case AbortMultipartUploadAction, DeleteObjectAction, GetObjectAction:
 		fallthrough
 	case ListMultipartUploadPartsAction, PutObjectAction:
+		return true
+	case PutObjectRetentionAction, GetObjectRetentionAction:
+		return true
+	case BypassGovernanceModeAction, BypassGovernanceRetentionAction:
 		return true
 	}
 
@@ -121,6 +139,12 @@ func (action Action) IsValid() bool {
 	case PutBucketPolicyAction, PutObjectAction:
 		fallthrough
 	case PutBucketLifecycleAction, GetBucketLifecycleAction:
+		return true
+	case BypassGovernanceModeAction, BypassGovernanceRetentionAction:
+		return true
+	case PutObjectRetentionAction, GetObjectRetentionAction:
+		return true
+	case PutBucketObjectLockConfigurationAction, GetBucketObjectLockConfigurationAction:
 		return true
 	}
 
@@ -204,4 +228,10 @@ var actionConditionKeyMap = map[Action]condition.KeySet{
 			condition.S3XAmzMetadataDirective,
 			condition.S3XAmzStorageClass,
 		}, condition.CommonKeys...)...),
+	PutObjectRetentionAction:               condition.NewKeySet(condition.CommonKeys...),
+	GetObjectRetentionAction:               condition.NewKeySet(condition.CommonKeys...),
+	BypassGovernanceModeAction:             condition.NewKeySet(condition.CommonKeys...),
+	BypassGovernanceRetentionAction:        condition.NewKeySet(condition.CommonKeys...),
+	GetBucketObjectLockConfigurationAction: condition.NewKeySet(condition.CommonKeys...),
+	PutBucketObjectLockConfigurationAction: condition.NewKeySet(condition.CommonKeys...),
 }


### PR DESCRIPTION
## Description
Implement Object locking API calls as per https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html

The global worm setting represented by MINIO_WORM continues to take precedence. The previous PR #8120 added enforcement of WORM at bucket level - however the API referenced above is more granular to lock at the object level and following that here.
## Motivation and Context
PUT, HEAD, GET, DELETE and GetObjectRetention calls have been enhanced to support object locking 
Note: for PUT operation
-- Since MinIO doesnt have versioning support, if PUT tries to overwrite a object under governance, the PUT is disallowed
-- Content-MD5 sum is required for this API and is currently not enforced in this PR.

Above API's are at a point where they can be reviewed/tested.

## How to test this PR?
- Use `mc lock` to set/clear governance/compliance modes
- Use aws-cli to test remaining api calls
```
 aws s3api put-object --bucket kannappan300 --key global --object-lock-mode GOVERNANCE --object-lock-retain-until-date "2019-11-20"   --body /etc/issue --profile minio  --endpoint-url http://localhost:9000

 aws s3api get-object-retention --bucket kannappan300 --key mykey --version-id 123 --endpoint-url http://localhost:9000 --profile minio
```
Create user1 with full permissions to governance (See sample policy below). 
Create user2 will specific governance permissions removed from policy.

Testing  governance enforcement for above users would be a good test.
Also turning on site wide WORM with MINIO_WORM or changing object lock modes and testing behavior after retention period is expired.
```
{
 "version": "2012-10-17",
 "Statement": [
   {
     "Action": [
      "s3:CreateBucket",
      "s3:DeleteBucket",
      "s3:ListBucket",
      "s3:ListAllMyBuckets",
      "s3:GetBucketLocation",
       "s3:PutObject",
       "s3:GetObject",
       "s3:PutObjectRetention",
       "s3:GetObjectRetention",
       "s3:AbortMultipartUpload",
      "s3:DeleteObject",
       "s3:ListMultipartUploadParts",
       "s3:BypassGovernanceMode",
       "s3:BypassGovernanceRetention",
       "s3:GetBucketObjectLockConfiguration",
       "s3:PutBucketObjectLockConfiguration"
     ],
     "Effect": "Allow",
     "Resource": [
                  "arn:aws:s3:::*"
                 ],
     "Sid": "AllowAllActions"
   }]
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
