### PR TITLE
Return a header in cluster/health indicating healing is happening

### DIFF
--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -2041,7 +2041,6 @@ type HealthResult struct {
 	HealingDrives    int
 	ZoneID, SetID    int
 	WriteQuorum      int
-	HealingInProgess bool
 }
 
 // Health - returns current status of the object layer health,
@@ -2114,7 +2113,6 @@ func (z *erasureZones) Health(ctx context.Context, opts HealthOptions) HealthRes
 		logger.LogIf(logger.SetReqInfo(ctx, reqInfo), fmt.Errorf("Unable to verify global heal status: %w", err))
 		return HealthResult{
 			Healthy:          false,
-			HealingInProgess: true,
 		}
 	}
 
@@ -2127,7 +2125,6 @@ func (z *erasureZones) Health(ctx context.Context, opts HealthOptions) HealthRes
 	return HealthResult{
 		Healthy:          healthy,
 		HealingDrives:    len(aggHealStateResult.HealDisks),
-		HealingInProgess: true,
 	}
 }
 

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -2037,10 +2037,11 @@ type HealthOptions struct {
 // additionally with any specific heuristic information which
 // was queried
 type HealthResult struct {
-	Healthy       bool
-	HealingDrives int
-	ZoneID, SetID int
-	WriteQuorum   int
+	Healthy          bool
+	HealingDrives    int
+	ZoneID, SetID    int
+	WriteQuorum      int
+	HealingInProgess bool
 }
 
 // Health - returns current status of the object layer health,
@@ -2112,7 +2113,8 @@ func (z *erasureZones) Health(ctx context.Context, opts HealthOptions) HealthRes
 	if err != nil {
 		logger.LogIf(logger.SetReqInfo(ctx, reqInfo), fmt.Errorf("Unable to verify global heal status: %w", err))
 		return HealthResult{
-			Healthy: false,
+			Healthy:          false,
+			HealingInProgess: true,
 		}
 	}
 
@@ -2123,8 +2125,9 @@ func (z *erasureZones) Health(ctx context.Context, opts HealthOptions) HealthRes
 	healthy := len(aggHealStateResult.HealDisks) == 0
 
 	return HealthResult{
-		Healthy:       healthy,
-		HealingDrives: len(aggHealStateResult.HealDisks),
+		Healthy:          healthy,
+		HealingDrives:    len(aggHealStateResult.HealDisks),
+		HealingInProgess: true,
 	}
 }
 

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -2037,10 +2037,10 @@ type HealthOptions struct {
 // additionally with any specific heuristic information which
 // was queried
 type HealthResult struct {
-	Healthy          bool
-	HealingDrives    int
-	ZoneID, SetID    int
-	WriteQuorum      int
+	Healthy       bool
+	HealingDrives int
+	ZoneID, SetID int
+	WriteQuorum   int
 }
 
 // Health - returns current status of the object layer health,
@@ -2112,7 +2112,7 @@ func (z *erasureZones) Health(ctx context.Context, opts HealthOptions) HealthRes
 	if err != nil {
 		logger.LogIf(logger.SetReqInfo(ctx, reqInfo), fmt.Errorf("Unable to verify global heal status: %w", err))
 		return HealthResult{
-			Healthy:          false,
+			Healthy: false,
 		}
 	}
 
@@ -2123,8 +2123,8 @@ func (z *erasureZones) Health(ctx context.Context, opts HealthOptions) HealthRes
 	healthy := len(aggHealStateResult.HealDisks) == 0
 
 	return HealthResult{
-		Healthy:          healthy,
-		HealingDrives:    len(aggHealStateResult.HealDisks),
+		Healthy:       healthy,
+		HealingDrives: len(aggHealStateResult.HealDisks),
 	}
 }
 

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -42,7 +42,7 @@ func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 		// down, this is for orchestrators to know if we can safely
 		// take this server down, return appropriate error.
 		if result.HealingInProgess {
-			w.Header().Set("X-Minio-Health-Healing-In-Progress","true")
+			w.Header().Set("X-Minio-Healing-Disks", strconv.Itoa(result.HealingDrives))
 		}
 		if opts.Maintenance {
 			writeResponse(w, http.StatusPreconditionFailed, nil, mimeNone)

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -40,7 +40,7 @@ func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 	result := objLayer.Health(ctx, opts)
 	if !result.Healthy {
 		// return how many drives are being healed if any
-		w.Header().Set("X-Minio-Healing-Disks", strconv.Itoa(result.HealingDrives))
+		w.Header().Set("X-Minio-Healing-Drives", strconv.Itoa(result.HealingDrives))
 		// As a maintenance call we are purposefully asked to be taken
 		// down, this is for orchestrators to know if we can safely
 		// take this server down, return appropriate error.

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -41,6 +41,9 @@ func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 		// As a maintenance call we are purposefully asked to be taken
 		// down, this is for orchestrators to know if we can safely
 		// take this server down, return appropriate error.
+		if result.HealingInProgess {
+			w.Header().Set("X-Minio-Health-Healing-In-Progress","true")
+		}
 		if opts.Maintenance {
 			writeResponse(w, http.StatusPreconditionFailed, nil, mimeNone)
 		} else {

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"net/http"
+	"strconv"
 )
 
 // ClusterCheckHandler returns if the server is ready for requests.
@@ -38,12 +39,11 @@ func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 	opts := HealthOptions{Maintenance: r.URL.Query().Get("maintenance") == "true"}
 	result := objLayer.Health(ctx, opts)
 	if !result.Healthy {
+		// return how many drives are being healed if any
+		w.Header().Set("X-Minio-Healing-Disks", strconv.Itoa(result.HealingDrives))
 		// As a maintenance call we are purposefully asked to be taken
 		// down, this is for orchestrators to know if we can safely
 		// take this server down, return appropriate error.
-		if result.HealingInProgess {
-			w.Header().Set("X-Minio-Healing-Disks", strconv.Itoa(result.HealingDrives))
-		}
 		if opts.Maintenance {
 			writeResponse(w, http.StatusPreconditionFailed, nil, mimeNone)
 		} else {


### PR DESCRIPTION
## Description

Adds a header to Cluster health that indicates ceiling is in progress

## Motivation and Context

Cluster Health only returns for 412 but doesn't distinguish whether quorum is about to be lost or healing is happening

## How to test this PR?

Me

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
