### PR TITLE
accessKeyId missing should return an appropriate error in AssumeRole

### DIFF
--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -83,14 +83,15 @@ func getOpName(name string) (op string) {
 	op = strings.TrimPrefix(name, "github.com/minio/minio/cmd.")
 	op = strings.TrimSuffix(op, "Handler-fm")
 	op = strings.Replace(op, "objectAPIHandlers", "s3", 1)
-	op = strings.Replace(op, "webAPIHandlers", "s3", 1)
+	op = strings.Replace(op, "webAPIHandlers", "webui", 1)
 	op = strings.Replace(op, "adminAPIHandlers", "admin", 1)
 	op = strings.Replace(op, "(*storageRESTServer)", "internal", 1)
 	op = strings.Replace(op, "(*peerRESTServer)", "internal", 1)
 	op = strings.Replace(op, "(*lockRESTServer)", "internal", 1)
-	op = strings.Replace(op, "stsAPIHandlers", "sts", 1)
+	op = strings.Replace(op, "(*stsAPIHandlers)", "sts", 1)
 	op = strings.Replace(op, "LivenessCheckHandler", "healthcheck", 1)
 	op = strings.Replace(op, "ReadinessCheckHandler", "healthcheck", 1)
+	op = strings.Replace(op, "-fm", "", 1)
 	return op
 }
 

--- a/cmd/sts-errors.go
+++ b/cmd/sts-errors.go
@@ -78,6 +78,7 @@ const (
 	ErrSTSInvalidParameterValue
 	ErrSTSWebIdentityExpiredToken
 	ErrSTSClientGrantsExpiredToken
+	ErrSTSInvalidAccessKey
 	ErrSTSInvalidClientGrantsToken
 	ErrSTSMalformedPolicyDocument
 	ErrSTSNotInitialized
@@ -126,6 +127,11 @@ var stsErrCodes = stsErrorCodeMap{
 		Code:           "InvalidClientGrantsToken",
 		Description:    "The client grants token that was passed could not be validated by MinIO.",
 		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrSTSInvalidAccessKey: {
+		Code:           "InvalidClientTokenId",
+		Description:    "The security token included in the request is invalid.",
+		HTTPStatusCode: http.StatusForbidden,
 	},
 	ErrSTSMalformedPolicyDocument: {
 		Code:           "MalformedPolicyDocument",

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -116,11 +116,17 @@ func checkAssumeRoleAuth(ctx context.Context, r *http.Request) (user auth.Creden
 	case authTypeSigned:
 		s3Err := isReqAuthenticated(ctx, r, globalServerRegion, serviceSTS)
 		if STSErrorCode(s3Err) != ErrSTSNone {
+			if s3Err == ErrInvalidAccessKeyID {
+				return user, ErrSTSInvalidAccessKey
+			}
 			return user, STSErrorCode(s3Err)
 		}
 		var owner bool
 		user, owner, s3Err = getReqAccessKeyV4(r, globalServerRegion, serviceSTS)
 		if STSErrorCode(s3Err) != ErrSTSNone {
+			if s3Err == ErrInvalidAccessKeyID {
+				return user, ErrSTSInvalidAccessKey
+			}
 			return user, STSErrorCode(s3Err)
 		}
 		// Root credentials are not allowed to use STS API


### PR DESCRIPTION


## Description
accessKeyId missing should return an appropriate error in AssumeRole

## Motivation and Context
For a non-existent user, server would return STS not initialized
```
aws --profile harsha --endpoint-url http://localhost:9000 \
      sts assume-role \
      --role-arn arn:xxx:xxx:xxx:xxxx \
      --role-session-name anything
```

instead return an appropriate error as expected by STS API

Additionally, also format the `trace` output for STS APIs

## How to test this PR?
As mentioned in the Context

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
