### PR TITLE
Check object names on windows

### DIFF
--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -183,6 +183,16 @@ func checkObjectNameForLengthAndSlash(bucket, object string) error {
 			Object: object,
 		}
 	}
+	if runtime.GOOS == globalWindowsOSName {
+		// Explicitly disallowed characters on windows.
+		// Avoids most problematic names.
+		if strings.ContainsAny(object, `:*?"|<>`) {
+			return ObjectNameInvalid{
+				Bucket: bucket,
+				Object: object,
+			}
+		}
+	}
 	return nil
 }
 

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -1289,6 +1289,9 @@ func (s *posix) CreateFile(volume, path string, fileSize int64, r io.Reader) (er
 	// Create top level directories if they don't exist.
 	// with mode 0777 mkdir honors system umask.
 	if err = mkdirAll(slashpath.Dir(filePath), 0777); err != nil {
+		if errors.Is(err, &os.PathError{}) {
+			return errFileAccessDenied
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Description

Uploading files with names that could not be written to disk would result in "reduce your request" errors returned.

Instead check explicitly for disallowed characters and reject files with `Object name contains unsupported characters.`

## How to test this PR?

Upload files with invalid characters.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
