### PR TITLE
keep bucket metadata fields to be consistent

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -538,9 +538,8 @@ func (api objectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 					return
 				}
 
-				if objectLockEnabled {
-					globalNotificationSys.LoadBucketMetadata(GlobalContext, bucket)
-				}
+				// Load updated bucket metadata into memory.
+				globalNotificationSys.LoadBucketMetadata(GlobalContext, bucket)
 
 				// Make sure to add Location information here only for bucket
 				w.Header().Set(xhttp.Location,
@@ -572,9 +571,8 @@ func (api objectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if objectLockEnabled {
-		globalNotificationSys.LoadBucketMetadata(GlobalContext, bucket)
-	}
+	// Load updated bucket metadata into memory.
+	globalNotificationSys.LoadBucketMetadata(GlobalContext, bucket)
 
 	// Make sure to add Location information here only for bucket
 	w.Header().Set(xhttp.Location, path.Clean(r.URL.Path)) // Clean any trailing slashes.

--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -74,6 +74,7 @@ func (sys *BucketMetadataSys) Update(bucket string, configFile string, configDat
 	}
 
 	if globalIsGateway {
+		// This code is needed only for gateway implementations.
 		if configFile == bucketPolicyConfig {
 			config, err := policy.ParseConfig(bytes.NewReader(configData), bucket)
 			if err != nil {
@@ -97,7 +98,7 @@ func (sys *BucketMetadataSys) Update(bucket string, configFile string, configDat
 	case bucketPolicyConfig:
 		meta.PolicyConfigJSON = configData
 	case bucketNotificationConfig:
-		meta.NotificationXML = configData
+		meta.NotificationConfigXML = configData
 	case bucketLifecycleConfig:
 		meta.LifecycleConfigXML = configData
 	case bucketSSEConfig:
@@ -105,7 +106,7 @@ func (sys *BucketMetadataSys) Update(bucket string, configFile string, configDat
 	case bucketTaggingConfigFile:
 		meta.TaggingConfigXML = configData
 	case objectLockConfig:
-		meta.ObjectLockConfigurationXML = configData
+		meta.ObjectLockConfigXML = configData
 	case bucketQuotaConfigFile:
 		meta.QuotaConfigJSON = configData
 	default:

--- a/cmd/bucket-metadata_gen.go
+++ b/cmd/bucket-metadata_gen.go
@@ -48,10 +48,10 @@ func (z *BucketMetadata) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "PolicyConfigJSON")
 				return
 			}
-		case "NotificationXML":
-			z.NotificationXML, err = dc.ReadBytes(z.NotificationXML)
+		case "NotificationConfigXML":
+			z.NotificationConfigXML, err = dc.ReadBytes(z.NotificationConfigXML)
 			if err != nil {
-				err = msgp.WrapError(err, "NotificationXML")
+				err = msgp.WrapError(err, "NotificationConfigXML")
 				return
 			}
 		case "LifecycleConfigXML":
@@ -60,10 +60,10 @@ func (z *BucketMetadata) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "LifecycleConfigXML")
 				return
 			}
-		case "ObjectLockConfigurationXML":
-			z.ObjectLockConfigurationXML, err = dc.ReadBytes(z.ObjectLockConfigurationXML)
+		case "ObjectLockConfigXML":
+			z.ObjectLockConfigXML, err = dc.ReadBytes(z.ObjectLockConfigXML)
 			if err != nil {
-				err = msgp.WrapError(err, "ObjectLockConfigurationXML")
+				err = msgp.WrapError(err, "ObjectLockConfigXML")
 				return
 			}
 		case "EncryptionConfigXML":
@@ -138,14 +138,14 @@ func (z *BucketMetadata) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "PolicyConfigJSON")
 		return
 	}
-	// write "NotificationXML"
-	err = en.Append(0xaf, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x58, 0x4d, 0x4c)
+	// write "NotificationConfigXML"
+	err = en.Append(0xb5, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x58, 0x4d, 0x4c)
 	if err != nil {
 		return
 	}
-	err = en.WriteBytes(z.NotificationXML)
+	err = en.WriteBytes(z.NotificationConfigXML)
 	if err != nil {
-		err = msgp.WrapError(err, "NotificationXML")
+		err = msgp.WrapError(err, "NotificationConfigXML")
 		return
 	}
 	// write "LifecycleConfigXML"
@@ -158,14 +158,14 @@ func (z *BucketMetadata) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "LifecycleConfigXML")
 		return
 	}
