### PR TITLE
Add canned `diagnostics` policy for admin users

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1392,6 +1392,10 @@ func setDefaultCannedPolicies(policies map[string]iampolicy.Policy) {
 	if !ok {
 		policies["readwrite"] = iampolicy.ReadWrite
 	}
+	_, ok = policies["diagnostics"]
+	if !ok {
+		policies["diagnostics"] = iampolicy.AdminDiagnostics
+	}
 }
 
 // buildUserGroupMemberships - builds the memberships map. IMPORTANT:

--- a/pkg/iam/policy/constants.go
+++ b/pkg/iam/policy/constants.go
@@ -64,3 +64,16 @@ var WriteOnly = Policy{
 		},
 	},
 }
+
+// AdminDiagnostics - provides admin diagnostics access.
+var AdminDiagnostics = Policy{
+	Version: DefaultVersion,
+	Statements: []Statement{
+		{
+			SID:       policy.ID(""),
+			Effect:    policy.Allow,
+			Actions:   NewActionSet(PerfInfoAdminAction, ProfilingAdminAction, TraceAdminAction, ConsoleLogAdminAction, ServerInfoAdminAction, ServerHardwareInfoAdminAction),
+			Resources: NewResourceSet(NewResource("*", "")),
+		},
+	},
+}


### PR DESCRIPTION
## Description


## Motivation and Context
Create a canned policy called `diagnostics` for access to admin trace, console logs, profiling and server info for user convenience

## How to test this PR?
Start minio with this patch, `mc admin policy list myminio` should show the new policy and you should be able to set this policy on a user.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
