### PR TITLE
copy-object tagging-directive REPLACE no tags

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -656,9 +656,9 @@ func getCpObjTagsFromHeader(ctx context.Context, r *http.Request, tags string) (
 		if tags := r.Header.Get(xhttp.AmzObjectTagging); tags != "" {
 			return extractTags(ctx, tags)
 		}
-		// Copy is default behavior if x-amz-tagging-directive is set, but x-amz-tagging is
-		// is not set
-		return tags, nil
+		// If x-amz-tagging-directive is explicitly set to replace and  x-amz-tagging is not set.
+		// The S3 behavior is to unset the tags.
+		return "", nil
 	}
 
 	// Copy is default behavior if x-amz-tagging-directive is not set.


### PR DESCRIPTION
Fixes #9477

## Description
Copy an object from a bucket to a different bucket with CopyObject API or copy-object CLI command with the tagging directive REPLACE but with no tags or tags set to blank.

## Motivation and Context
If tagging directive is REPLACE and no tags (or blank) is given, the copied object's object tags are to be removed or unset.

## How to test this PR?
Use CopyObject API or copy-object. With CLI command set --tagging-directive to REPLACE with no tags (--tagging).

## Types of changes
- [ √] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
