### PR TITLE
fix: crash in metrics handler when some disks are offline

### DIFF
--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -175,20 +175,21 @@ func getStorageInfo(disks []StorageAPI, endpoints Endpoints) StorageInfo {
 
 // StorageInfo - returns underlying storage statistics.
 func (xl xlObjects) StorageInfo(ctx context.Context, local bool) StorageInfo {
-	var endpoints = xl.endpoints
-	var disks []StorageAPI
 
-	if !local {
-		disks = xl.getDisks()
-	} else {
-		for i, d := range xl.getDisks() {
-			if endpoints[i].IsLocal && d.Hostname() == "" {
-				// Append this local disk since local flag is true
-				disks = append(disks, d)
+	disks := xl.getDisks()
+	if local {
+		var localDisks []StorageAPI
+		for i, disk := range disks {
+			if disk != nil {
+				if xl.endpoints[i].IsLocal && disk.Hostname() == "" {
+					// Append this local disk since local flag is true
+					localDisks = append(localDisks, disk)
+				}
 			}
 		}
+		disks = localDisks
 	}
-	return getStorageInfo(disks, endpoints)
+	return getStorageInfo(disks, xl.endpoints)
 }
 
 // GetMetrics - is not implemented and shouldn't be called.


### PR DESCRIPTION

## Description
fix: crash in metrics handler when some disks are offline

## Motivation and Context
Fixes #9449

## How to test this PR?
Take drives offline and metrics configured at the same time

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably yes
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
