### PR TITLE
Fix lifecycle rules not applied in some cases

### DIFF
--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -62,14 +62,19 @@ func (lc Lifecycle) HasActiveRules(prefix string, recursive bool) bool {
 		if rule.Status == Disabled {
 			continue
 		}
+
 		if len(prefix) > 0 && len(rule.Filter.Prefix) > 0 {
-			// incoming prefix must be in rule prefix
-			if !recursive && !strings.HasPrefix(prefix, rule.Filter.Prefix) {
-				continue
+			if !recursive {
+				// If not recursive, incoming prefix must be in rule prefix
+				if !strings.HasPrefix(prefix, rule.Filter.Prefix) {
+					continue
+				}
 			}
-			// If recursive, we can skip this rule if it doesn't match the tested prefix.
-			if recursive && !strings.HasPrefix(rule.Filter.Prefix, prefix) {
-				continue
+			if recursive {
+				// If recursive, we can skip this rule if it doesn't match the tested prefix.
+				if !strings.HasPrefix(prefix, rule.Filter.Prefix) && !strings.HasPrefix(rule.Filter.Prefix, prefix) {
+					continue
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description
HasActiveRules was not behaving as expected, this commit fixes it
and adds more unit tests.

## Motivation and Context
Fixing lifecycle expiration in some cases


## How to test this PR?
1. Apply a lifecycle rule with prefix = "doc/"
2. Upload objects to "doc/"
3. Change MinIO code to accelerate crawling

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
