### PR TITLE
Time getSize and use to estimate latency

### DIFF
--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"sync"
@@ -160,18 +159,11 @@ func updateUsage(basePath string, doneCh <-chan struct{}, waitForLowActiveIO fun
 	}
 
 	numWorkers := 4
-	walkInterval := 1 * time.Millisecond
-
 	var mutex sync.Mutex // Mutex to update dataUsageInfo
-
-	r := rand.New(rand.NewSource(UTCNow().UnixNano()))
 
 	fastWalk(basePath, numWorkers, doneCh, func(path string, typ os.FileMode) error {
 		// Wait for I/O to go down.
 		waitForLowActiveIO()
-
-		// Randomize sleep intervals, to stagger the walk.
-		defer time.Sleep(time.Duration(r.Float64() * float64(walkInterval)))
 
 		bucket, entry := path2BucketObjectWithBasePath(basePath, path)
 		if bucket == "" {
@@ -197,7 +189,13 @@ func updateUsage(basePath string, doneCh <-chan struct{}, waitForLowActiveIO fun
 			return nil
 		}
 
+		t := time.Now()
 		size, err := getSize(Item{path, typ})
+		// Use the response time of the getSize call to guess system load.
+		// Sleep equivalent time.
+		if d := time.Now().Sub(t); d > 100*time.Microsecond {
+			time.Sleep(d)
+		}
 		if err != nil {
 			return errSkipFile
 		}

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -193,7 +193,7 @@ func updateUsage(basePath string, doneCh <-chan struct{}, waitForLowActiveIO fun
 		size, err := getSize(Item{path, typ})
 		// Use the response time of the getSize call to guess system load.
 		// Sleep equivalent time.
-		if d := time.Now().Sub(t); d > 100*time.Microsecond {
+		if d := time.Since(t); d > 100*time.Microsecond {
 			time.Sleep(d)
 		}
 		if err != nil {


### PR DESCRIPTION
## Description

Remove the random sleep. This is running in 4 goroutines, so mostly doing nothing.

We use the getSize latency to estimate system load, meaning when there is little load on the system and we get the result fast we sleep a little.

If it took a long time we have high load and release ourselves longer. So it relies purely on sideeffects and reacts instantly.

We are sleeping inside the mutex so this affects all goroutines doing IO.

We could add a multiplier to the time. Not sure if that is actually needed.

## How to test this PR?

Run disk usage.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
