### PR TITLE
Fix panic in ServerInfoHandler 

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1470,10 +1470,13 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 }
 
 func fetchLambdaInfo(cfg config.Config) []map[string][]madmin.TargetIDStatus {
-	lambdaMap := make(map[string][]madmin.TargetIDStatus)
 
 	// Fetch the targets
-	targetList, _ := notify.RegisterNotificationTargets(cfg, GlobalServiceDoneCh, NewCustomHTTPTransport(), nil, true)
+	targetList, err := notify.RegisterNotificationTargets(cfg, GlobalServiceDoneCh, NewCustomHTTPTransport(), nil, true)
+	if err != nil {
+		return nil
+	}
+	lambdaMap := make(map[string][]madmin.TargetIDStatus)
 
 	for targetID, target := range targetList.TargetMap() {
 		targetIDStatus := make(map[string]madmin.Status)


### PR DESCRIPTION
when fetching notification target info.

## Description


## Motivation and Context
Panic is encountered if one of the notification targets is down 

## How to test this PR?
1. configure a notification target like elasticsearch with `mc admin event add`, then kill the elasticsearch instance.
2. 
```
mc admin config reset myminio notify_elastic
mc admin service restart myminio
```
On restart the server crashes 
```
➜  minio git:(tracebody) ./minio server ~/export

API: SYSTEM()
Time: 12:51:45 PST 01/30/2020
DeploymentID: a0e26cbc-048e-4f81-be50-fba60c333072
Error: Unable to initialize notification target(s): Post http://127.0.0.1:9200: dial tcp 127.0.0.1:9200: connect: connection refused
       7: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:429:cmd.lookupConfigs()
       6: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:544:cmd.loadConfig()
       5: /home/kp/code/src/github.com/minio/minio/cmd/config.go:281:cmd.initConfig()
       4: /home/kp/code/src/github.com/minio/minio/cmd/config.go:228:cmd.(*ConfigSys).Init()
       3: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:218:cmd.initAllSubsystems()
       2: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:209:cmd.initSafeMode()
       1: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:376:cmd.serverMain()

API: SYSTEM()
Time: 12:51:45 PST 01/30/2020
DeploymentID: a0e26cbc-048e-4f81-be50-fba60c333072
Error: Unable to initialize notification target(s): Post http://127.0.0.1:9200: dial tcp 127.0.0.1:9200: connect: connection refused
       7: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:429:cmd.lookupConfigs()
       6: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:544:cmd.loadConfig()
       5: /home/kp/code/src/github.com/minio/minio/cmd/config.go:281:cmd.initConfig()
       4: /home/kp/code/src/github.com/minio/minio/cmd/config.go:228:cmd.(*ConfigSys).Init()
       3: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:218:cmd.initAllSubsystems()
       2: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:209:cmd.initSafeMode()
       1: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:376:cmd.serverMain()
%v $w &{ { }  <nil>}
%v $w &{ { }  <nil>}
Endpoint:  http://192.168.1.196:9000  http://172.16.238.1:9000  http://172.17.0.1:9000  http://172.18.0.1:9000  http://192.168.122.1:9000  http://127.0.0.1:9000          
AccessKey: minio 
SecretKey: minio123 

Browser Access:
   http://192.168.1.196:9000  http://172.16.238.1:9000  http://172.17.0.1:9000  http://172.18.0.1:9000  http://192.168.122.1:9000  http://127.0.0.1:9000          

Command-line Access: https://docs.min.io/docs/minio-client-quickstart-guide
   $ mc config host add myminio http://192.168.1.196:9000 minio minio123

Object API (Amazon S3 compatible):
   Go:         https://docs.min.io/docs/golang-client-quickstart-guide
   Java:       https://docs.min.io/docs/java-client-quickstart-guide
   Python:     https://docs.min.io/docs/python-client-quickstart-guide
   JavaScript: https://docs.min.io/docs/javascript-client-quickstart-guide
   .NET:       https://docs.min.io/docs/dotnet-client-quickstart-guide
Restarting on service signal

API: SYSTEM()
Time: 12:52:11 PST 01/30/2020
DeploymentID: a0e26cbc-048e-4f81-be50-fba60c333072
Error: Unable to initialize notification target(s): Post http://127.0.0.1:9200: dial tcp 127.0.0.1:9200: connect: connection refused
       7: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:429:cmd.lookupConfigs()
       6: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:544:cmd.loadConfig()
       5: /home/kp/code/src/github.com/minio/minio/cmd/config.go:281:cmd.initConfig()
       4: /home/kp/code/src/github.com/minio/minio/cmd/config.go:228:cmd.(*ConfigSys).Init()
       3: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:218:cmd.initAllSubsystems()
       2: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:209:cmd.initSafeMode()
       1: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:376:cmd.serverMain()

API: SYSTEM()
Time: 12:52:11 PST 01/30/2020
DeploymentID: a0e26cbc-048e-4f81-be50-fba60c333072
Error: Unable to initialize notification target(s): Post http://127.0.0.1:9200: dial tcp 127.0.0.1:9200: connect: connection refused
       7: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:429:cmd.lookupConfigs()
       6: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:544:cmd.loadConfig()
       5: /home/kp/code/src/github.com/minio/minio/cmd/config.go:281:cmd.initConfig()
       4: /home/kp/code/src/github.com/minio/minio/cmd/config.go:228:cmd.(*ConfigSys).Init()
       3: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:218:cmd.initAllSubsystems()
       2: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:209:cmd.initSafeMode()
       1: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:376:cmd.serverMain()
Endpoint:  http://192.168.1.196:9000  http://172.16.238.1:9000  http://172.17.0.1:9000  http://172.18.0.1:9000  http://192.168.122.1:9000  http://127.0.0.1:9000          
AccessKey: minio 
SecretKey: minio123 

Browser Access:
   http://192.168.1.196:9000  http://172.16.238.1:9000  http://172.17.0.1:9000  http://172.18.0.1:9000  http://192.168.122.1:9000  http://127.0.0.1:9000          

Command-line Access: https://docs.min.io/docs/minio-client-quickstart-guide
   $ mc config host add myminio http://192.168.1.196:9000 minio minio123

Object API (Amazon S3 compatible):
   Go:         https://docs.min.io/docs/golang-client-quickstart-guide
   Java:       https://docs.min.io/docs/java-client-quickstart-guide
   Python:     https://docs.min.io/docs/python-client-quickstart-guide
   JavaScript: https://docs.min.io/docs/javascript-client-quickstart-guide
   .NET:       https://docs.min.io/docs/dotnet-client-quickstart-guide
2020/01/30 12:52:16 http: panic serving 127.0.0.1:39950: runtime error: invalid memory address or nil pointer dereference
goroutine 963 [running]:
net/http.(*conn).serve.func1(0xc0001f8be0)
	/usr/local/go/src/net/http/server.go:1767 +0x139
panic(0x18809c0, 0x3086940)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/minio/minio/cmd.criticalErrorHandler.ServeHTTP.func1(0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:776 +0x248
panic(0x18809c0, 0x3086940)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
sync.(*RWMutex).RLock(...)
	/usr/local/go/src/sync/rwmutex.go:48
github.com/minio/minio/pkg/event.(*TargetList).TargetMap(0x0, 0x0)
	/home/kp/code/src/github.com/minio/minio/pkg/event/targetlist.go:136 +0x35
github.com/minio/minio/cmd.fetchLambdaInfo(0xc000898090, 0x0, 0x0, 0x0)
	/home/kp/code/src/github.com/minio/minio/cmd/admin-handlers.go:1478 +0xda
github.com/minio/minio/cmd.adminAPIHandlers.ServerInfoHandler(0x1e3f400, 0xc0002d40a0, 0xc000906e00)
	/home/kp/code/src/github.com/minio/minio/cmd/admin-handlers.go:1361 +0x2db
net/http.HandlerFunc.ServeHTTP(...)
	/usr/local/go/src/net/http/server.go:2007
github.com/minio/minio/cmd.httpTraceAll.func1(0x1e3f400, 0xc0002d40a0, 0xc000906e00)
	/home/kp/code/src/github.com/minio/minio/cmd/handler-utils.go:339 +0x148
net/http.HandlerFunc.ServeHTTP(0xc000360f20, 0x1e3f400, 0xc0002d40a0, 0xc000906e00)
	/usr/local/go/src/net/http/server.go:2007 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00065c000, 0x1e3f400, 0xc0002d40a0, 0xc00021c200)
	/home/kp/go/pkg/mod/github.com/gorilla/mux@v1.7.0/mux.go:213 +0xe2
github.com/minio/minio/cmd.customHeaderHandler.ServeHTTP(0x1e10360, 0xc00065c000, 0x1e3f180, 0xc000596500, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:747 +0x162
github.com/minio/minio/cmd.securityHeaderHandler.ServeHTTP(0x1e13a60, 0xc000647c40, 0x1e3f180, 0xc000596500, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:762 +0x1d6
github.com/minio/minio/cmd.bucketForwardingHandler.ServeHTTP(0xc000774ba0, 0x1e13ba0, 0xc000647c60, 0x1e3f180, 0xc000596500, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:623 +0xcc
github.com/minio/minio/cmd.requestValidityHandler.ServeHTTP(0x1e139e0, 0xc00016a7e0, 0x1e3f180, 0xc000596500, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:607 +0x58f
github.com/minio/minio/cmd.httpStatsHandler.ServeHTTP(0x1e13b40, 0xc000647c90, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:543 +0x106
github.com/minio/minio/cmd.requestSizeLimitHandler.ServeHTTP(0x1e13a80, 0xc000647ca0, 0x50004000000, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:68 +0xcf
github.com/minio/minio/cmd.requestHeaderSizeLimitHandler.ServeHTTP(0x1e13b20, 0xc00016a800, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:93 +0x264
github.com/minio/minio/cmd.crossDomainPolicy.ServeHTTP(0x1e13b00, 0xc000647cc0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/crossdomain-xml-handler.go:51 +0x81
github.com/minio/minio/cmd.redirectHandler.ServeHTTP(0x1e13a40, 0xc000647cd0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:247 +0x68
github.com/minio/minio/cmd.minioReservedBucketHandler.ServeHTTP(0x1e13ae0, 0xc000647cf0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:315 +0xac
github.com/minio/minio/cmd.cacheControlHandler.ServeHTTP(0x1e13ac0, 0xc000647d00, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:274 +0x1c2
github.com/minio/minio/cmd.timeValidityHandler.ServeHTTP(0x1e13a00, 0xc000647d20, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:385 +0x32a
github.com/rs/cors.(*Cors).Handler.func1(0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/go/pkg/mod/github.com/rs/cors@v1.6.0/cors.go:207 +0x1af
net/http.HandlerFunc.ServeHTTP(0xc00016a8a0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/usr/local/go/src/net/http/server.go:2007 +0x44
github.com/minio/minio/cmd.resourceHandler.ServeHTTP(0x1e14620, 0xc00016a8a0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:523 +0xa8
github.com/minio/minio/cmd.authHandler.ServeHTTP(0x1e13b80, 0xc000647da0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/auth-handler.go:472 +0x392
github.com/minio/minio/cmd.sseTLSHandler.ServeHTTP(0x1e139c0, 0xc000647dc0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:797 +0x454
github.com/minio/minio/cmd.reservedMetadataHandler.ServeHTTP(0x1e13bc0, 0xc000647dd0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:136 +0x264
github.com/minio/minio/cmd.criticalErrorHandler.ServeHTTP(0x1e13b60, 0xc000647df0, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:779 +0xac
github.com/minio/minio/cmd/http.(*Server).Start.func1(0x1e41780, 0xc0002322a0, 0xc00021c200)
	/home/kp/code/src/github.com/minio/minio/cmd/http/server.go:104 +0x2ab
net/http.HandlerFunc.ServeHTTP(0xc0001a8b80, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/usr/local/go/src/net/http/server.go:2007 +0x44
net/http.serverHandler.ServeHTTP(0xc0003b4480, 0x1e41780, 0xc0002322a0, 0xc00021c200)
	/usr/local/go/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc0001f8be0, 0x1e49200, 0xc00008c500)
	/usr/local/go/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2927 +0x38e
2020/01/30 12:52:16 http: panic serving 127.0.0.1:39954: runtime error: invalid memory address or nil pointer dereference
goroutine 968 [running]:
net/http.(*conn).serve.func1(0xc0000cda40)
	/usr/local/go/src/net/http/server.go:1767 +0x139
panic(0x18809c0, 0x3086940)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/minio/minio/cmd.criticalErrorHandler.ServeHTTP.func1(0x1e41780, 0xc000232380, 0xc00036db00)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:776 +0x248
panic(0x18809c0, 0x3086940)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
sync.(*RWMutex).RLock(...)
	/usr/local/go/src/sync/rwmutex.go:48
github.com/minio/minio/pkg/event.(*TargetList).TargetMap(0x0, 0x0)
	/home/kp/code/src/github.com/minio/minio/pkg/event/targetlist.go:136 +0x35
github.com/minio/minio/cmd.fetchLambdaInfo(0xc000259770, 0x0, 0x0, 0x0)
	/home/kp/code/src/github.com/minio/minio/cmd/admin-handlers.go:1478 +0xda
github.com/minio/minio/cmd.adminAPIHandlers.ServerInfoHandler(0x1e3f400, 0xc00028c6e0, 0xc000906100)
	/home/kp/code/src/github.com/minio/minio/cmd/admin-handlers.go:1361 +0x2db
net/http.HandlerFunc.ServeHTTP(...)
```
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
