### PR TITLE
Matches s3 invalid compression format error for 'mc sql'

### DIFF
--- a/pkg/s3select/errors.go
+++ b/pkg/s3select/errors.go
@@ -71,6 +71,24 @@ func errInvalidCompressionFormat(err error) *s3Error {
 	}
 }
 
+func errInvalidBZIP2CompressionFormat(err error) *s3Error {
+	return &s3Error{
+		code:       "InvalidCompressionFormat",
+		message:    "BZIP2 is not applicable to the queried object. Please correct the request and try again.",
+		statusCode: 400,
+		cause:      err,
+	}
+}
+
+func errInvalidGZIPCompressionFormat(err error) *s3Error {
+	return &s3Error{
+		code:       "InvalidCompressionFormat",
+		message:    "GZIP is not applicable to the queried object. Please correct the request and try again.",
+		statusCode: 400,
+		cause:      err,
+	}
+}
+
 func errInvalidDataSource(err error) *s3Error {
 	return &s3Error{
 		code:       "InvalidDataSource",

--- a/pkg/s3select/progress.go
+++ b/pkg/s3select/progress.go
@@ -101,8 +101,11 @@ func newProgressReader(rc io.ReadCloser, compType CompressionType) (*progressRea
 		r = scannedReader
 	case gzipType:
 		if r, err = gzip.NewReader(scannedReader); err != nil {
-			return nil, errTruncatedInput(err)
+			if errors.Is(err, gzip.ErrHeader) || errors.Is(err, gzip.ErrChecksum) {
+				return nil, errInvalidGZIPCompressionFormat(err)
+			}
 		}
+		return nil, errTruncatedInput(err)
 	case bzip2Type:
 		r = bzip2.NewReader(scannedReader)
 	default:


### PR DESCRIPTION
## Description

`mc sql` command was issuing error messages about invalid compression formatted files in a different way than Amazon S3.
This fix rewords and adjusts these error messages.
Fixes minio/mc#2997 filed against `mc`

## Motivation and Context
S3 compatibility

## How to test this PR?
Copy a sample file, which is not in `"BZIP"` format, over into your MinIO bucket, and append `".bz2"` extension to the copied file name.
Then run the following command against your MinIO server:
```
mc sql -e="SELECT * from s3object LIMIT 1" --csv-input "rd=\n,fh=USE,fd=;" <MinIO-alias>/<bucket-name>/<file-name>.bz2
```
Run the same command with a file, not in `"GZIP"` format, but with `".gz"` extension.
Compare the above MinIO error messages with their S3 counterparts for the same commands. They should match.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
