### PR TITLE
fix: add proper errors for disks with preexisting content

### DIFF
--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -181,6 +181,12 @@ Example 1:
 		"",
 	)
 
+	ErrCorruptedBackend = newErrFn(
+		"Unable to use the specified backend, pre-existing content detected",
+		"Please ensure your disk mount does not have any pre-existing content",
+		"",
+	)
+
 	ErrUnableToWriteInBackend = newErrFn(
 		"Unable to write to the backend",
 		"Please ensure MinIO binary has write permissions for the backend",

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/minio/minio/cmd/config"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/cmd/rest"
@@ -227,7 +228,7 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 	// Check if we have
 	for i, sErr := range sErrs {
 		if _, ok := formatCriticalErrors[sErr]; ok {
-			return nil, nil, fmt.Errorf("Disk %s: %w", endpoints[i], sErr)
+			return nil, nil, config.ErrCorruptedBackend(err).Hint(fmt.Sprintf("Clear any pre-existing content on %s", endpoints[i]))
 		}
 		// not critical error but still print the error, nonetheless, which is perhaps unhandled
 		if sErr != errUnformattedDisk && sErr != errDiskNotFound && retryCount >= 5 {


### PR DESCRIPTION
## Description
fix: add proper errors for disks with preexisting content

## Motivation and Context
user friendly UI

## How to test this PR?
Just follow these steps

```
~ mkdir -p /tmp/test/{1..4}/data
~ minio server /tmp/test/{1..4}
ERROR Unable to initialize backend: Unable to use the specified backend, pre-existing content detected
      > Please ensure your disk mount does not have any pre-existing content
      HINT:
        Clear any pre-existing content on /tmp/test/1
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
