### PR TITLE
Add support for ILM transition.

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -129,14 +129,15 @@ func (a adminAPIHandlers) SetRemoteTargetHandler(w http.ResponseWriter, r *http.
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 
+	if !globalIsErasure {
+		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL)
+		return
+	}
+
 	// Get current object layer instance.
 	objectAPI, _ := validateAdminUsersReq(ctx, w, r, iampolicy.SetBucketTargetAction)
 	if objectAPI == nil {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrServerNotInitialized), r.URL)
-		return
-	}
-	if !globalIsErasure {
-		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL)
 		return
 	}
 
@@ -218,7 +219,10 @@ func (a adminAPIHandlers) ListRemoteTargetsHandler(w http.ResponseWriter, r *htt
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
 	arnType := vars["type"]
-
+	if !globalIsErasure {
+		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL)
+		return
+	}
 	// Get current object layer instance.
 	objectAPI, _ := validateAdminUsersReq(ctx, w, r, iampolicy.GetBucketTargetAction)
 	if objectAPI == nil {
@@ -255,14 +259,14 @@ func (a adminAPIHandlers) RemoveRemoteTargetHandler(w http.ResponseWriter, r *ht
 	bucket := vars["bucket"]
 	arn := vars["arn"]
 
+	if !globalIsErasure {
+		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL)
+		return
+	}
 	// Get current object layer instance.
 	objectAPI, _ := validateAdminUsersReq(ctx, w, r, iampolicy.SetBucketTargetAction)
 	if objectAPI == nil {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrServerNotInitialized), r.URL)
