### PR TITLE
fix: find current location of object in multi-zones

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,9 +4,7 @@ on:
   pull_request:
     branches:
     - master
-  push:
-    branches:
-    - master
+    - release
 
 jobs:
   build:

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -401,11 +401,12 @@ func (er erasureObjects) getObjectInfo(ctx context.Context, bucket, object strin
 	}
 
 	if fi.Deleted {
+		objInfo = fi.ToObjectInfo(bucket, object)
 		if opts.VersionID == "" {
 			return objInfo, toObjectErr(errFileNotFound, bucket, object)
 		}
 		// Make sure to return object info to provide extra information.
-		return fi.ToObjectInfo(bucket, object), toObjectErr(errMethodNotAllowed, bucket, object)
+		return objInfo, toObjectErr(errMethodNotAllowed, bucket, object)
 	}
 
 	return fi.ToObjectInfo(bucket, object), nil


### PR DESCRIPTION

## Description
PutObject on multiple-zone with versioning would not
overwrite the correct location of the object if the
object has delete marker, leading to duplicate objects
on two zones.

This PR fixes by adding affinity towards delete marker
when GetObjectInfo() returns error, use the zone index
which has the delete marker.

## Motivation and Context
Avoid duplicate objects

## How to test this PR?
Enable versioning on the bucket and create a delete marker on an object, try to upload
a new object which will result in it being created on the second zone.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
