### PR TITLE
fix: ensure buckets are preserved if one set returns error

### DIFF
--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -87,11 +87,9 @@ func newXLZones(ctx context.Context, endpointZones EndpointZones) (ObjectLayer, 
 			return nil, err
 		}
 	}
-	if !z.SingleZone() {
-		z.quickHealBuckets(ctx)
-	}
-	go intDataUpdateTracker.start(GlobalContext, localDrives...)
 
+	z.quickHealBuckets(ctx)
+	go intDataUpdateTracker.start(GlobalContext, localDrives...)
 	return z, nil
 }
 


### PR DESCRIPTION

## Description
fix: ensure buckets are preserved if one set returns error

## Motivation and Context
the bucket should be deleted if it can be successfully
deleted on all sets, if not we should ensure to
restore those buckets properly.

## How to test this PR?
Just create an object with multiple sets and try to delete the bucket `mc rb` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
