### PR TITLE
Avoid duplicate headers when proxying S3 listing requests

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -480,6 +480,12 @@ func getHostName(r *http.Request) (hostName string) {
 func proxyRequest(ctx context.Context, w http.ResponseWriter, r *http.Request, ep ProxyEndpoint) (success bool) {
 	success = true
 
+	// Make sure we remove any existing headers before
+	// proxying the request to another node.
+	for k := range w.Header() {
+		w.Header().Del(k)
+	}
+
 	f := handlers.NewForwarder(&handlers.Forwarder{
 		PassHost:     true,
 		RoundTripper: ep.Transport,


### PR DESCRIPTION
## Description
When a request is proxied to another server, such in case of listing, we need
to clear any existing headers first since the new node will also set its own headers.


## Motivation and Context
Fix https://github.com/minio/minio/issues/10216

## How to test this PR?
Follow instructions in  https://github.com/minio/minio/issues/10216

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