-	// write "ObjectLockConfigurationXML"
-	err = en.Append(0xba, 0x4f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x4c, 0x6f, 0x63, 0x6b, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x58, 0x4d, 0x4c)
+	// write "ObjectLockConfigXML"
+	err = en.Append(0xb3, 0x4f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x4c, 0x6f, 0x63, 0x6b, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x58, 0x4d, 0x4c)
 	if err != nil {
 		return
 	}
-	err = en.WriteBytes(z.ObjectLockConfigurationXML)
+	err = en.WriteBytes(z.ObjectLockConfigXML)
 	if err != nil {
-		err = msgp.WrapError(err, "ObjectLockConfigurationXML")
+		err = msgp.WrapError(err, "ObjectLockConfigXML")
 		return
 	}
 	// write "EncryptionConfigXML"
@@ -217,15 +217,15 @@ func (z *BucketMetadata) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "PolicyConfigJSON"
 	o = append(o, 0xb0, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x4a, 0x53, 0x4f, 0x4e)
 	o = msgp.AppendBytes(o, z.PolicyConfigJSON)
-	// string "NotificationXML"
-	o = append(o, 0xaf, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x58, 0x4d, 0x4c)
-	o = msgp.AppendBytes(o, z.NotificationXML)
+	// string "NotificationConfigXML"
+	o = append(o, 0xb5, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x58, 0x4d, 0x4c)
+	o = msgp.AppendBytes(o, z.NotificationConfigXML)
 	// string "LifecycleConfigXML"
 	o = append(o, 0xb2, 0x4c, 0x69, 0x66, 0x65, 0x63, 0x79, 0x63, 0x6c, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x58, 0x4d, 0x4c)
 	o = msgp.AppendBytes(o, z.LifecycleConfigXML)
-	// string "ObjectLockConfigurationXML"
-	o = append(o, 0xba, 0x4f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x4c, 0x6f, 0x63, 0x6b, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x58, 0x4d, 0x4c)
-	o = msgp.AppendBytes(o, z.ObjectLockConfigurationXML)
+	// string "ObjectLockConfigXML"
+	o = append(o, 0xb3, 0x4f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x4c, 0x6f, 0x63, 0x6b, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x58, 0x4d, 0x4c)
+	o = msgp.AppendBytes(o, z.ObjectLockConfigXML)
 	// string "EncryptionConfigXML"
 	o = append(o, 0xb3, 0x45, 0x6e, 0x63, 0x72, 0x79, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x58, 0x4d, 0x4c)
 	o = msgp.AppendBytes(o, z.EncryptionConfigXML)
@@ -280,10 +280,10 @@ func (z *BucketMetadata) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "PolicyConfigJSON")
 				return
 			}
-		case "NotificationXML":
-			z.NotificationXML, bts, err = msgp.ReadBytesBytes(bts, z.NotificationXML)
+		case "NotificationConfigXML":
+			z.NotificationConfigXML, bts, err = msgp.ReadBytesBytes(bts, z.NotificationConfigXML)
 			if err != nil {
-				err = msgp.WrapError(err, "NotificationXML")
+				err = msgp.WrapError(err, "NotificationConfigXML")
 				return
 			}
 		case "LifecycleConfigXML":
@@ -292,10 +292,10 @@ func (z *BucketMetadata) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "LifecycleConfigXML")
 				return
 			}
