### PR TITLE
Admin Info: Modify Uptime to return seconds

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -219,12 +219,12 @@ func (a adminAPIHandlers) ServiceActionHandler(w http.ResponseWriter, r *http.Re
 // ServerProperties holds some server information such as, version, region
 // uptime, etc..
 type ServerProperties struct {
-	Uptime       time.Duration `json:"uptime"`
-	Version      string        `json:"version"`
-	CommitID     string        `json:"commitID"`
-	DeploymentID string        `json:"deploymentID"`
-	Region       string        `json:"region"`
-	SQSARN       []string      `json:"sqsARN"`
+	Uptime       int64    `json:"uptime"`
+	Version      string   `json:"version"`
+	CommitID     string   `json:"commitID"`
+	DeploymentID string   `json:"deploymentID"`
+	Region       string   `json:"region"`
+	SQSARN       []string `json:"sqsARN"`
 }
 
 // ServerConnStats holds transferred bytes from/to the server

--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -242,7 +242,7 @@ func getLocalServerProperty(endpointZones EndpointZones, r *http.Request) madmin
 	return madmin.ServerProperties{
 		State:    "ok",
 		Endpoint: addr,
-		Uptime:   UTCNow().Sub(globalBootTime),
+		Uptime:   UTCNow().Unix() - globalBootTime.Unix(),
 		Version:  Version,
 		CommitID: CommitID,
 		Network:  network,

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -52,7 +52,7 @@ func getServerInfo() (*ServerInfoData, error) {
 		ConnStats: globalConnStats.toServerConnStats(),
 		HTTPStats: globalHTTPStats.toServerHTTPStats(),
 		Properties: ServerProperties{
-			Uptime:       UTCNow().Sub(globalBootTime),
+			Uptime:       UTCNow().Unix() - globalBootTime.Unix(),
 			Version:      Version,
 			CommitID:     CommitID,
 			DeploymentID: globalDeploymentID,

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/minio/pkg/cpu"
@@ -425,7 +424,7 @@ type XlBackend struct {
 type ServerProperties struct {
 	State    string            `json:"state"`
 	Endpoint string            `json:"endpoint"`
-	Uptime   time.Duration     `json:"uptime"`
+	Uptime   int64             `json:"uptime"`
 	Version  string            `json:"version"`
 	CommitID string            `json:"commitID"`
 	Network  map[string]string `json:"network"`


### PR DESCRIPTION
## Description
Convert Uptime to return seconds instead of time.Duration

## Motivation and Context
Easier to see instead of time.Duration

## How to test this PR?
use the madmin example file and look at the uptime field's value

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
