### PR TITLE
ListObjectsV1 requests unnecessarily fail with offline nodes

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -498,9 +499,9 @@ func proxyRequest(ctx context.Context, w http.ResponseWriter, r *http.Request, e
 		RoundTripper: ep.Transport,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			success = false
-		},
-		Logger: func(err error) {
-			logger.LogIf(GlobalContext, err)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				logger.LogIf(GlobalContext, err)
+			}
 		},
 	})
 

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -498,7 +498,6 @@ func proxyRequest(ctx context.Context, w http.ResponseWriter, r *http.Request, e
 		RoundTripper: ep.Transport,
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			success = false
-			w.WriteHeader(http.StatusBadGateway)
 		},
 		Logger: func(err error) {
 			logger.LogIf(GlobalContext, err)


### PR DESCRIPTION
## Description
List V1 requests are actually redirected to a specific node, depending
on the bucket name. The purpose of this behavior is to optimize long
listing.

However, the current code sends a Bad Gateway error if the
target node is offline, which is a bad behavior because it means
that the list request will fail, although this is unecessary since
we can still use the current node to list as well (the default behavior
 without using proxing optimization)

Currently you can see mint fails when there is one offline node, after
this PR, mint will always suceeed.

## Motivation and Context
Fix mint errors with one node down


## How to test this PR?
Start a 4 nodes cluster, kill one node, and run mint test on it. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
