### PR TITLE
avoid concurrent use of rand.NewSource

### DIFF
--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -354,12 +354,10 @@ func getHostsSlice(records []dns.SrvRecord) []string {
 	return hosts
 }
 
-var rng = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
-
 // returns an online host (and corresponding port) from a slice of DNS records
 func getHostFromSrv(records []dns.SrvRecord) (host string) {
 	hosts := getHostsSlice(records)
-
+	rng := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 	var d net.Dialer
 	var retry int
 	for retry < len(hosts) {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1235,10 +1235,10 @@ func getTestWebRPCResponse(resp *httptest.ResponseRecorder, data interface{}) er
 	return nil
 }
 
-var src = rand.NewSource(UTCNow().UnixNano())
-
 // Function to generate random string for bucket/object names.
 func randString(n int) string {
+	src := rand.NewSource(UTCNow().UnixNano())
+
 	b := make([]byte, n)
 	// A rand.Int63() generates 63 random bits, enough for letterIdxMax letters!
 	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {

--- a/pkg/s3select/select_benchmark_test.go
+++ b/pkg/s3select/select_benchmark_test.go
@@ -30,11 +30,11 @@ import (
 	humanize "github.com/dustin/go-humanize"
 )
 
-var randSrc = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 func newRandString(length int) string {
+	randSrc := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	b := make([]byte, length)
 	for i := range b {
 		b[i] = charset[randSrc.Intn(len(charset))]


### PR DESCRIPTION
## Description
avoid concurrent use of rand.NewSource

## Motivation and Context
getHostsSrv() was using rand.NewSource
concurrently, which can lead to racy behavior

## How to test this PR?
Nothing special test with `go build -race` and federation

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
