### PR TITLE
WIP: Integrate md5-simd

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -415,15 +415,15 @@ func isReqAuthenticated(ctx context.Context, r *http.Request, region string, sty
 			return ErrContentSHA256Mismatch
 		}
 	}
-
+	size := r.ContentLength
 	// Verify 'Content-Md5' and/or 'X-Amz-Content-Sha256' if present.
 	// The verification happens implicit during reading.
-	reader, err := hash.NewReader(r.Body, -1, hex.EncodeToString(contentMD5),
+	reader, err := hash.NewReader(r.Body, size, hex.EncodeToString(contentMD5),
 		hex.EncodeToString(contentSHA256), -1, globalCLIContext.StrictS3Compat)
 	if err != nil {
 		return toAPIErrorCode(ctx, err)
 	}
-	r.Body = ioutil.NopCloser(reader)
+	r.Body = reader
 	return ErrNone
 }
 

--- a/cmd/config-common.go
+++ b/cmd/config-common.go
@@ -62,6 +62,7 @@ func saveConfig(ctx context.Context, objAPI ObjectLayer, configFile string, data
 	if err != nil {
 		return err
 	}
+	defer hashReader.Close()
 
 	_, err = objAPI.PutObject(ctx, minioMetaBucket, configFile, NewPutObjReader(hashReader, nil, nil), ObjectOptions{})
 	return err

--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -354,6 +354,7 @@ func (d *dataUsageCache) save(ctx context.Context, store ObjectLayer, name strin
 	if err != nil {
 		return err
 	}
+	defer r.Close()
 
 	_, err = store.PutObject(ctx,
 		dataUsageBucket,

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -106,6 +106,7 @@ func runDataUsageInfo(ctx context.Context, objAPI ObjectLayer) {
 				}
 
 				_, err = objAPI.PutObject(ctx, dataUsageBucket, dataUsageBloomName, NewPutObjReader(r, nil, nil), ObjectOptions{})
+				r.Close()
 				if !isErrBucketNotFound(err) {
 					logger.LogIf(ctx, err)
 				}
@@ -133,6 +134,7 @@ func storeDataUsageInBackend(ctx context.Context, objAPI ObjectLayer, gui <-chan
 		if !isErrBucketNotFound(err) {
 			logger.LogIf(ctx, err)
 		}
+		r.Close()
 	}
 }
 

--- a/cmd/disk-cache_test.go
+++ b/cmd/disk-cache_test.go
@@ -209,6 +209,7 @@ func TestDiskCacheMaxUse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer hashReader.Close()
 	if !cache.diskAvailable(int64(size)) {
 		err = cache.Put(ctx, bucketName, objectName, hashReader, hashReader.Size(), nil, ObjectOptions{UserDefined: httpMeta}, false)
 		if err != errDiskFull {

--- a/cmd/hasher.go
+++ b/cmd/hasher.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 
+	md5simd "github.com/minio/md5-simd"
 	"github.com/minio/sha256-simd"
 )
 
@@ -35,9 +36,17 @@ func getSHA256Sum(data []byte) []byte {
 	return hash.Sum(nil)
 }
 
+// md5Server is a singleton md5 processor.
+var md5Server = md5simd.NewServer()
+
 // getMD5Sum returns MD5 sum of given data.
 func getMD5Sum(data []byte) []byte {
-	hash := md5.New()
+	if len(data) < 32<<10 {
+		v := md5.Sum(data)
+		return v[:]
+	}
+	hash := md5Server.NewHash()
+	defer hash.Close()
 	hash.Write(data)
 	return hash.Sum(nil)
 }

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1702,7 +1702,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 	for _, part := range parts {
 		_, err = obj.PutObjectPart(context.Background(), part.bucketName, part.objName, part.uploadID, part.PartID, mustGetPutObjReader(t, bytes.NewBufferString(part.inputReaderData), part.intputDataSize, part.inputMd5, sha256sum), opts)
 		if err != nil {
-			t.Fatalf("%s : %s", instanceType, err)
+			t.Fatalf("%s : %s, %d bytes input, part %d", instanceType, err, len(part.inputReaderData), part.PartID)
 		}
 	}
 	// Parts to be sent as input for CompleteMultipartUpload.

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -929,6 +929,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	defer srcInfo.Reader.Close()
 
 	rawReader := srcInfo.Reader
 	pReader := NewPutObjReader(srcInfo.Reader, nil, nil)
@@ -1037,6 +1038,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 				return
 			}
+			defer srcInfo.Reader.Close()
 
 			if isTargetEncrypted {
 				pReader = NewPutObjReader(rawReader, srcInfo.Reader, &objEncKey)
@@ -1348,6 +1350,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 			return
 		}
+		defer actualReader.Close()
 
 		// Set compression metrics.
 		s2c := newS2CompressReader(actualReader)
@@ -1363,6 +1366,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	defer hashReader.Close()
 
 	rawReader := hashReader
 	pReader := NewPutObjReader(rawReader, nil, nil)
@@ -1421,6 +1425,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 				return
 			}
+			defer hashReader.Close()
 			pReader = NewPutObjReader(rawReader, hashReader, &objectEncryptionKey)
 		}
 	}