-		return
-	}
-	if !globalIsErasure {
-		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL)
 		return
 	}
 

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -121,6 +121,7 @@ const (
 	ErrReplicationNeedsVersioningError
 	ErrReplicationBucketNeedsVersioningError
 	ErrBucketReplicationDisabledError
+	ErrObjectRestoreAlreadyInProgress
 	ErrNoSuchKey
 	ErrNoSuchUpload
 	ErrNoSuchVersion
@@ -915,6 +916,11 @@ var errorCodes = errorCodeMap{
 		Code:           "InvalidRequest",
 		Description:    "x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied",
 		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrObjectRestoreAlreadyInProgress: {
+		Code:           "RestoreAlreadyInProgress",
+		Description:    "Object restore is already in progress",
+		HTTPStatusCode: http.StatusConflict,
 	},
 	/// Bucket notification related errors.
 	ErrEventNotification: {

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -307,6 +307,9 @@ func registerAPIRouter(router *mux.Router) {
 		// DeleteBucket
 		bucket.Methods(http.MethodDelete).HandlerFunc(
 			maxClients(collectAPIStats("deletebucket", httpTraceAll(api.DeleteBucketHandler))))
+		// PostRestoreObject
+		bucket.Methods(http.MethodPost).Path("/{object:.+}").HandlerFunc(
+			maxClients(collectAPIStats("restoreobject", httpTraceAll(api.PostRestoreObjectHandler)))).Queries("restore", "")
 	}
 
 	/// Root operation

--- a/cmd/bucket-lifecycle-handlers.go
+++ b/cmd/bucket-lifecycle-handlers.go
@@ -78,6 +78,12 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 		return
 	}
 
+	// Validate the transition storage ARNs
+	if err = validateLifecycleTransition(ctx, bucket, bucketLifecycle); err != nil {
+		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+		return
+	}
+
 	configData, err := xml.Marshal(bucketLifecycle)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -17,7 +17,26 @@
 package cmd
 
 import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+
+	miniogo "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/tags"
+	"github.com/minio/minio/cmd/crypto"
+	xhttp "github.com/minio/minio/cmd/http"
+	"github.com/minio/minio/cmd/logger"
+	sse "github.com/minio/minio/pkg/bucket/encryption"
 	"github.com/minio/minio/pkg/bucket/lifecycle"
+	"github.com/minio/minio/pkg/event"
+	"github.com/minio/minio/pkg/hash"
+	"github.com/minio/minio/pkg/madmin"
+	"github.com/minio/minio/pkg/s3select"
 )
 
 const (
@@ -45,4 +64,548 @@ func (sys *LifecycleSys) Get(bucketName string) (lc *lifecycle.Lifecycle, err er
 // NewLifecycleSys - creates new lifecycle system.
 func NewLifecycleSys() *LifecycleSys {
 	return &LifecycleSys{}
+}
+
+type transitionState struct {
+	// add future metrics here
+	transitionCh chan ObjectInfo
+}
+
+func (t *transitionState) queueTransitionTask(oi ObjectInfo) {
+	select {
+	case t.transitionCh <- oi:
+	default:
+	}
+}
+
+var (
+	globalTransitionState      *transitionState
+	globalTransitionConcurrent = runtime.GOMAXPROCS(0) / 2
+)
+
+func newTransitionState() *transitionState {
+
+	// fix minimum concurrent transition to 1 for single CPU setup
+	if globalTransitionConcurrent == 0 {
+		globalTransitionConcurrent = 1
+	}
+	ts := &transitionState{
+		transitionCh: make(chan ObjectInfo, 10000),
+	}
+	go func() {
+		<-GlobalContext.Done()
+		close(ts.transitionCh)
+	}()
+	return ts
+}
+
+// addWorker creates a new worker to process tasks
+func (t *transitionState) addWorker(ctx context.Context, objectAPI ObjectLayer) {
+	// Add a new worker.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case oi, ok := <-t.transitionCh:
+				if !ok {
+					return
+				}
+				transitionObject(ctx, objectAPI, oi)
+			}
+		}
+	}()
+}
+
+func initBackgroundTransition(ctx context.Context, objectAPI ObjectLayer) {
+	if globalTransitionState == nil {
+		return
+	}
+
+	// Start with globalTransitionConcurrent.
+	for i := 0; i < globalTransitionConcurrent; i++ {
+		globalTransitionState.addWorker(ctx, objectAPI)
+	}
+}
+
+func validateLifecycleTransition(ctx context.Context, bucket string, lfc *lifecycle.Lifecycle) error {
+	for _, rule := range lfc.Rules {
+		if rule.Transition.StorageClass != "" {
+			sameTarget, destbucket, err := validateTransitionDestination(ctx, bucket, rule.Transition.StorageClass)
+			if err != nil {
+				return err
+			}
+			if sameTarget && destbucket == bucket {
+				return fmt.Errorf("Transition destination cannot be the same as the source bucket")
+			}
+		}
+	}
+	return nil
+}
+
+// validateTransitionDestination returns error if transition destination bucket missing or not configured
+// It also returns true if transition destination is same as this server.
+func validateTransitionDestination(ctx context.Context, bucket string, targetLabel string) (bool, string, error) {
+	tgt := globalBucketTargetSys.GetRemoteTargetWithLabel(ctx, bucket, targetLabel)
+	if tgt == nil {
+		return false, "", BucketRemoteTargetNotFound{Bucket: bucket}
+	}
+	arn, err := madmin.ParseARN(tgt.Arn)
+	if err != nil {
+		return false, "", BucketRemoteTargetNotFound{Bucket: bucket}
+	}
+	clnt := globalBucketTargetSys.GetRemoteTargetClient(ctx, tgt.Arn)
+	if clnt == nil {
+		return false, "", BucketRemoteTargetNotFound{Bucket: bucket}
+	}
+	if found, _ := clnt.BucketExists(ctx, arn.Bucket); !found {
+		return false, "", BucketRemoteDestinationNotFound{Bucket: arn.Bucket}
+	}
+	sameTarget, _ := isLocalHost(clnt.EndpointURL().Hostname(), clnt.EndpointURL().Port(), globalMinioPort)
+	return sameTarget, arn.Bucket, nil
+}
+
+// return true if ARN representing transition storage class is present in a active rule
+// for the lifecycle configured on this bucket
+func transitionSCInUse(ctx context.Context, lfc *lifecycle.Lifecycle, bucket, arnStr string) bool {
+	tgtLabel := globalBucketTargetSys.GetRemoteLabelWithArn(ctx, bucket, arnStr)
+	if tgtLabel == "" {
+		return false
+	}
+	for _, rule := range lfc.Rules {
+		if rule.Status == Disabled {
+			continue
+		}
+		if rule.Transition.StorageClass != "" && rule.Transition.StorageClass == tgtLabel {
+			return true
+		}
+	}
+	return false
+}
+
+// set PutObjectOptions for PUT operation to transition data to target cluster
+func putTransitionOpts(objInfo ObjectInfo) (putOpts miniogo.PutObjectOptions) {
+	meta := make(map[string]string)
+
+	tag, err := tags.ParseObjectTags(objInfo.UserTags)
+	if err != nil {
+		return
+	}
+	putOpts = miniogo.PutObjectOptions{
+		UserMetadata:    meta,
+		UserTags:        tag.ToMap(),
+		ContentType:     objInfo.ContentType,
+		ContentEncoding: objInfo.ContentEncoding,
+		StorageClass:    objInfo.StorageClass,
+		Internal: miniogo.AdvancedPutOptions{
+			SourceVersionID: objInfo.VersionID,
+			SourceMTime:     objInfo.ModTime,
+			SourceETag:      objInfo.ETag,
+		},
+	}
+	if mode, ok := objInfo.UserDefined[xhttp.AmzObjectLockMode]; ok {
+		rmode := miniogo.RetentionMode(mode)
+		putOpts.Mode = rmode
+	}
+	if retainDateStr, ok := objInfo.UserDefined[xhttp.AmzObjectLockRetainUntilDate]; ok {
+		rdate, err := time.Parse(time.RFC3339, retainDateStr)
+		if err != nil {
+			return
+		}
+		putOpts.RetainUntilDate = rdate
+	}
+	if lhold, ok := objInfo.UserDefined[xhttp.AmzObjectLockLegalHold]; ok {
+		putOpts.LegalHold = miniogo.LegalHoldStatus(lhold)
+	}
+
+	return
+}
+
+// handle deletes of transitioned objects or object versions when one of the following is true:
+// 1. temporarily restored copies of objects (restored with the PostRestoreObject API) expired.
+// 2. life cycle expiry date is met on the object.
+func deleteTransitionedObject(ctx context.Context, objectAPI ObjectLayer, bucket, object string, objInfo ObjectInfo, lcOpts lifecycle.ObjectOpts, action lifecycle.Action) error {
+	if objInfo.TransitionStatus == "" {
+		return nil
+	}
+	lc, err := globalLifecycleSys.Get(bucket)
+	if err != nil {
+		return err
+	}
+	arn := getLifecycleTransitionTargetArn(ctx, lc, bucket, lcOpts)
+	if arn == nil {
+		return fmt.Errorf("remote target not configured")
+	}
+	tgt := globalBucketTargetSys.GetRemoteTargetClient(ctx, arn.String())
+	if tgt == nil {
+		return fmt.Errorf("remote target not configured")
+	}
+
+	var opts ObjectOptions
+	opts.Versioned = globalBucketVersioningSys.Enabled(bucket)
+	opts.VersionID = objInfo.VersionID
+	switch action {
+	case lifecycle.DeleteRestoredAction, lifecycle.DeleteRestoredVersionAction:
+		// delete locally restored copy of object or object version
+		// from the source, while leaving metadata behind. The data on
+		// transitioned tier lies untouched and still accessible
+		opts.TransitionStatus = objInfo.TransitionStatus
+		_, err = objectAPI.DeleteObject(ctx, bucket, object, opts)
+		return err
+	case lifecycle.DeleteAction, lifecycle.DeleteVersionAction:
+		// When an object is past expiry, delete the data from transitioned tier and
+		// metadata from source
+		if err := tgt.RemoveObject(ctx, arn.Bucket, object, miniogo.RemoveObjectOptions{VersionID: objInfo.VersionID}); err != nil {
+			logger.LogIf(ctx, err)
+		}
+		_, err = objectAPI.DeleteObject(ctx, bucket, object, opts)
+		if err != nil {
+			return err
+		}
+		eventName := event.ObjectRemovedDelete
+		if objInfo.DeleteMarker {
+			eventName = event.ObjectRemovedDeleteMarkerCreated
+		}
+		// Notify object deleted event.
+		sendEvent(eventArgs{
+			EventName:  eventName,
+			BucketName: bucket,
+			Object:     objInfo,
+			Host:       "Internal: [ILM-EXPIRY]",
+		})
+	}
+
+	// should never reach here
+	return nil
+}
+
+// transition object to target specified by the transition ARN. When an object is transitioned to another
+// storage specified by the transition ARN, the metadata is left behind on source cluster and original content
+// is moved to the transition tier. Note that in the case of encrypted objects, entire encrypted stream is moved
+// to the transition tier without decrypting or re-encrypting.
+func transitionObject(ctx context.Context, objectAPI ObjectLayer, objInfo ObjectInfo) error {
+	lc, err := globalLifecycleSys.Get(objInfo.Bucket)
+	if err != nil {
+		return err
+	}
+	lcOpts := lifecycle.ObjectOpts{
+		Name:     objInfo.Name,
+		UserTags: objInfo.UserTags,
+	}
+	arn := getLifecycleTransitionTargetArn(ctx, lc, objInfo.Bucket, lcOpts)
+	if arn == nil {
+		return fmt.Errorf("remote target not configured")
+	}
+	tgt := globalBucketTargetSys.GetRemoteTargetClient(ctx, arn.String())
+	if tgt == nil {
+		return fmt.Errorf("remote target not configured")
+	}
+
+	gr, err := objectAPI.GetObjectNInfo(ctx, objInfo.Bucket, objInfo.Name, nil, http.Header{}, readLock, ObjectOptions{
+		VersionID:        objInfo.VersionID,
+		TransitionStatus: lifecycle.TransitionPending,
+	})
+	if err != nil {
+		return err
+	}
+	oi := gr.ObjInfo
+
+	if oi.TransitionStatus == lifecycle.TransitionComplete {
+		return nil
+	}
+
+	putOpts := putTransitionOpts(oi)
+	if _, err = tgt.PutObject(ctx, arn.Bucket, oi.Name, gr, oi.Size, "", "", putOpts); err != nil {
+		return err
+	}
+	gr.Close()
+
+	var opts ObjectOptions
+	opts.Versioned = globalBucketVersioningSys.Enabled(oi.Bucket)
+	opts.VersionID = oi.VersionID
+	opts.TransitionStatus = lifecycle.TransitionComplete
+
+	if _, err = objectAPI.DeleteObject(ctx, oi.Bucket, oi.Name, opts); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getLifecycleTransitionTargetArn returns transition ARN for storage class specified in the config.
+func getLifecycleTransitionTargetArn(ctx context.Context, lc *lifecycle.Lifecycle, bucket string, obj lifecycle.ObjectOpts) *madmin.ARN {
+	for _, rule := range lc.FilterActionableRules(obj) {
+		if rule.Transition.StorageClass != "" {
+			return globalBucketTargetSys.GetRemoteArnWithLabel(ctx, bucket, rule.Transition.StorageClass)
+		}
+	}
+	return nil
+}
+
+// getTransitionedObjectReader returns a reader from the transitioned tier.
+func getTransitionedObjectReader(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, oi ObjectInfo, opts ObjectOptions) (gr *GetObjectReader, err error) {
+	var lc *lifecycle.Lifecycle
+	lc, err = globalLifecycleSys.Get(bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	arn := getLifecycleTransitionTargetArn(ctx, lc, bucket, lifecycle.ObjectOpts{
+		Name:         object,
+		UserTags:     oi.UserTags,
+		ModTime:      oi.ModTime,
+		VersionID:    oi.VersionID,
+		DeleteMarker: oi.DeleteMarker,
+		IsLatest:     oi.IsLatest,
+	})
+	if arn == nil {
+		return nil, fmt.Errorf("remote target not configured")
+	}
+	tgt := globalBucketTargetSys.GetRemoteTargetClient(ctx, arn.String())
+	if tgt == nil {
+		return nil, fmt.Errorf("remote target not configured")
+	}
+	fn, off, length, err := NewGetObjectReader(rs, oi, opts)
+	if err != nil {
+		return nil, ErrorRespToObjectError(err, bucket, object)
+	}
+	gopts := miniogo.GetObjectOptions{VersionID: opts.VersionID}
+
+	// get correct offsets for encrypted object
+	if off >= 0 && length >= 0 {
+		if err := gopts.SetRange(off, off+length-1); err != nil {
+			return nil, ErrorRespToObjectError(err, bucket, object)
+		}
+	}
+
+	reader, _, _, err := tgt.GetObject(ctx, arn.Bucket, object, gopts)
+	if err != nil {
+		return nil, err
+	}
+	closeReader := func() { reader.Close() }
+
+	return fn(reader, h, opts.CheckPrecondFn, closeReader)
+}
+
+// RestoreRequestType represents type of restore.
+type RestoreRequestType string
+
+const (
+	// SelectRestoreRequest specifies select request. This is the only valid value
+	SelectRestoreRequest RestoreRequestType = "SELECT"
+)
+
+// Encryption specifies encryption setting on restored bucket
+type Encryption struct {
+	EncryptionType sse.SSEAlgorithm `xml:"EncryptionType"`
+	KMSContext     string           `xml:"KMSContext,omitempty"`
+	KMSKeyID       string           `xml:"KMSKeyId,omitempty"`
+}
+
+// MetadataEntry denotes name and value.
+type MetadataEntry struct {
+	Name  string `xml:"Name"`
+	Value string `xml:"Value"`
+}
+
+// S3Location specifies s3 location that receives result of a restore object request
+type S3Location struct {
+	BucketName   string          `xml:"BucketName,omitempty"`
+	Encryption   Encryption      `xml:"Encryption,omitempty"`
+	Prefix       string          `xml:"Prefix,omitempty"`
+	StorageClass string          `xml:"StorageClass,omitempty"`
+	Tagging      *tags.Tags      `xml:"Tagging,omitempty"`
+	UserMetadata []MetadataEntry `xml:"UserMetadata"`
+}
+
+// OutputLocation specifies bucket where object needs to be restored
+type OutputLocation struct {
+	S3 S3Location `xml:"S3,omitempty"`
+}
+
+// IsEmpty returns true if output location not specified.
+func (o *OutputLocation) IsEmpty() bool {
+	return o.S3.BucketName == ""
+}
+
+// SelectParameters specifies sql select parameters
+type SelectParameters struct {
+	s3select.S3Select
+}
+
+// IsEmpty returns true if no select parameters set
+func (sp *SelectParameters) IsEmpty() bool {
+	return sp == nil || sp.S3Select == s3select.S3Select{}
+}
+
+var (
+	selectParamsXMLName = "SelectParameters"
+)
+
+// UnmarshalXML - decodes XML data.
+func (sp *SelectParameters) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	// Essentially the same as S3Select barring the xml name.
+	if start.Name.Local == selectParamsXMLName {
+		start.Name = xml.Name{Space: "", Local: "SelectRequest"}
+	}
+	return sp.S3Select.UnmarshalXML(d, start)
+}
+
+// RestoreObjectRequest - xml to restore a transitioned object
+type RestoreObjectRequest struct {
+	XMLName          xml.Name           `xml:"http://s3.amazonaws.com/doc/2006-03-01/ RestoreRequest" json:"-"`
+	Days             int                `xml:"Days,omitempty"`
+	Type             RestoreRequestType `xml:"Type,omitempty"`
+	Tier             string             `xml:"Tier,-"`
+	Description      string             `xml:"Description,omitempty"`
+	SelectParameters *SelectParameters  `xml:"SelectParameters,omitempty"`
+	OutputLocation   OutputLocation     `xml:"OutputLocation,omitempty"`
+}
+
+// Maximum 2MiB size per restore object request.
+const maxRestoreObjectRequestSize = 2 << 20
+
+// parseRestoreRequest parses RestoreObjectRequest from xml
+func parseRestoreRequest(reader io.Reader) (*RestoreObjectRequest, error) {
+	req := RestoreObjectRequest{}
+	if err := xml.NewDecoder(io.LimitReader(reader, maxRestoreObjectRequestSize)).Decode(&req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+// validate a RestoreObjectRequest as per AWS S3 spec https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html
+func (r *RestoreObjectRequest) validate(ctx context.Context, objAPI ObjectLayer) error {
+	if r.Type != SelectRestoreRequest && !r.SelectParameters.IsEmpty() {
+		return fmt.Errorf("Select parameters can only be specified with SELECT request type")
+	}
+	if r.Type == SelectRestoreRequest && r.SelectParameters.IsEmpty() {
+		return fmt.Errorf("SELECT restore request requires select parameters to be specified")
+	}
+
+	if r.Type != SelectRestoreRequest && !r.OutputLocation.IsEmpty() {
+		return fmt.Errorf("OutputLocation required only for SELECT request type")
+	}
+	if r.Type == SelectRestoreRequest && r.OutputLocation.IsEmpty() {
+		return fmt.Errorf("OutputLocation required for SELECT requests")
+	}
+
+	if r.Days != 0 && r.Type == SelectRestoreRequest {
+		return fmt.Errorf("Days cannot be specified with SELECT restore request")
+	}
+	if r.Days == 0 && r.Type != SelectRestoreRequest {
+		return fmt.Errorf("restoration days should be at least 1")
+	}
+	// Check if bucket exists.
+	if !r.OutputLocation.IsEmpty() {
+		if _, err := objAPI.GetBucketInfo(ctx, r.OutputLocation.S3.BucketName); err != nil {
+			return err
+		}
+		if r.OutputLocation.S3.Prefix == "" {
+			return fmt.Errorf("Prefix is a required parameter in OutputLocation")
+		}
+		if r.OutputLocation.S3.Encryption.EncryptionType != crypto.SSEAlgorithmAES256 {
+			return NotImplemented{}
+		}
+	}
+	return nil
+}
+
+// set ObjectOptions for PUT call to restore temporary copy of transitioned data
+func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo ObjectInfo) (putOpts ObjectOptions) {
+	meta := make(map[string]string)
+	sc := rreq.OutputLocation.S3.StorageClass
+	if sc == "" {
+		sc = objInfo.StorageClass
+	}
+	meta[strings.ToLower(xhttp.AmzStorageClass)] = sc
+
+	if rreq.Type == SelectRestoreRequest {
+		for _, v := range rreq.OutputLocation.S3.UserMetadata {
+			if !strings.HasPrefix("x-amz-meta", strings.ToLower(v.Name)) {
+				meta["x-amz-meta-"+v.Name] = v.Value
+				continue
+			}
+			meta[v.Name] = v.Value
+		}
+		meta[xhttp.AmzObjectTagging] = rreq.OutputLocation.S3.Tagging.String()
+		if rreq.OutputLocation.S3.Encryption.EncryptionType != "" {
+			meta[crypto.SSEHeader] = crypto.SSEAlgorithmAES256
+		}
+		return ObjectOptions{
+			Versioned:        globalBucketVersioningSys.Enabled(bucket),
+			VersionSuspended: globalBucketVersioningSys.Suspended(bucket),
+			UserDefined:      meta,
+		}
+	}
+	for k, v := range objInfo.UserDefined {
+		meta[k] = v
+	}
+	meta[xhttp.AmzObjectTagging] = objInfo.UserTags
+
+	return ObjectOptions{
+		Versioned:        globalBucketVersioningSys.Enabled(bucket),
+		VersionSuspended: globalBucketVersioningSys.Suspended(bucket),
+		UserDefined:      meta,
+		VersionID:        objInfo.VersionID,
+		MTime:            objInfo.ModTime,
+		Expires:          objInfo.Expires,
+	}
+}
+
+var (
+	errRestoreHDRMissing   = fmt.Errorf("x-amz-restore header not found")
+	errRestoreHDRMalformed = fmt.Errorf("x-amz-restore header malformed")
+)
+
+// parse x-amz-restore header from user metadata to get the status of ongoing request and expiry of restoration
+// if any. This header value is of format: ongoing-request=true|false, expires=time
+func parseRestoreHeaderFromMeta(meta map[string]string) (ongoing bool, expiry time.Time, err error) {
+	restoreHdr, ok := meta[xhttp.AmzRestore]
+	if !ok {
+		return ongoing, expiry, errRestoreHDRMissing
+	}
+	rslc := strings.SplitN(restoreHdr, ",", 2)
+	if len(rslc) != 2 {
+		return ongoing, expiry, errRestoreHDRMalformed
+	}
+	rstatusSlc := strings.SplitN(rslc[0], "=", 2)
+	if len(rstatusSlc) != 2 {
+		return ongoing, expiry, errRestoreHDRMalformed
+	}
+	rExpSlc := strings.SplitN(rslc[1], "=", 2)
+	if len(rExpSlc) != 2 {
+		return ongoing, expiry, errRestoreHDRMalformed
+	}
+
+	expiry, err = time.Parse(http.TimeFormat, rExpSlc[1])
+	if err != nil {
+		return
+	}
+	return rstatusSlc[1] == "true", expiry, nil
+}
+
+// restoreTransitionedObject is similar to PostObjectRestore from AWS GLACIER
+// storage class. When PostObjectRestore API is called, a temporary copy of the object
+// is restored locally to the bucket on source cluster until the restore expiry date.
+// The copy that was transitioned continues to reside in the transitioned tier.
+func restoreTransitionedObject(ctx context.Context, bucket, object string, objAPI ObjectLayer, objInfo ObjectInfo, rreq *RestoreObjectRequest, restoreExpiry time.Time) error {
+	var rs *HTTPRangeSpec
+	gr, err := getTransitionedObjectReader(ctx, bucket, object, rs, http.Header{}, objInfo, ObjectOptions{
+		VersionID: objInfo.VersionID})
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+	hashReader, err := hash.NewReader(gr, objInfo.Size, "", "", objInfo.Size, globalCLIContext.StrictS3Compat)
+	if err != nil {
+		return err
+	}
+	pReader := NewPutObjReader(hashReader, nil, nil)
+	opts := putRestoreOpts(bucket, object, rreq, objInfo)
+	opts.UserDefined[xhttp.AmzRestore] = fmt.Sprintf("ongoing-request=%t, expiry-date=%s", false, restoreExpiry.Format(http.TimeFormat))
+	if _, err := objAPI.PutObject(ctx, bucket, object, pReader, opts); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -168,9 +168,6 @@ func (sys *BucketMetadataSys) Update(bucket string, configFile string, configDat
 		}
 		meta.ReplicationConfigXML = configData
 	case bucketTargetsFile:
-		if !globalIsErasure && !globalIsDistErasure {
-			return NotImplemented{}
-		}
 		meta.BucketTargetsConfigJSON = configData
 	default:
 		return fmt.Errorf("Unknown bucket %s metadata update requested %s", bucket, configFile)

--- a/cmd/erasure-decode.go
+++ b/cmd/erasure-decode.go
@@ -271,10 +271,12 @@ func (e Erasure) decode(ctx context.Context, writer io.Writer, readers []io.Read
 				return healRequired, err
 			}
 		}
+
 		if err = e.DecodeDataBlocks(bufs); err != nil {
 			logger.LogIf(ctx, err)
 			return healRequired, err
 		}
+
 		n, err := writeDataBlocks(ctx, writer, bufs, e.dataBlocks, blockOffset, blockLength)
 		if err != nil {
 			return healRequired, err

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -142,6 +142,9 @@ func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 	if fi.Deleted {
 		objInfo.ReplicationStatus = replication.StatusType(fi.DeleteMarkerReplicationStatus)
 	}
+
+	objInfo.TransitionStatus = fi.TransitionStatus
+
 	// etag/md5Sum has already been extracted. We need to
 	// remove to avoid it from appearing as part of
 	// response headers. e.g, X-Minio-* or X-Amz-*.
@@ -158,6 +161,11 @@ func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 		objInfo.StorageClass = globalMinioDefaultStorageClass
 	}
 	objInfo.VersionPurgeStatus = fi.VersionPurgeStatus
+	// set restore status for transitioned object
+	if ongoing, exp, err := parseRestoreHeaderFromMeta(fi.Metadata); err == nil {
+		objInfo.RestoreOngoing = ongoing
+		objInfo.RestoreExpires = exp
+	}
 	// Success.
 	return objInfo
 }

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -23,12 +23,14 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/tags"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/bucket/lifecycle"
 	"github.com/minio/minio/pkg/bucket/replication"
 	"github.com/minio/minio/pkg/mimedb"
 	"github.com/minio/minio/pkg/sync/errgroup"
@@ -169,13 +171,18 @@ func (er erasureObjects) GetObjectNInfo(ctx context.Context, bucket, object stri
 			ObjInfo: objInfo,
 		}, toObjectErr(errMethodNotAllowed, bucket, object)
 	}
