### PR TITLE
xl: All nodes create meta volumes in its local disks

### DIFF
--- a/cmd/format-xl_test.go
+++ b/cmd/format-xl_test.go
@@ -101,7 +101,7 @@ func TestFixFormatV3(t *testing.T) {
 		formats[j] = newFormat
 	}
 
-	if err = initFormatXLMetaVolume(storageDisks, formats); err != nil {
+	if err = initXLMetaVolumesInLocalDisks(storageDisks, formats); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -267,12 +267,6 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 		return format, nil
 	}
 
-	// The first will always recreate some directories inside .minio.sys
-	// such as, tmp, multipart and background-ops
-	if firstDisk {
-		initFormatXLMetaVolume(storageDisks, formatConfigs)
-	}
-
 	// Return error when quorum unformatted disks - indicating we are
 	// waiting for first server to be online.
 	if quorumUnformattedDisks(sErrs) && !firstDisk {
@@ -330,6 +324,10 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 	if err = formatXLFixLocalDeploymentID(endpoints, storageDisks, format); err != nil {
 		return nil, err
 	}
+
+	// The will always recreate some directories inside .minio.sys of
+	// the local disk such as tmp, multipart and background-ops
+	initXLMetaVolumesInLocalDisks(storageDisks, formatConfigs)
 
 	return format, nil
 }


### PR DESCRIPTION
## Description
    xl: All nodes create meta volumes in its local disks
    
    Meta volumes directories, tmp/, background-ops/, etc..
    under .minio.sys are created when disks are formatted
    but also when the cluster is started.
    
    The PR will make each node creates meta volumes
    in its local disks and stop relying on the first disk
    since the first node could be offline.

## Motivation and Context
Fixes #8781 


## How to test this PR?
1. Initialize a four nodes with four disks with this old version: minio.RELEASE.2019-10-12T01-39-57Z
2. Upgrade to the latest release 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
