### PR TITLE
allow lifecycle rules with overlapping prefixes

### DIFF
--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	errLifecycleTooManyRules      = Errorf("Lifecycle configuration allows a maximum of 1000 rules")
-	errLifecycleNoRule            = Errorf("Lifecycle configuration should have at least one rule")
-	errLifecycleDuplicateID       = Errorf("Lifecycle configuration has rule with the same ID. Rule ID must be unique.")
+	errLifecycleTooManyRules = Errorf("Lifecycle configuration allows a maximum of 1000 rules")
+	errLifecycleNoRule       = Errorf("Lifecycle configuration should have at least one rule")
+	errLifecycleDuplicateID  = Errorf("Lifecycle configuration has rule with the same ID. Rule ID must be unique.")
 )
 
 // Action represents a delete action or other transition

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -26,7 +26,7 @@ import (
 var (
 	errLifecycleTooManyRules      = Errorf("Lifecycle configuration allows a maximum of 1000 rules")
 	errLifecycleNoRule            = Errorf("Lifecycle configuration should have at least one rule")
-	errLifecycleOverlappingPrefix = Errorf("Lifecycle configuration has rules with overlapping prefix")
+	errLifecycleDuplicateID       = Errorf("Lifecycle configuration has rule with the same ID. Rule ID must be unique.")
 )
 
 // Action represents a delete action or other transition
@@ -115,17 +115,15 @@ func (lc Lifecycle) Validate() error {
 			return err
 		}
 	}
-	// Compare every rule's prefix with every other rule's prefix
+	// Make sure Rule ID is unique
 	for i := range lc.Rules {
 		if i == len(lc.Rules)-1 {
 			break
 		}
-		// N B Empty prefixes overlap with all prefixes
 		otherRules := lc.Rules[i+1:]
 		for _, otherRule := range otherRules {
-			if strings.HasPrefix(lc.Rules[i].Prefix(), otherRule.Prefix()) ||
-				strings.HasPrefix(otherRule.Prefix(), lc.Rules[i].Prefix()) {
-				return errLifecycleOverlappingPrefix
+			if lc.Rules[i].ID == otherRule.ID {
+				return errLifecycleDuplicateID
 			}
 		}
 	}

--- a/pkg/bucket/lifecycle/lifecycle_test.go
+++ b/pkg/bucket/lifecycle/lifecycle_test.go
@@ -43,7 +43,7 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 
 	// Test for lifecycle config with rules containing overlapping prefixes
 	rule1 := Rule{
-		ID: "rule1",
+		ID:         "rule1",
 		Status:     "Enabled",
 		Expiration: Expiration{Days: ExpirationDays(3)},
 		Filter: Filter{
@@ -51,7 +51,7 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 		},
 	}
 	rule2 := Rule{
-		ID: "rule2",
+		ID:         "rule2",
 		Status:     "Enabled",
 		Expiration: Expiration{Days: ExpirationDays(3)},
 		Filter: Filter{
@@ -68,7 +68,7 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 
 	// Test for lifecycle rules with duplicate IDs
 	rule3 := Rule{
-		ID: "duplicateID",
+		ID:         "duplicateID",
 		Status:     "Enabled",
 		Expiration: Expiration{Days: ExpirationDays(3)},
 		Filter: Filter{
@@ -76,7 +76,7 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 		},
 	}
 	rule4 := Rule{
-		ID: "duplicateID",
+		ID:         "duplicateID",
 		Status:     "Enabled",
 		Expiration: Expiration{Days: ExpirationDays(4)},
 		Filter: Filter{


### PR DESCRIPTION
## Description

This PR introduces fix for #10027:
- allow creation of lifecycle rules with overlapping filter prefixes
- forbid creation of livecycle rules with the same ID (it must be unique in AWS)

## Motivation and Context


## How to test this PR?
It should be covered by tests or you can use sample LC config which results in failure:
```
<LifecycleConfiguration><Rule><ID>1week</ID><Filter><Prefix>1week</Prefix><Tag><Key></Key><Value></Value></Tag></Filter><Status>Enabled</Status><Expiration><Days>7</Days></Expiration></Rule><Rule><ID>1week</ID><Filter><Prefix>21week</Prefix><Tag><Key></Key><Value></Value></Tag></Filter><Status>Enabled</Status><Expiration><Days>7</Days></Expiration></Rule><Rule><ID>2week</ID><Filter><Prefix>2week</Prefix><Tag><Key></Key><Value></Value></Tag></Filter><Status>Enabled</Status><Expiration><Days>14</Days></Expiration></Rule><Rule><ID>2week</ID><Filter><Prefix>22week</Prefix><Tag><Key></Key><Value></Value></Tag></Filter><Status>Enabled</Status><Expiration><Days>14</Days></Expiration></Rule></LifecycleConfiguration>
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
