### PR TITLE
Fix peer server update failure

### DIFF
--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -770,7 +770,7 @@ func (s *peerRESTServer) ServerUpdateHandler(w http.ResponseWriter, r *http.Requ
 	var latestReleaseTime time.Time
 	var err error
 	if latestRelease := vars[peerRESTLatestRelease]; latestRelease != "" {
-		latestReleaseTime, err = time.Parse(latestRelease, time.RFC3339)
+		latestReleaseTime, err = time.Parse(time.RFC3339, latestRelease)
 		if err != nil {
 			s.writeErrorResponse(w, err)
 			return


### PR DESCRIPTION
## Description
When updating all servers through `/minio/admin/v3/update` API by `mc admin update`,
only the endpoint server will be updated successfully.
All the other peer servers' updating failed due to the error below:
> parsing time "2006-01-02T15:04:05Z07:00" as "`release version`": cannot parse "-01-02T15:04:05Z07:00" as "0-" 


## Motivation and Context
Bug fix of server update

## How to test this PR?
1. Apply this patch on your own env with minium 2 nodes.
2. Start all servers manully:
    go run main.go server your_own_volume_sets
3. Update all servers using mc:
    mc --debug  admin update your_alias [your_own_private_mirror_site_of_minio]
4. All servers should be restarted and updated.
    (You can check the server version by /tmp/go-buildxxxx/b001/exe/main -v,
     which can be found uding "ps -ef | grep minio")

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
