### PR TITLE
typo "index max" to "index map"

### DIFF
--- a/pkg/s3select/csv/reader.go
+++ b/pkg/s3select/csv/reader.go
@@ -84,7 +84,7 @@ func (r *Reader) Read(dst sql.Record) (sql.Record, error) {
 		}
 	}
 
-	// If no index max, add that.
+	// If no index map, add that.
 	if r.nameIndexMap == nil {
 		r.nameIndexMap = make(map[string]int64)
 		for i := range r.columnNames {


### PR DESCRIPTION
## Description
"index map", not "index max." It's a typo.