### PR TITLE
fix write quorum calculation for bucket operations

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -94,7 +94,7 @@ func path2BucketObject(s string) (bucket, prefix string) {
 }
 
 func getDefaultParityBlocks(drive int) int {
-	return int(math.Floor(float64(drive) / 2))
+	return drive/2
 }
 
 func getDefaultDataBlocks(drive int) int {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -98,7 +98,7 @@ func getDefaultParityBlocks(drive int) int {
 }
 
 func getDefaultDataBlocks(drive int) int {
-	return int(math.Ceil(float64(drive) / 2))
+        return drive - getDefaultParityBlocks(drive)
 }
 
 func getReadQuorum(drive int) int {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -93,11 +94,11 @@ func path2BucketObject(s string) (bucket, prefix string) {
 }
 
 func getDefaultParityBlocks(drive int) int {
-	return drive / 2
+	return int(math.Floor(float64(drive) / 2))
 }
 
 func getDefaultDataBlocks(drive int) int {
-	return drive - getDefaultParityBlocks(drive)
+	return int(math.Ceil(float64(drive) / 2))
 }
 
 func getReadQuorum(drive int) int {
@@ -105,7 +106,7 @@ func getReadQuorum(drive int) int {
 }
 
 func getWriteQuorum(drive int) int {
-	return getDefaultDataBlocks(drive) + 1
+	return getDefaultDataBlocks(drive)
 }
 
 // URI scheme constants.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -106,7 +106,11 @@ func getReadQuorum(drive int) int {
 }
 
 func getWriteQuorum(drive int) int {
-	return getDefaultDataBlocks(drive)
+        quorum := getDefaultDataBlocks(drive)
+	if getDefaultParityBlocks(drive) == quorum {
+	            quorum++
+	} 
+	return quorum     
 }
 
 // URI scheme constants.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -94,11 +93,11 @@ func path2BucketObject(s string) (bucket, prefix string) {
 }
 
 func getDefaultParityBlocks(drive int) int {
-	return drive/2
+	return drive / 2
 }
 
 func getDefaultDataBlocks(drive int) int {
-        return drive - getDefaultParityBlocks(drive)
+	return drive - getDefaultParityBlocks(drive)
 }
 
 func getReadQuorum(drive int) int {
@@ -106,11 +105,11 @@ func getReadQuorum(drive int) int {
 }
 
 func getWriteQuorum(drive int) int {
-        quorum := getDefaultDataBlocks(drive)
+	quorum := getDefaultDataBlocks(drive)
 	if getDefaultParityBlocks(drive) == quorum {
-	            quorum++
-	} 
-	return quorum     
+		quorum++
+	}
+	return quorum
 }
 
 // URI scheme constants.


### PR DESCRIPTION
## Description
When the number of disks is odd, the calculation of data/parity disks
become incorrect.

For example, if we have 5 disks, and EC = 2, then it is enough to
require 3 disks to create a bucket.

## Motivation and Context
Fix an issue reported in Subnet

## How to test this PR?
1. Start a distributed setup with 5 nodes, each node has one disk with export MINIO_STORAGE_CLASS_STANDARD="EC:2" in the environment.
2. Kill two random nodes
3. mc mb myminio/testbucket/


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
