### PR TITLE
fix: throw error if symmetry cannot be obtained

### DIFF
--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -182,7 +182,7 @@ func getSetIndexes(args []string, totalSizes []uint64, customSetDriveCount uint6
 		setCounts = possibleSetCountsWithSymmetry(setCounts, argPatterns)
 
 		if len(setCounts) == 0 {
-			msg := fmt.Sprintf("No symmertric distribution detected with input endpoints provided %s, disks %d cannot be spread symmetrically by any supported erasure set sizes %d", args, commonSize, setSizes)
+			msg := fmt.Sprintf("No symmetric distribution detected with input endpoints provided %s, disks %d cannot be spread symmetrically by any supported erasure set sizes %d", args, commonSize, setSizes)
 			return nil, config.ErrInvalidNumberOfErasureEndpoints(nil).Msg(msg)
 		}
 

--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -181,6 +181,11 @@ func getSetIndexes(args []string, totalSizes []uint64, customSetDriveCount uint6
 		// Returns possible set counts with symmetry.
 		setCounts = possibleSetCountsWithSymmetry(setCounts, argPatterns)
 
+		if len(setCounts) == 0 {
+			msg := fmt.Sprintf("No symmertric distribution detected with input endpoints provided %s, disks %d cannot be spread symmetrically by any supported erasure set sizes %d", args, commonSize, setSizes)
+			return nil, config.ErrInvalidNumberOfErasureEndpoints(nil).Msg(msg)
+		}
+
 		// Final set size with all the symmetry accounted for.
 		setSize = commonSetDriveCount(commonSize, setCounts)
 	}

--- a/cmd/endpoint-ellipses_test.go
+++ b/cmd/endpoint-ellipses_test.go
@@ -211,6 +211,12 @@ func TestGetSetIndexes(t *testing.T) {
 			nil,
 			false,
 		},
+		{
+			[]string{"data{1...17}/export{1...52}"},
+			[]uint64{14144},
+			nil,
+			false,
+		},
 		// Valid inputs.
 		{
 			[]string{"data{1...27}"},
@@ -270,6 +276,12 @@ func TestGetSetIndexes(t *testing.T) {
 			[]string{"data/controller1/export{1...10}, data/controller2/export{1...10}, data/controller3/export{1...10}"},
 			[]uint64{10, 10, 10},
 			[][]uint64{{10}, {10}, {10}},
+			true,
+		},
+		{
+			[]string{"data{1...16}/export{1...52}"},
+			[]uint64{832},
+			[][]uint64{{16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16}},
 			true,
 		},
 	}


### PR DESCRIPTION

## Description
fix: throw an error if symmetry cannot be obtained

## Motivation and Context
For example `{1...17}/{1...52}` symmetrical
distribution of drives cannot be obtained

- Because 17 is a prime number
- Is not divisible by any pre-defined setCounts i.e
  from 1 to 16

# How to test this PR?
Just try to start the server as `minio server /tmp/data{1...17}/drives{1...52}` it would crash with
current master, this throws an appropriate error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
