### PR TITLE
change url for Total Population CSV, location has been changed

### DIFF
--- a/docs/select/README.md
+++ b/docs/select/README.md
@@ -62,7 +62,7 @@ for event in r['Payload']:
 ## 4. Run the Program
 Upload a sample dataset to MinIO using the following commands.
 ```sh
-$ curl "https://esa.un.org/unpd/wpp/DVD/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2017_TotalPopulationBySex.csv" > TotalPopulation.csv
+$ curl "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2019_TotalPopulationBySex.csv" > TotalPopulation.csv
 $ mc mb myminio/mycsvbucket
 $ gzip TotalPopulation.csv
 $ mc cp TotalPopulation.csv.gz myminio/mycsvbucket/sampledata/


### PR DESCRIPTION
## Description

Hello, I was following [select documentation](https://docs.min.io/docs/minio-select-api-quickstart-guide.html) and the csv file location (https://esa.un.org/unpd/wpp/DVD/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2017_TotalPopulationBySex.csv) has been changed

## Motivation and Context
I've just followed the new link to download the file

## How to test this PR?

Is the any tests for the documentation ?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [X ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )

Please let me know if I've missed something during the contribution workflow.
