### PR TITLE
fix: ListObjectVersions should return ordered Version & DeleteMarker

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -242,7 +242,7 @@ type ObjectVersion struct {
 	isDeleteMarker bool
 }
 
-// MarshalXML - marhsal ObjectVersion
+// MarshalXML - marshal ObjectVersion
 func (o ObjectVersion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if o.isDeleteMarker {
 		start.Name.Local = "DeleteMarker"

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -81,7 +81,6 @@ type ListVersionsResponse struct {
 
 	CommonPrefixes []CommonPrefix
 	Versions       []ObjectVersion
-	DeleteMarkers  []DeletedVersion
 
 	// Encoding type used to encode object keys in the response.
 	EncodingType string `xml:"EncodingType,omitempty"`
@@ -236,24 +235,23 @@ type Bucket struct {
 
 // ObjectVersion container for object version metadata
 type ObjectVersion struct {
-	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Version" json:"-"`
 	Object
 	IsLatest  bool
 	VersionID string `xml:"VersionId"`
+
+	isDeleteMarker bool
 }
 
-// DeletedVersion container for the delete object version metadata.
-type DeletedVersion struct {
-	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ DeleteMarker" json:"-"`
+// MarshalXML - marhsal ObjectVersion
+func (o ObjectVersion) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if o.isDeleteMarker {
+		start.Name.Local = "DeleteMarker"
+	} else {
+		start.Name.Local = "Version"
+	}
 
-	IsLatest     bool
-	Key          string
-	LastModified string // time string of format "2006-01-02T15:04:05.000Z"
-
-	// Owner of the object.
-	Owner Owner
-
-	VersionID string `xml:"VersionId"`
+	type objectVersionWrapper ObjectVersion
+	return e.EncodeElement(objectVersionWrapper(o), start)
 }
 
 // StringMap is a map[string]string.
@@ -431,7 +429,6 @@ func generateListBucketsResponse(buckets []BucketInfo) ListBucketsResponse {
 // generates an ListBucketVersions response for the said bucket with other enumerated options.
 func generateListVersionsResponse(bucket, prefix, marker, versionIDMarker, delimiter, encodingType string, maxKeys int, resp ListObjectVersionsInfo) ListVersionsResponse {
 	var versions []ObjectVersion
-	var deletedVersions []DeletedVersion
 	var prefixes []CommonPrefix
 	var owner = Owner{}
 	var data = ListVersionsResponse{}
@@ -459,23 +456,12 @@ func generateListVersionsResponse(bucket, prefix, marker, versionIDMarker, delim
 			content.VersionID = nullVersionID
 		}
 		content.IsLatest = object.IsLatest
+		content.isDeleteMarker = object.DeleteMarker
 		versions = append(versions, content)
-	}
-
-	for _, deleted := range resp.DeleteObjects {
-		var dv = DeletedVersion{
-			Key:          s3EncodeName(deleted.Name, encodingType),
-			Owner:        owner,
-			LastModified: deleted.ModTime.UTC().Format(iso8601TimeFormat),
-			VersionID:    deleted.VersionID,
-			IsLatest:     deleted.IsLatest,
-		}
-		deletedVersions = append(deletedVersions, dv)
 	}
 
 	data.Name = bucket
 	data.Versions = versions
-	data.DeleteMarkers = deletedVersions
 	data.EncodingType = encodingType
 	data.Prefix = s3EncodeName(prefix, encodingType)
 	data.KeyMarker = s3EncodeName(marker, encodingType)

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -1534,9 +1534,6 @@ func (s *erasureSets) Walk(ctx context.Context, bucket, prefix string, results c
 				for _, version := range entry.Versions {
 					results <- version.ToObjectInfo(bucket, version.Name)
 				}
-				for _, deleted := range entry.Deleted {
-					results <- deleted.ToObjectInfo(bucket, deleted.Name)
-				}
 			}
 			// skip entries which do not have quorum
 		}

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -1322,16 +1322,6 @@ func (z *erasureZones) listObjectVersions(ctx context.Context, bucket, prefix, m
 			}
 			loi.Objects = append(loi.Objects, objInfo)
 		}
-		for _, deleted := range entry.Deleted {
-			loi.DeleteObjects = append(loi.DeleteObjects, DeletedObjectInfo{
-				Bucket:    bucket,
-				Name:      entry.Name,
-				VersionID: deleted.VersionID,
-				ModTime:   deleted.ModTime,
-				IsLatest:  deleted.IsLatest,
-			})
-		}
-
 	}
 	if loi.IsTruncated {
 		for i, zone := range z.zones {
@@ -1847,9 +1837,6 @@ func (z *erasureZones) Walk(ctx context.Context, bucket, prefix string, results 
 				// Read quorum exists proceed
 				for _, version := range entry.Versions {
 					results <- version.ToObjectInfo(bucket, version.Name)
-				}
-				for _, deleted := range entry.Deleted {
-					results <- deleted.ToObjectInfo(bucket, deleted.Name)
 				}
 			}
 

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -368,9 +368,6 @@ type ListObjectVersionsInfo struct {
 	// List of objects info for this request.
 	Objects []ObjectInfo
 
-	// List of deleted objects for this request.
-	DeleteObjects []DeletedObjectInfo
-
 	// List of prefixes for this request.
 	Prefixes []string
 }

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -57,7 +57,6 @@ type FileInfoVersions struct {
 	LatestModTime time.Time
 
 	Versions []FileInfo
-	Deleted  []FileInfo
 }
 
 // FileInfo - represents file stat information.

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -26,7 +26,7 @@ func getFileInfoVersions(xlMetaBuf []byte, volume, path string) (FileInfoVersion
 		if err := xlMeta.Load(xlMetaBuf); err != nil {
 			return FileInfoVersions{}, err
 		}
-		versions, deletedVersions, latestModTime, err := xlMeta.ListVersions(volume, path)
+		versions, latestModTime, err := xlMeta.ListVersions(volume, path)
 		if err != nil {
 			return FileInfoVersions{}, err
 		}
@@ -34,7 +34,6 @@ func getFileInfoVersions(xlMetaBuf []byte, volume, path string) (FileInfoVersion
 			Volume:        volume,
 			Name:          path,
 			Versions:      versions,
-			Deleted:       deletedVersions,
 			LatestModTime: latestModTime,
 		}, nil
 	}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -409,12 +409,9 @@ func (s *xlStorage) CrawlAndGetDataUsage(ctx context.Context, cache dataUsageCac
 		var totalSize int64
 		for _, version := range fivs.Versions {
 			size := item.applyActions(ctx, objAPI, actionMeta{oi: version.ToObjectInfo(item.bucket, item.objectPath())})
-			totalSize += size
-		}
-
-		// Delete markers have no size, nothing to do here.
-		for _, deleted := range fivs.Deleted {
-			item.applyActions(ctx, objAPI, actionMeta{oi: deleted.ToObjectInfo(item.bucket, item.objectPath())})
+			if !version.Deleted {
+				totalSize += size
+			}
 		}
 
 		return totalSize, nil


### PR DESCRIPTION
## Description
The S3 specification says that versions are ordered in the response of
list object versions.

mc snapshot needs this to know which version comes first especially when
two versions have the same exact last-modified field.

## Motivation and Context
Return ordered version & delete marker XML tags

## How to test this PR?
1. Upload an object in a versioned bucket
2. Remove it the object
3. Upload the object  again

The returned xml should have this order
  <Version>
  <DeleteMarker>
  <Version>


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
