### PR TITLE
federation: Honor range with UploadObjectPart to a different cluster

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1916,7 +1916,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		}
 
 		partInfo, err := core.PutObjectPart(ctx, dstBucket, dstObject, uploadID, partID,
-			srcInfo.Reader, srcInfo.Size, "", "", dstOpts.ServerSideEncryption)
+			gr, length, "", "", dstOpts.ServerSideEncryption)
 		if err != nil {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 			return


### PR DESCRIPTION


## Description
Use gr & length instead of srcInfo.Reader & srcInfo.Size because they
don't honor range header

## Motivation and Context
Fix copy object part in federation mode.

## How to test this PR?
1. Setup two clusters with coredns following this https://github.com/krisis/minio-federated-setup
2. Create bucket1 in cluster1 and bucket2 in cluster2
3. Upload a 6gb file to bucket 1 in cluster 1
4. Copy 6gb from to bucket 2 in cluster 2 using the same alias of cluster1 
(mc mb alias1/bucket1/6gb alias1/bucket2/6gb)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
