### PR TITLE
fix: add virtual host style workaround for gorilla/mux issue

### DIFF
--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -84,7 +84,15 @@ func registerAPIRouter(router *mux.Router, encryptionEnabled, allowSSEKMS bool) 
 	apiRouter := router.PathPrefix(SlashSeparator).Subrouter()
 	var routers []*mux.Router
 	for _, domainName := range globalDomainNames {
-		routers = append(routers, apiRouter.Host("{bucket:.+}."+domainName).Subrouter())
+		if globalMinioPort == "80" || globalMinioPort == "443" {
+			// For standard ports its possible, incoming requests
+			// might not have a port assigned, in such scenarios use
+			// have wildcard routing.
+			// FIXME: remove this code once https://github.com/gorilla/mux/pull/579
+			// is merged and released upstream, as this entire change can become
+			// a single line.
+			routers = append(routers, apiRouter.Host("{bucket:.+}."+domainName).Subrouter())
+		}
 		routers = append(routers, apiRouter.Host("{bucket:.+}."+domainName+":{port:.*}").Subrouter())
 	}
 	routers = append(routers, apiRouter.PathPrefix("/{bucket}").Subrouter())

--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -256,8 +256,7 @@ func (iamOS *IAMObjectStore) loadPolicyDocs(ctx context.Context, m map[string]ia
 		}
 
 		policyName := item.Item
-		err := iamOS.loadPolicyDoc(policyName, m)
-		if err != nil {
+		if err := iamOS.loadPolicyDoc(policyName, m); err != nil && err != errNoSuchPolicy {
 			return err
 		}
 	}
@@ -325,8 +324,7 @@ func (iamOS *IAMObjectStore) loadUsers(ctx context.Context, userType IAMUserType
 		}
 
 		userName := item.Item
-		err := iamOS.loadUser(userName, userType, m)
-		if err != nil {
+		if err := iamOS.loadUser(userName, userType, m); err != errNoSuchUser {
 			return err
 		}
 	}
@@ -353,8 +351,7 @@ func (iamOS *IAMObjectStore) loadGroups(ctx context.Context, m map[string]GroupI
 		}
 
 		group := item.Item
-		err := iamOS.loadGroup(group, m)
-		if err != nil {
+		if err := iamOS.loadGroup(group, m); err != nil && err != errNoSuchGroup {
 			return err
 		}
 	}
@@ -397,8 +394,7 @@ func (iamOS *IAMObjectStore) loadMappedPolicies(ctx context.Context, userType IA
 
 		policyFile := item.Item
 		userOrGroupName := strings.TrimSuffix(policyFile, ".json")
-		err := iamOS.loadMappedPolicy(userOrGroupName, userType, isGroup, m)
-		if err != nil && err != errNoSuchPolicy {
+		if err := iamOS.loadMappedPolicy(userOrGroupName, userType, isGroup, m); err != nil && err != errNoSuchPolicy {
 			return err
 		}
 	}


### PR DESCRIPTION

## Description
fix: add virtual host style workaround for gorilla/mux issue

## Motivation and Context
gorilla/mux broke their recent release 1.7.4 which we
upgraded to, we need the current workaround to ensure
that our regex matches appropriately.

An upstream PR is sent, we should remove the
workaround once we have a new release.


## How to test this PR?
Have following entries your /etc/hosts

```
127.0.1.1	backspace testbucket.backspace
```
Start minio server
```
MINIO_DOMAIN=backspace minio server ~/test
```

```
mc config host add myminio http://backspace:9000  minio minio123  --lookup dns
mc mb myminio/testbucket
mc ls myminio/testbucket/
```

The request should succeed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes introduced in upstream gorilla/mux v1.7.2 release https://github.com/gorilla/mux/pull/579
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
