### PR TITLE
Fix crash on Windows when crawling

### DIFF
--- a/cmd/os-readdir_windows.go
+++ b/cmd/os-readdir_windows.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"syscall"
 )
@@ -79,10 +80,19 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 	}
 	defer f.Close()
 
+	// Check if file or dir. This is the quickest way.
+	_, err = f.Seek(0, io.SeekStart)
+	if err == nil {
+		return nil, errFileNotFound
+	}
 	data := &syscall.Win32finddata{}
+	if count == 0 {
+		return entries, nil
+	}
+	handle := syscall.Handle(f.Fd())
 
 	for count != 0 {
-		e := syscall.FindNextFile(syscall.Handle(f.Fd()), data)
+		e := syscall.FindNextFile(handle, data)
 		if e != nil {
 			if e == syscall.ERROR_NO_MORE_FILES {
 				break

--- a/cmd/os-readdir_windows.go
+++ b/cmd/os-readdir_windows.go
@@ -86,9 +86,6 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 		return nil, errFileNotFound
 	}
 	data := &syscall.Win32finddata{}
-	if count == 0 {
-		return entries, nil
-	}
 	handle := syscall.Handle(f.Fd())
 
 	for count != 0 {


### PR DESCRIPTION
## Description

`syscall.FindNextFile` crashes if the handle is a file.

`errFileNotFound` matches 'unix' functionality: https://github.com/minio/minio/blob/d19b434ffceb005d0673c53bf28209559a536ed3/cmd/os-readdir_unix.go#L106

Fixes #10384

## How to test this PR?

See #10384

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
