### PR TITLE
enable full linter across the codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+linters-settings:
+  golint:
+    min-confidence: 0
+
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - typecheck
+    - goimports
+    - misspell
+    - govet
+    - golint
+    - ineffassign
+    - gosimple
+    - deadcode
+    - structcheck
+
+issues:
+  exclude-use-default: false
+  exclude:
+      - should have a package comment
+      - error strings should not be capitalized or end with punctuation or a newline
+service:
+  golangci-lint-version: 1.20.0 # use the fixed version to not introduce new linters unexpectedly

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1185,7 +1185,7 @@ func (a adminAPIHandlers) OBDInfoHandler(w http.ResponseWriter, r *http.Request)
 		defer close(obdInfoCh)
 
 		if cpu, ok := vars["syscpu"]; ok && cpu == "true" {
-			cpuInfo := getLocalCPUOBDInfo(deadlinedCtx)
+			cpuInfo := getLocalCPUOBDInfo(deadlinedCtx, r)
 
 			obdInfo.Sys.CPUInfo = append(obdInfo.Sys.CPUInfo, cpuInfo)
 			obdInfo.Sys.CPUInfo = append(obdInfo.Sys.CPUInfo, globalNotificationSys.CPUOBDInfo(deadlinedCtx)...)
@@ -1193,7 +1193,7 @@ func (a adminAPIHandlers) OBDInfoHandler(w http.ResponseWriter, r *http.Request)
 		}
 
 		if diskHw, ok := vars["sysdiskhw"]; ok && diskHw == "true" {
-			diskHwInfo := getLocalDiskHwOBD(deadlinedCtx)
+			diskHwInfo := getLocalDiskHwOBD(deadlinedCtx, r)
 
 			obdInfo.Sys.DiskHwInfo = append(obdInfo.Sys.DiskHwInfo, diskHwInfo)
 			obdInfo.Sys.DiskHwInfo = append(obdInfo.Sys.DiskHwInfo, globalNotificationSys.DiskHwOBDInfo(deadlinedCtx)...)
@@ -1201,7 +1201,7 @@ func (a adminAPIHandlers) OBDInfoHandler(w http.ResponseWriter, r *http.Request)
 		}
 
 		if osInfo, ok := vars["sysosinfo"]; ok && osInfo == "true" {
-			osInfo := getLocalOsInfoOBD(deadlinedCtx)
+			osInfo := getLocalOsInfoOBD(deadlinedCtx, r)
 
 			obdInfo.Sys.OsInfo = append(obdInfo.Sys.OsInfo, osInfo)
 			obdInfo.Sys.OsInfo = append(obdInfo.Sys.OsInfo, globalNotificationSys.OsOBDInfo(deadlinedCtx)...)
@@ -1209,7 +1209,7 @@ func (a adminAPIHandlers) OBDInfoHandler(w http.ResponseWriter, r *http.Request)
 		}
 
 		if mem, ok := vars["sysmem"]; ok && mem == "true" {
-			memInfo := getLocalMemOBD(deadlinedCtx)
+			memInfo := getLocalMemOBD(deadlinedCtx, r)
 
 			obdInfo.Sys.MemInfo = append(obdInfo.Sys.MemInfo, memInfo)
 			obdInfo.Sys.MemInfo = append(obdInfo.Sys.MemInfo, globalNotificationSys.MemOBDInfo(deadlinedCtx)...)
@@ -1217,7 +1217,7 @@ func (a adminAPIHandlers) OBDInfoHandler(w http.ResponseWriter, r *http.Request)
 		}
 
 		if proc, ok := vars["sysprocess"]; ok && proc == "true" {
-			procInfo := getLocalProcOBD(deadlinedCtx)
+			procInfo := getLocalProcOBD(deadlinedCtx, r)
 
 			obdInfo.Sys.ProcInfo = append(obdInfo.Sys.ProcInfo, procInfo)
 			obdInfo.Sys.ProcInfo = append(obdInfo.Sys.ProcInfo, globalNotificationSys.ProcOBDInfo(deadlinedCtx)...)
@@ -1321,7 +1321,6 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 		usage = madmin.Usage{Size: dataUsageInfo.ObjectsTotalSize}
 	}
 
-	infoMsg := madmin.InfoMessage{}
 	vault := fetchVaultStatus(cfg)
 
 	ldap := madmin.LDAP{}
