### PR TITLE
Fix stream read IO count

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -219,11 +219,11 @@ func newPosix(path string) (*posix, error) {
 		},
 		stopUsageCh: make(chan struct{}),
 		diskMount:   mountinfo.IsLikelyMountPoint(path),
-		// Allow disk usage crawler to run upto 10 concurrent
+		// Allow disk usage crawler to run with up to 2 concurrent
 		// I/O ops, if and when activeIOCount reaches this
 		// value disk usage routine suspends the crawler
 		// and waits until activeIOCount reaches below this threshold.
-		maxActiveIOCount: 10,
+		maxActiveIOCount: 3,
 	}
 
 	// Success.


### PR DESCRIPTION
## Description

Streams are returning a readcloser and returning would decrement io count instantly.

I don't want this to be wrong, so written with a few safeties.

## How to test this PR?

Test diskusage thingie...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
