### PR TITLE
fix: sts to return appropriate errors

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -122,7 +122,8 @@ const (
 	ErrMissingCredTag
 	ErrCredMalformed
 	ErrInvalidRegion
-	ErrInvalidService
+	ErrInvalidServiceS3
+	ErrInvalidServiceSTS
 	ErrInvalidRequestVersion
 	ErrMissingSignTag
 	ErrMissingSignHeadersTag
@@ -653,9 +654,14 @@ var errorCodes = errorCodeMap{
 	// FIXME: Should contain the invalid param set as seen in https://github.com/minio/minio/issues/2385.
 	// right Description:   "Error parsing the X-Amz-Credential parameter; incorrect service \"s4\". This endpoint belongs to \"s3\".".
 	// Need changes to make sure variable messages can be constructed.
-	ErrInvalidService: {
-		Code:           "AuthorizationQueryParametersError",
-		Description:    "Error parsing the X-Amz-Credential parameter; incorrect service. This endpoint belongs to \"s3\".",
+	ErrInvalidServiceS3: {
+		Code:           "AuthorizationParametersError",
+		Description:    "Error parsing the Credential/X-Amz-Credential parameter; incorrect service. This endpoint belongs to \"s3\".",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidServiceSTS: {
+		Code:           "AuthorizationParametersError",
+		Description:    "Error parsing the Credential parameter; incorrect service. This endpoint belongs to \"sts\".",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	// FIXME: Should contain the invalid param set as seen in https://github.com/minio/minio/issues/2385.

--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -108,7 +108,11 @@ func parseCredentialHeader(credElement string, region string, stype serviceType)
 
 	}
 	if credElements[2] != string(stype) {
-		return ch, ErrInvalidService
+		switch stype {
+		case serviceSTS:
+			return ch, ErrInvalidServiceSTS
+		}
+		return ch, ErrInvalidServiceS3
 	}
 	cred.scope.service = credElements[2]
 	if credElements[3] != "aws4_request" {

--- a/cmd/signature-v4-parser_test.go
+++ b/cmd/signature-v4-parser_test.go
@@ -151,7 +151,7 @@ func TestParseCredentialHeader(t *testing.T) {
 				"ABCD",
 				"ABCD"),
 			expectedCredentials: credentialHeader{},
-			expectedErrCode:     ErrInvalidService,
+			expectedErrCode:     ErrInvalidServiceS3,
 		},
 		// Test Case - 7.
 		// Test case with invalid region.

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -119,17 +119,11 @@ func checkAssumeRoleAuth(ctx context.Context, r *http.Request) (user auth.Creden
 	case authTypeSigned:
 		s3Err := isReqAuthenticated(ctx, r, globalServerRegion, serviceSTS)
 		if STSErrorCode(s3Err) != ErrSTSNone {
-			if s3Err == ErrInvalidAccessKeyID {
-				return user, ErrSTSInvalidAccessKey
-			}
 			return user, STSErrorCode(s3Err)
 		}
 		var owner bool
 		user, owner, s3Err = getReqAccessKeyV4(r, globalServerRegion, serviceSTS)
 		if STSErrorCode(s3Err) != ErrSTSNone {
-			if s3Err == ErrInvalidAccessKeyID {
-				return user, ErrSTSInvalidAccessKey
-			}
 			return user, STSErrorCode(s3Err)
 		}
 		// Root credentials are not allowed to use STS API


### PR DESCRIPTION
## Description
fix: sts to return appropriate errors

## Motivation and Context
Under multiple various situations allow
 `sts` API to return appropriate errors.

## How to test this PR?
You may need to hand construct a few different variations using postman

- invalid service type
- invalid credential

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
