### PR TITLE
fix: replica set deployment for multi tenants

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -195,7 +195,7 @@ func handleCommonEnvVars() {
 	} else {
 		// Add found interfaces IP address to global domain IPS,
 		// loopback addresses will be naturally dropped.
-		updateDomainIPs(localIP4)
+		updateDomainIPs(mustGetLocalIP4())
 	}
 
 	// In place update is true by default if the MINIO_UPDATE is not set

--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -270,7 +270,7 @@ func createServerEndpoints(serverAddr string, args ...string) (EndpointZones, in
 		if err != nil {
 			return nil, -1, -1, err
 		}
-		endpointList, newSetupType, err := CreateEndpoints(serverAddr, setArgs...)
+		endpointList, newSetupType, err := CreateEndpoints(serverAddr, false, setArgs...)
 		if err != nil {
 			return nil, -1, -1, err
 		}
@@ -283,6 +283,8 @@ func createServerEndpoints(serverAddr string, args ...string) (EndpointZones, in
 		return endpointZones, len(setArgs[0]), setupType, nil
 	}
 
+	var foundPrevLocal bool
+
 	// Verify the args setup-type appropriately.
 	{
 		setArgs, err := GetAllSets(args...)
@@ -290,10 +292,13 @@ func createServerEndpoints(serverAddr string, args ...string) (EndpointZones, in
 			return nil, -1, -1, err
 		}
 
-		_, setupType, err = CreateEndpoints(serverAddr, setArgs...)
+		var endpoints Endpoints
+		endpoints, setupType, err = CreateEndpoints(serverAddr, foundPrevLocal, setArgs...)
 		if err != nil {
 			return nil, -1, -1, err
 		}
+
+		foundPrevLocal = endpoints.atleastOneEndpointLocal()
 	}
 
 	for _, arg := range args {
@@ -301,7 +306,7 @@ func createServerEndpoints(serverAddr string, args ...string) (EndpointZones, in
 		if err != nil {
 			return nil, -1, -1, err
 		}
-		endpointList, _, err := CreateEndpoints(serverAddr, setArgs...)
+		endpointList, _, err := CreateEndpoints(serverAddr, foundPrevLocal, setArgs...)
 		if err != nil {
 			return nil, -1, -1, err
 		}

--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -341,7 +341,7 @@ func TestCreateEndpoints(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run("", func(t *testing.T) {
-			endpoints, setupType, err := CreateEndpoints(testCase.serverAddr, testCase.args...)
+			endpoints, setupType, err := CreateEndpoints(testCase.serverAddr, false, testCase.args...)
 			if err == nil && testCase.expectedErr != nil {
 				t.Errorf("error: expected = %v, got = <nil>", testCase.expectedErr)
 			}
@@ -398,7 +398,7 @@ func TestGetLocalPeer(t *testing.T) {
 	for i, testCase := range testCases {
 		zendpoints := mustGetZoneEndpoints(testCase.endpointArgs...)
 		if !zendpoints[0].Endpoints[0].IsLocal {
-			if err := zendpoints[0].Endpoints.UpdateIsLocal(); err != nil {
+			if err := zendpoints[0].Endpoints.UpdateIsLocal(false); err != nil {
 				t.Fatalf("error: expected = <nil>, got = %v", err)
 			}
 		}
@@ -430,7 +430,7 @@ func TestGetRemotePeers(t *testing.T) {
 	for _, testCase := range testCases {
 		zendpoints := mustGetZoneEndpoints(testCase.endpointArgs...)
 		if !zendpoints[0].Endpoints[0].IsLocal {
-			if err := zendpoints[0].Endpoints.UpdateIsLocal(); err != nil {
+			if err := zendpoints[0].Endpoints.UpdateIsLocal(false); err != nil {
 				t.Fatalf("error: expected = <nil>, got = %v", err)
 			}
 		}

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -162,8 +162,8 @@ func sortIPs(ipList []string) []string {
 func getAPIEndpoints() (apiEndpoints []string) {
 	var ipList []string
 	if globalMinioHost == "" {
-		ipList = sortIPs(localIP4.ToSlice())
-		ipList = append(ipList, localIP6.ToSlice()...)
+		ipList = sortIPs(mustGetLocalIP4().ToSlice())
+		ipList = append(ipList, mustGetLocalIP6().ToSlice()...)
 	} else {
 		ipList = []string{globalMinioHost}
 	}
@@ -278,8 +278,8 @@ func isLocalHost(host string, port string, localPort string) (bool, error) {
 	}
 
 	// If intersection of two IP sets is not empty, then the host is localhost.
-	isLocalv4 := !localIP4.Intersection(hostIPs).IsEmpty()
-	isLocalv6 := !localIP6.Intersection(hostIPs).IsEmpty()
+	isLocalv4 := !mustGetLocalIP4().Intersection(hostIPs).IsEmpty()
+	isLocalv6 := !mustGetLocalIP6().Intersection(hostIPs).IsEmpty()
 	if port != "" {
 		return (isLocalv4 || isLocalv6) && (port == localPort), nil
 	}

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -798,6 +798,10 @@ func (sys *NotificationSys) RemoveRulesMap(bucketName string, rulesMap event.Rul
 
 // ConfiguredTargetIDs - returns list of configured target id's
 func (sys *NotificationSys) ConfiguredTargetIDs() []event.TargetID {
+	if sys == nil {
+		return nil
+	}
+
 	sys.RLock()
 	defer sys.RUnlock()
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -154,6 +154,11 @@ func IsDCOS() bool {
 	return false
 }
 
+// IsKubernetesReplicaSet returns true if minio is running in kubernetes replica set.
+func IsKubernetesReplicaSet() bool {
+	return IsKubernetes() && (env.Get("KUBERNETES_REPLICA_SET", "") != "")
+}
+
 // IsKubernetes returns true if minio is running in kubernetes.
 func IsKubernetes() bool {
 	if env.Get("SIMPLE_CI", "") == "" {


### PR DESCRIPTION
## Description
fix: replica set deployment for multi tenants

## Motivation and Context
Changes in IP underneath are dynamic in replica sets
with multiple tenants, so deploying in such a fashion
will not work until we wait for at least one participatory
server to be local.

This PR also ensures that multi-tenant zone expansion 
works in the replica set k8s deployments.

Introduces a new ENV `KUBERNETES_REPLICA_SET` check to call
appropriate code paths.


## How to test this PR?
You need `m3` setup with multiple tenants on the same pod, this PR 
also has support for zone expansions for these tenants.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression contination of the previous PR for more scenarios #8666 
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
