### PR TITLE
Skip building directio on platforms that don't support Direct IO

### DIFF
--- a/cmd/disk-cache-backend.go
+++ b/cmd/disk-cache-backend.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2019-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ import (
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/disk"
 	"github.com/minio/sio"
-	"github.com/ncw/directio"
 	"go.uber.org/atomic"
 )
 
@@ -158,7 +157,7 @@ func newDiskCache(dir string, quotaPct, after, lowWatermark, highWatermark int) 
 		onlineMutex:   &sync.RWMutex{},
 		pool: sync.Pool{
 			New: func() interface{} {
-				b := directio.AlignedBlock(int(cacheBlkSize))
+				b := disk.AlignedBlock(int(cacheBlkSize))
 				return &b
 			},
 		},

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2016-2019 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2016-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ import (
 	"github.com/minio/minio/pkg/disk"
 	xioutil "github.com/minio/minio/pkg/ioutil"
 	"github.com/minio/minio/pkg/mountinfo"
-	"github.com/ncw/directio"
 )
 
 const (
@@ -213,7 +212,7 @@ func newPosix(path string) (*posix, error) {
 		diskPath: path,
 		pool: sync.Pool{
 			New: func() interface{} {
-				b := directio.AlignedBlock(readBlockSize)
+				b := disk.AlignedBlock(readBlockSize)
 				return &b
 			},
 		},

--- a/pkg/disk/directio_darwin.go
+++ b/pkg/disk/directio_darwin.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2019 Minio, Inc.
+ * Minio Cloud Storage, (C) 2019-2020 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,4 +33,9 @@ func DisableDirectIO(f *os.File) error {
 	fd := f.Fd()
 	_, err := unix.FcntlInt(fd, unix.F_NOCACHE, 0)
 	return err
+}
+
+// AlignedBlock - pass through to directio implementation.
+func AlignedBlock(BlockSize int) []byte {
+	return directio.AlignedBlock(BlockSize)
 }

--- a/pkg/disk/directio_unix.go
+++ b/pkg/disk/directio_unix.go
@@ -1,7 +1,7 @@
 // +build linux netbsd freebsd
 
 /*
- * Minio Cloud Storage, (C) 2019 Minio, Inc.
+ * Minio Cloud Storage, (C) 2019-2020 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,4 +41,9 @@ func DisableDirectIO(f *os.File) error {
 	flag = flag & ^(syscall.O_DIRECT)
 	_, err = unix.FcntlInt(fd, unix.F_SETFL, flag)
 	return err
+}
+
+// AlignedBlock - pass through to directio implementation.
+func AlignedBlock(BlockSize int) []byte {
+	return directio.AlignedBlock(BlockSize)
 }

--- a/pkg/disk/directio_unsupported.go
+++ b/pkg/disk/directio_unsupported.go
@@ -1,7 +1,7 @@
 // +build !linux,!netbsd,!freebsd,!darwin
 
 /*
- * Minio Cloud Storage, (C) 2019 Minio, Inc.
+ * Minio Cloud Storage, (C) 2019-2020 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,30 @@ import (
 	"os"
 )
 
-// OpenBSD and Windows not supported.
-// On OpenBSD O_DIRECT is not supported
-// On Windows there is no documentation on disabling O_DIRECT
+// OpenBSD, Windows, and illumos do not support O_DIRECT.
+// On Windows there is no documentation on disabling O_DIRECT.
+// For these systems we do not attempt to build the 'directio' dependency since
+// the O_DIRECT symbol may not be exposed resulting in a failed build.
+//
+//
+// On illumos an explicit O_DIRECT flag is not necessary for two primary
+// reasons. Note that ZFS is effectively the default filesystem on illumos
+// systems.
+//
+// One benefit of using DirectIO on Linux is that the page cache will not be
+// polluted with single-access data. The ZFS read cache (ARC) is scan-resistant
+// so there is no risk of polluting the entire cache with data accessed once.
+// Another goal of DirectIO is to minimize the mutation of data by the kernel
+// before issuing IO to underlying devices. ZFS users often enable features like
+// compression and checksumming which currently necessitates mutating data in
+// the kernel.
+//
+// DirectIO semantics for a filesystem like ZFS would be quite different than
+// the semantics on filesystems like XFS, and these semantics are not
+// implemented at this time.
+// For more information on why typical DirectIO semantics do not apply to ZFS
+// see this ZFS-on-Linux commit message:
+// https://github.com/openzfs/zfs/commit/a584ef26053065f486d46a7335bea222cb03eeea
 
 func OpenFileDirectIO(filePath string, flag int, perm os.FileMode) (*os.File, error) {
 	return os.OpenFile(filePath, flag, perm)
@@ -32,4 +53,10 @@ func OpenFileDirectIO(filePath string, flag int, perm os.FileMode) (*os.File, er
 
 func DisableDirectIO(f *os.File) error {
 	return nil
+}
+
+// AlignedBlock simply returns an unaligned buffer for systems that do not
+// support DirectIO.
+func AlignedBlock(BlockSize int) []byte {
+	return make([]byte, BlockSize)
 }

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2018-2019 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2018-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ package disk
 
 import (
 	"os"
-
-	"github.com/ncw/directio"
 )
 
 // Info stat fs struct is container which holds following values
@@ -73,7 +71,7 @@ func doPerfMeasure(fsPath string, size int64) (writeSpeed, readSpeed float64, er
 	}
 
 	// Fetch aligned buf for direct-io
-	buf := directio.AlignedBlock(speedTestBlockSize)
+	buf := AlignedBlock(speedTestBlockSize)
 
 	writeSpeed, err = speedTestWrite(w, buf, size)
 	w.Close()


### PR DESCRIPTION
## Description
The minio server does not properly compile on illumos due to the inclusion of the `directio` package.

## Motivation and Context
illumos does not expose an O_DIRECT symbol under normal operation, and the illumos version of ZFS does not support O_DIRECT at this time. This causes the minio server build to fail since the `directio` package is always pulled in.

Rather than changing the upstream `directio` package to not send the O_DIRECT flag on platforms like illumos we should instead just abstract away the use of the `directio` package in minio. This results in `directio` only being pulled in on platforms that support it.

## How to test this PR?
I fixed the minio `cmd` test suite for illumos and ran the test suite on illumos and linux (debian) systems. I'll submit a PR for the illumos `cmd` test suite fixes once this PR lands.

I also did some basic smoke testing by uploading/downloading files to/from a local minio instance on illumos.

```
$ uname -a
SunOS rust.kkantor.com 5.11 joyent_20191122T201258Z i86pc i386 i86pc illumos

$ go test
PASS
ok      github.com/minio/minio/cmd      245.030s
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
