### PR TITLE
Add support for global namespace mode with etcd

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/minio/minio-go/v6/pkg/set"
+	"github.com/minio/minio/cmd/config/etcd"
 	"github.com/minio/minio/cmd/config/etcd/dns"
 	"github.com/minio/minio/cmd/crypto"
 	xhttp "github.com/minio/minio/cmd/http"
@@ -256,9 +257,9 @@ func (api objectAPIHandlers) ListBucketsHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// If etcd, dns federation configured list buckets from etcd.
+	// If etcd, dns federation configured list buckets from etcd (only in federation mode)
 	var bucketsInfo []BucketInfo
-	if globalDNSConfig != nil {
+	if globalDNSConfig != nil && globalEtcdMode == etcd.ModeFederation {
 		dnsBuckets, err := globalDNSConfig.List()
 		if err != nil && err != dns.ErrNoEntriesFound {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -144,6 +144,8 @@ func lookupConfigs(s config.Config) (err error) {
 	if err != nil {
 		return config.Errorf("Unable to initialize etcd config: %s", err)
 	}
+	// Set globalEtcdMode based on the current config value
+	globalEtcdMode = etcdCfg.Mode
 
 	if len(globalDomainNames) != 0 && !globalDomainIPs.IsEmpty() && globalEtcdClient != nil {
 		globalDNSConfig, err = dns.NewCoreDNS(etcdCfg.Config,

--- a/cmd/config/etcd/help.go
+++ b/cmd/config/etcd/help.go
@@ -32,6 +32,12 @@ var (
 			Type:        "path",
 		},
 		config.HelpKV{
+			Key:         Mode,
+			Description: `Mode in which MinIO will use etcd. Can be "federation" or "namespace", defaults to "federation"`,
+			Optional:    true,
+			Type:        "string",
+		},
+		config.HelpKV{
 			Key:         CoreDNSPath,
 			Description: `Default etcd path location to populate bucket DNS srv records eg: "/skydns"`,
 			Optional:    true,

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/minio/minio-go/v6/pkg/set"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/minio/minio/cmd/config/etcd"
 	"github.com/minio/minio/cmd/config/etcd/dns"
 	"github.com/minio/minio/cmd/crypto"
 	xhttp "github.com/minio/minio/cmd/http"
@@ -617,7 +618,7 @@ type bucketForwardingHandler struct {
 }
 
 func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if globalDNSConfig == nil || len(globalDomainNames) == 0 ||
+	if globalDNSConfig == nil || len(globalDomainNames) == 0 || globalEtcdMode == etcd.ModeNamespace ||
 		guessIsHealthCheckReq(r) || guessIsMetricsReq(r) ||
 		guessIsRPCReq(r) || guessIsLoginSTSReq(r) || isAdminReq(r) {
 		f.handler.ServeHTTP(w, r)

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -207,6 +207,9 @@ var (
 	// Allocated etcd endpoint for config and bucket DNS.
 	globalEtcdClient *etcd.Client
 
+	// Mode in which etcd should operate (federation or namespace)
+	globalEtcdMode string
+
 	// Allocated DNS config wrapper over etcd client.
 	globalDNSConfig *dns.CoreDNS
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gorilla/mux"
 	miniogo "github.com/minio/minio-go/v6"
 	"github.com/minio/minio-go/v6/pkg/encrypt"
+	"github.com/minio/minio/cmd/config/etcd"
 	"github.com/minio/minio/cmd/config/etcd/dns"
 	"github.com/minio/minio/cmd/config/storageclass"
 	"github.com/minio/minio/cmd/crypto"
@@ -631,7 +632,7 @@ func isRemoteCopyRequired(ctx context.Context, srcBucket, dstBucket string, objA
 
 // Check if the bucket is on a remote site, this code only gets executed when federation is enabled.
 func isRemoteCallRequired(ctx context.Context, bucket string, objAPI ObjectLayer) bool {
-	if globalDNSConfig == nil {
+	if globalDNSConfig == nil || globalEtcdMode == etcd.ModeNamespace {
 		return false
 	}
 	_, err := objAPI.GetBucketInfo(ctx, bucket)
@@ -2409,7 +2410,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(err), r.URL, guessIsBrowserReq(r))
 		return
 	}
-	if globalDNSConfig != nil {
+	if globalDNSConfig != nil && globalEtcdMode == etcd.ModeFederation {
 		_, err := globalDNSConfig.Get(bucket)
 		if err != nil {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -39,6 +39,7 @@ import (
 	"github.com/minio/minio-go/v6/pkg/s3utils"
 	"github.com/minio/minio-go/v6/pkg/set"
 	"github.com/minio/minio/browser"
+	"github.com/minio/minio/cmd/config/etcd"
 	"github.com/minio/minio/cmd/config/etcd/dns"
 	"github.com/minio/minio/cmd/config/identity/openid"
 	"github.com/minio/minio/cmd/crypto"
@@ -262,7 +263,7 @@ func (web *webAPIHandlers) DeleteBucket(r *http.Request, args *RemoveBucketArgs,
 	globalPolicySys.Remove(args.BucketName)
 	globalNotificationSys.DeleteBucket(ctx, args.BucketName)
 
-	if globalDNSConfig != nil {
+	if globalDNSConfig != nil && globalEtcdMode == etcd.ModeFederation {
 		if err := globalDNSConfig.Delete(args.BucketName); err != nil {
 			// Deleting DNS entry failed, attempt to create the bucket again.
 			objectAPI.MakeBucketWithLocation(ctx, args.BucketName, "")
@@ -308,7 +309,7 @@ func (web *webAPIHandlers) ListBuckets(r *http.Request, args *WebGenericArgs, re
 	r.Header.Set("delimiter", SlashSeparator)
 
 	// If etcd, dns federation configured list buckets from etcd.
-	if globalDNSConfig != nil {
+	if globalDNSConfig != nil && globalEtcdMode == etcd.ModeFederation {
 		dnsBuckets, err := globalDNSConfig.List()
 		if err != nil && err != dns.ErrNoEntriesFound {
 			return toJSONError(ctx, err)


### PR DESCRIPTION
## Description
This PR adds a `Namespace` mode for etcd configuration. With 
`namespace` mode, users can enforce unique bucket names across
given MinIO clusters. 

While `federation` enables single namespace for all operations, `namespace` 
mode is useful for enforcing bucket namespace only. For all other purposes
MinIO clusters configured with etcd in `namespace` mode behave like single 
cluster.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
