### PR TITLE
Add goroutine profiles

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -375,7 +375,7 @@ func (sys *NotificationSys) DownloadProfilingData(ctx context.Context, writer io
 	// Send profiling data to zip as file
 	for typ, data := range data {
 		header, zerr := zip.FileInfoHeader(dummyFileInfo{
-			name:    fmt.Sprintf("profiling-%s-%s.pprof", thisAddr, typ),
+			name:    fmt.Sprintf("profile-%s-%s", thisAddr, typ),
 			size:    int64(len(data)),
 			mode:    0600,
 			modTime: UTCNow(),

--- a/pkg/madmin/profiling-commands.go
+++ b/pkg/madmin/profiling-commands.go
@@ -33,12 +33,13 @@ type ProfilerType string
 
 // Different supported profiler types.
 const (
-	ProfilerCPU     ProfilerType = "cpu"     // represents CPU profiler type
-	ProfilerMEM     ProfilerType = "mem"     // represents MEM profiler type
-	ProfilerBlock   ProfilerType = "block"   // represents Block profiler type
-	ProfilerMutex   ProfilerType = "mutex"   // represents Mutex profiler type
-	ProfilerTrace   ProfilerType = "trace"   // represents Trace profiler type
-	ProfilerThreads ProfilerType = "threads" // represents ThreadCreate profiler type
+	ProfilerCPU        ProfilerType = "cpu"        // represents CPU profiler type
+	ProfilerMEM        ProfilerType = "mem"        // represents MEM profiler type
+	ProfilerBlock      ProfilerType = "block"      // represents Block profiler type
+	ProfilerMutex      ProfilerType = "mutex"      // represents Mutex profiler type
+	ProfilerTrace      ProfilerType = "trace"      // represents Trace profiler type
+	ProfilerThreads    ProfilerType = "threads"    // represents ThreadCreate profiler type
+	ProfilerGoroutines ProfilerType = "goroutines" // represents Goroutine dumps.
 )
 
 // StartProfilingResult holds the result of starting


### PR DESCRIPTION
## Description

Allow downloading goroutine dump to help detect leaks or overuse of goroutines.

Extensions are now type dependent.

Change `profiling` -> `profile` prefix, since that is what they are. Not the abstract concept.

BETTER NAME? I would like something shorter than `goroutines`. Any great ideas?

## Motivation and Context

Currently one 'trace' can give running (inactive) goroutine information. This allows accessing this information explicitly.

## How to test this PR?

Run trace with `goroutines` type. 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
