### PR TITLE
update continous heal metrics appropriately for scanned items

### DIFF
--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -101,6 +101,7 @@ func (h *healRoutine) run(ctx context.Context, objAPI ObjectLayer) {
 				ObjectPathUpdated(path.Join(task.bucket, task.object))
 			}
 			task.responseCh <- healResult{result: res, err: err}
+
 		case <-h.doneCh:
 			return
 		case <-ctx.Done():

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -84,7 +84,7 @@ func getLocalBackgroundHealStatus() (madmin.BgHealState, bool) {
 		ScannedItemsCount: bgSeq.getScannedItemsCount(),
 		LastHealActivity:  bgSeq.lastHealActivity,
 		HealDisks:         healDisks,
-		NextHealRound:     UTCNow().Add(dataCrawlStartDelay),
+		NextHealRound:     UTCNow(),
 	}, true
 }
 


### PR DESCRIPTION


## Description
update continous heal metrics appropriately for scanned items

## Motivation and Context
bonus make sure to ignore objectNotFound, and versionNotFound
errors properly at all layers, since HealObjects() returns
objectNotFound error if the bucket or prefix is empty.

## How to test this PR?
`mc admin heal --recursive myminio/emptybucket` shouldn't fail
and also scanned item counts are updated properly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
