### PR TITLE
Send the lower level error directly from GetDiskID()

### DIFF
--- a/cmd/format-disk-cache.go
+++ b/cmd/format-disk-cache.go
@@ -131,29 +131,11 @@ func createFormatCache(fsFormatPath string, format *formatCacheV1) error {
 // of format cache config
 func initFormatCache(ctx context.Context, drives []string) (formats []*formatCacheV2, err error) {
 	nformats := newFormatCacheV2(drives)
-	for _, drive := range drives {
-		_, err = os.Stat(drive)
-		if err == nil {
-			continue
-		}
-		if !os.IsNotExist(err) {
-			logger.GetReqInfo(ctx).AppendTags("drive", drive)
-			logger.LogIf(ctx, err, logger.Application)
-			return nil, err
-		}
-		if err = os.Mkdir(drive, 0777); err != nil {
-			logger.GetReqInfo(ctx).AppendTags("drive", drive)
-			logger.LogIf(ctx, err, logger.Application)
-			return nil, err
-		}
-	}
 	for i, drive := range drives {
-		if err = os.Mkdir(pathJoin(drive, minioMetaBucket), 0777); err != nil {
-			if !os.IsExist(err) {
-				logger.GetReqInfo(ctx).AppendTags("drive", drive)
-				logger.LogIf(ctx, err)
-				return nil, err
-			}
+		if err = os.MkdirAll(pathJoin(drive, minioMetaBucket), 0777); err != nil {
+			logger.GetReqInfo(ctx).AppendTags("drive", drive)
+			logger.LogIf(ctx, err)
+			return nil, err
 		}
 		cacheFormatPath := pathJoin(drive, minioMetaBucket, formatConfigFile)
 		// Fresh disk - create format.json for this cfs

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -103,6 +103,8 @@ func toStorageErr(err error) error {
 		return io.ErrUnexpectedEOF
 	case errDiskStale.Error():
 		return errDiskNotFound
+	case errDiskNotFound.Error():
+		return errDiskNotFound
 	}
 	return err
 }

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -114,12 +114,18 @@ func (s *storageRESTServer) IsValid(w http.ResponseWriter, r *http.Request) bool
 		return true
 	}
 	storedDiskID, err := s.storage.GetDiskID()
-	if err == nil && diskID == storedDiskID {
-		// If format.json is available and request sent the right disk-id, we allow the request
-		return true
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return false
 	}
-	s.writeErrorResponse(w, errDiskStale)
-	return false
+
+	if diskID != storedDiskID {
+		s.writeErrorResponse(w, errDiskStale)
+		return false
+	}
+
+	// If format.json is available and request sent the right disk-id, we allow the request
+	return true
 }
 
 // HealthHandler handler checks if disk is stale

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -509,7 +509,7 @@ func (s *xlStorage) GetDiskID() (string, error) {
 		if os.IsNotExist(err) {
 			_, err = os.Stat(s.diskPath)
 			if err == nil {
-				// Disk is present by missing `format.json`
+				// Disk is present but missing `format.json`
 				return "", errUnformattedDisk
 			}
 			if os.IsNotExist(err) {
@@ -2112,7 +2112,7 @@ func (s *xlStorage) RenameData(srcVolume, srcPath, dataDir, dstVolume, dstPath s
 		}
 		legacyDataPath := pathJoin(dstVolumeDir, dstPath, legacyDataDir)
 		// legacy data dir means its old content, honor system umask.
-		if err = os.Mkdir(legacyDataPath, 0777); err != nil {
+		if err = os.MkdirAll(legacyDataPath, 0777); err != nil {
 			if isSysErrIO(err) {
 				return errFaultyDisk
 			}
@@ -2133,10 +2133,10 @@ func (s *xlStorage) RenameData(srcVolume, srcPath, dataDir, dstVolume, dstPath s
 				}
 				return osErrToFileErr(err)
 			}
-
-			// Sync all the metadata operations once renames are done.
-			globalSync()
 		}
+
+		// Sync all the metadata operations once renames are done.
+		globalSync()
 	}
 
 	var oldDstDataPath string


### PR DESCRIPTION


## Description
Send the lower level error directly from GetDiskID()

## Motivation and Context
this is to detect situations of corruption disk
format etc errors quickly and keep the disk online
in such scenarios for requests to fail appropriately.

## How to test this PR?
Network failures are more granular

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
