### PR TITLE
fix: ignore symlinks in backend filesystems

### DIFF
--- a/cmd/posix-list-dir_other.go
+++ b/cmd/posix-list-dir_other.go
@@ -21,10 +21,7 @@ package cmd
 import (
 	"io"
 	"os"
-	"path"
 	"strings"
-
-	"github.com/minio/minio/cmd/logger"
 )
 
 // Return all the entries at the directory dirPath.
@@ -111,25 +108,8 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 			}
 		}
 		for _, fi := range fis {
-			// Stat symbolic link and follow to get the final value.
+			// Not need to follow symlink.
 			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-				var st os.FileInfo
-				st, err = os.Stat(path.Join(dirPath, fi.Name()))
-				if err != nil {
-					reqInfo := (&logger.ReqInfo{}).AppendTags("path", path.Join(dirPath, fi.Name()))
-					ctx := logger.SetReqInfo(GlobalContext, reqInfo)
-					logger.LogIf(ctx, err)
-					continue
-				}
-				// Append to entries if symbolic link exists and is valid.
-				if st.IsDir() {
-					entries = append(entries, fi.Name()+SlashSeparator)
-				} else if st.Mode().IsRegular() {
-					entries = append(entries, fi.Name())
-				}
-				if count > 0 {
-					remaining--
-				}
 				continue
 			}
 			if fi.Mode().IsDir() {

--- a/cmd/posix-list-dir_test.go
+++ b/cmd/posix-list-dir_test.go
@@ -149,7 +149,7 @@ func setupTestReadDirSymlink(t *testing.T) (testResults []result) {
 		}
 		// Add to entries.
 		entries = append(entries, name1)
-		entries = append(entries, name2)
+		// Symlinks are ignored.
 	}
 	if err := os.MkdirAll(filepath.Join(dir, "mydir"), 0777); err != nil {
 		t.Fatalf("Unable to create \"mydir\", %s", err)

--- a/cmd/posix-list-dir_unix.go
+++ b/cmd/posix-list-dir_unix.go
@@ -172,8 +172,8 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 		// Fallback for filesystems (like old XFS) that don't
 		// support Dirent.Type and have DT_UNKNOWN (0) there
 		// instead.
-		if typ == unexpectedFileMode || typ&os.ModeSymlink == os.ModeSymlink {
-			fi, err := os.Stat(pathJoin(dirPath, name))
+		if typ == unexpectedFileMode {
+			fi, err := os.Lstat(pathJoin(dirPath, name))
 			if err != nil {
 				// It got deleted in the meantime, not found
 				// or returns too many symlinks ignore this
@@ -185,6 +185,9 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 				return nil, err
 			}
 			typ = fi.Mode() & os.ModeType
+		}
+		if typ&os.ModeSymlink == os.ModeSymlink {
+			continue
 		}
 		if typ.IsRegular() {
 			entries = append(entries, name)


### PR DESCRIPTION

## Description
fix: ignore symlinks in backend filesystems

## Motivation and Context
fixes #9419

## How to test this PR?
symlinks cannot be easily supported as mentioned in #9419 
we have supported it since the beginning but if we end up deleting
symlink referenced files it way leads to unexpected issues.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
