### PR TITLE
handle fresh setup with mixed drives

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -86,7 +87,7 @@ func getLocalDisksToHeal(objAPI ObjectLayer) []Endpoints {
 			// Try to connect to the current endpoint
 			// and reformat if the current disk is not formatted
 			_, _, err := connectEndpoint(endpoint)
-			if err == errUnformattedDisk {
+			if errors.Is(err, errUnformattedDisk) {
 				localDisksToHeal = append(localDisksToHeal, endpoint)
 			}
 		}

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -154,6 +154,7 @@ func getDisksInfo(disks []StorageAPI, endpoints []string) (disksInfo []madmin.Di
 				UsedSpace:      info.Used,
 				AvailableSpace: info.Free,
 				UUID:           info.ID,
+				RootDisk:       info.RootDisk,
 				State:          diskErrToDriveState(err),
 			}
 			if info.Total > 0 {
@@ -175,7 +176,27 @@ func getDisksInfo(disks []StorageAPI, endpoints []string) (disksInfo []madmin.Di
 		onlineDisks[ep]++
 	}
 
-	// Success.
+	rootDiskCount := 0
+	for _, di := range disksInfo {
+		if di.RootDisk {
+			rootDiskCount++
+		}
+	}
+
+	if len(disksInfo) == rootDiskCount {
+		// Success.
+		return disksInfo, errs, onlineDisks, offlineDisks
+	}
+
+	// Root disk should be considered offline
+	for i := range disksInfo {
+		ep := disksInfo[i].Endpoint
+		if disksInfo[i].RootDisk {
+			offlineDisks[ep]++
+			onlineDisks[ep]--
+		}
+	}
+
 	return disksInfo, errs, onlineDisks, offlineDisks
 }
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -278,7 +278,7 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 			humanize.Ordinal(zoneCount), setCount, drivesPerSet)
 
 		// Initialize erasure code format on disks
-		format, err = initFormatErasure(GlobalContext, storageDisks, setCount, drivesPerSet, deploymentID)
+		format, err = initFormatErasure(GlobalContext, storageDisks, setCount, drivesPerSet, deploymentID, sErrs)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -300,6 +300,9 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 	if quorumUnformattedDisks(sErrs) && firstDisk {
 		return nil, nil, errFirstDiskWait
 	}
