### PR TITLE
fix: STS creds without "aud" should be honored with STS checks

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1367,8 +1367,13 @@ func (sys *IAMSys) IsAllowed(args iampolicy.Args) bool {
 		return true
 	}
 
-	// With claims set, we should do STS related checks and validation.
-	if _, ok := args.Claims["aud"]; ok {
+	// If the credential is temporary, perform STS related checks.
+	ok, err := sys.IsTempUser(args.AccountName)
+	if err != nil {
+		logger.LogIf(context.Background(), err)
+		return false
+	}
+	if ok {
 		return sys.IsAllowedSTS(args)
 	}
 


### PR DESCRIPTION

## Description
fix: STS creds without "aud" should be honored with STS checks

## Motivation and Context
Fixes #8865

## How to test this PR?
As mentioned in #8865

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably because we did have this working properly before.
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
