### PR TITLE
fix: set appropriate defaults when new keys added

### DIFF
--- a/cmd/config/cache/lookup.go
+++ b/cmd/config/cache/lookup.go
@@ -121,9 +121,7 @@ func LookupConfig(kvs config.KVS) (Config, error) {
 			return cfg, config.ErrInvalidCacheQuota(err)
 		}
 		cfg.Quota = cfg.MaxUse
-	}
-
-	if quotaStr := env.Get(EnvCacheQuota, kvs.Get(Quota)); quotaStr != "" {
+	} else if quotaStr := env.Get(EnvCacheQuota, kvs.Get(Quota)); quotaStr != "" {
 		cfg.Quota, err = strconv.Atoi(quotaStr)
 		if err != nil {
 			return cfg, config.ErrInvalidCacheQuota(err)

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -621,6 +621,12 @@ func (c Config) SetKVS(s string, defaultKVS map[string]KVS) error {
 	currKVS, ok := c[subSys][tgt]
 	if !ok {
 		currKVS = defaultKVS[subSys]
+	} else {
+		for _, kv := range defaultKVS[subSys] {
+			if _, ok = currKVS.Lookup(kv.Key); !ok {
+				currKVS.Set(kv.Key, kv.Value)
+			}
+		}
 	}
 
 	for _, kv := range kvs {

--- a/cmd/config/identity/openid/jwt.go
+++ b/cmd/config/identity/openid/jwt.go
@@ -326,6 +326,11 @@ func LookupConfig(kvs config.KVS, transport *http.Transport, closeRespFn func(io
 			return c, err
 		}
 	}
+
+	if c.ClaimName == "" {
+		c.ClaimName = iampolicy.PolicyName
+	}
+
 	if jwksURL == "" {
 		// Fallback to discovery document jwksURL
 		jwksURL = c.DiscoveryDoc.JwksURI


### PR DESCRIPTION


## Description
fix: set appropriate defaults when new keys added

A new key was added in identity_openid recently
required explicitly for the client to set the optional
value without that it would be empty, handle this
appropriately.

## Motivation and Context
Fixes #8787

## How to test this PR?
Just test by enabling keycloak with or without this PR

```
~ mc admin config set myminio/ identity_openid config_url=http://127.0.0.1:8080/auth/realms/demo/.well-known/openid-configuration client_id=account
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes but it is not stop of the world type issue.
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
