### PR TITLE
select: Fix automatic integer conversion overflow

### DIFF
--- a/pkg/s3select/sql/value.go
+++ b/pkg/s3select/sql/value.go
@@ -309,7 +309,7 @@ func (v Value) CSVString() string {
 // floatToValue converts a float into int representation if needed.
 func floatToValue(f float64) *Value {
 	intPart, fracPart := math.Modf(f)
-	if fracPart == 0 {
+	if fracPart == 0 && intPart < math.MaxInt64 && intPart > math.MinInt64 {
 		return FromInt(int64(intPart))
 	}
 	return FromFloat(f)


### PR DESCRIPTION
## Description

Do not convert float value to integer if it will over/underflow.

The comparison cannot be `<=` since rounding may overflow it.

Fixes #10436

## How to test this PR?

See linked issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
