### PR TITLE
Required change for the client side to get NotImplemented error

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -559,7 +559,8 @@ func (a *azureObjects) StorageInfo(ctx context.Context, _ bool) (si minio.Storag
 
 // MakeBucketWithLocation - Create a new container on azure backend.
 func (a *azureObjects) MakeBucketWithLocation(ctx context.Context, bucket string, opts minio.BucketOptions) error {
-	if opts.LockEnabled || opts.VersioningEnabled {
+	// Filter out unsupported features in Azure and return immediately with NotImplemented error
+	if opts.LockEnabled || opts.VersioningEnabled || strings.ContainsAny(bucket, ".") {
 		return minio.NotImplemented{}
 	}
 


### PR DESCRIPTION
minio-go mint tests running against minio azure gateway need this change to return "NotImplemented" as Azure does not support period, `"."` , in bucket names.

This is going to work together with minio/minio-go#1392

## Motivation and Context
Without this change, client side PR, minio/minio-go#1392, does bucket name validation check and fails with invalid bucket name error, although nothing is wrong with the name.

## How to test this PR?
Try to create bucket, "bucket.name" using minio-go sdk, and run against minio azure gateway.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

