### PR TITLE
fix: close and drain the response body always

### DIFF
--- a/cmd/config/identity/openid/jwt.go
+++ b/cmd/config/identity/openid/jwt.go
@@ -251,6 +251,7 @@ func parseDiscoveryDoc(u *xnet.URL, transport *http.Transport, closeRespFn func(
 	}
 	resp, err := clnt.Do(req)
 	if err != nil {
+		clnt.CloseIdleConnections()
 		return d, err
 	}
 	defer closeRespFn(resp.Body)

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -304,9 +304,12 @@ func IsBackendOnline(ctx context.Context, clnt *http.Client, urlStr string) bool
 	if err != nil {
 		return false
 	}
-	if _, err = clnt.Do(req); err != nil {
+	resp, err := clnt.Do(req)
+	if err != nil {
+		clnt.CloseIdleConnections()
 		return !xnet.IsNetworkOrHostDown(err)
 	}
+	xhttp.DrainBody(resp.Body)
 	return true
 }
 

--- a/cmd/logger/target/http/http.go
+++ b/cmd/logger/target/http/http.go
@@ -66,6 +66,7 @@ func (h *Target) startHTTPLogger() {
 
 			resp, err := h.client.Do(req)
 			if err != nil {
+				h.client.CloseIdleConnections()
 				continue
 			}
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -207,6 +207,7 @@ func IsServerResolvable(endpoint Endpoint) error {
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
+		httpClient.CloseIdleConnections()
 		return err
 	}
 	defer xhttp.DrainBody(resp.Body)

--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -69,6 +69,7 @@ func (c *Client) CallWithContext(ctx context.Context, method string, values url.
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		c.httpClient.CloseIdleConnections()
 		return nil, &NetworkError{err}
 	}
 

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -2029,6 +2029,7 @@ func (web *webAPIHandlers) LoginSTS(r *http.Request, args *LoginSTSArgs, reply *
 
 	resp, err := clnt.Do(req)
 	if err != nil {
+		clnt.CloseIdleConnections()
 		return toJSONError(ctx, err)
 	}
 	defer xhttp.DrainBody(resp.Body)

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
-	github.com/ugorji/go/codec v1.1.5-pre // indirect
+	github.com/ugorji/go v1.1.5-pre // indirect
 	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.3 // indirect

--- a/pkg/event/target/webhook.go
+++ b/pkg/event/target/webhook.go
@@ -142,15 +142,14 @@ func (target *WebhookTarget) send(eventData event.Event) error {
 
 	resp, err := target.httpClient.Do(req)
 	if err != nil {
+		target.Close()
 		return err
 	}
-
 	defer resp.Body.Close()
 	io.Copy(ioutil.Discard, resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		// close any idle connections upon any error.
-		target.httpClient.CloseIdleConnections()
+		target.Close()
 		return fmt.Errorf("sending event failed with %v", resp.Status)
 	}
 

--- a/pkg/madmin/api.go
+++ b/pkg/madmin/api.go
@@ -270,6 +270,9 @@ func (adm AdminClient) do(req *http.Request) (*http.Response, error) {
 	for {
 		resp, err = adm.httpClient.Do(req)
 		if err != nil {
+			// Close idle connections upon error.
+			adm.httpClient.CloseIdleConnections()
+
 			// Handle this specifically for now until future Golang
 			// versions fix this issue properly.
 			urlErr, ok := err.(*url.Error)

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -100,6 +102,7 @@ func (u URL) DialHTTP() error {
 	if err != nil {
 		return err
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 	return nil
 }


### PR DESCRIPTION
## Description
fix: close and drain the response body always

## Motivation and Context
Fix close and drain of response body across the codebase.

## How to test this PR?
Allows for proper keep-alive behavior in net/http clients, observed with
liveness checks hitting gateway backends

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
