### PR TITLE
Add missing amqp env var to enable notification in doc

### DIFF
--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -77,6 +77,7 @@ KEY:
 notify_amqp[:name]  publish bucket notifications to AMQP endpoints
 
 ARGS:
+MINIO_NOTIFY_AMQP_ENABLE         (on|off)    enable amqp notifications, default is 'off'
 MINIO_NOTIFY_AMQP_URL*           (url)       AMQP server endpoint e.g. `amqp://myuser:mypassword@localhost:5672`
 MINIO_NOTIFY_AMQP_EXCHANGE       (string)    name of the AMQP exchange
 MINIO_NOTIFY_AMQP_EXCHANGE_TYPE  (string)    AMQP exchange type


### PR DESCRIPTION
## Description
Amqp env var to enable notification not described

## Motivation and Context
Need to config amqp with en var but if not enabled nothing work.
I think other var to enable other notification mode are missing too, should be great to add them also.

## How to test this PR?
Nothing to test it's only doc

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
