### PR TITLE
fix: allow LDAP identity to support form body POST

### DIFF
--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"os"
 	"strings"
 
@@ -53,7 +55,9 @@ func handleSignals() {
 
 		if httpServer := newHTTPServerFn(); httpServer != nil {
 			err = httpServer.Shutdown()
-			logger.LogIf(context.Background(), err)
+			if !errors.Is(err, http.ErrServerClosed) {
+				logger.LogIf(context.Background(), err)
+			}
 		}
 
 		if objAPI := newObjectLayerWithoutSafeModeFn(); objAPI != nil {


### PR DESCRIPTION

## Description
fix: allow LDAP identity to support form body POST

## Motivation and Context
similar to other STS APIs


## How to test this PR?
Send LDAP STS requests along as POST form body

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
