### PR TITLE
lifecycle: Expiry should not delete versions

### DIFF
--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -596,8 +596,11 @@ func (i *crawlItem) applyActions(ctx context.Context, o ObjectLayer, meta action
 	}
 
 	opts := ObjectOptions{}
-	if action == lifecycle.DeleteVersionAction {
+	switch action {
+	case lifecycle.DeleteVersionAction:
 		opts.VersionID = versionID
+	case lifecycle.DeleteAction:
+		opts.Versioned = globalBucketVersioningSys.Enabled(i.bucket)
 	}
 
 	obj, err := o.DeleteObject(ctx, i.bucket, i.objectPath(), opts)

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -408,7 +408,7 @@ func (s *xlStorage) CrawlAndGetDataUsage(ctx context.Context, cache dataUsageCac
 
 		var totalSize int64
 		for _, version := range fivs.Versions {
-			size := item.applyActions(ctx, objAPI, actionMeta{oi: version.ToObjectInfo(item.bucket, item.objectPath())})
+			size := item.applyActions(ctx, objAPI, actionMeta{numVersions: len(fivs.Versions), oi: version.ToObjectInfo(item.bucket, item.objectPath())})
 			if !version.Deleted {
 				totalSize += size
 			}

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -209,8 +209,9 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 			return NoneAction
 		}
 
-		// All other expiration only applies to latest versions.
-		if obj.IsLatest {
+		// All other expiration only applies to latest versions
+		// (except if this is a delete marker)
+		if obj.IsLatest && !obj.DeleteMarker {
 			switch {
 			case !rule.Expiration.IsDateNull():
 				if time.Now().UTC().After(rule.Expiration.Date.Time) {

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -40,6 +40,8 @@ const (
 	NoneAction Action = iota
 	// DeleteAction means the object needs to be removed after evaluting lifecycle rules
 	DeleteAction
+	// DeleteVersionAction deletes a particular version
+	DeleteVersionAction
 )
 
 // Lifecycle - Configuration for bucket lifecycle.
@@ -176,6 +178,7 @@ type ObjectOpts struct {
 	VersionID    string
 	IsLatest     bool
 	DeleteMarker bool
+	NumVersions  int
 }
 
 // ComputeAction returns the action to perform by evaluating all lifecycle rules
@@ -187,19 +190,19 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 	}
 
 	for _, rule := range lc.FilterActionableRules(obj) {
-		if obj.DeleteMarker && obj.IsLatest && bool(rule.Expiration.DeleteMarker) {
+		if obj.DeleteMarker && obj.NumVersions == 1 && bool(rule.Expiration.DeleteMarker) {
 			// Indicates whether MinIO will remove a delete marker with no noncurrent versions.
 			// Only latest marker is removed. If set to true, the delete marker will be expired;
 			// if set to false the policy takes no action. This cannot be specified with Days or
 			// Date in a Lifecycle Expiration Policy.
-			return DeleteAction
+			return DeleteVersionAction
 		}
 
 		if !rule.NoncurrentVersionExpiration.IsDaysNull() {
 			if obj.VersionID != "" && !obj.IsLatest {
 				// Non current versions should be deleted.
 				if time.Now().After(expectedExpiryTime(obj.ModTime, rule.NoncurrentVersionExpiration.NoncurrentDays)) {
-					return DeleteAction
+					return DeleteVersionAction
 				}
 				return NoneAction
 			}


### PR DESCRIPTION
## Description

Currently, lifecycle expiry is deleting all object versions which is not
correct, unless noncurrentversions is specified.

Also, only delete the delete marker if it is the only version of the
given object.


## Motivation and Context
Review lifecycle rules with versioning

## How to test this PR?
- Review delete marker expiration
- See how an object is tested, see if noncurrent versions are removed


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
