### PR TITLE
jwt: Simplify JWT parsing

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -201,7 +201,9 @@ func getReqAccessCred(r *http.Request, region string) (cred auth.Credentials) {
 		if owner {
 			return globalActiveCred
 		}
-		cred, _ = globalIAMSys.GetUser(claims.AccessKey())
+		if claims != nil {
+			cred, _ = globalIAMSys.GetUser(claims.AccessKey)
+		}
 	}
 	return cred
 }

--- a/cmd/jwt/parser.go
+++ b/cmd/jwt/parser.go
@@ -1,0 +1,371 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+// This file is a re-implementation of the original code here with some
+// additional allocation tweaks reproduced using GODEBUG=allocfreetrace=1
+// original file https://github.com/dgrijalva/jwt-go/blob/master/parser.go
+// borrowed under MIT License https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	jwtgo "github.com/dgrijalva/jwt-go"
+	jsoniter "github.com/json-iterator/go"
+)
+
+// SigningMethodHMAC - Implements the HMAC-SHA family of signing methods signing methods
+// Expects key type of []byte for both signing and validation
+type SigningMethodHMAC struct {
+	Name string
+	Hash crypto.Hash
+}
+
+// Specific instances for HS256, HS384, HS512
+var (
+	SigningMethodHS256 *SigningMethodHMAC
+	SigningMethodHS384 *SigningMethodHMAC
+	SigningMethodHS512 *SigningMethodHMAC
+)
+
+var (
+	base64BufPool sync.Pool
+	hmacSigners   []*SigningMethodHMAC
+)
+
+func init() {
+	base64BufPool = sync.Pool{
+		New: func() interface{} {
+			buf := make([]byte, 1024)
+			return &buf
+		},
+	}
+
+	hmacSigners = []*SigningMethodHMAC{
+		{"HS256", crypto.SHA256},
+		{"HS384", crypto.SHA384},
+		{"HS512", crypto.SHA512},
+	}
+}
+
+// StandardClaims are basically standard claims with "accessKey"
+type StandardClaims struct {
+	AccessKey string `json:"accessKey,omitempty"`
+	jwtgo.StandardClaims
+}
+
+// MapClaims - implements custom unmarshaller
+type MapClaims struct {
+	AccessKey string `json:"accessKey,omitempty"`
+	jwtgo.MapClaims
+}
+
+// NewStandardClaims - initializes standard claims
+func NewStandardClaims() *StandardClaims {
+	return &StandardClaims{}
+}
+
+// SetIssuer sets issuer for these claims
+func (c *StandardClaims) SetIssuer(issuer string) {
+	c.Issuer = issuer
+}
+
+// SetAudience sets audience for these claims
+func (c *StandardClaims) SetAudience(aud string) {
+	c.Audience = aud
+}
+
+// SetExpiry sets expiry in unix epoch secs
+func (c *StandardClaims) SetExpiry(t time.Time) {
+	c.ExpiresAt = t.Unix()
+}
+
+// SetAccessKey sets access key as jwt subject and custom
+// "accessKey" field.
+func (c *StandardClaims) SetAccessKey(accessKey string) {
+	c.Subject = accessKey
+	c.AccessKey = accessKey
+}
+
+// Valid - implements https://godoc.org/github.com/dgrijalva/jwt-go#Claims compatible
+// claims interface, additionally validates "accessKey" fields.
+func (c *StandardClaims) Valid() error {
+	if err := c.StandardClaims.Valid(); err != nil {
+		return err
+	}
+
+	if c.AccessKey == "" && c.Subject == "" {
+		return jwtgo.NewValidationError("accessKey/sub missing",
+			jwtgo.ValidationErrorClaimsInvalid)
+	}
+
+	return nil
+}
+
+// NewMapClaims - Initializes a new map claims
+func NewMapClaims() *MapClaims {
+	return &MapClaims{MapClaims: jwtgo.MapClaims{}}
+}
+
+// Lookup returns the value and if the key is found.
+func (c *MapClaims) Lookup(key string) (value string, ok bool) {
+	var vinterface interface{}
+	vinterface, ok = c.MapClaims[key]
+	if ok {
+		value, ok = vinterface.(string)
+	}
+	return
+}
+
+// SetExpiry sets expiry in unix epoch secs
+func (c *MapClaims) SetExpiry(t time.Time) {
+	c.MapClaims["exp"] = t.Unix()
+}
+
+// SetAccessKey sets access key as jwt subject and custom
+// "accessKey" field.
+func (c *MapClaims) SetAccessKey(accessKey string) {
+	c.MapClaims["sub"] = accessKey
+	c.MapClaims["accessKey"] = accessKey
+}
+
+// Valid - implements https://godoc.org/github.com/dgrijalva/jwt-go#Claims compatible
+// claims interface, additionally validates "accessKey" fields.
+func (c *MapClaims) Valid() error {
+	if err := c.MapClaims.Valid(); err != nil {
+		return err
+	}
+
+	if c.AccessKey == "" {
+		return jwtgo.NewValidationError("accessKey/sub missing",
+			jwtgo.ValidationErrorClaimsInvalid)
+	}
+
+	return nil
+}
+
+// Map returns underlying low-level map claims.
+func (c *MapClaims) Map() map[string]interface{} {
+	return c.MapClaims
+}
+
+// MarshalJSON marshals the MapClaims struct
+func (c *MapClaims) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.MapClaims)
+}
+
+// ParseWithStandardClaims - parse the token string, valid methods.
+func ParseWithStandardClaims(tokenStr string, claims *StandardClaims, key []byte) error {
+	// Key is not provided.
+	if key == nil {
+		// keyFunc was not provided, return error.
+		return jwtgo.NewValidationError("no key was provided.", jwtgo.ValidationErrorUnverifiable)
+	}
+
+	bufp := base64BufPool.Get().(*[]byte)
+	defer base64BufPool.Put(bufp)
+
+	signer, err := ParseUnverifiedStandardClaims(tokenStr, claims, *bufp)
+	if err != nil {
+		return err
+	}
+
+	i := strings.LastIndex(tokenStr, ".")
+	if i < 0 {
+		return jwtgo.ErrSignatureInvalid
+	}
+
+	n, err := base64Decode(tokenStr[i+1:], *bufp)
+	if err != nil {
+		return err
+	}
+
+	hasher := hmac.New(signer.Hash.New, key)
+	hasher.Write([]byte(tokenStr[:i]))
+	if !hmac.Equal((*bufp)[:n], hasher.Sum(nil)) {
+		return jwtgo.ErrSignatureInvalid
+	}
+
+	if claims.AccessKey == "" && claims.Subject == "" {
+		return jwtgo.NewValidationError("accessKey/sub missing",
+			jwtgo.ValidationErrorClaimsInvalid)
+	}
+
+	// Signature is valid, lets validate the claims for
+	// other fields such as expiry etc.
+	return claims.Valid()
+}
+
+// https://tools.ietf.org/html/rfc7519#page-11
+type jwtHeader struct {
+	Algorithm string `json:"alg"`
+	Type      string `json:"typ"`
+}
+
+// ParseUnverifiedStandardClaims - WARNING: Don't use this method unless you know what you're doing
+//
+// This method parses the token but doesn't validate the signature. It's only
+// ever useful in cases where you know the signature is valid (because it has
+// been checked previously in the stack) and you want to extract values from
+// it.
+func ParseUnverifiedStandardClaims(tokenString string, claims *StandardClaims, buf []byte) (*SigningMethodHMAC, error) {
+	if strings.Count(tokenString, ".") != 2 {
+		return nil, jwtgo.ErrSignatureInvalid
+	}
+
+	i := strings.Index(tokenString, ".")
+	j := strings.LastIndex(tokenString, ".")
+
+	n, err := base64Decode(tokenString[:i], buf)
+	if err != nil {
+		return nil, &jwtgo.ValidationError{Inner: err, Errors: jwtgo.ValidationErrorMalformed}
+	}
+
+	var header = jwtHeader{}
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	if err = json.Unmarshal(buf[:n], &header); err != nil {
+		return nil, &jwtgo.ValidationError{Inner: err, Errors: jwtgo.ValidationErrorMalformed}
+	}
+
+	n, err = base64Decode(tokenString[i+1:j], buf)
+	if err != nil {
+		return nil, &jwtgo.ValidationError{Inner: err, Errors: jwtgo.ValidationErrorMalformed}
+	}
+
+	if err = json.Unmarshal(buf[:n], claims); err != nil {
+		return nil, &jwtgo.ValidationError{Inner: err, Errors: jwtgo.ValidationErrorMalformed}
+	}
+
+	for _, signer := range hmacSigners {
+		if header.Algorithm == signer.Name {
+			return signer, nil
+		}
+	}
+
+	return nil, jwtgo.NewValidationError(fmt.Sprintf("signing method (%s) is unavailable.", header.Algorithm),
+		jwtgo.ValidationErrorUnverifiable)
+}
+
+// ParseWithClaims - parse the token string, valid methods.
+func ParseWithClaims(tokenStr string, claims *MapClaims, fn func(*MapClaims) ([]byte, error)) error {
+	// Key lookup function has to be provided.
+	if fn == nil {
+		// keyFunc was not provided, return error.
+		return jwtgo.NewValidationError("no Keyfunc was provided.", jwtgo.ValidationErrorUnverifiable)
+	}
+
+	bufp := base64BufPool.Get().(*[]byte)
+	defer base64BufPool.Put(bufp)
+
+	signer, err := ParseUnverifiedMapClaims(tokenStr, claims, *bufp)
+	if err != nil {
+		return err
+	}
+
+	i := strings.LastIndex(tokenStr, ".")
+	if i < 0 {
+		return jwtgo.ErrSignatureInvalid
+	}
+
+	n, err := base64Decode(tokenStr[i+1:], *bufp)
+	if err != nil {
+		return err
+	}
+
+	var ok bool
+	claims.AccessKey, ok = claims.Lookup("accessKey")
+	if !ok {
+		claims.AccessKey, ok = claims.Lookup("sub")
+		if !ok {
+			return jwtgo.NewValidationError("accessKey/sub missing",
+				jwtgo.ValidationErrorClaimsInvalid)
+		}
+	}
+
+	// Lookup key from claims, claims may not be valid and may return
+	// invalid key which is okay as the signature verification will fail.
+	key, err := fn(claims)
+	if err != nil {
+		return err
+	}
+
+	hasher := hmac.New(signer.Hash.New, key)
+	hasher.Write([]byte(tokenStr[:i]))
+	if !hmac.Equal((*bufp)[:n], hasher.Sum(nil)) {
+		return jwtgo.ErrSignatureInvalid
+	}
+
+	// Signature is valid, lets validate the claims for
+	// other fields such as expiry etc.
+	return claims.Valid()
+}
+
+// base64Decode returns the bytes represented by the base64 string s.
+func base64Decode(s string, buf []byte) (int, error) {
+	return base64.RawURLEncoding.Decode(buf, []byte(s))
+}
+
+// ParseUnverifiedMapClaims - WARNING: Don't use this method unless you know what you're doing
+//
+// This method parses the token but doesn't validate the signature. It's only
+// ever useful in cases where you know the signature is valid (because it has
+// been checked previously in the stack) and you want to extract values from
+// it.
+func ParseUnverifiedMapClaims(tokenString string, claims *MapClaims, buf []byte) (*SigningMethodHMAC, error) {
+	if strings.Count(tokenString, ".") != 2 {
+		return nil, jwtgo.ErrSignatureInvalid
+	}
+
+	i := strings.Index(tokenString, ".")
+	j := strings.LastIndex(tokenString, ".")
+
+	n, err := base64Decode(tokenString[:i], buf)
+	if err != nil {
+		return nil, &jwtgo.ValidationError{Inner: err, Errors: jwtgo.ValidationErrorMalformed}
+	}
+
+	var header = jwtHeader{}
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	if err = json.Unmarshal(buf[:n], &header); err != nil {
+		return nil, &jwtgo.ValidationError{Inner: err, Errors: jwtgo.ValidationErrorMalformed}
+	}
+
+	n, err = base64Decode(tokenString[i+1:j], buf)
+	if err != nil {
+		return nil, &jwtgo.ValidationError{Inner: err, Errors: jwtgo.ValidationErrorMalformed}
+	}
+
+	if err = json.Unmarshal(buf[:n], &claims.MapClaims); err != nil {
+		return nil, &jwtgo.ValidationError{Inner: err, Errors: jwtgo.ValidationErrorMalformed}
+	}
+
+	for _, signer := range hmacSigners {
+		if header.Algorithm == signer.Name {
+			return signer, nil
+		}
+	}
+
+	return nil, jwtgo.NewValidationError(fmt.Sprintf("signing method (%s) is unavailable.", header.Algorithm),
+		jwtgo.ValidationErrorUnverifiable)
+}

