### PR TITLE
fix: multi-delete API write quorum failures

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -245,7 +245,7 @@ func (client *storageRESTClient) AppendFile(volume, path string, buffer []byte) 
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)
 	values.Set(storageRESTFilePath, path)
-	reader := bytes.NewBuffer(buffer)
+	reader := bytes.NewReader(buffer)
 	respBody, err := client.call(storageRESTMethodAppendFile, values, reader, -1)
 	defer http.DrainBody(respBody)
 	return err
@@ -405,10 +405,14 @@ func (client *storageRESTClient) DeleteFileBulk(volume string, paths []string) (
 	}
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)
+
+	var buffer bytes.Buffer
 	for _, path := range paths {
-		values.Add(storageRESTFilePath, path)
+		buffer.WriteString(path)
+		buffer.WriteString("\n")
 	}
-	respBody, err := client.call(storageRESTMethodDeleteFileBulk, values, nil, -1)
+
+	respBody, err := client.call(storageRESTMethodDeleteFileBulk, values, &buffer, -1)
 	defer http.DrainBody(respBody)
 
 	if err != nil {

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -17,7 +17,7 @@
 package cmd
 
 const (
-	storageRESTVersion       = "v13" // Introduced StorageErr error type.
+	storageRESTVersion       = "v14" // DeleteFileBulk API change
 	storageRESTVersionPrefix = SlashSeparator + storageRESTVersion
 	storageRESTPrefix        = minioReservedBucketPath + "/storage"
 )


### PR DESCRIPTION

## Description
fix: multi-delete API write quorum failures

## Motivation and Context
multi-delete API failed with write quorum errors
under following situations

- list of files requested for delete doesn't exist
  anymore can lead to quorum errors and failure
- due to usage of query param for paths, for really
  long paths MinIO server rejects these requests as
  malformed as unexpected.

This was reproduced with warp

## How to test this PR?
Use warp `get` benchmark on a distributed setup

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes since we moved to DeleteFileBulk as a remote API
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
