### PR TITLE
fix: use specified authToken for audit/logger HTTP targets

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -422,14 +422,28 @@ func lookupConfigs(s config.Config) {
 	for _, l := range loggerCfg.HTTP {
 		if l.Enabled {
 			// Enable http logging
-			logger.AddTarget(http.New(l.Endpoint, loggerUserAgent, string(logger.All), NewGatewayHTTPTransport()))
+			logger.AddTarget(
+				http.New(http.WithEndpoint(l.Endpoint),
+					http.WithAuthToken(l.AuthToken),
+					http.WithUserAgent(loggerUserAgent),
+					http.WithLogKind(string(logger.All)),
+					http.WithTransport(NewGatewayHTTPTransport()),
+				),
+			)
 		}
 	}
 
 	for _, l := range loggerCfg.Audit {
 		if l.Enabled {
 			// Enable http audit logging
-			logger.AddAuditTarget(http.New(l.Endpoint, loggerUserAgent, string(logger.All), NewGatewayHTTPTransport()))
+			logger.AddAuditTarget(
+				http.New(http.WithEndpoint(l.Endpoint),
+					http.WithAuthToken(l.AuthToken),
+					http.WithUserAgent(loggerUserAgent),
+					http.WithLogKind(string(logger.All)),
+					http.WithTransport(NewGatewayHTTPTransport()),
+				),
+			)
 		}
 	}
 

--- a/cmd/logger/target/http/http.go
+++ b/cmd/logger/target/http/http.go
@@ -37,7 +37,9 @@ type Target struct {
 
 	// HTTP(s) endpoint
 	endpoint string
-	// User-Agent to be set on each log request sent to the `endpoint`
+	// Authorization token for `endpoint`
+	authToken string
+	// User-Agent to be set on each log to `endpoint`
 	userAgent string
 	logKind   string
 	client    http.Client
@@ -53,7 +55,7 @@ func (h *Target) startHTTPLogger() {
 				continue
 			}
 
-			req, err := http.NewRequest(http.MethodPost, h.endpoint, bytes.NewBuffer(logJSON))
+			req, err := http.NewRequest(http.MethodPost, h.endpoint, bytes.NewReader(logJSON))
 			if err != nil {
 				continue
 			}
@@ -62,6 +64,10 @@ func (h *Target) startHTTPLogger() {
 			// Set user-agent to indicate MinIO release
 			// version to the configured log endpoint
 			req.Header.Set("User-Agent", h.userAgent)
+
+			if h.authToken != "" {
+				req.Header.Set("Authorization", h.authToken)
+			}
 
 			resp, err := h.client.Do(req)
 			if err != nil {
@@ -75,21 +81,62 @@ func (h *Target) startHTTPLogger() {
 	}()
 }
 
+// Option is a function type that accepts a pointer Target
+type Option func(*Target)
+
+// WithEndpoint adds a new endpoint
+func WithEndpoint(endpoint string) Option {
+	return func(t *Target) {
+		t.endpoint = endpoint
+	}
+}
+
+// WithLogKind adds a log type for this target
+func WithLogKind(logKind string) Option {
+	return func(t *Target) {
+		t.logKind = strings.ToUpper(logKind)
+	}
+}
+
+// WithUserAgent adds a custom user-agent sent to the target.
+func WithUserAgent(userAgent string) Option {
+	return func(t *Target) {
+		t.userAgent = userAgent
+	}
+}
+
+// WithAuthToken adds a new authorization header to be sent to target.
+func WithAuthToken(authToken string) Option {
+	return func(t *Target) {
+		t.authToken = authToken
+	}
+}
+
+// WithTransport adds a custom transport with custom timeouts and tuning.
+func WithTransport(transport *http.Transport) Option {
+	return func(t *Target) {
+		t.client = http.Client{
+			Transport: transport,
+		}
+	}
+}
+
 // New initializes a new logger target which
 // sends log over http to the specified endpoint
-func New(endpoint, userAgent, logKind string, transport *http.Transport) *Target {
-	h := Target{
-		endpoint:  endpoint,
-		userAgent: userAgent,
-		logKind:   strings.ToUpper(logKind),
-		client: http.Client{
-			Transport: transport,
-		},
+func New(opts ...Option) *Target {
+	h := &Target{
 		logCh: make(chan interface{}, 10000),
 	}
 
+	// Loop through each option
+	for _, opt := range opts {
+		// Call the option giving the instantiated
+		// *Target as the argument
+		opt(h)
+	}
+
 	h.startHTTPLogger()
-	return &h
+	return h
 }
 
 // Send log message 'e' to http target.
@@ -97,6 +144,7 @@ func (h *Target) Send(entry interface{}, errKind string) error {
 	if h.logKind != errKind && h.logKind != "ALL" {
 		return nil
 	}
+
 	select {
 	case h.logCh <- entry:
 	default:


### PR DESCRIPTION

## Description
fix: use specified authToken for audit/logger HTTP targets

## Motivation and Context
We were not using the auth token specified
even when config supports it.

## How to test this PR?
Use a webhook endpoint which supports auth-token, this can be as simple as 

```go
package main

import (
	"fmt"
	"io/ioutil"
	"log"
	"net/http"
)

func hello(w http.ResponseWriter, r *http.Request) {
	if r.URL.Path != "/" {
		http.Error(w, "404 not found.", http.StatusNotFound)
		return
	}

	switch r.Method {
	case "POST":
		body, err := ioutil.ReadAll(r.Body)
		if err != nil {
			fmt.Fprintf(w, "ReadError() err: %v", err)
			return
		}
		fmt.Println(string(body))
	default:
		fmt.Fprintf(w, "Sorry, only POST methods are supported.")
	}
}

func main() {
	http.HandleFunc("/", hello)

	if err := http.ListenAndServe(":8080", nil); err != nil {
		log.Fatal(err)
	}
}
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably not sure when it was introduced
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
