### PR TITLE
fix: [fs] an error upon rwPool.Write() just attempt rwPool.Create()

### DIFF
--- a/cmd/fs-v1-rwpool.go
+++ b/cmd/fs-v1-rwpool.go
@@ -157,6 +157,9 @@ func (fsi *fsIOPool) Write(path string) (wlk *lock.LockedFile, err error) {
 		case isSysErrIsDir(err):
 			return nil, errIsNotRegular
 		default:
+			if isSysErrPathNotFound(err) {
+				return nil, errFileNotFound
+			}
 			return nil, err
 		}
 	}

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -623,10 +622,6 @@ func (fs *FSObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBu
 		fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, srcBucket, srcObject, fs.metaJSONFile)
 		wlk, err := fs.rwPool.Write(fsMetaPath)
 		if err != nil {
-			if !errors.Is(err, errFileNotFound) {
-				logger.LogIf(ctx, err)
-				return oi, toObjectErr(err, srcBucket, srcObject)
-			}
 			wlk, err = fs.rwPool.Create(fsMetaPath)
 			if err != nil {
 				logger.LogIf(ctx, err)
@@ -1177,10 +1172,6 @@ func (fs *FSObjects) putObject(ctx context.Context, bucket string, object string
 		wlk, err = fs.rwPool.Write(fsMetaPath)
 		var freshFile bool
 		if err != nil {
-			if !errors.Is(err, errFileNotFound) {
-				logger.LogIf(ctx, err)
-				return ObjectInfo{}, toObjectErr(err, bucket, object)
-			}
 			wlk, err = fs.rwPool.Create(fsMetaPath)
 			if err != nil {
 				logger.LogIf(ctx, err)
@@ -1511,10 +1502,6 @@ func (fs *FSObjects) PutObjectTags(ctx context.Context, bucket, object string, t
 	fsMeta := fsMetaV1{}
 	wlk, err := fs.rwPool.Write(fsMetaPath)
 	if err != nil {
-		if !errors.Is(err, errFileNotFound) {
-			logger.LogIf(ctx, err)
-			return toObjectErr(err, bucket, object)
-		}
 		wlk, err = fs.rwPool.Create(fsMetaPath)
 		if err != nil {
 			logger.LogIf(ctx, err)

--- a/cmd/xl-storage-errors.go
+++ b/cmd/xl-storage-errors.go
@@ -94,6 +94,10 @@ func isSysErrNotEmpty(err error) bool {
 // Check if the given error corresponds to the specific ERROR_PATH_NOT_FOUND for windows
 func isSysErrPathNotFound(err error) bool {
 	if runtime.GOOS != globalWindowsOSName {
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) {
+			return pathErr.Err == syscall.ENOENT
+		}
 		return false
 	}
 	var pathErr *os.PathError


### PR DESCRIPTION
## Description
an error upon rwPool.Write() just attempt rwPool.Create()

## Motivation and Context
On some NFS clients looks like errno is incorrectly set,
which leads to incorrect errors thrown upwards.

## How to test this PR?
Not easy to reproduce, only seen at a customer environment

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
