### PR TITLE
fix: allow crawler to crawl on disks without usage constraints

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -252,7 +252,7 @@ func (er erasureObjects) crawlAndGetDataUsage(ctx context.Context, buckets []Buc
 	}
 
 	// Collect disks we can use.
-	disks := er.getLoadBalancedDisks(true)
+	disks := er.getOnlineDisks()
 	if len(disks) == 0 {
 		logger.Info(color.Green("data-crawl:") + " all disks are offline or being healed, skipping crawl")
 		return nil


### PR DESCRIPTION

## Description
fix: allow crawler to crawl on disks without usage constraints

additionally, also change the resolution usage wise
return of disks, allows to small byte-level differences
to be masked.

## Motivation and Context
crawler slowness fix

## How to test this PR?
Nothing special but according to @klauspost is the primary reason for crawler slowness.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
