### PR TITLE
licverifier: Fail verify if accountId is missing in license metadata

### DIFF
--- a/pkg/licverifier/verifier.go
+++ b/pkg/licverifier/verifier.go
@@ -64,7 +64,7 @@ func NewLicenseVerifier(pemBytes []byte) (*LicenseVerifier, error) {
 // the claim values are invalid.
 func toLicenseInfo(claims jwt.MapClaims) (LicenseInfo, error) {
 	accID, ok := claims[accountID].(float64)
-	if ok && accID <= 0 {
+	if !ok || ok && accID <= 0 {
 		return LicenseInfo{}, errors.New("Invalid accountId in claims")
 	}
 	email, ok := claims[sub].(string)


### PR DESCRIPTION
## Description
Fail verification if account id is missing in the license metadata

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
