### PR TITLE
Hardware offload MD5 calculation

### DIFF
--- a/cmd/erasure-encode.go
+++ b/cmd/erasure-encode.go
@@ -22,7 +22,9 @@ import (
 
 	"sync"
 
+	md5accel "github.com/liangintel/md5accel"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/hash"
 )
 
 // Writes in parallel to writers
@@ -70,14 +72,37 @@ func (p *parallelWriter) Write(ctx context.Context, blocks [][]byte) error {
 }
 
 // Encode reads from the reader, erasure-encodes the data and writes to the writers.
-func (e *Erasure) Encode(ctx context.Context, src io.Reader, writers []io.Writer, buf []byte, quorum int) (total int64, err error) {
+func (e *Erasure) Encode(ctx context.Context, src io.Reader, writers []io.Writer, buf_ori []byte, quorum int) (total int64, err error) {
 	writer := &parallelWriter{
 		writers:     writers,
 		writeQuorum: quorum,
 		errs:        make([]error, len(writers)),
 	}
 
+	buf := buf_ori[:]           // set to original buf which assumes no HW involved
+	eng := -1                   // init md5 HW engine index to -1 which assumes no HW involved
+	r, ok := src.(*hash.Reader) // check if it's hash.Reader which contains Md5Hash field
+	if ok {
+		// try to get the md5 engine
+		// 1) >= 0: HW engine is got. Previously r.Md5Hash = md5accel.New()
+		// 2) == -1: software engine. Previously r.Md5Hash = md5.New()
+		// 3) HW engine will be released in subsequent call to MD5Sum()
+		// 4) work flow is changed only when eng >= 0
+		eng = md5accel.GetAccelerator(r.Md5Hash)
+
+		// tell HW engine don't copy data from MinIO buffer to HW buffer in Md5Hash.Write()
+		// because MinIO will receive data from network and directly put data to HW buffer.
+		// see subsequent call to md5accel.Accel_get_next_buff
+		if(eng >= 0) {
+			md5accel.Set_zero_cpy(r.Md5Hash)
+		}
+	}
+
 	for {
+		if(eng >= 0) {
+			// use HW buf pool, so no memory copy happen between MinIO and HW, this can increase ~3% throughput
+			buf = md5accel.Accel_get_next_buff(r.Md5Hash)
+		}
 		var blocks [][]byte
 		n, err := io.ReadFull(src, buf)
 		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
@@ -85,6 +110,18 @@ func (e *Erasure) Encode(ctx context.Context, src io.Reader, writers []io.Writer
 			return 0, err
 		}
 		eof := err == io.EOF || err == io.ErrUnexpectedEOF
+		if(eng >= 0) {
+			if(eof || (n == 0 && total != 0)) {
+				// Not really write data, Set_zero_cpy is called in previous code
+				// just tell hw the total length of the object, data itself already in HW buf
+				md5accel.Accel_write_data(eng, buf, total+int64(n))
+		
+				// trigger HW to calculate md5 in a go routing
+				// 1) this will be running in parallel with subsequent calls of e.EncodeData and writer.Write
+				// 2) HW engine will be released here
+				md5accel.MD5Sum(r.Md5Hash)
+			}
+		}
 		if n == 0 && total != 0 {
 			// Reached EOF, nothing more to be done.
 			break

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// Block size used for all internal operations version 1.
-	blockSizeV1 = 10 * humanize.MiByte
+	blockSizeV1 = 4 * humanize.MiByte
 
 	// Staging buffer read size for all internal operations version 1.
 	readSizeV1 = 1 * humanize.MiByte


### PR DESCRIPTION
## Description
Use Intel QAT to offload MinIO MD5 calculation when putting objects.
This way can free CPU resource and get 0~12% throughput improvement in
typical storage server in specific scenario: when the server MinIO
running upon is with low end CPU or CPU become the bottleneck.

## Motivation and Context
Background:

1) MD5 calculation occupies more than 20% CPU resource when putting
objects to MinIO. It's the heavy task for CPU, so valuable to be
offloaded by some specific hardware accelerator.

2) Lots of servers (since Intel skylake platform) contain Intel QAT
component by default. So offload MD5 calculation to QAT will not
generate extra cost.


HW offload md5 calculation when:

1) env MINIO_MD5_HW_OFFLOAD is set to 'QAT'. So by default this feature
is not enabled.

2) with object size between 4MB and max object size hw supported
(e.g.128MB). It is not efficient if size too small or too big

3) HW exists, configured and has free resource. These are maintained in
a seperate repo: github.com/liangintel/md5accel

4) Switch to CPU if HW don't do offload

Another change:
Change block size - blockSizeV1 from 10MB to 4MB because Linux kernel
can only allocate maximum 4MB continues physical memory which is used by
QAT hardware.

## How to test this PR?
- gate test makes sure this PR introduced no regression
- performance test should be done in a server with Intel QAT accelerator. More documentation would be put in github.com/liangintel/md5accel

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
