### PR TITLE
fix: indicate PutBucketEncryption as a valid policy action

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1171,6 +1171,9 @@ var iamAccountOtherAccessActions = iampolicy.NewActionSet(
 	iampolicy.PutBucketPolicyAction,
 	iampolicy.DeleteBucketPolicyAction,
 	iampolicy.GetBucketPolicyAction,
+
+	iampolicy.PutBucketEncryptionAction,
+	iampolicy.GetBucketEncryptionAction,
 )
 
 // GetAccountAccess iterates over all policies documents associated to a user

--- a/pkg/bucket/policy/action.go
+++ b/pkg/bucket/policy/action.go
@@ -120,58 +120,71 @@ const (
 	GetBucketEncryptionAction = "s3:GetEncryptionConfiguration"
 )
 
+// List of all supported object actions.
+var supportedObjectActions = map[Action]struct{}{
+	AbortMultipartUploadAction:      {},
+	DeleteObjectAction:              {},
+	GetObjectAction:                 {},
+	ListMultipartUploadPartsAction:  {},
+	PutObjectAction:                 {},
+	BypassGovernanceModeAction:      {},
+	BypassGovernanceRetentionAction: {},
+	PutObjectRetentionAction:        {},
+	GetObjectRetentionAction:        {},
+	PutObjectLegalHoldAction:        {},
+	GetObjectLegalHoldAction:        {},
+	GetObjectTaggingAction:          {},
+	PutObjectTaggingAction:          {},
+	DeleteObjectTaggingAction:       {},
+}
+
 // isObjectAction - returns whether action is object type or not.
 func (action Action) isObjectAction() bool {
-	switch action {
-	case AbortMultipartUploadAction, DeleteObjectAction, GetObjectAction:
-		fallthrough
-	case ListMultipartUploadPartsAction, PutObjectAction:
-		return true
-	case PutObjectRetentionAction, GetObjectRetentionAction:
-		return true
-	case PutObjectLegalHoldAction, GetObjectLegalHoldAction:
-		return true
-	case BypassGovernanceModeAction, BypassGovernanceRetentionAction:
-		return true
-	case GetObjectTaggingAction, PutObjectTaggingAction, DeleteObjectTaggingAction:
-		return true
-	}
+	_, ok := supportedObjectActions[action]
+	return ok
+}
 
-	return false
+// List of all supported actions.
+var supportedActions = map[Action]struct{}{
+	AbortMultipartUploadAction:             {},
+	CreateBucketAction:                     {},
+	DeleteBucketAction:                     {},
+	DeleteBucketPolicyAction:               {},
+	DeleteObjectAction:                     {},
+	GetBucketLocationAction:                {},
+	GetBucketNotificationAction:            {},
+	GetBucketPolicyAction:                  {},
+	GetObjectAction:                        {},
+	HeadBucketAction:                       {},
+	ListAllMyBucketsAction:                 {},
+	ListBucketAction:                       {},
+	ListBucketMultipartUploadsAction:       {},
+	ListenBucketNotificationAction:         {},
+	ListMultipartUploadPartsAction:         {},
+	PutBucketNotificationAction:            {},
+	PutBucketPolicyAction:                  {},
+	PutObjectAction:                        {},
+	GetBucketLifecycleAction:               {},
+	PutBucketLifecycleAction:               {},
+	PutObjectRetentionAction:               {},
+	GetObjectRetentionAction:               {},
+	GetObjectLegalHoldAction:               {},
+	PutObjectLegalHoldAction:               {},
+	PutBucketObjectLockConfigurationAction: {},
+	GetBucketObjectLockConfigurationAction: {},
+	BypassGovernanceModeAction:             {},
+	BypassGovernanceRetentionAction:        {},
+	GetObjectTaggingAction:                 {},
+	PutObjectTaggingAction:                 {},
+	DeleteObjectTaggingAction:              {},
+	PutBucketEncryptionAction:              {},
+	GetBucketEncryptionAction:              {},
 }
 
 // IsValid - checks if action is valid or not.
 func (action Action) IsValid() bool {
-	switch action {
-	case AbortMultipartUploadAction, CreateBucketAction, DeleteBucketAction:
-		fallthrough
-	case DeleteBucketPolicyAction, DeleteObjectAction, GetBucketLocationAction:
-		fallthrough
-	case GetBucketNotificationAction, GetBucketPolicyAction, GetObjectAction:
-		fallthrough
-	case HeadBucketAction, ListAllMyBucketsAction, ListBucketAction:
-		fallthrough
-	case ListBucketMultipartUploadsAction, ListenBucketNotificationAction:
-		fallthrough
-	case ListMultipartUploadPartsAction, PutBucketNotificationAction:
-		fallthrough
-	case PutBucketPolicyAction, PutObjectAction:
-		fallthrough
-	case PutBucketLifecycleAction, GetBucketLifecycleAction:
-		return true
-	case BypassGovernanceModeAction, BypassGovernanceRetentionAction:
-		return true
-	case PutObjectRetentionAction, GetObjectRetentionAction:
-		return true
-	case PutObjectLegalHoldAction, GetObjectLegalHoldAction:
-		return true
-	case PutBucketObjectLockConfigurationAction, GetBucketObjectLockConfigurationAction:
-		return true
-	case GetObjectTaggingAction, PutObjectTaggingAction, DeleteObjectTaggingAction:
-		return true
-	}
-
-	return false
+	_, ok := supportedActions[action]
+	return ok
 }
 
 // MarshalJSON - encodes Action to JSON data.

