### PR TITLE
Reject mandatory KVS if not set for any sub-sys

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -644,6 +644,15 @@ func (c Config) SetKVS(s string, defaultKVS map[string]KVS) error {
 		currKVS.Set(Comment, v)
 	}
 
+	hkvs := HelpSubSysMap[subSys]
+	for _, hkv := range hkvs {
+		v, _ := currKVS.Lookup(hkv.Key)
+		if v == "" && !hkv.Optional {
+			return Errorf(SafeModeKind,
+				"'%s' is not optional for '%s' sub-system, please check '%s' documentation",
+				hkv.Key, subSys, subSys)
+		}
+	}
 	c[subSys][tgt] = currKVS
 	return nil
 }


### PR DESCRIPTION
## Description
Reject mandatory KVS if not set for any sub-sys

## Motivation and Context
Reject mandatory KVS if not set for any sub-sys

## How to test this PR?
If the sub-system indicates that some args are mandatory
they shall be rejected automatically, before even setting 
invalid config into the KV list.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
