### PR TITLE
Improve listobjects performance

### DIFF
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -109,7 +109,7 @@ func healErasureSet(ctx context.Context, setIndex int, xlObj *xlObjects) error {
 		}
 
 		// List all objects in the current bucket and heal them
-		listDir := listDirFactory(ctx, xlObj.getLoadBalancedDisks()...)
+		listDir := listDirFactory(ctx, xlObj.getLoadBalancedDisks(-1)...)
 		walkResultCh := startTreeWalk(ctx, bucket.Name, "", "", true, listDir, nil)
 		for walkEntry := range walkResultCh {
 			bgSeq.sourceCh <- healSource{

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -149,11 +149,11 @@ func (d *naughtyDisk) Walk(volume, path, marker string, recursive bool, leafFile
 	return d.disk.Walk(volume, path, marker, recursive, leafFile, readMetadataFn, endWalkCh)
 }
 
-func (d *naughtyDisk) ListDir(volume, path string, count int, leafFile string) (entries []string, err error) {
+func (d *naughtyDisk) ListDir(ctx context.Context, volume, dirPath string, count int, leafFile, mustPrefix, marker string) (entries []string, err error) {
 	if err := d.calcError(); err != nil {
 		return []string{}, err
 	}
-	return d.disk.ListDir(volume, path, count, leafFile)
+	return d.disk.ListDir(ctx, volume, dirPath, count, leafFile, mustPrefix, marker)
 }
 
 func (d *naughtyDisk) ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -105,7 +105,7 @@ func cleanupDir(ctx context.Context, storage StorageAPI, volume, dirPath string)
 		}
 
 		// If it's a directory, list and call delFunc() for each entry.
-		entries, err := storage.ListDir(volume, entryPath, -1, "")
+		entries, err := storage.ListDir(ctx, volume, entryPath, -1, "", "", "")
 		// If entryPath prefix never existed, safe to ignore.
 		if err == errFileNotFound {
 			return nil

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -132,11 +132,11 @@ func (p *posixDiskIDCheck) WalkSplunk(volume, dirPath string, marker string, end
 	return p.storage.WalkSplunk(volume, dirPath, marker, endWalkCh)
 }
 
-func (p *posixDiskIDCheck) ListDir(volume, dirPath string, count int, leafFile string) ([]string, error) {
+func (p *posixDiskIDCheck) ListDir(ctx context.Context, volume, dirPath string, count int, leafFile, mustPrefix, marker string) ([]string, error) {
 	if p.isDiskStale() {
 		return nil, errDiskNotFound
 	}
-	return p.storage.ListDir(volume, dirPath, count, leafFile)
+	return p.storage.ListDir(ctx, volume, dirPath, count, leafFile, mustPrefix, marker)
 }
 
 func (p *posixDiskIDCheck) ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -836,7 +836,7 @@ func (s *posix) Walk(volume, dirPath, marker string, recursive bool, leafFile st
 	go func() {
 		defer close(ch)
 		listDir := func(volume, dirPath, dirEntry string) (bool, []string) {
-			entries, err := s.ListDir(GlobalContext, volume, dirPath, -1, leafFile, "", "")
+			entries, err := s.ListDir(GlobalContext, volume, dirPath, -1, leafFile, dirEntry, marker)
 			if err != nil {
 				return false, nil
 			}

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"fmt"
 	"io"
@@ -792,7 +793,7 @@ func TestPosixPosixListDir(t *testing.T) {
 		if _, ok := posixStorage.(*posixDiskIDCheck); !ok {
 			t.Errorf("Expected the StorageAPI to be of type *posix")
 		}
-		dirList, err = posixStorage.ListDir(testCase.srcVol, testCase.srcPath, -1, "")
+		dirList, err = posixStorage.ListDir(context.Background(), testCase.srcVol, testCase.srcPath, -1, "", "", "")
 		if err != testCase.expectedErr {
 			t.Fatalf("TestPosix case %d: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
 		}

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -51,7 +51,7 @@ type StorageAPI interface {
 	WalkSplunk(volume, dirPath string, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error)
 
 	// File operations.
-	ListDir(volume, dirPath string, count int, leafFile string) ([]string, error)
+	ListDir(ctx context.Context, volume, dirPath string, count int, leafFile, mustPrefix, marker string) ([]string, error)
 	ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error)
 	AppendFile(volume string, path string, buf []byte) (err error)
 	CreateFile(volume, path string, size int64, reader io.Reader) error

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -63,6 +63,7 @@ const (
 	storageRESTCount       = "count"
 	storageRESTMarkerPath  = "marker"
 	storageRESTLeafFile    = "leaf-file"
+	storageRESTMustPrefix  = "must-prefix"
 	storageRESTRecursive   = "recursive"
 	storageRESTBitrotAlgo  = "bitrot-algo"
 	storageRESTBitrotHash  = "bitrot-hash"

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -490,13 +490,15 @@ func (s *storageRESTServer) ListDirHandler(w http.ResponseWriter, r *http.Reques
 	volume := vars[storageRESTVolume]
 	dirPath := vars[storageRESTDirPath]
 	leafFile := vars[storageRESTLeafFile]
+	mustPrefix := vars[storageRESTMustPrefix]
+	marker := vars[storageRESTMarkerPath]
 	count, err := strconv.Atoi(vars[storageRESTCount])
 	if err != nil {
 		s.writeErrorResponse(w, err)
 		return
 	}
 
-	entries, err := s.storage.ListDir(volume, dirPath, count, leafFile)
+	entries, err := s.storage.ListDir(r.Context(), volume, dirPath, count, leafFile, mustPrefix, marker)
 	if err != nil {
 		s.writeErrorResponse(w, err)
 		return

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http/httptest"
 	"os"
@@ -261,7 +262,7 @@ func testStorageAPIListDir(t *testing.T, storage StorageAPI) {
 	}
 
 	for i, testCase := range testCases {
-		result, err := storage.ListDir(testCase.volumeName, testCase.prefix, -1, "")
+		result, err := storage.ListDir(context.Background(), testCase.volumeName, testCase.prefix, -1, "", "", "")
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {

--- a/cmd/tree-walk.go
+++ b/cmd/tree-walk.go
@@ -51,7 +51,7 @@ func filterMatchingPrefix(entries []string, prefixEntry string) []string {
 		}
 		end--
 	}
-	sort.Strings(entries[start:end])
+	// Entries are already sorted, so returned slice should also be.
 	return entries[start:end]
 }
 

--- a/cmd/tree-walk_test.go
+++ b/cmd/tree-walk_test.go
@@ -234,6 +234,9 @@ func TestListDir(t *testing.T) {
 		t.Errorf("Unable to create tmp directory: %s", err)
 	}
 
+	if fsDir1 == fsDir2 {
+		t.Fatal(fsDir1, "==", fsDir2)
+	}
 	// Create two StorageAPIs disk1 and disk2.
 	endpoints := mustGetNewEndpoints(fsDir1)
 	disk1, err := newStorageAPI(endpoints[0])
@@ -280,10 +283,10 @@ func TestListDir(t *testing.T) {
 	// Should list "file2" from fsDir2.
 	_, entries = listDir(volume, "", "")
 	if len(entries) != 1 {
-		t.Fatal("Expected the number of entries to be 1")
+		t.Fatal("Expected the number of entries to be 1, was", len(entries))
 	}
 	if entries[0] != file2 {
-		t.Fatal("Expected the entry to be file2")
+		t.Fatal("Expected the entry to be file2, was ", entries[0])
 	}
 	err = os.RemoveAll(fsDir2)
 	if err != nil {

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -885,7 +885,7 @@ func (s *xlSets) startMergeWalksN(ctx context.Context, bucket, prefix, marker st
 	for _, set := range s.sets {
 		// Reset for the next erasure set.
 		success = ndisks
-		for _, disk := range set.getLoadBalancedDisks() {
+		for _, disk := range set.getLoadBalancedDisks(-1) {
 			if disk == nil {
 				// Disk can be offline
 				continue
@@ -915,7 +915,7 @@ func (s *xlSets) startSplunkMergeWalksN(ctx context.Context, bucket, prefix, mar
 	for _, set := range s.sets {
 		// Reset for the next erasure set.
 		success = ndisks
-		for _, disk := range set.getLoadBalancedDisks() {
+		for _, disk := range set.getLoadBalancedDisks(-1) {
 			if disk == nil {
 				// Disk can be offline
 				continue

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -88,7 +88,7 @@ func undoDeleteBucket(storageDisks []StorageAPI, bucket string) {
 // getBucketInfo - returns the BucketInfo from one of the load balanced disks.
 func (xl xlObjects) getBucketInfo(ctx context.Context, bucketName string) (bucketInfo BucketInfo, err error) {
 	var bucketErrs []error
-	for _, disk := range xl.getLoadBalancedDisks() {
+	for _, disk := range xl.getLoadBalancedDisks(-1) {
 		if disk == nil {
 			bucketErrs = append(bucketErrs, errDiskNotFound)
 			continue
@@ -125,7 +125,7 @@ func (xl xlObjects) GetBucketInfo(ctx context.Context, bucket string) (bi Bucket
 
 // listBuckets - returns list of all buckets from a disk picked at random.
 func (xl xlObjects) listBuckets(ctx context.Context) (bucketsInfo []BucketInfo, err error) {
-	for _, disk := range xl.getLoadBalancedDisks() {
+	for _, disk := range xl.getLoadBalancedDisks(-1) {
 		if disk == nil {
 			continue
 		}

--- a/cmd/xl-v1-common.go
+++ b/cmd/xl-v1-common.go
@@ -24,11 +24,15 @@ import (
 )
 
 // getLoadBalancedDisks - fetches load balanced (sufficiently randomized) disk slice.
-func (xl xlObjects) getLoadBalancedDisks() (newDisks []StorageAPI) {
+// If n <= 0 only up to n disks will be returned.
+func (xl xlObjects) getLoadBalancedDisks(n int) (newDisks []StorageAPI) {
 	disks := xl.getDisks()
 	// Based on the random shuffling return back randomized disks.
 	for _, i := range hashOrder(UTCNow().String(), len(disks)) {
 		newDisks = append(newDisks, disks[i-1])
+	}
+	if n > 0 && len(newDisks) > n {
+		newDisks = newDisks[:n]
 	}
 	return newDisks
 }

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -359,7 +359,7 @@ func (xl xlObjects) healObject(ctx context.Context, bucket string, object string
 		}
 
 		// List and delete the object directory,
-		files, derr := disk.ListDir(bucket, object, -1, "")
+		files, derr := disk.ListDir(ctx, bucket, object, -1, "", "", "")
 		if derr == nil {
 			for _, entry := range files {
 				_ = disk.DeleteFile(bucket,
@@ -625,7 +625,7 @@ func statAllDirs(ctx context.Context, storageDisks []StorageAPI, bucket, prefix 
 		}
 		index := index
 		g.Go(func() error {
-			entries, err := storageDisks[index].ListDir(bucket, prefix, 1, "")
+			entries, err := storageDisks[index].ListDir(ctx, bucket, prefix, 1, "", "", "")
 			if err != nil {
 				return err
 			}

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -337,7 +337,7 @@ func (xl xlObjects) getObjectInfoDir(ctx context.Context, bucket, object string)
 		index := index
 		g.Go(func() error {
 			// Check if 'prefix' is an object on this 'disk'.
-			entries, err := storageDisks[index].ListDir(bucket, object, 1, "")
+			entries, err := storageDisks[index].ListDir(ctx, bucket, object, 1, "", "", "")
 			if err != nil {
 				return err
 			}

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -231,7 +231,7 @@ func (xl xlObjects) CrawlAndGetDataUsage(ctx context.Context, bf *bloomFilter, u
 func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, buckets []BucketInfo, bf *bloomFilter, updates chan<- dataUsageCache) error {
 	var disks []StorageAPI
 
-	for _, d := range xl.getLoadBalancedDisks() {
+	for _, d := range xl.getLoadBalancedDisks(-1) {
 		if d == nil || !d.IsOnline() {
 			continue
 		}


### PR DESCRIPTION
## Description

* Only fetch objects from a limited number of disks.

For now it is set to max 3 disks. We should at least be able to reduce it to len(disks)/2.

* Only Stat objects we are interested in.

Filter out unwanted prefixed early, start at marker, listen for cancellations.

We keep upstream filtering so we don't have to upgrade REST version.

* List directories concurrently

When querying multiple disks in XL mode do it concurrently.

No benchs yet.


## How to test this PR?


## Types of changes
- [x] New feature (non-breaking change which adds functionality)

