### PR TITLE
Fix https healthcheck

### DIFF
--- a/mint/run/core/healthcheck/main.go
+++ b/mint/run/core/healthcheck/main.go
@@ -199,9 +199,10 @@ func testPrometheusEndpoint(endpoint string) {
 func main() {
 	endpoint := os.Getenv("SERVER_ENDPOINT")
 	secure := os.Getenv("ENABLE_HTTPS")
-	endpoint = "http://" + endpoint
 	if secure == "1" {
 		endpoint = "https://" + endpoint
+	} else {
+		endpoint = "http://" + endpoint
 	}
 
 	// Output to stdout instead of the default stderr


### PR DESCRIPTION
## Description
Fix running the Mint test, 'healthcheck', over https.

## Motivation and Context
Running mint test with ENABLE_HTTPS=1 produces:
> `"error": "Get \"https://http//..`

This PR fixes this.

## How to test this PR?
Run mint tests with ENABLE_HTTPS=1, as per the mint readme and healthcheck will pass

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
