### PR TITLE
Set Deployment ID before starting handlers

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -96,6 +96,10 @@ func ValidateGatewayArguments(serverAddr, endpointAddr string) error {
 
 // StartGateway - handler for 'minio gateway <name>'.
 func StartGateway(ctx *cli.Context, gw Gateway) {
+	// This is only to uniquely identify each gateway deployments.
+	globalDeploymentID = env.Get("MINIO_GATEWAY_DEPLOYMENT_ID", mustGetUUID())
+	logger.SetDeploymentID(globalDeploymentID)
+
 	if gw == nil {
 		logger.FatalIf(errUnexpected, "Gateway implementation not initialized")
 	}
@@ -260,9 +264,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		// is only enabled for "NAS" gateway.
 		globalConfigSys.WatchConfigNASDisk(GlobalContext, newObject)
 	}
-	// This is only to uniquely identify each gateway deployments.
-	globalDeploymentID = env.Get("MINIO_GATEWAY_DEPLOYMENT_ID", mustGetUUID())
-	logger.SetDeploymentID(globalDeploymentID)
 
 	if globalEtcdClient != nil {
 		// ****  WARNING ****


### PR DESCRIPTION
## Description

Global handler ID is added to response headers, so initialize it before the server starts.

Fixes #9634

## How to test this PR?

See ticket above.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
