### PR TITLE
Add support of TCP fast open in internode calls

### DIFF
--- a/cmd/http/dial_linux.go
+++ b/cmd/http/dial_linux.go
@@ -1,0 +1,53 @@
+// +build linux
+
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"context"
+	"net"
+	"syscall"
+	"time"
+)
+
+const (
+	// TCPFastOpenConnect sets the underlying socket to use
+	// the TCP fast open connect. This feature is supported
+	// since Linux 4.11.
+	TCPFastOpenConnect = 30
+)
+
+// DialContext is a function to make custom Dial for internode communications
+type DialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
+// NewCustomDialContext setups a custom dialer for internode communications
+func NewCustomDialContext(dialTimeout, dialKeepAlive time.Duration) DialContext {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialer := &net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: dialKeepAlive,
+			Control: func(network, address string, c syscall.RawConn) error {
+				return c.Control(func(fd uintptr) {
+					// Enable TCP fast connect
+					_ = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, TCPFastOpenConnect, 1)
+				})
+			},
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+}

--- a/cmd/http/dial_others.go
+++ b/cmd/http/dial_others.go
@@ -1,0 +1,39 @@
+// +build !linux
+
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// DialContext is a function to make custom Dial for internode communications
+type DialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
+// NewCustomDialContext configures a custom dialer for internode communications
+func NewCustomDialContext(dialTimeout, dialKeepAlive time.Duration) DialContext {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialer := &net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: dialKeepAlive,
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -450,25 +449,12 @@ func ToS3ETag(etag string) string {
 	return etag
 }
 
-type dialContext func(ctx context.Context, network, address string) (net.Conn, error)
-
-func newCustomDialContext(dialTimeout, dialKeepAlive time.Duration) dialContext {
-	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		dialer := &net.Dialer{
-			Timeout:   dialTimeout,
-			KeepAlive: dialKeepAlive,
-		}
-
-		return dialer.DialContext(ctx, network, addr)
-	}
-}
-
 func newCustomHTTPTransport(tlsConfig *tls.Config, dialTimeout time.Duration) func() *http.Transport {
 	// For more details about various values used here refer
 	// https://golang.org/pkg/net/http/#Transport documentation
 	tr := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           newCustomDialContext(dialTimeout, 15*time.Second),
+		DialContext:           xhttp.NewCustomDialContext(dialTimeout, 15*time.Second),
 		MaxIdleConnsPerHost:   16,
 		MaxIdleConns:          16,
 		IdleConnTimeout:       1 * time.Minute,


### PR DESCRIPTION
## Description
Add support of TCP fast open feature for inter-node communications
for Linux >= 4.11

## Motivation and Context
Cache TCP three way handshakes for accelerated reconnections between nodes

## How to test this PR?
Hard to test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
