### PR TITLE
Add Readiness Cache

### DIFF
--- a/cmd/bucket-listobjects-handlers.go
+++ b/cmd/bucket-listobjects-handlers.go
@@ -302,7 +302,7 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 
 	listObjects := objectAPI.ListObjects
 
-	// Inititate a list objects operation based on the input params.
+	// Initiate a list objects operation based on the input params.
 	// On success would return back ListObjectsInfo object to be
 	// marshaled into S3 compatible XML header.
 	listObjectsInfo, err := listObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)

--- a/cmd/config/api/api.go
+++ b/cmd/config/api/api.go
@@ -32,11 +32,13 @@ const (
 	apiRequestsMax      = "requests_max"
 	apiRequestsDeadline = "requests_deadline"
 	apiReadyDeadline    = "ready_deadline"
+	apiReadyCacheTTL    = "ready_cache_ttl"
 	apiCorsAllowOrigin  = "cors_allow_origin"
 
 	EnvAPIRequestsMax      = "MINIO_API_REQUESTS_MAX"
 	EnvAPIRequestsDeadline = "MINIO_API_REQUESTS_DEADLINE"
 	EnvAPIReadyDeadline    = "MINIO_API_READY_DEADLINE"
+	EnvAPIReadyCacheTTL    = "MINIO_API_READY_CACHE_TTL"
 	EnvAPICorsAllowOrigin  = "MINIO_API_CORS_ALLOW_ORIGIN"
 )
 
@@ -56,6 +58,10 @@ var (
 			Value: "10s",
 		},
 		config.KV{
+			Key:   apiReadyCacheTTL,
+			Value: "3s",
+		},
+		config.KV{
 			Key:   apiCorsAllowOrigin,
 			Value: "*",
 		},
@@ -67,6 +73,7 @@ type Config struct {
 	APIRequestsMax      int           `json:"requests_max"`
 	APIRequestsDeadline time.Duration `json:"requests_deadline"`
 	APIReadyDeadline    time.Duration `json:"ready_deadline"`
+	APIReadyCacheTTL    time.Duration `json:"ready_cache_ttl"`
 	APICorsAllowOrigin  []string      `json:"cors_allow_origin"`
 }
 
@@ -107,11 +114,17 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		return cfg, err
 	}
 
+	readyCacheTTL, err := time.ParseDuration(env.Get(EnvAPIReadyCacheTTL, kvs.Get(apiReadyCacheTTL)))
+	if err != nil {
+		return cfg, err
+	}
+
 	corsAllowOrigin := strings.Split(env.Get(EnvAPICorsAllowOrigin, kvs.Get(apiCorsAllowOrigin)), ",")
 	return Config{
 		APIRequestsMax:      requestsMax,
 		APIRequestsDeadline: requestsDeadline,
 		APIReadyDeadline:    readyDeadline,
+		APIReadyCacheTTL:    readyCacheTTL,
 		APICorsAllowOrigin:  corsAllowOrigin,
 	}, nil
 }

