### PR TITLE
crypto: allow multiple KES endpoints

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1582,12 +1582,12 @@ func fetchVaultStatus(cfg config.Config) madmin.Vault {
 	keyID := GlobalKMS.DefaultKeyID()
 	kmsInfo := GlobalKMS.Info()
 
-	if kmsInfo.Endpoint == "" {
+	if len(kmsInfo.Endpoints) == 0 {
 		vault.Status = "KMS configured using master key"
 		return vault
 	}
 
-	if err := checkConnection(kmsInfo.Endpoint, 15*time.Second); err != nil {
+	if err := checkConnection(kmsInfo.Endpoints[0], 15*time.Second); err != nil {
 		vault.Status = "offline"
 	} else {
 		vault.Status = "online"

--- a/cmd/crypto/kms.go
+++ b/cmd/crypto/kms.go
@@ -109,9 +109,9 @@ type masterKeyKMS struct {
 // KMSInfo contains some describing information about
 // the KMS.
 type KMSInfo struct {
-	Endpoint string
-	Name     string
-	AuthType string
+	Endpoints []string
+	Name      string
+	AuthType  string
 }
 
 // NewMasterKey returns a basic KMS implementation from a single 256 bit master key.
@@ -147,9 +147,9 @@ func (kms *masterKeyKMS) GenerateKey(keyID string, ctx Context) (key [32]byte, s
 // KMS is configured directly using master key
 func (kms *masterKeyKMS) Info() (info KMSInfo) {
 	return KMSInfo{
-		Endpoint: "",
-		Name:     "",
-		AuthType: "master-key",
+		Endpoints: []string{},
+		Name:      "",
+		AuthType:  "master-key",
 	}
 }
 

--- a/cmd/crypto/retry.go
+++ b/cmd/crypto/retry.go
@@ -23,7 +23,6 @@ import (
 const (
 	retryWaitMin = 500 * time.Millisecond // minimum retry limit.
 	retryWaitMax = 3 * time.Second        // 3 secs worth of max retry.
-	retryMax     = 2
 )
 
 // LinearJitterBackoff provides the time.Duration for a caller to

--- a/cmd/crypto/vault.go
+++ b/cmd/crypto/vault.go
@@ -199,13 +199,13 @@ func (v *vaultService) DefaultKeyID() string {
 }
 
 // Info returns some information about the Vault,
-// configuration - like the endpoint or authentication
+// configuration - like the endpoints or authentication
 // method.
 func (v *vaultService) Info() KMSInfo {
 	return KMSInfo{
-		Endpoint: v.config.Endpoint,
-		Name:     v.DefaultKeyID(),
-		AuthType: v.config.Auth.Type,
+		Endpoints: []string{v.config.Endpoint},
+		Name:      v.DefaultKeyID(),
+		AuthType:  v.config.Auth.Type,
 	}
 }
 


### PR DESCRIPTION
## Description
With this commit the MinIO server is able to use multiple KES endpoints
at the same time. The MinIO server will consume a comma-separated list
of endpoints - e.g. `https://127.0.0.1:7373,https://127.0.0.1:7374`.
The endpoints may also contain ellipses: `https://127.0.0.1:737{3...4}`

When MinIO has to talk to a KES server it will try each KES server
endpoint until it gets a successful response.
To prevent that all MinIO nodes with the same configuration
(i.e. the same KES endpoint list) will only hit the "first" endpoint,
the MinIO shuffles the list of endpoints on server startup.

So, one MinIO node may use a list of endpoints in the following order:
```
 1. https://kes-2.local
 2. https://kes-1.local
 3. https://kes-3.local
```
while another MinIO node may use the following order:
```
 1. https://kes-3.local
 2. https://kes-2.local
 3. https://kes-1.local
```

This commit addresses a maintenance / automation problem when MinIO-KES
is deployed on bare-metal. In orchestrated env. the orchestrator (K8S)
will make sure that `n` KES servers (IPs) are available via the same DNS
name. There it is sufficient to provide just one endpoint.


## Motivation and Context
HA on bare-metal

## How to test this PR?
 1. Start 2 KES servers - e.g. `https://127.0.0.1:7374` and `https://127.0.0.1:7374` by following: https://github.com/minio/kes/wiki/Filesystem-Keystore
 2. Monitor both instances via `kes log trace` - See: https://github.com/minio/kes/wiki/Logs-and-Monitoring#monitoring
 3. Start a MinIO server with KES as the KMS and auto-encryption.  
 4. Up/Download objects and watch the KES audit log

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
