### PR TITLE
cleanup: Lifecycle does not manage leader locks anymore

### DIFF
--- a/cmd/daily-lifecycle-ops.go
+++ b/cmd/daily-lifecycle-ops.go
@@ -44,21 +44,11 @@ func startDailyLifecycle(ctx context.Context, objAPI ObjectLayer) {
 			return
 		case <-time.NewTimer(bgLifecycleInterval).C:
 			// Perform one lifecycle operation
-			err := lifecycleRound(ctx, objAPI)
-			switch err.(type) {
-			case OperationTimedOut:
-				// Unable to hold a lock means there is another
-				// caller holding write lock, ignore and try next round.
-				continue
-			default:
-				logger.LogIf(ctx, err)
-			}
+			logger.LogIf(ctx, lifecycleRound(ctx, objAPI))
 		}
 
 	}
 }
-
-var lifecycleLockTimeout = newDynamicTimeout(60*time.Second, time.Second)
 
 func lifecycleRound(ctx context.Context, objAPI ObjectLayer) error {
 	buckets, err := objAPI.ListBuckets(ctx)


### PR DESCRIPTION
## Description
lifecycleRound() does not expect locking operation timeout anymore, clean the code.

## Motivation and Context
Code cleanup

## How to test this PR?
No testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
