### PR TITLE
update KMS guide to reflect latest KES changes

### DIFF
--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -368,8 +368,8 @@ MinIO identity and the KES CLI.
 
 In a new terminal window become the MinIO identity via:
 ```
-export KES_CLIENT_TLS_KEY_FILE=minio.key
-export KES_CLIENT_TLS_CERT_FILE=minio.cert
+export KES_CLIENT_KEY=minio.key
+export KES_CLIENT_CERT=minio.cert
 ```
 
 Then create the master key by running:


### PR DESCRIPTION
## Description
This commit updates the two client env. variables:
```
KES_CLIENT_TLS_KEY_FILE
KES_CLIENT_TLS_CERT_FILE
```

The KES CLI client expects the client key and certificate
as `KES_CLIENT_KEY` resp. `KES_CLIENT_CERT`.

## Motivation and Context
KMS, docs - See also minio/kes#50

## How to test this PR?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
