### PR TITLE
azure: Support CopyObjectPart API

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -1046,6 +1046,11 @@ func (a *azureObjects) NewMultipartUpload(ctx context.Context, bucket, object st
 	return uploadID, nil
 }
 
+func (a *azureObjects) CopyObjectPart(ctx context.Context, srcBucket, srcObject, dstBucket, dstObject string, uploadID string, partID int,
+	startOffset int64, length int64, srcInfo minio.ObjectInfo, srcOpts, dstOpts minio.ObjectOptions) (info minio.PartInfo, err error) {
+	return a.PutObjectPart(ctx, dstBucket, dstObject, uploadID, partID, srcInfo.PutObjReader, dstOpts)
+}
+
 // PutObjectPart - Use Azure equivalent `BlobURL.StageBlock`.
 func (a *azureObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID string, partID int, r *minio.PutObjReader, opts minio.ObjectOptions) (info minio.PartInfo, err error) {
 	data := r.Reader


### PR DESCRIPTION
## Description
This PR adds support of copy object part API. Currently Not Implemented is returned

## Motivation and Context
Good to have this support.

## How to test this PR?
1. Create testbucket in your azure blob storage
2. Upload a file called api.log under testbucket.
3. Make sure to put correct Azure credentials for your aws cli setup
4. Execute the script below:

```
#!/bin/bash

aws="aws --endpoint-url http://localhost:9001"

multipart_upload_id=$($aws s3api create-multipart-upload --bucket  testbucket --key api.go.copy | jq -r .UploadId)

part_1_etag=$($aws s3api upload-part-copy --copy-source "/testbucket/api.go" --upload-id $multipart_upload_id --part-number 1 --bucket testbucket --key api.go.copy --copy-source-range "bytes=1-10" | jq -r .CopyPartResult.ETag)

$aws s3api complete-multipart-upload --bucket testbucket --key api.go.copy --upload-id "$multipart_upload_id" --multipart-upload "Parts=[{ETag=$part_1_etag,PartNumber=1}]"

```

5. Check the new copied file testbucket/api.go.copy

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
