### PR TITLE
Fix heal result item output to properly count drives and sets

### DIFF
--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -1211,10 +1211,10 @@ func (z *xlZones) HealFormat(ctx context.Context, dryRun bool) (madmin.HealResul
 			logger.LogIf(ctx, err)
 			continue
 		}
-		r.DiskCount = result.DiskCount
-		r.SetCount = result.SetCount
-		r.Before.Drives = append(r.Before.Drives, r.Before.Drives...)
-		r.After.Drives = append(r.After.Drives, r.After.Drives...)
+		r.DiskCount += result.DiskCount
+		r.SetCount += result.SetCount
+		r.Before.Drives = append(r.Before.Drives, result.Before.Drives...)
+		r.After.Drives = append(r.After.Drives, result.After.Drives...)
 	}
 	return r, nil
 }
@@ -1234,10 +1234,10 @@ func (z *xlZones) HealBucket(ctx context.Context, bucket string, dryRun, remove 
 			}
 			return result, err
 		}
-		r.DiskCount = result.DiskCount
-		r.SetCount = result.SetCount
-		r.Before.Drives = append(r.Before.Drives, r.Before.Drives...)
-		r.After.Drives = append(r.After.Drives, r.After.Drives...)
+		r.DiskCount += result.DiskCount
+		r.SetCount += result.SetCount
+		r.Before.Drives = append(r.Before.Drives, result.Before.Drives...)
+		r.After.Drives = append(r.After.Drives, result.After.Drives...)
 	}
 	return r, nil
 }


### PR DESCRIPTION
## Description
Fix heal result item output to properly count drives and sets

## Motivation and Context
Testing bucket expansion

## How to test this PR?
- Start a cluster
- Upload few objects to a bucket
- Stop this cluster and create a fresh expanded cluster
- Imitate drive failure by delete contents of one of the data drive
- Try healing this object / bucket

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
