### PR TITLE
Fix minimum replication workers started

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -304,6 +304,11 @@ var (
 )
 
 func newReplicationState() *replicationState {
+
+	// fix minimum concurrent replication to 1 for single CPU setup
+	if globalReplicationConcurrent == 0 {
+		globalReplicationConcurrent = 1
+	}
 	rs := &replicationState{
 		replicaCh: make(chan ObjectInfo, globalReplicationConcurrent*2),
 	}

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -1025,7 +1025,7 @@ func (web *webAPIHandlers) Upload(w http.ResponseWriter, r *http.Request) {
 			BucketName:      bucket,
 			ConditionValues: getConditionValues(r, "", claims.AccessKey, claims.Map()),
 			IsOwner:         owner,
-			ObjectName:      object,
+			ObjectName:      "",
 			Claims:          claims.Map(),
 		}) {
 			replPerms = ErrNone

--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -129,6 +129,8 @@ Replication status can be seen in the metadata on the source and destination obj
 
 To perform bi-directional replication, repeat the above process on the target site - this time setting the source bucket as the replication target.
 
+It is recommended that replication be run in a system with atleast two CPU's available to the process, so that replication can run in its own thread.
+
 ![put](https://raw.githubusercontent.com/minio/minio/master/docs/bucket/replication/PUT_bucket_replication.png)
 
 ![head](https://raw.githubusercontent.com/minio/minio/master/docs/bucket/replication/HEAD_bucket_replication.png)


### PR DESCRIPTION
## Description


## Motivation and Context
Replication should not fail to start workers even in a test setup with one cpu, though replication essentially needs its own thread

Also fixing permissions issue in web-handlers.go for checking if user has GetReplicationConfiguration permission.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
