### PR TITLE
Add support for Object Tagging in LifeCycle configuration

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -32,6 +32,7 @@ import (
 	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
+	"github.com/minio/minio/pkg/bucket/lifecycle"
 	objectlock "github.com/minio/minio/pkg/bucket/object/lock"
 	"github.com/minio/minio/pkg/bucket/object/tagging"
 	"github.com/minio/minio/pkg/bucket/policy"
@@ -1787,6 +1788,12 @@ func toAPIError(ctx context.Context, err error) APIError {
 		// their internal error types. This code is only
 		// useful with gateway implementations.
 		switch e := err.(type) {
+		case lifecycle.Error:
+			apiErr = APIError{
+				Code:           "InvalidRequest",
+				Description:    e.Error(),
+				HTTPStatusCode: http.StatusBadRequest,
+			}
 		case tagging.Error:
 			apiErr = APIError{
 				Code:           "InvalidTag",

--- a/cmd/bucket-lifecycle-handler.go
+++ b/cmd/bucket-lifecycle-handler.go
@@ -67,7 +67,7 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 
 	bucketLifecycle, err := lifecycle.ParseLifecycleConfig(io.LimitReader(r.Body, r.ContentLength))
 	if err != nil {
-		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMalformedXML), r.URL, guessIsBrowserReq(r))
+		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
 

--- a/cmd/daily-lifecycle-ops.go
+++ b/cmd/daily-lifecycle-ops.go
@@ -129,7 +129,7 @@ func lifecycleRound(ctx context.Context, objAPI ObjectLayer) error {
 		// Calculate the common prefix of all lifecycle rules
 		var prefixes []string
 		for _, rule := range l.Rules {
-			prefixes = append(prefixes, rule.Filter.Prefix)
+			prefixes = append(prefixes, rule.Prefix())
 		}
 		commonPrefix := lcp(prefixes)
 
@@ -143,7 +143,7 @@ func lifecycleRound(ctx context.Context, objAPI ObjectLayer) error {
 			var objects []string
 			for _, obj := range res.Objects {
 				// Find the action that need to be executed
-				action := l.ComputeAction(obj.Name, obj.ModTime)
+				action := l.ComputeAction(obj.Name, obj.UserTags, obj.ModTime)
 				switch action {
 				case lifecycle.DeleteAction:
 					objects = append(objects, obj.Name)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2872,7 +2872,6 @@ func (api objectAPIHandlers) PutObjectTaggingHandler(w http.ResponseWriter, r *h
 	}
 
 	tagging, err := tagging.ParseTagging(io.LimitReader(r.Body, r.ContentLength))
-
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return

--- a/pkg/bucket/lifecycle/error.go
+++ b/pkg/bucket/lifecycle/error.go
@@ -14,28 +14,31 @@
  * limitations under the License.
  */
 
-package tagging
+package lifecycle
 
 import (
-	"encoding/xml"
+	"fmt"
 )
 
-// TagSet - Set of tags under Tagging
-type TagSet struct {
-	XMLName xml.Name `xml:"TagSet"`
-	Tags    []Tag    `xml:"Tag"`
+// Error is the generic type for any error happening during tag
+// parsing.
+type Error struct {
+	err error
 }
 
-// ContainsDuplicateTag - returns true if duplicate keys are present in TagSet
-func (t TagSet) ContainsDuplicateTag() bool {
-	x := make(map[string]struct{}, len(t.Tags))
+// Errorf - formats according to a format specifier and returns
+// the string as a value that satisfies error of type tagging.Error
+func Errorf(format string, a ...interface{}) error {
+	return Error{err: fmt.Errorf(format, a...)}
+}
 
-	for _, t := range t.Tags {
-		if _, has := x[t.Key]; has {
-			return true
-		}
-		x[t.Key] = struct{}{}
+// Unwrap the internal error.
+func (e Error) Unwrap() error { return e.err }
+
+// Error 'error' compatible method.
+func (e Error) Error() string {
+	if e.err == nil {
+		return "lifecycle: cause <nil>"
 	}
-
-	return false
+	return e.err.Error()
 }

--- a/pkg/bucket/lifecycle/expiration.go
+++ b/pkg/bucket/lifecycle/expiration.go
@@ -18,15 +18,14 @@ package lifecycle
 
 import (
 	"encoding/xml"
-	"errors"
 	"time"
 )
 
 var (
-	errLifecycleInvalidDate       = errors.New("Date must be provided in ISO 8601 format")
-	errLifecycleInvalidDays       = errors.New("Days must be positive integer when used with Expiration")
-	errLifecycleInvalidExpiration = errors.New("At least one of Days or Date should be present inside Expiration")
-	errLifecycleDateNotMidnight   = errors.New(" 'Date' must be at midnight GMT")
+	errLifecycleInvalidDate       = Errorf("Date must be provided in ISO 8601 format")
+	errLifecycleInvalidDays       = Errorf("Days must be positive integer when used with Expiration")
+	errLifecycleInvalidExpiration = Errorf("At least one of Days or Date should be present inside Expiration")
+	errLifecycleDateNotMidnight   = Errorf(" 'Date' must be at midnight GMT")
 )
 
 // ExpirationDays is a type alias to unmarshal Days in Expiration
@@ -121,7 +120,6 @@ func (e Expiration) Validate() error {
 // IsDaysNull returns true if days field is null
 func (e Expiration) IsDaysNull() bool {
 	return e.Days == ExpirationDays(0)
-
 }
 
 // IsDateNull returns true if date field is null

--- a/pkg/bucket/lifecycle/expiration.go
+++ b/pkg/bucket/lifecycle/expiration.go
@@ -25,7 +25,7 @@ var (
 	errLifecycleInvalidDate       = Errorf("Date must be provided in ISO 8601 format")
 	errLifecycleInvalidDays       = Errorf("Days must be positive integer when used with Expiration")
 	errLifecycleInvalidExpiration = Errorf("At least one of Days or Date should be present inside Expiration")
-	errLifecycleDateNotMidnight   = Errorf(" 'Date' must be at midnight GMT")
+	errLifecycleDateNotMidnight   = Errorf("'Date' must be at midnight GMT")
 )
 
 // ExpirationDays is a type alias to unmarshal Days in Expiration

--- a/pkg/bucket/lifecycle/filter_test.go
+++ b/pkg/bucket/lifecycle/filter_test.go
@@ -31,23 +31,91 @@ func TestUnsupportedFilters(t *testing.T) {
 	}{
 		{ // Filter with And tags
 			inputXML: ` <Filter>
-	                     <And>
-	                     <Prefix></Prefix>
-	                     </And>
-	                    </Filter>`,
-			expectedErr: errAndUnsupported,
+						<And>
+							<Prefix>key-prefix</Prefix>
+						</And>
+						</Filter>`,
+			expectedErr: nil,
 		},
 		{ // Filter with Tag tags
 			inputXML: ` <Filter>
-	                     <Tag></Tag>
-	                    </Filter>`,
-			expectedErr: errTagUnsupported,
+						<Tag>
+							<Key>key1</Key>
+							<Value>value1</Value>
+						</Tag>
+						</Filter>`,
+			expectedErr: nil,
+		},
+		{ // Filter with Prefix tag
+			inputXML: ` <Filter>
+							<Prefix>key-prefix</Prefix>
+						</Filter>`,
+			expectedErr: nil,
+		},
+		{ // Filter without And and multiple Tag tags
+			inputXML: ` <Filter>
+							<Prefix>key-prefix</Prefix>
+							<Tag>
+								<Key>key1</Key>
+								<Value>value1</Value>
+							</Tag>
+							<Tag>
+								<Key>key2</Key>
+								<Value>value2</Value>
+							</Tag>
+						</Filter>`,
+			expectedErr: errInvalidFilter,
+		},
+		{ // Filter with And, Prefix & multiple Tag tags
+			inputXML: ` <Filter>
+							<And>
+							<Prefix>key-prefix</Prefix>
+							<Tag>
+								<Key>key1</Key>
+								<Value>value1</Value>
+							</Tag>
+							<Tag>
+								<Key>key2</Key>
+								<Value>value2</Value>
+							</Tag>
+							</And>
+						</Filter>`,
+			expectedErr: nil,
+		},
+		{ // Filter with And and multiple Tag tags
+			inputXML: ` <Filter>
+							<And>
+							<Tag>
+								<Key>key1</Key>
+								<Value>value1</Value>
+							</Tag>
+							<Tag>
+								<Key>key2</Key>
+								<Value>value2</Value>
+							</Tag>
+							</And>
+						</Filter>`,
+			expectedErr: nil,
+		},
+		{ // Filter without And and single Tag tag
+			inputXML: ` <Filter>
+							<Prefix>key-prefix</Prefix>
+							<Tag>
+								<Key>key1</Key>
+								<Value>value1</Value>
+							</Tag>
+						</Filter>`,
+			expectedErr: errInvalidFilter,
 		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Test %d", i+1), func(t *testing.T) {
 			var filter Filter
 			err := xml.Unmarshal([]byte(tc.inputXML), &filter)
+			if err != nil {
+				t.Fatalf("%d: Expected no error but got %v", i+1, err)
+			}
+			err = filter.Validate()
 			if err != tc.expectedErr {
 				t.Fatalf("%d: Expected %v but got %v", i+1, tc.expectedErr, err)
 			}

--- a/pkg/bucket/lifecycle/noncurrentversion.go
+++ b/pkg/bucket/lifecycle/noncurrentversion.go
@@ -18,7 +18,6 @@ package lifecycle
 
 import (
 	"encoding/xml"
-	"errors"
 )
 
 // NoncurrentVersionExpiration - an action for lifecycle configuration rule.
@@ -34,8 +33,8 @@ type NoncurrentVersionTransition struct {
 }
 
 var (
-	errNoncurrentVersionExpirationUnsupported = errors.New("Specifying <NoncurrentVersionExpiration></NoncurrentVersionExpiration> is not supported")
-	errNoncurrentVersionTransitionUnsupported = errors.New("Specifying <NoncurrentVersionTransition></NoncurrentVersionTransition> is not supported")
+	errNoncurrentVersionExpirationUnsupported = Errorf("Specifying <NoncurrentVersionExpiration></NoncurrentVersionExpiration> is not supported")
+	errNoncurrentVersionTransitionUnsupported = Errorf("Specifying <NoncurrentVersionTransition></NoncurrentVersionTransition> is not supported")
 )
 
 // UnmarshalXML is extended to indicate lack of support for

--- a/pkg/bucket/lifecycle/tag.go
+++ b/pkg/bucket/lifecycle/tag.go
@@ -18,7 +18,6 @@ package lifecycle
 
 import (
 	"encoding/xml"
-	"errors"
 )
 
 // Tag - a tag for a lifecycle configuration Rule filter.
@@ -28,7 +27,7 @@ type Tag struct {
 	Value   string   `xml:"Value,omitempty"`
 }
 
-var errTagUnsupported = errors.New("Specifying <Tag></Tag> is not supported")
+var errTagUnsupported = Errorf("Specifying <Tag></Tag> is not supported")
 
 // UnmarshalXML is extended to indicate lack of support for Tag
 // xml tag in object lifecycle configuration

--- a/pkg/bucket/lifecycle/transition.go
+++ b/pkg/bucket/lifecycle/transition.go
@@ -18,7 +18,6 @@ package lifecycle
 
 import (
 	"encoding/xml"
-	"errors"
 )
 
 // Transition - transition actions for a rule in lifecycle configuration.
@@ -29,7 +28,7 @@ type Transition struct {
 	StorageClass string   `xml:"StorageClass"`
 }
 
-var errTransitionUnsupported = errors.New("Specifying <Transition></Transition> tag is not supported")
+var errTransitionUnsupported = Errorf("Specifying <Transition></Transition> tag is not supported")
 
 // UnmarshalXML is extended to indicate lack of support for Transition
 // xml tag in object lifecycle configuration

--- a/pkg/bucket/object/tagging/tag.go
+++ b/pkg/bucket/object/tagging/tag.go
@@ -18,14 +18,15 @@ package tagging
 
 import (
 	"encoding/xml"
+	"strings"
 	"unicode/utf8"
 )
 
 // Tag - single tag
 type Tag struct {
 	XMLName xml.Name `xml:"Tag"`
-	Key     string   `xml:"Key"`
-	Value   string   `xml:"Value"`
+	Key     string   `xml:"Key,omitempty"`
+	Value   string   `xml:"Value,omitempty"`
 }
 
 // Validate - validates the tag element
@@ -49,6 +50,10 @@ func (t Tag) validateKey() error {
 	if len(t.Key) == 0 {
 		return ErrInvalidTagKey
 	}
+	// Tag key shouldn't have "&"
+	if strings.Contains(t.Key, "&") {
+		return ErrInvalidTagKey
+	}
 	return nil
 }
 
@@ -58,5 +63,20 @@ func (t Tag) validateValue() error {
 	if utf8.RuneCountInString(t.Value) > maxTagValueLength {
 		return ErrInvalidTagValue
 	}
+	// Tag value shouldn't have "&"
+	if strings.Contains(t.Value, "&") {
+		return ErrInvalidTagValue
+	}
 	return nil
+}
+
+// IsEmpty - checks if tag is empty or not
+func (t Tag) IsEmpty() bool {
+	return t.Key == "" && t.Value == ""
+}
+
+// String - returns a string in format "tag1=value1" for the
+// current Tag
+func (t Tag) String() string {
+	return t.Key + "=" + t.Value
 }

--- a/pkg/bucket/object/tagging/tagging.go
+++ b/pkg/bucket/object/tagging/tagging.go
@@ -51,11 +51,11 @@ func (t Tagging) Validate() error {
 	if len(t.TagSet.Tags) > maxTags {
 		return ErrTooManyTags
 	}
+	if t.TagSet.ContainsDuplicateTag() {
+		return ErrInvalidTag
+	}
 	// Validate all the rules in the tagging config
 	for _, ts := range t.TagSet.Tags {
-		if t.TagSet.ContainsDuplicate(ts.Key) {
-			return ErrInvalidTag
-		}
 		if err := ts.Validate(); err != nil {
 			return err
 		}
@@ -71,8 +71,7 @@ func (t Tagging) String() string {
 		if buf.Len() > 0 {
 			buf.WriteString("&")
 		}
-		buf.WriteString(tag.Key + "=")
-		buf.WriteString(tag.Value)
+		buf.WriteString(tag.String())
 	}
 	return buf.String()
 }


### PR DESCRIPTION
## Description
This PR adds support for Object Tagging in LifeCycle configuration

## Motivation and Context
See #8870 

## How to test this PR?
- Add LifeCycle configuration with Object Tag fields.
- Upload objects with Object Tags
- Check if relevant objects get expired as configured in LifeCycle config

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
