### PR TITLE
getDisksInfo: Attribute failed disks to correct endpoint

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1499,6 +1499,9 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 	}
 	// add all the disks local to this server.
 	for _, disk := range storageInfo.Disks {
+		if disk.DrivePath == "" && disk.Endpoint == "" {
+			continue
+		}
 		if disk.Endpoint == disk.DrivePath {
 			servers[len(servers)-1].Disks = append(servers[len(servers)-1].Disks, disk)
 		}

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -146,6 +146,11 @@ func getDisksInfo(disks []StorageAPI, endpoints []string) (disksInfo []madmin.Di
 					ctx := logger.SetReqInfo(GlobalContext, reqInfo)
 					logger.LogIf(ctx, err)
 				}
+				disksInfo[index] = madmin.Disk{
+					State:    diskErrToDriveState(err),
+					Endpoint: endpoints[index],
+				}
+				return err
 			}
 			di := madmin.Disk{
 				Endpoint:       endpoints[index],


### PR DESCRIPTION
## Description

If DiskInfo calls failed the information returned was used anyway resulting in no endpoint being set.

This would make the drive be attributed to the local system since `disk.Endpoint == disk.DrivePath` in that case.

Instead if call fails record the endpoint and the error only.

## Motivation and Context

`mc admin info` displays data like this:
<img width="321" alt="Screenshot 2020-08-25 at 15 07 49" src="https://user-images.githubusercontent.com/5663952/91304218-6d738d00-e7a9-11ea-98c3-09e0d188e1d4.png">

Which corresponds to the json returned.

[mc-admin-info.json.gz](https://github.com/minio/minio/files/5129838/mc-admin-info.json.gz)

Note how the first server lacks 2 entries and the last (request local) has 2 `"state": "offline"` entries.

## How to test this PR?

Create a similar setup. Take 1 or more disks on a server. Make a request to the server that does not contain the failed drive.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
