### PR TITLE
Custom names for public and private key files

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -130,6 +130,13 @@ func handleCommonCmdArgs(ctx *cli.Context) {
 		logger.EnableAnonymous()
 	}
 
+	if ctx.IsSet("public-key") {
+		globalPublicKey = ctx.String("public-key")
+	}
+	if ctx.IsSet("private-key") {
+		globalPrivateKey = ctx.String("private-key")
+	}
+
 	// Fetch address option
 	globalCLIContext.Addr = ctx.GlobalString("address")
 	if globalCLIContext.Addr == "" || globalCLIContext.Addr == ":"+globalMinioDefaultPort {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -130,8 +130,8 @@ func handleCommonCmdArgs(ctx *cli.Context) {
 		logger.EnableAnonymous()
 	}
 
-	if ctx.IsSet("public-key") {
-		globalPublicKey = ctx.String("public-key")
+	if ctx.IsSet("public-crt") {
+		globalPublicKey = ctx.String("public-crt")
 	}
 	if ctx.IsSet("private-key") {
 		globalPrivateKey = ctx.String("private-key")

--- a/cmd/config-dir.go
+++ b/cmd/config-dir.go
@@ -62,11 +62,21 @@ func getDefaultCertsCADir() string {
 	return filepath.Join(getDefaultCertsDir(), certsCADir)
 }
 
+func getDefaultPublicKey() string {
+	return publicCertFile
+}
+
+func getDefaultPrivateKey() string {
+	return privateKeyFile
+}
+
 var (
 	// Default config, certs and CA directories.
 	defaultConfigDir  = &ConfigDir{path: getDefaultConfigDir()}
 	defaultCertsDir   = &ConfigDir{path: getDefaultCertsDir()}
 	defaultCertsCADir = &ConfigDir{path: getDefaultCertsCADir()}
+	defaultPublicKey  = getDefaultPublicKey()
+	defaultPrivateKey = getDefaultPrivateKey()
 
 	// Points to current configuration directory -- deprecated, to be removed in future.
 	globalConfigDir = defaultConfigDir
@@ -74,6 +84,10 @@ var (
 	globalCertsDir = defaultCertsDir
 	// Points to relative path to certs directory and is <value-of-certs-dir>/CAs
 	globalCertsCADir = defaultCertsCADir
+	// Points to current public certificate
+	globalPublicKey = defaultPublicKey
+	// Points to current private key
+	globalPrivateKey = defaultPrivateKey
 )
 
 // Get - returns current directory.
@@ -99,9 +113,9 @@ func getConfigFile() string {
 }
 
 func getPublicCertFile() string {
-	return filepath.Join(globalCertsDir.Get(), publicCertFile)
+	return filepath.Join(globalCertsDir.Get(), globalPublicKey)
 }
 
 func getPrivateKeyFile() string {
-	return filepath.Join(globalCertsDir.Get(), privateKeyFile)
+	return filepath.Join(globalCertsDir.Get(), globalPrivateKey)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,7 +40,7 @@ var GlobalFlags = []cli.Flag{
 		Usage: "path to certs directory",
 	},
 	cli.StringFlag{
-		Name:  "public-key",
+		Name:  "public-crt",
 		Value: defaultPublicKey,
 		Usage: "file name of the public cert",
 	},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,16 @@ var GlobalFlags = []cli.Flag{
 		Value: defaultCertsDir.Get(),
 		Usage: "path to certs directory",
 	},
+	cli.StringFlag{
+		Name:  "public-key",
+		Value: defaultPublicKey,
+		Usage: "file name of the public cert",
+	},
+	cli.StringFlag{
+		Name:  "private-key",
+		Value: defaultPrivateKey,
+		Usage: "file name of the private key",
+	},
 	cli.BoolFlag{
 		Name:  "quiet",
 		Usage: "disable startup information",


### PR DESCRIPTION
## Description

Allow user to define his own names for the public certificate and private key files instead of using the hardcoded `public.crt` and `private.key` names

## Motivation and Context

To allow user to specify his own files name, sometimes this files are autogenerated (like with [autocert](https://github.com/smallstep/autocert)) and users cannot change the names to match the hardcoded names used by Minio

## How to test this PR?

1.  [Generate a new key pair](https://rietta.com/blog/openssl-generating-rsa-key-from-command/) and put the files under `$HOME/.minio/certs` directory
2.  Start your minio instance using the new flags to define the name of the keys: `./minio server ~/Data --public-crt=public.pem --private-key=private.pem`
3. Minio should start correctly with TLS enabled, you can verify that by visiting [https://localhost:9000](https://localhost:9000)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
