### PR TITLE
Fix admin config set API for notifications

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -428,6 +428,10 @@ func lookupConfigs(s config.Config) {
 	if err != nil {
 		logger.LogIf(ctx, fmt.Errorf("Unable to initialize notification target(s): %w", err))
 	}
+	globalEnvTargetList, err = notify.GetNotificationTargets(newServerConfig(), GlobalServiceDoneCh, NewCustomHTTPTransport())
+	if err != nil {
+		logger.LogIf(ctx, fmt.Errorf("Unable to initialize notification target(s): %w", err))
+	}
 }
 
 // Help - return sub-system level help

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -144,8 +144,11 @@ var (
 
 	globalNotificationSys  *NotificationSys
 	globalConfigTargetList *event.TargetList
-	globalPolicySys        *PolicySys
-	globalIAMSys           *IAMSys
+	// globalEnvTargetList has list of targets configured via env.
+	globalEnvTargetList *event.TargetList
+
+	globalPolicySys *PolicySys
+	globalIAMSys    *IAMSys
 
 	globalLifecycleSys       *LifecycleSys
 	globalBucketSSEConfigSys *BucketSSEConfigSys

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -757,8 +757,14 @@ func (sys *NotificationSys) ConfiguredTargetIDs() []event.TargetID {
 			}
 		}
 	}
-
-	return targetIDs
+	// Filter out targets configured via env
+	var tIDs []event.TargetID
+	for _, targetID := range targetIDs {
+		if !globalEnvTargetList.Exists(targetID) {
+			tIDs = append(tIDs, targetID)
+		}
+	}
+	return tIDs
 }
 
 // RemoveNotification - removes all notification configuration for bucket name.


### PR DESCRIPTION
to filter out targets set via env when
validating incoming config change against
configured notification targets


Fixes #9066

## Description


## Motivation and Context
While setting config kv, env variables are turned off and incoming config change is validated to ensure that it doesn't delete configured notification targets. However this check would fail if the notification config was set via env.

## How to test this PR?
Run Rabbitmq and nats docker containers - configure notification for amqp via env and attempt nats config setting via mc
```
export MINIO_NOTIFY_AMQP_URL=amqp://localhost:5672;export MINIO_NOTIFY_AMQP_EXCHANGE=minioindex; export MINIO_NOTIFY_AMQP_ENABLE=on; export MINIO_NOTIFY_AMQP_EXCHANGE_TYPE="fanout"; export MINIO_NOTIFY_AMQP_DURABLE="ON"

./minio server /tmp/data

mc event add myminio/images arn:minio:sqs:us-east-1:_:amqp

mc admin config set myminio notify_nats address=0.0.0.0:4222 subject=minio.1
mc: <ERROR> Cannot set 'notify_nats address=0.0.0.0:4222 subject=minio.1' to server. Unable to disable configured targets '_:amqp'.
```
You should see the error reported by user with master, but not with this PR.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
