### PR TITLE
Align STS web-identity code snippet to documentation (minio#9114)

### DIFF
--- a/docs/sts/keycloak.md
+++ b/docs/sts/keycloak.md
@@ -39,15 +39,19 @@ $ go run docs/sts/web-identity.go -cid account -csec 072e7f00-4289-469c-9ab2-bbe
 2018/12/26 17:49:36 listening on http://localhost:8888/
 ```
 
-This will open the login page of keycloak, upon successful login, STS credentials will be printed on the screen, for example
+This will open the login page of keycloak, upon successful login, STS credentials along with any buckets discovered using the credentials will be printed on the screen, for example:
 
 ```
-##### Credentials
 {
-	"accessKey": "6N2BALX7ELO827DXS3GK",
-	"secretKey": "23JKqAD+um8ObHqzfIh+bfqwG9V8qs9tFY6MqeFR",
-	"expiration": "2019-10-01T07:22:34Z",
-	"sessionToken": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiI2TjJCQUxYN0VMTzgyN0RYUzNHSyIsImFjciI6IjAiLCJhdWQiOiJhY2NvdW50IiwiYXV0aF90aW1lIjoxNTY5OTEwNTUyLCJhenAiOiJhY2NvdW50IiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJleHAiOjE1Njk5MTQ1NTQsImlhdCI6MTU2OTkxMDk1NCwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgxL2F1dGgvcmVhbG1zL2RlbW8iLCJqdGkiOiJkOTk4YTBlZS01NDk2LTQ4OWYtYWJlMi00ZWE5MjJiZDlhYWYiLCJuYmYiOjAsInBvbGljeSI6InJlYWR3cml0ZSIsInByZWZlcnJlZF91c2VybmFtZSI6Im5ld3VzZXIxIiwic2Vzc2lvbl9zdGF0ZSI6IjJiYTAyYTI2LWE5MTUtNDUxNC04M2M1LWE0YjgwYjc4ZTgxNyIsInN1YiI6IjY4ZmMzODVhLTA5MjItNGQyMS04N2U5LTZkZTdhYjA3Njc2NSIsInR5cCI6IklEIn0._UG_-ZHgwdRnsp0gFdwChb7VlbPs-Gr_RNUz9EV7TggCD59qjCFAKjNrVHfOSVkKvYEMe0PvwfRKjnJl3A_mBA"
+  "buckets": [
+    "bucket-x"
+  ],
+  "credentials": {
+    "AccessKeyID": "6N2BALX7ELO827DXS3GK",
+    "SecretAccessKey": "23JKqAD+um8ObHqzfIh+bfqwG9V8qs9tFY6MqeFR+xxx",
+    "SessionToken": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiI2TjJCQUxYN0VMTzgyN0RYUzNHSyIsImFjciI6IjAiLCJhdWQiOiJhY2NvdW50IiwiYXV0aF90aW1lIjoxNTY5OTEwNTUyLCJhenAiOiJhY2NvdW50IiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJleHAiOjE1Njk5MTQ1NTQsImlhdCI6MTU2OTkxMDk1NCwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgxL2F1dGgvcmVhbG1zL2RlbW8iLCJqdGkiOiJkOTk4YTBlZS01NDk2LTQ4OWYtYWJlMi00ZWE5MjJiZDlhYWYiLCJuYmYiOjAsInBvbGljeSI6InJlYWR3cml0ZSIsInByZWZlcnJlZF91c2VybmFtZSI6Im5ld3VzZXIxIiwic2Vzc2lvbl9zdGF0ZSI6IjJiYTAyYTI2LWE5MTUtNDUxNC04M2M1LWE0YjgwYjc4ZTgxNyIsInN1YiI6IjY4ZmMzODVhLTA5MjItNGQyMS04N2U5LTZkZTdhYjA3Njc2NSIsInR5cCI6IklEIn0._UG_-ZHgwdRnsp0gFdwChb7VlbPs-Gr_RNUz9EV7TggCD59qjCFAKjNrVHfOSVkKvYEMe0PvwfRKjnJl3A_mBA"",
+    "SignerType": 1
+  }
 }
 ```
 

--- a/docs/sts/web-identity.go
+++ b/docs/sts/web-identity.go
@@ -143,6 +143,7 @@ func main() {
 
 	ddoc, err := parseDiscoveryDoc(configEndpoint)
 	if err != nil {
+		log.Println(fmt.Errorf("Failed to parse OIDC discovery document %s", err))
 		fmt.Println(err)
 		return
 	}
@@ -163,10 +164,16 @@ func main() {
 	state := randomState()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.RequestURI)
+		if r.RequestURI != "/" {
+			http.NotFound(w, r)
+			return
+		}
 		http.Redirect(w, r, config.AuthCodeURL(state), http.StatusFound)
 	})
 
 	http.HandleFunc("/oauth2/callback", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.RequestURI)
 		if r.URL.Query().Get("state") != state {
 			http.Error(w, "state did not match", http.StatusBadRequest)
 			return
@@ -189,12 +196,10 @@ func main() {
 
 		sts, err := credentials.NewSTSWebIdentity(stsEndpoint, getWebTokenExpiry)
 		if err != nil {
+			log.Println(fmt.Errorf("Could not get STS credentials: %s", err))
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-
-		// Uncomment this to use MinIO API operations by initializing minio
-		// client with obtained credentials.
 
 		opts := &minio.Options{
 			Creds:        sts,
@@ -203,23 +208,40 @@ func main() {
 
 		u, err := url.Parse(stsEndpoint)
 		if err != nil {
+			log.Println(fmt.Errorf("Failed to parse STS Endpoint: %s", err))
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
 		clnt, err := minio.NewWithOptions(u.Host, opts)
 		if err != nil {
+			log.Println(fmt.Errorf("Error while initializing Minio client, %s", err))
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		buckets, err := clnt.ListBuckets()
 		if err != nil {
+			log.Println(fmt.Errorf("Error while listing buckets, %s", err))
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		creds, _ := sts.Get()
+
+		bucketNames := []string{}
+
 		for _, bucket := range buckets {
-			log.Println(bucket)
+			log.Println(fmt.Sprintf("Bucket discovered: %s", bucket.Name))
+			bucketNames = append(bucketNames, bucket.Name)
 		}
+		response := make(map[string]interface{})
+		response["credentials"] = creds
+		response["buckets"] = bucketNames
+		c, err := json.MarshalIndent(response, "", "\t")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(c)
 	})
 
 	address := fmt.Sprintf("localhost:%v", port)


### PR DESCRIPTION
Description

Resolves #9114 

Also added some server logging, to help people debug any problems they might have in their setup.

## Motivation and Context
Align code snippet in docs with what the documentation actually says.
Slight update to the documentation.

## How to test this PR?
1. follow the instructions in the [STS/Keycloak documentation](http://github.com/gzur/minio/blob/db80b3cbb7bdd830781bce48d96884edc1ed3a4c/docs/sts/keycloak.md)

1. Visit http://localhost:8888 in a browser.

1. Log in via the configured identify provider.

Something like the following should appear in the browser:
```
{
  "buckets": [
    "bucket-x"
  ],
  "credentials": {
    "AccessKeyID": "xxxx",
    "SecretAccessKey": "xxxx+xxx",
    "SessionToken": "xxxxx",
    "SignerType": 1
  }
}

```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )

