### PR TITLE
heal: Check for truncated files

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1812,6 +1812,10 @@ func (s *xlStorage) CheckParts(volume, path string, fi FileInfo) error {
 		if st.Mode().IsDir() {
 			return errFileNotFound
 		}
+		// Check if shard is truncated.
+		if st.Size() < fi.Erasure.ShardFileSize(part.Size) {
+			return errFileCorrupt
+		}
 	}
 
 	return nil
@@ -1860,7 +1864,7 @@ func (s *xlStorage) CheckFile(volume, path string) error {
 	}
 
 	// If its a directory its not a regular file.
-	if st.Mode().IsDir() {
+	if st.Mode().IsDir() || st.Size() == 0 {
 		return errFileNotFound
 	}
 


### PR DESCRIPTION
## Description

When checking parts we already do a stat for each part.

Since we have the on disk size check if it is at least what we expect.

When checking metadata check if metadata is 0 bytes.

## How to test this PR?

Start distributed mode server. Upload a file. Truncate a part on disk. Run a normal heal scan or wait for it to be picked up by crawler for heal.

## Types of changes
- [x] Feature
