### PR TITLE
use HTTP/2 when connecting to KES

### DIFF
--- a/cmd/crypto/kes.go
+++ b/cmd/crypto/kes.go
@@ -112,6 +112,7 @@ func NewKes(cfg KesConfig) (KMS, error) {
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      certPool,
 	}
+	cfg.Transport.ForceAttemptHTTP2 = true
 	return &kesService{
 		client: &kesClient{
 			addr: cfg.Endpoint,


### PR DESCRIPTION
## Description
This commit makes the KES client use HTTP/2
when establishing a connection to the KES server.

This is necessary since the next KES server release
will require HTTP/2.

## Motivation and Context
KES, KMS

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
