### PR TITLE
Cache disk ID for a short while

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -396,12 +396,15 @@ func (s *posix) getDiskID() (string, error) {
 	lastCheck := s.formatLastCheck
 	s.RUnlock()
 
+	// check if we have a valid disk ID that is less than 1 second old.
 	if fileInfo != nil && diskID != "" && time.Now().Before(lastCheck.Add(time.Second)) {
 		return diskID, nil
 	}
 
 	s.Lock()
 	defer s.Unlock()
+
+	// If somebody else updated the disk ID and changed the time, return what they got.
 	if !s.formatLastCheck.Equal(lastCheck) {
 		// Somebody else got the lock first.
 		return diskID, nil

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -386,18 +386,18 @@ func (s *posix) getVolDir(volume string) (string, error) {
 func (s *posix) getDiskID() (string, error) {
 	s.RLock()
 	diskID := s.diskID
+	fileInfo := s.formatFileInfo
 	s.RUnlock()
+
+	if fileInfo != nil && diskID != "" {
+		return diskID, nil
+	}
 
 	formatFile := pathJoin(s.diskPath, minioMetaBucket, formatConfigFile)
 	fi, err := os.Stat(formatFile)
 	if err != nil {
 		// If the disk is still not initialized.
 		return "", err
-	}
-
-	if xioutil.SameFile(fi, s.formatFileInfo) {
-		// If the file has not changed, just return the cached diskID information.
-		return diskID, nil
 	}
 
 	s.Lock()

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -87,7 +87,8 @@ type posix struct {
 
 	diskID string
 
-	formatFileInfo os.FileInfo
+	formatFileInfo  os.FileInfo
+	formatLastCheck time.Time
 	// Disk usage metrics
 	stopUsageCh chan struct{}
 
@@ -387,12 +388,19 @@ func (s *posix) getDiskID() (string, error) {
 	s.RLock()
 	diskID := s.diskID
 	fileInfo := s.formatFileInfo
+	lastCheck := s.formatLastCheck
 	s.RUnlock()
 
-	if fileInfo != nil && diskID != "" {
+	if fileInfo != nil && diskID != "" && time.Now().Before(lastCheck.Add(time.Second)) {
 		return diskID, nil
 	}
 
+	s.Lock()
+	defer s.Unlock()
+	if !s.formatLastCheck.Equal(lastCheck) {
+		// Somebody else got the lock first.
+		return diskID, nil
+	}
 	formatFile := pathJoin(s.diskPath, minioMetaBucket, formatConfigFile)
 	fi, err := os.Stat(formatFile)
 	if err != nil {
@@ -400,8 +408,12 @@ func (s *posix) getDiskID() (string, error) {
 		return "", err
 	}
 
-	s.Lock()
-	defer s.Unlock()
+	if xioutil.SameFile(fi, fileInfo) {
+		// If the file has not changed, just return the cached diskID information.
+		s.formatLastCheck = time.Now()
+		return diskID, nil
+	}
+
 	b, err := ioutil.ReadFile(formatFile)
 	if err != nil {
 		return "", err
@@ -413,6 +425,7 @@ func (s *posix) getDiskID() (string, error) {
 	}
 	s.diskID = format.XL.This
 	s.formatFileInfo = fi
+	s.formatLastCheck = time.Now()
 	return s.diskID, nil
 }
 


### PR DESCRIPTION
## Motivation and Context

`*posix.getDiskID()` takes up to 30% of all CPU due to the `os.Stat` call on `GET` calls. (1MB objects)

Only check time on the format JSON at most every second.

Also `fileInfo` was accessed without proper lock.

Before:
```
Operation: GET - Concurrency: 12
* Average: 1333.97 MB/s, 1365.99 obj/s, 1365.98 ops ended/s (4m59.975s)
* First Byte: Average: 7.801487ms, Median: 7.9974ms, Best: 1.9822ms, Worst: 110.0021ms

Aggregated, split into 299 x 1s time segments:
* Fastest: 1453.50 MB/s, 1488.38 obj/s, 1492.00 ops ended/s (1s)
* 50% Median: 1360.47 MB/s, 1393.12 obj/s, 1393.00 ops ended/s (1s)
* Slowest: 978.68 MB/s, 1002.17 obj/s, 1004.00 ops ended/s (1s)
```

After:
```
Operation: GET - Concurrency: 12
* Average: 1759.10 MB/s, 1759.10 obj/s, 1759.09 ops ended/s (4m59.949s)
* First Byte: Average: 5.953116ms, Median: 5.9967ms, Best: 992.2µs, Worst: 166.9996ms

Aggregated, split into 299 x 1s time segments:
* Fastest: 1935.89 MB/s, 1935.89 obj/s, 1936.00 ops ended/s (1s)
* 50% Median: 1795.35 MB/s, 1795.35 obj/s, 1798.00 ops ended/s (1s)
* Slowest: 914.17 MB/s, 914.17 obj/s, 915.00 ops ended/s (1s)
```

![image](https://user-images.githubusercontent.com/5663952/69861127-fbacf800-1297-11ea-872b-4767e0319d1c.png)

## How to test this PR?

Needs to be reviewed by someone who knows if my assumptions above holds.

Alternatively we could add a check only every 10 seconds.

## Types of changes
- [x] Optimization
