### PR TITLE
fix: s3 gateway DNS cache initialization

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -21,6 +21,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/url"
 	"os"
@@ -33,6 +34,7 @@ import (
 	"github.com/minio/cli"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/cmd/config"
+	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/certs"
@@ -42,6 +44,9 @@ import (
 func init() {
 	logger.Init(GOPATH, GOROOT)
 	logger.RegisterError(config.FmtError)
+
+	rand.Seed(time.Now().UTC().UnixNano())
+	globalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second)
 
 	gob.Register(StorageErr(""))
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -19,14 +19,12 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/url"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/minio/cli"
@@ -155,9 +153,6 @@ func ValidateGatewayArguments(serverAddr, endpointAddr string) error {
 
 // StartGateway - handler for 'minio gateway <name>'.
 func StartGateway(ctx *cli.Context, gw Gateway) {
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	globalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second)
 	defer globalDNSCache.Stop()
 
 	// This is only to uniquely identify each gateway deployments.

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net"
 	"os"
 	"os/signal"
@@ -362,9 +361,6 @@ func initAllSubsystems(ctx context.Context, newObject ObjectLayer) (err error) {
 
 // serverMain handler called for 'minio server' command.
 func serverMain(ctx *cli.Context) {
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	globalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second)
 	defer globalDNSCache.Stop()
 
 	signal.Notify(globalOSSignalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)

--- a/pkg/dsync/drwmutex.go
+++ b/pkg/dsync/drwmutex.go
@@ -33,7 +33,6 @@ var dsyncLog bool
 func init() {
 	// Check for MINIO_DSYNC_TRACE env variable, if set logging will be enabled for failed REST operations.
 	dsyncLog = os.Getenv("MINIO_DSYNC_TRACE") == "1"
-	rand.Seed(time.Now().UnixNano())
 }
 
 func log(format string, data ...interface{}) {


### PR DESCRIPTION
## Description
fix: s3 gateway DNS cache initialization

## Motivation and Context
fixes #10705

## How to test this PR?
As per #10705 

```
#!/bin/bash

set -x
unset MINIO_KMS_KES_CERT_FILE
unset MINIO_KMS_KES_KEY_FILE
unset MINIO_KMS_KES_ENDPOINT
unset MINIO_KMS_KES_KEY_NAME
#unset MINIO_KMS_MASTER_KEY=my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574                                                                                     
unset MINIO_KMS_AUTO_ENCRYPTION

export MINIO_ACCESS_KEY=minio
export MINIO_SECRET_KEY=minio123
minio server --address ":9001" /tmp/fs-new{1...4} >/dev/null 2>&1 &
sleep 2
export MINIO_GATEWAY_DEPLOYMENT_ID="test"
minio gateway s3 http://localhost:9001
```

Following script runs fine without crash, the problem seems to be only with AWS S3 gateway.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes, surprising that mint-auto ran fine
- [ ] Documentation needed
- [ ] Unit tests needed