-
+	if objInfo.TransitionStatus == lifecycle.TransitionComplete {
+		// If transitioned, stream from transition tier unless object is restored locally or restore date is past.
+		restoreHdr, ok := objInfo.UserDefined[xhttp.AmzRestore]
+		if !ok || !strings.HasPrefix(restoreHdr, "ongoing-request=false") || (!objInfo.RestoreExpires.IsZero() && time.Now().After(objInfo.RestoreExpires)) {
+			return getTransitionedObjectReader(ctx, bucket, object, rs, h, objInfo, opts)
+		}
+	}
 	unlockOnDefer = false
 	fn, off, length, nErr := NewGetObjectReader(rs, objInfo, opts, nsUnlocker)
 	if nErr != nil {
 		return nil, nErr
 	}
-
 	pr, pw := io.Pipe()
 	go func() {
 		err := er.getObjectWithFileInfo(ctx, bucket, object, off, length, pw, fi, metaArr, onlineDisks)
@@ -257,8 +264,8 @@ func (er erasureObjects) getObjectWithFileInfo(ctx context.Context, bucket, obje
 	if err != nil {
 		return toObjectErr(err, bucket, object)
 	}
-
 	var healOnce sync.Once
+
 	for ; partIndex <= lastPartIndex; partIndex++ {
 		if length == totalBytesRead {
 			break
@@ -314,12 +321,10 @@ func (er erasureObjects) getObjectWithFileInfo(ctx context.Context, bucket, obje
 		}
 		// Track total bytes read from disk and written to the client.
 		totalBytesRead += partLength
-
 		// partOffset will be valid only for the first part, hence reset it to 0 for
 		// the remaining parts.
 		partOffset = 0
 	} // End of read all parts loop.
-
 	// Return success.
 	return nil
 }
@@ -998,6 +1003,8 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 					fi.VersionID = opts.VersionID
 				}
 			}
