### PR TITLE
add different TCP timeouts for internal and incoming

### DIFF
--- a/cmd/http/dial_linux.go
+++ b/cmd/http/dial_linux.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func setTCPParameters(c syscall.RawConn) error {
+func setInternalTCPParameters(c syscall.RawConn) error {
 	return c.Control(func(fdPtr uintptr) {
 		// got socket file descriptor to set parameters.
 		fd := int(fdPtr)
@@ -67,7 +67,7 @@ func NewCustomDialContext(dialTimeout time.Duration) DialContext {
 		dialer := &net.Dialer{
 			Timeout: dialTimeout,
 			Control: func(network, address string, c syscall.RawConn) error {
-				return setTCPParameters(c)
+				return setInternalTCPParameters(c)
 			},
 		}
 		return dialer.DialContext(ctx, network, addr)

--- a/cmd/http/dial_others.go
+++ b/cmd/http/dial_others.go
@@ -26,7 +26,7 @@ import (
 )
 
 // TODO: if possible implement for non-linux platforms, not a priority at the moment
-func setTCPParameters(c syscall.RawConn) error {
+func setInternalTCPParameters(c syscall.RawConn) error {
 	return nil
 }
 

--- a/cmd/http/listener.go
+++ b/cmd/http/listener.go
@@ -81,10 +81,7 @@ func (listener *httpListener) start() {
 
 	// Closure to handle single connection.
 	handleConn := func(tcpConn *net.TCPConn, doneCh <-chan struct{}) {
-		rawConn, err := tcpConn.SyscallConn()
-		if err == nil {
-			setTCPParameters(rawConn)
-		}
+		tcpConn.SetKeepAlive(true)
 		send(acceptResult{tcpConn, nil}, doneCh)
 	}
 


### PR DESCRIPTION
## Description
add different TCP timeouts for internal and incoming

## Motivation and Context
closes #10086

## How to test this PR?
Hard to test, is tested with the user #10086 to be working with reverse proxy over WAN

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
