### PR TITLE
feat: allow service accounts to be generated with OpenID STS

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/cmd/logger"
@@ -929,7 +930,7 @@ func (sys *IAMSys) NewServiceAccount(ctx context.Context, parentUser string, ses
 		if err != nil {
 			return auth.Credentials{}, err
 		}
-		if len(policyBuf) > 16*1024 {
+		if len(policyBuf) > 16*humanize.KiByte {
 			return auth.Credentials{}, fmt.Errorf("Session policy should not exceed 16 KiB characters")
 		}
 	}
@@ -948,14 +949,6 @@ func (sys *IAMSys) NewServiceAccount(ctx context.Context, parentUser string, ses
 
 	// Disallow service accounts to further create more service accounts.
 	if cr.IsServiceAccount() {
-		return auth.Credentials{}, errIAMActionNotAllowed
-	}
-
-	// FIXME: Disallow temporary users with no parent, this is most
-	// probably with OpenID which we don't support to provide
-	// any parent user, LDAPUsersType and MinIOUsersType are
-	// currently supported.
-	if cr.ParentUser == "" && cr.IsTemp() {
 		return auth.Credentials{}, errIAMActionNotAllowed
 	}
 

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -355,9 +355,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithJWT(w http.ResponseWriter, r *http.Requ
 			writeSTSErrorResponse(ctx, w, true, ErrSTSInvalidParameterValue, fmt.Errorf("Invalid session policy version"))
 			return
 		}
-	}
 
-	if len(sessionPolicyStr) > 0 {
 		m[iampolicy.SessionPolicyName] = base64.StdEncoding.EncodeToString([]byte(sessionPolicyStr))
 	}
 


### PR DESCRIPTION

## Description
feat: allow service accounts to be generated with OpenID STS

## Motivation and Context
Bonus also fix a bug where we did not purge relevant
service accounts generated by rotating credentials
appropriately, service accounts should become invalid
as soon as its corresponding parent user becomes invalid.

Since service account themselves carry parent claim always
we would never reach this problem, as the access get
rejected at IAM policy layer.

## How to test this PR?
You need to test the service account creates based on the 
STS obtained from OpenID auth flow. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
