### PR TITLE
Matches s3 invalid compression format error for 'mc sql'

### DIFF
--- a/pkg/s3select/errors.go
+++ b/pkg/s3select/errors.go
@@ -71,6 +71,24 @@ func errInvalidCompressionFormat(err error) *s3Error {
 	}
 }
 
+func errInvalidBZIP2CompressionFormat(err error) *s3Error {
+	return &s3Error{
+		code:       "InvalidCompressionFormat",
+		message:    "BZIP2 is not applicable to the queried object. Please correct the request and try again.",
+		statusCode: 400,
+		cause:      err,
+	}
+}
+
+func errInvalidGZIPCompressionFormat(err error) *s3Error {
+	return &s3Error{
+		code:       "InvalidCompressionFormat",
+		message:    "GZIP is not applicable to the queried object. Please correct the request and try again.",
+		statusCode: 400,
+		cause:      err,
+	}
+}
+
 func errInvalidDataSource(err error) *s3Error {
 	return &s3Error{
 		code:       "InvalidDataSource",

--- a/pkg/s3select/progress.go
+++ b/pkg/s3select/progress.go
@@ -101,8 +101,11 @@ func newProgressReader(rc io.ReadCloser, compType CompressionType) (*progressRea
 		r = scannedReader
 	case gzipType:
 		if r, err = gzip.NewReader(scannedReader); err != nil {
-			return nil, errTruncatedInput(err)
+			if errors.Is(err, gzip.ErrHeader) || errors.Is(err, gzip.ErrChecksum) {
+				return nil, errInvalidGZIPCompressionFormat(err)
+			}
 		}
+		return nil, errTruncatedInput(err)
 	case bzip2Type:
 		r = bzip2.NewReader(scannedReader)
 	default:


### PR DESCRIPTION
## Description
`mc sql -e="SELECT ... ` command for files in `json` and/or in `gz` or `bz2` formats behave differently than amazon s3 version. The error messages thrown was not helpful and incompatible with the s3 counterparts in certain conditions like incorrect `.gz` and `.bz2` files and etc.

## Motivation and Context
We need to be compatible with Amazon s3.

## How to test this PR?
Run the following commands with correct and incorrect formatted json, gzipped json and bzip2'ed json files and make sure MinIO AND s3 results match.
- `mc sql -e="SELECT * from s3object LIMIT 1" --json-input type="document" myminio/test/incorrect.bz2`
- `mc sql -e="SELECT * from s3object LIMIT 1" --json-input type="document" s3/test/incorrect.bz2`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Also requires library changes on top of @harshavardhana's PR, https://github.com/bcicen/jstream/pull/10

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
