### PR TITLE
fix: storageClass shouldn't set the value upon failure

### DIFF
--- a/cmd/config/storageclass/storage-class.go
+++ b/cmd/config/storageclass/storage-class.go
@@ -226,7 +226,7 @@ func LookupConfig(kvs config.KVS, drivesPerSet int) (cfg Config, err error) {
 	cfg.RRS.Parity = defaultRRSParity
 
 	if err = config.CheckValidKeys(config.StorageClassSubSys, kvs, DefaultKVS); err != nil {
-		return cfg, err
+		return Config{}, err
 	}
 
 	ssc := env.Get(StandardEnv, kvs.Get(ClassStandard))
@@ -235,7 +235,7 @@ func LookupConfig(kvs config.KVS, drivesPerSet int) (cfg Config, err error) {
 	if ssc != "" {
 		cfg.Standard, err = parseStorageClass(ssc)
 		if err != nil {
-			return cfg, err
+			return Config{}, err
 		}
 	}
 	if cfg.Standard.Parity == 0 {
@@ -245,7 +245,7 @@ func LookupConfig(kvs config.KVS, drivesPerSet int) (cfg Config, err error) {
 	if rrsc != "" {
 		cfg.RRS, err = parseStorageClass(rrsc)
 		if err != nil {
-			return cfg, err
+			return Config{}, err
 		}
 	}
 	if cfg.RRS.Parity == 0 {
@@ -255,7 +255,7 @@ func LookupConfig(kvs config.KVS, drivesPerSet int) (cfg Config, err error) {
 	// Validation is done after parsing both the storage classes. This is needed because we need one
 	// storage class value to deduce the correct value of the other storage class.
 	if err = validateParity(cfg.Standard.Parity, cfg.RRS.Parity, drivesPerSet); err != nil {
-		return cfg, err
+		return Config{}, err
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Description
fix: storageClass shouldn't set the value upon failure

## Motivation and Context
This can be disastrous in situations, luckily we had
double validation code to avoid this situation
at the lower layer. 

## How to test this PR?

This command with master results in following error
```
~ MINIO_STORAGE_CLASS_STANDARD=EC:5 minio server /tmp/fs{1...6}/disk{1...3}

API: SYSTEM()
Time: 17:53:22 PDT 08/14/2020
DeploymentID: 834070eb-fd40-4a38-9240-41e77101e5bf
Error: internal error: invalid version entry generated
       4: cmd/iam-object-store.go:197:cmd.(*IAMObjectStore).migrateToV1()
       3: cmd/iam-object-store.go:205:cmd.(*IAMObjectStore).migrateBackendFormat()
       2: cmd/iam.go:408:cmd.(*IAMSys).doIAMConfigMigration()
       1: cmd/iam.go:478:cmd.(*IAMSys).Init()

API: SYSTEM()
Time: 17:53:22 PDT 08/14/2020
DeploymentID: 834070eb-fd40-4a38-9240-41e77101e5bf
Error: Unable to migrate IAM users and policies to new format: internal error: invalid version entry generated
       1: cmd/iam.go:490:cmd.(*IAMSys).Init()

API: SYSTEM()
Time: 17:53:22 PDT 08/14/2020
DeploymentID: 834070eb-fd40-4a38-9240-41e77101e5bf
Error: IAM sub-system is partially initialized, some users may not be available
       1: cmd/iam.go:491:cmd.(*IAMSys).Init()
^CExiting on signal: INTERRUPT
```

This PR fixes this behavior properly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
