### PR TITLE
cpu package fails to build on illumos

### DIFF
--- a/pkg/cpu/counter_other.go
+++ b/pkg/cpu/counter_other.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd openbsd netbsd dragonfly windows
+// +build darwin freebsd openbsd netbsd dragonfly windows solaris
 
 /*
  * MinIO Cloud Storage, (C) 2019 MinIO, Inc.

--- a/pkg/cpu/counter_other.go
+++ b/pkg/cpu/counter_other.go
@@ -1,7 +1,7 @@
-// +build darwin freebsd openbsd netbsd dragonfly windows solaris
+// +build !linux
 
 /*
- * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2019-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Building minio currently fails on illumos systems. One problem is that the `cpu` package fails to build. It appears the problem is that the `solaris` build target is missing for the `counter_other.go` file. Adding the solaris build target allows the cpu package to compile.

## Motivation and Context
On the current minio master branch:
```
$ go build
# github.com/minio/minio/pkg/cpu
pkg/cpu/cpu.go:105:22: undefined: newCounter
```

## How to test this PR?

minio still does not build on illumos without a few patches to minio's dependencies. After applying those patches (which are not to the minio/minio project's tree) and this patch, we can run a build on an illumos machine:
```
$ uname -a
SunOS rust.kkantor.com 5.11 joyent_20191122T201258Z i86pc i386 i86pc illumos
$ git branch --show-current
illumos_build
$ go build
$ echo $?
0
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
