### PR TITLE
Increase response header timeout for gateway

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -495,7 +495,7 @@ func NewGatewayHTTPTransport() *http.Transport {
 		RootCAs: globalRootCAs,
 	}, defaultDialTimeout)()
 	// Set aggressive timeouts for gateway
-	tr.ResponseHeaderTimeout = 30 * time.Second
+	tr.ResponseHeaderTimeout = 1 * time.Minute
 
 	// Allow more requests to be in flight.
 	tr.MaxConnsPerHost = 256


### PR DESCRIPTION
Fixes: #9295

## Description


## Motivation and Context
See issue #9295 - Response header timeouts were introduced in RELEASE.2020-03-25T07-03-04Z which seems to be overly aggressive in timing out longer gateway operations. This PR bumps up the timeout to 60 seconds

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
