### PR TITLE
Fix ec2 iam auth s3 gateway

### DIFF
--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -362,11 +362,14 @@ func parseGatewaySSE(s string) (gatewaySSE, error) {
 }
 
 // handle gateway env vars
-func gatewayHandleEnvVars() {
+func gatewayHandleEnvVars(gw Gateway) {
 	// Handle common env vars.
 	handleCommonEnvVars()
 
-	if !globalActiveCred.IsValid() {
+	// S3 gateway implements chaining all credentials.
+	// If IAM creds are being used from EC2,
+	// globalActiveCred will not be set.
+	if gw.Name() != "s3" && !globalActiveCred.IsValid() {
 		logger.Fatal(config.ErrInvalidCredentials(nil),
 			"Unable to validate credentials inherited from the shell environment")
 	}

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -144,7 +144,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	}()
 
 	// Handle gateway specific env
-	gatewayHandleEnvVars()
+	gatewayHandleEnvVars(gw)
 
 	// Set system resources to maximum.
 	setMaxResources()


### PR DESCRIPTION
## Description
EC2 hosts were unable to use IAM roles to start minio in s3 gateway mode.

## Motivation and Context
This is a fix for https://github.com/minio/minio/issues/9370

## How to test this PR?
Launch minio as an s3 gateway from an ec2 system which has been given an S3 role. Confirm that that minio starts properly in gateway mode without api key and secret at the command line or in the environment.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
