### PR TITLE
Keep mrfOpCh open.

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -81,14 +81,6 @@ func (er erasureObjects) SetDriveCount() int {
 func (er erasureObjects) Shutdown(ctx context.Context) error {
 	// Add any object layer shutdown activities here.
 	closeStorageDisks(er.getDisks())
-	select {
-	case _, ok := <-er.mrfOpCh:
-		if ok {
-			close(er.mrfOpCh)
-		}
-	default:
-		close(er.mrfOpCh)
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Motivation and Context

Fix crash in CI:

```
2020-10-15T13:10:35.5160359Z panic: send on closed channel
2020-10-15T13:10:35.5160695Z
2020-10-15T13:10:35.5161029Z goroutine 70075 [running]:
2020-10-15T13:10:35.5162314Z github.com/minio/minio/cmd.erasureObjects.addPartial(0xc004154380, 0xc0041543a0, 0xc0041543c0, 0xc004154340, 0xc004154360, 0xc0043bc180, 0x1c9862f, 0xa, 0xc01e696b40, 0x58, ...)
2020-10-15T13:10:35.5164993Z 	D:/a/minio/minio/cmd/erasure-object.go:962 +0xac
2020-10-15T13:10:35.5166224Z github.com/minio/minio/cmd.erasureObjects.putObject(0xc004154380, 0xc0041543a0, 0xc0041543c0, 0xc004154340, 0xc004154360, 0xc0043bc180, 0x20f1000, 0xc00003c118, 0x1c9862f, 0xa, ...)
2020-10-15T13:10:35.5167313Z 	D:/a/minio/minio/cmd/erasure-object.go:691 +0x1041
2020-10-15T13:10:35.5168229Z github.com/minio/minio/cmd.erasureObjects.PutObject(...)
2020-10-15T13:10:35.5168970Z 	D:/a/minio/minio/cmd/erasure-object.go:521
2020-10-15T13:10:35.5170119Z github.com/minio/minio/cmd.(*erasureSets).PutObject(0xc00c1ea000, 0x20f1000, 0xc00003c118, 0x1c9862f, 0xa, 0xc01e696b40, 0x58, 0xc002ec0520, 0x0, 0x0, ...)
2020-10-15T13:10:35.5171489Z 	D:/a/minio/minio/cmd/erasure-sets.go:729 +0x1f6
2020-10-15T13:10:35.5172748Z github.com/minio/minio/cmd.(*erasureZones).PutObject(0xc004607720, 0x20f1000, 0xc00003c118, 0x1c9862f, 0xa, 0xc01e696b40, 0x58, 0xc002ec0520, 0x0, 0x0, ...)
2020-10-15T13:10:35.5173677Z 	D:/a/minio/minio/cmd/erasure-zones.go:526 +0x1b4
2020-10-15T13:10:35.5174636Z github.com/minio/minio/cmd.(*bucketMetacache).save(0xc019e12e40, 0x20f1000, 0xc00003c118, 0x0, 0x0)
2020-10-15T13:10:35.5175296Z 	D:/a/minio/minio/cmd/metacache.go:230 +0x3c9
2020-10-15T13:10:35.5176072Z github.com/minio/minio/cmd.(*metacacheManager).initManager.func1(0x3458dc0)
2020-10-15T13:10:35.5176799Z 	D:/a/minio/minio/cmd/metacache_manager.go:68 +0xaf
2020-10-15T13:10:35.5177681Z created by github.com/minio/minio/cmd.(*metacacheManager).initManager
2020-10-15T13:10:35.5178484Z 	D:/a/minio/minio/cmd/metacache_manager.go:47 +0x46
````

There doesn't seem to be any benefit to closing the channel, so just keep it open and let it die with the server.


## How to test this PR?

CI should take care of that.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
