### PR TITLE
Relax validation when loading lifecycle document from the backend

### DIFF
--- a/cmd/bucket-lifecycle-handler.go
+++ b/cmd/bucket-lifecycle-handler.go
@@ -72,6 +72,12 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 		return
 	}
 
+	// Validate the received bucket policy document
+	if err = bucketLifecycle.Validate(); err != nil {
+		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+		return
+	}
+
 	if err = objAPI.SetBucketLifecycle(ctx, bucket, bucketLifecycle); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"sync"
 
+	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/bucket/lifecycle"
 )
 
@@ -148,9 +149,15 @@ func (sys *LifecycleSys) load(buckets []BucketInfo, objAPI ObjectLayer) error {
 			return err
 		}
 
+		// Do not load the lifecycle configuration if it is not valid
+		err = config.Validate()
+		if err != nil {
+			logger.LogIf(context.Background(), err)
+			continue
+		}
+
 		sys.Set(bucket.Name, config)
 	}
-
 	return nil
 }
 

--- a/pkg/bucket/lifecycle/and.go
+++ b/pkg/bucket/lifecycle/and.go
@@ -18,15 +18,13 @@ package lifecycle
 
 import (
 	"encoding/xml"
-
-	"github.com/minio/minio-go/v6/pkg/tags"
 )
 
 // And - a tag to combine a prefix and multiple tags for lifecycle configuration rule.
 type And struct {
-	XMLName xml.Name   `xml:"And"`
-	Prefix  string     `xml:"Prefix,omitempty"`
-	Tags    []tags.Tag `xml:"Tag,omitempty"`
+	XMLName xml.Name `xml:"And"`
+	Prefix  string   `xml:"Prefix,omitempty"`
+	Tags    []Tag    `xml:"Tag,omitempty"`
 }
 
 var errDuplicateTagKey = Errorf("Duplicate Tag Keys are not allowed")

--- a/pkg/bucket/lifecycle/filter.go
+++ b/pkg/bucket/lifecycle/filter.go
@@ -18,8 +18,6 @@ package lifecycle
 
 import (
 	"encoding/xml"
-
-	"github.com/minio/minio-go/v6/pkg/tags"
 )
 
 var (
@@ -31,7 +29,7 @@ type Filter struct {
 	XMLName xml.Name `xml:"Filter"`
 	Prefix  string
 	And     And
-	Tag     tags.Tag
+	Tag     Tag
 }
 
 // MarshalXML - produces the xml representation of the Filter struct

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -57,9 +57,6 @@ func ParseLifecycleConfig(reader io.Reader) (*Lifecycle, error) {
 	if err := xml.NewDecoder(reader).Decode(&lc); err != nil {
 		return nil, err
 	}
-	if err := lc.Validate(); err != nil {
-		return nil, err
-	}
 	return &lc, nil
 }
 

--- a/pkg/bucket/lifecycle/tag.go
+++ b/pkg/bucket/lifecycle/tag.go
@@ -18,6 +18,7 @@ package lifecycle
 
 import (
 	"encoding/xml"
+	"unicode/utf8"
 )
 
 // Tag - a tag for a lifecycle configuration Rule filter.
@@ -27,15 +28,29 @@ type Tag struct {
 	Value   string   `xml:"Value,omitempty"`
 }
 
-var errTagUnsupported = Errorf("Specifying <Tag></Tag> is not supported")
+var (
+	errInvalidTagKey   = Errorf("The TagKey you have provided is invalid")
+	errInvalidTagValue = Errorf("The TagValue you have provided is invalid")
+)
 
-// UnmarshalXML is extended to indicate lack of support for Tag
-// xml tag in object lifecycle configuration
-func (t Tag) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	return errTagUnsupported
+func (tag Tag) String() string {
+	return tag.Key + "=" + tag.Value
 }
 
-// MarshalXML is extended to leave out <Tag></Tag> tags
-func (t Tag) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+// IsEmpty returns whether this tag is empty or not.
+func (tag Tag) IsEmpty() bool {
+	return tag.Key == ""
+}
+
+// Validate checks this tag.
+func (tag Tag) Validate() error {
+	if len(tag.Key) == 0 || utf8.RuneCountInString(tag.Key) > 128 {
+		return errInvalidTagKey
+	}
+
+	if utf8.RuneCountInString(tag.Value) > 256 {
+		return errInvalidTagValue
+	}
+
 	return nil
 }


### PR DESCRIPTION
This PR depends on https://github.com/minio/minio-go/pull/1289

## Description
Some deployments contain empty key in Tag field of the bucket lifecycle configuration.

Before supporting tagging, it was not a problem having Tag field in the bucket lifecycle document, but now since tagging is supported, we validate the Tag key and we require from it to be not empty.

This is causing migration issue in some deployments.

This PR relaxes the validation during loading from the disk. Bucket life-cycle documents which are not valid are not taken in consideration, but it won't stop the server from starting.

## Motivation and Context
Fixes https://github.com/minio/minio/issues/9609


## How to test this PR?




## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