+			fi.TransitionStatus = opts.TransitionStatus
+
 			// versioning suspended means we add `null`
 			// version as delete marker
 			// Add delete marker, since we don't have any version specified explicitly.
@@ -1018,6 +1025,7 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 		ModTime:                       modTime,
 		DeleteMarkerReplicationStatus: opts.DeleteMarkerReplicationStatus,
 		VersionPurgeStatus:            opts.VersionPurgeStatus,
+		TransitionStatus:              opts.TransitionStatus,
 	}); err != nil {
 		return objInfo, toObjectErr(err, bucket, object)
 	}

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -479,7 +479,6 @@ var supportedDummyObjectAPIs = map[string][]string{
 
 // List of not implemented object APIs
 var notImplementedObjectResourceNames = map[string]struct{}{
-	"restore": {},
 	"torrent": {},
 }
 

--- a/cmd/http/headers.go
+++ b/cmd/http/headers.go
@@ -66,6 +66,12 @@ const (
 	AmzTagCount      = "x-amz-tagging-count"
 	AmzTagDirective  = "X-Amz-Tagging-Directive"
 
+	// S3 transition restore
+	AmzRestore            = "x-amz-restore"
+	AmzRestoreExpiryDays  = "X-Amz-Restore-Expiry-Days"
+	AmzRestoreRequestDate = "X-Amz-Restore-Request-Date"
+	AmzRestoreOutputPath  = "x-amz-restore-output-path"
+
 	// S3 extensions
 	AmzCopySourceIfModifiedSince   = "x-amz-copy-source-if-modified-since"
 	AmzCopySourceIfUnmodifiedSince = "x-amz-copy-source-if-unmodified-since"

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -163,6 +163,15 @@ type ObjectInfo struct {
 	// to a delete marker on an object.
 	DeleteMarker bool
 
+	// TransitionStatus indicates if transition is complete/pending
+	TransitionStatus string
+
+	// RestoreExpires indicates date a restored object expires
+	RestoreExpires time.Time
+
+	// RestoreOngoing indicates if a restore is in progress
+	RestoreOngoing bool
+
 	// A standard MIME type describing the format of the object.
 	ContentType string
 

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -36,18 +36,21 @@ type GetObjectInfoFn func(ctx context.Context, bucket, object string, opts Objec
 
 // ObjectOptions represents object options for ObjectLayer object operations
 type ObjectOptions struct {
-	ServerSideEncryption          encrypt.ServerSide
-	VersionSuspended              bool                   // indicates if the bucket was previously versioned but is currently suspended.
-	Versioned                     bool                   // indicates if the bucket is versioned
-	WalkVersions                  bool                   // indicates if the we are interested in walking versions
-	VersionID                     string                 // Specifies the versionID which needs to be overwritten or read
-	MTime                         time.Time              // Is only set in POST/PUT operations
+	ServerSideEncryption encrypt.ServerSide
+	VersionSuspended     bool      // indicates if the bucket was previously versioned but is currently suspended.
+	Versioned            bool      // indicates if the bucket is versioned
+	WalkVersions         bool      // indicates if the we are interested in walking versions
+	VersionID            string    // Specifies the versionID which needs to be overwritten or read
+	MTime                time.Time // Is only set in POST/PUT operations
+	Expires              time.Time // Is only used in POST/PUT operations
+
 	DeleteMarker                  bool                   // Is only set in DELETE operations for delete marker replication
 	UserDefined                   map[string]string      // only set in case of POST/PUT operations
 	PartNumber                    int                    // only useful in case of GetObject/HeadObject
 	CheckPrecondFn                CheckPreconditionFn    // only set during GetObject/HeadObject/CopyObjectPart preconditional valuation
 	DeleteMarkerReplicationStatus string                 // Is only set in DELETE operations
 	VersionPurgeStatus            VersionPurgeStatusType // Is only set in DELETE operations for delete marker version to be permanently deleted.
+	TransitionStatus              string                 // status of the transition
 }
 
 // BucketOptions represents bucket options for ObjectLayer bucket operations

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -235,6 +235,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 		}
 		metadata["etag"] = etag
 	}
+
 	// In the case of multipart custom format, the metadata needs to be checked in addition to header to see if it
 	// is SSE-S3 encrypted, primarily because S3 protocol does not require SSE-S3 headers in PutObjectPart calls
 	if GlobalGatewaySSE.SSES3() && (crypto.S3.IsRequested(r.Header) || crypto.S3.IsEncrypted(metadata)) {

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -43,6 +43,7 @@ import (
 	"github.com/minio/minio/cmd/crypto"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/bucket/lifecycle"
 	"github.com/minio/minio/pkg/hash"
 	"github.com/minio/minio/pkg/ioutil"
 	"github.com/minio/minio/pkg/trie"
@@ -590,7 +591,10 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, opts ObjectOptions, cl
 	if err != nil {
 		return nil, 0, 0, err
 	}
-
+	// if object is encrypted, transition content without decrypting.
+	if opts.TransitionStatus == lifecycle.TransitionPending && isEncrypted {
+		isEncrypted = false
+	}
 	var skipLen int64
 	// Calculate range to read (different for
 	// e.g. encrypted/compressed objects)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -425,6 +425,8 @@ func serverMain(ctx *cli.Context) {
 		globalAllHealState = newHealState()
 		globalBackgroundHealState = newHealState()
 		globalReplicationState = newReplicationState()
+		globalTransitionState = newTransitionState()
+
 	}
 
 	// Configure server.
@@ -479,6 +481,7 @@ func serverMain(ctx *cli.Context) {
 	if globalIsErasure {
 		initAutoHeal(GlobalContext, newObject)
 		initBackgroundReplication(GlobalContext, newObject)
+		initBackgroundTransition(GlobalContext, newObject)
 	}
 
 	if err = initServer(GlobalContext, newObject); err != nil {

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -112,6 +112,10 @@ type FileInfo struct {
 	// a deleted marker for a versioned bucket.
 	Deleted bool
 
+	// TransitionStatus is set to Pending/Complete for transitioned
+	// entries based on state of transition
+	TransitionStatus string
+
 	// DataDir of the file
 	DataDir string
 

--- a/cmd/storage-datatypes_gen.go
+++ b/cmd/storage-datatypes_gen.go
@@ -342,8 +342,8 @@ func (z *FileInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	if zb0001 != 16 {
-		err = msgp.ArrayError{Wanted: 16, Got: zb0001}
+	if zb0001 != 17 {
+		err = msgp.ArrayError{Wanted: 17, Got: zb0001}
 		return
 	}
 	z.Volume, err = dc.ReadString()
@@ -369,6 +369,11 @@ func (z *FileInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 	z.Deleted, err = dc.ReadBool()
 	if err != nil {
 		err = msgp.WrapError(err, "Deleted")
+		return
+	}
+	z.TransitionStatus, err = dc.ReadString()
+	if err != nil {
+		err = msgp.WrapError(err, "TransitionStatus")
 		return
 	}
 	z.DataDir, err = dc.ReadString()
@@ -472,8 +477,8 @@ func (z *FileInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *FileInfo) EncodeMsg(en *msgp.Writer) (err error) {
-	// array header, size 16
-	err = en.Append(0xdc, 0x0, 0x10)
+	// array header, size 17
+	err = en.Append(0xdc, 0x0, 0x11)
 	if err != nil {
 		return
 	}
@@ -500,6 +505,11 @@ func (z *FileInfo) EncodeMsg(en *msgp.Writer) (err error) {
 	err = en.WriteBool(z.Deleted)
 	if err != nil {
 		err = msgp.WrapError(err, "Deleted")
+		return
+	}
+	err = en.WriteString(z.TransitionStatus)
+	if err != nil {
+		err = msgp.WrapError(err, "TransitionStatus")
 		return
 	}
 	err = en.WriteString(z.DataDir)
@@ -582,13 +592,14 @@ func (z *FileInfo) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *FileInfo) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// array header, size 16
-	o = append(o, 0xdc, 0x0, 0x10)
+	// array header, size 17
+	o = append(o, 0xdc, 0x0, 0x11)
 	o = msgp.AppendString(o, z.Volume)
 	o = msgp.AppendString(o, z.Name)
 	o = msgp.AppendString(o, z.VersionID)
 	o = msgp.AppendBool(o, z.IsLatest)
 	o = msgp.AppendBool(o, z.Deleted)
+	o = msgp.AppendString(o, z.TransitionStatus)
 	o = msgp.AppendString(o, z.DataDir)
 	o = msgp.AppendBool(o, z.XLV1)
 	o = msgp.AppendTime(o, z.ModTime)
@@ -626,8 +637,8 @@ func (z *FileInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	if zb0001 != 16 {
-		err = msgp.ArrayError{Wanted: 16, Got: zb0001}
+	if zb0001 != 17 {
+		err = msgp.ArrayError{Wanted: 17, Got: zb0001}
 		return
 	}
 	z.Volume, bts, err = msgp.ReadStringBytes(bts)
@@ -653,6 +664,11 @@ func (z *FileInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	z.Deleted, bts, err = msgp.ReadBoolBytes(bts)
 	if err != nil {
 		err = msgp.WrapError(err, "Deleted")
+		return
+	}
+	z.TransitionStatus, bts, err = msgp.ReadStringBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err, "TransitionStatus")
 		return
 	}
 	z.DataDir, bts, err = msgp.ReadStringBytes(bts)
@@ -757,7 +773,7 @@ func (z *FileInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *FileInfo) Msgsize() (s int) {
-	s = 3 + msgp.StringPrefixSize + len(z.Volume) + msgp.StringPrefixSize + len(z.Name) + msgp.StringPrefixSize + len(z.VersionID) + msgp.BoolSize + msgp.BoolSize + msgp.StringPrefixSize + len(z.DataDir) + msgp.BoolSize + msgp.TimeSize + msgp.Int64Size + msgp.Uint32Size + msgp.MapHeaderSize
+	s = 3 + msgp.StringPrefixSize + len(z.Volume) + msgp.StringPrefixSize + len(z.Name) + msgp.StringPrefixSize + len(z.VersionID) + msgp.BoolSize + msgp.BoolSize + msgp.StringPrefixSize + len(z.TransitionStatus) + msgp.StringPrefixSize + len(z.DataDir) + msgp.BoolSize + msgp.TimeSize + msgp.Int64Size + msgp.Uint32Size + msgp.MapHeaderSize
 	if z.Metadata != nil {
 		for za0001, za0002 := range z.Metadata {
 			_ = za0002

--- a/cmd/xl-storage-format-v1.go
+++ b/cmd/xl-storage-format-v1.go
@@ -182,7 +182,11 @@ func (m *xlMetaV1Object) ToFileInfo(volume, path string) (FileInfo, error) {
 	if !m.valid() {
 		return FileInfo{}, errFileCorrupt
 	}
-	return FileInfo{
+	var transitionStatus string
+	if st, ok := m.Meta[ReservedMetadataPrefixLower+"transition-status"]; ok {
+		transitionStatus = st
+	}
+	fi := FileInfo{
 		Volume:    volume,
 		Name:      path,
 		ModTime:   m.Stat.ModTime,
@@ -192,7 +196,11 @@ func (m *xlMetaV1Object) ToFileInfo(volume, path string) (FileInfo, error) {
 		Erasure:   m.Erasure,
 		VersionID: m.VersionID,
 		DataDir:   m.DataDir,
-	}, nil
+	}
+	if transitionStatus != "" {
+		fi.TransitionStatus = transitionStatus
+	}
+	return fi, nil
 }
 
 // XL metadata constants.

--- a/pkg/bucket/lifecycle/lifecycle_test.go
+++ b/pkg/bucket/lifecycle/lifecycle_test.go
@@ -240,7 +240,7 @@ func TestExpectedExpiryTime(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Test %d", i+1), func(t *testing.T) {
-			got := expectedExpiryTime(tc.modTime, tc.days)
+			got := ExpectedExpiryTime(tc.modTime, int(tc.days))
 			if !got.Equal(tc.expected) {
 				t.Fatalf("Expected %v to be equal to %v", got, tc.expected)
 			}

--- a/pkg/bucket/lifecycle/noncurrentversion.go
+++ b/pkg/bucket/lifecycle/noncurrentversion.go
@@ -32,10 +32,6 @@ type NoncurrentVersionTransition struct {
 	StorageClass   string         `xml:"StorageClass"`
 }
 
-var (
-	errNoncurrentVersionTransitionUnsupported = Errorf("Specifying <NoncurrentVersionTransition></NoncurrentVersionTransition> is not supported")
-)
-
 // MarshalXML if non-current days not set to non zero value
 func (n NoncurrentVersionExpiration) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if n.IsDaysNull() {
@@ -50,13 +46,6 @@ func (n NoncurrentVersionExpiration) IsDaysNull() bool {
 	return n.NoncurrentDays == ExpirationDays(0)
 }
 
-// UnmarshalXML is extended to indicate lack of support for
-// NoncurrentVersionTransition xml tag in object lifecycle
-// configuration
-func (n NoncurrentVersionTransition) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
-	return errNoncurrentVersionTransitionUnsupported
-}
-
 // MarshalXML is extended to leave out
 // <NoncurrentVersionTransition></NoncurrentVersionTransition> tags
 func (n NoncurrentVersionTransition) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -64,4 +53,9 @@ func (n NoncurrentVersionTransition) MarshalXML(e *xml.Encoder, start xml.StartE
 		return nil
 	}
 	return e.EncodeElement(&n, start)
+}
+
+// IsDaysNull returns true if days field is null
+func (n NoncurrentVersionTransition) IsDaysNull() bool {
+	return n.NoncurrentDays == ExpirationDays(0)
 }

--- a/pkg/bucket/lifecycle/rule.go
+++ b/pkg/bucket/lifecycle/rule.go
@@ -100,6 +100,10 @@ func (r Rule) validateFilter() error {
 	return r.Filter.Validate()
 }
 
+func (r Rule) validateTransition() error {
+	return r.Transition.Validate()
+}
+
 // Prefix - a rule can either have prefix under <filter></filter> or under
 // <filter><and></and></filter>. This method returns the prefix from the
 // location where it is available
@@ -145,6 +149,9 @@ func (r Rule) Validate() error {
 		return err
 	}
 	if err := r.validateFilter(); err != nil {
+		return err
+	}
+	if err := r.validateTransition(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/bucket/lifecycle/rule_test.go
+++ b/pkg/bucket/lifecycle/rule_test.go
@@ -22,39 +22,6 @@ import (
 	"testing"
 )
 
-// TestUnsupportedRules checks if Rule xml with unsuported tags return
-// appropriate errors on parsing
-func TestUnsupportedRules(t *testing.T) {
-	// NoncurrentVersionTransition, and Transition tags aren't supported
-	unsupportedTestCases := []struct {
-		inputXML    string
-		expectedErr error
-	}{
-		{ // Rule with unsupported NoncurrentVersionTransition
-			inputXML: ` <Rule>
-	                     <NoncurrentVersionTransition></NoncurrentVersionTransition>
-	                    </Rule>`,
-			expectedErr: errNoncurrentVersionTransitionUnsupported,
-		},
-		{ // Rule with unsupported Transition action
-			inputXML: ` <Rule>
-	                     <Transition></Transition>
-	                    </Rule>`,
-			expectedErr: errTransitionUnsupported,
-		},
-	}
-
-	for i, tc := range unsupportedTestCases {
-		t.Run(fmt.Sprintf("Test %d", i+1), func(t *testing.T) {
-			var rule Rule
-			err := xml.Unmarshal([]byte(tc.inputXML), &rule)
-			if err != tc.expectedErr {
-				t.Fatalf("%d: Expected %v but got %v", i+1, tc.expectedErr, err)
-			}
-		})
-	}
-}
-
 // TestInvalidRules checks if Rule xml with invalid elements returns
 // appropriate errors on validation
 func TestInvalidRules(t *testing.T) {

--- a/pkg/bucket/lifecycle/transition.go
+++ b/pkg/bucket/lifecycle/transition.go
@@ -18,25 +18,147 @@ package lifecycle
 
 import (
 	"encoding/xml"
+	"time"
 )
+
+var (
+	errTransitionInvalidDays     = Errorf("Days must be 0 or greater when used with Transition")
+	errTransitionInvalidDate     = Errorf("Date must be provided in ISO 8601 format")
+	errTransitionInvalid         = Errorf("Exactly one of Days (0 or greater) or Date (positive ISO 8601 format) should be present inside Expiration.")
+	errTransitionDateNotMidnight = Errorf("'Date' must be at midnight GMT")
+)
+
+// TransitionDate is a embedded type containing time.Time to unmarshal
+// Date in Transition
+type TransitionDate struct {
+	time.Time
+}
+
+// UnmarshalXML parses date from Transition and validates date format
+func (tDate *TransitionDate) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
+	var dateStr string
+	err := d.DecodeElement(&dateStr, &startElement)
+	if err != nil {
+		return err
+	}
+	// While AWS documentation mentions that the date specified
+	// must be present in ISO 8601 format, in reality they allow
+	// users to provide RFC 3339 compliant dates.
+	trnDate, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		return errTransitionInvalidDate
+	}
+	// Allow only date timestamp specifying midnight GMT
+	hr, min, sec := trnDate.Clock()
+	nsec := trnDate.Nanosecond()
+	loc := trnDate.Location()
+	if !(hr == 0 && min == 0 && sec == 0 && nsec == 0 && loc.String() == time.UTC.String()) {
+		return errTransitionDateNotMidnight
+	}
+
+	*tDate = TransitionDate{trnDate}
+	return nil
+}
+
+// MarshalXML encodes expiration date if it is non-zero and encodes
+// empty string otherwise
+func (tDate TransitionDate) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+	if tDate.Time.IsZero() {
+		return nil
+	}
+	return e.EncodeElement(tDate.Format(time.RFC3339), startElement)
+}
+
+// TransitionDays is a type alias to unmarshal Days in Transition
+type TransitionDays int
+
+// UnmarshalXML parses number of days from Transition and validates if
+// >= 0
+func (tDays *TransitionDays) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
+	var numDays int
+	err := d.DecodeElement(&numDays, &startElement)
+	if err != nil {
+		return err
+	}
+	if numDays < 0 {
+		return errTransitionInvalidDays
+	}
+	*tDays = TransitionDays(numDays)
+	return nil
+}
+
+// MarshalXML encodes number of days to expire if it is non-zero and
+// encodes empty string otherwise
+func (tDays TransitionDays) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+	if tDays == 0 {
+		return nil
+	}
+	return e.EncodeElement(int(tDays), startElement)
+}
 
 // Transition - transition actions for a rule in lifecycle configuration.
 type Transition struct {
-	XMLName      xml.Name `xml:"Transition"`
-	Days         int      `xml:"Days,omitempty"`
-	Date         string   `xml:"Date,omitempty"`
-	StorageClass string   `xml:"StorageClass"`
+	XMLName      xml.Name       `xml:"Transition"`
+	Days         TransitionDays `xml:"Days,omitempty"`
+	Date         TransitionDate `xml:"Date,omitempty"`
+	StorageClass string         `xml:"StorageClass,omitempty"`
+
+	set bool
 }
 
-var errTransitionUnsupported = Errorf("Specifying <Transition></Transition> tag is not supported")
-
-// UnmarshalXML is extended to indicate lack of support for Transition
-// xml tag in object lifecycle configuration
-func (t Transition) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	return errTransitionUnsupported
+// MarshalXML encodes transition field into an XML form.
+func (t Transition) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	if !t.set {
+		return nil
+	}
+	type transitionWrapper Transition
+	return enc.EncodeElement(transitionWrapper(t), start)
 }
 
-// MarshalXML is extended to leave out <Transition></Transition> tags
-func (t Transition) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+// UnmarshalXML decodes transition field from the XML form.
+func (t *Transition) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
+	type transitionWrapper Transition
+	var trw transitionWrapper
+	err := d.DecodeElement(&trw, &startElement)
+	if err != nil {
+		return err
+	}
+	*t = Transition(trw)
+	t.set = true
 	return nil
+}
+
+// Validate - validates the "Expiration" element
+func (t Transition) Validate() error {
+	if !t.set {
+		return nil
+	}
+
+	if t.IsDaysNull() && t.IsDateNull() {
+		return errXMLNotWellFormed
+	}
+
+	// Both transition days and date are specified
+	if !t.IsDaysNull() && !t.IsDateNull() {
+		return errTransitionInvalid
+	}
+	if t.StorageClass == "" {
+		return errXMLNotWellFormed
+	}
+	return nil
+}
+
+// IsDaysNull returns true if days field is null
+func (t Transition) IsDaysNull() bool {
+	return t.Days == TransitionDays(0)
+}
+
+// IsDateNull returns true if date field is null
+func (t Transition) IsDateNull() bool {
+	return t.Date.Time.IsZero()
+}
+
+// IsNull returns true if both date and days fields are null
+func (t Transition) IsNull() bool {
+	return t.IsDaysNull() && t.IsDateNull()
 }

--- a/pkg/bucket/policy/action.go
+++ b/pkg/bucket/policy/action.go
@@ -169,6 +169,9 @@ const (
 
 	// GetObjectVersionForReplicationAction  - GetObjectVersionForReplication REST API action
 	GetObjectVersionForReplicationAction = "s3:GetObjectVersionForReplication"
+
+	// RestoreObjectAction - RestoreObject REST API action
+	RestoreObjectAction = "s3:RestoreObject"
 )
 
 // List of all supported object actions.
@@ -195,6 +198,7 @@ var supportedObjectActions = map[Action]struct{}{
 	ReplicateDeleteAction:                {},
 	ReplicateTagsAction:                  {},
 	GetObjectVersionForReplicationAction: {},
+	RestoreObjectAction:                  {},
 }
 
 // isObjectAction - returns whether action is object type or not.
@@ -255,6 +259,7 @@ var supportedActions = map[Action]struct{}{
 	ReplicateDeleteAction:                  {},
 	ReplicateTagsAction:                    {},
 	GetObjectVersionForReplicationAction:   {},
+	RestoreObjectAction:                    {},
 }
 
 // IsValid - checks if action is valid or not.
@@ -410,4 +415,5 @@ var actionConditionKeyMap = map[Action]condition.KeySet{
 	ReplicateDeleteAction:                condition.NewKeySet(condition.CommonKeys...),
 	ReplicateTagsAction:                  condition.NewKeySet(condition.CommonKeys...),
 	GetObjectVersionForReplicationAction: condition.NewKeySet(condition.CommonKeys...),
+	RestoreObjectAction:                  condition.NewKeySet(condition.CommonKeys...),
 }

--- a/pkg/event/name.go
+++ b/pkg/event/name.go
@@ -50,6 +50,9 @@ const (
 	ObjectReplicationMissedThreshold
 	ObjectReplicationReplicatedAfterThreshold
 	ObjectReplicationNotTracked
+	ObjectRestorePostInitiated
+	ObjectRestorePostCompleted
+	ObjectRestorePostAll
 )
 
 // Expand - returns expanded values of abbreviated event type.
@@ -81,6 +84,11 @@ func (name Name) Expand() []Name {
 			ObjectReplicationNotTracked,
 			ObjectReplicationMissedThreshold,
 			ObjectReplicationReplicatedAfterThreshold,
+		}
+	case ObjectRestorePostAll:
+		return []Name{
+			ObjectRestorePostInitiated,
+			ObjectRestorePostCompleted,
 		}
 	default:
 		return []Name{name}
@@ -132,6 +140,10 @@ func (name Name) String() string {
 		return "s3:Replication:OperationMissedThreshold"
 	case ObjectReplicationReplicatedAfterThreshold:
 		return "s3:Replication:OperationReplicatedAfterThreshold"
+	case ObjectRestorePostInitiated:
+		return "s3:ObjectRestore:Post"
+	case ObjectRestorePostCompleted:
+		return "s3:ObjectRestore:Completed"
 	}
 
 	return ""
@@ -226,6 +238,13 @@ func ParseName(s string) (Name, error) {
 		return ObjectReplicationReplicatedAfterThreshold, nil
 	case "s3:Replication:OperationNotTracked":
 		return ObjectReplicationNotTracked, nil
+	case "s3:ObjectRestore:*":
+		return ObjectRestorePostAll, nil
+	case "s3:ObjectRestore:Post":
+		return ObjectRestorePostInitiated, nil
+	case "s3:ObjectRestore:Completed":
+		return ObjectRestorePostCompleted, nil
+
 	default:
 		return 0, &ErrInvalidEventName{s}
 	}

--- a/pkg/madmin/remote-target-commands.go
+++ b/pkg/madmin/remote-target-commands.go
@@ -35,11 +35,13 @@ type ServiceType string
 const (
 	// ReplicationService specifies replication service
 	ReplicationService ServiceType = "replication"
+	// ILMService specifies ilm service
+	ILMService ServiceType = "ilm"
 )
 
-// IsValid returns true if ARN type represents replication
+// IsValid returns true if ARN type represents replication or ilm
 func (t ServiceType) IsValid() bool {
-	return t == ReplicationService
+	return t == ReplicationService || t == ILMService
 }
 
 // ARN is a struct to define arn.


### PR DESCRIPTION
This PR adds transition support for ILM
to transition data to another MinIO target
represented by a storage class ARN. Subsequent
GET or HEAD for that object will be streamed from
the transition tier. If PostRestoreObject API is
invoked, the transitioned object can be restored for
duration specified to the source cluster.

## Description
Needs https://github.com/minio/minio-go/pull/1390 and https://github.com/minio/mc/pull/3420

## Motivation and Context
Allows applications to transition data to less expensive storage, e.g from NVME to hard disks. 

## How to test this PR?
Use companion PR(s) listed above. 
```
1. Set up a transition target for srcbucket on myminio to dstbucket on minio2:9000
mc admin bucket remote add  myminio/srcbucket \
        https://foobar:foo12345@minio2:9000/dstbucket \
        --service "ilm" --region "us-west-1" --label "transitiontier"

2. Use arn generated above to add a ilm rule with transition destination specified by the --storageclass flag
mc ilm add --expiry-days 3 --transition-days 2 --storage-class "transitiontier" source/srcbucket                         

When a object qualifies for transitioning per the rules set in the ilm config, it should be moved to the destination cluster. However all GET and HEAD should work. If post restore object API is called on a transitioned object, it should generate a local copy of object on source cluster.

For example:
aws s3api restore-object --endpoint-url http://localhost:9008 --profile minio \
--bucket srcbucket \
--key x2 \
--restore-request Days=1
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
