### PR TITLE
fix: reduce healthcheck interval for storage rest client

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -29,7 +29,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/minio/minio/cmd/http"
 	xhttp "github.com/minio/minio/cmd/http"
@@ -669,7 +668,6 @@ func newStorageRESTClient(endpoint Endpoint) *storageRESTClient {
 
 	trFn := newInternodeHTTPTransport(tlsConfig, rest.DefaultRESTTimeout)
 	restClient := rest.NewClient(serverURL, trFn, newAuthToken)
-	restClient.HealthCheckInterval = 500 * time.Millisecond
 	restClient.HealthCheckFn = func() bool {
 		ctx, cancel := context.WithTimeout(GlobalContext, restClient.HealthCheckTimeout)
 		// Instantiate a new rest client for healthcheck


### PR DESCRIPTION
## Description
fix: reduce health check interval for storage rest-client

## Motivation and Context
keep a more aggressive check if nodes are down

## How to test this PR?
Keeping 500 milliseconds can delay the server coming
online, in k8s like environments where network flakyness 
is common.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
