### PR TITLE
tests: Fix common Windows failure

### DIFF
--- a/cmd/http/listener_test.go
+++ b/cmd/http/listener_test.go
@@ -186,6 +186,10 @@ func TestHTTPListenerStartClose(t *testing.T) {
 			testCase.serverAddrs,
 		)
 		if err != nil {
+			if strings.Contains(err.Error(), "The requested address is not valid in its context") {
+				// Ignore if IP is unbindable.
+				continue
+			}
 			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 		}
 
@@ -225,6 +229,10 @@ func TestHTTPListenerAddr(t *testing.T) {
 			testCase.serverAddrs,
 		)
 		if err != nil {
+			if strings.Contains(err.Error(), "The requested address is not valid in its context") {
+				// Ignore if IP is unbindable.
+				continue
+			}
 			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 		}
 
@@ -261,6 +269,10 @@ func TestHTTPListenerAddrs(t *testing.T) {
 			testCase.serverAddrs,
 		)
 		if err != nil {
+			if strings.Contains(err.Error(), "The requested address is not valid in its context") {
+				// Ignore if IP is unbindable.
+				continue
+			}
 			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 		}
 


### PR DESCRIPTION
## Motivation and Context

The `getNonLoopBackIP` may grab an IP from an interface that doesn't allow binding (on Windows), so this test consistently fails.

## Description

We exclude that specific error.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
