### PR TITLE
Change madmin SetBucketQuota API signature

### DIFF
--- a/pkg/madmin/quota-commands.go
+++ b/pkg/madmin/quota-commands.go
@@ -91,11 +91,8 @@ func (adm *AdminClient) GetBucketQuota(ctx context.Context, bucket string) (q Bu
 
 // SetBucketQuota - sets a bucket's quota, if quota is set to '0'
 // quota is disabled.
-func (adm *AdminClient) SetBucketQuota(ctx context.Context, bucket string, quota uint64, quotaType QuotaType) error {
-	data, err := json.Marshal(BucketQuota{
-		Quota: quota,
-		Type:  quotaType,
-	})
+func (adm *AdminClient) SetBucketQuota(ctx context.Context, bucket string, quota *BucketQuota) error {
+	data, err := json.Marshal(quota)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
to allow both setting and removing quota config.

## Description


## Motivation and Context
RemoveBucketQuota API was recently removed - change SetBucketQuota to accept BucketQuota as parameter instead of expecting quota and type to be set individually.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
