### PR TITLE
Facilitate selective running of single CI stages

### DIFF
--- a/Dockerfile.simpleci
+++ b/Dockerfile.simpleci
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------
-# Stage 1: Build and Unit tests
+# Stage 0: Build and Unit tests
 #-------------------------------------------------------------
-FROM golang:1.13
+FROM golang:1.13 AS core
 
 COPY . /go/src/github.com/minio/minio
 WORKDIR /go/src/github.com/minio/minio
@@ -42,9 +42,9 @@ RUN make verify
 RUN make verify-healing
 
 #-------------------------------------------------------------
-# Stage 2: Test Frontend
+# Stage 1: Test Frontend
 #-------------------------------------------------------------
-FROM node:10.15-stretch-slim
+FROM node:10.15-stretch-slim AS frontend
 
 ENV SIMPLE_CI 1
 
@@ -55,9 +55,9 @@ RUN yarn
 RUN yarn test
 
 #-------------------------------------------------------------
-# Stage 3: Run Gateway Tests
+# Stage 2: Run Gateway Tests
 #-------------------------------------------------------------
-FROM ubuntu:18.04
+FROM ubuntu:18.04 AS gateway
 
 COPY --from=0 /go/src/github.com/minio/minio/minio /usr/bin/minio
 COPY buildscripts/gateway-tests.sh /usr/bin/gateway-tests.sh


### PR DESCRIPTION
## Description
Pass '--target core' to docker build in order to only test core.
Pass '--target frontend' to docker build in order to only test frontend.
Pass '--target gateway' to docker build in order to only test gateway.

Numerical references might be supported in the future: https://github.com/moby/buildkit/issues/1503

## Motivation and Context
Possibility to only test frontend (browser component) before submitting changes.

## How to test this PR?
`docker build --no-cache -f Dockerfile.simpleci --target frontend .`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
