### PR TITLE
Add logs when quorum is lost during readiness checks

### DIFF
--- a/cmd/xl-zones.go
+++ b/cmd/xl-zones.go
@@ -1608,7 +1608,7 @@ func (z *xlZones) getZoneAndSet(id string) (int, int, error) {
 			}
 		}
 	}
-	return 0, 0, errDiskNotFound
+	return 0, 0, fmt.Errorf("ID(%s) %w", errDiskNotFound)
 }
 
 // IsReady - Returns true all the erasure sets are writable.
@@ -1625,6 +1625,7 @@ func (z *xlZones) IsReady(ctx context.Context) bool {
 	for _, id := range diskIDs {
 		zoneIdx, setIdx, err := z.getZoneAndSet(id)
 		if err != nil {
+			logger.LogIf(ctx, err)
 			continue
 		}
 		erasureSetUpCount[zoneIdx][setIdx]++
@@ -1643,6 +1644,8 @@ func (z *xlZones) IsReady(ctx context.Context) bool {
 		}
 		for setIdx := range erasureSetUpCount[zoneIdx] {
 			if erasureSetUpCount[zoneIdx][setIdx] < writeQuorum {
+				logger.LogIf(ctx, fmt.Errorf("Write quorum lost on zone: %d, set: %d, expected write quorum: %d",
+					zoneIdx, setIdx, writeQuorum))
 				return false
 			}
 		}


### PR DESCRIPTION
## Description
Add logs when quorum is lost during readiness checks

## Motivation and Context
Just informative logs for users to understand if a quorum is lost.

## How to test this PR?
Nothing special

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
