### PR TITLE
dataupdate: Bump bloom filters to force rescan

### DIFF
--- a/cmd/data-update-tracker.go
+++ b/cmd/data-update-tracker.go
@@ -46,7 +46,7 @@ const (
 	dataUpdateTrackerQueueSize = 10000
 
 	dataUpdateTrackerFilename     = dataUsageBucket + SlashSeparator + ".tracker.bin"
-	dataUpdateTrackerVersion      = 2
+	dataUpdateTrackerVersion      = 3
 	dataUpdateTrackerSaveInterval = 5 * time.Minute
 )
 
@@ -363,7 +363,7 @@ func (d *dataUpdateTracker) deserialize(src io.Reader, newerThan time.Time) erro
 		return err
 	}
 	switch tmp[0] {
-	case 1:
+	case 1, 2:
 		logger.Info(color.Green("dataUpdateTracker: ") + "deprecated data version, updating.")
 		return nil
 	case dataUpdateTrackerVersion:


### PR DESCRIPTION
## Description

This will invalidate the current bloom filters and make the crawler go through everything.


## Motivation and Context

After #10594 let's invalidate the bloom filters to force the next cycles to go through all data in the following cycles.

There is a small chance that the linked PR could have caused missing bloom filter data.


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
