### PR TITLE
fix: avoid crash copy map before reading

### DIFF
--- a/cmd/http-stats.go
+++ b/cmd/http-stats.go
@@ -95,7 +95,7 @@ func newConnStats() *ConnStats {
 // HTTPAPIStats holds statistics information about
 // a given API in the requests.
 type HTTPAPIStats struct {
-	APIStats map[string]int
+	apiStats map[string]int
 	sync.RWMutex
 }
 
@@ -106,14 +106,14 @@ func (stats *HTTPAPIStats) Inc(api string) {
 	if stats == nil {
 		return
 	}
-	if stats.APIStats == nil {
-		stats.APIStats = make(map[string]int)
+	if stats.apiStats == nil {
+		stats.apiStats = make(map[string]int)
 	}
-	if _, ok := stats.APIStats[api]; ok {
-		stats.APIStats[api]++
+	if _, ok := stats.apiStats[api]; ok {
+		stats.apiStats[api]++
 		return
 	}
-	stats.APIStats[api] = 1
+	stats.apiStats[api] = 1
 }
 
 // Dec increments the api stats counter.
@@ -123,8 +123,8 @@ func (stats *HTTPAPIStats) Dec(api string) {
 	if stats == nil {
 		return
 	}
-	if val, ok := stats.APIStats[api]; ok && val > 0 {
-		stats.APIStats[api]--
+	if val, ok := stats.apiStats[api]; ok && val > 0 {
+		stats.apiStats[api]--
 	}
 }
 
@@ -132,7 +132,11 @@ func (stats *HTTPAPIStats) Dec(api string) {
 func (stats *HTTPAPIStats) Load() map[string]int {
 	stats.Lock()
 	defer stats.Unlock()
-	return stats.APIStats
+	var apiStats = make(map[string]int, len(stats.apiStats))
+	for k, v := range stats.apiStats {
+		apiStats[k] = v
+	}
+	return apiStats
 }
 
 // HTTPStats holds statistics information about


### PR DESCRIPTION

## Description
fix: avoid crash copy map before reading

## Motivation and Context
code of this form is always racy when the
the map itself is being written to as well

```
func (r Map) retMap() map[string]string {
     .. lock ..
     return r.internalMap
}

func (r Map) addMap(k, v string) {
     .. lock ..
     r.internalMap[k] = v
}
```

Anyone reading from `retMap()` is not protected
because of locking and we need to make sure
to avoid code in this manner. Always safe to
copy the map and return.

## How to test this PR?
Just enable Prometheus metrics for distributed setup with 
lots of concurrent I/O and Prometheus scraping this also rigorously. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
