### PR TITLE
fix: add missing content-disposition from CORS handler

### DIFF
--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -322,7 +322,7 @@ func corsHandler(handler http.Handler) http.Handler {
 		xhttp.ContentEncoding,
 		xhttp.ContentLength,
 		xhttp.ContentType,
-		xhttp.ContentEncoding,
+		xhttp.ContentDisposition,
 		xhttp.LastModified,
 		xhttp.ContentLanguage,
 		xhttp.CacheControl,

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -413,6 +413,9 @@ func extractAPIVersion(r *http.Request) string {
 
 // If none of the http routes match respond with appropriate errors
 func errorResponseHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		return
+	}
 	version := extractAPIVersion(r)
 	switch {
 	case strings.HasPrefix(r.URL.Path, peerRESTPrefix):

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -327,7 +327,7 @@ func UnstartedTestServer(t TestErrHandler, instanceType string) TestServer {
 	}
 
 	// Run TestServer.
-	testServer.Server = httptest.NewUnstartedServer(httpHandler)
+	testServer.Server = httptest.NewUnstartedServer(criticalErrorHandler{corsHandler(httpHandler)})
 
 	globalObjLayerMutex.Lock()
 	globalObjectAPI = objLayer


### PR DESCRIPTION
## Description
fix: add missing content-disposition from CORS handler

## Motivation and Context
continuation of #10124

## How to test this PR?
Use `curl`
```
curl -i -H "Origin: http://foobar.com" -X OPTIONS http://localhost:9000/
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://foobar.com
Access-Control-Expose-Headers: Date, Etag, Server, Connection, Accept-Ranges, Content-Range, Content-Encoding, Content-Length, Content-Type, Content-Disposition, Last-Modified, Content-Language, Cache-Control, Retry-After, X-Amz-Bucket-Region, Expires, X-Amz*, X-Amz*, *
Vary: Origin
Date: Mon, 27 Jul 2020 03:09:30 GMT
Content-Length: 0
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
