### PR TITLE
avoid double healing if drive heal is in progress

### DIFF
--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -451,6 +451,16 @@ func (f *folderScanner) scanQueuedLevels(ctx context.Context, folders []cachedFo
 			continue
 		}
 
+		healState, err := getAggregatedBackgroundHealState(ctx, false)
+		if err != nil {
+			continue
+		}
+
+		if len(healState.HealDisks) > 0 {
+			// Disks are healing do not need to proceed to healing the objects.
+			continue
+		}
+
 		// Whatever remains in 'existing' are folders at this level
 		// that existed in the previous run but wasn't found now.
 		//


### PR DESCRIPTION
## Description
avoid double healing if drive heal is in progress

## Motivation and Context
Avoid continuous heal when drive healing is in progress

## How to test this PR?
Check by replacing drives such that conflicting healing
doesn't need to happen on the same drives

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
