### PR TITLE
Update funceval.go

### DIFF
--- a/pkg/s3select/sql/funceval.go
+++ b/pkg/s3select/sql/funceval.go
@@ -465,7 +465,9 @@ func intCast(v *Value) (int64, error) {
 	case string:
 		// Parse as number, truncate floating point if
 		// needed.
-		res, ok := strToInt(x)
+		// String might contain trimming spaces, which
+		// needs to be trimmed.
+		res, ok := strToInt(strings.TrimSpace(x))
 		if !ok {
 			return 0, errCastFailure("could not parse as int")
 		}
@@ -473,7 +475,9 @@ func intCast(v *Value) (int64, error) {
 	case []byte:
 		// Parse as number, truncate floating point if
 		// needed.
-		res, ok := strToInt(string(x))
+		// String might contain trimming spaces, which
+		// needs to be trimmed.
+		res, ok := strToInt(strings.TrimSpace(string(x)))
 		if !ok {
 			return 0, errCastFailure("could not parse as int")
 		}


### PR DESCRIPTION
String might contain trimming spaces, which needs to be trimmed. For example, in csv files, there might be trimming spaces in a field that ought to meet a query condition that contains the value in the field without trimming spaces.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
