### PR TITLE
fix racy tests when editing xl.getDisks

### DIFF
--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -1590,12 +1590,14 @@ func TestWebObjectLayerFaultyDisks(t *testing.T) {
 	z := obj.(*xlZones)
 	xl := z.zones[0].sets[0]
 	xlDisks := xl.getDisks()
+	z.zones[0].xlDisksMu.Lock()
 	xl.getDisks = func() []StorageAPI {
 		for i, d := range xlDisks {
 			xlDisks[i] = newNaughtyDisk(d, nil, errFaultyDisk)
 		}
 		return xlDisks
 	}
+	z.zones[0].xlDisksMu.Unlock()
 
 	// Initialize web rpc endpoint.
 	apiRouter := initTestWebRPCEndPoint(obj)

--- a/cmd/xl-v1-healing_test.go
+++ b/cmd/xl-v1-healing_test.go
@@ -270,6 +270,7 @@ func TestHealObjectXL(t *testing.T) {
 	}
 
 	xlDisks := xl.getDisks()
+	z.zones[0].xlDisksMu.Lock()
 	xl.getDisks = func() []StorageAPI {
 		// Nil more than half the disks, to remove write quorum.
 		for i := 0; i <= len(xlDisks)/2; i++ {
@@ -277,6 +278,7 @@ func TestHealObjectXL(t *testing.T) {
 		}
 		return xlDisks
 	}
+	z.zones[0].xlDisksMu.Unlock()
 
 	// Try healing now, expect to receive errDiskNotFound.
 	_, err = obj.HealObject(context.Background(), bucket, object, false, false, madmin.HealDeepScan)


### PR DESCRIPTION
## Description
fix racy tests when editing xl.getDisks

## Motivation and Context
Observed frequently in SimpleCI

## How to test this PR?
go test -race - should reveal the issue. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
