### PR TITLE
ilm: Remove null version if not latest with proper config

### DIFF
--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -341,7 +341,10 @@ func (j xlMetaV2DeleteMarker) ToFileInfo(volume, path string) (FileInfo, error) 
 	// check if the version is not "null"
 	if !bytes.Equal(j.VersionID[:], uv[:]) {
 		versionID = uuid.UUID(j.VersionID).String()
+	} else {
+		versionID = nullVersionID
 	}
+
 	fi := FileInfo{
 		Volume:    volume,
 		Name:      path,
@@ -358,7 +361,10 @@ func (j xlMetaV2Object) ToFileInfo(volume, path string) (FileInfo, error) {
 	// check if the version is not "null"
 	if !bytes.Equal(j.VersionID[:], uv[:]) {
 		versionID = uuid.UUID(j.VersionID).String()
+	} else {
+		versionID = nullVersionID
 	}
+
 	fi := FileInfo{
 		Volume:    volume,
 		Name:      path,


### PR DESCRIPTION
## Description
An object with 'null' version is not removed when it is not latest
and 'NoncurrentVersionExpiration' is activated in the lifecycle
document. This commit fixes this.

## Motivation and Context
Fixing a bug with lfiecycle

## How to test this PR?
1. Start a MinIO server instance with 4 disks
2. Create a bucket and upload a file
3. Enable versioning on that bucket
4. Upload another file
5. Set the following ILM in that bucket:
```
{
    "Rules": [
        {
            "ID": "Remove old non current versions",
            "Status": "Enabled",
            "NoncurrentVersionExpiration": {
                "NoncurrentDays": 1
            }
        }
    ]
}
```
6. Add 3 days in your machine time and waits until lifecycle is kicked in

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
