### PR TITLE
localizes jstream library and fixes incompatible behaviors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190307165228-86c17b95fcd5
 	github.com/aws/aws-sdk-go v1.20.21
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
-	github.com/bcicen/jstream v0.0.0-20190220045926-16c1f8af81c2
 	github.com/beevik/ntp v0.2.0
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/cheggaaa/pb v1.0.28

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/aws/aws-sdk-go v1.20.21 h1:22vHWL9rur+SRTYPHAXlxJMFIA9OSYsYDIAHFDhQ7Z
 github.com/aws/aws-sdk-go v1.20.21/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
-github.com/bcicen/jstream v0.0.0-20190220045926-16c1f8af81c2 h1:M+TYzBcNIRyzPRg66ndEqUMd7oWDmhvdQmaPC6EZNwM=
-github.com/bcicen/jstream v0.0.0-20190220045926-16c1f8af81c2/go.mod h1:RDu/qcrnpEdJC/p8tx34+YBFqqX71lB7dOX9QE+ZC4M=
 github.com/beevik/ntp v0.2.0 h1:sGsd+kAXzT0bfVfzJfce04g+dSRfrs+tbQW8lweuYgw=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=

--- a/pkg/s3select/csv/record.go
+++ b/pkg/s3select/csv/record.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/bcicen/jstream"
 	csv "github.com/minio/minio/pkg/csvparser"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 	"github.com/minio/minio/pkg/s3select/sql"
 )
 

--- a/pkg/s3select/json/errors.go
+++ b/pkg/s3select/json/errors.go
@@ -52,10 +52,10 @@ func errInvalidJSONType(err error) *s3Error {
 	}
 }
 
