### PR TITLE
Use source scheme retrieved from X-Forwarded headers

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -2058,12 +2058,6 @@ type LoginSTSArgs struct {
 	Token string `json:"token" form:"token"`
 }
 
-// LoginSTSRep - login reply.
-type LoginSTSRep struct {
-	Token     string `json:"token"`
-	UIVersion string `json:"uiVersion"`
-}
-
 // LoginSTS - STS user login handler.
 func (web *webAPIHandlers) LoginSTS(r *http.Request, args *LoginSTSArgs, reply *LoginRep) error {
 	ctx := newWebContext(r, args, "WebLoginSTS")

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -2073,7 +2073,7 @@ func (web *webAPIHandlers) LoginSTS(r *http.Request, args *LoginSTSArgs, reply *
 	v.Set("WebIdentityToken", args.Token)
 	v.Set("Version", stsAPIVersion)
 
-	scheme := "http"
+	scheme := handlers.GetSourceScheme(r)
 	if globalIsSSL {
 		scheme = "https"
 	}

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -2073,7 +2073,10 @@ func (web *webAPIHandlers) LoginSTS(r *http.Request, args *LoginSTSArgs, reply *
 	v.Set("WebIdentityToken", args.Token)
 	v.Set("Version", stsAPIVersion)
 
-	scheme := handlers.GetSourceScheme(r)
+	scheme := "http"
+	if sourceScheme := handlers.GetSourceScheme(r); sourceScheme != "" {
+		scheme = sourceScheme
+	}
 	if globalIsSSL {
 		scheme = "https"
 	}


### PR DESCRIPTION
## Description
The PR modifies the mechanism of scheme selection for outbound POST-requests to obtain STS credentials and allows to use source scheme in outbound request for STS credentials. The source scheme is retrieved from the X-Forwarded headers.

## Motivation and Context
Current implementation always uses 'http' scheme to retrieve STS credentials from themselves until Minio TLS termination is configured in the one.
Such behaviour doesn't work well in the case of TLS-termination at a reverse-proxy side in front of the Minio. It becomes even more problematic if https protocol is enforced by the proxy by means of 301/2 redirects on plain-text http requests.

## How to test this PR?



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
