### PR TITLE
[WIP] Fix GetObjectInfo to return correct IsLatest

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -906,7 +906,7 @@ func lexicallySortedEntryVersions(entryChs []FileInfoVersionsCh, entries []FileI
 
 		// Entries are duplicated across disks,
 		// we should simply skip such entries.
-		if lentry.Name == entries[i].Name && lentry.LatestModTime.Equal(entries[i].LatestModTime) {
+		if lentry.Name == entries[i].Name {
 			lexicallySortedEntryCount++
 			continue
 		}

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -1088,7 +1088,7 @@ func lexicallySortedEntryZoneVersions(zoneEntryChs [][]FileInfoVersionsCh, zoneE
 
 			// Entries are duplicated across disks,
 			// we should simply skip such entries.
-			if lentry.Name == zoneEntries[i][j].Name && lentry.LatestModTime.Equal(zoneEntries[i][j].LatestModTime) {
+			if lentry.Name == zoneEntries[i][j].Name {
 				lexicallySortedEntryCount++
 				continue
 			}

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -52,10 +52,6 @@ type FileInfoVersions struct {
 	// Name of the file.
 	Name string
 
-	// Represents the latest mod time of the
-	// latest version.
-	LatestModTime time.Time
-
 	Versions []FileInfo
 }
 

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -26,15 +26,14 @@ func getFileInfoVersions(xlMetaBuf []byte, volume, path string) (FileInfoVersion
 		if err := xlMeta.Load(xlMetaBuf); err != nil {
 			return FileInfoVersions{}, err
 		}
-		versions, latestModTime, err := xlMeta.ListVersions(volume, path)
+		versions, err := xlMeta.ListVersions(volume, path)
 		if err != nil {
 			return FileInfoVersions{}, err
 		}
 		return FileInfoVersions{
-			Volume:        volume,
-			Name:          path,
-			Versions:      versions,
-			LatestModTime: latestModTime,
+			Volume:   volume,
+			Name:     path,
+			Versions: versions,
 		}, nil
 	}
 
@@ -44,17 +43,15 @@ func getFileInfoVersions(xlMetaBuf []byte, volume, path string) (FileInfoVersion
 		return FileInfoVersions{}, errFileCorrupt
 	}
 
-	fi, err := xlMeta.ToFileInfo(volume, path)
+	fi, err := xlMeta.ToFileInfo(volume, path, true)
 	if err != nil {
 		return FileInfoVersions{}, err
 	}
 
-	fi.IsLatest = true // No versions so current version is latest.
 	return FileInfoVersions{
-		Volume:        volume,
-		Name:          path,
-		Versions:      []FileInfo{fi},
-		LatestModTime: fi.ModTime,
+		Volume:   volume,
+		Name:     path,
+		Versions: []FileInfo{fi},
 	}, nil
 }
 
@@ -72,7 +69,7 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string) (FileInfo, er
 	if err := json.Unmarshal(xlMetaBuf, xlMeta); err != nil {
 		return FileInfo{}, errFileCorrupt
 	}
-	fi, err := xlMeta.ToFileInfo(volume, path)
+	fi, err := xlMeta.ToFileInfo(volume, path, true)
 	if err == errFileNotFound && versionID != "" {
 		return fi, errFileVersionNotFound
 	}

--- a/cmd/xl-storage-format-v1.go
+++ b/cmd/xl-storage-format-v1.go
@@ -178,13 +178,14 @@ func (c *ChecksumInfo) UnmarshalJSON(data []byte) error {
 // constant and shouldn't be changed.
 const legacyDataDir = "legacy"
 
-func (m *xlMetaV1Object) ToFileInfo(volume, path string) (FileInfo, error) {
+func (m *xlMetaV1Object) ToFileInfo(volume, path string, isLatest bool) (FileInfo, error) {
 	if !m.valid() {
 		return FileInfo{}, errFileCorrupt
 	}
 	return FileInfo{
 		Volume:    volume,
 		Name:      path,
+		IsLatest:  isLatest,
 		ModTime:   m.Stat.ModTime,
 		Size:      m.Stat.Size,
 		Metadata:  m.Meta,


### PR DESCRIPTION
## Description

GetObjetInfo does not return correctly IsLatest in ObjectInfo structure
result.

This PR simplifies a little bit setting IsLatest by considering if the
found version is the latest element in the list of versions read from
erasure meta file.

This found while testing lifecycle, since it relies on IsLatest.

More fixes for lifecycle will follow

## Motivation and Context
Fix GetObjetInfo returned result

## How to test this PR?
aws head-object while logging GetObjectInfo result.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
