### PR TITLE
Fix Dropzone height to fill all screen height

### DIFF
--- a/browser/app/js/uploads/Dropzone.js
+++ b/browser/app/js/uploads/Dropzone.js
@@ -36,7 +36,7 @@ export class Dropzone extends React.Component {
     // Overwrite the default styling from react-dropzone; otherwise it
     // won't handle child elements correctly.
     const style = {
-      height: "100%",
+      flex: "1",
       borderWidth: "0",
       borderStyle: "dashed",
       borderColor: "#fff"

--- a/browser/app/less/inc/file-explorer.less
+++ b/browser/app/less/inc/file-explorer.less
@@ -20,7 +20,8 @@
 	@media(max-width: @screen-sm-max) {
 		padding: 75px 0 80px;
 	}
-
+  display: flex;
+  flex-direction: column;
 	min-height:100vh;
 	overflow: auto;
 }


### PR DESCRIPTION
## Description
The Dropzone height 100% not work then if there is no item in bucket and you want to drag and drop a file, you must only drop on header of page. like this:  
![Untitled](https://user-images.githubusercontent.com/22843329/93972478-33cd7c00-fd7f-11ea-9fab-117e09babe99.jpg)


## Motivation and Context
Fix drag and drop a file on full height of page.

## How to test this PR?
Drag and drop a file on empty directory

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

