### PR TITLE
Allow CNAME records when specified as MINIO_PUBLIC_IPS

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -188,7 +188,6 @@ func handleCommonEnvVars() {
 				for _, addr := range addrs {
 					domainIPs.Add(addr)
 				}
-				continue
 			}
 			domainIPs.Add(endpoint)
 		}

--- a/cmd/config/etcd/dns/etcd_dns.go
+++ b/cmd/config/etcd/dns/etcd_dns.go
@@ -154,6 +154,8 @@ func (c *CoreDNS) list(key string) ([]SrvRecord, error) {
 
 // Put - Adds DNS entries into etcd endpoint in CoreDNS etcd message format.
 func (c *CoreDNS) Put(bucket string) error {
+	c.Delete(bucket) // delete any existing entries.
+
 	for ip := range c.domainIPs {
 		bucketMsg, err := newCoreDNSMsg(ip, c.domainPort, defaultTTL)
 		if err != nil {


### PR DESCRIPTION

## Description
Allow CNAME records when specified as MINIO_PUBLIC_IPS

## Motivation and Context
This is necessary for `m3` global bucket support

## How to test this PR?
You need to deploy in k8s infrastructure with MINIO_PUBLIC_IPS 
point to the service hostname instead of actual IPs

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
