### PR TITLE
fix: handle concurrent lockers with multiple optimizations

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -368,7 +368,7 @@ func lriToLockEntry(l lockRequesterInfo, resource, server string, rquorum, wquor
 	return entry
 }
 
-func topLockEntries(peerLocks []*PeerLocks, count int, rquorum, wquorum int, stale bool) madmin.LockEntries {
+func topLockEntries(peerLocks []*PeerLocks, rquorum, wquorum int, stale bool) madmin.LockEntries {
 	entryMap := make(map[string]*madmin.LockEntry)
 	for _, peerLock := range peerLocks {
 		if peerLock == nil {
@@ -388,9 +388,6 @@ func topLockEntries(peerLocks []*PeerLocks, count int, rquorum, wquorum int, sta
 	}
 	var lockEntries madmin.LockEntries
 	for _, v := range entryMap {
-		if len(lockEntries) == count {
-			break
-		}
 		if stale {
 			lockEntries = append(lockEntries, *v)
 			continue
@@ -436,9 +433,13 @@ func (a adminAPIHandlers) TopLocksHandler(w http.ResponseWriter, r *http.Request
 	rquorum := getReadQuorum(objectAPI.SetDriveCount())
 	wquorum := getWriteQuorum(objectAPI.SetDriveCount())
 
-	topLocks := topLockEntries(peerLocks, count, rquorum, wquorum, stale)
+	topLocks := topLockEntries(peerLocks, rquorum, wquorum, stale)
 
-	// Marshal API response
+	// Marshal API response upto requested count.
+	if len(topLocks) > count && count > 0 {
+		topLocks = topLocks[:count]
+	}
+
 	jsonBytes, err := json.Marshal(topLocks)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)

--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -54,7 +54,7 @@ const (
 
 var (
 	globalCrawlerConfig          crawler.Config
-	dataCrawlerLeaderLockTimeout = newDynamicTimeout(1*time.Minute, 30*time.Second)
+	dataCrawlerLeaderLockTimeout = newDynamicTimeout(30*time.Second, 10*time.Second)
 )
 
 // initDataCrawler will start the crawler unless disabled.

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -770,10 +770,11 @@ func GetProxyEndpoints(endpointZones EndpointZones) ([]ProxyEndpoint, error) {
 				}
 			}
 
-			tr := newCustomHTTPTransport(tlsConfig, rest.DefaultTimeout)()
+			// allow transport to be HTTP/1.1 for proxying.
+			tr := newCustomHTTP11Transport(tlsConfig, rest.DefaultTimeout)()
+
 			// Allow more requests to be in flight with higher response header timeout.
 			tr.ResponseHeaderTimeout = 30 * time.Minute
-			tr.MaxIdleConns = 64
 			tr.MaxIdleConnsPerHost = 64
 
 			proxyEps = append(proxyEps, ProxyEndpoint{

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -273,6 +273,13 @@ func (s *erasureSets) GetLockers(setIndex int) func() ([]dsync.NetLocker, string
 	return func() ([]dsync.NetLocker, string) {
 		lockers := make([]dsync.NetLocker, s.setDriveCount)
 		copy(lockers, s.erasureLockers[setIndex])
+		sort.Slice(lockers, func(i, j int) bool {
+			// re-order lockers with affinity for
+			// - non-local lockers
+			// - online lockers
+			// are used first
+			return !lockers[i].IsLocal() && lockers[i].IsOnline()
+		})
 		return lockers, s.erasureLockOwner
 	}
 }

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -568,6 +568,7 @@ func (z *erasureZones) DeleteObject(ctx context.Context, bucket string, object s
 			break
 		}
 	}
+
 	return objInfo, err
 }
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -210,7 +210,8 @@ var (
 	globalDomainNames []string      // Root domains for virtual host style requests
 	globalDomainIPs   set.StringSet // Root domain IP address(s) for a distributed MinIO deployment
 
-	globalOperationTimeout = newDynamicTimeout(10*time.Minute, 5*time.Minute) // default timeout for general ops
+	globalOperationTimeout       = newDynamicTimeout(10*time.Minute, 5*time.Minute) // default timeout for general ops
+	globalDeleteOperationTimeout = newDynamicTimeout(5*time.Minute, 1*time.Minute)  // default time for delete ops
 
 	globalBucketObjectLockSys *BucketObjectLockSys
 	globalBucketQuotaSys      *BucketQuotaSys

--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -203,8 +203,13 @@ func (l *localLocker) Close() error {
 	return nil
 }
 
-// Local locker is always online.
+// IsOnline - local locker is always online.
 func (l *localLocker) IsOnline() bool {
+	return true
+}
+
+// IsLocal - local locker returns true.
+func (l *localLocker) IsLocal() bool {
 	return true
 }
 

--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -76,6 +76,11 @@ func (client *lockRESTClient) IsOnline() bool {
 	return client.restClient.IsOnline()
 }
 
+// Not a local locker
+func (client *lockRESTClient) IsLocal() bool {
+	return false
+}
+
 // Close - marks the client as closed.
 func (client *lockRESTClient) Close() error {
 	client.restClient.Close()

--- a/cmd/logger/audit.go
+++ b/cmd/logger/audit.go
@@ -60,15 +60,15 @@ func NewResponseWriter(w http.ResponseWriter) *ResponseWriter {
 }
 
 func (lrw *ResponseWriter) Write(p []byte) (int, error) {
-	n, err := lrw.ResponseWriter.Write(p)
-	lrw.bytesWritten += n
-	if lrw.TimeToFirstByte == 0 {
-		lrw.TimeToFirstByte = time.Now().UTC().Sub(lrw.StartTime)
-	}
 	if !lrw.headersLogged {
 		// We assume the response code to be '200 OK' when WriteHeader() is not called,
 		// that way following Golang HTTP response behavior.
 		lrw.WriteHeader(http.StatusOK)
+	}
+	n, err := lrw.ResponseWriter.Write(p)
+	lrw.bytesWritten += n
+	if lrw.TimeToFirstByte == 0 {
+		lrw.TimeToFirstByte = time.Now().UTC().Sub(lrw.StartTime)
 	}
 	if (lrw.LogErrBody && lrw.StatusCode >= http.StatusBadRequest) || lrw.LogAllBody {
 		// Always logging error responses.

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -534,13 +534,13 @@ func (sys *NotificationSys) GetLocks(ctx context.Context, r *http.Request) []*Pe
 	}
 	// Once we have received all the locks currently used from peers
 	// add the local peer locks list as well.
-	var getRespLocks GetLocksResp
+	llockers := make(GetLocksResp, 0, len(globalLockServers))
 	for _, llocker := range globalLockServers {
-		getRespLocks = append(getRespLocks, llocker.DupLockMap())
+		llockers = append(llockers, llocker.DupLockMap())
 	}
 	locksResp = append(locksResp, &PeerLocks{
 		Addr:  getHostName(r),
-		Locks: getRespLocks,
+		Locks: llockers,
 	})
 	return locksResp
 }

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -322,6 +322,10 @@ func isStringEqual(s1 string, s2 string) bool {
 
 // Ignores all reserved bucket names or invalid bucket names.
 func isReservedOrInvalidBucket(bucketEntry string, strict bool) bool {
+	if bucketEntry == "" {
+		return true
+	}
+
 	bucketEntry = strings.TrimSuffix(bucketEntry, SlashSeparator)
 	if strict {
 		if err := s3utils.CheckValidBucketNameStrict(bucketEntry); err != nil {

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -261,18 +261,20 @@ func setPutObjHeaders(w http.ResponseWriter, objInfo ObjectInfo, delete bool) {
 		}
 	}
 
-	if lc, err := globalLifecycleSys.Get(objInfo.Bucket); err == nil && !delete {
-		ruleID, expiryTime := lc.PredictExpiryTime(lifecycle.ObjectOpts{
-			Name:         objInfo.Name,
-			UserTags:     objInfo.UserTags,
-			VersionID:    objInfo.VersionID,
-			ModTime:      objInfo.ModTime,
-			IsLatest:     objInfo.IsLatest,
-			DeleteMarker: objInfo.DeleteMarker,
-		})
-		if !expiryTime.IsZero() {
-			w.Header()[xhttp.AmzExpiration] = []string{
-				fmt.Sprintf(`expiry-date="%s", rule-id="%s"`, expiryTime.Format(http.TimeFormat), ruleID),
+	if objInfo.Bucket != "" {
+		if lc, err := globalLifecycleSys.Get(objInfo.Bucket); err == nil && !delete {
+			ruleID, expiryTime := lc.PredictExpiryTime(lifecycle.ObjectOpts{
+				Name:         objInfo.Name,
+				UserTags:     objInfo.UserTags,
+				VersionID:    objInfo.VersionID,
+				ModTime:      objInfo.ModTime,
+				IsLatest:     objInfo.IsLatest,
+				DeleteMarker: objInfo.DeleteMarker,
+			})
+			if !expiryTime.IsZero() {
+				w.Header()[xhttp.AmzExpiration] = []string{
+					fmt.Sprintf(`expiry-date="%s", rule-id="%s"`, expiryTime.Format(http.TimeFormat), ruleID),
+				}
 			}
 		}
 	}

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -47,7 +47,7 @@ func (s *peerRESTServer) GetLocksHandler(w http.ResponseWriter, r *http.Request)
 
 	ctx := newContext(r, w, "GetLocks")
 
-	llockers := make([]map[string][]lockRequesterInfo, 0, len(globalLockServers))
+	llockers := make(GetLocksResp, 0, len(globalLockServers))
 	for _, llocker := range globalLockServers {
 		llockers = append(llockers, llocker.DupLockMap())
 	}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -661,21 +661,7 @@ func (s *xlStorage) ListVols(context.Context) (volsInfo []VolInfo, err error) {
 		atomic.AddInt32(&s.activeIOCount, -1)
 	}()
 
-	volsInfo, err = listVols(s.diskPath)
-	if err != nil {
-		if isSysErrIO(err) {
-			return nil, errFaultyDisk
-		}
-		return nil, err
-	}
-	for i, vol := range volsInfo {
-		volInfo := VolInfo{
-			Name:    vol.Name,
-			Created: vol.Created,
-		}
-		volsInfo[i] = volInfo
-	}
-	return volsInfo, nil
+	return listVols(s.diskPath)
 }
 
 // List all the volumes from diskPath.

--- a/pkg/dsync/rpc-client-impl_test.go
+++ b/pkg/dsync/rpc-client-impl_test.go
@@ -50,6 +50,10 @@ func (rpcClient *ReconnectRPCClient) IsOnline() bool {
 	return rpcClient.rpc != nil
 }
 
+func (rpcClient *ReconnectRPCClient) IsLocal() bool {
+	return false
+}
+
 // Close closes the underlying socket file descriptor.
 func (rpcClient *ReconnectRPCClient) Close() error {
 	rpcClient.mutex.Lock()

--- a/pkg/dsync/rpc-client-interface.go
+++ b/pkg/dsync/rpc-client-interface.go
@@ -68,4 +68,7 @@ type NetLocker interface {
 
 	// Is the underlying connection online? (is always true for any local lockers)
 	IsOnline() bool
+
+	// Is the underlying locker local to this server?
+	IsLocal() bool
 }


### PR DESCRIPTION


## Description
fix: handle concurrent lockers with multiple optimizations

## Motivation and Context
- select lockers which are non-local and online to have
  affinity towards remote servers for lock contention

- optimize lock retry interval to avoid sending too many
  messages during lock contention, reduces average CPU
  usage as well

- if bucket is not set, when deleteObject fails make sure
  setPutObjHeaders() honors lifecycle only if bucket name
  is set.

- fix top locks to list out always the oldest lockers always,
  avoid getting bogged down into map's unordered nature.

## How to test this PR?
```go

// +build delete

// Start the minio servers in another terminal.
// --------------------
// #!/bin/bash
//
// for i in $(seq 1 6); do
//      minio server --address localhost:900${i} http://localhost:9001/tmp/disk1 http://localhost:9002/tmp/disk2 \
//            http://localhost:9003/tmp/disk3 http://localhost:9004/tmp/disk4 http://localhost:9005/tmp/disk5 \
//            http://localhost:9006/tmp/disk6 &
// done
// ---------------------
//
// This starts 6 disk distributed setup locally.
//
// On another terminal compile the code.
//
//   go build parallel-put.go
//
// Grab accessKey and secretKey from minio servers and set them as env
// MINIO_ACCESS_KEY and MINIO_SECRET_KEY respectively.
//
// Proceed to run the test on all the 6 nodes.
//
//  ./parallel-put localhost:900{1..6}
//
package main

import (
        "context"
        "fmt"
        "log"
        "math/rand"
        "os"
        "strings"
        "sync"
        "time"

        "github.com/minio/minio-go/v7"
        "github.com/minio/minio-go/v7/pkg/credentials"
)

func getMinioClients(minioNodes []string) ([]*minio.Client, error) {
        accessKey := os.Getenv("MINIO_ACCESS_KEY")
        secretKey := os.Getenv("MINIO_SECRET_KEY")

        clnts := make([]*minio.Client, len(minioNodes))
        for i, minioNode := range minioNodes {
                client, err := minio.New(minioNode, &minio.Options{
                        Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
                        Secure: false,
                })
                if err != nil {
                        return nil, err
                }
                clnts[i] = client
        }
        return clnts, nil
}

func main() {
        clnts, err := getMinioClients(os.Args[1:])
        if err != nil {
                log.Fatalln(err)
        }

        clnts[0].PutObject(context.Background(), "spark-bucket", "testobject-dir/", strings.NewReader(""), 0, minio.PutObjectOptions{})

        // Continuously delete on all nodes.
        j := 0

        t1 := time.Now()
        tFinished := make([]time.Time, len(clnts)*300)

        var wg sync.WaitGroup
        wg.Add(len(clnts) * 300)
        // upto 100 objects per client
        for ; j < len(clnts)*300; j++ {
                fmt.Println("Running: ", j)
                go func(j int) {
                        defer wg.Done()
                        perr := clnts[rand.Intn(len(clnts))].RemoveObject(context.Background(), "spark-bucket", "testobject-dir/", minio.RemoveObjectOptions{})
                        if perr != nil {
                                log.Println(perr)
                        }
                        tFinished[j] = time.Now()
                }(j)

        }
        wg.Wait()
        for j := range tFinished {
                fmt.Println(tFinished[j].Sub(t1), "Time taken under conflicting locks")
        }
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression most probably with many dsync refactors.
- [ ] Documentation needed
- [ ] Unit tests needed
