### PR TITLE
fix: delete marker compatibility behavior for suspended bucket

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -449,14 +449,15 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 
 	deleteList := toNames(objectsToDelete)
 	dObjects, errs := deleteObjectsFn(ctx, bucket, deleteList, ObjectOptions{
-		Versioned: globalBucketVersioningSys.Enabled(bucket),
+		Versioned:        globalBucketVersioningSys.Enabled(bucket),
+		VersionSuspended: globalBucketVersioningSys.Suspended(bucket),
 	})
 
 	deletedObjects := make([]DeletedObject, len(deleteObjects.Objects))
 	for i := range errs {
 		dindex := objectsToDelete[deleteList[i]]
 		apiErr := toAPIError(ctx, errs[i])
-		if apiErr.Code == "" || apiErr.Code == "NoSuchKey" {
+		if apiErr.Code == "" || apiErr.Code == "NoSuchKey" || apiErr.Code == "InvalidArgument" {
 			deletedObjects[dindex] = dObjects[i]
 			continue
 		}

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -37,6 +37,7 @@ type GetObjectInfoFn func(ctx context.Context, bucket, object string, opts Objec
 // ObjectOptions represents object options for ObjectLayer object operations
 type ObjectOptions struct {
 	ServerSideEncryption encrypt.ServerSide
+	VersionSuspended     bool                // indicates if the bucket was previously versioned but is currently suspended.
 	Versioned            bool                // indicates if the bucket is versioned
 	WalkVersions         bool                // indicates if the we are interested in walking versions
 	VersionID            string              // Specifies the versionID which needs to be overwritten or read

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -133,6 +133,7 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 		return opts, err
 	}
 	opts.Versioned = versioned
+	opts.VersionSuspended = globalBucketVersioningSys.Suspended(bucket)
 	return opts, nil
 }
 

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -679,7 +679,8 @@ func (web *webAPIHandlers) RemoveObject(r *http.Request, args *RemoveObjectArgs,
 	}
 
 	opts := ObjectOptions{
-		Versioned: globalBucketVersioningSys.Enabled(args.BucketName),
+		Versioned:        globalBucketVersioningSys.Enabled(args.BucketName),
+		VersionSuspended: globalBucketVersioningSys.Suspended(args.BucketName),
 	}
 	var err error
 next:


### PR DESCRIPTION


## Description
fix: delete marker compatibility behavior for suspended bucket

## Motivation and Context
- delete-marker should be created on a suspended bucket as `null`
- delete-marker should delete any pre-existing `null` versioned
  object and create an entry `null`

## How to test this PR?
Use `mc version` to create a few scenarios to test this behavior.

```
~ mc mb myminio/testbucket
~ mc cp /etc/hosts myminio/mybucket
~ mc version enable myminio/mybucket/
~ mc cp /etc/hosts myminio/mybucket/hosts
~ mc cp /etc/hosts myminio/mybucket/hosts
~ mc cp /etc/hosts myminio/mybucket/hosts
~ mc rm myminio/mybucket/hosts
~ mc ls --versions myminio/testbucket/     
[2020-08-31 23:12:51 PDT]      0B hosts (5th, vid=c77bf981-79ae-4f10-bdb8-7a24858b3c66, delete-marker)                                                                                        
[2020-08-31 22:33:05 PDT]    478B hosts (4th, vid=e96ef3b8-5e8a-43b7-94eb-2b32417f2153)        
[2020-08-31 22:33:04 PDT]    478B hosts (3rd, vid=c1b8a507-5106-42e5-8e3c-890897b3f848)                                                                                                       
[2020-08-31 22:33:03 PDT]    478B hosts (2nd, vid=3ef1ad6a-a9fd-45d8-8e93-9c42ab43cca3)                                                                                                       
[2020-08-31 22:32:48 PDT]    478B hosts (1st, vid=null)              
```

```
~ mc version suspend myminio/mybucket/
~ mc rm  myminio/mybucket/hosts
~ mc ls --versions myminio/testbucket/ 
[2020-08-31 23:17:18 PDT]      0B hosts (5th, vid=null, delete-marker)
[2020-08-31 23:12:51 PDT]      0B hosts (4th, vid=c77bf981-79ae-4f10-bdb8-7a24858b3c66, delete-marker)
[2020-08-31 22:33:05 PDT]    478B hosts (3rd, vid=e96ef3b8-5e8a-43b7-94eb-2b32417f2153)
[2020-08-31 22:33:04 PDT]    478B hosts (2nd, vid=c1b8a507-5106-42e5-8e3c-890897b3f848)                                                                                                       
[2020-08-31 22:33:03 PDT]    478B hosts (1st, vid=3ef1ad6a-a9fd-45d8-8e93-9c42ab43cca3)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
