### PR TITLE
Avoid overwriting object tags when changing lock

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2699,8 +2699,11 @@ func (api objectAPIHandlers) PutObjectLegalHoldHandler(w http.ResponseWriter, r 
 		return
 	}
 	objInfo.UserDefined[strings.ToLower(xhttp.AmzObjectLockLegalHold)] = strings.ToUpper(string(legalHold.Status))
+	if objInfo.UserTags != "" {
+		objInfo.UserDefined[xhttp.AmzTagDirective] = replaceDirective
+		objInfo.UserDefined[xhttp.AmzObjectTagging] = objInfo.UserTags
+	}
 	objInfo.metadataOnly = true
-
 	if _, err = objectAPI.CopyObject(ctx, bucket, object, bucket, object, objInfo, ObjectOptions{}, ObjectOptions{}); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
@@ -2857,6 +2860,10 @@ func (api objectAPIHandlers) PutObjectRetentionHandler(w http.ResponseWriter, r 
 
 	objInfo.UserDefined[strings.ToLower(xhttp.AmzObjectLockMode)] = string(objRetention.Mode)
 	objInfo.UserDefined[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)] = objRetention.RetainUntilDate.UTC().Format(time.RFC3339)
+	if objInfo.UserTags != "" {
+		objInfo.UserDefined[xhttp.AmzTagDirective] = replaceDirective
+		objInfo.UserDefined[xhttp.AmzObjectTagging] = objInfo.UserTags
+	}
 	objInfo.metadataOnly = true // Perform only metadata updates.
 	if _, err = objectAPI.CopyObject(ctx, bucket, object, bucket, object, objInfo, ObjectOptions{}, ObjectOptions{}); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -85,7 +85,7 @@ func (entry FileInfo) ToObjectInfo() ObjectInfo {
 			ContentEncoding: entry.Metadata["content-encoding"],
 		}
 
-		// Extrat object tagging information
+		// Extract object tagging information
 		objInfo.UserTags = entry.Metadata[xhttp.AmzObjectTagging]
 
 		// Extract etag from metadata.


### PR DESCRIPTION
configuration via PutObjectRetention/PutObjectLegalHold
API's

## Description


## Motivation and Context
Currently user set tags on a object get overwritten when retention or legal hold configurations are changed.

## How to test this PR?
Set tags using `mc tag` on a object in lock enabled bucket
set `mc legalhold` to enable legal hold 
With this PR tags would not get overwritten
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
