### PR TITLE
Proxy ListObjects request to the server holding the paginated state

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -17,8 +17,10 @@
 package cmd
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -31,6 +33,7 @@ import (
 	"github.com/minio/minio-go/v6/pkg/set"
 	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/cmd/rest"
 	"github.com/minio/minio/pkg/env"
 	"github.com/minio/minio/pkg/mountinfo"
 )
@@ -47,6 +50,14 @@ const (
 
 	retryInterval = 5 // In Seconds.
 )
+
+// ListEndpoint - endpoint used for list redirects
+// See proxyListRequest() for details.
+type ListEndpoint struct {
+	host    string
+	t       *http.Transport
+	isLocal bool
+}
 
 // Endpoint - any type of endpoint.
 type Endpoint struct {
@@ -708,6 +719,50 @@ func GetRemotePeers(endpointZones EndpointZones) []string {
 		}
 	}
 	return peerSet.ToSlice()
+}
+
+// GetListEndpoints - get all endpoints that can be used to proxy list request.
+func GetListEndpoints(endpointZones EndpointZones) ([]ListEndpoint, error) {
+	var listeps []ListEndpoint
+
+	listepExists := func(host string) bool {
+		for _, listep := range listeps {
+			if listep.host == host {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, ep := range endpointZones {
+		for _, endpoint := range ep.Endpoints {
+			if endpoint.Type() != URLEndpointType {
+				continue
+			}
+
+			host := endpoint.Host
+			if listepExists(host) {
+				continue
+			}
+			hostName, _, err := net.SplitHostPort(host)
+			if err != nil {
+				return nil, err
+			}
+			var tlsConfig *tls.Config
+			if globalIsSSL {
+				tlsConfig = &tls.Config{
+					ServerName: hostName,
+					RootCAs:    globalRootCAs,
+				}
+			}
+			listeps = append(listeps, ListEndpoint{
+				host,
+				newCustomHTTPTransport(tlsConfig, rest.DefaultRESTTimeout)(),
+				endpoint.IsLocal,
+			})
+		}
+	}
+	return listeps, nil
 }
 
 func updateDomainIPs(endPoints set.StringSet) {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -276,6 +276,7 @@ var (
 	// If writes to FS backend should be O_SYNC.
 	globalFSOSync bool
 
+	globalListEndpoints []ListEndpoint
 	// Add new variable global values here.
 )
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -390,6 +390,9 @@ func serverMain(ctx *cli.Context) {
 	globalRootCAs, err = config.GetRootCAs(globalCertsCADir.Get())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
 
+	globalListEndpoints, err = GetListEndpoints(globalEndpoints)
+	logger.FatalIf(err, "Invalid command line arguments")
+
 	globalMinioEndpoint = func() string {
 		host := globalMinioHost
 		if host == "" {


### PR DESCRIPTION
## Description
ListObjects API is paginated, i.e the client can request for the list batch-by-batch. To serve the list request, MinIO holds state in memory to serve the paginated requests. This PR is to ensure that the request is proxied to the right minio server.

## Motivation and Context
This will make sure that if the client sends list requests to different minio servers, it is handled properly at the server side.

## How to test this PR?
Set bucket to public. Send hand crafted list requests to different servers.
Look at `mc admin trace` and see that list is getting proxied to the right server.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
