### PR TITLE
Fix docs to use default chunk size of 25MB as 0.25MB provided in the example is too small

### DIFF
--- a/docs/gateway/azure.md
+++ b/docs/gateway/azure.md
@@ -7,7 +7,6 @@ MinIO Gateway adds Amazon S3 compatibility to Microsoft Azure Blob Storage.
 docker run -p 9000:9000 --name azure-s3 \
  -e "MINIO_ACCESS_KEY=azurestorageaccountname" \
  -e "MINIO_SECRET_KEY=azurestorageaccountkey" \
- -e "MINIO_AZURE_CHUNK_SIZE_MB=0.25" \
  minio/minio gateway azure
 ```
 
@@ -15,7 +14,6 @@ docker run -p 9000:9000 --name azure-s3 \
 ```
 export MINIO_ACCESS_KEY=azureaccountname
 export MINIO_SECRET_KEY=azureaccountkey
-export MINIO_AZURE_CHUNK_SIZE_MB=0.25
 minio gateway azure
 ```
 ## Test using MinIO Browser


### PR DESCRIPTION
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed