### PR TITLE
DeleteObjectTagging: Return 204 on success

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2981,5 +2981,5 @@ func (api objectAPIHandlers) DeleteObjectTaggingHandler(w http.ResponseWriter, r
 		return
 	}
 
-	writeSuccessResponseHeadersOnly(w)
+	writeSuccessNoContent(w)
 }


### PR DESCRIPTION
## Description
Delete Object Tagging returns 200 currently instead of 204.

## Motivation and Context
Minio-go DeleteObjectTagging API was also incorrectly checking for `200` instead of `204` so the calls were failing against AWS S3

## How to test this PR?
Use the delete object tagging example given in minio-go SDK examples and turn on mc admin trace and check the return code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
