### PR TITLE
make sure to delete data-usage cache upon bucket deletes

### DIFF
--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -319,9 +319,15 @@ func (b *BucketMetadata) Save(ctx context.Context, api ObjectLayer) error {
 // deleteBucketMetadata deletes bucket metadata
 // If config does not exist no error is returned.
 func deleteBucketMetadata(ctx context.Context, obj ObjectLayer, bucket string) error {
-	configFile := path.Join(bucketConfigPrefix, bucket, bucketMetadataFile)
-	if err := deleteConfig(ctx, obj, configFile); err != nil && err != errConfigNotFound {
-		return err
+	metadataFiles := []string{
+		dataUsageCacheName,
+		bucketMetadataFile,
+	}
+	for _, metaFile := range metadataFiles {
+		configFile := path.Join(bucketConfigPrefix, bucket, metaFile)
+		if err := deleteConfig(ctx, obj, configFile); err != nil && err != errConfigNotFound {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
make sure to delete data-usage cache upon bucket deletes

## Motivation and Context
`.usage-cache.bin` was getting leftover even after buckets
were deleted from the system, ideally, the crawler should GC
if these are missed out in any way but we can do it pro-actively
while deleting the bucket itself. 

## How to test this PR?
Just delete the bucket and see the `.minio.sys/buckets/bucket/.usage-cache.bin`
is still lingering around. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
