### PR TITLE
Ensure comment is always a valid key

### DIFF
--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -484,6 +484,9 @@ func (sts *stsAPIHandlers) AssumeRoleWithLDAPIdentity(w http.ResponseWriter, r *
 		return
 	}
 
+	// Close ldap connection to avoid leaks.
+	defer ldapConn.Close()
+
 	usernameSubs, _ := xldap.NewSubstituter("username", ldapUsername)
 	// We ignore error below as we already validated the username
 	// format string at startup.


### PR DESCRIPTION

## Description
Ensure comment is always a valid key

## Motivation and Context
Ensure comment is always a valid key

Also, fix LDAP leaky connection

## How to test this PR?
Use latest `mc` to enable

```
~ mc admin config set myminio region comment="my empty region"
```

and restarting server - server will complain about `comment` as an invalid key.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
