### PR TITLE
fix remove LDAPPassword from audit logs

### DIFF
--- a/cmd/logger/audit.go
+++ b/cmd/logger/audit.go
@@ -135,7 +135,7 @@ func AddAuditTarget(t Target) {
 }
 
 // AuditLog - logs audit logs to all audit targets.
-func AuditLog(w http.ResponseWriter, r *http.Request, api string, reqClaims map[string]interface{}) {
+func AuditLog(w http.ResponseWriter, r *http.Request, api string, reqClaims map[string]interface{}, filterKeys ...string) {
 	// Fast exit if there is not audit target configured
 	if len(AuditTargets) == 0 {
 		return
@@ -162,6 +162,12 @@ func AuditLog(w http.ResponseWriter, r *http.Request, api string, reqClaims map[
 	}
 
 	entry := audit.ToEntry(w, r, reqClaims, globalDeploymentID)
+	for _, filterKey := range filterKeys {
+		delete(entry.ReqClaims, filterKey)
+		delete(entry.ReqQuery, filterKey)
+		delete(entry.ReqHeader, filterKey)
+		delete(entry.RespHeader, filterKey)
+	}
 	entry.API.Name = api
 	entry.API.Bucket = bucket
 	entry.API.Object = object

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
-github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
-github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=


### PR DESCRIPTION


## Description
fix remove LDAPPassword from audit logs

## Motivation and Context
The previous fix for #9707 was not correct,
fix this properly passing the right
filter keys to be filtered from the audit
log output.

## How to test this PR?
Run the webhook.go

```go
package main

import (
	"fmt"
	"io/ioutil"
	"log"
	"net/http"
)

func hello(w http.ResponseWriter, r *http.Request) {
	if r.URL.Path != "/" {
		http.Error(w, "404 not found.", http.StatusNotFound)
		return
	}

	fmt.Println("Authorization header", r.Header.Get("Authorization"))
	switch r.Method {
	case "POST":
		body, err := ioutil.ReadAll(r.Body)
		if err != nil {
			fmt.Fprintf(w, "ReadError() err: %v", err)
			return
		}
		fmt.Println(string(body))
	default:
		fmt.Fprintf(w, "Sorry, only POST methods are supported.")
	}
}

func main() {
	http.HandleFunc("/", hello)

	if err := http.ListenAndServe(":9056", nil); err != nil {
		log.Fatal(err)
	}
}
```

Configure the server to send audit logs to this webhook server
```
~ MINIO_AUDIT_WEBHOOK_ENABLE=on MINIO_AUDIT_WEBHOOK_ENDPOINT=http://localhost:9056 minio server ~/test
```

And send curl request
```
~ curl --data-urlencode "" "http://localhost:9000/?Action=AssumeRoleWithLDAPIdentity&LDAPUsername=foouser&LDAPPassword=foouserpassword&Version=2011-06-15" 
```

Observe on the webhook console that LDAPPassword shouldn't be displayed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
