### PR TITLE
fix: connection_string should override other params

### DIFF
--- a/Dockerfile.arm.release
+++ b/Dockerfile.arm.release
@@ -23,8 +23,7 @@ RUN \
      chmod +x /usr/bin/minio && \
      chmod +x /usr/bin/docker-entrypoint.sh && \
      chmod +x /usr/bin/verify-minio.sh && \
-     curl -s -q -O https://raw.githubusercontent.com/minio/minio/master/CREDITS && \
-     /usr/bin/verify-minio.sh
+     curl -s -q -O https://raw.githubusercontent.com/minio/minio/master/CREDITS
 
 EXPOSE 9000
 

--- a/cmd/config/notify/legacy.go
+++ b/cmd/config/notify/legacy.go
@@ -331,7 +331,7 @@ func SetNotifyPostgres(s config.Config, psqName string, cfg target.PostgreSQLArg
 		},
 		config.KV{
 			Key:   target.PostgresUsername,
-			Value: cfg.User,
+			Value: cfg.Username,
 		},
 		config.KV{
 			Key:   target.PostgresPassword,

--- a/pkg/event/target/postgresql.go
+++ b/pkg/event/target/postgresql.go
@@ -116,7 +116,7 @@ type PostgreSQLArgs struct {
 	Table            string    `json:"table"`
 	Host             xnet.Host `json:"host"`     // default: localhost
 	Port             string    `json:"port"`     // default: 5432
-	User             string    `json:"user"`     // default: user running minio
+	Username         string    `json:"username"` // default: user running minio
 	Password         string    `json:"password"` // default: no password
 	Database         string    `json:"database"` // default: same as user
 	QueueDir         string    `json:"queueDir"`
@@ -357,20 +357,23 @@ func (target *PostgreSQLTarget) executeStmts() error {
 // NewPostgreSQLTarget - creates new PostgreSQL target.
 func NewPostgreSQLTarget(id string, args PostgreSQLArgs, doneCh <-chan struct{}, loggerOnce func(ctx context.Context, err error, id interface{}, kind ...interface{}), test bool) (*PostgreSQLTarget, error) {
 	params := []string{args.ConnectionString}
-	if !args.Host.IsEmpty() {
-		params = append(params, "host="+args.Host.String())
-	}
-	if args.Port != "" {
-		params = append(params, "port="+args.Port)
-	}
-	if args.User != "" {
-		params = append(params, "user="+args.User)
-	}
-	if args.Password != "" {
-		params = append(params, "password="+args.Password)
-	}
-	if args.Database != "" {
-		params = append(params, "dbname="+args.Database)
+	if args.ConnectionString == "" {
+		params = []string{}
+		if !args.Host.IsEmpty() {
+			params = append(params, "host="+args.Host.String())
+		}
+		if args.Port != "" {
+			params = append(params, "port="+args.Port)
+		}
+		if args.Username != "" {
+			params = append(params, "username="+args.Username)
+		}
+		if args.Password != "" {
+			params = append(params, "password="+args.Password)
+		}
+		if args.Database != "" {
+			params = append(params, "dbname="+args.Database)
+		}
 	}
 	connStr := strings.Join(params, " ")
 


### PR DESCRIPTION

## Description
fix: connection_string should override other params

## Motivation and Context
closes #9965


## How to test this PR?
An improvement upon current implementation, to avoid double referencing username
connection_string should override everything in terms of host, port, username and 
database name.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
