### PR TITLE
fix: add public certs automatically as part of global CAs

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -180,6 +180,11 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	globalRootCAs, err = certs.GetRootCAs(globalCertsCADir.Get())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
 
+	// Add the global public crts as part of global root CAs
+	for _, publicCrt := range globalPublicCerts {
+		globalRootCAs.AddCert(publicCrt)
+	}
+
 	// Register root CAs for remote ENVs
 	env.RegisterGlobalCAs(globalRootCAs)
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -122,6 +122,11 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	globalRootCAs, err = certs.GetRootCAs(globalCertsCADir.Get())
 	logger.FatalIf(err, "Failed to read root CAs (%v)", err)
 
+	// Add the global public crts as part of global root CAs
+	for _, publicCrt := range globalPublicCerts {
+		globalRootCAs.AddCert(publicCrt)
+	}
+
 	// Register root CAs for remote ENVs
 	env.RegisterGlobalCAs(globalRootCAs)
 


### PR DESCRIPTION
## Description
fix: add public certs automatically as part of global CAs

## Motivation and Context
no need to drop the same `public.crt` into CAs folder
if it can be automatically added to global CAs

## How to test this PR?
Just create `public,crt` and `private.key`  with wildcard cert
for all server nodes in a tenant, there is no need to copy
this public.crt again to CAs folder.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
