### PR TITLE
fix: remove extra newline from GetConfig() output

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -427,6 +427,10 @@ func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Reques
 
 	var s strings.Builder
 	hkvs := config.HelpSubSysMap[""]
+	var count int
+	for _, hkv := range hkvs {
+		count += len(cfg[hkv.Key])
+	}
 	for _, hkv := range hkvs {
 		v := cfg[hkv.Key]
 		for target, kv := range v {
@@ -460,7 +464,10 @@ func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Reques
 			}
 			s.WriteString(config.KvSpaceSeparator)
 			s.WriteString(kv.String())
-			s.WriteString(config.KvNewline)
+			count--
+			if count > 0 {
+				s.WriteString(config.KvNewline)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
fix: remove extra newline from GetConfig() output

## Motivation and Context
The cosmetic change removes an extra spurious newline

## How to test this PR?
Compile and inspect `mc admin config expory myminio` output

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
