### PR TITLE
fix mc admin trace don't show any errors when minio server is shutdown.

### DIFF
--- a/pkg/madmin/service-commands.go
+++ b/pkg/madmin/service-commands.go
@@ -95,6 +95,7 @@ func (adm AdminClient) ServiceTrace(ctx context.Context, allTrace, errTrace bool
 			resp, err := adm.executeMethod(ctx, http.MethodGet, reqData)
 			if err != nil {
 				closeResponse(resp)
+				traceInfoCh <- ServiceTraceInfo{Err: err}
 				return
 			}
 


### PR DESCRIPTION
## Description
Fixed #10369 

## Motivation and Context
mc admin trace show error information when minio server is shutdown

## How to test this PR?
1.shutdown `local` minio server.
2.use commond `mc admin trace --verbose local` in shell.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
