### PR TITLE
fix: requests without bucket should route to the original router

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -679,9 +679,12 @@ func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	bucket, object := request2BucketObjectName(r)
 
-	// ListBucket requests should be handled at current endpoint as
-	// all buckets data can be fetched from here.
-	if r.Method == http.MethodGet && bucket == "" && object == "" {
+	// Requests in federated setups for STS type calls which are
+	// performed at '/' resource should be routed by the muxer,
+	// the assumption is simply such that requests without a bucket
+	// in a federated setup cannot be proxied, so serve them at
+	// current server.
+	if bucket == "" {
 		f.handler.ServeHTTP(w, r)
 		return
 	}


### PR DESCRIPTION

## Description
fix: requests without bucket should route to the original router

## Motivation and Context
requests in federated setups for STS type calls which are
performed at '/' resource should be routed by the muxer, 
the assumption is simply such that requests without a bucket 
in a federated setup cannot be proxied, so serve them at
current server.

## How to test this PR?
```
~  MINIO_ETCD_ENDPOINTS=http://localhost:2379 MINIO_DOMAIN=localhost minio server ~/test
```

and see if `assume-role` works

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
