### PR TITLE
Add ObjectTagging Support

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -22,6 +22,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -95,6 +96,14 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 		w.Header().Set(xhttp.XCache, objInfo.CacheStatus.String())
 		w.Header().Set(xhttp.XCacheLookup, objInfo.CacheLookupStatus.String())
 	}
+
+	// Set tag count if object has tags
+	tags, _ := url.ParseQuery(objInfo.UserTags)
+	tagCount := len(tags)
+	if tagCount != 0 {
+		w.Header().Set(xhttp.AmzTagCount, strconv.Itoa(tagCount))
+	}
+
 	// Set all other user defined metadata.
 	for k, v := range objInfo.UserDefined {
 		if HasPrefix(k, ReservedMetadataPrefix) {

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -105,8 +105,12 @@ func registerAPIRouter(router *mux.Router, encryptionEnabled, allowSSEKMS bool) 
 		bucket.Methods(http.MethodDelete).Path("/{object:.+}").HandlerFunc(collectAPIStats("abortmultipartupload", httpTraceAll(api.AbortMultipartUploadHandler))).Queries("uploadId", "{uploadId:.*}")
 		// GetObjectACL - this is a dummy call.
 		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(collectAPIStats("getobjectacl", httpTraceHdrs(api.GetObjectACLHandler))).Queries("acl", "")
-		// GetObjectTagging - this is a dummy call.
+		// GetObjectTagging
 		bucket.Methods(http.MethodGet).Path("/{object:.+}").HandlerFunc(collectAPIStats("getobjecttagging", httpTraceHdrs(api.GetObjectTaggingHandler))).Queries("tagging", "")
+		// PutObjectTagging
+		bucket.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(collectAPIStats("putobjecttagging", httpTraceHdrs(api.PutObjectTaggingHandler))).Queries("tagging", "")
+		// DeleteObjectTagging
+		bucket.Methods(http.MethodDelete).Path("/{object:.+}").HandlerFunc(collectAPIStats("deleteobjecttagging", httpTraceHdrs(api.DeleteObjectTaggingHandler))).Queries("tagging", "")
 		// SelectObjectContent
 		bucket.Methods(http.MethodPost).Path("/{object:.+}").HandlerFunc(collectAPIStats("selectobjectcontent", httpTraceHdrs(api.SelectObjectContentHandler))).Queries("select", "").Queries("select-type", "2")
 		// GetObjectRetention

--- a/cmd/fs-v1-metadata.go
+++ b/cmd/fs-v1-metadata.go
@@ -182,9 +182,14 @@ func (m fsMetaV1) ToObjectInfo(bucket, object string, fi os.FileInfo) ObjectInfo
 			objInfo.Expires = t.UTC()
 		}
 	}
+
+	// Add user tags to the object info
+	objInfo.UserTags = m.Meta[xhttp.AmzObjectTagging]
+
 	// etag/md5Sum has already been extracted. We need to
 	// remove to avoid it from appearing as part of
 	// response headers. e.g, X-Minio-* or X-Amz-*.
+	// Tags have also been extracted, we remove that as well.
 	objInfo.UserDefined = cleanMetadata(m.Meta)
 
 	// All the parts per object.

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -24,6 +24,7 @@ import (
 	"github.com/minio/minio/pkg/lifecycle"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/policy"
+	"github.com/minio/minio/pkg/tagging"
 )
 
 // GatewayLocker implements custom NeNSLock implementation
