### PR TITLE
Do not rely on quorum for StorageInfo()

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -55,6 +55,9 @@ type NotificationSys struct {
 // GetARNList - returns available ARNs.
 func (sys *NotificationSys) GetARNList() []string {
 	arns := []string{}
+	if sys == nil {
+		return arns
+	}
 	region := globalServerRegion
 	for _, targetID := range sys.targetList.List() {
 		// httpclient target is part of ListenBucketNotification
@@ -439,8 +442,9 @@ func (sys *NotificationSys) ServerInfo(ctx context.Context) []ServerInfo {
 				info, err := sys.peerClients[index].ServerInfo()
 				if err != nil {
 					serverInfo[index].Error = err.Error()
+				} else {
+					serverInfo[index].Data = &info
 				}
-				serverInfo[index].Data = &info
 				// Last iteration log the error.
 				if i == 2 {
 					return err

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -385,20 +385,17 @@ func (s *xlSets) StorageInfo(ctx context.Context) StorageInfo {
 
 	errs := combineStorageErrors(dErrs, sErrs)
 	drivesInfo := formatsToDrivesInfo(s.endpoints, formats, errs)
-	refFormat, err := getFormatXLInQuorum(formats)
-	if err != nil {
-		// Ignore errors here, since this call cannot do anything at
-		// this point. too many disks are down already.
-		return storageInfo
-	}
 
 	// fill all the available/online endpoints
-	for _, drive := range drivesInfo {
+	for k, drive := range drivesInfo {
 		if drive.UUID == "" {
 			continue
 		}
-		for i := range refFormat.XL.Sets {
-			for j, driveUUID := range refFormat.XL.Sets[i] {
+		if formats[k] == nil {
+			continue
+		}
+		for i := range formats[k].XL.Sets {
+			for j, driveUUID := range formats[k].XL.Sets[i] {
 				if driveUUID == drive.UUID {
 					storageInfo.Backend.Sets[i][j] = drive
 				}


### PR DESCRIPTION
## Description
Do not rely on quorum for StorageInfo()

## Motivation and Context
StorageInfo() call is supposed to give each
server/disk information independently, rely on
this appropriately so that `mc admin info server`
gets correct information all the time.

## How to test this PR?
```
version: "3.3"
# starts 4 docker containers running minio server instances. Each
# minio server's web interface will be accessible on the host at port
# 9001 through 9004.
services:
  minio1:
    image: minio/minio:edge
    volumes:
      - type: bind
        source: /tmp/1/1
        target: /data1
      - type: bind
        source: /tmp/1/2
        target: /data2
    ports:
      - "9001:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/data{1...2} http://minio{5...8}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio2:
    image: minio/minio:edge
    volumes:
      - type: bind
        source: /tmp/2/1
        target: /data1
      - type: bind
        source: /tmp/2/2
        target: /data2
    ports:
      - "9002:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/data{1...2} http://minio{5...8}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio3:
    image: minio/minio:edge
    volumes:
      - type: bind
        source: /tmp/3/1
        target: /data1
      - type: bind
        source: /tmp/3/2
        target: /data2
    ports:
      - "9003:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/data{1...2} http://minio{5...8}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio4:
    image: minio/minio:edge
    volumes:
      - type: bind
        source: /tmp/4/1
        target: /data1
      - type: bind
        source: /tmp/4/2
        target: /data2
    ports:
      - "9004:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/data{1...2} http://minio{5...8}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio5:
    image: minio/minio:edge
    volumes:
      - type: bind
        source: /tmp/5/1
        target: /data1
      - type: bind
        source: /tmp/5/2
        target: /data2
    ports:
      - "9005:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/data{1...2} http://minio{5...8}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio6:
    image: minio/minio:edge
    volumes:
      - type: bind
        source: /tmp/6/1
        target: /data1
      - type: bind
        source: /tmp/6/2
        target: /data2
    ports:
      - "9006:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/data{1...2} http://minio{5...8}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio7:
    image: minio/minio:edge
    volumes:
      - type: bind
        source: /tmp/7/1
        target: /data1
      - type: bind
        source: /tmp/7/2
        target: /data2
    ports:
      - "9007:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/data{1...2} http://minio{5...8}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio8:
    image: minio/minio:edge
    volumes:
      - type: bind
        source: /tmp/8/1
        target: /data1
      - type: bind
        source: /tmp/8/2
        target: /data2
    ports:
      - "9008:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...4}/data{1...2} http://minio{5...8}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
```

```
docker-compose -f docker-compose.yml up
```

Kill three containers and check that `mc admin info server` will return 0/0 for one of the nodes


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
