### PR TITLE
ilm: Send delete marker creation event when appropriate

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -487,19 +487,21 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 
 	// Notify deleted event for objects.
 	for _, dobj := range deletedObjects {
+		eventName := event.ObjectRemovedDelete
+
 		objInfo := ObjectInfo{
 			Name:      dobj.ObjectName,
 			VersionID: dobj.VersionID,
 		}
+
 		if dobj.DeleteMarker {
-			objInfo = ObjectInfo{
-				Name:         dobj.ObjectName,
-				DeleteMarker: dobj.DeleteMarker,
-				VersionID:    dobj.DeleteMarkerVersionID,
-			}
+			objInfo.DeleteMarker = dobj.DeleteMarker
+			objInfo.VersionID = dobj.DeleteMarkerVersionID
+			eventName = event.ObjectRemovedDeleteMarkerCreated
 		}
+
 		sendEvent(eventArgs{
-			EventName:    event.ObjectRemovedDelete,
+			EventName:    eventName,
 			BucketName:   bucket,
 			Object:       objInfo,
 			ReqParams:    extractReqParams(r),

--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -747,9 +747,14 @@ func (i *crawlItem) applyActions(ctx context.Context, o ObjectLayer, meta action
 		return size
 	}
 
+	eventName := event.ObjectRemovedDelete
+	if obj.DeleteMarker {
+		eventName = event.ObjectRemovedDeleteMarkerCreated
+	}
+
 	// Notify object deleted event.
 	sendEvent(eventArgs{
-		EventName:  event.ObjectRemovedDelete,
+		EventName:  eventName,
 		BucketName: i.bucket,
 		Object:     obj,
 		Host:       "Internal: [ILM-EXPIRY]",

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -291,30 +291,20 @@ func deleteObject(ctx context.Context, obj ObjectLayer, cache CacheObjectLayer, 
 	// Proceed to delete the object.
 	objInfo, err = deleteObject(ctx, bucket, object, opts)
 	if objInfo.Name != "" {
-		// Requesting only a delete marker which was successfully attempted.
+		eventName := event.ObjectRemovedDelete
 		if objInfo.DeleteMarker {
-			// Notify object deleted marker event.
-			sendEvent(eventArgs{
-				EventName:    event.ObjectRemovedDeleteMarkerCreated,
-				BucketName:   bucket,
-				Object:       objInfo,
-				ReqParams:    extractReqParams(r),
-				RespElements: extractRespElements(w),
-				UserAgent:    r.UserAgent(),
-				Host:         handlers.GetSourceIP(r),
-			})
-		} else {
-			// Notify object deleted event.
-			sendEvent(eventArgs{
-				EventName:    event.ObjectRemovedDelete,
-				BucketName:   bucket,
-				Object:       objInfo,
-				ReqParams:    extractReqParams(r),
-				RespElements: extractRespElements(w),
-				UserAgent:    r.UserAgent(),
-				Host:         handlers.GetSourceIP(r),
-			})
+			eventName = event.ObjectRemovedDeleteMarkerCreated
 		}
+		// Notify object deleted marker event.
+		sendEvent(eventArgs{
+			EventName:    eventName,
+			BucketName:   bucket,
+			Object:       objInfo,
+			ReqParams:    extractReqParams(r),
+			RespElements: extractRespElements(w),
+			UserAgent:    r.UserAgent(),
+			Host:         handlers.GetSourceIP(r),
+		})
 	}
 	return objInfo, err
 }


### PR DESCRIPTION
## Description
Before this commit, the crawler ILM will always send object delete event
notification though this is wrong.

## Motivation and Context
Fix a bug while reviewing the code

## How to test this PR?
Setup a notification target, enable versioning on a bucket, upload an object and delete it.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
