### PR TITLE
NAS gateway: fix notification initialization

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -243,12 +243,16 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	// sub-systems, make sure that we do not move the above codeblock elsewhere.
 	if enableConfigOps {
 		logger.FatalIf(globalConfigSys.Init(newObject), "Unable to initialize config system")
+		buckets, err := newObject.ListBuckets(context.Background())
+		if err != nil {
+			logger.Fatal(err, "Unable to list buckets")
+		}
 
+		logger.FatalIf(globalNotificationSys.Init(buckets, newObject), "Unable to initialize notification system")
 		// Start watching disk for reloading config, this
 		// is only enabled for "NAS" gateway.
 		globalConfigSys.WatchConfigNASDisk(newObject)
 	}
-
 	// This is only to uniquely identify each gateway deployments.
 	globalDeploymentID = env.Get("MINIO_GATEWAY_DEPLOYMENT_ID", mustGetUUID())
 	logger.SetDeploymentID(globalDeploymentID)

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -704,7 +704,7 @@ func (sys *NotificationSys) Init(buckets []BucketInfo, objAPI ObjectLayer) error
 	}
 
 	// In gateway mode, notifications are not supported.
-	if globalIsGateway {
+	if globalIsGateway && !objAPI.IsNotificationSupported() {
 		return nil
 	}
 


### PR DESCRIPTION
## Description


## Motivation and Context

NAS gateway notification initialization is not working
```
mc event add myminio/testbucket arn:minio:sqs::_:elasticsearch --event put 
mc: <ERROR> Cannot enable notification on the specified bucket. An object key name filtering rule defined with overlapping prefixes, overlapping suffixes, or overlapping combinations of prefixes and suffixes for the same event types.
➜  config 

```
## How to test this PR?
configure elasticsearch using `mc admin config set myminio notify_elasticsearch` and then try adding a notification configuration on a bucket as above. It should succeed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) From recent config updates.
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
