### PR TITLE
fs: Fix expiry regression after versioning refactor

### DIFF
--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -210,9 +210,8 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 			}
 		}
 
-		// All other expiration only applies to latest versions
-		// (except if this is a delete marker)
-		if obj.IsLatest && !obj.DeleteMarker {
+		// Remove the object or simply add a delete marker (once) in a versioned bucket
+		if obj.VersionID == "" || obj.IsLatest && !obj.DeleteMarker {
 			switch {
 			case !rule.Expiration.IsDateNull():
 				if time.Now().UTC().After(rule.Expiration.Date.Time) {
@@ -225,6 +224,7 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 			}
 		}
 	}
+
 	return action
 }
 


### PR DESCRIPTION
## Description
Do not ignore non versioned objects in lifecycle compute action
function.

## Motivation and Context
Fix regression in lifecycle expiry in FS mode

## How to test this PR?
Apply the following diff to faciliate testing:
```diff
diff --git a/cmd/data-crawler.go b/cmd/data-crawler.go
index af35b5ab0..de21d4394 100644
--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -40,8 +40,8 @@ import (
 const (
        dataCrawlSleepPerFolder  = time.Millisecond // Time to wait between folders.
        dataCrawlSleepDefMult    = 10.0             // Default multiplier for waits between operations.
-       dataCrawlStartDelay      = 5 * time.Minute  // Time to wait on startup and between cycles.
-       dataUsageUpdateDirCycles = 16               // Visit all folders every n cycles.
+       dataCrawlStartDelay      = 3 * time.Second  // Time to wait on startup and between cycles.
+       dataUsageUpdateDirCycles = 3                // Visit all folders every n cycles.
 
 )
 
```

1. mc mb myminio/testbucket/
2. mc ilm add --id "Devices" --expiry-days "3" myminio/testbucket/
3. mc cp file myminio/testbucket
4. sudo date +%Y%m%d -s "20221115"


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
