### PR TITLE
Fix obd goroutine leak

### DIFF
--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -232,6 +232,7 @@ func (client *peerRESTClient) doNetOBDTest(ctx context.Context, dataSize int64, 
 		}
 	}
 	wg.Wait()
+	close(transferChan)
 
 	if err != nil {
 		return info, err


### PR DESCRIPTION
## Description

The gouroutine collecting transfer stats never exits. Add missing channel close.

## How to test this PR?

Run obd test. Observe leaked goroutines.

## Types of changes
- [x] Cleanup
