### PR TITLE
Add missing comment key from key list

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -200,8 +200,16 @@ func (kvs KVS) Empty() bool {
 // Keys returns the list of keys for the current KVS
 func (kvs KVS) Keys() []string {
 	var keys = make([]string, len(kvs))
+	var foundComment bool
 	for i := range kvs {
+		if kvs[i].Key == madmin.CommentKey {
+			foundComment = true
+		}
 		keys[i] = kvs[i].Key
+	}
+	// Comment KV not found, add it explicitly.
+	if !foundComment {
+		keys = append(keys, madmin.CommentKey)
 	}
 	return keys
 }


### PR DESCRIPTION
## Description
Add missing comment key from key list

## Motivation and Context
Continuing from previous PR #9304, comment
is a special key is not present in the
default KV list. Add it explicitly when
tokenizing fields as it may be possible that
some clients might try to set comments.

## How to test this PR?
Test with or without this change following `mc admin config set` - needs an `mc` PR as well https://github.com/minio/mc/pull/3151
```
~ mc admin config set myminio notify_postgres:3 enable=off connection_string="host=localhost port=5432 dbname=minio_events user=postgres password = password sslmode=disable" table="bucketevents" format="namespace" comment=""
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
