### PR TITLE
Add MINIO_ETCD_REQUIRED flag to exit minio server

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -325,13 +325,21 @@ func lookupConfigs(s config.Config) {
 
 	etcdCfg, err := etcd.LookupConfig(s[config.EtcdSubSys][config.Default], globalRootCAs)
 	if err != nil {
-		logger.LogIf(ctx, fmt.Errorf("Unable to initialize etcd config: %w", err))
+		if etcdCfg.Required {
+			logger.FatalIf(err, "Unable to initialize etcd config")
+		} else {
+			logger.LogIf(ctx, fmt.Errorf("Unable to initialize etcd config: %w", err))
+		}
 	}
 
 	if etcdCfg.Enabled {
 		globalEtcdClient, err = etcd.New(etcdCfg)
 		if err != nil {
-			logger.LogIf(ctx, fmt.Errorf("Unable to initialize etcd config: %w", err))
+			if etcdCfg.Required {
+				logger.FatalIf(err, "Unable to initialize etcd config")
+			} else {
+				logger.LogIf(ctx, fmt.Errorf("Unable to initialize etcd config: %w", err))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Use `MINIO_ETCD_REQUIRED=on` to exit minio when etcd initialization fails.

This solves a startup ordering problem with etcd and minio. Namely, that minio disables etcd functionality when etcd is unavailable on initialization (even when etcd is online only moments later)

See full discussion https://github.com/minio/minio/issues/9788

## Motivation and Context

Avoid cluster upgrade problems and workload ordering.

## How to test this PR?

Works as usual (i.e. log error and continue)
```
MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test1234 GOOGLE_APPLICATION_CREDENTIALS=gcs.json MINIO_ETCD_ENDPOINTS=http://doesntexist:2379 MINIO_ETCD_REQUIRED=off go run . gateway gcs xxx
```

New feature: exit with 1 and error message
```
MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test1234 GOOGLE_APPLICATION_CREDENTIALS=gcs.json MINIO_ETCD_ENDPOINTS=http://doesntexist:2379 MINIO_ETCD_REQUIRED=on go run . gateway gcs xxx
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )

---
Help!

Not sure if tests are needed and how to do them. Also not sure how to update documentation.