### PR TITLE
fix: add lock ownership to expire locks

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -52,7 +52,7 @@ type erasureObjects struct {
 	getDisks func() []StorageAPI
 
 	// getLockers returns list of remote and local lockers.
-	getLockers func() []dsync.NetLocker
+	getLockers func() ([]dsync.NetLocker, string)
 
 	// getEndpoints returns list of endpoint strings belonging this set.
 	// some may be local and some remote.

--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -87,6 +87,7 @@ func (client *lockRESTClient) Close() error {
 func (client *lockRESTClient) restCall(ctx context.Context, call string, args dsync.LockArgs) (reply bool, err error) {
 	values := url.Values{}
 	values.Set(lockRESTUID, args.UID)
+	values.Set(lockRESTOwner, args.Owner)
 	values.Set(lockRESTSource, args.Source)
 	var buffer bytes.Buffer
 	for _, resource := range args.Resources {

--- a/cmd/lock-rest-server-common.go
+++ b/cmd/lock-rest-server-common.go
@@ -34,8 +34,12 @@ const (
 	lockRESTMethodRUnlock = "/runlock"
 	lockRESTMethodExpired = "/expired"
 
+	// lockRESTOwner represents owner UUID
+	lockRESTOwner = "owner"
+
 	// Unique ID of lock/unlock request.
 	lockRESTUID = "uid"
+
 	// Source contains the line number, function and file name of the code
 	// on the client node that requested the lock.
 	lockRESTSource = "source"

--- a/cmd/lock-rest-server.go
+++ b/cmd/lock-rest-server.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// Lock maintenance interval.
-	lockMaintenanceInterval = 1 * time.Minute
+	lockMaintenanceInterval = 30 * time.Second
 
 	// Lock validity check interval.
 	lockValidityCheckInterval = 2 * time.Minute
@@ -64,6 +64,7 @@ func (l *lockRESTServer) IsValid(w http.ResponseWriter, r *http.Request) bool {
 
 func getLockArgs(r *http.Request) (args dsync.LockArgs, err error) {
 	args = dsync.LockArgs{
+		Owner:  r.URL.Query().Get(lockRESTOwner),
 		UID:    r.URL.Query().Get(lockRESTUID),
 		Source: r.URL.Query().Get(lockRESTSource),
 	}
@@ -246,10 +247,28 @@ func lockMaintenance(ctx context.Context, interval time.Duration) error {
 		return nil
 	}
 
+	type nlock struct {
+		locks  int
+		writer bool
+	}
+
+	updateNlocks := func(nlripsMap map[string]nlock, name string, writer bool) {
+		nlk, ok := nlripsMap[name]
+		if !ok {
+			nlripsMap[name] = nlock{
+				locks:  1,
+				writer: writer,
+			}
+		} else {
+			nlk.locks++
+			nlripsMap[name] = nlk
+		}
+	}
+
 	// Validate if long lived locks are indeed clean.
 	// Get list of long lived locks to check for staleness.
 	for lendpoint, nlrips := range getLongLivedLocks(interval) {
-		nlripsMap := make(map[string]int, len(nlrips))
+		nlripsMap := make(map[string]nlock, len(nlrips))
 		for _, nlrip := range nlrips {
 			// Locks are only held on first zone, make sure that
 			// we only look for ownership of locks from endpoints
@@ -257,7 +276,7 @@ func lockMaintenance(ctx context.Context, interval time.Duration) error {
 			for _, endpoint := range globalEndpoints[0].Endpoints {
 				c := newLockAPI(endpoint)
 				if !c.IsOnline() {
-					nlripsMap[nlrip.name]++
+					updateNlocks(nlripsMap, nlrip.name, nlrip.lri.Writer)
 					continue
 				}
 
@@ -266,18 +285,19 @@ func lockMaintenance(ctx context.Context, interval time.Duration) error {
 				// Call back to original server verify whether the lock is
 				// still active (based on name & uid)
 				expired, err := c.Expired(ctx, dsync.LockArgs{
+					Owner:     nlrip.lri.Owner,
 					UID:       nlrip.lri.UID,
 					Resources: []string{nlrip.name},
 				})
 				cancel()
 				if err != nil {
-					nlripsMap[nlrip.name]++
+					updateNlocks(nlripsMap, nlrip.name, nlrip.lri.Writer)
 					c.Close()
 					continue
 				}
 
 				if !expired {
-					nlripsMap[nlrip.name]++
+					updateNlocks(nlripsMap, nlrip.name, nlrip.lri.Writer)
 				}
 
 				// Close the connection regardless of the call response.
@@ -285,14 +305,13 @@ func lockMaintenance(ctx context.Context, interval time.Duration) error {
 			}
 
 			// Read locks we assume quorum for be N/2 success
-			quorum := objAPI.SetDriveCount() / 2
+			quorum := getReadQuorum(objAPI.SetDriveCount())
 			if nlrip.lri.Writer {
-				// For write locks we need N/2+1 success
-				quorum = objAPI.SetDriveCount()/2 + 1
+				quorum = getWriteQuorum(objAPI.SetDriveCount())
 			}
 
 			// less than the quorum, we have locks expired.
-			if nlripsMap[nlrip.name] < quorum {
+			if nlripsMap[nlrip.name].locks < quorum {
 				// The lock is no longer active at server that originated
 				// the lock, attempt to remove the lock.
 				globalLockServers[lendpoint].mutex.Lock()
@@ -348,7 +367,6 @@ func startLockMaintenance(ctx context.Context) {
 
 // registerLockRESTHandlers - register lock rest router.
 func registerLockRESTHandlers(router *mux.Router, endpointZones EndpointZones) {
-	queries := restQueries(lockRESTUID, lockRESTSource)
 	for _, ep := range endpointZones {
 		for _, endpoint := range ep.Endpoints {
 			if !endpoint.IsLocal {
@@ -361,11 +379,11 @@ func registerLockRESTHandlers(router *mux.Router, endpointZones EndpointZones) {
 
 			subrouter := router.PathPrefix(path.Join(lockRESTPrefix, endpoint.Path)).Subrouter()
 			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodHealth).HandlerFunc(httpTraceHdrs(lockServer.HealthHandler))
-			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodLock).HandlerFunc(httpTraceHdrs(lockServer.LockHandler)).Queries(queries...)
-			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodRLock).HandlerFunc(httpTraceHdrs(lockServer.RLockHandler)).Queries(queries...)
-			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodUnlock).HandlerFunc(httpTraceHdrs(lockServer.UnlockHandler)).Queries(queries...)
-			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodRUnlock).HandlerFunc(httpTraceHdrs(lockServer.RUnlockHandler)).Queries(queries...)
-			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodExpired).HandlerFunc(httpTraceAll(lockServer.ExpiredHandler)).Queries(queries...)
+			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodLock).HandlerFunc(httpTraceHdrs(lockServer.LockHandler))
+			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodRLock).HandlerFunc(httpTraceHdrs(lockServer.RLockHandler))
+			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodUnlock).HandlerFunc(httpTraceHdrs(lockServer.UnlockHandler))
+			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodRUnlock).HandlerFunc(httpTraceHdrs(lockServer.RUnlockHandler))
+			subrouter.Methods(http.MethodPost).Path(lockRESTVersionPrefix + lockRESTMethodExpired).HandlerFunc(httpTraceAll(lockServer.ExpiredHandler))
 
 			globalLockServers[endpoint] = lockServer.ll
 		}

--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/minio/minio/cmd/config/storageclass"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/dsync"
 	"github.com/minio/minio/pkg/lsync"
@@ -148,17 +147,8 @@ func (di *distLockInstance) GetLock(timeout *dynamicTimeout) (timedOutErr error)
 	lockSource := getSource(2)
 	start := UTCNow()
 
-	// Lockers default to standard storage class always, why because
-	// we always dictate storage tolerance in terms of standard
-	// storage class be it number of drives or a multiplicative
-	// of number of nodes, defaulting lockers to this value
-	// simply means that locking is always similar in behavior
-	// and effect with erasure coded drive tolerance.
-	tolerance := globalStorageClass.GetParityForSC(storageclass.STANDARD)
-
 	if !di.rwMutex.GetLock(di.ctx, di.opsID, lockSource, dsync.Options{
-		Timeout:   timeout.Timeout(),
-		Tolerance: tolerance,
+		Timeout: timeout.Timeout(),
 	}) {
 		timeout.LogFailure()
 		return OperationTimedOut{}
@@ -177,12 +167,8 @@ func (di *distLockInstance) GetRLock(timeout *dynamicTimeout) (timedOutErr error
 	lockSource := getSource(2)
 	start := UTCNow()
 
-	// Lockers default to standard storage class always.
-	tolerance := globalStorageClass.GetParityForSC(storageclass.STANDARD)
-
 	if !di.rwMutex.GetRLock(di.ctx, di.opsID, lockSource, dsync.Options{
-		Timeout:   timeout.Timeout(),
-		Tolerance: tolerance,
+		Timeout: timeout.Timeout(),
 	}) {
 		timeout.LogFailure()
 		return OperationTimedOut{}
@@ -208,11 +194,11 @@ type localLockInstance struct {
 // NewNSLock - returns a lock instance for a given volume and
 // path. The returned lockInstance object encapsulates the nsLockMap,
 // volume, path and operation ID.
-func (n *nsLockMap) NewNSLock(ctx context.Context, lockersFn func() []dsync.NetLocker, volume string, paths ...string) RWLocker {
+func (n *nsLockMap) NewNSLock(ctx context.Context, lockers func() ([]dsync.NetLocker, string), volume string, paths ...string) RWLocker {
 	opsID := mustGetUUID()
 	if n.isDistErasure {
 		drwmutex := dsync.NewDRWMutex(&dsync.Dsync{
-			GetLockersFn: lockersFn,
+			GetLockers: lockers,
 		}, pathsJoinPrefix(volume, paths...)...)
 		return &distLockInstance{drwmutex, opsID, ctx}
 	}

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"sort"
 	"strings"
@@ -505,34 +506,22 @@ func (sys *NotificationSys) updateBloomFilter(ctx context.Context, current uint6
 }
 
 // GetLocks - makes GetLocks RPC call on all peers.
-func (sys *NotificationSys) GetLocks(ctx context.Context) []*PeerLocks {
+func (sys *NotificationSys) GetLocks(ctx context.Context, r *http.Request) []*PeerLocks {
 	locksResp := make([]*PeerLocks, len(sys.peerClients))
 	g := errgroup.WithNErrs(len(sys.peerClients))
 	for index, client := range sys.peerClients {
-		if client == nil {
-			continue
-		}
 		index := index
 		g.Go(func() error {
-			// Try to fetch serverInfo remotely in three attempts.
-			for i := 0; i < 3; i++ {
-				serverLocksResp, err := sys.peerClients[index].GetLocks()
-				if err == nil {
-					locksResp[index] = &PeerLocks{
-						Addr:  sys.peerClients[index].host.String(),
-						Locks: serverLocksResp,
-					}
-					return nil
-				}
-
-				// Last iteration log the error.
-				if i == 2 {
-					return err
-				}
-				// Wait for one second and no need wait after last attempt.
-				if i < 2 {
-					time.Sleep(1 * time.Second)
-				}
+			if client == nil {
+				return nil
+			}
+			serverLocksResp, err := sys.peerClients[index].GetLocks()
+			if err != nil {
+				return err
+			}
+			locksResp[index] = &PeerLocks{
+				Addr:  sys.peerClients[index].host.String(),
+				Locks: serverLocksResp,
 			}
 			return nil
 		}, index)
@@ -543,6 +532,16 @@ func (sys *NotificationSys) GetLocks(ctx context.Context) []*PeerLocks {
 		ctx := logger.SetReqInfo(ctx, reqInfo)
 		logger.LogOnceIf(ctx, err, sys.peerClients[index].host.String())
 	}
+	// Once we have received all the locks currently used from peers
+	// add the local peer locks list as well.
+	var getRespLocks GetLocksResp
+	for _, llocker := range globalLockServers {
+		getRespLocks = append(getRespLocks, llocker.DupLockMap())
+	}
+	locksResp = append(locksResp, &PeerLocks{
+		Addr:  getHostName(r),
+		Locks: getRespLocks,
+	})
 	return locksResp
 }
 

--- a/pkg/dsync/dsync.go
+++ b/pkg/dsync/dsync.go
@@ -20,5 +20,5 @@ package dsync
 // authenticated clients, used to initiate lock REST calls.
 type Dsync struct {
 	// List of rest client objects, one per lock server.
-	GetLockersFn func() []NetLocker
+	GetLockers func() ([]NetLocker, string)
 }

--- a/pkg/dsync/dsync_test.go
+++ b/pkg/dsync/dsync_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/minio/minio/pkg/dsync"
 )
 
@@ -78,7 +79,7 @@ func TestMain(m *testing.M) {
 	}
 
 	ds = &Dsync{
-		GetLockersFn: func() []NetLocker { return clnts },
+		GetLockers: func() ([]NetLocker, string) { return clnts, uuid.New().String() },
 	}
 
 	startRPCServers(nodes)

--- a/pkg/dsync/rpc-client-interface.go
+++ b/pkg/dsync/rpc-client-interface.go
@@ -29,6 +29,10 @@ type LockArgs struct {
 	// Source contains the line number, function and file name of the code
 	// on the client node that requested the lock.
 	Source string
+
+	// Owner represents unique ID for this instance, an owner who originally requested
+	// the locked resource, useful primarily in figuring our stale locks.
+	Owner string
 }
 
 // NetLocker is dsync compatible locker interface.

--- a/pkg/madmin/top-commands.go
+++ b/pkg/madmin/top-commands.go
@@ -36,7 +36,9 @@ type LockEntry struct {
 	Type       string    `json:"type"`       // Type indicates if 'Write' or 'Read' lock
 	Source     string    `json:"source"`     // Source at which lock was granted
 	ServerList []string  `json:"serverlist"` // List of servers participating in the lock.
+	Owner      string    `json:"owner"`      // Owner UUID indicates server owns the lock.
 	ID         string    `json:"id"`         // UID to uniquely identify request of client.
+	Quorum     int       `json:"quorum"`     // represents quorum number of servers required to hold this lock, used to look for stale locks.
 }
 
 // LockEntries - To sort the locks
@@ -54,13 +56,21 @@ func (l LockEntries) Swap(i, j int) {
 	l[i], l[j] = l[j], l[i]
 }
 
-// TopNLocks - returns the count number of oldest locks currently active on the server.
-func (adm *AdminClient) TopNLocks(ctx context.Context, count int) (LockEntries, error) {
+// TopLockOpts top lock options
+type TopLockOpts struct {
+	Count int
+	Stale bool
+}
+
+// TopLocksWithOpts - returns the count number of oldest locks currently active on the server.
+// additionally we can also enable `stale` to get stale locks currently present on server.
+func (adm *AdminClient) TopLocksWithOpts(ctx context.Context, opts TopLockOpts) (LockEntries, error) {
 	// Execute GET on /minio/admin/v3/top/locks?count=10
 	// to get the 'count' number of oldest locks currently
 	// active on the server.
 	queryVals := make(url.Values)
-	queryVals.Set("count", strconv.Itoa(count))
+	queryVals.Set("count", strconv.Itoa(opts.Count))
+	queryVals.Set("stale", strconv.FormatBool(opts.Stale))
 	resp, err := adm.executeMethod(ctx,
 		http.MethodGet,
 		requestData{
@@ -89,5 +99,5 @@ func (adm *AdminClient) TopNLocks(ctx context.Context, count int) (LockEntries, 
 
 // TopLocks - returns top '10' oldest locks currently active on the server.
 func (adm *AdminClient) TopLocks(ctx context.Context) (LockEntries, error) {
-	return adm.TopNLocks(ctx, 10)
+	return adm.TopLocksWithOpts(ctx, TopLockOpts{Count: 10})
 }


### PR DESCRIPTION


## Description
fix: add lock ownership to expire locks

## Motivation and Context
- Add owner information for expiry, locking, unlocking a resource
- TopLocks returns now locks in quorum by default, provides
  a way to capture stale locks as well with `?stale=true`
- Simplify the quorum handling for locks to avoid storage
  class, because there were challenges to make it consistent
  across all situations.
- And other tiny simplifications to reset locks.

## How to test this PR?
Primarily to clean up stale locks properly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
