### PR TITLE
Preserve client sent config appropriately

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -466,14 +466,10 @@ func (c Config) SetKVS(s string, defaultKVS map[string]KVS) error {
 		tgt = subSystemValue[1]
 	}
 
-	_, ok := c[subSys][tgt]
-	if !ok {
-		c[subSys][tgt] = KVS{}
-	} else {
-		c[subSys][tgt] = kvs
-	}
+	// Save client sent kvs
+	c[subSys][tgt] = kvs
 
-	_, ok = c[subSys][tgt].Lookup(State)
+	_, ok := c[subSys][tgt].Lookup(State)
 	if !ok {
 		// implicit state "on" if not specified.
 		c[subSys][tgt] = append(c[subSys][tgt], KV{

--- a/cmd/config/notify/parse.go
+++ b/cmd/config/notify/parse.go
@@ -564,6 +564,7 @@ func GetNotifyMQTT(mqttKVS map[string]config.KVS, rootCAs *x509.CertPool) (map[s
 		if k != config.Default {
 			brokerEnv = brokerEnv + config.Default + k
 		}
+
 		brokerURL, err := xnet.ParseURL(env.Get(brokerEnv, kv.Get(target.MqttBroker)))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description
Preserve client sent config appropriately

## Motivation and Context
Preserve client sent config appropriately

## How to test this PR?
Just test this with master branch without this PR 

```
~ mc admin config set myminio notify_mqtt:1 broker="tcp://localhost:1883" topic=test
mc: <ERROR> Cannot set 'notify_mqtt:1 broker=tcp://localhost:1883 topic=test' to server: unknown protocol in broker address.
```

Instead should fail with 
```
~ mc admin config set myminio notify_mqtt:1 broker="tcp://localhost:1883" topic=test
mc: <ERROR> Cannot set 'notify_mqtt:1 broker=tcp://localhost:1883 topic=test' to server. Network Error : dial tcp 127.0.0.1:1883: connect: connection refused.
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes introduced in #8541 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
