### PR TITLE
fix: temp credentials shouldn't allow policy/group changes

### DIFF
--- a/pkg/auth/credentials.go
+++ b/pkg/auth/credentials.go
@@ -117,6 +117,11 @@ func (cred Credentials) IsExpired() bool {
 	return cred.Expiration.Before(time.Now().UTC())
 }
 
+// IsTemp - returns whether credential is temporary or not.
+func (cred Credentials) IsTemp() bool {
+	return cred.SessionToken != ""
+}
+
 // IsValid - returns whether credential is valid or not.
 func (cred Credentials) IsValid() bool {
 	// Verify credentials if its enabled or not set.


### PR DESCRIPTION

## Description
fix: temp credentials shouldn't allow policy/group changes

## Motivation and Context
This PR fixes the issue where we might allow policy changes
for temporary credentials out of band, this situation doesn't
allow privilege escalation as such but it allows for a denial of
service for those temporary credentials. We should disallow
any external actions on temporary creds as a practice and we
should clearly differentiate which are static and which are
temporary credentials.

## How to test this PR?
Refer #8667


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably but this has been there for a while after IAM refactor
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
