### PR TITLE
Bump default idleConnsPerHost to control conns in time_wait

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -334,7 +334,8 @@ func checkRequestAuthTypeToAccessKey(ctx context.Context, r *http.Request, actio
 		r.Body = ioutil.NopCloser(bytes.NewReader(payload))
 	}
 
-	if cred.AccessKey == "" {
+	if action != policy.ListAllMyBucketsAction && cred.AccessKey == "" {
+		// Anonymous checks are not meant for ListBuckets action
 		if globalPolicySys.IsAllowed(policy.Args{
 			AccountName:     cred.AccessKey,
 			Action:          action,
@@ -378,6 +379,7 @@ func checkRequestAuthTypeToAccessKey(ctx context.Context, r *http.Request, actio
 		// Request is allowed return the appropriate access key.
 		return cred.AccessKey, owner, ErrNone
 	}
+
 	if action == policy.ListBucketVersionsAction {
 		// In AWS S3 s3:ListBucket permission is same as s3:ListBucketVersions permission
 		// verify as a fallback.

--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"time"
 
 	minio "github.com/minio/minio-go/v7"
 	miniogo "github.com/minio/minio-go/v7"
@@ -281,8 +282,9 @@ func (sys *BucketTargetSys) getRemoteTargetClient(tcfg *madmin.BucketTarget) (*m
 	creds := credentials.NewStaticV4(config.AccessKey, config.SecretKey, "")
 
 	getRemoteTargetInstanceTransportOnce.Do(func() {
-		getRemoteTargetInstanceTransport = NewGatewayHTTPTransport()
+		getRemoteTargetInstanceTransport = newGatewayHTTPTransport(1 * time.Hour)
 	})
+
 	core, err := miniogo.NewCore(tcfg.Endpoint, &miniogo.Options{
 		Creds:     creds,
 		Secure:    tcfg.Secure,

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -771,11 +771,7 @@ func GetProxyEndpoints(endpointZones EndpointZones) ([]ProxyEndpoint, error) {
 			}
 
 			// allow transport to be HTTP/1.1 for proxying.
-			tr := newCustomHTTP11Transport(tlsConfig, rest.DefaultTimeout)()
-
-			// Allow more requests to be in flight with higher response header timeout.
-			tr.ResponseHeaderTimeout = 30 * time.Minute
-			tr.MaxIdleConnsPerHost = 64
+			tr := newCustomHTTPProxyTransport(tlsConfig, rest.DefaultTimeout)()
 
 			proxyEps = append(proxyEps, ProxyEndpoint{
 				Endpoint:  endpoint,

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -449,7 +449,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 		}
 	}
 
-	defer er.deleteObject(ctx, minioMetaTmpBucket, tmpID, len(storageDisks)/2+1)
+	defer er.deleteObject(context.Background(), minioMetaTmpBucket, tmpID, len(storageDisks)/2+1)
 
 	// Generate and write `xl.meta` generated from other disks.
 	outDatedDisks, err = writeUniqueFileInfo(ctx, outDatedDisks, minioMetaTmpBucket, tmpID,

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -277,7 +277,7 @@ func (er erasureObjects) newMultipartUpload(ctx context.Context, bucket string, 
 	// Delete the tmp path later in case we fail to commit (ignore
 	// returned errors) - this will be a no-op in case of a commit
 	// success.
-	defer er.deleteObject(ctx, minioMetaTmpBucket, tempUploadIDPath, writeQuorum)
+	defer er.deleteObject(context.Background(), minioMetaTmpBucket, tempUploadIDPath, writeQuorum)
 
 	var partsMetadata = make([]FileInfo, len(onlineDisks))
 	for i := range onlineDisks {
@@ -396,7 +396,7 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 	tmpPartPath := pathJoin(tmpPart, partSuffix)
 
 	// Delete the temporary object part. If PutObjectPart succeeds there would be nothing to delete.
-	defer er.deleteObject(ctx, minioMetaTmpBucket, tmpPart, writeQuorum)
+	defer er.deleteObject(context.Background(), minioMetaTmpBucket, tmpPart, writeQuorum)
 
 	erasure, err := NewErasure(ctx, fi.Erasure.DataBlocks, fi.Erasure.ParityBlocks, fi.Erasure.BlockSize)
 	if err != nil {

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -271,6 +271,17 @@ func (s *erasureSets) monitorAndConnectEndpoints(ctx context.Context, monitorInt
 	}
 }
 
+// GetAllLockers return a list of all lockers for all sets.
+func (s *erasureSets) GetAllLockers() []dsync.NetLocker {
+	allLockers := make([]dsync.NetLocker, s.setDriveCount*s.setCount)
+	for i, lockers := range s.erasureLockers {
+		for j, locker := range lockers {
+			allLockers[i*s.setDriveCount+j] = locker
+		}
+	}
+	return allLockers
+}
+
 func (s *erasureSets) GetLockers(setIndex int) func() ([]dsync.NetLocker, string) {
 	return func() ([]dsync.NetLocker, string) {
 		lockers := make([]dsync.NetLocker, s.setDriveCount)

--- a/cmd/erasure-zones.go
+++ b/cmd/erasure-zones.go
@@ -33,6 +33,7 @@ import (
 	"github.com/minio/minio/cmd/config/storageclass"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/dsync"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/sync/errgroup"
 )
@@ -90,6 +91,10 @@ func newErasureZones(ctx context.Context, endpointZones EndpointZones) (ObjectLa
 
 func (z *erasureZones) NewNSLock(ctx context.Context, bucket string, objects ...string) RWLocker {
 	return z.zones[0].NewNSLock(ctx, bucket, objects...)
+}
+
+func (z *erasureZones) GetAllLockers() []dsync.NetLocker {
+	return z.zones[0].GetAllLockers()
 }
 
 func (z *erasureZones) SetDriveCount() int {

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -289,7 +289,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	globalHTTPServer = httpServer
 	globalObjLayerMutex.Unlock()
 
-	signal.Notify(globalOSSignalCh, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(globalOSSignalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 
 	newObject, err := gw.NewGatewayLayer(globalActiveCred)
 	if err != nil {
@@ -323,8 +323,8 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	}
 
 	if enableIAMOps {
-		// Initialize IAM sys.
-		startBackgroundIAMLoad(GlobalContext, newObject)
+		// Initialize users credentials and policies in background.
+		go globalIAMSys.Init(GlobalContext, newObject)
 	}
 
 	if globalCacheConfig.Enabled {

--- a/cmd/http/listen_nix.go
+++ b/cmd/http/listen_nix.go
@@ -27,9 +27,9 @@ import (
 var cfg = &tcplisten.Config{
 	DeferAccept: true,
 	FastOpen:    true,
-	// Bump up the soMaxConn value from 128 to 2048 to
+	// Bump up the soMaxConn value from 128 to 4096 to
 	// handle large incoming concurrent requests.
-	Backlog: 2048,
+	Backlog: 4096,
 }
 
 // Unix listener with special TCP options.

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -408,13 +408,6 @@ func (sys *IAMSys) doIAMConfigMigration(ctx context.Context) error {
 	return sys.store.migrateBackendFormat(ctx)
 }
 
-// Loads IAM users and policies in background, any un-handled
-// error means this code can potentially crash the server
-// in such a situation manual intervention is necessary.
-func startBackgroundIAMLoad(ctx context.Context, objAPI ObjectLayer) {
-	go globalIAMSys.Init(ctx, objAPI)
-}
-
 // Init - initializes config system by reading entries from config/iam
 func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 	if objAPI == nil {

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -19,6 +19,7 @@ package logger
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"go/build"
 	"hash"
@@ -59,11 +60,6 @@ var globalDeploymentID string
 
 // TimeFormat - logging time format.
 const TimeFormat string = "15:04:05 MST 01/02/2006"
-
-// List of error strings to be ignored by LogIf
-const (
-	diskNotFoundError = "disk not found"
-)
 
 var matchingFuncNames = [...]string{
 	"http.HandlerFunc.ServeHTTP",
@@ -303,7 +299,7 @@ func LogIf(ctx context.Context, err error, errKind ...interface{}) {
 		return
 	}
 
-	if err.Error() != diskNotFoundError {
+	if !errors.Is(err, context.Canceled) {
 		logIf(ctx, err, errKind...)
 	}
 }

--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -74,11 +74,10 @@ type Client struct {
 	// Should only be modified before any calls are made.
 	MaxErrResponseSize int64
 
-	httpClient          *http.Client
-	httpIdleConnsCloser func()
-	url                 *url.URL
-	newAuthToken        func(audience string) string
-	connected           int32
+	httpClient   *http.Client
+	url          *url.URL
+	newAuthToken func(audience string) string
+	connected    int32
 }
 
 // URL query separator constants
@@ -157,9 +156,6 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 // Close closes all idle connections of the underlying http client
 func (c *Client) Close() {
 	atomic.StoreInt32(&c.connected, closed)
-	if c.httpIdleConnsCloser != nil {
-		c.httpIdleConnsCloser()
-	}
 }
 
 // NewClient - returns new REST client.
@@ -169,7 +165,6 @@ func NewClient(url *url.URL, newCustomTransport func() *http.Transport, newAuthT
 	tr := newCustomTransport()
 	return &Client{
 		httpClient:          &http.Client{Transport: tr},
-		httpIdleConnsCloser: tr.CloseIdleConnections,
 		url:                 url,
 		newAuthToken:        newAuthToken,
 		connected:           online,

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -148,21 +148,24 @@ func IsNetworkOrHostDown(err error) bool {
 	if errors.Is(err, context.Canceled) {
 		return false
 	}
+
 	// We need to figure if the error either a timeout
 	// or a non-temporary error.
 	e, ok := err.(net.Error)
 	if ok {
-		urlErr, ok := e.(*url.Error)
-		if ok {
+		if urlErr, ok := e.(*url.Error); ok {
 			switch urlErr.Err.(type) {
 			case *net.DNSError, *net.OpError, net.UnknownNetworkError:
 				return true
 			}
 		}
+
 		if e.Timeout() {
 			return true
 		}
+
 	}
+
 	ok = false
 	// Fallback to other mechanisms.
 	if strings.Contains(err.Error(), "Connection closed by foreign host") {


### PR DESCRIPTION


## Description
This PR fixes a hang which occurs quite commonly at higher concurrency
by allowing the following changes

- allowing lower connections in time_wait allows faster socket open's
- lower idle connection timeout to ensure that we let the kernel
  reclaim the time_wait connections quickly
- increase somaxconn to 4096 instead of 2048 to allow larger TCP
  syn backlogs.

## Motivation and Context
Fixes #10413

## How to test this PR?
The issue provides a nice reproducer that I used against a 
4 node distributed setup on NVMe drives over a 100G network.

Two things to observe 

- Latency of the calls increase dramatically as the number of time_wait increases
- Also the disks go offline due to "connection reset by peer" - which in-fact
  not an error to take the disk offline, instead, the subsequent calls should continue
  properly.

This PR goes to fix both issues, allowing consistent performance for large concurrent workloads.

```go
package main

import (
        "fmt"
        "log"
        "math/rand"
        "os"
        "strconv"
        "strings"
        "sync"
        "time"

        "github.com/aws/aws-sdk-go/aws"
        "github.com/aws/aws-sdk-go/aws/credentials"
        "github.com/aws/aws-sdk-go/aws/session"
        "github.com/aws/aws-sdk-go/service/s3"
)

var endpoint = "http://localhost:9000"
var bucket = aws.String("mybucket")
var accessKey = "admin"
var secretKey = "changeme"
var prefix = "loadtest/"
var objectCount = 1000
var oneshot = true

func init() {
        rand.Seed(time.Now().UnixNano())
}

func main() {
        var err error

        if os.Getenv("LOADTEST_ENDPOINT") != "" {
                endpoint = os.Getenv("LOADTEST_ENDPOINT")
                if err != nil {
                        log.Fatalf("Couldn't get LOADTEST_ENDPOINT: %v\n", err)
                }
        }

        if os.Getenv("LOADTEST_BUCKET") != "" {
                bucket = aws.String(os.Getenv("LOADTEST_BUCKET"))
                if err != nil {
                        log.Fatalf("Couldn't get LOADTEST_BUCKET: %v\n", err)
                }
        }

        if os.Getenv("LOADTEST_ACCESS_KEY") != "" {
                accessKey = os.Getenv("LOADTEST_ACCESS_KEY")
               if err != nil {
                        log.Fatalf("Couldn't get LOADTEST_ACCESS_KEY: %v\n", err)
                }
        }

        if os.Getenv("LOADTEST_SECRET_KEY") != "" {
                secretKey = os.Getenv("LOADTEST_SECRET_KEY")
                if err != nil {
                        log.Fatalf("Couldn't get LOADTEST_SECRET_KEY: %v\n", err)
                }
        }

        if os.Getenv("LOADTEST_OBJ_COUNT") != "" {
                objectCount, err = strconv.Atoi(os.Getenv("LOADTEST_OBJ_COUNT"))
                if err != nil {
                        log.Fatalf("Couldn't parse LOADTEST_OBJ_COUNT: %v\n", err)
                }
        }

        if os.Getenv("LOADTEST_ONESHOT") != "" {
                oneshot, err = strconv.ParseBool(os.Getenv("LOADTEST_ONESHOT"))
                if err != nil {
                        log.Fatalf("Couldn't parse LOADTEST_ONESHOT: %v\n", err)
                }
        }

        s3Config := &aws.Config{
                Credentials:      credentials.NewStaticCredentials(accessKey, secretKey, ""),
                Endpoint:         aws.String(endpoint),
                Region:           aws.String("us-east-1"),
                DisableSSL:       aws.Bool(true),
                S3ForcePathStyle: aws.Bool(true),
        }
        newSession := session.New(s3Config)

        s3Client := s3.New(newSession)
        for {
                var wg sync.WaitGroup
                log.Printf("Starting object uploads\n")
                for i := 0; i < objectCount; i++ {
                        wg.Add(1)
                        go uploadObject(&wg, s3Client)
                }
                wg.Wait()
                log.Printf("Uploaded %d objects\n", objectCount)

                if oneshot {
                        break
                }

                nextTime := time.Now().Truncate(time.Minute).Add(time.Minute)
                time.Sleep(time.Until(nextTime))
        }
}

func uploadObject(wg *sync.WaitGroup, s3Client *s3.S3) {
        defer wg.Done()

        var err error
        key := aws.String(prefix + RandStringRunes(30))

        // Upload a new object "testobject" with the string "Hello World!" to our "newbucket".
        randStr := RandStringRunes(rand.Intn(1024))
        start := time.Now()
        _, err = s3Client.PutObject(&s3.PutObjectInput{
                Body:   strings.NewReader(randStr),
                Bucket: bucket,
                Key:    key,
        })
        end := time.Now()
        uploadDuration := end.Sub(start)
        if err != nil {
                fmt.Printf("Failed to upload data to %s/%s, %s\n", *bucket, *key, err.Error())
                return
        }
        log.Printf("Successfully uploaded %d bytes with key %s in %v\n", len(randStr), *key, uploadDuration)
}

// https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go/35399339
var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")

func RandStringRunes(n int) string {
        b := make([]rune, n)
        for i := range b {
                b[i] = letterRunes[rand.Intn(len(letterRunes))]
        }
        return string(b)
}
```

Test with 3500 concurrent operations, without this change servers, will disconnect and hang for all operations. 
```
~ LOADTEST_ENDPOINT=http://minio-3:8080 LOADTEST_BUCKET=testbucket LOADTEST_ACCESS_KEY=minio LOADTEST_SECRET_KEY=minio123 LOADTEST_OBJ_COUNT=3500 LOADTEST_ONESHOT=true  ./upload
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
