### PR TITLE
move the certPool loader function into pkg/certs

### DIFF
--- a/cmd/config/certs.go
+++ b/cmd/config/certs.go
@@ -24,8 +24,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
-	"os"
-	"path"
 
 	"github.com/minio/minio/pkg/env"
 )
@@ -67,38 +65,6 @@ func ParsePublicCertFile(certFile string) (x509Certs []*x509.Certificate, err er
 	}
 
 	return x509Certs, nil
-}
-
-// GetRootCAs - returns all the root CAs into certPool
-// at the input certsCADir
-func GetRootCAs(certsCAsDir string) (*x509.CertPool, error) {
-	rootCAs, _ := x509.SystemCertPool()
-	if rootCAs == nil {
-		// In some systems (like Windows) system cert pool is
-		// not supported or no certificates are present on the
-		// system - so we create a new cert pool.
-		rootCAs = x509.NewCertPool()
-	}
-
-	fis, err := ioutil.ReadDir(certsCAsDir)
-	if err != nil {
-		if os.IsNotExist(err) || os.IsPermission(err) {
-			// Return success if CA's directory is missing or permission denied.
-			err = nil
-		}
-		return rootCAs, err
-	}
-
-	// Load all custom CA files.
-	for _, fi := range fis {
-		caCert, err := ioutil.ReadFile(path.Join(certsCAsDir, fi.Name()))
-		if err != nil {
-			// ignore files which are not readable.
-			continue
-		}
-		rootCAs.AppendCertsFromPEM(caCert)
-	}
-	return rootCAs, nil
 }
 
 // LoadX509KeyPair - load an X509 key pair (private key , certificate)

--- a/cmd/config/certs_test.go
+++ b/cmd/config/certs_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 )
@@ -190,60 +189,6 @@ M9ofSEt/bdRD
 
 		if len(certs) != testCase.expectedResultLen {
 			t.Fatalf("certs: expected = %v, got = %v", testCase.expectedResultLen, len(certs))
-		}
-	}
-}
-
-func TestGetRootCAs(t *testing.T) {
-	emptydir, err := ioutil.TempDir("", "test-get-root-cas")
-	if err != nil {
-		t.Fatalf("Unable create temp directory. %v", emptydir)
-	}
-	defer os.RemoveAll(emptydir)
-
-	dir1, err := ioutil.TempDir("", "test-get-root-cas")
-	if err != nil {
-		t.Fatalf("Unable create temp directory. %v", dir1)
-	}
-	defer os.RemoveAll(dir1)
-	if err = os.Mkdir(filepath.Join(dir1, "empty-dir"), 0755); err != nil {
-		t.Fatalf("Unable create empty dir. %v", err)
-	}
-
-	dir2, err := ioutil.TempDir("", "test-get-root-cas")
-	if err != nil {
-		t.Fatalf("Unable create temp directory. %v", dir2)
-	}
-	defer os.RemoveAll(dir2)
-	if err = ioutil.WriteFile(filepath.Join(dir2, "empty-file"), []byte{}, 0644); err != nil {
-		t.Fatalf("Unable create test file. %v", err)
-	}
-
-	testCases := []struct {
-		certCAsDir  string
-		expectedErr error
-	}{
-		// ignores non-existent directories.
-		{"nonexistent-dir", nil},
-		// Ignores directories.
-		{dir1, nil},
-		// Ignore empty directory.
-		{emptydir, nil},
-		// Loads the cert properly.
-		{dir2, nil},
-	}
-
-	for _, testCase := range testCases {
-		_, err := GetRootCAs(testCase.certCAsDir)
-
-		if testCase.expectedErr == nil {
-			if err != nil {
-				t.Fatalf("error: expected = <nil>, got = %v", err)
-			}
-		} else if err == nil {
-			t.Fatalf("error: expected = %v, got = <nil>", testCase.expectedErr)
-		} else if testCase.expectedErr.Error() != err.Error() {
-			t.Fatalf("error: expected = %v, got = %v", testCase.expectedErr, err)
 		}
 	}
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/minio/cli"
-	"github.com/minio/minio/cmd/config"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/certs"
@@ -178,7 +177,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	logger.FatalIf(err, "Invalid TLS certificate file")
 
 	// Check and load Root CAs.
-	globalRootCAs, err = config.GetRootCAs(globalCertsCADir.Get())
+	globalRootCAs, err = certs.GetRootCAs(globalCertsCADir.Get())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
 
 	// Register root CAs for remote ENVs

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -119,7 +119,7 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	logger.FatalIf(err, "Unable to load the TLS configuration")
 
 	// Check and load Root CAs.
-	globalRootCAs, err = config.GetRootCAs(globalCertsCADir.Get())
+	globalRootCAs, err = certs.GetRootCAs(globalCertsCADir.Get())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
 
 	// Register root CAs for remote ENVs

--- a/pkg/certs/ca-certs.go
+++ b/pkg/certs/ca-certs.go
@@ -1,0 +1,57 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package certs
+
+import (
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+// GetRootCAs - returns all the root CAs into certPool
+// at the input certsCADir
+func GetRootCAs(certsCAsDir string) (*x509.CertPool, error) {
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		// In some systems (like Windows) system cert pool is
+		// not supported or no certificates are present on the
+		// system - so we create a new cert pool.
+		rootCAs = x509.NewCertPool()
+	}
+
+	fis, err := ioutil.ReadDir(certsCAsDir)
+	if err != nil {
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			// Return success if CA's directory is missing or permission denied.
+			err = nil
+		}
+		return rootCAs, err
+	}
+
+	// Load all custom CA files.
+	for _, fi := range fis {
+		caCert, err := ioutil.ReadFile(path.Join(certsCAsDir, fi.Name()))
+		if err != nil {
+			// ignore files which are not readable.
+			continue
+		}
+		rootCAs.AppendCertsFromPEM(caCert)
+	}
+
+	return rootCAs, nil
+}

