### PR TITLE
fix: save deleteMarker properly, precision upto UnixNano()

### DIFF
--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -950,6 +950,16 @@ func getOpts(ctx context.Context, r *http.Request, bucket, object string) (Objec
 	return opts, nil
 }
 
+func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts ObjectOptions, err error) {
+	versioned := globalBucketVersioningSys.Enabled(bucket)
+	opts, err = getOpts(ctx, r, bucket, object)
+	if err != nil {
+		return opts, err
+	}
+	opts.Versioned = versioned
+	return opts, nil
+}
+
 // get ObjectOptions for PUT calls from encryption headers and metadata
 func putOpts(ctx context.Context, r *http.Request, bucket, object string, metadata map[string]string) (opts ObjectOptions, err error) {
 	versioned := globalBucketVersioningSys.Enabled(bucket)

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -1867,7 +1867,7 @@ func (z *erasureZones) getZoneAndSet(id string) (int, int, error) {
 			}
 		}
 	}
-	return 0, 0, fmt.Errorf("ID(%s) %w", errDiskNotFound)
+	return 0, 0, fmt.Errorf("DiskID(%s) %w", id, errDiskNotFound)
 }
 
 // IsReady - Returns true, when all the erasure sets are writable.

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2584,7 +2584,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		}
 	}
 
-	opts, err := getOpts(ctx, r, bucket, object)
+	opts, err := delOpts(ctx, r, bucket, object)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -231,7 +231,7 @@ func (z *xlMetaV2) AddVersion(fi FileInfo) error {
 			Type: DeleteType,
 			DeleteMarker: &xlMetaV2DeleteMarker{
 				VersionID: uv,
-				ModTime:   fi.ModTime.Unix(),
+				ModTime:   fi.ModTime.UnixNano(),
 			},
 		})
 		return nil
@@ -262,7 +262,7 @@ func (z *xlMetaV2) AddVersion(fi FileInfo) error {
 			VersionID:          uv,
 			DataDir:            dd,
 			StatSize:           fi.Size,
-			StatModTime:        fi.ModTime.Unix(),
+			StatModTime:        fi.ModTime.UnixNano(),
 			ErasureAlgorithm:   ReedSolomon,
 			ErasureM:           fi.Erasure.DataBlocks,
 			ErasureN:           fi.Erasure.ParityBlocks,
@@ -342,7 +342,7 @@ func (j xlMetaV2DeleteMarker) ToFileInfo(volume, path string) (FileInfo, error) 
 	fi := FileInfo{
 		Volume:    volume,
 		Name:      path,
-		ModTime:   time.Unix(j.ModTime, 0).UTC(),
+		ModTime:   time.Unix(0, j.ModTime).UTC(),
 		VersionID: uuid.UUID(j.VersionID).String(),
 		Deleted:   true,
 	}
@@ -360,7 +360,7 @@ func (j xlMetaV2Object) ToFileInfo(volume, path string) (FileInfo, error) {
 		Volume:    volume,
 		Name:      path,
 		Size:      j.StatSize,
-		ModTime:   time.Unix(j.StatModTime, 0).UTC(),
+		ModTime:   time.Unix(0, j.StatModTime).UTC(),
 		VersionID: versionID,
 	}
 	fi.Parts = make([]ObjectPartInfo, len(j.PartNumbers))
@@ -536,9 +536,9 @@ func (z xlMetaV2) ToFileInfo(volume, path, versionID string) (FileInfo, error) {
 			var modTime time.Time
 			switch version.Type {
 			case ObjectType:
-				modTime = time.Unix(version.ObjectV2.StatModTime, 0)
+				modTime = time.Unix(0, version.ObjectV2.StatModTime)
 			case DeleteType:
-				modTime = time.Unix(version.DeleteMarker.ModTime, 0)
+				modTime = time.Unix(0, version.DeleteMarker.ModTime)
 			case LegacyType:
 				modTime = version.ObjectV1.Stat.ModTime
 			default:


### PR DESCRIPTION
## Description
fix: save deleteMarker properly, precision upto UnixNano()

## Motivation and Context
Bugs found during functional tests using minio-go versioning PR

## How to test this PR?
https://gist.github.com/harshavardhana/2012fcce5fdcefd94f967e3b8661ebe1

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
