### PR TITLE
Avoid storing X-Amz-Tagging-Directive in metadata

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2710,7 +2710,6 @@ func (api objectAPIHandlers) PutObjectLegalHoldHandler(w http.ResponseWriter, r 
 	}
 	objInfo.UserDefined[strings.ToLower(xhttp.AmzObjectLockLegalHold)] = strings.ToUpper(string(legalHold.Status))
 	if objInfo.UserTags != "" {
-		objInfo.UserDefined[xhttp.AmzTagDirective] = replaceDirective
 		objInfo.UserDefined[xhttp.AmzObjectTagging] = objInfo.UserTags
 	}
 	objInfo.metadataOnly = true
@@ -2871,7 +2870,6 @@ func (api objectAPIHandlers) PutObjectRetentionHandler(w http.ResponseWriter, r 
 	objInfo.UserDefined[strings.ToLower(xhttp.AmzObjectLockMode)] = string(objRetention.Mode)
 	objInfo.UserDefined[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)] = objRetention.RetainUntilDate.UTC().Format(time.RFC3339)
 	if objInfo.UserTags != "" {
-		objInfo.UserDefined[xhttp.AmzTagDirective] = replaceDirective
 		objInfo.UserDefined[xhttp.AmzObjectTagging] = objInfo.UserTags
 	}
 	objInfo.metadataOnly = true // Perform only metadata updates.


### PR DESCRIPTION
## Description


## Motivation and Context
X-Amz-Tagging-Directive is useful only to process the client request, not needed to store as metadata. Commit 3d3b75fb8d42409d717c27b1c1c70b4a925d0e3f should have avoided storing this key.

## How to test this PR?
See xl.json after doing a `mc tag set` and setting `mc legalhold` on an object - the X-Amz-Tagging-Directive is also stored in metadata on the master branch.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
