### PR TITLE
mint: Fix error in building image due to outdated ivy version

### DIFF
--- a/mint/build/aws-sdk-java/build.xml
+++ b/mint/build/aws-sdk-java/build.xml
@@ -1,5 +1,5 @@
 <project xmlns:ivy="antlib:org.apache.ivy.ant" name="aws-sdk-java-tests" default="run">
-    <property name="ivy.install.version" value="2.1.0-rc2" />
+    <property name="ivy.install.version" value="2.5.0" />
     <condition property="ivy.home" value="${env.IVY_HOME}">
       <isset property="env.IVY_HOME" />
     </condition>

--- a/mint/build/aws-sdk-java/ivy.xml
+++ b/mint/build/aws-sdk-java/ivy.xml
@@ -1,6 +1,6 @@
 <ivy-module version="2.0">
     <info organisation="org.apache" module="aws-sdk-java-tests"/>
     <dependencies>
-	<dependency org="com.amazonaws" name="aws-java-sdk-s3" rev="1.11.289"/>
+	<dependency org="com.amazonaws" name="aws-java-sdk-s3" rev="1.11.706"/>
     </dependencies>
 </ivy-module>

--- a/mint/build/minio-java/install.sh
+++ b/mint/build/minio-java/install.sh
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-MINIO_JAVA_VERSION=$(curl --retry 10 -s "http://repo1.maven.org/maven2/io/minio/minio/maven-metadata.xml" | sed -n "/<latest>/{s/<.[^>]*>//g;p;q}" | sed "s/  *//g")
+MINIO_JAVA_VERSION=$(curl --retry 10 -s "https://repo1.maven.org/maven2/io/minio/minio/maven-metadata.xml" | sed -n "/<latest>/{s/<.[^>]*>//g;p;q}" | sed "s/  *//g")
 if [ -z "$MINIO_JAVA_VERSION" ]; then
     echo "unable to get latest minio-java version from maven"
     exit 1
@@ -24,7 +24,7 @@ fi
 test_run_dir="$MINT_RUN_CORE_DIR/minio-java"
 git clone --quiet https://github.com/minio/minio-java.git "$test_run_dir/minio-java.git"
 (cd "$test_run_dir/minio-java.git"; git checkout --quiet "tags/${MINIO_JAVA_VERSION}")
-$WGET --output-document="$test_run_dir/minio-${MINIO_JAVA_VERSION}-all.jar" "http://repo1.maven.org/maven2/io/minio/minio/${MINIO_JAVA_VERSION}/minio-${MINIO_JAVA_VERSION}-all.jar"
+$WGET --output-document="$test_run_dir/minio-${MINIO_JAVA_VERSION}-all.jar" "https://repo1.maven.org/maven2/io/minio/minio/${MINIO_JAVA_VERSION}/minio-${MINIO_JAVA_VERSION}-all.jar"
 javac -cp "$test_run_dir/minio-${MINIO_JAVA_VERSION}-all.jar" "${test_run_dir}/minio-java.git/functional"/*.java
 cp -a "${test_run_dir}/minio-java.git/functional"/*.class "$test_run_dir/"
 rm -fr "$test_run_dir/minio-java.git"


### PR DESCRIPTION
## Description
Ivy in aws-sdk-java is outdated, use the latest ivy version to
be able successfully build mint image.

Also bump aws sdk version to the latest.

## Motivation and Context
Fixing error while building mint image


## How to test this PR?
```
$ cd mint/
$ docker build -t my-local-minio -f Dockerfile.dev .
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
