### PR TITLE
fix: Do not parse heal client token when empty

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -652,7 +652,7 @@ func (a adminAPIHandlers) HealHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if globalIsDistErasure {
+	if globalIsDistErasure && hip.clientToken != "" {
 		// Analyze the heal token and route the request accordingly
 		_, nodeIndex, parsed := parseRequestToken(hip.clientToken)
 		if parsed {


### PR DESCRIPTION
## Description
A regression makes healing unable to work using mc admin heal command

## Motivation and Context
Fix healing


## How to test this PR?
mc admin heal -r alias/


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
