### PR TITLE
DeleteBucketLockConfig: set retentionMap bucket entry to it's zero value

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1069,8 +1069,8 @@ func (api objectAPIHandlers) PutBucketObjectLockConfigHandler(w http.ResponseWri
 		globalBucketObjectLockConfig.Set(bucket, retention)
 		globalNotificationSys.PutBucketObjectLockConfig(ctx, bucket, retention)
 	} else {
-		globalBucketObjectLockConfig.Remove(bucket)
-		globalNotificationSys.RemoveBucketObjectLockConfig(ctx, bucket)
+		globalBucketObjectLockConfig.Set(bucket, objectlock.Retention{})
+		globalNotificationSys.PutBucketObjectLockConfig(ctx, bucket, objectlock.Retention{})
 	}
 
 	// Write success response.


### PR DESCRIPTION
instead of deleting the entry in the map, the corresponding value
in the bucketlockconfig fields should be set to its zero value.

Fixes #9476

## Description
When a call is made to delete the BucketLockConfig, the corresponding retentionMap entry for the bucket was getting deleted in memory, causing MinIO to act as if the bucket was never created with lock enabled. This caused issues reported in #9476 

## Motivation and Context
Fix issue reported in #9476

## How to test this PR?
As explained in #9476

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
