### PR TITLE
Added 'close' to results channel in

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -61,7 +61,7 @@ func (l *GatewayLocker) Walk(ctx context.Context, bucket, prefix string, results
 	walk := func(ctx context.Context, bucket, prefix string, results chan<- ObjectInfo) error {
 		var marker string
 
-		//Make sure the results channel is ready to be read when we're done.
+		// Make sure the results channel is ready to be read when we're done.
 		defer close(results)
 
 		for {

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -60,6 +60,10 @@ func (l *GatewayLocker) NewNSLock(ctx context.Context, bucket string, objects ..
 func (l *GatewayLocker) Walk(ctx context.Context, bucket, prefix string, results chan<- ObjectInfo) error {
 	walk := func(ctx context.Context, bucket, prefix string, results chan<- ObjectInfo) error {
 		var marker string
+
+		//Make sure the results channel is ready to be read when we're done.
+		defer close(results)
+
 		for {
 			// set maxKeys to '0' to list maximum possible objects in single call.
 			loi, err := l.ObjectLayer.ListObjects(ctx, bucket, prefix, marker, "", 0)


### PR DESCRIPTION
## Description
After implementation of generic Walk for gateway, results channel was left open, causing deadlock on read. Added a close for the channel.

## Motivation and Context
fixes https://github.com/minio/minio/issues/9891

## How to test this PR?

Test deletion of both versioned and non-versioned files in gateway mode where the objectLayer does not implement its own Walk.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
