### PR TITLE
xl: Avoid undoing bucket creation and return the first err instead

### DIFF
--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -150,10 +150,6 @@ func healBucket(ctx context.Context, storageDisks []StorageAPI, bucket string, w
 
 	reducedErr = reduceWriteQuorumErrs(ctx, errs, bucketOpIgnoredErrs, writeQuorum)
 	if reducedErr != nil {
-		if reducedErr == errXLWriteQuorum {
-			// Purge successfully created buckets if we don't have writeQuorum.
-			undoMakeBucket(storageDisks, bucket)
-		}
 		return res, reducedErr
 	}
 

--- a/cmd/xl-v1-healing_test.go
+++ b/cmd/xl-v1-healing_test.go
@@ -25,43 +25,6 @@ import (
 	"github.com/minio/minio/pkg/madmin"
 )
 
-// Tests undoes and validates if the undoing completes successfully.
-func TestUndoMakeBucket(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	nDisks := 16
-	fsDirs, err := getRandomDisks(nDisks)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer removeRoots(fsDirs)
-
-	// Remove format.json on 16 disks.
-	obj, _, err := initObjectLayer(ctx, mustGetZoneEndpoints(fsDirs...))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	bucketName := getRandomBucketName()
-	if err = obj.MakeBucketWithLocation(ctx, bucketName, "", false); err != nil {
-		t.Fatal(err)
-	}
-	z := obj.(*xlZones)
-	xl := z.zones[0].sets[0]
-	undoMakeBucket(xl.getDisks(), bucketName)
-
-	// Validate if bucket was deleted properly.
-	_, err = obj.GetBucketInfo(ctx, bucketName)
-	if err != nil {
-		switch err.(type) {
-		case BucketNotFound:
-		default:
-			t.Fatal(err)
-		}
-	}
-}
-
 func TestHealObjectCorrupted(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Description
Some code starting to delete empty buckets during the startup of the cluster,
*) The code which creates buckets in a newly added zone
*) Heal buckets executed in the startup

The reason is that, undoing bucket creation is called when the bucket creation
fails, but it could easily fail when starting the cluster since not all nodes will
be up quickly.

This commit removes the code which undo bucket creation and returns
an error for any issue while creating a bucket.
 

## Motivation and Context
Avoid trying to  remove empty buckets are removed when the cluster is started

## How to test this PR?
Use 32 nodes, 1 disk per node. Slowly start nodes (one second between each two nodes)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
