### PR TITLE
fix: ignore lost+found properly while reading disks

### DIFF
--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -378,21 +378,22 @@ func saveFormatXL(disk StorageAPI, format interface{}, diskID string) error {
 	return nil
 }
 
-var ignoredHiddenDirectories = []string{
-	minioMetaBucket,
-	".snapshot",
-	"lost+found",
-	"$RECYCLE.BIN",
-	"System Volume Information",
+var ignoredHiddenDirectories = map[string]struct{}{
+	minioMetaBucket:             {},
+	".snapshot":                 {},
+	"lost+found":                {},
+	"$RECYCLE.BIN":              {},
+	"System Volume Information": {},
 }
 
-func isIgnoreHiddenDirectories(dir string) bool {
-	for _, ignDir := range ignoredHiddenDirectories {
-		if dir == ignDir {
-			return true
+func isHiddenDirectories(vols ...VolInfo) bool {
+	for _, vol := range vols {
+		if _, ok := ignoredHiddenDirectories[vol.Name]; ok {
+			continue
 		}
+		return false
 	}
-	return false
+	return true
 }
 
 // loadFormatXL - loads format.json from disk.
@@ -407,9 +408,8 @@ func loadFormatXL(disk StorageAPI) (format *formatXLV3, err error) {
 			if err != nil {
 				return nil, err
 			}
-			if len(vols) > 1 || (len(vols) == 1 && !isIgnoreHiddenDirectories(vols[0].Name)) {
-				// 'format.json' not found, but we
-				// found user data.
+			if !isHiddenDirectories(vols...) {
+				// 'format.json' not found, but we found user data, reject such disks.
 				return nil, errCorruptedFormat
 			}
 			// No other data found, its a fresh disk.


### PR DESCRIPTION

## Description
fix: ignore lost+found properly while reading disks

## Motivation and Context
Fixes #9277

## How to test this PR?
Just use it with ext4 volume `minio server /tmp/{1...4}` with all 4 disks mounted with ext4 partitions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
