### PR TITLE
fix: policy setting error in LDAP setups

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -703,7 +703,7 @@ func (a adminAPIHandlers) SetPolicyForUserOrGroup(w http.ResponseWriter, r *http
 
 	if !isGroup {
 		ok, err := globalIAMSys.IsTempUser(entityName)
-		if err != nil {
+		if err != nil && err != errNoSuchUser {
 			writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 			return
 		}


### PR DESCRIPTION
Fixes #8667

In addition to the above, if the user is mapped to a policy or belongs in a
group, the user-info API returns this information, but otherwise the API will
now return a non-existent user error.


## How to test this PR?

Needs an LDAP setup or at least a fake one - we don't need to actually query any ldap info to reproduce the issue or to test the fix. Just configure dummy ldap, after setting up a echo server:

```
nc -l 11636 # fake ldap server

# now configure your minio server to use the ldap server above with mc:
mc admin config set myminio identity_ldap server_addr=localhost:11636 \
    username_format="uid=%s,cn=accounts,dc=myldapserver,dc=com" \
    username_search_filter="(uid=%s)" \
    group_search_filter="(&(objectclass=groupOfNames)(memberUid=%s))" \
    group_search_base_dn="dc=myldapserver,dc=com" \
    server_insecure=on group_name_attribute=group
```

Now should be able to reproduce the issue as well as test this fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
