### PR TITLE
Make multistage Dockerfile self-contained

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ ENV MINIO_ACCESS_KEY_FILE=access_key \
 EXPOSE 9000
 
 COPY --from=0 /go/bin/minio /usr/bin/minio
-COPY CREDITS /third_party/
-COPY dockerscripts/docker-entrypoint.sh /usr/bin/
+COPY --from=0 /go/minio/CREDITS /third_party/
+COPY --from=0 /go/minio/dockerscripts/docker-entrypoint.sh /usr/bin/
 
 RUN  \
      apk add --no-cache ca-certificates 'curl>7.61.0' 'su-exec>=0.2' && \


### PR DESCRIPTION
## Description

Make multistage Dockerfile standalone so that it can be run without a local Git clone of the repository.

## Motivation and Context

Picking up all support files from the builder image has the advantage that the Dockerfile is now fully selfcontained and can be also run just standalone.

This allows also cross-compilation and pushing with the proper manifests with Docker Buildkit and also has the advantage that the Dockerfile could be the same for all platforms.

## How to test this PR?

```
docker buildx create --name xbuilder
docker buildx use xbuilder

docker buildx build -f Dockerfile.minio --platform linux/arm/v7,linux/amd64 --progress plain --push -t minio/minio .
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
