### PR TITLE
Support for context with long running Disk calls

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1156,18 +1156,18 @@ func (fs *FSObjects) DeleteObject(ctx context.Context, bucket, object string) er
 // is a leaf or non-leaf entry.
 func (fs *FSObjects) listDirFactory() ListDirFunc {
 	// listDir - lists all the entries at a given prefix and given entry in the prefix.
-	listDir := func(bucket, prefixDir, prefixEntry string) (emptyDir bool, entries []string) {
+	listDir := func(ctx context.Context, bucket, prefixDir, prefixEntry string) (emptyDir bool, entries []string, aborted bool) {
 		var err error
 		entries, err = readDir(pathJoin(fs.fsPath, bucket, prefixDir))
 		if err != nil && err != errFileNotFound {
-			logger.LogIf(GlobalContext, err)
-			return false, nil
+			logger.LogIf(ctx, err)
+			return false, nil, true
 		}
 		if len(entries) == 0 {
-			return true, nil
+			return true, nil, false
 		}
 		sort.Strings(entries)
-		return false, filterMatchingPrefix(entries, prefixEntry)
+		return false, filterMatchingPrefix(entries, prefixEntry), false
 	}
 
 	// Return list factory instance.

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -114,7 +114,7 @@ func healErasureSet(ctx context.Context, setIndex int, xlObj *xlObjects, drivesP
 				// Disk can be offline
 				continue
 			}
-			entryCh, err := disk.Walk(bucket.Name, "", "", true, xlMetaJSONFile, readMetadata, ctx.Done())
+			entryCh, err := disk.Walk(ctx, bucket.Name, "", "", true, xlMetaJSONFile, readMetadata, ctx.Done())
 			if err != nil {
 				// Disk walk returned error, ignore it.
 				continue

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -128,6 +128,7 @@ func (d *naughtyDisk) StatVol(volume string) (volInfo VolInfo, err error) {
 	}
 	return d.disk.StatVol(volume)
 }
+
 func (d *naughtyDisk) DeleteVol(volume string, forceDelete bool) (err error) {
 	if err := d.calcError(); err != nil {
 		return err
@@ -135,25 +136,25 @@ func (d *naughtyDisk) DeleteVol(volume string, forceDelete bool) (err error) {
 	return d.disk.DeleteVol(volume, forceDelete)
 }
 
-func (d *naughtyDisk) WalkSplunk(volume, path, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error) {
+func (d *naughtyDisk) WalkSplunk(ctx context.Context, volume, path, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error) {
 	if err := d.calcError(); err != nil {
 		return nil, err
 	}
-	return d.disk.WalkSplunk(volume, path, marker, endWalkCh)
+	return d.disk.WalkSplunk(ctx, volume, path, marker, endWalkCh)
 }
 
-func (d *naughtyDisk) Walk(volume, path, marker string, recursive bool, leafFile string, readMetadataFn readMetadataFunc, endWalkCh <-chan struct{}) (chan FileInfo, error) {
+func (d *naughtyDisk) Walk(ctx context.Context, volume, path, marker string, recursive bool, leafFile string, readMetadataFn readMetadataFunc, endWalkCh <-chan struct{}) (chan FileInfo, error) {
 	if err := d.calcError(); err != nil {
 		return nil, err
 	}
-	return d.disk.Walk(volume, path, marker, recursive, leafFile, readMetadataFn, endWalkCh)
+	return d.disk.Walk(ctx, volume, path, marker, recursive, leafFile, readMetadataFn, endWalkCh)
 }
 
-func (d *naughtyDisk) ListDir(volume, path string, count int, leafFile string) (entries []string, err error) {
+func (d *naughtyDisk) ListDir(ctx context.Context, volume, path string, count int, leafFile string) (entries []string, err error) {
 	if err := d.calcError(); err != nil {
 		return []string{}, err
 	}
-	return d.disk.ListDir(volume, path, count, leafFile)
+	return d.disk.ListDir(ctx, volume, path, count, leafFile)
 }
 
 func (d *naughtyDisk) ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
@@ -205,19 +206,11 @@ func (d *naughtyDisk) DeleteFile(volume string, path string) (err error) {
 	return d.disk.DeleteFile(volume, path)
 }
 
-func (d *naughtyDisk) DeleteFileBulk(volume string, paths []string) ([]error, error) {
-	errs := make([]error, len(paths))
-	for idx, path := range paths {
-		errs[idx] = d.disk.DeleteFile(volume, path)
-	}
-	return errs, nil
-}
-
-func (d *naughtyDisk) DeletePrefixes(volume string, paths []string) ([]error, error) {
+func (d *naughtyDisk) DeletePrefixes(ctx context.Context, volume string, paths []string) ([]error, error) {
 	if err := d.calcError(); err != nil {
 		return nil, err
 	}
-	return d.disk.DeletePrefixes(volume, paths)
+	return d.disk.DeletePrefixes(ctx, volume, paths)
 }
 
 func (d *naughtyDisk) WriteAll(volume string, path string, reader io.Reader) (err error) {
@@ -234,9 +227,9 @@ func (d *naughtyDisk) ReadAll(volume string, path string) (buf []byte, err error
 	return d.disk.ReadAll(volume, path)
 }
 
-func (d *naughtyDisk) VerifyFile(volume, path string, size int64, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
+func (d *naughtyDisk) VerifyFile(ctx context.Context, volume, path string, size int64, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
 	if err := d.calcError(); err != nil {
 		return err
 	}
-	return d.disk.VerifyFile(volume, path, size, algo, sum, shardSize)
+	return d.disk.VerifyFile(ctx, volume, path, size, algo, sum, shardSize)
 }

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -105,7 +105,7 @@ func cleanupDir(ctx context.Context, storage StorageAPI, volume, dirPath string)
 		}
 
 		// If it's a directory, list and call delFunc() for each entry.
-		entries, err := storage.ListDir(volume, entryPath, -1, "")
+		entries, err := storage.ListDir(ctx, volume, entryPath, -1, "")
 		// If entryPath prefix never existed, safe to ignore.
 		if err == errFileNotFound {
 			return nil

--- a/cmd/posix-diskid-check.go
+++ b/cmd/posix-diskid-check.go
@@ -118,25 +118,25 @@ func (p *posixDiskIDCheck) DeleteVol(volume string, forceDelete bool) (err error
 	return p.storage.DeleteVol(volume, forceDelete)
 }
 
-func (p *posixDiskIDCheck) Walk(volume, dirPath string, marker string, recursive bool, leafFile string, readMetadataFn readMetadataFunc, endWalkCh <-chan struct{}) (chan FileInfo, error) {
+func (p *posixDiskIDCheck) Walk(ctx context.Context, volume, dirPath string, marker string, recursive bool, leafFile string, readMetadataFn readMetadataFunc, endWalkCh <-chan struct{}) (chan FileInfo, error) {
 	if p.isDiskStale() {
 		return nil, errDiskNotFound
 	}
-	return p.storage.Walk(volume, dirPath, marker, recursive, leafFile, readMetadataFn, endWalkCh)
+	return p.storage.Walk(ctx, volume, dirPath, marker, recursive, leafFile, readMetadataFn, endWalkCh)
 }
 
-func (p *posixDiskIDCheck) WalkSplunk(volume, dirPath string, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error) {
+func (p *posixDiskIDCheck) WalkSplunk(ctx context.Context, volume, dirPath string, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error) {
 	if p.isDiskStale() {
 		return nil, errDiskNotFound
 	}
-	return p.storage.WalkSplunk(volume, dirPath, marker, endWalkCh)
+	return p.storage.WalkSplunk(ctx, volume, dirPath, marker, endWalkCh)
 }
 
-func (p *posixDiskIDCheck) ListDir(volume, dirPath string, count int, leafFile string) ([]string, error) {
+func (p *posixDiskIDCheck) ListDir(ctx context.Context, volume, dirPath string, count int, leafFile string) ([]string, error) {
 	if p.isDiskStale() {
 		return nil, errDiskNotFound
 	}
-	return p.storage.ListDir(volume, dirPath, count, leafFile)
+	return p.storage.ListDir(ctx, volume, dirPath, count, leafFile)
 }
 
 func (p *posixDiskIDCheck) ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
@@ -188,25 +188,18 @@ func (p *posixDiskIDCheck) DeleteFile(volume string, path string) (err error) {
 	return p.storage.DeleteFile(volume, path)
 }
 
-func (p *posixDiskIDCheck) DeleteFileBulk(volume string, paths []string) (errs []error, err error) {
+func (p *posixDiskIDCheck) DeletePrefixes(ctx context.Context, volume string, paths []string) (errs []error, err error) {
 	if p.isDiskStale() {
 		return nil, errDiskNotFound
 	}
-	return p.storage.DeleteFileBulk(volume, paths)
+	return p.storage.DeletePrefixes(ctx, volume, paths)
 }
 
-func (p *posixDiskIDCheck) DeletePrefixes(volume string, paths []string) (errs []error, err error) {
-	if p.isDiskStale() {
-		return nil, errDiskNotFound
-	}
-	return p.storage.DeletePrefixes(volume, paths)
-}
-
-func (p *posixDiskIDCheck) VerifyFile(volume, path string, size int64, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
+func (p *posixDiskIDCheck) VerifyFile(ctx context.Context, volume, path string, size int64, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
 	if p.isDiskStale() {
 		return errDiskNotFound
 	}
-	return p.storage.VerifyFile(volume, path, size, algo, sum, shardSize)
+	return p.storage.VerifyFile(ctx, volume, path, size, algo, sum, shardSize)
 }
 
 func (p *posixDiskIDCheck) WriteAll(volume string, path string, reader io.Reader) (err error) {

--- a/cmd/posix_test.go
+++ b/cmd/posix_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"fmt"
 	"io"
@@ -792,7 +793,7 @@ func TestPosixPosixListDir(t *testing.T) {
 		if _, ok := posixStorage.(*posixDiskIDCheck); !ok {
 			t.Errorf("Expected the StorageAPI to be of type *posix")
 		}
-		dirList, err = posixStorage.ListDir(testCase.srcVol, testCase.srcPath, -1, "")
+		dirList, err = posixStorage.ListDir(context.Background(), testCase.srcVol, testCase.srcPath, -1, "")
 		if err != testCase.expectedErr {
 			t.Fatalf("TestPosix case %d: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
 		}
@@ -1670,7 +1671,7 @@ func TestPosixVerifyFile(t *testing.T) {
 	if err := posixStorage.WriteAll(volName, fileName, bytes.NewBuffer(data)); err != nil {
 		t.Fatal(err)
 	}
-	if err := posixStorage.VerifyFile(volName, fileName, size, algo, hashBytes, 0); err != nil {
+	if err := posixStorage.VerifyFile(context.Background(), volName, fileName, size, algo, hashBytes, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1680,12 +1681,12 @@ func TestPosixVerifyFile(t *testing.T) {
 	}
 
 	// Check if VerifyFile reports the incorrect file length (the correct length is `size+1`)
-	if err := posixStorage.VerifyFile(volName, fileName, size, algo, hashBytes, 0); err == nil {
+	if err := posixStorage.VerifyFile(context.Background(), volName, fileName, size, algo, hashBytes, 0); err == nil {
 		t.Fatal("expected to fail bitrot check")
 	}
 
 	// Check if bitrot fails
-	if err := posixStorage.VerifyFile(volName, fileName, size+1, algo, hashBytes, 0); err == nil {
+	if err := posixStorage.VerifyFile(context.Background(), volName, fileName, size+1, algo, hashBytes, 0); err == nil {
 		t.Fatal("expected to fail bitrot check")
 	}
 
@@ -1713,7 +1714,7 @@ func TestPosixVerifyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	w.Close()
-	if err := posixStorage.VerifyFile(volName, fileName, size, algo, nil, shardSize); err != nil {
+	if err := posixStorage.VerifyFile(context.Background(), volName, fileName, size, algo, nil, shardSize); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1727,10 +1728,10 @@ func TestPosixVerifyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.Close()
-	if err := posixStorage.VerifyFile(volName, fileName, size, algo, nil, shardSize); err == nil {
+	if err := posixStorage.VerifyFile(context.Background(), volName, fileName, size, algo, nil, shardSize); err == nil {
 		t.Fatal("expected to fail bitrot check")
 	}
-	if err := posixStorage.VerifyFile(volName, fileName, size+1, algo, nil, shardSize); err == nil {
+	if err := posixStorage.VerifyFile(context.Background(), volName, fileName, size+1, algo, nil, shardSize); err == nil {
 		t.Fatal("expected to fail bitrot check")
 	}
 }

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -45,13 +45,13 @@ type StorageAPI interface {
 	DeleteVol(volume string, forceDelete bool) (err error)
 
 	// Walk in sorted order directly on disk.
-	Walk(volume, dirPath string, marker string, recursive bool, leafFile string,
+	Walk(ctx context.Context, volume, dirPath string, marker string, recursive bool, leafFile string,
 		readMetadataFn readMetadataFunc, endWalkCh <-chan struct{}) (chan FileInfo, error)
 	// Walk in sorted order directly on disk.
-	WalkSplunk(volume, dirPath string, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error)
+	WalkSplunk(ctx context.Context, volume, dirPath string, marker string, endWalkCh <-chan struct{}) (chan FileInfo, error)
 
 	// File operations.
-	ListDir(volume, dirPath string, count int, leafFile string) ([]string, error)
+	ListDir(ctx context.Context, volume, dirPath string, count int, leafFile string) ([]string, error)
 	ReadFile(volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error)
 	AppendFile(volume string, path string, buf []byte) (err error)
 	CreateFile(volume, path string, size int64, reader io.Reader) error
@@ -59,9 +59,8 @@ type StorageAPI interface {
 	RenameFile(srcVolume, srcPath, dstVolume, dstPath string) error
 	StatFile(volume string, path string) (file FileInfo, err error)
 	DeleteFile(volume string, path string) (err error)
-	DeleteFileBulk(volume string, paths []string) (errs []error, err error)
-	DeletePrefixes(volume string, paths []string) (errs []error, err error)
-	VerifyFile(volume, path string, size int64, algo BitrotAlgorithm, sum []byte, shardSize int64) error
+	DeletePrefixes(ctx context.Context, volume string, paths []string) (errs []error, err error)
+	VerifyFile(ctx context.Context, volume, path string, size int64, algo BitrotAlgorithm, sum []byte, shardSize int64) error
 
 	// Write all data, syncs the data to disk.
 	WriteAll(volume string, path string, reader io.Reader) (err error)

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -42,7 +42,6 @@ const (
 	storageRESTMethodWalk           = "/walk"
 	storageRESTMethodWalkSplunk     = "/walksplunk"
 	storageRESTMethodDeleteFile     = "/deletefile"
-	storageRESTMethodDeleteFileBulk = "/deletefilebulk"
 	storageRESTMethodDeletePrefixes = "/deleteprefixes"
 	storageRESTMethodRenameFile     = "/renamefile"
 	storageRESTMethodVerifyFile     = "/verifyfile"

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http/httptest"
 	"os"
@@ -261,7 +262,7 @@ func testStorageAPIListDir(t *testing.T, storage StorageAPI) {
 	}
 
 	for i, testCase := range testCases {
-		result, err := storage.ListDir(testCase.volumeName, testCase.prefix, -1, "")
+		result, err := storage.ListDir(context.Background(), testCase.volumeName, testCase.prefix, -1, "")
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {

--- a/cmd/tree-walk_test.go
+++ b/cmd/tree-walk_test.go
@@ -31,16 +31,16 @@ import (
 // disks - used for doing disk.ListDir()
 func listDirFactory(ctx context.Context, disk StorageAPI) ListDirFunc {
 	// Returns sorted merged entries from all the disks.
-	listDir := func(volume, dirPath, dirEntry string) (bool, []string) {
-		entries, err := disk.ListDir(volume, dirPath, -1, xlMetaJSONFile)
+	listDir := func(ctx context.Context, volume, dirPath, dirEntry string) (bool, []string, bool) {
+		entries, err := disk.ListDir(ctx, volume, dirPath, -1, xlMetaJSONFile)
 		if err != nil {
-			return false, nil
+			return false, nil, true
 		}
 		if len(entries) == 0 {
-			return true, nil
+			return true, nil, false
 		}
 		sort.Strings(entries)
-		return false, filterMatchingPrefix(entries, dirEntry)
+		return false, filterMatchingPrefix(entries, dirEntry), false
 	}
 	return listDir
 }
@@ -278,7 +278,7 @@ func TestListDir(t *testing.T) {
 	}
 
 	// Should list "file1" from fsDir1.
-	_, entries := listDir1(volume, "", "")
+	_, entries, _ := listDir1(context.Background(), volume, "", "")
 	if len(entries) != 1 {
 		t.Fatal("Expected the number of entries to be 1")
 	}
@@ -287,7 +287,7 @@ func TestListDir(t *testing.T) {
 		t.Fatal("Expected the entry to be file1")
 	}
 
-	_, entries = listDir2(volume, "", "")
+	_, entries, _ = listDir2(context.Background(), volume, "", "")
 	if len(entries) != 1 {
 		t.Fatal("Expected the number of entries to be 1")
 	}

--- a/cmd/xl-v1-healing-common.go
+++ b/cmd/xl-v1-healing-common.go
@@ -179,7 +179,7 @@ func disksWithAllParts(ctx context.Context, onlineDisks []StorageAPI, partsMetad
 			for _, part := range partsMetadata[i].Parts {
 				checksumInfo := erasure.GetChecksumInfo(part.Number)
 				partPath := pathJoin(object, fmt.Sprintf("part.%d", part.Number))
-				err := onlineDisk.VerifyFile(bucket, partPath, erasure.ShardFileSize(part.Size), checksumInfo.Algorithm, checksumInfo.Hash, erasure.ShardSize())
+				err := onlineDisk.VerifyFile(ctx, bucket, partPath, erasure.ShardFileSize(part.Size), checksumInfo.Algorithm, checksumInfo.Hash, erasure.ShardSize())
 				if err != nil {
 					if !IsErr(err, []error{
 						errFileNotFound,

--- a/cmd/xl-v1-healing.go
+++ b/cmd/xl-v1-healing.go
@@ -351,7 +351,7 @@ func (xl xlObjects) healObject(ctx context.Context, bucket string, object string
 		}
 
 		// List and delete the object directory,
-		files, derr := disk.ListDir(bucket, object, -1, "")
+		files, derr := disk.ListDir(ctx, bucket, object, -1, "")
 		if derr == nil {
 			for _, entry := range files {
 				_ = disk.DeleteFile(bucket,
@@ -616,7 +616,7 @@ func statAllDirs(ctx context.Context, storageDisks []StorageAPI, bucket, prefix 
 		}
 		index := index
 		g.Go(func() error {
-			entries, err := storageDisks[index].ListDir(bucket, prefix, 1, "")
+			entries, err := storageDisks[index].ListDir(ctx, bucket, prefix, 1, "")
 			if err != nil {
 				return err
 			}

--- a/cmd/xl-v1-multipart.go
+++ b/cmd/xl-v1-multipart.go
@@ -115,7 +115,7 @@ func (xl xlObjects) ListMultipartUploads(ctx context.Context, bucket, object, ke
 		if disk == nil {
 			continue
 		}
-		uploadIDs, err := disk.ListDir(minioMetaMultipartBucket, xl.getMultipartSHADir(bucket, object), -1, "")
+		uploadIDs, err := disk.ListDir(ctx, minioMetaMultipartBucket, xl.getMultipartSHADir(bucket, object), -1, "")
 		if err != nil {
 			if err == errFileNotFound {
 				return result, nil
@@ -807,12 +807,12 @@ func (xl xlObjects) cleanupStaleMultipartUploads(ctx context.Context, cleanupInt
 // Remove the old multipart uploads on the given disk.
 func (xl xlObjects) cleanupStaleMultipartUploadsOnDisk(ctx context.Context, disk StorageAPI, expiry time.Duration) {
 	now := time.Now()
-	shaDirs, err := disk.ListDir(minioMetaMultipartBucket, "", -1, "")
+	shaDirs, err := disk.ListDir(ctx, minioMetaMultipartBucket, "", -1, "")
 	if err != nil {
 		return
 	}
 	for _, shaDir := range shaDirs {
-		uploadIDDirs, err := disk.ListDir(minioMetaMultipartBucket, shaDir, -1, "")
+		uploadIDDirs, err := disk.ListDir(ctx, minioMetaMultipartBucket, shaDir, -1, "")
 		if err != nil {
 			continue
 		}

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -325,7 +325,7 @@ func (xl xlObjects) getObjectInfoDir(ctx context.Context, bucket, object string)
 		index := index
 		g.Go(func() error {
 			// Check if 'prefix' is an object on this 'disk'.
-			entries, err := storageDisks[index].ListDir(bucket, object, 1, "")
+			entries, err := storageDisks[index].ListDir(ctx, bucket, object, 1, "")
 			if err != nil {
 				return err
 			}
@@ -798,7 +798,7 @@ func (xl xlObjects) doDeleteObjects(ctx context.Context, bucket string, objects 
 		wg.Add(1)
 		go func(index int, disk StorageAPI) {
 			defer wg.Done()
-			delObjErrs[index], opErrs[index] = disk.DeletePrefixes(minioMetaTmpBucket, tmpObjs)
+			delObjErrs[index], opErrs[index] = disk.DeletePrefixes(ctx, minioMetaTmpBucket, tmpObjs)
 			if opErrs[index] == errVolumeNotFound || opErrs[index] == errFileNotFound {
 				opErrs[index] = nil
 			}

--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -1308,7 +1308,7 @@ func (z *xlZones) DeleteBucket(ctx context.Context, bucket string, forceDelete b
 	for _, err := range errs {
 		if err != nil {
 			if _, ok := err.(InsufficientWriteQuorum); ok {
-				undoDeleteBucketZones(bucket, z.zones, errs)
+				undoDeleteBucketZones(ctx, bucket, z.zones, errs)
 			}
 
 			return err
@@ -1320,7 +1320,7 @@ func (z *xlZones) DeleteBucket(ctx context.Context, bucket string, forceDelete b
 }
 
 // This function is used to undo a successful DeleteBucket operation.
-func undoDeleteBucketZones(bucket string, zones []*xlSets, errs []error) {
+func undoDeleteBucketZones(ctx context.Context, bucket string, zones []*xlSets, errs []error) {
 	g := errgroup.WithNErrs(len(zones))
 
 	// Undo previous delete bucket on all underlying zones.
@@ -1328,7 +1328,7 @@ func undoDeleteBucketZones(bucket string, zones []*xlSets, errs []error) {
 		index := index
 		g.Go(func() error {
 			if errs[index] == nil {
-				return zones[index].MakeBucketWithLocation(GlobalContext, bucket, "", false)
+				return zones[index].MakeBucketWithLocation(ctx, bucket, "", false)
 			}
 			return nil
 		}, index)


### PR DESCRIPTION
## Description
Support for context with long-running Disk calls

## Motivation and Context
ListObjects, Walkers do not timeout quickly if the
client has disconnected, this leads to quite a lot
of resources being spent on the drives perpetually
until some form to timeout happens. This can be
quite slow.

Many such operations can lead to quickly overwhelming
the server with too many List requests which are
yet to be finished.

To avoid this pass down context everywhere, and timeout
as connections timeout or reach deadline whichever comes
first.

## How to test this PR?
Generate random list requests and do not read the response
, you can see the existing go-routines spawned inside 
do not timeout as the client disconnects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
