### PR TITLE
Avoid object names with '//' to avoid hash inconsistencies

### DIFF
--- a/buildscripts/gateway-tests.sh
+++ b/buildscripts/gateway-tests.sh
@@ -46,7 +46,9 @@ function main()
     gw_pid="$(start_minio_gateway_s3)"
 
     SERVER_ENDPOINT=127.0.0.1:24240 ENABLE_HTTPS=0 ACCESS_KEY=minio \
-                   SECRET_KEY=minio123 MINT_MODE="full" /mint/entrypoint.sh
+                   SECRET_KEY=minio123 MINT_MODE="full" /mint/entrypoint.sh \
+                   awscli aws-sdk-java aws-sdk-ruby mc minio-go minio-js s3cmd \
+                   aws-sdk-go aws-sdk-php healthcheck minio-dotnet minio-py security
     rv=$?
 
     kill "$sr_pid"

--- a/cmd/object-api-input-checks.go
+++ b/cmd/object-api-input-checks.go
@@ -162,6 +162,7 @@ func checkObjectArgs(ctx context.Context, bucket, object string, obj ObjectLayer
 	if err := checkObjectNameForLengthAndSlash(bucket, object); err != nil {
 		return err
 	}
+
 	// Validates object name validity after bucket exists.
 	if !IsValidObjectName(object) {
 		return ObjectNameInvalid{

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -166,7 +166,10 @@ func IsValidObjectPrefix(object string) bool {
 		return false
 	}
 	// Reject unsupported characters in object name.
-	if strings.ContainsAny(object, "\\") {
+	if strings.ContainsAny(object, `\`) {
+		return false
+	}
+	if strings.Contains(object, `//`) {
 		return false
 	}
 	return true

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -122,7 +122,9 @@ func TestIsValidObjectName(t *testing.T) {
 		{" ../etc", false},
 		{"./././", false},
 		{"./etc", false},
-		{"contains-\\-backslash", false},
+		{`contains-\-backslash`, false},
+		{`contains//double/forwardslash`, false},
+		{`//contains/double-forwardslash-prefix`, false},
 		{string([]byte{0xff, 0xfe, 0xfd}), false},
 	}
 


### PR DESCRIPTION


## Description
Avoid object names with '//' to avoid hash inconsistencies

## Motivation and Context
This is to fix a situation where an object name incorrectly
is sent with '//' in its path heirarchy, we should reject
such object names because they may be hashed to a set where
the object might not originally belong because, this can
cause situations where once object is uploaded we cannot
delete it anymore.

Fixes #8873

## How to test this PR?
As mentioned in the reproducer in #8873 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
