### PR TITLE
Simplify cast of string to rune slice in wildcard matching

### DIFF
--- a/pkg/wildcard/match.go
+++ b/pkg/wildcard/match.go
@@ -26,16 +26,8 @@ func MatchSimple(pattern, name string) bool {
 	if pattern == "*" {
 		return true
 	}
-	rname := make([]rune, 0, len(name))
-	rpattern := make([]rune, 0, len(pattern))
-	for _, r := range name {
-		rname = append(rname, r)
-	}
-	for _, r := range pattern {
-		rpattern = append(rpattern, r)
-	}
-	simple := true // Does only wildcard '*' match.
-	return deepMatchRune(rname, rpattern, simple)
+	// Does only wildcard '*' match.
+	return deepMatchRune([]rune(name), []rune(pattern), true)
 }
 
 // Match -  finds whether the text matches/satisfies the pattern string.
@@ -49,16 +41,8 @@ func Match(pattern, name string) (matched bool) {
 	if pattern == "*" {
 		return true
 	}
-	rname := make([]rune, 0, len(name))
-	rpattern := make([]rune, 0, len(pattern))
-	for _, r := range name {
-		rname = append(rname, r)
-	}
-	for _, r := range pattern {
-		rpattern = append(rpattern, r)
-	}
-	simple := false // Does extended wildcard '*' and '?' match.
-	return deepMatchRune(rname, rpattern, simple)
+	// Does extended wildcard '*' and '?' match.
+	return deepMatchRune([]rune(name), []rune(pattern), false)
 }
 
 func deepMatchRune(str, pattern []rune, simple bool) bool {


### PR DESCRIPTION
## Description
Simplified `string` -> `[]rune` cast
Just used `[]rune("string")` instead of appending each char to rune slice

## Motivation and Context
Context: needed wildcard match logic, found your repo.
Motivation: make your code a bit simpler

## How to test this PR?
Running existing `TestMatch` and `TestMatchSimple` unit test is enough imo

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
