### PR TITLE
update rulesMap of the peers when reloading bucketMetadata

### DIFF
--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -606,6 +606,10 @@ func (s *peerRESTServer) LoadBucketMetadataHandler(w http.ResponseWriter, r *htt
 	}
 
 	globalBucketMetadataSys.Set(bucketName, meta)
+
+	if meta.notificationConfig != nil {
+		globalNotificationSys.AddRulesMap(bucketName, meta.notificationConfig.ToRulesMap())
+	}
 }
 
 // ReloadFormatHandler - Reload Format.


### PR DESCRIPTION
## Description

After writing the notification config to the peers, Update the rulesMap of the peers.

Currently, We aren't updating the rulesMap of the peers after successfully writing the config to the peer disks.

## Motivation and Context
Avoid restarting the peers after setting the bucket config

## How to test this PR?
- Start a 4-node cluster
- Set the webhook and restart the server
- Create a bucket
- Add an event listener for the bucket. `mc event add ..`
- Upload objects to other nodes and check for events
- You should be seeing events from all the nodes. No matter where you upload.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)#
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
