### PR TITLE
keep long running obd network tests alive

### DIFF
--- a/cmd/obdinfo.go
+++ b/cmd/obdinfo.go
@@ -317,16 +317,14 @@ func getLocalProcOBD(ctx context.Context) madmin.ServerProcOBDInfo {
 		sysProc.PageFaults = pageFaults
 
 		parent, err := proc.ParentWithContext(ctx)
-		if err != nil {
-			return errProcInfo(err)
+		if err == nil {
+			sysProc.Parent = parent.Pid
 		}
-		sysProc.Parent = parent.Pid
 
 		ppid, err := proc.PpidWithContext(ctx)
-		if err != nil {
-			return errProcInfo(err)
+		if err == nil {
+			sysProc.Ppid = ppid
 		}
-		sysProc.Ppid = ppid
 
 		rlimit, err := proc.RlimitWithContext(ctx)
 		if err != nil {

--- a/cmd/obdinfo.go
+++ b/cmd/obdinfo.go
@@ -402,13 +402,8 @@ func getLocalOsInfoOBD(ctx context.Context) madmin.ServerOsOBDInfo {
 		}
 	}
 
-	users, err := host.UsersWithContext(ctx)
-	if err != nil {
-		return madmin.ServerOsOBDInfo{
-			Addr:  addr,
-			Error: err.Error(),
-		}
-	}
+	// ignore user err, as it cannot be obtained reliably inside containers
+	users, _ := host.UsersWithContext(ctx)
 
 	return madmin.ServerOsOBDInfo{
 		Addr:    addr,

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -374,7 +374,11 @@ func (client *peerRESTClient) DispatchNetOBDInfo(ctx context.Context) (info madm
 		return
 	}
 	defer http.DrainBody(respBody)
-	err = gob.NewDecoder(respBody).Decode(&info)
+	waitReader, err := waitForHTTPResponse(respBody)
+	if err != nil {
+		return
+	}
+	err = gob.NewDecoder(waitReader).Decode(&info)
 	return
 }
 

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -403,6 +403,9 @@ func (s *peerRESTServer) DispatchNetOBDInfoHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
+	done := keepHTTPResponseAlive(w)
+	defer done()
+
 	ctx := newContext(r, w, "DispatchNetOBDInfo")
 	info := globalNotificationSys.NetOBDInfo(ctx)
 

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -404,11 +404,11 @@ func (s *peerRESTServer) DispatchNetOBDInfoHandler(w http.ResponseWriter, r *htt
 	}
 
 	done := keepHTTPResponseAlive(w)
-	defer done()
 
 	ctx := newContext(r, w, "DispatchNetOBDInfo")
 	info := globalNotificationSys.NetOBDInfo(ctx)
 
+	done()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
 	w.(http.Flusher).Flush()
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -471,7 +471,6 @@ func newCustomHTTPTransport(tlsConfig *tls.Config, dialTimeout time.Duration) fu
 		DialContext:           newCustomDialContext(dialTimeout, 15*time.Second),
 		MaxIdleConnsPerHost:   16,
 		MaxIdleConns:          16,
-		MaxConnsPerHost:       64, // This is used per drive/rpc host. More requests will block until free.
 		IdleConnTimeout:       1 * time.Minute,
 		ResponseHeaderTimeout: 3 * time.Minute, // Set conservative timeouts for MinIO internode.
 		TLSHandshakeTimeout:   10 * time.Second,


### PR DESCRIPTION
@harshavardhana - in case of really large clusters, or clusters with inconsistent latencies, we need to keep the connection alive.

Tested it in our DC