### PR TITLE
Add Metrics support for Azure & GCS Gateway

### DIFF
--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -417,3 +417,32 @@ func gatewayHandleEnvVars() {
 		}
 	}
 }
+
+// shouldMeterRequest checks whether incoming request should be added to prometheus gateway metrics
+func shouldMeterRequest(req *http.Request) bool {
+	return !(guessIsBrowserReq(req) || guessIsHealthCheckReq(req) || guessIsMetricsReq(req))
+}
+
+// MetricsTransport is a custom wrapper around Transport to track metrics
+type MetricsTransport struct {
+	Transport *http.Transport
+	Metrics   *Metrics
+}
+
+// RoundTrip implements the RoundTrip method for MetricsTransport
+func (m MetricsTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	metered := shouldMeterRequest(r)
+	if metered && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+		m.Metrics.IncRequests(r.Method)
+		m.Metrics.IncBytesSent(r.ContentLength)
+	}
+	// Make the request to the server.
+	resp, err := m.Transport.RoundTrip(r)
+	if err != nil {
+		return nil, err
+	}
+	if metered && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+		m.Metrics.IncBytesReceived(resp.ContentLength)
+	}
+	return resp, nil
+}

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -146,7 +146,14 @@ func (g *Azure) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, erro
 		return &azureObjects{}, err
 	}
 
-	httpClient := &http.Client{Transport: minio.NewCustomHTTPTransport()}
+	metrics := minio.NewMetrics()
+
+	t := &minio.MetricsTransport{
+		Transport: minio.NewCustomHTTPTransport(),
+		Metrics:   metrics,
+	}
+
+	httpClient := &http.Client{Transport: t}
 	userAgent := fmt.Sprintf("APN/1.0 MinIO/1.0 MinIO/%s", minio.Version)
 
 	pipeline := azblob.NewPipeline(credential, azblob.PipelineOptions{
@@ -168,6 +175,7 @@ func (g *Azure) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, erro
 		endpoint:   endpointURL.String(),
 		httpClient: httpClient,
 		client:     client,
+		metrics:    metrics,
 	}, nil
 }
 
@@ -357,6 +365,7 @@ type azureObjects struct {
 	minio.GatewayUnsupported
 	endpoint   string
 	httpClient *http.Client
+	metrics    *minio.Metrics
 	client     azblob.ServiceURL // Azure sdk client
 }
 
@@ -458,6 +467,11 @@ func parseAzurePart(metaPartFileName, prefix string) (partID int, err error) {
 		return
 	}
 	return
+}
+
+// GetMetrics returns this gateway's metrics
+func (a *azureObjects) GetMetrics(ctx context.Context) (*minio.Metrics, error) {
+	return a.metrics, nil
 }
 
 // Shutdown - save any gateway metadata to disk

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -272,12 +272,12 @@ func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
 		)
 	}
 
-	if globalIsGateway && globalGatewayName == "s3" {
+	if globalIsGateway && (globalGatewayName == "s3" || globalGatewayName == "azure" || globalGatewayName == "gcs") {
 		m, _ := globalObjectAPI.GetMetrics(context.Background())
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
 				prometheus.BuildFQName("gateway", globalGatewayName, "bytes_received"),
-				"Total number of bytes received by current MinIO S3 Gateway from AWS S3",
+				"Total number of bytes received by current MinIO Gateway "+globalGatewayName+" backend",
 				nil, nil),
 			prometheus.CounterValue,
 			float64(m.GetBytesReceived()),
@@ -285,7 +285,7 @@ func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
 				prometheus.BuildFQName("gateway", globalGatewayName, "bytes_sent"),
-				"Total number of bytes sent by current MinIO S3 Gateway to AWS S3",
+				"Total number of bytes sent by current MinIO Gateway to "+globalGatewayName+" backend",
 				nil, nil),
 			prometheus.CounterValue,
 			float64(m.GetBytesSent()),
@@ -294,7 +294,7 @@ func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
 				prometheus.BuildFQName("gateway", globalGatewayName, "requests"),
-				"Total number of requests made to AWS S3 by current MinIO S3 Gateway",
+				"Total number of requests made to "+globalGatewayName+" by current MinIO Gateway",
 				[]string{"method"}, nil),
 			prometheus.CounterValue,
 			float64(s.Get.Load()),
@@ -303,7 +303,7 @@ func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
 				prometheus.BuildFQName("gateway", globalGatewayName, "requests"),
-				"Total number of requests made to AWS S3 by current MinIO S3 Gateway",
+				"Total number of requests made to "+globalGatewayName+" by current MinIO Gateway",
 				[]string{"method"}, nil),
 			prometheus.CounterValue,
 			float64(s.Head.Load()),

--- a/docs/metrics/prometheus/README.md
+++ b/docs/metrics/prometheus/README.md
@@ -147,13 +147,15 @@ MinIO Gateway instances enabled with Disk-Caching expose caching related metrics
 - `cache_hits_total`: Total number of cache hits.
 - `cache_misses_total`: Total number of cache misses.
 
-### S3 Gateway & Cache specific metrics
+### Gateway & Cache specific metrics
 
-MinIO S3 Gateway instance exposes metrics related to Gateway communication with AWS S3.
+MinIO Gateway instance exposes metrics related to Gateway communication with the cloud backend (S3, Azure & GCS Gateway).
 
-- `gateway_s3_requests`: Total number of GET & HEAD requests made to AWS S3. This metrics has a label `method` that identifies GET & HEAD Requests.
-- `gateway_s3_bytes_sent`: Total number of bytes sent to AWS S3 (in GET & HEAD Requests).
-- `gateway_s3_bytes_received`: Total number of bytes received from AWS S3 (in GET & HEAD Requests).
+- `gateway_<gateway_type>_requests`: Total number of GET & HEAD requests made to cloud backend. This metrics has a label `method` that identifies GET & HEAD Requests.
+- `gateway_<gateway_type>_bytes_sent`: Total number of bytes sent to cloud backend (in GET & HEAD Requests).
+- `gateway_<gateway_type>_bytes_received`: Total number of bytes received from cloud backend (in GET & HEAD Requests).
+
+Note that this is currently only support for Azure, S3 and GCS Gateway.
 
 ## Migration guide for the new set of metrics
 


### PR DESCRIPTION
## Description
We added support for caching and S3 related metrics in #8591. As
a continuation, it would be helpful to add support for Azure & GCS
gateway related metrics as well.

## Motivation and Context
Better Prometheus metrics

## How to test this PR?
Deploy MinIO in Azure Gateway mode and observe Prometheus metrics

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
