### PR TITLE
Tune tcp keep-alives with new kernel timeout options

### DIFF
--- a/cmd/http/dial_others.go
+++ b/cmd/http/dial_others.go
@@ -21,18 +21,23 @@ package http
 import (
 	"context"
 	"net"
+	"syscall"
 	"time"
 )
+
+// TODO: if possible implement for non-linux platforms, not a priority at the moment
+func setTCPParameters(c syscall.RawConn) error {
+	return nil
+}
 
 // DialContext is a function to make custom Dial for internode communications
 type DialContext func(ctx context.Context, network, address string) (net.Conn, error)
 
 // NewCustomDialContext configures a custom dialer for internode communications
-func NewCustomDialContext(dialTimeout, dialKeepAlive time.Duration) DialContext {
+func NewCustomDialContext(dialTimeout time.Duration) DialContext {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		dialer := &net.Dialer{
-			Timeout:   dialTimeout,
-			KeepAlive: dialKeepAlive,
+			Timeout: dialTimeout,
 		}
 		return dialer.DialContext(ctx, network, addr)
 	}

--- a/cmd/http/listener_test.go
+++ b/cmd/http/listener_test.go
@@ -151,7 +151,6 @@ func TestNewHTTPListener(t *testing.T) {
 	for _, testCase := range testCases {
 		listener, err := newHTTPListener(
 			testCase.serverAddrs,
-			testCase.tcpKeepAliveTimeout,
 		)
 
 		if !testCase.expectedErr {
@@ -185,7 +184,6 @@ func TestHTTPListenerStartClose(t *testing.T) {
 	for i, testCase := range testCases {
 		listener, err := newHTTPListener(
 			testCase.serverAddrs,
-			time.Duration(0),
 		)
 		if err != nil {
 			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
@@ -225,7 +223,6 @@ func TestHTTPListenerAddr(t *testing.T) {
 	for i, testCase := range testCases {
 		listener, err := newHTTPListener(
 			testCase.serverAddrs,
-			time.Duration(0),
 		)
 		if err != nil {
 			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
@@ -262,7 +259,6 @@ func TestHTTPListenerAddrs(t *testing.T) {
 	for i, testCase := range testCases {
 		listener, err := newHTTPListener(
 			testCase.serverAddrs,
-			time.Duration(0),
 		)
 		if err != nil {
 			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)

--- a/cmd/http/server_test.go
+++ b/cmd/http/server_test.go
@@ -73,10 +73,6 @@ func TestNewServer(t *testing.T) {
 			t.Fatalf("Case %v: server.ShutdownTimeout: expected: %v, got: %v", (i + 1), DefaultShutdownTimeout, server.ShutdownTimeout)
 		}
 
-		if server.TCPKeepAliveTimeout != DefaultTCPKeepAliveTimeout {
-			t.Fatalf("Case %v: server.TCPKeepAliveTimeout: expected: %v, got: %v", (i + 1), DefaultTCPKeepAliveTimeout, server.TCPKeepAliveTimeout)
-		}
-
 		if server.MaxHeaderBytes != DefaultMaxHeaderBytes {
 			t.Fatalf("Case %v: server.MaxHeaderBytes: expected: %v, got: %v", (i + 1), DefaultMaxHeaderBytes, server.MaxHeaderBytes)
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -409,7 +409,7 @@ const updateTimeout = 10 * time.Second
 func getUpdateTransport(timeout time.Duration) http.RoundTripper {
 	var updateTransport http.RoundTripper = &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           xhttp.NewCustomDialContext(timeout, timeout),
+		DialContext:           xhttp.NewCustomDialContext(timeout),
 		IdleConnTimeout:       timeout,
 		TLSHandshakeTimeout:   timeout,
 		ExpectContinueTimeout: timeout,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -454,7 +454,7 @@ func newCustomHTTPTransport(tlsConfig *tls.Config, dialTimeout time.Duration) fu
 	// https://golang.org/pkg/net/http/#Transport documentation
 	tr := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           xhttp.NewCustomDialContext(dialTimeout, 15*time.Second),
+		DialContext:           xhttp.NewCustomDialContext(dialTimeout),
 		MaxIdleConnsPerHost:   16,
 		MaxIdleConns:          16,
 		IdleConnTimeout:       1 * time.Minute,


### PR DESCRIPTION

## Description
Tune TCP keep-alive with new kernel timeout options

## Motivation and Context
For deeper understanding https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/

## How to test this PR?
Requires 4 different docker instances and various steps in taking
the network offline by manipulating

- iptables
- abrupt shutdown

This PR is to ensure that we detect idle connections and network
failures quickly, to have a more responsive distributed server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
