### PR TITLE
fix: if OPA set do not enforce policy claim

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -92,7 +92,7 @@ func initHelp() {
 		},
 		config.HelpKV{
 			Key:         config.PolicyOPASubSys,
-			Description: "enable external OPA for policy enforcement",
+			Description: "[DEPRECATED] enable external OPA for policy enforcement",
 		},
 		config.HelpKV{
 			Key:         config.KmsVaultSubSys,

--- a/cmd/config/policy/opa/help.go
+++ b/cmd/config/policy/opa/help.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2019,2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ var (
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         URL,
-			Description: `OPA HTTP(s) endpoint e.g. "http://localhost:8181/v1/data/httpapi/authz/allow"`,
+			Description: `[DEPRECATED] OPA HTTP(s) endpoint e.g. "http://localhost:8181/v1/data/httpapi/authz/allow"`,
 			Type:        "url",
 		},
 		config.HelpKV{
 			Key:         AuthToken,
-			Description: "authorization token for OPA endpoint",
+			Description: "[DEPRECATED] authorization token for OPA endpoint",
 			Optional:    true,
 			Type:        "string",
 		},

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -328,7 +328,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithJWT(w http.ResponseWriter, r *http.Requ
 		policyName = globalIAMSys.currentPolicies(strings.Join(policySet.ToSlice(), ","))
 	}
 
-	if policyName == "" {
+	if policyName == "" && globalPolicyOPA == nil {
 		writeSTSErrorResponse(ctx, w, true, ErrSTSInvalidParameterValue, fmt.Errorf("%s claim missing from the JWT token, credentials will not be generated", iamPolicyClaimNameOpenID()))
 		return
 	}

--- a/docs/sts/sts.env
+++ b/docs/sts/sts.env
@@ -1,5 +1,0 @@
-export MINIO_ACCESS_KEY=minio
-export MINIO_SECRET_KEY=minio123
-export MINIO_IDENTITY_OPENID_CONFIG_URL=https://localhost:9443/oauth2/oidcdiscovery/.well-known/openid-configuration
-export MINIO_POLICY_OPA_URL=http://localhost:8181/v1/data/httpapi/authz
-export MINIO_ETCD_ENDPOINTS=http://localhost:2379


### PR DESCRIPTION
## Description
fix: if OPA set do not enforce policy claim

## Motivation and Context
add "DEPRECATED" tag for OPA config help
to discourage its usage and remove it in future

## How to test this PR?
Nothing special just allow JWT without policy
claims, when OPA is configured.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
