### PR TITLE
add dnsStore interface for upcoming operator webhook

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -223,7 +223,11 @@ func handleCommonEnvVars() {
 	} else {
 		// Add found interfaces IP address to global domain IPS,
 		// loopback addresses will be naturally dropped.
-		updateDomainIPs(mustGetLocalIP4())
+		domainIPs := mustGetLocalIP4()
+		for _, host := range globalEndpoints.Hostnames() {
+			domainIPs.Add(host)
+		}
+		updateDomainIPs(domainIPs)
 	}
 
 	// In place update is true by default if the MINIO_UPDATE is not set

--- a/cmd/config/etcd/dns/etcd_dns.go
+++ b/cmd/config/etcd/dns/etcd_dns.go
@@ -48,8 +48,9 @@ func newCoreDNSMsg(ip string, port string, ttl uint32, t time.Time) ([]byte, err
 }
 
 // Close closes the internal etcd client and cannot be used further
-func (c *CoreDNS) Close() {
+func (c *CoreDNS) Close() error {
 	c.etcdClient.Close()
+	return nil
 }
 
 // List - Retrieves list of DNS entries for the domain.
@@ -259,7 +260,7 @@ func CoreDNSPath(prefix string) Option {
 }
 
 // NewCoreDNS - initialize a new coreDNS set/unset values.
-func NewCoreDNS(cfg clientv3.Config, setters ...Option) (*CoreDNS, error) {
+func NewCoreDNS(cfg clientv3.Config, setters ...Option) (Store, error) {
 	etcdClient, err := clientv3.New(cfg)
 	if err != nil {
 		return nil, err

--- a/cmd/config/etcd/dns/store.go
+++ b/cmd/config/etcd/dns/store.go
@@ -1,0 +1,27 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dns
+
+// Store dns record store
+type Store interface {
+	Put(bucket string) error
+	Get(bucket string) ([]SrvRecord, error)
+	Delete(bucket string) error
+	List() (map[string][]SrvRecord, error)
+	DeleteRecord(record SrvRecord) error
+	Close() error
+}

--- a/cmd/data-update-tracker.go
+++ b/cmd/data-update-tracker.go
@@ -206,7 +206,7 @@ func (d *dataUpdateTracker) load(ctx context.Context, drives ...string) {
 			continue
 		}
 		err = d.deserialize(f, d.Saved)
-		if err != nil && err != io.EOF {
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 			logger.LogIf(ctx, err)
 		}
 		f.Close()

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -239,15 +239,15 @@ func (l EndpointZones) NEndpoints() (count int) {
 	return count
 }
 
-// Hosts - returns list of unique hosts
-func (l EndpointZones) Hosts() []string {
+// Hostnames - returns list of unique hostnames
+func (l EndpointZones) Hostnames() []string {
 	foundSet := set.NewStringSet()
 	for _, ep := range l {
 		for _, endpoint := range ep.Endpoints {
-			if foundSet.Contains(endpoint.Host) {
+			if foundSet.Contains(endpoint.Hostname()) {
 				continue
 			}
-			foundSet.Add(endpoint.Host)
+			foundSet.Add(endpoint.Hostname())
 		}
 	}
 	return foundSet.ToSlice()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -234,7 +234,7 @@ var (
 	globalBucketFederation bool
 
 	// Allocated DNS config wrapper over etcd client.
-	globalDNSConfig *dns.CoreDNS
+	globalDNSConfig dns.Store
 
 	// GlobalKMS initialized KMS configuration
 	GlobalKMS crypto.KMS

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -44,8 +44,8 @@ func (t *apiConfig) init(cfg api.Config) {
 	}
 
 	apiRequestsMax := cfg.APIRequestsMax
-	if len(globalEndpoints.Hosts()) > 0 {
-		apiRequestsMax /= len(globalEndpoints.Hosts())
+	if len(globalEndpoints.Hostnames()) > 0 {
+		apiRequestsMax /= len(globalEndpoints.Hostnames())
 	}
 
 	t.requestsPool = make(chan struct{}, apiRequestsMax)


### PR DESCRIPTION
## Description
add dnsStore interface for upcoming operator webhook

## Motivation and Context
brings interface for the upcoming webhook feature in operator

## How to test this PR?
Additionally also adds all zones and all servers as part of the service records

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
