### PR TITLE
Clear cache if reverting to backend

### DIFF
--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -585,12 +585,14 @@ func (c *cacheObjects) PutObject(ctx context.Context, bucket, object string, r *
 		return putObjectFn(ctx, bucket, object, r, opts)
 	}
 	if opts.ServerSideEncryption != nil {
+		dcache.Delete(ctx, bucket, object)
 		return putObjectFn(ctx, bucket, object, r, opts)
 	}
 
 	// skip cache for objects with locks
 	objRetention := getObjectRetentionMeta(opts.UserDefined)
 	if objRetention.Mode == Governance || objRetention.Mode == Compliance {
+		dcache.Delete(ctx, bucket, object)
 		return putObjectFn(ctx, bucket, object, r, opts)
 	}
 


### PR DESCRIPTION
Clear cached entry before reverting to backend for
encrypted objects or those under retention to avoid
stale objects remaining in cache.

## Description


## Motivation and Context
Avoid stale entry being left in cache if plain text object is overwritten by encrypted object. (which is not cached by default unless env to encrypt cache is set up)

## How to test this PR?
```
MINIO_CACHE_DRIVES=/tmp/cache ./minio server /tmp/data
mc cp /etc/issue myminio/testbucket/object
mc cp /etc/issue myminio/testbucket/object --encrypt "myminio" 
mc stat myminio/testbucket/object won't show encryption headers without this PR, as it is picking a stale entry
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
