### PR TITLE
fix: Send x-amz-mp-parts-count for multiparted objects

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/minio/minio/cmd/crypto"
@@ -79,6 +80,10 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 	// Set Etag if available.
 	if objInfo.ETag != "" {
 		w.Header()[xhttp.ETag] = []string{"\"" + objInfo.ETag + "\""}
+	}
+
+	if strings.Contains(objInfo.ETag, "-") && len(objInfo.Parts) > 0 {
+		w.Header().Set(xhttp.AmzMpPartsCount, strconv.Itoa(len(objInfo.Parts)))
 	}
 
 	if objInfo.ContentType != "" {

--- a/cmd/http/headers.go
+++ b/cmd/http/headers.go
@@ -77,6 +77,9 @@ const (
 	AmzObjectLockLegalHold        = "X-Amz-Object-Lock-Legal-Hold"
 	AmzObjectLockBypassGovernance = "X-Amz-Bypass-Governance-Retention"
 
+	// Multipart parts count
+	AmzMpPartsCount = "x-amz-mp-parts-count"
+
 	// Dummy putBucketACL
 	AmzACL = "x-amz-acl"
 


### PR DESCRIPTION


## Description
fix: Send x-amz-mp-parts-count for multiparted objects

## Motivation and Context
Some AWS SDKs latently rely on this value some times
to calculate the right number of parts during a parallel
GetObject request, this is a feature used along with
content-range - we should support this as well.

## How to test this PR?
Nothing just upload multipart objects and see `mc stat` to return `x-amz-mp-parts-count`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
