### PR TITLE
Refactor replication target management.

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -183,14 +183,14 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 			}
 			// Bucket replication operations
 			// GetBucketTargetHandler
-			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-bucket-target").HandlerFunc(
-				httpTraceHdrs(adminAPI.GetBucketTargetsHandler)).Queries("bucket", "{bucket:.*}")
-			// GetBucketTargetARN	Handler
-			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/get-bucket-target-arn").HandlerFunc(
-				httpTraceHdrs(adminAPI.GetBucketTargetARNHandler)).Queries("url", "{url:.*}")
+			adminRouter.Methods(http.MethodGet).Path(adminVersion+"/list-bucket-targets").HandlerFunc(
+				httpTraceHdrs(adminAPI.ListBucketTargetsHandler)).Queries("bucket", "{bucket:.*}", "type", "{type:.*}")
 			// SetBucketTargetHandler
 			adminRouter.Methods(http.MethodPut).Path(adminVersion+"/set-bucket-target").HandlerFunc(
 				httpTraceHdrs(adminAPI.SetBucketTargetHandler)).Queries("bucket", "{bucket:.*}")
+			// SetBucketTargetHandler
+			adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/remove-bucket-target").HandlerFunc(
+				httpTraceHdrs(adminAPI.RemoveBucketTargetHandler)).Queries("bucket", "{bucket:.*}", "arn", "{arn:.*}")
 		}
 
 		// -- Top APIs --

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -108,6 +108,11 @@ const (
 	ErrReplicationConfigurationNotFoundError
 	ErrReplicationDestinationNotFoundError
 	ErrReplicationTargetNotFoundError
+	ErrBucketRemoteIdenticalToSource
+	ErrBucketRemoteAlreadyExists
+	ErrBucketRemoteArnTypeInvalid
+	ErrBucketRemoteArnInvalid
+	ErrBucketRemoteRemoveDisallowed
 	ErrReplicationTargetNotVersionedError
 	ErrReplicationNeedsVersioningError
 	ErrReplicationBucketNeedsVersioningError
@@ -826,14 +831,39 @@ var errorCodes = errorCodeMap{
 		HTTPStatusCode: http.StatusNotFound,
 	},
 	ErrReplicationTargetNotFoundError: {
-		Code:           "ReplicationTargetNotFoundError",
+		Code:           "XminioAdminReplicationTargetNotFoundError",
 		Description:    "The replication target does not exist",
 		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrBucketRemoteIdenticalToSource: {
+		Code:           "XminioAdminRemoteIdenticalToSource",
+		Description:    "The remote target cannot be identical to source",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrBucketRemoteAlreadyExists: {
+		Code:           "XminioAdminBucketRemoteAlreadyExists",
+		Description:    "The remote target already exists",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrBucketRemoteRemoveDisallowed: {
+		Code:           "XMinioAdminRemoteRemoveDisallowed",
+		Description:    "Replication configuration exists with this ARN.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrBucketRemoteArnTypeInvalid: {
+		Code:           "XMinioAdminRemoteARNTypeInvalid",
+		Description:    "The bucket remote ARN type is not valid",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrBucketRemoteArnInvalid: {
+		Code:           "XMinioAdminRemoteArnInvalid",
+		Description:    "The bucket remote ARN does not have correct format",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrReplicationTargetNotVersionedError: {
 		Code:           "ReplicationTargetNotVersionedError",
 		Description:    "The replication target does not have versioning enabled",
-		HTTPStatusCode: http.StatusNotFound,
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrReplicationNeedsVersioningError: {
 		Code:           "InvalidRequest",
@@ -1879,8 +1909,16 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrReplicationConfigurationNotFoundError
 	case BucketReplicationDestinationNotFound:
 		apiErr = ErrReplicationDestinationNotFoundError
-	case BucketReplicationTargetNotFound:
+	case BucketRemoteTargetNotFound:
 		apiErr = ErrReplicationTargetNotFoundError
+	case BucketRemoteAlreadyExists:
+		apiErr = ErrBucketRemoteAlreadyExists
+	case BucketRemoteArnTypeInvalid:
+		apiErr = ErrBucketRemoteArnTypeInvalid
+	case BucketRemoteArnInvalid:
+		apiErr = ErrBucketRemoteArnInvalid
+	case BucketRemoteRemoveDisallowed:
+		apiErr = ErrBucketRemoteRemoveDisallowed
 	case BucketReplicationTargetNotVersioned:
 		apiErr = ErrReplicationTargetNotVersionedError
 	case BucketQuotaExceeded:

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1271,7 +1271,7 @@ func (api objectAPIHandlers) PutBucketReplicationConfigHandler(w http.ResponseWr
 		writeErrorResponse(ctx, w, apiErr, r.URL, guessIsBrowserReq(r))
 		return
 	}
-	sameTarget, err := globalBucketReplicationSys.validateDestination(ctx, bucket, replicationConfig)
+	sameTarget, err := validateReplicationDestination(ctx, bucket, replicationConfig)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return

--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -340,15 +340,15 @@ func (sys *BucketMetadataSys) GetReplicationConfig(ctx context.Context, bucket s
 	return meta.replicationConfig, nil
 }
 
-// GetReplicationTargetConfig returns configured bucket replication target for this bucket
+// GetBucketTargetsConfig returns configured bucket targets for this bucket
 // The returned object may not be modified.
-func (sys *BucketMetadataSys) GetReplicationTargetConfig(bucket string) (*madmin.BucketTarget, error) {
+func (sys *BucketMetadataSys) GetBucketTargetsConfig(bucket string) (*madmin.BucketTargets, error) {
 	meta, err := sys.GetConfig(bucket)
 	if err != nil {
 		return nil, err
 	}
 	if meta.bucketTargetConfig == nil {
-		return nil, BucketReplicationTargetNotFound{Bucket: bucket}
+		return nil, BucketRemoteTargetNotFound{Bucket: bucket}
 	}
 	return meta.bucketTargetConfig, nil
 }

--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -85,7 +85,7 @@ type BucketMetadata struct {
 	taggingConfig      *tags.Tags
 	quotaConfig        *madmin.BucketQuota
 	replicationConfig  *replication.Config
-	bucketTargetConfig *madmin.BucketTarget
+	bucketTargetConfig *madmin.BucketTargets
 }
 
 // newBucketMetadata creates BucketMetadata with the supplied name and Created to Now.
@@ -100,7 +100,7 @@ func newBucketMetadata(name string) BucketMetadata {
 		versioningConfig: &versioning.Versioning{
 			XMLNS: "http://s3.amazonaws.com/doc/2006-03-01/",
 		},
-		bucketTargetConfig: &madmin.BucketTarget{},
+		bucketTargetConfig: &madmin.BucketTargets{},
 	}
 }
 
@@ -232,7 +232,7 @@ func (b *BucketMetadata) parseAllConfigs(ctx context.Context, objectAPI ObjectLa
 			return err
 		}
 	} else {
-		b.bucketTargetConfig = &madmin.BucketTarget{}
+		b.bucketTargetConfig = &madmin.BucketTargets{}
 	}
 	return nil
 }

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -18,35 +18,22 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"strings"
-	"sync"
 	"time"
 
 	miniogo "github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/minio/minio-go/v7/pkg/tags"
 	"github.com/minio/minio/cmd/crypto"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/bucket/replication"
-	"github.com/minio/minio/pkg/bucket/versioning"
 	"github.com/minio/minio/pkg/event"
 	iampolicy "github.com/minio/minio/pkg/iam/policy"
-	"github.com/minio/minio/pkg/madmin"
 )
 
-// BucketReplicationSys represents replication subsystem
-type BucketReplicationSys struct {
-	sync.RWMutex
-	targetsMap    map[string]*miniogo.Core
-	targetsARNMap map[string]string
-}
-
-// GetConfig - gets replication config associated to a given bucket name.
-func (sys *BucketReplicationSys) GetConfig(ctx context.Context, bucketName string) (rc *replication.Config, err error) {
+// gets replication config associated to a given bucket name.
+func getReplicationConfig(ctx context.Context, bucketName string) (rc *replication.Config, err error) {
 	if globalIsGateway {
 		objAPI := newObjectLayerWithoutSafeModeFn()
 		if objAPI == nil {
@@ -59,153 +46,29 @@ func (sys *BucketReplicationSys) GetConfig(ctx context.Context, bucketName strin
 	return globalBucketMetadataSys.GetReplicationConfig(ctx, bucketName)
 }
 
-// SetTarget - sets a new minio-go client replication target for this bucket.
-func (sys *BucketReplicationSys) SetTarget(ctx context.Context, bucket string, tgt *madmin.BucketTarget) error {
-	if globalIsGateway {
-		return nil
-	}
-	// delete replication targets that were removed
-	if tgt.Empty() {
-		sys.Lock()
-		if currTgt, ok := sys.targetsMap[bucket]; ok {
-			delete(sys.targetsARNMap, currTgt.EndpointURL().String())
-		}
-		delete(sys.targetsMap, bucket)
-		sys.Unlock()
-		return nil
-	}
-	clnt, err := getReplicationTargetClient(tgt)
-	if err != nil {
-		return BucketReplicationTargetNotFound{Bucket: tgt.TargetBucket}
-	}
-	ok, err := clnt.BucketExists(ctx, tgt.TargetBucket)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return BucketReplicationDestinationNotFound{Bucket: tgt.TargetBucket}
-	}
-	vcfg, err := clnt.GetBucketVersioning(ctx, tgt.TargetBucket)
-	if err != nil || vcfg.Status != string(versioning.Enabled) {
-		return BucketReplicationTargetNotVersioned{Bucket: tgt.TargetBucket}
-	}
-	sys.Lock()
-	sys.targetsMap[bucket] = clnt
-	sys.targetsARNMap[tgt.URL()] = tgt.Arn
-	sys.Unlock()
-	return nil
-}
-
-// GetTargetClient returns minio-go client for target instance
-func (sys *BucketReplicationSys) GetTargetClient(ctx context.Context, bucket string) *miniogo.Core {
-	var clnt *miniogo.Core
-	sys.RLock()
-	if c, ok := sys.targetsMap[bucket]; ok {
-		clnt = c
-	}
-	sys.RUnlock()
-	return clnt
-}
-
-// validateDestination returns error if replication destination bucket missing or not configured
+// validateReplicationDestination returns error if replication destination bucket missing or not configured
 // It also returns true if replication destination is same as this server.
-func (sys *BucketReplicationSys) validateDestination(ctx context.Context, bucket string, rCfg *replication.Config) (bool, error) {
-	clnt := sys.GetTargetClient(ctx, bucket)
+func validateReplicationDestination(ctx context.Context, bucket string, rCfg *replication.Config) (bool, error) {
+	clnt := globalBucketTargetSys.GetReplicationTargetClient(ctx, rCfg.ReplicationArn)
 	if clnt == nil {
-		return false, BucketReplicationTargetNotFound{Bucket: bucket}
+		return false, BucketRemoteTargetNotFound{Bucket: bucket}
 	}
 	if found, _ := clnt.BucketExists(ctx, rCfg.GetDestination().Bucket); !found {
 		return false, BucketReplicationDestinationNotFound{Bucket: rCfg.GetDestination().Bucket}
 	}
 	// validate replication ARN against target endpoint
-	for k, v := range sys.targetsARNMap {
-		if v == rCfg.ReplicationArn {
-			if k == clnt.EndpointURL().String() {
-				sameTarget, _ := isLocalHost(clnt.EndpointURL().Hostname(), clnt.EndpointURL().Port(), globalMinioPort)
-				return sameTarget, nil
-			}
+	c, ok := globalBucketTargetSys.arnRemotesMap[rCfg.ReplicationArn]
+	if ok {
+		if c.EndpointURL().String() == clnt.EndpointURL().String() {
+			sameTarget, _ := isLocalHost(clnt.EndpointURL().Hostname(), clnt.EndpointURL().Port(), globalMinioPort)
+			return sameTarget, nil
 		}
 	}
-	return false, BucketReplicationTargetNotFound{Bucket: bucket}
-}
-
-// NewBucketReplicationSys - creates new replication system.
-func NewBucketReplicationSys() *BucketReplicationSys {
-	return &BucketReplicationSys{
-		targetsMap:    make(map[string]*miniogo.Core),
-		targetsARNMap: make(map[string]string),
-	}
-}
-
-// Init initializes the bucket replication subsystem for buckets with replication config
-func (sys *BucketReplicationSys) Init(ctx context.Context, buckets []BucketInfo, objAPI ObjectLayer) error {
-	if objAPI == nil {
-		return errServerNotInitialized
-	}
-
-	// In gateway mode, replication is not supported.
-	if globalIsGateway {
-		return nil
-	}
-
-	// Load bucket replication targets once during boot.
-	sys.load(ctx, buckets, objAPI)
-	return nil
-}
-
-// create minio-go clients for buckets having replication targets
-func (sys *BucketReplicationSys) load(ctx context.Context, buckets []BucketInfo, objAPI ObjectLayer) {
-	for _, bucket := range buckets {
-		tgt, err := globalBucketMetadataSys.GetReplicationTargetConfig(bucket.Name)
-		if err != nil {
-			continue
-		}
-		if tgt == nil || tgt.Empty() {
-			continue
-		}
-		tgtClient, err := getReplicationTargetClient(tgt)
-		if err != nil {
-			continue
-		}
-		sys.Lock()
-		sys.targetsMap[bucket.Name] = tgtClient
-		sys.targetsARNMap[tgt.URL()] = tgt.Arn
-		sys.Unlock()
-	}
-}
-
-// GetARN returns the ARN associated with replication target URL
-func (sys *BucketReplicationSys) getARN(endpoint string) string {
-	return sys.targetsARNMap[endpoint]
-}
-
-// getReplicationTargetInstanceTransport contains a singleton roundtripper.
-var getReplicationTargetInstanceTransport http.RoundTripper
-var getReplicationTargetInstanceTransportOnce sync.Once
-
-// Returns a minio-go Client configured to access remote host described in replication target config.
-var getReplicationTargetClient = func(tcfg *madmin.BucketTarget) (*miniogo.Core, error) {
-	config := tcfg.Credentials
-	// if Signature version '4' use NewV4 directly.
-	creds := credentials.NewStaticV4(config.AccessKey, config.SecretKey, "")
-	// if Signature version '2' use NewV2 directly.
-	if strings.ToUpper(tcfg.API) == "S3V2" {
-		creds = credentials.NewStaticV2(config.AccessKey, config.SecretKey, "")
-	}
-
-	getReplicationTargetInstanceTransportOnce.Do(func() {
-		getReplicationTargetInstanceTransport = NewGatewayHTTPTransport()
-	})
-	core, err := miniogo.NewCore(tcfg.Endpoint, &miniogo.Options{
-		Creds:     creds,
-		Secure:    tcfg.Secure,
-		Transport: getReplicationTargetInstanceTransport,
-	})
-	return core, err
+	return false, BucketRemoteTargetNotFound{Bucket: bucket}
 }
 
 // mustReplicate returns true if object meets replication criteria.
-func (sys *BucketReplicationSys) mustReplicate(ctx context.Context, r *http.Request, bucket, object string, meta map[string]string, replStatus string) bool {
+func mustReplicate(ctx context.Context, r *http.Request, bucket, object string, meta map[string]string, replStatus string) bool {
 	if globalIsGateway {
 		return false
 	}
@@ -218,7 +81,7 @@ func (sys *BucketReplicationSys) mustReplicate(ctx context.Context, r *http.Requ
 	if s3Err := isPutActionAllowed(getRequestAuthType(r), bucket, object, r, iampolicy.GetReplicationConfigurationAction); s3Err != ErrNone {
 		return false
 	}
-	cfg, err := globalBucketReplicationSys.GetConfig(ctx, bucket)
+	cfg, err := getReplicationConfig(ctx, bucket)
 	if err != nil {
 		return false
 	}
@@ -279,12 +142,12 @@ func putReplicationOpts(dest replication.Destination, objInfo ObjectInfo) (putOp
 // replicateObject replicates the specified version of the object to destination bucket
 // The source object is then updated to reflect the replication status.
 func replicateObject(ctx context.Context, bucket, object, versionID string, objectAPI ObjectLayer, eventArg *eventArgs, healPending bool) {
-	cfg, err := globalBucketReplicationSys.GetConfig(ctx, bucket)
+	cfg, err := getReplicationConfig(ctx, bucket)
 	if err != nil {
 		logger.LogIf(ctx, err)
 		return
 	}
-	tgt := globalBucketReplicationSys.GetTargetClient(ctx, bucket)
+	tgt := globalBucketTargetSys.GetReplicationTargetClient(ctx, cfg.ReplicationArn)
 	if tgt == nil {
 		return
 	}
@@ -343,13 +206,4 @@ func replicateObject(ctx context.Context, bucket, object, versionID string, obje
 	}, ObjectOptions{VersionID: objInfo.VersionID}); err != nil {
 		logger.LogIf(ctx, err)
 	}
-}
-
-// getReplicationARN gets existing ARN for an endpoint or generates a new one.
-func (sys *BucketReplicationSys) getReplicationARN(endpoint string) string {
-	arn, ok := sys.targetsARNMap[endpoint]
-	if ok {
-		return arn
-	}
-	return fmt.Sprintf("arn:minio:s3::%s:*", mustGetUUID())
 }

--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -1,0 +1,242 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	miniogo "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio/pkg/bucket/versioning"
+	"github.com/minio/minio/pkg/madmin"
+)
+
+// BucketTargetSys represents bucket targets subsystem
+type BucketTargetSys struct {
+	sync.RWMutex
+	arnRemotesMap map[string]*miniogo.Core
+	targetsMap    map[string][]madmin.BucketTarget
+	clientsCache  map[string]*miniogo.Core
+}
+
+// ListTargets - gets list of bucket targets for this bucket.
+func (sys *BucketTargetSys) ListTargets(ctx context.Context, bucket string) (*madmin.BucketTargets, error) {
+	if globalIsGateway {
+		return nil, nil
+	}
+	tgts, ok := sys.targetsMap[bucket]
+	if ok {
+		return &madmin.BucketTargets{Targets: tgts}, nil
+	}
+	return nil, fmt.Errorf("No remote targets exist for bucket %s", bucket)
+}
+
+// SetTarget - sets a new minio-go client target for this bucket.
+func (sys *BucketTargetSys) SetTarget(ctx context.Context, bucket string, tgt *madmin.BucketTarget) error {
+	if globalIsGateway {
+		return nil
+	}
+	if !tgt.Type.IsValid() {
+		return BucketRemoteArnTypeInvalid{Bucket: bucket}
+	}
+	clnt, err := sys.getRemoteTargetClient(tgt)
+	if err != nil {
+		return BucketRemoteTargetNotFound{Bucket: tgt.TargetBucket}
+	}
+
+	if tgt.Type == madmin.ReplicationArn {
+		vcfg, err := clnt.GetBucketVersioning(ctx, tgt.TargetBucket)
+		if err != nil || vcfg.Status != string(versioning.Enabled) {
+			if isErrBucketNotFound(err) {
+				return BucketRemoteTargetNotFound{Bucket: tgt.TargetBucket}
+			}
+			return BucketReplicationTargetNotVersioned{Bucket: tgt.TargetBucket}
+		}
+	}
+
+	sys.Lock()
+	defer sys.Unlock()
+
+	tgts := sys.targetsMap[bucket]
+	newtgts := make([]madmin.BucketTarget, len(tgts))
+	found := false
+	for idx, t := range tgts {
+		if t.Type == tgt.Type {
+			if t.Arn == tgt.Arn {
+				return BucketRemoteAlreadyExists{Bucket: t.TargetBucket}
+			}
+			newtgts[idx] = *tgt
+			found = true
+			continue
+		}
+		newtgts[idx] = t
+	}
+	if !found {
+		newtgts = append(newtgts, *tgt)
+	}
+
+	sys.targetsMap[bucket] = newtgts
+	sys.arnRemotesMap[tgt.Arn] = clnt
+	if _, ok := sys.clientsCache[clnt.EndpointURL().String()]; !ok {
+		sys.clientsCache[clnt.EndpointURL().String()] = clnt
+	}
+	return nil
+}
+
+// RemoveTarget - removes a remote bucket target for this source bucket.
+func (sys *BucketTargetSys) RemoveTarget(ctx context.Context, bucket, arnStr string) error {
+	if globalIsGateway {
+		return nil
+	}
+	if arnStr == "" {
+		return BucketRemoteArnInvalid{Bucket: bucket}
+	}
+	arn, err := madmin.ParseARN(arnStr)
+	if err != nil {
+		return BucketRemoteArnInvalid{Bucket: bucket}
+	}
+	if arn.Type == madmin.ReplicationArn {
+		// reject removal of remote target if replication configuration is present
+		rcfg, err := getReplicationConfig(ctx, bucket)
+		if err == nil && rcfg.ReplicationArn == arnStr {
+			if _, ok := sys.arnRemotesMap[arnStr]; ok {
+				return BucketRemoteRemoveDisallowed{Bucket: bucket}
+			}
+		}
+	}
+	// delete ARN type from list of matching targets
+	sys.Lock()
+	defer sys.Unlock()
+	targets := make([]madmin.BucketTarget, 0)
+	tgts := sys.targetsMap[bucket]
+	for _, tgt := range tgts {
+		if tgt.Arn != arnStr {
+			targets = append(targets, tgt)
+		}
+	}
+	sys.targetsMap[bucket] = targets
+	delete(sys.arnRemotesMap, arnStr)
+	return nil
+}
+
+// GetReplicationTargetClient returns minio-go client for replication target instance
+func (sys *BucketTargetSys) GetReplicationTargetClient(ctx context.Context, arn string) *miniogo.Core {
+	sys.RLock()
+	defer sys.RUnlock()
+	return sys.arnRemotesMap[arn]
+}
+
+// NewBucketTargetSys - creates new replication system.
+func NewBucketTargetSys() *BucketTargetSys {
+	return &BucketTargetSys{
+		arnRemotesMap: make(map[string]*miniogo.Core),
+		targetsMap:    make(map[string][]madmin.BucketTarget),
+		clientsCache:  make(map[string]*miniogo.Core),
+	}
+}
+
+// Init initializes the bucket targets subsystem for buckets which have targets configured.
+func (sys *BucketTargetSys) Init(ctx context.Context, buckets []BucketInfo, objAPI ObjectLayer) error {
+	if objAPI == nil {
+		return errServerNotInitialized
+	}
+
+	// In gateway mode, bucket targets is not supported.
+	if globalIsGateway {
+		return nil
+	}
+
+	// Load bucket targets once during boot.
+	sys.load(ctx, buckets, objAPI)
+	return nil
+}
+
+// create minio-go clients for buckets having remote targets
+func (sys *BucketTargetSys) load(ctx context.Context, buckets []BucketInfo, objAPI ObjectLayer) {
+	for _, bucket := range buckets {
+		cfg, err := globalBucketMetadataSys.GetBucketTargetsConfig(bucket.Name)
+		if err != nil {
+			continue
+		}
+		if cfg == nil || cfg.Empty() {
+			continue
+		}
+		if len(cfg.Targets) > 0 {
+			sys.targetsMap[bucket.Name] = cfg.Targets
+		}
+		for _, tgt := range cfg.Targets {
+			tgtClient, err := sys.getRemoteTargetClient(&tgt)
+			if err != nil {
+				continue
+			}
+			sys.arnRemotesMap[tgt.Arn] = tgtClient
+			if _, ok := sys.clientsCache[tgtClient.EndpointURL().String()]; !ok {
+				sys.clientsCache[tgtClient.EndpointURL().String()] = tgtClient
+			}
+		}
+		sys.targetsMap[bucket.Name] = cfg.Targets
+	}
+}
+
+// getRemoteTargetInstanceTransport contains a singleton roundtripper.
+var getRemoteTargetInstanceTransport http.RoundTripper
+var getRemoteTargetInstanceTransportOnce sync.Once
+
+// Returns a minio-go Client configured to access remote host described in replication target config.
+func (sys *BucketTargetSys) getRemoteTargetClient(tcfg *madmin.BucketTarget) (*miniogo.Core, error) {
+	if clnt, ok := sys.clientsCache[tcfg.Endpoint]; ok {
+		return clnt, nil
+	}
+	config := tcfg.Credentials
+	creds := credentials.NewStaticV4(config.AccessKey, config.SecretKey, "")
+
+	getRemoteTargetInstanceTransportOnce.Do(func() {
+		getRemoteTargetInstanceTransport = NewGatewayHTTPTransport()
+	})
+	core, err := miniogo.NewCore(tcfg.Endpoint, &miniogo.Options{
+		Creds:     creds,
+		Secure:    tcfg.Secure,
+		Transport: getRemoteTargetInstanceTransport,
+	})
+	return core, err
+}
+
+// getRemoteARN gets existing ARN for an endpoint or generates a new one.
+func (sys *BucketTargetSys) getRemoteARN(bucket string, target *madmin.BucketTarget) string {
+	if target == nil {
+		return ""
+	}
+	tgts := sys.targetsMap[bucket]
+	for _, tgt := range tgts {
+		if tgt.Type == target.Type && tgt.TargetBucket == target.TargetBucket && target.URL() == tgt.URL() {
+			return tgt.Arn
+		}
+	}
+	if !madmin.ArnType(target.Type).IsValid() {
+		return ""
+	}
+	arn := madmin.ARN{
+		Type:   target.Type,
+		ID:     mustGetUUID(),
+		Region: target.Region,
+		Bucket: target.TargetBucket,
+	}
+	return arn.String()
+}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -154,9 +154,9 @@ var (
 	globalPolicySys         *PolicySys
 	globalIAMSys            *IAMSys
 
-	globalLifecycleSys         *LifecycleSys
-	globalBucketSSEConfigSys   *BucketSSEConfigSys
-	globalBucketReplicationSys *BucketReplicationSys
+	globalLifecycleSys       *LifecycleSys
+	globalBucketSSEConfigSys *BucketSSEConfigSys
+	globalBucketTargetSys    *BucketTargetSys
 	// globalAPIConfig controls S3 API requests throttling,
 	// healthcheck readiness deadlines and cors settings.
 	globalAPIConfig apiConfig

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -362,11 +362,39 @@ func (e BucketReplicationDestinationNotFound) Error() string {
 	return "Destination bucket does not exist: " + e.Bucket
 }
 
-// BucketReplicationTargetNotFound replication target does not exist.
-type BucketReplicationTargetNotFound GenericError
+// BucketRemoteTargetNotFound remote target does not exist.
+type BucketRemoteTargetNotFound GenericError
 
-func (e BucketReplicationTargetNotFound) Error() string {
-	return "Replication target not found: " + e.Bucket
+func (e BucketRemoteTargetNotFound) Error() string {
+	return "Remote target not found: " + e.Bucket
+}
+
+// BucketRemoteAlreadyExists remote already exists for this target type.
+type BucketRemoteAlreadyExists GenericError
+
+func (e BucketRemoteAlreadyExists) Error() string {
+	return "Remote already exists for this bucket: " + e.Bucket
+}
+
+// BucketRemoteArnTypeInvalid arn type for remote is not valid.
+type BucketRemoteArnTypeInvalid GenericError
+
+func (e BucketRemoteArnTypeInvalid) Error() string {
+	return "Remote ARN type not valid: " + e.Bucket
+}
+
+// BucketRemoteArnInvalid arn needs to be specified.
+type BucketRemoteArnInvalid GenericError
+
+func (e BucketRemoteArnInvalid) Error() string {
+	return "Remote ARN has invalid format: " + e.Bucket
+}
+
+// BucketRemoteRemoveDisallowed when replication configuration exists
+type BucketRemoteRemoveDisallowed GenericError
+
+func (e BucketRemoteRemoveDisallowed) Error() string {
+	return "Replication configuration exists with this ARN:" + e.Bucket
 }
 
 // BucketReplicationTargetNotVersioned replication target does not have versioning enabled.

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1177,7 +1177,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
 		return
 	}
-	if globalBucketReplicationSys.mustReplicate(ctx, r, dstBucket, dstObject, srcInfo.UserDefined, srcInfo.ReplicationStatus.String()) {
+	if mustReplicate(ctx, r, dstBucket, dstObject, srcInfo.UserDefined, srcInfo.ReplicationStatus.String()) {
 		srcInfo.UserDefined[xhttp.AmzBucketReplicationStatus] = replication.Pending.String()
 	}
 
@@ -1258,7 +1258,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	objInfo.ETag = getDecryptedETag(r.Header, objInfo, false)
 	response := generateCopyObjectResponse(objInfo.ETag, objInfo.ModTime)
 	encodedSuccessResponse := encodeResponse(response)
-	if globalBucketReplicationSys.mustReplicate(ctx, r, dstBucket, dstObject, objInfo.UserDefined, objInfo.ReplicationStatus.String()) {
+	if mustReplicate(ctx, r, dstBucket, dstObject, objInfo.UserDefined, objInfo.ReplicationStatus.String()) {
 		defer replicateObject(ctx, dstBucket, dstObject, objInfo.VersionID, objectAPI, &eventArgs{
 			EventName:    event.ObjectCreatedCopy,
 			BucketName:   dstBucket,
@@ -1511,7 +1511,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
 		return
 	}
-	if globalBucketReplicationSys.mustReplicate(ctx, r, bucket, object, metadata, "") {
+	if mustReplicate(ctx, r, bucket, object, metadata, "") {
 		metadata[xhttp.AmzBucketReplicationStatus] = string(replication.Pending)
 	}
 	if r.Header.Get(xhttp.AmzBucketReplicationStatus) == replication.Replica.String() {
@@ -1574,7 +1574,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 			}
 		}
 	}
-	if globalBucketReplicationSys.mustReplicate(ctx, r, bucket, object, metadata, "") {
+	if mustReplicate(ctx, r, bucket, object, metadata, "") {
 		defer replicateObject(ctx, bucket, object, objInfo.VersionID, objectAPI, &eventArgs{
 			EventName:    event.ObjectCreatedPut,
 			BucketName:   bucket,
@@ -1696,7 +1696,7 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL, guessIsBrowserReq(r))
 		return
 	}
-	if globalBucketReplicationSys.mustReplicate(ctx, r, bucket, object, metadata, "") {
+	if mustReplicate(ctx, r, bucket, object, metadata, "") {
 		metadata[xhttp.AmzBucketReplicationStatus] = string(replication.Pending)
 	}
 	// We need to preserve the encryption headers set in EncryptRequest,
@@ -2647,7 +2647,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 	}
 
 	setPutObjHeaders(w, objInfo, false)
-	if globalBucketReplicationSys.mustReplicate(ctx, r, bucket, object, objInfo.UserDefined, objInfo.ReplicationStatus.String()) {
+	if mustReplicate(ctx, r, bucket, object, objInfo.UserDefined, objInfo.ReplicationStatus.String()) {
 		defer replicateObject(ctx, bucket, object, objInfo.VersionID, objectAPI, &eventArgs{
 			EventName:    event.ObjectCreatedCompleteMultipartUpload,
 			BucketName:   bucket,

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -170,7 +170,7 @@ func newAllSubsystems() {
 	globalBucketVersioningSys = NewBucketVersioningSys()
 
 	// Create new bucket replication subsytem
-	globalBucketReplicationSys = NewBucketReplicationSys()
+	globalBucketTargetSys = NewBucketTargetSys()
 }
 
 func initSafeMode(ctx context.Context, newObject ObjectLayer) (err error) {
@@ -340,10 +340,11 @@ func initAllSubsystems(ctx context.Context, newObject ObjectLayer) (err error) {
 		return fmt.Errorf("Unable to initialize notification system: %w", err)
 	}
 
-	// Initialize bucket replication sub-system.
-	if err = globalBucketReplicationSys.Init(GlobalContext, buckets, newObject); err != nil {
-		return fmt.Errorf("Unable to initialize bucket replication sub-system: %w", err)
+	// Initialize bucket targets sub-system.
+	if err = globalBucketTargetSys.Init(GlobalContext, buckets, newObject); err != nil {
+		return fmt.Errorf("Unable to initialize bucket target sub-system: %w", err)
 	}
+
 	return nil
 }
 

--- a/pkg/madmin/examples/bucket-target.go
+++ b/pkg/madmin/examples/bucket-target.go
@@ -42,19 +42,24 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	target := madmin.BucketTarget{Endpoint: "site2:9000", Credentials: creds, TargetBucket: "destbucket", IsSSL: false}
+	target := madmin.BucketTarget{Endpoint: "site2:9000", Credentials: creds, TargetBucket: "destbucket", IsSSL: false, Type: madmin.ReplicationArn}
 	// Set bucket target
 	if err := madmClnt.SetBucketTarget(ctx, "srcbucket", &target); err != nil {
 		log.Fatalln(err)
 	}
-	// Get bucket target
-	target, err = madmClnt.GetBucketTarget(ctx, "srcbucket")
+	// List all bucket target(s)
+	target, err = madmClnt.ListBucketTargets(ctx, "srcbucket", "")
 	if err != nil {
 		log.Fatalln(err)
 	}
-
+	// Get bucket target for arn type "replica"
+	target, err = madmClnt.ListBucketTargets(ctx, "srcbucket", "replica")
+	if err != nil {
+		log.Fatalln(err)
+	}
 	// Remove bucket target
-	if err := madmClnt.SetBucketTarget(ctx, "srcbucket", nil); err != nil {
+	arn := "arn:minio:replica::ac66b2cf-dd8f-4e7e-a882-9a64132f0d59:dest"
+	if err := madmClnt.RemoveBucketTarget(ctx, "srcbucket", arn); err != nil {
 		log.Fatalln(err)
 	}
 


### PR DESCRIPTION
Generalize replication target management so
that remote targets for a bucket can be
managed with ARNs. `mc admin bucket remote`
command will be used to manage targets.

## Description


## Motivation and Context
generalize remote target management for reuse across ilm

## How to test this PR?
With companion [PR](https://github.com/minio/mc/pull/3328) for mc

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
