### PR TITLE
Forward RPC errors from crawler

### DIFF
--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -277,7 +277,7 @@ func (f *folderScanner) scanQueuedLevels(ctx context.Context, folders []cachedFo
 			size, err := f.getSize(Item{Path: path.Join(f.root, entName), Typ: typ})
 
 			sleepDuration(time.Since(t), f.dataUsageCrawlMult)
-			if err == errSkipFile {
+			if err == errSkipFile || err == errFileNotFound {
 				return nil
 			}
 			logger.LogIf(ctx, err)

--- a/cmd/fastwalk.go
+++ b/cmd/fastwalk.go
@@ -19,6 +19,9 @@ var errSkipFile = errors.New("fastwalk: skip this file")
 func readDirFn(dirName string, fn func(entName string, typ os.FileMode) error) error {
 	fis, err := readDir(dirName)
 	if err != nil {
+		if os.IsNotExist(err) || err == errFileNotFound {
+			return nil
+		}
 		return err
 	}
 	for _, fi := range fis {

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -473,7 +473,7 @@ func (s *peerRESTServer) DispatchNetOBDInfoHandler(w http.ResponseWriter, r *htt
 	ctx := newContext(r, w, "DispatchNetOBDInfo")
 	info := globalNotificationSys.NetOBDInfo(ctx)
 
-	done()
+	done(nil)
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
 	w.(http.Flusher).Flush()
 }


### PR DESCRIPTION
## Motivation and Context

Sometimes occasional errors are printed:

```
API: SYSTEM()
Time: 21:20:39 UTC 05/06/2020
DeploymentID: ce11fafd-07f8-43f8-80ca-6a0c31e709b8
Error: file not found
       1: cmd/xl-v1.go:349:cmd.xlObjects.crawlAndGetDataUsage.func2()
API: SYSTEM()
Time: 21:20:41 UTC 05/06/2020
DeploymentID: ce11fafd-07f8-43f8-80ca-6a0c31e709b8
Error: dataUsageCache: unknown version: 102
       1: cmd/xl-v1.go:349:cmd.xlObjects.crawlAndGetDataUsage.func2()
```

## Description

The `keepHTTPResponseAlive` would cause errors to be returned with status OK.

Add value `1` for errors and return as error.

Clear out 'file not found' errors from dir walker, since it may be in a folder that has been deleted since it was scanned.

## How to test this PR?

Deploy, run server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
