### PR TITLE
admin: Change the type of backend description in server info

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1554,19 +1554,19 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 
 	var OnDisks int
 	var OffDisks int
-	var backend interface{}
+	var backend = madmin.Backend{
+		Type: madmin.BackendType(storageInfo.Backend.Type),
+	}
 
-	if storageInfo.Backend.Type == BackendType(madmin.Erasure) {
-
+	switch backend.Type {
+	case madmin.Erasure:
 		for _, v := range storageInfo.Backend.OnlineDisks {
 			OnDisks += v
 		}
 		for _, v := range storageInfo.Backend.OfflineDisks {
 			OffDisks += v
 		}
-
-		backend = madmin.XLBackend{
-			Type:             madmin.ErasureType,
+		backend.XL = madmin.XLBackend{
 			OnlineDisks:      OnDisks,
 			OfflineDisks:     OffDisks,
 			StandardSCData:   storageInfo.Backend.StandardSCData,
@@ -1574,10 +1574,8 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 			RRSCData:         storageInfo.Backend.RRSCData,
 			RRSCParity:       storageInfo.Backend.RRSCParity,
 		}
-	} else {
-		backend = madmin.FSBackend{
-			Type: madmin.FsType,
-		}
+	case madmin.FS:
+		backend.FS = madmin.FSBackend{}
 	}
 
 	mode := ""

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -51,7 +51,8 @@ const (
 	FS
 	// Multi disk Erasure (single, distributed) backend.
 	Erasure
-
+	// Gateway type
+	Gateway
 	// Add your own backend.
 )
 
@@ -456,8 +457,15 @@ type InfoMessage struct {
 	Objects      Objects            `json:"objects,omitempty"`
 	Usage        Usage              `json:"usage,omitempty"`
 	Services     Services           `json:"services,omitempty"`
-	Backend      interface{}        `json:"backend,omitempty"`
+	Backend      Backend            `json:"backend,omitempty"`
 	Servers      []ServerProperties `json:"servers,omitempty"`
+}
+
+// Backend contains information of the underlying object API
+type Backend struct {
+	Type BackendType `json:"type"`
+	XL   XLBackend   `json:"xl"`
+	FS   FSBackend   `json:"fs"`
 }
 
 // Services contains different services information
@@ -522,14 +530,12 @@ const (
 
 // FSBackend contains specific FS storage information
 type FSBackend struct {
-	Type backendType `json:"backendType,omitempty"`
 }
 
 // XLBackend contains specific erasure storage information
 type XLBackend struct {
-	Type         backendType `json:"backendType,omitempty"`
-	OnlineDisks  int         `json:"onlineDisks,omitempty"`
-	OfflineDisks int         `json:"offlineDisks,omitempty"`
+	OnlineDisks  int `json:"onlineDisks,omitempty"`
+	OfflineDisks int `json:"offlineDisks,omitempty"`
 	// Data disks for currently configured Standard storage class.
 	StandardSCData int `json:"standardSCData,omitempty"`
 	// Parity disks for currently configured Standard storage class.


### PR DESCRIPTION
## Description
It is hard for a library using madmin package to detect the type
of the backend in the response of Server Info admin API.

This commit cleary adds the type of the backend in the response.

## Motivation and Context
Simple enhancement in the code


## How to test this PR?
No testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
