### PR TITLE
fix: honor token based authentication in NATS streaming

### DIFF
--- a/pkg/event/target/nats.go
+++ b/pkg/event/target/nats.go
@@ -121,6 +121,10 @@ func (n NATSArgs) Validate() error {
 		return errors.New("cert and key must be specified as a pair")
 	}
 
+	if n.Username != "" && n.Password == "" || n.Username == "" && n.Password != "" {
+		return errors.New("username and password must be specified as a pair")
+	}
+
 	if n.Streaming.Enable {
 		if n.Streaming.ClusterID == "" {
 			return errors.New("empty cluster id")
@@ -168,7 +172,15 @@ func (n NATSArgs) connectStan() (stan.Conn, error) {
 	if n.Secure {
 		scheme = "tls"
 	}
-	addressURL := scheme + "://" + n.Username + ":" + n.Password + "@" + n.Address.String()
+
+	var addressURL string
+	if n.Username != "" && n.Password != "" {
+		addressURL = scheme + "://" + n.Username + ":" + n.Password + "@" + n.Address.String()
+	} else if n.Token != "" {
+		addressURL = scheme + "://" + n.Token + "@" + n.Address.String()
+	} else {
+		addressURL = scheme + "://" + n.Address.String()
+	}
 
 	clientID, err := getNewUUID()
 	if err != nil {


### PR DESCRIPTION

## Description
Currently we aren't supporting token auth in NatsURL while connecting to Streaming Nats

## Motivation and Context
Fixes #9148

## How to test this PR?
- Start nats-streaming server with token auth enabled -  `nats-streaming-server --auth mytoken`
- Try to set the token in the config 
```
./mc admin config set myminio/ notify_nats:1 address="0.0.0.0:4222" subject=minio username= password= token= tls=off tls_skip_verify=off cert_authority= client_cert= client_key= ping_interval=0 streaming=on streaming_async=on streaming_cluster_id=test-cluster streaming_max_pub_acks_in_flight=0 queue_dir= queue_limit=0
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