--- a/pkg/iam/policy/action.go
+++ b/pkg/iam/policy/action.go
@@ -123,6 +123,12 @@ const (
 	// DeleteObjectTaggingAction - Delete Object Tags API action
 	DeleteObjectTaggingAction = "s3:DeleteObjectTagging"
 
+	// PutBucketEncryptionAction - PutBucketEncryption REST API action
+	PutBucketEncryptionAction = "s3:PutEncryptionConfiguration"
+
+	// GetBucketEncryptionAction - GetBucketEncryption REST API action
+	GetBucketEncryptionAction = "s3:GetEncryptionConfiguration"
+
 	// AllActions - all API actions
 	AllActions = "s3:*"
 )
@@ -161,26 +167,33 @@ var supportedActions = map[Action]struct{}{
 	GetObjectTaggingAction:                 {},
 	PutObjectTaggingAction:                 {},
 	DeleteObjectTaggingAction:              {},
+	PutBucketEncryptionAction:              {},
+	GetBucketEncryptionAction:              {},
+}
+
+// List of all supported object actions.
+var supportedObjectActions = map[Action]struct{}{
+	AllActions:                      {},
+	AbortMultipartUploadAction:      {},
+	DeleteObjectAction:              {},
+	GetObjectAction:                 {},
+	ListMultipartUploadPartsAction:  {},
+	PutObjectAction:                 {},
+	BypassGovernanceModeAction:      {},
+	BypassGovernanceRetentionAction: {},
+	PutObjectRetentionAction:        {},
+	GetObjectRetentionAction:        {},
+	PutObjectLegalHoldAction:        {},
+	GetObjectLegalHoldAction:        {},
+	GetObjectTaggingAction:          {},
+	PutObjectTaggingAction:          {},
+	DeleteObjectTaggingAction:       {},
 }
 
 // isObjectAction - returns whether action is object type or not.
 func (action Action) isObjectAction() bool {
-	switch action {
-	case AbortMultipartUploadAction, DeleteObjectAction, GetObjectAction:
-		fallthrough
-	case ListMultipartUploadPartsAction, PutObjectAction, AllActions:
-		return true
-	case BypassGovernanceModeAction, BypassGovernanceRetentionAction:
-		return true
-	case PutObjectRetentionAction, GetObjectRetentionAction:
-		return true
-	case PutObjectLegalHoldAction, GetObjectLegalHoldAction:
-		return true
-	case GetObjectTaggingAction, PutObjectTaggingAction, DeleteObjectTaggingAction:
-		return true
-	}
-
-	return false
+	_, ok := supportedObjectActions[action]
+	return ok
 }
 
 // Match - matches object name with resource pattern.


### PR DESCRIPTION
## Description
fix: indicate PutBucketEncryption as a valid policy action

## Motivation and Context
PutBucketEncryption/GetBucketEncryption are not considered valid actions and fail.

## How to test this PR?
Create a user and then apply a policy with `s3:PutEncryptionConfiguration` set

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
