### PR TITLE
lifecycle: Accept document without expiration configuration

### DIFF
--- a/pkg/bucket/lifecycle/expiration_test.go
+++ b/pkg/bucket/lifecycle/expiration_test.go
@@ -78,7 +78,7 @@ func TestInvalidExpiration(t *testing.T) {
 		{ // Expiration with neither number of days nor a date
 			inputXML: `<Expiration>
                                     </Expiration>`,
-			expectedErr: errLifecycleInvalidExpiration,
+			expectedErr: errXMLNotWellFormed,
 		},
 		{ // Expiration with both number of days and a date
 			inputXML: `<Expiration>
@@ -86,6 +86,13 @@ func TestInvalidExpiration(t *testing.T) {
                                     <Date>2019-04-20T00:00:00Z</Date>
                                     </Expiration>`,
 			expectedErr: errLifecycleInvalidExpiration,
+		},
+		{ // Expiration with both ExpiredObjectDeleteMarker and days
+			inputXML: `<Expiration>
+                                    <Days>3</Days>
+			            <ExpiredObjectDeleteMarker>false</ExpiredObjectDeleteMarker>
+                                    </Expiration>`,
+			expectedErr: errLifecycleInvalidDeleteMarker,
 		},
 	}
 	for i, tc := range validationTestCases {
@@ -98,7 +105,7 @@ func TestInvalidExpiration(t *testing.T) {
 
 			err = expiration.Validate()
 			if err != tc.expectedErr {
-				t.Fatalf("%d: %v", i+1, err)
+				t.Fatalf("%d: got: %v, expected: %v", i+1, err, tc.expectedErr)
 			}
 		})
 	}

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -27,6 +27,7 @@ var (
 	errLifecycleTooManyRules = Errorf("Lifecycle configuration allows a maximum of 1000 rules")
 	errLifecycleNoRule       = Errorf("Lifecycle configuration should have at least one rule")
 	errLifecycleDuplicateID  = Errorf("Lifecycle configuration has rule with the same ID. Rule ID must be unique.")
+	errXMLNotWellFormed      = Errorf("The XML you provided was not well-formed or did not validate against our published schema")
 )
 
 // Action represents a delete action or other transition
@@ -154,7 +155,7 @@ func (lc Lifecycle) FilterActionableRules(obj ObjectOpts) []Rule {
 		// be expired; if set to false the policy takes no action. This
 		// cannot be specified with Days or Date in a Lifecycle
 		// Expiration Policy.
-		if rule.Expiration.DeleteMarker {
+		if rule.Expiration.DeleteMarker.val {
 			rules = append(rules, rule)
 			continue
 		}
@@ -193,7 +194,7 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 	}
 
 	for _, rule := range lc.FilterActionableRules(obj) {
-		if obj.DeleteMarker && obj.NumVersions == 1 && bool(rule.Expiration.DeleteMarker) {
+		if obj.DeleteMarker && obj.NumVersions == 1 && rule.Expiration.DeleteMarker.val {
 			// Indicates whether MinIO will remove a delete marker with no noncurrent versions.
 			// Only latest marker is removed. If set to true, the delete marker will be expired;
 			// if set to false the policy takes no action. This cannot be specified with Days or

--- a/pkg/bucket/lifecycle/rule_test.go
+++ b/pkg/bucket/lifecycle/rule_test.go
@@ -62,13 +62,6 @@ func TestInvalidRules(t *testing.T) {
 		inputXML    string
 		expectedErr error
 	}{
-		{ // Rule without expiration action
-			inputXML: ` <Rule>
-			                <ID>rule without expiration</ID>
-                            <Status>Enabled</Status>
-	                    </Rule>`,
-			expectedErr: errLifecycleInvalidExpiration,
-		},
 		{ // Rule with ID longer than 255 characters
 			inputXML: ` <Rule>
 	                    <ID> babababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab </ID>


### PR DESCRIPTION
## Description
It is not possible to send a life-cycle policy document without expiration rule. But since the introduction of versioning, this should be possible since we support versioning related config now.

## Motivation and Context
Fix a bug after review

## How to test this PR?
Send the below document using the following command: `aws --endpoint-url http://localhost:9000/ s3api put-bucket-lifecycle-configuration --bucket testbucket --lifecycle-configuration file://bucket-lifecycle.json`
```
{
    "Rules": [
        {
            "ID": "Remove old non current versions",
            "Status": "Enabled",
            "NoncurrentVersionExpiration": {
                "NoncurrentDays": 1
            }
        }
    ]
}

```



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
