### PR TITLE
Fix CheckParts REST endpoint

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -335,7 +335,7 @@ func (client *storageRESTClient) CheckParts(volume, path string, fi FileInfo) er
 		return err
 	}
 
-	respBody, err := client.call(storageRESTMethodWriteMetadata, values, &reader, -1)
+	respBody, err := client.call(storageRESTMethodCheckParts, values, &reader, -1)
 	defer http.DrainBody(respBody)
 	return err
 }


### PR DESCRIPTION
## Description

CheckParts is calling the wrong endpoint, so instead of checking parts it is writing metadata.

## How to test this PR?

Perform healing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
