### PR TITLE
fix: Don't allow to set unconfigured notification ARNs

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -25,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"reflect"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -54,7 +54,6 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 
 	vars := mux.Vars(r)
 	bucketName := vars["bucket"]
-	var config *event.Config
 
 	objAPI := api.ObjectAPI()
 	if objAPI == nil {
@@ -81,21 +80,55 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 	// Construct path to notification.xml for the given bucket.
 	configFile := path.Join(bucketConfigPrefix, bucketName, bucketNotificationConfig)
 
+	var config = event.Config{}
 	configData, err := readConfig(ctx, objAPI, configFile)
 	if err != nil {
 		if err != errConfigNotFound {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 			return
 		}
-		config = &event.Config{}
-	} else {
-		if err = xml.NewDecoder(bytes.NewReader(configData)).Decode(&config); err != nil {
+		config.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
+		config.SetRegion(globalServerRegion)
+		notificationBytes, err := xml.Marshal(config)
+		if err != nil {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 			return
 		}
+
+		writeSuccessResponseXML(w, notificationBytes)
+		return
 	}
 
 	config.SetRegion(globalServerRegion)
+
+	if err = xml.Unmarshal(configData, &config); err != nil {
+		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+		return
+	}
+
+	if err = config.Validate(globalServerRegion, globalNotificationSys.targetList); err != nil {
+		arnErr, ok := err.(*event.ErrARNNotFound)
+		if !ok {
+			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+			return
+		}
+		for i, queue := range config.QueueList {
+			// Remove ARN not found queues, because we previously allowed
+			// adding unexpected entries into the config.
+			//
+			// With newer config disallowing changing / turning off
+			// notification targets without removing ARN in notification
+			// configuration we won't see this problem anymore.
+			if reflect.DeepEqual(queue.ARN, arnErr.ARN) {
+				config.QueueList = append(config.QueueList[:i],
+					config.QueueList[i+1:]...)
+			}
+			// This is a one time activity we shall do this
+			// here and allow stale ARN to be removed. We shall
+			// never reach a stage where we will have stale
+			// notification configs.
+		}
+	}
 
 	// If xml namespace is empty, set a default value before returning.
 	if config.XMLNS == "" {
@@ -149,17 +182,15 @@ func (api objectAPIHandlers) PutBucketNotificationHandler(w http.ResponseWriter,
 		return
 	}
 
-	var config *event.Config
-	config, err = event.ParseConfig(io.LimitReader(r.Body, r.ContentLength), globalServerRegion, globalNotificationSys.targetList)
+	lreader := io.LimitReader(r.Body, r.ContentLength)
+	config, err := event.ParseConfig(lreader, globalServerRegion, globalNotificationSys.targetList)
 	if err != nil {
 		apiErr := errorCodes.ToAPIErr(ErrMalformedXML)
 		if event.IsEventError(err) {
 			apiErr = toAPIError(ctx, err)
 		}
-		if _, ok := err.(*event.ErrARNNotFound); !ok {
-			writeErrorResponse(ctx, w, apiErr, r.URL, guessIsBrowserReq(r))
-			return
-		}
+		writeErrorResponse(ctx, w, apiErr, r.URL, guessIsBrowserReq(r))
+		return
 	}
 
 	if err = saveNotificationConfig(ctx, objectAPI, bucketName, config); err != nil {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -282,7 +282,8 @@ func validateConfig(s config.Config) error {
 		return err
 	}
 
-	return notify.TestNotificationTargets(s, GlobalServiceDoneCh, NewCustomHTTPTransport())
+	return notify.TestNotificationTargets(s, GlobalServiceDoneCh, NewCustomHTTPTransport(),
+		globalNotificationSys.ConfiguredTargetIDs())
 }
 
 func lookupConfigs(s config.Config) (err error) {

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -894,6 +894,23 @@ func (sys *NotificationSys) RemoveRulesMap(bucketName string, rulesMap event.Rul
 	}
 }
 
+// ConfiguredTargetIDs - returns list of configured target id's
+func (sys *NotificationSys) ConfiguredTargetIDs() []event.TargetID {
+	sys.RLock()
+	defer sys.RUnlock()
+
+	var targetIDs []event.TargetID
+	for _, rmap := range sys.bucketRulesMap {
+		for _, rules := range rmap {
+			for _, targetSet := range rules {
+				targetIDs = append(targetIDs, targetSet.ToSlice()...)
+			}
+		}
+	}
+
+	return targetIDs
+}
+
 // RemoveNotification - removes all notification configuration for bucket name.
 func (sys *NotificationSys) RemoveNotification(bucketName string) {
 	sys.Lock()

--- a/pkg/event/config.go
+++ b/pkg/event/config.go
@@ -255,8 +255,6 @@ func (conf Config) Validate(region string, targetList *TargetList) error {
 		if err := queue.Validate(region, targetList); err != nil {
 			return err
 		}
-
-		// TODO: Need to discuss/check why same ARN cannot be used in another queue configuration.
 	}
 
 	return nil
@@ -283,13 +281,14 @@ func (conf *Config) ToRulesMap() RulesMap {
 // ParseConfig - parses data in reader to notification configuration.
 func ParseConfig(reader io.Reader, region string, targetList *TargetList) (*Config, error) {
 	var config Config
-	var err error
 
-	if err = xml.NewDecoder(reader).Decode(&config); err != nil {
+	if err := xml.NewDecoder(reader).Decode(&config); err != nil {
 		return nil, err
 	}
 
-	err = config.Validate(region, targetList)
+	if err := config.Validate(region, targetList); err != nil {
+		return nil, err
+	}
 
 	config.SetRegion(region)
 
@@ -298,5 +297,5 @@ func ParseConfig(reader io.Reader, region string, targetList *TargetList) (*Conf
 		config.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
 	}
 
-	return &config, err
+	return &config, nil
 }


### PR DESCRIPTION

## Description
fix: Don't allow to set unconfigured notification ARNs

## Motivation and Context
Fixes #8642

## How to test this PR?
As mentioned in the issue #8642

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in 63e0a81760fbd3763e36049cd820cd26b7945790
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
