### PR TITLE
Remove dead link related to DC/OS Deployment Guide

### DIFF
--- a/docs/orchestration/README.md
+++ b/docs/orchestration/README.md
@@ -7,7 +7,6 @@ MinIO is a cloud-native application designed to scale in a sustainable manner in
 | [`Docker Swarm`](https://docs.min.io/docs/deploy-minio-on-docker-swarm) |
 | [`Docker Compose`](https://docs.min.io/docs/deploy-minio-on-docker-compose) |
 | [`Kubernetes`](https://docs.min.io/docs/deploy-minio-on-kubernetes) |
-| [`DC/OS`](https://docs.min.io/docs/deploy-minio-on-dc-os) |
 
 ## Why is MinIO cloud-native?
 The term cloud-native revolves around the idea of applications deployed as micro services, that scale well. It is not about just retrofitting monolithic applications onto modern container based compute environment. A cloud-native application is portable and resilient by design, and can scale horizontally by simply replicating. Modern orchestration platforms like Swarm, Kubernetes and DC/OS make replicating and managing containers in huge clusters easier than ever.


### PR DESCRIPTION
## Description

Work done in [this commit](https://github.com/minio/minio/commit/e45c90060f5228b269b1e3ab149e9ec15e4a239f#diff-e8e63fa7b12a8704d49b8eab4691c7c1) removed the DC/OS Quickstart guide, but we have a trailing link that currently dead-ends. 


## Motivation and Context

Just pruning a link so we don't have a 404 out from that page.

## How to test this PR?

Modify gluegun ``site.yml`` to point to the local copy of the file instead of github.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ]  Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
