### PR TITLE
fix: protect updating latencies/throughput slices in obd

### DIFF
--- a/pkg/disk/obd.go
+++ b/pkg/disk/obd.go
@@ -27,9 +27,6 @@ import (
 	"github.com/montanaflynn/stats"
 )
 
-var globalLatency = map[string]Latency{}
-var globalThroughput = map[string]Throughput{}
-
 // Latency holds latency information for write operations to the drive
 type Latency struct {
 	Avg          float64 `json:"avg_secs,omitempty"`
@@ -154,6 +151,7 @@ func GetOBDInfo(ctx context.Context, drive, fsPath string) (Latency, Throughput,
 	if minThroughput, err = stats.Min(throughputs); err != nil {
 		return Latency{}, Throughput{}, err
 	}
+
 	t := Throughput{
 		Avg:          avgThroughput,
 		Percentile50: percentile50Throughput,
@@ -162,9 +160,6 @@ func GetOBDInfo(ctx context.Context, drive, fsPath string) (Latency, Throughput,
 		Min:          minThroughput,
 		Max:          maxThroughput,
 	}
-
-	globalLatency[drive] = l
-	globalThroughput[drive] = t
 
 	return l, t, nil
 }


### PR DESCRIPTION

## Description
fix: protect updating latencies/throughput slices in obd

## Motivation and Context
Additionally, close the transferChan upon function exit.

## How to test this PR?
`go test -race` on the `doNetOBDTest` reports races for slice updates

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
