### PR TITLE
Modify struct of LegalHold, Retention, Lock and Notification config to set default namespace

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -84,7 +84,6 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 			return
 		}
-		config.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
 		config.SetRegion(globalServerRegion)
 		notificationBytes, err := xml.Marshal(config)
 		if err != nil {
@@ -125,11 +124,6 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 			// never reach a stage where we will have stale
 			// notification configs.
 		}
-	}
-
-	// If xml namespace is empty, set a default value before returning.
-	if config.XMLNS == "" {
-		config.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
 	}
 
 	notificationBytes, err := xml.Marshal(config)

--- a/pkg/bucket/object/lock/lock.go
+++ b/pkg/bucket/object/lock/lock.go
@@ -233,8 +233,7 @@ func (dr *DefaultRetention) UnmarshalXML(d *xml.Decoder, start xml.StartElement)
 // Config - object lock configuration specified in
 // https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_ObjectLockConfiguration.html
 type Config struct {
-	XMLNS             string   `xml:"xmlns,attr,omitempty"`
-	XMLName           xml.Name `xml:"ObjectLockConfiguration"`
+	XMLName           xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ObjectLockConfiguration"`
 	ObjectLockEnabled string   `xml:"ObjectLockEnabled"`
 	Rule              *struct {
 		DefaultRetention DefaultRetention `xml:"DefaultRetention"`
@@ -336,8 +335,7 @@ func (rDate *RetentionDate) MarshalXML(e *xml.Encoder, startElement xml.StartEle
 // ObjectRetention specified in
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html
 type ObjectRetention struct {
-	XMLNS           string        `xml:"xmlns,attr,omitempty"`
-	XMLName         xml.Name      `xml:"Retention"`
+	XMLName         xml.Name      `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Retention"`
 	Mode            Mode          `xml:"Mode,omitempty"`
 	RetainUntilDate RetentionDate `xml:"RetainUntilDate,omitempty"`
 }
@@ -440,8 +438,7 @@ func GetObjectRetentionMeta(meta map[string]string) ObjectRetention {
 			retainTill = RetentionDate{t.UTC()}
 		}
 	}
-
-	return ObjectRetention{XMLNS: "http://s3.amazonaws.com/doc/2006-03-01/", Mode: mode, RetainUntilDate: retainTill}
+	return ObjectRetention{Mode: mode, RetainUntilDate: retainTill}
 }
 
 // GetObjectLegalHoldMeta constructs ObjectLegalHold from metadata
@@ -471,8 +468,7 @@ func ParseObjectLockLegalHoldHeaders(h http.Header) (lhold ObjectLegalHold, err 
 // ObjectLegalHold specified in
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html
 type ObjectLegalHold struct {
-	XMLNS   string          `xml:"xmlns,attr,omitempty"`
-	XMLName xml.Name        `xml:"LegalHold"`
+	XMLName xml.Name        `xml:"http://s3.amazonaws.com/doc/2006-03-01/ LegalHold"`
 	Status  LegalHoldStatus `xml:"Status,omitempty"`
 }
 

--- a/pkg/bucket/object/lock/lock.go
+++ b/pkg/bucket/object/lock/lock.go
@@ -440,7 +440,8 @@ func GetObjectRetentionMeta(meta map[string]string) ObjectRetention {
 			retainTill = RetentionDate{t.UTC()}
 		}
 	}
-	return ObjectRetention{Mode: mode, RetainUntilDate: retainTill}
+
+	return ObjectRetention{XMLNS: "http://s3.amazonaws.com/doc/2006-03-01/", Mode: mode, RetainUntilDate: retainTill}
 }
 
 // GetObjectLegalHoldMeta constructs ObjectLegalHold from metadata

