### PR TITLE
Export command prints turned-off sub-sys as comments

### DIFF
--- a/cmd/config/cache/config_test.go
+++ b/cmd/config/cache/config_test.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"reflect"
 	"runtime"
-	"strings"
 	"testing"
 )
 
@@ -65,6 +64,11 @@ func TestParseCacheDrives(t *testing.T) {
 			driveStr         string
 			expectedPatterns []string
 			success          bool
+		}{"/home/drive1,/home/drive2,/home/drive3", []string{"/home/drive1", "/home/drive2", "/home/drive3"}, true})
+		testCases = append(testCases, struct {
+			driveStr         string
+			expectedPatterns []string
+			success          bool
 		}{"/home/drive{1...3}", []string{"/home/drive1", "/home/drive2", "/home/drive3"}, true})
 		testCases = append(testCases, struct {
 			driveStr         string
@@ -73,7 +77,7 @@ func TestParseCacheDrives(t *testing.T) {
 		}{"/home/drive{1..3}", []string{}, false})
 	}
 	for i, testCase := range testCases {
-		drives, err := parseCacheDrives(strings.Split(testCase.driveStr, cacheDelimiterLegacy))
+		drives, err := parseCacheDrives(testCase.driveStr)
 		if err != nil && testCase.success {
 			t.Errorf("Test %d: Expected success but failed instead %s", i+1, err)
 		}
@@ -102,11 +106,12 @@ func TestParseCacheExclude(t *testing.T) {
 
 		// valid input
 		{"bucket1/*;*.png;images/trip/barcelona/*", []string{"bucket1/*", "*.png", "images/trip/barcelona/*"}, true},
+		{"bucket1/*,*.png,images/trip/barcelona/*", []string{"bucket1/*", "*.png", "images/trip/barcelona/*"}, true},
 		{"bucket1", []string{"bucket1"}, true},
 	}
 
 	for i, testCase := range testCases {
-		excludes, err := parseCacheExcludes(strings.Split(testCase.excludeStr, cacheDelimiterLegacy))
+		excludes, err := parseCacheExcludes(testCase.excludeStr)
 		if err != nil && testCase.success {
 			t.Errorf("Test %d: Expected success but failed instead %s", i+1, err)
 		}

--- a/cmd/config/cache/lookup.go
+++ b/cmd/config/cache/lookup.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"errors"
 	"strconv"
-	"strings"
 
 	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/pkg/env"
@@ -84,42 +83,43 @@ func LookupConfig(kvs config.KVS) (Config, error) {
 		return cfg, err
 	}
 
-	// Check if cache is explicitly disabled
-	stateBool, err := config.ParseBool(env.Get(EnvCacheState, kvs.Get(config.State)))
-	if err != nil {
-		// Parsing failures happen due to empty KVS, ignore it.
-		if kvs.Empty() {
-			return cfg, nil
-		}
-		return cfg, err
-	}
-
 	drives := env.Get(EnvCacheDrives, kvs.Get(Drives))
-	if stateBool {
-		if len(drives) == 0 {
-			return cfg, config.Error("'drives' key cannot be empty if you wish to enable caching")
-		}
-	}
-	if len(drives) == 0 {
-		return cfg, nil
-	}
-
-	cfg.Drives, err = parseCacheDrives(strings.Split(drives, cacheDelimiter))
-	if err != nil {
-		cfg.Drives, err = parseCacheDrives(strings.Split(drives, cacheDelimiterLegacy))
+	if len(drives) > 0 {
+		// Drives is not-empty means user wishes to enable this explicitly, but
+		// check if ENV is set to false to disable caching.
+		stateBool, err := config.ParseBool(env.Get(EnvCacheState, config.StateOn))
 		if err != nil {
 			return cfg, err
 		}
+		if !stateBool {
+			return cfg, nil
+		}
+	} else {
+		// Check if cache is explicitly disabled
+		stateBool, err := config.ParseBool(env.Get(EnvCacheState, kvs.Get(config.State)))
+		if err != nil {
+			if kvs.Empty() {
+				return cfg, nil
+			}
+			return cfg, err
+		}
+		if stateBool {
+			return cfg, config.Error("'drives' key cannot be empty to enable caching")
+		}
+		return cfg, nil
+	}
+
+	var err error
+	cfg.Drives, err = parseCacheDrives(drives)
+	if err != nil {
+		return cfg, err
 	}
 
 	cfg.Enabled = true
 	if excludes := env.Get(EnvCacheExclude, kvs.Get(Exclude)); excludes != "" {
-		cfg.Exclude, err = parseCacheExcludes(strings.Split(excludes, cacheDelimiter))
+		cfg.Exclude, err = parseCacheExcludes(excludes)
 		if err != nil {
-			cfg.Exclude, err = parseCacheExcludes(strings.Split(excludes, cacheDelimiterLegacy))
-			if err != nil {
-				return cfg, err
-			}
+			return cfg, err
 		}
 	}
 

--- a/cmd/config/storageclass/help.go
+++ b/cmd/config/storageclass/help.go
@@ -22,14 +22,14 @@ import "github.com/minio/minio/cmd/config"
 var (
 	Help = config.HelpKVS{
 		config.HelpKV{
-			Key:         ClassRRS,
-			Description: `Set reduced redundancy storage class parity ratio. eg: "EC:2"`,
+			Key:         ClassStandard,
+			Description: `Set standard storage class parity ratio. eg: "EC:4"`,
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
-			Key:         ClassStandard,
-			Description: `Set standard storage class parity ratio. eg: "EC:4"`,
+			Key:         ClassRRS,
+			Description: `Set reduced redundancy storage class parity ratio. eg: "EC:2"`,
 			Optional:    true,
 			Type:        "string",
 		},

--- a/pkg/madmin/config-kv-commands.go
+++ b/pkg/madmin/config-kv-commands.go
@@ -51,11 +51,7 @@ func (adm *AdminClient) DelConfigKV(k string) (err error) {
 
 // SetConfigKV - set key value config to server.
 func (adm *AdminClient) SetConfigKV(kv string) (err error) {
-	targets, err := ParseSubSysTarget([]byte(kv))
-	if err != nil {
-		return err
-	}
-	econfigBytes, err := EncryptData(adm.secretAccessKey, []byte(targets.String()))
+	econfigBytes, err := EncryptData(adm.secretAccessKey, []byte(kv))
 	if err != nil {
 		return err
 	}

--- a/pkg/madmin/parse-kv.go
+++ b/pkg/madmin/parse-kv.go
@@ -59,22 +59,33 @@ func (kvs KVS) Lookup(key string) (string, bool) {
 	return "", false
 }
 
-// Targets sub-system targets
-type Targets map[string]map[string]KVS
+// Target signifies an individual target
+type Target struct {
+	SubSystem string `json:"subSys"`
+	KVS       KVS    `json:"kvs"`
+}
 
+// Targets sub-system targets
+type Targets []Target
+
+// Standard config keys and values.
 const (
-	stateKey   = "state"
-	commentKey = "comment"
+	StateKey   = "state"
+	CommentKey = "comment"
+
+	// State values
+	StateOn  = "on"
+	StateOff = "off"
 )
 
 func (kvs KVS) String() string {
 	var s strings.Builder
 	for _, kv := range kvs {
-		// Do not need to print state
-		if kv.Key == stateKey {
+		// Do not need to print state which is on.
+		if kv.Key == StateKey && kv.Value == StateOn {
 			continue
 		}
-		if kv.Key == commentKey && kv.Value == "" {
+		if kv.Key == CommentKey && kv.Value == "" {
 			continue
 		}
 		s.WriteString(kv.Key)
@@ -94,13 +105,7 @@ func (kvs KVS) String() string {
 
 // Count - returns total numbers of target
 func (t Targets) Count() int {
-	var count int
-	for _, targetKV := range t {
-		for range targetKV {
-			count++
-		}
-	}
-	return count
+	return len(t)
 }
 
 func hasSpace(s string) bool {
@@ -115,19 +120,15 @@ func hasSpace(s string) bool {
 func (t Targets) String() string {
 	var s strings.Builder
 	count := t.Count()
-	for subSys, targetKV := range t {
-		for target, kv := range targetKV {
-			count--
-			s.WriteString(subSys)
-			if target != Default {
-				s.WriteString(SubSystemSeparator)
-				s.WriteString(target)
-			}
-			s.WriteString(KvSpaceSeparator)
-			s.WriteString(kv.String())
-			if (len(t) > 1 || len(targetKV) > 1) && count > 0 {
-				s.WriteString(KvNewline)
-			}
+	// Print all "on" states entries
+	for _, targetKV := range t {
+		kv := targetKV.KVS
+		count--
+		s.WriteString(targetKV.SubSystem)
+		s.WriteString(KvSpaceSeparator)
+		s.WriteString(kv.String())
+		if len(t) > 1 && count > 0 {
+			s.WriteString(KvNewline)
 		}
 	}
 	return s.String()
@@ -137,6 +138,7 @@ func (t Targets) String() string {
 const (
 	SubSystemSeparator = `:`
 	KvSeparator        = `=`
+	KvComment          = `#`
 	KvSpaceSeparator   = ` `
 	KvNewline          = "\n"
 	KvDoubleQuote      = `"`
@@ -145,13 +147,14 @@ const (
 	Default = `_`
 )
 
-// This function is needed, to trim off single or double quotes, creeping into the values.
-func sanitizeValue(v string) string {
+// SanitizeValue - this function is needed, to trim off single or double quotes, creeping into the values.
+func SanitizeValue(v string) string {
 	v = strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(v), KvDoubleQuote), KvDoubleQuote)
 	return strings.TrimSuffix(strings.TrimPrefix(v, KvSingleQuote), KvSingleQuote)
 }
 
-func convertTargets(s string, targets Targets) error {
+// AddTarget - adds new targets, by parsing the input string s.
+func (t *Targets) AddTarget(s string) error {
 	inputs := strings.SplitN(s, KvSpaceSeparator, 2)
 	if len(inputs) <= 1 {
 		return fmt.Errorf("invalid number of arguments '%s'", s)
@@ -170,7 +173,7 @@ func convertTargets(s string, targets Targets) error {
 		if len(kv) == 1 && prevK != "" {
 			kvs = append(kvs, KV{
 				Key:   prevK,
-				Value: strings.Join([]string{kvs.Get(prevK), sanitizeValue(kv[0])}, KvSpaceSeparator),
+				Value: strings.Join([]string{kvs.Get(prevK), SanitizeValue(kv[0])}, KvSpaceSeparator),
 			})
 			continue
 		}
@@ -180,28 +183,24 @@ func convertTargets(s string, targets Targets) error {
 		prevK = kv[0]
 		kvs = append(kvs, KV{
 			Key:   kv[0],
-			Value: sanitizeValue(kv[1]),
+			Value: SanitizeValue(kv[1]),
 		})
 	}
 
-	_, ok := targets[subSystemValue[0]]
-	if !ok {
-		targets[subSystemValue[0]] = map[string]KVS{}
-	}
-	if len(subSystemValue) == 2 {
-		targets[subSystemValue[0]][subSystemValue[1]] = kvs
-	} else {
-		targets[subSystemValue[0]][Default] = kvs
-	}
+	*t = append(*t, Target{
+		SubSystem: inputs[0],
+		KVS:       kvs,
+	})
+
 	return nil
 }
 
 // ParseSubSysTarget - parse sub-system target
 func ParseSubSysTarget(buf []byte) (Targets, error) {
-	targets := make(map[string]map[string]KVS)
+	var targets Targets
 	bio := bufio.NewScanner(bytes.NewReader(buf))
 	for bio.Scan() {
-		if err := convertTargets(bio.Text(), targets); err != nil {
+		if err := targets.AddTarget(bio.Text()); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION


## Description
Export command prints turned-off sub-sys as comments

## Motivation and Context
This PR also tries to

- Preserve the order of keys printed in export command
- Fix cache to be enabled with _STATE env to keep
  backward compatibility

## How to test this PR?
You need an update `mc` version to test the export command.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
