### PR TITLE
usage: Fix buckets count calculation when no object is present

### DIFF
--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -227,8 +227,10 @@ func (xl xlObjects) CrawlAndGetDataUsage(ctx context.Context, endCh <-chan struc
 	}
 	wg.Wait()
 
-	var dataUsageInfo DataUsageInfo
-	for i := 0; i < len(dataUsageResults); i++ {
+	var dataUsageInfo = dataUsageResults[0]
+	// Pick the crawling result of the disk which has the most
+	// number of objects in it.
+	for i := 1; i < len(dataUsageResults); i++ {
 		if dataUsageResults[i].ObjectsCount > dataUsageInfo.ObjectsCount {
 			dataUsageInfo = dataUsageResults[i]
 		}


### PR DESCRIPTION
## Description
XL crawling wrongly returns a zero buckets count when there is
no objects uploaded in the server yet. The reason is data
of the crawler of posix returns invalid result when all disks has zero objects.

A simple fix is to always pick the crawling result of the first disk
but choose over the result of the disk which has the most objects in it.



## Motivation and Context
Fix counting the number of buckets when no object is uploaded

## How to test this PR?
1. `minio server /tmp/xl/{1..4}`
2. `mc mb myminio/bucket1; mc mb myminio/bucket2`
3. `killall minio; rm -r /tmp/xl/*/.minio.sys/background-ops/data-usage`
4. `minio server /tmp/xl/{1..4}  # start MinIO server again
5. `mc admin info myminio/`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
