### PR TITLE
Fix command to match output file tree

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -21,7 +21,7 @@ TLS certificates by default are stored under ``${HOME}/.minio/certs`` directory.
 Following is the directory structure for MinIO server with TLS certificates.
 
 ```sh
-$ mc tree --files ~/.minio
+$ tree ~/.minio
 /home/user1/.minio
 └─ certs
    ├─ CAs


### PR DESCRIPTION
The command `mc tree --files ~/.minio` will result in error in Ubuntu 18.04. The command that outputs the directory tree should be `tree ~/.minio`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