@@ -1840,6 +1845,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	defer srcInfo.Reader.Close()
 
 	rawReader := srcInfo.Reader
 	pReader := NewPutObjReader(rawReader, nil, nil)
@@ -1896,6 +1902,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 				return
 			}
+			defer srcInfo.Reader.Close()
 			pReader = NewPutObjReader(rawReader, srcInfo.Reader, &objectEncryptionKey)
 		}
 	}
@@ -2070,6 +2077,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 			return
 		}
+		defer actualReader.Close()
 
 		// Set compression metrics.
 		s2c := newS2CompressReader(actualReader)
@@ -2086,6 +2094,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	defer hashReader.Close()
 	rawReader := hashReader
 	pReader := NewPutObjReader(rawReader, nil, nil)
 
@@ -2148,6 +2157,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 				return
 			}
+			defer hashReader.Close()
 			pReader = NewPutObjReader(rawReader, hashReader, &objectEncryptionKey)
 		}
 	}

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -1088,6 +1088,7 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 		writeWebErrorResponse(w, err)
 		return
 	}
+	defer hashReader.Close()
 	if objectAPI.IsCompressionSupported() && isCompressible(r.Header, object) && size > 0 {
 		// Storing the compression metadata.
 		metadata[ReservedMetadataPrefix+"compression"] = compressionAlgorithmV2
@@ -1098,6 +1099,7 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 			writeWebErrorResponse(w, err)
 			return
 		}
+		defer actualReader.Close()
 
 		// Set compression metrics.
 		size = -1 // Since compressed size is un-predictable.
@@ -1109,6 +1111,7 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 			writeWebErrorResponse(w, err)
 			return
 		}
+		defer hashReader.Close()
 	}
 	pReader = NewPutObjReader(hashReader, nil, nil)
 	// get gateway encryption options
@@ -1134,6 +1137,7 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 				return
 			}
+			defer hashReader.Close()
 			pReader = NewPutObjReader(rawReader, hashReader, &objectEncryptionKey)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/json-iterator/go v1.1.9
 	github.com/klauspost/compress v1.10.3
-	github.com/klauspost/cpuid v1.2.2
+	github.com/klauspost/cpuid v1.2.3
 	github.com/klauspost/pgzip v1.2.1
 	github.com/klauspost/readahead v1.3.1
 	github.com/klauspost/reedsolomon v1.9.3
