### PR TITLE
Fix panic when checking if es/nats event target is active

### DIFF
--- a/pkg/event/target/elasticsearch.go
+++ b/pkg/event/target/elasticsearch.go
@@ -103,6 +103,13 @@ func (target *ElasticsearchTarget) IsActive() (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	if target.client == nil {
+		client, err := newClient(target.args)
+		if err != nil {
+			return false, err
+		}
+		target.client = client
+	}
 	_, code, err := target.client.Ping(target.args.URL.String()).HttpHeadOnly(true).Do(ctx)
 	if err != nil {
 		if elastic.IsConnErr(err) || elastic.IsContextErr(err) || xnet.IsNetworkOrHostDown(err) {

--- a/pkg/event/target/nsq.go
+++ b/pkg/event/target/nsq.go
@@ -106,7 +106,7 @@ func (target *NSQTarget) HasQueueStore() bool {
 
 // IsActive - Return true if target is up and active
 func (target *NSQTarget) IsActive() (bool, error) {
-	if target.producer != nil {
+	if target.producer == nil {
 		producer, err := nsq.NewProducer(target.args.NSQDAddress.String(), target.config)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
## Description

Saw a panic when notification targets are offline, and minio help prompt asks to try `mc admin info --json ` to check which targets are offline. Issuing this command gave a crash because the es target client is nil. nats also has a similar issue.
## Motivation and Context

```
API: SYSTEM()
Time: 18:27:56 PDT 05/12/2020
DeploymentID: a0e26cbc-048e-4f81-be50-fba60c333072
Error: Unable to initialize notification target(s): one or more targets are offline. Please use `mc admin info --json` to check the offline targets
       7: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:474:cmd.lookupConfigs()
       6: /home/kp/code/src/github.com/minio/minio/cmd/config-current.go:594:cmd.loadConfig()
       5: /home/kp/code/src/github.com/minio/minio/cmd/config.go:251:cmd.initConfig()
       4: /home/kp/code/src/github.com/minio/minio/cmd/config.go:211:cmd.(*ConfigSys).Init()
       3: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:308:cmd.initAllSubsystems()
       2: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:233:cmd.initSafeMode()
       1: /home/kp/code/src/github.com/minio/minio/cmd/server-main.go:524:cmd.serverMain()
Server startup failed with 'Unable to initialize sub-systems: Unable to initialize lifecycle system: The TagKey you have provided is invalid'
Server switching to safe mode
Please use 'mc admin config' commands fix this issue
Endpoint:  http://10.0.0.224:9000  http://172.17.0.1:9000  http://172.23.0.1:9000  http://192.168.122.1:9000  http://127.0.0.1:9000          
AccessKey: minio 
SecretKey: minio123 
Region:    us-east-1

Command-line Access: https://docs.min.io/docs/minio-admin-complete-guide.html
   $ mc config host add myminio http://10.0.0.224:9000 minio minio123 --api s3v4
2020/05/12 18:28:39 http: panic serving 127.0.0.1:45968: runtime error: invalid memory address or nil pointer dereference
goroutine 2403 [running]:
net/http.(*conn).serve.func1(0xc000596000)
	/usr/local/go/src/net/http/server.go:1767 +0x139
panic(0x1968f20, 0x3298790)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/minio/minio/cmd.criticalErrorHandler.ServeHTTP.func1(0xc0001df400, 0x1fd2480, 0xc0003820e0)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:788 +0x192
panic(0x1968f20, 0x3298790)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
sync.(*RWMutex).RLock(...)
	/usr/local/go/src/sync/rwmutex.go:48
gopkg.in/olivere/elastic%2ev5.(*PingService).Do(0xc000a6b9e8, 0x1fda680, 0xc0002e8a80, 0x0, 0x0, 0x0, 0x0)
	/home/kp/go/pkg/mod/gopkg.in/olivere/elastic.v5@v5.0.80/ping.go:76 +0x65
github.com/minio/minio/pkg/event/target.(*ElasticsearchTarget).IsActive(0xc00036b700, 0xc000850e00, 0x0, 0x0)
	/home/kp/code/src/github.com/minio/minio/pkg/event/target/elasticsearch.go:106 +0x1c7
github.com/minio/minio/cmd.fetchLambdaInfo(0xc00040c210, 0x0, 0x0, 0x0)
	/home/kp/code/src/github.com/minio/minio/cmd/admin-handlers.go:1536 +0x26d
github.com/minio/minio/cmd.adminAPIHandlers.ServerInfoHandler(0x1fd0080, 0xc0005961e0, 0xc0001df700)
	/home/kp/code/src/github.com/minio/minio/cmd/admin-handlers.go:1410 +0x37a
```

## How to test this PR?
Enable event target with es/nats for a bucket in minio, then disconnect from the target. Restarting minio should take it to safe mode. Then issue a `mc admin info --json myminio` , should see a panic with master but not with this PR

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) Seems #9332 is introducing error with nats target. 
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
