### PR TITLE
Fix erasure block allocation

### DIFF
--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -353,7 +353,7 @@ func (xl xlObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID 
 		defer xl.bp.Put(buffer)
 	case size < blockSizeV1:
 		// No need to allocate fully blockSizeV1 buffer if the incoming data is smaller.
-		buffer = make([]byte, size, 2*size)
+		buffer = make([]byte, size, 2*size+int64(erasure.parityBlocks+erasure.dataBlocks-1))
 	}
 
 	if len(buffer) > int(xlMeta.Erasure.BlockSize) {

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -559,7 +559,7 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
 		defer xl.bp.Put(buffer)
 	case size < blockSizeV1:
 		// No need to allocate fully blockSizeV1 buffer if the incoming data is smaller.
-		buffer = make([]byte, size, 2*size)
+		buffer = make([]byte, size, 2*size+int64(erasure.parityBlocks+erasure.dataBlocks-1))
 	}
 
 	if len(buffer) > int(xlMeta.Erasure.BlockSize) {


### PR DESCRIPTION
## Description

Small blocks are undersized when file size isn't divisible by the shard number. This leads to allocation+copy in reedsolomon Split().

## Discussion

The allocation also assumes 1 parity shard per data shard. This leads to overallocation when server setup is different. Not a big deal, though.

## How to test this PR?

* Start minio in XL mode
* Execute `warp mixed -obj.randsize -serverprof=mem -duration=1m`
* Extract downloaded profile.
* Inspect `go tool pprof -alloc_space profiling-127.0.0.1_9000-mem.pprof`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
