### PR TITLE
fix: deletes on older format properly

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1100,12 +1100,7 @@ func (s *xlStorage) DeleteVersion(volume, path string, fi FileInfo) error {
 	if !isXL2V1Format(buf) {
 		// Delete the meta file, if there are no more versions the
 		// top level parent is automatically removed.
-		filePath := pathJoin(volumeDir, path, xlStorageFormatFile)
-		if err = checkPathLength(filePath); err != nil {
-			return err
-		}
-
-		return deleteFile(volumeDir, filePath, false)
+		return deleteFile(volumeDir, pathJoin(volumeDir, path), true)
 	}
 
 	var xlMeta xlMetaV2


### PR DESCRIPTION


## Description
fix: deletes on older format properly

## Motivation and Context
while we handle all situations for writes and reads
on the older format, what we didn't cater for properly
yet was delete where we only ended up deleting
just `xl.meta` - instead, we should allow all the
deletes to go through for older format without
versioning enabled buckets.

## How to test this PR?
Use an older release, create a bucket and create some content
and then upgrade to latest release - execute

>  `mc rm -r --force myminio/testbucket`

should delete the content, whereas in the current release from
older releases this will not happen and would leave stale 
dangling objects

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
