### PR TITLE
tests: Fix flaky TestXLStorageVerifyFile

### DIFF
--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -1704,7 +1704,8 @@ func TestXLStorageVerifyFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := f.WriteString("a"); err != nil {
+	// Replace first 256 with 'a'.
+	if _, err := f.WriteString(strings.Repeat("a", 256)); err != nil {
 		t.Fatal(err)
 	}
 	f.Close()


### PR DESCRIPTION
## Description

`TestXLStorageVerifyFile` would fail 1 in 256 if the first random character was 'a'.

Instead write 256 bytes which has 1 in 256^256 probability.


## How to test this PR?

In `minio/cmd` run `go test -test.run TestXLStorageVerifyFile -count=1000`

Before: 

```
λ go test -test.run TestXLStorageVerifyFile -count=100
--- FAIL: TestXLStorageVerifyFile (0.03s)
    xl-storage_test.go:1713: expected to fail bitrot check
--- FAIL: TestXLStorageVerifyFile (0.03s)
    xl-storage_test.go:1713: expected to fail bitrot check
FAIL
exit status 1
```
After:

```
λ go test -test.run TestXLStorageVerifyFile -count=1000
PASS
ok      github.com/minio/minio/cmd      29.147s
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
