### PR TITLE
Update Kubernetes examples to use Readiness Checks

### DIFF
--- a/docs/orchestration/kubernetes/minio-distributed-headless-service.yaml
+++ b/docs/orchestration/kubernetes/minio-distributed-headless-service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: minio
 spec:
+  publishNotReadyAddresses: true
   clusterIP: None
   ports:
     - port: 9000

--- a/docs/orchestration/kubernetes/minio-distributed-statefulset.yaml
+++ b/docs/orchestration/kubernetes/minio-distributed-statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   name: minio
 spec:
   serviceName: minio
+  podManagementPolicy: Parallel
   replicas: 4
   selector:
     matchLabels:
@@ -38,6 +39,15 @@ spec:
         livenessProbe:
           httpGet:
             path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+        # Readiness probe detects situations where MinIO server instance
+        # is not ready to accept connections. Kubernetes automatically
+        # stops all the traffic to the pods if readiness checks fail.
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
             port: 9000
           initialDelaySeconds: 120
           periodSeconds: 20


### PR DESCRIPTION
## Description
This PR updates the Kubernetes example docs to demonstrate how to use Readiness
checks for distributed clusters

## Motivation and Context
With #8681 Readiness check is now based on quorum instead of go-routine count.
This approach combined with Headless service as `publishNotReadyAddresses` and
PodManagementPolicy set to `Parallel`, will enable Readiness checks to be available
for distributed MinIO instances.

## How to test this PR?
Run the sample files on a Kubernetes cluster.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
