### PR TITLE
Fix: Policy action name for Get/Put BucketLifeCycle

### DIFF
--- a/pkg/iam/policy/action.go
+++ b/pkg/iam/policy/action.go
@@ -78,10 +78,10 @@ const (
 	ListMultipartUploadPartsAction = "s3:ListMultipartUploadParts"
 
 	// PutBucketLifecycleAction - PutBucketLifecycle Rest API action.
-	PutBucketLifecycleAction = "s3:PutBucketLifecycle"
+	PutBucketLifecycleAction = "s3:PutLifecycleConfiguration"
 
 	// GetBucketLifecycleAction - GetBucketLifecycle Rest API action.
-	GetBucketLifecycleAction = "s3:GetBucketLifecycle"
+	GetBucketLifecycleAction = "s3:GetLifecycleConfiguration"
 
 	// PutBucketNotificationAction - PutObjectNotification Rest API action.
 	PutBucketNotificationAction = "s3:PutBucketNotification"


### PR DESCRIPTION
## Description
S3:GetBucketLifeCycle should be changed to S3:GetLifeCycleConfiguration
S3:PutBucketLifeCycle should be changed to S3:PutLifeCycleConfiguration

## Motivation and Context
https://github.com/minio/mc/issues/3265

## How to test this PR?
```
package main

import (
	"bytes"
	"log"
	iampolicy "github.com/minio/minio/pkg/iam/policy"
)

func main() {
	policy := "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Action\": [\"s3:GetLifecycleConfiguration\", \"s3:PutLifecycleConfiguration\"],\"Effect\": \"Allow\",\"Resource\": \"arn:aws:s3:::*\" }  ]}"

	_, e := iampolicy.ParseConfig(bytes.NewReader([]byte(policy)))
	log.Println(e)
}
```
The above code can be used to reproduce the error

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