@@ -1426,7 +1425,7 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 		Notifications: notifyTarget,
 	}
 
-	infoMsg = madmin.InfoMessage{
+	infoMsg := madmin.InfoMessage{
 		Mode:         mode,
 		Domain:       domain,
 		Region:       globalServerRegion,

--- a/cmd/bucket-quota.go
+++ b/cmd/bucket-quota.go
@@ -211,7 +211,7 @@ func enforceFIFOQuota(ctx context.Context, objectAPI ObjectLayer) error {
 		if dataUsageInfo.BucketsSizes[bucket] > cfg.Quota {
 			toFree = dataUsageInfo.BucketsSizes[bucket] - cfg.Quota
 		}
-		if toFree <= 0 {
+		if toFree == 0 {
 			continue
 		}
 		// Allocate new results channel to receive ObjectInfo.

--- a/cmd/config/etcd/dns/types.go
+++ b/cmd/config/etcd/dns/types.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	defaultTTL            = 30
-	defaultPrefixPath     = "/skydns"
 	defaultContextTimeout = 5 * time.Minute
 )
 

--- a/cmd/config/identity/openid/ecdsa-sha3.go
+++ b/cmd/config/identity/openid/ecdsa-sha3.go
@@ -18,7 +18,9 @@ package openid
 
 import (
 	"crypto"
+
 	"github.com/dgrijalva/jwt-go"
+
 	// Needed for SHA3 to work - See: https://golang.org/src/crypto/crypto.go?s=1034:1288
 	_ "golang.org/x/crypto/sha3"
 )

--- a/cmd/config/identity/openid/jwt.go
+++ b/cmd/config/identity/openid/jwt.go
@@ -30,7 +30,7 @@ import (
 	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/env"
-	"github.com/minio/minio/pkg/iam/policy"
+	iampolicy "github.com/minio/minio/pkg/iam/policy"
 	xnet "github.com/minio/minio/pkg/net"
 )
 

--- a/cmd/config/identity/openid/rsa-sha3.go
+++ b/cmd/config/identity/openid/rsa-sha3.go
@@ -18,7 +18,9 @@ package openid
 
 import (
 	"crypto"
+
 	"github.com/dgrijalva/jwt-go"
+
 	// Needed for SHA3 to work - See: https://golang.org/src/crypto/crypto.go?s=1034:1288
 	_ "golang.org/x/crypto/sha3"
 )

--- a/cmd/config/notify/parse.go
+++ b/cmd/config/notify/parse.go
@@ -36,7 +36,6 @@ import (
 
 const (
 	formatNamespace = "namespace"
-	formatAccess    = "access"
 )
 
 // ErrTargetsOffline - Indicates single/multiple target failures.

--- a/cmd/disk-cache-utils.go
+++ b/cmd/disk-cache-utils.go
@@ -358,7 +358,7 @@ func (f *fileScorer) adjustSaveBytes(n int64) bool {
 	} else {
 		f.saveBytes += uint64(n)
 	}
-	if f.saveBytes <= 0 {
+	if f.saveBytes == 0 {
 		f.queue.Init()
 		f.saveBytes = 0
 		return false

--- a/cmd/format-xl.go
+++ b/cmd/format-xl.go
@@ -204,7 +204,7 @@ func formatXLMigrate(export string) error {
 			return err
 		}
 		// Migrate successful v2 => v3, v3 is latest
-		version = formatXLVersionV3
+		// version = formatXLVersionV3
 		fallthrough
 	case formatXLVersionV3:
 		// v3 is the latest version, return.

--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -899,16 +899,20 @@ func (l *gcsGateway) GetObjectInfo(ctx context.Context, bucket string, object st
 func (l *gcsGateway) PutObject(ctx context.Context, bucket string, key string, r *minio.PutObjReader, opts minio.ObjectOptions) (minio.ObjectInfo, error) {
 	data := r.Reader
 
+	nctx, cancel := context.WithCancel(ctx)
+
+	defer cancel()
+
 	// if we want to mimic S3 behavior exactly, we need to verify if bucket exists first,
 	// otherwise gcs will just return object not exist in case of non-existing bucket
-	if _, err := l.client.Bucket(bucket).Attrs(ctx); err != nil {
+	if _, err := l.client.Bucket(bucket).Attrs(nctx); err != nil {
 		logger.LogIf(ctx, err, logger.Application)
 		return minio.ObjectInfo{}, gcsToObjectError(err, bucket)
 	}
 
 	object := l.client.Bucket(bucket).Object(key)
 
-	w := object.NewWriter(ctx)
+	w := object.NewWriter(nctx)
 
 	// Disable "chunked" uploading in GCS client if the size of the data to be uploaded is below
 	// the current chunk-size of the writer. This avoids an unnecessary memory allocation.
@@ -919,7 +923,6 @@ func (l *gcsGateway) PutObject(ctx context.Context, bucket string, key string, r
 
 	if _, err := io.Copy(w, data); err != nil {
 		// Close the object writer upon error.
-		w.CloseWithError(err)
 		logger.LogIf(ctx, err)
 		return minio.ObjectInfo{}, gcsToObjectError(err, bucket, key)
 	}

--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -642,7 +642,6 @@ func (l *s3EncObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 	for {
 		loi, lerr := l.s3Objects.ListObjectsV2(ctx, bucket, uploadPrefix, continuationToken, delimiter, 1000, false, startAfter)
 		if lerr != nil {
-			done = true
 			break
 		}
 		for _, obj := range loi.Objects {

--- a/cmd/metrics-router.go
+++ b/cmd/metrics-router.go
@@ -48,6 +48,8 @@ func registerMetricsRouter(router *mux.Router) {
 	switch prometheusAuthType(authType) {
 	case prometheusPublic:
 		metricsRouter.Handle(prometheusMetricsPath, metricsHandler())
+	case prometheusJWT:
+		fallthrough
 	default:
 		metricsRouter.Handle(prometheusMetricsPath, AuthMiddleware(metricsHandler()))
 	}

--- a/cmd/obdinfo.go
+++ b/cmd/obdinfo.go
@@ -32,12 +32,10 @@ import (
 	"github.com/shirou/gopsutil/process"
 )
 
-func getLocalCPUOBDInfo(ctx context.Context) madmin.ServerCPUOBDInfo {
-	addr := ""
+func getLocalCPUOBDInfo(ctx context.Context, r *http.Request) madmin.ServerCPUOBDInfo {
+	addr := r.Host
 	if globalIsDistXL {
 		addr = GetLocalPeer(globalEndpoints)
-	} else {
-		addr = "minio"
 	}
 
 	info, err := cpuhw.InfoWithContext(ctx)
@@ -60,16 +58,15 @@ func getLocalCPUOBDInfo(ctx context.Context) madmin.ServerCPUOBDInfo {
 		Addr:     addr,
 		CPUStat:  info,
 		TimeStat: time,
-		Error:    "",
 	}
 
 }
 
 func getLocalDrivesOBD(ctx context.Context, parallel bool, endpointZones EndpointZones, r *http.Request) madmin.ServerDrivesOBDInfo {
 	var drivesOBDInfo []madmin.DriveOBDInfo
-	wg := sync.WaitGroup{}
+	var wg sync.WaitGroup
 	for _, ep := range endpointZones {
-		for i, endpoint := range ep.Endpoints {
+		for _, endpoint := range ep.Endpoints {
 			// Only proceed for local endpoints
 			if endpoint.IsLocal {
 				if _, err := os.Stat(endpoint.Path); err != nil {
@@ -81,34 +78,34 @@ func getLocalDrivesOBD(ctx context.Context, parallel bool, endpointZones Endpoin
 					continue
 				}
 				measurePath := pathJoin(minioMetaTmpBucket, mustGetUUID())
-				measure := func(index int, path string) {
-					var driveOBDInfo madmin.DriveOBDInfo
+				measure := func(path string) {
+					defer wg.Done()
+					driveOBDInfo := madmin.DriveOBDInfo{
+						Path: path,
+					}
 					latency, throughput, err := disk.GetOBDInfo(ctx, path, pathJoin(path, measurePath))
 					if err != nil {
 						driveOBDInfo.Error = err.Error()
+					} else {
+						driveOBDInfo.Latency = latency
+						driveOBDInfo.Throughput = throughput
 					}
-					driveOBDInfo.Path = path
-					driveOBDInfo.Latency = latency
-					driveOBDInfo.Throughput = throughput
 					drivesOBDInfo = append(drivesOBDInfo, driveOBDInfo)
-					wg.Done()
 				}
 				wg.Add(1)
 
 				if parallel {
-					go measure(i, endpoint.Path)
+					go measure(endpoint.Path)
 				} else {
-					measure(i, endpoint.Path)
+					measure(endpoint.Path)
 				}
 			}
 		}
 	}
 	wg.Wait()
-	addr := ""
+	addr := r.Host
 	if globalIsDistXL {
 		addr = GetLocalPeer(endpointZones)
-	} else {
-		addr = "minio"
 	}
 	if parallel {
 		return madmin.ServerDrivesOBDInfo{
@@ -122,12 +119,10 @@ func getLocalDrivesOBD(ctx context.Context, parallel bool, endpointZones Endpoin
 	}
 }
 
-func getLocalMemOBD(ctx context.Context) madmin.ServerMemOBDInfo {
-	addr := ""
+func getLocalMemOBD(ctx context.Context, r *http.Request) madmin.ServerMemOBDInfo {
+	addr := r.Host
 	if globalIsDistXL {
 		addr = GetLocalPeer(globalEndpoints)
-	} else {
-		addr = "minio"
 	}
 
 	swap, err := memhw.SwapMemoryWithContext(ctx)
@@ -150,16 +145,13 @@ func getLocalMemOBD(ctx context.Context) madmin.ServerMemOBDInfo {
 		Addr:       addr,
 		SwapMem:    swap,
 		VirtualMem: vm,
-		Error:      "",
 	}
 }
 
-func getLocalProcOBD(ctx context.Context) madmin.ServerProcOBDInfo {
-	addr := ""
+func getLocalProcOBD(ctx context.Context, r *http.Request) madmin.ServerProcOBDInfo {
+	addr := r.Host
 	if globalIsDistXL {
 		addr = GetLocalPeer(globalEndpoints)
-	} else {
-		addr = "minio"
 	}
 
 	errProcInfo := func(err error) madmin.ServerProcOBDInfo {
@@ -374,16 +366,13 @@ func getLocalProcOBD(ctx context.Context) madmin.ServerProcOBDInfo {
 	return madmin.ServerProcOBDInfo{
 		Addr:      addr,
 		Processes: sysProcs,
-		Error:     "",
 	}
 }
 
-func getLocalOsInfoOBD(ctx context.Context) madmin.ServerOsOBDInfo {
-	addr := ""
+func getLocalOsInfoOBD(ctx context.Context, r *http.Request) madmin.ServerOsOBDInfo {
+	addr := r.Host
 	if globalIsDistXL {
 		addr = GetLocalPeer(globalEndpoints)
-	} else {
-		addr = "minio"
 	}
 
 	info, err := host.InfoWithContext(ctx)
@@ -410,6 +399,5 @@ func getLocalOsInfoOBD(ctx context.Context) madmin.ServerOsOBDInfo {
 		Info:    info,
 		Sensors: sensors,
 		Users:   users,
-		Error:   "",
 	}
 }

--- a/cmd/obdinfo_freebsd.go
+++ b/cmd/obdinfo_freebsd.go
@@ -19,16 +19,15 @@ package cmd
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/minio/minio/pkg/madmin"
 )
 
-func getLocalDiskHwOBD(ctx context.Context) madmin.ServerDiskHwOBDInfo {
-	addr := ""
+func getLocalDiskHwOBD(ctx context.Context, r *http.Request) madmin.ServerDiskHwOBDInfo {
+	addr := r.Host
 	if globalIsDistXL {
 		addr = GetLocalPeer(globalEndpoints)
-	} else {
-		addr = "minio"
 	}
 
 	return madmin.ServerDiskHwOBDInfo{

--- a/cmd/obdinfo_other.go
+++ b/cmd/obdinfo_other.go
@@ -21,18 +21,17 @@ package cmd
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/minio/minio/pkg/madmin"
 	diskhw "github.com/shirou/gopsutil/disk"
 )
 
-func getLocalDiskHwOBD(ctx context.Context) madmin.ServerDiskHwOBDInfo {
-	addr := ""
+func getLocalDiskHwOBD(ctx context.Context, r *http.Request) madmin.ServerDiskHwOBDInfo {
+	addr := r.Host
 	if globalIsDistXL {
 		addr = GetLocalPeer(globalEndpoints)
-	} else {
-		addr = "minio"
 	}
 
 	partitions, err := diskhw.PartitionsWithContext(ctx, true)

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -534,7 +534,7 @@ func (client *peerRESTClient) cycleServerBloomFilter(ctx context.Context, req bl
 	if err != nil {
 		return nil, err
 	}
-	respBody, err := client.call(peerRESTMethodCycleBloom, nil, &reader, -1)
+	respBody, err := client.callWithContext(ctx, peerRESTMethodCycleBloom, nil, &reader, -1)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -493,9 +493,10 @@ func (s *peerRESTServer) CPUOBDInfoHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	ctx, cancel := context.WithCancel(newContext(r, w, "CpuOBDInfo"))
+	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	info := getLocalCPUOBDInfo(ctx)
+
+	info := getLocalCPUOBDInfo(ctx, r)
 
 	defer w.(http.Flusher).Flush()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
@@ -508,9 +509,10 @@ func (s *peerRESTServer) DiskHwOBDInfoHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	ctx, cancel := context.WithCancel(newContext(r, w, "DiskHwOBDInfo"))
+	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	info := getLocalDiskHwOBD(ctx)
+
+	info := getLocalDiskHwOBD(ctx, r)
 
 	defer w.(http.Flusher).Flush()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
@@ -523,9 +525,10 @@ func (s *peerRESTServer) OsOBDInfoHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	ctx, cancel := context.WithCancel(newContext(r, w, "OsOBDInfo"))
+	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	info := getLocalOsInfoOBD(ctx)
+
+	info := getLocalOsInfoOBD(ctx, r)
 
 	defer w.(http.Flusher).Flush()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
@@ -538,9 +541,10 @@ func (s *peerRESTServer) ProcOBDInfoHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	ctx, cancel := context.WithCancel(newContext(r, w, "ProcOBDInfo"))
+	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	info := getLocalProcOBD(ctx)
+
+	info := getLocalProcOBD(ctx, r)
 
 	defer w.(http.Flusher).Flush()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
@@ -553,9 +557,10 @@ func (s *peerRESTServer) MemOBDInfoHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	ctx, cancel := context.WithCancel(newContext(r, w, "MemOBDInfo"))
+	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	info := getLocalMemOBD(ctx)
+
+	info := getLocalMemOBD(ctx, r)
 
 	defer w.(http.Flusher).Flush()
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -630,18 +630,17 @@ func TestPosixStatVol(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		var volInfo VolInfo
 		if _, ok := posixStorage.(*posixDiskIDCheck); !ok {
 			t.Errorf("Expected the StorageAPI to be of type *posix")
 		}
-		volInfo, err = posixStorage.StatVol(testCase.volName)
+		volInfo, err := posixStorage.StatVol(testCase.volName)
 		if err != testCase.expectedErr {
 			t.Fatalf("TestPosix case : %d, Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
 		}
 
 		if err == nil {
-			if volInfo.Name != volInfo.Name {
-				t.Errorf("TestPosix case %d: Expected the volume name to be \"%s\", instead found \"%s\"", i+1, volInfo.Name, volInfo.Name)
+			if volInfo.Name != testCase.volName {
+				t.Errorf("TestPosix case %d: Expected the volume name to be \"%s\", instead found \"%s\"", i+1, volInfo.Name, testCase.volName)
 			}
 		}
 	}

--- a/cmd/post-policy_test.go
+++ b/cmd/post-policy_test.go
@@ -494,8 +494,8 @@ func testPostPolicyBucketHandlerRedirect(obj ObjectLayer, instanceType string, t
 	expectedLocation := redirectURL.String()
 
 	// Check the new location url
-	if rec.HeaderMap.Get("Location") != expectedLocation {
-		t.Errorf("Unexpected location, expected = %s, found = `%s`", rec.HeaderMap.Get("Location"), expectedLocation)
+	if rec.Header().Get("Location") != expectedLocation {
+		t.Errorf("Unexpected location, expected = %s, found = `%s`", rec.Header().Get("Location"), expectedLocation)
 	}
 
 }

--- a/cmd/sts-errors.go
+++ b/cmd/sts-errors.go
@@ -45,12 +45,12 @@ func writeSTSErrorResponse(ctx context.Context, w http.ResponseWriter, errCode S
 	if errCtxt != nil {
 		stsErrorResponse.Error.Message = fmt.Sprintf("%v", errCtxt)
 	}
-	logKind := logger.All
+	var logKind logger.Kind
 	switch errCode {
 	case ErrSTSInternalError, ErrSTSNotInitialized:
 		logKind = logger.Minio
 	default:
-		logKind = logger.Application
+		logKind = logger.All
 	}
 	logger.LogIf(ctx, errCtxt, logKind)
 	encodedErrorResponse := encodeResponse(stsErrorResponse)

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -2425,11 +2425,16 @@ func uploadTestObject(t *testing.T, apiRouter http.Handler, creds auth.Credentia
 			rec = httptest.NewRecorder()
 			apiRouter.ServeHTTP(rec, req)
 			checkRespErr(rec, http.StatusOK)
-			etag := rec.Header()["ETag"][0]
-			if etag == "" {
-				t.Fatalf("Unexpected empty etag")
+			header := rec.Header()
+			if v, ok := header["ETag"]; ok {
+				etag := v[0]
+				if etag == "" {
+					t.Fatalf("Unexpected empty etag")
+				}
+				cp = append(cp, CompletePart{partID, etag[1 : len(etag)-1]})
+			} else {
+				t.Fatalf("Missing etag header")
 			}
-			cp = append(cp, CompletePart{partID, etag[1 : len(etag)-1]})
 		}
 
 		// Call CompleteMultipart API

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -262,7 +262,6 @@ func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, buckets []BucketIn
 	}
 
 	close(bucketCh)
-	buckets = nil
 	bucketResults := make(chan dataUsageEntryInfo, len(disks))
 
 	// Start async collector/saver.

--- a/mint/run/core/aws-sdk-go/quick-tests.go
+++ b/mint/run/core/aws-sdk-go/quick-tests.go
@@ -46,13 +46,14 @@ const (
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
+
+// different kinds of test failures
 const (
 	PASS = "PASS" // Indicate that a test passed
 	FAIL = "FAIL" // Indicate that a test failed
-	NA   = "NA"   // Indicate that a test is not applicable
 )
 
-type ErrorResponse struct {
+type errorResponse struct {
 	XMLName    xml.Name `xml:"Error" json:"-"`
 	Code       string
 	Message    string
@@ -250,7 +251,7 @@ func testPresignedPutInvalidHash(s3Client *s3.S3) {
 	defer resp.Body.Close()
 
 	dec := xml.NewDecoder(resp.Body)
-	errResp := ErrorResponse{}
+	errResp := errorResponse{}
 	err = dec.Decode(&errResp)
 	if err != nil {
 		failureLog(function, args, startTime, "", "AWS SDK Go unmarshalling xml failed", err).Fatal()

--- a/mint/run/core/security/tls-tests.go
+++ b/mint/run/core/security/tls-tests.go
@@ -53,19 +53,19 @@ func main() {
 	testTLSEllipticCurves(endpoint)
 }
 
-// Tests whether the endpoint accepts SSL3.0, TLS1.0 or TLS1.1 connections - fail if so.
+// Tests whether the endpoint accepts TLS1.0 or TLS1.1 connections - fail if so.
 // Tests whether the endpoint accepts TLS1.2 connections - fail if not.
 func testTLSVersions(endpoint string) {
 	const function = "TLSVersions"
 	startTime := time.Now()
 
-	// Tests whether the endpoint accepts SSL3.0, TLS1.0 or TLS1.1 connections
+	// Tests whether the endpoint accepts TLS1.0 or TLS1.1 connections
 	args := map[string]interface{}{
-		"MinVersion": "tls.VersionSSL30",
+		"MinVersion": "tls.VersionTLS10",
 		"MaxVersion": "tls.VersionTLS11",
 	}
 	_, err := tls.Dial("tcp", endpoint, &tls.Config{
-		MinVersion: tls.VersionSSL30,
+		MinVersion: tls.VersionTLS10,
 		MaxVersion: tls.VersionTLS11,
 	})
 	if err == nil {

--- a/pkg/bucket/lifecycle/filter.go
+++ b/pkg/bucket/lifecycle/filter.go
@@ -86,8 +86,3 @@ func (f Filter) Validate() error {
 	}
 	return nil
 }
-
-// isEmpty - returns true if Filter tag is empty
-func (f Filter) isEmpty() bool {
-	return f.And.isEmpty() && f.Prefix == "" && f.Tag.IsEmpty()
-}

--- a/pkg/dsync/drwmutex_test.go
+++ b/pkg/dsync/drwmutex_test.go
@@ -314,7 +314,7 @@ func benchmarkRWMutex(b *testing.B, localWork, writeRatio int) {
 				rwm.Unlock()
 			} else {
 				rwm.RLock(id, source)
-				for i := 0; i != localWork; i += 1 {
+				for i := 0; i != localWork; i++ {
 					foo *= 2
 					foo /= 2
 				}

--- a/pkg/dsync/retry.go
+++ b/pkg/dsync/retry.go
@@ -128,13 +128,6 @@ const (
 	defaultRetryCap  = 1 * time.Second // 1 second.
 )
 
-// newRetryTimer creates a timer with exponentially increasing delays
-// until the maximum retry attempts are reached. - this function provides
-// resulting retry values to be of maximum jitter.
-func newRetryTimer(ctx context.Context, unit time.Duration, cap time.Duration) <-chan int {
-	return newRetryTimerWithJitter(ctx, unit, cap, MaxJitter)
-}
-
 // newRetryTimerSimple creates a timer with exponentially increasing delays
 // until the maximum retry attempts are reached. - this function is a
 // simpler version with all default values.

--- a/pkg/event/target/nsq_test.go
+++ b/pkg/event/target/nsq_test.go
@@ -17,8 +17,9 @@
 package target
 
 import (
-	xnet "github.com/minio/minio/pkg/net"
 	"testing"
+
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 func TestNSQArgs_Validate(t *testing.T) {

--- a/pkg/iam/policy/admin-action.go
+++ b/pkg/iam/policy/admin-action.go
@@ -148,15 +148,6 @@ var supportedAdminActions = map[AdminAction]struct{}{
 	AllAdminActions:                {},
 }
 
-func parseAdminAction(s string) (AdminAction, error) {
-	action := AdminAction(s)
-	if action.IsValid() {
-		return action, nil
-	}
-
-	return action, Errorf("unsupported action '%v'", s)
-}
-
 // IsValid - checks if action is valid or not.
 func (action AdminAction) IsValid() bool {
 	_, ok := supportedAdminActions[action]

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"time"
 )
@@ -126,23 +125,6 @@ func (adm *AdminClient) StorageInfo(ctx context.Context) (StorageInfo, error) {
 	}
 
 	return storageInfo, nil
-}
-
-type objectHistogramInterval struct {
-	name       string
-	start, end int64
-}
-
-// ObjectsHistogramIntervals contains the list of intervals
-// of an histogram analysis of objects sizes.
-var ObjectsHistogramIntervals = []objectHistogramInterval{
-	{"LESS_THAN_1024_B", -1, 1024 - 1},
-	{"BETWEEN_1024_B_AND_1_MB", 1024, 1024*1024 - 1},
-	{"BETWEEN_1_MB_AND_10_MB", 1024 * 1024, 1024*1024*10 - 1},
-	{"BETWEEN_10_MB_AND_64_MB", 1024 * 1024 * 10, 1024*1024*64 - 1},
-	{"BETWEEN_64_MB_AND_128_MB", 1024 * 1024 * 64, 1024*1024*128 - 1},
-	{"BETWEEN_128_MB_AND_512_MB", 1024 * 1024 * 128, 1024*1024*512 - 1},
-	{"GREATER_THAN_512_MB", 1024 * 1024 * 512, math.MaxInt64},
 }
 
 // DataUsageInfo represents data usage of an Object API

--- a/pkg/madmin/retry.go
+++ b/pkg/madmin/retry.go
@@ -20,10 +20,7 @@ package madmin
 import (
 	"context"
 	"math/rand"
-	"net"
 	"net/http"
-	"net/url"
-	"strings"
 	"sync"
 	"time"
 )
@@ -114,37 +111,6 @@ func (adm AdminClient) newRetryTimer(ctx context.Context, maxRetry int, unit tim
 		}
 	}()
 	return attemptCh
-}
-
-// isHTTPReqErrorRetryable - is http requests error retryable, such
-// as i/o timeout, connection broken etc..
-func isHTTPReqErrorRetryable(err error) bool {
-	if err == nil {
-		return false
-	}
-	switch e := err.(type) {
-	case *url.Error:
-		switch e.Err.(type) {
-		case *net.DNSError, *net.OpError, net.UnknownNetworkError:
-			return true
-		}
-		if strings.Contains(err.Error(), "Connection closed by foreign host") {
-			return true
-		} else if strings.Contains(err.Error(), "net/http: TLS handshake timeout") {
-			// If error is - tlsHandshakeTimeoutError, retry.
-			return true
-		} else if strings.Contains(err.Error(), "i/o timeout") {
-			// If error is - tcp timeoutError, retry.
-			return true
-		} else if strings.Contains(err.Error(), "connection timed out") {
-			// If err is a net.Dial timeout, retry.
-			return true
-		} else if strings.Contains(err.Error(), "net/http: HTTP/1.x transport connection broken") {
-			// If error is transport connection broken, retry.
-			return true
-		}
-	}
-	return false
 }
 
 // List of AWS S3 error codes which are retryable.

--- a/pkg/s3select/csv/args.go
+++ b/pkg/s3select/csv/args.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	none   = "none"
-	use    = "use"
-	ignore = "ignore"
+	none = "none"
+	use  = "use"
 
 	defaultRecordDelimiter      = "\n"
 	defaultFieldDelimiter       = ","
@@ -36,7 +35,6 @@ const (
 	defaultQuoteEscapeCharacter = `"`
 	defaultCommentCharacter     = "#"
 
-	always   = "always"
 	asneeded = "asneeded"
 )
 

--- a/pkg/s3select/csv/errors.go
+++ b/pkg/s3select/csv/errors.go
@@ -43,24 +43,6 @@ func (err *s3Error) Error() string {
 	return err.message
 }
 
-func errInvalidFileHeaderInfo(err error) *s3Error {
-	return &s3Error{
-		code:       "InvalidFileHeaderInfo",
-		message:    "The FileHeaderInfo is invalid. Only NONE, USE, and IGNORE are supported.",
-		statusCode: 400,
-		cause:      err,
-	}
-}
-
-func errInvalidQuoteFields(err error) *s3Error {
-	return &s3Error{
-		code:       "InvalidQuoteFields",
-		message:    "The QuoteFields is invalid. Only ALWAYS and ASNEEDED are supported.",
-		statusCode: 400,
-		cause:      err,
-	}
-}
-
 func errCSVParsingError(err error) *s3Error {
 	return &s3Error{
 		code:       "CSVParsingError",

--- a/pkg/s3select/select_test.go
+++ b/pkg/s3select/select_test.go
@@ -996,7 +996,7 @@ func TestParquetInput(t *testing.T) {
 					offset = fi.Size() + offset
 				}
 
-				if _, err = file.Seek(offset, os.SEEK_SET); err != nil {
+				if _, err = file.Seek(offset, io.SeekStart); err != nil {
 					return nil, err
 				}
 

--- a/pkg/s3select/simdj/errors.go
+++ b/pkg/s3select/simdj/errors.go
@@ -45,15 +45,6 @@ func (err *s3Error) Error() string {
 	return err.message
 }
 
-func errInvalidJSONType(err error) *s3Error {
-	return &s3Error{
-		code:       "InvalidJsonType",
-		message:    "The JsonType is invalid. Only DOCUMENT and LINES are supported.",
-		statusCode: 400,
-		cause:      err,
-	}
-}
-
 func errJSONParsingError(err error) *s3Error {
 	return &s3Error{
 		code:       "JSONParsingError",

--- a/pkg/s3select/sql/value_test.go
+++ b/pkg/s3select/sql/value_test.go
@@ -160,9 +160,6 @@ func TestValue_Equals(t *testing.T) {
 }
 
 func TestValue_CSVString(t *testing.T) {
-	type fields struct {
-		value interface{}
-	}
 	type test struct {
 		name    string
 		want    string


### PR DESCRIPTION

## Description
enable full linter across the codebase

## Motivation and Context
enable linter using golangci-lint across
codebase to run a bunch of linters together,
we shall enable new linters as we fix more
things the codebase.

This PR fixes the first stage of this
cleanup.

## How to test this PR?
Nothing new changes fix unexpected code

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
