### PR TITLE
Use atomic.Uint64 for gateway metrics count instead of mutex

### DIFF
--- a/cmd/gateway-metrics.go
+++ b/cmd/gateway-metrics.go
@@ -17,60 +17,58 @@
 package cmd
 
 import (
-	"sync"
+	"net/http"
 
 	"go.uber.org/atomic"
 )
 
+// RequestStats - counts for Get and Head requests
+type RequestStats struct {
+	Get  atomic.Uint64 `json:"Get"`
+	Head atomic.Uint64 `json:"Head"`
+}
+
 // Metrics - represents bytes served from backend
 // only implemented for S3 Gateway
 type Metrics struct {
-	BytesReceived atomic.Uint64
-	BytesSent     atomic.Uint64
-	RequestStats  map[string]int
-	sync.RWMutex
+	bytesReceived atomic.Uint64
+	bytesSent     atomic.Uint64
+	requestStats  RequestStats
 }
 
 // IncBytesReceived - Increase total bytes received from gateway backend
 func (s *Metrics) IncBytesReceived(n int64) {
-	s.BytesReceived.Add(uint64(n))
+	s.bytesReceived.Add(uint64(n))
 }
 
 // GetBytesReceived - Get total bytes received from gateway backend
 func (s *Metrics) GetBytesReceived() uint64 {
-	return s.BytesReceived.Load()
+	return s.bytesReceived.Load()
 }
 
 // IncBytesSent - Increase total bytes sent to gateway backend
 func (s *Metrics) IncBytesSent(n int64) {
-	s.BytesSent.Add(uint64(n))
+	s.bytesSent.Add(uint64(n))
 }
 
 // GetBytesSent - Get total bytes received from gateway backend
 func (s *Metrics) GetBytesSent() uint64 {
-	return s.BytesSent.Load()
+	return s.bytesSent.Load()
 }
 
-// IncRequests - Increase request sent to gateway backend by 1
+// IncRequests - Increase request count sent to gateway backend by 1
 func (s *Metrics) IncRequests(method string) {
-	s.Lock()
-	defer s.Unlock()
-	if s == nil {
-		return
+	// Only increment for Head & Get requests, else no op
+	if method == http.MethodGet {
+		s.requestStats.Get.Add(1)
+	} else if method == http.MethodHead {
+		s.requestStats.Head.Add(1)
 	}
-	if s.RequestStats == nil {
-		s.RequestStats = make(map[string]int)
-	}
-	if _, ok := s.RequestStats[method]; ok {
-		s.RequestStats[method]++
-		return
-	}
-	s.RequestStats[method] = 1
 }
 
-// GetRequests - Get total number of requests sent to gateway backend
-func (s *Metrics) GetRequests() map[string]int {
-	return s.RequestStats
+// GetRequests - Get total number of Get & Headrequests sent to gateway backend
+func (s *Metrics) GetRequests() RequestStats {
+	return s.requestStats
 }
 
 // NewMetrics - Prepare new Metrics structure

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -290,17 +290,25 @@ func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.CounterValue,
 			float64(m.GetBytesSent()),
 		)
-		for method, count := range m.GetRequests() {
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(
-					prometheus.BuildFQName("gateway", globalGatewayName, "requests"),
-					"Total number of requests made to AWS S3 by current MinIO S3 Gateway",
-					[]string{"method"}, nil),
-				prometheus.CounterValue,
-				float64(count),
-				method,
-			)
-		}
+		s := m.GetRequests()
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName("gateway", globalGatewayName, "requests"),
+				"Total number of requests made to AWS S3 by current MinIO S3 Gateway",
+				[]string{"method"}, nil),
+			prometheus.CounterValue,
+			float64(s.Get.Load()),
+			http.MethodGet,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName("gateway", globalGatewayName, "requests"),
+				"Total number of requests made to AWS S3 by current MinIO S3 Gateway",
+				[]string{"method"}, nil),
+			prometheus.CounterValue,
+			float64(s.Head.Load()),
+			http.MethodHead,
+		)
 	}
 }
 


### PR DESCRIPTION
## Description
Use atomic.Uint64 for gateway metrics count instead of mutex

## Motivation and Context
Code improvement as a follow up of #8591 

## How to test this PR?
- Start MinIO Gateway mode with S3 backend
- Enable Cache
- Monitor Prometheus Scrape endpoint to see the relevant fields updating

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
