### PR TITLE
gateway tagging handle copyobject replace tagging

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -511,6 +511,12 @@ func (l *s3Objects) CopyObject(ctx context.Context, srcBucket string, srcObject 
 		srcInfo.UserDefined[k] = v[0]
 	}
 
+	if _, ok := srcInfo.UserDefined[xhttp.AmzObjectTagging]; ok {
+		// Tags are set by user. Default behavior is copy for the existing tags.
+		// If tags are set the x-amz-tagging-directive header is set to REPLACE.
+		srcInfo.UserDefined[xhttp.AmzTagDirective] = "REPLACE"
+	}
+
 	if _, err = l.Client.CopyObject(srcBucket, srcObject, dstBucket, dstObject, srcInfo.UserDefined); err != nil {
 		return objInfo, minio.ErrorRespToObjectError(err, srcBucket, srcObject)
 	}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1076,6 +1076,9 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 			return
 		}
+		if globalIsGateway && globalGatewayName == "s3" && objTags == "" {
+			srcInfo.UserDefined[xhttp.AmzObjectTagging] = objTags
+		}
 	}
 
 	if objTags != "" {


### PR DESCRIPTION

## Description
`X-Amz-Tagging-Directive` set to REPLACE for CopyObject in gateway for some conditions.
Also handles the very specific case where replace tagging directive is set but no tags are given

## Motivation and Context


## How to test this PR?
Use CopyObject() API or copy-object cli command with arguments/values suitably set for tagging-directive and tagging. Below are 4 different cases:

1. Copy object without tagging-directive (default is COPY)
2. Copy object with tagging-directive (COPY)
3. Copy object with tagging-directive (REPLACE) with tags to replace existing tagging
4. Copy object with tagging-directive (REPLACE) but without any tags, so it should remove the existing tags.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
