### PR TITLE
go.mod: Require Go 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/minio
 
-go 1.13
+go 1.14
 
 require (
 	cloud.google.com/go v0.39.0


### PR DESCRIPTION
## Description

MinIO requires Go 1.14, so bump mod version.

Fixes #10440
