### PR TITLE
isEndpointConnected should take local disk inputs

### DIFF
--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -190,7 +190,11 @@ func (s *xlSets) connectDisks() {
 	var wg sync.WaitGroup
 	diskMap := s.getDiskMap()
 	for _, endpoint := range s.endpoints {
-		if isEndpointConnected(diskMap, endpoint.String()) {
+		diskPath := endpoint.String()
+		if endpoint.IsLocal {
+			diskPath = endpoint.Path
+		}
+		if isEndpointConnected(diskMap, diskPath) {
 			continue
 		}
 		wg.Add(1)


### PR DESCRIPTION

## Description
isEndpointConnected should take local disk inputs

## Motivation and Context
PR #9801 while it is correct, the loop isEndpointConnected()
was changed to rely on endpoint.String() which has the host
information as well, which is not correct value as input to
detect if the disk is down or up, if endpoint is local use
its local path value instead.


## How to test this PR?
Nothing special just check that local disks shouldn't 
be mistaken as offline. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
