### PR TITLE
heal: Fix passing healing opts

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -296,8 +296,8 @@ func (ahs *allHealState) PopHealStatusJSON(path string,
 
 // healSource denotes single entity and heal option.
 type healSource struct {
-	path string          // entity path (format, buckets, objects) to heal
-	opts madmin.HealOpts // optional heal option overrides default setting
+	path string           // entity path (format, buckets, objects) to heal
+	opts *madmin.HealOpts // optional heal option overrides default setting
 }
 
 // healSequence - state for each heal sequence initiated on the
@@ -622,8 +622,8 @@ func (h *healSequence) queueHealTask(source healSource, healType madmin.HealItem
 		opts:       h.settings,
 		responseCh: h.respCh,
 	}
-	if !source.opts.Equal(h.settings) {
-		task.opts = source.opts
+	if source.opts != nil {
+		task.opts = *source.opts
 	}
 	globalBackgroundHealRoutine.queueHealTask(task)
 

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -128,7 +128,7 @@ func deepHealObject(objectPath string) {
 
 	bgSeq.sourceCh <- healSource{
 		path: objectPath,
-		opts: madmin.HealOpts{ScanMode: madmin.HealDeepScan},
+		opts: &madmin.HealOpts{ScanMode: madmin.HealDeepScan},
 	}
 }
 


### PR DESCRIPTION
## Description
Manual healing (as background healing) creates a heal task with a
possiblity to override healing options, such as deep or normal mode.

Use a pointer type in heal opts so nil would mean use the default
healing options.

## Motivation and Context
https://github.com/minio/minio/issues/9724

## How to test this PR?
Described in the issue above

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
