### PR TITLE
Fix the URL for MinIO update when using custom download server

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -141,9 +141,9 @@ func (a adminAPIHandlers) ServerUpdateHandler(w http.ResponseWriter, r *http.Req
 		}
 
 		if runtime.GOOS == "windows" {
-			u.Path = path.Dir(u.Path) + "minio.exe"
+			u.Path = path.Dir(u.Path) + SlashSeparator + "minio.exe"
 		} else {
-			u.Path = path.Dir(u.Path) + "minio"
+			u.Path = path.Dir(u.Path) + SlashSeparator + "minio"
 		}
 
 		updateURL = u.String()


### PR DESCRIPTION
## Description
Fix the URL for MinIO update when using custom download server

## Motivation and Context
When using a custom download server for MinIO binary, the URL 
was incorrect as it was missing a `/` after `path.Dir`. This PR
fixes that.

## How to test this PR?
Try updating a MinIO cluster with custom download server like this 
`mc admin update myminio http://localhost:8080/release_info`

More details here https://github.com/minio/mc/pull/3110

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
