### PR TITLE
fix: remove any duplicate statements in policy input

### DIFF
--- a/pkg/bucket/policy/policy_test.go
+++ b/pkg/bucket/policy/policy_test.go
@@ -393,8 +393,8 @@ func TestPolicyIsValid(t *testing.T) {
 		{case6Policy, true},
 		// Duplicate statement success different effects.
 		{case7Policy, false},
-		// Duplicate statement error.
-		{case8Policy, true},
+		// Duplicate statement success, duplicate statement dropped.
+		{case8Policy, false},
 	}
 
 	for i, testCase := range testCases {
@@ -991,6 +991,20 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
     ]
 }`)
 
+	case10Policy := Policy{
+		ID:      "MyPolicyForMyBucket1",
+		Version: DefaultVersion,
+		Statements: []Statement{
+			NewStatement(
+				Allow,
+				NewPrincipal("*"),
+				NewActionSet(PutObjectAction),
+				NewResourceSet(NewResource("mybucket", "myobject*")),
+				condition.NewFunctions(),
+			),
+		},
+	}
+
 	case11Data := []byte(`{
     "ID": "MyPolicyForMyBucket1",
     "Version": "2012-10-17",
@@ -1046,8 +1060,8 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 		{case8Data, case8Policy, false},
 		// Invalid version error.
 		{case9Data, Policy{}, true},
-		// Duplicate statement error.
-		{case10Data, Policy{}, true},
+		// Duplicate statement success, duplicate statement removed.
+		{case10Data, case10Policy, false},
 		// Duplicate statement success (Effect differs).
 		{case11Data, case11Policy, false},
 	}
@@ -1058,12 +1072,12 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {
-			t.Fatalf("case %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+			t.Errorf("case %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
 		}
 
 		if !testCase.expectErr {
 			if !reflect.DeepEqual(result, testCase.expectedResult) {
-				t.Fatalf("case %v: result: expected: %v, got: %v", i+1, testCase.expectedResult, result)
+				t.Errorf("case %v: result: expected: %v, got: %v", i+1, testCase.expectedResult, result)
 			}
 		}
 	}

--- a/pkg/iam/policy/policy_test.go
+++ b/pkg/iam/policy/policy_test.go
@@ -373,8 +373,8 @@ func TestPolicyIsValid(t *testing.T) {
 		{case6Policy, true},
 		// Duplicate statement different Effects.
 		{case7Policy, false},
-		// Duplicate statement same Effects.
-		{case8Policy, true},
+		// Duplicate statement same Effects, duplicate effect will be removed.
+		{case8Policy, false},
 	}
 
 	for i, testCase := range testCases {
@@ -923,6 +923,18 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
         }
     ]
 }`)
+	case10Policy := Policy{
+		ID:      "MyPolicyForMyBucket1",
+		Version: DefaultVersion,
+		Statements: []Statement{
+			NewStatement(
+				policy.Allow,
+				NewActionSet(PutObjectAction),
+				NewResourceSet(NewResource("mybucket", "myobject*")),
+				condition.NewFunctions(),
+			),
+		},
+	}
 
 	case11Data := []byte(`{
     "ID": "MyPolicyForMyBucket1",
@@ -975,8 +987,8 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 		{case8Data, case8Policy, false},
 		// Invalid version error.
 		{case9Data, Policy{}, true},
-		// Duplicate statement error.
-		{case10Data, Policy{}, true},
+		// Duplicate statement success, duplicate statement is removed.
+		{case10Data, case10Policy, false},
 		// Duplicate statement success (Effect differs).
 		{case11Data, case11Policy, false},
 	}
@@ -987,12 +999,12 @@ func TestPolicyUnmarshalJSON(t *testing.T) {
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {
-			t.Fatalf("case %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
+			t.Errorf("case %v: error: expected: %v, got: %v", i+1, testCase.expectErr, expectErr)
 		}
 
 		if !testCase.expectErr {
 			if !reflect.DeepEqual(result, testCase.expectedResult) {
-				t.Fatalf("case %v: result: expected: %v, got: %v", i+1, testCase.expectedResult, result)
+				t.Errorf("case %v: result: expected: %v, got: %v", i+1, testCase.expectedResult, result)
 			}
 		}
 	}


### PR DESCRIPTION

## Description
fix: remove any duplicate statements in policy input

## Motivation and Context
Add support for removing duplicate statements automatically


## How to test this PR?
Unit tests added already you can try with `mc admin policy set` as well 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
