### PR TITLE
Fix TestDataUpdateTracker hanging

### DIFF
--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -80,7 +80,7 @@ func newErasureZones(ctx context.Context, endpointZones EndpointZones) (ObjectLa
 		}
 	}
 
-	go intDataUpdateTracker.start(GlobalContext, localDrives...)
+	go intDataUpdateTracker.start(ctx, localDrives...)
 	return z, nil
 }
 

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -179,7 +179,7 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 	fs.fsFormatRlk = rlk
 
 	go fs.cleanupStaleMultipartUploads(ctx, GlobalMultipartCleanupInterval, GlobalMultipartExpiry)
-	go intDataUpdateTracker.start(GlobalContext, fsPath)
+	go intDataUpdateTracker.start(ctx, fsPath)
 
 	// Return successfully initialized object layer.
 	return fs, nil


### PR DESCRIPTION
## Description

Keep dataUpdateTracker while goroutine is starting.

This will ensure the object is updated one `start` returns

Fixes #10295

## How to test this PR?

Tested with

```
λ go test -cpu=1,2,4,8 -test.run TestDataUpdateTracker -count=1000
PASS
ok      github.com/minio/minio/cmd      8.913s
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
