### PR TITLE
PutObject: Less locking while uploading

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -735,7 +735,12 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	if onlineDisks, err = writeUniqueFileInfo(ctx, onlineDisks, minioMetaTmpBucket, tempObj, partsMetadata, writeQuorum); err != nil {
 		return ObjectInfo{}, toObjectErr(err, bucket, object)
 	}
-
+	if r.lock != nil {
+		if err := r.lock.GetLock(globalObjectTimeout); err != nil {
+			return ObjectInfo{}, toObjectErr(err, bucket, object)
+		}
+		defer r.lock.Unlock()
+	}
 	// Rename the successfully written temporary object to final location.
 	if onlineDisks, err = renameData(ctx, onlineDisks, minioMetaTmpBucket, tempObj, fi.DataDir, bucket, object, writeQuorum, nil); err != nil {
 		return ObjectInfo{}, toObjectErr(err, bucket, object)

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -766,6 +766,8 @@ type PutObjReader struct {
 	*hash.Reader              // actual data stream
 	rawReader    *hash.Reader // original data stream
 	sealMD5Fn    SealMD5CurrFn
+
+	lock RWLocker // Used for grabbing the lock when moving data.
 }
 
 // Size returns the absolute number of bytes the Reader


### PR DESCRIPTION
## Description

Only lock objects while uploading when creating now objects in a multizoned setup and when doing the final move of the temporary object.

Fixes #10240

## How to test this PR?

Should be covered by existing tests, but do concurrent PutObject while listing, see #10240

## Types of changes
- [x] Optimization
