### PR TITLE
Do not add quotes around etag, if already present

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -601,7 +601,7 @@ func (l *s3Objects) CompleteMultipartUpload(ctx context.Context, bucket string, 
 		return oi, minio.ErrorRespToObjectError(err, bucket, object)
 	}
 
-	return minio.ObjectInfo{Bucket: bucket, Name: object, ETag: etag}, nil
+	return minio.ObjectInfo{Bucket: bucket, Name: object, ETag: strings.Trim(etag, "\"")}, nil
 }
 
 // SetBucketPolicy sets policy on bucket


### PR DESCRIPTION
## Description
ETag returned from Complete multipart upload in the case of S3 Gateway had two double quote characters before the actual tag. Adding a fix to trim the quote returned by the backend s3.

## Motivation and Context
An aws cli functional test was failing etag match because of this bug.

## How to test this PR?
```
AWS_ACCESS_KEY_ID=minio AWS_SECRET_ACCESS_KEY=minio123 aws --endpoint-url http://localhost:9000 s3api create-multipart-upload --bucket mybucket --key object

AWS_ACCESS_KEY_ID=minio AWS_SECRET_ACCESS_KEY=minio123 aws --endpoint-url http://localhost:9000 s3api upload-part --bucket mybucket --key object --body /tmp/0b --upload-id 7277606d-7e7c-4342-b2c7-e0e066c2ed19 --part-number 1


AWS_ACCESS_KEY_ID=minio AWS_SECRET_ACCESS_KEY=minio123 aws --endpoint-url http://localhost:9001 s3api complete-multipart-upload --multipart-upload file:///tmp/multipart --bucket mybucket --key object --upload-id 7277606d-7e7c-4342-b2c7-e0e066c2ed19

AWS_ACCESS_KEY_ID=minio AWS_SECRET_ACCESS_KEY=minio123 aws --endpoint-url http://localhost:9000 s3api head-object --bucket mybucket --key object
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
