### PR TITLE
ability to configure the HDFS meta bucket through an environment variable

### DIFF
--- a/cmd/gateway/hdfs/gateway-hdfs-utils.go
+++ b/cmd/gateway/hdfs/gateway-hdfs-utils.go
@@ -17,22 +17,29 @@
 package hdfs
 
 import (
+	"github.com/minio/minio/pkg/env"
 	"strings"
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	minio "github.com/minio/minio/cmd"
 )
 
-const (
+var (
 	// Minio meta bucket.
-	minioMetaBucket = ".minio.sys"
+	minioMetaBucket string
 
 	// Minio Tmp meta prefix.
-	minioMetaTmpBucket = minioMetaBucket + "/tmp"
+	minioMetaTmpBucket string
 
 	// Minio reserved bucket name.
-	minioReservedBucket = "minio"
+	minioReservedBucket string
 )
+
+func init() {
+	minioMetaBucket = env.Get("MINIO_HDFS_META_BUCKET", ".minio.sys")
+	minioMetaTmpBucket = env.Get("MINIO_HDFS_META_TMP_BUCKET", minioMetaBucket+"/tmp")
+	minioReservedBucket = env.Get("MINIO_HDFS_RESERVED_BUCKET", "minio")
+}
 
 // Ignores all reserved bucket names or invalid bucket names.
 func isReservedOrInvalidBucket(bucketEntry string, strict bool) bool {

--- a/cmd/gateway/hdfs/gateway-hdfs-utils.go
+++ b/cmd/gateway/hdfs/gateway-hdfs-utils.go
@@ -17,11 +17,11 @@
 package hdfs
 
 import (
-	"github.com/minio/minio/pkg/env"
 	"strings"
 
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	minio "github.com/minio/minio/cmd"
+	"github.com/minio/minio/pkg/env"
 )
 
 var (

--- a/cmd/gateway/hdfs/gateway-hdfs.go
+++ b/cmd/gateway/hdfs/gateway-hdfs.go
@@ -79,6 +79,12 @@ EXAMPLES:
      {{.Prompt}} {{.EnvVarSetCommand}} MINIO_CACHE_WATERMARK_LOW{{.AssignmentOperator}}75
      {{.Prompt}} {{.EnvVarSetCommand}} MINIO_CACHE_WATERMARK_HIGH{{.AssignmentOperator}}85
      {{.Prompt}} {{.HelpName}} hdfs://namenode:8200
+  
+  3. Start minio gateway server for HDFS with custom meta bucket
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ACCESS_KEY{{.AssignmentOperator}}accesskey
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_SECRET_KEY{{.AssignmentOperator}}secretkey
+     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_HDFS_META_BUCKET{{.AssignmentOperator}}/.minio.sys
+     {{.Prompt}} {{.HelpName}} hdfs://namenode:8200
 `
 
 	minio.RegisterGatewayCommand(cli.Command{


### PR DESCRIPTION
Signed-off-by: Arno Broekhof <arnobroekhof@gmail.com>

## Description
Added the ability to configure the metadata bucket that is being used on HDFS through an environment variable

## Motivation and Context
Created this option:
*  because in some occasions people are not allowed to create folders in the root of the HDFS tree or have special folders.



## How to test this PR?
from the commandline

```
Start minio gateway server for HDFS with custom meta bucket
     $ export MINIO_ACCESS_KEY=accesskey
     $ export MINIO_SECRET_KEY=secretkey
     $ export MINIO_HDFS_META_BUCKET=/somefolder-with-write-permissions/.minio.sys
     $ minio gateway hdfs hdfs://namenode:8200
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
