### PR TITLE
List v1/versions routes based on source IP or bucket name

### DIFF
--- a/cmd/bucket-listobjects-handlers.go
+++ b/cmd/bucket-listobjects-handlers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/minio/minio/cmd/logger"
 
 	"github.com/minio/minio/pkg/bucket/policy"
+	"github.com/minio/minio/pkg/handlers"
 	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
@@ -113,7 +114,12 @@ func (api objectAPIHandlers) ListObjectVersionsHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	if proxyRequestByBucket(ctx, w, r, bucket) {
+	// Forward the request using Source IP or bucket
+	forwardStr := handlers.GetSourceIPFromHeaders(r)
+	if forwardStr == "" {
+		forwardStr = bucket
+	}
+	if proxyRequestByStringHash(ctx, w, r, forwardStr) {
 		return
 	}
 
@@ -340,8 +346,8 @@ func proxyRequestByNodeIndex(ctx context.Context, w http.ResponseWriter, r *http
 	return proxyRequest(ctx, w, r, ep)
 }
 
-func proxyRequestByBucket(ctx context.Context, w http.ResponseWriter, r *http.Request, bucket string) (success bool) {
-	return proxyRequestByNodeIndex(ctx, w, r, crcHashMod(bucket, len(globalProxyEndpoints)))
+func proxyRequestByStringHash(ctx context.Context, w http.ResponseWriter, r *http.Request, str string) (success bool) {
+	return proxyRequestByNodeIndex(ctx, w, r, crcHashMod(str, len(globalProxyEndpoints)))
 }
 
 // ListObjectsV1Handler - GET Bucket (List Objects) Version 1.
@@ -382,7 +388,12 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if proxyRequestByBucket(ctx, w, r, bucket) {
+	// Forward the request using Source IP or bucket
+	forwardStr := handlers.GetSourceIPFromHeaders(r)
+	if forwardStr == "" {
+		forwardStr = bucket
+	}
+	if proxyRequestByStringHash(ctx, w, r, forwardStr) {
 		return
 	}
 

--- a/pkg/handlers/proxy.go
+++ b/pkg/handlers/proxy.go
@@ -74,10 +74,9 @@ func GetSourceScheme(r *http.Request) string {
 	return scheme
 }
 
-// GetSourceIP retrieves the IP from the X-Forwarded-For, X-Real-IP and RFC7239
-// Forwarded headers (in that order), falls back to r.RemoteAddr when all
-// else fails.
-func GetSourceIP(r *http.Request) string {
+// GetSourceIPFromHeaders retrieves the IP from the X-Forwarded-For, X-Real-IP
+// and RFC7239 Forwarded headers (in that order)
+func GetSourceIPFromHeaders(r *http.Request) string {
 	var addr string
 
 	if fwd := r.Header.Get(xForwardedFor); fwd != "" {
@@ -106,6 +105,13 @@ func GetSourceIP(r *http.Request) string {
 		}
 	}
 
+	return addr
+}
+
+// GetSourceIP retrieves the IP from the request headers
+// and falls back to r.RemoteAddr when necessary.
+func GetSourceIP(r *http.Request) string {
+	addr := GetSourceIPFromHeaders(r)
 	if addr != "" {
 		return addr
 	}


### PR DESCRIPTION
##  Description
Routing using on source IP is better than bucket name,
this should distribute the listing load for V1 and
versioning on multiple nodes evenly between different
clients.

## Motivation and Context
Distribute listing versions loading if requests have X-Forwarded-For headers, which usually happens when requests pass through a load balancer.

## How to test this PR?
Hard to test locally, but should work

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
