### PR TITLE
fix size accounting for encrypted/compressed objects

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -120,20 +120,9 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 		w.Header().Set(k, v)
 	}
 
-	var totalObjectSize int64
-	switch {
-	case crypto.IsEncrypted(objInfo.UserDefined):
-		totalObjectSize, err = objInfo.DecryptedSize()
-		if err != nil {
-			return err
-		}
-	case objInfo.IsCompressed():
-		totalObjectSize = objInfo.GetActualSize()
-		if totalObjectSize < 0 {
-			return errInvalidDecompressedSize
-		}
-	default:
-		totalObjectSize = objInfo.Size
+	totalObjectSize, err := objInfo.GetActualSize()
+	if err != nil {
+		return err
 	}
 
 	// for providing ranged content

--- a/cmd/bucket-listobjects-handlers.go
+++ b/cmd/bucket-listobjects-handlers.go
@@ -99,24 +99,13 @@ func (api objectAPIHandlers) ListBucketObjectVersionsHandler(w http.ResponseWrit
 	}
 
 	for i := range listObjectsInfo.Objects {
-		var actualSize int64
-		if listObjectsInfo.Objects[i].IsCompressed() {
-			// Read the decompressed size from the meta.json.
-			actualSize = listObjectsInfo.Objects[i].GetActualSize()
-			if actualSize < 0 {
-				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDecompressedSize),
-					r.URL, guessIsBrowserReq(r))
-				return
-			}
-			// Set the info.Size to the actualSize.
-			listObjectsInfo.Objects[i].Size = actualSize
-		} else if crypto.IsEncrypted(listObjectsInfo.Objects[i].UserDefined) {
+		if crypto.IsEncrypted(listObjectsInfo.Objects[i].UserDefined) {
 			listObjectsInfo.Objects[i].ETag = getDecryptedETag(r.Header, listObjectsInfo.Objects[i], false)
-			listObjectsInfo.Objects[i].Size, err = listObjectsInfo.Objects[i].DecryptedSize()
-			if err != nil {
-				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
-				return
-			}
+		}
+		listObjectsInfo.Objects[i].Size, err = listObjectsInfo.Objects[i].GetActualSize()
+		if err != nil {
+			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+			return
 		}
 	}
 
@@ -181,23 +170,13 @@ func (api objectAPIHandlers) ListObjectsV2MHandler(w http.ResponseWriter, r *htt
 	}
 
 	for i := range listObjectsV2Info.Objects {
-		var actualSize int64
-		if listObjectsV2Info.Objects[i].IsCompressed() {
-			// Read the decompressed size from the meta.json.
-			actualSize = listObjectsV2Info.Objects[i].GetActualSize()
-			if actualSize < 0 {
-				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDecompressedSize), r.URL, guessIsBrowserReq(r))
-				return
-			}
-			// Set the info.Size to the actualSize.
-			listObjectsV2Info.Objects[i].Size = actualSize
-		} else if crypto.IsEncrypted(listObjectsV2Info.Objects[i].UserDefined) {
+		if crypto.IsEncrypted(listObjectsV2Info.Objects[i].UserDefined) {
 			listObjectsV2Info.Objects[i].ETag = getDecryptedETag(r.Header, listObjectsV2Info.Objects[i], false)
-			listObjectsV2Info.Objects[i].Size, err = listObjectsV2Info.Objects[i].DecryptedSize()
-			if err != nil {
-				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
-				return
-			}
+		}
+		listObjectsV2Info.Objects[i].Size, err = listObjectsV2Info.Objects[i].GetActualSize()
+		if err != nil {
+			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+			return
 		}
 	}
 
@@ -265,23 +244,13 @@ func (api objectAPIHandlers) ListObjectsV2Handler(w http.ResponseWriter, r *http
 	}
 
 	for i := range listObjectsV2Info.Objects {
-		var actualSize int64
-		if listObjectsV2Info.Objects[i].IsCompressed() {
-			// Read the decompressed size from the meta.json.
-			actualSize = listObjectsV2Info.Objects[i].GetActualSize()
-			if actualSize < 0 {
-				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDecompressedSize), r.URL, guessIsBrowserReq(r))
-				return
-			}
-			// Set the info.Size to the actualSize.
-			listObjectsV2Info.Objects[i].Size = actualSize
-		} else if crypto.IsEncrypted(listObjectsV2Info.Objects[i].UserDefined) {
+		if crypto.IsEncrypted(listObjectsV2Info.Objects[i].UserDefined) {
 			listObjectsV2Info.Objects[i].ETag = getDecryptedETag(r.Header, listObjectsV2Info.Objects[i], false)
-			listObjectsV2Info.Objects[i].Size, err = listObjectsV2Info.Objects[i].DecryptedSize()
-			if err != nil {
-				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
-				return
-			}
+		}
+		listObjectsV2Info.Objects[i].Size, err = listObjectsV2Info.Objects[i].GetActualSize()
+		if err != nil {
+			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+			return
 		}
 	}
 
