### PR TITLE
fix: list object versions in distributed setup

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -942,6 +942,7 @@ func (s *erasureSets) startMergeWalksVersionsN(ctx context.Context, bucket, pref
 			}
 			entryCh, err := disk.WalkVersions(bucket, prefix, marker, recursive, endWalkCh)
 			if err != nil {
+				logger.LogIf(ctx, err)
 				// Disk walk returned error, ignore it.
 				continue
 			}

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -454,7 +454,7 @@ func (client *storageRESTClient) WalkVersions(volume, dirPath, marker string, re
 	values.Set(storageRESTDirPath, dirPath)
 	values.Set(storageRESTMarkerPath, marker)
 	values.Set(storageRESTRecursive, strconv.FormatBool(recursive))
-	respBody, err := client.call(storageRESTMethodWalk, values, nil, -1)
+	respBody, err := client.call(storageRESTMethodWalkVersions, values, nil, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -469,6 +469,9 @@ func (client *storageRESTClient) WalkVersions(volume, dirPath, marker string, re
 			var fi FileInfoVersions
 			if gerr := decoder.Decode(&fi); gerr != nil {
 				// Upon error return
+				if gerr != io.EOF {
+					logger.LogIf(context.Background(), gerr)
+				}
 				return
 			}
 			select {
@@ -476,7 +479,6 @@ func (client *storageRESTClient) WalkVersions(volume, dirPath, marker string, re
 			case <-endWalkCh:
 				return
 			}
-
 		}
 	}()
 

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -576,7 +576,6 @@ func (s *storageRESTServer) WalkHandler(w http.ResponseWriter, r *http.Request) 
 
 	fch, err := s.storage.Walk(volume, dirPath, markerPath, recursive, r.Context().Done())
 	if err != nil {
-		logger.LogIf(r.Context(), err)
 		s.writeErrorResponse(w, err)
 		return
 	}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -901,11 +901,7 @@ func (s *xlStorage) WalkVersions(volume, dirPath, marker string, recursive bool,
 		}
 
 		walkResultCh := startTreeWalk(GlobalContext, volume, dirPath, marker, recursive, listDir, endWalkCh)
-		for {
-			walkResult, ok := <-walkResultCh
-			if !ok {
-				return
-			}
+		for walkResult := range walkResultCh {
 			var fiv FileInfoVersions
 			if HasSuffix(walkResult.entry, SlashSeparator) {
 				fiv = FileInfoVersions{
@@ -981,11 +977,7 @@ func (s *xlStorage) Walk(volume, dirPath, marker string, recursive bool, endWalk
 		}
 
 		walkResultCh := startTreeWalk(GlobalContext, volume, dirPath, marker, recursive, listDir, endWalkCh)
-		for {
-			walkResult, ok := <-walkResultCh
-			if !ok {
-				return
-			}
+		for walkResult := range walkResultCh {
 			var fi FileInfo
 			if HasSuffix(walkResult.entry, SlashSeparator) {
 				fi = FileInfo{


### PR DESCRIPTION
## Description

Remote calls to `WalkVersions` was calling the wrong endpoint, so unless quorum could be reached with local disks no results would ever be returned.

Add missing "recursive" parameter.

Thanks to @vadmeste for helping debug the latter issue.

## How to test this PR?

Run in a distributed mode where there is no more than 1 disk per server.

List versions of a bucket, eg: 

`aws s3api list-object-versions --bucket src --endpoint-url http://127.0.0.1:9001`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
