### PR TITLE
Add bucket and object count along with total object size in admin-info

### DIFF
--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -408,12 +408,12 @@ type Services struct {
 
 // Buckets contains the number of buckets
 type Buckets struct {
-	Count int `json:"count,omitempty"`
+	Count uint64 `json:"count,omitempty"`
 }
 
 // Objects contains the number of objects
 type Objects struct {
-	Count int `json:"count,omitempty"`
+	Count uint64 `json:"count,omitempty"`
 }
 
 // Usage contains the tottal size used


### PR DESCRIPTION
## Description
`fetchLambdaInfo` modified to use `NewCustomHTTPTransport()` to fetch targetList.
Add bucket and object count along with total object size in admin-info

## Motivation and Context


## How to test this PR?


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
