### PR TITLE
Fix throttling of events during replay

### DIFF
--- a/pkg/event/target/store.go
+++ b/pkg/event/target/store.go
@@ -112,8 +112,9 @@ func sendEvents(target event.Target, eventKeyCh <-chan string, doneCh <-chan str
 				loggerOnce(context.Background(),
 					fmt.Errorf("target.Send() failed with '%w'", err),
 					target.ID())
-				continue
 			}
+
+			// Retrying after 3secs back-off
 
 			select {
 			case <-retryTicker.C:


### PR DESCRIPTION
## Description
The events were been throttled without any time interval between replays when the response code was 400. The 3-sec delay was not properly handled in this case. This PR fixes that.

## Motivation and Context
Fixes #9115 

## How to test this PR?
Steps provided in the PR 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
