### PR TITLE
Support for "directory" objects

### DIFF
--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -422,7 +422,7 @@ func TestHealEmptyDirectoryErasure(t *testing.T) {
 	z := obj.(*erasureZones)
 	er := z.zones[0].sets[0]
 	firstDisk := er.getDisks()[0]
-	err = firstDisk.DeleteFile(context.Background(), bucket, object)
+	err = firstDisk.DeleteVol(context.Background(), pathJoin(bucket, encodeDirObject(object)), true)
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -434,7 +434,7 @@ func TestHealEmptyDirectoryErasure(t *testing.T) {
 	}
 
 	// Check if the empty directory is restored in the first disk
-	_, err = firstDisk.StatVol(context.Background(), pathJoin(bucket, object))
+	_, err = firstDisk.StatVol(context.Background(), pathJoin(bucket, encodeDirObject(object)))
 	if err != nil {
 		t.Fatalf("Expected object to be present but stat failed - %v", err)
 	}

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -96,22 +96,14 @@ func (fi FileInfo) IsValid() bool {
 
 // ToObjectInfo - Converts metadata to object info.
 func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
-	if HasSuffix(object, SlashSeparator) {
-		return ObjectInfo{
-			Bucket:  bucket,
-			Name:    object,
-			IsDir:   true,
-			ModTime: fi.ModTime,
-		}
-	}
-
+	object = decodeDirObject(object)
 	versionID := fi.VersionID
 	if globalBucketVersioningSys.Enabled(bucket) && versionID == "" {
 		versionID = nullVersionID
 	}
 
 	objInfo := ObjectInfo{
-		IsDir:           false,
+		IsDir:           HasSuffix(object, SlashSeparator),
 		Bucket:          bucket,
 		Name:            object,
 		VersionID:       versionID,

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -98,9 +98,10 @@ func (fi FileInfo) IsValid() bool {
 func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 	if HasSuffix(object, SlashSeparator) {
 		return ObjectInfo{
-			Bucket: bucket,
-			Name:   object,
-			IsDir:  true,
+			Bucket:  bucket,
+			Name:    object,
+			IsDir:   true,
+			ModTime: fi.ModTime,
 		}
 	}
 

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -460,6 +460,10 @@ func (z *erasureZones) MakeBucketWithLocation(ctx context.Context, bucket string
 }
 
 func (z *erasureZones) GetObjectNInfo(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error) {
+	if HasSuffix(object, slashSeparator) {
+		object = strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
+
 	for _, zone := range z.zones {
 		gr, err = zone.GetObjectNInfo(ctx, bucket, object, rs, h, lockType, opts)
 		if err != nil {
@@ -477,6 +481,10 @@ func (z *erasureZones) GetObjectNInfo(ctx context.Context, bucket, object string
 }
 
 func (z *erasureZones) GetObject(ctx context.Context, bucket, object string, startOffset int64, length int64, writer io.Writer, etag string, opts ObjectOptions) error {
+	if HasSuffix(object, slashSeparator) {
+		object = strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
+
 	for _, zone := range z.zones {
 		if err := zone.GetObject(ctx, bucket, object, startOffset, length, writer, etag, opts); err != nil {
 			if isErrObjectNotFound(err) || isErrVersionNotFound(err) {
@@ -493,6 +501,10 @@ func (z *erasureZones) GetObject(ctx context.Context, bucket, object string, sta
 }
 
 func (z *erasureZones) GetObjectInfo(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+	if HasSuffix(object, slashSeparator) {
+		object = strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
+
 	for _, zone := range z.zones {
 		objInfo, err = zone.GetObjectInfo(ctx, bucket, object, opts)
 		if err != nil {
@@ -511,6 +523,10 @@ func (z *erasureZones) GetObjectInfo(ctx context.Context, bucket, object string,
 
 // PutObject - writes an object to least used erasure zone.
 func (z *erasureZones) PutObject(ctx context.Context, bucket string, object string, data *PutObjReader, opts ObjectOptions) (ObjectInfo, error) {
+	if HasSuffix(object, slashSeparator) {
+		object = strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
+
 	if z.SingleZone() {
 		return z.zones[0].PutObject(ctx, bucket, object, data, opts)
 	}
@@ -525,6 +541,10 @@ func (z *erasureZones) PutObject(ctx context.Context, bucket string, object stri
 }
 
 func (z *erasureZones) DeleteObject(ctx context.Context, bucket string, object string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
+	if HasSuffix(object, slashSeparator) {
+		object = strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
+
 	if z.SingleZone() {
 		return z.zones[0].DeleteObject(ctx, bucket, object, opts)
 	}
@@ -545,6 +565,10 @@ func (z *erasureZones) DeleteObjects(ctx context.Context, bucket string, objects
 	dobjects := make([]DeletedObject, len(objects))
 	objSets := set.NewStringSet()
 	for i := range derrs {
+		if HasSuffix(objects[i].ObjectName, slashSeparator) {
+			objects[i].ObjectName = strings.TrimSuffix(objects[i].ObjectName, slashSeparator) + globalDirSuffix
+		}
+
 		derrs[i] = checkDelObjArgs(ctx, bucket, objects[i].ObjectName)
 		objSets.Add(objects[i].ObjectName)
 	}
@@ -576,6 +600,12 @@ func (z *erasureZones) DeleteObjects(ctx context.Context, bucket string, objects
 }
 
 func (z *erasureZones) CopyObject(ctx context.Context, srcBucket, srcObject, dstBucket, dstObject string, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (objInfo ObjectInfo, err error) {
+	if HasSuffix(srcObject, slashSeparator) {
+		srcObject = strings.TrimSuffix(srcObject, slashSeparator) + globalDirSuffix
+	}
+	if HasSuffix(dstObject, slashSeparator) {
+		dstObject = strings.TrimSuffix(dstObject, slashSeparator) + globalDirSuffix
+	}
 	cpSrcDstSame := isStringEqual(pathJoin(srcBucket, srcObject), pathJoin(dstBucket, dstObject))
 
 	zoneIdx, err := z.getZoneIdx(ctx, dstBucket, dstObject, dstOpts, srcInfo.Size)
@@ -935,7 +965,16 @@ func lexicallySortedEntryZone(zoneEntryChs [][]FileInfoCh, zoneEntries [][]FileI
 				zoneIndex = i
 				continue
 			}
-			if zoneEntries[i][j].Name < lentry.Name {
+			str1 := zoneEntries[i][j].Name
+			str2 := lentry.Name
+			if HasSuffix(str1, globalDirSuffix) {
+				str1 = strings.TrimSuffix(str1, globalDirSuffix) + slashSeparator
+			}
+			if HasSuffix(str2, globalDirSuffix) {
+				str2 = strings.TrimSuffix(str2, globalDirSuffix) + slashSeparator
+			}
+
+			if str1 < str2 {
 				lentry = zoneEntries[i][j]
 				zoneIndex = i
 			}
@@ -966,6 +1005,10 @@ func lexicallySortedEntryZone(zoneEntryChs [][]FileInfoCh, zoneEntries [][]FileI
 			// and will be returned later in Pop()
 			zoneEntryChs[i][j].Push(zoneEntries[i][j])
 		}
+	}
+
+	if HasSuffix(lentry.Name, globalDirSuffix) {
+		lentry.Name = strings.TrimSuffix(lentry.Name, globalDirSuffix) + slashSeparator
 	}
 
 	return lentry, lexicallySortedEntryCount, zoneIndex, isTruncated
@@ -1013,7 +1056,16 @@ func lexicallySortedEntryZoneVersions(zoneEntryChs [][]FileInfoVersionsCh, zoneE
 				zoneIndex = i
 				continue
 			}
-			if zoneEntries[i][j].Name < lentry.Name {
+			str1 := zoneEntries[i][j].Name
+			str2 := lentry.Name
+			if HasSuffix(str1, globalDirSuffix) {
+				str1 = strings.TrimSuffix(str1, globalDirSuffix) + slashSeparator
+			}
+			if HasSuffix(str2, globalDirSuffix) {
+				str2 = strings.TrimSuffix(str2, globalDirSuffix) + slashSeparator
+			}
+
+			if str1 < str2 {
 				lentry = zoneEntries[i][j]
 				zoneIndex = i
 			}
@@ -1044,6 +1096,10 @@ func lexicallySortedEntryZoneVersions(zoneEntryChs [][]FileInfoVersionsCh, zoneE
 			// and will be returned later in Pop()
 			zoneEntryChs[i][j].Push(zoneEntries[i][j])
 		}
+	}
+
+	if HasSuffix(lentry.Name, globalDirSuffix) {
+		lentry.Name = strings.TrimSuffix(lentry.Name, globalDirSuffix) + slashSeparator
 	}
 
 	return lentry, lexicallySortedEntryCount, zoneIndex, isTruncated
@@ -2019,6 +2075,9 @@ func (z *erasureZones) Health(ctx context.Context, opts HealthOptions) HealthRes
 
 // PutObjectTags - replace or add tags to an existing object
 func (z *erasureZones) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) error {
+	if HasSuffix(object, slashSeparator) {
+		object = strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
 	if z.SingleZone() {
 		return z.zones[0].PutObjectTags(ctx, bucket, object, tags, opts)
 	}
@@ -2048,6 +2107,9 @@ func (z *erasureZones) PutObjectTags(ctx context.Context, bucket, object string,
 
 // DeleteObjectTags - delete object tags from an existing object
 func (z *erasureZones) DeleteObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) error {
+	if HasSuffix(object, slashSeparator) {
+		object = strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
 	if z.SingleZone() {
 		return z.zones[0].DeleteObjectTags(ctx, bucket, object, opts)
 	}
@@ -2076,6 +2138,9 @@ func (z *erasureZones) DeleteObjectTags(ctx context.Context, bucket, object stri
 
 // GetObjectTags - get object tags from an existing object
 func (z *erasureZones) GetObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) (*tags.Tags, error) {
+	if HasSuffix(object, slashSeparator) {
+		object = strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
 	if z.SingleZone() {
 		return z.zones[0].GetObjectTags(ctx, bucket, object, opts)
 	}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -63,6 +63,8 @@ const (
 	globalMinioModeErasure         = "mode-server-xl"
 	globalMinioModeDistErasure     = "mode-server-distributed-xl"
 	globalMinioModeGatewayPrefix   = "mode-gateway-"
+	globalDirSuffix                = "__MINIO_DIR__"
+	globalDirSuffixWithSlash       = "__MINIO_DIR__" + slashSeparator
 
 	// Add new global values here.
 )

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -63,8 +63,8 @@ const (
 	globalMinioModeErasure         = "mode-server-xl"
 	globalMinioModeDistErasure     = "mode-server-distributed-xl"
 	globalMinioModeGatewayPrefix   = "mode-gateway-"
-	globalDirSuffix                = "__MINIO_DIR__"
-	globalDirSuffixWithSlash       = "__MINIO_DIR__" + slashSeparator
+	globalDirSuffix                = "__XLDIR__"
+	globalDirSuffixWithSlash       = globalDirSuffix + slashSeparator
 
 	// Add new global values here.
 )

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -22,12 +22,18 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"strings"
 )
 
 // Converts underlying storage error. Convenience function written to
 // handle all cases where we have known types of errors returned by
 // underlying storage layer.
 func toObjectErr(err error, params ...string) error {
+	if len(params) > 1 {
+		if HasSuffix(params[1], globalDirSuffix) {
+			params[1] = strings.TrimSuffix(params[1], globalDirSuffix) + slashSeparator
+		}
+	}
 	switch err {
 	case errVolumeNotFound:
 		if len(params) >= 1 {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -131,6 +131,7 @@ func TestServerSuite(t *testing.T) {
 		// Init and run test on ErasureSet backend.
 		{serverType: "ErasureSet", signer: signerV4},
 	}
+	globalCLIContext.StrictS3Compat = true
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("Test: %d, ServerType: %s", i+1, testCase.serverType), func(t *testing.T) {
 			runAllTests(testCase, &check{t, testCase.serverType})
@@ -261,20 +262,6 @@ func (s *TestSuiteCommon) TestObjectDir(c *check) {
 	c.Assert(err, nil)
 	// assert the http response status code.
 	c.Assert(response.StatusCode, http.StatusOK)
-
-	request, err = newTestSignedRequest(http.MethodPut, getPutObjectURL(s.endPoint, bucketName, "my-object-directory/"),
-		0, nil, s.accessKey, s.secretKey, s.signer)
-	c.Assert(err, nil)
-
-	helloReader := bytes.NewReader([]byte("Hello, World"))
-	request.ContentLength = helloReader.Size()
-	request.Body = ioutil.NopCloser(helloReader)
-
-	// execute the HTTP request.
-	response, err = s.client.Do(request)
-
-	c.Assert(err, nil)
-	verifyError(c, response, "XMinioInvalidObjectName", "Object name contains unsupported characters.", http.StatusBadRequest)
 
 	request, err = newTestSignedRequest(http.MethodHead, getHeadObjectURL(s.endPoint, bucketName, "my-object-directory/"),
 		0, nil, s.accessKey, s.secretKey, s.signer)

--- a/cmd/tree-walk.go
+++ b/cmd/tree-walk.go
@@ -57,6 +57,9 @@ func filterMatchingPrefix(entries []string, prefixEntry string) []string {
 // isLeaf should be done in listDir()
 func delayIsLeafCheck(entries []string) bool {
 	for i, entry := range entries {
+		if HasSuffix(entry, globalDirSuffixWithSlash) {
+			return false
+		}
 		if i == len(entries)-1 {
 			break
 		}
@@ -96,7 +99,20 @@ func filterListEntries(bucket, prefixDir string, entries []string, prefixEntry s
 	entries = filterMatchingPrefix(entries, prefixEntry)
 
 	// Listing needs to be sorted.
-	sort.Strings(entries)
+	sort.Slice(entries, func(i, j int) bool {
+		if !HasSuffix(entries[i], globalDirSuffixWithSlash) && !HasSuffix(entries[j], globalDirSuffixWithSlash) {
+			return entries[i] < entries[j]
+		}
+		first := entries[i]
+		second := entries[j]
+		if HasSuffix(first, globalDirSuffixWithSlash) {
+			first = strings.TrimSuffix(first, globalDirSuffixWithSlash) + slashSeparator
+		}
+		if HasSuffix(second, globalDirSuffixWithSlash) {
+			second = strings.TrimSuffix(second, globalDirSuffixWithSlash) + slashSeparator
+		}
+		return first < second
+	})
 
 	// Can isLeaf() check be delayed till when it has to be sent down the
 	// TreeWalkResult channel?
@@ -114,8 +130,20 @@ func filterListEntries(bucket, prefixDir string, entries []string, prefixEntry s
 
 	// Sort again after removing trailing "/" for objects as the previous sort
 	// does not hold good anymore.
-	sort.Strings(entries)
-
+	sort.Slice(entries, func(i, j int) bool {
+		if !HasSuffix(entries[i], globalDirSuffix) && !HasSuffix(entries[j], globalDirSuffix) {
+			return entries[i] < entries[j]
+		}
+		first := entries[i]
+		second := entries[j]
+		if HasSuffix(first, globalDirSuffix) {
+			first = strings.TrimSuffix(first, globalDirSuffix) + slashSeparator
+		}
+		if HasSuffix(second, globalDirSuffix) {
+			second = strings.TrimSuffix(second, globalDirSuffix) + slashSeparator
+		}
+		return first < second
+	})
 	return entries, false
 }
 
@@ -169,10 +197,10 @@ func doTreeWalk(ctx context.Context, bucket, prefixDir, entryPrefixMatch, marker
 				entry = strings.TrimSuffix(entry, slashSeparator)
 			}
 		} else {
-			leaf = !strings.HasSuffix(entry, slashSeparator)
+			leaf = !HasSuffix(entry, slashSeparator)
 		}
 
-		if strings.HasSuffix(entry, slashSeparator) {
+		if HasSuffix(entry, slashSeparator) {
 			leafDir = isLeafDir(bucket, pathJoin(prefixDir, entry))
 		}
 

--- a/cmd/tree-walk.go
+++ b/cmd/tree-walk.go
@@ -142,6 +142,9 @@ func filterListEntries(bucket, prefixDir string, entries []string, prefixEntry s
 		if HasSuffix(second, globalDirSuffix) {
 			second = strings.TrimSuffix(second, globalDirSuffix) + slashSeparator
 		}
+		if first == second {
+			return HasSuffix(entries[i], globalDirSuffix)
+		}
 		return first < second
 	})
 	return entries, false

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -737,3 +737,20 @@ func (t *timedValue) Invalidate() {
 	t.value = nil
 	t.mu.Unlock()
 }
+
+// On MinIO a directory object is stored as a regular object with "__XLDIR__" suffix.
+// For ex. "prefix/" is stored as "prefix__XLDIR__"
+func encodeDirObject(object string) string {
+	if HasSuffix(object, slashSeparator) {
+		return strings.TrimSuffix(object, slashSeparator) + globalDirSuffix
+	}
+	return object
+}
+
+// Reverse process of encodeDirObject()
+func decodeDirObject(object string) string {
+	if HasSuffix(object, globalDirSuffix) {
+		return strings.TrimSuffix(object, globalDirSuffix) + slashSeparator
+	}
+	return object
+}


### PR DESCRIPTION
## Description

This is a requirement from a potential customer:

Without the fix:
```
krishna@escape:~$ mc mb min/test/
Bucket created successfully `min/test/`.
krishna@escape:~$ mc mb min/test/prefix/
Bucket created successfully `min/test/prefix/`.
krishna@escape:~$ mc cp /etc/passwd min/test/prefix/
/etc/passwd:                          2.42 KiB / 2.42 KiB ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 50.28 KiB/s 0skrishna@escape:~$ mc rm min/test/prefix/passwd
Removing `min/test/prefix/passwd`.
krishna@escape:~$ mc ls min/test/
krishna@escape:~$ 
```
i.e "prefix/" is gone.

With fix, "prefix/" is not deleted:

```
krishna@escape:~$ mc mb min/test/
Bucket created successfully `min/test/`.
krishna@escape:~$ mc mb min/test/prefix/
Bucket created successfully `min/test/prefix/`.
krishna@escape:~$ mc cp /etc/passwd min/test/prefix/
/etc/passwd:                          2.42 KiB / 2.42 KiB ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 43.41 KiB/s 0skrishna@escape:~$ mc rm min/test/prefix/passwd
Removing `min/test/prefix/passwd`.
krishna@escape:~$ mc ls min/test/
[2020-09-16 12:59:44 PDT]      0B prefix/
krishna@escape:~$ mc ls -r min/test/
[2020-09-16 12:59:30 PDT]      0B prefix/
krishna@escape:~$ 
```

Request to reviewers: Please see if this causes any side effects to healing of the "prefix/' object.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
