### PR TITLE
Use registry to check Atime support on Windows

### DIFF
--- a/cmd/disk-cache-check-support_other.go
+++ b/cmd/disk-cache-check-support_other.go
@@ -1,0 +1,56 @@
+// +build !windows
+
+/*
+ * MinIO Cloud Storage, (C) 2019-2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/djherbis/atime"
+)
+
+// Return error if Atime is disabled on the O/S
+func checkAtimeSupport(dir string) (err error) {
+	file, err := ioutil.TempFile(dir, "prefix")
+	if err != nil {
+		return
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+	finfo1, err := os.Stat(file.Name())
+	if err != nil {
+		return
+	}
+	// add a sleep to ensure atime change is detected
+	time.Sleep(10 * time.Millisecond)
+
+	if _, err = io.Copy(ioutil.Discard, file); err != nil {
+		return
+	}
+
+	finfo2, err := os.Stat(file.Name())
+
+	if atime.Get(finfo2).Equal(atime.Get(finfo1)) {
+		return errors.New("Atime not supported")
+	}
+	return
+}

--- a/cmd/disk-cache-check-support_windows.go
+++ b/cmd/disk-cache-check-support_windows.go
@@ -1,0 +1,60 @@
+// +build windows
+
+/*
+ * MinIO Cloud Storage, (C) 2019-2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+
+	"github.com/djherbis/atime"
+	"golang.org/x/sys/windows/registry"
+)
+
+// Return error if Atime is disabled on the O/S
+func checkAtimeSupport(dir string) (err error) {
+	file, err := ioutil.TempFile(dir, "prefix")
+	if err != nil {
+		return
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+	finfo1, err := os.Stat(file.Name())
+	if err != nil {
+		return
+	}
+	atime.Get(finfo1)
+
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Control\FileSystem`, registry.QUERY_VALUE)
+	if err != nil {
+		return
+	}
+	defer k.Close()
+
+	setting, _, err := k.GetIntegerValue("NtfsDisableLastAccessUpdate")
+	if err != nil {
+		return
+	}
+
+	lowSetting := setting & 0xFFFF
+	if lowSetting != uint64(0x0000) && lowSetting != uint64(0x0002) {
+		return errors.New("Atime not supported")
+	}
+	return
+}


### PR DESCRIPTION
## Description
Instead of directly checking for access time support by reading a file, use the registry to check for current setting.

To enable access time updates on Windows, the following needs ran:

```powershell
fsutil behavior set DisableLastAccess 0
```

## Motivation and Context
#5182 added caching, but it didn't work on Windows because the check didn't pass. #7891 added a delay between `os.Stat()` calls, but that isn't enough on Windows.  When enabled, [NTFS has an access time resolution of an hour](https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime?redirectedfrom=MSDN#remarks).

For Windows, instead rely on a registry key called [NtfsDisableLastAccessUpdate](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-behavior#remarks). This is a system wide setting and does have performance implications.

If the ReFS file system is being used, then there's another registry key, [RefsDisableLastAccessUpdate](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831724(v=ws.11)#refs-registry-entry) that isn't being checked. However, it is toggled at the same time when the above `fsutil` command is ran.

Also closes temporary check file before attempting to delete it.

## How to test this PR?
Run on Windows with [caching enabled](https://docs.min.io/docs/minio-quickstart-guide).  Tested with FS configuration.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
