### PR TITLE
Add TopLocksAdminAction to diagnostics canned policy

### DIFF
--- a/pkg/iam/policy/constants.go
+++ b/pkg/iam/policy/constants.go
@@ -72,7 +72,7 @@ var AdminDiagnostics = Policy{
 		{
 			SID:       policy.ID(""),
 			Effect:    policy.Allow,
-			Actions:   NewActionSet(PerfInfoAdminAction, ProfilingAdminAction, TraceAdminAction, ConsoleLogAdminAction, ServerInfoAdminAction, ServerHardwareInfoAdminAction),
+			Actions:   NewActionSet(PerfInfoAdminAction, ProfilingAdminAction, TraceAdminAction, ConsoleLogAdminAction, ServerInfoAdminAction, ServerHardwareInfoAdminAction, TopLocksAdminAction),
 			Resources: NewResourceSet(NewResource("*", "")),
 		},
 	},


### PR DESCRIPTION
## Description
Add TopLocksAdminAction to diagnostics canned policy

## Motivation and Context
Be able to issue `mc admin top locks` command with an account that has the diagnostics canned policy

## How to test this PR?
Create an account that has `diagnostics` canned policy. With the latest released version, you will not be able to issue `mc admin top locks` command. With this PR, you will be able to issue that command

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
