### PR TITLE
fix: pass around the correct drives per set

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -73,7 +73,6 @@ DIR:
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}{{end}}
-
 EXAMPLES:
   1. Start minio server on "/home/shared" directory.
      {{.Prompt}} {{.HelpName}} /home/shared
@@ -91,7 +90,6 @@ EXAMPLES:
      {{.Prompt}} {{.EnvVarSetCommand}} MINIO_SECRET_KEY{{.AssignmentOperator}}miniostorage
      {{.Prompt}} {{.HelpName}} http://node{1...16}.example.com/mnt/export{1...32} \
             http://node{17...64}.example.com/mnt/export{1...64}
-
 `,
 }
 


### PR DESCRIPTION


## Description
fix: pass around the correct drives per set

## Motivation and Context
this is a precursor change before adding parity
based SLA across zones instead of same stripe size

## How to test this PR?
Nothing special all functionality should work as is

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
