### PR TITLE
fail if port is not accessible

### DIFF
--- a/cmd/config/errors-utils.go
+++ b/cmd/config/errors-utils.go
@@ -19,7 +19,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"syscall"
 
@@ -111,18 +110,16 @@ func ErrorToErr(err error) Err {
 		case *net.OpError:
 			return ErrPortAccess(err).Msg("Insufficient permissions to use specified port")
 		}
-		return ErrNoPermissionsToAccessDirFiles(err).Msg("Insufficient permissions to access path")
-	} else if errors.Is(err, io.ErrUnexpectedEOF) {
-		return ErrUnexpectedDataContent(err)
-	} else {
-		// Failed to identify what type of error this, return a simple UI error
-		return Err{msg: err.Error()}
 	}
+
+	// Failed to identify what type of error this, return a simple UI error
+	return Err{msg: err.Error()}
 }
 
 // FmtError converts a fatal error message to a more clear error
 // using some colors
 func FmtError(introMsg string, err error, jsonFlag bool) string {
+
 	renderedTxt := ""
 	uiErr := ErrorToErr(err)
 	// JSON print

--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -205,12 +205,6 @@ Example 1:
 		`Use 'sudo setcap cap_net_bind_service=+ep /path/to/minio' to provide sufficient permissions`,
 	)
 
-	ErrNoPermissionsToAccessDirFiles = newErrFn(
-		"Missing permissions to access the specified path",
-		"Please ensure the specified path can be accessed",
-		"",
-	)
-
 	ErrSSLUnexpectedError = newErrFn(
 		"Invalid TLS certificate",
 		"Please check the content of your certificate data",
@@ -244,12 +238,6 @@ Example 1:
 	ErrSSLWrongPassword = newErrFn(
 		"Unable to decrypt the private key using the provided password",
 		"Please set the correct password in environment variable `MINIO_CERT_PASSWD`",
-		"",
-	)
-
-	ErrUnexpectedDataContent = newErrFn(
-		"Unexpected data content",
-		"Please contact MinIO at https://slack.min.io",
 		"",
 	)
 

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"syscall"
 
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/cmd/config"
@@ -199,9 +198,7 @@ func checkPortAvailability(host, port string) (err error) {
 			if err = l.Close(); err != nil {
 				return err
 			}
-		} else if errors.Is(err, syscall.EADDRINUSE) {
-			// As we got EADDRINUSE error, the port is in use by other process.
-			// Return the error.
+		} else {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description
fail if port is not accessible

## Motivation and Context
throw proper error when port is not accessible
for the regular user, this is possibly a regression.
    
```
ERROR Unable to start the server: Insufficient permissions to use specified port
   > Please ensure MinIO binary has 'cap_net_bind_service=+ep' permissions
   HINT:
      Use 'sudo setcap cap_net_bind_service=+ep /path/to/minio' to provide sufficient permissions
```

## How to test this PR?
```
~ minio server --address :443 /mnt/disk{1...4}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression not sure when but clearly a regression
- [ ] Documentation needed
- [ ] Unit tests needed