-		case "ObjectLockConfigurationXML":
-			z.ObjectLockConfigurationXML, bts, err = msgp.ReadBytesBytes(bts, z.ObjectLockConfigurationXML)
+		case "ObjectLockConfigXML":
+			z.ObjectLockConfigXML, bts, err = msgp.ReadBytesBytes(bts, z.ObjectLockConfigXML)
 			if err != nil {
-				err = msgp.WrapError(err, "ObjectLockConfigurationXML")
+				err = msgp.WrapError(err, "ObjectLockConfigXML")
 				return
 			}
 		case "EncryptionConfigXML":
@@ -330,6 +330,6 @@ func (z *BucketMetadata) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *BucketMetadata) Msgsize() (s int) {
-	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 8 + msgp.TimeSize + 12 + msgp.BoolSize + 17 + msgp.BytesPrefixSize + len(z.PolicyConfigJSON) + 16 + msgp.BytesPrefixSize + len(z.NotificationXML) + 19 + msgp.BytesPrefixSize + len(z.LifecycleConfigXML) + 27 + msgp.BytesPrefixSize + len(z.ObjectLockConfigurationXML) + 20 + msgp.BytesPrefixSize + len(z.EncryptionConfigXML) + 17 + msgp.BytesPrefixSize + len(z.TaggingConfigXML) + 16 + msgp.BytesPrefixSize + len(z.QuotaConfigJSON)
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 8 + msgp.TimeSize + 12 + msgp.BoolSize + 17 + msgp.BytesPrefixSize + len(z.PolicyConfigJSON) + 22 + msgp.BytesPrefixSize + len(z.NotificationConfigXML) + 19 + msgp.BytesPrefixSize + len(z.LifecycleConfigXML) + 20 + msgp.BytesPrefixSize + len(z.ObjectLockConfigXML) + 20 + msgp.BytesPrefixSize + len(z.EncryptionConfigXML) + 17 + msgp.BytesPrefixSize + len(z.TaggingConfigXML) + 16 + msgp.BytesPrefixSize + len(z.QuotaConfigJSON)
 	return
 }

--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -74,6 +74,7 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	config.SetRegion(globalServerRegion)
 	if err = config.Validate(globalServerRegion, globalNotificationSys.targetList); err != nil {
 		arnErr, ok := err.(*event.ErrARNNotFound)
 		if ok {

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -616,6 +616,7 @@ func (sys *NotificationSys) load(buckets []BucketInfo, objAPI ObjectLayer) error
 		if err != nil {
 			return err
 		}
+		config.SetRegion(globalServerRegion)
 		if err = config.Validate(globalServerRegion, globalNotificationSys.targetList); err != nil {
 			if _, ok := err.(*event.ErrARNNotFound); !ok {
 				logger.LogIf(ctx, err)

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -325,7 +325,7 @@ func (z *xlZones) MakeBucketWithLocation(ctx context.Context, bucket, location s
 		// If it doesn't exist we get a new, so ignore errors
 		meta := newBucketMetadata(bucket)
 		if lockEnabled {
-			meta.ObjectLockConfigurationXML = defaultBucketObjectLockConfig
+			meta.ObjectLockConfigXML = enabledBucketObjectLockConfig
 		}
 		if err := meta.Save(ctx, z); err != nil {
 			return toObjectErr(err, bucket)
@@ -355,7 +355,7 @@ func (z *xlZones) MakeBucketWithLocation(ctx context.Context, bucket, location s
 	// If it doesn't exist we get a new, so ignore errors
 	meta := newBucketMetadata(bucket)
 	if lockEnabled {
-		meta.ObjectLockConfigurationXML = defaultBucketObjectLockConfig
+		meta.ObjectLockConfigXML = enabledBucketObjectLockConfig
 	}
 	if err := meta.Save(ctx, z); err != nil {
 		return toObjectErr(err, bucket)


### PR DESCRIPTION


## Description
keep bucket metadata fields to be consistent

## Motivation and Context
added bonus reload bucket metadata always after
a successful MakeBucket, current we were only
doing it with object locking enabled.

## How to test this PR?
Nothing new, just a simple rename and functionality change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably with ListBuckets CreateTime value
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
