### PR TITLE
Add data usage collect with its new admin API

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -290,6 +290,31 @@ func (a adminAPIHandlers) StorageInfoHandler(w http.ResponseWriter, r *http.Requ
 
 }
 
+// DataUsageInfoHandler - GET /minio/admin/v2/datausage
+// ----------
+// Get server/cluster data usage info
+func (a adminAPIHandlers) DataUsageInfoHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := newContext(r, w, "DataUsageInfo")
+	objectAPI, _ := validateAdminReq(ctx, w, r, iampolicy.ListServerInfoAdminAction)
+	if objectAPI == nil {
+		return
+	}
+
+	dataUsageInfo, err := loadDataUsageFromBackend(ctx, objectAPI)
+	if err != nil {
+		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrInternalError), r.URL)
+		return
+	}
+
+	dataUsageInfoJSON, err := json.Marshal(dataUsageInfo)
+	if err != nil {
+		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrInternalError), r.URL)
+		return
+	}
+
+	writeSuccessResponseJSON(w, dataUsageInfoJSON)
+}
+
 // ServerCPULoadInfo holds informantion about cpu utilization
 // of one minio node. It also reports any errors if encountered
 // while trying to reach this server.

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -587,6 +587,11 @@ func (h *healSequence) healItemsFromSourceCh() error {
 		logger.LogIf(h.ctx, err)
 	}
 
