### PR TITLE
Print goroutines when shutdown hangs

### DIFF
--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -20,6 +20,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"net/http"
+	"os"
+	"runtime/pprof"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -137,6 +139,8 @@ func (srv *Server) Shutdown() error {
 	for {
 		select {
 		case <-shutdownTimer.C:
+			// Print all running goroutines.
+			_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
 			return errors.New("timed out. some connections are still active. doing abnormal shutdown")
 		case <-ticker.C:
 			if atomic.LoadInt32(&srv.requestCount) <= 0 {

--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"runtime/pprof"
 	"sync"
 	"sync/atomic"
@@ -143,7 +142,7 @@ func (srv *Server) Shutdown() error {
 			// Write all running goroutines.
 			tmp, err := ioutil.TempFile("", "minio-goroutines-*.txt")
 			if err == nil {
-				_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+				_ = pprof.Lookup("goroutine").WriteTo(tmp, 1)
 				tmp.Close()
 				return errors.New("timed out. some connections are still active. doing abnormal shutdown. goroutines written to %s" + tmp.Name())
 			}

--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -144,7 +144,7 @@ func (srv *Server) Shutdown() error {
 			if err == nil {
 				_ = pprof.Lookup("goroutine").WriteTo(tmp, 1)
 				tmp.Close()
-				return errors.New("timed out. some connections are still active. doing abnormal shutdown. goroutines written to %s" + tmp.Name())
+				return errors.New("timed out. some connections are still active. doing abnormal shutdown. goroutines written to " + tmp.Name())
 			}
 			return errors.New("timed out. some connections are still active. doing abnormal shutdown")
 		case <-ticker.C:


### PR DESCRIPTION
## Motivation and Context

To make debugging easier print out running goroutines to stderr when shutdown times out.

This will make debugging of hanging requests much easier.

I am not entirely sure if stderr or stdout is most appropriate.

## How to test this PR?

Insert a `select{}` into a handler and execute a request on it.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
