### PR TITLE
storage: Implement GetDiskID request in REST server side

### DIFF
--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -31,7 +31,7 @@ type StorageAPI interface {
 	IsLocal() bool
 	Hostname() string // Returns host name if remote host.
 	Close() error
-	GetDiskID() (string, error)
+	GetDiskID() (string, error) // Could be expensive
 	SetDiskID(id string)
 
 	DiskInfo() (info DiskInfo, err error)

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -24,6 +24,7 @@ const (
 
 const (
 	storageRESTMethodDiskInfo             = "/diskinfo"
+	storageRESTMethodGetDiskID            = "/getdiskid"
 	storageRESTMethodCrawlAndGetDataUsage = "/crawlandgetdatausage"
 	storageRESTMethodMakeVol              = "/makevol"
 	storageRESTMethodMakeVolBulk          = "/makevolbulk"

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -132,6 +132,22 @@ func (s *storageRESTServer) DiskInfoHandler(w http.ResponseWriter, r *http.Reque
 	gob.NewEncoder(w).Encode(info)
 }
 
+// GetDiskIDHandler - returns disk id.
+func (s *storageRESTServer) GetDiskIDHandler(w http.ResponseWriter, r *http.Request) {
+	if err := storageServerRequestValidate(r); err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+
+	info, err := s.storage.GetDiskID()
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+	defer w.(http.Flusher).Flush()
+	gob.NewEncoder(w).Encode(info)
+}
+
 func (s *storageRESTServer) CrawlAndGetDataUsageHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.IsValid(w, r) {
 		return
@@ -784,6 +800,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointZones EndpointZones
 			subrouter := router.PathPrefix(path.Join(storageRESTPrefix, endpoint.Path)).Subrouter()
 
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodDiskInfo).HandlerFunc(httpTraceHdrs(server.DiskInfoHandler))
+			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodGetDiskID).HandlerFunc(httpTraceHdrs(server.GetDiskIDHandler))
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodCrawlAndGetDataUsage).HandlerFunc(httpTraceHdrs(server.CrawlAndGetDataUsageHandler))
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodMakeVol).HandlerFunc(httpTraceHdrs(server.MakeVolHandler)).Queries(restQueries(storageRESTVolume)...)
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodMakeVolBulk).HandlerFunc(httpTraceHdrs(server.MakeVolBulkHandler)).Queries(restQueries(storageRESTVolumes)...)


### PR DESCRIPTION
## Description
GetDiskID() in storage rest client does not really issue a REST request
to the remote disk, but returns an in-memory value instead.

However, GetDiskID() should return an error when format.json is not
found or for other similar issues (unmounted disks, etc..)

GetDiskID() is only called when formatting disks and getting storage
informatio, hence this commit should not have a performance degradation.

## Motivation and Context
Fixing issue when mc admin info returns no offline disks when some disks are umounted without restarting the cluster


## How to test this PR?
1. Create 4 fake disks:
```
dd if=/dev/zero of=/tmp/disk1 bs=1M count=1200
```
and do the same for disks 2, 3 and 4.

2. 
```
mkfs.ext4 /tmp/disk1
```
 and do the same for disks 2, 3 and 4

3. `mkdir -p /tmp/mnt/{1..4}/`
4. `mount -t loop /tmp/disk1 /tmp/mnt/1` (same for disks 2, 3 and 4)
5. Start a cluster of four nodes (one disk per node)
6. `umount /tmp/disk4`
7. `mc admin info myminio/`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
