### PR TITLE
heal: Fix reporting heal buckets result

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -122,11 +122,6 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 				Endpoint: drive,
 				State:    beforeState[i],
 			})
-			res.After.Drives = append(res.After.Drives, madmin.HealDriveInfo{
-				UUID:     "",
-				Endpoint: drive,
-				State:    afterState[i],
-			})
 		}
 	}
 
@@ -151,12 +146,26 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 	errs = g.Wait()
 
 	reducedErr = reduceWriteQuorumErrs(ctx, errs, bucketOpIgnoredErrs, writeQuorum)
-	if reducedErr == errXLWriteQuorum {
-		// Purge successfully created buckets if we don't have writeQuorum.
-		undoMakeBucket(storageDisks, bucket)
+	if reducedErr != nil {
+		if reducedErr == errXLWriteQuorum {
+			// Purge successfully created buckets if we don't have writeQuorum.
+			undoMakeBucket(storageDisks, bucket)
+		}
+		return res, reducedErr
 	}
 
-	return res, reducedErr
+	for i := range afterState {
+		if storageDisks[i] != nil {
+			drive := storageDisks[i].String()
+			res.After.Drives = append(res.After.Drives, madmin.HealDriveInfo{
+				UUID:     "",
+				Endpoint: drive,
+				State:    afterState[i],
+			})
+		}
+	}
+
+	return res, nil
 }
 
 // listAllBuckets lists all buckets from all disks. It also


### PR DESCRIPTION
## Description
healBucket() was not propertly collecting results after healing
buckets. 

This commit adds After drives information correctly after updating
afterState slice in creating buckets goroutines. 

## Motivation and Context
Fixes https://github.com/minio/minio/issues/9318

## How to test this PR?
In the issue description.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
