### PR TITLE
fix: data usage crawler env handling, usage-cache.bin location

### DIFF
--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/pkg/color"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/tinylib/msgp/msgp"
 )
@@ -114,7 +113,7 @@ func (d *dataUsageCache) find(path string) *dataUsageEntry {
 func (d *dataUsageCache) dui(path string, buckets []BucketInfo) DataUsageInfo {
 	e := d.find(path)
 	if e == nil {
-		return DataUsageInfo{LastUpdate: time.Now()}
+		return DataUsageInfo{LastUpdate: UTCNow()}
 	}
 	flat := d.flatten(*e)
 	return DataUsageInfo{
@@ -213,9 +212,6 @@ func (d *dataUsageCache) pathSizes(buckets []BucketInfo) map[string]uint64 {
 	for _, bucket := range buckets {
 		e := d.find(bucket.Name)
 		if e == nil {
-			if dataUsageDebug {
-				logger.Info(color.Green("data-usage:")+" Bucket not found in cache: %v", bucket.Name)
-			}
 			continue
 		}
 		flat := d.flatten(*e)

--- a/cmd/data-usage_test.go
+++ b/cmd/data-usage_test.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -30,8 +29,8 @@ type usageTestFile struct {
 	size int
 }
 
-func Test_updateUsage(t *testing.T) {
-	base, err := ioutil.TempDir("", "Test_updateUsage")
+func TestDataUsageUpdate(t *testing.T) {
+	base, err := ioutil.TempDir("", "TestDataUsageUpdate")
 	if err != nil {
 		t.Skip(err)
 	}
@@ -58,6 +57,7 @@ func Test_updateUsage(t *testing.T) {
 		}
 		return 0, nil
 	}
+
 	got, err := updateUsage(context.Background(), base, dataUsageCache{}, func() {}, getSize)
 	if err != nil {
 		t.Fatal(err)
@@ -316,17 +316,10 @@ func Test_updateUsage(t *testing.T) {
 			}
 		})
 	}
-
-	t.Log(got.StringAll())
-
-	t.Logf("Root, flat: %+v", got.flatten(*got.root()))
-	t.Logf("Root: %+v", *got.root())
-	t.Logf("/dir1/dira: %+v", *got.find("/dir1/dira"))
-
 }
 
-func Test_updateUsagePrefix(t *testing.T) {
-	base, err := ioutil.TempDir("", "Test_updateUsagePrefix")
+func TestDataUsageUpdatePrefix(t *testing.T) {
+	base, err := ioutil.TempDir("", "TestDataUpdateUsagePrefix")
 	if err != nil {
 		t.Skip(err)
 	}
@@ -593,12 +586,6 @@ func Test_updateUsagePrefix(t *testing.T) {
 			}
 		})
 	}
-
-	t.Log(got.StringAll())
-
-	t.Logf("Root, flat: %+v", got.flatten(*got.root()))
-	t.Logf("Root: %+v", *got.root())
-	t.Logf("bucket/dir1/dira: %+v", *got.find("bucket/dir1/dira"))
 }
 
 func createUsageTestFiles(t *testing.T, base string, files []usageTestFile) {
@@ -614,8 +601,8 @@ func createUsageTestFiles(t *testing.T, base string, files []usageTestFile) {
 	}
 }
 
-func Test_dataUsageCacheSerialize(t *testing.T) {
-	base, err := ioutil.TempDir("", "Test_dataUsageCacheSerialize")
+func TestDataUsageCacheSerialize(t *testing.T) {
+	base, err := ioutil.TempDir("", "TestDataUsageCacheSerialize")
 	if err != nil {
 		t.Skip(err)
 	}
@@ -646,19 +633,19 @@ func Test_dataUsageCacheSerialize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b := want.serialize()
-	t.Log("serialize -> ", len(b), "bytes")
 
+	b := want.serialize()
 	var got dataUsageCache
 	err = got.deserialize(b)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if got.Info.LastUpdate.IsZero() {
 		t.Error("lastupdate not set")
 	}
 
-	if fmt.Sprint(want) == fmt.Sprint(got) {
+	if !want.Info.LastUpdate.Equal(got.Info.LastUpdate) {
 		t.Fatalf("deserialize mismatch\nwant: %+v\ngot:  %+v", want, got)
 	}
 }

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -41,7 +41,6 @@ import (
 	"github.com/minio/minio/pkg/bucket/lifecycle"
 	"github.com/minio/minio/pkg/bucket/object/tagging"
 	"github.com/minio/minio/pkg/bucket/policy"
-	"github.com/minio/minio/pkg/color"
 	"github.com/minio/minio/pkg/lock"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/mimedb"
@@ -244,14 +243,10 @@ func (fs *FSObjects) CrawlAndGetDataUsage(ctx context.Context, updates chan<- Da
 	if oldCache.Info.Name == "" {
 		oldCache.Info.Name = dataUsageRoot
 	}
-	if dataUsageDebug {
-		logger.Info(color.Green("FSObjects.CrawlAndGetDataUsage:") + " Start crawl cycle")
-	}
 	buckets, err := fs.ListBuckets(ctx)
 	if err != nil {
 		return err
 	}
-	t := time.Now()
 	cache, err := updateUsage(ctx, fs.fsPath, oldCache, fs.waitForLowActiveIO, func(item Item) (int64, error) {
 		// Get file size, symlinks which cannot be
 		// followed are automatically filtered by fastwalk.
@@ -261,9 +256,7 @@ func (fs *FSObjects) CrawlAndGetDataUsage(ctx context.Context, updates chan<- Da
 		}
 		return fi.Size(), nil
 	})
-	if dataUsageDebug {
-		logger.Info(color.Green("FSObjects.CrawlAndGetDataUsage:")+" Crawl time: %v", time.Since(t))
-	}
+
 	// Even if there was an error, the new cache may have better info.
 	if cache.Info.LastUpdate.After(oldCache.Info.LastUpdate) {
 		logger.LogIf(ctx, cache.save(ctx, fs, dataUsageCacheName))

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -19,14 +19,12 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"path"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/bpool"
-	"github.com/minio/minio/pkg/color"
 	"github.com/minio/minio/pkg/dsync"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/sync/errgroup"
@@ -321,11 +319,9 @@ func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, buckets []BucketIn
 					return
 				default:
 				}
-				if dataUsageDebug {
-					logger.Info(color.Green("crawlAndGetDataUsage:")+" Scanning bucket %v.", bucket.Name)
-				}
+
 				// Load cache for bucket
-				cacheName := path.Join(dataUsageBucketCacheDir, bucket.Name+".bin")
+				cacheName := pathJoin(bucket.Name, dataUsageCacheName)
 				cache := dataUsageCache{}
 				logger.LogIf(ctx, cache.load(ctx, xl, cacheName))
 				if cache.Info.Name == "" {

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -32,7 +32,6 @@ import (
 	"github.com/minio/minio/pkg/bucket/lifecycle"
 	"github.com/minio/minio/pkg/bucket/object/tagging"
 	"github.com/minio/minio/pkg/bucket/policy"
-	"github.com/minio/minio/pkg/color"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/sync/errgroup"
 )
@@ -227,10 +226,6 @@ func (z *xlZones) CrawlAndGetDataUsage(ctx context.Context, updates chan<- DataU
 	var knownBuckets = make(map[string]struct{}) // used to deduplicate buckets.
 	var allBuckets []BucketInfo
 
-	t := time.Now()
-	if dataUsageDebug {
-		logger.Info(color.Green("xlZones.CrawlAndGetDataUsage:") + " Start crawl cycle")
-	}
 	// Collect for each set in zones.
 	for _, z := range z.zones {
 		for _, xlObj := range z.sets {
@@ -314,9 +309,6 @@ func (z *xlZones) CrawlAndGetDataUsage(ctx context.Context, updates chan<- DataU
 	}()
 
 	wg.Wait()
-	if dataUsageDebug {
-		logger.Info(color.Green("xlZones.CrawlAndGetDataUsage:")+" Cycle scan time: %v", time.Since(t))
-	}
 	ch := make(chan struct{})
 	updateCloser <- ch
 	<-ch

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -235,8 +235,22 @@ This behavior is consistent across all keys, each key self documents itself with
 
 ## Environment only settings (not in config)
 
-#### Worm
-Enable this to turn on Write-Once-Read-Many. By default it is set to `off`. Set ``MINIO_WORM=on`` environment variable to enable WORM mode.
+#### Usage crawler
+Data usage crawler is enabled by default, following ENVs allow for more staggered delay in terms of usage calculation. 
+
+The crawler adapts to the system speed and completely pauses when the system is under load. It is possible to adjust the speed of the crawler and thereby the latency of updates being reflected. The delays between each operation of the crawl can be adjusted by the `MINIO_DISK_USAGE_CRAWL_DELAY` environment variable. By default the value is `10`. This means the crawler will sleep *10x* the time each operation takes.
+
+This will in most setups make the crawler slow enough to not impact overall system performance. Setting `MINIO_DISK_USAGE_CRAWL_DELAY` to a *lower* value will make the crawler faster and setting it to 0 will make the crawler run at full speed (not recommended). Setting it to a higher value will make the crawler slower, further consume less resources.
+
+Example: Following setting will decrease the crawler speed by a factor of 3, reducing the system resource use, but increasing the latency of updates being reflected.
+
+```sh
+export MINIO_DISK_USAGE_CRAWL_DELAY=30
+minio server /data
+```
+
+#### Worm (deprecated)
+Enable this to turn on Write-Once-Read-Many. By default it is set to `off`. Set ``MINIO_WORM=on`` environment variable to enable WORM mode. This ENV setting is not recommended anymore, please use Object Locking and Object Retention APIs documented [here](https://github.com/minio/minio/tree/master/docs/retention).
 
 Example:
 


### PR DESCRIPTION
## Description
fix: data usage crawler env handling, usage-cache.bin location

## Motivation and Context
canonicalize the envs such that we can bring
these envs as part of the config values,
as a subsequent change.

also fix the location of `usage-cache.bin` per bucket,
it should be inside `.minio.sys/buckets/<bucket_name>/usage-cache.bin`

this is the correct idiomatic location

## How to test this PR?
```
export MINIO_DISK_USAGE_CRAWL_ENABLE=off
``` 
To turn-off crawler

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
