### PR TITLE
etcd unavailable start of minio or during run

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -313,7 +313,7 @@ func validateConfig(s config.Config) error {
 
 var syncEtcdOnce sync.Once
 
-func lookupConfigs(s config.Config) {
+func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 	ctx := GlobalContext
 
 	var err error
@@ -345,6 +345,9 @@ func lookupConfigs(s config.Config) {
 				}
 			}
 		})
+	} else if !etcdCfg.Enabled && globalIAMSys != nil {
+		globalIAMSys.store = newIAMObjectStore(ctx, objAPI)
+		globalEtcdClient = nil
 	}
 
 	// Bucket federation is 'true' only when IAM assets are not namespaced
@@ -578,7 +581,7 @@ func newSrvConfig(objAPI ObjectLayer) error {
 	srvCfg := newServerConfig()
 
 	// Override any values from ENVs.
-	lookupConfigs(srvCfg)
+	lookupConfigs(srvCfg, objAPI)
 
 	// hold the mutex lock before a new config is assigned.
 	globalServerConfigMu.Lock()
@@ -602,7 +605,7 @@ func loadConfig(objAPI ObjectLayer) error {
 	}
 
 	// Override any values from ENVs.
-	lookupConfigs(srvCfg)
+	lookupConfigs(srvCfg, objAPI)
 
 	// hold the mutex lock before a new config is assigned.
 	globalServerConfigMu.Lock()

--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -32,6 +32,7 @@ func etcdErrToErr(err error, etcdEndpoints []string) error {
 	}
 	switch err {
 	case context.DeadlineExceeded:
+		globalEtcdClient = nil
 		return fmt.Errorf("%w %s", errEtcdUnreachable, etcdEndpoints)
 	default:
 		return fmt.Errorf("unexpected error %w from etcd, please check your endpoints %s", err, etcdEndpoints)

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -162,7 +162,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	srvCfg := newServerConfig()
 
 	// Override any values from ENVs.
-	lookupConfigs(srvCfg)
+	lookupConfigs(srvCfg, nil)
 
 	// hold the mutex lock before a new config is assigned.
 	globalServerConfigMu.Lock()

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -30,9 +30,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/minio/minio/cmd/config/etcd"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
+	"github.com/minio/minio/pkg/env"
 	"github.com/minio/minio/pkg/handlers"
 	"github.com/minio/minio/pkg/madmin"
 )
@@ -424,7 +426,13 @@ func errorResponseHandler(w http.ResponseWriter, r *http.Request) {
 		if version == "v1" {
 			desc = fmt.Sprintf("Server expects client requests with 'admin' API version '%s', found '%s', please upgrade the client to latest releases", madmin.AdminAPIVersion, version)
 		} else if version == madmin.AdminAPIVersion {
-			desc = fmt.Sprintf("This 'admin' API is not supported by server in '%s'", getMinioMode())
+			var descstr string
+			if env.Get(etcd.EnvEtcdEndpoints, "") != "" && globalEtcdClient == nil {
+				descstr = "This 'admin' API is not supported by server while etcd is unreachable, please check your endpoints"
+			} else {
+				descstr = "This 'admin' API is not supported by server in '" + getMinioMode() + "'"
+			}
+			desc = fmt.Sprintf(descstr)
 		} else {
 			desc = fmt.Sprintf("Unexpected client 'admin' API version found '%s', expected '%s', please downgrade the client to older releases", version, madmin.AdminAPIVersion)
 		}


### PR DESCRIPTION
Fixes #9788

## Description
etcd dependent operations like mc admin policy add ... fail during execution.

## Motivation and Context
Case 1.
Start etcd, minio in that order. Minio should configure the etcd endpoint. Stop etcd and run `mc admin policy add ...` to check.
Case 2.
Start minio with etcd endpoint. Run mc admin policy add ... to check. Restart etcd and check again.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
