### PR TITLE
nas: Ensure loading of bucket notifications during startup

### DIFF
--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -251,7 +251,7 @@ func (sys *BucketMetadataSys) GetConfig(bucket string) (BucketMetadata, error) {
 		return newBucketMetadata(bucket), errServerNotInitialized
 	}
 
-	if globalIsGateway {
+	if globalIsGateway && globalGatewayName != "nas" {
 		return newBucketMetadata(bucket), NotImplemented{}
 	}
 


### PR DESCRIPTION
## Description
After a recent refactor in the code, NAS gateway fails to load notification config from bucket sys meta although it is very similar to FS. This PR fix it

## Motivation and Context
Fix starting NAS in master version

## How to test this PR?
1. minio gateway nas /tmp/nas
2. mc mb mynas/testbucket/
3. Restart NAS gateway

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
