### PR TITLE
Parallelize mint tests

### DIFF
--- a/mint/mint.sh
+++ b/mint/mint.sh
@@ -182,20 +182,18 @@ function main()
         pids+=" $!"
     done
 
-    completed=0
+    test_ok=0
     for p in $pids; do
         if wait $p; then
-            (( completed++ ))
-        else
-            (( completed-- ))
+            (( test_ok++ ))
         fi
     done
 
     ## Report when all tests in run_list are run
-    if [ $completed -eq "$count" ]; then
+    if [ $test_ok -eq "$count" ]; then
         echo -e "\nAll tests ran successfully"
     else
-        echo -e "\nExecuted $i out of $count tests successfully."
+        echo -e "\nExecuted $test_ok out of $count tests successfully."
         exit 1
     fi
 }


### PR DESCRIPTION
## Description
Run mint tests in parallell

## Motivation and Context
Mint test takes a lot of time. This update will run them in parallell.

## How to test this PR?
Should just be the plain old
```
$ docker build -t minio/mint . -f Dockerfile.mint
$ docker run -e SERVER_ENDPOINT=play.minio.io:9000 -e ACCESS_KEY=Q3AM3UQ867SPQQA43P2F \
             -e SECRET_KEY=zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG \
             -e ENABLE_HTTPS=1 -e MINT_MODE=full minio/mint
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
