### PR TITLE
More fixes for support lifecycle with versioning

### DIFF
--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -582,6 +582,7 @@ func (i *crawlItem) applyActions(ctx context.Context, o ObjectLayer, meta action
 				VersionID:    obj.VersionID,
 				DeleteMarker: obj.DeleteMarker,
 				IsLatest:     obj.IsLatest,
+				NumVersions:  meta.numVersions,
 			})
 		if i.debug {
 			logger.Info(color.Green("applyActions:")+" lifecycle: Secondary scan: %v", action)

--- a/pkg/bucket/lifecycle/expiration.go
+++ b/pkg/bucket/lifecycle/expiration.go
@@ -108,26 +108,13 @@ type Expiration struct {
 	DeleteMarker ExpireDeleteMarker `xml:"ExpiredObjectDeleteMarker,omitempty"`
 }
 
-// UnmarshalXML parses delete marker and validates if it is set.
-func (b *ExpireDeleteMarker) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
-	if !*b {
-		return nil
-	}
-	var deleteMarker bool
-	err := d.DecodeElement(&deleteMarker, &startElement)
-	if err != nil {
-		return err
-	}
-	*b = ExpireDeleteMarker(deleteMarker)
-	return nil
-}
-
 // MarshalXML encodes delete marker boolean into an XML form.
-func (b *ExpireDeleteMarker) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
-	if !*b {
+func (b ExpireDeleteMarker) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+	if !b {
 		return nil
 	}
-	return e.EncodeElement(*b, startElement)
+	type expireDeleteMarkerWrapper ExpireDeleteMarker
+	return e.EncodeElement(expireDeleteMarkerWrapper(b), startElement)
 }
 
 // Validate - validates the "Expiration" element

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -204,9 +204,7 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 				if time.Now().After(expectedExpiryTime(obj.ModTime, rule.NoncurrentVersionExpiration.NoncurrentDays)) {
 					return DeleteVersionAction
 				}
-				return NoneAction
 			}
-			return NoneAction
 		}
 
 		// All other expiration only applies to latest versions

--- a/pkg/bucket/lifecycle/noncurrentversion.go
+++ b/pkg/bucket/lifecycle/noncurrentversion.go
@@ -36,12 +36,13 @@ var (
 	errNoncurrentVersionTransitionUnsupported = Errorf("Specifying <NoncurrentVersionTransition></NoncurrentVersionTransition> is not supported")
 )
 
-// MarshalXML if non-current days not set returns empty tags
-func (n *NoncurrentVersionExpiration) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	if n.NoncurrentDays == ExpirationDays(0) {
+// MarshalXML if non-current days not set to non zero value
+func (n NoncurrentVersionExpiration) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if n.IsDaysNull() {
 		return nil
 	}
-	return e.EncodeElement(&n, start)
+	type noncurrentVersionExpirationWrapper NoncurrentVersionExpiration
+	return e.EncodeElement(noncurrentVersionExpirationWrapper(n), start)
 }
 
 // IsDaysNull returns true if days field is null


### PR DESCRIPTION
## Description
* Fix crash when NoncurrentVersionExpiration or ExpireDeleteMarker tag is sent in the lifecycle xml
* Make ExpireDeleteMarker works as expected
* Avoid returning early when the action is ActionNone in ComputeLifecycle() function because we could have another delete action in one of the subsequent rules.

## Motivation and Context
More fixes for lifecycle after the introduction of the versioning


## How to test this PR?
Not trivial, contact me.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
