### PR TITLE
Avoid unnecessary statPart() calls in PutObjectPart

### DIFF
--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -40,7 +40,7 @@ const erasureAlgorithmKlauspost = "klauspost/reedsolomon/vandermonde"
 type ObjectPartInfo struct {
 	Number     int    `json:"number"`
 	Name       string `json:"name"`
-	ETag       string `json:"etag"`
+	ETag       string `json:"etag,omitempty"`
 	Size       int64  `json:"size"`
 	ActualSize int64  `json:"actualSize"`
 }


### PR DESCRIPTION


## Description
Avoid unnecessary statPart() calls in PutObjectPart

## Motivation and Context
Assume `xl.json` as the source of truth for all operations.

## How to test this PR?
Nothing new, it's an optimization

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
