### PR TITLE
feat: cache env value in-case network is not reachable

### DIFF
--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -2088,6 +2088,14 @@ func (z *erasureZones) Health(ctx context.Context, opts HealthOptions) HealthRes
 		}
 	}
 
+	// when maintenance is not specified we don't have
+	// to look at the healing side of the code.
+	if !opts.Maintenance {
+		return HealthResult{
+			Healthy: true,
+		}
+	}
+
 	// check if local disks are being healed, if they are being healed
 	// we need to tell healthy status as 'false' so that this server
 	// is not taken down for maintenance

--- a/pkg/env/web_env_test.go
+++ b/pkg/env/web_env_test.go
@@ -1,0 +1,81 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package env
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func GetenvHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	if vars["namespace"] != "default" {
+		http.Error(w, "namespace not found", http.StatusNotFound)
+		return
+	}
+	if vars["name"] != "minio" {
+		http.Error(w, "tenant not found", http.StatusNotFound)
+		return
+	}
+	if vars["key"] != "MINIO_ARGS" {
+		http.Error(w, "key not found", http.StatusNotFound)
+		return
+	}
+	w.Write([]byte("http://127.0.0.{1..4}:9000/data{1...4}"))
+	w.(http.Flusher).Flush()
+}
+
+func startTestServer(t *testing.T) *httptest.Server {
+	router := mux.NewRouter().SkipClean(true).UseEncodedPath()
+	router.Methods(http.MethodGet).
+		Path("/webhook/v1/getenv/{namespace}/{name}").
+		HandlerFunc(GetenvHandler).Queries("key", "{key:.*}")
+
+	ts := httptest.NewServer(router)
+	t.Cleanup(func() {
+		ts.Close()
+	})
+
+	return ts
+}
+
+func TestWebEnv(t *testing.T) {
+	ts := startTestServer(t)
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := getEnvValueFromHTTP(
+		fmt.Sprintf("env://minio:minio123@%s/webhook/v1/getenv/default/minio",
+			u.Host),
+		"MINIO_ARGS")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v != "http://127.0.0.{1..4}:9000/data{1...4}" {
+		t.Fatalf("Unexpected value %s", v)
+	}
+}


### PR DESCRIPTION
## Description
feat: cache env value in-case network is not reachable

## Motivation and Context
In-case of remote webhook is not available we rely
on the cached value

## How to test this PR?
```bash
#!/usr/bin/env bash
export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
export MINIO_ARGS="env://ZGRNOO8RJKAIFXZ7BGXE:qfQk7YkafUsE3zwsH5gfmMasUM7WN2gIcC9ofBWP@localhost:4222/webhook/v1/getenv/default/minio"

for i in {02..09}; do
    "${GOPATH}/bin/minio" server --certs-dir ../minio-go/testcerts/ --address ":90${i}" &
done```

```go
package main

import (
        "fmt"
        "io/ioutil"
        "log"
        "net/http"
        "time"

        "github.com/gorilla/mux"
)

func GetenvHandler(w http.ResponseWriter, r *http.Request) {
        fmt.Println(mux.Vars(r))
        fmt.Println("Authorization header", r.Header.Get("Authorization"))
        switch r.Method {
        case "GET":
                fmt.Println(r.URL)
                if r.URL.Query().Get("key") == "MINIO_ARGS" {
                        w.Write([]byte(`https://localhost:9002/tmp/02 https://localhost:9003/tmp/03 https://localhost:9004/tmp/04 https://localhost:9005/tmp/05 https://localhost:9006/tmp/06 https://localhost:9007/tmp/07 https://localhost:9008/tmp/08 https://localhost:9009/tmp/09`))
                        w.(http.Flusher).Flush()
                }
        case "POST":
                body, err := ioutil.ReadAll(r.Body)
                if err != nil {
                        fmt.Fprintf(w, "ReadError() err: %v", err)
                        return
                }
                fmt.Println(string(body))
        default:
                fmt.Fprintf(w, "Sorry, only POST methods are supported.")
        }
}

func main() {
        router := mux.NewRouter().SkipClean(true).UseEncodedPath()
        router.Methods(http.MethodGet).
                Path("/webhook/v1/getenv/{namespace}/{name}").
                HandlerFunc(GetenvHandler).Queries("key", "{key:.*}")

        s := &http.Server{
                Addr:           ":4222",
                Handler:        router,
                ReadTimeout:    10 * time.Second,
                WriteTimeout:   10 * time.Second,
                MaxHeaderBytes: 1 << 20,
        }

        if err := s.ListenAndServe(); err != nil {
                log.Fatal(err)
        }
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
