### PR TITLE
posix: Remove a non needed nil check in DiskInfo()

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -440,10 +440,6 @@ func (s *posix) DiskInfo() (info DiskInfo, err error) {
 		}
 	}()
 
-	if s == nil {
-		return info, errFaultyDisk
-	}
-
 	if atomic.LoadInt32(&s.ioErrCount) > maxAllowedIOError {
 		return info, errFaultyDisk
 	}


### PR DESCRIPTION


## Description
posix.DiskInfo() returns errFaultyDisk when posix is nil,
but there is no way that this would happen any time, therefore
removing un-needed code.

## Motivation and Context
Remove a confusing code

## How to test this PR?
No test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
