### PR TITLE
Initialize local nsLocker for gateway instances

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -220,6 +220,8 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(err, "Unable to initialize gateway backend")
 	}
 
+	newObject = NewGatewayLayerWithLocker(newObject)
+
 	// Re-enable logging
 	logger.Disable = false
 

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -26,6 +26,22 @@ import (
 	"github.com/minio/minio/pkg/policy"
 )
 
+// GatewayLocker implements custom NeNSLock implementation
+type GatewayLocker struct {
+	ObjectLayer
+	nsMutex *nsLockMap
+}
+
+// NewNSLock - implements gateway level locker
+func (l *GatewayLocker) NewNSLock(ctx context.Context, bucket string, object string) RWLocker {
+	return l.nsMutex.NewNSLock(ctx, nil, bucket, object)
+}
+
+// NewGatewayLayerWithLocker - initialize gateway with locker.
+func NewGatewayLayerWithLocker(gwLayer ObjectLayer) ObjectLayer {
+	return &GatewayLocker{ObjectLayer: gwLayer, nsMutex: newNSLock(false)}
+}
+
 // GatewayUnsupported list of unsupported call stubs for gateway.
 type GatewayUnsupported struct{}
 


### PR DESCRIPTION
## Description
Initialize local nsLocker for gateway instances

## Motivation and Context
Avoids NewNSLock crash

## How to test this PR?
Test by adding etcd and check that migration code panics at NewNSLock

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably introduced in #8492 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
