### PR TITLE
Reconnect RPC client async

### DIFF
--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/gob"
+	"errors"
 	"io"
 	"io/ioutil"
 	"math"
@@ -104,7 +105,7 @@ func (client *peerRESTClient) MarkOffline() {
 				respBody, err := client.callWithContext(ctx, peerRESTMethodServerInfo, nil, nil, -1)
 				http.DrainBody(respBody)
 				cancel()
-				if !isNetworkError(err) {
+				if !errors.Is(err, context.DeadlineExceeded) && !isNetworkError(err) {
 					atomic.CompareAndSwapInt32(&client.connected, 0, 1)
 					return
 				}

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -102,7 +102,7 @@ func (client *peerRESTClient) MarkOffline() {
 			defer ticker.Stop()
 			for range ticker.C {
 				ctx, cancel := context.WithTimeout(GlobalContext, retryTimeout)
-				respBody, err := client.callWithContext(ctx, peerRESTMethodServerInfo, nil, nil, -1)
+				respBody, err := client.callWithContext(ctx, peerRESTMethodGetLocalDiskIDs, nil, nil, -1)
 				http.DrainBody(respBody)
 				cancel()
 				if !errors.Is(err, context.DeadlineExceeded) && !isNetworkError(err) {

--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -42,6 +42,11 @@ func (n *NetworkError) Error() string {
 	return n.Err.Error()
 }
 
+// Unwrap returns the wrapped NetworkError.
+func (n *NetworkError) Unwrap() error {
+	return n.Err
+}
+
 // Client - http based RPC client.
 type Client struct {
 	httpClient          *http.Client

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -44,6 +44,9 @@ var errDataTooSmall = errors.New("Object size smaller than expected")
 // errServerNotInitialized - server not initialized.
 var errServerNotInitialized = errors.New("Server not initialized, please try again")
 
+// errServerOffline - server marked as offline.
+var errServerOffline = errors.New("Server offline, please try again")
+
 // errRPCAPIVersionUnsupported - unsupported rpc API version.
 var errRPCAPIVersionUnsupported = errors.New("Unsupported rpc API version")
 


### PR DESCRIPTION
## Motivation and Context

Currently marking a client as offline has no other effect than all calls trying to reconnect anyway, so it is a waste of resources.

When encountering a rest network error we spawn a goroutine that will attempt to reconnect every 200ms and reject requests until the server is reconnected.

Closing a client will also keep the connection closed whereas now it has no effect.

The effect should be that an offline server will make the rest of the cluster behave much better since requests will fail instantly and not put additional pressure on the system.

Fixes #9508

## How to test this PR?

Start cluster, kill a server.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
