### PR TITLE
fix: document _ENABLE for all notification targets

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -38,6 +38,7 @@ import (
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/cmd/logger/target/http"
 	"github.com/minio/minio/pkg/env"
+	"github.com/minio/minio/pkg/madmin"
 )
 
 func initHelp() {
@@ -469,6 +470,20 @@ func GetHelp(subSys, key string, envOnly bool) (Help, error) {
 
 	envHelp := config.HelpKVS{}
 	if envOnly {
+		// Only for multiple targets, make sure
+		// to list the ENV, for regular k/v EnableKey is
+		// implicit, for ENVs we cannot make it implicit.
+		if subSysHelp.MultipleTargets {
+			envK := config.EnvPrefix + strings.Join([]string{
+				strings.ToTitle(subSys), strings.ToTitle(madmin.EnableKey),
+			}, config.EnvWordDelimiter)
+			envHelp = append(envHelp, config.HelpKV{
+				Key:         envK,
+				Description: fmt.Sprintf("enable %s target, default is 'off'", subSys),
+				Optional:    false,
+				Type:        "on|off",
+			})
+		}
 		for _, hkv := range h {
 			envK := config.EnvPrefix + strings.Join([]string{
 				strings.ToTitle(subSys), strings.ToTitle(hkv.Key),

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -77,7 +77,7 @@ KEY:
 notify_amqp[:name]  publish bucket notifications to AMQP endpoints
 
 ARGS:
-MINIO_NOTIFY_AMQP_ENABLE         (on|off)    enable amqp notifications, default is 'off'
+MINIO_NOTIFY_AMQP_ENABLE*        (on|off)    enable notify_amqp target, default is 'off'
 MINIO_NOTIFY_AMQP_URL*           (url)       AMQP server endpoint e.g. `amqp://myuser:mypassword@localhost:5672`
 MINIO_NOTIFY_AMQP_EXCHANGE       (string)    name of the AMQP exchange
 MINIO_NOTIFY_AMQP_EXCHANGE_TYPE  (string)    AMQP exchange type
@@ -211,6 +211,7 @@ KEY:
 notify_mqtt[:name]  publish bucket notifications to MQTT endpoints
 
 ARGS:
+MINIO_NOTIFY_MQTT_ENABLE*              (on|off)    enable notify_mqtt target, default is 'off'
 MINIO_NOTIFY_MQTT_BROKER*              (uri)       MQTT server endpoint e.g. `tcp://localhost:1883`
 MINIO_NOTIFY_MQTT_TOPIC*               (string)    name of the MQTT topic to publish
 MINIO_NOTIFY_MQTT_USERNAME             (string)    MQTT username
@@ -343,6 +344,7 @@ KEY:
 notify_elasticsearch[:name]  publish bucket notifications to Elasticsearch endpoints
 
 ARGS:
+MINIO_NOTIFY_ELASTICSEARCH_ENABLE*      (on|off)             enable notify_elasticsearch target, default is 'off'
 MINIO_NOTIFY_ELASTICSEARCH_URL*         (url)                Elasticsearch server's address, with optional authentication info
 MINIO_NOTIFY_ELASTICSEARCH_INDEX*       (string)             Elasticsearch index to store/update events, index is auto-created
 MINIO_NOTIFY_ELASTICSEARCH_FORMAT*      (namespace*|access)  'namespace' reflects current bucket/object list and 'access' reflects a journal of object operations, defaults to 'namespace'
@@ -508,7 +510,7 @@ KEY:
 notify_redis[:name]  publish bucket notifications to Redis datastores
 
 ARGS:
-MINIO_NOTIFY_REDIS_ADDRESS*     (address)            Redis server's address. For example: `localhost:6379`
+MINIO_NOTIFY_REDIS_ENABLE*      (on|off)             enable notify_redis target, default is 'off'
 MINIO_NOTIFY_REDIS_KEY*         (string)             Redis key to store/update events, key is auto-created
 MINIO_NOTIFY_REDIS_FORMAT*      (namespace*|access)  'namespace' reflects current bucket/object list and 'access' reflects a journal of object operations, defaults to 'namespace'
 MINIO_NOTIFY_REDIS_PASSWORD     (string)             Redis server password
@@ -619,6 +621,7 @@ KEY:
 notify_nats[:name]  publish bucket notifications to NATS endpoints
 
 ARGS:
+MINIO_NOTIFY_NATS_ENABLE*                           (on|off)    enable notify_nats target, default is 'off'
 MINIO_NOTIFY_NATS_ADDRESS*                          (address)   NATS server address e.g. '0.0.0.0:4222'
 MINIO_NOTIFY_NATS_SUBJECT*                          (string)    NATS subscription subject
 MINIO_NOTIFY_NATS_USERNAME                          (string)    NATS username
@@ -843,6 +846,7 @@ KEY:
 notify_postgres[:name]  publish bucket notifications to Postgres databases
 
 ARGS:
+MINIO_NOTIFY_POSTGRES_ENABLE*             (on|off)             enable notify_postgres target, default is 'off'
 MINIO_NOTIFY_POSTGRES_CONNECTION_STRING*  (string)             Postgres server connection-string
 MINIO_NOTIFY_POSTGRES_TABLE*              (string)             DB table name to store/update events, table is auto-created
 MINIO_NOTIFY_POSTGRES_FORMAT*             (namespace*|access)  'namespace' reflects current bucket/object list and 'access' reflects a journal of object operations, defaults to 'namespace'
@@ -959,6 +963,7 @@ KEY:
 notify_mysql[:name]  publish bucket notifications to MySQL databases
 
 ARGS:
+MINIO_NOTIFY_MYSQL_ENABLE*      (on|off)             enable notify_mysql target, default is 'off'
 MINIO_NOTIFY_MYSQL_DSN_STRING*  (string)             MySQL data-source-name connection string
 MINIO_NOTIFY_MYSQL_TABLE*       (string)             DB table name to store/update events, table is auto-created
 MINIO_NOTIFY_MYSQL_FORMAT*      (namespace*|access)  'namespace' reflects current bucket/object list and 'access' reflects a journal of object operations, defaults to 'namespace'
@@ -1071,6 +1076,7 @@ KEY:
 notify_kafka[:name]  publish bucket notifications to Kafka endpoints
 
 ARGS:
+MINIO_NOTIFY_KAFKA_ENABLE*          (on|off)    enable notify_kafka target, default is 'off'
 MINIO_NOTIFY_KAFKA_BROKERS*         (csv)       comma separated list of Kafka broker addresses
 MINIO_NOTIFY_KAFKA_TOPIC            (string)    Kafka topic used for bucket notifications
 MINIO_NOTIFY_KAFKA_SASL_USERNAME    (string)    username for SASL/PLAIN or SASL/SCRAM authentication
@@ -1213,6 +1219,7 @@ KEY:
 notify_webhook[:name]  publish bucket notifications to webhook endpoints
 
 ARGS:
+MINIO_NOTIFY_WEBHOOK_ENABLE*      (on|off)    enable notify_webhook target, default is 'off'
 MINIO_NOTIFY_WEBHOOK_ENDPOINT*    (url)       webhook server endpoint e.g. http://localhost:8080/minio/events
 MINIO_NOTIFY_WEBHOOK_AUTH_TOKEN   (string)    opaque string or JWT authorization token
 MINIO_NOTIFY_WEBHOOK_QUEUE_DIR    (path)      staging dir for undelivered messages e.g. '/home/events'
@@ -1318,6 +1325,7 @@ KEY:
 notify_nsq[:name]  publish bucket notifications to NSQ endpoints
 
 ARGS:
+MINIO_NOTIFY_NSQ_ENABLE*          (on|off)    enable notify_nsq target, default is 'off'
 MINIO_NOTIFY_NSQ_NSQD_ADDRESS*    (address)   NSQ server address e.g. '127.0.0.1:4150'
 MINIO_NOTIFY_NSQ_TOPIC*           (string)    NSQ topic
 MINIO_NOTIFY_NSQ_TLS              (on|off)    set to 'on' to enable TLS

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
-	github.com/ugorji/go/codec v1.1.5-pre // indirect
+	github.com/ugorji/go v1.1.5-pre // indirect
 	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.3 // indirect


### PR DESCRIPTION

## Description
fix: document _ENABLE for all notification targets

## Motivation and Context
Fixes #8863

## How to test this PR?
Just by `mc admin config set myminio/ notify_kafka --env`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
