### PR TITLE
Handle localhost distributed setups properly

### DIFF
--- a/buildscripts/verify-build.sh
+++ b/buildscripts/verify-build.sh
@@ -134,17 +134,6 @@ function start_minio_zone_erasure_sets()
     declare -a minio_pids
     export MINIO_ACCESS_KEY=$ACCESS_KEY
     export MINIO_SECRET_KEY=$SECRET_KEY
-    "${MINIO[@]}" server --address=:9000 "http://127.0.0.1:9000${WORK_DIR}/zone-disk-sets{1...4}" >/dev/null 2>&1 &
-    current_pid=$!
-
-    sleep 10
-    kill -9 "${current_pid}"
-
-    "${MINIO[@]}" server --address=:9001 "http://127.0.0.1:9001${WORK_DIR}/zone-disk-sets{5...8}" >/dev/null 2>&1 &
-    current_pid=$!
-
-    sleep 10
-    kill -9 "${current_pid}"
 
     "${MINIO[@]}" server --address=:9000 "http://127.0.0.1:9000${WORK_DIR}/zone-disk-sets{1...4}" "http://127.0.0.1:9001${WORK_DIR}/zone-disk-sets{5...8}" >"$WORK_DIR/zone-minio-9000.log" 2>&1 &
     minio_pids[0]=$!
@@ -152,7 +141,7 @@ function start_minio_zone_erasure_sets()
     "${MINIO[@]}" server --address=:9001 "http://127.0.0.1:9000${WORK_DIR}/zone-disk-sets{1...4}" "http://127.0.0.1:9001${WORK_DIR}/zone-disk-sets{5...8}" >"$WORK_DIR/zone-minio-9001.log" 2>&1 &
     minio_pids[1]=$!
 
-    sleep 10
+    sleep 35
     echo "${minio_pids[@]}"
 }
 

--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -283,9 +283,17 @@ func createServerEndpoints(serverAddr string, args ...string) (EndpointZones, in
 		return endpointZones, len(setArgs[0]), setupType, nil
 	}
 
