### PR TITLE
fix: optimize IAM users load, add fallback

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -899,13 +899,26 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 			HTTPStatusCode: e.StatusCode,
 		}
 	default:
-		if errors.Is(err, errConfigNotFound) {
+		switch {
+		case errors.Is(err, errConfigNotFound):
 			apiErr = APIError{
 				Code:           "XMinioConfigError",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusNotFound,
 			}
-		} else {
+		case errors.Is(err, errIAMActionNotAllowed):
+			apiErr = APIError{
+				Code:           "XMinioIAMActionNotAllowed",
+				Description:    err.Error(),
+				HTTPStatusCode: http.StatusForbidden,
+			}
+		case errors.Is(err, errIAMNotInitialized):
+			apiErr = APIError{
+				Code:           "XMinioIAMNotInitialized",
+				Description:    err.Error(),
+				HTTPStatusCode: http.StatusServiceUnavailable,
+			}
+		default:
 			apiErr = errorCodes.ToAPIErrWithErr(toAdminAPIErrCode(ctx, err), err)
 		}
 	}

--- a/cmd/iam-etcd-store.go
+++ b/cmd/iam-etcd-store.go
@@ -449,18 +449,43 @@ func (ies *IAMEtcdStore) loadMappedPolicies(ctx context.Context, userType IAMUse
 func (ies *IAMEtcdStore) loadAll(ctx context.Context, sys *IAMSys) error {
 	iamUsersMap := make(map[string]auth.Credentials)
 	iamGroupsMap := make(map[string]GroupInfo)
-	iamPolicyDocsMap := make(map[string]iampolicy.Policy)
 	iamUserPolicyMap := make(map[string]MappedPolicy)
 	iamGroupPolicyMap := make(map[string]MappedPolicy)
 
-	isMinIOUsersSys := false
 	ies.rlock()
-	if sys.usersSysType == MinIOUsersSysType {
-		isMinIOUsersSys = true
-	}
+	isMinIOUsersSys := sys.usersSysType == MinIOUsersSysType
 	ies.runlock()
 
-	if err := ies.loadPolicyDocs(ctx, iamPolicyDocsMap); err != nil {
+	ies.lock()
+	if err := ies.loadPolicyDocs(ctx, sys.iamPolicyDocsMap); err != nil {
+		ies.unlock()
+		return err
+	}
+	// Sets default canned policies, if none are set.
+	setDefaultCannedPolicies(sys.iamPolicyDocsMap)
+
+	ies.unlock()
+
+	if isMinIOUsersSys {
+		if err := ies.loadUsers(ctx, regularUser, iamUsersMap); err != nil {
+			return err
+		}
+		if err := ies.loadGroups(ctx, iamGroupsMap); err != nil {
+			return err
+		}
+	}
+
+	// load polices mapped to users
+	if err := ies.loadMappedPolicies(ctx, regularUser, false, iamUserPolicyMap); err != nil {
+		return err
+	}
+
+	// load policies mapped to groups
+	if err := ies.loadMappedPolicies(ctx, regularUser, true, iamGroupPolicyMap); err != nil {
+		return err
+	}
+
+	if err := ies.loadUsers(ctx, srvAccUser, iamUsersMap); err != nil {
 		return err
 	}
 
@@ -469,28 +494,8 @@ func (ies *IAMEtcdStore) loadAll(ctx context.Context, sys *IAMSys) error {
 		return err
 	}
 
-	if isMinIOUsersSys {
-		// load long term users
-		if err := ies.loadUsers(ctx, regularUser, iamUsersMap); err != nil {
-			return err
-		}
-		if err := ies.loadUsers(ctx, srvAccUser, iamUsersMap); err != nil {
-			return err
-		}
-		if err := ies.loadGroups(ctx, iamGroupsMap); err != nil {
-			return err
-		}
-		if err := ies.loadMappedPolicies(ctx, regularUser, false, iamUserPolicyMap); err != nil {
-			return err
-		}
-	}
-
-	// load STS policy mappings into the same map
+	// load STS policy mappings
 	if err := ies.loadMappedPolicies(ctx, stsUser, false, iamUserPolicyMap); err != nil {
-		return err
-	}
-	// load policies mapped to groups
-	if err := ies.loadMappedPolicies(ctx, regularUser, true, iamGroupPolicyMap); err != nil {
 		return err
 	}
 
@@ -505,13 +510,6 @@ func (ies *IAMEtcdStore) loadAll(ctx context.Context, sys *IAMSys) error {
 	for k, v := range iamUsersMap {
 		sys.iamUsersMap[k] = v
 	}
-
-	for k, v := range iamPolicyDocsMap {
-		sys.iamPolicyDocsMap[k] = v
-	}
-
-	// Sets default canned policies, if none are set.
-	setDefaultCannedPolicies(sys.iamPolicyDocsMap)
 
 	for k, v := range iamUserPolicyMap {
 		sys.iamUserPolicyMap[k] = v
@@ -535,6 +533,7 @@ func (ies *IAMEtcdStore) loadAll(ctx context.Context, sys *IAMSys) error {
 	}
 
 	sys.buildUserGroupMemberships()
+	sys.storeFallback = false
 
 	return nil
 }

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -216,7 +216,8 @@ type IAMSys struct {
 	iamGroupPolicyMap map[string]MappedPolicy
 
 	// Persistence layer for IAM subsystem
-	store IAMStorageAPI
+	store         IAMStorageAPI
+	storeFallback bool
 }
 
 // IAMUserType represents a user type inside MinIO server
@@ -413,7 +414,7 @@ func startBackgroundIAMLoad(ctx context.Context) {
 	go globalIAMSys.Init(ctx, newObjectLayerWithoutSafeModeFn())
 }
 
-// Init - initializes config system from iam.json
+// Init - initializes config system by reading entries from config/iam
 func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 	if objAPI == nil {
 		logger.LogIf(ctx, errServerNotInitialized)
@@ -461,7 +462,8 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 			// IAM sub-system, make sure that we do not move the above codeblock elsewhere.
 			if err := migrateIAMConfigsEtcdToEncrypted(ctx, globalEtcdClient); err != nil {
 				txnLk.Unlock()
-				logger.LogIf(ctx, fmt.Errorf("Unable to handle encrypted backend for iam and policies: %w", err))
+				logger.LogIf(ctx, fmt.Errorf("Unable to decrypt an encrypted ETCD backend for IAM users and policies: %w", err))
+				logger.LogIf(ctx, errors.New("IAM sub-system is partially initialized, some users may not be available"))
 				return
 			}
 		}
@@ -471,7 +473,7 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 			logger.Info("Waiting for all MinIO IAM sub-system to be initialized.. lock acquired")
 		}
 
-		// Migrate IAM configuration
+		// Migrate IAM configuration, if necessary.
 		if err := sys.doIAMConfigMigration(ctx); err != nil {
 			txnLk.Unlock()
 			if errors.Is(err, errDiskNotFound) ||
@@ -484,19 +486,24 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 				logger.Info("Waiting for all MinIO IAM sub-system to be initialized.. possible cause (%v)", err)
 				continue
 			}
-			logger.LogIf(ctx, fmt.Errorf("Unable to migration IAM users and policies: %w", err))
+			logger.LogIf(ctx, fmt.Errorf("Unable to migrate IAM users and policies to new format: %w", err))
+			logger.LogIf(ctx, errors.New("IAM sub-system is partially initialized, some users may not be available"))
 			return
 		}
 
-		// Successfully migrated
+		// Successfully migrated, proceed to load the users.
 		txnLk.Unlock()
 		break
 	}
 
-	logger.LogIf(ctx, sys.store.loadAll(ctx, sys))
+	err := sys.store.loadAll(ctx, sys)
 
-	// Invalidate the old cred after finishing IAM initialization
+	// Invalidate the old cred always, even upon error to avoid any leakage.
 	globalOldCred = auth.Credentials{}
+
+	if err != nil {
+		logger.LogIf(ctx, fmt.Errorf("Unable to initialize IAM sub-system, some users may not be available %w", err))
+	}
 
 	go sys.store.watch(ctx, sys)
 }
