### PR TITLE
Fix typo in parsing non remote env variables

### DIFF
--- a/pkg/env/web_env.go
+++ b/pkg/env/web_env.go
@@ -152,7 +152,7 @@ func LookupEnv(key string) (string, bool) {
 	if ok {
 		u, err := url.Parse(v)
 		if err != nil {
-			return "", false
+			return v, true
 		}
 		if !isValidEnvScheme(u.Scheme) {
 			return v, true


### PR DESCRIPTION
## Description
Fix typo in parsing non remote env variables

## Motivation and Context
Fixes https://github.com/minio/minio/issues/10221

## How to test this PR?
MINIO_ACCESS_KEY='minio*minio%minio' MINIO_SECRET_KEY='minio12312432' minio server /tmp/data 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