+
+	// Mark all root disks down
+	markRootDisksAsDown(storageDisks, sErrs)
 
 	// Following function is added to fix a regressions which was introduced
 	// in release RELEASE.2018-03-16T22-52-12Z after migrating v1 to v2 to v3.

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -29,6 +29,7 @@ type StorageAPI interface {
 	// Storage operations.
 	IsOnline() bool // Returns true if disk is online.
 	IsLocal() bool
+
 	Hostname() string // Returns host name if remote host.
 	Close() error
 	GetDiskID() (string, error)

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -45,7 +45,6 @@ import (
 	"github.com/minio/minio/pkg/disk"
 	"github.com/minio/minio/pkg/env"
 	xioutil "github.com/minio/minio/pkg/ioutil"
-	"github.com/minio/minio/pkg/mountinfo"
 )
 
 const (
@@ -97,7 +96,7 @@ type xlStorage struct {
 
 	globalSync bool
 
-	diskMount bool // indicates if the path is an actual mount.
+	rootDisk bool
 
 	diskID string
 
@@ -240,6 +239,11 @@ func newXLStorage(path string, hostname string) (*xlStorage, error) {
 		return nil, err
 	}
 
+	rootDisk, err := disk.IsRootDisk(path)
+	if err != nil {
+		return nil, err
+	}
+
 	p := &xlStorage{
 		diskPath: path,
 		hostname: hostname,
@@ -250,13 +254,13 @@ func newXLStorage(path string, hostname string) (*xlStorage, error) {
 			},
 		},
 		globalSync: env.Get(config.EnvFSOSync, config.EnableOff) == config.EnableOn,
-		diskMount:  mountinfo.IsLikelyMountPoint(path),
 		// Allow disk usage crawler to run with up to 2 concurrent
 		// I/O ops, if and when activeIOCount reaches this
 		// value disk usage routine suspends the crawler
 		// and waits until activeIOCount reaches below this threshold.
 		maxActiveIOCount: 3,
 		ctx:              GlobalContext,
+		rootDisk:         rootDisk,
 	}
 
 	// Success.
@@ -412,16 +416,11 @@ func (s *xlStorage) DiskInfo() (info DiskInfo, err error) {
 		return info, err
 	}
 
-	rootDisk, err := disk.IsRootDisk(s.diskPath)
-	if err != nil {
-		return info, err
-	}
-
 	info = DiskInfo{
 		Total:     di.Total,
 		Free:      di.Free,
 		Used:      di.Total - di.Free,
-		RootDisk:  rootDisk,
+		RootDisk:  s.rootDisk,
 		MountPath: s.diskPath,
 	}
 

--- a/pkg/disk/root_disk_unix.go
+++ b/pkg/disk/root_disk_unix.go
@@ -31,17 +31,31 @@ func IsRootDisk(diskPath string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	rootInfo, err := os.Stat("/etc/hosts")
+	rootHostsInfo, err := os.Stat("/etc/hosts")
+	if err != nil {
+		return false, err
+	}
+	rootInfo, err := os.Stat("/")
 	if err != nil {
 		return false, err
 	}
 	diskStat, diskStatOK := diskInfo.Sys().(*syscall.Stat_t)
+	rootHostsStat, rootHostsStatOK := rootHostsInfo.Sys().(*syscall.Stat_t)
 	rootStat, rootStatOK := rootInfo.Sys().(*syscall.Stat_t)
-	if diskStatOK && rootStatOK {
-		if diskStat.Dev == rootStat.Dev {
+	if diskStatOK && rootHostsStatOK {
+		if diskStat.Dev == rootHostsStat.Dev {
 			// Indicate if the disk path is on root disk. This is used to indicate the healing
 			// process not to format the drive and end up healing it.
 			rootDisk = true
+		}
+	}
+	if !rootDisk {
+		if diskStatOK && rootStatOK {
+			if diskStat.Dev == rootStat.Dev {
+				// Indicate if the disk path is on root disk. This is used to indicate the healing
+				// process not to format the drive and end up healing it.
+				rootDisk = true
+			}
 		}
 	}
 	return rootDisk, nil

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -270,6 +270,7 @@ type ServerProperties struct {
 // Disk holds Disk information
 type Disk struct {
 	Endpoint        string  `json:"endpoint,omitempty"`
+	RootDisk        bool    `json:"rootDisk,omitempty"`
 	DrivePath       string  `json:"path,omitempty"`
 	State           string  `json:"state,omitempty"`
 	UUID            string  `json:"uuid,omitempty"`


### PR DESCRIPTION

## Description
handle fresh setup with mixed drives

## Motivation and Context
fresh drive setups when one of the drive is
a root drive, we should ignore such a root
drive and not proceed to format.

This PR handles this properly by marking
the disks which are root disk and they are
taken offline.

## How to test this PR?

Run the following docker-compose to test with root disks v/s different partitions such that
we avoid root disks to be either used or even formatted during a fresh setup. Reject
such drives and never heal them

```yaml
version: '3.7'

# starts 4 docker containers running minio server instances. Each
# minio server's web interface will be accessible on the host at port
# 9001 through 9004.
services:
  minio1:
    image: y4m4/minio:dev
    volumes:
      - /home/harsha/data1-1:/data1
    ports:
      - "9001:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...5}/data1
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3

  minio2:
    image: y4m4/minio:dev
    volumes:
      - /tmp/harsha/data2-1:/data1
    ports:
      - "9002:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...5}/data1
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3

  minio3:
    image: y4m4/minio:dev
    volumes:
      - /home/harsha/data3-1:/data1
    ports:
      - "9003:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...5}/data1
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3

  minio4:
    image: y4m4/minio:dev
    volumes:
      - /home/harsha/data4-1:/data1
    ports:
      - "9004:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...5}/data1
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3

  minio5:
    image: y4m4/minio:dev
    volumes:
      - /home/harsha/data5-1:/data1
    ports:
      - "9005:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server http://minio{1...5}/data1
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
