### PR TITLE
Add a reasonable default if unable to get total RAM

### DIFF
--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/minio/minio/cmd/config/api"
+	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/sys"
 )
 
@@ -45,7 +46,9 @@ func (t *apiConfig) init(cfg api.Config, setDriveCount int) {
 	if cfg.RequestsMax <= 0 {
 		stats, err := sys.GetStats()
 		if err != nil {
-			return
+			logger.LogIf(GlobalContext, err)
+			// Default to 16 GiB, not critical.
+			stats.TotalRAM = 16 << 30
 		}
 		// max requests per node is calculated as
 		// total_ram / ram_per_request


### PR DESCRIPTION
## Description

Though unlikely we shouldn't skip initializing the API if we cannot get RAM.

Assume 16GiB as a default and log the error.


## Types of changes
- [x] Bug fix (defensive programming)
