### PR TITLE
xl: Fix counting offline disks in StorageInfo

### DIFF
--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -302,10 +302,16 @@ func newXLSets(endpoints Endpoints, format *formatXLV3, setCount int, drivesPerS
 		s.xlDisks[i] = make([]StorageAPI, drivesPerSet)
 		s.xlLockers[i] = make([]dsync.NetLocker, drivesPerSet)
 
+		var endpoints Endpoints
+		for j := 0; j < drivesPerSet; j++ {
+			endpoints = append(endpoints, s.endpoints[i*s.drivesPerSet+j])
+		}
+
 		// Initialize xl objects for a given set.
 		s.sets[i] = &xlObjects{
 			getDisks:    s.GetDisks(i),
 			getLockers:  s.GetLockers(i),
+			endpoints:   endpoints,
 			nsMutex:     mutex,
 			bp:          bp,
 			mrfUploadCh: make(chan partialUpload, 10000),


### PR DESCRIPTION

## Description
Recent modification in the code led to incorrect calculation
of offline disks.

This commit saves the endpoint list in a xlObjects then we know
the name of each disk.



## Motivation and Context
Fix counting offline disks when there is one or more offline nodes


## How to test this PR?
Run a cluster of multiple nodes where one node is down


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (https://github.com/minio/minio/commit/d4dcf1d7225a38ecf94abe7cbe7c69a93dc7c0b0)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
