### PR TITLE
Support HashiCorp Vault secrets in docker-entrypoint.sh

### DIFF
--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -39,6 +39,23 @@ docker_secrets_env() {
     fi
 }
 
+## Look for hashicorp vault secrets in default location.
+vault_secrets_env() {
+    ACCESS_KEY_FILE="/vault/secrets/$MINIO_ACCESS_KEY_FILE"
+    SECRET_KEY_FILE="/vault/secrets/$MINIO_SECRET_KEY_FILE"
+
+    if [ -f "$ACCESS_KEY_FILE" ] && [ -f "$SECRET_KEY_FILE" ]; then
+        if [ -f "$ACCESS_KEY_FILE" ]; then
+            MINIO_ACCESS_KEY="$(cat "$ACCESS_KEY_FILE")"
+            export MINIO_ACCESS_KEY
+        fi
+        if [ -f "$SECRET_KEY_FILE" ]; then
+            MINIO_SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
+            export MINIO_SECRET_KEY
+        fi
+    fi
+}
+
 ## Set KMS_MASTER_KEY from docker secrets if provided
 docker_kms_encryption_env() {
     KMS_MASTER_KEY_FILE="/run/secrets/$MINIO_KMS_MASTER_KEY_FILE"
@@ -46,7 +63,6 @@ docker_kms_encryption_env() {
     if [ -f "$KMS_MASTER_KEY_FILE" ]; then
         MINIO_KMS_MASTER_KEY="$(cat "$KMS_MASTER_KEY_FILE")"
         export MINIO_KMS_MASTER_KEY
-
     fi
 }
 
@@ -58,7 +74,6 @@ docker_sse_encryption_env() {
     if [ -f "$SSE_MASTER_KEY_FILE" ]; then
         MINIO_SSE_MASTER_KEY="$(cat "$SSE_MASTER_KEY_FILE")"
         export MINIO_SSE_MASTER_KEY
-
     fi
 }
 
@@ -83,6 +98,7 @@ docker_switch_user() {
 
 ## Set access env from secrets if necessary.
 docker_secrets_env
+vault_secrets_env
 
 ## Set kms encryption from secrets if necessary.
 docker_kms_encryption_env


### PR DESCRIPTION
## Description
Support fetching the access and secret key from HashiCorp Vault secrets injected into MinIO pods via docker-entrypoint.sh.

## Motivation and Context
At the moment, MinIO supports overriding generated access and secret keys via environment variables and Docker Secrets. As Vault is a commonly used Secret Management Tool and already supported as KMS, there should be a way to provide the MinIO access and secret keys via Vault natively.

Injecting secrets via HashiCorp Vault has a similar end result as Docker secrets by mounting the secrets into the container/pod. However, the secrets are mounted to /vault/secrets instead of /run/secrets. In docker-entrypoint.sh /run/secrets is hard-coded for the file paths for the keys, so I added another bash function using the mount path of Vault secrets and to not break existing deployments using Docker Secrets.

I've also added some basic documentation to configure MinIO with the usage of the official MinIO Helm chart. Honestly, I don't know if this is the most appropriate place. Probably, this documenation should be better added to the Helm chart repo (https://github.com/minio/charts).

## How to test this PR?
1) Setup and create the keys in Vault & deploy MinIO with the official Helm chart as described in the documentation added in this PR.
2) (without Vault) Mount some test secrets to /vault/secrets/{access_key,secret_key} and set the enviroment variables MINIO_ACCESS_KEY_FILE and MINIO_SECRET_KEY_FILE accordingly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
