### PR TITLE
fix: [fs] CompleteMultipart use trie structure for prefixMatch

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,21 +102,19 @@ func newApp(name string) *cli.App {
 
 	findClosestCommands := func(command string) []string {
 		var closestCommands []string
-		for _, value := range commandsTree.PrefixMatch(command) {
-			closestCommands = append(closestCommands, value.(string))
-		}
+		closestCommands = append(closestCommands, commandsTree.PrefixMatch(command)...)
 
 		sort.Strings(closestCommands)
 		// Suggest other close commands - allow missed, wrongly added and
 		// even transposed characters
 		for _, value := range commandsTree.Walk(commandsTree.Root()) {
-			if sort.SearchStrings(closestCommands, value.(string)) < len(closestCommands) {
+			if sort.SearchStrings(closestCommands, value) < len(closestCommands) {
 				continue
 			}
 			// 2 is arbitrary and represents the max
 			// allowed number of typed errors
-			if words.DamerauLevenshteinDistance(command, value.(string)) < 2 {
-				closestCommands = append(closestCommands, value.(string))
+			if words.DamerauLevenshteinDistance(command, value) < 2 {
+				closestCommands = append(closestCommands, value)
 			}
 		}
 

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -45,6 +45,7 @@ import (
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/ioutil"
+	"github.com/minio/minio/pkg/trie"
 	"github.com/minio/minio/pkg/wildcard"
 )
 
@@ -487,13 +488,12 @@ func hasPattern(patterns []string, matchStr string) bool {
 }
 
 // Returns the part file name which matches the partNumber and etag.
-func getPartFile(entries []string, partNumber int, etag string) string {
-	for _, entry := range entries {
-		if strings.HasPrefix(entry, fmt.Sprintf("%.5d.%s.", partNumber, etag)) {
-			return entry
-		}
+func getPartFile(entriesTrie *trie.Trie, partNumber int, etag string) (partFile string) {
+	for _, match := range entriesTrie.PrefixMatch(fmt.Sprintf("%.5d.%s.", partNumber, etag)) {
+		partFile = match
+		break
 	}
-	return ""
+	return partFile
 }
 
 // Returns the compressed offset which should be skipped.

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -21,7 +21,7 @@ package trie
 // Node trie tree node container carries value and children.
 type Node struct {
 	exists bool
-	value  interface{}
+	value  string
 	child  map[rune]*Node // runes as child.
 }
 
@@ -29,7 +29,7 @@ type Node struct {
 func newNode() *Node {
 	return &Node{
 		exists: false,
-		value:  nil,
+		value:  "",
 		child:  make(map[rune]*Node),
 	}
 }
@@ -65,16 +65,16 @@ func (t *Trie) Insert(key string) {
 }
 
 // PrefixMatch - prefix match.
-func (t *Trie) PrefixMatch(key string) []interface{} {
+func (t *Trie) PrefixMatch(key string) []string {
 	node, _ := t.findNode(key)
-	if node != nil {
-		return t.Walk(node)
+	if node == nil {
+		return nil
 	}
-	return []interface{}{}
+	return t.Walk(node)
 }
 
 // Walk the tree.
-func (t *Trie) Walk(node *Node) (ret []interface{}) {
+func (t *Trie) Walk(node *Node) (ret []string) {
 	if node.exists {
 		ret = append(ret, node.value)
 	}


### PR DESCRIPTION
## Description
fix: [fs] CompleteMultipart use trie structure for partMatch

## Motivation and Context
performance improves by around 100x or more

```
go test -v -run NONE -bench BenchmarkGetPartFile
goos: linux
goarch: amd64
pkg: github.com/minio/minio/cmd
BenchmarkGetPartFileWithTrie
BenchmarkGetPartFileWithTrie-4          1000000000               0.140 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/minio/minio/cmd      1.737s
```

fixes #10520 

## How to test this PR?
As per #10520 - the issue can be seen by re-using the older code with the same Benchmark

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
