### PR TITLE
Fix IsAllowed Method

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1367,6 +1367,11 @@ func (sys *IAMSys) IsAllowed(args iampolicy.Args) bool {
 		return true
 	}
 
+	// Check whether the account is a temp user obtained from Assume-role
+	if yeah, _ := sys.IsTempUser(args.AccountName); yeah {
+		return sys.IsAllowedSTS(args)
+	}
+	
 	// With claims set, we should do STS related checks and validation.
 	if _, ok := args.Claims["aud"]; ok {
 		return sys.IsAllowedSTS(args)


### PR DESCRIPTION
Should checked whether an account is a temp user, if yes, should validate its policy sessions. Previously, all users were just checked against their parent policies, which could be a bug. 

See issue:
Assume-role inline policy does not work properly #8865

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
