### PR TITLE
Fix data update tracker exiting

### DIFF
--- a/cmd/data-update-tracker.go
+++ b/cmd/data-update-tracker.go
@@ -236,7 +236,7 @@ func (d *dataUpdateTracker) startSaver(ctx context.Context, interval time.Durati
 		d.mu.Lock()
 		if !d.dirty {
 			d.mu.Unlock()
-			return
+			continue
 		}
 		d.Saved = UTCNow()
 		err := d.serialize(&buf)

--- a/cmd/data-update-tracker.go
+++ b/cmd/data-update-tracker.go
@@ -236,6 +236,9 @@ func (d *dataUpdateTracker) startSaver(ctx context.Context, interval time.Durati
 		d.mu.Lock()
 		if !d.dirty {
 			d.mu.Unlock()
+			if exit {
+				return
+			}
 			continue
 		}
 		d.Saved = UTCNow()


### PR DESCRIPTION
## Description

The data update tracker saver would exit if data wasn't updated for between cycles.

## How to test this PR?

If no updates were received between save cycles the bloom filter saver would exit.

The effects would be lost bloom filter cycles forcing the crawler to recrawl.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
