### PR TITLE
avoid unnecessary logging on fresh/newly replaced drives

### DIFF
--- a/cmd/data-update-tracker.go
+++ b/cmd/data-update-tracker.go
@@ -45,8 +45,8 @@ const (
 	dataUpdateTrackerFP        = 0.99
 	dataUpdateTrackerQueueSize = 10000
 
+	dataUpdateTrackerFilename     = dataUsageBucket + SlashSeparator + ".tracker.bin"
 	dataUpdateTrackerVersion      = 1
-	dataUpdateTrackerFilename     = minioMetaBucket + SlashSeparator + bucketMetaPrefix + SlashSeparator + ".tracker.bin"
 	dataUpdateTrackerSaveInterval = 5 * time.Minute
 
 	// Reset bloom filters every n cycle
@@ -195,6 +195,7 @@ func (d *dataUpdateTracker) load(ctx context.Context, drives ...string) {
 		return
 	}
 	for _, drive := range drives {
+
 		cacheFormatPath := pathJoin(drive, dataUpdateTrackerFilename)
 		f, err := os.Open(cacheFormatPath)
 		if err != nil {
@@ -255,6 +256,9 @@ func (d *dataUpdateTracker) startSaver(ctx context.Context, interval time.Durati
 			cacheFormatPath := pathJoin(drive, dataUpdateTrackerFilename)
 			err := ioutil.WriteFile(cacheFormatPath, buf.Bytes(), os.ModePerm)
 			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
 				logger.LogIf(ctx, err)
 				continue
 			}

--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -360,6 +360,9 @@ func (d *dataUsageCache) save(ctx context.Context, store ObjectLayer, name strin
 		name,
 		NewPutObjReader(r, nil, nil),
 		ObjectOptions{})
+	if isErrBucketNotFound(err) {
+		return nil
+	}
 	return err
 }
 

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -485,8 +485,8 @@ func (s *posix) SetDiskID(id string) {
 func (s *posix) MakeVolBulk(volumes ...string) (err error) {
 	for _, volume := range volumes {
 		if err = s.MakeVol(volume); err != nil {
-			if err != errVolumeExists {
-				return err
+			if os.IsPermission(err) {
+				return errVolumeAccessDenied
 			}
 		}
 	}


### PR DESCRIPTION

## Description
avoid unnecessary logging on fresh/newly replaced drives

## Motivation and Context
data usage tracker and crawler seem to be logging
non-actionable information on the console, which is not
useful and is fixed on its own in almost all deployments,
let's keep this logging to minimal.

## How to test this PR?
run a distributed setup, replace some drives or during init

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
