### PR TITLE
Only enforce quota on success

### DIFF
--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -371,8 +371,10 @@ func (z *erasureZones) CrawlAndGetDataUsage(ctx context.Context, bf *bloomFilter
 			case v := <-updateCloser:
 				update()
 				// Enforce quotas when all is done.
-				for _, b := range allBuckets {
-					enforceFIFOQuotaBucket(ctx, z, b.Name, allMerged.bucketUsageInfo(b.Name))
+				if firstErr == nil {
+					for _, b := range allBuckets {
+						enforceFIFOQuotaBucket(ctx, z, b.Name, allMerged.bucketUsageInfo(b.Name))
+					}
 				}
 				close(v)
 				return
@@ -388,6 +390,9 @@ func (z *erasureZones) CrawlAndGetDataUsage(ctx context.Context, bf *bloomFilter
 	case updateCloser <- ch:
 		<-ch
 	case <-ctx.Done():
+		if firstErr == nil {
+			firstErr = ctx.Err()
+		}
 	}
 	return firstErr
 }


### PR DESCRIPTION
## Description

We should only enforce quotas if no error has been returned.

`firstErr` is safe to access since all goroutines have exited at this point.

If `firstErr` hasn't been set by something else return the context error if cancelled.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