@@ -344,25 +313,16 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 	}
 
 	for i := range listObjectsInfo.Objects {
-		var actualSize int64
-		if listObjectsInfo.Objects[i].IsCompressed() {
-			// Read the decompressed size from the meta.json.
-			actualSize = listObjectsInfo.Objects[i].GetActualSize()
-			if actualSize < 0 {
-				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDecompressedSize), r.URL, guessIsBrowserReq(r))
-				return
-			}
-			// Set the info.Size to the actualSize.
-			listObjectsInfo.Objects[i].Size = actualSize
-		} else if crypto.IsEncrypted(listObjectsInfo.Objects[i].UserDefined) {
+		if crypto.IsEncrypted(listObjectsInfo.Objects[i].UserDefined) {
 			listObjectsInfo.Objects[i].ETag = getDecryptedETag(r.Header, listObjectsInfo.Objects[i], false)
-			listObjectsInfo.Objects[i].Size, err = listObjectsInfo.Objects[i].DecryptedSize()
-			if err != nil {
-				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
-				return
-			}
+		}
+		listObjectsInfo.Objects[i].Size, err = listObjectsInfo.Objects[i].GetActualSize()
+		if err != nil {
+			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+			return
 		}
 	}
+
 	response := generateListObjectsV1Response(bucket, prefix, marker, delimiter, encodingType, maxKeys, listObjectsInfo)
 
 	// Write success response.

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -521,7 +521,7 @@ func TestGetActualSize(t *testing.T) {
 		},
 	}
 	for i, test := range testCases {
-		got := test.objInfo.GetActualSize()
+		got, _ := test.objInfo.GetActualSize()
 		if got != test.result {
 			t.Errorf("Test %d - expected %d but received %d",
 				i+1, test.result, got)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1188,10 +1188,6 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	// Write success response.
 	writeSuccessResponseXML(w, encodedSuccessResponse)
 
-	if objInfo.IsCompressed() {
-		objInfo.Size = actualSize
-	}
-
 	// Notify object created event.
 	sendEvent(eventArgs{
 		EventName:    event.ObjectCreatedCopy,
@@ -1507,6 +1503,9 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	setAmzExpirationHeader(w, bucket, objInfo)
 
 	writeSuccessResponseHeadersOnly(w)
+
+	// Set the etag sent to the client as part of the event.
+	objInfo.ETag = etag
 
 	// Notify object created event.
 	sendEvent(eventArgs{

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -383,7 +383,15 @@ func (s *posix) CrawlAndGetDataUsage(ctx context.Context, cache dataUsageCache) 
 			return 0, nil
 		}
 
-		return meta.Stat.Size, nil
+		// we don't necessarily care about the names
+		// of bucket and object, only interested in size.
+		// so use some dummy names.
+		size, err := meta.ToObjectInfo("dummy", "dummy").GetActualSize()
+		if err != nil {
+			return 0, errSkipFile
+		}
+		return size, nil
+
 	})
 	if err != nil {
 		return dataUsageInfo, err

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	github.com/stretchr/testify v1.5.1 // indirect
 	github.com/tinylib/msgp v1.1.1
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
-	github.com/ugorji/go/codec v1.1.5-pre // indirect
+	github.com/ugorji/go v1.1.5-pre // indirect
 	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a
 	github.com/willf/bitset v1.1.10 // indirect
 	github.com/willf/bloom v2.0.3+incompatible


### PR DESCRIPTION
## Description
fix size accounting for encrypted/compressed objects

## Motivation and Context
size calculation in crawler was using the real size
of the object instead of its actual size i.e either
a decrypted or uncompressed size.

this is needed to make sure all other accounting
such as bucket quota and mcs UI to display the
correct values.

## How to test this PR?
Nothing special crawling for encrypted objects should
now display correct usage in erasure-coded deployments

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
