### PR TITLE
fix: allow any 127.0.0.x as bind IPs

### DIFF
--- a/cmd/net.go
+++ b/cmd/net.go
@@ -277,9 +277,23 @@ func isLocalHost(host string, port string, localPort string) (bool, error) {
 		return false, err
 	}
 
+	nonInterIPV4s := mustGetLocalIP4().Intersection(hostIPs)
+	if nonInterIPV4s.IsEmpty() {
+		hostIPs = hostIPs.ApplyFunc(func(ip string) string {
+			if net.ParseIP(ip).IsLoopback() {
+				// Any loopback IP which is not 127.0.0.1
+				// convert it to check for intersections.
+				return "127.0.0.1"
+			}
+			return ip
+		})
+		nonInterIPV4s = mustGetLocalIP4().Intersection(hostIPs)
+	}
+	nonInterIPV6s := mustGetLocalIP6().Intersection(hostIPs)
+
 	// If intersection of two IP sets is not empty, then the host is localhost.
-	isLocalv4 := !mustGetLocalIP4().Intersection(hostIPs).IsEmpty()
-	isLocalv6 := !mustGetLocalIP6().Intersection(hostIPs).IsEmpty()
+	isLocalv4 := !nonInterIPV4s.IsEmpty()
+	isLocalv6 := !nonInterIPV6s.IsEmpty()
 	if port != "" {
 		return (isLocalv4 || isLocalv6) && (port == localPort), nil
 	}


### PR DESCRIPTION

## Description
fix: allow any 127.0.0.x as bind IPs

## Motivation and Context
It is some times common and convenient to use
just local IPs for testing purposes, 127.0.0.x
are special IPs regardless of being available on
an interface they can be bound to on all operating
systems.

Allow this behavior to work for minio server

fixes #9274

## How to test this PR?
Just run `minio server --address "127.0.0.28:9000"` ~/test`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
