### PR TITLE
add preview width constraint

### DIFF
--- a/browser/app/js/objects/PreviewObjectModal.js
+++ b/browser/app/js/objects/PreviewObjectModal.js
@@ -46,7 +46,7 @@ class PreviewObjectModal extends React.Component {
         <ModalBody>
           <div className="input-group">
             {this.state.url && (
-              <object data={this.state.url}>
+              <object data={this.state.url} style={{ display: "block", width: "100%" }}>
                 <h3 style={{ textAlign: "center", display: "block", width: "100%" }}>
                   Do not have read permissions to preview "{this.props.object.name}"
                 </h3>

--- a/browser/app/less/inc/list.less
+++ b/browser/app/less/inc/list.less
@@ -349,6 +349,7 @@ div.fesl-row {
         margin: 0;
         height: 100%;
         text-align: right;
+        white-space: nowrap;
     }
 
     .dropdown {


### PR DESCRIPTION
## Description
add preview object width constraint. #10061 

## Motivation and Context
fix preview modal when picture width greater than 900px

## How to test this PR?
upload a picture(width greater than 900px) and preview.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed

Close #10061 