### PR TITLE
fix: crash observed when position of drives different

### DIFF
--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -333,12 +333,15 @@ func newXLSets(ctx context.Context, endpoints Endpoints, storageDisks []StorageA
 	for i := 0; i < setCount; i++ {
 		s.xlDisks[i] = make([]StorageAPI, drivesPerSet)
 		s.xlLockers[i] = make([]dsync.NetLocker, drivesPerSet)
+	}
 
+	for i := 0; i < setCount; i++ {
 		var endpoints Endpoints
 		for j := 0; j < drivesPerSet; j++ {
 			endpoints = append(endpoints, s.endpoints[i*drivesPerSet+j])
 			// Rely on endpoints list to initialize, init lockers and available disks.
 			s.xlLockers[i][j] = newLockAPI(s.endpoints[i*drivesPerSet+j])
+
 			disk := storageDisks[i*drivesPerSet+j]
 			if disk == nil {
 				continue


### PR DESCRIPTION

## Description
fix: crash observed when the position of drives different

## Motivation and Context
allocate the disk slice properly before populating
disk by its ID and its position.

Fixes #9416

## How to test this PR?
Hard to test and reproduce, requires disks position, not in order. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably because previously we never used to reuse the drives
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
