### PR TITLE
mint: Change aws cli version

### DIFF
--- a/mint/build/awscli/install.sh
+++ b/mint/build/awscli/install.sh
@@ -15,6 +15,6 @@
 #  limitations under the License.
 #
 
-AWS_CLI_VERSION="1.11.177"
+AWS_CLI_VERSION="1.16.309"
 
 python -m pip install awscli==$AWS_CLI_VERSION


### PR DESCRIPTION
## Description
Increase the aws cli version to 1.16.309 Newer aws cli has support for new APIs like object locking

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
