### PR TITLE
enable --compat flag by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,5 @@ mc admin update <minio alias, e.g., myminio>
 ## Contribute to MinIO Project
 Please follow MinIO [Contributor's Guide](https://github.com/minio/minio/blob/master/CONTRIBUTING.md)
 
-## Caveats
-MinIO in its default mode doesn't use MD5Sum checkums of incoming streams unless requested by the client in `Content-Md5` header for validation. This may lead to incompatibility with rare S3 clients like `s3ql` which unfortunately do not set `Content-Md5` but depend on hex MD5Sum for the stream to be calculated by the server. MinIO considers this as a bug in `s3ql` and should be fixed on the client side because MD5Sum is a poor way to checksum and validate the authenticity of the objects. Although MinIO provides a workaround until client applications are fixed use `--compat` option instead to start the server.
-```sh
-./minio --compat server /data
-```
-
 ## License
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fminio%2Fminio.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fminio%2Fminio?ref=badge_large)

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -149,6 +149,12 @@ func handleCommonCmdArgs(ctx *cli.Context) {
 		globalCLIContext.Addr = ctx.String("address")
 	}
 
+	// Check "no-compat" flag from command line argument.
+	globalCLIContext.StrictS3Compat = true
+	if ctx.IsSet("no-compat") || ctx.GlobalIsSet("no-compat") {
+		globalCLIContext.StrictS3Compat = false
+	}
+
 	// Set all config, certs and CAs directories.
 	var configSet, certsSet bool
 	globalConfigDir, configSet = newConfigDirFromCtx(ctx, "config-dir", defaultConfigDir.Get)
@@ -164,9 +170,6 @@ func handleCommonCmdArgs(ctx *cli.Context) {
 	globalCertsCADir = &ConfigDir{path: filepath.Join(globalCertsDir.Get(), certsCADir)}
 
 	logger.FatalIf(mkdirAllIgnorePerm(globalCertsCADir.Get()), "Unable to create certs CA directory at %s", globalCertsCADir.Get())
-
-	// Check "compat" flag from command line argument.
-	globalCLIContext.StrictS3Compat = ctx.IsSet("compat") || ctx.GlobalIsSet("compat")
 }
 
 func handleCommonEnvVars() {

--- a/cmd/gateway/b2/gateway-b2.go
+++ b/cmd/gateway/b2/gateway-b2.go
@@ -87,8 +87,13 @@ EXAMPLES:
 
 // Handler for 'minio gateway b2' command line.
 func b2GatewayMain(ctx *cli.Context) {
+	strictS3Compat := true
+	if ctx.IsSet("no-compat") || ctx.GlobalIsSet("no-compat") {
+		strictS3Compat = false
+	}
+
 	minio.StartGateway(ctx, &B2{
-		strictS3Compat: ctx.IsSet("compat") || ctx.GlobalIsSet("compat"),
+		strictS3Compat: strictS3Compat,
 	})
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,10 +29,12 @@ import (
 
 // GlobalFlags - global flags for minio.
 var GlobalFlags = []cli.Flag{
+	// Deprecated flag, so its hidden now - existing deployments will keep working.
 	cli.StringFlag{
-		Name:  "config-dir, C",
-		Value: defaultConfigDir.Get(),
-		Usage: "[DEPRECATED] path to legacy configuration directory",
+		Name:   "config-dir, C",
+		Value:  defaultConfigDir.Get(),
+		Usage:  "[DEPRECATED] path to legacy configuration directory",
+		Hidden: true,
 	},
 	cli.StringFlag{
 		Name:  "certs-dir, S",
@@ -51,9 +53,17 @@ var GlobalFlags = []cli.Flag{
 		Name:  "json",
 		Usage: "output server logs and startup information in json format",
 	},
+	// Deprecated flag, so its hidden now, existing deployments will keep working.
 	cli.BoolFlag{
-		Name:  "compat",
-		Usage: "enable strict S3 compatibility by turning off certain performance optimizations",
+		Name:   "compat",
+		Usage:  "enable strict S3 compatibility by turning off certain performance optimizations",
+		Hidden: true,
+	},
+	// This flag is hidden and to be used only during certain performance testing.
+	cli.BoolFlag{
+		Name:   "no-compat",
+		Usage:  "disable strict S3 compatibility by turning on certain performance optimizations",
+		Hidden: true,
 	},
 }
 

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -252,7 +252,7 @@ func getStorageInfoMsgSafeMode(storageInfo StorageInfo) string {
 	var mcMessage string
 	if storageInfo.Backend.Type == BackendErasure {
 		if storageInfo.Backend.OfflineDisks.Sum() > 0 {
-			mcMessage = "Use `mc admin info` to look for latest server/disk info`"
+			mcMessage = "Use `mc admin info` to look for latest server/disk info\n"
 		}
 		diskInfo := fmt.Sprintf(" %d Online, %d Offline. ", storageInfo.Backend.OnlineDisks.Sum(), storageInfo.Backend.OfflineDisks.Sum())
 		msg += color.Red("Status:") + fmt.Sprintf(getFormatStr(len(diskInfo), 8), diskInfo)
@@ -269,7 +269,7 @@ func getStorageInfoMsg(storageInfo StorageInfo) string {
 	var mcMessage string
 	if storageInfo.Backend.Type == BackendErasure {
 		if storageInfo.Backend.OfflineDisks.Sum() > 0 {
-			mcMessage = "Use `mc admin info` to look for latest server/disk info"
+			mcMessage = "Use `mc admin info` to look for latest server/disk info\n"
 		}
 
 		diskInfo := fmt.Sprintf(" %d Online, %d Offline. ", storageInfo.Backend.OnlineDisks.Sum(), storageInfo.Backend.OfflineDisks.Sum())


### PR DESCRIPTION



## Description
if needed use --no-compat to disable md5sum while
verifying any performance numbers.

bring back --compat behavior as default to avoid
additional documentation and confusing behavior,
as we are working towards improving md5sum to
be faster on AVX instructions, enabling this
should be hardly a problem in future versions
of MinIO.

## Motivation and Context
fixes #8012
fixes #7859
fixes #7642

## How to test this PR?
Nothing special, --compat is enabled by default now. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
