### PR TITLE
fix: initialize config once per startup

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -162,7 +162,9 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	srvCfg := newServerConfig()
 
 	// Override any values from ENVs.
-	lookupConfigs(srvCfg)
+	lookupConfigOnce.Do(func() {
+		lookupConfigs(srvCfg)
+	})
 
 	// hold the mutex lock before a new config is assigned.
 	globalServerConfigMu.Lock()


### PR DESCRIPTION
## Description
fix: initialize config once per startup

## Motivation and Context
avoid any config leaks as must

## How to test this PR?
This PR is meant to avoid any double initialization 
when lookupConfigs gets repeatedly used. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
