### PR TITLE
Disregard healing disks

### DIFF
--- a/cmd/bitrot_test.go
+++ b/cmd/bitrot_test.go
@@ -34,7 +34,7 @@ func testBitrotReaderWriterAlgo(t *testing.T, bitrotAlgo BitrotAlgorithm) {
 	volume := "testvol"
 	filePath := "testfile"
 
-	disk, err := newXLStorage(tmpDir, "")
+	disk, err := newLocalXLStorage(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -82,7 +82,7 @@ func dirObjectInfo(bucket, object string, size int64, metadata map[string]string
 // Depending on the disk type network or local, initialize storage API.
 func newStorageAPI(endpoint Endpoint) (storage StorageAPI, err error) {
 	if endpoint.IsLocal {
-		storage, err := newXLStorage(endpoint.Path, endpoint.Host)
+		storage, err := newXLStorage(endpoint)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -826,7 +826,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointZones EndpointZones
 			if !endpoint.IsLocal {
 				continue
 			}
-			storage, err := newXLStorage(endpoint.Path, endpoint.Host)
+			storage, err := newXLStorage(endpoint)
 			if err != nil {
 				if err == errMinDiskSize {
 					logger.Fatal(config.ErrUnableToWriteInBackend(err).Hint(err.Error()), "Unable to initialize backend")

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -122,7 +122,7 @@ func newXLStorageTestSetup() (*xlStorageDiskIDCheck, string, error) {
 	}
 
 	// Initialize a new xlStorage layer.
-	storage, err := newXLStorage(diskPath, "")
+	storage, err := newLocalXLStorage(diskPath)
 	if err != nil {
 		return nil, "", err
 	}
@@ -377,7 +377,7 @@ func TestNewXLStorage(t *testing.T) {
 	// Validate all test cases.
 	for i, testCase := range testCases {
 		// Initialize a new xlStorage layer.
-		_, err := newXLStorage(testCase.name, "")
+		_, err := newLocalXLStorage(testCase.name)
 		if err != testCase.err {
 			t.Fatalf("TestXLStorage %d failed wanted: %s, got: %s", i+1, err, testCase.err)
 		}
@@ -451,7 +451,7 @@ func TestXLStorageMakeVol(t *testing.T) {
 		}
 
 		// Initialize xlStorage storage layer for permission denied error.
-		_, err = newXLStorage(permDeniedDir, "")
+		_, err = newLocalXLStorage(permDeniedDir)
 		if err != nil && !os.IsPermission(err) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -460,7 +460,7 @@ func TestXLStorageMakeVol(t *testing.T) {
 			t.Fatalf("Unable to change permission to temporary directory %v. %v", permDeniedDir, err)
 		}
 
-		xlStorageNew, err := newXLStorage(permDeniedDir, "")
+		xlStorageNew, err := newLocalXLStorage(permDeniedDir)
 		if err != nil {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -550,7 +550,7 @@ func TestXLStorageDeleteVol(t *testing.T) {
 		}
 
 		// Initialize xlStorage storage layer for permission denied error.
-		_, err = newXLStorage(permDeniedDir, "")
+		_, err = newLocalXLStorage(permDeniedDir)
 		if err != nil && !os.IsPermission(err) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -559,7 +559,7 @@ func TestXLStorageDeleteVol(t *testing.T) {
 			t.Fatalf("Unable to change permission to temporary directory %v. %v", permDeniedDir, err)
 		}
 
-		xlStorageNew, err := newXLStorage(permDeniedDir, "")
+		xlStorageNew, err := newLocalXLStorage(permDeniedDir)
 		if err != nil {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -802,7 +802,7 @@ func TestXLStorageXlStorageListDir(t *testing.T) {
 		defer removePermDeniedFile(permDeniedDir)
 
 		// Initialize xlStorage storage layer for permission denied error.
-		_, err = newXLStorage(permDeniedDir, "")
+		_, err = newLocalXLStorage(permDeniedDir)
 		if err != nil && !os.IsPermission(err) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -811,7 +811,7 @@ func TestXLStorageXlStorageListDir(t *testing.T) {
 			t.Fatalf("Unable to change permission to temporary directory %v. %v", permDeniedDir, err)
 		}
 
-		xlStorageNew, err := newXLStorage(permDeniedDir, "")
+		xlStorageNew, err := newLocalXLStorage(permDeniedDir)
 		if err != nil {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -926,7 +926,7 @@ func TestXLStorageDeleteFile(t *testing.T) {
 		defer removePermDeniedFile(permDeniedDir)
 
 		// Initialize xlStorage storage layer for permission denied error.
-		_, err = newXLStorage(permDeniedDir, "")
+		_, err = newLocalXLStorage(permDeniedDir)
 		if err != nil && !os.IsPermission(err) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -935,7 +935,7 @@ func TestXLStorageDeleteFile(t *testing.T) {
 			t.Fatalf("Unable to change permission to temporary directory %v. %v", permDeniedDir, err)
 		}
 
-		xlStorageNew, err := newXLStorage(permDeniedDir, "")
+		xlStorageNew, err := newLocalXLStorage(permDeniedDir)
 		if err != nil {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -1124,7 +1124,7 @@ func TestXLStorageReadFile(t *testing.T) {
 		defer removePermDeniedFile(permDeniedDir)
 
 		// Initialize xlStorage storage layer for permission denied error.
-		_, err = newXLStorage(permDeniedDir, "")
+		_, err = newLocalXLStorage(permDeniedDir)
 		if err != nil && !os.IsPermission(err) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -1133,7 +1133,7 @@ func TestXLStorageReadFile(t *testing.T) {
 			t.Fatalf("Unable to change permission to temporary directory %v. %v", permDeniedDir, err)
 		}
 
-		xlStoragePermStorage, err := newXLStorage(permDeniedDir, "")
+		xlStoragePermStorage, err := newLocalXLStorage(permDeniedDir)
 		if err != nil {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -1294,7 +1294,7 @@ func TestXLStorageAppendFile(t *testing.T) {
 
 		var xlStoragePermStorage StorageAPI
 		// Initialize xlStorage storage layer for permission denied error.
-		_, err = newXLStorage(permDeniedDir, "")
+		_, err = newLocalXLStorage(permDeniedDir)
 		if err != nil && !os.IsPermission(err) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
@@ -1303,7 +1303,7 @@ func TestXLStorageAppendFile(t *testing.T) {
 			t.Fatalf("Unable to change permission to temporary directory %v. %v", permDeniedDir, err)
 		}
 
-		xlStoragePermStorage, err = newXLStorage(permDeniedDir, "")
+		xlStoragePermStorage, err = newLocalXLStorage(permDeniedDir)
 		if err != nil {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}

--- a/cmd/xl-storage_unix_test.go
+++ b/cmd/xl-storage_unix_test.go
@@ -49,7 +49,7 @@ func TestIsValidUmaskVol(t *testing.T) {
 	testCase := testCases[0]
 
 	// Initialize a new xlStorage layer.
-	disk, err := newXLStorage(tmpPath, "")
+	disk, err := newLocalXLStorage(tmpPath)
 	if err != nil {
 		t.Fatalf("Initializing xlStorage failed with %s.", err)
 	}
@@ -91,7 +91,7 @@ func TestIsValidUmaskFile(t *testing.T) {
 	testCase := testCases[0]
 
 	// Initialize a new xlStorage layer.
-	disk, err := newXLStorage(tmpPath, "")
+	disk, err := newLocalXLStorage(tmpPath)
 	if err != nil {
 		t.Fatalf("Initializing xlStorage failed with %s.", err)
 	}

--- a/cmd/xl-storage_windows_test.go
+++ b/cmd/xl-storage_windows_test.go
@@ -48,7 +48,7 @@ func TestUNCPaths(t *testing.T) {
 
 	// Instantiate posix object to manage a disk
 	var fs StorageAPI
-	fs, err = newXLStorage(dir, "")
+	fs, err = newLocalXLStorage(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestUNCPathENOTDIR(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	var fs StorageAPI
-	fs, err = newXLStorage(dir, "")
+	fs, err = newLocalXLStorage(dir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Disregard disks that are healing when crawling.

When crawling a set never use a disk we know is healing.

Most of the change involves keeping track of the original endpoint on xlstorage and this also fixes DiskInfo.Endpoint never being populated.

Heal master will print `data-crawl: Disk "http://localhost:9001/data/mindev/data2/xl1" is Healing, skipping disk` once on a cycle (no more often than every 5m).

Replaces #10343

## How to test this PR?

Start server, delete content on a disk or replace it. When healing starts when a crawl cycle starts, the master should indicate that it isn't using the disk as described above.

Once healing is done it should stop showing within 5 minutes.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
