### PR TITLE
Fixes HINT to also change .minio.sys ownership and its contents

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -140,7 +140,7 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 		} else {
 			username = "<your-username>"
 		}
-		hint := fmt.Sprintf("Use 'sudo chown %s %s && sudo chmod u+rxw %s' to provide sufficient permissions.", username, fsPath, fsPath)
+		hint := fmt.Sprintf("Use 'sudo chown -R %s %s && sudo chmod u+rxw %s' to provide sufficient permissions.", username, fsPath, fsPath)
 		return nil, config.ErrUnableToWriteInBackend(err).Hint(hint)
 	}
 

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -820,7 +820,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointZones EndpointZones
 				} else {
 					username = "<your-username>"
 				}
-				hint := fmt.Sprintf("Run the following command to add the convenient permissions: `sudo chown %s %s && sudo chmod u+rxw %s`", username, endpoint.Path, endpoint.Path)
+				hint := fmt.Sprintf("Run the following command to add the convenient permissions: `sudo chown -R %s %s && sudo chmod u+rxw %s`", username, endpoint.Path, endpoint.Path)
 				logger.Fatal(config.ErrUnableToWriteInBackend(err).Hint(hint), "Unable to initialize posix backend")
 			}
 


### PR DESCRIPTION
Fixes #9746
When there is an ownership problem with the data directory or endpoint during minio server start time, the provided HINT in the error message was not applied to the internal `.minio.sys` directory and its content since "-R" option was not included in the suggestion.

## Motivation and Context
To give user the correct HINT that works

## How to test this PR?
- Start minio server with a simple data directory, like `/tmp/dir/` as user "user1"
- Change user and be "user2" and run the same command to start minio server at the same data directory
- You'll hit the error message with the HINT. Run the proposed first command in the error message to fix the error conditon and make sure the same command can start the minio server 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
