### PR TITLE
[wip]s3select sql evaluation of Where In clause

### DIFF
--- a/pkg/s3select/sql/evaluate.go
+++ b/pkg/s3select/sql/evaluate.go
@@ -272,6 +272,13 @@ func (e *In) evalInNode(r Record, lhs *Value) (*Value, error) {
 		aF, aOK := a.ToFloat()
 		bF, bOK := b.ToFloat()
 
+		// Try CSV values
+		aCsv := a.CSVString()
+		bCSV := b.CSVString()
+		if aCsv != "" && bCSV != "" && aCsv == bCSV {
+			return true
+		}
+
 		// FIXME: more type inference?
 		return aOK && bOK && aF == bF
 	}


### PR DESCRIPTION
Evaluation has to check for equality of CSV values

## Description
For SelectObjectContent API calls with a sql select statement with where condition including an IN clause with valid values, nothing is returned.

## Motivation and Context
If we test with minio client mc.
_mc sql --query "select * from S3Object s where s.Jurisdiction IN ('Alabama', 'California')" minio-alias/minio-bucket/StatesReportingCasesOfCOVID-19ToCDC_copy.csv_
Nothing is returned.

## How to test this PR?
With commands like:
_mc sql --query "select * from S3Object s where s.Jurisdiction IN ('Alabama', 'California')" minio-alias/minio-bucket/StatesReportingCasesOfCOVID-19ToCDC_copy.csv_
_mc sql --compression GZIP --csv-input "fh=USE,fd=,,rd=\n" --query "select * from S3Object s where s.ID IN ('1','3')" minio-alias/minio-bucket/employeeID_name_Location_List.csv.gz_
OR
You could also use minio-go or AWS CLI using selectobjectcontentAPI that invokes a where IN clause.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
