### PR TITLE
madmin: Strip 80/443 from the endpoint when http/https

### DIFF
--- a/pkg/madmin/utils.go
+++ b/pkg/madmin/utils.go
@@ -67,10 +67,20 @@ func getEndpointURL(endpoint string, secure bool) (*url.URL, error) {
 			return nil, ErrInvalidArgument(msg)
 		}
 	}
+
 	// If secure is false, use 'http' scheme.
 	scheme := "https"
 	if !secure {
 		scheme = "http"
+	}
+
+	// Strip the obvious :443 and :80 from the endpoint
+	// to avoid the signature mismatch error.
+	if secure && strings.HasSuffix(endpoint, ":443") {
+		endpoint = strings.TrimSuffix(endpoint, ":443")
+	}
+	if !secure && strings.HasSuffix(endpoint, ":80") {
+		endpoint = strings.TrimSuffix(endpoint, ":80")
 	}
 
 	// Construct a secured endpoint URL.


### PR DESCRIPTION
## Description
Users having endpoints with this format http://url:80 or http://url:443
will face signature mismatch error.

The reason is that  S3 spec ignores :80 or :443 port in the endpoint
when calculating the signature, so this PR will just strip them.

## Motivation and Context
Avoid signature mismatch error when there is :80 or :443 in the madmin endpoint url.

## How to test this PR?

1. Add ':443' in the endpoint URL of play in ~/.mc/config.json 
2. mc admin info play/


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
