### PR TITLE
Set X-Cache header to record cache hits/misses

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -91,7 +91,10 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 	if !objInfo.Expires.IsZero() {
 		w.Header().Set(xhttp.Expires, objInfo.Expires.UTC().Format(http.TimeFormat))
 	}
-
+	if globalCacheConfig.Enabled {
+		w.Header().Set(xhttp.XCache, objInfo.CacheStatus.String())
+		w.Header().Set(xhttp.XCacheLookup, objInfo.CacheLookupStatus.String())
+	}
 	// Set all other user defined metadata.
 	for k, v := range objInfo.UserDefined {
 		if HasPrefix(k, ReservedMetadataPrefix) {

--- a/cmd/disk-cache-backend.go
+++ b/cmd/disk-cache-backend.go
@@ -89,8 +89,10 @@ func (m *cacheMeta) ToObjectInfo(bucket, object string) (o ObjectInfo) {
 	}
 
 	o = ObjectInfo{
-		Bucket: bucket,
-		Name:   object,
+		Bucket:            bucket,
+		Name:              object,
+		CacheStatus:       CacheHit,
+		CacheLookupStatus: CacheHit,
 	}
 
 	// We set file info only if its valid.

--- a/cmd/disk-cache-utils.go
+++ b/cmd/disk-cache-utils.go
@@ -28,6 +28,24 @@ import (
 	"github.com/minio/minio/cmd/crypto"
 )
 
+// CacheStatusType - whether the request was served from cache.
+type CacheStatusType string
+
+const (
+	// CacheHit - whether object was served from cache.
+	CacheHit CacheStatusType = "HIT"
+
+	// CacheMiss - object served from backend.
+	CacheMiss CacheStatusType = "MISS"
+)
+
+func (c CacheStatusType) String() string {
+	if c != "" {
+		return string(c)
+	}
+	return string(CacheMiss)
+}
+
 type cacheControl struct {
 	expiry       time.Time
 	maxAge       int

--- a/cmd/http/headers.go
+++ b/cmd/http/headers.go
@@ -40,6 +40,12 @@ const (
 	Action             = "Action"
 )
 
+// Non standard S3 HTTP response constants
+const (
+	XCache       = "X-Cache"
+	XCacheLookup = "X-Cache-Lookup"
+)
+
 // Standard S3 HTTP request constants
 const (
 	IfModifiedSince   = "If-Modified-Since"

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -143,6 +143,11 @@ type ObjectInfo struct {
 	// Date and time at which the object is no longer able to be cached
 	Expires time.Time
 
+	// CacheStatus sets status of whether this is a cache hit/miss
+	CacheStatus CacheStatusType
+	// CacheLookupStatus sets whether a cacheable response is present in the cache
+	CacheLookupStatus CacheStatusType
+
 	// Specify object storage class
 	StorageClass string
 


### PR DESCRIPTION
## Description

Also set X-Cache-Lookup status to HIT if object was found in cache, but not served from cache (e.g. if Cache-Control: no-cache is set and the ETag verification failed)

## Motivation and Context


## How to test this PR?
```
MINIO_CACHE_DRIVES=/tmp/cache minio gateway s3
```
`mc cat` on a pre-existing object in the cache should show X-Cache with MISS the first time, and HIT on subsequent requests.
Overwrite object on backend directly without cache and do a `mc cat` on the object - now the `X-Cache` should show `MISS` and `X-Cache-Lookup` shows `HIT` because a cache entry was found.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
