### PR TITLE
fix: extract array type for policy claim if present

### DIFF
--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -357,8 +357,9 @@ func (sts *stsAPIHandlers) AssumeRoleWithJWT(w http.ResponseWriter, r *http.Requ
 	// be set and configured on your identity provider as part of
 	// JWT custom claims.
 	var policyName string
-	if v, ok := m[iamPolicyClaimNameOpenID()]; ok {
-		policyName, _ = v.(string)
+	policySet, ok := iampolicy.GetPoliciesFromClaims(m, iamPolicyClaimNameOpenID())
+	if ok {
+		policyName = strings.Join(policySet.ToSlice(), ",")
 	}
 
 	var subFromToken string

--- a/docs/gateway/hdfs.md
+++ b/docs/gateway/hdfs.md
@@ -1,6 +1,8 @@
 # MinIO HDFS Gateway [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
 MinIO HDFS gateway adds Amazon S3 API support to Hadoop HDFS filesystem. Applications can use both the S3 and file APIs concurrently without requiring any data migration. Since the gateway is stateless and shared-nothing, you may elastically provision as many MinIO instances as needed to distribute the load.
 
+> NOTE: Intention of this gateway implementation it to make it easy to migrate your existing data on HDFS clusters to MinIO clusters using standard tools like `mc` or `aws-cli`, if the goal is to use HDFS perpetually we recommend that HDFS should be used directly for all write operations.
+
 ## Run MinIO Gateway for HDFS Storage
 
 ### Using Binary
@@ -58,13 +60,7 @@ Gateway inherits the following limitations of HDFS storage layer:
 - No bucket notification APIs are not supported (HDFS has no support for fsnotify)
 - No server side encryption support (Intentionally not implemented)
 - No server side compression support (Intentionally not implemented)
-
-## Roadmap
-- Additional metadata support for PutObject operations
-- Additional metadata support for Multipart operations
-- Background append to provide concurrency support for multipart operations
-
-Please open a GitHub issue if you wish these to be fixed https://github.com/minio/minio/issues
+- Concurrent multipart operations are not supported (HDFS lacks safe locking support, or poorly implemented)
 
 ## Explore Further
 - [`mc` command-line interface](https://docs.minio.io/docs/minio-client-quickstart-guide)

--- a/pkg/iam/policy/policy.go
+++ b/pkg/iam/policy/policy.go
@@ -39,10 +39,11 @@ type Args struct {
 	Claims          map[string]interface{} `json:"claims"`
 }
 
-// GetPolicies get policies
-func (a Args) GetPolicies(policyClaimName string) (set.StringSet, bool) {
+// GetPoliciesFromClaims returns the list of policies to be applied for this
+// incoming request, extracting the information from input JWT claims.
+func GetPoliciesFromClaims(claims map[string]interface{}, policyClaimName string) (set.StringSet, bool) {
 	s := set.NewStringSet()
-	pname, ok := a.Claims[policyClaimName]
+	pname, ok := claims[policyClaimName]
 	if !ok {
 		return s, false
 	}
@@ -65,6 +66,12 @@ func (a Args) GetPolicies(policyClaimName string) (set.StringSet, bool) {
 		s.Add(pname)
 	}
 	return s, true
+}
+
+// GetPolicies returns the list of policies to be applied for this
+// incoming request, extracting the information from JWT claims.
+func (a Args) GetPolicies(policyClaimName string) (set.StringSet, bool) {
+	return GetPoliciesFromClaims(a.Claims, policyClaimName)
 }
 
 // Policy - iam bucket iamp.


### PR DESCRIPTION
## Description
fix: extract array type for policy claim if present

## Motivation and Context
Add missing claims extraction to support `arrays` as well.

## How to test this PR?
You need `dex` installed and tested which supports custom claims of `groups` only as arrays.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
- [ ] Functional tests needed (If yes, add [mint](https://github.com/minio/mint) PR # here: )
