### PR TITLE
[WIP] Group healing new disks features in one place

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -678,11 +678,6 @@ func (h *healSequence) queueHealTask(source healSource, healType madmin.HealItem
 }
 
 func (h *healSequence) healItemsFromSourceCh() error {
-	bucketsOnly := true // heal buckets only, not objects.
-	if err := h.healItems(bucketsOnly); err != nil {
-		logger.LogIf(h.ctx, err)
-	}
-
 	for {
 		select {
 		case source, ok := <-h.sourceCh:


### PR DESCRIPTION
## Description
Reformatting disks, healing .minio.sys objects.. and recreating
buckets (e.g. after a bucket expansion) is all moved in the
background heal of new disks code.

The functional change in this is that healing will only happen
when *all* nodes are online.

Another function change is that there will be one leader node
which will coordinate this (healing new disks).

## Motivation and Context
Fix some use case where healing background disks is not executed

## How to test this PR?
*) Change healing new disks interval
```diff
diff --git a/cmd/background-newdisks-heal-ops.go b/cmd/background-newdisks-heal-ops.go
index 3ef8b26f..d6a589b7 100644
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -24,7 +24,7 @@ import (
        "github.com/minio/minio/pkg/madmin"
 )
 
-const defaultMonitorNewDiskInterval = time.Minute * 10
+const defaultMonitorNewDiskInterval = time.Minute * 1
 
 func initDisksAutoHeal(ctx context.Context, objAPI ObjectLayer) {
        go monitorDisksAndHeal(ctx, objAPI)
```

and compile

2. Start a distributed setup of 4 nodes (one node, one disk)
3. Create a bucket and upload an object
4. Kill one minio instance, remove the content of one backend disk
5. Start the cluster again
6. See if the new backend disk is formatted, wait one minute to see if bucket and object are healed




## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
