### PR TITLE
Reduce MemProfileRate

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -252,7 +252,7 @@ func startProfiler(profilerType string) (minioProfiler, error) {
 		}
 	case "mem":
 		old := runtime.MemProfileRate
-		runtime.MemProfileRate = 1
+		runtime.MemProfileRate = 4096
 		prof.stopFn = func() ([]byte, error) {
 			var buf bytes.Buffer
 			runtime.MemProfileRate = old


### PR DESCRIPTION
## Motivation and Context

Enabling the memory profiling has a significant impact on performance.

Reduce the profiling rate by 2 orders of magnitude. It is still 128x smaller than default so it should be plenty.

## How to test this PR?

Enable memory profiling.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
