### PR TITLE
Fix Retention, ObjectLock, LegalHold struct namespaces

### DIFF
--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -85,6 +85,7 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 			return
 		}
 		config.SetRegion(globalServerRegion)
+		config.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
 		notificationBytes, err := xml.Marshal(config)
 		if err != nil {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
@@ -124,6 +125,11 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 			// never reach a stage where we will have stale
 			// notification configs.
 		}
+	}
+
+	// If xml namespace is empty, set a default value before returning.
+	if config.XMLNS == "" {
+		config.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
 	}
 
 	notificationBytes, err := xml.Marshal(config)

--- a/pkg/bucket/object/lock/lock.go
+++ b/pkg/bucket/object/lock/lock.go
@@ -233,7 +233,8 @@ func (dr *DefaultRetention) UnmarshalXML(d *xml.Decoder, start xml.StartElement)
 // Config - object lock configuration specified in
 // https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_ObjectLockConfiguration.html
 type Config struct {
-	XMLName           xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ObjectLockConfiguration"`
+	XMLNS             string   `xml:"xmlns,attr,omitempty"`
+	XMLName           xml.Name `xml:"ObjectLockConfiguration"`
 	ObjectLockEnabled string   `xml:"ObjectLockEnabled"`
 	Rule              *struct {
 		DefaultRetention DefaultRetention `xml:"DefaultRetention"`
@@ -335,7 +336,8 @@ func (rDate *RetentionDate) MarshalXML(e *xml.Encoder, startElement xml.StartEle
 // ObjectRetention specified in
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html
 type ObjectRetention struct {
-	XMLName         xml.Name      `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Retention"`
+	XMLNS           string        `xml:"xmlns,attr,omitempty"`
+	XMLName         xml.Name      `xml:"Retention"`
 	Mode            Mode          `xml:"Mode,omitempty"`
 	RetainUntilDate RetentionDate `xml:"RetainUntilDate,omitempty"`
 }
@@ -438,7 +440,7 @@ func GetObjectRetentionMeta(meta map[string]string) ObjectRetention {
 			retainTill = RetentionDate{t.UTC()}
 		}
 	}
-	return ObjectRetention{Mode: mode, RetainUntilDate: retainTill}
+	return ObjectRetention{XMLNS: "http://s3.amazonaws.com/doc/2006-03-01/", Mode: mode, RetainUntilDate: retainTill}
 }
 
 // GetObjectLegalHoldMeta constructs ObjectLegalHold from metadata
@@ -446,7 +448,7 @@ func GetObjectLegalHoldMeta(meta map[string]string) ObjectLegalHold {
 
 	holdStr, ok := meta[strings.ToLower(xhttp.AmzObjectLockLegalHold)]
 	if ok {
-		return ObjectLegalHold{Status: parseLegalHoldStatus(holdStr)}
+		return ObjectLegalHold{XMLNS: "http://s3.amazonaws.com/doc/2006-03-01/", Status: parseLegalHoldStatus(holdStr)}
 	}
 	return ObjectLegalHold{}
 }
@@ -468,7 +470,8 @@ func ParseObjectLockLegalHoldHeaders(h http.Header) (lhold ObjectLegalHold, err 
 // ObjectLegalHold specified in
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectLegalHold.html
 type ObjectLegalHold struct {
-	XMLName xml.Name        `xml:"http://s3.amazonaws.com/doc/2006-03-01/ LegalHold"`
+	XMLNS   string          `xml:"xmlns,attr,omitempty"`
+	XMLName xml.Name        `xml:"LegalHold"`
 	Status  LegalHoldStatus `xml:"Status,omitempty"`
 }
 
@@ -480,6 +483,9 @@ func ParseObjectLegalHold(reader io.Reader) (hold *ObjectLegalHold, err error) {
 
 	if hold.Status != ON && hold.Status != OFF {
 		return nil, ErrMalformedXML
+	}
+	if hold.XMLNS == "" {
+		hold.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
 	}
 	return
 }

--- a/pkg/event/config.go
+++ b/pkg/event/config.go
@@ -209,7 +209,8 @@ type topic struct {
 // Config - notification configuration described in
 // http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html
 type Config struct {
-	XMLName    xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ NotificationConfiguration"`
+	XMLNS      string   `xml:"xmlns,attr,omitempty"`
+	XMLName    xml.Name `xml:"NotificationConfiguration"`
 	QueueList  []Queue  `xml:"QueueConfiguration,omitempty"`
 	LambdaList []lambda `xml:"CloudFunctionConfiguration,omitempty"`
 	TopicList  []topic  `xml:"TopicConfiguration,omitempty"`
@@ -290,6 +291,9 @@ func ParseConfig(reader io.Reader, region string, targetList *TargetList) (*Conf
 	}
 
 	config.SetRegion(region)
-
+	//If xml namespace is empty, set a default value before returning.
+	if config.XMLNS == "" {
+		config.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
+	}
 	return &config, nil
 }

--- a/pkg/event/config_test.go
+++ b/pkg/event/config_test.go
@@ -433,7 +433,7 @@ func TestConfigUnmarshalXML(t *testing.T) {
 	`)
 
 	dataCase3 := []byte(`
-	<NotificationConfiguration  xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+	<NotificationConfiguration>
 	   <QueueConfiguration>
 	      <Id>1</Id>
 	      <Filter></Filter>


### PR DESCRIPTION
correctly.

Reverts #8903 to allow structs to
be unmarshaled even if namespace is missing.

## Description


## Motivation and Context
The previous fix #8903 will prevent server starting correctly if a preexisting ObjectLockConfiguration for example is missing the xml namespace string.

## How to test this PR?
Go to a commit older than 5bd0e95eefd8a1b055e6ab128a528291a53c8cfc and create a bucket with object lock enabled and default lock configuration.
```
mc mb myminio/bucket --with-lock
mc lock myminio/bucket compliance 30d
```
Now restart the server with current master - it would fail to start with
```
Server startup failed with 'Unable to initialize notification system: expected element <ObjectLockConfiguration> in name space http://s3.amazonaws.com/doc/2006-03-01/ but have no name space'
Server switching to safe mode
Please use 'mc admin config' commands fix this issue

```
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
