### PR TITLE
fix: Avoid crash when there is an error testing a target notif

### DIFF
--- a/cmd/config/notify/parse.go
+++ b/cmd/config/notify/parse.go
@@ -65,19 +65,19 @@ func GetNotificationTargets(cfg config.Config, doneCh <-chan struct{}, transport
 // * Add a new target in pkg/event/target package.
 // * Add newly added target configuration to serverConfig.Notify.<TARGET_NAME>.
 // * Handle the configuration in this function to create/add into TargetList.
-func RegisterNotificationTargets(cfg config.Config, doneCh <-chan struct{}, transport *http.Transport, targetIDs []event.TargetID, test bool) (targetList *event.TargetList, registerErr error) {
-	targetList = event.NewTargetList()
+func RegisterNotificationTargets(cfg config.Config, doneCh <-chan struct{}, transport *http.Transport, targetIDs []event.TargetID, test bool) (_ *event.TargetList, err error) {
+	targetList := event.NewTargetList()
 
-	// Automatially close all connections when an error occur
 	defer func() {
-		if registerErr != nil {
+		// Automatically close all connections to targets when an error occur
+		if err != nil {
 			for _, t := range targetList.TargetMap() {
 				_ = t.Close()
 			}
 		}
 	}()
 
-	if err := checkValidNotificationKeys(cfg); err != nil {
+	if err = checkValidNotificationKeys(cfg); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description
RegisterNotificationTargets() cleans up all connections that it mades to
notification targets when an error occurs during its execution.

However there is a typo in the code that makes the function to always
try to access to a nil pointer in the defer code since the function
in question will always return nil in the case of any error.

This commit fixes the typo in the code.


## Motivation and Context
Fix a crash detected by @klauspost 


## How to test this PR?
- Start a fresh installation of MinIO server
- Enable a notification target
- Restart the server when the notification target is down

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (https://github.com/minio/minio/pull/8966)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
