### PR TITLE
Only show active/available ARNs in server startup banner

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1457,7 +1457,7 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 		Mode:         mode,
 		Domain:       domain,
 		Region:       globalServerRegion,
-		SQSARN:       globalNotificationSys.GetARNList(),
+		SQSARN:       globalNotificationSys.GetARNList(false),
 		DeploymentID: globalDeploymentID,
 		Buckets:      buckets,
 		Objects:      objects,

--- a/cmd/config/notify/parse.go
+++ b/cmd/config/notify/parse.go
@@ -102,8 +102,10 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 	var targetsOffline bool
 
 	defer func() {
-		// Automatically close all connections to targets when an error occur
-		if err != nil {
+		// Automatically close all connections to targets when an error occur.
+		// Close all the targets if returnOnTargetError is set
+		// Else, close only the failed targets
+		if err != nil && returnOnTargetError {
 			for _, t := range targetList.TargetMap() {
 				_ = t.Close()
 			}
@@ -174,6 +176,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 
 		if err = targetList.Add(newTarget); err != nil {
@@ -194,6 +197,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -214,6 +218,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -234,6 +239,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -253,6 +259,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -272,6 +279,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -291,6 +299,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -310,6 +319,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -329,6 +339,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)
@@ -348,6 +359,7 @@ func FetchRegisteredTargets(cfg config.Config, doneCh <-chan struct{}, transport
 			if returnOnTargetError {
 				return nil, err
 			}
+			_ = newTarget.Close()
 		}
 		if err = targetList.Add(newTarget); err != nil {
 			logger.LogIf(context.Background(), err)

--- a/cmd/peer-rest-client-target.go
+++ b/cmd/peer-rest-client-target.go
@@ -36,6 +36,11 @@ func (target *PeerRESTClientTarget) IsActive() (bool, error) {
 	return true, nil
 }
 
+// HasQueueStore - No-Op. Added for interface compatibility
+func (target PeerRESTClientTarget) HasQueueStore() bool {
+	return false
+}
+
 // Save - Sends event directly without persisting.
 func (target *PeerRESTClientTarget) Save(eventData event.Event) error {
 	return target.send(eventData)

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -59,7 +59,7 @@ func getServerInfo() (*ServerInfoData, error) {
 			Version:      Version,
 			CommitID:     CommitID,
 			DeploymentID: globalDeploymentID,
-			SQSARN:       globalNotificationSys.GetARNList(),
+			SQSARN:       globalNotificationSys.GetARNList(false),
 			Region:       globalServerRegion,
 		},
 	}, nil

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -202,7 +202,7 @@ func printEventNotifiers() {
 		return
 	}
 
-	arns := globalNotificationSys.GetARNList()
+	arns := globalNotificationSys.GetARNList(true)
 	if len(arns) == 0 {
 		return
 	}

--- a/pkg/event/target/amqp.go
+++ b/pkg/event/target/amqp.go
@@ -132,6 +132,11 @@ func (target *AMQPTarget) IsActive() (bool, error) {
 	return true, nil
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *AMQPTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 func (target *AMQPTarget) channel() (*amqp.Channel, error) {
 	var err error
 	var conn *amqp.Connection

--- a/pkg/event/target/elasticsearch.go
+++ b/pkg/event/target/elasticsearch.go
@@ -91,6 +91,11 @@ func (target *ElasticsearchTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *ElasticsearchTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *ElasticsearchTarget) IsActive() (bool, error) {
 	if dErr := target.args.URL.DialHTTP(nil); dErr != nil {

--- a/pkg/event/target/httpclient.go
+++ b/pkg/event/target/httpclient.go
@@ -49,6 +49,11 @@ func (target *HTTPClientTarget) IsActive() (bool, error) {
 	return true, nil
 }
 
+// HasQueueStore - No-Op. Added for interface compatibility
+func (target *HTTPClientTarget) HasQueueStore() bool {
+	return false
+}
+
 func (target *HTTPClientTarget) start() {
 	go func() {
 		defer func() {

--- a/pkg/event/target/kafka.go
+++ b/pkg/event/target/kafka.go
@@ -133,6 +133,11 @@ func (target *KafkaTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *KafkaTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *KafkaTarget) IsActive() (bool, error) {
 	if !target.args.pingBrokers() {

--- a/pkg/event/target/mqtt.go
+++ b/pkg/event/target/mqtt.go
@@ -118,6 +118,11 @@ func (target *MQTTTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *MQTTTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *MQTTTarget) IsActive() (bool, error) {
 	if !target.client.IsConnectionOpen() {

--- a/pkg/event/target/mysql.go
+++ b/pkg/event/target/mysql.go
@@ -183,6 +183,11 @@ func (target *MySQLTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *MySQLTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *MySQLTarget) IsActive() (bool, error) {
 	if target.db == nil {

--- a/pkg/event/target/nats.go
+++ b/pkg/event/target/nats.go
@@ -207,6 +207,11 @@ func (target *NATSTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *NATSTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *NATSTarget) IsActive() (bool, error) {
 	var connErr error

--- a/pkg/event/target/nsq.go
+++ b/pkg/event/target/nsq.go
@@ -99,6 +99,11 @@ func (target *NSQTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *NSQTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *NSQTarget) IsActive() (bool, error) {
 	if target.producer != nil {

--- a/pkg/event/target/postgresql.go
+++ b/pkg/event/target/postgresql.go
@@ -182,6 +182,11 @@ func (target *PostgreSQLTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *PostgreSQLTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *PostgreSQLTarget) IsActive() (bool, error) {
 	if target.db == nil {

--- a/pkg/event/target/redis.go
+++ b/pkg/event/target/redis.go
@@ -128,6 +128,11 @@ func (target *RedisTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *RedisTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *RedisTarget) IsActive() (bool, error) {
 	conn := target.pool.Get()

--- a/pkg/event/target/webhook.go
+++ b/pkg/event/target/webhook.go
@@ -87,6 +87,11 @@ func (target WebhookTarget) ID() event.TargetID {
 	return target.id
 }
 
+// HasQueueStore - Checks if the queueStore has been configured for the target
+func (target *WebhookTarget) HasQueueStore() bool {
+	return target.store != nil
+}
+
 // IsActive - Return true if target is up and active
 func (target *WebhookTarget) IsActive() (bool, error) {
 	u, pErr := xnet.ParseHTTPURL(target.args.Endpoint.String())

--- a/pkg/event/targetlist.go
+++ b/pkg/event/targetlist.go
@@ -28,6 +28,7 @@ type Target interface {
 	Save(Event) error
 	Send(string) error
 	Close() error
+	HasQueueStore() bool
 }
 
 // TargetList - holds list of targets indexed by target ID.

--- a/pkg/event/targetlist_test.go
+++ b/pkg/event/targetlist_test.go
@@ -71,6 +71,11 @@ func (target ExampleTarget) IsActive() (bool, error) {
 	return false, errors.New("not connected to target server/service")
 }
 
+// HasQueueStore - No-Op. Added for interface compatibility
+func (target ExampleTarget) HasQueueStore() bool {
+	return false
+}
+
 func TestTargetListAdd(t *testing.T) {
 	targetListCase1 := NewTargetList()
 


### PR DESCRIPTION
## Description
Currently we show the ARNs of all the configured targets.

## Motivation and Context
- The inactive ARNs are of no use and it may confuse and is difficult to differentiate b/w available and non-available targets.
- Display only the ARNs which are active and available (store is setup) to be configured. MinIO always treats a queue store configured target to be a valid one.

## How to test this PR?
- Start the server with inactive targets (w/o configuring queue store). 
- You should see only the active/available ARN list in the startup banner

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
