### PR TITLE
Strip standard ports off remote target url

### DIFF
--- a/pkg/madmin/remote-target-commands.go
+++ b/pkg/madmin/remote-target-commands.go
@@ -118,7 +118,15 @@ func (t BucketTarget) URL() string {
 	if t.Secure {
 		scheme = "https"
 	}
-	return fmt.Sprintf("%s://%s", scheme, t.Endpoint)
+	urlStr := fmt.Sprintf("%s://%s", scheme, t.Endpoint)
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return urlStr
+	}
+	if u.Port() == "80" || u.Port() == "443" {
+		u.Host = u.Hostname()
+	}
+	return u.String()
 }
 
 // Empty returns true if struct is empty.


### PR DESCRIPTION
## Description


## Motivation and Context
Url displayed in `mc admin bucket remote ls` shows standard ports in url.

## How to test this PR?
add play as a remote target using `mc admin bucket remote add` . The `mc admin bucket remote ls` should list target url without port.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
