### PR TITLE
set max API requests automatically based on RAM

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -377,7 +377,7 @@ func lookupConfigs(s config.Config, setDriveCount int) {
 		logger.LogIf(ctx, fmt.Errorf("Invalid api configuration: %w", err))
 	}
 
-	globalAPIConfig.init(apiConfig)
+	globalAPIConfig.init(apiConfig, setDriveCount)
 
 	if globalIsErasure {
 		globalStorageClass, err = storageclass.LookupConfig(s[config.StorageClassSubSys][config.Default], setDriveCount)

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/minio/minio/cmd/config/api"
+	"github.com/minio/minio/pkg/sys"
 )
 
 type apiConfig struct {
@@ -33,22 +34,30 @@ type apiConfig struct {
 	corsAllowOrigins []string
 }
 
-func (t *apiConfig) init(cfg api.Config) {
+func (t *apiConfig) init(cfg api.Config, setDriveCount int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	t.readyDeadline = cfg.APIReadyDeadline
 	t.corsAllowOrigins = cfg.APICorsAllowOrigin
+	var apiRequestsMaxPerNode int
 	if cfg.APIRequestsMax <= 0 {
-		return
+		stats, err := sys.GetStats()
+		if err != nil {
+			return
+		}
+		// max requests per node is calculated as
+		// total_ram / ram_per_request
+		// ram_per_request is 4MiB * setDriveCount + 2 * 10MiB (default erasure block size)
+		apiRequestsMaxPerNode = int(stats.TotalRAM / uint64(setDriveCount*readBlockSize+blockSizeV1*2))
+	} else {
+		apiRequestsMaxPerNode = cfg.APIRequestsMax
+		if len(globalEndpoints.Hostnames()) > 0 {
+			apiRequestsMaxPerNode /= len(globalEndpoints.Hostnames())
+		}
 	}
 
-	apiRequestsMax := cfg.APIRequestsMax
-	if len(globalEndpoints.Hostnames()) > 0 {
-		apiRequestsMax /= len(globalEndpoints.Hostnames())
-	}
-
-	t.requestsPool = make(chan struct{}, apiRequestsMax)
+	t.requestsPool = make(chan struct{}, apiRequestsMaxPerNode)
 	t.requestsDeadline = cfg.APIRequestsDeadline
 }
 


### PR DESCRIPTION
## Description
set max API requests automatically based on RAM

## Motivation and Context
automatically set max requests per server based on RAM

## How to test this PR?
honors cgroup limits as well 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
