### PR TITLE
fix: diskInfo should check diskID only if disk is online

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/minio/minio/cmd/logger"
 )
 
-const defaultMonitorNewDiskInterval = time.Minute * 10
+const defaultMonitorNewDiskInterval = time.Minute * 5
 
 func initLocalDisksAutoHeal(ctx context.Context, objAPI ObjectLayer) {
 	go monitorLocalDisksAndHeal(ctx, objAPI)
@@ -81,6 +82,13 @@ func monitorLocalDisksAndHeal(ctx context.Context, objAPI ObjectLayer) {
 			// Reformat disks only if needed.
 			if !healNewDisks {
 				continue
+			}
+
+			logger.Info("New unformatted drives detected attempting to heal...")
+			for i, disks := range localDisksInZoneHeal {
+				for _, disk := range disks {
+					logger.Info("Healing disk '%s' on %s zone", disk, humanize.Ordinal(i+1))
+				}
 			}
 
 			// Reformat disks

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -89,8 +89,12 @@ func (p *xlStorageDiskIDCheck) DiskInfo() (info DiskInfo, err error) {
 	if err != nil {
 		return info, err
 	}
-	if p.diskID != info.ID {
-		return info, errDiskNotFound
+	// check cached diskID against backend
+	// only if its non-empty.
+	if p.diskID != "" {
+		if p.diskID != info.ID {
+			return info, errDiskNotFound
+		}
 	}
 	return info, nil
 }


### PR DESCRIPTION

## Description
fix: diskInfo should check diskID only is taken online

## Motivation and Context
closes #10057

## How to test this PR?
Easy to reproduce `minio server /tmp/{1..4}`, copy some content
`rm -rf /tmp/1` - restart the server and observe the disk 
cannot be healed at all.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes introduced in e7d7d5232c6047bc82374e1a87769cd25126560b
- [ ] Documentation needed
- [ ] Unit tests needed
