### PR TITLE
[feat] Preserve version supplied by client

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -142,7 +142,10 @@ func (er erasureObjects) newMultipartUpload(ctx context.Context, bucket string, 
 
 	// Calculate the version to be saved.
 	if opts.Versioned {
-		fi.VersionID = mustGetUUID()
+		fi.VersionID = opts.VersionID
+		if fi.VersionID == "" {
+			fi.VersionID = mustGetUUID()
+		}
 	}
 
 	fi.DataDir = mustGetUUID()

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -608,7 +608,10 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	fi := newFileInfo(object, dataDrives, parityDrives)
 
 	if opts.Versioned {
-		fi.VersionID = mustGetUUID()
+		fi.VersionID = opts.VersionID
+		if fi.VersionID == "" {
+			fi.VersionID = mustGetUUID()
+		}
 	}
 	fi.DataDir = mustGetUUID()
 

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -794,7 +794,12 @@ func (s *erasureSets) CopyObject(ctx context.Context, srcBucket, srcObject, dstB
 		return srcSet.CopyObject(ctx, srcBucket, srcObject, dstBucket, dstObject, srcInfo, srcOpts, dstOpts)
 	}
 
-	putOpts := ObjectOptions{ServerSideEncryption: dstOpts.ServerSideEncryption, UserDefined: srcInfo.UserDefined}
+	putOpts := ObjectOptions{
+		ServerSideEncryption: dstOpts.ServerSideEncryption,
+		UserDefined:          srcInfo.UserDefined,
+		Versioned:            dstOpts.Versioned,
+		VersionID:            dstOpts.VersionID,
+	}
 	return dstSet.putObject(ctx, dstBucket, dstObject, srcInfo.PutObjReader, putOpts)
 }
 

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -594,7 +594,13 @@ func (z *erasureZones) CopyObject(ctx context.Context, srcBucket, srcObject, dst
 		return objInfo, err
 	}
 
-	putOpts := ObjectOptions{ServerSideEncryption: dstOpts.ServerSideEncryption, UserDefined: srcInfo.UserDefined}
+	putOpts := ObjectOptions{
+		ServerSideEncryption: dstOpts.ServerSideEncryption,
+		UserDefined:          srcInfo.UserDefined,
+		Versioned:            dstOpts.Versioned,
+		VersionID:            dstOpts.VersionID,
+	}
+
 	if cpSrcDstSame && srcInfo.metadataOnly {
 		return z.zones[zoneIdx].CopyObject(ctx, srcBucket, srcObject, dstBucket, dstObject, srcInfo, srcOpts, dstOpts)
 	}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1735,6 +1735,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 	if srcOpts.ServerSideEncryption != nil {
 		getOpts.ServerSideEncryption = encrypt.SSE(srcOpts.ServerSideEncryption)
 	}
+
 	dstOpts, err = copyDstOpts(ctx, r, dstBucket, dstObject, nil)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -237,14 +237,16 @@ func (z *xlMetaV2) AddVersion(fi FileInfo) error {
 		return nil
 	}
 
-	var uv uuid.UUID
-	var err error
-	// null version Id means empty version Id.
-	if fi.VersionID == nullVersionID {
-		fi.VersionID = ""
+	if fi.VersionID == "" {
+		// this means versioning is not yet
+		// enabled i.e all versions are basically
+		// default value i.e "null"
+		fi.VersionID = nullVersionID
 	}
 
-	if fi.VersionID != "" {
+	var uv uuid.UUID
+	var err error
+	if fi.VersionID != "" && fi.VersionID != nullVersionID {
 		uv, err = uuid.Parse(fi.VersionID)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description
[feat] Preserve version supplied by the client

## Motivation and Context
Just like GET/DELETE APIs it is possible to preserve
client-supplied versionId's, of course, the versionIds
have to be uuid, if an existing versionId is found
it is overwritten if no object locking policies
are found.

- PUT /bucketname/objectname?versionId=<id>
- POST /bucketname/objectname?uploads=&versionId=<id>
- PUT /bucketname/objectname?verisonId=<id> (with x-amz-copy-source)

## How to test this PR?
Needs a custom API where versionId is added as part of the PUT request

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
