### PR TITLE
Add ExpiresAt to LicenseInfo

### DIFF
--- a/pkg/licverifier/verifier.go
+++ b/pkg/licverifier/verifier.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 )
@@ -32,17 +33,19 @@ type LicenseVerifier struct {
 
 // LicenseInfo holds customer metadata present in the license key.
 type LicenseInfo struct {
-	Email           string // Email of the license key requestor
-	TeamName        string // Subnet team name
-	AccountID       int64  // Subnet account id
-	StorageCapacity int64  // Storage capacity used in TB
-	ServiceType     string // Subnet service type
+	Email           string    // Email of the license key requestor
+	TeamName        string    // Subnet team name
+	AccountID       int64     // Subnet account id
+	StorageCapacity int64     // Storage capacity used in TB
+	ServiceType     string    // Subnet service type
+	ExpiresAt       time.Time // Time of license expiry
 }
 
 // license key JSON field names
 const (
 	accountID   = "accountId"
 	sub         = "sub"
+	expiresAt   = "exp"
 	teamName    = "teamName"
 	capacity    = "capacity"
 	serviceType = "serviceType"
@@ -71,6 +74,11 @@ func toLicenseInfo(claims jwt.MapClaims) (LicenseInfo, error) {
 	if !ok {
 		return LicenseInfo{}, errors.New("Invalid email in claims")
 	}
+	expiryTS, ok := claims[expiresAt].(float64)
+	if !ok {
+		return LicenseInfo{}, errors.New("Invalid time of expiry in claims")
+	}
+	expiresAt := time.Unix(int64(expiryTS), 0)
 	tName, ok := claims[teamName].(string)
 	if !ok {
 		return LicenseInfo{}, errors.New("Invalid team name in claims")
@@ -89,6 +97,7 @@ func toLicenseInfo(claims jwt.MapClaims) (LicenseInfo, error) {
 		AccountID:       int64(accID),
 		StorageCapacity: int64(storageCap),
 		ServiceType:     sType,
+		ExpiresAt:       expiresAt,
 	}, nil
 
 }

--- a/pkg/licverifier/verifier_test.go
+++ b/pkg/licverifier/verifier_test.go
@@ -31,6 +31,13 @@ func at(t time.Time, f func()) {
 	jwt.TimeFunc = time.Now
 }
 
+func areEqLicenseInfo(a, b LicenseInfo) bool {
+	if a.Email == b.Email && a.TeamName == b.TeamName && a.AccountID == b.AccountID && a.ServiceType == b.ServiceType && a.StorageCapacity == b.StorageCapacity && a.ExpiresAt.Equal(b.ExpiresAt) {
+		return true
+	}
+	return false
+}
+
 // TestLicenseVerify tests the license key verification process with a valid and
 // an invalid key.
 func TestLicenseVerify(t *testing.T) {
@@ -54,6 +61,7 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 			AccountID:       1,
 			StorageCapacity: 50,
 			ServiceType:     "STANDARD",
+			ExpiresAt:       time.Date(2021, time.August, 5, 15, 17, 42, 0, time.FixedZone("PDT", -7*60*60)),
 		}, true},
 	}
 
@@ -69,7 +77,7 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 				if !tc.shouldPass {
 					t.Fatalf("%d: Expected license to fail verification but passed", i+1)
 				}
-				if tc.expectedLicInfo != licInfo {
+				if !areEqLicenseInfo(tc.expectedLicInfo, licInfo) {
 					t.Fatalf("%d: Expected license info %v but got %v", i+1, tc.expectedLicInfo, licInfo)
 				}
 			}


### PR DESCRIPTION
## Description
Add expiry information to LicenseInfo type. 

## Motivation and Context
This allows applications to warn users of an upcoming license expiry.

## How to test this PR?
`go test -v ./pkg/licverifier`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