+	// Start healing the background ops prefix.
+	if err := h.healMinioSysMeta(backgroundOpsMetaPrefix)(); err != nil {
+		logger.LogIf(h.ctx, err)
+	}
+
 	for path := range h.sourceCh {
 
 		var itemType madmin.HealItemType
@@ -631,6 +636,11 @@ func (h *healSequence) healItems() error {
 	// Start healing the bucket config prefix.
 	if err := h.healMinioSysMeta(bucketConfigPrefix)(); err != nil {
 		return err
+	}
+
+	// Start healing the background ops prefix.
+	if err := h.healMinioSysMeta(backgroundOpsMetaPrefix)(); err != nil {
+		logger.LogIf(h.ctx, err)
 	}
 
 	// Heal buckets and objects

--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -53,6 +53,8 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 
 	// StorageInfo operations
 	adminRouter.Methods(http.MethodGet).Path(adminAPIVersionPrefix + "/storageinfo").HandlerFunc(httpTraceAll(adminAPI.StorageInfoHandler))
+	// DataUsageInfo operations
+	adminRouter.Methods(http.MethodGet).Path(adminAPIVersionPrefix + "/datausageinfo").HandlerFunc(httpTraceAll(adminAPI.DataUsageInfoHandler))
 
 	if globalIsDistXL || globalIsXL {
 		/// Heal operations

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -61,6 +61,7 @@ func runDataUsageInfoUpdateRoutine() {
 
 func runDataUsageInfoForFS(ctx context.Context, fsObj *FSObjects, endCh <-chan struct{}) {
 	t := time.NewTicker(dataUsageCrawlInterval)
+	defer t.Stop()
 	for {
 		// Get data usage info of the FS Object
 		usageInfo := fsObj.crawlAndGetDataUsageInfo(ctx, endCh)
@@ -91,6 +92,7 @@ func runDataUsageInfoForXLZones(ctx context.Context, z *xlZones, endCh <-chan st
 	}
 
 	t := time.NewTicker(dataUsageCrawlInterval)
+	defer t.Stop()
 	for {
 		usageInfo := z.crawlAndGetDataUsage(ctx, endCh)
 		err := storeDataUsageInBackend(ctx, z, usageInfo)

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -59,7 +59,7 @@ func runDataUsageInfoUpdateRoutine() {
 	}
 }
 
-func runDataUsageInfoForFS(ctx context.Context, fsObj *FSObjects, endCh chan struct{}) {
+func runDataUsageInfoForFS(ctx context.Context, fsObj *FSObjects, endCh <-chan struct{}) {
 	t := time.NewTicker(dataUsageCrawlInterval)
 	for {
 		// Get data usage info of the FS Object
@@ -78,7 +78,7 @@ func runDataUsageInfoForFS(ctx context.Context, fsObj *FSObjects, endCh chan str
 	}
 }
 
-func runDataUsageInfoForXLZones(ctx context.Context, z *xlZones, endCh chan struct{}) {
+func runDataUsageInfoForXLZones(ctx context.Context, z *xlZones, endCh <-chan struct{}) {
 	locker := z.NewNSLock(ctx, minioMetaBucket, "leader-data-usage-info")
 	for {
 		err := locker.GetLock(newDynamicTimeout(time.Millisecond, time.Millisecond))

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -1,0 +1,198 @@
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/hash"
+)
+
+const (
+	dataUsageObjName       = "data-usage"
+	dataUsageCrawlInterval = 12 * time.Hour
+)
+
+func initDataUsageStats() {
+	go runDataUsageInfoUpdateRoutine()
+}
+
+func runDataUsageInfoUpdateRoutine() {
+	// Wait until the object layer is ready
+	var objAPI ObjectLayer
+	for {
+		objAPI = newObjectLayerWithoutSafeModeFn()
+		if objAPI == nil {
+			time.Sleep(time.Second)
+			continue
+		}
+		break
+	}
+
+	ctx := context.Background()
+
+	switch v := objAPI.(type) {
+	case *xlZones:
+		runDataUsageInfoForXLZones(ctx, v)
+	case *FSObjects:
+		runDataUsageInfoForFS(ctx, v)
+	default:
+		return
+	}
+}
+
+func runDataUsageInfoForFS(ctx context.Context, fsObj *FSObjects) {
+	for {
+		// Get data usage info of the FS Object
+		usageInfo := fsObj.crawlAndGetDataUsageInfo(ctx)
+		// Save the data usage in the disk
+		err := storeDataUsageInBackend(ctx, fsObj, usageInfo)
+		if err != nil {
+			logger.LogIf(ctx, err)
+		}
+		// Wait until the next crawl interval
+		time.Sleep(dataUsageCrawlInterval)
+	}
+}
+
+func runDataUsageInfoForXLZones(ctx context.Context, zones *xlZones) {
+	for {
+		locker := zones.NewNSLock(ctx, minioMetaBucket, "leader-data-usage-info")
+		err := locker.GetLock(newDynamicTimeout(time.Millisecond, time.Millisecond))
+		if err != nil {
+			time.Sleep(5 * time.Minute)
+			continue
+		}
+		// Break without locking
+		break
+	}
+
+	for {
+		usageInfo := zonesCrawlAndGetDataUsage(ctx, zones)
+		err := storeDataUsageInBackend(ctx, zones, usageInfo)
+		if err != nil {
+			logger.LogIf(ctx, err)
+		}
+
+		time.Sleep(dataUsageCrawlInterval)
+	}
+
+}
+
+func zonesCrawlAndGetDataUsage(ctx context.Context, zones *xlZones) DataUsageInfo {
+	// Calculate the aggregated data usage, meaning
+	// accumulate data usage of all zones.
+	var aggregatedDataUsageInfo = DataUsageInfo{
+		ObjectsSizesHistogram: make(map[string]uint64),
+		BucketsSizes:          make(map[string]uint64),
+	}
+
+	addUpUsageInfo := func(dataUsageInfo DataUsageInfo) {
+		aggregatedDataUsageInfo.ObjectsCount += dataUsageInfo.ObjectsCount
+		aggregatedDataUsageInfo.ObjectsTotalSize += dataUsageInfo.ObjectsTotalSize
+		if aggregatedDataUsageInfo.BucketsCount < dataUsageInfo.BucketsCount {
+			aggregatedDataUsageInfo.BucketsCount = dataUsageInfo.BucketsCount
+		}
+		for k, v := range dataUsageInfo.ObjectsSizesHistogram {
+			aggregatedDataUsageInfo.ObjectsSizesHistogram[k] += v
+		}
+		for k, v := range dataUsageInfo.BucketsSizes {
+			aggregatedDataUsageInfo.BucketsSizes[k] += v
+		}
+	}
+
+	for _, z := range zones.zones {
+		for _, xl := range z.sets {
+			var randomDisks []StorageAPI
+			for _, d := range xl.getLoadBalancedDisks() {
+				if d == nil || !d.IsOnline() {
+					continue
+				}
+				if len(randomDisks) > 3 {
+					break
+				}
+				randomDisks = append(randomDisks, d)
+			}
+
+			var dataUsageResult = make([]DataUsageInfo, len(randomDisks))
+
+			var wg sync.WaitGroup
+			for i := 0; i < len(randomDisks); i++ {
+				wg.Add(1)
+				go func(index int, disk StorageAPI) {
+					defer wg.Done()
+					var err error
+					dataUsageResult[index], err = disk.CrawlAndGetDataUsage()
+					if err != nil {
+						logger.LogIf(ctx, err)
+					}
+				}(i, randomDisks[i])
+			}
+			wg.Wait()
+
+			var reliableDataUsageResult DataUsageInfo
+			for i := 0; i < len(dataUsageResult); i++ {
+				if dataUsageResult[i].ObjectsCount > reliableDataUsageResult.ObjectsCount {
+					reliableDataUsageResult = dataUsageResult[i]
+				}
+			}
+
+			addUpUsageInfo(reliableDataUsageResult)
+		}
+	}
+
+	aggregatedDataUsageInfo.LastUpdate = UTCNow()
+	return aggregatedDataUsageInfo
+}
+
+func storeDataUsageInBackend(ctx context.Context, objAPI ObjectLayer, dataUsageInfo DataUsageInfo) error {
+	dataUsageJSON, err := json.Marshal(dataUsageInfo)
+	if err != nil {
+		return err
+	}
+
+	size := int64(len(dataUsageJSON))
+	r, err := hash.NewReader(bytes.NewReader(dataUsageJSON), size, "", "", size, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = objAPI.PutObject(ctx, minioMetaBackgroundOpsBucket, dataUsageObjName, NewPutObjReader(r, nil, nil), ObjectOptions{})
+	return err
+}
+
+func loadDataUsageFromBackend(ctx context.Context, objAPI ObjectLayer) (DataUsageInfo, error) {
+	var dataUsageInfoJSON bytes.Buffer
+
+	err := objAPI.GetObject(ctx, minioMetaBackgroundOpsBucket, dataUsageObjName, 0, -1, &dataUsageInfoJSON, "", ObjectOptions{})
+	if err != nil {
+		return DataUsageInfo{}, nil
+	}
+
+	var dataUsageInfo DataUsageInfo
+	err = json.Unmarshal(dataUsageInfoJSON.Bytes(), &dataUsageInfo)
+	if err != nil {
+		return DataUsageInfo{}, err
+	}
+
+	return dataUsageInfo, nil
+}

--- a/cmd/fastwalk.go
+++ b/cmd/fastwalk.go
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// This code is imported from "golang.org/x/tools/internal/fastwalk",
+// only fastwalk.go is imported since we already implement readDir()
+// with some little tweaks.
+
 package cmd
 
 import (

--- a/cmd/fastwalk.go
+++ b/cmd/fastwalk.go
@@ -1,0 +1,224 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// fastwalk provides a faster version of filepath.Walk for file system
+// scanning tools.
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// TraverseLink is used as a return value from WalkFuncs to indicate that the
+// symlink named in the call may be traversed.
+var TraverseLink = errors.New("fastwalk: traverse symlink, assuming target is a directory")
+
+// SkipFiles is a used as a return value from WalkFuncs to indicate that the
+// callback should not be called for any other files in the current directory.
+// Child directories will still be traversed.
+var SkipFiles = errors.New("fastwalk: skip remaining files in directory")
+
+// Walk is a faster implementation of filepath.Walk.
+//
+// filepath.Walk's design necessarily calls os.Lstat on each file,
+// even if the caller needs less info.
+// Many tools need only the type of each file.
+// On some platforms, this information is provided directly by the readdir
+// system call, avoiding the need to stat each file individually.
+// fastwalk_unix.go contains a fork of the syscall routines.
+//
+// See golang.org/issue/16399
+//
+// Walk walks the file tree rooted at root, calling walkFn for
+// each file or directory in the tree, including root.
+//
+// If fastWalk returns filepath.SkipDir, the directory is skipped.
+//
+// Unlike filepath.Walk:
+//   * file stat calls must be done by the user.
+//     The only provided metadata is the file type, which does not include
+//     any permission bits.
+//   * multiple goroutines stat the filesystem concurrently. The provided
+//     walkFn must be safe for concurrent use.
+//   * fastWalk can follow symlinks if walkFn returns the TraverseLink
+//     sentinel error. It is the walkFn's responsibility to prevent
+//     fastWalk from going into symlink cycles.
+func fastWalk(root string, walkFn func(path string, typ os.FileMode) error) error {
+	// TODO(bradfitz): make numWorkers configurable? We used a
+	// minimum of 4 to give the kernel more info about multiple
+	// things we want, in hopes its I/O scheduling can take
+	// advantage of that. Hopefully most are in cache. Maybe 4 is
+	// even too low of a minimum. Profile more.
+	numWorkers := 4
+	if n := runtime.NumCPU(); n > numWorkers {
+		numWorkers = n
+	}
+
+	// Make sure to wait for all workers to finish, otherwise
+	// walkFn could still be called after returning. This Wait call
+	// runs after close(e.donec) below.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	w := &walker{
+		fn:       walkFn,
+		enqueuec: make(chan walkItem, numWorkers), // buffered for performance
+		workc:    make(chan walkItem, numWorkers), // buffered for performance
+		donec:    make(chan struct{}),
+
+		// buffered for correctness & not leaking goroutines:
+		resc: make(chan error, numWorkers),
+	}
+	defer close(w.donec)
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go w.doWork(&wg)
+	}
+	todo := []walkItem{{dir: root}}
+	out := 0
+	for {
+		workc := w.workc
+		var workItem walkItem
+		if len(todo) == 0 {
+			workc = nil
+		} else {
+			workItem = todo[len(todo)-1]
+		}
+		select {
+		case workc <- workItem:
+			todo = todo[:len(todo)-1]
+			out++
+		case it := <-w.enqueuec:
+			todo = append(todo, it)
+		case err := <-w.resc:
+			out--
+			if err != nil {
+				return err
+			}
+			if out == 0 && len(todo) == 0 {
+				// It's safe to quit here, as long as the buffered
+				// enqueue channel isn't also readable, which might
+				// happen if the worker sends both another unit of
+				// work and its result before the other select was
+				// scheduled and both w.resc and w.enqueuec were
+				// readable.
+				select {
+				case it := <-w.enqueuec:
+					todo = append(todo, it)
+				default:
+					return nil
+				}
+			}
+		}
+	}
+}
+
+// doWork reads directories as instructed (via workc) and runs the
+// user's callback function.
+func (w *walker) doWork(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-w.donec:
+			return
+		case it := <-w.workc:
+			select {
+			case <-w.donec:
+				return
+			case w.resc <- w.walk(it.dir, !it.callbackDone):
+			}
+		}
+	}
+}
+
+type walker struct {
+	fn func(path string, typ os.FileMode) error
+
+	donec    chan struct{} // closed on fastWalk's return
+	workc    chan walkItem // to workers
+	enqueuec chan walkItem // from workers
+	resc     chan error    // from workers
+}
+
+type walkItem struct {
+	dir          string
+	callbackDone bool // callback already called; don't do it again
+}
+
+func (w *walker) enqueue(it walkItem) {
+	select {
+	case w.enqueuec <- it:
+	case <-w.donec:
+	}
+}
+
+func (w *walker) onDirEnt(dirName, baseName string, typ os.FileMode) error {
+	joined := dirName + string(os.PathSeparator) + baseName
+	if typ == os.ModeDir {
+		w.enqueue(walkItem{dir: joined})
+		return nil
+	}
+
+	err := w.fn(joined, typ)
+	if typ == os.ModeSymlink {
+		if err == TraverseLink {
+			// Set callbackDone so we don't call it twice for both the
+			// symlink-as-symlink and the symlink-as-directory later:
+			w.enqueue(walkItem{dir: joined, callbackDone: true})
+			return nil
+		}
+		if err == filepath.SkipDir {
+			// Permit SkipDir on symlinks too.
+			return nil
+		}
+	}
+	return err
+}
+
+func readDirFn(dirName string, fn func(dirName, entName string, typ os.FileMode) error) error {
+	fis, err := readDir(dirName)
+	if err != nil {
+		return err
+	}
+	skipFiles := false
+	for _, fi := range fis {
+		var mode os.FileMode
+		if strings.HasSuffix(fi, SlashSeparator) {
+			mode |= os.ModeDir
+		}
+
+		if mode == 0 && skipFiles {
+			continue
+		}
+
+		if err := fn(dirName, fi, mode); err != nil {
+			if err == SkipFiles {
+				skipFiles = true
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *walker) walk(root string, runUserCallback bool) error {
+	if runUserCallback {
+		err := w.fn(root, os.ModeDir)
+		if err == filepath.SkipDir {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return readDirFn(root, w.onDirEnt)
+}

--- a/cmd/fastwalk.go
+++ b/cmd/fastwalk.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// fastwalk provides a faster version of filepath.Walk for file system
-// scanning tools.
 package cmd
 
 import (
@@ -15,14 +13,14 @@ import (
 	"sync"
 )
 
-// TraverseLink is used as a return value from WalkFuncs to indicate that the
+// ErrTraverseLink is used as a return value from WalkFuncs to indicate that the
 // symlink named in the call may be traversed.
-var TraverseLink = errors.New("fastwalk: traverse symlink, assuming target is a directory")
+var ErrTraverseLink = errors.New("fastwalk: traverse symlink, assuming target is a directory")
 
-// SkipFiles is a used as a return value from WalkFuncs to indicate that the
+// ErrSkipFiles is a used as a return value from WalkFuncs to indicate that the
 // callback should not be called for any other files in the current directory.
 // Child directories will still be traversed.
-var SkipFiles = errors.New("fastwalk: skip remaining files in directory")
+var ErrSkipFiles = errors.New("fastwalk: skip remaining files in directory")
 
 // Walk is a faster implementation of filepath.Walk.
 //
@@ -168,7 +166,7 @@ func (w *walker) onDirEnt(dirName, baseName string, typ os.FileMode) error {
 
 	err := w.fn(joined, typ)
 	if typ == os.ModeSymlink {
-		if err == TraverseLink {
+		if err == ErrTraverseLink {
 			// Set callbackDone so we don't call it twice for both the
 			// symlink-as-symlink and the symlink-as-directory later:
 			w.enqueue(walkItem{dir: joined, callbackDone: true})
@@ -199,7 +197,7 @@ func readDirFn(dirName string, fn func(dirName, entName string, typ os.FileMode)
 		}
 
 		if err := fn(dirName, fi, mode); err != nil {
-			if err == SkipFiles {
+			if err == ErrSkipFiles {
 				skipFiles = true
 				continue
 			}

--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -746,7 +746,7 @@ func initFormatXL(ctx context.Context, storageDisks []StorageAPI, setCount, driv
 	}
 
 	// Initialize meta volume, if volume already exists ignores it.
-	if err := initFormatXLMetaVolume(storageDisks); err != nil {
+	if err := initFormatXLMetaVolume(storageDisks, formats); err != nil {
 		return format, fmt.Errorf("Unable to initialize '.minio.sys' meta volume, %w", err)
 	}
 
@@ -787,7 +787,7 @@ func makeFormatXLMetaVolumes(disk StorageAPI) error {
 var initMetaVolIgnoredErrs = append(baseIgnoredErrs, errVolumeExists)
 
 // Initializes meta volume on all input storage disks.
-func initFormatXLMetaVolume(storageDisks []StorageAPI) error {
+func initFormatXLMetaVolume(storageDisks []StorageAPI, formats []*formatXLV3) error {
 	// This happens for the first time, but keep this here since this
 	// is the only place where it can be made expensive optimizing all
 	// other calls. Create minio meta volume, if it doesn't exist yet.
@@ -799,7 +799,7 @@ func initFormatXLMetaVolume(storageDisks []StorageAPI) error {
 	for index := range storageDisks {
 		index := index
 		g.Go(func() error {
-			if storageDisks[index] == nil {
+			if formats[index] == nil || storageDisks[index] == nil {
 				// Ignore create meta volume on disks which are not found.
 				return nil
 			}

--- a/cmd/format-xl_test.go
+++ b/cmd/format-xl_test.go
@@ -101,7 +101,7 @@ func TestFixFormatV3(t *testing.T) {
 		formats[j] = newFormat
 	}
 
-	if err = initFormatXLMetaVolume(storageDisks, formats); err != nil {
+	if err = initFormatXLMetaVolume(storageDisks); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/format-xl_test.go
+++ b/cmd/format-xl_test.go
@@ -101,7 +101,7 @@ func TestFixFormatV3(t *testing.T) {
 		formats[j] = newFormat
 	}
 
-	if err = initFormatXLMetaVolume(storageDisks); err != nil {
+	if err = initFormatXLMetaVolume(storageDisks, formats); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -255,6 +255,7 @@ func (fs *FSObjects) crawlAndGetDataUsageInfo(ctx context.Context, endCh chan st
 		if prefix == "" {
 			dataUsageInfoMu.Lock()
 			dataUsageInfo.BucketsCount++
+			dataUsageInfo.BucketsSizes[bucket] = 0
 			dataUsageInfoMu.Unlock()
 			return nil
 		}

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -236,7 +236,7 @@ func (fs *FSObjects) waitForLowActiveIO() error {
 }
 
 // crawlAndGetDataUsageInfo returns data usage stats of the current FS deployment
-func (fs *FSObjects) crawlAndGetDataUsageInfo(ctx context.Context, endCh chan struct{}) DataUsageInfo {
+func (fs *FSObjects) crawlAndGetDataUsageInfo(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
 
 	var dataUsageInfoMu sync.Mutex
 	var dataUsageInfo = DataUsageInfo{

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -80,8 +80,8 @@ func (d *naughtyDisk) calcError() (err error) {
 func (d *naughtyDisk) SetDiskID(id string) {
 }
 
-func (d *naughtyDisk) CrawlAndGetDataUsage() (info DataUsageInfo, err error) {
-	return d.disk.CrawlAndGetDataUsage()
+func (d *naughtyDisk) CrawlAndGetDataUsage(endCh chan struct{}) (info DataUsageInfo, err error) {
+	return d.disk.CrawlAndGetDataUsage(endCh)
 }
 
 func (d *naughtyDisk) DiskInfo() (info DiskInfo, err error) {

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -80,6 +80,10 @@ func (d *naughtyDisk) calcError() (err error) {
 func (d *naughtyDisk) SetDiskID(id string) {
 }
 
+func (d *naughtyDisk) CrawlAndGetDataUsage() (info DataUsageInfo, err error) {
+	return d.disk.CrawlAndGetDataUsage()
+}
+
 func (d *naughtyDisk) DiskInfo() (info DiskInfo, err error) {
 	if err := d.calcError(); err != nil {
 		return info, err

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -80,7 +80,7 @@ func (d *naughtyDisk) calcError() (err error) {
 func (d *naughtyDisk) SetDiskID(id string) {
 }
 
-func (d *naughtyDisk) CrawlAndGetDataUsage(endCh chan struct{}) (info DataUsageInfo, err error) {
+func (d *naughtyDisk) CrawlAndGetDataUsage(endCh <-chan struct{}) (info DataUsageInfo, err error) {
 	return d.disk.CrawlAndGetDataUsage(endCh)
 }
 

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -450,3 +450,26 @@ func listObjects(ctx context.Context, obj ObjectLayer, bucket, prefix, marker, d
 	// Success.
 	return result, nil
 }
+
+// Fetch the histogram interval corresponding
+// to the passed object size.
+func objSizeToHistoInterval(usize uint64) string {
+	size := int64(usize)
+
+	var interval objectHistogramInterval
+	for _, interval = range ObjectsHistogramIntervals {
+		var cond1, cond2 bool
+		if size >= interval.start || interval.start == -1 {
+			cond1 = true
+		}
+		if size <= interval.end || interval.end == -1 {
+			cond2 = true
+		}
+		if cond1 && cond2 {
+			return interval.name
+		}
+	}
+
+	// This would be the last element of histogram intervals
+	return interval.name
+}

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -70,6 +70,39 @@ type StorageInfo struct {
 	}
 }
 
+// objectHistogramInterval is an interval that will be
+// used to report the histogram of objects data sizes
+type objectHistogramInterval struct {
+	name       string
+	start, end int64
+}
+
+// ObjectsHistogramIntervals is the list of all intervals
+// of object sizes to be included in objects histogram.
+var ObjectsHistogramIntervals = []objectHistogramInterval{
+	{"LESS_THAN_1024_B", -1, 1024 - 1},
+	{"BETWEEN_1024_B_AND_1_MB", 1024, 1024*1024 - 1},
+	{"BETWEEN_1_MB_AND_10_MB", 1024 * 1024, 1024*1024*10 - 1},
+	{"BETWEEN_10_MB_AND_64_MB", 1024 * 1024 * 10, 1024*1024*64 - 1},
+	{"BETWEEN_64_MB_AND_128_MB", 1024 * 1024 * 64, 1024*1024*128 - 1},
+	{"BETWEEN_128_MB_AND_512_MB", 1024 * 1024 * 128, 1024*1024*512 - 1},
+	{"GREATER_THAN_512_MB", 1024 * 1024 * 512, -1},
+}
+
+// DataUsageInfo represents data usage stats of the underlying Object API
+type DataUsageInfo struct {
+	// The timestamp of when the data usage info is generated
+	LastUpdate time.Time
+
+	ObjectsCount uint64
+	// Objects total size
+	ObjectsTotalSize      uint64
+	ObjectsSizesHistogram map[string]uint64
+
+	BucketsCount uint64
+	BucketsSizes map[string]uint64
+}
+
 // BucketInfo - represents bucket metadata.
 type BucketInfo struct {
 	// Name of the bucket.

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -92,15 +92,15 @@ var ObjectsHistogramIntervals = []objectHistogramInterval{
 // DataUsageInfo represents data usage stats of the underlying Object API
 type DataUsageInfo struct {
 	// The timestamp of when the data usage info is generated
-	LastUpdate time.Time
+	LastUpdate time.Time `json:"lastUpdate"`
 
-	ObjectsCount uint64
+	ObjectsCount uint64 `json:"objectsCount"`
 	// Objects total size
-	ObjectsTotalSize      uint64
-	ObjectsSizesHistogram map[string]uint64
+	ObjectsTotalSize      uint64            `json:"objectsTotalSize"`
+	ObjectsSizesHistogram map[string]uint64 `json:"objectsSizesHistogram"`
 
-	BucketsCount uint64
-	BucketsSizes map[string]uint64
+	BucketsCount uint64            `json:"bucketsCount"`
+	BucketsSizes map[string]uint64 `json:"bucketsSizes"`
 }
 
 // BucketInfo - represents bucket metadata.

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -51,6 +51,10 @@ import (
 const (
 	// MinIO meta bucket.
 	minioMetaBucket = ".minio.sys"
+	// Background ops meta prefix
+	backgroundOpsMetaPrefix = "background-ops"
+	// MinIO Stats meta prefix.
+	minioMetaBackgroundOpsBucket = minioMetaBucket + SlashSeparator + backgroundOpsMetaPrefix
 	// Multipart meta prefix.
 	mpartMetaPrefix = "multipart"
 	// MinIO Multipart meta prefix.
@@ -72,7 +76,8 @@ const (
 func isMinioMetaBucketName(bucket string) bool {
 	return bucket == minioMetaBucket ||
 		bucket == minioMetaMultipartBucket ||
-		bucket == minioMetaTmpBucket
+		bucket == minioMetaTmpBucket ||
+		bucket == minioMetaBackgroundOpsBucket
 }
 
 // IsValidBucketName verifies that a bucket name is in accordance with

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -38,8 +38,8 @@ func (p *posixDiskIDCheck) IsOnline() bool {
 	return storedDiskID == p.diskID
 }
 
-func (p *posixDiskIDCheck) CrawlAndGetDataUsage() (DataUsageInfo, error) {
-	return p.storage.CrawlAndGetDataUsage()
+func (p *posixDiskIDCheck) CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error) {
+	return p.storage.CrawlAndGetDataUsage(endCh)
 }
 
 func (p *posixDiskIDCheck) LastError() error {

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -38,6 +38,10 @@ func (p *posixDiskIDCheck) IsOnline() bool {
 	return storedDiskID == p.diskID
 }
 
+func (p *posixDiskIDCheck) CrawlAndGetDataUsage() (DataUsageInfo, error) {
+	return p.storage.CrawlAndGetDataUsage()
+}
+
 func (p *posixDiskIDCheck) LastError() error {
 	return p.storage.LastError()
 }

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -38,7 +38,7 @@ func (p *posixDiskIDCheck) IsOnline() bool {
 	return storedDiskID == p.diskID
 }
 
-func (p *posixDiskIDCheck) CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error) {
+func (p *posixDiskIDCheck) CrawlAndGetDataUsage(endCh <-chan struct{}) (DataUsageInfo, error) {
 	return p.storage.CrawlAndGetDataUsage(endCh)
 }
 

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -346,8 +346,6 @@ func (s *posix) waitForLowActiveIO() {
 
 func (s *posix) CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error) {
 
-	s.waitForLowActiveIO()
-
 	var dataUsageInfoMu sync.Mutex
 	var dataUsageInfo = DataUsageInfo{
 		BucketsSizes:          make(map[string]uint64),
@@ -355,6 +353,9 @@ func (s *posix) CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error)
 	}
 
 	walkFn := func(origPath string, typ os.FileMode) error {
+
+		s.waitForLowActiveIO()
+
 		path := strings.TrimPrefix(origPath, s.diskPath)
 		path = strings.TrimPrefix(path, SlashSeparator)
 

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -388,6 +388,7 @@ func (s *posix) CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error)
 		if prefix == "" {
 			dataUsageInfoMu.Lock()
 			dataUsageInfo.BucketsCount++
+			dataUsageInfo.BucketsSizes[bucket] = 0
 			dataUsageInfoMu.Unlock()
 			return nil
 		}

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -351,7 +351,7 @@ func (s *posix) waitForLowActiveIO() error {
 	return nil
 }
 
-func (s *posix) CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error) {
+func (s *posix) CrawlAndGetDataUsage(endCh <-chan struct{}) (DataUsageInfo, error) {
 
 	var dataUsageInfoMu sync.Mutex
 	var dataUsageInfo = DataUsageInfo{

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -224,7 +224,11 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 		// minio server managing the first disk
 		globalDeploymentID = format.ID
 	} else {
-		initFormatXLMetaVolume(storageDisks)
+		// The first will always recreate some directories inside .minio.sys
+		// such as, tmp, multipart and background-ops
+		if firstDisk {
+			initFormatXLMetaVolume(storageDisks, formatConfigs)
+		}
 	}
 
 	// Return error when quorum unformatted disks - indicating we are

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -223,6 +223,8 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 		// Assign globalDeploymentID on first run for the
 		// minio server managing the first disk
 		globalDeploymentID = format.ID
+	} else {
+		initFormatXLMetaVolume(storageDisks)
 	}
 
 	// Return error when quorum unformatted disks - indicating we are

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -437,6 +437,7 @@ func serverMain(ctx *cli.Context) {
 		globalObjLayerMutex.Unlock()
 	}
 
+	initDataUsageStats()
 	initDailyLifecycle()
 
 	if globalIsXL {

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -32,6 +32,7 @@ type StorageAPI interface {
 	SetDiskID(id string)
 
 	DiskInfo() (info DiskInfo, err error)
+	CrawlAndGetDataUsage() (DataUsageInfo, error)
 
 	// Volume operations.
 	MakeVol(volume string) (err error)

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -32,7 +32,7 @@ type StorageAPI interface {
 	SetDiskID(id string)
 
 	DiskInfo() (info DiskInfo, err error)
-	CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error)
+	CrawlAndGetDataUsage(endCh <-chan struct{}) (DataUsageInfo, error)
 
 	// Volume operations.
 	MakeVol(volume string) (err error)

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -32,7 +32,7 @@ type StorageAPI interface {
 	SetDiskID(id string)
 
 	DiskInfo() (info DiskInfo, err error)
-	CrawlAndGetDataUsage() (DataUsageInfo, error)
+	CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error)
 
 	// Volume operations.
 	MakeVol(volume string) (err error)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -147,7 +147,7 @@ func (client *storageRESTClient) IsOnline() bool {
 	return atomic.LoadInt32(&client.connected) == 1
 }
 
-func (client *storageRESTClient) CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error) {
+func (client *storageRESTClient) CrawlAndGetDataUsage(endCh <-chan struct{}) (DataUsageInfo, error) {
 	respBody, err := client.call(storageRESTMethodCrawlAndGetDataUsage, nil, nil, -1)
 	defer http.DrainBody(respBody)
 	if err != nil {

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -147,6 +147,17 @@ func (client *storageRESTClient) IsOnline() bool {
 	return atomic.LoadInt32(&client.connected) == 1
 }
 
+func (client *storageRESTClient) CrawlAndGetDataUsage() (DataUsageInfo, error) {
+	respBody, err := client.call(storageRESTMethodCrawlAndGetDataUsage, nil, nil, -1)
+	if err != nil {
+		return DataUsageInfo{}, err
+	}
+	defer http.DrainBody(respBody)
+	var usageInfo DataUsageInfo
+	err = gob.NewDecoder(respBody).Decode(&usageInfo)
+	return usageInfo, err
+}
+
 // LastError - returns the network error if any.
 func (client *storageRESTClient) LastError() error {
 	return client.lastError

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -147,7 +147,7 @@ func (client *storageRESTClient) IsOnline() bool {
 	return atomic.LoadInt32(&client.connected) == 1
 }
 
-func (client *storageRESTClient) CrawlAndGetDataUsage() (DataUsageInfo, error) {
+func (client *storageRESTClient) CrawlAndGetDataUsage(endCh chan struct{}) (DataUsageInfo, error) {
 	respBody, err := client.call(storageRESTMethodCrawlAndGetDataUsage, nil, nil, -1)
 	defer http.DrainBody(respBody)
 	if err != nil {

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -17,17 +17,18 @@
 package cmd
 
 const (
-	storageRESTVersion       = "v10"
-	storageRESTVersionPrefix = SlashSeparator + "v10"
+	storageRESTVersion       = "v11"
+	storageRESTVersionPrefix = SlashSeparator + storageRESTVersion
 	storageRESTPrefix        = minioReservedBucketPath + "/storage"
 )
 
 const (
-	storageRESTMethodDiskInfo  = "/diskinfo"
-	storageRESTMethodMakeVol   = "/makevol"
-	storageRESTMethodStatVol   = "/statvol"
-	storageRESTMethodDeleteVol = "/deletevol"
-	storageRESTMethodListVols  = "/listvols"
+	storageRESTMethodDiskInfo             = "/diskinfo"
+	storageRESTMethodCrawlAndGetDataUsage = "/crawlandgetdatausage"
+	storageRESTMethodMakeVol              = "/makevol"
+	storageRESTMethodStatVol              = "/statvol"
+	storageRESTMethodDeleteVol            = "/deletevol"
+	storageRESTMethodListVols             = "/listvols"
 
 	storageRESTMethodAppendFile     = "/appendfile"
 	storageRESTMethodCreateFile     = "/createfile"

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -112,6 +112,31 @@ func (s *storageRESTServer) DiskInfoHandler(w http.ResponseWriter, r *http.Reque
 	gob.NewEncoder(w).Encode(info)
 }
 
+func (s *storageRESTServer) CrawlAndGetDataUsageHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.IsValid(w, r) {
+		return
+	}
+
+	usageInfo, err := s.storage.CrawlAndGetDataUsage()
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+
+	w.Header().Set(xhttp.ContentType, "text/event-stream")
+	doneCh := sendWhiteSpaceToHTTPResponse(w)
+	usageInfo, err = s.storage.CrawlAndGetDataUsage()
+	<-doneCh
+
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+
+	gob.NewEncoder(w).Encode(usageInfo)
+	w.(http.Flusher).Flush()
+}
+
 // MakeVolHandler - make a volume.
 func (s *storageRESTServer) MakeVolHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.IsValid(w, r) {
@@ -489,8 +514,9 @@ func (s *storageRESTServer) RenameFileHandler(w http.ResponseWriter, r *http.Req
 	}
 }
 
-// Send whitespace to the client to avoid timeouts as bitrot verification can take time on spinning/slow disks.
-func sendWhiteSpaceVerifyFile(w http.ResponseWriter) <-chan struct{} {
+// Send whitespace to the client to avoid timeouts with long storage
+// operations, such as bitrot verification or data usage crawling.
+func sendWhiteSpaceToHTTPResponse(w http.ResponseWriter) <-chan struct{} {
 	doneCh := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(time.Second * 10)
@@ -548,7 +574,7 @@ func (s *storageRESTServer) VerifyFile(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set(xhttp.ContentType, "text/event-stream")
 	encoder := gob.NewEncoder(w)
-	doneCh := sendWhiteSpaceVerifyFile(w)
+	doneCh := sendWhiteSpaceToHTTPResponse(w)
 	err = s.storage.VerifyFile(volume, filePath, size, BitrotAlgorithmFromString(algoStr), hash, int64(shardSize))
 	<-doneCh
 	vresp := &VerifyFileResp{}
@@ -577,6 +603,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointZones EndpointZones
 			subrouter := router.PathPrefix(path.Join(storageRESTPrefix, endpoint.Path)).Subrouter()
 
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodDiskInfo).HandlerFunc(httpTraceHdrs(server.DiskInfoHandler))
+			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodCrawlAndGetDataUsage).HandlerFunc(httpTraceHdrs(server.CrawlAndGetDataUsageHandler))
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodMakeVol).HandlerFunc(httpTraceHdrs(server.MakeVolHandler)).Queries(restQueries(storageRESTVolume)...)
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodStatVol).HandlerFunc(httpTraceHdrs(server.StatVolHandler)).Queries(restQueries(storageRESTVolume)...)
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodDeleteVol).HandlerFunc(httpTraceHdrs(server.DeleteVolHandler)).Queries(restQueries(storageRESTVolume)...)

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -117,7 +117,7 @@ func (s *storageRESTServer) CrawlAndGetDataUsageHandler(w http.ResponseWriter, r
 		return
 	}
 
-	usageInfo, err := s.storage.CrawlAndGetDataUsage()
+	usageInfo, err := s.storage.CrawlAndGetDataUsage(GlobalServiceDoneCh)
 	if err != nil {
 		s.writeErrorResponse(w, err)
 		return
@@ -125,7 +125,7 @@ func (s *storageRESTServer) CrawlAndGetDataUsageHandler(w http.ResponseWriter, r
 
 	w.Header().Set(xhttp.ContentType, "text/event-stream")
 	doneCh := sendWhiteSpaceToHTTPResponse(w)
-	usageInfo, err = s.storage.CrawlAndGetDataUsage()
+	usageInfo, err = s.storage.CrawlAndGetDataUsage(GlobalServiceDoneCh)
 	<-doneCh
 
 	if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -525,6 +525,16 @@ func getMinioMode() string {
 	return mode
 }
 
+func splitN(str, delim string, num int) []string {
+	stdSplit := strings.SplitN(str, delim, num)
+	retSplit := make([]string, num)
+	for i := 0; i < len(stdSplit); i++ {
+		retSplit[i] = stdSplit[i]
+	}
+
+	return retSplit
+}
+
 func iamPolicyName() string {
 	return globalOpenIDConfig.ClaimPrefix + iampolicy.PolicyName
 }

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -1493,7 +1493,7 @@ func (s *xlSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.HealRe
 
 		// Initialize meta volume, if volume already exists ignores it, all disks which
 		// are not found are ignored as well.
-		if err = initFormatXLMetaVolume(storageDisks, tmpNewFormats); err != nil {
+		if err = initFormatXLMetaVolume(storageDisks); err != nil {
 			return madmin.HealResultItem{}, fmt.Errorf("Unable to initialize '.minio.sys' meta volume, %w", err)
 		}
 

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -1493,7 +1493,7 @@ func (s *xlSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.HealRe
 
 		// Initialize meta volume, if volume already exists ignores it, all disks which
 		// are not found are ignored as well.
-		if err = initFormatXLMetaVolume(storageDisks); err != nil {
+		if err = initFormatXLMetaVolume(storageDisks, tmpNewFormats); err != nil {
 			return madmin.HealResultItem{}, fmt.Errorf("Unable to initialize '.minio.sys' meta volume, %w", err)
 		}
 

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -208,7 +208,7 @@ func (xl xlObjects) GetMetrics(ctx context.Context) (*Metrics, error) {
 	return &Metrics{}, NotImplemented{}
 }
 
-func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, endCh chan struct{}) DataUsageInfo {
+func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
 	var randomDisks []StorageAPI
 	for _, d := range xl.getLoadBalancedDisks() {
 		if d == nil || !d.IsOnline() {

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/bpool"
@@ -205,4 +206,42 @@ func (xl xlObjects) StorageInfo(ctx context.Context) StorageInfo {
 func (xl xlObjects) GetMetrics(ctx context.Context) (*Metrics, error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return &Metrics{}, NotImplemented{}
+}
+
+func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, endCh chan struct{}) DataUsageInfo {
+	var randomDisks []StorageAPI
+	for _, d := range xl.getLoadBalancedDisks() {
+		if d == nil || !d.IsOnline() {
+			continue
+		}
+		if len(randomDisks) > 3 {
+			break
+		}
+		randomDisks = append(randomDisks, d)
+	}
+
+	var dataUsageResults = make([]DataUsageInfo, len(randomDisks))
+
+	var wg sync.WaitGroup
+	for i := 0; i < len(randomDisks); i++ {
+		wg.Add(1)
+		go func(index int, disk StorageAPI) {
+			defer wg.Done()
+			var err error
+			dataUsageResults[index], err = disk.CrawlAndGetDataUsage(endCh)
+			if err != nil {
+				logger.LogIf(ctx, err)
+			}
+		}(i, randomDisks[i])
+	}
+	wg.Wait()
+
+	var dataUsageInfo DataUsageInfo
+	for i := 0; i < len(dataUsageResults); i++ {
+		if dataUsageResults[i].ObjectsCount > dataUsageInfo.ObjectsCount {
+			dataUsageInfo = dataUsageResults[i]
+		}
+	}
+
+	return dataUsageInfo
 }

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -212,7 +212,7 @@ func (z *xlZones) StorageInfo(ctx context.Context) StorageInfo {
 	return storageInfo
 }
 
-func (z *xlZones) crawlAndGetDataUsage(ctx context.Context) DataUsageInfo {
+func (z *xlZones) crawlAndGetDataUsage(ctx context.Context, endCh chan struct{}) DataUsageInfo {
 	// Calculate the aggregated data usage, meaning accumulate data usage of all zones.
 	var aggregatedDataUsageInfo = DataUsageInfo{
 		ObjectsSizesHistogram: make(map[string]uint64),
@@ -254,7 +254,7 @@ func (z *xlZones) crawlAndGetDataUsage(ctx context.Context) DataUsageInfo {
 				go func(index int, disk StorageAPI) {
 					defer wg.Done()
 					var err error
-					dataUsageResult[index], err = disk.CrawlAndGetDataUsage()
+					dataUsageResult[index], err = disk.CrawlAndGetDataUsage(endCh)
 					if err != nil {
 						logger.LogIf(ctx, err)
 					}
@@ -275,7 +275,6 @@ func (z *xlZones) crawlAndGetDataUsage(ctx context.Context) DataUsageInfo {
 
 	aggregatedDataUsageInfo.LastUpdate = UTCNow()
 	return aggregatedDataUsageInfo
-
 }
 
 // This function is used to undo a successful MakeBucket operation.

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strings"
+	"sync"
 
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
@@ -209,6 +210,72 @@ func (z *xlZones) StorageInfo(ctx context.Context) StorageInfo {
 	storageInfo.Backend.RRSCParity = storageInfos[0].Backend.RRSCParity
 
 	return storageInfo
+}
+
+func (z *xlZones) crawlAndGetDataUsage(ctx context.Context) DataUsageInfo {
+	// Calculate the aggregated data usage, meaning accumulate data usage of all zones.
+	var aggregatedDataUsageInfo = DataUsageInfo{
+		ObjectsSizesHistogram: make(map[string]uint64),
+		BucketsSizes:          make(map[string]uint64),
+	}
+
+	addUpUsageInfo := func(dataUsageInfo DataUsageInfo) {
+		aggregatedDataUsageInfo.ObjectsCount += dataUsageInfo.ObjectsCount
+		aggregatedDataUsageInfo.ObjectsTotalSize += dataUsageInfo.ObjectsTotalSize
+		if aggregatedDataUsageInfo.BucketsCount < dataUsageInfo.BucketsCount {
+			aggregatedDataUsageInfo.BucketsCount = dataUsageInfo.BucketsCount
+		}
+		for k, v := range dataUsageInfo.ObjectsSizesHistogram {
+			aggregatedDataUsageInfo.ObjectsSizesHistogram[k] += v
+		}
+		for k, v := range dataUsageInfo.BucketsSizes {
+			aggregatedDataUsageInfo.BucketsSizes[k] += v
+		}
+	}
+
+	for _, z := range z.zones {
+		for _, xl := range z.sets {
+			var randomDisks []StorageAPI
+			for _, d := range xl.getLoadBalancedDisks() {
+				if d == nil || !d.IsOnline() {
+					continue
+				}
+				if len(randomDisks) > 3 {
+					break
+				}
+				randomDisks = append(randomDisks, d)
+			}
+
+			var dataUsageResult = make([]DataUsageInfo, len(randomDisks))
+
+			var wg sync.WaitGroup
+			for i := 0; i < len(randomDisks); i++ {
+				wg.Add(1)
+				go func(index int, disk StorageAPI) {
+					defer wg.Done()
+					var err error
+					dataUsageResult[index], err = disk.CrawlAndGetDataUsage()
+					if err != nil {
+						logger.LogIf(ctx, err)
+					}
+				}(i, randomDisks[i])
+			}
+			wg.Wait()
+
+			var reliableDataUsageResult DataUsageInfo
+			for i := 0; i < len(dataUsageResult); i++ {
+				if dataUsageResult[i].ObjectsCount > reliableDataUsageResult.ObjectsCount {
+					reliableDataUsageResult = dataUsageResult[i]
+				}
+			}
+
+			addUpUsageInfo(reliableDataUsageResult)
+		}
+	}
+
+	aggregatedDataUsageInfo.LastUpdate = UTCNow()
+	return aggregatedDataUsageInfo
+
 }
 
 // This function is used to undo a successful MakeBucket operation.

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -212,7 +212,7 @@ func (z *xlZones) StorageInfo(ctx context.Context) StorageInfo {
 	return storageInfo
 }
 
-func (z *xlZones) crawlAndGetDataUsage(ctx context.Context, endCh chan struct{}) DataUsageInfo {
+func (z *xlZones) crawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
 	var aggDataUsageInfo = struct {
 		sync.Mutex
 		DataUsageInfo

--- a/pkg/madmin/examples/data-usage-info.go
+++ b/pkg/madmin/examples/data-usage-info.go
@@ -1,0 +1,44 @@
+// +build ignore
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"log"
+
+	"github.com/minio/minio/pkg/madmin"
+)
+
+func main() {
+	// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+	// dummy values, please replace them with original values.
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTPS) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.New("your-minio.example.com:9000", "YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", true)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	dataUsageInfo, err := madmClnt.DataUsageInfo()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(dataUsageInfo)
+}

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/minio/pkg/cpu"

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -159,13 +159,13 @@ var ObjectsHistogramIntervals = []objectHistogramInterval{
 
 // DataUsageInfo represents data usage of an Object API
 type DataUsageInfo struct {
-	LastUpdate            time.Time
-	ObjectsCount          uint64
-	ObjectsTotalSize      uint64
-	ObjectsSizesHistogram map[string]uint64
+	LastUpdate            time.Time         `json:"lastUpdate"`
+	ObjectsCount          uint64            `json:"objectsCount"`
+	ObjectsTotalSize      uint64            `json:"objectsTotalSize"`
+	ObjectsSizesHistogram map[string]uint64 `json:"objectsSizesHistogram"`
 
-	BucketsCount uint64
-	BucketsSizes map[string]uint64
+	BucketsCount uint64            `json:"bucketsCount"`
+	BucketsSizes map[string]uint64 `json:"bucketsSizes"`
 }
 
 // DataUsageInfo - returns data usage of the current object API

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -140,6 +140,63 @@ func (adm *AdminClient) StorageInfo() (StorageInfo, error) {
 	return storageInfo, nil
 }
 
+type objectHistogramInterval struct {
+	name       string
+	start, end int64
+}
+
+// ObjectsHistogramIntervals contains the list of intervals
+// of an histogram analysis of objects sizes.
+var ObjectsHistogramIntervals = []objectHistogramInterval{
+	{"LESS_THAN_1024_B", -1, 1024 - 1},
+	{"BETWEEN_1024_B_AND_1_MB", 1024, 1024*1024 - 1},
+	{"BETWEEN_1_MB_AND_10_MB", 1024 * 1024, 1024*1024*10 - 1},
+	{"BETWEEN_10_MB_AND_64_MB", 1024 * 1024 * 10, 1024*1024*64 - 1},
+	{"BETWEEN_64_MB_AND_128_MB", 1024 * 1024 * 64, 1024*1024*128 - 1},
+	{"BETWEEN_128_MB_AND_512_MB", 1024 * 1024 * 128, 1024*1024*512 - 1},
+	{"GREATER_THAN_512_MB", 1024 * 1024 * 512, -1},
+}
+
+// DataUsageInfo represents data usage of an Object API
+type DataUsageInfo struct {
+	LastUpdate            time.Time
+	ObjectsCount          uint64
+	ObjectsTotalSize      uint64
+	ObjectsSizesHistogram map[string]uint64
+
+	BucketsCount uint64
+	BucketsSizes map[string]uint64
+}
+
+// DataUsageInfo - returns data usage of the current object API
+func (adm *AdminClient) DataUsageInfo() (DataUsageInfo, error) {
+	resp, err := adm.executeMethod("GET", requestData{relPath: adminAPIPrefix + "/datausageinfo"})
+	defer closeResponse(resp)
+	if err != nil {
+		return DataUsageInfo{}, err
+	}
+
+	// Check response http status code
+	if resp.StatusCode != http.StatusOK {
+		return DataUsageInfo{}, httpRespToErrorResponse(resp)
+	}
+
+	// Unmarshal the server's json response
+	var dataUsageInfo DataUsageInfo
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return DataUsageInfo{}, err
+	}
+
+	err = json.Unmarshal(respBytes, &dataUsageInfo)
+	if err != nil {
+		return DataUsageInfo{}, err
+	}
+
+	return dataUsageInfo, nil
+}
+
 // ServerDrivesPerfInfo holds informantion about address and write speed of
 // all drives in a single server node
 type ServerDrivesPerfInfo struct {


### PR DESCRIPTION


## Description
The new admin data usage info API returns the following
information of the current initialized object API.

(Only FS & XL, for now)

*) Number of buckets
*) Number of objects
*) Total size of objects
*) Objects histogram
*) Bucket sizes


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
