### PR TITLE
Fix Error Codes for incorrect ObjectTagging fields

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1810,7 +1810,7 @@ func toAPIError(ctx context.Context, err error) APIError {
 			}
 		case tagging.Error:
 			apiErr = APIError{
-				Code:           "InvalidTag",
+				Code:           e.Code(),
 				Description:    e.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}

--- a/pkg/bucket/object/tagging/error.go
+++ b/pkg/bucket/object/tagging/error.go
@@ -23,13 +23,14 @@ import (
 // Error is the generic type for any error happening during tag
 // parsing.
 type Error struct {
-	err error
+	err  error
+	code string
 }
 
 // Errorf - formats according to a format specifier and returns
 // the string as a value that satisfies error of type tagging.Error
-func Errorf(format string, a ...interface{}) error {
-	return Error{err: fmt.Errorf(format, a...)}
+func Errorf(format, code string, a ...interface{}) error {
+	return Error{err: fmt.Errorf(format, a...), code: code}
 }
 
 // Unwrap the internal error.
@@ -41,4 +42,12 @@ func (e Error) Error() string {
 		return "tagging: cause <nil>"
 	}
 	return e.err.Error()
+}
+
+// Code returns appropriate error code.
+func (e Error) Code() string {
+	if e.code == "" {
+		return "BadRequest"
+	}
+	return e.code
 }

--- a/pkg/bucket/object/tagging/tagging.go
+++ b/pkg/bucket/object/tagging/tagging.go
@@ -33,10 +33,10 @@ const (
 
 // errors returned by tagging package
 var (
-	ErrTooManyTags     = Errorf("Cannot have more than 10 object tags")
-	ErrInvalidTagKey   = Errorf("The TagKey you have provided is invalid")
-	ErrInvalidTagValue = Errorf("The TagValue you have provided is invalid")
-	ErrInvalidTag      = Errorf("Cannot provide multiple Tags with the same key")
+	ErrTooManyTags     = Errorf("Object tags cannot be greater than 10", "BadRequest")
+	ErrInvalidTagKey   = Errorf("The TagKey you have provided is invalid", "InvalidTag")
+	ErrInvalidTagValue = Errorf("The TagValue you have provided is invalid", "InvalidTag")
+	ErrInvalidTag      = Errorf("Cannot provide multiple Tags with the same key", "InvalidTag")
 )
 
 // Tagging - object tagging interface
@@ -51,14 +51,14 @@ func (t Tagging) Validate() error {
 	if len(t.TagSet.Tags) > maxTags {
 		return ErrTooManyTags
 	}
-	if t.TagSet.ContainsDuplicateTag() {
-		return ErrInvalidTag
-	}
 	// Validate all the rules in the tagging config
 	for _, ts := range t.TagSet.Tags {
 		if err := ts.Validate(); err != nil {
 			return err
 		}
+	}
+	if t.TagSet.ContainsDuplicateTag() {
+		return ErrInvalidTag
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Fix Error Codes for incorrect ObjectTagging fields

## Motivation and Context
MinIO responded with different error code and messages as compared to AWS S3, when ObjectTagging Input Fields when parsed and found incorrect. This PR fixes the behaviour.

## How to test this PR?
Test 4 scenarios against AWS S3 and MinIO, the error code and message should match.
- Too many tags > 10
- Duplicate Tag Keys
- Long Tag Key > 128 Chars
- Long Tag Value > 256 Chars

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
