### PR TITLE
Update sysctl.sh

### DIFF
--- a/docs/deployment/kernel-tuning/sysctl.sh
+++ b/docs/deployment/kernel-tuning/sysctl.sh
@@ -33,8 +33,8 @@ net.core.wmem_default = 4194304
 net.core.optmem_max = 4194304
 
 # increase memory thresholds to prevent packet dropping:
-net.ipv4.tcp_rmem = "4096 87380 4194304"
-net.ipv4.tcp_wmem = "4096 65536 4194304"
+net.ipv4.tcp_rmem = 4096 87380 4194304
+net.ipv4.tcp_wmem = 4096 65536 4194304
 
 # enable low latency mode for TCP:
 net.ipv4.tcp_low_latency = 1


### PR DESCRIPTION
Having double double for net.ipv4.tcp_rmem and tcp_wmem will cause error in centos 7

sysctl: setting key "net.ipv4.tcp_rmem": Invalid argument
net.ipv4.tcp_rmem = "4096 87380 4194304"
sysctl: setting key "net.ipv4.tcp_wmem": Invalid argument
net.ipv4.tcp_wmem = "4096 65536 4194304"

## Description
Having double double for net.ipv4.tcp_rmem and tcp_wmem will cause error in centos7


## Motivation and Context


## How to test this PR?
sudo sysctl -p

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
