### PR TITLE
Enable multiple concurrent profile types

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -571,30 +571,47 @@ func (a adminAPIHandlers) StartProfilingHandler(w http.ResponseWriter, r *http.R
 	}
 
 	vars := mux.Vars(r)
-	profiler := vars["profilerType"]
-
+	profiles := strings.Split(vars["profilerType"], ",")
+	if len(profiles) == 1 && profiles[0] == "all" {
+		profiles = []string{"cpu", "mem", "block", "mutex", "trace"}
+	}
 	thisAddr, err := xnet.ParseHost(GetLocalPeer(globalEndpoints))
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
 	}
 
-	// Start profiling on remote servers.
-	hostErrs := globalNotificationSys.StartProfiling(profiler)
+	globalProfilerMu.Lock()
+	defer globalProfilerMu.Unlock()
 
-	// Start profiling locally as well.
-	{
-		if globalProfiler != nil {
-			globalProfiler.Stop()
+	if globalProfiler == nil {
+		globalProfiler = make(map[string]minioProfiler, 10)
+	}
+
+	// Stop profiler of all types if already running
+	for k, v := range globalProfiler {
+		for _, p := range profiles {
+			if p == k {
+				v.Stop()
+				delete(globalProfiler, k)
+			}
 		}
-		prof, err := startProfiler(profiler, "")
+	}
+
+	// Start profiling on remote servers.
+	var hostErrs []NotificationPeerErr
+	for _, profiler := range profiles {
+		hostErrs = append(hostErrs, globalNotificationSys.StartProfiling(profiler)...)
+
+		// Start profiling locally as well.
+		prof, err := startProfiler(profiler)
 		if err != nil {
 			hostErrs = append(hostErrs, NotificationPeerErr{
 				Host: *thisAddr,
 				Err:  err,
 			})
 		} else {
-			globalProfiler = prof
+			globalProfiler[profiler] = prof
 			hostErrs = append(hostErrs, NotificationPeerErr{
 				Host: *thisAddr,
 			})
@@ -620,7 +637,7 @@ func (a adminAPIHandlers) StartProfilingHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	writeSuccessResponseJSON(w, []byte(startProfilingResultInBytes))
+	writeSuccessResponseJSON(w, startProfilingResultInBytes)
 }
 
 // dummyFileInfo represents a dummy representation of a profile data file

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -572,9 +572,6 @@ func (a adminAPIHandlers) StartProfilingHandler(w http.ResponseWriter, r *http.R
 
 	vars := mux.Vars(r)
 	profiles := strings.Split(vars["profilerType"], ",")
-	if len(profiles) == 1 && profiles[0] == "all" {
-		profiles = []string{"cpu", "mem", "block", "mutex", "trace"}
-	}
 	thisAddr, err := xnet.ParseHost(GetLocalPeer(globalEndpoints))
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -225,7 +225,7 @@ func (client *peerRESTClient) StartProfiling(profiler string) error {
 }
 
 // DownloadProfileData - download profiled data from a remote node.
-func (client *peerRESTClient) DownloadProfileData() (data []byte, err error) {
+func (client *peerRESTClient) DownloadProfileData() (data map[string][]byte, err error) {
 	respBody, err := client.call(peerRESTMethodDownloadProfilingData, nil, nil, -1)
 	if err != nil {
 		return

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -417,7 +417,7 @@ func (s *peerRESTServer) StartProfilingHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	for _, profiler := range profiles {
-		prof, err := startProfiler(profiler, "")
+		prof, err := startProfiler(profiler)
 		if err != nil {
 			s.writeErrorResponse(w, err)
 			return

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -395,28 +395,41 @@ func (s *peerRESTServer) StartProfilingHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	vars := mux.Vars(r)
-	profiler := vars[peerRESTProfiler]
-	if profiler == "" {
+	profiles := strings.Split(vars[peerRESTProfiler], ",")
+	if len(profiles) == 0 {
 		s.writeErrorResponse(w, errors.New("profiler name is missing"))
 		return
 	}
-
-	if globalProfiler != nil {
-		globalProfiler.Stop()
+	globalProfilerMu.Lock()
+	defer globalProfilerMu.Unlock()
+	if globalProfiler == nil {
+		globalProfiler = make(map[string]minioProfiler, 10)
 	}
 
-	var err error
-	globalProfiler, err = startProfiler(profiler, "")
-	if err != nil {
-		s.writeErrorResponse(w, err)
-		return
+	// Stop profiler of all types if already running
+	for k, v := range globalProfiler {
+		for _, p := range profiles {
+			if p == k {
+				v.Stop()
+				delete(globalProfiler, k)
+			}
+		}
+	}
+
+	for _, profiler := range profiles {
+		prof, err := startProfiler(profiler, "")
+		if err != nil {
+			s.writeErrorResponse(w, err)
+			return
+		}
+		globalProfiler[profiler] = prof
 	}
 
 	w.(http.Flusher).Flush()
 }
 
-// DownloadProflingDataHandler - returns proflied data.
-func (s *peerRESTServer) DownloadProflingDataHandler(w http.ResponseWriter, r *http.Request) {
+// DownloadProfilingDataHandler - returns profiled data.
+func (s *peerRESTServer) DownloadProfilingDataHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.IsValid(w, r) {
 		s.writeErrorResponse(w, errors.New("Invalid request"))
 		return
@@ -1156,7 +1169,7 @@ func registerPeerRESTHandlers(router *mux.Router) {
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodLoadGroup).HandlerFunc(httpTraceAll(server.LoadGroupHandler)).Queries(restQueries(peerRESTGroup)...)
 
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodStartProfiling).HandlerFunc(httpTraceAll(server.StartProfilingHandler)).Queries(restQueries(peerRESTProfiler)...)
-	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodDownloadProfilingData).HandlerFunc(httpTraceHdrs(server.DownloadProflingDataHandler))
+	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodDownloadProfilingData).HandlerFunc(httpTraceHdrs(server.DownloadProfilingDataHandler))
 
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodTargetExists).HandlerFunc(httpTraceHdrs(server.TargetExistsHandler)).Queries(restQueries(peerRESTBucket)...)
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodSendEvent).HandlerFunc(httpTraceHdrs(server.SendEventHandler)).Queries(restQueries(peerRESTBucket)...)

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -28,8 +28,12 @@ func handleSignals() {
 	// Custom exit function
 	exit := func(success bool) {
 		// If global profiler is set stop before we exit.
-		if globalProfiler != nil {
-			globalProfiler.Stop()
+		globalProfilerMu.Lock()
+		defer globalProfilerMu.Unlock()
+		if len(globalProfiler) > 0 {
+			for _, p := range globalProfiler {
+				p.Stop()
+			}
 		}
 
 		if success {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -191,7 +191,7 @@ func TestURL2BucketObjectName(t *testing.T) {
 
 // Add tests for starting and stopping different profilers.
 func TestStartProfiler(t *testing.T) {
-	_, err := startProfiler("", "")
+	_, err := startProfiler("")
 	if err == nil {
 		t.Fatal("Expected a non nil error, but nil error returned for invalid profiler.")
 	}

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,6 @@ require (
 	github.com/ncw/directio v1.0.5
 	github.com/nsqio/go-nsq v1.0.7
 	github.com/pkg/errors v0.8.1
-	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20190704165056-9c2d0518ed81 // indirect


### PR DESCRIPTION
Fixes #8771

MinIO only allows for one profiling type to run concurrently. However when identifying complex issues it is often beneficial to run several profiling types at the same time.

**Describe the solution you'd like**

When starting profiling, enable several types to be specified in `profilerType`, maybe comma separated.

Relevant handlers: 

* [StartProfilingHandler](https://github.com/minio/minio/blob/6695fd6a61afa9cb0a652cc45b2e1c23efd73d5f/cmd/admin-handlers.go#L562)
* [DownloadProfilingHandler](https://github.com/minio/minio/blob/6695fd6a61afa9cb0a652cc45b2e1c23efd73d5f/cmd/admin-handlers.go#L644)

When downloading, include all active profiles in the zip file.
This add the described functionality and also fixes the unprotected access on globalProfiler. 

## How to test this PR?

Send multiple profile types as comma separated values.

Tested with warp, using PR https://github.com/minio/warp/pull/18
```
λ go build && warp get -serverprof=cpu,mem,trace,block,mutex -duration=15s -objects=250
[...]
warp: Server profiling successfully started.
[...]
warp: Profile data successfully downloaded as warp-get-2020-01-10[174800]-kI0v.profiles.zip
warp: Benchmark data written to "warp-get-2020-01-10[174800]-kI0v.csv.zst"

λ unzip -l warp-get-2020-01-10[174800]-kI0v.profiles.zip
Archive:  warp-get-2020-01-10[174800]-kI0v.profiles.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
   126881  2020-01-10 17:48   profiling-localhost:9002-mem.pprof
    10603  2020-01-10 17:48   profiling-localhost:9002-block.pprof
   192232  2020-01-10 17:48   profiling-localhost:9002-cpu.pprof
 24782645  2020-01-10 17:48   profiling-localhost:9002-trace.pprof
     7628  2020-01-10 17:48   profiling-localhost:9002-mutex.pprof
   132246  2020-01-10 17:48   profiling-localhost:9001-mem.pprof
   290396  2020-01-10 17:48   profiling-localhost:9001-cpu.pprof
 26639419  2020-01-10 17:48   profiling-localhost:9001-trace.pprof
    10916  2020-01-10 17:48   profiling-localhost:9001-block.pprof
     8531  2020-01-10 17:48   profiling-localhost:9001-mutex.pprof
---------                     -------
 52201497                     10 files
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