--- a/pkg/certs/ca-certs_test.go
+++ b/pkg/certs/ca-certs_test.go
@@ -1,0 +1,78 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package certs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetRootCAs(t *testing.T) {
+	emptydir, err := ioutil.TempDir("", "test-get-root-cas")
+	if err != nil {
+		t.Fatalf("Unable create temp directory. %v", emptydir)
+	}
+	defer os.RemoveAll(emptydir)
+
+	dir1, err := ioutil.TempDir("", "test-get-root-cas")
+	if err != nil {
+		t.Fatalf("Unable create temp directory. %v", dir1)
+	}
+	defer os.RemoveAll(dir1)
+	if err = os.Mkdir(filepath.Join(dir1, "empty-dir"), 0755); err != nil {
+		t.Fatalf("Unable create empty dir. %v", err)
+	}
+
+	dir2, err := ioutil.TempDir("", "test-get-root-cas")
+	if err != nil {
+		t.Fatalf("Unable create temp directory. %v", dir2)
+	}
+	defer os.RemoveAll(dir2)
+	if err = ioutil.WriteFile(filepath.Join(dir2, "empty-file"), []byte{}, 0644); err != nil {
+		t.Fatalf("Unable create test file. %v", err)
+	}
+
+	testCases := []struct {
+		certCAsDir  string
+		expectedErr error
+	}{
+		// ignores non-existent directories.
+		{"nonexistent-dir", nil},
+		// Ignores directories.
+		{dir1, nil},
+		// Ignore empty directory.
+		{emptydir, nil},
+		// Loads the cert properly.
+		{dir2, nil},
+	}
+
+	for _, testCase := range testCases {
+		_, err := GetRootCAs(testCase.certCAsDir)
+
+		if testCase.expectedErr == nil {
+			if err != nil {
+				t.Fatalf("error: expected = <nil>, got = %v", err)
+			}
+		} else if err == nil {
+			t.Fatalf("error: expected = %v, got = <nil>", testCase.expectedErr)
+		} else if testCase.expectedErr.Error() != err.Error() {
+			t.Fatalf("error: expected = %v, got = %v", testCase.expectedErr, err)
+		}
+	}
+}


### PR DESCRIPTION
## Description
move the certPool loader function into pkg/certs

## Motivation and Context
certPool doesn't need to be part of `config` 

## How to test this PR?
Nothing special just move the code around for readability

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