@@ -171,6 +172,24 @@ func (a GatewayUnsupported) CopyObject(ctx context.Context, srcBucket string, sr
 func (a GatewayUnsupported) GetMetrics(ctx context.Context) (*Metrics, error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return &Metrics{}, NotImplemented{}
+}
+
+// PutObjectTag - not implemented.
+func (a GatewayUnsupported) PutObjectTag(ctx context.Context, bucket, object string, tags string) error {
+	logger.LogIf(ctx, NotImplemented{})
+	return NotImplemented{}
+}
+
+// GetObjectTag - not implemented.
+func (a GatewayUnsupported) GetObjectTag(ctx context.Context, bucket, object string) (tagging.Tagging, error) {
+	logger.LogIf(ctx, NotImplemented{})
+	return tagging.Tagging{}, NotImplemented{}
+}
+
+// DeleteObjectTag - not implemented.
+func (a GatewayUnsupported) DeleteObjectTag(ctx context.Context, bucket, object string) error {
+	logger.LogIf(ctx, NotImplemented{})
+	return NotImplemented{}
 }
 
 // IsNotificationSupported returns whether bucket notification is applicable for this layer.

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -467,8 +467,8 @@ func ignoreNotImplementedBucketResources(req *http.Request) bool {
 // Checks requests for not implemented Object resources
 func ignoreNotImplementedObjectResources(req *http.Request) bool {
 	for name := range req.URL.Query() {
-		// Enable GetObjectACL and GetObjectTagging dummy calls specifically.
-		if (name == "acl" || name == "tagging") && req.Method == http.MethodGet {
+		// Enable GetObjectACL dummy call specifically.
+		if name == "acl" && req.Method == http.MethodGet {
 			return false
 		}
 		if notimplementedObjectResourceNames[name] {
@@ -497,7 +497,6 @@ var notimplementedBucketResourceNames = map[string]bool{
 var notimplementedObjectResourceNames = map[string]bool{
 	"acl":     true,
 	"restore": true,
-	"tagging": true,
 	"torrent": true,
 }
 

--- a/cmd/http/headers.go
+++ b/cmd/http/headers.go
@@ -56,6 +56,11 @@ const (
 	// S3 storage class
 	AmzStorageClass = "x-amz-storage-class"
 
+	// S3 object tagging
+	AmzObjectTagging = "X-Amz-Tagging"
+	AmzTagCount      = "X-Amz-Tag-Count"
+	AmzTagDirective  = "X-Amz-Tagging-Directive"
+
 	// S3 extensions
 	AmzCopySourceIfModifiedSince   = "x-amz-copy-source-if-modified-since"
 	AmzCopySourceIfUnmodifiedSince = "x-amz-copy-source-if-unmodified-since"

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -154,6 +154,9 @@ type ObjectInfo struct {
 	// User-Defined metadata
 	UserDefined map[string]string
 
+	// User-Defined object tags
+	UserTags string
+
 	// List of individual parts, maximum size of upto 10,000
 	Parts []ObjectPartInfo `json:"-"`
 

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -25,6 +25,7 @@ import (
 	"github.com/minio/minio/pkg/lifecycle"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/policy"
+	"github.com/minio/minio/pkg/tagging"
 )
 
 // CheckCopyPreconditionFn returns true if copy precondition check failed.
@@ -125,4 +126,9 @@ type ObjectLayer interface {
 
 	// Check Readiness
 	IsReady(ctx context.Context) bool
+
+	// ObjectTagging operations
+	PutObjectTag(context.Context, string, string, string) error
+	GetObjectTag(context.Context, string, string) (tagging.Tagging, error)
+	DeleteObjectTag(context.Context, string, string) error
 }

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -239,8 +239,8 @@ func getCompleteMultipartMD5(parts []CompletePart) string {
 func cleanMetadata(metadata map[string]string) map[string]string {
 	// Remove STANDARD StorageClass
 	metadata = removeStandardStorageClass(metadata)
-	// Clean meta etag keys 'md5Sum', 'etag', "expires".
-	return cleanMetadataKeys(metadata, "md5Sum", "etag", "expires")
+	// Clean meta etag keys 'md5Sum', 'etag', "expires", "x-amz-tagging".
+	return cleanMetadataKeys(metadata, "md5Sum", "etag", "expires", xhttp.AmzObjectTagging)
 }
 
 // Filter X-Amz-Storage-Class field only if it is set to STANDARD.

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -35,6 +35,7 @@ import (
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/policy"
 	"github.com/minio/minio/pkg/sync/errgroup"
+	"github.com/minio/minio/pkg/tagging"
 )
 
 // setsStorageAPI is encapsulated type for Close()
@@ -1659,6 +1660,21 @@ func (s *xlSets) HealObjects(ctx context.Context, bucket, prefix string, healObj
 
 func (s *xlSets) ListObjectsHeal(ctx context.Context, bucket, prefix, marker, delimiter string, maxKeys int) (loi ListObjectsInfo, err error) {
 	return s.listObjects(ctx, bucket, prefix, marker, delimiter, maxKeys, true)
+}
+
+// PutObjectTag - replace or add tags to an existing object
+func (s *xlSets) PutObjectTag(ctx context.Context, bucket, object string, tags string) error {
+	return s.getHashedSet(object).PutObjectTag(ctx, bucket, object, tags)
+}
+
+// DeleteObjectTag - delete object tags from an existing object
+func (s *xlSets) DeleteObjectTag(ctx context.Context, bucket, object string) error {
+	return s.getHashedSet(object).DeleteObjectTag(ctx, bucket, object)
+}
+
+// GetObjectTag - get object tags from an existing object
+func (s *xlSets) GetObjectTag(ctx context.Context, bucket, object string) (tagging.Tagging, error) {
+	return s.getHashedSet(object).GetObjectTag(ctx, bucket, object)
 }
 
 // GetMetrics - no op

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -245,9 +245,13 @@ func (m xlMetaV1) ToObjectInfo(bucket, object string) ObjectInfo {
 	// Extract etag from metadata.
 	objInfo.ETag = extractETag(m.Meta)
 
+	// Add user tags to the object info
+	objInfo.UserTags = m.Meta[xhttp.AmzObjectTagging]
+
 	// etag/md5Sum has already been extracted. We need to
 	// remove to avoid it from appearing as part of
 	// response headers. e.g, X-Minio-* or X-Amz-*.
+	// Tags have also been extracted, we remove that as well.
 	objInfo.UserDefined = cleanMetadata(m.Meta)
 
 	// All the parts per object.

--- a/docs/minio-limits.md
+++ b/docs/minio-limits.md
@@ -51,7 +51,6 @@ We found the following APIs to be redundant or less useful outside of AWS S3. If
 - ObjectACL (Use [bucket policies](https://docs.min.io/docs/minio-client-complete-guide#policy) instead)
 - ObjectTorrent
 - ObjectVersions
-- ObjectTagging
 
 ### Object name restrictions on MinIO
 Object names that contain characters `^*|\/&";` are unsupported on Windows and other file systems which do not support filenames with these characters. Note that this list is not exhaustive, and depends on the maintainers of the filesystem itself.

--- a/pkg/iam/policy/action.go
+++ b/pkg/iam/policy/action.go
@@ -114,6 +114,15 @@ const (
 	// PutBucketObjectLockConfigurationAction - PutBucketObjectLockConfiguration Rest API action
 	PutBucketObjectLockConfigurationAction = "s3:PutBucketObjectLockConfiguration"
 
+	// GetObjectTaggingAction - Get Object Tags API action
+	GetObjectTaggingAction = "s3:GetObjectTagging"
+
+	// PutObjectTaggingAction - Put Object Tags API action
+	PutObjectTaggingAction = "s3:PutObjectTagging"
+
+	// DeleteObjectTaggingAction - Delete Object Tags API action
+	DeleteObjectTaggingAction = "s3:DeleteObjectTagging"
+
 	// AllActions - all API actions
 	AllActions = "s3:*"
 )
@@ -149,6 +158,9 @@ var supportedActions = map[Action]struct{}{
 	GetBucketObjectLockConfigurationAction: {},
 	BypassGovernanceModeAction:             {},
 	BypassGovernanceRetentionAction:        {},
+	GetObjectTaggingAction:                 {},
+	PutObjectTaggingAction:                 {},
+	DeleteObjectTaggingAction:              {},
 }
 
 // isObjectAction - returns whether action is object type or not.
@@ -163,6 +175,8 @@ func (action Action) isObjectAction() bool {
 	case PutObjectRetentionAction, GetObjectRetentionAction:
 		return true
 	case PutObjectLegalHoldAction, GetObjectLegalHoldAction:
+		return true
+	case GetObjectTaggingAction, PutObjectTaggingAction, DeleteObjectTaggingAction:
 		return true
 	}
 
@@ -283,4 +297,7 @@ var actionConditionKeyMap = map[Action]condition.KeySet{
 	BypassGovernanceRetentionAction:        condition.NewKeySet(condition.CommonKeys...),
 	GetBucketObjectLockConfigurationAction: condition.NewKeySet(condition.CommonKeys...),
 	PutBucketObjectLockConfigurationAction: condition.NewKeySet(condition.CommonKeys...),
+	PutObjectTaggingAction:                 condition.NewKeySet(condition.CommonKeys...),
+	GetObjectTaggingAction:                 condition.NewKeySet(condition.CommonKeys...),
+	DeleteObjectTaggingAction:              condition.NewKeySet(condition.CommonKeys...),
 }

--- a/pkg/policy/action.go
+++ b/pkg/policy/action.go
@@ -106,6 +106,13 @@ const (
 	GetBucketObjectLockConfigurationAction = "s3:GetBucketObjectLockConfiguration"
 	// PutBucketObjectLockConfigurationAction - PutObjectLockConfiguration Rest API action
 	PutBucketObjectLockConfigurationAction = "s3:PutBucketObjectLockConfiguration"
+
+	// GetObjectTaggingAction - Get Object Tags API action
+	GetObjectTaggingAction = "s3:GetObjectTagging"
+	// PutObjectTaggingAction - Put Object Tags API action
+	PutObjectTaggingAction = "s3:PutObjectTagging"
+	// DeleteObjectTaggingAction - Delete Object Tags API action
+	DeleteObjectTaggingAction = "s3:DeleteObjectTagging"
 )
 
 // isObjectAction - returns whether action is object type or not.
@@ -120,6 +127,8 @@ func (action Action) isObjectAction() bool {
 	case PutObjectLegalHoldAction, GetObjectLegalHoldAction:
 		return true
 	case BypassGovernanceModeAction, BypassGovernanceRetentionAction:
+		return true
+	case GetObjectTaggingAction, PutObjectTaggingAction, DeleteObjectTaggingAction:
 		return true
 	}
 
@@ -152,6 +161,8 @@ func (action Action) IsValid() bool {
 	case PutObjectLegalHoldAction, GetObjectLegalHoldAction:
 		return true
 	case PutBucketObjectLockConfigurationAction, GetBucketObjectLockConfigurationAction:
+		return true
+	case GetObjectTaggingAction, PutObjectTaggingAction, DeleteObjectTaggingAction:
 		return true
 	}
 
@@ -243,4 +254,7 @@ var actionConditionKeyMap = map[Action]condition.KeySet{
 	GetObjectLegalHoldAction:               condition.NewKeySet(condition.CommonKeys...),
 	GetBucketObjectLockConfigurationAction: condition.NewKeySet(condition.CommonKeys...),
 	PutBucketObjectLockConfigurationAction: condition.NewKeySet(condition.CommonKeys...),
+	PutObjectTaggingAction:                 condition.NewKeySet(condition.CommonKeys...),
+	GetObjectTaggingAction:                 condition.NewKeySet(condition.CommonKeys...),
+	DeleteObjectTaggingAction:              condition.NewKeySet(condition.CommonKeys...),
 }

--- a/pkg/tagging/error.go
+++ b/pkg/tagging/error.go
@@ -1,0 +1,44 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tagging
+
+import (
+	"fmt"
+)
+
+// Error is the generic type for any error happening during tag
+// parsing.
+type Error struct {
+	err error
+}
+
+// Errorf - formats according to a format specifier and returns
+// the string as a value that satisfies error of type tagging.Error
+func Errorf(format string, a ...interface{}) error {
+	return Error{err: fmt.Errorf(format, a...)}
+}
+
+// Unwrap the internal error.
+func (e Error) Unwrap() error { return e.err }
+
+// Error 'error' compatible method.
+func (e Error) Error() string {
+	if e.err == nil {
+		return "tagging: cause <nil>"
+	}
+	return e.err.Error()
+}

--- a/pkg/tagging/tag.go
+++ b/pkg/tagging/tag.go
@@ -1,0 +1,62 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tagging
+
+import (
+	"encoding/xml"
+	"unicode/utf8"
+)
+
+// Tag - single tag
+type Tag struct {
+	XMLName xml.Name `xml:"Tag"`
+	Key     string   `xml:"Key"`
+	Value   string   `xml:"Value"`
+}
+
+// Validate - validates the tag element
+func (t Tag) Validate() error {
+	if err := t.validateKey(); err != nil {
+		return err
+	}
+	if err := t.validateValue(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateKey - checks if key is valid or not.
+func (t Tag) validateKey() error {
+	// cannot be longer than maxTagKeyLength characters
+	if utf8.RuneCountInString(t.Key) > maxTagKeyLength {
+		return ErrInvalidTagKey
+	}
+	// cannot be empty
+	if len(t.Key) == 0 {
+		return ErrInvalidTagKey
+	}
+	return nil
+}
+
+// validateValue - checks if value is valid or not.
+func (t Tag) validateValue() error {
+	// cannot be longer than maxTagValueLength characters
+	if utf8.RuneCountInString(t.Value) > maxTagValueLength {
+		return ErrInvalidTagValue
+	}
+	return nil
+}

--- a/pkg/tagging/tagging.go
+++ b/pkg/tagging/tagging.go
@@ -1,0 +1,113 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tagging
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"net/url"
+)
+
+// S3 API limits for tags
+// Ref: https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html
+const (
+	maxTags           = 10
+	maxTagKeyLength   = 128
+	maxTagValueLength = 256
+)
+
+// errors returned by tagging package
+var (
+	ErrTooManyTags     = Errorf("Cannot have more than 10 object tags")
+	ErrInvalidTagKey   = Errorf("The TagKey you have provided is invalid")
+	ErrInvalidTagValue = Errorf("The TagValue you have provided is invalid")
+	ErrInvalidTag      = Errorf("Cannot provide multiple Tags with the same key")
+)
+
+// Tagging - object tagging interface
+type Tagging struct {
+	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Tagging"`
+	TagSet  TagSet   `xml:"TagSet"`
+}
+
+// Validate - validates the tagging configuration
+func (t Tagging) Validate() error {
+	// Tagging can't have more than 10 tags
+	if len(t.TagSet.Tags) > maxTags {
+		return ErrTooManyTags
+	}
+	// Validate all the rules in the tagging config
+	for _, ts := range t.TagSet.Tags {
+		if t.TagSet.ContainsDuplicate(ts.Key) {
+			return ErrInvalidTag
+		}
+		if err := ts.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// String - returns a string in format "tag1=value1&tag2=value2" with all the
+// tags in this Tagging Struct
+func (t Tagging) String() string {
+	var buf bytes.Buffer
+	for _, tag := range t.TagSet.Tags {
+		if buf.Len() > 0 {
+			buf.WriteString("&")
+		}
+		buf.WriteString(tag.Key + "=")
+		buf.WriteString(tag.Value)
+	}
+	return buf.String()
+}
+
+// FromString - returns a Tagging struct when given a string in format
+// "tag1=value1&tag2=value2"
+func FromString(tagStr string) (Tagging, error) {
+	tags, err := url.ParseQuery(tagStr)
+	if err != nil {
+		return Tagging{}, err
+	}
+	var idx = 0
+	parsedTags := make([]Tag, len(tags))
+	for k := range tags {
+		parsedTags[idx].Key = k
+		parsedTags[idx].Value = tags.Get(k)
+		idx++
+	}
+	return Tagging{
+		TagSet: TagSet{
+			Tags: parsedTags,
+		},
+	}, nil
+}
+
+// ParseTagging - parses incoming xml data in given reader
+// into Tagging interface. After parsing, also validates the
+// parsed fields based on S3 API constraints.
+func ParseTagging(reader io.Reader) (*Tagging, error) {
+	var t Tagging
+	if err := xml.NewDecoder(reader).Decode(&t); err != nil {
+		return nil, err
+	}
+	if err := t.Validate(); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}

--- a/pkg/tagging/tagset.go
+++ b/pkg/tagging/tagset.go
@@ -1,0 +1,41 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tagging
+
+import (
+	"encoding/xml"
+)
+
+// TagSet - Set of tags under Tagging
+type TagSet struct {
+	XMLName xml.Name `xml:"TagSet"`
+	Tags    []Tag    `xml:"Tag"`
+}
+
+// ContainsDuplicate - returns true if duplicate keys are present in TagSet
+func (t TagSet) ContainsDuplicate(key string) bool {
+	var found bool
+	for _, tag := range t.Tags {
+		if tag.Key == key {
+			if found {
+				return true
+			}
+			found = true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description
This PR adds support for AWS S3 ObjectTagging API as explained here https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html

## Motivation and Context
AWS S3 Compatibility

## How to test this PR?
Use any S3 compatible system to send object tagging requests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
