### PR TITLE
Add support for searching objects

### DIFF
--- a/browser/app/js/browser/Header.js
+++ b/browser/app/js/browser/Header.js
@@ -15,6 +15,7 @@
  */
 
 import React from "react"
+import ObjectsSearch from "../objects/ObjectsSearch"
 import Path from "../objects/Path"
 import StorageInfo from "./StorageInfo"
 import BrowserDropdown from "./BrowserDropdown"
@@ -27,6 +28,7 @@ export const Header = () => {
     <header className="fe-header">
       <Path />
       {loggedIn && <StorageInfo />}
+      {loggedIn && <ObjectsSearch />}
       <ul className="feh-actions">
         {loggedIn ? (
           <BrowserDropdown />

--- a/browser/app/js/objects/ObjectsListContainer.js
+++ b/browser/app/js/objects/ObjectsListContainer.js
@@ -18,6 +18,7 @@ import React from "react"
 import { connect } from "react-redux"
 import InfiniteScroll from "react-infinite-scroller"
 import ObjectsList from "./ObjectsList"
+import { getFilteredObjects } from "./selectors"
 
 export class ObjectsListContainer extends React.Component {
   constructor(props) {
@@ -39,22 +40,29 @@ export class ObjectsListContainer extends React.Component {
       })
     }
   }
+  componentDidUpdate(prevProps) {
+    if (this.props.filter !== prevProps.filter) {
+      this.setState({
+        page: 1
+      })
+    }
+  }
   loadNextPage() {
     this.setState(state => {
       return { page: state.page + 1 }
     })
   }
   render() {
-    const { objects, listLoading } = this.props
+    const { filteredObjects, listLoading } = this.props
 
-    const visibleObjects = objects.slice(0, this.state.page * 100)
+    const visibleObjects = filteredObjects.slice(0, this.state.page * 100)
 
     return (
       <div style={{ position: "relative" }}>
         <InfiniteScroll
           pageStart={0}
           loadMore={this.loadNextPage}
-          hasMore={objects.length > visibleObjects.length}
+          hasMore={filteredObjects.length > visibleObjects.length}
           useWindow={true}
           initialLoad={false}
         >
@@ -70,7 +78,8 @@ const mapStateToProps = state => {
   return {
     currentBucket: state.buckets.currentBucket,
     currentPrefix: state.objects.currentPrefix,
-    objects: state.objects.list,
+    filteredObjects: getFilteredObjects(state),
+    filter: state.objects.filter,
     sortBy: state.objects.sortBy,
     sortOrder: state.objects.sortOrder,
     listLoading: state.objects.listLoading

--- a/browser/app/js/objects/ObjectsSearch.js
+++ b/browser/app/js/objects/ObjectsSearch.js
@@ -1,0 +1,43 @@
+/*
+ * MinIO Cloud Storage (C) 2016, 2018, 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { connect } from "react-redux"
+import * as actionsObjects from "./actions"
+
+export const ObjectsSearch = ({ onChange }) => (
+  <div
+    className="input-group ig-left ig-search-dark"
+    style={{ display: "block" }}
+  >
+    <input
+      className="ig-text"
+      type="input"
+      placeholder="Search Objects..."
+      onChange={e => onChange(e.target.value)}
+    />
+    <i className="ig-helpers" />
+  </div>
+)
+
+const mapDispatchToProps = dispatch => {
+  return {
+    onChange: filter =>
+      dispatch(actionsObjects.setFilter(filter))
+  }
+}
+
+export default connect(undefined, mapDispatchToProps)(ObjectsSearch)

--- a/browser/app/js/objects/__tests__/ObjectsListContainer.test.js
+++ b/browser/app/js/objects/__tests__/ObjectsListContainer.test.js
@@ -20,13 +20,13 @@ import { ObjectsListContainer } from "../ObjectsListContainer"
 
 describe("ObjectsList", () => {
   it("should render without crashing", () => {
-    shallow(<ObjectsListContainer objects={[]} />)
+    shallow(<ObjectsListContainer filteredObjects={[]} />)
   })
 
   it("should render ObjectsList with objects", () => {
     const wrapper = shallow(
       <ObjectsListContainer
-        objects={[{ name: "test1.jpg" }, { name: "test2.jpg" }]}
+        filteredObjects={[{ name: "test1.jpg" }, { name: "test2.jpg" }]}
       />
     )
     expect(wrapper.find("ObjectsList").length).toBe(1)
@@ -40,7 +40,7 @@ describe("ObjectsList", () => {
     const wrapper = shallow(
       <ObjectsListContainer
         currentBucket="test1"
-        objects={[]}
+        filteredObjects={[]}
         listLoading={true}
       />
     )

--- a/browser/app/js/objects/__tests__/ObjectsSearch.test.js
+++ b/browser/app/js/objects/__tests__/ObjectsSearch.test.js
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-import { createSelector } from "reselect"
+import React from "react"
+import { mount, shallow } from "enzyme"
+import { ObjectsSearch } from "../ObjectsSearch"
 
-export const getCurrentPrefix = state => state.objects.currentPrefix
+describe("ObjectsSearch", () => {
+  it("should render without crashing", () => {
+    shallow(<ObjectsSearch />)
+  })
 
-export const getCheckedList = state => state.objects.checkedList
-
-export const getPrefixWritable = state => state.objects.prefixWritable
-
-const objectsSelector = state => state.objects.list
-const objectsFilterSelector = state => state.objects.filter
-
-export const getFilteredObjects = createSelector(
-  objectsSelector,
-  objectsFilterSelector,
-  (objects, filter) => objects.filter(object => object.name.startsWith(filter))
-)
+  it("should call onChange with search text", () => {
+    const onChange = jest.fn()
+    const wrapper = mount(<ObjectsSearch onChange={onChange} />)
+    console.log(wrapper.html())
+    wrapper.find("input").simulate("change", { target: { value: "a" } })
+    expect(onChange).toHaveBeenCalledWith("a")
+  })
+})

--- a/browser/app/js/objects/__tests__/reducer.test.js
+++ b/browser/app/js/objects/__tests__/reducer.test.js
@@ -23,6 +23,7 @@ describe("objects reducer", () => {
     const initialState = reducer(undefined, {})
     expect(initialState).toEqual({
       list: [],
+      filter: "",
       listLoading: false,
       sortBy: "",
       sortOrder: SORT_ORDER_ASC,

--- a/browser/app/js/objects/actions.js
+++ b/browser/app/js/objects/actions.js
@@ -36,6 +36,7 @@ import { getServerInfo, hasServerPublicDomain } from '../browser/selectors'
 
 export const SET_LIST = "objects/SET_LIST"
 export const RESET_LIST = "objects/RESET_LIST"
+export const SET_FILTER = "objects/SET_FILTER"
 export const APPEND_LIST = "objects/APPEND_LIST"
 export const REMOVE = "objects/REMOVE"
 export const SET_SORT_BY = "objects/SET_SORT_BY"
@@ -56,6 +57,13 @@ export const setList = (objects) => ({
 export const resetList = () => ({
   type: RESET_LIST,
 })
+
+export const setFilter = filter => {
+  return {
+    type: SET_FILTER,
+    filter
+  }
+}
 
 export const setListLoading = (listLoading) => ({
   type: SET_LIST_LOADING,

--- a/browser/app/js/objects/reducer.js
+++ b/browser/app/js/objects/reducer.js
@@ -28,6 +28,7 @@ const removeObject = (list, objectToRemove, lookup) => {
 export default (
   state = {
     list: [],
+    filter: "",
     listLoading: false,
     sortBy: "",
     sortOrder: SORT_ORDER_ASC,
@@ -52,6 +53,11 @@ export default (
       return {
         ...state,
         list: []
+      }
+    case actionsObjects.SET_FILTER:
+      return {
+        ...state,
+        filter: action.filter
       }
     case actionsObjects.SET_LIST_LOADING:
       return {

--- a/browser/app/less/inc/form.less
+++ b/browser/app/less/inc/form.less
@@ -169,6 +169,24 @@ select.form-control {
     }
 }
 
+.ig-search-dark {
+    &:before {
+        font-family: @font-family-icon;
+        font-weight: 900;
+        content: '\f002';
+        font-size: 15px;
+        position: absolute;
+        left: 2px;
+        top: 8px;
+        color: rgba(0, 0, 0, 0.5);
+    }
+
+    .ig-text {
+        padding-left: 25px;
+        .placeholder(rgba(0, 0, 0, 0.5))
+    }
+}
+
 .ig-search {
     &:before {
         font-family: @font-family-icon;


### PR DESCRIPTION
## Description
Fixes the request in #9531 

## Motivation and Context
In case of too many objects in a directory, it can be difficult to search for an object. This uses the method used for implementation Bucket Search to provide an Object Search.

## How to test this PR?
Use the newly added Search Input control in the Object Browser Header. Type in a text to search for objects that have the query as a prefix.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed

Output from **npm run test** 
Test Suites: 53 passed, 53 total
Tests:       258 passed, 258 total
Snapshots:   0 total
Time:        9.253s
Ran all test suites.
