### PR TITLE
fix: readiness should return 200 OK with first zone online

### DIFF
--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -1374,13 +1374,5 @@ func (z *xlZones) GetMetrics(ctx context.Context) (*Metrics, error) {
 
 // IsReady - Returns True if all the zones have enough quorum to accept requests.
 func (z *xlZones) IsReady(ctx context.Context) bool {
-	if z.SingleZone() {
-		return z.zones[0].IsReady(ctx)
-	}
-	for _, xlsets := range z.zones {
-		if !xlsets.IsReady(ctx) {
-			return false
-		}
-	}
-	return true
+	return z.zones[0].IsReady(ctx)
 }

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -1372,7 +1372,7 @@ func (z *xlZones) GetMetrics(ctx context.Context) (*Metrics, error) {
 	return &Metrics{}, NotImplemented{}
 }
 
-// IsReady - Returns True if all the zones have enough quorum to accept requests.
+// IsReady - Returns true if first zone returns true
 func (z *xlZones) IsReady(ctx context.Context) bool {
 	return z.zones[0].IsReady(ctx)
 }


### PR DESCRIPTION
## Description
fix: readiness should return 200 OK with first zone online

## Motivation and Context
Readiness probes should return 200 OK in expanded setups
if the first zone is online

## How to test this PR?
Deploy an expanded setup in Kubernetes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
