### PR TITLE
Add object version info to Postgres notifications

### DIFF
--- a/cmd/api-datatypes.go
+++ b/cmd/api-datatypes.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"encoding/xml"
+	"time"
 )
 
 // DeletedObject objects deleted
@@ -26,6 +27,7 @@ type DeletedObject struct {
 	DeleteMarkerVersionID string `xml:"DeleteMarkerVersionId,omitempty"`
 	ObjectName            string `xml:"Key,omitempty"`
 	VersionID             string `xml:"VersionId,omitempty"`
+	ModTime               time.Time
 }
 
 // ObjectToDelete carries key name for the object to delete.

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -496,6 +496,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 				Name:         dobj.ObjectName,
 				DeleteMarker: dobj.DeleteMarker,
 				VersionID:    dobj.DeleteMarkerVersionID,
+				ModTime:      dobj.ModTime,
 			}
 		}
 		sendEvent(eventArgs{

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -856,6 +856,7 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 					DeleteMarker:          versions[objIndex].Deleted,
 					DeleteMarkerVersionID: versions[objIndex].VersionID,
 					ObjectName:            decodeDirObject(versions[objIndex].Name),
+					ModTime:               versions[objIndex].ModTime,
 				}
 			} else {
 				dobjects[objIndex] = DeletedObject{

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1246,9 +1246,11 @@ func (args eventArgs) ToEvent(escape bool) event.Event {
 				ARN:           policy.ResourceARNPrefix + args.BucketName,
 			},
 			Object: event.Object{
-				Key:       keyName,
-				VersionID: args.Object.VersionID,
-				Sequencer: uniqueID,
+				Key:          keyName,
+				VersionID:    args.Object.VersionID,
+				DeleteMarker: args.Object.DeleteMarker,
+				LastModified: args.Object.ModTime,
+				Sequencer:    uniqueID,
 			},
 		},
 		Source: event.Source{

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -16,6 +16,10 @@
 
 package event
 
+import (
+	"time"
+)
+
 const (
 	// NamespaceFormat - namespace log format used in some event targets.
 	NamespaceFormat = "namespace"
@@ -44,9 +48,11 @@ type Object struct {
 	Key          string            `json:"key"`
 	Size         int64             `json:"size,omitempty"`
 	ETag         string            `json:"eTag,omitempty"`
+	LastModified time.Time         `json:"lastModified,omitempty"`
 	ContentType  string            `json:"contentType,omitempty"`
 	UserMetadata map[string]string `json:"userMetadata,omitempty"`
 	VersionID    string            `json:"versionId,omitempty"`
+	DeleteMarker bool              `json:"deleteMarker,omitempty"`
 	Sequencer    string            `json:"sequencer"`
 }
 


### PR DESCRIPTION
## Description

This change updates the table structure used to store namespace information in
the Postgres notification target when used with format=namespace configuration.

- Update firstPing being set to true when table is created
- Migrate data from old format to new format in the background by renaming
  existing table and copying rows incrementally.
- Populating namespace table for deletes including bulk deletes
- Add lastModified info to delete markers
- In case of multiple PutObjects on the same object on unversioned bucket, rows
  are replaced with latest event data
- In case of multiple PutObjects on the same object on versioned bucket, rows
  are added for each new version
- A deleteObject on unversioned bucket removes corresponding row.
- A deleteObject on versioned bucket without a version-id adds a row for a
  delete marker.
- A deleteObject on versioned bucket that removes an object removes
  corresponding row from the table.
- Not all objects in the namespace are guaranteed to be present in the table:
  - Rows may be missing for multi-version objects created before this
    change (see data migration notes).
  - Rows may be missing for objects created earlier than when notifications were
    enabled on the bucket.
- A GetObject on an object missing in the table will end up adding a row with
  info from the latest event. However a GetObject on an object with an existing
  row, will not update the row.

Data Migration:

- Existing rows in the old table never replace matching rows in the new table,
  as the data in the new table is definitely more recent.
- Old format did not allow for storing multiple versions of an object, so data
  may not be complete in the new table when migrating - on scanning of the
  namespace is performed.


## Motivation and Context

This change brings in version aware notifications info for namespace data for the Postgresql notification target. With this change, the namespace format table will include bucket, object name, version_id, is_delete_marker, last_modified, etag and event_data columns.

## How to test this PR?

1. Start Postgres in a container:
```
# last argument causes all SQL to be logged to console
docker run --rm -it -e POSTGRES_PASSWORD=example -p 5432:5432 postgres:11.7-alpine -c log_statement=all
```
2. Start minio server in erasure coding mode and configure mc with alias `myminio`
3. Configure the postgres target:
```
mc admin config set myminio notify_postgres:1 connection_string="host=localhost dbname=postgres user=postgres password=example sslmode=disable" table=ns
```
4. Configure event for bucket `test` (assumed to be created, and has versioning enabled).
```
mc event add myminio/test arn:minio:sqs::1:postgresql
```
5. With the above setup, see the content of the table `ns` in a postgres client like psql:
```
psql -h localhost -U postgres postgres
> SELECT * FROM ns;
```
while creating objects with multiple versions, delete objects, delete versions and delete delete-markers.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
