### PR TITLE
sync to disk only upon successful legacy metadata rename

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1232,7 +1232,12 @@ func (s *xlStorage) renameLegacyMetadata(volume, path string) error {
 	dstFilePath := pathJoin(filePath, xlStorageFormatFile)
 
 	// Renaming xl.json to xl.meta should be fully synced to disk.
-	defer globalSync()
+	defer func() {
+		if err == nil {
+			// Sync to disk only upon success.
+			globalSync()
+		}
+	}()
 
 	if err = os.Rename(srcFilePath, dstFilePath); err != nil {
 		switch {
@@ -2111,7 +2116,7 @@ func (s *xlStorage) RenameData(srcVolume, srcPath, dataDir, dstVolume, dstPath s
 			return osErrToFileErr(err)
 		}
 
-		// Sync all the directory operations.
+		// Sync all the previous directory operations.
 		globalSync()
 
 		for _, entry := range entries {


### PR DESCRIPTION
## Description
sync to disk only upon successful legacy metadata rename

## Motivation and Context
unnecessary sync was called during rename of 
legacy metadata slowing down the calls

## How to test this PR?
Nothing special, just see that with lots of
buckets startup time should dramatically
improve.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
