### PR TITLE
fix: network failure err check should ignore context canceled errors

### DIFF
--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -112,7 +112,7 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		if xnet.IsNetworkOrHostDown(err) || errors.Is(err, context.DeadlineExceeded) {
+		if xnet.IsNetworkOrHostDown(err) {
 			c.MarkOffline()
 		}
 		return nil, &NetworkError{err}
@@ -141,6 +141,9 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 		// Limit the ReadAll(), just in case, because of a bug, the server responds with large data.
 		b, err := ioutil.ReadAll(io.LimitReader(resp.Body, c.MaxErrResponseSize))
 		if err != nil {
+			if xnet.IsNetworkOrHostDown(err) {
+				c.MarkOffline()
+			}
 			return nil, err
 		}
 		if len(b) > 0 {

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -17,6 +17,7 @@
 package net
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -142,6 +143,9 @@ func ParseURL(s string) (u *URL, err error) {
 // IsNetworkOrHostDown - if there was a network error or if the host is down.
 func IsNetworkOrHostDown(err error) bool {
 	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
 		return false
 	}
 	// We need to figure if the error either a timeout


### PR DESCRIPTION


## Description
fix: network failure err check should ignore context canceled errors

## Motivation and Context
context canceled errors bubbling up from the network
layer has the potential to be misconstrued as network
errors, taking prematurely a server offline and triggering
a health check routine avoid this potential occurrence.

## How to test this PR?
Requires some manual work to test this.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
