### PR TITLE
reload bucket metadata outside the locker

### DIFF
--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -258,9 +258,9 @@ func (sys *BucketMetadataSys) GetConfig(bucket string) (BucketMetadata, error) {
 		return newBucketMetadata(bucket), errInvalidArgument
 	}
 
-	sys.Lock()
-	defer sys.Unlock()
+	sys.RLock()
 	meta, ok := sys.metadataMap[bucket]
+	sys.RUnlock()
 	if ok {
 		return meta, nil
 	}
@@ -268,7 +268,9 @@ func (sys *BucketMetadataSys) GetConfig(bucket string) (BucketMetadata, error) {
 	if err != nil {
 		return meta, err
 	}
+	sys.Lock()
 	sys.metadataMap[bucket] = meta
+	sys.Unlock()
 	return meta, nil
 }
 


### PR DESCRIPTION
## Description
reload bucket metadata outside the locker

## Motivation and Context
Just helps reading metadata to be not blocked

## How to test this PR?
Nothing special, just continuation from #9650

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
