### PR TITLE
Support custom paths for secret files in docker-entrypoint.sh

### DIFF
--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -22,10 +22,18 @@ if [ "${1}" != "minio" ]; then
     fi
 fi
 
-## Look for docker secrets in default documented location.
+## Look for docker secrets at given absolute path or in default documented location.
 docker_secrets_env() {
-    ACCESS_KEY_FILE="/run/secrets/$MINIO_ACCESS_KEY_FILE"
-    SECRET_KEY_FILE="/run/secrets/$MINIO_SECRET_KEY_FILE"
+    if [ -f "$MINIO_ACCESS_KEY_FILE" ]; then
+        ACCESS_KEY_FILE="$MINIO_ACCESS_KEY_FILE"
+    else
+        ACCESS_KEY_FILE="/run/secrets/$MINIO_ACCESS_KEY_FILE"
+    fi
+    if [ -f "$MINIO_SECRET_KEY_FILE" ]; then
+        SECRET_KEY_FILE="$MINIO_SECRET_KEY_FILE"
+    else
+        SECRET_KEY_FILE="/run/secrets/$MINIO_SECRET_KEY_FILE"
+    fi
 
     if [ -f "$ACCESS_KEY_FILE" ] && [ -f "$SECRET_KEY_FILE" ]; then
         if [ -f "$ACCESS_KEY_FILE" ]; then
@@ -41,12 +49,15 @@ docker_secrets_env() {
 
 ## Set KMS_MASTER_KEY from docker secrets if provided
 docker_kms_encryption_env() {
-    KMS_MASTER_KEY_FILE="/run/secrets/$MINIO_KMS_MASTER_KEY_FILE"
+    if [ -f "$MINIO_KMS_MASTER_KEY_FILE" ]; then
+        KMS_MASTER_KEY_FILE="$MINIO_KMS_MASTER_KEY_FILE"
+    else
+        KMS_MASTER_KEY_FILE="/run/secrets/$MINIO_KMS_MASTER_KEY_FILE"
+    fi
 
     if [ -f "$KMS_MASTER_KEY_FILE" ]; then
         MINIO_KMS_MASTER_KEY="$(cat "$KMS_MASTER_KEY_FILE")"
         export MINIO_KMS_MASTER_KEY
-
     fi
 }
 
@@ -58,7 +69,6 @@ docker_sse_encryption_env() {
     if [ -f "$SSE_MASTER_KEY_FILE" ]; then
         MINIO_SSE_MASTER_KEY="$(cat "$SSE_MASTER_KEY_FILE")"
         export MINIO_SSE_MASTER_KEY
-
     fi
 }
 

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -121,6 +121,11 @@ docker service create --name="minio-service" \
   --env="MINIO_SECRET_KEY_FILE=my_secret_key" \
   minio/minio server /data
 ```
+`MINIO_ACCESS_KEY_FILE` and `MINIO_SECRET_KEY_FILE` also support custom absolute paths, in case Docker secrets are mounted to custom locations or other tools are used to mount secrets into the container. For example, HashiCorp Vault injects secrets to `/vault/secrets`. With the custom names above, set the environment variables to
+```
+MINIO_ACCESS_KEY_FILE=/vault/secrets/my_access_key
+MINIO_SECRET_KEY_FILE=/vault/secrets/my_secret_key
+```
 
 ### Retrieving Container ID
 To use Docker commands on a specific container, you need to know the `Container ID` for that container. To get the `Container ID`, run


### PR DESCRIPTION
## Description
Support setting a custom absolute path for MINIO_ACCESS_KEY_FILE, MINIO_SECRET_KEY_FILE and MINIO_KMS_MASTER_KEY_FILE in docker-entrypoints.sh.
This supports custom locations for Docker secrets as well as any other mechanism which mounts secret files into containers, e.g. HashiCorp Vault.

## Motivation and Context
At the moment, MinIO supports overriding generated access, secret and kms master keys via environment variables and Docker secrets. However, in docker-entrypoint.sh /run/secrets is hard-coded for the file paths for the keys.
To support custom locations and other secret management tools, which mount secrets to other locations, this PR adds the ability to specify custom absolute paths for those keys.

## How to test this PR?
Mount the Docker secrets for the key files to a custom path and set the environment variables accordingly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
