### PR TITLE
fix: Add missing return in admin requests auth

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -140,6 +140,7 @@ func validateAdminSignature(ctx context.Context, r *http.Request, region string)
 		reqInfo := (&logger.ReqInfo{}).AppendTags("requestHeaders", dumpRequest(r))
 		ctx := logger.SetReqInfo(ctx, reqInfo)
 		logger.LogIf(ctx, errors.New(getAPIError(s3Err).Description), logger.Application)
+		return cred, nil, owner, s3Err
 	}
 
 	claims, s3Err := checkClaimsFromToken(r, cred)


### PR DESCRIPTION
## Description
Add missing return in admin requests auth, also add some units to cover more cases.

## Motivation and Context
Fix auth issue

## How to test this PR?
Trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