-func errJSONParsingError(err error) *s3Error {
+func ErrJSONParsingError(err error) *s3Error {
 	return &s3Error{
 		code:       "JSONParsingError",
-		message:    "Encountered an error parsing the JSON file. Check the file and try again.",
+		message:    "Error parsing JSON file. Please check the file and try again.",
 		statusCode: 400,
 		cause:      err,
 	}

--- a/pkg/s3select/json/jstream/LICENSE
+++ b/pkg/s3select/json/jstream/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Bradley Cicenas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/pkg/s3select/json/jstream/README.md
+++ b/pkg/s3select/json/jstream/README.md
@@ -1,0 +1,93 @@
+<p align="center"><img width="350px" src="jstream.png" alt="jstream"/></p>
+
+#
+
+[![GoDoc](https://godoc.org/github.com/bcicen/jstream?status.svg)](https://godoc.org/github.com/bcicen/jstream)
+
+
+`jstream` is a streaming JSON parser and value extraction library for Go.
+
+Unlike most JSON parsers, `jstream` is document position- and depth-aware -- this enables the extraction of values at a specified depth, eliminating the overhead of allocating encompassing arrays or objects; e.g:
+
+Using the below example document:
+<img width="85%" src="https://bradley.codes/static/img/jstream-levels.gif" alt="jstream"/>
+
+we can choose to extract and act only the objects within the top-level array:
+```go
+f, _ := os.Open("input.json")
+decoder := jstream.NewDecoder(f, 1) // extract JSON values at a depth level of 1
+for mv := range decoder.Stream() {
+  fmt.Printf("%v\n ", mv.Value)
+}
+```
+
+output:
+```
+map[desc:RGB colors:[red green blue]]
+map[desc:CMYK colors:[cyan magenta yellow black]]
+```
+
+likewise, increasing depth level to `3` yields:
+```
+red
+green
+blue
+cyan
+magenta
+yellow
+black
+```
+
+optionally, kev:value pairs can be emitted as an individual struct:
+```go
+decoder := jstream.NewDecoder(f, 2).EmitKV() // enable KV streaming at a depth level of 2
+```
+
+```
+jstream.KV{desc RGB}
+jstream.KV{colors [red green blue]}
+jstream.KV{desc CMYK}
+jstream.KV{colors [cyan magenta yellow black]}
+```
+
+## Installing 
+
+```bash
+go get github.com/bcicen/jstream
+```
+
+## Commandline
+
+`jstream` comes with a cli tool for quick viewing of parsed values from JSON input:
+
+```bash
+cat input.json | jstream -v -d 1
+depth	start	end	type   | value
+
+1	004	069	object | {"colors":["red","green","blue"],"desc":"RGB"}
+1	073	153	object | {"colors":["cyan","magenta","yellow","black"],"desc":"CMYK"}
+```
+
+### Options
+
+Opt | Description
+--- | ---
+-d \<n\> | emit values at depth n. if n < 0, all values will be emitted
+-v | output depth and offset details for each value
+-h | display help dialog
+
+## Benchmarks
+
+Obligatory benchmarks performed on files with arrays of objects, where the decoded objects are to be extracted.
+
+Two file sizes are used -- regular (1.6mb, 1000 objects) and large (128mb, 100000 objects)
+
+input size | lib | MB/s | Allocated
+--- | --- | --- | ---
+regular | standard | 97 | 3.6MB
+regular | jstream | 175 | 2.1MB
+large | standard | 92 | 305MB
+large | jstream | 404 | 69MB
+
+In a real world scenario, including initialization and reader overhead from varying blob sizes, performance can be expected as below:
+<img src="https://bradley.codes/static/img/bench.svg" alt="jstream"/>

--- a/pkg/s3select/json/jstream/cmd/jstream/main.go
+++ b/pkg/s3select/json/jstream/cmd/jstream/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/minio/minio/pkg/s3select/json/jstream"
+)
+
+var (
+	depthFlag   = flag.Int("d", 0, "emit values at depth <int>")
+	kvFlag      = flag.Bool("kv", false, "output key value pairs. default behavior is to emit only JSON object values.")
+	verboseFlag = flag.Bool("v", false, "output depth and offset details for each value")
+	helpFlag    = flag.Bool("h", false, "display this help dialog")
+)
+
+func exitErr(err error) {
+	fmt.Fprintf(os.Stderr, "[\033[31merror\033[0m] %s", err)
+	os.Exit(1)
+}
+
+func printVal(mv *jstream.MetaValue) {
+	b, err := json.Marshal(mv.Value)
+	if err != nil {
+		exitErr(err)
+	}
+
+	s := string(b)
+	var label string
+
+	switch mv.Value.(type) {
+	case []interface{}:
+		label = "array  "
+	case float64:
+		label = "float  "
+	case jstream.KV:
+		label = "kv     "
+	case string:
+		label = "string "
+	case map[string]interface{}:
+		label = "object "
+	}
+
+	if *verboseFlag {
+		end := mv.Offset + mv.Length
+		fmt.Printf("%d\t%03d\t%03d\t%s| %s\n", mv.Depth, mv.Offset, end, label, s)
+		return
+	}
+	fmt.Printf("%s| %s\n", label, s)
+}
+
+func main() {
+	flag.Parse()
+	if *helpFlag {
+		help()
+		os.Exit(0)
+	}
+
+	if *verboseFlag {
+		fmt.Println("depth\tstart\tend\ttype   | value")
+	}
+
+	decoder := jstream.NewDecoder(os.Stdin, *depthFlag)
+	if *kvFlag {
+		decoder = decoder.EmitKV()
+	}
+	metaValChan, err := decoder.Stream()
+	if err != nil {
+		exitErr(err)
+	}
+	for mv := range metaValChan {
+		printVal(mv)
+	}
+	if err := decoder.Err(); err != nil {
+		exitErr(err)
+	}
+}
+
+var helpMsg = `jstream - stream parsed values from JSON
+
+usage: jstream [options]
+
+options:
+
+  -d <n> emit values at depth n. if n < 0, all values will be emitted
+  -v     output depth and offset details for each value
+  -h     display this help dialog
+`
+
+func help() {
+	fmt.Println(helpMsg)
+}

--- a/pkg/s3select/json/jstream/decoder.go
+++ b/pkg/s3select/json/jstream/decoder.go
@@ -1,0 +1,823 @@
+package jstream
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strconv"
+	"sync/atomic"
+	"unicode/utf16"
+)
+
+// ValueType - defines the type of each JSON value
+type ValueType int
+
+// Different types of JSON value
+const (
+	Unknown ValueType = iota
+	Null
+	String
+	Number
+	Boolean
+	Array
+	Object
+)
+
+// MetaValue wraps a decoded interface value with the document
+// position and depth at which the value was parsed
+type MetaValue struct {
+	Offset    int
+	Length    int
+	Depth     int
+	Value     interface{}
+	ValueType ValueType
+}
+
+// KV contains a key and value pair parsed from a decoded object
+type KV struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+// KVS - represents key values in an JSON object
+type KVS []KV
+
+// MarshalJSON - implements converting a KVS datastructure into a JSON
+// object with multiple keys and values.
+func (kvs KVS) MarshalJSON() ([]byte, error) {
+	b := new(bytes.Buffer)
+	b.Write([]byte("{"))
+	for i, kv := range kvs {
+		b.Write([]byte("\"" + kv.Key + "\"" + ":"))
+		valBuf, err := json.Marshal(kv.Value)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(valBuf)
+		if i < len(kvs)-1 {
+			b.Write([]byte(","))
+		}
+	}
+	b.Write([]byte("}"))
+	return b.Bytes(), nil
+}
+
+// Decoder wraps an io.Reader to provide incremental decoding of
+// JSON values
+type Decoder struct {
+	*scanner
+	emitDepth     int
+	emitKV        bool
+	emitRecursive bool
+	objectAsKVS   bool
+
+	depth   int
+	scratch *scratch
+	metaCh  chan *MetaValue
+	err     error
+
+	// follow line position to add context to errors
+	lineNo    int
+	lineStart int64
+}
+
+// NewDecoder creates new Decoder to read JSON values at the provided
+// emitDepth from the provider io.Reader.
+// If emitDepth is < 0, values at every depth will be emitted.
+func NewDecoder(r io.Reader, emitDepth int) *Decoder {
+	d := &Decoder{
+		scanner:   newScanner(r),
+		emitDepth: emitDepth,
+		scratch:   &scratch{data: make([]byte, 1024)},
+		metaCh:    make(chan *MetaValue, 128),
+	}
+	if emitDepth < 0 {
+		d.emitDepth = 0
+		d.emitRecursive = true
+	}
+	return d
+}
+
+// ObjectAsKVS - by default JSON returns map[string]interface{} this
+// is usually fine in most cases, but when you need to preserve the
+// input order its not a right data structure. To preserve input
+// order please use this option.
+func (d *Decoder) ObjectAsKVS() *Decoder {
+	d.objectAsKVS = true
+	return d
+}
+
+// EmitKV enables emitting a jstream.KV struct when the items(s) parsed
+// at configured emit depth are within a JSON object. By default, only
+// the object values are emitted.
+func (d *Decoder) EmitKV() *Decoder {
+	d.emitKV = true
+	return d
+}
+
+// Recursive enables emitting all values at a depth higher than the
+// configured emit depth; e.g. if an array is found at emit depth, all
+// values within the array are emitted to the stream, then the array
+// containing those values is emitted.
+func (d *Decoder) Recursive() *Decoder {
+	d.emitRecursive = true
+	return d
+}
+
+// Stream begins decoding from the underlying reader and returns a
+// streaming MetaValue channel for JSON values at the configured emitDepth.
+func (d *Decoder) Stream() (chan *MetaValue, error) {
+	if err := d.decode(); err != nil {
+		return nil, err
+	}
+	return d.metaCh, nil
+}
+
+// Pos returns the number of bytes consumed from the underlying reader
+func (d *Decoder) Pos() int { return int(d.pos) }
+
+// Err returns the most recent decoder error if any, or nil
+func (d *Decoder) Err() error { return d.err }
+
+// Decode parses the JSON-encoded data and returns an interface value
+func (d *Decoder) decode() error {
+	defer close(d.metaCh)
+	_, err := d.skipSpaces()
+	if err != nil {
+		return err
+	}
+	for d.pos < atomic.LoadInt64(&d.end) {
+		_, err := d.emitAny()
+		if err != nil {
+			d.err = err
+			break
+		}
+		_, err = d.skipSpaces()
+		if err != nil {
+			return err
+		}
+	}
+	if d.err != nil {
+		return d.err
+	}
+	return nil
+}
+
+func (d *Decoder) emitAny() (interface{}, error) {
+	if d.pos >= atomic.LoadInt64(&d.end) {
+		return nil, d.mkError(ErrUnexpectedEOF)
+	}
+	offset := d.pos - 1
+	i, t, err := d.any()
+	if d.willEmit() {
+		d.metaCh <- &MetaValue{
+			Offset:    int(offset),
+			Length:    int(d.pos - offset),
+			Depth:     d.depth,
+			Value:     i,
+			ValueType: t,
+		}
+	}
+	return i, err
+}
+
+// return whether, at the current depth, the value being decoded will
+// be emitted to stream
+func (d *Decoder) willEmit() bool {
+	if d.emitRecursive {
+		return d.depth >= d.emitDepth
+	}
+	return d.depth == d.emitDepth
+}
+
+// any used to decode any valid JSON value, and returns an
+// interface{} that holds the actual data
+func (d *Decoder) any() (interface{}, ValueType, error) {
+	c := d.cur()
+
+	switch c {
+	case '"':
+		i, err := d.string()
+		return i, String, err
+	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		i, err := d.number()
+		return i, Number, err
+	case '-':
+		c, err := d.next()
+		if err != nil {
+			return nil, Unknown, err
+		}
+		if c < '0' && c > '9' {
+			return nil, Unknown, d.mkError(ErrSyntax, "in negative numeric literal")
+		}
+		n, err := d.number()
+		if err != nil {
+			return nil, Unknown, err
+		}
+		return -n, Number, nil
+	case 'f':
+		if d.remaining() < 4 {
+			return nil, Unknown, d.mkError(ErrUnexpectedEOF)
+		}
+		found := true
+		for _, r := range []byte{'a', 'l', 's', 'e'} {
+			c, err := d.next()
+			if err != nil {
+				return false, Unknown, err
+			}
+			if c != r {
+				found = false
+			}
+			// found 'r'
+		}
+		if found {
+			return false, Boolean, nil
+		}
+		return nil, Unknown, d.mkError(ErrSyntax, "in literal false")
+	case 't':
+		if d.remaining() < 3 {
+			return nil, Unknown, d.mkError(ErrUnexpectedEOF)
+		}
+		found := true
+		for _, r := range []byte{'r', 'u', 'e'} {
+			c, err := d.next()
+			if err != nil {
+				return false, Unknown, err
+			}
+			if c != r {
+				found = false
+			}
+			// found 'r'
+		}
+		if found {
+			return true, Boolean, nil
+		}
+		return nil, Unknown, d.mkError(ErrSyntax, "in literal true")
+	case 'n':
+		if d.remaining() < 3 {
+			return nil, Unknown, d.mkError(ErrUnexpectedEOF)
+		}
+		found := true
+		for _, r := range []byte{'u', 'l', 'l'} {
+			c, err := d.next()
+			if err != nil {
+				return false, Unknown, err
+			}
+			if c != r {
+				found = false
+			}
+			// found 'r'
+		}
+		if found {
+			return nil, Null, nil
+		}
+		return nil, Unknown, d.mkError(ErrSyntax, "in literal null")
+	case '[':
+		i, err := d.array()
+		return i, Array, err
+	case '{':
+		var i interface{}
+		var err error
+		if d.objectAsKVS {
+			i, err = d.objectOrdered()
+		} else {
+			i, err = d.object()
+		}
+		return i, Object, err
+	default:
+		return nil, Unknown, d.mkError(ErrSyntax, "looking for beginning of value")
+	}
+}
+
+// string called by `any` or `object`(for map keys) after reading `"`
+func (d *Decoder) string() (string, error) {
+	d.scratch.reset()
+
+	var (
+		c, err = d.next()
+	)
+	if err != nil {
+		return "", err
+	}
+scan:
+	for {
+		switch {
+		case c == '"':
+			return string(d.scratch.bytes()), nil
+		case c == '\\':
+			c, err = d.next()
+			if err != nil {
+				return "", err
+			}
+			goto scan_esc
+		case c < 0x20:
+			return "", d.mkError(ErrSyntax, "in string literal")
+		// Coerce to well-formed UTF-8.
+		default:
+			d.scratch.add(c)
+			if d.remaining() == 0 {
+				return "", d.mkError(ErrSyntax, "in string literal")
+			}
+			c, err = d.next()
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+
+scan_esc:
+	switch c {
+	case '"', '\\', '/', '\'':
+		d.scratch.add(c)
+	case 'u':
+		goto scan_u
+	case 'b':
+		d.scratch.add('\b')
+	case 'f':
+		d.scratch.add('\f')
+	case 'n':
+		d.scratch.add('\n')
+	case 'r':
+		d.scratch.add('\r')
+	case 't':
+		d.scratch.add('\t')
+	default:
+		return "", d.mkError(ErrSyntax, "in string escape code")
+	}
+	c, err = d.next()
+	if err != nil {
+		return "", err
+	}
+	goto scan
+
+scan_u:
+	r, err := d.u4()
+	if err != nil {
+		return "", err
+	}
+
+	// check for proceeding surrogate pair
+	c, err = d.next()
+	if err != nil {
+		return "", err
+	}
+
+	if !utf16.IsSurrogate(r) || c != '\\' {
+		d.scratch.addRune(r)
+		goto scan
+	}
+	c, err = d.next()
+	if err != nil {
+		return "", err
+	}
+	if c != 'u' {
+		d.scratch.addRune(r)
+		goto scan_esc
+	}
+
+	r2, err := d.u4()
+	if err != nil {
+		return "", err
+	}
+
+	// write surrogate pair
+	d.scratch.addRune(utf16.DecodeRune(r, r2))
+	c, err = d.next()
+	if err != nil {
+		return "", err
+	}
+	goto scan
+}
+
+// u4 reads four bytes following a \u escape
+func (d *Decoder) u4() (rune, error) {
+	// logic taken from:
+	// github.com/buger/jsonparser/blob/master/escape.go#L20
+	var h [4]int
+	for i := 0; i < 4; i++ {
+		c, err := d.next()
+		if err != nil {
+			return -1, err
+		}
+		switch {
+		case c >= '0' && c <= '9':
+			h[i] = int(c - '0')
+		case c >= 'A' && c <= 'F':
+			h[i] = int(c - 'A' + 10)
+		case c >= 'a' && c <= 'f':
+			h[i] = int(c - 'a' + 10)
+		default:
+			return -1, d.mkError(ErrSyntax, "in unicode escape sequence")
+		}
+	}
+	return rune(h[0]<<12 + h[1]<<8 + h[2]<<4 + h[3]), nil
+}
+
+// number called by `any` after reading number between 0 to 9
+func (d *Decoder) number() (float64, error) {
+	d.scratch.reset()
+
+	var (
+		c       = d.cur()
+		err     error
+		n       float64
+		isFloat bool
+	)
+
+	// digits first
+	switch {
+	case c == '0':
+		d.scratch.add(c)
+		c, err = d.next()
+		if err != nil {
+			return n, err
+		}
+	case '1' <= c && c <= '9':
+		for {
+			if c >= '0' && c <= '9' {
+				n = 10*n + float64(c-'0')
+				d.scratch.add(c)
+
+				c, err = d.next()
+				if err != nil {
+					return n, err
+				}
+				continue
+			}
+			break
+		}
+	}
+
+	// . followed by 1 or more digits
+	if c == '.' {
+		isFloat = true
+		d.scratch.add(c)
+
+		// first char following must be digit
+		c, err = d.next()
+		if err != nil {
+			return 0, err
+		}
+		if c < '0' && c > '9' {
+			return 0, d.mkError(ErrSyntax, "after decimal point in numeric literal")
+		}
+		d.scratch.add(c)
+
+		for {
+			if d.remaining() == 0 {
+				return 0, d.mkError(ErrUnexpectedEOF)
+			}
+			c, err = d.next()
+			if err != nil {
+				return 0, err
+			}
+			if c < '0' || c > '9' {
+				break
+			}
+			d.scratch.add(c)
+		}
+	}
+
+	// e or E followed by an optional - or + and
+	// 1 or more digits.
+	if c == 'e' || c == 'E' {
+		isFloat = true
+		d.scratch.add(c)
+
+		c, err = d.next()
+		if err != nil {
+			return 0, err
+		}
+		if c == '+' || c == '-' {
+			d.scratch.add(c)
+			c, err = d.next()
+			if err != nil {
+				return 0, err
+			}
+			if c < '0' || c > '9' {
+				return 0, d.mkError(ErrSyntax, "in exponent of numeric literal")
+			}
+			d.scratch.add(c)
+		}
+		for {
+			c, err = d.next()
+			if err != nil {
+				return 0, err
+			}
+			if c >= '0' && c <= '9' {
+				d.scratch.add(c)
+				continue
+			}
+			break
+		}
+	}
+
+	if isFloat {
+		var (
+			err error
+			sn  string
+		)
+		sn = string(d.scratch.bytes())
+		if n, err = strconv.ParseFloat(sn, 64); err != nil {
+			return 0, err
+		}
+	}
+
+	d.back()
+	return n, nil
+}
+
+// array accept valid JSON array value
+func (d *Decoder) array() ([]interface{}, error) {
+	d.depth++
+
+	var (
+		c     byte
+		v     interface{}
+		err   error
+		array = make([]interface{}, 0)
+	)
+
+	// look ahead for ] - if the array is empty.
+	c, err = d.skipSpaces()
+	if err != nil {
+		return nil, err
+	}
+
+	if c == ']' {
+		goto out
+	}
+
+scan:
+	if v, err = d.emitAny(); err != nil {
+		goto out
+	}
+
+	if d.depth > d.emitDepth { // skip alloc for array if it won't be emitted
+		array = append(array, v)
+	}
+
+	// next token must be ',' or ']'
+	c, err = d.skipSpaces()
+	if err != nil {
+		return nil, err
+	}
+
+	switch c {
+	case ',':
+		c, err = d.skipSpaces()
+		if err != nil {
+			return nil, err
+		}
+		goto scan
+	case ']':
+		goto out
+	default:
+		err = d.mkError(ErrSyntax, "after array element")
+	}
+
+out:
+	d.depth--
+	return array, err
+}
+
+// object accept valid JSON array value
+func (d *Decoder) object() (map[string]interface{}, error) {
+	d.depth++
+
+	var (
+		c   byte
+		k   string
+		v   interface{}
+		t   ValueType
+		err error
+		obj map[string]interface{}
+	)
+
+	// skip allocating map if it will not be emitted
+	if d.depth > d.emitDepth {
+		obj = make(map[string]interface{})
+	}
+
+	// if the object has no keys
+	c, err = d.skipSpaces()
+	if err != nil {
+		goto out
+	}
+
+	if c == '}' {
+		goto out
+	}
+
+scan:
+	for {
+		offset := d.pos - 1
+
+		// read string key
+		if c != '"' {
+			err = d.mkError(ErrSyntax, "looking for beginning of object key string")
+			break
+		}
+		if k, err = d.string(); err != nil {
+			break
+		}
+
+		// read colon before value
+		c, err = d.skipSpaces()
+		if err != nil {
+			break
+		}
+		if c != ':' {
+			err = d.mkError(ErrSyntax, "after object key")
+			break
+		}
+
+		// read value
+		c, err = d.skipSpaces()
+		if err != nil {
+			return nil, err
+		}
+		if d.emitKV {
+			if v, t, err = d.any(); err != nil {
+				break
+			}
+			if d.willEmit() {
+				d.metaCh <- &MetaValue{
+					Offset:    int(offset),
+					Length:    int(d.pos - offset),
+					Depth:     d.depth,
+					Value:     KV{k, v},
+					ValueType: t,
+				}
+			}
+		} else {
+			if v, err = d.emitAny(); err != nil {
+				break
+			}
+		}
+
+		if obj != nil {
+			obj[k] = v
+		}
+
+		// next token must be ',' or '}'
+		c, err = d.skipSpaces()
+		if err != nil {
+			goto out
+		}
+		switch c {
+		case '}':
+			goto out
+		case ',':
+			c, err = d.skipSpaces()
+			if err != nil {
+				goto out
+			}
+			goto scan
+		default:
+			err = d.mkError(ErrSyntax, "after object key:value pair")
+			goto out
+		}
+	}
+
+out:
+	d.depth--
+	return obj, err
+}
+
+// object (ordered) accept valid JSON array value
+func (d *Decoder) objectOrdered() (KVS, error) {
+	d.depth++
+
+	var (
+		c   byte
+		k   string
+		v   interface{}
+		t   ValueType
+		err error
+		obj KVS
+	)
+
+	// skip allocating map if it will not be emitted
+	if d.depth > d.emitDepth {
+		obj = make(KVS, 0)
+	}
+
+	// if the object has no keys
+	c, err = d.skipSpaces()
+	if err != nil {
+		goto out
+	}
+
+	if c == '}' {
+		goto out
+	}
+
+scan:
+	for {
+		offset := d.pos - 1
+
+		// read string key
+		if c != '"' {
+			err = d.mkError(ErrSyntax, "looking for beginning of object key string")
+			break
+		}
+		if k, err = d.string(); err != nil {
+			break
+		}
+
+		// read colon before value
+		c, err = d.skipSpaces()
+		if err != nil {
+			break
+		}
+		if c != ':' {
+			err = d.mkError(ErrSyntax, "after object key")
+			break
+		}
+
+		// read value
+		c, err = d.skipSpaces()
+		if err != nil {
+			return nil, err
+		}
+		if d.emitKV {
+			if v, t, err = d.any(); err != nil {
+				break
+			}
+			if d.willEmit() {
+				d.metaCh <- &MetaValue{
+					Offset:    int(offset),
+					Length:    int(d.pos - offset),
+					Depth:     d.depth,
+					Value:     KV{k, v},
+					ValueType: t,
+				}
+			}
+		} else {
+			if v, err = d.emitAny(); err != nil {
+				break
+			}
+		}
+
+		if obj != nil {
+			obj = append(obj, KV{k, v})
+		}
+
+		// next token must be ',' or '}'
+		c, err = d.skipSpaces()
+		if err != nil {
+			goto out
+		}
+
+		switch c {
+		case '}':
+			goto out
+		case ',':
+			c, err = d.skipSpaces()
+			if err != nil {
+				goto out
+			}
+			goto scan
+		default:
+			err = d.mkError(ErrSyntax, "after object key:value pair")
+			goto out
+		}
+	}
+
+out:
+	d.depth--
+	return obj, err
+}
+
+// returns the next char after white spaces
+func (d *Decoder) skipSpaces() (byte, error) {
+	for d.pos < atomic.LoadInt64(&d.end) {
+		c, err := d.next()
+		if err != nil {
+			return byte(0), err
+		}
+		switch c {
+		case '\n':
+			d.lineStart = d.pos
+			d.lineNo++
+			continue
+		case ' ', '\t', '\r':
+			continue
+		default:
+			return c, nil
+		}
+	}
+	return 0, nil
+}
+
+// create syntax errors at current position, with optional context
+func (d *Decoder) mkError(err SyntaxError, context ...string) error {
+	if len(context) > 0 {
+		err.context = context[0]
+	}
+	err.atChar = d.cur()
+	err.pos[0] = d.lineNo + 1
+	err.pos[1] = int(d.pos - d.lineStart)
+	return err
+}

--- a/pkg/s3select/json/jstream/decoder_test.go
+++ b/pkg/s3select/json/jstream/decoder_test.go
@@ -1,0 +1,228 @@
+package jstream
+
+import (
+	"bytes"
+	"testing"
+)
+
+func mkReader(s string) *bytes.Reader { return bytes.NewReader([]byte(s)) }
+
+func TestDecoderSimple(t *testing.T) {
+	var (
+		counter int
+		body    = `[{"bio":"bada bing bada boom","id":1,"name":"Charles","falseVal":false}]`
+	)
+
+	decoder := NewDecoder(mkReader(body), 1)
+
+	metaValChan, err := decoder.Stream()
+	if err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	for mv := range metaValChan {
+		counter++
+		t.Logf("depth=%d offset=%d len=%d (%v)", mv.Depth, mv.Offset, mv.Length, mv.Value)
+	}
+
+	if err := decoder.Err(); err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+}
+
+func TestDecoderNested(t *testing.T) {
+	var (
+		counter int
+		body    = `{
+  "1": {
+    "bio": "bada bing bada boom",
+    "id": 0,
+    "name": "Roberto",
+    "nested1": {
+      "bio": "utf16 surrogate (\ud834\udcb2)\n\u201cutf 8\u201d",
+      "id": 1.5,
+      "name": "Roberto*Maestro",
+      "nested2": { "nested2arr": [0,1,2], "nested3": {
+        "nested4": { "depth": "recursion" }}
+			}
+		}
+  },
+  "2": {
+    "nullfield": null,
+    "id": -2
+  }
+}`
+	)
+
+	decoder := NewDecoder(mkReader(body), 2)
+
+	metaValChan, err := decoder.Stream()
+	if err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	for mv := range metaValChan {
+		counter++
+		t.Logf("depth=%d offset=%d len=%d (%v)", mv.Depth, mv.Offset, mv.Length, mv.Value)
+	}
+
+	if err := decoder.Err(); err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+}
+
+func TestDecoderFlat(t *testing.T) {
+	var (
+		counter int
+		body    = `[
+  "1st test string",
+  "Roberto*Maestro", "Charles",
+  0, null, false,
+  1, 2.5
+]`
+		expected = []struct {
+			Value     interface{}
+			ValueType ValueType
+		}{
+			{
+				"1st test string",
+				String,
+			},
+			{
+				"Roberto*Maestro",
+				String,
+			},
+			{
+				"Charles",
+				String,
+			},
+			{
+				0.0,
+				Number,
+			},
+			{
+				nil,
+				Null,
+			},
+			{
+				false,
+				Boolean,
+			},
+			{
+				1.0,
+				Number,
+			},
+			{
+				2.5,
+				Number,
+			},
+		}
+	)
+
+	decoder := NewDecoder(mkReader(body), 1)
+
+	metaValChan, err := decoder.Stream()
+	if err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	for mv := range metaValChan {
+		if mv.Value != expected[counter].Value {
+			t.Fatalf("got %v, expected: %v", mv.Value, expected[counter])
+		}
+		if mv.ValueType != expected[counter].ValueType {
+			t.Fatalf("got %v value type, expected: %v value type", mv.ValueType, expected[counter].ValueType)
+		}
+		counter++
+		t.Logf("depth=%d offset=%d len=%d (%v)", mv.Depth, mv.Offset, mv.Length, mv.Value)
+	}
+
+	if err := decoder.Err(); err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+}
+
+func TestDecoderMultiDoc(t *testing.T) {
+	var (
+		counter int
+		body    = `{ "bio": "bada bing bada boom", "id": 1, "name": "Charles" }
+{ "bio": "bada bing bada boom", "id": 2, "name": "Charles" }
+{ "bio": "bada bing bada boom", "id": 3, "name": "Charles" }
+{ "bio": "bada bing bada boom", "id": 4, "name": "Charles" }
+{ "bio": "bada bing bada boom", "id": 5, "name": "Charles" }
+`
+	)
+
+	decoder := NewDecoder(mkReader(body), 0)
+
+	metaValChan, err := decoder.Stream()
+	if err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	for mv := range metaValChan {
+		if mv.ValueType != Object {
+			t.Fatalf("got %v value type, expected: Object value type", mv.ValueType)
+		}
+		counter++
+		t.Logf("depth=%d offset=%d len=%d (%v)", mv.Depth, mv.Offset, mv.Length, mv.Value)
+	}
+	if err := decoder.Err(); err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	if counter != 5 {
+		t.Fatalf("expected 5 items, got %d", counter)
+	}
+
+	// test at depth level 1
+	counter = 0
+	kvcounter := 0
+	decoder = NewDecoder(mkReader(body), 1)
+
+	metaValChan, err = decoder.Stream()
+	if err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	for mv := range metaValChan {
+		switch mv.Value.(type) {
+		case KV:
+			kvcounter++
+		default:
+			counter++
+		}
+		t.Logf("depth=%d offset=%d len=%d (%v)", mv.Depth, mv.Offset, mv.Length, mv.Value)
+	}
+	if err := decoder.Err(); err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	if kvcounter != 0 {
+		t.Fatalf("expected 0 keyvalue items, got %d", kvcounter)
+	}
+	if counter != 15 {
+		t.Fatalf("expected 15 items, got %d", counter)
+	}
+
+	// test at depth level 1 w/ emitKV
+	counter = 0
+	kvcounter = 0
+	decoder = NewDecoder(mkReader(body), 1).EmitKV()
+
+	metaValChan, err = decoder.Stream()
+	if err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	for mv := range metaValChan {
+		switch mv.Value.(type) {
+		case KV:
+			kvcounter++
+		default:
+			counter++
+		}
+		t.Logf("depth=%d offset=%d len=%d (%v)", mv.Depth, mv.Offset, mv.Length, mv.Value)
+	}
+	if err := decoder.Err(); err != nil {
+		t.Fatalf("decoder error: %s", err)
+	}
+	if kvcounter != 15 {
+		t.Fatalf("expected 15 keyvalue items, got %d", kvcounter)
+	}
+	if counter != 0 {
+		t.Fatalf("expected 0 items, got %d", counter)
+	}
+}

--- a/pkg/s3select/json/jstream/errors.go
+++ b/pkg/s3select/json/jstream/errors.go
@@ -1,0 +1,41 @@
+package jstream
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Predefined errors
+var (
+	ErrSyntax        = SyntaxError{msg: "invalid character"}
+	ErrUnexpectedEOF = SyntaxError{msg: "unexpected end of JSON input"}
+)
+
+type errPos [2]int // line number, byte offset where error occurred
+
+type SyntaxError struct {
+	msg     string // description of error
+	context string // additional error context
+	pos     errPos
+	atChar  byte
+}
+
+func (e SyntaxError) Error() string {
+	loc := fmt.Sprintf("%s [%d,%d]", quoteChar(e.atChar), e.pos[0], e.pos[1])
+	return fmt.Sprintf("%s %s: %s", e.msg, e.context, loc)
+}
+
+// quoteChar formats c as a quoted character literal
+func quoteChar(c byte) string {
+	// special cases - different from quoted strings
+	if c == '\'' {
+		return `'\''`
+	}
+	if c == '"' {
+		return `'"'`
+	}
+
+	// use quoted string with different quotation marks
+	s := strconv.Quote(string(c))
+	return "'" + s[1:len(s)-1] + "'"
+}

--- a/pkg/s3select/json/jstream/scanner.go
+++ b/pkg/s3select/json/jstream/scanner.go
@@ -1,0 +1,119 @@
+package jstream
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+const (
+	chunk   = 4095 // ~4k
+	maxUint = ^uint(0)
+	maxInt  = int64(maxUint >> 1)
+)
+
+type fillReady struct {
+	fill int64
+	err  error
+}
+
+type scanner struct {
+	pos       int64 // position in reader
+	ipos      int64 // internal buffer position
+	ifill     int64 // internal buffer fill
+	end       int64
+	buf       [chunk + 1]byte // internal buffer (with a lookback size of 1)
+	nbuf      [chunk]byte     // next internal buffer
+	fillReq   chan struct{}
+	fillReady chan fillReady
+}
+
+func newScanner(r io.Reader) *scanner {
+	sr := &scanner{
+		end:       maxInt,
+		fillReq:   make(chan struct{}),
+		fillReady: make(chan fillReady),
+	}
+
+	go func() {
+		var rpos int64 // total bytes read into buffer
+
+		for range sr.fillReq {
+		scan:
+			n, err := r.Read(sr.nbuf[:])
+			if n == 0 {
+				switch err {
+				case io.EOF: // reader is exhausted
+					atomic.StoreInt64(&sr.end, rpos)
+					close(sr.fillReady)
+					return
+				case nil: // no data and no error, retry fill
+					goto scan
+				default:
+					sr.fillReady <- fillReady{0, err}
+					close(sr.fillReady)
+					return
+				}
+			}
+
+			rpos += int64(n)
+			sr.fillReady <- fillReady{int64(n), nil}
+		}
+	}()
+
+	sr.fillReq <- struct{}{} // initial fill
+
+	return sr
+}
+
+// remaining returns the number of unread bytes
+// if EOF for the underlying reader has not yet been found,
+// maximum possible integer value will be returned
+func (s *scanner) remaining() int64 {
+	if atomic.LoadInt64(&s.end) == maxInt {
+		return maxInt
+	}
+	return atomic.LoadInt64(&s.end) - s.pos
+}
+
+// read byte at current position (without advancing)
+func (s *scanner) cur() byte { return s.buf[s.ipos] }
+
+// read next byte
+func (s *scanner) next() (byte, error) {
+	if s.pos >= atomic.LoadInt64(&s.end) {
+		return byte(0), nil
+	}
+	s.ipos++
+
+	if s.ipos > s.ifill { // internal buffer is exhausted
+		fr := <-s.fillReady
+		if fr.err != nil {
+			// Unhandled error return to the caller.
+			return byte(0), fr.err
+		}
+
+		s.ifill = fr.fill
+		s.buf[0] = s.buf[len(s.buf)-1] // copy current last item to guarantee lookback
+		copy(s.buf[1:], s.nbuf[:])     // copy contents of pre-filled next buffer
+		s.ipos = 1                     // move to beginning of internal buffer
+
+		// request next fill to be prepared
+		if s.end == maxInt {
+			s.fillReq <- struct{}{}
+		}
+	}
+
+	s.pos++
+	return s.buf[s.ipos], nil
+}
+
+// back undoes a previous call to next(), moving backward one byte in the internal buffer.
+// as we only guarantee a lookback buffer size of one, any subsequent calls to back()
+// before calling next() may panic
+func (s *scanner) back() {
+	if s.ipos <= 0 {
+		panic("back buffer exhausted")
+	}
+	s.ipos--
+	s.pos--
+}

--- a/pkg/s3select/json/jstream/scanner_test.go
+++ b/pkg/s3select/json/jstream/scanner_test.go
@@ -1,0 +1,122 @@
+package jstream
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"sync/atomic"
+	"testing"
+)
+
+var (
+	smallInput  = make([]byte, 1024*12)       // 12K
+	mediumInput = make([]byte, 1024*1024*12)  // 12MB
+	largeInput  = make([]byte, 1024*1024*128) // 128MB
+)
+
+func TestScanner(t *testing.T) {
+	data := []byte("abcdefghijklmnopqrstuvwxyz0123456789")
+
+	var i int
+	r := bytes.NewReader(data)
+	scanner := newScanner(r)
+	for scanner.pos < atomic.LoadInt64(&scanner.end) {
+		c, err := scanner.next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c != data[i] {
+			t.Fatalf("expected %s, got %s", string(data[i]), string(c))
+		}
+		t.Logf("pos=%d remaining=%d (%s)", i, r.Len(), string(c))
+		i++
+	}
+
+}
+
+func BenchmarkBufioScanner(b *testing.B) {
+	b.Run("small", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkBufioScanner(smallInput)
+		}
+	})
+	b.Run("medium", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkBufioScanner(mediumInput)
+		}
+	})
+	b.Run("large", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkBufioScanner(largeInput)
+		}
+	})
+}
+
+func benchmarkBufioScanner(b []byte) {
+	s := bufio.NewScanner(bytes.NewReader(b))
+	s.Split(bufio.ScanBytes)
+	for s.Scan() {
+		s.Bytes()
+	}
+}
+
+func BenchmarkBufioReader(b *testing.B) {
+	b.Run("small", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkBufioReader(smallInput)
+		}
+	})
+	b.Run("medium", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkBufioReader(mediumInput)
+		}
+	})
+	b.Run("large", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkBufioReader(largeInput)
+		}
+	})
+}
+
+func benchmarkBufioReader(b []byte) {
+	br := bufio.NewReader(bytes.NewReader(b))
+loop:
+	for {
+		_, err := br.ReadByte()
+		switch err {
+		case nil:
+			continue loop
+		case io.EOF:
+			break loop
+		default:
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkScanner(b *testing.B) {
+	b.Run("small", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkScanner(smallInput)
+		}
+	})
+	b.Run("medium", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkScanner(mediumInput)
+		}
+	})
+	b.Run("large", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkScanner(largeInput)
+		}
+	})
+}
+
+func benchmarkScanner(b []byte) {
+	r := bytes.NewReader(b)
+
+	scanner := newScanner(r)
+	for scanner.remaining() > 0 {
+		scanner.next()
+	}
+}

