### PR TITLE
fix a crash in base64 buffer pool

### DIFF
--- a/cmd/jwt/parser.go
+++ b/cmd/jwt/parser.go
@@ -57,7 +57,7 @@ var (
 func init() {
 	base64BufPool = sync.Pool{
 		New: func() interface{} {
-			buf := make([]byte, 1024)
+			buf := make([]byte, 8192)
 			return &buf
 		},
 	}


### PR DESCRIPTION
## Description
fix a crash in base64 buffer pool

## Motivation and Context
looks like 1024 buffer size is not enough in
all situations, use 8192 instead which
can satisfy all the rare situations that
may arise in base64 decoding.

## How to test this PR?
Reproduced using warp GET benchmark in a distributed setup

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably yes but this is a functionality change anyways introduced in bfe8a9bccccb86233bf627f4627c724a70e4a188
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
