### PR TITLE
config: More fixes in parsing Audit & Logger env variables

### DIFF
--- a/cmd/logger/legacy.go
+++ b/cmd/logger/legacy.go
@@ -20,7 +20,8 @@ import "github.com/minio/minio/cmd/config"
 
 // Legacy envs
 const (
-	EnvAuditLoggerHTTPEndpoint = "MINIO_AUDIT_LOGGER_HTTP_ENDPOINT"
+	legacyEnvAuditLoggerHTTPEndpoint = "MINIO_AUDIT_LOGGER_HTTP_ENDPOINT"
+	legacyEnvLoggerHTTPEndpoint      = "MINIO_LOGGER_HTTP_ENDPOINT"
 )
 
 // SetLoggerHTTPAudit - helper for migrating older config to newer KV format.


### PR DESCRIPTION
## Description
- Add support of missed legacy Logger webhook
- Disable enabling Audit or logger if _ENABLE
  if not explicity set to "on".

This commit also moves loading legacy audit
& logger env variables to a separate function.

## Motivation and Context
Fix legacy legacy Audit & HTTP

## How to test this PR?
Test old legacy env vars: MINIO_AUDIT_LOGGER_HTTP_ENDPOINT and MINIO_LOGGER_HTTP_ENDPOINT


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
