### PR TITLE
Support looking up environment remotely

### DIFF
--- a/cmd/config/constants.go
+++ b/cmd/config/constants.go
@@ -31,11 +31,12 @@ const (
 	EnvDomain       = "MINIO_DOMAIN"
 	EnvRegionName   = "MINIO_REGION_NAME"
 	EnvPublicIPs    = "MINIO_PUBLIC_IPS"
-	EnvEndpoints    = "MINIO_ENDPOINTS"
 	EnvFSOSync      = "MINIO_FS_OSYNC"
+	EnvArgs         = "MINIO_ARGS"
 
 	EnvUpdate = "MINIO_UPDATE"
 
-	EnvWorm   = "MINIO_WORM"   // legacy
-	EnvRegion = "MINIO_REGION" // legacy
+	EnvEndpoints = "MINIO_ENDPOINTS" // legacy
+	EnvWorm      = "MINIO_WORM"      // legacy
+	EnvRegion    = "MINIO_REGION"    // legacy
 )

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -18,7 +18,6 @@
 package env
 
 import (
-	"os"
 	"strings"
 	"sync"
 )
@@ -46,7 +45,7 @@ func SetEnvOn() {
 
 // IsSet returns if the given env key is set.
 func IsSet(key string) bool {
-	_, ok := os.LookupEnv(key)
+	_, ok := LookupEnv(key)
 	return ok
 }
 
@@ -61,7 +60,7 @@ func Get(key, defaultValue string) string {
 	if ok {
 		return defaultValue
 	}
-	if v, ok := os.LookupEnv(key); ok {
+	if v, ok := LookupEnv(key); ok {
 		return v
 	}
 	return defaultValue
@@ -69,7 +68,7 @@ func Get(key, defaultValue string) string {
 
 // List all envs with a given prefix.
 func List(prefix string) (envs []string) {
-	for _, env := range os.Environ() {
+	for _, env := range Environ() {
 		if strings.HasPrefix(env, prefix) {
 			values := strings.SplitN(env, "=", 2)
 			if len(values) == 2 {

--- a/pkg/env/web_env.go
+++ b/pkg/env/web_env.go
@@ -1,0 +1,167 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package env
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"time"
+)
+
+const (
+	webEnvScheme       = "env"
+	webEnvSchemeSecure = "env+tls"
+)
+
+var (
+	globalRootCAs *x509.CertPool
+)
+
+// RegisterGlobalCAs register the global root CAs
+func RegisterGlobalCAs(CAs *x509.CertPool) {
+	globalRootCAs = CAs
+}
+
+func isValidEnvScheme(scheme string) bool {
+	switch scheme {
+	case webEnvScheme:
+		fallthrough
+	case webEnvSchemeSecure:
+		return true
+	}
+	return false
+}
+
+var (
+	hostKeys = regexp.MustCompile("^(https?://)(.*?):(.*?)@(.*?)$")
+)
+
+func fetchEnvHTTP(envKey string, u *url.URL) (string, error) {
+	switch u.Scheme {
+	case webEnvScheme:
+		u.Scheme = "http"
+	case webEnvSchemeSecure:
+		u.Scheme = "https"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var (
+		username, password string
+	)
+
+	envURL := u.String()
+	if hostKeys.MatchString(envURL) {
+		parts := hostKeys.FindStringSubmatch(envURL)
+		if len(parts) != 5 {
+			return "", errors.New("invalid arguments")
+		}
+		username = parts[2]
+		password = parts[3]
+		envURL = fmt.Sprintf("%s%s", parts[1], parts[4])
+	}
+
+	if username == "" && password == "" && u.User != nil {
+		username = u.User.Username()
+		password, _ = u.User.Password()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, envURL+"?key="+envKey, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if username != "" && password != "" {
+		req.SetBasicAuth(username, password)
+	}
+
+	clnt := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   3 * time.Second,
+				KeepAlive: 5 * time.Second,
+			}).DialContext,
+			ResponseHeaderTimeout: 3 * time.Second,
+			TLSHandshakeTimeout:   3 * time.Second,
+			ExpectContinueTimeout: 3 * time.Second,
+			TLSClientConfig: &tls.Config{
+				RootCAs: globalRootCAs,
+			},
+			// Go net/http automatically unzip if content-type is
+			// gzip disable this feature, as we are always interested
+			// in raw stream.
+			DisableCompression: true,
+		},
+	}
+
+	resp, err := clnt.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	envValueBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(envValueBytes), nil
+}
+
+// Environ returns a copy of strings representing the
+// environment, in the form "key=value".
+func Environ() []string {
+	return os.Environ()
+}
+
+// LookupEnv retrieves the value of the environment variable
+// named by the key. If the variable is present in the
+// environment the value (which may be empty) is returned
+// and the boolean is true. Otherwise the returned value
+// will be empty and the boolean will be false.
+//
+// Additionally if the input is env://username:password@remote:port/
+// to fetch ENV values for the env value from a remote server.
+func LookupEnv(key string) (string, bool) {
+	v, ok := os.LookupEnv(key)
+	if ok {
+		u, err := url.Parse(v)
+		if err != nil {
+			return "", false
+		}
+		if !isValidEnvScheme(u.Scheme) {
+			return v, true
+		}
+		v, err = fetchEnvHTTP(key, u)
+		if err != nil {
+			return "", false
+		}
+		return v, true
+	}
+	return "", false
+}


### PR DESCRIPTION
## Description
Support looking up environment remotely

## Motivation and Context
adds a feature where we can fetch the MinIO
command-line can be obtained remotely, this
is primarily meant to add some stateless
nature to the MinIO deployment in k8s
environments, MinIO operator would run a
webhook service would be the endpoint
which can be used to fetch any environment
value in a generalized approach.

## How to test this PR?
Run a sample webhook to return ARGS remotely
```go
package main

import (
        "fmt"
        "io/ioutil"
        "log"
        "net/http"
)

func hello(w http.ResponseWriter, r *http.Request) {
        if r.URL.Path != "/" {
                http.Error(w, "404 not found.", http.StatusNotFound)
                return
        }

        fmt.Println("Authorization header", r.Header.Get("Authorization"))
        switch r.Method {
        case "GET":
                fmt.Println(r.URL)
                if r.URL.Query().Get("key") == "MINIO_ARGS" {
                        w.Write([]byte(`https://localhost:9002/tmp/02 https://localhost:9003/tmp/03 https://localhost:9004/tmp/04 https://localhost:9005/tmp/05 https://localhost:9006/tmp/06 https://localhost:9007/tmp/07 https://localhost:9008/tmp/08 https://localhost:9009/tmp/09`))
                        w.(http.Flusher).Flush()
                }
        default:
                fmt.Fprintf(w, "Sorry, only POST methods are supported.")
        }
}

func main() {
        http.HandleFunc("/", hello)

        if err := http.ListenAndServe(":9056", nil); err != nil {
                log.Fatal(err)
        }
}
```

```sh
#!/usr/bin/env bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"

## Set this if you want the ARGS to be taken locally
# export MINIO_ARGS="https://localhost:9002/tmp/02 https://localhost:9003/tmp/03 https://localhost:9004/tmp/04 https://localhost:9005/tmp/05 https://localhost:9006/tmp/06 https://localhost:9007/tmp/07 https://localhost:9008/tmp/08 https://localhost:9009/tmp/09"
## Set this if you want the ARGS to be taken remotely
# export MINIO_ARGS="env://localhost:9056/"

for i in {02..09}; do
    "${GOPATH}/bin/minio" server --certs-dir ../minio-go/testcerts/ --address ":90${i}" &
done
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
