### PR TITLE
IAM: Fix nil panic due to uninitialised iamGroupPolicyMap. Fixes #9730

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1798,6 +1798,7 @@ func NewIAMSys() *IAMSys {
 		iamUsersMap:             make(map[string]auth.Credentials),
 		iamPolicyDocsMap:        make(map[string]iampolicy.Policy),
 		iamUserPolicyMap:        make(map[string]MappedPolicy),
+		iamGroupPolicyMap:       make(map[string]MappedPolicy),
 		iamGroupsMap:            make(map[string]GroupInfo),
 		iamUserGroupMemberships: make(map[string]set.StringSet),
 	}


### PR DESCRIPTION
## Description
Fixes potential nil panic due to uninitialised `iamGroupPolicyMap`.

## Motivation and Context
with the latest release it's impossible to assign a policy to a group due to uninitialised iamGroupPolicyMap. The same happens for Server upgrades with existing Policies assigned to groups.

See #9730

## How to test this PR?
```
mc admin user add localhost newuser userpass123
mc admin group add localhost newgroup newuser
mc admin policy set localhost readonly group=newgroup
```
The pervious version would fail with panic at the last command

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #9730
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
