### PR TITLE
usage: Fix creating .minio.sys/background-ops bucket

### DIFF
--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -643,7 +643,7 @@ func initXLMetaVolumesInLocalDisks(storageDisks []StorageAPI, formats []*formatX
 		// goroutine will return its own instance of index variable.
 		index := index
 		g.Go(func() error {
-			return makeFormatXLMetaVolumes(storageDisks[index])
+			return makeFormatXLMetaVolumes(disksToInit[index])
 		}, index)
 	}
 


### PR DESCRIPTION

## Description
Due to a typo in the code, a cluster was not correctly creating
`background-ops` in all disks and nodes print the following error:

minio3_1  | API: SYSTEM()
minio3_1  | Time: 19:32:45 UTC 02/06/2020
minio3_1  | DeploymentID: d67c20fa-4a1e-41f5-b319-7e3e90f425d8
minio3_1  | Error: Bucket not found: .minio.sys/background-ops
minio3_1  |        2: cmd/data-usage.go:109:cmd.runDataUsageInfo()
minio3_1  |        1: cmd/data-usage.go:56:cmd.runDataUsageInfoUpdateRoutine()

This commit fixes the typo.


## Motivation and Context
Fixing data usage in complicated cluster setup

## How to test this PR?
1. Run the following docker-compose

```
version: '3.7'

# starts 4 docker containers running minio server instances. Each
# minio server's web interface will be accessible on the host at port
# 9001 through 9004.
services:
  minio1:
    image: minio/minio:RELEASE.2019-09-05T23-24-38Z
    ports:
      - "9001:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...6}/data/minio-data-{1...12}

  minio2:
    image: minio/minio:RELEASE.2019-09-05T23-24-38Z
    ports:
      - "9002:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...6}/data/minio-data-{1...12}

  minio3:
    image: minio/minio:RELEASE.2019-09-05T23-24-38Z
    ports:
      - "9003:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...6}/data/minio-data-{1...12}

  minio4:
    image: minio/minio:RELEASE.2019-09-05T23-24-38Z
    ports:
      - "9004:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...6}/data/minio-data-{1...12}

  minio5:
    image: minio/minio:RELEASE.2019-09-05T23-24-38Z
    ports:
      - "9005:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...6}/data/minio-data-{1...12}

  minio6:
    image: minio/minio:RELEASE.2019-09-05T23-24-38Z
    ports:
      - "9006:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...6}/data/minio-data-{1...12}
```

2. Create a bucket in that cluster
3. Stop the cluster, change the version of MinIO to latest, and start the cluster again.
4. The error message will disappear and data usage info will be shown correctly in `mc admin info`



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
