### PR TITLE
Add missing error check in cache GetObjectNInfo

### DIFF
--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -284,6 +284,9 @@ func (c *cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	}
 
 	bkReader, bkErr := c.GetObjectNInfoFn(ctx, bucket, object, rs, h, lockType, opts)
+	if bkErr != nil {
+		return bkReader, bkErr
+	}
 	// Record if cache has a hit that was invalidated by ETag verification
 	if cacheErr == nil {
 		bkReader.ObjInfo.CacheLookupStatus = CacheHit


### PR DESCRIPTION
## Description


## Motivation and Context
Need to check if backend GetObjectNInfo call succeeded before accessing bkReader.ObjInfo

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
