### PR TITLE
Set default endpoint for IAM Provider

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -154,6 +154,7 @@ var defaultAWSCredProviders = []credentials.Provider{
 		Client: &http.Client{
 			Transport: minio.NewCustomHTTPTransport(),
 		},
+		Endpoint: "http://169.254.169.254",
 	},
 	&credentials.EnvMinio{},
 }


### PR DESCRIPTION
## Description
This sets the default IAM credential endpoint.

## Motivation and Context
This is needed to resolve minio/minio-go#1223.

## How to test this PR?
Compile the code, run it on an EC2 instance (`minio gateway s3`) which is configured to use IAM roles to access S3. Note that minio/minio-go#1224 is needed for this to compile correctly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
