### PR TITLE
Copy Object: Allow multipart uploads

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1181,14 +1181,13 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 			ServerSideEncryption: dstOpts.ServerSideEncryption,
 			UserTags:             tag.ToMap(),
 		}
-		remoteObjInfo, rerr := client.PutObject(dstBucket, dstObject, srcInfo.Reader,
-			srcInfo.Size, "", "", opts)
+		_, rerr = client.Client.PutObject(dstBucket, dstObject, srcInfo.Reader,
+			srcInfo.Size, opts)
 		if rerr != nil {
 			writeErrorResponse(ctx, w, toAPIError(ctx, rerr), r.URL, guessIsBrowserReq(r))
 			return
 		}
-		objInfo.ETag = remoteObjInfo.ETag
-		objInfo.ModTime = remoteObjInfo.LastModified
+		objInfo.ModTime = UTCNow()
 	} else {
 		copyObjectFn := objectAPI.CopyObject
 		if api.CacheAPI() != nil {


### PR DESCRIPTION
## Description

The `minio-go.Core` does not switch automatically to multipart uploads as the `minio-go.Client` does.

This means that no matter the size files would always be attempted to be uploaded with a single PUT calls.

We have to do an additional stat to get the last modified and the resulting etag.

Cherrypick for release.

## How to test this PR?

Upload a big file. Trigger a copy that requires moving the object to a second server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
