### PR TITLE
Do not select zones with <5% free after upload

### DIFF
--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -209,7 +209,7 @@ func (z *erasureZones) getZoneIdx(ctx context.Context, bucket, object string, op
 	// We multiply the size by 2 to account for erasure coding.
 	idx = z.getAvailableZoneIdx(ctx, size*2)
 	if idx < 0 {
-		return -1, errDiskFull
+		return -1, toObjectErr(errDiskFull)
 	}
 	return idx, nil
 }
@@ -1337,8 +1337,8 @@ func (z *erasureZones) NewMultipartUpload(ctx context.Context, bucket, object st
 		return z.zones[0].NewMultipartUpload(ctx, bucket, object, opts)
 	}
 
-	// We don't know the exact size, so we ask for at least 100MB.
-	idx, err := z.getZoneIdx(ctx, bucket, object, opts, 100<<20)
+	// We don't know the exact size, so we ask for at least 1GiB file.
+	idx, err := z.getZoneIdx(ctx, bucket, object, opts, 1<<30)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -96,6 +96,9 @@ const (
 
 	// Maximum size of default bucket encryption configuration allowed
 	maxBucketSSEConfigSize = 1 * humanize.MiByte
+
+	// diskFillFraction is the fraction of a disk we allow to be filled.
+	diskFillFraction = 0.95
 )
 
 var globalCLIContext = struct {

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -288,7 +288,7 @@ var ignoreDiskFreeOS = []string{
 func checkDiskMinTotal(di disk.Info) (err error) {
 	// Remove 5% from total space for cumulative disk space
 	// used for journalling, inodes etc.
-	totalDiskSpace := float64(di.Total) * 0.95
+	totalDiskSpace := float64(di.Total) * diskFillFraction
 	if int64(totalDiskSpace) <= diskMinTotalSpace {
 		return errMinDiskSize
 	}
@@ -298,7 +298,7 @@ func checkDiskMinTotal(di disk.Info) (err error) {
 // check if disk free has minimum required size.
 func checkDiskMinFree(di disk.Info) error {
 	// Remove 5% from free space for cumulative disk space used for journalling, inodes etc.
-	availableDiskSpace := float64(di.Free) * 0.95
+	availableDiskSpace := float64(di.Free) * diskFillFraction
 	if int64(availableDiskSpace) <= diskMinFreeSpace {
 		return errDiskFull
 	}
@@ -328,7 +328,7 @@ func checkDiskFree(diskPath string, neededSpace int64) (err error) {
 	}
 
 	// Check if we have enough space to store data
-	if neededSpace > int64(float64(di.Free)*0.95) {
+	if neededSpace > int64(float64(di.Free)*diskFillFraction) {
 		return errDiskFull
 	}
 


### PR DESCRIPTION
## Motivation and Context

In zoned setups `Storage backend has reached its minimum free disk threshold` is more common than it should be.

We don't take the 5% space requirement into account when selecting a zone. That is easy to fix.

The interesting part is that even considering this we don't know the size of the object the user wants to upload when they do multipart uploads.

It seems quite defensive and sub-optimal to always upload multiparts to the zone where there is the most space since all load will be directed to a part of the cluster.
In these cases we make sure it can at least hold a 1GiB file and we disadvantage fuller zones more by subtracting the expected size before weighing.

Furthermore, if cluster is indeed full, we reject the upload at once instead of having it attempt to start.

## How to test this PR?

In a heavily unbalanced zoned setup, upload files.

If multiparts are < 1GiB it should not be possible for uploads to fail.

## Types of changes
- [x] Bug fix/feature - you decide.
