### PR TITLE
allow rolling upgrades, remove same MinIO version requirement

### DIFF
--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -86,7 +86,6 @@ func authenticateNode(accessKey, secretKey, audience string) (string, error) {
 	claims.SetExpiry(UTCNow().Add(defaultInterNodeJWTExpiry))
 	claims.SetAccessKey(accessKey)
 	claims.SetAudience(audience)
-	claims.SetIssuer(ReleaseTag)
 
 	jwt := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, claims)
 	return jwt.SignedString([]byte(secretKey))

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -79,10 +79,6 @@ func storageServerRequestValidate(r *http.Request) error {
 		return errAuthentication
 	}
 
-	if claims.Issuer != ReleaseTag {
-		return errAuthentication
-	}
-
 	requestTimeStr := r.Header.Get("X-Minio-Time")
 	requestTime, err := time.Parse(time.RFC3339, requestTimeStr)
 	if err != nil {


### PR DESCRIPTION

## Description
Upgrades between releases are failing due to strict
rule to avoid rolling upgrades, it is enough to bump up
APIs between versions to allow for a quorum
failure and wait times. Authentication failures are
catastrophic in nature which leads to server not
be able to upgrade properly.


## Motivation and Context
Fixes #9021
Fixes #8968

## How to test this PR?
Easy to reproduce to follow steps in #9021 and #8968 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression indeed a regression in introduced in #8802
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
