### PR TITLE
fix: assume parentUser correctly for serviceAccounts

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -461,7 +461,12 @@ func (a adminAPIHandlers) ListServiceAccounts(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	serviceAccounts, err := globalIAMSys.ListServiceAccounts(ctx, cred.AccessKey)
+	parentUser := cred.AccessKey
+	if cred.ParentUser != "" {
+		parentUser = cred.ParentUser
+	}
+
+	serviceAccounts, err := globalIAMSys.ListServiceAccounts(ctx, parentUser)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
@@ -521,8 +526,15 @@ func (a adminAPIHandlers) DeleteServiceAccount(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if cred.AccessKey != user || cred.ParentUser != user {
-		// The service account belongs to another user but return not found error to mitigate brute force attacks.
+	parentUser := cred.AccessKey
+	if cred.ParentUser != "" {
+		parentUser = cred.ParentUser
+	}
+
+	if parentUser != user || user == "" {
+		// The service account belongs to another user but return not
+		// found error to mitigate brute force attacks. or the
+		// serviceAccount doesn't exist.
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrServiceAccountNotFound), r.URL)
 		return
 	}

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -889,11 +889,10 @@ func (sys *IAMSys) GetServiceAccountParent(ctx context.Context, accessKey string
 	defer sys.store.runlock()
 
 	sa, ok := sys.iamUsersMap[accessKey]
-	if !ok || !sa.IsServiceAccount() {
-		return "", errNoSuchServiceAccount
+	if ok && sa.IsServiceAccount() {
+		return sa.ParentUser, nil
 	}
-
-	return sa.ParentUser, nil
+	return "", nil
 }
 
 // DeleteServiceAccount - delete a service account
@@ -908,7 +907,7 @@ func (sys *IAMSys) DeleteServiceAccount(ctx context.Context, accessKey string) e
 
 	sa, ok := sys.iamUsersMap[accessKey]
 	if !ok || !sa.IsServiceAccount() {
-		return errNoSuchServiceAccount
+		return nil
 	}
 
 	// It is ok to ignore deletion error on the mapped policy

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -77,9 +77,6 @@ var errInvalidDecompressedSize = errors.New("Invalid Decompressed Size")
 // error returned in IAM subsystem when user doesn't exist.
 var errNoSuchUser = errors.New("Specified user does not exist")
 
-// error returned in IAM subsystem when the service account doesn't exist.
-var errNoSuchServiceAccount = errors.New("Specified service account does not exist")
-
 // error returned in IAM subsystem when groups doesn't exist.
 var errNoSuchGroup = errors.New("Specified group does not exist")
 


### PR DESCRIPTION


## Description
fix: assume parentUser correctly for serviceAccounts

## Motivation and Context
ListServiceAccounts/DeleteServiceAccount didn't work properly
with STS credentials yet due to incorrect Parent user.

## How to test this PR?
Test with AssumeRole creds over admin account.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
