### PR TITLE
Fixes broken image preview for anon user

### DIFF
--- a/browser/app/js/objects/PreviewObjectModal.js
+++ b/browser/app/js/objects/PreviewObjectModal.js
@@ -23,7 +23,10 @@ class PreviewObjectModal extends React.Component {
     this.state = {
       url: "",
     }
-    props.getObjectURL(props.object.name, (url) => {
+  }
+
+  componentDidMount() {
+    this.props.getObjectURL(this.props.object.name, (url) => {
       this.setState({
         url: url,
       })


### PR DESCRIPTION
Fixes #9411
Image preview fails when bucket is anonymously accessed on MinIO Browser

## Motivation and Context
Anonymous user is also supposed to be able to preview image objects

## How to test this PR?
Check if both anonymous and authorized users can preview an image object.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
