### PR TITLE
Implement Splunk specific list call when the delimiter=guidSplunk

### DIFF
--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -126,6 +126,13 @@ func (d *naughtyDisk) DeleteVol(volume string) (err error) {
 	return d.disk.DeleteVol(volume)
 }
 
+func (d *naughtyDisk) WalkSplunk(volume, path, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error) {
+	if err := d.calcError(); err != nil {
+		return nil, err
+	}
+	return d.disk.WalkSplunk(volume, path, marker, endWalkCh)
+}
+
 func (d *naughtyDisk) Walk(volume, path, marker string, recursive bool, leafFile string, readMetadataFn readMetadataFunc, endWalkCh <-chan struct{}) (chan FileInfo, error) {
 	if err := d.calcError(); err != nil {
 		return nil, err

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -117,6 +117,13 @@ func (p *posixDiskIDCheck) Walk(volume, dirPath string, marker string, recursive
 	return p.storage.Walk(volume, dirPath, marker, recursive, leafFile, readMetadataFn, endWalkCh)
 }
 
+func (p *posixDiskIDCheck) WalkSplunk(volume, dirPath string, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error) {
+	if p.isDiskStale() {
+		return nil, errDiskNotFound
+	}
+	return p.storage.WalkSplunk(volume, dirPath, marker, endWalkCh)
+}
+
 func (p *posixDiskIDCheck) ListDir(volume, dirPath string, count int, leafFile string) ([]string, error) {
 	if p.isDiskStale() {
 		return nil, errDiskNotFound

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -45,6 +45,8 @@ type StorageAPI interface {
 	// Walk in sorted order directly on disk.
 	Walk(volume, dirPath string, marker string, recursive bool, leafFile string,
 		readMetadataFn readMetadataFunc, endWalkCh <-chan struct{}) (chan FileInfo, error)
+	// Walk in sorted order directly on disk.
+	WalkSplunk(volume, dirPath string, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error)
 
 	// File operations.
 	ListDir(volume, dirPath string, count int, leafFile string) ([]string, error)

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -40,6 +40,7 @@ const (
 	storageRESTMethodReadFileStream = "/readfilestream"
 	storageRESTMethodListDir        = "/listdir"
 	storageRESTMethodWalk           = "/walk"
+	storageRESTMethodWalkSplunk     = "/walksplunk"
 	storageRESTMethodDeleteFile     = "/deletefile"
 	storageRESTMethodDeleteFileBulk = "/deletefilebulk"
 	storageRESTMethodDeletePrefixes = "/deleteprefixes"


### PR DESCRIPTION
## Description

(Need to test this)

Splunk makes list call with delimiter=guidSplunk, this PR is to handle this request specifically.

backend paths look like:
`{2 letter hash} / {2 letter hash} / {bucket_id_number-origin_guid} / {"guidSplunk"-uploader_guid}/ (bucket contents)
example:
```
f7/58/2~283797EC-26C3-4894-9C52-AE2AF0859C07/guidSplunk-283797EC-26C3-4894-9C52-AE2AF0859C07/
```

Advantage over the generic listObjectsNonSlash is:
* we dont stat for xl.json in `f7` and `58` and `2~283797EC-26C3-4894-9C52-AE2AF0859C07/` directories.
* we dont recurse into `guidSplunk-283797EC-26C3-4894-9C52-AE2AF0859C07/`


## How to test this PR?

Issue custom list call with delimiter=guidSplunk

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
