### PR TITLE
Workaround for Windows Docker Engine 19.03.8

### DIFF
--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -367,7 +367,7 @@ func fsFAllocate(fd int, offset int64, len int64) (err error) {
 		switch {
 		case isSysErrNoSpace(e):
 			err = errDiskFull
-		case isSysErrNoSys(e) && !isSysErrOpNotSupported(e):
+		case isSysErrNoSys(e) || isSysErrOpNotSupported(e):
 			// Ignore errors when Fallocate is not supported in the current system
 		case isSysErrInvalidArg(e):
 			// Workaround for Windows Docker Engine 19.03.8.

--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -363,11 +363,15 @@ func fsCreateFile(ctx context.Context, filePath string, reader io.Reader, buf []
 // wrapper to handle various operating system specific errors.
 func fsFAllocate(fd int, offset int64, len int64) (err error) {
 	e := Fallocate(fd, offset, len)
-	// Ignore errors when Fallocate is not supported in the current system
-	if e != nil && !isSysErrNoSys(e) && !isSysErrOpNotSupported(e) {
+	if e != nil {
 		switch {
 		case isSysErrNoSpace(e):
 			err = errDiskFull
+		case isSysErrNoSys(e) && !isSysErrOpNotSupported(e):
+			// Ignore errors when Fallocate is not supported in the current system
+		case isSysErrInvalidArg(e):
+			// Workaround for Windows Docker Engine 19.03.8.
+			// See https://github.com/minio/minio/issues/9726
 		case isSysErrIO(e):
 			err = e
 		default:


### PR DESCRIPTION
## Description

Add workaround for issue preventing servers from starting on Windows Docker Engine 19.03.8

Fixes #9726


## How to test this PR?

On Windows:

```
SET GOOS=linux
SET GOARCH=amd64
go build .

docker build -t minio -f Dockerfile.dev .
docker run -p 9000:9000 --name minio1 -e "MINIO_ACCESS_KEY=minio" -e "MINIO_SECRET_KEY=minio123" -v d:\data\docker:/data --rm -it minio server /data
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
