### PR TITLE
Added bucket name param to ToJSONError call

### DIFF
--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -166,7 +166,7 @@ func (web *webAPIHandlers) MakeBucket(r *http.Request, args *MakeBucketArgs, rep
 
 	// Check if bucket is a reserved bucket name or invalid.
 	if isReservedOrInvalidBucket(args.BucketName, true) {
-		return toJSONError(ctx, errInvalidBucketName)
+		return toJSONError(ctx, errInvalidBucketName, args.BucketName)
 	}
 
 	opts := BucketOptions{
@@ -233,7 +233,7 @@ func (web *webAPIHandlers) DeleteBucket(r *http.Request, args *RemoveBucketArgs,
 
 	// Check if bucket is a reserved bucket name or invalid.
 	if isReservedOrInvalidBucket(args.BucketName, false) {
-		return toJSONError(ctx, errInvalidBucketName)
+		return toJSONError(ctx, errInvalidBucketName, args.BucketName)
 	}
 
 	reply.UIVersion = browser.UIVersion
@@ -523,7 +523,7 @@ func (web *webAPIHandlers) ListObjects(r *http.Request, args *ListObjectsArgs, r
 
 	// Check if bucket is a reserved bucket name or invalid.
 	if isReservedOrInvalidBucket(args.BucketName, false) {
-		return toJSONError(ctx, errInvalidBucketName)
+		return toJSONError(ctx, errInvalidBucketName, args.BucketName)
 	}
 
 	nextMarker := ""
@@ -618,7 +618,7 @@ func (web *webAPIHandlers) RemoveObject(r *http.Request, args *RemoveObjectArgs,
 
 	// Check if bucket is a reserved bucket name or invalid.
 	if isReservedOrInvalidBucket(args.BucketName, false) {
-		return toJSONError(ctx, errInvalidBucketName)
+		return toJSONError(ctx, errInvalidBucketName, args.BucketName)
 	}
 
 	reply.UIVersion = browser.UIVersion
@@ -1599,7 +1599,7 @@ func (web *webAPIHandlers) GetBucketPolicy(r *http.Request, args *GetBucketPolic
 
 	// Check if bucket is a reserved bucket name or invalid.
 	if isReservedOrInvalidBucket(args.BucketName, false) {
-		return toJSONError(ctx, errInvalidBucketName)
+		return toJSONError(ctx, errInvalidBucketName, args.BucketName)
 	}
 
 	var policyInfo = &miniogopolicy.BucketAccessPolicy{Version: "2012-10-17"}
@@ -1696,7 +1696,7 @@ func (web *webAPIHandlers) ListAllBucketPolicies(r *http.Request, args *ListAllB
 
 	// Check if bucket is a reserved bucket name or invalid.
 	if isReservedOrInvalidBucket(args.BucketName, false) {
-		return toJSONError(ctx, errInvalidBucketName)
+		return toJSONError(ctx, errInvalidBucketName, args.BucketName)
 	}
 
 	var policyInfo = new(miniogopolicy.BucketAccessPolicy)
@@ -1787,7 +1787,7 @@ func (web *webAPIHandlers) SetBucketPolicy(r *http.Request, args *SetBucketPolic
 
 	// Check if bucket is a reserved bucket name or invalid.
 	if isReservedOrInvalidBucket(args.BucketName, false) {
-		return toJSONError(ctx, errInvalidBucketName)
+		return toJSONError(ctx, errInvalidBucketName, args.BucketName)
 	}
 
 	policyType := miniogopolicy.BucketPolicy(args.Policy)
@@ -1939,7 +1939,7 @@ func (web *webAPIHandlers) PresignedGet(r *http.Request, args *PresignedGetArgs,
 
 	// Check if bucket is a reserved bucket name or invalid.
 	if isReservedOrInvalidBucket(args.BucketName, false) {
-		return toJSONError(ctx, errInvalidBucketName)
+		return toJSONError(ctx, errInvalidBucketName, args.BucketName)
 	}
 
 	// Check if the user indeed has GetObject access,

--- a/cmd/web-handlers_test.go
+++ b/cmd/web-handlers_test.go
@@ -329,13 +329,23 @@ func testDeleteBucketWebHandler(obj ObjectLayer, instanceType string, t TestErrH
 		// Empty string = no error
 		expect string
 	}{
-		{"", false, token, "The specified bucket is not valid"},
+		{"", false, token, "Bucket Name  is invalid. Lowercase letters, period, " +
+			"hyphen, numerals are the only allowed characters and should be minimum " +
+			"3 characters in length."},
 		{".", false, "auth", "Authentication failed"},
-		{".", false, token, "The specified bucket is not valid"},
-		{"..", false, token, "The specified bucket is not valid"},
-		{"ab", false, token, "The specified bucket is not valid"},
+		{".", false, token, "Bucket Name . is invalid. Lowercase letters, period, " +
+			"hyphen, numerals are the only allowed characters and should be minimum " +
+			"3 characters in length."},
+		{"..", false, token, "Bucket Name .. is invalid. Lowercase letters, period, " +
+			"hyphen, numerals are the only allowed characters and should be minimum " +
+			"3 characters in length."},
+		{"ab", false, token, "Bucket Name ab is invalid. Lowercase letters, period, " +
+			"hyphen, numerals are the only allowed characters and should be minimum " +
+			"3 characters in length."},
 		{"minio", false, "false token", "Authentication failed"},
-		{"minio", false, token, "The specified bucket is not valid"},
+		{"minio", false, token, "Bucket Name minio is invalid. Lowercase letters, period, " +
+			"hyphen, numerals are the only allowed characters and should be minimum " +
+			"3 characters in length."},
 		{bucketName, false, token, ""},
 		{bucketName, true, token, "The bucket you tried to delete is not empty"},
 		{bucketName, false, "", "JWT token missing"},


### PR DESCRIPTION
Added bucket name param to ToJSONError call
when called with InvalidBucketName error.
The user is shown a more specific error
when the param is present.

## Description


## Motivation and Context

https://github.com/minio/minio/issues/9832

## How to test this PR?

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
