### PR TITLE
fix: crash in serverInfo handler when ldap is configured

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1398,10 +1398,10 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 		} else if ldapConn == nil {
 			ldap.Status = "Not Configured"
 		} else {
+			// Close ldap connection to avoid leaks.
+			ldapConn.Close()
 			ldap.Status = "online"
 		}
-		// Close ldap connection to avoid leaks.
-		defer ldapConn.Close()
 	}
 
 	log, audit := fetchLoggerInfo(cfg)


### PR DESCRIPTION
## Description
fix: crash in serverInfo handler when ldap is configured

## Motivation and Context
fixes the crash
```
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/workspace/src/github.com/minio/minio/cmd/generic-handlers.go:777 +0x248
Mar 12 00:54:42 play minio[24385]: panic(0x18bf980, 0x30fb210)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/go/src/runtime/panic.go:679 +0x1b2
Mar 12 00:54:42 play minio[24385]: sync.(*Mutex).Lock(...)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/go/src/sync/mutex.go:74
Mar 12 00:54:42 play minio[24385]: gopkg.in/ldap%2ev3.(*Conn).Close(0x0)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/workspace/pkg/mod/gopkg.in/ldap.v3@v3.0.3/conn.go:207 +0x3e
Mar 12 00:54:42 play minio[24385]: github.com/minio/minio/cmd.adminAPIHandlers.ServerInfoHandler(0x1e8a0e0, 0xc0004fcd20, 0xc002089d00)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/workspace/src/github.com/minio/minio/cmd/admin-handlers.go:1519 +0x128c
Mar 12 00:54:42 play minio[24385]: net/http.HandlerFunc.ServeHTTP(...)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/go/src/net/http/server.go:2007
Mar 12 00:54:42 play minio[24385]: github.com/minio/minio/cmd.httpTraceAll.func1(0x1e8a0e0, 0xc0004fcd20, 0xc002089d00)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/workspace/src/github.com/minio/minio/cmd/handler-utils.go:341 +0x148
Mar 12 00:54:42 play minio[24385]: net/http.HandlerFunc.ServeHTTP(0xc000348b00, 0x1e8a0e0, 0xc0004fcd20, 0xc002089d00)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/go/src/net/http/server.go:2007 +0x44
Mar 12 00:54:42 play minio[24385]: github.com/gorilla/mux.(*Router).ServeHTTP(0xc0004fa000, 0x1e8a0e0, 0xc0004fcd20, 0xc002089b00)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/workspace/pkg/mod/github.com/gorilla/mux@v1.7.0/mux.go:212 +0xe2
Mar 12 00:54:42 play minio[24385]: github.com/minio/minio/cmd.customHeaderHandler.ServeHTTP(0x1e5af00, 0xc0004fa000, 0x1e89e60, 0xc001fe1380, 0xc002089b00)
Mar 12 00:54:42 play minio[24385]: #011/home/gocode/workspace/src/github.com/minio/minio/cmd/generic-handlers.go:748 +0x162
```

## How to test this PR?
configure LDAP and take the LDAP server down, then run `mc admin info`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes introduced in PR #8497 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
