### PR TITLE
simplify recordAPIStats wrapper for ResponseWriters

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -538,9 +538,8 @@ func setHTTPStatsHandler(h http.Handler) http.Handler {
 func (h httpStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	isS3Request := !strings.HasPrefix(r.URL.Path, minioReservedBucketPath)
 	// record s3 connection stats.
-	recordRequest := &recordTrafficRequest{ReadCloser: r.Body, isS3Request: isS3Request}
-	r.Body = recordRequest
-	recordResponse := &recordTrafficResponse{w, isS3Request}
+	r.Body = &recordTrafficRequest{ReadCloser: r.Body, isS3Request: isS3Request}
+	recordResponse := &recordTrafficResponse{ResponseWriter: w, isS3Request: isS3Request}
 	// Execute the request
 	h.handler.ServeHTTP(recordResponse, r)
 }

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -362,14 +362,16 @@ func collectAPIStats(api string, f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		isS3Request := !strings.HasPrefix(r.URL.Path, minioReservedBucketPath)
-		apiStatsWriter := &recordAPIStats{w, UTCNow(), false, 0, isS3Request}
 
 		// Time start before the call is about to start.
 		tBefore := UTCNow()
 
+		apiStatsWriter := &recordAPIStats{ResponseWriter: w, TTFB: tBefore, isS3Request: isS3Request}
+
 		if isS3Request {
 			globalHTTPStats.currentS3Requests.Inc(api)
 		}
+
 		// Execute the request
 		f.ServeHTTP(apiStatsWriter, r)
 

--- a/cmd/http-traffic-recorder.go
+++ b/cmd/http-traffic-recorder.go
@@ -41,23 +41,13 @@ func (r *recordTrafficRequest) Read(p []byte) (n int, err error) {
 // Records the outgoing bytes through the responseWriter.
 type recordTrafficResponse struct {
 	// wrapper for underlying http.ResponseWriter.
-	writer      http.ResponseWriter
+	http.ResponseWriter
 	isS3Request bool
-}
-
-// Calls the underlying WriteHeader.
-func (r *recordTrafficResponse) WriteHeader(i int) {
-	r.writer.WriteHeader(i)
-}
-
-// Calls the underlying Header.
-func (r *recordTrafficResponse) Header() http.Header {
-	return r.writer.Header()
 }
 
 // Records the output bytes
 func (r *recordTrafficResponse) Write(p []byte) (n int, err error) {
-	n, err = r.writer.Write(p)
+	n, err = r.ResponseWriter.Write(p)
 	globalConnStats.incOutputBytes(n)
 	// Check if it is s3 request
 	if r.isS3Request {
@@ -68,13 +58,12 @@ func (r *recordTrafficResponse) Write(p []byte) (n int, err error) {
 
 // Calls the underlying Flush.
 func (r *recordTrafficResponse) Flush() {
-	r.writer.(http.Flusher).Flush()
+	r.ResponseWriter.(http.Flusher).Flush()
 }
 
 // Records the outgoing bytes through the responseWriter.
 type recordAPIStats struct {
-	// wrapper for underlying http.ResponseWriter.
-	writer         http.ResponseWriter
+	http.ResponseWriter
 	TTFB           time.Time // TimeToFirstByte.
 	firstByteRead  bool
 	respStatusCode int
@@ -84,12 +73,7 @@ type recordAPIStats struct {
 // Calls the underlying WriteHeader.
 func (r *recordAPIStats) WriteHeader(i int) {
 	r.respStatusCode = i
-	r.writer.WriteHeader(i)
-}
-
-// Calls the underlying Header.
-func (r *recordAPIStats) Header() http.Header {
-	return r.writer.Header()
+	r.ResponseWriter.WriteHeader(i)
 }
 
 // Records the TTFB on the first byte write.
@@ -98,10 +82,10 @@ func (r *recordAPIStats) Write(p []byte) (n int, err error) {
 		r.TTFB = UTCNow()
 		r.firstByteRead = true
 	}
-	return r.writer.Write(p)
+	return r.ResponseWriter.Write(p)
 }
 
 // Calls the underlying Flush.
 func (r *recordAPIStats) Flush() {
-	r.writer.(http.Flusher).Flush()
+	r.ResponseWriter.(http.Flusher).Flush()
 }


### PR DESCRIPTION
## Description
simplify recordAPIStats wrapper for ResponseWriters

## Motivation and Context
simplify, remove redundant code

## How to test this PR?
Fixes while trying to debug errors like 

```
Feb  8 03:44:20 doc-node01 minio: 2020/02/08 03:44:20 http: superfluous response.WriteHeader call from github.com/minio/minio/cmd.(*recordTrafficResponse).WriteHeader (http-traffic-recorder.go:50)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
