### PR TITLE
fix: listenBucket should filter events based on bucket

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -228,6 +228,7 @@ func (api objectAPIHandlers) ListenBucketNotificationHandler(w http.ResponseWrit
 	bucketName := vars["bucket"]
 
 	values := r.URL.Query()
+	values.Set(peerRESTListenBucket, bucketName)
 
 	var prefix string
 	if len(values[peerRESTListenPrefix]) > 1 {
@@ -295,6 +296,9 @@ func (api objectAPIHandlers) ListenBucketNotificationHandler(w http.ResponseWrit
 		if !ok {
 			return false
 		}
+		if ev.S3.Bucket.Name != values.Get(peerRESTListenBucket) {
+			return false
+		}
 		objectName, uerr := url.QueryUnescape(ev.S3.Object.Key)
 		if uerr != nil {
 			objectName = ev.S3.Object.Key
@@ -306,7 +310,7 @@ func (api objectAPIHandlers) ListenBucketNotificationHandler(w http.ResponseWrit
 		if peer == nil {
 			continue
 		}
-		peer.Listen(listenCh, doneCh, r.URL.Query())
+		peer.Listen(listenCh, doneCh, values)
 	}
 
 	keepAliveTicker := time.NewTicker(500 * time.Millisecond)

--- a/cmd/peer-rest-common.go
+++ b/cmd/peer-rest-common.go
@@ -82,6 +82,7 @@ const (
 	peerRESTTraceAll      = "all"
 	peerRESTTraceErr      = "err"
 
+	peerRESTListenBucket = "bucket"
 	peerRESTListenPrefix = "prefix"
 	peerRESTListenSuffix = "suffix"
 	peerRESTListenEvents = "events"

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -978,6 +978,9 @@ func (s *peerRESTServer) ListenHandler(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return false
 		}
+		if ev.S3.Bucket.Name != values.Get(peerRESTListenBucket) {
+			return false
+		}
 		objectName, uerr := url.QueryUnescape(ev.S3.Object.Key)
 		if uerr != nil {
 			objectName = ev.S3.Object.Key


### PR DESCRIPTION

## Description
fix: listenBucket should filter events based on the bucket

## Motivation and Context
Currently, all bucket events are sent to all watchers
with matching prefix and event names, this becomes
problematic and prone to performance issues, fix this
situation by filtering based on buckets as well.

## How to test this PR?
Just do `mc watch --events put myminio/bucket1` and upload objects on bucket2
if they match the prefix which is the case here, you will see these events.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes perhaps introduced in the ListenBucket notification overhaul
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
