### PR TITLE
Handle changes to versioning config for replication

### DIFF
--- a/cmd/bucket-versioning-handler.go
+++ b/cmd/bucket-versioning-handler.go
@@ -70,6 +70,14 @@ func (api objectAPIHandlers) PutBucketVersioningHandler(w http.ResponseWriter, r
 		}, r.URL, guessIsBrowserReq(r))
 		return
 	}
+	if _, err := getReplicationConfig(ctx, bucket); err == nil && v.Suspended() {
+		writeErrorResponse(ctx, w, APIError{
+			Code:           "InvalidBucketState",
+			Description:    "A replication configuration is present on this bucket, so the versioning state cannot be changed.",
+			HTTPStatusCode: http.StatusConflict,
+		}, r.URL, guessIsBrowserReq(r))
+		return
+	}
 
 	configData, err := xml.Marshal(v)
 	if err != nil {

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -151,6 +151,13 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 				VersionID: vid,
 			}
 		}
+		if !versioned {
+			return opts, InvalidArgument{
+				Bucket: bucket,
+				Object: object,
+				Err:    fmt.Errorf("VersionID specified %s, but versioning not enabled on  %s", opts.VersionID, bucket),
+			}
+		}
 	}
 	mtime := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceMTime))
 	if mtime != "" {


### PR DESCRIPTION
Disallow versioning suspension on a bucket with
pre-existing replication configuration

If versioning is suspended on the target,replication
should fail.

## Description


## Motivation and Context
https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-and-other-bucket-configs.html#replication-and-versioning

## How to test this PR?
set up [replication](https://github.com/minio/minio/tree/master/docs/bucket/replication) between 2 MinIO clusters. 
> Try to suspend versioning on source bucket when replication config is present 
> upload to source when versioning is suspended on target bucket

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
