### PR TITLE
azure: Return success when deleting non-existent object

### DIFF
--- a/cmd/api-datatypes.go
+++ b/cmd/api-datatypes.go
@@ -22,7 +22,7 @@ import (
 
 // DeletedObject objects deleted
 type DeletedObject struct {
-	DeleteMarker          bool   `xml:"DeleteMarker"`
+	DeleteMarker          bool   `xml:"DeleteMarker,omitempty"`
 	DeleteMarkerVersionID string `xml:"DeleteMarkerVersionId,omitempty"`
 	ObjectName            string `xml:"Key,omitempty"`
 	VersionID             string `xml:"VersionId,omitempty"`

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -376,6 +376,13 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 		return
 	}
 
+	// Before proceeding validate if bucket exists.
+	_, err := objectAPI.GetBucketInfo(ctx, bucket)
+	if err != nil {
+		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+		return
+	}
+
 	deleteObjectsFn := objectAPI.DeleteObjects
 	if api.CacheAPI() != nil {
 		deleteObjectsFn = api.CacheAPI().DeleteObjects


### PR DESCRIPTION
## Description
Currently, instead of returning success when a non-existent object is deleted, nothing is returned

## Motivation and Context
failure seen in Azure gateway when non-existent object is part of deleteobjects API call in minio-java functional test

## How to test this PR?
minio-java functional test against Azure Gateway should pass with this PR

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
