### PR TITLE
heal: Fix periodic healing cleanup

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -528,7 +528,7 @@ func (h *healSequence) hasEnded() bool {
 	if h.clientToken == bgHealingUUID {
 		return false
 	}
-	return len(h.currentStatus.Items) == 0 || h.currentStatus.Summary == healStoppedStatus || h.currentStatus.Summary == healFinishedStatus
+	return !h.endTime.IsZero()
 }
 
 // stops the heal sequence - safe to call multiple times.


### PR DESCRIPTION
## Description
isEnded() was incorrectly calculating if the current healing sequence is
ended or not. h.currentStatus.Items could be empty if healing is very
slow and mc admin heal consumed all items.

## Motivation and Context
Fix mc admin heal erroring out

## How to test this PR?
1. Create an erasure standalone with many files
2. Apply the following diff on MinIO server code to facilitate testing:
```diff
diff --git a/cmd/admin-heal-ops.go b/cmd/admin-heal-ops.go
index a54fae9a8..7a2770e68 100644
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -145,7 +145,7 @@ func (ahs *allHealState) periodicHealSeqsClean(ctx context.Context) {
        // it ends) from the global state after timeout has elapsed.
        for {
                select {
-               case <-time.After(time.Minute * 5):
+               case <-time.After(time.Second * 5):
                        now := UTCNow()
                        ahs.Lock()
                        for path, h := range ahs.healSeqMap {
```
3. `mc admin heal -r` command


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