--- a/pkg/s3select/json/jstream/scratch.go
+++ b/pkg/s3select/json/jstream/scratch.go
@@ -1,0 +1,44 @@
+package jstream
+
+import (
+	"unicode/utf8"
+)
+
+type scratch struct {
+	data []byte
+	fill int
+}
+
+// reset scratch buffer
+func (s *scratch) reset() { s.fill = 0 }
+
+// bytes returns the written contents of scratch buffer
+func (s *scratch) bytes() []byte { return s.data[0:s.fill] }
+
+// grow scratch buffer
+func (s *scratch) grow() {
+	ndata := make([]byte, cap(s.data)*2)
+	copy(ndata, s.data[:])
+	s.data = ndata
+}
+
+// append single byte to scratch buffer
+func (s *scratch) add(c byte) {
+	if s.fill+1 >= cap(s.data) {
+		s.grow()
+	}
+
+	s.data[s.fill] = c
+	s.fill++
+}
+
+// append encoded rune to scratch buffer
+func (s *scratch) addRune(r rune) int {
+	if s.fill+utf8.UTFMax >= cap(s.data) {
+		s.grow()
+	}
+
+	n := utf8.EncodeRune(s.data[s.fill:], r)
+	s.fill += n
+	return n
+}

--- a/pkg/s3select/json/preader.go
+++ b/pkg/s3select/json/preader.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/bcicen/jstream"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 	"github.com/minio/minio/pkg/s3select/sql"
 )
 
