### PR TITLE
add unformatted disk as part of the error list

### DIFF
--- a/cmd/erasure-bucket.go
+++ b/cmd/erasure-bucket.go
@@ -26,7 +26,7 @@ import (
 )
 
 // list all errors that can be ignore in a bucket operation.
-var bucketOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied)
+var bucketOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errUnformattedDisk)
 
 // list all errors that can be ignored in a bucket metadata operation.
 var bucketMetadataOpIgnoredErrs = append(bucketOpIgnoredErrs, errVolumeNotFound)

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -33,7 +33,7 @@ import (
 )
 
 // list all errors which can be ignored in object operations.
-var objectOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied)
+var objectOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errUnformattedDisk)
 
 // putObjectDir hints the bottom layer to create a new directory.
 func (er erasureObjects) putObjectDir(ctx context.Context, bucket, object string, writeQuorum int) error {

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -100,7 +100,9 @@ func cleanupDir(ctx context.Context, storage StorageAPI, volume, dirPath string)
 		if !HasSuffix(entryPath, SlashSeparator) {
 			// Delete the file entry.
 			err := storage.DeleteFile(volume, entryPath)
-			logger.LogIf(ctx, err)
+			if err != errDiskNotFound && err != errUnformattedDisk {
+				logger.LogIf(ctx, err)
+			}
 			return err
 		}
 
@@ -110,14 +112,18 @@ func cleanupDir(ctx context.Context, storage StorageAPI, volume, dirPath string)
 		if err == errFileNotFound {
 			return nil
 		} else if err != nil { // For any other errors fail.
-			logger.LogIf(ctx, err)
+			if err != errDiskNotFound && err != errUnformattedDisk {
+				logger.LogIf(ctx, err)
+			}
 			return err
 		} // else on success..
 
 		// Entry path is empty, just delete it.
 		if len(entries) == 0 {
 			err = storage.DeleteFile(volume, entryPath)
-			logger.LogIf(ctx, err)
+			if err != errDiskNotFound && err != errUnformattedDisk {
+				logger.LogIf(ctx, err)
+			}
 			return err
 		}
 

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -715,6 +715,7 @@ next:
 
 			_, err = deleteObject(ctx, objectAPI, web.CacheAPI(), args.BucketName, objectName, r, opts)
 			logger.LogIf(ctx, err)
+			continue
 		}
 
 		if authErr == errNoAuthToken {


### PR DESCRIPTION
## Description
add unformatted disk as part of the error list

## Motivation and Context
these errors should be ignored for quorum
error calculation to ensure that we don't
prematurely return unformatted disk error
as part of API calls

## How to test this PR?
Upload a large file on the browser in a distributed setup
and delete some backend directories - with master branch
you shall see an unhandled error

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes because we used to rely on errDiskNotFound but we now return errUnformattedDisk
- [ ] Documentation needed
- [ ] Unit tests needed
