### PR TITLE
allow delete of a group with no policy set

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1053,7 +1053,7 @@ func (sys *IAMSys) RemoveUsersFromGroup(group string, members []string) error {
 		// mapped policy.
 		err := sys.store.deleteMappedPolicy(group, regularUser, true)
 		// No-mapped-policy case is ignored.
-		if err != nil && err != errConfigNotFound {
+		if err != nil && err != errNoSuchPolicy {
 			return err
 		}
 		err = sys.store.deleteGroupInfo(group)


### PR DESCRIPTION
## Description
Solves #9262 
## Motivation and Context
When a group ends up empty it is not allowed to be deleted unless a permission is set on it.
This Pr removes that constraint.
Notes:
`deleteMappedPolicy()` was always handling `errConfigNotFound` and returning `errNoSuchPolicy` so that's why the condition on the code modified `&& err != errConfigNotFound ` was never happening.

## How to test this PR?

1. Create a user
2. Create a group with the user created on step 1
3. Remove the user from the group so that now it is empty
4. Delete the empty group

## Expected Result
4. Deletion of a group should be done successfully  without having to set a policy on the group.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
