### PR TITLE
Added a function which allows passing the UID/GID for suexec

### DIFF
--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -65,8 +65,14 @@ docker_sse_encryption_env() {
 # su-exec to requested user, if service cannot run exec will fail.
 docker_switch_user() {
     if [ ! -z "${MINIO_USERNAME}" ] && [ ! -z "${MINIO_GROUPNAME}" ]; then
-        addgroup -S "$MINIO_GROUPNAME" >/dev/null 2>&1 && \
-            adduser -S -G "$MINIO_GROUPNAME" "$MINIO_USERNAME" >/dev/null 2>&1
+
+	if [ ! -z "${MINIO_UID}" ] && [ ! -z "${MINIO_GID}" ]; then
+		addgroup -S -g "$MINIO_GID" "$MINIO_GROUPNAME" && \
+                        adduser -S -u "$MINIO_UID" -G "$MINIO_GROUPNAME" "$MINIO_USERNAME"
+	else
+		addgroup -S "$MINIO_GROUPNAME" && \
+                	adduser -S -G "$MINIO_GROUPNAME" "$MINIO_USERNAME"
+	fi
 
         exec su-exec "${MINIO_USERNAME}:${MINIO_GROUPNAME}" "$@"
     else


### PR DESCRIPTION
## Description

Allows passing UID/GID in environment variables into Docker container.

## Motivation and Context

For multitenant environments with directory quotas enabled like XFS, UIDS/GIDS in the docker container must match to UIDS/GIDS in the FS, so not only username/group should be defined, but also UID/GID.

## How to test this PR?

Say, you have user `john` in group `users`. 

1. Create data directory for him in his homedir. 

2. Next, get his UID/GID like

```
$ id
```

3. Run the container

```
$ docker run --rm --name minio -e MINIO_GID=1010 -e MINIO_UID=1001 -e MINIO_USERNAME=john -e MINIO_GROUPNAME=users -p9000:9000 -v /home/john/data:/data minio-bw server /data
```

4. Check that all files inside the `/home/john/data` have correct permissions:

```
$ ls -lam /home/john/data
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
