### PR TITLE
fix: make sure to use new restClient for healthcheck

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -462,7 +462,7 @@ func azureToObjectError(err error, params ...string) error {
 
 func azureCodesToObjectError(err error, serviceCode string, statusCode int, bucket string, object string) error {
 	switch serviceCode {
-	case "ContainerNotFound":
+	case "ContainerNotFound", "ContainerBeingDeleted":
 		err = minio.BucketNotFound{Bucket: bucket}
 	case "ContainerAlreadyExists":
 		err = minio.BucketExists{Bucket: bucket}

--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -158,7 +158,7 @@ func (c *Client) Close() {
 }
 
 // NewClient - returns new REST client.
-func NewClient(url *url.URL, newCustomTransport func() *http.Transport, newAuthToken func(aud string) string) (*Client, error) {
+func NewClient(url *url.URL, newCustomTransport func() *http.Transport, newAuthToken func(aud string) string) *Client {
 	// Transport is exactly same as Go default in https://golang.org/pkg/net/http/#RoundTripper
 	// except custom DialContext and TLSClientConfig.
 	tr := newCustomTransport()
@@ -172,7 +172,7 @@ func NewClient(url *url.URL, newCustomTransport func() *http.Transport, newAuthT
 		MaxErrResponseSize:  4096,
 		HealthCheckInterval: 200 * time.Millisecond,
 		HealthCheckTimeout:  time.Second,
-	}, nil
+	}
 }
 
 // IsOnline returns whether the client is likely to be online.

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -66,6 +66,13 @@ import (
 
 // Tests should initNSLock only once.
 func init() {
+	globalActiveCred = auth.Credentials{
+		AccessKey: auth.DefaultAccessKey,
+		SecretKey: auth.DefaultSecretKey,
+	}
+
+	globalConfigEncrypted = true
+
 	// disable ENVs which interfere with tests.
 	for _, env := range []string{
 		crypto.EnvAutoEncryptionLegacy,
@@ -462,13 +469,6 @@ func newTestConfig(bucketLocation string, obj ObjectLayer) (err error) {
 	if err = newSrvConfig(obj); err != nil {
 		return err
 	}
-
-	globalActiveCred = auth.Credentials{
-		AccessKey: auth.DefaultAccessKey,
-		SecretKey: auth.DefaultSecretKey,
-	}
-
-	globalConfigEncrypted = true
 
 	// Set a default region.
 	config.SetRegion(globalServerConfig, bucketLocation)


### PR DESCRIPTION
## Description
fix: make sure to use new restClient for healthcheck

## Motivation and Context
Without instantiating a new rest-client we can
have a recursive error which can lead to
health check returning always offline, this can
prematurely take the servers offline.

## How to test this PR?
reproducible easily in container/k8s environments

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
