### PR TITLE
Omit empty algorithm tags in bucket encryption XML

### DIFF
--- a/pkg/bucket/encryption/bucket-sse-config.go
+++ b/pkg/bucket/encryption/bucket-sse-config.go
@@ -58,8 +58,8 @@ func (alg *SSEAlgorithm) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 
 // EncryptionAction - for ApplyServerSideEncryptionByDefault XML tag
 type EncryptionAction struct {
-	Algorithm   SSEAlgorithm `xml:"SSEAlgorithm"`
-	MasterKeyID string       `xml:"KMSMasterKeyID"`
+	Algorithm   SSEAlgorithm `xml:"SSEAlgorithm,omitempty"`
+	MasterKeyID string       `xml:"KMSMasterKeyID,omitempty"`
 }
 
 // SSERule - for ServerSideEncryptionConfiguration XML tag
@@ -67,8 +67,11 @@ type SSERule struct {
 	DefaultEncryptionAction EncryptionAction `xml:"ApplyServerSideEncryptionByDefault"`
 }
 
+const xmlNS = "http://s3.amazonaws.com/doc/2006-03-01/"
+
 // BucketSSEConfig - represents default bucket encryption configuration
 type BucketSSEConfig struct {
+	XMLNS   string    `xml:"xmlns,attr,omitempty"`
 	XMLName xml.Name  `xml:"ServerSideEncryptionConfiguration"`
 	Rules   []SSERule `xml:"Rule"`
 }
@@ -99,5 +102,10 @@ func ParseBucketSSEConfig(r io.Reader) (*BucketSSEConfig, error) {
 			}
 		}
 	}
+
+	if config.XMLNS == "" {
+		config.XMLNS = xmlNS
+	}
+
 	return &config, nil
 }


### PR DESCRIPTION
## Description
MinIO server returns empty XML tags that weren't part of the default bucket encryption XML. This is fixed by adding `omitempty` annotation to the corresponding members of the underlying type.

## Motivation and Context
See above

## How to test this PR?
1. Set bucket encryption config on a bucket
2. Get the config from the same bucket and confirm that the XMLs match.
N B The namespace attribute of the top-level XML tag will always be present (S3 compatbility). Ignore this difference between the input XML and the one received through GET bucket encryption call.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
