### PR TITLE
introduce WalkOptions to customize object traversal

### DIFF
--- a/cmd/daily-lifecycle-ops.go
+++ b/cmd/daily-lifecycle-ops.go
@@ -133,11 +133,9 @@ func lifecycleRound(ctx context.Context, objAPI ObjectLayer) error {
 		}
 		commonPrefix := lcp(prefixes)
 
-		// Allocate new results channel to receive ObjectInfo.
-		objInfoCh := make(chan ObjectInfo)
-
 		// Walk through all objects
-		if err := objAPI.Walk(ctx, bucket.Name, commonPrefix, objInfoCh); err != nil {
+		objInfoCh, err := objAPI.Walk(ctx, bucket.Name, commonPrefix, WalkOptions{Recursive: true})
+		if err != nil {
 			return err
 		}
 

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1246,13 +1246,13 @@ func (fs *FSObjects) HealBucket(ctx context.Context, bucket string, dryRun, remo
 	return madmin.HealResultItem{}, NotImplemented{}
 }
 
-// Walk a bucket, optionally prefix recursively, until we have returned
-// all the content to objectInfo channel, it is callers responsibility
-// to allocate a receive channel for ObjectInfo, upon any unhandled
-// error walker returns error. Optionally if context.Done() is received
-// then Walk() stops the walker.
-func (fs *FSObjects) Walk(ctx context.Context, bucket, prefix string, results chan<- ObjectInfo) error {
-	return fsWalk(ctx, fs, bucket, prefix, fs.listDirFactory(), results, fs.getObjectInfo, fs.getObjectInfo)
+// Walk traverses all objects inside a bucket under an optionally prefix and
+// returns a receive-only channel that returns all traversed objects.
+//
+// Walk closes the returned channel once it has visited all objects or
+// once the ctx.Done() stops blocking.
+func (fs *FSObjects) Walk(ctx context.Context, bucket, prefix string, opts WalkOptions) (<-chan ObjectInfo, error) {
+	return fsWalk(ctx, fs, bucket, prefix, fs.listDirFactory(), opts, fs.getObjectInfo, fs.getObjectInfo)
 }
 
 // HealObjects - no-op for fs. Valid only for XL.

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -177,8 +177,8 @@ func (a GatewayUnsupported) ListObjectsV2(ctx context.Context, bucket, prefix, c
 }
 
 // Walk - Not implemented stub
-func (a GatewayUnsupported) Walk(ctx context.Context, bucket, prefix string, results chan<- ObjectInfo) error {
-	return NotImplemented{}
+func (a GatewayUnsupported) Walk(ctx context.Context, bucket, prefix string, opts WalkOptions) (<-chan ObjectInfo, error) {
+	return nil, NotImplemented{}
 }
 
 // HealObjects - Not implemented stub

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -43,6 +43,13 @@ type ObjectOptions struct {
 	CheckCopyPrecondFn   CheckCopyPreconditionFn
 }
 
+// WalkOptions allows to customize how an ObjectLayer implementation
+// performs a Walk - e.g. whether the traversal walk should be recursive
+// or not.
+type WalkOptions struct {
+	Recursive bool
+}
+
 // LockType represents required locking for ObjectLayer operations
 type LockType int
 
@@ -69,7 +76,7 @@ type ObjectLayer interface {
 	DeleteBucket(ctx context.Context, bucket string) error
 	ListObjects(ctx context.Context, bucket, prefix, marker, delimiter string, maxKeys int) (result ListObjectsInfo, err error)
 	ListObjectsV2(ctx context.Context, bucket, prefix, continuationToken, delimiter string, maxKeys int, fetchOwner bool, startAfter string) (result ListObjectsV2Info, err error)
-	Walk(ctx context.Context, bucket, prefix string, results chan<- ObjectInfo) error
+	Walk(ctx context.Context, bucket, prefix string, opts WalkOptions) (<-chan ObjectInfo, error)
 
 	// Object operations.
 

--- a/cmd/xl-v1-list-objects-heal.go
+++ b/cmd/xl-v1-list-objects-heal.go
@@ -35,7 +35,7 @@ func (xl xlObjects) HealObjects(ctx context.Context, bucket, prefix string, fn h
 }
 
 // this is not implemented/needed anymore, look for xl-sets.Walk()
-func (xl xlObjects) Walk(ctx context.Context, bucket, prefix string, results chan<- ObjectInfo) error {
+func (xl xlObjects) Walk(ctx context.Context, bucket, prefix string, opts WalkOptions) (<-chan ObjectInfo, error) {
 	logger.LogIf(ctx, NotImplemented{})
-	return NotImplemented{}
+	return nil, NotImplemented{}
 }


### PR DESCRIPTION
## Description
This commit adds a `WalkOptions` struct to allow
customization of object traversal via the `Walk`
method.

This commit only adds the recursive flag. More options
may be added in the future.

Further, this commit changes who has to create the
`ObjectInfo` channel used to communicate the object
traversal results. Now, the caller of the `Walk` just
obtains a receive-only channel and can iterate over it.
The `Walk` implementation itself is now responsible to
create the channel.

## Motivation and Context
This functionality is needed for KMS key rotation since the rotation may be not recursive 
See: #8965 

## How to test this PR?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
