### PR TITLE
Use layering in Dockerfile.mint

### DIFF
--- a/Dockerfile.mint
+++ b/Dockerfile.mint
@@ -8,11 +8,12 @@ ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
 ENV MINT_ROOT_DIR /mint
 
 RUN apt-get --yes update && apt-get --yes upgrade && \
-    apt-get --yes --quiet install wget jq curl git dnsmasq
+    apt-get --yes --quiet install wget jq curl git dnsmasq \
+    --no-install-recommends
 
 COPY mint /mint
-RUN cd /mint && /mint/release.sh
-
 WORKDIR /mint
+RUN /mint/release.sh
+
 
 ENTRYPOINT ["/mint/entrypoint.sh"]

--- a/Dockerfile.mint
+++ b/Dockerfile.mint
@@ -8,12 +8,10 @@ ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
 ENV MINT_ROOT_DIR /mint
 
 RUN apt-get --yes update && apt-get --yes upgrade && \
-    apt-get --yes --quiet install wget jq curl git dnsmasq \
-    --no-install-recommends
+    apt-get --yes --quiet install wget jq curl git dnsmasq
 
 COPY mint /mint
 WORKDIR /mint
 RUN /mint/release.sh
-
 
 ENTRYPOINT ["/mint/entrypoint.sh"]

--- a/Dockerfile.mint
+++ b/Dockerfile.mint
@@ -6,11 +6,12 @@ ENV GOROOT /usr/local/go
 ENV GOPATH /usr/local/gopath
 ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
 ENV MINT_ROOT_DIR /mint
-COPY mint /mint
 
 RUN apt-get --yes update && apt-get --yes upgrade && \
-    apt-get --yes --quiet install wget jq curl git dnsmasq && \
-    cd /mint && /mint/release.sh
+    apt-get --yes --quiet install wget jq curl git dnsmasq
+
+COPY mint /mint
+RUN cd /mint && /mint/release.sh
 
 WORKDIR /mint
 


### PR DESCRIPTION
## Description
Use layering in docker build to it's advantage

## Motivation and Context
Dockerfile.mint is very slow to build. This will create a separate step for copying files which will improve build times when rebuilding.

## How to test this PR?
$ docker build -t minio/mint . -f Dockerfile.mint
$ echo "# comment for fun" >> mint/mint.sh
$ docker build -t minio/mint . -f Dockerfile.mint

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
