### PR TITLE
fix: crash in storage rest-client due to spurious query params

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -289,8 +289,9 @@ func (client *storageRESTClient) DeleteVersion(volume, path string, fi FileInfo)
 	values.Set(storageRESTFilePath, path)
 
 	var buffer bytes.Buffer
-	encoder := gob.NewEncoder(&buffer)
-	encoder.Encode(&fi)
+	if err := gob.NewEncoder(&buffer).Encode(fi); err != nil {
+		return err
+	}
 
 	respBody, err := client.call(storageRESTMethodDeleteVersion, values, &buffer, -1)
 	defer http.DrainBody(respBody)

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -61,7 +61,6 @@ const (
 	storageRESTFilePath      = "file-path"
 	storageRESTVersionID     = "version-id"
 	storageRESTTotalVersions = "total-versions"
-	storageRESTDeleteMarker  = "delete-marker"
 	storageRESTSrcVolume     = "source-volume"
 	storageRESTSrcPath       = "source-path"
 	storageRESTDataDir       = "data-dir"

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -287,9 +287,13 @@ func (s *storageRESTServer) DeleteVersionHandler(w http.ResponseWriter, r *http.
 	volume := vars[storageRESTVolume]
 	filePath := vars[storageRESTFilePath]
 
+	if r.ContentLength < 0 {
+		s.writeErrorResponse(w, errInvalidArgument)
+		return
+	}
+
 	var fi FileInfo
-	decoder := gob.NewDecoder(r.Body)
-	if err := decoder.Decode(&fi); err != nil {
+	if err := gob.NewDecoder(r.Body).Decode(&fi); err != nil {
 		s.writeErrorResponse(w, err)
 		return
 	}
@@ -300,7 +304,7 @@ func (s *storageRESTServer) DeleteVersionHandler(w http.ResponseWriter, r *http.
 	}
 }
 
-// ReadVersion delete updated metadata.
+// ReadVersion read metadata of versionID
 func (s *storageRESTServer) ReadVersionHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.IsValid(w, r) {
 		return
@@ -858,7 +862,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointZones EndpointZones
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodWriteMetadata).HandlerFunc(httpTraceHdrs(server.WriteMetadataHandler)).
 				Queries(restQueries(storageRESTVolume, storageRESTFilePath)...)
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodDeleteVersion).HandlerFunc(httpTraceHdrs(server.DeleteVersionHandler)).
-				Queries(restQueries(storageRESTVolume, storageRESTFilePath, storageRESTVersionID, storageRESTDeleteMarker)...)
+				Queries(restQueries(storageRESTVolume, storageRESTFilePath)...)
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodReadVersion).HandlerFunc(httpTraceHdrs(server.ReadVersionHandler)).
 				Queries(restQueries(storageRESTVolume, storageRESTFilePath, storageRESTVersionID)...)
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodRenameData).HandlerFunc(httpTraceHdrs(server.RenameDataHandler)).


### PR DESCRIPTION
## Description
fix: crash in storage rest-client due to spurious query params

## Motivation and Context
regression got introduced in dee3cf2d7fe2d98732302a29140a33afc7daae53
when the DeleteVersion API was changed, but the corresponding query
params were left in-tact.

## How to test this PR?
In a distributed cluster running mint tests should crash the server

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes introduced in dee3cf2d7fe2d98732302a29140a33afc7daae53
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
