### PR TITLE
fix: preserve modTime for DeleteMarker on remote disks

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -287,10 +287,12 @@ func (client *storageRESTClient) DeleteVersion(volume, path string, fi FileInfo)
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)
 	values.Set(storageRESTFilePath, path)
-	values.Set(storageRESTVersionID, fi.VersionID)
-	values.Set(storageRESTDeleteMarker, strconv.FormatBool(fi.Deleted))
 
-	respBody, err := client.call(storageRESTMethodDeleteVersion, values, nil, -1)
+	var buffer bytes.Buffer
+	encoder := gob.NewEncoder(&buffer)
+	encoder.Encode(&fi)
+
+	respBody, err := client.call(storageRESTMethodDeleteVersion, values, &buffer, -1)
 	defer http.DrainBody(respBody)
 	return err
 }

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -286,10 +286,15 @@ func (s *storageRESTServer) DeleteVersionHandler(w http.ResponseWriter, r *http.
 	vars := mux.Vars(r)
 	volume := vars[storageRESTVolume]
 	filePath := vars[storageRESTFilePath]
-	versionID := vars[storageRESTVersionID]
-	deleteMarker := vars[storageRESTDeleteMarker] == "true"
 
-	err := s.storage.DeleteVersion(volume, filePath, FileInfo{VersionID: versionID, Deleted: deleteMarker})
+	var fi FileInfo
+	decoder := gob.NewDecoder(r.Body)
+	if err := decoder.Decode(&fi); err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+
+	err := s.storage.DeleteVersion(volume, filePath, fi)
 	if err != nil {
 		s.writeErrorResponse(w, err)
 	}


### PR DESCRIPTION
## Description
fix: preserve modTime for DeleteMarker on remote disks

## Motivation and Context
modTime should be preserved for DeleteMarker otherwise
can lead to negative values in a distributed setup.

## How to test this PR?
Run a local distributed setup, copy few files to a bucket, enable 
versioning and then perform DeleteObject() on the exact object.
This should create a deleteMarker but without this fix it creates
a deleteMarker with negative modTime.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
