### PR TITLE
Fix Tagging XML Unmarshalling

### DIFF
--- a/pkg/bucket/object/tagging/tagging.go
+++ b/pkg/bucket/object/tagging/tagging.go
@@ -41,7 +41,7 @@ var (
 
 // Tagging - object tagging interface
 type Tagging struct {
-	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Tagging"`
+	XMLName xml.Name `xml:"Tagging"`
 	TagSet  TagSet   `xml:"TagSet"`
 }
 


### PR DESCRIPTION
## Description
Fix Tagging XML Unmarshalling

## Motivation and Context
AWS S3 doesn't strictly enforce the presence of URL in tagging XML.
This PR updates MinIO to behave similarly.

Fixes #8976

## How to test this PR?
As explained in #8976 or trying sending a PutObjectTagging request with 
XMLNS not set.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
