### PR TITLE
fix: Speed up multi-object delete by taking bulk locks

### DIFF
--- a/buildscripts/verify-healing.sh
+++ b/buildscripts/verify-healing.sh
@@ -74,7 +74,7 @@ function __init__()
     echo '{"version": "3", "credential": {"accessKey": "minio", "secretKey": "minio123"}, "region": "us-east-1"}' > "$MINIO_CONFIG_DIR/config.json"
 }
 
-function perform_test_1() {
+function perform_test() {
     minio_pids=( $(start_minio_3_node 60) )
     for pid in "${minio_pids[@]}"; do
         if ! kill "$pid"; then
@@ -86,59 +86,14 @@ function perform_test_1() {
             purge "$WORK_DIR"
             exit 1
         fi
+        # forcibly killing, to proceed further properly.
+        kill -9 "$pid"
     done
 
-    echo "Testing in Distributed Erasure setup healing test case 1"
-    echo "Remove the contents of the disks belonging to '2' erasure set"
+    echo "Testing Distributed Erasure setup healing of drives"
+    echo "Remove the contents of the disks belonging to '${1}' erasure set"
 
-    rm -rf ${WORK_DIR}/2/*/
-
-    minio_pids=( $(start_minio_3_node 60) )
-    for pid in "${minio_pids[@]}"; do
-        if ! kill "$pid"; then
-            for i in $(seq 1 3); do
-                echo "server$i log:"
-                cat "${WORK_DIR}/dist-minio-$[8000+$i].log"
-            done
-            echo "FAILED"
-            purge "$WORK_DIR"
-            exit 1
-        fi
-    done
-
-    rv=$(check_online)
-    if [ "$rv" == "1" ]; then
-        for pid in "${minio_pids[@]}"; do
-            kill -9 "$pid"
-        done
-        for i in $(seq 1 3); do
-            echo "server$i log:"
-            cat "${WORK_DIR}/dist-minio-$[8000+$i].log"
-        done
-        echo "FAILED"
-        purge "$WORK_DIR"
-        exit 1
-    fi
-}
-
-function perform_test_2() {
-    minio_pids=( $(start_minio_3_node 60) )
-    for pid in "${minio_pids[@]}"; do
-        if ! kill "$pid"; then
-            for i in $(seq 1 3); do
-                echo "server$i log:"
-                cat "${WORK_DIR}/dist-minio-$[8000+$i].log"
-            done
-            echo "FAILED"
-            purge "$WORK_DIR"
-            exit 1
-        fi
-    done
-
-    echo "Testing in Distributed Erasure setup healing test case 2"
-    echo "Remove the contents of the disks belonging to '1' erasure set"
-
-    rm -rf ${WORK_DIR}/1/*/
+    rm -rf ${WORK_DIR}/${1}/*/
 
     minio_pids=( $(start_minio_3_node 60) )
     for pid in "${minio_pids[@]}"; do
@@ -151,53 +106,9 @@ function perform_test_2() {
             purge "$WORK_DIR"
             exit 1
         fi
-    done
-
-    rv=$(check_online)
-    if [ "$rv" == "1" ]; then
-        for pid in "${minio_pids[@]}"; do
-            kill -9 "$pid"
-        done
-        for i in $(seq 1 3); do
-            echo "server$i log:"
-            cat "${WORK_DIR}/dist-minio-$[8000+$i].log"
-        done
-        echo "FAILED"
-        purge "$WORK_DIR"
-        exit 1
-    fi
-}
-
-function perform_test_3() {
-    minio_pids=( $(start_minio_3_node 60) )
-    for pid in "${minio_pids[@]}"; do
-        if ! kill "$pid"; then
-            for i in $(seq 1 3); do
-                echo "server$i log:"
-                cat "${WORK_DIR}/dist-minio-$[8000+$i].log"
-            done
-            echo "FAILED"
-            purge "$WORK_DIR"
-            exit 1
-        fi
-    done
-
-    echo "Testing in Distributed Erasure setup healing test case 3"
-    echo "Remove the contents of the disks belonging to '3' erasure set"
-
-    rm -rf ${WORK_DIR}/3/*/
-
-    minio_pids=( $(start_minio_3_node 60) )
-    for pid in "${minio_pids[@]}"; do
-        if ! kill "$pid"; then
-            for i in $(seq 1 3); do
-                echo "server$i log:"
-                cat "${WORK_DIR}/dist-minio-$[8000+$i].log"
-            done
-            echo "FAILED"
-            purge "$WORK_DIR"
-            exit 1
-        fi
+        # forcibly killing, to proceed further properly.
+        # if the previous kill is taking time.
+        kill -9 "$pid"
     done
 
     rv=$(check_online)
@@ -217,9 +128,9 @@ function perform_test_3() {
 
 function main()
 {
-    perform_test_1
-    perform_test_2
-    perform_test_3
+    perform_test "2"
+    perform_test "1"
+    perform_test "3"
 }
 
 ( __init__ "$@" && main "$@" )

--- a/cmd/daily-lifecycle-ops.go
+++ b/cmd/daily-lifecycle-ops.go
@@ -104,12 +104,12 @@ func startDailyLifecycle() {
 	}
 }
 
-var lifecycleTimeout = newDynamicTimeout(60*time.Second, time.Second)
+var lifecycleLockTimeout = newDynamicTimeout(60*time.Second, time.Second)
 
 func lifecycleRound(ctx context.Context, objAPI ObjectLayer) error {
 	// Lock to avoid concurrent lifecycle ops from other nodes
 	sweepLock := objAPI.NewNSLock(ctx, "system", "daily-lifecycle-ops")
-	if err := sweepLock.GetLock(lifecycleTimeout); err != nil {
+	if err := sweepLock.GetLock(lifecycleLockTimeout); err != nil {
 		return err
 	}
 	defer sweepLock.Unlock()

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -79,10 +79,12 @@ func timeToCrawl(ctx context.Context, objAPI ObjectLayer) time.Duration {
 	return dataUsageCrawlInterval - waitDuration
 }
 
+var dataUsageLockTimeout = lifecycleLockTimeout
+
 func runDataUsageInfo(ctx context.Context, objAPI ObjectLayer, endCh <-chan struct{}) {
 	locker := objAPI.NewNSLock(ctx, minioMetaBucket, "leader-data-usage-info")
 	for {
-		err := locker.GetLock(newDynamicTimeout(time.Millisecond, time.Millisecond))
+		err := locker.GetLock(dataUsageLockTimeout)
 		if err != nil {
 			time.Sleep(5 * time.Minute)
 			continue

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -188,9 +188,9 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 }
 
 // NewNSLock - initialize a new namespace RWLocker instance.
-func (fs *FSObjects) NewNSLock(ctx context.Context, bucket string, object string) RWLocker {
+func (fs *FSObjects) NewNSLock(ctx context.Context, bucket string, objects ...string) RWLocker {
 	// lockers are explicitly 'nil' for FS mode since there are only local lockers
-	return fs.nsMutex.NewNSLock(ctx, nil, bucket, object)
+	return fs.nsMutex.NewNSLock(ctx, nil, bucket, objects...)
 }
 
 // Shutdown - should be called when process shuts down.
@@ -490,7 +490,6 @@ func (fs *FSObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBu
 // GetObjectNInfo - returns object info and a reader for object
 // content.
 func (fs *FSObjects) GetObjectNInfo(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error) {
-
 	if err = checkGetObjArgs(ctx, bucket, object); err != nil {
 		return nil, err
 	}

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -37,8 +37,8 @@ type GatewayLocker struct {
 }
 
 // NewNSLock - implements gateway level locker
-func (l *GatewayLocker) NewNSLock(ctx context.Context, bucket string, object string) RWLocker {
-	return l.nsMutex.NewNSLock(ctx, nil, bucket, object)
+func (l *GatewayLocker) NewNSLock(ctx context.Context, bucket string, objects ...string) RWLocker {
+	return l.nsMutex.NewNSLock(ctx, nil, bucket, objects...)
 }
 
 // NewGatewayLayerWithLocker - initialize gateway with locker.
@@ -56,7 +56,7 @@ func (a GatewayUnsupported) CrawlAndGetDataUsage(ctx context.Context, endCh <-ch
 }
 
 // NewNSLock is a dummy stub for gateway.
-func (a GatewayUnsupported) NewNSLock(ctx context.Context, bucket string, object string) RWLocker {
+func (a GatewayUnsupported) NewNSLock(ctx context.Context, bucket string, objects ...string) RWLocker {
 	logger.CriticalIf(ctx, errors.New("not implemented"))
 	return nil
 }

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -337,14 +337,6 @@ func (sys *IAMSys) Load() error {
 
 // Perform IAM configuration migration.
 func (sys *IAMSys) doIAMConfigMigration(objAPI ObjectLayer) error {
-	// Take IAM configuration migration lock
-	lockPath := iamConfigPrefix + "/migration.lock"
-	objLock := objAPI.NewNSLock(context.Background(), minioMetaBucket, lockPath)
-	if err := objLock.GetLock(globalOperationTimeout); err != nil {
-		return err
-	}
-	defer objLock.Unlock()
-
 	return sys.store.migrateBackendFormat(objAPI)
 }
 

--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -104,9 +105,12 @@ func (client *lockRESTClient) restCall(call string, args dsync.LockArgs) (reply 
 	values := url.Values{}
 	values.Set(lockRESTUID, args.UID)
 	values.Set(lockRESTSource, args.Source)
-	values.Set(lockRESTResource, args.Resource)
-
-	respBody, err := client.call(call, values, nil, -1)
+	var buffer bytes.Buffer
+	for _, resource := range args.Resources {
+		buffer.WriteString(resource)
+		buffer.WriteString("\n")
+	}
+	respBody, err := client.call(call, values, &buffer, -1)
 	defer http.DrainBody(respBody)
 	switch err {
 	case nil:

--- a/cmd/lock-rest-server-common.go
+++ b/cmd/lock-rest-server-common.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	lockRESTVersion       = "v2"
-	lockRESTVersionPrefix = SlashSeparator + "v2"
+	lockRESTVersion       = "v3"
+	lockRESTVersionPrefix = SlashSeparator + lockRESTVersion
 	lockRESTPrefix        = minioReservedBucketPath + "/lock"
 )
 
@@ -38,8 +38,6 @@ const (
 	// Source contains the line number, function and file name of the code
 	// on the client node that requested the lock.
 	lockRESTSource = "source"
-	// Resource contains a entity to be locked/unlocked.
-	lockRESTResource = "resource"
 )
 
 var (

--- a/cmd/namespace-lock_test.go
+++ b/cmd/namespace-lock_test.go
@@ -18,184 +18,20 @@ package cmd
 
 import (
 	"testing"
-	"time"
 )
 
 // WARNING:
 //
-// Expected source line number is hard coded, 32, in the
+// Expected source line number is hard coded, 31, in the
 // following test. Adding new code before this test or changing its
 // position will cause the line number to change and the test to FAIL
 // Tests getSource().
 func TestGetSource(t *testing.T) {
 	currentSource := func() string { return getSource() }
 	gotSource := currentSource()
-	// Hard coded line number, 32, in the "expectedSource" value
-	expectedSource := "[namespace-lock_test.go:32:TestGetSource()]"
+	// Hard coded line number, 31, in the "expectedSource" value
+	expectedSource := "[namespace-lock_test.go:31:TestGetSource()]"
 	if gotSource != expectedSource {
 		t.Errorf("expected : %s, got : %s", expectedSource, gotSource)
 	}
-}
-
-// Tests functionality provided by namespace lock.
-func TestNamespaceLockTest(t *testing.T) {
-	isDistXL := false
-	nsMutex := newNSLock(isDistXL)
-
-	// List of test cases.
-	testCases := []struct {
-		lk               func(s1, s2, s3 string, t time.Duration) bool
-		unlk             func(s1, s2, s3 string)
-		rlk              func(s1, s2, s3 string, t time.Duration) bool
-		runlk            func(s1, s2, s3 string)
-		lockedRefCount   uint
-		unlockedRefCount uint
-		shouldPass       bool
-	}{
-		{
-			lk:               nsMutex.Lock,
-			unlk:             nsMutex.Unlock,
-			lockedRefCount:   1,
-			unlockedRefCount: 0,
-			shouldPass:       true,
-		},
-		{
-			rlk:              nsMutex.RLock,
-			runlk:            nsMutex.RUnlock,
-			lockedRefCount:   4,
-			unlockedRefCount: 2,
-			shouldPass:       true,
-		},
-		{
-			rlk:              nsMutex.RLock,
-			runlk:            nsMutex.RUnlock,
-			lockedRefCount:   1,
-			unlockedRefCount: 0,
-			shouldPass:       true,
-		},
-	}
-
-	// Run all test cases.
-
-	// Write lock tests.
-	testCase := testCases[0]
-	if !testCase.lk("a", "b", "c", 60*time.Second) { // lock once.
-		t.Fatalf("Failed to acquire lock")
-	}
-	nsLk, ok := nsMutex.lockMap[nsParam{"a", "b"}]
-	if !ok && testCase.shouldPass {
-		t.Errorf("Lock in map missing.")
-	}
-	// Validate locked ref count.
-	if testCase.lockedRefCount != nsLk.ref && testCase.shouldPass {
-		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 1, testCase.lockedRefCount, nsLk.ref)
-	}
-	testCase.unlk("a", "b", "c") // unlock once.
-	if testCase.unlockedRefCount != nsLk.ref && testCase.shouldPass {
-		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 1, testCase.unlockedRefCount, nsLk.ref)
-	}
-	_, ok = nsMutex.lockMap[nsParam{"a", "b"}]
-	if ok && !testCase.shouldPass {
-		t.Errorf("Lock map found after unlock.")
-	}
-
-	// Read lock tests.
-	testCase = testCases[1]
-	if !testCase.rlk("a", "b", "c", 60*time.Second) { // lock once.
-		t.Fatalf("Failed to acquire first read lock")
-	}
-	if !testCase.rlk("a", "b", "c", 60*time.Second) { // lock second time.
-		t.Fatalf("Failed to acquire second read lock")
-	}
-	if !testCase.rlk("a", "b", "c", 60*time.Second) { // lock third time.
-		t.Fatalf("Failed to acquire third read lock")
-	}
-	if !testCase.rlk("a", "b", "c", 60*time.Second) { // lock fourth time.
-		t.Fatalf("Failed to acquire fourth read lock")
-	}
-	nsLk, ok = nsMutex.lockMap[nsParam{"a", "b"}]
-	if !ok && testCase.shouldPass {
-		t.Errorf("Lock in map missing.")
-	}
-	// Validate locked ref count.
-	if testCase.lockedRefCount != nsLk.ref && testCase.shouldPass {
-		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 1, testCase.lockedRefCount, nsLk.ref)
-	}
-
-	testCase.runlk("a", "b", "c") // unlock once.
-	testCase.runlk("a", "b", "c") // unlock second time.
-	if testCase.unlockedRefCount != nsLk.ref && testCase.shouldPass {
-		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 2, testCase.unlockedRefCount, nsLk.ref)
-	}
-	_, ok = nsMutex.lockMap[nsParam{"a", "b"}]
-	if !ok && testCase.shouldPass {
-		t.Errorf("Lock map not found.")
-	}
-
-	// Read lock 0 ref count.
-	testCase = testCases[2]
-	if !testCase.rlk("a", "c", "d", 60*time.Second) { // lock once.
-		t.Fatalf("Failed to acquire read lock")
-	}
-
-	nsLk, ok = nsMutex.lockMap[nsParam{"a", "c"}]
-	if !ok && testCase.shouldPass {
-		t.Errorf("Lock in map missing.")
-	}
-	// Validate locked ref count.
-	if testCase.lockedRefCount != nsLk.ref && testCase.shouldPass {
-		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 3, testCase.lockedRefCount, nsLk.ref)
-	}
-	testCase.runlk("a", "c", "d") // unlock once.
-	if testCase.unlockedRefCount != nsLk.ref && testCase.shouldPass {
-		t.Errorf("Test %d fails, expected to pass. Wanted ref count is %d, got %d", 3, testCase.unlockedRefCount, nsLk.ref)
-	}
-	_, ok = nsMutex.lockMap[nsParam{"a", "c"}]
-	if ok && !testCase.shouldPass {
-		t.Errorf("Lock map not found.")
-	}
-}
-
-func TestNamespaceLockTimedOut(t *testing.T) {
-	isDistXL := false
-	nsMutex := newNSLock(isDistXL)
-	// Get write lock
-	if !nsMutex.Lock("my-bucket", "my-object", "abc", 60*time.Second) {
-		t.Fatalf("Failed to acquire lock")
-	}
-
-	// Second attempt for write lock on same resource should time out
-	locked := nsMutex.Lock("my-bucket", "my-object", "def", 1*time.Second)
-	if locked {
-		t.Fatalf("Should not have acquired lock")
-	}
-
-	// Read lock on same resource should also time out
-	locked = nsMutex.RLock("my-bucket", "my-object", "def", 1*time.Second)
-	if locked {
-		t.Fatalf("Should not have acquired read lock while write lock is active")
-	}
-
-	// Release write lock
-	nsMutex.Unlock("my-bucket", "my-object", "abc")
-
-	// Get read lock
-	if !nsMutex.RLock("my-bucket", "my-object", "ghi", 60*time.Second) {
-		t.Fatalf("Failed to acquire read lock")
-	}
-
-	// Write lock on same resource should time out
-	locked = nsMutex.Lock("my-bucket", "my-object", "klm", 1*time.Second)
-	if locked {
-		t.Fatalf("Should not have acquired lock")
-	}
-
-	// 2nd read lock should be just fine
-	if !nsMutex.RLock("my-bucket", "my-object", "nop", 60*time.Second) {
-		t.Fatalf("Failed to acquire second read lock")
-	}
-
-	// Release both read locks
-	nsMutex.RUnlock("my-bucket", "my-object", "ghi")
-	nsMutex.RUnlock("my-bucket", "my-object", "nop")
 }

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -348,11 +348,10 @@ func (e ObjectTooSmall) Error() string {
 
 // OperationTimedOut - a timeout occurred.
 type OperationTimedOut struct {
-	Path string
 }
 
 func (e OperationTimedOut) Error() string {
-	return "Operation timed out: " + e.Path
+	return "Operation timed out"
 }
 
 /// Multipart related errors.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -55,7 +55,7 @@ const (
 // ObjectLayer implements primitives for object API layer.
 type ObjectLayer interface {
 	// Locking operations on object.
-	NewNSLock(ctx context.Context, bucket string, object string) RWLocker
+	NewNSLock(ctx context.Context, bucket string, objects ...string) RWLocker
 
 	// Storage operations.
 	Shutdown(context.Context) error

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -198,6 +198,16 @@ func retainSlash(s string) string {
 	return strings.TrimSuffix(s, SlashSeparator) + SlashSeparator
 }
 
+// pathsJoinPrefix - like pathJoin retains trailing SlashSeparator
+// for all elements, prepends them with 'prefix' respectively.
+func pathsJoinPrefix(prefix string, elem ...string) (paths []string) {
+	paths = make([]string, len(elem))
+	for i, e := range elem {
+		paths[i] = pathJoin(prefix, e)
+	}
+	return paths
+}
+
 // pathJoin - like path.Join() but retains trailing SlashSeparator of the last element
 func pathJoin(elem ...string) string {
 	trailingSlash := ""

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -335,8 +335,11 @@ func newXLSets(endpoints Endpoints, format *formatXLV3, setCount int, drivesPerS
 }
 
 // NewNSLock - initialize a new namespace RWLocker instance.
-func (s *xlSets) NewNSLock(ctx context.Context, bucket string, object string) RWLocker {
-	return s.getHashedSet(object).NewNSLock(ctx, bucket, object)
+func (s *xlSets) NewNSLock(ctx context.Context, bucket string, objects ...string) RWLocker {
+	if len(objects) == 1 {
+		return s.getHashedSet(objects[0]).NewNSLock(ctx, bucket, objects...)
+	}
+	return s.getHashedSet("").NewNSLock(ctx, bucket, objects...)
 }
 
 // StorageInfo - combines output of StorageInfo across all erasure coded object sets.

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -66,8 +66,8 @@ type xlObjects struct {
 }
 
 // NewNSLock - initialize a new namespace RWLocker instance.
-func (xl xlObjects) NewNSLock(ctx context.Context, bucket string, object string) RWLocker {
-	return xl.nsMutex.NewNSLock(ctx, xl.getLockers, bucket, object)
+func (xl xlObjects) NewNSLock(ctx context.Context, bucket string, objects ...string) RWLocker {
+	return xl.nsMutex.NewNSLock(ctx, xl.getLockers, bucket, objects...)
 }
 
 // Shutdown function for object storage interface.

--- a/pkg/dsync/drwmutex_test.go
+++ b/pkg/dsync/drwmutex_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -37,7 +36,7 @@ const (
 
 func testSimpleWriteLock(t *testing.T, duration time.Duration) (locked bool) {
 
-	drwm := NewDRWMutex(context.Background(), "simplelock", ds)
+	drwm := NewDRWMutex(context.Background(), ds, "simplelock")
 
 	if !drwm.GetRLock(id, source, time.Second) {
 		panic("Failed to acquire read lock")
@@ -93,7 +92,7 @@ func TestSimpleWriteLockTimedOut(t *testing.T) {
 
 func testDualWriteLock(t *testing.T, duration time.Duration) (locked bool) {
 
-	drwm := NewDRWMutex(context.Background(), "duallock", ds)
+	drwm := NewDRWMutex(context.Background(), ds, "duallock")
 
 	// fmt.Println("Getting initial write lock")
 	if !drwm.GetLock(id, source, time.Second) {
@@ -153,7 +152,7 @@ func parallelReader(m *DRWMutex, clocked, cunlock, cdone chan bool) {
 // Borrowed from rwmutex_test.go
 func doTestParallelReaders(numReaders, gomaxprocs int) {
 	runtime.GOMAXPROCS(gomaxprocs)
-	m := NewDRWMutex(context.Background(), "test-parallel", ds)
+	m := NewDRWMutex(context.Background(), ds, "test-parallel")
 
 	clocked := make(chan bool)
 	cunlock := make(chan bool)
@@ -221,7 +220,7 @@ func HammerRWMutex(gomaxprocs, numReaders, numIterations int) {
 	runtime.GOMAXPROCS(gomaxprocs)
 	// Number of active readers + 10000 * number of active writers.
 	var activity int32
-	rwm := NewDRWMutex(context.Background(), "test", ds)
+	rwm := NewDRWMutex(context.Background(), ds, "test")
 	cdone := make(chan bool)
 	go writer(rwm, numIterations, &activity, cdone)
 	var i int
@@ -258,49 +257,13 @@ func TestRWMutex(t *testing.T) {
 }
 
 // Borrowed from rwmutex_test.go
-func TestDRLocker(t *testing.T) {
-	wl := NewDRWMutex(context.Background(), "test", ds)
-	var rl sync.Locker
-	wlocked := make(chan bool, 1)
-	rlocked := make(chan bool, 1)
-	rl = wl.DRLocker()
-	n := 10
-	go func() {
-		for i := 0; i < n; i++ {
-			rl.Lock()
-			rl.Lock()
-			rlocked <- true
-			wl.Lock(id, source)
-			wlocked <- true
-		}
-	}()
-	for i := 0; i < n; i++ {
-		<-rlocked
-		rl.Unlock()
-		select {
-		case <-wlocked:
-			t.Fatal("RLocker() didn't read-lock it")
-		default:
-		}
-		rl.Unlock()
-		<-wlocked
-		select {
-		case <-rlocked:
-			t.Fatal("RLocker() didn't respect the write lock")
-		default:
-		}
-		wl.Unlock()
-	}
-}
-
-// Borrowed from rwmutex_test.go
 func TestUnlockPanic(t *testing.T) {
 	defer func() {
 		if recover() == nil {
 			t.Fatalf("unlock of unlocked RWMutex did not panic")
 		}
 	}()
-	mu := NewDRWMutex(context.Background(), "test", ds)
+	mu := NewDRWMutex(context.Background(), ds, "test")
 	mu.Unlock()
 }
 
@@ -311,7 +274,7 @@ func TestUnlockPanic2(t *testing.T) {
 			t.Fatalf("unlock of unlocked RWMutex did not panic")
 		}
 	}()
-	mu := NewDRWMutex(context.Background(), "test-unlock-panic-2", ds)
+	mu := NewDRWMutex(context.Background(), ds, "test-unlock-panic-2")
 	mu.RLock(id, source)
 	mu.Unlock()
 }
@@ -323,7 +286,7 @@ func TestRUnlockPanic(t *testing.T) {
 			t.Fatalf("read unlock of unlocked RWMutex did not panic")
 		}
 	}()
-	mu := NewDRWMutex(context.Background(), "test", ds)
+	mu := NewDRWMutex(context.Background(), ds, "test")
 	mu.RUnlock()
 }
 
@@ -334,14 +297,14 @@ func TestRUnlockPanic2(t *testing.T) {
 			t.Fatalf("read unlock of unlocked RWMutex did not panic")
 		}
 	}()
-	mu := NewDRWMutex(context.Background(), "test-runlock-panic-2", ds)
+	mu := NewDRWMutex(context.Background(), ds, "test-runlock-panic-2")
 	mu.Lock(id, source)
 	mu.RUnlock()
 }
 
 // Borrowed from rwmutex_test.go
 func benchmarkRWMutex(b *testing.B, localWork, writeRatio int) {
-	rwm := NewDRWMutex(context.Background(), "test", ds)
+	rwm := NewDRWMutex(context.Background(), ds, "test")
 	b.RunParallel(func(pb *testing.PB) {
 		foo := 0
 		for pb.Next() {

--- a/pkg/dsync/dsync-server_test.go
+++ b/pkg/dsync/dsync-server_test.go
@@ -35,8 +35,8 @@ type lockServer struct {
 func (l *lockServer) Lock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if _, *reply = l.lockMap[args.Resource]; !*reply {
-		l.lockMap[args.Resource] = WriteLock // No locks held on the given name, so claim write lock
+	if _, *reply = l.lockMap[args.Resources[0]]; !*reply {
+		l.lockMap[args.Resources[0]] = WriteLock // No locks held on the given name, so claim write lock
 	}
 	*reply = !*reply // Negate *reply to return true when lock is granted or false otherwise
 	return nil
@@ -46,13 +46,13 @@ func (l *lockServer) Unlock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply { // No lock is held on the given name
-		return fmt.Errorf("Unlock attempted on an unlocked entity: %s", args.Resource)
+	if locksHeld, *reply = l.lockMap[args.Resources[0]]; !*reply { // No lock is held on the given name
+		return fmt.Errorf("Unlock attempted on an unlocked entity: %s", args.Resources[0])
 	}
 	if *reply = locksHeld == WriteLock; !*reply { // Unless it is a write lock
-		return fmt.Errorf("Unlock attempted on a read locked entity: %s (%d read locks active)", args.Resource, locksHeld)
+		return fmt.Errorf("Unlock attempted on a read locked entity: %s (%d read locks active)", args.Resources[0], locksHeld)
 	}
-	delete(l.lockMap, args.Resource) // Remove the write lock
+	delete(l.lockMap, args.Resources[0]) // Remove the write lock
 	return nil
 }
 
@@ -62,12 +62,12 @@ func (l *lockServer) RLock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply {
-		l.lockMap[args.Resource] = ReadLock // No locks held on the given name, so claim (first) read lock
+	if locksHeld, *reply = l.lockMap[args.Resources[0]]; !*reply {
+		l.lockMap[args.Resources[0]] = ReadLock // No locks held on the given name, so claim (first) read lock
 		*reply = true
 	} else {
 		if *reply = locksHeld != WriteLock; *reply { // Unless there is a write lock
-			l.lockMap[args.Resource] = locksHeld + ReadLock // Grant another read lock
+			l.lockMap[args.Resources[0]] = locksHeld + ReadLock // Grant another read lock
 		}
 	}
 	return nil
@@ -77,16 +77,16 @@ func (l *lockServer) RUnlock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply { // No lock is held on the given name
-		return fmt.Errorf("RUnlock attempted on an unlocked entity: %s", args.Resource)
+	if locksHeld, *reply = l.lockMap[args.Resources[0]]; !*reply { // No lock is held on the given name
+		return fmt.Errorf("RUnlock attempted on an unlocked entity: %s", args.Resources[0])
 	}
 	if *reply = locksHeld != WriteLock; !*reply { // A write-lock is held, cannot release a read lock
-		return fmt.Errorf("RUnlock attempted on a write locked entity: %s", args.Resource)
+		return fmt.Errorf("RUnlock attempted on a write locked entity: %s", args.Resources[0])
 	}
 	if locksHeld > ReadLock {
-		l.lockMap[args.Resource] = locksHeld - ReadLock // Remove one of the read locks held
+		l.lockMap[args.Resources[0]] = locksHeld - ReadLock // Remove one of the read locks held
 	} else {
-		delete(l.lockMap, args.Resource) // Remove the (last) read lock
+		delete(l.lockMap, args.Resources[0]) // Remove the (last) read lock
 	}
 	return nil
 }
@@ -97,7 +97,7 @@ func (l *lockServer) ForceUnlock(args *LockArgs, reply *bool) error {
 	if len(args.UID) != 0 {
 		return fmt.Errorf("ForceUnlock called with non-empty UID: %s", args.UID)
 	}
-	delete(l.lockMap, args.Resource) // Remove the lock (irrespective of write or read lock)
+	delete(l.lockMap, args.Resources[0]) // Remove the lock (irrespective of write or read lock)
 	*reply = true
 	return nil
 }

--- a/pkg/dsync/dsync_test.go
+++ b/pkg/dsync/dsync_test.go
@@ -89,7 +89,7 @@ func TestMain(m *testing.M) {
 
 func TestSimpleLock(t *testing.T) {
 
-	dm := NewDRWMutex(context.Background(), "test", ds)
+	dm := NewDRWMutex(context.Background(), ds, "test")
 
 	dm.Lock(id, source)
 
@@ -101,7 +101,7 @@ func TestSimpleLock(t *testing.T) {
 
 func TestSimpleLockUnlockMultipleTimes(t *testing.T) {
 
-	dm := NewDRWMutex(context.Background(), "test", ds)
+	dm := NewDRWMutex(context.Background(), ds, "test")
 
 	dm.Lock(id, source)
 	time.Sleep(time.Duration(10+(rand.Float32()*50)) * time.Millisecond)
@@ -127,8 +127,8 @@ func TestSimpleLockUnlockMultipleTimes(t *testing.T) {
 // Test two locks for same resource, one succeeds, one fails (after timeout)
 func TestTwoSimultaneousLocksForSameResource(t *testing.T) {
 
-	dm1st := NewDRWMutex(context.Background(), "aap", ds)
-	dm2nd := NewDRWMutex(context.Background(), "aap", ds)
+	dm1st := NewDRWMutex(context.Background(), ds, "aap")
+	dm2nd := NewDRWMutex(context.Background(), ds, "aap")
 
 	dm1st.Lock(id, source)
 
@@ -151,9 +151,9 @@ func TestTwoSimultaneousLocksForSameResource(t *testing.T) {
 // Test three locks for same resource, one succeeds, one fails (after timeout)
 func TestThreeSimultaneousLocksForSameResource(t *testing.T) {
 
-	dm1st := NewDRWMutex(context.Background(), "aap", ds)
-	dm2nd := NewDRWMutex(context.Background(), "aap", ds)
-	dm3rd := NewDRWMutex(context.Background(), "aap", ds)
+	dm1st := NewDRWMutex(context.Background(), ds, "aap")
+	dm2nd := NewDRWMutex(context.Background(), ds, "aap")
+	dm3rd := NewDRWMutex(context.Background(), ds, "aap")
 
 	dm1st.Lock(id, source)
 
@@ -216,8 +216,8 @@ func TestThreeSimultaneousLocksForSameResource(t *testing.T) {
 // Test two locks for different resources, both succeed
 func TestTwoSimultaneousLocksForDifferentResources(t *testing.T) {
 
-	dm1 := NewDRWMutex(context.Background(), "aap", ds)
-	dm2 := NewDRWMutex(context.Background(), "noot", ds)
+	dm1 := NewDRWMutex(context.Background(), ds, "aap")
+	dm2 := NewDRWMutex(context.Background(), ds, "noot")
 
 	dm1.Lock(id, source)
 	dm2.Lock(id, source)
@@ -243,7 +243,7 @@ func HammerMutex(m *DRWMutex, loops int, cdone chan bool) {
 // Borrowed from mutex_test.go
 func TestMutex(t *testing.T) {
 	c := make(chan bool)
-	m := NewDRWMutex(context.Background(), "test", ds)
+	m := NewDRWMutex(context.Background(), ds, "test")
 	for i := 0; i < 10; i++ {
 		go HammerMutex(m, 1000, c)
 	}
@@ -257,7 +257,7 @@ func BenchmarkMutexUncontended(b *testing.B) {
 		*DRWMutex
 	}
 	b.RunParallel(func(pb *testing.PB) {
-		var mu = PaddedMutex{NewDRWMutex(context.Background(), "", ds)}
+		var mu = PaddedMutex{NewDRWMutex(context.Background(), ds, "")}
 		for pb.Next() {
 			mu.Lock(id, source)
 			mu.Unlock()
@@ -266,7 +266,7 @@ func BenchmarkMutexUncontended(b *testing.B) {
 }
 
 func benchmarkMutex(b *testing.B, slack, work bool) {
-	mu := NewDRWMutex(context.Background(), "", ds)
+	mu := NewDRWMutex(context.Background(), ds, "")
 	if slack {
 		b.SetParallelism(10)
 	}
@@ -309,7 +309,7 @@ func BenchmarkMutexNoSpin(b *testing.B) {
 	// These goroutines yield during local work, so that switching from
 	// a blocked goroutine to other goroutines is profitable.
 	// As a matter of fact, this benchmark still triggers some spinning in the mutex.
-	m := NewDRWMutex(context.Background(), "", ds)
+	m := NewDRWMutex(context.Background(), ds, "")
 	var acc0, acc1 uint64
 	b.SetParallelism(4)
 	b.RunParallel(func(pb *testing.PB) {
@@ -341,7 +341,7 @@ func BenchmarkMutexSpin(b *testing.B) {
 	// profitable. To achieve this we create a goroutine per-proc.
 	// These goroutines access considerable amount of local data so that
 	// unnecessary rescheduling is penalized by cache misses.
-	m := NewDRWMutex(context.Background(), "", ds)
+	m := NewDRWMutex(context.Background(), ds, "")
 	var acc0, acc1 uint64
 	b.RunParallel(func(pb *testing.PB) {
 		var data [16 << 10]uint64

--- a/pkg/dsync/rpc-client-interface.go
+++ b/pkg/dsync/rpc-client-interface.go
@@ -21,8 +21,8 @@ type LockArgs struct {
 	// Unique ID of lock/unlock request.
 	UID string
 
-	// Resource contains a entity to be locked/unlocked.
-	Resource string
+	// Resources contains single or multiple entries to be locked/unlocked.
+	Resources []string
 
 	// Source contains the line number, function and file name of the code
 	// on the client node that requested the lock.


### PR DESCRIPTION


## Description
fix: Speed up multi-object delete by taking bulk locks

## Motivation and Context
Change distributed locking to allow taking bulk locks
across objects, reduces usually 1000 calls to 1.

Also allows for situations where multiple clients send
delete requests to objects with following names

```
{1,2,3,4,5}
```

```
{5,4,3,2,1}
```

will block and ensure that we do not fail the request
on each other.

## How to test this PR?
Run `warp delete` benchmarks

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
