### PR TITLE
Add neater metadata printer

### DIFF
--- a/docs/bucket/versioning/xl-meta-to-json.go
+++ b/docs/bucket/versioning/xl-meta-to-json.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"github.com/minio/cli"
 	"github.com/tinylib/msgp/msgp"
 )
+
+var xlHeader = [4]byte{'X', 'L', '2', ' '}
 
 func main() {
 	app := cli.NewApp()
@@ -16,21 +22,69 @@ func main() {
 	app.HideHelpCommand = true
 
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Usage: "path to xl.meta file",
-			Name:  "f, file",
+		cli.BoolFlag{
+			Usage: "Print each file as a separate line without formatting",
+			Name:  "ndjson",
 		},
 	}
 
 	app.Action = func(c *cli.Context) error {
-		r, err := os.Open(c.String("file"))
-		if err != nil {
-			return err
+		for _, file := range c.Args() {
+			var r io.Reader
+			switch file {
+			case "-":
+				r = os.Stdin
+			default:
+				f, err := os.Open(file)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				r = f
+			}
+
+			// Read header
+			var tmp [4]byte
+			_, err := io.ReadFull(r, tmp[:])
+			if err != nil {
+				return err
+			}
+			if !bytes.Equal(tmp[:], xlHeader[:]) {
+				return fmt.Errorf("xlMeta: unknown XLv2 header, expected %v, got %v", xlHeader[:4], tmp[:4])
+			}
+			// Skip version check for now
+			_, err = io.ReadFull(r, tmp[:])
+			if err != nil {
+				return err
+			}
+
+			var buf bytes.Buffer
+			_, err = msgp.CopyToJSON(&buf, r)
+			if err != nil {
+				return err
+			}
+			if c.Bool("ndjson") {
+				fmt.Println(buf.String())
+				continue
+			}
+			var msi map[string]interface{}
+			dec := json.NewDecoder(&buf)
+			// Use number to preserve integers.
+			dec.UseNumber()
+			err = dec.Decode(&msi)
+			if err != nil {
+				return err
+			}
+			b, err := json.MarshalIndent(msi, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(b))
 		}
-		r.Seek(8, io.SeekStart)
-		defer r.Close()
-		_, err = msgp.CopyToJSON(os.Stdout, r)
-		return err
+		return nil
 	}
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
## Motivation and Context

* Just read files from args (more than 1 now supported)
* Pretty print by default. `-ndjson` will disable.
* Check header.
* Support stdin as '-'
* Don't just ignore errors.

## How to test this PR?

Build & run the command.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
