### PR TITLE
cache: Only start at high watermark

### DIFF
--- a/cmd/disk-cache-utils.go
+++ b/cmd/disk-cache-utils.go
@@ -489,9 +489,15 @@ func (f *fileScorer) queueString() string {
 // bytesToClear() returns the number of bytes to clear to reach low watermark
 // w.r.t quota given disk total and free space, quota in % allocated to cache
 // and low watermark % w.r.t allowed quota.
-func bytesToClear(total, free int64, quotaPct, lowWatermark uint64) uint64 {
-	used := (total - free)
+// If the high watermark hasn't been reached 0 will be returned.
+func bytesToClear(total, free int64, quotaPct, lowWatermark, highWatermark uint64) uint64 {
+	used := total - free
 	quotaAllowed := total * (int64)(quotaPct) / 100
-	lowWMUsage := (total * (int64)(lowWatermark*quotaPct) / (100 * 100))
+	highWMUsage := total * (int64)(highWatermark*quotaPct) / (100 * 100)
+	if used < highWMUsage {
+		return 0
+	}
+	// Return bytes needed to reach low watermark.
+	lowWMUsage := total * (int64)(lowWatermark*quotaPct) / (100 * 100)
 	return (uint64)(math.Min(float64(quotaAllowed), math.Max(0.0, float64(used-lowWMUsage))))
 }

--- a/cmd/disk-cache-utils_test.go
+++ b/cmd/disk-cache-utils_test.go
@@ -149,22 +149,26 @@ func TestNewFileScorer(t *testing.T) {
 }
 func TestBytesToClear(t *testing.T) {
 	testCases := []struct {
-		total        int64
-		free         int64
-		quotaPct     uint64
-		watermarkLow uint64
-		expected     uint64
+		total         int64
+		free          int64
+		quotaPct      uint64
+		watermarkLow  uint64
+		watermarkHigh uint64
+		expected      uint64
 	}{
-		{1000, 800, 40, 90, 0},
-		{1000, 200, 40, 90, 400},
-		{1000, 400, 40, 90, 240},
-		{1000, 600, 40, 90, 40},
-		{1000, 600, 40, 70, 120},
-		{1000, 1000, 90, 70, 0},
-		{1000, 0, 90, 70, 370},
+		{total: 1000, free: 800, quotaPct: 40, watermarkLow: 90, watermarkHigh: 90, expected: 0},
+		{total: 1000, free: 200, quotaPct: 40, watermarkLow: 90, watermarkHigh: 90, expected: 400},
+		{total: 1000, free: 400, quotaPct: 40, watermarkLow: 90, watermarkHigh: 90, expected: 240},
+		{total: 1000, free: 600, quotaPct: 40, watermarkLow: 90, watermarkHigh: 90, expected: 40},
+		{total: 1000, free: 600, quotaPct: 40, watermarkLow: 70, watermarkHigh: 70, expected: 120},
+		{total: 1000, free: 1000, quotaPct: 90, watermarkLow: 70, watermarkHigh: 70, expected: 0},
+
+		// High not yet reached..
+		{total: 1000, free: 250, quotaPct: 100, watermarkLow: 50, watermarkHigh: 90, expected: 0},
+		{total: 1000, free: 250, quotaPct: 100, watermarkLow: 50, watermarkHigh: 90, expected: 0},
 	}
 	for i, tc := range testCases {
-		toClear := bytesToClear(tc.total, tc.free, tc.quotaPct, tc.watermarkLow)
+		toClear := bytesToClear(tc.total, tc.free, tc.quotaPct, tc.watermarkLow, tc.watermarkHigh)
 		if tc.expected != toClear {
 			t.Errorf("test %d expected %v, got %v", i, tc.expected, toClear)
 		}

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -284,12 +284,6 @@ func (c *cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	// Reaching here implies cache miss
 	c.cacheStats.incMiss()
 
-	// Since we got here, we are serving the request from backend,
-	// and also adding the object to the cache.
-	if dcache.diskUsageHigh() {
-		dcache.triggerGC <- struct{}{} // this is non-blocking
-	}
-
 	bkReader, bkErr := c.GetObjectNInfoFn(ctx, bucket, object, rs, h, lockType, opts)
 
 	if bkErr != nil {
@@ -306,7 +300,9 @@ func (c *cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	if cacheErr == nil {
 		bkReader.ObjInfo.CacheLookupStatus = CacheHit
 	}
-	if !dcache.diskAvailable(objInfo.Size) {
+
+	// Check if we can add it without exceeding total cache size.
+	if !dcache.diskSpaceAvailable(objInfo.Size) {
 		return bkReader, bkErr
 	}
 
@@ -612,9 +608,10 @@ func (c *cacheObjects) PutObject(ctx context.Context, bucket, object string, r *
 	}
 
 	// fetch from backend if there is no space on cache drive
-	if !dcache.diskAvailable(size) {
+	if !dcache.diskSpaceAvailable(size) {
 		return putObjectFn(ctx, bucket, object, r, opts)
 	}
+
 	if opts.ServerSideEncryption != nil {
 		dcache.Delete(ctx, bucket, object)
 		return putObjectFn(ctx, bucket, object, r, opts)
@@ -721,7 +718,9 @@ func (c *cacheObjects) gc(ctx context.Context) {
 			}
 			for _, dcache := range c.cache {
 				if dcache != nil {
-					dcache.triggerGC <- struct{}{}
+					// Check if there is disk.
+					// Will queue a GC scan if at high watermark.
+					dcache.diskSpaceAvailable(0)
 				}
 			}
 		}

--- a/docs/disk-caching/README.md
+++ b/docs/disk-caching/README.md
@@ -29,6 +29,10 @@ export MINIO_CACHE_WATERMARK_HIGH=90
 minio gateway s3
 ```
 
+The `CACHE_WATERMARK` numbers are percentages of `CACHE_QUOTA`. 
+In the example above this means that  `MINIO_CACHE_WATERMARK_LOW` is effectively `0.8 * 0.7 * 100 = 56%` and the `MINIO_CACHE_WATERMARK_LOW` is effectively `0.8 * 0.9 * 100 = 72%` of total disk space.     
+
+
 ### 3. Test your setup
 
 To test this setup, access the MinIO gateway via browser or [`mc`](https://docs.min.io/docs/minio-client-quickstart-guide). You’ll see the uploaded files are accessible from all the MinIO endpoints.


### PR DESCRIPTION
## Motivation and Context

Currently cache purges are triggered as soon as low watermark is exceeded.

To reduce IO this should only be done when reaching the high watermark.

## Description

This simplifies checks and reduces all calls for a GC to go through `dcache.diskSpaceAvailable(size)`.

While a comment claims that `dcache.triggerGC <- struct{}{}` was non-blocking I don't see how that was possible.

Instead we add a 1 size to the queue channel and use channel semantics to avoid blocking when a GC has already been requested.

`bytesToClear` now takes the high watermark into account to it will not request any bytes to be cleared until that is reached.

## How to test this PR?

Setup server with cache.

## Types of changes
- [x] Bug fix (it now does what the documentation states)
