### PR TITLE
fix: readiness needs to be like liveness

### DIFF
--- a/cmd/config/api/help.go
+++ b/cmd/config/api/help.go
@@ -34,12 +34,6 @@ var (
 			Type:        "duration",
 		},
 		config.HelpKV{
-			Key:         apiReadyDeadline,
-			Description: `set the deadline for health check API /minio/health/ready e.g. "1m"`,
-			Optional:    true,
-			Type:        "duration",
-		},
-		config.HelpKV{
 			Key:         apiCorsAllowOrigin,
 			Description: `set comma separated list of origins allowed for CORS requests e.g. "https://example1.com,https://example2.com"`,
 			Optional:    true,

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -44,8 +44,6 @@ const (
 
 	// URLEndpointType - URL style endpoint type enum.
 	URLEndpointType
-
-	retryInterval = 5 // In Seconds.
 )
 
 // Endpoint - any type of endpoint.
@@ -302,7 +300,7 @@ func (endpoints Endpoints) UpdateIsLocal(foundPrevLocal bool) error {
 	resolvedList := make([]bool, len(endpoints))
 	// Mark the starting time
 	startTime := time.Now()
-	keepAliveTicker := time.NewTicker(retryInterval * time.Second)
+	keepAliveTicker := time.NewTicker(10 * time.Millisecond)
 	defer keepAliveTicker.Stop()
 	for {
 		// Break if the local endpoint is found already Or all the endpoints are resolved.

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -21,13 +21,11 @@ import (
 	"net/http"
 )
 
-// ReadinessCheckHandler returns if the server is ready to receive requests.
-// For FS - Checks if the backend disk is available
-// For Erasure backend - Checks if all the erasure sets are writable
-func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := newContext(r, w, "ReadinessCheckHandler")
+// ClusterCheckHandler returns if the server is ready for requests.
+func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := newContext(r, w, "ClusterCheckCheckHandler")
 
-	objLayer := newObjectLayerWithoutSafeModeFn()
+	objLayer := newObjectLayerFn()
 	// Service not initialized yet
 	if objLayer == nil {
 		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
@@ -37,11 +35,18 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(ctx, globalAPIConfig.getReadyDeadline())
 	defer cancel()
 
-	if !objLayer.IsReady(ctx) && newObjectLayerFn() == nil {
+	if !objLayer.IsReady(ctx) {
 		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
 		return
 	}
 
+	writeResponse(w, http.StatusOK, nil, mimeNone)
+}
+
+// ReadinessCheckHandler Checks if the process is up. Always returns success.
+func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: only implement this function to notify that this pod is
+	// busy, at a local scope in future, for now '200 OK'.
 	writeResponse(w, http.StatusOK, nil, mimeNone)
 }
 

--- a/cmd/healthcheck-router.go
+++ b/cmd/healthcheck-router.go
@@ -26,6 +26,7 @@ const (
 	healthCheckPath          = "/health"
 	healthCheckLivenessPath  = "/live"
 	healthCheckReadinessPath = "/ready"
+	healthCheckClusterPath   = "/cluster"
 	healthCheckPathPrefix    = minioReservedBucketPath + healthCheckPath
 )
 
@@ -34,6 +35,9 @@ func registerHealthCheckRouter(router *mux.Router) {
 
 	// Healthcheck router
 	healthRouter := router.PathPrefix(healthCheckPathPrefix).Subrouter()
+
+	// Cluster check handler to verify cluster is active
+	healthRouter.Methods(http.MethodGet).Path(healthCheckClusterPath).HandlerFunc(httpTraceAll(ClusterCheckHandler))
 
 	// Liveness handler
 	healthRouter.Methods(http.MethodGet).Path(healthCheckLivenessPath).HandlerFunc(httpTraceAll(LivenessCheckHandler))

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -190,7 +190,6 @@ or environment variables
 ```
 MINIO_API_REQUESTS_MAX       (number)    set the maximum number of concurrent requests, e.g. "1600"
 MINIO_API_REQUESTS_DEADLINE  (duration)  set the deadline for API requests waiting to be processed e.g. "1m"
-MINIO_API_READY_DEADLINE     (duration)  set the deadline for health check API /minio/health/ready e.g. "1m"
 MINIO_API_CORS_ALLOW_ORIGIN  (csv)       set comma separated list of origins allowed for CORS requests e.g. "https://example1.com,https://example2.com"
 ```
 


### PR DESCRIPTION

## Description
fix: readiness needs to be like liveness

## Motivation and Context
Readiness has no reasoning to be cluster scope
because that is not how the k8s networking works
for pods, all the pods to a deployment are not
sharing the network in a singleton. Instead they
are run as local scopes to themselves, with
readiness failures the pod is potentially taken
out of the network to be resolvable - this
affects the distributed setup in a myriad of
different ways.

Instead, readiness should behave like liveness
with local scope alone, and should be a dummy
implementation.

This PR all the startup times and overall k8s
startup time dramatically improves.

Added another handler called as `/minio/health/cluster`
to understand the cluster scope health.

## How to test this PR?
Deploy in k8s to figure out the necessary understanding 

```yml
## Create service of minio dist xl StatefulSet.
apiVersion: v1
kind: Service
metadata:
  name: minio-large-bucket-edge
spec:
  type: NodePort
  ports:
  - port: 9000
  selector:
    app: minio-large-bucket-app-edge
---
## Create headless service to StatefulSet to work.
apiVersion: v1
kind: Service
metadata:
  name: minio-large-bucket-headless-edge
  labels:
    app: minio-large-bucket-headless-edge
spec:
  ports:
  - port: 9000
  clusterIP: None
  selector:
    app: minio-large-bucket-app-edge
---
## Run minio dist xl StatefulSet.
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: minio-large-bucket-edge
spec:
  updateStrategy:
    type: RollingUpdate
  podManagementPolicy: "Parallel"
  serviceName: "minio-large-bucket-headless-edge"
  replicas: 8
  selector:
    matchLabels:
      app: minio-large-bucket-app-edge
  template:
    metadata:
      labels:
        app: minio-large-bucket-app-edge
    spec:
      containers:
      - name: minio-large-bucket-edge
        env:
        - name: MINIO_ACCESS_KEY
          value: "minio"
        - name: MINIO_SECRET_KEY
          value: "minio123"
        image: y4m4/minio:dev
        imagePullPolicy: Always
        args:
        - server
        - http://minio-large-bucket-edge-{0...7}.minio-large-bucket-headless-edge.default.svc.cluster.local/data{0...3}
        ports:
        - containerPort: 9000
        readinessProbe:
          httpGet:
            path: /minio/health/ready
            port: 9000
            scheme: HTTP
          initialDelaySeconds: 5
          periodSeconds: 1
          timeoutSeconds: 1
          successThreshold: 1
          failureThreshold: 3
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