--- a/pkg/bucket/object/lock/lock_test.go
+++ b/pkg/bucket/object/lock/lock_test.go
@@ -154,17 +154,17 @@ func TestParseObjectLockConfig(t *testing.T) {
 		expectErr   bool
 	}{
 		{
-			value:       "<ObjectLockConfiguration><ObjectLockEnabled>yes</ObjectLockEnabled></ObjectLockConfiguration>",
+			value:       "<ObjectLockConfiguration  xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\" ><ObjectLockEnabled>yes</ObjectLockEnabled></ObjectLockConfiguration>",
 			expectedErr: fmt.Errorf("only 'Enabled' value is allowd to ObjectLockEnabled element"),
 			expectErr:   true,
 		},
 		{
-			value:       "<ObjectLockConfiguration><ObjectLockEnabled>Enabled</ObjectLockEnabled><Rule><DefaultRetention><Mode>COMPLIANCE</Mode><Days>0</Days></DefaultRetention></Rule></ObjectLockConfiguration>",
+			value:       "<ObjectLockConfiguration  xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><ObjectLockEnabled>Enabled</ObjectLockEnabled><Rule><DefaultRetention><Mode>COMPLIANCE</Mode><Days>0</Days></DefaultRetention></Rule></ObjectLockConfiguration>",
 			expectedErr: fmt.Errorf("Default retention period must be a positive integer value for 'Days'"),
 			expectErr:   true,
 		},
 		{
-			value:       "<ObjectLockConfiguration><ObjectLockEnabled>Enabled</ObjectLockEnabled><Rule><DefaultRetention><Mode>COMPLIANCE</Mode><Days>30</Days></DefaultRetention></Rule></ObjectLockConfiguration>",
+			value:       "<ObjectLockConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><ObjectLockEnabled>Enabled</ObjectLockEnabled><Rule><DefaultRetention><Mode>COMPLIANCE</Mode><Days>30</Days></DefaultRetention></Rule></ObjectLockConfiguration>",
 			expectedErr: nil,
 			expectErr:   false,
 		},

--- a/pkg/event/config.go
+++ b/pkg/event/config.go
@@ -209,8 +209,7 @@ type topic struct {
 // Config - notification configuration described in
 // http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html
 type Config struct {
-	XMLNS      string   `xml:"xmlns,attr,omitempty"`
-	XMLName    xml.Name `xml:"NotificationConfiguration"`
+	XMLName    xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ NotificationConfiguration"`
 	QueueList  []Queue  `xml:"QueueConfiguration,omitempty"`
 	LambdaList []lambda `xml:"CloudFunctionConfiguration,omitempty"`
 	TopicList  []topic  `xml:"TopicConfiguration,omitempty"`
@@ -291,11 +290,6 @@ func ParseConfig(reader io.Reader, region string, targetList *TargetList) (*Conf
 	}
 
 	config.SetRegion(region)
-
-	// If xml namespace is empty, set a default value before returning.
-	if config.XMLNS == "" {
-		config.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
-	}
 
 	return &config, nil
 }

--- a/pkg/event/config_test.go
+++ b/pkg/event/config_test.go
@@ -398,7 +398,7 @@ func TestQueueToRulesMap(t *testing.T) {
 
 func TestConfigUnmarshalXML(t *testing.T) {
 	dataCase1 := []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration   xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -411,88 +411,88 @@ func TestConfigUnmarshalXML(t *testing.T) {
 `)
 
 	dataCase2 := []byte(`
-<NotificationConfiguration>
-   <QueueConfiguration>
-      <Id>1</Id>
-       <Filter>
-           <S3Key>
-               <FilterRule>
-                   <Name>prefix</Name>
-                   <Value>images/</Value>
-               </FilterRule>
-               <FilterRule>
-                   <Name>suffix</Name>
-                   <Value>jpg</Value>
-               </FilterRule>
-           </S3Key>
-      </Filter>
-      <Queue>arn:minio:sqs:us-east-1:1:webhook</Queue>
-      <Event>s3:ObjectCreated:Put</Event>
-   </QueueConfiguration>
-</NotificationConfiguration>
-`)
+	<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+	   <QueueConfiguration>
+	      <Id>1</Id>
+	       <Filter>
+	           <S3Key>
+	               <FilterRule>
+	                   <Name>prefix</Name>
+	                   <Value>images/</Value>
+	               </FilterRule>
+	               <FilterRule>
+	                   <Name>suffix</Name>
+	                   <Value>jpg</Value>
+	               </FilterRule>
+	           </S3Key>
+	      </Filter>
+	      <Queue>arn:minio:sqs:us-east-1:1:webhook</Queue>
+	      <Event>s3:ObjectCreated:Put</Event>
+	   </QueueConfiguration>
+	</NotificationConfiguration>
+	`)
 
 	dataCase3 := []byte(`
-<NotificationConfiguration>
-   <QueueConfiguration>
-      <Id>1</Id>
-      <Filter></Filter>
-      <Queue>arn:minio:sqs:us-east-1:1:webhook</Queue>
-      <Event>s3:ObjectAccessed:*</Event>
-      <Event>s3:ObjectCreated:*</Event>
-      <Event>s3:ObjectRemoved:*</Event>
-   </QueueConfiguration>
-   <QueueConfiguration>
-      <Id>2</Id>
-       <Filter>
-           <S3Key>
-               <FilterRule>
-                   <Name>prefix</Name>
-                   <Value>images/</Value>
-               </FilterRule>
-               <FilterRule>
-                   <Name>suffix</Name>
-                   <Value>jpg</Value>
-               </FilterRule>
-           </S3Key>
-      </Filter>
-      <Queue>arn:minio:sqs:us-east-1:1:webhook</Queue>
-      <Event>s3:ObjectCreated:Put</Event>
-   </QueueConfiguration>
-</NotificationConfiguration>
-`)
+	<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+	   <QueueConfiguration>
+	      <Id>1</Id>
+	      <Filter></Filter>
+	      <Queue>arn:minio:sqs:us-east-1:1:webhook</Queue>
+	      <Event>s3:ObjectAccessed:*</Event>
+	      <Event>s3:ObjectCreated:*</Event>
+	      <Event>s3:ObjectRemoved:*</Event>
+	   </QueueConfiguration>
+	   <QueueConfiguration>
+	      <Id>2</Id>
+	       <Filter>
+	           <S3Key>
+	               <FilterRule>
+	                   <Name>prefix</Name>
+	                   <Value>images/</Value>
+	               </FilterRule>
+	               <FilterRule>
+	                   <Name>suffix</Name>
+	                   <Value>jpg</Value>
+	               </FilterRule>
+	           </S3Key>
+	      </Filter>
+	      <Queue>arn:minio:sqs:us-east-1:1:webhook</Queue>
+	      <Event>s3:ObjectCreated:Put</Event>
+	   </QueueConfiguration>
+	</NotificationConfiguration>
+	`)
 
 	dataCase4 := []byte(`
-<NotificationConfiguration>
-   <QueueConfiguration>
-      <Id>1</Id>
-      <Filter></Filter>
-      <Queue>arn:minio:sqs:us-east-1:1:webhook</Queue>
-      <Event>s3:ObjectAccessed:*</Event>
-      <Event>s3:ObjectCreated:*</Event>
-      <Event>s3:ObjectRemoved:*</Event>
-   </QueueConfiguration>
-   <CloudFunctionConfiguration>
-      <Id>1</Id>
-      <Filter>
-             <S3Key>
-                 <FilterRule>
-                     <Name>suffix</Name>
-                     <Value>.jpg</Value>
-                 </FilterRule>
-             </S3Key>
-      </Filter>
-      <Cloudcode>arn:aws:lambda:us-west-2:444455556666:cloud-function-A</Cloudcode>
-      <Event>s3:ObjectCreated:Put</Event>
-   </CloudFunctionConfiguration>
-   <TopicConfiguration>
-      <Topic>arn:aws:sns:us-west-2:444455556666:sns-notification-one</Topic>
-      <Event>s3:ObjectCreated:*</Event>
-  </TopicConfiguration>
-</NotificationConfiguration>
-`)
+	<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+	   <QueueConfiguration>
+	      <Id>1</Id>
+	      <Filter></Filter>
+	      <Queue>arn:minio:sqs:us-east-1:1:webhook</Queue>
+	      <Event>s3:ObjectAccessed:*</Event>
+	      <Event>s3:ObjectCreated:*</Event>
+	      <Event>s3:ObjectRemoved:*</Event>
+	   </QueueConfiguration>
+	   <CloudFunctionConfiguration>
+	      <Id>1</Id>
+	      <Filter>
+	             <S3Key>
+	                 <FilterRule>
+	                     <Name>suffix</Name>
+	                     <Value>.jpg</Value>
+	                 </FilterRule>
+	             </S3Key>
+	      </Filter>
+	      <Cloudcode>arn:aws:lambda:us-west-2:444455556666:cloud-function-A</Cloudcode>
+	      <Event>s3:ObjectCreated:Put</Event>
+	   </CloudFunctionConfiguration>
+	   <TopicConfiguration>
+	      <Topic>arn:aws:sns:us-west-2:444455556666:sns-notification-one</Topic>
+	      <Event>s3:ObjectCreated:*</Event>
+	  </TopicConfiguration>
+	</NotificationConfiguration>
+	`)
 
-	dataCase5 := []byte(`<NotificationConfiguration></NotificationConfiguration>`)
+	dataCase5 := []byte(`<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/" ></NotificationConfiguration>`)
 
 	testCases := []struct {
 		data      []byte
@@ -518,7 +518,7 @@ func TestConfigUnmarshalXML(t *testing.T) {
 
 func TestConfigValidate(t *testing.T) {
 	data := []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -535,7 +535,7 @@ func TestConfigValidate(t *testing.T) {
 	}
 
 	data = []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
        <Filter>
@@ -561,7 +561,7 @@ func TestConfigValidate(t *testing.T) {
 	}
 
 	data = []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -625,7 +625,7 @@ func TestConfigValidate(t *testing.T) {
 
 func TestConfigSetRegion(t *testing.T) {
 	data := []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -642,7 +642,7 @@ func TestConfigSetRegion(t *testing.T) {
 	}
 
 	data = []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
        <Filter>
@@ -668,7 +668,7 @@ func TestConfigSetRegion(t *testing.T) {
 	}
 
 	data = []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -729,7 +729,7 @@ func TestConfigSetRegion(t *testing.T) {
 
 func TestConfigToRulesMap(t *testing.T) {
 	data := []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -746,7 +746,7 @@ func TestConfigToRulesMap(t *testing.T) {
 	}
 
 	data = []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
        <Filter>
@@ -772,7 +772,7 @@ func TestConfigToRulesMap(t *testing.T) {
 	}
 
 	data = []byte(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -832,7 +832,7 @@ func TestConfigToRulesMap(t *testing.T) {
 
 func TestParseConfig(t *testing.T) {
 	reader1 := strings.NewReader(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -845,7 +845,7 @@ func TestParseConfig(t *testing.T) {
 `)
 
 	reader2 := strings.NewReader(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
        <Filter>
@@ -867,7 +867,7 @@ func TestParseConfig(t *testing.T) {
 `)
 
 	reader3 := strings.NewReader(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>
@@ -897,7 +897,7 @@ func TestParseConfig(t *testing.T) {
 `)
 
 	reader4 := strings.NewReader(`
-<NotificationConfiguration>
+<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <QueueConfiguration>
       <Id>1</Id>
       <Filter></Filter>


### PR DESCRIPTION
## Description
 Set retention  namespace for ObjectRetention
The name space is correct as per AWS  . Refer https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html.

This PR is on the very same line as  PR https://github.com/minio/minio/pull/6789 which was to resolve the issue https://github.com/minio/minio-java/issues/710


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
