### PR TITLE
Fix readiness to return 200 for read-only mode

### DIFF
--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -26,7 +26,7 @@ import (
 
 // ReadinessCheckHandler -- Checks if the quorum number of disks are available.
 // For FS - Checks if the backend disk is available
-// For Zones - Checks if all the zones have enough quorum
+// For Zones - Checks if all the zones have enough read quorum
 func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "ReadinessCheckHandler")
 

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -1657,7 +1657,7 @@ func (s *xlSets) GetMetrics(ctx context.Context) (*Metrics, error) {
 	return &Metrics{}, NotImplemented{}
 }
 
-// IsReady - Returns true if more than n/2 disks (quorum) are online
+// IsReady - Returns true if atleast n/2 disks (read quorum) are online
 func (s *xlSets) IsReady(_ context.Context) bool {
 	s.xlDisksMu.RLock()
 	defer s.xlDisksMu.RUnlock()
@@ -1674,8 +1674,8 @@ func (s *xlSets) IsReady(_ context.Context) bool {
 			if s.xlDisks[i][j].IsOnline() {
 				activeDisks++
 			}
-			// Return if more than n/2 disks are online.
-			if activeDisks > len(s.endpoints)/2 {
+			// Return true if read quorum is available.
+			if activeDisks >= len(s.endpoints)/2 {
 				return true
 			}
 		}


### PR DESCRIPTION

## Description
- We should declare a cluster ready even if read quorum is achieved (atleast n/2 disks are online).
- Such that, all the zones should have enough read quorum. Thus making the cluster ready for reads.

## Motivation and Context
Make the cluster ready for reads

## How to test this PR?
Checking the readiness URL

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
