### PR TITLE
Reduce Mutex test runs

### DIFF
--- a/pkg/dsync/drwmutex_test.go
+++ b/pkg/dsync/drwmutex_test.go
@@ -240,7 +240,7 @@ func HammerRWMutex(gomaxprocs, numReaders, numIterations int) {
 // Borrowed from rwmutex_test.go
 func TestRWMutex(t *testing.T) {
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
-	n := 1000
+	n := 100
 	if testing.Short() {
 		n = 5
 	}

--- a/pkg/dsync/dsync_test.go
+++ b/pkg/dsync/dsync_test.go
@@ -242,10 +242,14 @@ func HammerMutex(m *DRWMutex, loops int, cdone chan bool) {
 
 // Borrowed from mutex_test.go
 func TestMutex(t *testing.T) {
+	loops := 200
+	if testing.Short() {
+		loops = 5
+	}
 	c := make(chan bool)
 	m := NewDRWMutex(context.Background(), ds, "test")
 	for i := 0; i < 10; i++ {
-		go HammerMutex(m, 1000, c)
+		go HammerMutex(m, loops, c)
 	}
 	for i := 0; i < 10; i++ {
 		<-c


### PR DESCRIPTION
## Motivation and Context

Some tests take a long time on CI:

* `--- PASS: TestRWMutex (226.49s)`
* ` --- PASS: TestRWMutex (7.13s)`

Reduce the number of runs.

Before/after locally:

```
--- PASS: TestRWMutex (20.95s)
--- PASS: TestRWMutex (7.13s)

--- PASS: TestMutex (3.01s)
--- PASS: TestMutex (1.65s)
```
