### PR TITLE
allow turning off secure ciphers

### DIFF
--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -29,7 +29,9 @@ import (
 	humanize "github.com/dustin/go-humanize"
 
 	"github.com/minio/minio-go/v6/pkg/set"
+	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/pkg/certs"
+	"github.com/minio/minio/pkg/env"
 )
 
 const (
@@ -163,7 +165,7 @@ func (srv *Server) Shutdown() error {
 //                              (CBC-SHA ciphers can be enabled again if required)
 //  - RSA key exchange ciphers: Disabled because of dangerous PKCS1-v1.5 RSA
 //                              padding scheme. See Bleichenbacher attacks.
-var defaultCipherSuites = []uint16{
+var secureCipherSuites = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -175,15 +177,19 @@ var defaultCipherSuites = []uint16{
 // Go only provides constant-time implementations of Curve25519 and NIST P-256 curve.
 var secureCurves = []tls.CurveID{tls.X25519, tls.CurveP256}
 
+const (
+	enableSecureCiphersEnv = "MINIO_API_SECURE_CIPHERS"
+)
+
 // NewServer - creates new HTTP server using given arguments.
 func NewServer(addrs []string, handler http.Handler, getCert certs.GetCertificateFunc) *Server {
+	secureCiphers := env.Get(enableSecureCiphersEnv, config.EnableOn) == config.EnableOn
+
 	var tlsConfig *tls.Config
 	if getCert != nil {
 		tlsConfig = &tls.Config{
 			// TLS hardening
 			PreferServerCipherSuites: true,
-			CipherSuites:             defaultCipherSuites,
-			CurvePreferences:         secureCurves,
 			MinVersion:               tls.VersionTLS12,
 			// Do not edit the next line, protos priority is kept
 			// on purpose in this manner for HTTP 2.0, we would
@@ -195,6 +201,11 @@ func NewServer(addrs []string, handler http.Handler, getCert certs.GetCertificat
 			NextProtos: []string{"http/1.1", "h2"},
 		}
 		tlsConfig.GetCertificate = getCert
+	}
+
+	if secureCiphers && tlsConfig != nil {
+		tlsConfig.CipherSuites = secureCipherSuites
+		tlsConfig.CurvePreferences = secureCurves
 	}
 
 	httpServer := &Server{


### PR DESCRIPTION

## Description
allow turning off secure ciphers

## Motivation and Context
this PR to allow legacy support for big-data
applications which run older Java versions
which do not support the secure ciphers
currently defaulted in MinIO. This option
allows optionally to turn them off such
that client and server can negotiate the
best ciphers themselves.

This env is purposefully not documented,
meant as a last resort when a client
application cannot be changed easily.

## How to test this PR?
You need a CDH5 Oracle Java8 build which doesn't support our server ciphers. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
