### PR TITLE
make sure lifecycle rule ID is present

### DIFF
--- a/pkg/bucket/lifecycle/lifecycle_test.go
+++ b/pkg/bucket/lifecycle/lifecycle_test.go
@@ -146,7 +146,7 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 			expectedParsingErr:    nil,
 			expectedValidationErr: nil,
 		},
-		{ // lifecycle config with rules having overlapping prefix
+		{ // lifecycle config with rules having duplicate ID
 			inputConfig:           string(duplicateIDLcConfig),
 			expectedParsingErr:    nil,
 			expectedValidationErr: errLifecycleDuplicateID,

--- a/pkg/bucket/lifecycle/rule.go
+++ b/pkg/bucket/lifecycle/rule.go
@@ -19,6 +19,8 @@ package lifecycle
 import (
 	"bytes"
 	"encoding/xml"
+
+	"github.com/google/uuid"
 )
 
 // Status represents lifecycle configuration status
@@ -44,17 +46,34 @@ type Rule struct {
 }
 
 var (
-	errInvalidRuleID           = Errorf("ID cannot be empty, must be unique and allowed maximal length is 255 characters")
+	errInvalidRuleID           = Errorf("ID length is limited to 255 characters")
 	errEmptyRuleStatus         = Errorf("Status should not be empty")
 	errInvalidRuleStatus       = Errorf("Status must be set to either Enabled or Disabled")
 	errMissingExpirationAction = Errorf("No expiration action found")
 )
 
+// generates random UUID
+func getNewUUID() (string, error) {
+	u, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+
+	return u.String(), nil
+}
+
 // validateID - checks if ID is valid or not.
 func (r Rule) validateID() error {
-	// cannot be empty and longer than 255 characters
-	idLen := len(string(r.ID))
-	if idLen == 0 || idLen > 255 {
+	IDLen := len(string(r.ID))
+	// generate new ID when not provided
+	// cannot be longer than 255 characters
+	if IDLen == 0 {
+		if newID, err := getNewUUID(); err == nil {
+			r.ID = newID
+		} else {
+			return err
+		}
+	} else if IDLen > 255 {
 		return errInvalidRuleID
 	}
 	return nil

--- a/pkg/bucket/lifecycle/rule.go
+++ b/pkg/bucket/lifecycle/rule.go
@@ -44,7 +44,7 @@ type Rule struct {
 }
 
 var (
-	errInvalidRuleID           = Errorf("ID must be less than 255 characters")
+	errInvalidRuleID           = Errorf("ID cannot be empty, must be unique and allowed maximal length is 255 characters")
 	errEmptyRuleStatus         = Errorf("Status should not be empty")
 	errInvalidRuleStatus       = Errorf("Status must be set to either Enabled or Disabled")
 	errMissingExpirationAction = Errorf("No expiration action found")
@@ -52,8 +52,9 @@ var (
 
 // validateID - checks if ID is valid or not.
 func (r Rule) validateID() error {
-	// cannot be longer than 255 characters
-	if len(string(r.ID)) > 255 {
+	// cannot be empty and longer than 255 characters
+	idLen := len(string(r.ID))
+	if idLen == 0 || idLen > 255 {
 		return errInvalidRuleID
 	}
 	return nil

--- a/pkg/bucket/lifecycle/rule_test.go
+++ b/pkg/bucket/lifecycle/rule_test.go
@@ -76,10 +76,14 @@ func TestInvalidRules(t *testing.T) {
 			expectedErr: errInvalidRuleID,
 		},
 		{ // Rule with empty ID
-			inputXML: ` <Rule>
-	                    <ID></ID>
+			inputXML: `<Rule>
+							<ID></ID>
+							<Expiration>
+								<Days>365</Days>
+							</Expiration>
+                            <Status>Enabled</Status>
 	                    </Rule>`,
-			expectedErr: errInvalidRuleID,
+			expectedErr: nil,
 		},
 		{ // Rule with empty status
 			inputXML: ` <Rule>

--- a/pkg/bucket/lifecycle/rule_test.go
+++ b/pkg/bucket/lifecycle/rule_test.go
@@ -64,6 +64,7 @@ func TestInvalidRules(t *testing.T) {
 	}{
 		{ // Rule without expiration action
 			inputXML: ` <Rule>
+			                <ID>rule without expiration</ID>
                             <Status>Enabled</Status>
 	                    </Rule>`,
 			expectedErr: errMissingExpirationAction,
@@ -74,14 +75,22 @@ func TestInvalidRules(t *testing.T) {
 	                    </Rule>`,
 			expectedErr: errInvalidRuleID,
 		},
+		{ // Rule with empty ID
+			inputXML: ` <Rule>
+	                    <ID></ID>
+	                    </Rule>`,
+			expectedErr: errInvalidRuleID,
+		},
 		{ // Rule with empty status
 			inputXML: ` <Rule>
+			                  <ID>rule with empty status</ID>
                               <Status></Status>
 	                    </Rule>`,
 			expectedErr: errEmptyRuleStatus,
 		},
 		{ // Rule with invalid status
 			inputXML: ` <Rule>
+			                  <ID>rule with invalid status</ID>
                               <Status>OK</Status>
 	                    </Rule>`,
 			expectedErr: errInvalidRuleStatus,


### PR DESCRIPTION
## Description
PR #10053 (#10027) introduced check that lifecycle rule ID must be unique. Based on that we should also check that ID is provided for new rules.

## Motivation and Context
AWS S3 enforces presence of rule ID as well.

## How to test this PR?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
