### PR TITLE
Repurpose Get/SetConfig as import/export support

### DIFF
--- a/cmd/config/identity/openid/help.go
+++ b/cmd/config/identity/openid/help.go
@@ -27,6 +27,12 @@ var (
 			Type:        "url",
 		},
 		config.HelpKV{
+			Key:         ClaimPrefix,
+			Description: `OpenID JWT claim namespace prefix. eg: "customer"`,
+			Optional:    true,
+			Type:        "string",
+		},
+		config.HelpKV{
 			Key:         config.Comment,
 			Description: "A comment to describe the OpenID identity setting",
 			Optional:    true,

--- a/cmd/config/identity/openid/jwt.go
+++ b/cmd/config/identity/openid/jwt.go
@@ -263,15 +263,15 @@ var (
 			Value: config.StateOff,
 		},
 		config.KV{
-			Key:   JwksURL,
-			Value: "",
-		},
-		config.KV{
 			Key:   ConfigURL,
 			Value: "",
 		},
 		config.KV{
 			Key:   ClaimPrefix,
+			Value: "",
+		},
+		config.KV{
+			Key:   JwksURL,
 			Value: "",
 		},
 	}


### PR DESCRIPTION
## Description
Repurpose Get/SetConfig as import/export support

## Motivation and Context
To be able to export/import entire server configs

## How to test this PR?
https://github.com/minio/mc/pull/2974 new `mc` PR to test this

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
