### PR TITLE
Select object if user clicks anywhere on object name for browser

### DIFF
--- a/browser/app/js/objects/ObjectItem.js
+++ b/browser/app/js/objects/ObjectItem.js
@@ -54,8 +54,11 @@ export const ObjectItem = ({
           href={getDataType(name, contentType) === "folder" ? name : "#"}
           onClick={e => {
             e.preventDefault()
+            // onclick function is passed only when we have a prefix
             if (onClick) {
               onClick()
+            } else {
+              checked ? uncheckObject(name) : checkObject(name)
             }
           }}
         >

--- a/browser/app/js/objects/__tests__/ObjectItem.test.js
+++ b/browser/app/js/objects/__tests__/ObjectItem.test.js
@@ -30,7 +30,10 @@ describe("ObjectItem", () => {
 
   it("shouldn't call onClick when the object isclicked", () => {
     const onClick = jest.fn()
-    const wrapper = shallow(<ObjectItem name={"test"} />)
+    const checkObject = jest.fn()
+    const wrapper = shallow(
+      <ObjectItem name={"test"} checkObject={checkObject} />
+    )
     wrapper.find("a").simulate("click", { preventDefault: jest.fn() })
     expect(onClick).not.toHaveBeenCalled()
   })
@@ -57,9 +60,15 @@ describe("ObjectItem", () => {
   })
 
   it("should call uncheckObject when the object/prefix is unchecked", () => {
+    const checkObject = jest.fn()
     const uncheckObject = jest.fn()
     const wrapper = shallow(
-      <ObjectItem name={"test"} checked={true} uncheckObject={uncheckObject} />
+      <ObjectItem
+        name={"test"}
+        checked={true}
+        checkObject={checkObject}
+        uncheckObject={uncheckObject}
+      />
     )
     wrapper.find("input[type='checkbox']").simulate("change")
     expect(uncheckObject).toHaveBeenCalledWith("test")

--- a/browser/app/less/inc/list.less
+++ b/browser/app/less/inc/list.less
@@ -105,7 +105,7 @@ div.fesl-row {
 
     .fesl-item-name {
         a {
-            cursor: default;
+            cursor: pointer;
         }
     }
 
@@ -114,12 +114,6 @@ div.fesl-row {
     ----------------------------*/
     &[data-type=folder] {
         .list-type(#a1d6dd, '\f07b');
-
-        .fesl-item-name {
-            a {
-                cursor: pointer;
-            }
-        }
     }
     &[data-type=pdf] {.list-type(#fa7775, '\f1c1'); }
     &[data-type=zip] { .list-type(#427089, '\f1c6'); }


### PR DESCRIPTION
## Description
This commit selects/deselects the object if user clicks anywhere on object name for the MinIO browser.

## Motivation and Context
Fixes #9647

## How to test this PR?
- Upload an object into a bucket, click on the object name and make sure that object is selected (and deselected). Also make sure that the object is selected (and deselected) when the user clicks on the checkbox next to the object name.
- Create a new path (prefix/folder) inside a bucket, upload a file in it, click on the path name and make sure that the user is navigated inside the path. Also make sure that the path is selected (and deselected) when the user clicks on the checkbox next to the object name.
- Make sure that the download/delete functionalities work as expected for the selected items

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
