### PR TITLE
Updates the usage documentation of OpenID custom scopes

### DIFF
--- a/docs/sts/keycloak.md
+++ b/docs/sts/keycloak.md
@@ -57,6 +57,7 @@ Set `identity_openid` config with `config_url`, `client_id` and restart MinIO
 ```
 ~ mc admin config set myminio identity_openid config_url="http://localhost:8080/auth/realms/demo/.well-known/openid-configuration" client_id="account"
 ```
+> Note: You can configure the `scopes` parameter to restrict the OpenID scopes requested by minio to the IdP, for example, `"openid,policy_role_attribute"`, being `policy_role_attribute` a client_scope / client_mapper that maps a role attribute called policy to a `policy` claim returned by Keycloak
 
 Once successfully set restart the MinIO instance.
 ```
@@ -86,6 +87,8 @@ This will open the login page of keycloak, upon successful login, STS credential
   }
 }
 ```
+
+> Note: You can use the `-cscopes` parameter to restrict the requested scopes, for example to `"openid,policy_role_attribute"`, being `policy_role_attribute` a client_scope / client_mapper that maps a role attribute called policy to a `policy` claim returned by Keycloak.
 
 These credentials can now be used to perform MinIO API operations.
 

--- a/docs/sts/web-identity.go
+++ b/docs/sts/web-identity.go
@@ -30,6 +30,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -79,6 +80,7 @@ var (
 	configEndpoint string
 	clientID       string
 	clientSec      string
+	clientScopes   string
 	port           int
 )
 
@@ -131,6 +133,7 @@ func init() {
 		"OpenID discovery document endpoint")
 	flag.StringVar(&clientID, "cid", "", "Client ID")
 	flag.StringVar(&clientSec, "csec", "", "Client Secret")
+	flag.StringVar(&clientScopes, "cscopes", "openid", "Client Scopes")
 	flag.IntVar(&port, "port", 8080, "Port")
 }
 
@@ -148,6 +151,11 @@ func main() {
 		return
 	}
 
+	scopes :=  ddoc.ScopesSupported
+	if clientScopes != "" {
+		scopes = strings.Split(clientScopes, ",");
+	}
+
 	ctx := context.Background()
 
 	config := oauth2.Config{
@@ -158,7 +166,7 @@ func main() {
 			TokenURL: ddoc.TokenEndpoint,
 		},
 		RedirectURL: fmt.Sprintf("http://localhost:%d/oauth2/callback", port),
-		Scopes:      ddoc.ScopesSupported,
+		Scopes:      scopes,
 	}
 
 	state := randomState()

--- a/docs/sts/web-identity.md
+++ b/docs/sts/web-identity.md
@@ -95,6 +95,8 @@ export MINIO_ACCESS_KEY=minio
 export MINIO_SECRET_KEY=minio123
 export MINIO_IDENTITY_OPENID_CONFIG_URL=https://accounts.google.com/.well-known/openid-configuration
 export MINIO_IDENTITY_OPENID_CLIENT_ID="843351d4-1080-11ea-aa20-271ecba3924a"
+# Optional: Allow to specify the requested OpenID scopes (OpenID only requires the `openid` scope)
+#export MINIO_IDENTITY_OPENID_SCOPES="openid,profile,email"
 minio server /mnt/export
 ```
 


### PR DESCRIPTION
## Description

~~Allow to customize the OpenID scopes that minio requests to an IdP and use the custom scopes from the UI too~~.

~~You guys are fast :) I realized when I was just about to submit the PR that @harshavardhana has already pushed a PR. I've redone my PR on top of #9880 adding additional changes~~:
- ~~Improve example documentation and example command line tools~~.
- ~~Modify the RPC API to serve the configured scopes~~.
- ~~Modify the UI to use the configured scopes~~.

Improves the usage documentation of the new feature that allows users  to customize the OpenID scopes used by minio.

## Motivation and Context

#9238, #9010, updates #9880

## How to test this PR?

1. ~~Deploy an instance of keycloak (tested on 10.0.2)~~
2. ~~Configure a new client following [github.com/minio/minio/docs/sts/keycloak.md]~~(https://github.com/minio/minio/blob/master/docs/sts/keycloak.md)~~
3. ~~Launch minio with the following environment variable~~:
```
export MINIO_IDENTITY_OPENID_SCOPES="openid"
```
4. ~~Open the minio UI an login using OpenID~~
5. ~~Verify the URL of Keycloak only has the `openid` value for the `scope` parameter~~.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
