### PR TITLE
print version with proper indentation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,7 +74,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}{{end}}
 VERSION:
-{{.Version}}
+  {{.Version}}
 `
 
 func newApp(name string) *cli.App {


### PR DESCRIPTION
## Description
print version with proper indentation

## Motivation and Context
currently, version is printed as

```
VERSION:
DEVELOPMENT.2020-02-26T14-30-02Z
```

this is what we want

```
VERSION:
  DEVELOPMENT.2020-02-26T14-30-02Z
```

## How to test this PR?
`minio --help` and see the VERSION string at the end

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably yes not sure when
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
