### PR TITLE
sa: Allow empty policy to indicate parent user's policy is inherited

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -211,8 +211,9 @@ func getClaimsFromToken(r *http.Request) (map[string]interface{}, error) {
 		// If OPA is not set, session token should
 		// have a policy and its mandatory, reject
 		// requests without policy claim.
-		_, pok := claims.Lookup(iamPolicyClaimName())
-		if !pok {
+		_, pokOpenID := claims.Lookup(iamPolicyClaimNameOpenID())
+		_, pokSA := claims.Lookup(iamPolicyClaimNameSA())
+		if !pokOpenID && !pokSA {
 			return nil, errAuthentication
 		}
 

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -58,6 +58,8 @@ const (
 
 	// JWT claim to check the parent user
 	parentClaim = "parent"
+	// JWT claim to inherit parent policy
+	inheritParentPolicyClaim = "inherit-parent-policy"
 
 	// LDAP claim keys
 	ldapUser   = "ldapUser"

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -58,8 +58,6 @@ const (
 
 	// JWT claim to check the parent user
 	parentClaim = "parent"
-	// JWT claim to inherit parent policy
-	inheritParentPolicyClaim = "inherit-parent-policy"
 
 	// LDAP claim keys
 	ldapUser   = "ldapUser"
@@ -217,7 +215,7 @@ func (sts *stsAPIHandlers) AssumeRole(w http.ResponseWriter, r *http.Request) {
 	// This policy is the policy associated with the user
 	// requesting for temporary credentials. The temporary
 	// credentials will inherit the same policy requirements.
-	m[iamPolicyClaimName()] = policyName
+	m[iamPolicyClaimNameOpenID()] = policyName
 
 	if len(sessionPolicyStr) > 0 {
 		m[iampolicy.SessionPolicyName] = base64.StdEncoding.EncodeToString([]byte(sessionPolicyStr))
@@ -353,7 +351,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithJWT(w http.ResponseWriter, r *http.Requ
 	// be set and configured on your identity provider as part of
 	// JWT custom claims.
 	var policyName string
-	if v, ok := m[iamPolicyClaimName()]; ok {
+	if v, ok := m[iamPolicyClaimNameOpenID()]; ok {
 		policyName, _ = v.(string)
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -620,8 +620,12 @@ func getMinioMode() string {
 	return mode
 }
 
-func iamPolicyClaimName() string {
+func iamPolicyClaimNameOpenID() string {
 	return globalOpenIDConfig.ClaimPrefix + globalOpenIDConfig.ClaimName
+}
+
+func iamPolicyClaimNameSA() string {
+	return "sa-policy"
 }
 
 func isWORMEnabled(bucket string) bool {


### PR DESCRIPTION

## Description
Before this commit, creating a service account was always requiring
a valid policy document.

Now, sending an empty string means inherits the same policy of
the parent user: If a parent user is able to access to a resource,
then the derived service accounts will also able to.


## Motivation and Context
Allow empty policy when creating service accounts

## How to test this PR?
1. Compile this https://github.com/minio/mc/pull/3105
2. Start an FS minio server
3. mc admin user add myminio/ foobar foo12345
4. mc admin user sa generate myminio/ foobar
5. Use the generated credentials in 

```
package main

import (
	"io"
	"log"
	"os"

	"github.com/minio/minio-go/v6"
	"github.com/minio/minio-go/v6/pkg/credentials"
)

func main() {


	var creds = credentials.NewStaticV4(
		"UFVK5AAUPXW41N44AJF6",
		"ig2ENLHpPk+DSuWsfqRbfzqXdB8dok8UFYHuCYmt",
		"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiJVRlZLNUFBVVBYVzQxTjQ0QUpGNiIsImluaGVyaXQtcGFyZW50LXBvbGljeSI6InRydWUiLCJwYXJlbnQiOiJmb29iYXIiLCJwb2xpY3kiOiJpbmhlcml0ZWQtcG9saWN5In0.NAoyL8bCZPn27xxeQeow7PcrAEOjGVguzWA84-QQLcB0xPBHc9sYkc7DsacWqt2Re8TglJ4TcuLzJLakZRQCeQ",
	)

	s3Client, err := minio.NewWithCredentials("localhost:9000", creds, false, "us-east-1")
	if err != nil {
		log.Fatalln(err)
	}

	reader, err := s3Client.GetObject("testbucket", "testobject", minio.GetObjectOptions{})
	if err != nil {
		log.Fatalln(err)
	}
	defer reader.Close()

	if _, err := io.Copy(os.Stdout, reader); err != nil {
		log.Fatalln(err)
	}
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
