### PR TITLE
fix: Avoid double usage calculation on every restart

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -302,13 +302,13 @@ func (a adminAPIHandlers) DataUsageInfoHandler(w http.ResponseWriter, r *http.Re
 
 	dataUsageInfo, err := loadDataUsageFromBackend(ctx, objectAPI)
 	if err != nil {
-		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrInternalError), r.URL)
+		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
 	}
 
 	dataUsageInfoJSON, err := json.Marshal(dataUsageInfo)
 	if err != nil {
-		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrInternalError), r.URL)
+		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
 	}
 

--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -75,7 +75,7 @@ func (h *healRoutine) run() {
 
 			var res madmin.HealResultItem
 			var err error
-			bucket, object := urlPath2BucketObjectName(task.path)
+			bucket, object := path2BucketObject(task.path)
 			switch {
 			case bucket == "" && object == "":
 				res, err = bgHealDiskFormat(ctx, task.opts)

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -48,40 +50,36 @@ func runDataUsageInfoUpdateRoutine() {
 		break
 	}
 
-	ctx := context.Background()
-
-	switch v := objAPI.(type) {
-	case *xlZones:
-		runDataUsageInfoForXLZones(ctx, v, GlobalServiceDoneCh)
-	case *FSObjects:
-		runDataUsageInfoForFS(ctx, v, GlobalServiceDoneCh)
-	default:
-		return
-	}
+	runDataUsageInfo(context.Background(), objAPI, GlobalServiceDoneCh)
 }
 
-func runDataUsageInfoForFS(ctx context.Context, fsObj *FSObjects, endCh <-chan struct{}) {
-	t := time.NewTicker(dataUsageCrawlInterval)
-	defer t.Stop()
-	for {
-		// Get data usage info of the FS Object
-		usageInfo := fsObj.crawlAndGetDataUsageInfo(ctx, endCh)
-		// Save the data usage in the disk
-		err := storeDataUsageInBackend(ctx, fsObj, usageInfo)
-		if err != nil {
-			logger.LogIf(ctx, err)
-		}
-		select {
-		case <-endCh:
-			return
-		// Wait until the next crawl interval
-		case <-t.C:
-		}
+// timeToNextCrawl returns the duration until next crawl should occur
+// this is validated by verifying the LastUpdate time.
+func timeToCrawl(ctx context.Context, objAPI ObjectLayer) time.Duration {
+	dataUsageInfo, err := loadDataUsageFromBackend(ctx, objAPI)
+	if err != nil {
+		// Upon an error wait for like 10
+		// seconds to start the crawler.
+		return 10 * time.Second
 	}
+	// File indeed doesn't exist when LastUpdate is zero
+	// so we have never crawled, start crawl right away.
+	if dataUsageInfo.LastUpdate.IsZero() {
+		return 1 * time.Second
+	}
+	waitDuration := dataUsageInfo.LastUpdate.Sub(UTCNow())
+	if waitDuration > dataUsageCrawlInterval {
+		// Waited long enough start crawl in a 1 second
+		return 1 * time.Second
+	}
+	// No crawling needed, ask the routine to wait until
+	// the daily interval 12hrs - delta between last update
+	// with current time.
+	return dataUsageCrawlInterval - waitDuration
 }
 
-func runDataUsageInfoForXLZones(ctx context.Context, z *xlZones, endCh <-chan struct{}) {
-	locker := z.NewNSLock(ctx, minioMetaBucket, "leader-data-usage-info")
+func runDataUsageInfo(ctx context.Context, objAPI ObjectLayer, endCh <-chan struct{}) {
+	locker := objAPI.NewNSLock(ctx, minioMetaBucket, "leader-data-usage-info")
 	for {
 		err := locker.GetLock(newDynamicTimeout(time.Millisecond, time.Millisecond))
 		if err != nil {
@@ -93,19 +91,17 @@ func runDataUsageInfoForXLZones(ctx context.Context, z *xlZones, endCh <-chan st
 		break
 	}
 
-	t := time.NewTicker(dataUsageCrawlInterval)
-	defer t.Stop()
 	for {
-		usageInfo := z.crawlAndGetDataUsage(ctx, endCh)
-		err := storeDataUsageInBackend(ctx, z, usageInfo)
-		if err != nil {
-			logger.LogIf(ctx, err)
-		}
+		wait := timeToCrawl(ctx, objAPI)
 		select {
 		case <-endCh:
 			locker.Unlock()
 			return
-		case <-t.C:
+		case <-time.NewTimer(wait).C:
+			// Crawl only when no previous crawl has occurred,
+			// or its been too long since last crawl.
+			err := storeDataUsageInBackend(ctx, objAPI, objAPI.CrawlAndGetDataUsage(ctx, endCh))
+			logger.LogIf(ctx, err)
 		}
 	}
 }
@@ -131,7 +127,10 @@ func loadDataUsageFromBackend(ctx context.Context, objAPI ObjectLayer) (DataUsag
 
 	err := objAPI.GetObject(ctx, minioMetaBackgroundOpsBucket, dataUsageObjName, 0, -1, &dataUsageInfoJSON, "", ObjectOptions{})
 	if err != nil {
-		return DataUsageInfo{}, nil
+		if isErrObjectNotFound(err) {
+			return DataUsageInfo{}, nil
+		}
+		return DataUsageInfo{}, toObjectErr(err, minioMetaBackgroundOpsBucket, dataUsageObjName)
 	}
 
 	var dataUsageInfo DataUsageInfo
@@ -142,4 +141,86 @@ func loadDataUsageFromBackend(ctx context.Context, objAPI ObjectLayer) (DataUsag
 	}
 
 	return dataUsageInfo, nil
+}
+
+// Item represents each file while walking.
+type Item struct {
+	Path string
+	Typ  os.FileMode
+}
+
+type getSizeFn func(item Item) (int64, error)
+type activeIOFn func() error
+
+func updateUsage(basePath string, endCh <-chan struct{}, waitForLowActiveIO activeIOFn, getSize getSizeFn) DataUsageInfo {
+	var dataUsageInfo = DataUsageInfo{
+		BucketsSizes:          make(map[string]uint64),
+		ObjectsSizesHistogram: make(map[string]uint64),
+	}
+
+	itemCh := make(chan Item)
+	skipCh := make(chan error)
+	defer close(skipCh)
+
+	go func() {
+		defer close(itemCh)
+		fastWalk(basePath, func(path string, typ os.FileMode) error {
+			if err := waitForLowActiveIO(); err != nil {
+				return filepath.SkipDir
+			}
+
+			select {
+			case <-endCh:
+				return filepath.SkipDir
+			case itemCh <- Item{path, typ}:
+			}
+			return <-skipCh
+		})
+	}()
+
+	for {
+		select {
+		case <-endCh:
+			return dataUsageInfo
+		case item, ok := <-itemCh:
+			if !ok {
+				return dataUsageInfo
+			}
+
+			bucket, entry := path2BucketObjectWithBasePath(basePath, item.Path)
+			if bucket == "" {
+				skipCh <- nil
+				continue
+			}
+
+			if isReservedOrInvalidBucket(bucket, false) {
+				skipCh <- filepath.SkipDir
+				continue
+			}
+
+			if entry == "" && item.Typ&os.ModeDir != 0 {
+				dataUsageInfo.BucketsCount++
+				dataUsageInfo.BucketsSizes[bucket] = 0
+				skipCh <- nil
+				continue
+			}
+
+			if item.Typ&os.ModeDir != 0 {
+				skipCh <- nil
+				continue
+			}
+
+			size, err := getSize(item)
+			if err != nil {
+				skipCh <- errSkipFile
+				continue
+			}
+
+			dataUsageInfo.ObjectsCount++
+			dataUsageInfo.ObjectsTotalSize += uint64(size)
+			dataUsageInfo.BucketsSizes[bucket] += uint64(size)
+			dataUsageInfo.ObjectsSizesHistogram[objSizeToHistoInterval(uint64(size))]++
+			skipCh <- nil
+		}
+	}
 }

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -46,6 +46,12 @@ func NewGatewayLayerWithLocker(gwLayer ObjectLayer) ObjectLayer {
 // GatewayUnsupported list of unsupported call stubs for gateway.
 type GatewayUnsupported struct{}
 
+// CrawlAndGetDataUsage - crawl is not implemented for gateway
+func (a GatewayUnsupported) CrawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
+	logger.CriticalIf(ctx, errors.New("not implemented"))
+	return DataUsageInfo{}
+}
+
 // NewNSLock is a dummy stub for gateway.
 func (a GatewayUnsupported) NewNSLock(ctx context.Context, bucket string, object string) RWLocker {
 	logger.CriticalIf(ctx, errors.New("not implemented"))

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -631,11 +631,11 @@ func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		switch r.Method {
 		case http.MethodPut:
 			if getRequestAuthType(r) == authTypeJWT {
-				bucket, _ = urlPath2BucketObjectName(strings.TrimPrefix(r.URL.Path, minioReservedBucketPath+"/upload"))
+				bucket, _ = path2BucketObjectWithBasePath(minioReservedBucketPath+"/upload", r.URL.Path)
 			}
 		case http.MethodGet:
 			if t := r.URL.Query().Get("token"); t != "" {
-				bucket, _ = urlPath2BucketObjectName(strings.TrimPrefix(r.URL.Path, minioReservedBucketPath+"/download"))
+				bucket, _ = path2BucketObjectWithBasePath(minioReservedBucketPath+"/download", r.URL.Path)
 			} else if getRequestAuthType(r) != authTypeJWT && !strings.HasPrefix(r.URL.Path, minioReservedBucketPath) {
 				bucket, _ = request2BucketObjectName(r)
 			}
@@ -687,7 +687,7 @@ func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// requests have target bucket and object in URI and source details are in
 	// header fields
 	if r.Method == http.MethodPut && r.Header.Get(xhttp.AmzCopySource) != "" {
-		bucket, object = urlPath2BucketObjectName(r.Header.Get(xhttp.AmzCopySource))
+		bucket, object = path2BucketObject(r.Header.Get(xhttp.AmzCopySource))
 		if bucket == "" || object == "" {
 			f.handler.ServeHTTP(w, r)
 			return

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -98,23 +98,6 @@ func isDirectiveReplace(value string) bool {
 	return value == replaceDirective
 }
 
-// Splits an incoming path into bucket and object components.
-func path2BucketAndObject(path string) (bucket, object string) {
-	// Skip the first element if it is '/', split the rest.
-	path = strings.TrimPrefix(path, SlashSeparator)
-	pathComponents := strings.SplitN(path, SlashSeparator, 2)
-
-	// Save the bucket and object extracted from path.
-	switch len(pathComponents) {
-	case 1:
-		bucket = pathComponents[0]
-	case 2:
-		bucket = pathComponents[0]
-		object = pathComponents[1]
-	}
-	return bucket, object
-}
-
 // userMetadataKeyPrefixes contains the prefixes of used-defined metadata keys.
 // All values stored with a key starting with one of the following prefixes
 // must be extracted from the header.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -57,6 +57,7 @@ type ObjectLayer interface {
 
 	// Storage operations.
 	Shutdown(context.Context) error
+	CrawlAndGetDataUsage(context.Context, <-chan struct{}) DataUsageInfo
 	StorageInfo(context.Context) StorageInfo
 
 	// Bucket operations.

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -743,7 +743,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	srcBucket, srcObject := path2BucketAndObject(cpSrcPath)
+	srcBucket, srcObject := path2BucketObject(cpSrcPath)
 	// If source object is empty or bucket is empty, reply back invalid copy source.
 	if srcObject == "" || srcBucket == "" {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidCopySource), r.URL, guessIsBrowserReq(r))
@@ -1578,7 +1578,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		}
 	}
 
-	srcBucket, srcObject := path2BucketAndObject(cpSrcPath)
+	srcBucket, srcObject := path2BucketObject(cpSrcPath)
 	// If source object is empty or bucket is empty, reply back invalid copy source.
 	if srcObject == "" || srcBucket == "" {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidCopySource), r.URL, guessIsBrowserReq(r))

--- a/cmd/posix-errors.go
+++ b/cmd/posix-errors.go
@@ -58,6 +58,11 @@ func isSysErrTooLong(err error) bool {
 	return errors.Is(err, syscall.ENAMETOOLONG)
 }
 
+// Check if the given error corresponds to the ELOOP (too many symlinks).
+func isSysErrTooManySymlinks(err error) bool {
+	return errors.Is(err, syscall.ELOOP)
+}
+
 // Check if the given error corresponds to ENOTEMPTY for unix
 // and ERROR_DIR_NOT_EMPTY for windows (directory not empty).
 func isSysErrNotEmpty(err error) bool {

--- a/cmd/posix-list-dir_unix.go
+++ b/cmd/posix-list-dir_unix.go
@@ -122,8 +122,11 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 		if typ == unexpectedFileMode || typ&os.ModeSymlink == os.ModeSymlink {
 			fi, err := os.Stat(pathJoin(dirPath, name))
 			if err != nil {
-				// It got deleted in the meantime.
-				if os.IsNotExist(err) {
+				// It got deleted in the meantime, not found
+				// or returns too many symlinks ignore this
+				// file/directory.
+				if os.IsNotExist(err) || isSysErrPathNotFound(err) ||
+					isSysErrTooManySymlinks(err) {
 					continue
 				}
 				return nil, err

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -107,85 +107,74 @@ func TestMaxPartID(t *testing.T) {
 	}
 }
 
-// Tests extracting bucket and objectname from various types of URL paths.
-func TestURL2BucketObjectName(t *testing.T) {
+// Tests extracting bucket and objectname from various types of paths.
+func TestPath2BucketObjectName(t *testing.T) {
 	testCases := []struct {
-		u              *url.URL
+		path           string
 		bucket, object string
 	}{
 		// Test case 1 normal case.
 		{
-			u: &url.URL{
-				Path: "/bucket/object",
-			},
+			path:   "/bucket/object",
 			bucket: "bucket",
 			object: "object",
 		},
 		// Test case 2 where url only has separator.
 		{
-			u: &url.URL{
-				Path: SlashSeparator,
-			},
+			path:   SlashSeparator,
 			bucket: "",
 			object: "",
 		},
 		// Test case 3 only bucket is present.
 		{
-			u: &url.URL{
-				Path: "/bucket",
-			},
+			path:   "/bucket",
 			bucket: "bucket",
 			object: "",
 		},
 		// Test case 4 many separators and object is a directory.
 		{
-			u: &url.URL{
-				Path: "/bucket/object/1/",
-			},
+			path:   "/bucket/object/1/",
 			bucket: "bucket",
 			object: "object/1/",
 		},
 		// Test case 5 object has many trailing separators.
 		{
-			u: &url.URL{
-				Path: "/bucket/object/1///",
-			},
+			path:   "/bucket/object/1///",
 			bucket: "bucket",
 			object: "object/1///",
 		},
 		// Test case 6 object has only trailing separators.
 		{
-			u: &url.URL{
-				Path: "/bucket/object///////",
-			},
+			path:   "/bucket/object///////",
 			bucket: "bucket",
 			object: "object///////",
 		},
 		// Test case 7 object has preceding separators.
 		{
-			u: &url.URL{
-				Path: "/bucket////object////",
-			},
+			path:   "/bucket////object////",
 			bucket: "bucket",
 			object: "///object////",
 		},
-		// Test case 9 url path is empty.
+		// Test case 8 url path is empty.
 		{
-			u:      &url.URL{},
+			path:   "",
 			bucket: "",
 			object: "",
 		},
 	}
 
 	// Validate all test cases.
-	for i, testCase := range testCases {
-		bucketName, objectName := urlPath2BucketObjectName(testCase.u.Path)
-		if bucketName != testCase.bucket {
-			t.Errorf("Test %d: failed expected bucket name \"%s\", got \"%s\"", i+1, testCase.bucket, bucketName)
-		}
-		if objectName != testCase.object {
-			t.Errorf("Test %d: failed expected bucket name \"%s\", got \"%s\"", i+1, testCase.object, objectName)
-		}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run("", func(t *testing.T) {
+			bucketName, objectName := path2BucketObject(testCase.path)
+			if bucketName != testCase.bucket {
+				t.Errorf("failed expected bucket name \"%s\", got \"%s\"", testCase.bucket, bucketName)
+			}
+			if objectName != testCase.object {
+				t.Errorf("failed expected bucket name \"%s\", got \"%s\"", testCase.object, objectName)
+			}
+		})
 	}
 }
 

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -1723,7 +1723,7 @@ func (web *webAPIHandlers) ListAllBucketPolicies(r *http.Request, args *ListAllB
 
 	reply.UIVersion = browser.UIVersion
 	for prefix, policy := range miniogopolicy.GetPolicies(policyInfo.Statements, args.BucketName, "") {
-		bucketName, objectPrefix := urlPath2BucketObjectName(prefix)
+		bucketName, objectPrefix := path2BucketObject(prefix)
 		objectPrefix = strings.TrimSuffix(objectPrefix, "*")
 		reply.Policies = append(reply.Policies, BucketAccessPolicy{
 			Bucket: bucketName,

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -435,6 +435,10 @@ func (s *xlSets) StorageInfo(ctx context.Context) StorageInfo {
 	return storageInfo
 }
 
+func (s *xlSets) CrawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
+	return DataUsageInfo{}
+}
+
 // Shutdown shutsdown all erasure coded sets in parallel
 // returns error upon first error.
 func (s *xlSets) Shutdown(ctx context.Context) error {

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -192,15 +192,14 @@ func (xl xlObjects) StorageInfo(ctx context.Context) StorageInfo {
 	return getStorageInfo(xl.getDisks())
 }
 
-// GetMetrics - no op
+// GetMetrics - is not implemented and shouldn't be called.
 func (xl xlObjects) GetMetrics(ctx context.Context) (*Metrics, error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return &Metrics{}, NotImplemented{}
 }
 
-// crawlAndGetDataUsage picks three random disks to crawl and get data usage
-func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
-
+// CrawlAndGetDataUsage picks three random disks to crawl and get data usage
+func (xl xlObjects) CrawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
 	var randomDisks []StorageAPI
 	for _, d := range xl.getLoadBalancedDisks() {
 		if d == nil || !d.IsOnline() {

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -212,7 +212,7 @@ func (z *xlZones) StorageInfo(ctx context.Context) StorageInfo {
 	return storageInfo
 }
 
-func (z *xlZones) crawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
+func (z *xlZones) CrawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{}) DataUsageInfo {
 	var aggDataUsageInfo = struct {
 		sync.Mutex
 		DataUsageInfo
@@ -227,7 +227,7 @@ func (z *xlZones) crawlAndGetDataUsage(ctx context.Context, endCh <-chan struct{
 			wg.Add(1)
 			go func(xl *xlObjects) {
 				defer wg.Done()
-				info := xl.crawlAndGetDataUsage(ctx, endCh)
+				info := xl.CrawlAndGetDataUsage(ctx, endCh)
 
 				aggDataUsageInfo.Lock()
 				aggDataUsageInfo.ObjectsCount += info.ObjectsCount


### PR DESCRIPTION


## Description
fix: Avoid double usage calculation on every restart

## Motivation and Context
On every restart of the server, usage was being
calculated which is not useful instead wait for
sufficient time to start the crawling routine.

This PR also avoids lots of double allocations
through strings, optimizes usage of string builders
and also avoids crawling through symbolic links.

Fixes #8844

## How to test this PR?
As mentioned in the PR #8844 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
