### PR TITLE
fix: regression in CopyObject not preserving ETag in --compat

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -993,7 +993,9 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 				return
 			}
 
-			pReader = NewPutObjReader(rawReader, srcInfo.Reader, &objEncKey)
+			if isTargetEncrypted {
+				pReader = NewPutObjReader(rawReader, srcInfo.Reader, &objEncKey)
+			}
 		}
 	}
 


### PR DESCRIPTION

## Description
fix: regression in CopyObject not preserving ETag in --compat

## Motivation and Context
issue found after `git bisect` to commit db4195361876fbe2410236bce55f173da3ef3b2b

## How to test this PR?
Try to CopyObject from source and destination see it doesn't preserve
the ETag, SSE/SSEC works properly plain-text doesn't work.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in db4195361876fbe2410236bce55f173da3ef3b2b
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
