### PR TITLE
Usage: Reset merged info when updating

### DIFF
--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -340,12 +340,13 @@ func (z *erasureZones) CrawlAndGetDataUsage(ctx context.Context, bf *bloomFilter
 
 		// We need to merge since we will get the same buckets from each zone.
 		// Therefore to get the exact bucket sizes we must merge before we can convert.
-		allMerged := dataUsageCache{Info: dataUsageCacheInfo{Name: dataUsageRoot}}
+		var allMerged dataUsageCache
 
 		update := func() {
 			mu.Lock()
 			defer mu.Unlock()
 
+			allMerged = dataUsageCache{Info: dataUsageCacheInfo{Name: dataUsageRoot}}
 			for _, info := range results {
 				if info.Info.LastUpdate.IsZero() {
 					// Not filled yet.


### PR DESCRIPTION
## Description

When merging multiple buckets reset between each update.

Avoids merging the same usage multiple times resulting in duplicate data entries.

## How to test this PR?

Requires multiple zones and rather slow crawls and multiple buckets.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