@@ -581,6 +588,10 @@ func (sys *IAMSys) ListPolicies() (map[string]iampolicy.Policy, error) {
 
 	sys.store.rlock()
 	defer sys.store.runlock()
+
+	if sys.storeFallback {
+		return nil, errIAMNotInitialized
+	}
 
 	policyDocsMap := make(map[string]iampolicy.Policy, len(sys.iamPolicyDocsMap))
 	for k, v := range sys.iamPolicyDocsMap {
@@ -729,6 +740,10 @@ func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
 
 	if sys.usersSysType != MinIOUsersSysType {
 		return nil, errIAMActionNotAllowed
+	}
+
+	if sys.storeFallback {
+		return nil, errIAMNotInitialized
 	}
 
 	for k, v := range sys.iamUsersMap {
@@ -965,6 +980,10 @@ func (sys *IAMSys) ListServiceAccounts(ctx context.Context, accessKey string) ([
 	sys.store.rlock()
 	defer sys.store.runlock()
 
+	if sys.storeFallback {
+		return nil, errIAMNotInitialized
+	}
+
 	var serviceAccounts []string
 
 	for k, v := range sys.iamUsersMap {
@@ -1094,6 +1113,44 @@ func (sys *IAMSys) GetUser(accessKey string) (cred auth.Credentials, ok bool) {
 	objectAPI := newObjectLayerWithoutSafeModeFn()
 	if objectAPI == nil || sys == nil || sys.store == nil {
 		return cred, false
+	}
+
+	sys.store.rlock()
+	fallback := sys.storeFallback
+	sys.store.runlock()
+	if fallback {
+		sys.store.lock()
+		// If user is already found proceed.
+		if _, found := sys.iamUsersMap[accessKey]; !found {
+			sys.store.loadUser(accessKey, regularUser, sys.iamUsersMap)
+			if _, found = sys.iamUsersMap[accessKey]; found {
+				// found user, load its mapped policies
+				sys.store.loadMappedPolicy(accessKey, regularUser, false, sys.iamUserPolicyMap)
+			} else {
+				sys.store.loadUser(accessKey, srvAccUser, sys.iamUsersMap)
+				if svc, found := sys.iamUsersMap[accessKey]; found {
+					// Found service account, load its parent user and its mapped policies.
+					if sys.usersSysType == MinIOUsersSysType {
+						sys.store.loadUser(svc.ParentUser, regularUser, sys.iamUsersMap)
+					}
+					sys.store.loadMappedPolicy(svc.ParentUser, regularUser, false, sys.iamUserPolicyMap)
+				} else {
+					// None found fall back to STS users.
+					sys.store.loadUser(accessKey, stsUser, sys.iamUsersMap)
+					if _, found = sys.iamUsersMap[accessKey]; found {
+						// STS user found, load its mapped policy.
+						sys.store.loadMappedPolicy(accessKey, stsUser, false, sys.iamUserPolicyMap)
+					}
+				}
+			}
+		}
+		// Load associated policies if any.
+		for _, policy := range sys.iamUserPolicyMap[accessKey].toSlice() {
+			if _, found := sys.iamPolicyDocsMap[policy]; !found {
+				sys.store.loadPolicyDoc(policy, sys.iamPolicyDocsMap)
+			}
+		}
+		sys.store.unlock()
 	}
 
 	sys.store.rlock()
@@ -1343,6 +1400,10 @@ func (sys *IAMSys) ListGroups() (r []string, err error) {
 
 	sys.store.rlock()
 	defer sys.store.runlock()
+
+	if sys.storeFallback {
+		return nil, errIAMNotInitialized
+	}
 
 	if sys.usersSysType != MinIOUsersSysType {
 		return nil, errIAMActionNotAllowed
@@ -1869,5 +1930,6 @@ func NewIAMSys() *IAMSys {
 		iamGroupPolicyMap:       make(map[string]MappedPolicy),
 		iamGroupsMap:            make(map[string]GroupInfo),
 		iamUserGroupMemberships: make(map[string]set.StringSet),
+		storeFallback:           true,
 	}
 }

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -88,7 +88,10 @@ var errGroupNotEmpty = errors.New("Specified group is not empty - cannot remove 
 var errNoSuchPolicy = errors.New("Specified canned policy does not exist")
 
 // error returned in IAM subsystem when an external users systems is configured.
-var errIAMActionNotAllowed = errors.New("Specified IAM action is not allowed under the current configuration")
+var errIAMActionNotAllowed = errors.New("Specified IAM action is not allowed with LDAP configuration")
+
+// error returned in IAM subsystem when IAM sub-system is still being initialized.
+var errIAMNotInitialized = errors.New("IAM sub-system is being initialized, please try again")
 
 // error returned when access is denied.
 var errAccessDenied = errors.New("Do not have enough permissions to access this resource")


### PR DESCRIPTION

## Description
fix: optimize IAM users load, add a fallback

## Motivation and Context
Bonus fix, load service accounts properly
when service accounts were generated with
LDAP

# How to test this PR?
Have a list of 1000 users and start the server, some users slowly 
will become available as the IAM sub-system lazily loads, allow
a fallback until then if the client requests come in with requests
as the S3 API is initialized already. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
