### PR TITLE
node 6.x is EOL'ed upgrade to latest stable

### DIFF
--- a/buildscripts/gateway-tests.sh
+++ b/buildscripts/gateway-tests.sh
@@ -46,10 +46,7 @@ function main()
     gw_pid="$(start_minio_gateway_s3)"
 
     SERVER_ENDPOINT=127.0.0.1:24240 ENABLE_HTTPS=0 ACCESS_KEY=minio \
-                   SECRET_KEY=minio123 MINT_MODE="full" /mint/entrypoint.sh \
-                   aws-sdk-go aws-sdk-java aws-sdk-php aws-sdk-ruby awscli \
-                   healthcheck mc minio-dotnet minio-go minio-java minio-py \
-                   s3cmd security
+                   SECRET_KEY=minio123 MINT_MODE="full" /mint/entrypoint.sh
     rv=$?
 
     kill "$sr_pid"

--- a/mint/preinstall.sh
+++ b/mint/preinstall.sh
@@ -19,7 +19,7 @@ export APT="apt --quiet --yes"
 export WGET="wget --quiet --no-check-certificate"
 
 # install nodejs source list
-if ! $WGET --output-document=- https://deb.nodesource.com/setup_6.x | bash -; then
+if ! $WGET --output-document=- https://deb.nodesource.com/setup_13.x | bash -; then
     echo "unable to set nodejs repository"
     exit 1
 fi
@@ -32,7 +32,7 @@ rm -f packages-microsoft-prod.deb
 $APT update
 
 # download and install golang
-GO_VERSION="1.13"
+GO_VERSION="1.13.5"
 GO_INSTALL_PATH="/usr/local"
 download_url="https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz"
 if ! $WGET --output-document=- "$download_url" | tar -C "${GO_INSTALL_PATH}" -zxf -; then


### PR DESCRIPTION
## Description
node 6.x is EOL'ed upgrade to latest stable

## Motivation and Context
Fixes our current CI failures seen across many PRs

## How to test this PR?
You would have to build a new container, then the current minio/mint:edge-buggy, 
minio/minio:edge is already fixed with this patch.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes new release of minio-js is not fully compatible with older node versions looks like, the behavior has changed.
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
