### PR TITLE
Fix client errors for DNS related put bucket errors

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1956,6 +1956,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrBackendDown
 	case ObjectNameTooLong:
 		apiErr = ErrKeyTooLongError
+	case dns.ErrInvalidBucketName:
+		apiErr = ErrInvalidBucketName
 	default:
 		var ie, iw int
 		// This work-around is to handle the issue golang/go#30648
@@ -1992,6 +1994,12 @@ func toAPIError(ctx context.Context, err error) APIError {
 	}
 
 	var apiErr = errorCodes.ToAPIErr(toAPIErrorCode(ctx, err))
+	e, ok := err.(dns.ErrInvalidBucketName)
+	if ok {
+		code := toAPIErrorCode(ctx, e)
+		apiErr = errorCodes.ToAPIErrWithErr(code, e)
+	}
+
 	if apiErr.Code == "InternalError" {
 		// If we see an internal error try to interpret
 		// any underlying errors if possible depending on

--- a/cmd/config/dns/store.go
+++ b/cmd/config/dns/store.go
@@ -16,6 +16,22 @@
 
 package dns
 
+// Error - DNS related errors error.
+type Error struct {
+	Bucket string
+	Err    error
+}
+
+// ErrInvalidBucketName for buckets with invalid name
+type ErrInvalidBucketName Error
+
+func (e ErrInvalidBucketName) Error() string {
+	return "invalid bucket name error: " + e.Err.Error()
+}
+func (e Error) Error() string {
+	return "dns related error: " + e.Err.Error()
+}
+
 // Store dns record store
 type Store interface {
 	Put(bucket string) error


### PR DESCRIPTION
## Description
When creating a bucket with "." in the name in an operator-based deployment, the operation will fail but the error code returned needs to be fixed to avoid mc or other clients from retrying.

## Motivation and Context
mc command that failed due to DNS names not being complaint unnecessarily retry a failed request and the error code is not appropriate to the error.

## How to test this PR?
```
> mc mb mk8s/test.bucket.4 --insecure --debug
mc: <DEBUG> PUT /test.bucket.4/ HTTP/1.1
Host: localhost:9001
User-Agent: MinIO (linux; amd64) minio-go/v7.0.5 mc/2020-08-20T00:23:01Z
Content-Length: 0
Authorization: AWS4-HMAC-SHA256 Credential=minio/20200929/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
X-Amz-Content-Sha256: UNSIGNED-PAYLOAD
X-Amz-Date: 20200929T062033Z
Accept-Encoding: gzip

mc: <DEBUG> HTTP/1.1 400 Bad Request
Content-Length: 473
Accept-Ranges: bytes
Content-Security-Policy: block-all-mixed-content
Content-Type: application/xml
Date: Tue, 29 Sep 2020 06:20:33 GMT
Server: MinIO/DEVELOPMENT.2020-09-29T06-17-43Z
Vary: Origin
X-Amz-Request-Id: 16392CD457223B9B
X-Xss-Protection: 1; mode=block

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid. (invalid bucket name error: service create for bucket test.bucket.4, failed with status 400 Bad Request, error invalid bucket name: . in bucket name: test.bucket.4&#xA;)</Message><BucketName>test.bucket.4</BucketName><Resource>/test.bucket.4/</Resource><RequestId>16392CD457223B9B</RequestId><HostId>27f1ab4d-db0d-4942-a882-b3cb416634e6</HostId></Error>mc: <DEBUG> TLS Certificate found: 
mc: <DEBUG>  >> Country: US
mc: <DEBUG>  >> Organization: MyCompany
mc: <DEBUG>  >> Expires: 2020-10-15 04:51:36 +0000 UTC
mc: <DEBUG> Response Time:  160.606048ms

mc: <ERROR> Unable to make bucket `mk8s/test.bucket.4`. The specified bucket is not valid. (invalid bucket name error: service create for bucket test.bucket.4, failed with status 400 Bad Request, error invalid bucket name: . in bucket name: test.bucket.4
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
