### PR TITLE
Fix bug preventing overwrite of object

### DIFF
--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -683,7 +683,7 @@ func (fs *FSObjects) CompleteMultipartUpload(ctx context.Context, bucket string,
 	}
 
 	// Deny if WORM is enabled
-	if _, ok := isWORMEnabled(bucket); ok {
+	if isWORMEnabled(bucket) {
 		if _, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object)); err == nil {
 			return ObjectInfo{}, ObjectAlreadyExists{Bucket: bucket, Object: object}
 		}

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1032,7 +1032,7 @@ func (fs *FSObjects) putObject(ctx context.Context, bucket string, object string
 	// Entire object was written to the temp location, now it's safe to rename it to the actual location.
 	fsNSObjPath := pathJoin(fs.fsPath, bucket, object)
 	// Deny if WORM is enabled
-	if _, ok := isWORMEnabled(bucket); ok {
+	if isWORMEnabled(bucket) {
 		if _, err := fsStatFile(ctx, fsNSObjPath); err == nil {
 			return ObjectInfo{}, ObjectAlreadyExists{Bucket: bucket, Object: object}
 		}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2563,7 +2563,7 @@ func (api objectAPIHandlers) PutObjectRetentionHandler(w http.ResponseWriter, r 
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDigest), r.URL, guessIsBrowserReq(r))
 		return
 	}
-	if _, isWORMBucket := isWORMEnabled(bucket); !isWORMBucket {
+	if _, ok := globalBucketObjectLockConfig.Get(bucket); !ok {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidBucketObjectLockConfiguration), r.URL, guessIsBrowserReq(r))
 		return
 	}

--- a/cmd/object-lock.go
+++ b/cmd/object-lock.go
@@ -477,8 +477,7 @@ func enforceRetentionBypassForPut(ctx context.Context, r *http.Request, bucket, 
 	ret := getObjectRetentionMeta(oi.UserDefined)
 	// no retention metadata on object
 	if ret.Mode == Invalid {
-		_, isWORMBucket := isWORMEnabled(bucket)
-		if !isWORMBucket {
+		if _, isWORMBucket := globalBucketObjectLockConfig.Get(bucket); !isWORMBucket {
 			return oi, ErrInvalidBucketObjectLockConfiguration
 		}
 		return oi, ErrNone
@@ -527,7 +526,7 @@ func checkPutObjectRetentionAllowed(ctx context.Context, r *http.Request, bucket
 	var mode RetentionMode
 	var retainDate RetentionDate
 
-	retention, isWORMBucket := isWORMEnabled(bucket)
+	retention, isWORMBucket := globalBucketObjectLockConfig.Get(bucket)
 
 	retentionRequested := isObjectLockRequested(r.Header)
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -540,12 +540,9 @@ func iamPolicyClaimName() string {
 	return globalOpenIDConfig.ClaimPrefix + globalOpenIDConfig.ClaimName
 }
 
-func isWORMEnabled(bucket string) (Retention, bool) {
+func isWORMEnabled(bucket string) bool {
 	if isMinioMetaBucketName(bucket) {
-		return Retention{}, false
+		return false
 	}
-	if globalWORMEnabled {
-		return Retention{}, true
-	}
-	return globalBucketObjectLockConfig.Get(bucket)
+	return globalWORMEnabled
 }

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -708,7 +708,7 @@ func (xl xlObjects) CompleteMultipartUpload(ctx context.Context, bucket string, 
 
 	if xl.isObject(bucket, object) {
 		// Deny if WORM is enabled
-		if _, ok := isWORMEnabled(bucket); ok {
+		if isWORMEnabled(bucket) {
 			if _, err := xl.getObjectInfo(ctx, bucket, object); err == nil {
 				return ObjectInfo{}, ObjectAlreadyExists{Bucket: bucket, Object: object}
 			}

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -611,7 +611,7 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 
 	if xl.isObject(bucket, object) {
 		// Deny if WORM is enabled
-		if _, ok := isWORMEnabled(bucket); ok {
+		if isWORMEnabled(bucket) {
 			if _, err := xl.getObjectInfo(ctx, bucket, object); err == nil {
 				return ObjectInfo{}, ObjectAlreadyExists{Bucket: bucket, Object: object}
 			}


### PR DESCRIPTION
if object lock config is enabled for a bucket.

Creating a bucket with object lock configuration
enabled does not automatically cause WORM protection
to be applied. PUT operation needs to specifically
request object locking or bucket has to have default
retention settings configured.

Fixes regresssion introduced in #8657

## Description


## Motivation and Context


## How to test this PR?
With master, you should see overwrite disallowed even if no default object lock configuration is set on a bucket
```
mc mb --with-lock myminio/testbucket
mc cp /etc/issue myminio/testbucket/
mc cp /etc/issue myminio/testbucket/
mc: <ERROR> Failed to copy `/etc/issue`. Object `issue` already exists.
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