--- a/cmd/jwt/parser_test.go
+++ b/cmd/jwt/parser_test.go
@@ -1,0 +1,214 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jwt
+
+// This file is a re-implementation of the original code here with some
+// additional allocation tweaks reproduced using GODEBUG=allocfreetrace=1
+// original file https://github.com/dgrijalva/jwt-go/blob/master/parser.go
+// borrowed under MIT License https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/dgrijalva/jwt-go"
+)
+
+var (
+	defaultKeyFunc = func(claim *MapClaims) ([]byte, error) { return []byte("HelloSecret"), nil }
+	emptyKeyFunc   = func(claim *MapClaims) ([]byte, error) { return nil, nil }
+	errorKeyFunc   = func(claim *MapClaims) ([]byte, error) { return nil, fmt.Errorf("error loading key") }
+)
+
+var jwtTestData = []struct {
+	name        string
+	tokenString string
+	keyfunc     func(*MapClaims) ([]byte, error)
+	claims      jwt.Claims
+	valid       bool
+	errors      int32
+}{
+	{
+		"basic",
+		"",
+		defaultKeyFunc,
+		&MapClaims{
+			MapClaims: jwtgo.MapClaims{
+				"foo": "bar",
+			},
+		},
+		true,
+		0,
+	},
+	{
+		"basic expired",
+		"", // autogen
+		defaultKeyFunc,
+		&MapClaims{
+			MapClaims: jwtgo.MapClaims{
+				"foo": "bar",
+				"exp": float64(time.Now().Unix() - 100),
+			},
+		},
+		false,
+		-1,
+	},
+	{
+		"basic nbf",
+		"", // autogen
+		defaultKeyFunc,
+		&MapClaims{
+			MapClaims: jwtgo.MapClaims{
+				"foo": "bar",
+				"nbf": float64(time.Now().Unix() + 100),
+			},
+		},
+		false,
+		-1,
+	},
+	{
+		"expired and nbf",
+		"", // autogen
+		defaultKeyFunc,
+		&MapClaims{
+			MapClaims: jwtgo.MapClaims{
+				"foo": "bar",
+				"nbf": float64(time.Now().Unix() + 100),
+				"exp": float64(time.Now().Unix() - 100),
+			},
+		},
+		false,
+		-1,
+	},
+	{
+		"basic invalid",
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.EhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		defaultKeyFunc,
+		&MapClaims{
+			MapClaims: jwtgo.MapClaims{
+				"foo": "bar",
+			},
+		},
+		false,
+		-1,
+	},
+	{
+		"basic nokeyfunc",
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		nil,
+		&MapClaims{
+			MapClaims: jwtgo.MapClaims{
+				"foo": "bar",
+			},
+		},
+		false,
+		-1,
+	},
+	{
+		"basic nokey",
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		emptyKeyFunc,
+		&MapClaims{
+			MapClaims: jwtgo.MapClaims{
+				"foo": "bar",
+			},
+		},
+		false,
+		-1,
+	},
+	{
+		"basic errorkey",
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+		errorKeyFunc,
+		&MapClaims{
+			MapClaims: jwtgo.MapClaims{
+				"foo": "bar",
+			},
+		},
+		false,
+		-1,
+	},
+	{
+		"Standard Claims",
+		"",
+		defaultKeyFunc,
+		&StandardClaims{
+			StandardClaims: jwtgo.StandardClaims{
+				ExpiresAt: time.Now().Add(time.Second * 10).Unix(),
+			},
+		},
+		true,
+		0,
+	},
+}
+
+func mapClaimsToken(claims *MapClaims) string {
+	claims.SetAccessKey("test")
+	j := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, claims)
+	tk, _ := j.SignedString([]byte("HelloSecret"))
+	return tk
+}
+
+func standardClaimsToken(claims *StandardClaims) string {
+	claims.AccessKey = "test"
+	claims.Subject = "test"
+	j := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, claims)
+	tk, _ := j.SignedString([]byte("HelloSecret"))
+	return tk
+}
+
+func TestParserParse(t *testing.T) {
+	// Iterate over test data set and run tests
+	for _, data := range jwtTestData {
+		data := data
+		t.Run(data.name, func(t *testing.T) {
+			// Parse the token
+			var err error
+
+			// Figure out correct claims type
+			switch claims := data.claims.(type) {
+			case *MapClaims:
+				if data.tokenString == "" {
+					data.tokenString = mapClaimsToken(claims)
+				}
+				err = ParseWithClaims(data.tokenString, &MapClaims{}, data.keyfunc)
+			case *StandardClaims:
+				if data.tokenString == "" {
+					data.tokenString = standardClaimsToken(claims)
+				}
+				err = ParseWithStandardClaims(data.tokenString, &StandardClaims{}, []byte("HelloSecret"))
+			}
+
+			if data.valid && err != nil {
+				t.Errorf("Error while verifying token: %T:%v", err, err)
+			}
+
+			if !data.valid && err == nil {
+				t.Errorf("Invalid token passed validation")
+			}
+
+			if data.errors != 0 {
+				_, ok := err.(*jwt.ValidationError)
+				if !ok {
+					t.Errorf("Expected *jwt.ValidationError, but got %#v instead", err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/lock-rest-server-common_test.go
+++ b/cmd/lock-rest-server-common_test.go
@@ -40,7 +40,7 @@ func createLockTestServer(t *testing.T) (string, *lockRESTServer, string) {
 		},
 	}
 	creds := globalActiveCred
-	token, err := authenticateNode(creds.AccessKey, creds.SecretKey)
+	token, err := authenticateNode(creds.AccessKey, creds.SecretKey, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -47,7 +47,7 @@ type Client struct {
 	httpClient          *http.Client
 	httpIdleConnsCloser func()
 	url                 *url.URL
-	newAuthToken        func() string
+	newAuthToken        func(audience string) string
 }
 
 // URL query separator constants
@@ -62,7 +62,7 @@ func (c *Client) CallWithContext(ctx context.Context, method string, values url.
 		return nil, &NetworkError{err}
 	}
 	req = req.WithContext(ctx)
-	req.Header.Set("Authorization", "Bearer "+c.newAuthToken())
+	req.Header.Set("Authorization", "Bearer "+c.newAuthToken(req.URL.Query().Encode()))
 	req.Header.Set("X-Minio-Time", time.Now().UTC().Format(time.RFC3339))
 	if length > 0 {
 		req.ContentLength = length
@@ -102,7 +102,7 @@ func (c *Client) Close() {
 }
 
 // NewClient - returns new REST client.
-func NewClient(url *url.URL, newCustomTransport func() *http.Transport, newAuthToken func() string) (*Client, error) {
+func NewClient(url *url.URL, newCustomTransport func() *http.Transport, newAuthToken func(aud string) string) (*Client, error) {
 	// Transport is exactly same as Go default in https://golang.org/pkg/net/http/#RoundTripper
 	// except custom DialContext and TLSClientConfig.
 	tr := newCustomTransport()

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -101,7 +101,7 @@ func (web *webAPIHandlers) ServerInfo(r *http.Request, args *WebGenericArgs, rep
 	}
 
 	if !owner {
-		creds, ok := globalIAMSys.GetUser(claims.AccessKey())
+		creds, ok := globalIAMSys.GetUser(claims.AccessKey)
 		if ok && creds.SessionToken != "" {
 			reply.MinioUserInfo["isTempUser"] = true
 		}
@@ -154,10 +154,10 @@ func (web *webAPIHandlers) MakeBucket(r *http.Request, args *MakeBucketArgs, rep
 
 	// For authenticated users apply IAM policy.
 	if !globalIAMSys.IsAllowed(iampolicy.Args{
-		AccountName:     claims.AccessKey(),
+		AccountName:     claims.AccessKey,
 		Action:          iampolicy.CreateBucketAction,
 		BucketName:      args.BucketName,
-		ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+		ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 		IsOwner:         owner,
 		Claims:          claims.Map(),
 	}) {
@@ -216,10 +216,10 @@ func (web *webAPIHandlers) DeleteBucket(r *http.Request, args *RemoveBucketArgs,
 
 	// For authenticated users apply IAM policy.
 	if !globalIAMSys.IsAllowed(iampolicy.Args{
-		AccountName:     claims.AccessKey(),
+		AccountName:     claims.AccessKey,
 		Action:          iampolicy.DeleteBucketAction,
 		BucketName:      args.BucketName,
-		ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+		ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 		IsOwner:         owner,
 		Claims:          claims.Map(),
 	}) {
@@ -319,10 +319,10 @@ func (web *webAPIHandlers) ListBuckets(r *http.Request, args *WebGenericArgs, re
 			}
 
 			if globalIAMSys.IsAllowed(iampolicy.Args{
-				AccountName:     claims.AccessKey(),
+				AccountName:     claims.AccessKey,
 				Action:          iampolicy.ListBucketAction,
 				BucketName:      dnsRecord.Key,
-				ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+				ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 				IsOwner:         owner,
 				ObjectName:      "",
 				Claims:          claims.Map(),
@@ -342,10 +342,10 @@ func (web *webAPIHandlers) ListBuckets(r *http.Request, args *WebGenericArgs, re
 		}
 		for _, bucket := range buckets {
 			if globalIAMSys.IsAllowed(iampolicy.Args{
-				AccountName:     claims.AccessKey(),
+				AccountName:     claims.AccessKey,
 				Action:          iampolicy.ListBucketAction,
 				BucketName:      bucket.Name,
-				ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+				ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 				IsOwner:         owner,
 				ObjectName:      "",
 				Claims:          claims.Map(),
@@ -495,19 +495,19 @@ func (web *webAPIHandlers) ListObjects(r *http.Request, args *ListObjectsArgs, r
 		r.Header.Set("delimiter", SlashSeparator)
 
 		readable := globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.ListBucketAction,
 			BucketName:      args.BucketName,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			Claims:          claims.Map(),
 		})
 
 		writable := globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.PutObjectAction,
 			BucketName:      args.BucketName,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			ObjectName:      args.Prefix + SlashSeparator,
 			Claims:          claims.Map(),
@@ -675,10 +675,10 @@ next:
 			govBypassPerms := ErrAccessDenied
 			if authErr != errNoAuthToken {
 				if !globalIAMSys.IsAllowed(iampolicy.Args{
-					AccountName:     claims.AccessKey(),
+					AccountName:     claims.AccessKey,
 					Action:          iampolicy.DeleteObjectAction,
 					BucketName:      args.BucketName,
-					ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+					ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 					IsOwner:         owner,
 					ObjectName:      objectName,
 					Claims:          claims.Map(),
@@ -686,10 +686,10 @@ next:
 					return toJSONError(ctx, errAccessDenied)
 				}
 				if globalIAMSys.IsAllowed(iampolicy.Args{
-					AccountName:     claims.AccessKey(),
+					AccountName:     claims.AccessKey,
 					Action:          iampolicy.BypassGovernanceRetentionAction,
 					BucketName:      args.BucketName,
-					ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+					ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 					IsOwner:         owner,
 					ObjectName:      objectName,
 					Claims:          claims.Map(),
@@ -719,10 +719,10 @@ next:
 		}
 
 		if !globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.DeleteObjectAction,
 			BucketName:      args.BucketName,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			ObjectName:      objectName,
 			Claims:          claims.Map(),
@@ -844,8 +844,8 @@ func (web *webAPIHandlers) SetAuth(r *http.Request, args *SetAuthArgs, reply *Se
 	}
 
 	// for IAM users, access key cannot be updated
-	// claims.AccessKey() is used instead of accesskey from args
-	prevCred, ok := globalIAMSys.GetUser(claims.AccessKey())
+	// claims.AccessKey is used instead of accesskey from args
+	prevCred, ok := globalIAMSys.GetUser(claims.AccessKey)
 	if !ok {
 		return errInvalidAccessKeyID
 	}
@@ -855,7 +855,7 @@ func (web *webAPIHandlers) SetAuth(r *http.Request, args *SetAuthArgs, reply *Se
 		return errIncorrectCreds
 	}
 
-	creds, err := auth.CreateCredentials(claims.AccessKey(), args.NewSecretKey)
+	creds, err := auth.CreateCredentials(claims.AccessKey, args.NewSecretKey)
 	if err != nil {
 		return toJSONError(ctx, err)
 	}
@@ -892,7 +892,7 @@ func (web *webAPIHandlers) CreateURLToken(r *http.Request, args *WebGenericArgs,
 	creds := globalActiveCred
 	if !owner {
 		var ok bool
-		creds, ok = globalIAMSys.GetUser(claims.AccessKey())
+		creds, ok = globalIAMSys.GetUser(claims.AccessKey)
 		if !ok {
 			return toJSONError(ctx, errInvalidAccessKeyID)
 		}
@@ -954,10 +954,10 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 	// For authenticated users apply IAM policy.
 	if authErr == nil {
 		if !globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.PutObjectAction,
 			BucketName:      bucket,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			ObjectName:      object,
 			Claims:          claims.Map(),
@@ -966,10 +966,10 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.PutObjectRetentionAction,
 			BucketName:      bucket,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			ObjectName:      object,
 			Claims:          claims.Map(),
@@ -977,10 +977,10 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 			retPerms = ErrNone
 		}
 		if globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.PutObjectLegalHoldAction,
 			BucketName:      bucket,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			ObjectName:      object,
 			Claims:          claims.Map(),
@@ -1188,10 +1188,10 @@ func (web *webAPIHandlers) Download(w http.ResponseWriter, r *http.Request) {
 	// For authenticated users apply IAM policy.
 	if authErr == nil {
 		if !globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.GetObjectAction,
 			BucketName:      bucket,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			ObjectName:      object,
 			Claims:          claims.Map(),
@@ -1200,10 +1200,10 @@ func (web *webAPIHandlers) Download(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.GetObjectRetentionAction,
 			BucketName:      bucket,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			ObjectName:      object,
 			Claims:          claims.Map(),
@@ -1211,10 +1211,10 @@ func (web *webAPIHandlers) Download(w http.ResponseWriter, r *http.Request) {
 			getRetPerms = ErrNone
 		}
 		if globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     claims.AccessKey(),
+			AccountName:     claims.AccessKey,
 			Action:          iampolicy.GetObjectLegalHoldAction,
 			BucketName:      bucket,
-			ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
 			ObjectName:      object,
 			Claims:          claims.Map(),
@@ -1390,10 +1390,10 @@ func (web *webAPIHandlers) DownloadZip(w http.ResponseWriter, r *http.Request) {
 	if authErr == nil {
 		for _, object := range args.Objects {
 			if !globalIAMSys.IsAllowed(iampolicy.Args{
-				AccountName:     claims.AccessKey(),
+				AccountName:     claims.AccessKey,
 				Action:          iampolicy.GetObjectAction,
 				BucketName:      args.BucketName,
-				ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+				ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 				IsOwner:         owner,
 				ObjectName:      pathJoin(args.Prefix, object),
 				Claims:          claims.Map(),
@@ -1403,10 +1403,10 @@ func (web *webAPIHandlers) DownloadZip(w http.ResponseWriter, r *http.Request) {
 			}
 			retentionPerm := ErrAccessDenied
 			if globalIAMSys.IsAllowed(iampolicy.Args{
-				AccountName:     claims.AccessKey(),
+				AccountName:     claims.AccessKey,
 				Action:          iampolicy.GetObjectRetentionAction,
 				BucketName:      args.BucketName,
-				ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+				ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 				IsOwner:         owner,
 				ObjectName:      pathJoin(args.Prefix, object),
 				Claims:          claims.Map(),
@@ -1417,10 +1417,10 @@ func (web *webAPIHandlers) DownloadZip(w http.ResponseWriter, r *http.Request) {
 
 			legalHoldPerm := ErrAccessDenied
 			if globalIAMSys.IsAllowed(iampolicy.Args{
-				AccountName:     claims.AccessKey(),
+				AccountName:     claims.AccessKey,
 				Action:          iampolicy.GetObjectLegalHoldAction,
 				BucketName:      args.BucketName,
-				ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+				ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 				IsOwner:         owner,
 				ObjectName:      pathJoin(args.Prefix, object),
 				Claims:          claims.Map(),
@@ -1570,10 +1570,10 @@ func (web *webAPIHandlers) GetBucketPolicy(r *http.Request, args *GetBucketPolic
 
 	// For authenticated users apply IAM policy.
 	if !globalIAMSys.IsAllowed(iampolicy.Args{
-		AccountName:     claims.AccessKey(),
+		AccountName:     claims.AccessKey,
 		Action:          iampolicy.GetBucketPolicyAction,
 		BucketName:      args.BucketName,
-		ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+		ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 		IsOwner:         owner,
 		Claims:          claims.Map(),
 	}) {
@@ -1668,10 +1668,10 @@ func (web *webAPIHandlers) ListAllBucketPolicies(r *http.Request, args *ListAllB
 
 	// For authenticated users apply IAM policy.
 	if !globalIAMSys.IsAllowed(iampolicy.Args{
-		AccountName:     claims.AccessKey(),
+		AccountName:     claims.AccessKey,
 		Action:          iampolicy.GetBucketPolicyAction,
 		BucketName:      args.BucketName,
-		ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+		ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 		IsOwner:         owner,
 		Claims:          claims.Map(),
 	}) {
@@ -1759,10 +1759,10 @@ func (web *webAPIHandlers) SetBucketPolicy(r *http.Request, args *SetBucketPolic
 
 	// For authenticated users apply IAM policy.
 	if !globalIAMSys.IsAllowed(iampolicy.Args{
-		AccountName:     claims.AccessKey(),
+		AccountName:     claims.AccessKey,
 		Action:          iampolicy.PutBucketPolicyAction,
 		BucketName:      args.BucketName,
-		ConditionValues: getConditionValues(r, "", claims.AccessKey(), claims.Map()),
+		ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 		IsOwner:         owner,
 		Claims:          claims.Map(),
 	}) {
@@ -1905,7 +1905,7 @@ func (web *webAPIHandlers) PresignedGet(r *http.Request, args *PresignedGetArgs,
 	var creds auth.Credentials
 	if !owner {
 		var ok bool
-		creds, ok = globalIAMSys.GetUser(claims.AccessKey())
+		creds, ok = globalIAMSys.GetUser(claims.AccessKey)
 		if !ok {
 			return toJSONError(ctx, errInvalidAccessKeyID)
 		}

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -36,6 +36,7 @@ import (
 	jwtgo "github.com/dgrijalva/jwt-go"
 	humanize "github.com/dustin/go-humanize"
 	miniogopolicy "github.com/minio/minio-go/v6/pkg/policy"
+	xjwt "github.com/minio/minio/cmd/jwt"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/bucket/policy"
 	"github.com/minio/minio/pkg/bucket/policy/condition"
@@ -753,12 +754,10 @@ func TestWebCreateURLToken(t *testing.T) {
 }
 
 func getTokenString(accessKey, secretKey string) (string, error) {
-	utcNow := UTCNow()
-	mapClaims := jwtgo.MapClaims{}
-	mapClaims["exp"] = utcNow.Add(defaultJWTExpiry).Unix()
-	mapClaims["sub"] = accessKey
-	mapClaims["accessKey"] = accessKey
-	token := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, mapClaims)
+	claims := xjwt.NewMapClaims()
+	claims.SetExpiry(UTCNow().Add(defaultJWTExpiry))
+	claims.SetAccessKey(accessKey)
+	token := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, claims)
 	return token.SignedString([]byte(secretKey))
 }
 
@@ -1002,7 +1001,7 @@ func testDownloadWebHandler(obj ObjectLayer, instanceType string, t TestErrHandl
 	}
 
 	if !bytes.Equal(bodyContent, bytes.NewBufferString("Authentication failed, check your access credentials").Bytes()) {
-		t.Fatalf("Expected authentication error message, got %v", bodyContent)
+		t.Fatalf("Expected authentication error message, got %s", string(bodyContent))
 	}
 
 	// Unauthenticated download should fail.


### PR DESCRIPTION
## Description
JWT parsing is simplified by using a custom claim
data structure such as MapClaims{}, also writes
a custom Unmarshaller for faster unmarshalling.

- Avoid as many reflections as possible
- Provide the right types for functions as much
  as possible
- Avoid strings.Join, strings.Split to reduce
  allocations rely on indexes directly.

## Motivation and Context
Potential fix for #8799

## How to test this PR?
There are potential fixes in this PR for allocations issue mentioned in #8799 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
