### PR TITLE
Validate object lock when setting replication config

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -107,6 +107,7 @@ const (
 	ErrNoSuchWebsiteConfiguration
 	ErrReplicationConfigurationNotFoundError
 	ErrReplicationDestinationNotFoundError
+	ErrReplicationDestinationMissingLock
 	ErrReplicationTargetNotFoundError
 	ErrBucketRemoteIdenticalToSource
 	ErrBucketRemoteAlreadyExists
@@ -829,6 +830,11 @@ var errorCodes = errorCodeMap{
 		Code:           "ReplicationDestinationNotFoundError",
 		Description:    "The replication destination bucket does not exist",
 		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrReplicationDestinationMissingLock: {
+		Code:           "ReplicationDestinationMissingLockError",
+		Description:    "The replication destination bucket does not have object locking enabled",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrReplicationTargetNotFoundError: {
 		Code:           "XminioAdminReplicationTargetNotFoundError",
@@ -1909,6 +1915,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrReplicationConfigurationNotFoundError
 	case BucketReplicationDestinationNotFound:
 		apiErr = ErrReplicationDestinationNotFoundError
+	case BucketReplicationDestinationMissingLock:
+		apiErr = ErrReplicationDestinationMissingLock
 	case BucketRemoteTargetNotFound:
 		apiErr = ErrReplicationTargetNotFoundError
 	case BucketRemoteAlreadyExists:

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -362,6 +362,13 @@ func (e BucketReplicationDestinationNotFound) Error() string {
 	return "Destination bucket does not exist: " + e.Bucket
 }
 
+// BucketReplicationDestinationMissingLock bucket does not have object lock enabled.
+type BucketReplicationDestinationMissingLock GenericError
+
+func (e BucketReplicationDestinationMissingLock) Error() string {
+	return "Destination bucket does not have object lock enabled: " + e.Bucket
+}
+
 // BucketRemoteTargetNotFound remote target does not exist.
 type BucketRemoteTargetNotFound GenericError
 


### PR DESCRIPTION
check if object lock is enabled on
destination bucket while setting replication
configuration on a object lock enabled bucket.

## Description


## Motivation and Context
identified above issues while reviewing replication

## How to test this PR?
```
mc mb myminio/source --with-lock
mc versioning enable myminio/source
mc mb myminio/dest
mc versioning enable myminio/dest
mc admin bucket remote set myminio/source http://minio:minio123@localhost:9001/dest --type replica 
mc replicate import myminio/source < replication-config.json  // use latest [pr](https://github.com/minio/mc/pull/3335/files)
this should fail to set replication config 
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
