### PR TITLE
create the final file with mode 0666 for multipart-uploads

### DIFF
--- a/pkg/ioutil/append-file_nix.go
+++ b/pkg/ioutil/append-file_nix.go
@@ -25,7 +25,7 @@ import (
 
 // AppendFile - appends the file "src" to the file "dst"
 func AppendFile(dst string, src string) error {
-	appendFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+	appendFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
MinIO Gateway for NAS creates non-multipart-uploads with mode 0666.
In cmd/fs-v1-helpers.go:324 mode 0666 is used to create new files.
But multipart-uploads are created with a differing mode of 0644.

Both modes should be equal! Else it leads to files with different
permissions based on its file-size. This patch solves that by
using 0666 for both cases.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
