### PR TITLE
Copyobject: Filter all encryption headers in gateway

### DIFF
--- a/cmd/crypto/metadata.go
+++ b/cmd/crypto/metadata.go
@@ -44,6 +44,8 @@ func RemoveSensitiveEntries(metadata map[string]string) { // The functions is te
 // header entries from the metadata map.
 func RemoveSSEHeaders(metadata map[string]string) {
 	delete(metadata, SSEHeader)
+	delete(metadata, SSEKmsID)
+	delete(metadata, SSEKmsContext)
 	delete(metadata, SSECKeyMD5)
 	delete(metadata, SSECAlgorithm)
 }


### PR DESCRIPTION
Fixes #9655

## Description
`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id` and `X-Amz-Server-Side-Encryption-Context` headers were not removed from the source object causing partial encryption headers to be passed to the backend. This caused a failure in copyobject.

## Motivation and Context
Issue #9655

## How to test this PR?
Using the steps described in #9655

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