@@ -185,7 +185,12 @@ func (r *PReader) startReaders() {
 				}
 
 				d := jstream.NewDecoder(bytes.NewBuffer(in.input), 0).ObjectAsKVS()
-				stream := d.Stream()
+				stream, err := d.Stream()
+				if err != nil {
+					// Exit on any error.
+					return
+				}
+
 				all := dst[:0]
 				for mv := range stream {
 					var kvs jstream.KVS

--- a/pkg/s3select/json/reader_test.go
+++ b/pkg/s3select/json/reader_test.go
@@ -38,7 +38,7 @@ func TestNewReader(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			r := NewReader(f, &ReaderArgs{})
+			r, err := NewReader(f, &ReaderArgs{})
 			var record sql.Record
 			for {
 				record, err = r.Read(record)
@@ -57,7 +57,7 @@ func TestNewReader(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			r := NewReader(f, &ReaderArgs{})
+			r, err := NewReader(f, &ReaderArgs{})
 			r.Close()
 			var record sql.Record
 			for {
@@ -89,7 +89,7 @@ func BenchmarkReader(b *testing.B) {
 			b.ResetTimer()
 			var record sql.Record
 			for i := 0; i < b.N; i++ {
-				r := NewReader(ioutil.NopCloser(bytes.NewBuffer(f)), &ReaderArgs{})
+				r, err := NewReader(ioutil.NopCloser(bytes.NewBuffer(f)), &ReaderArgs{})
 				for {
 					record, err = r.Read(record)
 					if err != nil {

--- a/pkg/s3select/json/record.go
+++ b/pkg/s3select/json/record.go
@@ -25,8 +25,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bcicen/jstream"
 	csv "github.com/minio/minio/pkg/csvparser"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 	"github.com/minio/minio/pkg/s3select/sql"
 )
 

--- a/pkg/s3select/parquet/reader.go
+++ b/pkg/s3select/parquet/reader.go
@@ -19,8 +19,8 @@ package parquet
 import (
 	"io"
 
-	"github.com/bcicen/jstream"
 	jsonfmt "github.com/minio/minio/pkg/s3select/json"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 	"github.com/minio/minio/pkg/s3select/sql"
 	parquetgo "github.com/minio/parquet-go"
 	parquetgen "github.com/minio/parquet-go/gen-go/parquet"

--- a/pkg/s3select/simdj/reader_test.go
+++ b/pkg/s3select/simdj/reader_test.go
@@ -116,7 +116,7 @@ func TestNDJSON(t *testing.T) {
 					t.Fatal("unexpected type:", typ.String())
 				}
 			}
-			refDec := json.NewReader(ioutil.NopCloser(bytes.NewBuffer(ref)), &json.ReaderArgs{ContentType: "json"})
+			refDec, err := json.NewReader(ioutil.NopCloser(bytes.NewBuffer(ref)), &json.ReaderArgs{ContentType: "json"})
 
 			for {
 				rec, err := dec.Read(nil)

--- a/pkg/s3select/simdj/record.go
+++ b/pkg/s3select/simdj/record.go
@@ -22,8 +22,8 @@ import (
 
 	csv "github.com/minio/minio/pkg/csvparser"
 
-	"github.com/bcicen/jstream"
 	"github.com/minio/minio/pkg/s3select/json"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 	"github.com/minio/minio/pkg/s3select/sql"
 	"github.com/minio/simdjson-go"
 )

--- a/pkg/s3select/sql/evaluate.go
+++ b/pkg/s3select/sql/evaluate.go
@@ -23,7 +23,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/bcicen/jstream"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 	"github.com/minio/simdjson-go"
 )
 

--- a/pkg/s3select/sql/jsonpath.go
+++ b/pkg/s3select/sql/jsonpath.go
@@ -19,7 +19,7 @@ package sql
 import (
 	"errors"
 
-	"github.com/bcicen/jstream"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 	"github.com/minio/simdjson-go"
 )
 

--- a/pkg/s3select/sql/jsonpath_test.go
+++ b/pkg/s3select/sql/jsonpath_test.go
@@ -26,13 +26,14 @@ import (
 	"testing"
 
 	"github.com/alecthomas/participle"
-	"github.com/bcicen/jstream"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 )
 
 func getJSONStructs(b []byte) ([]interface{}, error) {
 	dec := jstream.NewDecoder(bytes.NewBuffer(b), 0).ObjectAsKVS()
 	var result []interface{}
-	for parsedVal := range dec.Stream() {
+	metaChan, _ := dec.Stream()
+	for parsedVal := range metaChan {
 		result = append(result, parsedVal.Value)
 	}
 	if err := dec.Err(); err != nil {

--- a/pkg/s3select/sql/statement.go
+++ b/pkg/s3select/sql/statement.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bcicen/jstream"
+	"github.com/minio/minio/pkg/s3select/json/jstream"
 	"github.com/minio/simdjson-go"
 )
 


### PR DESCRIPTION
## Description
`mc sql -e="SELECT ...` command for files in `json` and/or in `gz` or `bz2` formats behave differently than amazon s3 version. The error messages thrown was not helpful and incompatible with the s3 counterparts in certain conditions like incorrect `.gz` and `.bz2` files and etc.
Also localized the jstream library.
## Motivation and Context
We need to be compatible with Amazon s3.

## How to test this PR?
Run the following commands with correct and incorrect formatted json, gzipped json and bzip2'ed json files and make sure MinIO AND s3 results match.

```
- mc sql -e="SELECT * from s3object LIMIT 1" --json-input type="document" myminio/test/incorrect.bz2
- mc sql -e="SELECT * from s3object LIMIT 1" --json-input type="document" s3/test/incorrect.bz2
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