--- a/cmd/config/api/help.go
+++ b/cmd/config/api/help.go
@@ -40,6 +40,12 @@ var (
 			Type:        "duration",
 		},
 		config.HelpKV{
+			Key:         apiReadyCacheTTL,
+			Description: `set the cache TTL for the health check API /minio/health/ready response e.g. "5s"`,
+			Optional:    true,
+			Type:        "duration",
+		},
+		config.HelpKV{
 			Key:         apiCorsAllowOrigin,
 			Description: `set comma separated list of origins allowed for CORS requests e.g. "https://example1.com,https://example2.com"`,
 			Optional:    true,

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -38,6 +38,8 @@ import (
 type erasureZones struct {
 	GatewayUnsupported
 
+	readinessCache timedValue
+
 	zones []*erasureSets
 }
 
@@ -1973,44 +1975,57 @@ func (z *erasureZones) getZoneAndSet(id string) (int, int, error) {
 
 // IsReady - Returns true, when all the erasure sets are writable.
 func (z *erasureZones) IsReady(ctx context.Context) bool {
-	erasureSetUpCount := make([][]int, len(z.zones))
-	for i := range z.zones {
-		erasureSetUpCount[i] = make([]int, len(z.zones[i].sets))
-	}
-
-	diskIDs := globalNotificationSys.GetLocalDiskIDs(ctx)
-
-	diskIDs = append(diskIDs, getLocalDiskIDs(z)...)
-
-	for _, id := range diskIDs {
-		zoneIdx, setIdx, err := z.getZoneAndSet(id)
-		if err != nil {
-			logger.LogIf(ctx, err)
-			continue
+	ready := func() bool {
+		erasureSetUpCount := make([][]int, len(z.zones))
+		for i := range z.zones {
+			erasureSetUpCount[i] = make([]int, len(z.zones[i].sets))
 		}
-		erasureSetUpCount[zoneIdx][setIdx]++
-	}
 
-	for zoneIdx := range erasureSetUpCount {
-		parityDrives := globalStorageClass.GetParityForSC(storageclass.STANDARD)
-		diskCount := len(z.zones[zoneIdx].format.Erasure.Sets[0])
-		if parityDrives == 0 {
-			parityDrives = getDefaultParityBlocks(diskCount)
+		diskIDs := globalNotificationSys.GetLocalDiskIDs(ctx)
+
+		diskIDs = append(diskIDs, getLocalDiskIDs(z)...)
+
+		for _, id := range diskIDs {
+			zoneIdx, setIdx, err := z.getZoneAndSet(id)
+			if err != nil {
+				logger.LogIf(ctx, err)
+				continue
+			}
+			erasureSetUpCount[zoneIdx][setIdx]++
 		}
-		dataDrives := diskCount - parityDrives
-		writeQuorum := dataDrives
-		if dataDrives == parityDrives {
-			writeQuorum++
-		}
-		for setIdx := range erasureSetUpCount[zoneIdx] {
-			if erasureSetUpCount[zoneIdx][setIdx] < writeQuorum {
-				logger.LogIf(ctx, fmt.Errorf("Write quorum lost on zone: %d, set: %d, expected write quorum: %d",
-					zoneIdx, setIdx, writeQuorum))
-				return false
+
+		for zoneIdx := range erasureSetUpCount {
+			parityDrives := globalStorageClass.GetParityForSC(storageclass.STANDARD)
+			diskCount := len(z.zones[zoneIdx].format.Erasure.Sets[0])
+			if parityDrives == 0 {
+				parityDrives = getDefaultParityBlocks(diskCount)
+			}
+			dataDrives := diskCount - parityDrives
+			writeQuorum := dataDrives
+			if dataDrives == parityDrives {
+				writeQuorum++
+			}
+			for setIdx := range erasureSetUpCount[zoneIdx] {
+				if erasureSetUpCount[zoneIdx][setIdx] < writeQuorum {
+					logger.LogIf(ctx, fmt.Errorf("Write quorum lost on zone: %d, set: %d, expected write quorum: %d",
+						zoneIdx, setIdx, writeQuorum))
+					return false
+				}
 			}
 		}
+		return true
 	}
-	return true
+
+	z.readinessCache.Once.Do(func() {
+		z.readinessCache.TTL = globalAPIConfig.getReadyCacheTTL()
+		z.readinessCache.Update = func() (interface{}, error) {
+			return ready(), nil
+		}
+	})
+
+	v, _ := z.readinessCache.Get()
+	return v.(bool)
+
 }
 
 // PutObjectTags - replace or add tags to an existing object

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -30,6 +30,7 @@ type apiConfig struct {
 	requestsDeadline time.Duration
 	requestsPool     chan struct{}
 	readyDeadline    time.Duration
+	readyCacheTTL    time.Duration
 	corsAllowOrigins []string
 }
 
@@ -38,6 +39,7 @@ func (t *apiConfig) init(cfg api.Config) {
 	defer t.mu.Unlock()
 
 	t.readyDeadline = cfg.APIReadyDeadline
+	t.readyCacheTTL = cfg.APIReadyCacheTTL
 	t.corsAllowOrigins = cfg.APICorsAllowOrigin
 	if cfg.APIRequestsMax <= 0 {
 		return
@@ -57,6 +59,17 @@ func (t *apiConfig) getCorsAllowOrigins() []string {
 	defer t.mu.RUnlock()
 
 	return t.corsAllowOrigins
+}
+
+func (t *apiConfig) getReadyCacheTTL() time.Duration {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.readyCacheTTL == 0 {
+		return 5 * time.Second
+	}
+
+	return t.readyCacheTTL
 }
 
 func (t *apiConfig) getReadyDeadline() time.Duration {

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -58,7 +58,7 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	// If not ready force to re evaluate health bypassing cached value.
 	v, _ = globalReadyCache.ForceUpdate()
-	if v.(bool) == true {
+	if v.(bool) {
 		writeResponse(w, http.StatusOK, nil, mimeNone)
 		return
 	}

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -51,7 +51,7 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Get cached value
 	v, _ := globalReadyCache.Get()
-	if v.(bool) == true {
+	if v.(bool) {
 		writeResponse(w, http.StatusOK, nil, mimeNone)
 		return
 	}

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -36,7 +36,7 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 		ctx, cancel := context.WithTimeout(ctx, globalAPIConfig.getReadyDeadline())
 		defer cancel()
-		if !objLayer.IsReady(ctx) && newObjectLayerFn() == nil {
+		return objLayer.IsReady(ctx)
 			return false
 		}
 		return true

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -49,6 +49,9 @@ var globalObjectAPI ObjectLayer
 //Global cacheObjects, only accessed by newCacheObjectsFn().
 var globalCacheObjectAPI CacheObjectLayer
 
+//Global cached readiness flag
+var globalReadyCache timedValue
+
 // Checks if the object is a directory, this logic uses
 // if size == 0 and object ends with SlashSeparator then
 // returns true.

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -49,7 +49,7 @@ var globalObjectAPI ObjectLayer
 //Global cacheObjects, only accessed by newCacheObjectsFn().
 var globalCacheObjectAPI CacheObjectLayer
 
-//Global cached readiness flag
+// Global cached readiness flag
 var globalReadyCache timedValue
 
 // Checks if the object is a directory, this logic uses

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -658,7 +658,7 @@ type timedValue struct {
 	mu         sync.Mutex
 }
 
-// ForceUpdates the value and caches it.
+// ForceUpdate the value and caches it.
 // If the Update function returns an error the value is forwarded as is and not cached.
 func (t *timedValue) ForceUpdate() (interface{}, error) {
 	t.mu.Lock()

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -658,6 +658,20 @@ type timedValue struct {
 	mu         sync.Mutex
 }
 
+// ForceUpdates the value and caches it.
+// If the Update function returns an error the value is forwarded as is and not cached.
+func (t *timedValue) ForceUpdate() (interface{}, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	v, err := t.Update()
+	if err != nil {
+		return v, err
+	}
+	t.value = v
+	t.lastUpdate = time.Now()
+	return v, nil
+}
+
 // Get will return a cached value or fetch a new one.
 // If the Update function returns an error the value is forwarded as is and not cached.
 func (t *timedValue) Get() (interface{}, error) {


### PR DESCRIPTION
## Description
Allow an eager probing of readiness value while controlling chattiness if the last status was ready.

## Motivation and Context
This is to allow faster detection of readiness by probes such as those that are included in k8s.

## How to test this PR?
Bring up minio using operator

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
