### PR TITLE
Call Sync() on write to ensure data commit to the disk

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1694,10 +1694,13 @@ func (s *xlStorage) CreateFile(volume, path string, fileSize int64, r io.Reader)
 		return err
 	}
 
-	defer w.Close()
-
 	bufp := s.pool.Get().(*[]byte)
 	defer s.pool.Put(bufp)
+
+	defer func() {
+		w.Sync()
+		w.Close()
+	}()
 
 	written, err := xioutil.CopyAligned(w, r, *bufp, fileSize)
 	if err != nil {


### PR DESCRIPTION
## Motivation and Context
Though we write in O_DIRECT, last few bytes might be written without O_DIRECT as the buffer might be unaligned. Also O_DIRECT does not guarantee metadata commits to the FS. Hence the PR does `w.Sync()` to ensure proper commits.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
