### PR TITLE
Disallow creating buckets even with different domains

### DIFF
--- a/cmd/config/etcd/dns/etcd_dns.go
+++ b/cmd/config/etcd/dns/etcd_dns.go
@@ -117,9 +117,6 @@ func (c *CoreDNS) list(key string) ([]SrvRecord, error) {
 		if err != nil {
 			return nil, err
 		}
-		if r.Count == 0 {
-			return nil, ErrNoEntriesFound
-		}
 	}
 
 	var srvRecords []SrvRecord
@@ -142,9 +139,6 @@ func (c *CoreDNS) list(key string) ([]SrvRecord, error) {
 		srvRecord.Key = msgUnPath(srvRecord.Key)
 		srvRecords = append(srvRecords, srvRecord)
 
-	}
-	if len(srvRecords) == 0 {
-		return nil, ErrNoEntriesFound
 	}
 	sort.Slice(srvRecords, func(i int, j int) bool {
 		return srvRecords[i].Key < srvRecords[j].Key


### PR DESCRIPTION
## Description
If two distinct clusters are started with different domains
along with single common domain, this situation was leading
to conflicting buckets getting created on different clusters

To avoid this do not prematurely error out if the key has no
entries, let the caller decide on which entry matches and
which entry is valid. This allows support for MINIO_DOMAIN
with one common domain, but each cluster may have its own
domains.

## Motivation and Context
Fixes #8705

## How to test this PR?
As mentioned in the issue itself but it can be as simple as below

```
~ MINIO_ETCD_ENDPOINTS=http://localhost:2379 MINIO_DOMAIN=mydomain.com,somedomain.com minio server --address ":9001" /tmp/1`
```

```
~ MINIO_ETCD_ENDPOINTS=http://localhost:2379 MINIO_DOMAIN=mydomain.com,somedomain.com minio server --address ":9002" /tmp/2
```

With master branch and latest release, this creates a conflicting situation where 
we end up creating duplicate buckets, with this PR it is clearly disallowed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
