### PR TITLE
Use 204 rather than 200 ok

### DIFF
--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -37,7 +37,7 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeResponse(w, http.StatusOK, nil, mimeNone)
+	writeResponse(w, http.StatusNoContent, nil, mimeNone)
 }
 
 // LivenessCheckHandler -- checks if server can reach its disks internally.
@@ -66,7 +66,7 @@ func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 				writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
 				return
 			}
-			writeResponse(w, http.StatusOK, nil, mimeNone)
+			writeResponse(w, http.StatusNoContent, nil, mimeNone)
 			return
 		}
 	}
@@ -96,5 +96,5 @@ func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeResponse(w, http.StatusOK, nil, mimeNone)
+	writeResponse(w, http.StatusNoContent, nil, mimeNone)
 }


### PR DESCRIPTION
## Description

For healthcheck endpoints, return HTTP 204 (no content) rather than HTTP 200.

## Motivation and Context

Use status to show there's no response body

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
