### PR TITLE
fix: Walk() should require quorum number of disks only

### DIFF
--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -1642,11 +1642,10 @@ func (s *xlSets) Walk(ctx context.Context, bucket, prefix string, results chan<-
 				return
 			}
 
-			if quorumCount != s.drivesPerSet {
-				return
+			if quorumCount >= s.drivesPerSet/2 {
+				results <- entry.ToObjectInfo() // Read quorum exists proceed
 			}
-
-			results <- entry.ToObjectInfo()
+			// skip entries which do not have quorum
 		}
 	}()
 

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -1394,11 +1394,11 @@ func (z *xlZones) Walk(ctx context.Context, bucket, prefix string, results chan<
 				return
 			}
 
-			if quorumCount != zoneDrivesPerSet[zoneIndex] {
-				continue
+			if quorumCount >= zoneDrivesPerSet[zoneIndex]/2 {
+				results <- entry.ToObjectInfo() // Read quorum exists proceed
 			}
 
-			results <- entry.ToObjectInfo()
+			// skip entries which do not have quorum
 		}
 	}()
 


### PR DESCRIPTION
## Description
fix: Walk() should require quorum number of disks only

## Motivation and Context
Walker required all disks to return all entries, which is not necessary.

## How to test this PR?
Remove content from few disks and check if the lifecycle policy
is still applied to objects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
