### PR TITLE
Show the cause error in startup when directio is not supported

### DIFF
--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -175,7 +175,7 @@ func getValidPath(path string) (string, error) {
 	var rnd [8]byte
 	_, _ = rand.Read(rnd[:])
 	fn := pathJoin(path, ".writable-check-"+hex.EncodeToString(rnd[:])+".tmp")
-	file, err := os.Create(fn)
+	file, err := disk.OpenFileDirectIO(fn, os.O_CREATE, 0600)
 	if err != nil {
 		return path, err
 	}

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -747,7 +747,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointZones EndpointZones
 				}
 				hint := fmt.Sprintf("Run the following command to add the convenient permissions: `sudo chown %s %s && sudo chmod u+rxw %s`",
 					username, endpoint.Path, endpoint.Path)
-				logger.Fatal(config.ErrUnableToWriteInBackend(err).Hint(hint),
+				logger.Fatal(config.ErrUnableToWriteInBackend(err).Msg(err.Error()).Hint(hint),
 					"Unable to initialize posix backend")
 			}
 


### PR DESCRIPTION
## Description
This commit tries to create a file using direct i/o in the startup
so the server returns quickly and avoids printing cryptic other errors.

## Motivation and Context
Quit early when directio is not supported

## How to test this PR?
`minio server /dev/shm/xl/{1..4}/`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
