### PR TITLE
Simplify redis access event format to faciliate parsing

### DIFF
--- a/pkg/event/target/redis.go
+++ b/pkg/event/target/redis.go
@@ -191,7 +191,7 @@ func (target *RedisTarget) send(eventData event.Event) error {
 	}
 
 	if target.args.Format == event.AccessFormat {
-		data, err := json.Marshal([]RedisAccessEvent{RedisAccessEvent{Event: []event.Event{eventData}, EventTime: eventData.EventTime}})
+		data, err := json.Marshal([]RedisAccessEvent{{Event: []event.Event{eventData}, EventTime: eventData.EventTime}})
 		if err != nil {
 			return err
 		}

--- a/pkg/event/target/redis.go
+++ b/pkg/event/target/redis.go
@@ -61,6 +61,12 @@ type RedisArgs struct {
 	QueueLimit uint64    `json:"queueLimit"`
 }
 
+// RedisAccessEvent holds event log data and timestamp
+type RedisAccessEvent struct {
+	Event     []event.Event
+	EventTime string
+}
+
 // Validate RedisArgs fields
 func (r RedisArgs) Validate() error {
 	if !r.Enable {
@@ -185,10 +191,7 @@ func (target *RedisTarget) send(eventData event.Event) error {
 	}
 
 	if target.args.Format == event.AccessFormat {
-		data, err := json.Marshal(struct {
-			Event     []event.Event
-			EventTime string
-		}{Event: []event.Event{eventData}, EventTime: eventData.EventTime})
+		data, err := json.Marshal([]RedisAccessEvent{RedisAccessEvent{Event: []event.Event{eventData}, EventTime: eventData.EventTime}})
 		if err != nil {
 			return err
 		}

--- a/pkg/event/target/redis.go
+++ b/pkg/event/target/redis.go
@@ -185,7 +185,10 @@ func (target *RedisTarget) send(eventData event.Event) error {
 	}
 
 	if target.args.Format == event.AccessFormat {
-		data, err := json.Marshal([]interface{}{eventData.EventTime, []event.Event{eventData}})
+		data, err := json.Marshal(struct {
+			Event     []event.Event
+			EventTime string
+		}{Event: []event.Event{eventData}, EventTime: eventData.EventTime})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description
As per #7362; Change the output format so it's more "correct" JSON. It can be parsed easily now into the following struct in golang;

```
import "github.com/minio/minio-go"

type MinioEvent struct {
	Event     []minio.NotificationEvent
	EventTime string
}
```
EventTime is currently a string so I don't see a need to parse it to a `time.Time` only to marshal it back immediately after and potentially changing the time format.

## Motivation and Context
Attempting to read the access format event log using a client such as Redis in Golang meant parsing the format was difficult to to having different types inside of a JSON array. This change allows the Golang json.Marshaler to do so automatically.

## How to test this PR?
The following example code shows a successful parsing of the event received from Redis into the struct above;

It assumes Redis is running at `localhost:6379` and that notification events have been set with the key "bucketevents"
```
package main

import (
	"encoding/json"
	"log"

	"github.com/go-redis/redis"
	"github.com/minio/minio-go"
)

// MinioEvent holds the (access format) event received from Minio via Redis
type MinioEvent struct {
	Event     []minio.NotificationEvent
	EventTime string
}

func popEvents(cli *redis.Client) {

	for {
		vals, err := cli.BLPop(0, "bucketevents").Result()
		if err != nil {
			log.Println("BLPop error: ", err)
			continue
		}

		ev := []MinioEvent{}
		err = json.Unmarshal([]byte(vals[1]), &ev)
		if err != nil {
			log.Println("Unmarshal error: ", err)
			continue
		}

		log.Printf("MinioEvent: %s, value: %+v", vals[0], ev)
	}
}

func main() {

	opts := &redis.Options{
		Addr: "localhost:6379",
	}

	cli := redis.NewClient(opts)

	popEvents(cli)

}

```


## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
