### PR TITLE
Change "disks" node to "drives" in OBD output

### DIFF
--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -264,7 +264,7 @@ type ServerProperties struct {
 	Version  string            `json:"version,omitempty"`
 	CommitID string            `json:"commitID,omitempty"`
 	Network  map[string]string `json:"network,omitempty"`
-	Disks    []Disk            `json:"disks,omitempty"`
+	Disks    []Disk            `json:"drives,omitempty"`
 }
 
 // Disk holds Disk information

--- a/pkg/madmin/obd.go
+++ b/pkg/madmin/obd.go
@@ -61,7 +61,7 @@ type ServerLogOBDInfo struct {
 // SysOBDInfo - Includes hardware and system information of the MinIO cluster
 type SysOBDInfo struct {
 	CPUInfo    []ServerCPUOBDInfo    `json:"cpus,omitempty"`
-	DiskHwInfo []ServerDiskHwOBDInfo `json:"disks,omitempty"`
+	DiskHwInfo []ServerDiskHwOBDInfo `json:"drives,omitempty"`
 	OsInfo     []ServerOsOBDInfo     `json:"osinfos,omitempty"`
 	MemInfo    []ServerMemOBDInfo    `json:"meminfos,omitempty"`
 	ProcInfo   []ServerProcOBDInfo   `json:"procinfos,omitempty"`


### PR DESCRIPTION
## Description

Change "disks" node to "drives" in OBD output

## Motivation and Context

A "drive" is a more appropriate term than "disk"

## How to test this PR?

* Build both `minio` and `mc` using these changes
* Generate OBD report using the command `mc admin obd <alias> --json`
* Under `obdInfo -> minio -> info -> servers` and `obdInfo -> sys -> cpus` in the generated report, you should now see a `drives` node instead of the previous `disks`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
