### PR TITLE
fix: remove the sleep from listing operations

### DIFF
--- a/buildscripts/race.sh
+++ b/buildscripts/race.sh
@@ -3,5 +3,5 @@
 set -e
 
 for d in $(go list ./... | grep -v browser); do
-    CGO_ENABLED=1 go test -v -race --timeout 20m "$d"
+    CGO_ENABLED=1 go test -v -race --timeout 50m "$d"
 done


### PR DESCRIPTION

## Description
fix: remove the sleep from listing operations

## Motivation and Context
make rest of the Walk() function more predictable,
it was observed that in nominal deployments even
without much workload, the drives are generally
slow for respond for readdir operations, for the
sleepDuration factor of 10 this can cause
unexpected slowness in the Listing calls, while
it is good for all other I/O, it may simply slow
down Listing immensely which is not useful.

fixes #9261

## How to test this PR?
Test when an active I/O is in progress and try to List() this can be slow.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes most probably introduced in cfc9cfd84a0064ad9a7bb7eefe4d0415a783e209 and borrowed into 45b1c66195e806c62a4497672614061b8cc11d4b
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
