### PR TITLE
fix: avoid double ListBuckets() loading object lock

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -263,7 +263,12 @@ func initAllSubsystems(buckets []BucketInfo, newObject ObjectLayer) (err error) 
 
 	// Initialize policy system.
 	if err = globalPolicySys.Init(buckets, newObject); err != nil {
-		return fmt.Errorf("Unable to initialize policy system; %w", err)
+		return fmt.Errorf("Unable to initialize policy system: %w", err)
+	}
+
+	// Initialize bucket object lock.
+	if err = initBucketObjectLockConfig(buckets, newObject); err != nil {
+		return fmt.Errorf("Unable to initialize object lock system: %w", err)
 	}
 
 	// Initialize lifecycle system.
@@ -275,6 +280,7 @@ func initAllSubsystems(buckets []BucketInfo, newObject ObjectLayer) (err error) 
 	if err = globalBucketSSEConfigSys.Init(buckets, newObject); err != nil {
 		return fmt.Errorf("Unable to initialize bucket encryption subsystem: %w", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description
fix: avoid double ListBuckets() loading object lock

## Motivation and Context
just code review fix, related to #8994 

## How to test this PR?
observe speedups during server startup

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression not sure but it does look like this speed up was achieved last time.
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
