### PR TITLE
Fix Windows memory leak

### DIFF
--- a/pkg/disk/type_windows.go
+++ b/pkg/disk/type_windows.go
@@ -31,10 +31,10 @@ var (
 
 // getFSType returns the filesystem type of the underlying mounted filesystem
 func getFSType(path string) string {
-	var volumeNameSize uint32 = 260
-	var nFileSystemNameSize, lpVolumeSerialNumber uint32
+	volumeNameSize, nFileSystemNameSize := uint32(260), uint32(260)
+	var lpVolumeSerialNumber uint32
 	var lpFileSystemFlags, lpMaximumComponentLength uint32
-	var lpFileSystemNameBuffer, volumeName [260]byte
+	var lpFileSystemNameBuffer, volumeName [130]uint16
 	var ps = syscall.StringToUTF16Ptr(filepath.VolumeName(path))
 
 	// Extract values safely
@@ -56,15 +56,7 @@ func getFSType(path string) string {
 		uintptr(unsafe.Pointer(&lpMaximumComponentLength)),
 		uintptr(unsafe.Pointer(&lpFileSystemFlags)),
 		uintptr(unsafe.Pointer(&lpFileSystemNameBuffer)),
-		uintptr(unsafe.Pointer(&nFileSystemNameSize)), 0)
-	var bytes []byte
-	if lpFileSystemNameBuffer[6] == 0 {
-		bytes = []byte{lpFileSystemNameBuffer[0], lpFileSystemNameBuffer[2],
-			lpFileSystemNameBuffer[4]}
-	} else {
-		bytes = []byte{lpFileSystemNameBuffer[0], lpFileSystemNameBuffer[2],
-			lpFileSystemNameBuffer[4], lpFileSystemNameBuffer[6]}
-	}
+		uintptr(nFileSystemNameSize))
 
-	return string(bytes)
+	return syscall.UTF16ToString(lpFileSystemNameBuffer[:])
 }


### PR DESCRIPTION
## Description

When running a zoned setup simply uploading will run the system out of memory very fast.

Root cause: nFileSystemNameSize is a DWORD and not a pointer. No idea how this didn't crash hard.

Furthermore replace poor mans utf16 -> string conversion to support arbitrary output.

Fixes #9630

## How to test this PR?

See referred ticket.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
