### PR TITLE
Handle indexes correctly in DeleteMultipleObjectsHandler

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -404,20 +404,24 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 
 	toNames := func(input map[string]int) (output []string) {
 		output = make([]string, len(input))
-		for name, index := range input {
-			output[index] = name
+		idx := 0
+		for name := range input {
+			output[idx] = name
+			idx++
 		}
 		return
 	}
 
-	errs, err := deleteObjectsFn(ctx, bucket, toNames(objectsToDelete))
+	deleteList := toNames(objectsToDelete)
+	errs, err := deleteObjectsFn(ctx, bucket, deleteList)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
 
-	for _, index := range objectsToDelete {
-		dErrs[index] = toAPIErrorCode(ctx, errs[index])
+	for i, objName := range deleteList {
+		dIdx := objectsToDelete[objName]
+		dErrs[dIdx] = toAPIErrorCode(ctx, errs[i])
 	}
 
 	// Collect deleted objects and errors if any.


### PR DESCRIPTION
Regression from #8509 which changes objectsToDelete entry
from a list to map. This will cause index out of range
panic if object is not selected for delete.

## Description

## Motivation and Context
Found this while testing object retention PR where some entries need to be skipped if user has no permission to delete the object. 
## How to test this PR?

Give s3:DeleteObjects permission to user only on certain prefixes on a resource. Create a few objects under the prefix and others which user has no permission to delete.
 Do a ```mc rb --force testbucket``` - this should trigger a panic

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
