### PR TITLE
audit: Merge ResponseWriter with RecordAPIStats

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -36,8 +36,6 @@ import (
 	"github.com/minio/minio/pkg/bucket/object/tagging"
 	"github.com/minio/minio/pkg/handlers"
 	"github.com/minio/minio/pkg/madmin"
-
-	stats "github.com/minio/minio/cmd/http/stats"
 )
 
 const (
@@ -366,7 +364,7 @@ func collectAPIStats(api string, f http.HandlerFunc) http.HandlerFunc {
 		globalHTTPStats.currentS3Requests.Inc(api)
 		defer globalHTTPStats.currentS3Requests.Dec(api)
 
-		statsWriter := stats.NewRecordAPIStats(w)
+		statsWriter := logger.NewResponseWriter(w)
 
 		f.ServeHTTP(statsWriter, r)
 

--- a/cmd/http-stats.go
+++ b/cmd/http-stats.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	stats "github.com/minio/minio/cmd/http/stats"
+	"github.com/minio/minio/cmd/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 )
@@ -167,13 +167,13 @@ func (st *HTTPStats) toServerHTTPStats() ServerHTTPStats {
 }
 
 // Update statistics from http request and response data
-func (st *HTTPStats) updateStats(api string, r *http.Request, w *stats.RecordAPIStats, durationSecs float64) {
+func (st *HTTPStats) updateStats(api string, r *http.Request, w *logger.ResponseWriter, durationSecs float64) {
 	// A successful request has a 2xx response code
-	successReq := (w.RespStatusCode >= 200 && w.RespStatusCode < 300)
+	successReq := (w.StatusCode >= 200 && w.StatusCode < 300)
 
 	if !strings.HasSuffix(r.URL.Path, prometheusMetricsPath) {
 		st.totalS3Requests.Inc(api)
-		if !successReq && w.RespStatusCode != 0 {
+		if !successReq && w.StatusCode != 0 {
 			st.totalS3Errors.Inc(api)
 		}
 	}

--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -123,7 +123,8 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 	}
 
 	rw := logger.NewResponseWriter(w)
-	rw.LogBody = logBody
+	rw.LogErrBody = true
+	rw.LogAllBody = logBody
 	f(rw, r)
 
 	rq := trace.RequestInfo{

--- a/cmd/http/stats/http-traffic-recorder.go
+++ b/cmd/http/stats/http-traffic-recorder.go
@@ -19,7 +19,6 @@ package stats
 import (
 	"io"
 	"net/http"
-	"time"
 )
 
 // IncomingTrafficMeter counts the incoming bytes from the underlying request.Body.
@@ -62,46 +61,4 @@ func (w *OutgoingTrafficMeter) Flush() {
 // BytesCount returns the number of transferred bytes
 func (w OutgoingTrafficMeter) BytesCount() int {
 	return w.countBytes
-}
-
-// RecordAPIStats is a response writer which stores
-// information of the underlying http response.
-type RecordAPIStats struct {
-	http.ResponseWriter
-	TTFB           time.Duration // TimeToFirstByte.
-	StartTime      time.Time
-	RespStatusCode int
-
-	firstByteRead bool
-}
-
-// NewRecordAPIStats creates a new response writer with
-// start time set to the function call time.
-func NewRecordAPIStats(w http.ResponseWriter) *RecordAPIStats {
-	return &RecordAPIStats{
-		ResponseWriter: w,
-		StartTime:      time.Now().UTC(),
-	}
-}
-
-// WriteHeader calls the underlying WriteHeader
-// and records the response status code.
-func (r *RecordAPIStats) WriteHeader(i int) {
-	r.RespStatusCode = i
-	r.ResponseWriter.WriteHeader(i)
-}
-
-// Write calls the underlying Write and updates TTFB and other info
-func (r *RecordAPIStats) Write(p []byte) (n int, err error) {
-	if !r.firstByteRead {
-		r.TTFB = time.Now().UTC().Sub(r.StartTime)
-		r.firstByteRead = true
-	}
-	n, err = r.ResponseWriter.Write(p)
-	return
-}
-
-// Flush calls the underlying Flush.
-func (r *RecordAPIStats) Flush() {
-	r.ResponseWriter.(http.Flusher).Flush()
 }


### PR DESCRIPTION
## Description
ResponseWriter & RecordAPIStats have similar role, merge them.

This commit will also fix wrong auditing for STS and Web and others
since they are using ResponseWriter instead of the RecordAPIStats.

## Motivation and Context
Fix issue with audit STS & web browser

## How to test this PR?
```python
import socket
import thread

def handle(client_socket, address):
  # while True:
  data = client_socket.recv(2048)
  #   if not data: break
  print(data)
  client_socket.close()

server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
server.bind((socket.gethostname(), 8080))
server.listen(20)

while True: # listen for incoming connections
  client_socket, address = server.accept()
  print("request from the ip",address[0])
  # spawn a new thread that run the function handle()
  thread.start_new_thread(handle, (client_socket, address))
```

2.
```
$ export MINIO_AUDIT_WEBHOOK_ENABLE_target1=on
$ export MINIO_AUDIT_WEBHOOK_ENDPOINT_target1=http://localhost:8080/
$ minio server /tmp/fs/
```

3. Upload a file with Minio Browser

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