@@ -67,6 +67,7 @@ require (
 	github.com/minio/hdfs/v3 v3.0.1
 	github.com/minio/highwayhash v1.0.0
 	github.com/minio/lsync v1.0.1
+	github.com/minio/md5-simd v1.0.1
 	github.com/minio/minio-go/v6 v6.0.55-0.20200424204115-7506d2996b22
 	github.com/minio/parquet-go v0.0.0-20200414234858-838cfa8aae61
 	github.com/minio/sha256-simd v0.1.1
@@ -126,4 +127,8 @@ require (
 	gopkg.in/ldap.v3 v3.0.3
 	gopkg.in/olivere/elastic.v5 v5.0.80
 	gopkg.in/yaml.v2 v2.2.4
+)
+
+replace (
+	github.com/minio/md5-simd v1.0.1  => ..\md5-simd\
 )

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,8 @@ github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eT
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.2 h1:1xAgYebNnsb9LKCdLOvFWtAxGU/33mjJtyOVbmUa0Us=
 github.com/klauspost/cpuid v1.2.2/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid v1.2.3 h1:CCtW0xUnWGVINKvE/WWOYKdsPV6mawAtvQuSl8guwQs=
+github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.1 h1:oIPZROsWuPHpOdMVWLuJZXwgjhrW8r1yEX8UqMyeNHM=
 github.com/klauspost/pgzip v1.2.1/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/readahead v1.3.1 h1:QqXNYvm+VvqYcbrRT4LojUciM0XrznFRIDrbHiJtu/0=
@@ -274,6 +276,8 @@ github.com/minio/highwayhash v1.0.0 h1:iMSDhgUILCr0TNm8LWlSjF8N0ZIj2qbO8WHp6Q/J2
 github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5dxBpaMbdc=
 github.com/minio/lsync v1.0.1 h1:AVvILxA976xc27hstd1oR+X9PQG0sPSom1MNb1ImfUs=
 github.com/minio/lsync v1.0.1/go.mod h1:tCFzfo0dlvdGl70IT4IAK/5Wtgb0/BrTmo/jE8pArKA=
+github.com/minio/md5-simd v1.0.1 h1:tj/FH8APTKxIkOGUX2YGAVJVXXC3AJ5T2SkHoT/dUFI=
+github.com/minio/md5-simd v1.0.1/go.mod h1:EhdyA+Dr0guvfyc8d6yrgs9YzHGfaI+YIjA6gt/7mJk=
 github.com/minio/minio-go/v6 v6.0.53 h1:8jzpwiOzZ5Iz7/goFWqNZRICbyWYShbb5rARjrnSCNI=
 github.com/minio/minio-go/v6 v6.0.53/go.mod h1:DIvC/IApeHX8q1BAMVCXSXwpmrmM+I+iBvhvztQorfI=
 github.com/minio/minio-go/v6 v6.0.55-0.20200424204115-7506d2996b22 h1:nZEve4vdUhwHBoV18zRvPDgjL6NYyDJE5QJvz3l9bRs=
@@ -375,6 +379,7 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190704165056-9c2d0518ed81 h1:zQTtDd7fQiF9e80lbl+ShnD9/5NSq5r1EhcS8955ECg=
 github.com/rcrowley/go-metrics v0.0.0-20190704165056-9c2d0518ed81/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/hash/reader.go
+++ b/pkg/hash/reader.go
@@ -17,18 +17,17 @@
 package hash
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
-	"errors"
 	"hash"
 	"io"
 
+	md5simd "github.com/minio/md5-simd"
 	sha256 "github.com/minio/sha256-simd"
 )
-
-var errNestedReader = errors.New("Nesting of Reader detected, not allowed")
 
 // Reader writes what it reads from an io.Reader to an MD5 and SHA256 hash.Hash.
 // Reader verifies that the content of the io.Reader matches the expected checksums.
@@ -37,15 +36,39 @@ type Reader struct {
 	size       int64
 	actualSize int64
 
-	md5sum, sha256sum   []byte // Byte values of md5sum, sha256sum of client sent values.
-	md5Hash, sha256Hash hash.Hash
+	md5sum, sha256sum []byte // Byte values of md5sum, sha256sum of client sent values.
+	sha256Hash        hash.Hash
+	// If md5Buffer is non-nil write to this instead of md5Hash
+	md5Buffer *bufio.Writer
+	md5Hash   md5simd.Hasher
+
+	// md5Got is the sum at the end of the stream
+	md5Got []byte
 }
