### PR TITLE
Fix bug with fields that contain trimming spaces

### DIFF
--- a/pkg/s3select/sql/funceval.go
+++ b/pkg/s3select/sql/funceval.go
@@ -465,8 +465,8 @@ func intCast(v *Value) (int64, error) {
 	case string:
 		// Parse as number, truncate floating point if
 		// needed.
-		// String might contain trimming spaces, which 
-		// needs to be trimmed.	
+		// String might contain trimming spaces, which
+		// needs to be trimmed.
 		res, ok := strToInt(strings.TrimSpace(x))
 		if !ok {
 			return 0, errCastFailure("could not parse as int")

--- a/pkg/s3select/sql/funceval.go
+++ b/pkg/s3select/sql/funceval.go
@@ -475,8 +475,8 @@ func intCast(v *Value) (int64, error) {
 	case []byte:
 		// Parse as number, truncate floating point if
 		// needed.
-		// String might contain trimming spaces, which 
-		// needs to be trimmed.	
+		// String might contain trimming spaces, which
+		// needs to be trimmed.
 		res, ok := strToInt(strings.TrimSpace(string(x)))
 		if !ok {
 			return 0, errCastFailure("could not parse as int")

--- a/pkg/s3select/sql/funceval.go
+++ b/pkg/s3select/sql/funceval.go
@@ -465,7 +465,9 @@ func intCast(v *Value) (int64, error) {
 	case string:
 		// Parse as number, truncate floating point if
 		// needed.
-		res, ok := strToInt(x)
+		// String might contain trimming spaces, which 
+		// needs to be trimmed.	
+		res, ok := strToInt(strings.TrimSpace(x))
 		if !ok {
 			return 0, errCastFailure("could not parse as int")
 		}
@@ -473,7 +475,9 @@ func intCast(v *Value) (int64, error) {
 	case []byte:
 		// Parse as number, truncate floating point if
 		// needed.
-		res, ok := strToInt(string(x))
+		// String might contain trimming spaces, which 
+		// needs to be trimmed.	
+		res, ok := strToInt(strings.TrimSpace(string(x)))
 		if !ok {
 			return 0, errCastFailure("could not parse as int")
 		}
@@ -491,13 +495,13 @@ func floatCast(v *Value) (float64, error) {
 	case int:
 		return float64(x), nil
 	case string:
-		f, err := strconv.ParseFloat(x, 64)
+		f, err := strconv.ParseFloat(strings.TrimSpace(x), 64)
 		if err != nil {
 			return 0, errCastFailure("could not parse as float")
 		}
 		return f, nil
 	case []byte:
-		f, err := strconv.ParseFloat(string(x), 64)
+		f, err := strconv.ParseFloat(strings.TrimSpace(string(x)), 64)
 		if err != nil {
 			return 0, errCastFailure("could not parse as float")
 		}


### PR DESCRIPTION
String x might contain trimming spaces. And it needs to be trimmed. For
example, in csv files, there might be trimming spaces in a field that
ought to meet a query condition that contains the value without
trimming spaces. This applies to both intCast and floatCast functions.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
