### PR TITLE
Improve connectDisks() performance

### DIFF
--- a/cmd/xl-v1-common.go
+++ b/cmd/xl-v1-common.go
@@ -24,12 +24,13 @@ import (
 )
 
 // getLoadBalancedDisks - fetches load balanced (sufficiently randomized) disk slice.
-func (xl xlObjects) getLoadBalancedDisks() (disks []StorageAPI) {
+func (xl xlObjects) getLoadBalancedDisks() (newDisks []StorageAPI) {
+	disks := xl.getDisks()
 	// Based on the random shuffling return back randomized disks.
-	for _, i := range hashOrder(UTCNow().String(), len(xl.getDisks())) {
-		disks = append(disks, xl.getDisks()[i-1])
+	for _, i := range hashOrder(UTCNow().String(), len(disks)) {
+		newDisks = append(newDisks, disks[i-1])
 	}
-	return disks
+	return newDisks
 }
 
 // This function does the following check, suppose


### PR DESCRIPTION
## Description
When there are large number of disks
1) we observe slowness during boot
2) High CPU in `s.isConnected()`

To fix this:
* Parallelize connectEndpoint() calls
* Use diskMap to check if an endpoint is connected
* Use RLock when doing xl.GetDisks()
* fix getLoadBalancedDisks() to call xl.getDisks() only once



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
