### PR TITLE
Remove safe mode for invalid entries in config

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -213,6 +213,11 @@ func handleCommonEnvVars() {
 		globalActiveCred = cred
 		globalConfigEncrypted = true
 	}
+
+	globalWORMEnabled, err = config.LookupWorm()
+	if err != nil {
+		logger.Fatal(config.ErrInvalidWormValue(err), "Invalid worm configuration")
+	}
 }
 
 func logStartupMessage(msg string) {

--- a/cmd/config/etcd/etcd.go
+++ b/cmd/config/etcd/etcd.go
@@ -109,8 +109,7 @@ func parseEndpoints(endpoints string) ([]string, bool, error) {
 			return nil, false, err
 		}
 		if etcdSecure && u.Scheme == "http" {
-			return nil, false, config.Errorf(config.SafeModeKind,
-				"all endpoints should be https or http: %s", endpoint)
+			return nil, false, config.Errorf("all endpoints should be https or http: %s", endpoint)
 		}
 		// If one of the endpoint is https, we will use https directly.
 		etcdSecure = etcdSecure || u.Scheme == "https"

--- a/cmd/config/notify/parse.go
+++ b/cmd/config/notify/parse.go
@@ -283,7 +283,7 @@ func RegisterNotificationTargets(cfg config.Config, doneCh <-chan struct{}, tran
 		// notification targets, based on their target IDs
 		for _, targetID := range targetIDs {
 			if !targetList.Exists(targetID) {
-				return nil, config.Errorf(config.SafeModeKind,
+				return nil, config.Errorf(
 					"Unable to disable configured targets '%v'",
 					targetID)
 			}
@@ -423,7 +423,7 @@ func GetNotifyKafka(kafkaKVS map[string]config.KVS) (map[string]target.KafkaArgs
 		}
 		kafkaBrokers := env.Get(brokersEnv, kv.Get(target.KafkaBrokers))
 		if len(kafkaBrokers) == 0 {
-			return nil, config.Errorf(config.SafeModeKind, "kafka 'brokers' cannot be empty")
+			return nil, config.Errorf("kafka 'brokers' cannot be empty")
 		}
 		for _, s := range strings.Split(kafkaBrokers, config.ValueSeparator) {
 			var host *xnet.Host

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -38,6 +38,7 @@ import (
 func init() {
 	logger.Init(GOPATH, GOROOT)
 	logger.RegisterError(config.FmtError)
+	logger.AddTarget(globalConsoleSys.Console())
 }
 
 var (
@@ -104,10 +105,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(errUnexpected, "Gateway implementation not initialized")
 	}
 
-	// Disable logging until gateway initialization is complete, any
-	// error during initialization will be shown as a fatal message
-	logger.Disable = true
-
 	// Validate if we have access, secret set through environment.
 	globalGatewayName = gw.Name()
 	gatewayName := gw.Name()
@@ -161,9 +158,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	srvCfg := newServerConfig()
 
 	// Override any values from ENVs.
-	if err := lookupConfigs(srvCfg); err != nil {
-		logger.FatalIf(err, "Unable to initialize server config")
-	}
+	lookupConfigs(srvCfg)
 
 	// hold the mutex lock before a new config is assigned.
 	globalServerConfigMu.Lock()
@@ -227,9 +222,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(err, "Unable to initialize gateway backend")
 	}
 	newObject = NewGatewayLayerWithLocker(newObject)
-
-	// Re-enable logging
-	logger.Disable = false
 
 	// Once endpoints are finalized, initialize the new object api in safe mode.
 	globalObjLayerMutex.Lock()


### PR DESCRIPTION

## Description
Remove safe mode for invalid entries in config

## Motivation and Context
The approach is that now safe mode is only invoked when
we cannot read the config or under some catastrophic
situations, but not under situations when config entries
are invalid or unreachable. This allows for maximum
availability for MinIO and not fail on our users unlike
most of our historical releases.

## How to test this PR?
Set valid configs such enable vault endpoint and then 
take the vault endpoint down restart the server. This 
shouldn't take the server into safe-mode - since this
can be a quite common occurrence. Allow server to
continue regardless of the failure and let the internal
sub-system code retry.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