-	// Look for duplicate args.
-	if _, err := GetAllSets(args...); err != nil {
-		return nil, -1, -1, err
+	// Verify the args setup-type appropriately.
+	{
+		setArgs, err := GetAllSets(args...)
+		if err != nil {
+			return nil, -1, -1, err
+		}
+
+		_, setupType, err = CreateEndpoints(serverAddr, setArgs...)
+		if err != nil {
+			return nil, -1, -1, err
+		}
 	}
 
 	for _, arg := range args {
@@ -293,13 +301,9 @@ func createServerEndpoints(serverAddr string, args ...string) (EndpointZones, in
 		if err != nil {
 			return nil, -1, -1, err
 		}
-		endpointList, newSetupType, err := CreateEndpoints(serverAddr, setArgs...)
+		endpointList, _, err := CreateEndpoints(serverAddr, setArgs...)
 		if err != nil {
 			return nil, -1, -1, err
-		}
-		if setupType != 0 && setupType != newSetupType {
-			return nil, -1, -1, fmt.Errorf("Mixed modes of operation %s and %s are not allowed",
-				setupType, newSetupType)
 		}
 		if drivesPerSet != 0 && drivesPerSet != len(setArgs[0]) {
 			return nil, -1, -1, fmt.Errorf("All zones should have same drive per set ratio - expected %d, got %d", drivesPerSet, len(setArgs[0]))
@@ -310,7 +314,7 @@ func createServerEndpoints(serverAddr string, args ...string) (EndpointZones, in
 			Endpoints:    endpointList,
 		})
 		drivesPerSet = len(setArgs[0])
-		setupType = newSetupType
 	}
+
 	return endpointZones, drivesPerSet, setupType, nil
 }

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -22,13 +22,13 @@ import (
 	"net"
 	"net/url"
 	"sort"
-	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/minio/minio-go/v6/pkg/set"
 	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/cmd/logger"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // IPv4 addresses of local host.
@@ -39,13 +39,11 @@ var localIP6 = mustGetLocalIP6()
 
 // mustSplitHostPort is a wrapper to net.SplitHostPort() where error is assumed to be a fatal.
 func mustSplitHostPort(hostPort string) (host, port string) {
-	host, port, err := net.SplitHostPort(hostPort)
-	// Strip off IPv6 zone information.
-	if i := strings.Index(host, "%"); i > -1 {
-		host = host[:i]
+	xh, err := xnet.ParseHost(hostPort)
+	if err != nil {
+		logger.FatalIf(err, "Unable to split host port %s", hostPort)
 	}
-	logger.FatalIf(err, "Unable to split host port %s", hostPort)
-	return host, port
+	return xh.Name, xh.Port.String()
 }
 
 // mustGetLocalIP4 returns IPv4 addresses of localhost.  It panics on error.
@@ -273,7 +271,7 @@ func extractHostPort(hostAddr string) (string, string, error) {
 // isLocalHost - checks if the given parameter
 // correspond to one of the local IP of the
 // current machine
-func isLocalHost(host string) (bool, error) {
+func isLocalHost(host string, port string, localPort string) (bool, error) {
 	hostIPs, err := getHostIP(host)
 	if err != nil {
 		return false, err
@@ -282,6 +280,9 @@ func isLocalHost(host string) (bool, error) {
 	// If intersection of two IP sets is not empty, then the host is localhost.
 	isLocalv4 := !localIP4.Intersection(hostIPs).IsEmpty()
 	isLocalv6 := !localIP6.Intersection(hostIPs).IsEmpty()
+	if port != "" {
+		return (isLocalv4 || isLocalv6) && (port == localPort), nil
+	}
 	return isLocalv4 || isLocalv6, nil
 }
 
@@ -307,7 +308,7 @@ func sameLocalAddrs(addr1, addr2 string) (bool, error) {
 		addr1Local = true
 	} else {
 		// Host not empty, check if it is local
-		if addr1Local, err = isLocalHost(host1); err != nil {
+		if addr1Local, err = isLocalHost(host1, port1, port1); err != nil {
 			return false, err
 		}
 	}
@@ -317,7 +318,7 @@ func sameLocalAddrs(addr1, addr2 string) (bool, error) {
 		addr2Local = true
 	} else {
 		// Host not empty, check if it is local
-		if addr2Local, err = isLocalHost(host2); err != nil {
+		if addr2Local, err = isLocalHost(host2, port2, port2); err != nil {
 			return false, err
 		}
 	}
@@ -334,33 +335,20 @@ func sameLocalAddrs(addr1, addr2 string) (bool, error) {
 
 // CheckLocalServerAddr - checks if serverAddr is valid and local host.
 func CheckLocalServerAddr(serverAddr string) error {
-	host, port, err := net.SplitHostPort(serverAddr)
+	host, err := xnet.ParseHost(serverAddr)
 	if err != nil {
 		return config.ErrInvalidAddressFlag(err)
-	}
-
-	// Strip off IPv6 zone information.
-	if i := strings.Index(host, "%"); i > -1 {
-		host = host[:i]
-	}
-
-	// Check whether port is a valid port number.
-	p, err := strconv.Atoi(port)
-	if err != nil {
-		return config.ErrInvalidAddressFlag(err).Msg("invalid port number")
-	} else if p < 1 || p > 65535 {
-		return config.ErrInvalidAddressFlag(nil).Msg("port number must be between 1 to 65535")
 	}
 
 	// 0.0.0.0 is a wildcard address and refers to local network
 	// addresses. I.e, 0.0.0.0:9000 like ":9000" refers to port
 	// 9000 on localhost.
-	if host != "" && host != net.IPv4zero.String() && host != net.IPv6zero.String() {
-		isLocalHost, err := isLocalHost(host)
+	if host.Name != "" && host.Name != net.IPv4zero.String() && host.Name != net.IPv6zero.String() {
+		localHost, err := isLocalHost(host.Name, host.Port.String(), host.Port.String())
 		if err != nil {
 			return err
 		}
-		if !isLocalHost {
+		if !localHost {
 			return config.ErrInvalidAddressFlag(nil).Msg("host in server address should be this server")
 		}
 	}

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -742,9 +742,9 @@ func (sys *NotificationSys) initListeners(ctx context.Context, objAPI ObjectLaye
 	}
 
 	for _, args := range listenerList {
-		found, err := isLocalHost(args.Addr.Name)
+		found, err := isLocalHost(args.Addr.Name, args.Addr.Port.String(), args.Addr.Port.String())
 		if err != nil {
-			logger.GetReqInfo(ctx).AppendTags("host", args.Addr.Name)
+			logger.GetReqInfo(ctx).AppendTags("host", args.Addr.String())
 			logger.LogIf(ctx, err)
 			return err
 		}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -144,6 +144,10 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	var setupType SetupType
 	var err error
 
+	globalMinioAddr = globalCLIContext.Addr
+
+	globalMinioHost, globalMinioPort = mustSplitHostPort(globalMinioAddr)
+
 	endpoints := strings.Fields(env.Get(config.EnvEndpoints, ""))
 	if len(endpoints) > 0 {
 		globalEndpoints, globalXLSetDriveCount, setupType, err = createServerEndpoints(globalCLIContext.Addr, endpoints...)
@@ -152,10 +156,7 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	}
 	logger.FatalIf(err, "Invalid command line arguments")
 
-	globalMinioAddr = globalCLIContext.Addr
 	logger.LogIf(context.Background(), checkEndpointsSubOptimal(ctx, setupType, globalEndpoints))
-
-	globalMinioHost, globalMinioPort = mustSplitHostPort(globalMinioAddr)
 
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -158,7 +158,6 @@ func stripStandardPorts(apiEndpoints []string) (newAPIEndpoints []string) {
 	for i, apiEndpoint := range apiEndpoints {
 		u, err := xnet.ParseHTTPURL(apiEndpoint)
 		if err != nil {
-			newAPIEndpoints[i] = apiEndpoint
 			continue
 		}
 		if globalMinioHost == "" && isNotIPv4(u.Host) {

--- a/cmd/server-startup-msg_test.go
+++ b/cmd/server-startup-msg_test.go
@@ -103,7 +103,7 @@ func TestStripStandardPorts(t *testing.T) {
 
 	apiEndpoints = []string{"http://%%%%%:9000"}
 	newAPIEndpoints = stripStandardPorts(apiEndpoints)
-	if !reflect.DeepEqual(apiEndpoints, newAPIEndpoints) {
+	if !reflect.DeepEqual([]string{""}, newAPIEndpoints) {
 		t.Fatalf("Expected %#v, got %#v", apiEndpoints, newAPIEndpoints)
 	}
 

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -490,6 +490,11 @@ func testStorageAPIRenameFile(t *testing.T, storage StorageAPI) {
 }
 
 func newStorageRESTHTTPServerClient(t *testing.T) (*httptest.Server, *storageRESTClient, config.Config, string) {
+	prevHost, prevPort := globalMinioHost, globalMinioPort
+	defer func() {
+		globalMinioHost, globalMinioPort = prevHost, prevPort
+	}()
+
 	endpointPath, err := ioutil.TempDir("", ".TestStorageREST.")
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -504,18 +509,21 @@ func newStorageRESTHTTPServerClient(t *testing.T) (*httptest.Server, *storageRES
 	}
 	url.Path = endpointPath
 
+	globalMinioHost, globalMinioPort = mustSplitHostPort(url.Host)
+
 	endpoint, err := NewEndpoint(url.String())
 	if err != nil {
 		t.Fatalf("NewEndpoint failed %v", endpoint)
 	}
 
-	if err := endpoint.UpdateIsLocal(); err != nil {
+	if err = endpoint.UpdateIsLocal(); err != nil {
 		t.Fatalf("UpdateIsLocal failed %v", err)
 	}
 
 	registerStorageRESTHandlers(router, []ZoneEndpoints{{
 		Endpoints: Endpoints{endpoint},
 	}})
+
 	restClient := newStorageRESTClient(endpoint)
 	prevGlobalServerConfig := globalServerConfig
 	globalServerConfig = newServerConfig()

--- a/pkg/net/host.go
+++ b/pkg/net/host.go
@@ -81,9 +81,12 @@ func (host *Host) UnmarshalJSON(data []byte) (err error) {
 
 // ParseHost - parses string into Host
 func ParseHost(s string) (*Host, error) {
+	if s == "" {
+		return nil, errors.New("invalid argument")
+	}
 	isValidHost := func(host string) bool {
 		if host == "" {
-			return false
+			return true
 		}
 
 		if ip := net.ParseIP(host); ip != nil {

--- a/pkg/net/host_test.go
+++ b/pkg/net/host_test.go
@@ -137,7 +137,7 @@ func TestHostUnmarshalJSON(t *testing.T) {
 		{[]byte(`"12play"`), &Host{"12play", 0, false}, false},
 		{[]byte(`"play-minio-io"`), &Host{"play-minio-io", 0, false}, false},
 		{[]byte(`"play--min.io"`), &Host{"play--min.io", 0, false}, false},
-		{[]byte(`":9000"`), nil, true},
+		{[]byte(`":9000"`), &Host{"", 9000, true}, false},
 		{[]byte(`"[fe80::8097:76eb:b397:e067%wlp2s0]"`), &Host{"fe80::8097:76eb:b397:e067%wlp2s0", 0, false}, false},
 		{[]byte(`"[fe80::8097:76eb:b397:e067]:9000"`), &Host{"fe80::8097:76eb:b397:e067", 9000, true}, false},
 		{[]byte(`"fe80::8097:76eb:b397:e067%wlp2s0"`), nil, true},
@@ -154,20 +154,23 @@ func TestHostUnmarshalJSON(t *testing.T) {
 		{[]byte(`":"`), nil, true},
 	}
 
-	for i, testCase := range testCases {
-		var host Host
-		err := host.UnmarshalJSON(testCase.data)
-		expectErr := (err != nil)
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run("", func(t *testing.T) {
+			var host Host
+			err := host.UnmarshalJSON(testCase.data)
+			expectErr := (err != nil)
 
-		if expectErr != testCase.expectErr {
-			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
-		}
-
-		if !testCase.expectErr {
-			if !reflect.DeepEqual(&host, testCase.expectedHost) {
-				t.Fatalf("test %v: host: expected: %#v, got: %#v", i+1, testCase.expectedHost, host)
+			if expectErr != testCase.expectErr {
+				t.Errorf("error: expected: %v, got: %v", testCase.expectErr, expectErr)
 			}
-		}
+
+			if !testCase.expectErr {
+				if !reflect.DeepEqual(&host, testCase.expectedHost) {
+					t.Errorf("host: expected: %#v, got: %#v", testCase.expectedHost, host)
+				}
+			}
+		})
 	}
 }
 
@@ -188,7 +191,7 @@ func TestParseHost(t *testing.T) {
 		{"12play", &Host{"12play", 0, false}, false},
 		{"play-minio-io", &Host{"play-minio-io", 0, false}, false},
 		{"play--min.io", &Host{"play--min.io", 0, false}, false},
-		{":9000", nil, true},
+		{":9000", &Host{"", 9000, true}, false},
 		{"play:", nil, true},
 		{"play::", nil, true},
 		{"play:90000", nil, true},
@@ -199,19 +202,22 @@ func TestParseHost(t *testing.T) {
 		{"", nil, true},
 	}
 
-	for i, testCase := range testCases {
-		host, err := ParseHost(testCase.s)
-		expectErr := (err != nil)
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run("", func(t *testing.T) {
+			host, err := ParseHost(testCase.s)
+			expectErr := (err != nil)
 
-		if expectErr != testCase.expectErr {
-			t.Fatalf("test %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
-		}
-
-		if !testCase.expectErr {
-			if !reflect.DeepEqual(host, testCase.expectedHost) {
-				t.Fatalf("test %v: host: expected: %#v, got: %#v", i+1, testCase.expectedHost, host)
+			if expectErr != testCase.expectErr {
+				t.Errorf("error: expected: %v, got: %v", testCase.expectErr, expectErr)
 			}
-		}
+
+			if !testCase.expectErr {
+				if !reflect.DeepEqual(host, testCase.expectedHost) {
+					t.Errorf("host: expected: %#v, got: %#v", testCase.expectedHost, host)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/net/port.go
+++ b/pkg/net/port.go
@@ -31,6 +31,12 @@ func (p Port) String() string {
 
 // ParsePort - parses string into Port
 func ParsePort(s string) (p Port, err error) {
+	if s == "https" {
+		return Port(443), nil
+	} else if s == "http" {
+		return Port(80), nil
+	}
+
 	var i int
 	if i, err = strconv.Atoi(s); err != nil {
 		return p, errors.New("invalid port number")

--- a/pkg/net/port_test.go
+++ b/pkg/net/port_test.go
@@ -49,10 +49,11 @@ func TestParsePort(t *testing.T) {
 		{"0", Port(0), false},
 		{"9000", Port(9000), false},
 		{"65535", Port(65535), false},
+		{"http", Port(80), false},
+		{"https", Port(443), false},
 		{"90000", Port(0), true},
 		{"-10", Port(0), true},
 		{"", Port(0), true},
-		{"http", Port(0), true},
 		{" 1024", Port(0), true},
 	}
 

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -126,12 +126,23 @@ func ParseURL(s string) (u *URL, err error) {
 		return nil, err
 	}
 
-	if uu.Host == "" {
+	if uu.Hostname() == "" {
 		if uu.Scheme != "" {
 			return nil, errors.New("scheme appears with empty host")
 		}
-	} else if _, err = ParseHost(uu.Host); err != nil {
-		return nil, err
+	} else {
+		portStr := uu.Port()
+		if portStr == "" {
+			switch uu.Scheme {
+			case "http":
+				portStr = "80"
+			case "https":
+				portStr = "443"
+			}
+		}
+		if _, err = ParseHost(net.JoinHostPort(uu.Hostname(), portStr)); err != nil {
+			return nil, err
+		}
 	}
 
 	// Clean path in the URL.


### PR DESCRIPTION


## Description
Handle localhost distributed setups properly

## Motivation and Context
Fixes an issue reported by @klauspost and @vadmeste

This PR also allows users to expand their clusters
from single node XL deployment to distributed mode.

## How to test this PR?
```sh
#!/bin/bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
rm -rf /tmp/mindev

minio server --address :9001 http://localhost:9001/tmp/mindev/data/disterasure/xl{1...4} http://localhost:9002/tmp/mindev/data/disterasure/xl{5...8} &
minio server --address :9002 http://localhost:9001/tmp/mindev/data/disterasure/xl{1...4} http://localhost:9002/tmp/mindev/data/disterasure/xl{5...8} &
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
