### PR TITLE
NAS gateway: Allow bucket policy to be set

### DIFF
--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -40,7 +40,7 @@ type BucketMetadataSys struct {
 
 // Remove bucket metadata from memory.
 func (sys *BucketMetadataSys) Remove(bucket string) {
-	if globalIsGateway {
+	if globalIsGateway && globalGatewayName != "nas" {
 		return
 	}
 	sys.Lock()
@@ -73,7 +73,7 @@ func (sys *BucketMetadataSys) Update(bucket string, configFile string, configDat
 		return errServerNotInitialized
 	}
 
-	if globalIsGateway {
+	if globalIsGateway && globalGatewayName != "nas" {
 		// This code is needed only for gateway implementations.
 		if configFile == bucketPolicyConfig {
 			config, err := policy.ParseConfig(bytes.NewReader(configData), bucket)

--- a/mint/run/core/aws-sdk-php/quick-tests.php
+++ b/mint/run/core/aws-sdk-php/quick-tests.php
@@ -186,7 +186,7 @@ function testHeadObject($s3Client, $objects) {
         if (getStatusCode($result) != HTTP_OK)
             throw new Exception('headObject API failed for ' .
                                 $bucket . '/' . $object);
-        if ($result['Metadata'] != TEST_METADATA) {
+        if (strtolower($result['Metadata']) != strtolower(TEST_METADATA)) {
             throw new Exception("headObject API Metadata didn't match for " .
                                 $bucket . '/' . $object);
         }


### PR DESCRIPTION
## Description
Allow bucket policy to be set in NAS gateway

## Motivation and Context
minio-js bucket policy tests were failing in the case of NAS gateway

## How to test this PR?
```
var Minio = require('minio')

var s3Client = new Minio.Client({
    endPoint: 'localhost',
    port: 9000,
    useSSL: false,
    accessKey: 'minio',
    secretKey: 'minio123'
});

// Bucket policy - GET requests on "testbucket" bucket will not need authentication.
var policy = `
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "s3:GetBucketLocation",
        "s3:ListBucket"
      ],
      "Effect": "Allow",
      "Principal": {
        "AWS": [
          "*"
        ]
      },
      "Resource": [
        "arn:aws:s3:::testbucket"
      ],
      "Sid": ""
    },
    {
      "Action": [
        "s3:GetObject"
      ],
      "Effect": "Allow",
      "Principal": {
        "AWS": [
          "*"
        ]
      },
      "Resource": [
        "arn:aws:s3:::testbucket/*"
      ],
      "Sid": ""
    }
  ]
}
`

s3Client.setBucketPolicy('testbucket', policy, (err) => {
	if (err) throw err

	console.log('Set bucket policy')
})
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
