### PR TITLE
fix: broken gzip handling with Select API

### DIFF
--- a/pkg/s3select/progress.go
+++ b/pkg/s3select/progress.go
@@ -100,12 +100,13 @@ func newProgressReader(rc io.ReadCloser, compType CompressionType) (*progressRea
 	case noneType:
 		r = scannedReader
 	case gzipType:
-		if r, err = gzip.NewReader(scannedReader); err != nil {
+		r, err = gzip.NewReader(scannedReader)
+		if err != nil {
 			if errors.Is(err, gzip.ErrHeader) || errors.Is(err, gzip.ErrChecksum) {
 				return nil, errInvalidGZIPCompressionFormat(err)
 			}
+			return nil, errTruncatedInput(err)
 		}
-		return nil, errTruncatedInput(err)
 	case bzip2Type:
 		r = bzip2.NewReader(scannedReader)
 	default:


### PR DESCRIPTION

## Description
fix: broken gzip handling with Select API

## Motivation and Context
This PR fixes a regression introduced in a1c7c9ea73d7cb563156f4a6278d4ac66b9fe34c

## How to test this PR?
With this PR
```
~ mc sql -e 'select * from S3Object s where s.length>2000' play/s3select/star2000.csv.gz
0,2168,154610,154612,2,20000726.0707250014,1208003,0,0,0,-9999,10
0,2007,153785,153787,2,20000703.1328400001,1185007,0,0,0,-9999,48
1,2179,150510,150512,2,20000824.1210540012,1237021,10,0,59,0.60702205,74
0,2082,127377,127379,2,20000831.0735189989,1244013,0,0,0,-9999,20
```

Without this PR 
```
~ mc sql -e 'select * from S3Object s where s.length>2000' play/s3select/star2000.csv.gz
mc: <ERROR> Unable to run sql Object decompression failed. Check that the object is properly compressed using the format specified in the request.
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in a1c7c9ea73d7cb563156f4a6278d4ac66b9fe34c
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
