### PR TITLE
xl: Tree walking should not quit when one disk returns empty

### DIFF
--- a/cmd/xl-v1-list-objects.go
+++ b/cmd/xl-v1-list-objects.go
@@ -34,12 +34,8 @@ func listDirFactory(ctx context.Context, disks ...StorageAPI) ListDirFunc {
 			var newEntries []string
 			var err error
 			entries, err = disk.ListDir(bucket, prefixDir, -1, xlMetaJSONFile)
-			if err != nil {
+			if err != nil || len(entries) == 0 {
 				continue
-			}
-
-			if len(entries) == 0 {
-				return true, nil
 			}
 
 			// Find elements in entries which are not in mergedEntries
@@ -58,6 +54,11 @@ func listDirFactory(ctx context.Context, disks ...StorageAPI) ListDirFunc {
 				sort.Strings(mergedEntries)
 			}
 		}
+
+		if len(mergedEntries) == 0 {
+			return true, nil
+		}
+
 		return false, filterMatchingPrefix(mergedEntries, prefixEntry)
 	}
 	return listDir


### PR DESCRIPTION


## Description
Currently, a tree walking, needed to a list objects in a specific
set quits listing as long as it finds no entries in a disk, which
is wrong.

This affected background healing, because the latter is using
tree walk directly. If one object does not exist in the first
disk for example, it will be seemed like the object does not
exist at all and no healing work is needed.

This commit fixes the behavior.

## Motivation and Context
Fix background healing

## How to test this PR?
1. Apply the following diff to simplify testing:

```diff
diff --git a/cmd/global-heal.go b/cmd/global-heal.go
index 7af88d897..b219a3c05 100644
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -28,8 +28,8 @@ import (
 
 const (
        bgHealingUUID = "0000-0000-0000-0000"
-       leaderTick    = time.Hour
-       healInterval  = 30 * 24 * time.Hour
+       leaderTick    = time.Second
+       healInterval  = time.Minute
 )
```
and compile code:
2. Run MinIO with 4 disks
3. Create a bucket and upload an object
4. Remove the object in the first disk in the backend
5. Wait one minute and see if healing is able to successfully heal

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
