### PR TITLE
xl/zones: return errNoHealRequired when no heal is required

### DIFF
--- a/buildscripts/verify-healing.sh
+++ b/buildscripts/verify-healing.sh
@@ -75,7 +75,7 @@ function __init__()
 }
 
 function perform_test_1() {
-    minio_pids=( $(start_minio_3_node 30) )
+    minio_pids=( $(start_minio_3_node 60) )
     for pid in "${minio_pids[@]}"; do
         kill "$pid"
     done
@@ -111,7 +111,7 @@ function perform_test_1() {
 }
 
 function perform_test_2() {
-    minio_pids=( $(start_minio_3_node 30) )
+    minio_pids=( $(start_minio_3_node 60) )
     for pid in "${minio_pids[@]}"; do
         kill "$pid"
     done
@@ -148,7 +148,7 @@ function perform_test_2() {
 }
 
 function perform_test_3() {
-    minio_pids=( $(start_minio_3_node 30) )
+    minio_pids=( $(start_minio_3_node 60) )
     for pid in "${minio_pids[@]}"; do
         kill "$pid"
     done

--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -762,7 +762,6 @@ func initFormatXL(ctx context.Context, storageDisks []StorageAPI, setCount, driv
 	formats := make([]*formatXLV3, len(storageDisks))
 	wantAtMost := ecDrivesNoConfig(drivesPerSet)
 
-	logger.Info("Formatting zone, %v set(s), %v drives per set.", setCount, drivesPerSet)
 	for i := 0; i < setCount; i++ {
 		hostCount := make(map[string]int, drivesPerSet)
 		for j := 0; j < drivesPerSet; j++ {

--- a/mint/build/aws-sdk-java/build.xml
+++ b/mint/build/aws-sdk-java/build.xml
@@ -9,7 +9,7 @@
 
     <target name="download-ivy" unless="offline">
         <mkdir dir="${ivy.jar.dir}"/>
-        <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" 
+        <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
              dest="${ivy.jar.file}" usetimestamp="true"/>
     </target>
 


### PR DESCRIPTION


## Description
xl/zones: return errNoHealRequired when no heal is required

## Motivation and Context
Zone abstraction of object layer was returning `nil`
incorrectly under situations where disk healing is
not required. Returning `nil` is considered as healing
successful, which leads to unexpected ReloadFormat()
peer notification calls during startup.

This PR fixes this behavior properly for zones.

## How to test this PR?
Just run 
```sh
#!/bin/bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"

set -x
endpoints=""
for i in {02..05}; do
    endpoints="$endpoints http://127.0.0.1:90${i}/tmp/${i}"
done

for i in {02..05}; do
    minio server --address ":90${i}" ${endpoints} &
done
```

You shall "Server not initialized" errors which are spurious and caused by the issue in master branch.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes introduced during the zone expansion implementation
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
