### PR TITLE
Ignore config values from unknown subsystems

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/minio/minio-go/v7/pkg/set"
+	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/env"
 	"github.com/minio/minio/pkg/madmin"
@@ -447,6 +448,11 @@ func (c Config) Merge() Config {
 				if !ok {
 					ckvs.Set(kv.Key, kv.Value)
 				}
+			}
+			if _, ok := cp[subSys]; !ok {
+				// A config subsystem was removed or server was downgraded.
+				logger.Info("config: removing unknown subsystem config %q", subSys)
+				continue
 			}
 			cp[subSys][tgt] = ckvs
 		}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/minio/minio-go/v7/pkg/set"
-	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/env"
 	"github.com/minio/minio/pkg/madmin"
@@ -451,7 +450,7 @@ func (c Config) Merge() Config {
 			}
 			if _, ok := cp[subSys]; !ok {
 				// A config subsystem was removed or server was downgraded.
-				logger.Info("config: removing unknown subsystem config %q", subSys)
+				fmt.Printf("config: removing unknown subsystem config %q\n", subSys)
 				continue
 			}
 			cp[subSys][tgt] = ckvs

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -450,7 +450,7 @@ func (c Config) Merge() Config {
 			}
 			if _, ok := cp[subSys]; !ok {
 				// A config subsystem was removed or server was downgraded.
-				fmt.Printf("config: removing unknown subsystem config %q\n", subSys)
+				Logger.Info("config: ignoring unknown subsystem config %q\n", subSys)
 				continue
 			}
 			cp[subSys][tgt] = ckvs

--- a/cmd/config/logger.go
+++ b/cmd/config/logger.go
@@ -1,3 +1,19 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package config
 
 import "context"

--- a/cmd/config/logger.go
+++ b/cmd/config/logger.go
@@ -1,0 +1,11 @@
+package config
+
+import "context"
+
+// Logger contains injected logger methods.
+var Logger = struct {
+	Info  func(msg string, data ...interface{})
+	LogIf func(ctx context.Context, err error, errKind ...interface{})
+}{
+	// Initialized via injection.
+}

--- a/cmd/logger/config.go
+++ b/cmd/logger/config.go
@@ -56,6 +56,12 @@ const (
 	EnvAuditWebhookAuthToken = "MINIO_AUDIT_WEBHOOK_AUTH_TOKEN"
 )
 
+// Inject into config package.
+func init() {
+	config.Logger.Info = Info
+	config.Logger.LogIf = LogIf
+}
+
 // Default KVS for loggerHTTP and loggerAuditHTTP
 var (
 	DefaultKVS = config.KVS{


### PR DESCRIPTION
## Description

When encountering a config value from an unknown subsystem the servers will crash with `panic: assignment to nil map`.

Instead log a message and ignore the config.

While this is mostly a thing that will happen on downgrades it the server shouldn't crash when an unknown config subsystem is seen.

## How to test this PR?

Add a config value for a new subsystem. Remove the subsystem.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
