### PR TITLE
fix: cors handling again for not just OPTIONS request

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -267,7 +267,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	}
 
 	httpServer := xhttp.NewServer([]string{globalCLIContext.Addr},
-		criticalErrorHandler{router}, getCert)
+		criticalErrorHandler{corsHandler(router)}, getCert)
 	httpServer.BaseContext = func(listener net.Listener) context.Context {
 		return GlobalContext
 	}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -466,7 +466,7 @@ func serverMain(ctx *cli.Context) {
 		}
 	}()
 
-	httpServer := xhttp.NewServer([]string{globalMinioAddr}, criticalErrorHandler{handler}, getCert)
+	httpServer := xhttp.NewServer([]string{globalMinioAddr}, criticalErrorHandler{corsHandler(handler)}, getCert)
 	httpServer.ErrorLog = log.New(pw, "", 0)
 	httpServer.BaseContext = func(listener net.Listener) context.Context {
 		return GlobalContext


### PR DESCRIPTION


## Description
fix: cors handling again for not just OPTIONS request

## Motivation and Context
CORS is notorious requires specific headers to be
handled appropriately in request and response,
using cors package as part of handlerFunc() for
options method lacks the necessary control this
the package needs to add headers.

## How to test this PR?
PRs #10020 and #9980 do not fix the CORS request handling
properly. This PR finally fully fixes the behavior. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
