### PR TITLE
Fix bug on Redis Target

### DIFF
--- a/pkg/event/target/redis.go
+++ b/pkg/event/target/redis.go
@@ -310,7 +310,7 @@ func NewRedisTarget(id string, args RedisArgs, doneCh <-chan struct{}, loggerOnc
 
 	_, pingErr := conn.Do("PING")
 	if pingErr != nil {
-		if target.store == nil || !(IsConnRefusedErr(pingErr) || IsConnResetErr(pingErr)) {
+		if target.store == nil && !(IsConnRefusedErr(pingErr) || IsConnResetErr(pingErr)) {
 			return nil, pingErr
 		}
 	} else {


### PR DESCRIPTION
## Description
 There was a bug on the Redis Target that returned an error for refused/reset connections even if there was logic to prevent this from happening

## How to test this PR?

1. Add a redis notification endpoint with a valid redis online
2. Stop redis
3. perform `mc admin info myminio`
4. no service is returned because the list of targets was never generated due to the error

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
