### PR TITLE
Validate XL sets on format

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
-	"github.com/minio/cli"
 	"github.com/minio/minio-go/v6/pkg/set"
 	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/cmd/logger"
@@ -458,28 +457,6 @@ func NewEndpoints(args ...string) (endpoints Endpoints, err error) {
 	}
 
 	return endpoints, nil
-}
-
-func checkEndpointsSubOptimal(ctx *cli.Context, setupType SetupType, endpointZones EndpointZones) (err error) {
-	// Validate sub optimal ordering only for distributed setup.
-	if setupType != DistXLSetupType {
-		return nil
-	}
-	var endpointOrder int
-	err = fmt.Errorf("Too many disk args are local, input is in sub-optimal order. Please review input args: %s", ctx.Args())
-	for _, endpoints := range endpointZones {
-		for _, endpoint := range endpoints.Endpoints {
-			if endpoint.IsLocal {
-				endpointOrder++
-			} else {
-				endpointOrder--
-			}
-			if endpointOrder >= 2 {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 // Checks if there are any cross device mounts.

--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"flag"
 	"fmt"
 	"net"
 	"net/url"
@@ -25,46 +24,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/minio/cli"
 	"github.com/minio/minio-go/v6/pkg/set"
 )
-
-func TestSubOptimalEndpointInput(t *testing.T) {
-	args1 := []string{"http://localhost/d1", "http://localhost/d2", "http://localhost/d3", "http://localhost/d4"}
-	args2 := []string{"http://example.org/d1", "http://example.com/d1", "http://example.net/d1", "http://example.edu/d1"}
-
-	tests := []struct {
-		setupType SetupType
-		ctx       *cli.Context
-		endpoints EndpointZones
-		isErr     bool
-	}{
-		{
-			setupType: DistXLSetupType,
-			ctx:       cli.NewContext(cli.NewApp(), flag.NewFlagSet("", flag.ContinueOnError), nil),
-			endpoints: mustGetZoneEndpoints(args1...),
-			isErr:     false,
-		},
-		{
-			setupType: DistXLSetupType,
-			ctx:       cli.NewContext(cli.NewApp(), flag.NewFlagSet("", flag.ContinueOnError), nil),
-			endpoints: mustGetZoneEndpoints(args2...),
-			isErr:     false,
-		},
-	}
-	for i, test := range tests {
-		test := test
-		t.Run(fmt.Sprintf("Test%d", i+1), func(t *testing.T) {
-			err := checkEndpointsSubOptimal(test.ctx, test.setupType, test.endpoints)
-			if test.isErr && err == nil {
-				t.Error("expected err but found nil")
-			}
-			if !test.isErr && err != nil {
-				t.Errorf("expected err nil but found an err %s", err)
-			}
-		})
-	}
-}
 
 func TestNewEndpoint(t *testing.T) {
 	u2, _ := url.Parse("https://example.org/path")

--- a/cmd/erasure-encode_test.go
+++ b/cmd/erasure-encode_test.go
@@ -44,7 +44,7 @@ func (a badDisk) CreateFile(volume, path string, size int64, reader io.Reader) e
 	return errFaultyDisk
 }
 
-func (_ badDisk) Hostname() string {
+func (badDisk) Hostname() string {
 	return ""
 }
 

--- a/cmd/erasure-encode_test.go
+++ b/cmd/erasure-encode_test.go
@@ -44,6 +44,10 @@ func (a badDisk) CreateFile(volume, path string, size int64, reader io.Reader) e
 	return errFaultyDisk
 }
 
+func (_ badDisk) Hostname() string {
+	return ""
+}
+
 const oneMiByte = 1 * humanize.MiByte
 
 var erasureEncodeTests = []struct {

--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -765,7 +765,7 @@ func initFormatXL(ctx context.Context, storageDisks []StorageAPI, setCount, driv
 			if deploymentID != "" {
 				newFormat.ID = deploymentID
 			}
-			logger.Info("   - Drive: %s, host: %v", disk.String(), disk.Hostname())
+			logger.Info("   - Drive: %s", disk.String())
 			hostCount[disk.Hostname()]++
 			formats[i*drivesPerSet+j] = newFormat
 		}

--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -769,7 +769,7 @@ func initFormatXL(ctx context.Context, storageDisks []StorageAPI, setCount, driv
 			hostCount[disk.Hostname()]++
 			formats[i*drivesPerSet+j] = newFormat
 		}
-		if len(hostCount) > 0 {
+		if len(hostCount) > 1 {
 			// Config
 			wantAtMost := globalStorageClass.GetParityForSC(storageclass.STANDARD)
 			if wantAtMost == 0 {

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -53,7 +53,7 @@ func (d *naughtyDisk) IsOnline() bool {
 	return d.disk.IsOnline()
 }
 
-func (_ naughtyDisk) Hostname() string {
+func (_ *naughtyDisk) Hostname() string {
 	return ""
 }
 

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -53,6 +53,10 @@ func (d *naughtyDisk) IsOnline() bool {
 	return d.disk.IsOnline()
 }
 
+func (_ naughtyDisk) Hostname() string {
+	return ""
+}
+
 func (d *naughtyDisk) LastError() (err error) {
 	return nil
 }

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -53,7 +53,7 @@ func (d *naughtyDisk) IsOnline() bool {
 	return d.disk.IsOnline()
 }
 
-func (_ *naughtyDisk) Hostname() string {
+func (*naughtyDisk) Hostname() string {
 	return ""
 }
 

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -42,6 +42,10 @@ func (p *posixDiskIDCheck) CrawlAndGetDataUsage(endCh <-chan struct{}) (DataUsag
 	return p.storage.CrawlAndGetDataUsage(endCh)
 }
 
+func (p *posixDiskIDCheck) Hostname() string {
+	return p.storage.Hostname()
+}
+
 func (p *posixDiskIDCheck) LastError() error {
 	return p.storage.LastError()
 }

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -309,6 +309,10 @@ func (s *posix) String() string {
 	return s.diskPath
 }
 
+func (_ *posix) Hostname() string {
+	return ""
+}
+
 func (s *posix) LastError() error {
 	if atomic.LoadInt32(&s.ioErrCount) > maxAllowedIOError {
 		return errFaultyDisk

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -309,7 +309,7 @@ func (s *posix) String() string {
 	return s.diskPath
 }
 
-func (_ *posix) Hostname() string {
+func (*posix) Hostname() string {
 	return ""
 }
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -160,6 +160,7 @@ func validateXLFormats(format *formatXLV3, formats []*formatXLV3, endpoints Endp
 	if len(format.XL.Sets[0]) != drivesPerSet {
 		return fmt.Errorf("Current backend format is inconsistent with input args (%s), Expected drive count per set %d, got %d", endpoints, len(format.XL.Sets[0]), drivesPerSet)
 	}
+
 	return nil
 }
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -127,10 +127,6 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	}
 	logger.FatalIf(err, "Invalid command line arguments")
 
-	if err = checkEndpointsSubOptimal(ctx, setupType, globalEndpoints); err != nil {
-		logger.Info("Optimal endpoint check failed %s", err)
-	}
-
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back
 	// to IPv6 address ie minio will start listening on IPv6 address whereas another
 	// (non-)minio process is listening on IPv4 of given port.

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -26,7 +26,8 @@ type StorageAPI interface {
 	String() string
 
 	// Storage operations.
-	IsOnline() bool // Returns true if disk is online.
+	IsOnline() bool   // Returns true if disk is online.
+	Hostname() string // Returns host name if remote host.
 	LastError() error
 	Close() error
 	SetDiskID(id string)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -148,6 +148,10 @@ func (client *storageRESTClient) IsOnline() bool {
 	return atomic.LoadInt32(&client.connected) == 1
 }
 
+func (client *storageRESTClient) Hostname() string {
+	return client.endpoint.Host
+}
+
 func (client *storageRESTClient) CrawlAndGetDataUsage(endCh <-chan struct{}) (DataUsageInfo, error) {
 	respBody, err := client.call(storageRESTMethodCrawlAndGetDataUsage, nil, nil, -1)
 	defer http.DrainBody(respBody)


### PR DESCRIPTION
## Description

When formatting a set validate if a host failure will likely lead to data loss.

While we don't know what config will be set in the future, we evaluate to our best knowledge, assuming default settings if no env var is set.

Example of bad setup (2 zones, each server having all disks in set):
```
minio server --address ":9000" http://127.0.0.1:9000/tmp/0/{1...4} http://127.0.0.1:9001/tmp/1/{1...4}
Formatting zone, 1 set(s), 4 drives per set.
WARNING: Host local has more than 2 drives of set. A host failure will result in data becoming unavailable.
Formatting zone, 1 set(s), 4 drives per set.
WARNING: Host 127.0.0.1:9001 has more than 2 drives of set. A host failure will result in data becoming unavailable.
```

Example of good config that no longer prints a warning:
```
minio server --address ":9000" http://127.0.0.1:9000/tmp/0/1 http://127.0.0.1:9000/tmp/0/2 http://127.0.0.1:9000/tmp/0/3 http://127.0.0.1:9000/tmp/0/4 http://127.0.0.1:9001/tmp/1/1 http://127.0.0.1:9001/tmp/1/2 http://127.0.0.1:9001/tmp/1/3 http://127.0.0.1:9001/tmp/1/4
Formatting zone, 1 set(s), 8 drives per set.
```

However, setting `MINIO_STORAGE_CLASS_STANDARD=EC:3` will correctly display an error:

```
minio server --address ":9000" http://127.0.0.1:9000/tmp/0/1 http://127.0.0.1:9000/tmp/0/2 http://127.0.0.1:9000/tmp/0/3 http://127.0.0.1:9000/tmp/0/4 http://127.0.0.1:9001/tmp/1/1 http://127.0.0.1:9001/tmp/1/2 http://127.0.0.1:9001/tmp/1/3 http://127.0.0.1:9001/tmp/1/4
Formatting zone, 1 set(s), 8 drives per set.
 * Set 1:
   - Drive: c:\tmp\0\1
   - Drive: c:\tmp\0\2
   - Drive: c:\tmp\0\3
   - Drive: c:\tmp\0\4
   - Drive: http://127.0.0.1:9001/tmp/1/1
   - Drive: http://127.0.0.1:9001/tmp/1/2
   - Drive: http://127.0.0.1:9001/tmp/1/3
   - Drive: http://127.0.0.1:9001/tmp/1/4
WARNING: Host local has more than 3 drives of set. A host failure will result in data becoming unavailable.
WARNING: Host 127.0.0.1:9001 has more than 3 drives of set. A host failure will result in data becoming unavailable.
```

This information is only displayed when formatting.

Clear `tmp` between runs.

## How to test this PR?

Examples provided above. Tweaking `MINIO_STORAGE_CLASS_STANDARD` is the easiest way to evaluate.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
