### PR TITLE
Always add existing cache when skipping

### DIFF
--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -261,9 +261,9 @@ func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, buckets []BucketIn
 	for _, b := range buckets {
 		e := oldCache.find(b.Name)
 		if e != nil {
+			cache.replace(b.Name, dataUsageRoot, *e)
 			if bf == nil || bf.containsDir(b.Name) {
 				bucketCh <- b
-				cache.replace(b.Name, dataUsageRoot, *e)
 			} else {
 				if intDataUpdateTracker.debug {
 					logger.Info(color.Green("crawlAndGetDataUsage:")+" Skipping bucket %v, not updated", b.Name)

--- a/cmd/xl-v1.go
+++ b/cmd/xl-v1.go
@@ -262,7 +262,9 @@ func (xl xlObjects) crawlAndGetDataUsage(ctx context.Context, buckets []BucketIn
 		e := oldCache.find(b.Name)
 		if e != nil {
 			cache.replace(b.Name, dataUsageRoot, *e)
-			if bf == nil || bf.containsDir(b.Name) {
+			lc, err := globalLifecycleSys.Get(b.Name)
+			activeLC := err == nil && lc.HasActiveRules("", true)
+			if activeLC || bf == nil || bf.containsDir(b.Name) {
 				bucketCh <- b
 			} else {
 				if intDataUpdateTracker.debug {


### PR DESCRIPTION
## Description

Always add existing cache values, even when skipping.

ONLY for `release` branch.

#9579 scans bloom filters in another place, but it seems this was not included in the latest release.

Fixes intermediate missing buckets and skipped lifecycle checks.

## Types of changes
- [x] Bug fix
