### PR TITLE
Remove nuget from docker mint build

### DIFF
--- a/mint/install-packages.list
+++ b/mint/install-packages.list
@@ -7,7 +7,6 @@ dirmngr
 apt-transport-https
 dotnet-sdk-2.1
 ca-certificates-mono
-nuget
 libunwind8
 ruby
 ruby-dev

--- a/mint/preinstall.sh
+++ b/mint/preinstall.sh
@@ -48,8 +48,6 @@ fi
 
 xargs --arg-file="${MINT_ROOT_DIR}/install-packages.list" apt --quiet --yes install
 
-nuget update -self
-
 # set python 3.6 as default
 update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
 

--- a/mint/remove-packages.list
+++ b/mint/remove-packages.list
@@ -6,4 +6,3 @@ ruby-bundler
 openjdk-8-jdk
 ant
 dotnet
-nuget


### PR DESCRIPTION
## Description


## Motivation and Context
nuget is not required in the mint build. Removing it.

## How to test this PR?
nothing special required. Build container and run dotnet tests - should pass ok.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
