### PR TITLE
Add support for minioreleaser a fork for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,167 @@
+project_name: minio
+
+release:
+   name_template: "Version {{.MinIO.Version}}"
+   disable: true
+   github:
+    owner: minio
+    name: minio
+
+env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+
+before:
+  hooks:
+    - make clean
+    - go generate ./...
+    - go mod tidy
+    - go mod download
+
+builds:
+  -
+    goos:
+      - linux
+      - darwin
+      - windows
+      - freebsd
+
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - ppc64le
+      - s390x
+
+    goarm:
+      - 7
+
+    ignore:
+      - goos: darwin
+        goarch: arm64
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: ppc64le
+      - goos: darwin
+        goarch: s390x
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: ppc64le
+      - goos: windows
+        goarch: s390x
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: arm64
+      - goos: freebsd
+        goarch: ppc64le
+      - goos: freebsd
+        goarch: s390x
+
+    flags:
+      - -tags=kqueue
+      - -trimpath
+
+    ldflags:
+      - "-s -w -X github.com/minio/minio/cmd.Version={{.Version}} -X github.com/minio/minio/cmd.ReleaseTag={{.Tag}} -X github.com/minio/minio/cmd.CommitID={{.FullCommit}} -X github.com/minio/minio/cmd.ShortCommitID={{.ShortCommit}}"
+
+archives:
+  -
+    format: binary
+    name_template: "{{ .Binary }}-release/{{ .Os }}-{{ .Arch }}/{{ .Binary }}.{{ .Version }}"
+
+nfpms:
+  -
+    id: minio
+    package_name: minio
+    vendor: MinIO, Inc.
+    homepage: https://min.io/
+    maintainer: dev@min.io
+    description: MinIO is a High Performance Object Storage released under Apache License v2.0. It is API compatible with Amazon S3 cloud storage service. Use MinIO to build high performance infrastructure for machine learning, analytics and application data workloads.
+    license: Apache 2.0
+    bindir: /usr/bin
+    formats:
+      - deb
+      - rpm
+    overrides:
+      deb:
+        file_name_template: "{{ .Binary }}-release/debs/{{ .ProjectName }}-{{ .Version }}_{{ .Arch }}"
+        replacements:
+          arm: armv7
+        files:
+          "NOTICE": "/usr/share/minio/NOTICE"
+          "CREDITS": "/usr/share/minio/CREDITS"
+          "LICENSE": "/usr/share/minio/LICENSE"
+          "README.md": "/usr/share/minio/README.md"
+      rpm:
+        file_name_template: "{{ .Binary }}-release/rpms/{{ .ProjectName }}-{{ .Version }}.{{ .Arch }}"
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          arm: armv7
+        files:
+          "NOTICE": "/usr/share/minio/NOTICE"
+          "CREDITS": "/usr/share/minio/CREDITS"
+          "LICENSE": "/usr/share/minio/LICENSE"
+          "README.md": "/usr/share/minio/README.md"
+
+checksum:
+  algorithm: sha256
+
+signs:
+  -
+    signature: "${artifact}.asc"
+    cmd: "sh"
+    args:
+      - '-c'
+      - 'gpg --quiet --detach-sign -a ${artifact}'
+    artifacts: all
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^Update yaml files'
+
+dockers:
+  -
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.release
+    image_templates:
+      - minio/minio:{{ .Tag }}
+      - minio/minio:latest
+
+  -
+    goos: linux
+    goarch: ppc64le
+    dockerfile: Dockerfile.ppc64le.release
+    image_templates:
+      - minio/minio:{{ .Tag }}-ppc64le
+
+  -
+    goos: linux
+    goarch: s390x
+    dockerfile: Dockerfile.s390x.release
+    image_templates:
+      - minio/minio:{{ .Tag }}-s390x
+
+  -
+    goos: linux
+    goarch: arm64
+    goarm: ''
+    dockerfile: Dockerfile.arm64.release
+    image_templates:
+      - minio/minio:{{ .Tag }}-arm64
+
+  -
+    goos: linux
+    goarch: arm
+    goarm: '7'
+    dockerfile: Dockerfile.arm.release
+    image_templates:
+      - minio/minio:{{ .Tag }}-arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.13-alpine as builder
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
 
@@ -21,9 +21,9 @@ ENV MINIO_ACCESS_KEY_FILE=access_key \
 
 EXPOSE 9000
 
-COPY --from=0 /go/bin/minio /usr/bin/minio
-COPY --from=0 /go/minio/CREDITS /third_party/
-COPY --from=0 /go/minio/dockerscripts/docker-entrypoint.sh /usr/bin/
+COPY --from=builder /go/bin/minio /usr/bin/minio
+COPY --from=builder /go/minio/CREDITS /third_party/
+COPY --from=builder /go/minio/dockerscripts/docker-entrypoint.sh /usr/bin/
 
 RUN  \
      apk add --no-cache ca-certificates 'curl>7.61.0' 'su-exec>=0.2' && \

--- a/Dockerfile.arm.release
+++ b/Dockerfile.arm.release
@@ -1,23 +1,10 @@
-FROM golang:1.13-alpine as builder
-
-WORKDIR /home
-
-ENV GOPATH /go
-ENV CGO_ENABLED 0
-ENV GO111MODULE on
-
-RUN  \
-     apk add --no-cache git 'curl>7.61.0' && \
-     git clone https://github.com/minio/minio && \
-     curl -L https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz | tar zxvf - -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static .
-
+FROM multiarch/qemu-user-static:x86_64-arm as qemu
 FROM arm32v7/alpine:3.10
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
 