+
+// md5Server is a singleton md5 processor.
+var md5Server = md5simd.NewServer()
+
+func newMd5(size int64) (md5simd.Hasher, *bufio.Writer) {
+	if true && (size < 0 || size > 32<<10) {
+		h := md5Server.NewHash()
+		return h, bufio.NewWriterSize(h, 32<<10)
+		//return h, nil
+	}
+	return &md5stdWrapper{Hash: md5.New()}, nil
+}
+
+type md5stdWrapper struct {
+	hash.Hash
+}
+
+func (*md5stdWrapper) Close() {}
 
 // NewReader returns a new hash Reader which computes the MD5 sum and
 // SHA256 sum (if set) of the provided io.Reader at EOF.
 func NewReader(src io.Reader, size int64, md5Hex, sha256Hex string, actualSize int64, strictCompat bool) (*Reader, error) {
-	if _, ok := src.(*Reader); ok {
-		return nil, errNestedReader
+	if r, ok := src.(*Reader); ok {
+		return r.merge(size, md5Hex, sha256Hex, actualSize, strictCompat)
 	}
 
 	sha256sum, err := hex.DecodeString(sha256Hex)
@@ -57,37 +80,83 @@ func NewReader(src io.Reader, size int64, md5Hex, sha256Hex string, actualSize i
 	if err != nil {
 		return nil, BadDigest{}
 	}
-
-	var sha256Hash hash.Hash
-	if len(sha256sum) != 0 {
-		sha256Hash = sha256.New()
-	}
-	var md5Hash hash.Hash
-	if strictCompat {
-		// Strict compatibility is set then we should
-		// calculate md5sum always.
-		md5Hash = md5.New()
-	} else if len(md5sum) != 0 {
-		md5Hash = md5.New()
-	}
 	if size >= 0 {
 		src = io.LimitReader(src, size)
 	}
-	return &Reader{
+	r := Reader{
 		md5sum:     md5sum,
 		sha256sum:  sha256sum,
 		src:        src,
 		size:       size,
-		md5Hash:    md5Hash,
-		sha256Hash: sha256Hash,
 		actualSize: actualSize,
-	}, nil
+	}
+
+	if len(sha256sum) != 0 {
+		r.sha256Hash = sha256.New()
+	}
+
+	if strictCompat || len(md5sum) != 0 {
+		// Strict compatibility is set then we should
+		// calculate md5sum always.
+		r.md5Hash, r.md5Buffer = newMd5(size)
+	}
+
+	return &r, nil
+}
+
+// merge another hash into this one.
+// There cannot be conflicting information given.
+func (r *Reader) merge(size int64, md5Hex, sha256Hex string, actualSize int64, strictCompat bool) (*Reader, error) {
+	// Merge sizes.
+	if r.size < 0 && size >= 0 {
+		r.size = size
+		if size > 0 {
+			r.src = io.LimitReader(r.src, size)
+		}
+	}
+	if r.actualSize < 0 && actualSize >= 0 {
+		r.actualSize = actualSize
+	}
+
+	// Merge SHA256.
+	// If both are set, they must expect the same.
+	sha256sum, err := hex.DecodeString(sha256Hex)
+	if err != nil {
+		return nil, SHA256Mismatch{}
+	}
+
+	if r.sha256Hash != nil && len(sha256sum) > 0 {
+		if !bytes.Equal(r.sha256sum, sha256sum) {
+			return nil, SHA256Mismatch{hex.EncodeToString(r.sha256sum), sha256Hex}
+		}
+	} else if len(sha256sum) > 0 {
+		r.sha256Hash = sha256.New()
+		r.sha256sum = sha256sum
+	}
+
+	// Merge MD5 Sum.
+	// If both are set, they must expect the same.
+	md5sum, err := hex.DecodeString(md5Hex)
+	if err != nil {
+		return nil, BadDigest{}
+	}
+	if r.md5Hash != nil && len(md5sum) > 0 {
+		if !bytes.Equal(r.md5sum, md5sum) {
+			return nil, BadDigest{hex.EncodeToString(r.md5sum), md5Hex}
+		}
+	} else if len(md5sum) > 0 || (r.md5Hash == nil && strictCompat) {
+		r.md5Hash, r.md5Buffer = newMd5(size)
+		r.md5sum = md5sum
+	}
+	return r, nil
 }
 
 func (r *Reader) Read(p []byte) (n int, err error) {
 	n, err = r.src.Read(p)
 	if n > 0 {
-		if r.md5Hash != nil {
+		if r.md5Buffer != nil {
+			r.md5Buffer.Write(p[:n])
+		} else if r.md5Hash != nil {
 			r.md5Hash.Write(p[:n])
 		}
 		if r.sha256Hash != nil {
@@ -97,12 +166,24 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 
 	// At io.EOF verify if the checksums are right.
 	if err == io.EOF {
-		if cerr := r.Verify(); cerr != nil {
+		if cerr := r.verify(); cerr != nil {
 			return 0, cerr
 		}
 	}
 
 	return
+}
+
+// Close and release resources.
+func (r *Reader) Close() error {
+	if r == nil {
+		return nil
+	}
+	if r.md5Hash != nil {
+		r.md5Hash.Close()
+		r.md5Hash = nil
+	}
+	return nil
 }
 
 // Size returns the absolute number of bytes the Reader
@@ -114,17 +195,18 @@ func (r *Reader) Size() int64 { return r.size }
 // DecompressedSize - For compressed objects.
 func (r *Reader) ActualSize() int64 { return r.actualSize }
 
-// MD5 - returns byte md5 value
-func (r *Reader) MD5() []byte {
-	return r.md5sum
-}
-
 // MD5Current - returns byte md5 value of the current state
 // of the md5 hash after reading the incoming content.
 // NOTE: Calling this function multiple times might yield
 // different results if they are intermixed with Reader.
 func (r *Reader) MD5Current() []byte {
+	if len(r.md5Got) > 0 {
+		return r.md5Got
+	}
 	if r.md5Hash != nil {
+		if r.md5Buffer != nil {
+			r.md5Buffer.Flush()
+		}
 		return r.md5Hash.Sum(nil)
 	}
 	return nil
@@ -150,17 +232,28 @@ func (r *Reader) SHA256HexString() string {
 	return hex.EncodeToString(r.sha256sum)
 }
 
-// Verify verifies if the computed MD5 sum and SHA256 sum are
+// verify verifies if the computed MD5 sum and SHA256 sum are
 // equal to the ones specified when creating the Reader.
-func (r *Reader) Verify() error {
+func (r *Reader) verify() error {
 	if r.sha256Hash != nil && len(r.sha256sum) > 0 {
 		if sum := r.sha256Hash.Sum(nil); !bytes.Equal(r.sha256sum, sum) {
 			return SHA256Mismatch{hex.EncodeToString(r.sha256sum), hex.EncodeToString(sum)}
 		}
 	}
-	if r.md5Hash != nil && len(r.md5sum) > 0 {
-		if sum := r.md5Hash.Sum(nil); !bytes.Equal(r.md5sum, sum) {
-			return BadDigest{hex.EncodeToString(r.md5sum), hex.EncodeToString(sum)}
+
+	if r.md5Hash != nil || len(r.md5Got) > 0 {
+		if len(r.md5Got) == 0 {
+			if r.md5Buffer != nil {
+				r.md5Buffer.Flush()
+			}
+			r.md5Got = r.md5Hash.Sum(nil)
+			r.md5Hash.Close()
+			r.md5Hash = nil
+		}
+		if len(r.md5sum) > 0 {
+			if !bytes.Equal(r.md5sum, r.md5Got) {
+				return BadDigest{hex.EncodeToString(r.md5sum), hex.EncodeToString(r.md5Got)}
+			}
 		}
 	}
 	return nil

--- a/pkg/hash/reader.go
+++ b/pkg/hash/reader.go
@@ -52,8 +52,8 @@ var md5Server = md5simd.NewServer()
 func newMd5(size int64) (md5simd.Hasher, *bufio.Writer) {
 	if true && (size < 0 || size > 32<<10) {
 		h := md5Server.NewHash()
+		// We add a 32 KB buffer
 		return h, bufio.NewWriterSize(h, 32<<10)
-		//return h, nil
 	}
 	return &md5stdWrapper{Hash: md5.New()}, nil
 }

--- a/pkg/hash/reader_test.go
+++ b/pkg/hash/reader_test.go
@@ -30,6 +30,7 @@ func TestHashReaderHelperMethods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer r.Close()
 	_, err = io.Copy(ioutil.Discard, r)
 	if err != nil {
 		t.Fatal(err)
@@ -53,7 +54,7 @@ func TestHashReaderHelperMethods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(r.MD5(), expectedMD5) {
+	if !bytes.Equal(r.md5sum, expectedMD5) {
 		t.Errorf("Expected md5hex \"e2fc714c4727ee9395f324cd2e7f331f\", got %s", r.MD5HexString())
 	}
 	if !bytes.Equal(r.MD5Current(), expectedMD5) {
@@ -111,6 +112,7 @@ func TestHashReaderVerification(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test %d: Initializing reader failed %s", i+1, err)
 		}
+		defer r.Close()
 		_, err = io.Copy(ioutil.Discard, r)
 		if err != nil {
 			if err.Error() != testCase.err.Error() {
@@ -153,8 +155,8 @@ func TestHashReaderInvalidArguments(t *testing.T) {
 			src:         &Reader{src: bytes.NewReader([]byte("abcd"))},
 			size:        4,
 			actualSize:  4,
-			success:     false,
-			expectedErr: errNestedReader,
+			success:     true,
+			expectedErr: nil,
 		},
 		// Expected inputs, NewReader() will succeed.
 		{


### PR DESCRIPTION
# ABANDONED: Slower.

## Description

Biggest change is that `hash.Reader` now implements `io.Closer` and must be closed to release resources.

Chaining is also now allowed and the readers are merged.

However, testing with warp shows significant performance regressions:

Using `warp put --md5 -duration=1m -concurrent=16` against 4 XL servers, 1 drive each.

```
λ warp cmp warp-put-10MB-DISABLED.csv.zst warp-put-10MB-ENABLED2.csv.zst
-------------------
Operation: PUT
Operations: 2694 -> 2492
* Average: -7.40% (-33.1 MiB/s) throughput, -7.40% (-3.3) obj/s
* Fastest: -15.72% (-88.4 MiB/s) throughput, -15.72% (-8.8) obj/s
* 50% Median: -5.77% (-25.6 MiB/s) throughput, -5.77% (-2.6) obj/s
* Slowest: +102.12% (+147.6 MiB/s) throughput, +102.12% (+14.8) obj/s

λ warp cmp warp-put-10MB-DISABLED2.csv.zst warp-put-10MB-ENABLED3.csv.zst
-------------------
Operation: PUT
Operations: 2625 -> 2282
* Average: -13.09% (-57.1 MiB/s) throughput, -13.09% (-5.7) obj/s
* Fastest: -22.22% (-122.0 MiB/s) throughput, -22.22% (-12.2) obj/s
* 50% Median: -12.42% (-54.9 MiB/s) throughput, -12.42% (-5.5) obj/s
* Slowest: +91.84% (+124.6 MiB/s) throughput, +91.84% (+12.5) obj/s
```
However my system is very close to being IO limited.

Running in FS mode paints a clearer picture, 2 runs:

```
λ warp cmp warp-put-FS-DISABLED.csv.zst warp-put-FS-ENABLED.csv.zst
-------------------
Operation: PUT
Operations: 4616 -> 2336
Duration: 1m0s -> 59s
* Average: -49.47% (-380.1 MiB/s) throughput, -49.47% (-38.0) obj/s
* Fastest: -25.56% (-237.3 MiB/s) throughput, -25.56% (-23.7) obj/s
* 50% Median: -55.34% (-427.7 MiB/s) throughput, -55.34% (-42.8) obj/s
* Slowest: -59.37% (-389.8 MiB/s) throughput, -59.37% (-39.0) obj/s

λ warp cmp warp-put-FS-DISABLED2.csv.zst warp-put-FS-ENABLED2.csv.zst
-------------------
Operation: PUT
Operations: 4513 -> 2279
Duration: 1m0s -> 59s
* Average: -49.59% (-372.7 MiB/s) throughput, -49.59% (-37.3) obj/s
* Fastest: -27.42% (-253.8 MiB/s) throughput, -27.42% (-25.4) obj/s
* 50% Median: -54.30% (-409.0 MiB/s) throughput, -54.30% (-40.9) obj/s
* Slowest: -56.70% (-339.3 MiB/s) throughput, -56.70% (-33.9) obj/s
```

With `--concurrent=32`:

```
λ warp cmp warp-put-FS-32C-DISABLED.csv.zst warp-put-FS-32C-ENABLED.csv.zst
-------------------
Operation: PUT
Operations: 4827 -> 3149
* Average: -34.68% (-278.0 MiB/s) throughput, -34.68% (-27.8) obj/s
* Fastest: -21.96% (-211.5 MiB/s) throughput, -21.96% (-21.1) obj/s
* 50% Median: -37.09% (-299.9 MiB/s) throughput, -37.09% (-30.0) obj/s
* Slowest: -43.06% (-276.0 MiB/s) throughput, -43.06% (-27.6) obj/s
```
## How to test this PR?

Upload stuff with MD5.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

