### PR TITLE
Ignore slow/failed disks during all S3 requests

### DIFF
--- a/cmd/erasure-decode_test.go
+++ b/cmd/erasure-decode_test.go
@@ -111,7 +111,7 @@ func TestErasureDecode(t *testing.T) {
 			writers[i] = newBitrotWriter(disk, "testbucket", "object", erasure.ShardFileSize(test.data), writeAlgorithm, erasure.ShardSize())
 		}
 		n, err := erasure.Encode(context.Background(), bytes.NewReader(data[:]), writers, buffer, erasure.dataBlocks+1)
-		closeBitrotWriters(writers)
+		closeBitrotWriters(writers, true)
 		if err != nil {
 			setup.Remove()
 			t.Fatalf("Test %d: failed to create erasure test file: %v", i, err)
@@ -243,7 +243,7 @@ func TestErasureDecodeRandomOffsetLength(t *testing.T) {
 	// Create a test file to read from.
 	buffer := make([]byte, blockSize, 2*blockSize)
 	n, err := erasure.Encode(context.Background(), bytes.NewReader(data), writers, buffer, erasure.dataBlocks+1)
-	closeBitrotWriters(writers)
+	closeBitrotWriters(writers, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func benchmarkErasureDecode(data, parity, dataDown, parityDown int, size int64, 
 	content := make([]byte, size)
 	buffer := make([]byte, blockSizeV1, 2*blockSizeV1)
 	_, err = erasure.Encode(context.Background(), bytes.NewReader(content), writers, buffer, erasure.dataBlocks+1)
-	closeBitrotWriters(writers)
+	closeBitrotWriters(writers, true)
 	if err != nil {
 		b.Fatalf("failed to create erasure test file: %v", err)
 	}

--- a/cmd/erasure-encode_test.go
+++ b/cmd/erasure-encode_test.go
@@ -111,7 +111,7 @@ func TestErasureEncode(t *testing.T) {
 			writers[i] = newBitrotWriter(disk, "testbucket", "object", erasure.ShardFileSize(int64(len(data[test.offset:]))), test.algorithm, erasure.ShardSize())
 		}
 		n, err := erasure.Encode(context.Background(), bytes.NewReader(data[test.offset:]), writers, buffer, erasure.dataBlocks+1)
-		closeBitrotWriters(writers)
+		closeBitrotWriters(writers, true)
 		if err != nil && !test.shouldFail {
 			t.Errorf("Test %d: should pass but failed with: %v", i, err)
 		}
@@ -146,7 +146,7 @@ func TestErasureEncode(t *testing.T) {
 				writers[0] = nil
 			}
 			n, err = erasure.Encode(context.Background(), bytes.NewReader(data[test.offset:]), writers, buffer, erasure.dataBlocks+1)
-			closeBitrotWriters(writers)
+			closeBitrotWriters(writers, true)
 			if err != nil && !test.shouldFailQuorum {
 				t.Errorf("Test %d: should pass but failed with: %v", i, err)
 			}
@@ -199,7 +199,7 @@ func benchmarkErasureEncode(data, parity, dataDown, parityDown int, size int64, 
 			writers[i] = newBitrotWriter(disk, "testbucket", "object", erasure.ShardFileSize(size), DefaultBitrotAlgorithm, erasure.ShardSize())
 		}
 		_, err := erasure.Encode(context.Background(), bytes.NewReader(content), writers, buffer, erasure.dataBlocks+1)
-		closeBitrotWriters(writers)
+		closeBitrotWriters(writers, true)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/erasure-heal_test.go
+++ b/cmd/erasure-heal_test.go
@@ -90,7 +90,7 @@ func TestErasureHeal(t *testing.T) {
 			writers[i] = newBitrotWriter(disk, "testbucket", "testobject", erasure.ShardFileSize(test.size), test.algorithm, erasure.ShardSize())
 		}
 		_, err = erasure.Encode(context.Background(), bytes.NewReader(data), writers, buffer, erasure.dataBlocks+1)
-		closeBitrotWriters(writers)
+		closeBitrotWriters(writers, true)
 		if err != nil {
 			setup.Remove()
 			t.Fatalf("Test %d: failed to create random test data: %v", i, err)
@@ -136,7 +136,7 @@ func TestErasureHeal(t *testing.T) {
 		// test case setup is complete - now call Heal()
 		err = erasure.Heal(context.Background(), readers, staleWriters, test.size)
 		closeBitrotReaders(readers)
-		closeBitrotWriters(staleWriters)
+		closeBitrotWriters(staleWriters, true)
 		if err != nil && !test.shouldFail {
 			t.Errorf("Test %d: should pass but it failed with: %v", i, err)
 		}

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -407,7 +407,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 			}
 			err = erasure.Heal(ctx, readers, writers, partSize)
 			closeBitrotReaders(readers)
-			closeBitrotWriters(writers)
+			closeBitrotWriters(writers, true)
 			if err != nil {
 				return result, toObjectErr(err, bucket, object)
 			}

--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -130,7 +130,7 @@ func readAllFileInfo(ctx context.Context, disks []StorageAPI, bucket, object, ve
 func readVersionFromDisks(ctx context.Context, disks []StorageAPI, bucket, object, versionID string, checkDataDir bool) ([]FileInfo, []error) {
 	metadataArray := make([]FileInfo, len(disks))
 
-	g := errgroup.WithNErrs(len(disks))
+	g := errgroup.New(errgroup.Opts{Total: len(disks), FailFactor: 10, Quorum: len(disks)/2 + 1, ValidErrs: []error{errFileNotFound}})
 	// Read `xl.meta` in parallel across disks.
 	for index := range disks {
 		index := index

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -280,7 +280,7 @@ func pickValidFileInfo(ctx context.Context, metaArr []FileInfo, modTime time.Tim
 func renameFileInfo(ctx context.Context, disks []StorageAPI, srcBucket, srcEntry, dstBucket, dstEntry string, quorum int) ([]StorageAPI, error) {
 	ignoredErr := []error{errFileNotFound}
 
-	g := errgroup.WithNErrs(len(disks))
+	g := errgroup.New(errgroup.Opts{Total: len(disks), FailFactor: 10, Quorum: quorum})
 
 	// Rename file on all underlying storage disks.
 	for index := range disks {
@@ -309,7 +309,7 @@ func renameFileInfo(ctx context.Context, disks []StorageAPI, srcBucket, srcEntry
 
 // writeUniqueFileInfo - writes unique `xl.meta` content for each disk concurrently.
 func writeUniqueFileInfo(ctx context.Context, disks []StorageAPI, bucket, prefix string, files []FileInfo, quorum int) ([]StorageAPI, error) {
-	g := errgroup.WithNErrs(len(disks))
+	g := errgroup.New(errgroup.Opts{Total: len(disks), FailFactor: 10, Quorum: quorum})
 
 	// Start writing `xl.meta` to all disks in parallel.
 	for index := range disks {

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -435,7 +435,7 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 	}
 
 	n, err := erasure.Encode(ctx, data, writers, buffer, writeQuorum)
-	closeBitrotWriters(writers)
+	closeBitrotWriters(writers, false)
 	if err != nil {
 		return pi, toObjectErr(err, bucket, object)
 	}

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -124,7 +124,7 @@ func getDisksInfo(disks []StorageAPI, endpoints []string) (disksInfo []madmin.Di
 		}
 	}
 
-	g := errgroup.WithNErrs(len(disks))
+	g := errgroup.New(errgroup.Opts{Total: len(disks), FailFactor: 10, MinWaitTime: 10 * time.Second})
 	for index := range disks {
 		index := index
 		g.Go(func() error {

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2016 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2016-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,10 @@ func (d *naughtyDisk) Hostname() string {
 
 func (d *naughtyDisk) Healing() bool {
 	return d.disk.Healing()
+}
+
+func (d *naughtyDisk) Latency() int64 {
+	return d.disk.Latency()
 }
 
 func (d *naughtyDisk) Close() (err error) {

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -74,12 +74,12 @@ var printEndpointError = func() func(Endpoint, error, bool) {
 // Migrates backend format of local disks.
 func formatErasureMigrateLocalEndpoints(endpoints Endpoints) error {
 	g := errgroup.WithNErrs(len(endpoints))
-	for index, endpoint := range endpoints {
-		if !endpoint.IsLocal {
-			continue
-		}
+	for index := range endpoints {
 		index := index
 		g.Go(func() error {
+			if !endpoints[index].IsLocal {
+				return nil
+			}
 			epPath := endpoints[index].Path
 			err := formatErasureMigrate(epPath)
 			if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -99,12 +99,12 @@ func formatErasureMigrateLocalEndpoints(endpoints Endpoints) error {
 // Cleans up tmp directory of local disks.
 func formatErasureCleanupTmpLocalEndpoints(endpoints Endpoints) error {
 	g := errgroup.WithNErrs(len(endpoints))
-	for index, endpoint := range endpoints {
-		if !endpoint.IsLocal {
-			continue
-		}
+	for index := range endpoints {
 		index := index
 		g.Go(func() error {
+			if !endpoints[index].IsLocal {
+				return nil
+			}
 			epPath := endpoints[index].Path
 			// Need to move temporary objects left behind from previous run of minio
 			// server to a unique directory under `minioMetaTmpBucket-old` to clean

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -39,6 +39,10 @@ type StorageAPI interface {
 	Healing() bool // Returns if disk is healing.
 
 	DiskInfo(ctx context.Context) (info DiskInfo, err error)
+
+	// Lower is better
+	Latency() int64
+
 	CrawlAndGetDataUsage(ctx context.Context, cache dataUsageCache) (dataUsageCache, error)
 
 	// Volume operations.

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -55,6 +55,10 @@ func (p *xlStorageDiskIDCheck) Healing() bool {
 	return p.storage.Healing()
 }
 
+func (p *xlStorageDiskIDCheck) Latency() int64 {
+	return p.storage.Latency()
+}
+
 func (p *xlStorageDiskIDCheck) CrawlAndGetDataUsage(ctx context.Context, cache dataUsageCache) (dataUsageCache, error) {
 	if err := p.checkDiskStale(); err != nil {
 		return dataUsageCache{}, err

--- a/pkg/sync/errgroup/errgroup.go
+++ b/pkg/sync/errgroup/errgroup.go
@@ -17,28 +17,147 @@
 package errgroup
 
 import (
-	"sync"
+	"errors"
+	"sync/atomic"
+	"time"
 )
+
+// ErrTaskIgnored indicates that the corresponding
+// has not being executed by the parallel goroutine
+// manager because quorum was reached already.
+var ErrTaskIgnored = errors.New("task ignored")
+
+type taskStatus struct {
+	err      error
+	duration time.Duration
+}
 
 // A Group is a collection of goroutines working on subtasks that are part of
 // the same overall task.
 //
 // A zero Group is valid and does not cancel on error.
 type Group struct {
-	wg   sync.WaitGroup
-	errs []error
+	errs     []error
+	doneCh   chan taskStatus
+	total    int64
+	quitting int64
+
+	minWaitTime time.Duration
+	failFactor  int
+	quorum      int64
+	validErrs   []error
 }
 
-// WithNErrs returns a new Group with length of errs slice upto nerrs,
-// upon Wait() errors are returned collected from all tasks.
+// Opts holds configuration of the errgroup go-routine manager
+type Opts struct {
+	Total       int
+	Quorum      int
+	ValidErrs   []error
+	FailFactor  int
+	MinWaitTime time.Duration
+}
+
+// New returns a new Group upon Wait() errors are returned collected from all tasks.
+func New(opts Opts) *Group {
+	errs := make([]error, opts.Total)
+	for i := range errs {
+		errs[i] = ErrTaskIgnored
+	}
+
+	waitTime := 100 * time.Millisecond
+	if opts.MinWaitTime > 0 {
+		waitTime = opts.MinWaitTime
+	}
+
+	return &Group{
+		errs:        errs,
+		doneCh:      make(chan taskStatus, opts.Total),
+		failFactor:  opts.FailFactor,
+		minWaitTime: waitTime,
+		quorum:      int64(opts.Quorum),
+		validErrs:   opts.ValidErrs,
+	}
+}
+
+// WithNErrs returns a parallel goroutine manager
 func WithNErrs(nerrs int) *Group {
-	return &Group{errs: make([]error, nerrs)}
+	return New(Opts{Total: nerrs})
 }
 
 // Wait blocks until all function calls from the Go method have returned, then
 // returns the slice of errors from all function calls.
-func (g *Group) Wait() []error {
-	g.wg.Wait()
+func (g *Group) Wait() (ret []error) {
+	/*
+		// TODO: remove the following debug code
+		debugCh := make(chan struct{})
+		defer func() {
+			debugCh <- struct{}{}
+		}()
+		var stack strings.Builder
+		stack.Write(debug.Stack())
+		go func() {
+			select {
+			case <-time.NewTimer(5 * time.Second).C:
+				fmt.Println(stack.String())
+				os.Exit(-1)
+			case <-debugCh:
+				return
+			}
+		}()
+	*/
+
+	if atomic.LoadInt64(&g.total) == 0 {
+		return g.errs
+	}
+
+	var done, success, ignored int64
+	var maxTaskDuration time.Duration
+	var abortTime = 5 * time.Minute
+
+	for {
+		var abortTimer <-chan time.Time
+		quorum := g.total
+		if g.quorum != 0 {
+			quorum = g.quorum
+		}
+
+		if success >= quorum || ignored >= quorum {
+			if g.failFactor > 0 {
+				abortTime = maxTaskDuration * time.Duration(g.failFactor)
+				if abortTime < g.minWaitTime {
+					abortTime = g.minWaitTime
+				}
+			}
+		}
+
+		abortTimer = time.NewTimer(abortTime).C
+
+		select {
+		case st := <-g.doneCh:
+			done++
+			if done == atomic.LoadInt64(&g.total) {
+				goto quit
+			}
+			if st.err == nil {
+				success++
+			} else {
+				for _, e := range g.validErrs {
+					if st.err == e {
+						ignored++
+						break
+					}
+				}
+			}
+			if st.duration > maxTaskDuration {
+				maxTaskDuration = st.duration
+			}
+		case <-abortTimer:
+			goto quit
+		}
+	}
+
+quit:
+	atomic.StoreInt64(&g.quitting, 1)
 	return g.errs
 }
 
@@ -47,13 +166,14 @@ func (g *Group) Wait() []error {
 // The first call to return a non-nil error will be
 // collected in errs slice and returned by Wait().
 func (g *Group) Go(f func() error, index int) {
-	g.wg.Add(1)
-
+	if atomic.LoadInt64(&g.quitting) > 0 {
+		return
+	}
+	atomic.AddInt64(&g.total, 1)
 	go func() {
-		defer g.wg.Done()
-
-		if err := f(); err != nil {
-			g.errs[index] = err
-		}
+		now := time.Now()
+		g.errs[index] = f()
+		d := time.Since(now)
+		g.doneCh <- taskStatus{duration: d, err: g.errs[index]}
 	}()
 }


### PR DESCRIPTION
## Description

This PR has two changes:


1. sync/errgroup

No functional changes for the already present APIs but I added a new API called New() with
options when we can tweak some behavior of the errgroup package.

opts.Quorum:
- If not specified, the code will follow the old behavior (WithNErrs()), so
it will try to get results from all disks.
- If specified, then it will wait until having quorum *success* posix calls (err == nil)
or any error from opts.IgnoreErrs list.

opts.IgnoreErrs:
HEAD /bucket/inexistant-object leads to some xl-storage calls that return errFileNotFound,
we should consider errFileNotFound as a good error and not require having opts.Quorum here

Basically opts.IgnoreErrs is the list of errors that can be added to the quorum result

FailFactor:
It helps to tweak how much time to wait for requests on slow/failed disks.
e.g.: If FailFactor is ten, then sync/errgroup will wait 10x the longest time
that a call is returned from differents disks.


2. getLoadBalancedDisks() change

getLoadBalancedDisks() is used in operations when we don't want to send requests
to all disks, like getting bucket info, or listing multipart calls, etc..

getLoadBalancedDisks() will return faster disks first, like a load balancer.
xl-storage.go is updated to try to read data from the disk (format.json) each
1 minute and calculate the time spent for this operation. That way, it can
prefer a remote good disk than a slow local disk.

---
Currently a 4 nodes cluster with 4 disks, where one of them is failed, makes functional minio-go tests to finish in x 10 the standard time. 10 is the one we configured by default. (We do not want to abondon writing on a node so quickly)
---

## Motivation and Context
Fix cluster stuck with failed/slow disks

## How to test this PR?
Contact me

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
