### PR TITLE
fix: populate buckets on etcd after config has loaded

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -229,15 +229,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	globalObjectAPI = newObject
 	globalObjLayerMutex.Unlock()
 
-	// Populate existing buckets to the etcd backend
-	if globalDNSConfig != nil {
-		buckets, err := newObject.ListBuckets(context.Background())
-		if err != nil {
-			logger.Fatal(err, "Unable to list buckets")
-		}
-		initFederatorBackend(buckets, newObject)
-	}
-
 	// Migrate all backend configs to encrypted backend, also handles rotation as well.
 	// For "nas" gateway we need to specially handle the backend migration as well.
 	// Internally code handles migrating etcd if enabled automatically.
@@ -284,6 +275,15 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		globalObjLayerMutex.Lock()
 		globalCacheObjectAPI = cacheAPI
 		globalObjLayerMutex.Unlock()
+	}
+
+	// Populate existing buckets to the etcd backend
+	if globalDNSConfig != nil {
+		buckets, err := newObject.ListBuckets(context.Background())
+		if err != nil {
+			logger.Fatal(err, "Unable to list buckets")
+		}
+		initFederatorBackend(buckets, newObject)
 	}
 
 	// Verify if object layer supports

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -374,11 +374,6 @@ func serverMain(ctx *cli.Context) {
 		logger.Fatal(err, "Unable to list buckets")
 	}
 
-	// Populate existing buckets to the etcd backend
-	if globalDNSConfig != nil {
-		initFederatorBackend(buckets, newObject)
-	}
-
 	logger.FatalIf(initSafeMode(buckets), "Unable to initialize server switching into safe-mode")
 
 	if globalCacheConfig.Enabled {
@@ -390,6 +385,11 @@ func serverMain(ctx *cli.Context) {
 		globalObjLayerMutex.Lock()
 		globalCacheObjectAPI = cacheAPI
 		globalObjLayerMutex.Unlock()
+	}
+
+	// Populate existing buckets to the etcd backend
+	if globalDNSConfig != nil {
+		initFederatorBackend(buckets, newObject)
 	}
 
 	initDataUsageStats()


### PR DESCRIPTION
## Description
fix: populate buckets on etcd after config has loaded

## Motivation and Context
etcd should have the missing buckets on etcd

## How to test this PR?
Without this PR existing buckets are not populated on etcd.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably due to config change
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
