### PR TITLE
avoid a one extra object encryption key copy in tryDecryptedETag

### DIFF
--- a/cmd/disk-cache-utils.go
+++ b/cmd/disk-cache-utils.go
@@ -253,7 +253,7 @@ func decryptCacheObjectETag(info *ObjectInfo) error {
 		if err = objectKey.Unseal(extKey, sealedKey, crypto.S3.String(), info.Bucket, info.Name); err != nil {
 			return err
 		}
-		etagStr := tryDecryptETag(objectKey[:], info.ETag, false)
+		etagStr := tryDecryptETag(objectKey, info.ETag, false)
 		// backend ETag was hex encoded before encrypting, so hex decode to get actual ETag
 		etag, err := hex.DecodeString(etagStr)
 		if err != nil {

--- a/cmd/encryption-v1_test.go
+++ b/cmd/encryption-v1_test.go
@@ -52,6 +52,34 @@ var encryptRequestTests = []struct {
 	},
 }
 
+func TestTryDecryptedETag(t *testing.T) {
+	tests := []struct {
+		base64Key     string
+		encryptedETag string
+		etag          string
+	}{
+		{
+			"ieCaxXUnFY7QmlIjwuY8/d+6h6jiZ4t+J0gQSL1L5nw=",
+			"20000f00fb93cf5539a2d8441539409f7fa39e62de0a408c9ad3d25b1a0698626ac51c97cae0840b8798365ca01285fd",
+			"760e3d2850682cd3359254511ad15d0f",
+		},
+		{
+			"4y38dA0BVkYTJukZQ9/MX9iTYPsKfe1gnYCUZ0ZgEaY=",
+			"20000f00a0b3cb774c97fa7f8cacca0dfc19ea2338227fe187522eeed98bdd6f9de331bb8d7564803a1c46daa2b28ad7",
+			"2adb567636fb9539618ad327f58c3aaf",
+		},
+	}
+	var ckey crypto.ObjectKey
+	for _, test := range tests {
+		key, _ := base64.StdEncoding.DecodeString(test.base64Key)
+		copy(ckey[:], key)
+		gotETag := tryDecryptETag(ckey, test.encryptedETag, false)
+		if gotETag != test.etag {
+			t.Errorf("Expected etag %s, got %s", test.etag, gotETag)
+		}
+	}
+}
+
 func TestEncryptRequest(t *testing.T) {
 	defer func(flag bool) { globalIsSSL = flag }(globalIsSSL)
 	globalIsSSL = true


### PR DESCRIPTION
## Description
avoid a double copy in tryDecryptedETag

## Motivation and Context
ListObjects return value is reliant on tryDecryptedETag to
be faster, this PR retries to reduce an extra allocation
by re-using the object encryption key already obtained as
part of decryptObjectInfo()

## How to test this PR?
Nothing special all encryption functionalities should work

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
