### PR TITLE
One click OpenID authorization on Login page

### DIFF
--- a/browser/app/js/browser/Login.js
+++ b/browser/app/js/browser/Login.js
@@ -16,16 +16,13 @@
 
 import React from "react"
 import { connect } from "react-redux"
-import classNames from "classnames"
 import logo from "../../img/logo.svg"
 import Alert from "../alert/Alert"
 import * as actionsAlert from "../alert/actions"
 import InputGroup from "./InputGroup"
 import web from "../web"
 import { Redirect, Link } from "react-router-dom"
-import qs from "query-string"
-import storage from "local-storage-fallback"
-import history from "../history"
+import { OpenIDLoginButton } from './OpenIDLoginButton'
 
 export class Login extends React.Component {
   constructor(props) {
@@ -33,7 +30,8 @@ export class Login extends React.Component {
     this.state = {
       accessKey: "",
       secretKey: "",
-      discoveryDoc: {}
+      discoveryDoc: {},
+      clientId: ""
     }
   }
 
@@ -88,8 +86,9 @@ export class Login extends React.Component {
   }
 
   componentDidMount() {
-    web.GetDiscoveryDoc().then(({ DiscoveryDoc }) => {
+    web.GetDiscoveryDoc().then(({ DiscoveryDoc, clientId }) => {
       this.setState({
+        clientId,
         discoveryDoc: DiscoveryDoc
       })
     })
@@ -107,6 +106,8 @@ export class Login extends React.Component {
     let alertBox = <Alert {...alert} onDismiss={clearAlert} />
     // Make sure you don't show a fading out alert box on the initial web-page load.
     if (!alert.message) alertBox = ""
+
+    const showOpenID = Boolean(this.state.discoveryDoc && this.state.discoveryDoc.authorization_endpoint)
     return (
       <div className="login">
         {alertBox}
@@ -139,13 +140,24 @@ export class Login extends React.Component {
               <i className="fas fa-sign-in-alt" />
             </button>
           </form>
-          {this.state.discoveryDoc &&
-            this.state.discoveryDoc.authorization_endpoint && (
+          {showOpenID && (
             <div className="openid-login">
               <div className="or">or</div>
-              <a href={"/login/openid"} className="btn openid-btn">
-                Log in with OpenID
-              </a>
+              {
+                this.state.clientId ? (
+                  <OpenIDLoginButton
+                    className="btn openid-btn"
+                    clientId={this.state.clientId}
+                    authorizationEndpoint={this.state.discoveryDoc.authorization_endpoint}
+                  >
+                    Log in with OpenID
+                  </OpenIDLoginButton>
+                ) : (
+                  <Link to={"/login/openid"} className="btn openid-btn">
+                    Log in with OpenID
+                  </Link>
+                )
+              }
             </div>
           )}
         </div>

--- a/browser/app/js/browser/OpenIDLoginButton.js
+++ b/browser/app/js/browser/OpenIDLoginButton.js
@@ -1,0 +1,57 @@
+/*
+ * MinIO Cloud Storage (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { getRandomString } from "../utils"
+import storage from "local-storage-fallback"
+import { buildOpenIDAuthURL, OPEN_ID_NONCE_KEY } from './utils'
+
+export class OpenIDLoginButton extends React.Component {
+  constructor(props) {
+    super(props)
+    this.handleClick = this.handleClick.bind(this)
+  }
+
+  handleClick(event) {
+    event.stopPropagation()
+    const { authorizationEndpoint, clientId } = this.props
+
+    let redirectURI = window.location.href.split("#")[0]
+    if (redirectURI.endsWith('/')) {
+      redirectURI += 'openid'
+    } else {
+      redirectURI += '/openid'
+    }
+
+    // Store nonce in localstorage to check again after the redirect
+    const nonce = getRandomString(16)
+    storage.setItem(OPEN_ID_NONCE_KEY, nonce)
+
+    const authURL = buildOpenIDAuthURL(authorizationEndpoint, redirectURI, clientId, nonce)
+    window.location = authURL
+  }
+
+  render() {
+    const { children, className } = this.props
+    return (
+      <div onClick={this.handleClick} className={className}>
+        {children}
+      </div>
+    )
+  }
+}
+
+export default OpenIDLoginButton

--- a/browser/app/js/browser/utils.js
+++ b/browser/app/js/browser/utils.js
@@ -1,0 +1,29 @@
+/*
+ * MinIO Cloud Storage (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const OPEN_ID_NONCE_KEY = 'openIDKey'
+
+export const buildOpenIDAuthURL = (authorizationEndpoint, redirectURI, clientID, nonce) => {
+  const params = new URLSearchParams()
+  params.set("response_type", "id_token")
+  params.set("scope", "openid")
+  params.set("client_id", clientID)
+  params.set("redirect_uri", redirectURI)
+  params.set("nonce", nonce)
+
+  return `${authorizationEndpoint}?${params.toString()}`
+}
+

--- a/browser/app/less/inc/login.less
+++ b/browser/app/less/inc/login.less
@@ -109,6 +109,7 @@
     &:hover {
         color: @link-color;
         opacity: 1;
+        cursor: pointer;
     }
 }
 

--- a/cmd/config/identity/openid/jwt.go
+++ b/cmd/config/identity/openid/jwt.go
@@ -41,6 +41,7 @@ type Config struct {
 	URL          *xnet.URL `json:"url,omitempty"`
 	ClaimPrefix  string    `json:"claimPrefix,omitempty"`
 	DiscoveryDoc DiscoveryDoc
+	ClientId     string
 	publicKeys   map[string]crypto.PublicKey
 	transport    *http.Transport
 	closeRespFn  func(io.ReadCloser)
@@ -208,6 +209,7 @@ const (
 	ClaimPrefix = "claim_prefix"
 
 	EnvIdentityOpenIDState       = "MINIO_IDENTITY_OPENID_STATE"
+	EnvIdentityOpenIDClientId    = "MINIO_IDENTITY_OPENID_CLIENT_ID"
 	EnvIdentityOpenIDJWKSURL     = "MINIO_IDENTITY_OPENID_JWKS_URL"
 	EnvIdentityOpenIDURL         = "MINIO_IDENTITY_OPENID_CONFIG_URL"
 	EnvIdentityOpenIDClaimPrefix = "MINIO_IDENTITY_OPENID_CLAIM_PREFIX"
@@ -291,6 +293,8 @@ func LookupConfig(kvs config.KVS, transport *http.Transport, closeRespFn func(io
 		return c, err
 	}
 
+	openIDClientId := env.Get(EnvIdentityOpenIDClientId, "")
+
 	jwksURL := env.Get(EnvIamJwksURL, "") // Legacy
 	if jwksURL == "" {
 		jwksURL = env.Get(EnvIdentityOpenIDJWKSURL, kvs.Get(JwksURL))
@@ -299,6 +303,7 @@ func LookupConfig(kvs config.KVS, transport *http.Transport, closeRespFn func(io
 	c = Config{
 		ClaimPrefix: env.Get(EnvIdentityOpenIDClaimPrefix, kvs.Get(ClaimPrefix)),
 		publicKeys:  make(map[string]crypto.PublicKey),
+		ClientId:    openIDClientId,
 		transport:   transport,
 		closeRespFn: closeRespFn,
 	}

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -1909,12 +1909,14 @@ func presignedGet(host, bucket, object string, expiry int64, creds auth.Credenti
 type DiscoveryDocResp struct {
 	DiscoveryDoc openid.DiscoveryDoc
 	UIVersion    string `json:"uiVersion"`
+	ClientId     string `json:"clientId"`
 }
 
 // GetDiscoveryDoc - returns parsed value of OpenID discovery document
 func (web *webAPIHandlers) GetDiscoveryDoc(r *http.Request, args *WebGenericArgs, reply *DiscoveryDocResp) error {
 	if globalOpenIDConfig.DiscoveryDoc.AuthEndpoint != "" {
 		reply.DiscoveryDoc = globalOpenIDConfig.DiscoveryDoc
+		reply.ClientId = globalOpenIDConfig.ClientId
 	}
 	reply.UIVersion = browser.UIVersion
 	return nil


### PR DESCRIPTION
## Description
Adds new `MINIO_IDENTITY_OPENID_CLIENT_ID` environment variable by definition it on minio start OpenID button on login page starts redirecting to OIDC auth page, instead of sending to minio openid login page.

## Motivation and Context
Simplify log in by OIDC for constant client id

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
