### PR TITLE
Reroute requests based on token heal/listing

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -370,13 +370,18 @@ func newHealSequence(ctx context.Context, bucket, objPrefix, clientAddr string,
 	reqInfo.AppendTags("prefix", objPrefix)
 	ctx, cancel := context.WithCancel(logger.SetReqInfo(ctx, reqInfo))
 
+	clientToken := mustGetUUID()
+	if globalIsDistErasure {
+		clientToken = fmt.Sprintf("%s@%d", clientToken, getLocalPeerIndex(globalEndpoints))
+	}
+
 	return &healSequence{
 		respCh:         make(chan healResult),
 		bucket:         bucket,
 		object:         objPrefix,
 		reportProgress: true,
 		startTime:      UTCNow(),
-		clientToken:    mustGetUUID(),
+		clientToken:    clientToken,
 		clientAddress:  clientAddr,
 		forceStarted:   forceStart,
 		settings:       hs,

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -372,7 +372,7 @@ func newHealSequence(ctx context.Context, bucket, objPrefix, clientAddr string,
 
 	clientToken := mustGetUUID()
 	if globalIsDistErasure {
-		clientToken = fmt.Sprintf("%s@%d", clientToken, getLocalPeerIndex(globalEndpoints))
+		clientToken = fmt.Sprintf("%s@%d", clientToken, GetProxyEndpointLocalIndex(globalProxyEndpoints))
 	}
 
 	return &healSequence{

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -279,7 +279,7 @@ var (
 	// If writes to FS backend should be O_SYNC.
 	globalFSOSync bool
 
-	globalListEndpoints []ListEndpoint
+	globalProxyEndpoints []ProxyEndpoint
 	// Add new variable global values here.
 )
 

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2015, 2016, 2017 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2015-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -451,4 +451,27 @@ func getHostName(r *http.Request) (hostName string) {
 		hostName = r.Host
 	}
 	return
+}
+
+// Proxy any request to an endpoint.
+func proxyRequest(ctx context.Context, w http.ResponseWriter, r *http.Request, ep ProxyEndpoint) (success bool) {
+	if ep.IsLocal {
+		return false
+	}
+	f := handlers.NewForwarder(&handlers.Forwarder{
+		PassHost:     true,
+		RoundTripper: ep.Transport,
+		Logger: func(err error) {
+			logger.LogIf(GlobalContext, err)
+		},
+	})
+
+	r.URL.Scheme = "http"
+	if globalIsSSL {
+		r.URL.Scheme = "https"
+	}
+
+	r.URL.Host = ep.Host
+	f.ServeHTTP(w, r)
+	return true
 }

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -459,7 +459,7 @@ func proxyRequest(ctx context.Context, w http.ResponseWriter, r *http.Request, e
 
 	f := handlers.NewForwarder(&handlers.Forwarder{
 		PassHost:     true,
-		RoundTripper: NewGatewayHTTPTransport(),
+		RoundTripper: ep.Transport,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			success = false
 			w.WriteHeader(http.StatusBadGateway)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -396,7 +396,7 @@ func serverMain(ctx *cli.Context) {
 	globalRootCAs, err = config.GetRootCAs(globalCertsCADir.Get())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
 
-	globalListEndpoints, err = GetListEndpoints(globalEndpoints)
+	globalProxyEndpoints, err = GetProxyEndpoints(globalEndpoints)
 	logger.FatalIf(err, "Invalid command line arguments")
 
 	globalMinioEndpoint = func() string {

--- a/pkg/handlers/forwarder.go
+++ b/pkg/handlers/forwarder.go
@@ -33,6 +33,7 @@ type Forwarder struct {
 	RoundTripper http.RoundTripper
 	PassHost     bool
 	Logger       func(error)
+	ErrorHandler func(http.ResponseWriter, *http.Request, error)
 
 	// internal variables
 	rewriter *headerRewriter
@@ -61,6 +62,11 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, inReq *http.Request) {
 		FlushInterval: defaultFlushInterval,
 		ErrorHandler:  f.customErrHandler,
 	}
+
+	if f.ErrorHandler != nil {
+		revproxy.ErrorHandler = f.ErrorHandler
+	}
+
 	revproxy.ServeHTTP(w, outReq)
 }
 


### PR DESCRIPTION
## Description
This PR is based on @krishnasrinivas and @harshavardhana work.

It optimizes listing by routing listing requests to servers that treated
the listing requests and have the cache of listing results according 
to the following rule:

- List Objects V1 routes the request to the node by hashing the bucket name
- List Objects V2 analyzes the continuation token which contains the node index
of the node that first treated the listing request
- Healing requests also contain now the node index in the token.


## Motivation and Context
Routing

## How to test this PR?
*) Run a 4 nodes with a reverse proxy with round robin
*) Run mc admin heal command
*) Run listing with a load balancer


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
