### PR TITLE
tests: Fix one multi-delete test failure in Windows CI

### DIFF
--- a/cmd/os-reliable.go
+++ b/cmd/os-reliable.go
@@ -131,7 +131,11 @@ func renameAll(srcFilePath, dstFilePath string) (err error) {
 
 	if err = reliableRename(srcFilePath, dstFilePath); err != nil {
 		switch {
-		case isSysErrNotDir(err):
+		case isSysErrNotDir(err) && !os.IsNotExist(err):
+			// Windows can have both isSysErrNotDir(err) and os.IsNotExist(err) returning
+			// true if the source file path contains an inexistant directory. In that case,
+			// we want to return errFileNotFound instead, which will honored in subsequent
+			// switch cases
 			return errFileAccessDenied
 		case isSysErrPathNotFound(err):
 			// This is a special case should be handled only for

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -28,7 +28,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -121,9 +120,6 @@ func runAllTests(suite *TestSuiteCommon, c *check) {
 }
 
 func TestServerSuite(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("cannot set up server reliably on Windows")
-	}
 	testCases := []*TestSuiteCommon{
 		// Init and run test on FS backend with signature v4.
 		{serverType: "FS", signer: signerV4},


### PR DESCRIPTION
## Description
There is a disparency of behavior under Linux & Windows about
the returned error when trying to rename a non existant path.

err := os.Rename("/path/does/not/exist", "/tmp/copy")

Linux:
  isSysErrNotDir(err) = false
  os.IsNotExist(err) = true

Windows:
  isSysErrNotDir(err) = true
  os.IsNotExist(err) = true

ENOTDIR in Linux is returned when the destination path
of the rename call contains a file in one of the middle
segments of the path (e.g. /tmp/file/dst, where /tmp/file
is an actual file not a directory)

However, as shown above, Windows has more scenarios when
it returns ENOTDIR. For example, when the source path contains
an inexistant directory in its path.

In that case, we want errFileNotFound returned and not
errFileAccessDenied, so this commit will add a further check to close
the disparency between Windows & Linux.

## Motivation and Context
Fix one test failure under Windows

## How to test this PR?
go test under Windows

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
