### PR TITLE
PutBucketLifeCycleConfiguration: Return 200 instead of 204

### DIFF
--- a/cmd/bucket-lifecycle-handler.go
+++ b/cmd/bucket-lifecycle-handler.go
@@ -80,7 +80,7 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 	globalNotificationSys.SetBucketLifecycle(ctx, bucket, bucketLifecycle)
 
 	// Success.
-	writeSuccessNoContent(w)
+	writeSuccessResponseHeadersOnly(w)
 }
 
 // GetBucketLifecycleHandler - This HTTP handler returns bucket policy configuration.


### PR DESCRIPTION
## Description
According to https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html
```
If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.

```


## Motivation and Context
https://github.com/minio/minio-go/issues/1205

## How to test this PR?
Explained in https://github.com/minio/minio-go/issues/1205

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
