### PR TITLE
Fix stale context for quota bucket retrieval

### DIFF
--- a/cmd/bucket-quota.go
+++ b/cmd/bucket-quota.go
@@ -71,6 +71,8 @@ func (sys *BucketQuotaSys) check(ctx context.Context, bucket string, size int64)
 	sys.bucketStorageCache.Once.Do(func() {
 		sys.bucketStorageCache.TTL = 1 * time.Second
 		sys.bucketStorageCache.Update = func() (interface{}, error) {
+			ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+			defer done()
 			return loadDataUsageFromBackend(ctx, objAPI)
 		}
 	})


### PR DESCRIPTION
## Description

The provided context gets captured by the closure making all subsequent calls fail.

## How to test this PR?

Enable quotas, upload stuff.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
