### PR TITLE
Add custom policy claim name

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -226,7 +226,7 @@ func getClaimsFromToken(r *http.Request) (map[string]interface{}, error) {
 		// If OPA is not set, session token should
 		// have a policy and its mandatory, reject
 		// requests without policy claim.
-		p, pok := claims[iamPolicyName()]
+		p, pok := claims[iamPolicyClaimName()]
 		if !pok {
 			return nil, errAuthentication
 		}

--- a/cmd/config/identity/openid/help.go
+++ b/cmd/config/identity/openid/help.go
@@ -33,8 +33,14 @@ var (
 			Optional:    true,
 		},
 		config.HelpKV{
+			Key:         ClaimName,
+			Description: `JWT canned policy claim name, defaults to "policy"`,
+			Optional:    true,
+			Type:        "string",
+		},
+		config.HelpKV{
 			Key:         ClaimPrefix,
-			Description: `JWT claim namespace prefix e.g. "customer1"`,
+			Description: `JWT claim namespace prefix e.g. "customer1/"`,
 			Optional:    true,
 			Type:        "string",
 		},

--- a/cmd/crypto/metadata_test.go
+++ b/cmd/crypto/metadata_test.go
@@ -188,8 +188,16 @@ var s3ParseMetadataTests = []struct {
 func TestS3ParseMetadata(t *testing.T) {
 	for i, test := range s3ParseMetadataTests {
 		keyID, dataKey, sealedKey, err := S3.ParseMetadata(test.Metadata)
-		if err != test.ExpectedErr {
+		if err != nil && test.ExpectedErr == nil {
 			t.Errorf("Test %d: got error '%v' - want error '%v'", i, err, test.ExpectedErr)
+		}
+		if err == nil && test.ExpectedErr != nil {
+			t.Errorf("Test %d: got error '%v' - want error '%v'", i, err, test.ExpectedErr)
+		}
+		if err != nil && test.ExpectedErr != nil {
+			if err.Error() != test.ExpectedErr.Error() {
+				t.Errorf("Test %d: got error '%v' - want error '%v'", i, err, test.ExpectedErr)
+			}
 		}
 		if !bytes.Equal(dataKey, test.DataKey) {
 			t.Errorf("Test %d: got data key '%v' - want data key '%v'", i, dataKey, test.DataKey)
@@ -267,8 +275,16 @@ func TestCreateMultipartMetadata(t *testing.T) {
 func TestSSECParseMetadata(t *testing.T) {
 	for i, test := range ssecParseMetadataTests {
 		sealedKey, err := SSEC.ParseMetadata(test.Metadata)
-		if err != test.ExpectedErr {
+		if err != nil && test.ExpectedErr == nil {
 			t.Errorf("Test %d: got error '%v' - want error '%v'", i, err, test.ExpectedErr)
+		}
+		if err == nil && test.ExpectedErr != nil {
+			t.Errorf("Test %d: got error '%v' - want error '%v'", i, err, test.ExpectedErr)
+		}
+		if err != nil && test.ExpectedErr != nil {
+			if err.Error() != test.ExpectedErr.Error() {
+				t.Errorf("Test %d: got error '%v' - want error '%v'", i, err, test.ExpectedErr)
+			}
 		}
 		if sealedKey.Algorithm != test.SealedKey.Algorithm {
 			t.Errorf("Test %d: got sealed key algorithm '%v' - want sealed key algorithm '%v'", i, sealedKey.Algorithm, test.SealedKey.Algorithm)

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -214,7 +214,7 @@ func (sts *stsAPIHandlers) AssumeRole(w http.ResponseWriter, r *http.Request) {
 	// This policy is the policy associated with the user
 	// requesting for temporary credentials. The temporary
 	// credentials will inherit the same policy requirements.
-	m[iamPolicyName()] = policyName
+	m[iamPolicyClaimName()] = policyName
 
 	if len(sessionPolicyStr) > 0 {
 		m[iampolicy.SessionPolicyName] = base64.StdEncoding.EncodeToString([]byte(sessionPolicyStr))
@@ -350,7 +350,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithJWT(w http.ResponseWriter, r *http.Requ
 	// be set and configured on your identity provider as part of
 	// JWT custom claims.
 	var policyName string
-	if v, ok := m[iamPolicyName()]; ok {
+	if v, ok := m[iamPolicyClaimName()]; ok {
 		policyName, _ = v.(string)
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -39,7 +39,6 @@ import (
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/handlers"
-	iampolicy "github.com/minio/minio/pkg/iam/policy"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/gorilla/mux"
@@ -535,8 +534,8 @@ func splitN(str, delim string, num int) []string {
 	return retSplit
 }
 
-func iamPolicyName() string {
-	return globalOpenIDConfig.ClaimPrefix + iampolicy.PolicyName
+func iamPolicyClaimName() string {
+	return globalOpenIDConfig.ClaimPrefix + globalOpenIDConfig.ClaimName
 }
 
 func isWORMEnabled(bucket string) (Retention, bool) {

--- a/pkg/iam/policy/policy.go
+++ b/pkg/iam/policy/policy.go
@@ -19,6 +19,7 @@ package iampolicy
 import (
 	"encoding/json"
 	"io"
+	"strings"
 
 	"github.com/minio/minio/pkg/policy"
 )
@@ -35,6 +36,20 @@ type Args struct {
 	IsOwner         bool                   `json:"owner"`
 	ObjectName      string                 `json:"object"`
 	Claims          map[string]interface{} `json:"claims"`
+}
+
+// GetPolicies get policies
+func (a Args) GetPolicies(policyClaimName string) ([]string, bool) {
+	pname, ok := a.Claims[policyClaimName]
+	if !ok {
+		return nil, false
+	}
+	pnameStr, ok := pname.(string)
+	if ok {
+		return strings.Split(pnameStr, ","), true
+	}
+	pnameSlice, ok := pname.([]string)
+	return pnameSlice, ok
 }
 
 // Policy - iam bucket iamp.


### PR DESCRIPTION


## Description
Add custom policy claim name

## Motivation and Context
In certain organizations policy claim names
can be not just 'policy' but also things like
'roles', the value of this field might also
be *string* or *[]string* support this as well

In this PR we are still not supporting multiple
policies per STS account which will require a
more comprehensive change.

## How to test this PR?
You need to use Azure AD to bring in roles parameter which is different than `policy`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
