### PR TITLE
lifecycle: Fix object expiration date

### DIFF
--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -257,7 +257,7 @@ func isETagEqual(left, right string) bool {
 // after analyzing the current bucket lifecycle rules if any.
 func setAmzExpirationHeader(w http.ResponseWriter, bucket string, objInfo ObjectInfo) {
 	if lc, err := globalLifecycleSys.Get(bucket); err == nil {
-		ruleID, expiryTime := lc.PredictExpiryTime(objInfo.Name, objInfo.UserTags)
+		ruleID, expiryTime := lc.PredictExpiryTime(objInfo.Name, objInfo.ModTime, objInfo.UserTags)
 		if !expiryTime.IsZero() {
 			w.Header()[xhttp.AmzExpiration] = []string{
 				fmt.Sprintf(`expiry-date="%s", rule-id="%s"`, expiryTime.Format(http.TimeFormat), ruleID),

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -122,20 +122,10 @@ func (lc Lifecycle) ComputeAction(objName, objTags string, modTime time.Time) (a
 	if modTime.IsZero() {
 		return
 	}
-	rules := lc.FilterActionableRules(objName, objTags)
-	for _, rule := range rules {
-		if !rule.Expiration.IsDateNull() {
-			if time.Now().After(rule.Expiration.Date.Time) {
-				action = DeleteAction
-				return
-			}
-		}
-		if !rule.Expiration.IsDaysNull() {
-			if time.Now().After(expectedExpiryTime(modTime, rule.Expiration.Days)) {
-				action = DeleteAction
-				return
-			}
-		}
+
+	_, expiryTime := lc.PredictExpiryTime(objName, modTime, objTags)
+	if !expiryTime.IsZero() && time.Now().After(expiryTime) {
+		return DeleteAction
 	}
 	return
 }
@@ -152,7 +142,7 @@ func expectedExpiryTime(modTime time.Time, days ExpirationDays) time.Time {
 
 // PredictExpiryTime returns the expiry date/time of a given object
 // after evaluting the current lifecycle document.
-func (lc Lifecycle) PredictExpiryTime(objName, objTags string) (string, time.Time) {
+func (lc Lifecycle) PredictExpiryTime(objName string, modTime time.Time, objTags string) (string, time.Time) {
 	var finalExpiryDate time.Time
 	var finalExpiryRuleID string
 
@@ -166,7 +156,7 @@ func (lc Lifecycle) PredictExpiryTime(objName, objTags string) (string, time.Tim
 			}
 		}
 		if !rule.Expiration.IsDaysNull() {
-			expectedExpiry := expectedExpiryTime(time.Now(), rule.Expiration.Days)
+			expectedExpiry := expectedExpiryTime(modTime, rule.Expiration.Days)
 			if finalExpiryDate.IsZero() || finalExpiryDate.After(expectedExpiry) {
 				finalExpiryRuleID = rule.ID
 				finalExpiryDate = expectedExpiry


### PR DESCRIPTION
## Description
This commit will also use PredictExpiryTime() in ComputeAction()
to avoid code redundancy.

## Motivation and Context
Fix https://github.com/minio/minio/issues/9786

## How to test this PR?
Set a bucket lifecycle in a given bucket (docs/lifecycle/README.md), upload an object and check its expiry time using `mc --debug stat` command.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
