### PR TITLE
data-usage: Avoid crawling duplicated call

### DIFF
--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -88,7 +88,8 @@ func runDataUsageInfoForXLZones(ctx context.Context, z *xlZones, endCh <-chan st
 			time.Sleep(5 * time.Minute)
 			continue
 		}
-		// Break without locking
+		// Break without unlocking, this node will acquire
+		// data usage calculator role for its lifetime.
 		break
 	}
 

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -119,15 +119,9 @@ func (s *storageRESTServer) CrawlAndGetDataUsageHandler(w http.ResponseWriter, r
 		return
 	}
 
-	usageInfo, err := s.storage.CrawlAndGetDataUsage(GlobalServiceDoneCh)
-	if err != nil {
-		s.writeErrorResponse(w, err)
-		return
-	}
-
 	w.Header().Set(xhttp.ContentType, "text/event-stream")
 	doneCh := sendWhiteSpaceToHTTPResponse(w)
-	usageInfo, err = s.storage.CrawlAndGetDataUsage(GlobalServiceDoneCh)
+	usageInfo, err := s.storage.CrawlAndGetDataUsage(GlobalServiceDoneCh)
 	<-doneCh
 
 	if err != nil {

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -198,16 +198,18 @@ func (xl xlObjects) GetMetrics(ctx context.Context) (*Metrics, error) {
 	return &Metrics{}, NotImplemented{}
 }
 
+// crawlAndGetDataUsage picks three random disks to crawl and get data usage
 func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
+
 	var randomDisks []StorageAPI
 	for _, d := range xl.getLoadBalancedDisks() {
 		if d == nil || !d.IsOnline() {
 			continue
 		}
-		if len(randomDisks) > 3 {
+		randomDisks = append(randomDisks, d)
+		if len(randomDisks) >= 3 {
 			break
 		}
-		randomDisks = append(randomDisks, d)
 	}
 
 	var dataUsageResults = make([]DataUsageInfo, len(randomDisks))


### PR DESCRIPTION
## Description
Avoid a typo in data usage which used to calculate the data usage of a disk twice in a storage server handler.

This fix will also picks 3 and not 4 disks from a single erasure set.

## Motivation and Context
Fixing after a review

## How to test this PR?
Add some entry log call in posix.CrawlAndGetDataUsage() to check for duplicated calculation.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
