### PR TITLE
Fix typo in prometheus monitoring docs

### DIFF
--- a/docs/metrics/prometheus/README.md
+++ b/docs/metrics/prometheus/README.md
@@ -120,7 +120,7 @@ The list of metrics and its definition are as follows. (NOTE: instance here is o
 
 - standard go runtime metrics prefixed by `go_`
 - process level metrics prefixed with `process_`
-- prometheus scrap metrics prefixed with `promhttp_`
+- prometheus scrape metrics prefixed with `promhttp_`
 
 - `disk_storage_used` : Disk space used by the disk.
 - `disk_storage_available`: Available disk space left on the disk.


### PR DESCRIPTION
## Description
Fixes a typo in the prometheus monitoring docs.

## Motivation and Context
I found this typo while reading the online documentation and was confused on the meaning of the sentence since the word `scrap` is an English word with a much different meaning to `scrape`.

## How to test this PR?
I am unsure if there's an easy way to test the rendered docs. I could not find any doc builds in the Makefile. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
