### PR TITLE
auto enable versioning with object locking

### DIFF
--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -186,6 +186,10 @@ func (b *BucketMetadata) parseAllConfigs(ctx context.Context, objectAPI ObjectLa
 		b.taggingConfig = nil
 	}
 
+	if bytes.Equal(b.ObjectLockConfigXML, enabledBucketObjectLockConfig) {
+		b.VersioningConfigXML = enabledBucketVersioningConfig
+	}
+
 	if len(b.ObjectLockConfigXML) != 0 {
 		b.objectLockConfig, err = objectlock.ParseObjectLockConfig(bytes.NewReader(b.ObjectLockConfigXML))
 		if err != nil {


### PR DESCRIPTION

## Description
auto enable versioning with object locking

## Motivation and Context
this is to preserve versioning for object-locked
buckets from the current release code.

## How to test this PR?
Run server with the current release `mc mb -l` to create an object locked bucket
copy some content, and then upgrade to latest master and `copy` some content
make sure to see existing content moved into `null` version and the new
content is generated with version Id

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
