### PR TITLE
delete: Use physical Dir() for proper prefix cleanup in Windows

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -1452,10 +1452,7 @@ func deleteFile(basePath, deletePath string, recursive bool) error {
 		}
 	}
 
-	// Trailing slash is removed when found to ensure
-	// slashpath.Dir() to work as intended.
-	deletePath = strings.TrimSuffix(deletePath, SlashSeparator)
-	deletePath = slashpath.Dir(deletePath)
+	deletePath = filepath.Dir(deletePath)
 
 	// Delete parent directory obviously not recursively. Errors for
 	// parent directories shouldn't trickle down.


### PR DESCRIPTION
## Description
In FS mode under Windows, removing an object will not automatically.
remove parent empty prefixes.

The reason is that path.Dir() was used, however filepath.Dir() is
more appropriate since filepath is physical (meaning it operates
on OS filesystem paths)

This is not caught because failure for Windows CI is not caught.


## Motivation and Context
Fix remove API in Windows FS mode

## How to test this PR?
1. c:\minio.exe server c:\test\
2. Upload a file under a prefix, and remove the file
3. Check the prefix which becomes empty is removed or not

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
