### PR TITLE
support multiple policies for temporary users

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1649,7 +1649,7 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 	if err == nil {
 		return ErrNone
 	}
-	// Verify if the underlying error is signature mismatch.
+
 	switch err {
 	case errInvalidArgument:
 		apiErr = ErrAdminInvalidArgument


### PR DESCRIPTION
## Description
support multiple policies for temporary users

## Motivation and Context
Fixes #8651

we already concatenate groups/user policies,
all we had to do was honor it.

## How to test this PR?
- set a user with policy
- set a group with policy
- set the user to be part of this group
- generate assume-role with temporary credentials
```
MC_HOST_alias=http://54Q59RGI9M7TCIL0Q2JB:Zs35s75Y+CTlkPz1RnapH3nxwZ3FlwtneofPvBsr:eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiI1NFE1OVJHSTlNN1RDSUwwUTJKQiIsImV4cCI6MzYwMDAwMDAwMDAwMCwicG9saWN5IjoicmVhZHdyaXRlLHJlYWR3cml0ZSJ9.H7FDP2CfX8zGphCT4kTgl2ZEH4Vt7bs-y7Xlm69eEMEYjJaBQKyWB0Tf2KlllEzbyVe6g3YUJJkyOVtXUUR14w@localhost:9000 mc ls alias/testbucket/
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
