### PR TITLE
fix: copyObject key rotation issue

### DIFF
--- a/cmd/bucket-policy.go
+++ b/cmd/bucket-policy.go
@@ -75,9 +75,6 @@ func getConditionValues(r *http.Request, lc string, username string, claims map[
 		if u, err := url.Parse(r.Header.Get(xhttp.AmzCopySource)); err == nil {
 			vid = u.Query().Get("versionId")
 		}
-		if vid == "" {
-			vid = r.Header.Get(xhttp.AmzCopySourceVersionID)
-		}
 	}
 
 	args := map[string][]string{

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -612,7 +612,6 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, opts ObjectOptions, cl
 				}
 				return nil, err
 			}
-			oi.ETag = getDecryptedETag(h, oi, copySource) // Decrypt the ETag before top layer consumes this value.
 
 			if opts.CheckPrecondFn != nil && opts.CheckPrecondFn(oi) {
 				// Call the cleanup funcs
@@ -621,6 +620,8 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, opts ObjectOptions, cl
 				}
 				return nil, PreConditionFailed{}
 			}
+
+			oi.ETag = getDecryptedETag(h, oi, false)
 
 			// Apply the skipLen and limit on the
 			// decrypted stream

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -612,10 +612,6 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
 
 	// Set encryption response headers
 	if objectAPI.IsEncryptionSupported() {
-		if _, err = DecryptObjectInfo(&objInfo, r); err != nil {
-			writeErrorResponseHeadersOnly(w, toAPIError(ctx, err))
-			return
-		}
 		if crypto.IsEncrypted(objInfo.UserDefined) {
 			switch {
 			case crypto.S3.IsEncrypted(objInfo.UserDefined):
@@ -1743,9 +1739,6 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		vid = strings.TrimSpace(u.Query().Get(xhttp.VersionID))
 		// Note that url.Parse does the unescaping
 		cpSrcPath = u.Path
-	}
-	if vid == "" {
-		vid = strings.TrimSpace(r.Header.Get(xhttp.AmzCopySourceVersionID))
 	}
 
 	srcBucket, srcObject := path2BucketObject(cpSrcPath)


### PR DESCRIPTION

## Description
fix: copyObject key rotation issue

## Motivation and Context
- copyObject in-place decryption failed
  due to incorrect verification of headers
- do not decode ETag when an object is encrypted
  with SSE-C, so that pre-conditions don't fail
  prematurely.


## How to test this PR?
Use minio-go `make functional-test` by running a local TLS server `minio server /tmp/{1..4} --certs-dir ../minio-go/testcerts` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably there were other bugs prior to this #10045
- [ ] Documentation needed
- [ ] Unit tests needed
