### PR TITLE
rootDisk on containers can have different device Id

### DIFF
--- a/pkg/disk/root_disk_unix.go
+++ b/pkg/disk/root_disk_unix.go
@@ -31,7 +31,7 @@ func IsRootDisk(diskPath string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	rootInfo, err := os.Stat("/")
+	rootInfo, err := os.Stat("/etc/hosts")
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION

## Description
rootDisk on containers can have different device Id

## Motivation and Context
use `/etc/hosts` instead of `/` to check for common
device id, if the device is the same for `/etc/hosts`
and the --bind mount to detect root disks.

Bonus enhance healthcheck logging by adding maintenance
tags, for all messages.

## How to test this PR?
Test with mounted disks with one of them being root partition

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
