### PR TITLE
Prevent healing to be stuck with many concurrent event listeners

### DIFF
--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -56,6 +56,10 @@ func (h *healRoutine) queueHealTask(task healTask) {
 }
 
 func waitForLowHTTPReq(tolerance int32) {
+	// Bucket notification and http trace are not costly, it is okay to ignore them
+	// while counting the number of concurrent connections
+	tolerance += int32(globalHTTPListen.NumSubscribers() + globalHTTPTrace.NumSubscribers())
+
 	if httpServer := newHTTPServerFn(); httpServer != nil {
 		// Wait at max 10 minute for an inprogress request before proceeding to heal
 		waitCount := 600

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -73,9 +73,14 @@ func (ps *PubSub) Subscribe(subCh chan interface{}, doneCh <-chan struct{}, filt
 
 // HasSubscribers returns true if pubsub system has subscribers
 func (ps *PubSub) HasSubscribers() bool {
+	return ps.NumSubscribers() > 0
+}
+
+// NumSubscribers returns the number of current subscribers
+func (ps *PubSub) NumSubscribers() int {
 	ps.RLock()
 	defer ps.RUnlock()
-	return len(ps.subs) > 0
+	return len(ps.subs)
 }
 
 // New inits a PubSub system


### PR DESCRIPTION
## Description
If there are many listeners to bucket notifications or to the trace
subsystem, healing fails to work properly since it suspends itself when
the number of concurrent connections is above a certain threshold.

These connections are also continuous and not costly (*no disk access*),
it is okay to just ignore them in waitForLowHTTPReq().

## Motivation and Context
Fix https://github.com/minio/minio/issues/9717

## How to test this PR?
1. Start a MinIO standalone erasure with 4 disks
2. Create a bucket and upload hundred of files
3. Start multiple mc watch commands:
```
for i in $(seq 1 10); do
   mc watch myminio/testbucket/ &
done
```
4. Run in another termina: `mc admin heal -r myminio/testbucket/`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