-COPY dockerscripts/docker-entrypoint.sh /usr/bin/
-COPY CREDITS /third_party/
-COPY --from=builder /home/qemu-arm-static /usr/bin/qemu-arm-static
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
+COPY minio /usr/bin/minio
 
 ENV MINIO_UPDATE off
 ENV MINIO_ACCESS_KEY_FILE=access_key \
@@ -28,9 +15,9 @@ ENV MINIO_ACCESS_KEY_FILE=access_key \
 RUN \
      apk add --no-cache ca-certificates 'curl>7.61.0' 'su-exec>=0.2' && \
      echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-     curl https://dl.min.io/server/minio/release/linux-arm/minio > /usr/bin/minio && \
-     chmod +x /usr/bin/minio  && \
-     chmod +x /usr/bin/docker-entrypoint.sh
+     curl -s -q https://raw.githubusercontent.com/minio/minio/release/dockerscripts/docker-entrypoint.sh -o /usr/bin/docker-entrypoint.sh && \
+     chmod +x /usr/bin/docker-entrypoint.sh && \
+     curl -s -q -O https://raw.githubusercontent.com/minio/minio/release/CREDITS
 
 EXPOSE 9000
 

--- a/Dockerfile.arm64.release
+++ b/Dockerfile.arm64.release
@@ -1,23 +1,10 @@
-FROM golang:1.13-alpine as builder
-
-WORKDIR /home
-
-ENV GOPATH /go
-ENV CGO_ENABLED 0
-ENV GO111MODULE on
-
-RUN  \
-     apk add --no-cache git 'curl>7.61.0' && \
-     git clone https://github.com/minio/minio && \
-     curl -L https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz | tar zxvf - -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static .
-
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
 FROM arm64v8/alpine:3.10
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
 
-COPY dockerscripts/docker-entrypoint.sh /usr/bin/
-COPY CREDITS /third_party/
-COPY --from=builder /home/qemu-arm-static /usr/bin/qemu-arm-static
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+COPY minio /usr/bin/minio
 
 ENV MINIO_UPDATE off
 ENV MINIO_ACCESS_KEY_FILE=access_key \
@@ -28,9 +15,9 @@ ENV MINIO_ACCESS_KEY_FILE=access_key \
 RUN \
      apk add --no-cache ca-certificates 'curl>7.61.0' 'su-exec>=0.2' && \
      echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-     curl https://dl.min.io/server/minio/release/linux-arm64/minio > /usr/bin/minio && \
-     chmod +x /usr/bin/minio  && \
-     chmod +x /usr/bin/docker-entrypoint.sh
+     curl -s -q https://raw.githubusercontent.com/minio/minio/release/dockerscripts/docker-entrypoint.sh -o /usr/bin/docker-entrypoint.sh && \
+     chmod +x /usr/bin/docker-entrypoint.sh && \
+     curl -s -q -O https://raw.githubusercontent.com/minio/minio/release/CREDITS
 
 EXPOSE 9000
 

--- a/Dockerfile.ppc64le.release
+++ b/Dockerfile.ppc64le.release
@@ -1,7 +1,9 @@
-FROM alpine:3.10
+FROM multiarch/qemu-user-static:x86_64-ppc64le as qemu
+FROM ppc64le/alpine:3.10
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
 
+COPY --from=qemu /usr/bin/qemu-ppc64le-static /usr/bin
 COPY minio /usr/bin/minio
 
 ENV MINIO_UPDATE off

--- a/Dockerfile.s390x.release
+++ b/Dockerfile.s390x.release
@@ -1,7 +1,9 @@
-FROM alpine:3.10
+FROM multiarch/qemu-user-static:x86_64-s390x as qemu
+FROM s390x/alpine:3.10
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
 
+COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin
 COPY minio /usr/bin/minio
 
 ENV MINIO_UPDATE off

--- a/cmd/build-constants.go
+++ b/cmd/build-constants.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2015, 2016 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2015-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,15 +25,15 @@ var (
 	// GOROOT - GOROOT value at the time of build.
 	GOROOT = ""
 
-	// Go get development tag.
-	goGetTag = "DEVELOPMENT.GOGET"
-
 	// Version - version time.RFC3339.
-	Version = goGetTag
+	Version = "DEVELOPMENT.GOGET"
+
 	// ReleaseTag - release tag in TAG.%Y-%m-%dT%H-%M-%SZ.
-	ReleaseTag = goGetTag
+	ReleaseTag = "DEVELOPMENT.GOGET"
+
 	// CommitID - latest commit id.
-	CommitID = goGetTag
+	CommitID = "DEVELOPMENT.GOGET"
+
 	// ShortCommitID - first 12 characters from CommitID.
-	ShortCommitID = CommitID[:12]
+	ShortCommitID = "DEVELOPMENT.GOGET"
 )

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tidwall/gjson v1.3.5 h1:2oW9FBNu8qt9jy5URgrzsVx/T/KSn3qn/smJQ0crlDQ=
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=


### PR DESCRIPTION

## Description
Add support for minioreleaser a fork for goreleaser

## Motivation and Context
This is to support building containers for multiple
platforms, rpms and debs all in a single build process

https://github.com/harshavardhana/minioreleaser

## How to test this PR?
Not easily, for now we just accept this PR as
I am working through integrating this fully into our 
release process `q` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
