### PR TITLE
Allow Content-Md5 to be extracted as metadata

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -70,6 +70,7 @@ func isValidLocation(location string) bool {
 // Supported headers that needs to be extracted.
 var supportedHeaders = []string{
 	"content-type",
+	"content-md5",
 	"cache-control",
 	"content-language",
 	"content-encoding",


### PR DESCRIPTION
## Description

The correct behaviour of e.g. Azure gateway depends on this.

Some applications rely on Content-Md5 field being preserved, but for objects greater than azureBlockSize/2 it is not being filled on the Azure side, leading to ETag field being used instead, which doesn’t match the value those applications expect.

## Motivation and Context

We’re using MinIO as a gateway for Aptly to be able to access Azure, which it doesn’t natively support. When publishing repositories, Aptly uses the MD5 hashes to save traffic but not reuploading files already in the target repository. When running Aptly with MinIO we noticed a lot of files are being reuploaded due to a checksum mismatch:

```
poolPath = pool/target/l/llvm-toolchain-7/clang-tidy-7-dbgsym_7.0.1-8_amd64.deb
sourceMD5 = 91256eff9433aba8d0735f2458b7c95c, destinationMD5 = 91256eff9433aba8d0735f2458b7c95c
===
poolPath = pool/target/l/llvm-toolchain-6.0/clang-tools-6.0_6.0.1-10_amd64.deb
sourceMD5 = 7c8ad17005acf632580267a4be67a623, destinationMD5 = 0x8D823460D800301-1
===
poolPath = pool/target/l/llvm-toolchain-6.0/clang-tools-6.0-dbgsym_6.0.1-10_amd64.deb
sourceMD5 = aa7ee9f3a2f6cd75c65b19331dc8bafa, destinationMD5 = aa7ee9f3a2f6cd75c65b19331dc8bafa
===
poolPath = pool/target/l/llvm-toolchain-7/clang-tools-7_7.0.1-8_amd64.deb
sourceMD5 = 196df1d02620ce2161116be9b4ce8317, destinationMD5 = 0x8D8234616A9E449-1
===
poolPath = pool/target/l/llvm-toolchain-7/clang-tools-7-dbgsym_7.0.1-8_amd64.deb
sourceMD5 = 359480dc5152c9ad06ec82e311db35b2, destinationMD5 = 0x8D823463C03E96F-1
```
During the investigation, I found that some files have an additional field set to an MD5 of an empty object:
```
=== s3MetaToAzureProperties ===
s3Metadata: map[content-type:application/octet-stream x-amz-meta-md5sum:d41d8cd98f00b204e9800998ecf8427e]
=== s3MetaToAzureProperties ===
s3Metadata: map[content-type:application/octet-stream]
```
This led me to a condition in the `PutObject` implementation:
```
if data.Size() > azureBlockSize/2 {
```
For some reason, all files bigger than `azureBlockSize/2` lose their `Content-Md5`. I tried debugging `azblob` to find out why this is happening, but realised it probably would be better to make sure the field is preserved regardless of what `azblob` does.

I guess it would also be useful to find the reason why this happens, but my limited knowledge of Go and Azure prevents me from going deeper into that.

I have not yet verified how this change can affect other modes of operation.

## How to test this PR?

Attempt to upload any file bigger than `azureBlockSize/2` with correctly generated `Content-Md5` set, observe the field being unset without this patch and preserved when it is applied.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
