### PR TITLE
data-usage: Fix the calculation of the next crawling round

### DIFF
--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -74,15 +74,15 @@ func timeToCrawl(ctx context.Context, objAPI ObjectLayer) time.Duration {
 	if dataUsageInfo.LastUpdate.IsZero() {
 		return 1 * time.Second
 	}
-	waitDuration := dataUsageInfo.LastUpdate.Sub(UTCNow())
-	if waitDuration > dataUsageCrawlInterval {
+	timeSinceLastUpdate := UTCNow().Sub(dataUsageInfo.LastUpdate)
+	if timeSinceLastUpdate > dataUsageCrawlInterval {
 		// Waited long enough start crawl in a 1 second
 		return 1 * time.Second
 	}
 	// No crawling needed, ask the routine to wait until
 	// the daily interval 12hrs - delta between last update
 	// with current time.
-	return dataUsageCrawlInterval - waitDuration
+	return dataUsageCrawlInterval - timeSinceLastUpdate
 }
 
 var dataUsageLockTimeout = lifecycleLockTimeout


### PR DESCRIPTION
## Description
This commit fixes a simple typo miscalculated the waiting time
until the next round of data crawling to compute the data usage.


## Motivation and Context
Data usage is not updated sometimes

## How to test this PR?
1. `minio server /tmp/fs/`
2. `mc mb myminio/testbucket; mc cp file myminio/testbucket/`
3. Kill MinIO server
4. Change the last update time in /tmp/fs/.minio.sys/background-ops/data-usage to 3 days earlier for example
5. Run MinIO server again



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
