### PR TITLE
metrics: Fix erroneous high value gateway received bytes

### DIFF
--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -434,7 +434,9 @@ func (m MetricsTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	metered := shouldMeterRequest(r)
 	if metered && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
 		m.Metrics.IncRequests(r.Method)
-		m.Metrics.IncBytesSent(r.ContentLength)
+		if r.ContentLength > 0 {
+			m.Metrics.IncBytesSent(uint64(r.ContentLength))
+		}
 	}
 	// Make the request to the server.
 	resp, err := m.Transport.RoundTrip(r)
@@ -442,7 +444,9 @@ func (m MetricsTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 	if metered && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
-		m.Metrics.IncBytesReceived(resp.ContentLength)
+		if r.ContentLength > 0 {
+			m.Metrics.IncBytesReceived(uint64(resp.ContentLength))
+		}
 	}
 	return resp, nil
 }

--- a/cmd/gateway-metrics.go
+++ b/cmd/gateway-metrics.go
@@ -37,8 +37,8 @@ type Metrics struct {
 }
 
 // IncBytesReceived - Increase total bytes received from gateway backend
-func (s *Metrics) IncBytesReceived(n int64) {
-	s.bytesReceived.Add(uint64(n))
+func (s *Metrics) IncBytesReceived(n uint64) {
+	s.bytesReceived.Add(n)
 }
 
 // GetBytesReceived - Get total bytes received from gateway backend
@@ -47,8 +47,8 @@ func (s *Metrics) GetBytesReceived() uint64 {
 }
 
 // IncBytesSent - Increase total bytes sent to gateway backend
-func (s *Metrics) IncBytesSent(n int64) {
-	s.bytesSent.Add(uint64(n))
+func (s *Metrics) IncBytesSent(n uint64) {
+	s.bytesSent.Add(n)
 }
 
 // GetBytesSent - Get total bytes received from gateway backend


### PR DESCRIPTION

## Description
http.Request.ContentLength can be negative, which affects
the gateway_s3_bytes_received value in prometheus output.

The commit only increases the value of the total received bytes
in gateway mode when r.ContentLength is greater than zero.


## Motivation and Context
Fix a erroneous value in prometheus gateway_s3_bytes_received

## How to test this PR?
*) Start MinIO server in S3 gateway mode
```
$ MINIO_PROMETHEUS_AUTH_TYPE="public" MINIO_ACCESS_KEY=xxx MINIO_SECRET_KEY=xxx minio gateway s3
```
*) Fetch gateway_s3_bytes_received value
```
 $  curl -v http://localhost:9000/minio/prometheus/metrics 2>/dev/null | gateway_s3_bytes_received
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
