### PR TITLE
Fix Legal Hold request parsing

### DIFF
--- a/pkg/bucket/object/lock/lock.go
+++ b/pkg/bucket/object/lock/lock.go
@@ -484,9 +484,6 @@ func ParseObjectLegalHold(reader io.Reader) (hold *ObjectLegalHold, err error) {
 	if hold.Status != ON && hold.Status != OFF {
 		return nil, ErrMalformedXML
 	}
-	if hold.XMLNS == "" {
-		hold.XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
-	}
 	return
 }
 


### PR DESCRIPTION
## Description
Fix Legal Hold request parsing

## Motivation and Context
AWS S3 doesn't enforce the URL in XMLNS, accordingly, removing the
URL in XMLNS for ObjectLegalHold.

This was found while testing https://github.com/minio/minio-go/pull/1226

## How to test this PR?
Use the code in https://github.com/minio/minio-go/pull/1226 against S3
and MinIO.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
