### PR TITLE
validate if iam store is initialized

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -386,7 +386,7 @@ func (sys *IAMSys) LoadUser(objAPI ObjectLayer, accessKey string, userType IAMUs
 
 // LoadServiceAccount - reloads a specific service account from backend disks or etcd.
 func (sys *IAMSys) LoadServiceAccount(accessKey string) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -505,7 +505,7 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 
 // DeletePolicy - deletes a canned policy from backend or etcd.
 func (sys *IAMSys) DeletePolicy(policyName string) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -557,7 +557,7 @@ func (sys *IAMSys) DeletePolicy(policyName string) error {
 
 // InfoPolicy - expands the canned policy into its JSON structure.
 func (sys *IAMSys) InfoPolicy(policyName string) (iampolicy.Policy, error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return iampolicy.Policy{}, errServerNotInitialized
 	}
 
@@ -574,7 +574,7 @@ func (sys *IAMSys) InfoPolicy(policyName string) (iampolicy.Policy, error) {
 
 // ListPolicies - lists all canned policies.
 func (sys *IAMSys) ListPolicies() (map[string]iampolicy.Policy, error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return nil, errServerNotInitialized
 	}
 
@@ -595,7 +595,7 @@ func (sys *IAMSys) ListPolicies() (map[string]iampolicy.Policy, error) {
 
 // SetPolicy - sets a new name policy.
 func (sys *IAMSys) SetPolicy(policyName string, p iampolicy.Policy) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -616,7 +616,7 @@ func (sys *IAMSys) SetPolicy(policyName string, p iampolicy.Policy) error {
 
 // DeleteUser - delete user (only for long-term users not STS users).
 func (sys *IAMSys) DeleteUser(accessKey string) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -669,6 +669,9 @@ func (sys *IAMSys) DeleteUser(accessKey string) error {
 // after validating if there are any current policies which exist
 // on MinIO corresponding to the input.
 func (sys *IAMSys) currentPolicies(policyName string) string {
+	if sys.store == nil {
+		return ""
+	}
 	sys.store.rlock()
 	defer sys.store.runlock()
 
@@ -685,7 +688,7 @@ func (sys *IAMSys) currentPolicies(policyName string) string {
 
 // SetTempUser - set temporary user credentials, these credentials have an expiry.
 func (sys *IAMSys) SetTempUser(accessKey string, cred auth.Credentials, policyName string) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -734,7 +737,7 @@ func (sys *IAMSys) SetTempUser(accessKey string, cred auth.Credentials, policyNa
 
 // ListUsers - list all users.
 func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return nil, errServerNotInitialized
 	}
 
@@ -770,7 +773,7 @@ func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
 
 // IsTempUser - returns if given key is a temporary user.
 func (sys *IAMSys) IsTempUser(name string) (bool, error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return false, errServerNotInitialized
 	}
 
@@ -787,7 +790,7 @@ func (sys *IAMSys) IsTempUser(name string) (bool, error) {
 
 // IsServiceAccount - returns if given key is a service account
 func (sys *IAMSys) IsServiceAccount(name string) (bool, string, error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return false, "", errServerNotInitialized
 	}
 
@@ -808,7 +811,7 @@ func (sys *IAMSys) IsServiceAccount(name string) (bool, string, error) {
 
 // GetUserInfo - get info on a user.
 func (sys *IAMSys) GetUserInfo(name string) (u madmin.UserInfo, err error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return u, errServerNotInitialized
 	}
 
@@ -854,7 +857,7 @@ func (sys *IAMSys) GetUserInfo(name string) (u madmin.UserInfo, err error) {
 // SetUserStatus - sets current user status, supports disabled or enabled.
 func (sys *IAMSys) SetUserStatus(accessKey string, status madmin.AccountStatus) error {
 
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -900,7 +903,7 @@ func (sys *IAMSys) SetUserStatus(accessKey string, status madmin.AccountStatus) 
 // NewServiceAccount - create a new service account
 func (sys *IAMSys) NewServiceAccount(ctx context.Context, parentUser string, sessionPolicy *iampolicy.Policy) (auth.Credentials, error) {
 
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return auth.Credentials{}, errServerNotInitialized
 	}
 
@@ -967,7 +970,7 @@ func (sys *IAMSys) NewServiceAccount(ctx context.Context, parentUser string, ses
 // ListServiceAccounts - lists all services accounts associated to a specific user
 func (sys *IAMSys) ListServiceAccounts(ctx context.Context, accessKey string) ([]string, error) {
 
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return nil, errServerNotInitialized
 	}
 
@@ -992,7 +995,7 @@ func (sys *IAMSys) ListServiceAccounts(ctx context.Context, accessKey string) ([
 // GetServiceAccountParent - gets information about a service account
 func (sys *IAMSys) GetServiceAccountParent(ctx context.Context, accessKey string) (string, error) {
 
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return "", errServerNotInitialized
 	}
 
@@ -1009,7 +1012,7 @@ func (sys *IAMSys) GetServiceAccountParent(ctx context.Context, accessKey string
 // DeleteServiceAccount - delete a service account
 func (sys *IAMSys) DeleteServiceAccount(ctx context.Context, accessKey string) error {
 
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -1038,7 +1041,7 @@ func (sys *IAMSys) DeleteServiceAccount(ctx context.Context, accessKey string) e
 // SetUser - set user credentials and policy.
 func (sys *IAMSys) SetUser(accessKey string, uinfo madmin.UserInfo) error {
 
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -1076,7 +1079,7 @@ func (sys *IAMSys) SetUser(accessKey string, uinfo madmin.UserInfo) error {
 // SetUserSecretKey - sets user secret key
 func (sys *IAMSys) SetUserSecretKey(accessKey string, secretKey string) error {
 
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -1104,7 +1107,7 @@ func (sys *IAMSys) SetUserSecretKey(accessKey string, secretKey string) error {
 
 // GetUser - get user credentials
 func (sys *IAMSys) GetUser(accessKey string) (cred auth.Credentials, ok bool) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return cred, false
 	}
 
@@ -1170,7 +1173,7 @@ func (sys *IAMSys) GetUser(accessKey string) (cred auth.Credentials, ok bool) {
 // AddUsersToGroup - adds users to a group, creating the group if
 // needed. No error if user(s) already are in the group.
 func (sys *IAMSys) AddUsersToGroup(group string, members []string) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -1230,7 +1233,7 @@ func (sys *IAMSys) AddUsersToGroup(group string, members []string) error {
 // RemoveUsersFromGroup - remove users from group. If no users are
 // given, and the group is empty, deletes the group as well.
 func (sys *IAMSys) RemoveUsersFromGroup(group string, members []string) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -1310,7 +1313,7 @@ func (sys *IAMSys) RemoveUsersFromGroup(group string, members []string) error {
 
 // SetGroupStatus - enable/disabled a group
 func (sys *IAMSys) SetGroupStatus(group string, enabled bool) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -1345,7 +1348,7 @@ func (sys *IAMSys) SetGroupStatus(group string, enabled bool) error {
 
 // GetGroupDescription - builds up group description
 func (sys *IAMSys) GetGroupDescription(group string) (gd madmin.GroupDesc, err error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return gd, errServerNotInitialized
 	}
 
@@ -1385,7 +1388,7 @@ func (sys *IAMSys) GetGroupDescription(group string) (gd madmin.GroupDesc, err e
 
 // ListGroups - lists groups.
 func (sys *IAMSys) ListGroups() (r []string, err error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return r, errServerNotInitialized
 	}
 
@@ -1408,7 +1411,7 @@ func (sys *IAMSys) ListGroups() (r []string, err error) {
 
 // PolicyDBSet - sets a policy for a user or group in the PolicyDB.
 func (sys *IAMSys) PolicyDBSet(name, policy string, isGroup bool) error {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return errServerNotInitialized
 	}
 
@@ -1474,7 +1477,7 @@ func (sys *IAMSys) policyDBSet(name, policyName string, userType IAMUserType, is
 // be a member of multiple groups, this function returns an array of
 // applicable policies (each group is mapped to at most one policy).
 func (sys *IAMSys) PolicyDBGet(name string, isGroup bool) ([]string, error) {
-	if sys == nil {
+	if sys == nil || sys.store == nil {
 		return nil, errServerNotInitialized
 	}
 


### PR DESCRIPTION
Fixes panic - regression from d6d770c1b16670771640d606690f05d63c5dbea4

## Description


## Motivation and Context
in gateway mode, if accessing with incorrect credentials - see a panic while validating signature. This is because the iam store is not initialized.
```
2020/10/20 18:45:12 http: panic serving 127.0.0.1:48844: runtime error: invalid memory address or nil pointer dereference
goroutine 27 [running]:
net/http.(*conn).serve.func1(0xc000bc26e0)
	/usr/local/go/src/net/http/server.go:1801 +0x147
panic(0x1b0bc80, 0x3206940)
	/usr/local/go/src/runtime/panic.go:975 +0x3e9
github.com/minio/minio/cmd.criticalErrorHandler.ServeHTTP.func1(0xc000e3ab00, 0x20e7860, 0xc0002ca620)
	/home/kp/code/src/github.com/minio/minio/cmd/generic-handlers.go:755 +0x1a8
panic(0x1b0bc80, 0x3206940)
	/usr/local/go/src/runtime/panic.go:969 +0x175
github.com/minio/minio/cmd.(*IAMSys).GetUser(0xc000dc3260, 0xc000cd601c, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/kp/code/src/github.com/minio/minio/cmd/iam.go:1111 +0x94
github.com/minio/minio/cmd.checkKeyValid(0xc000cd601c, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/kp/code/src/github.com/minio/minio/cmd/signature-v4-utils.go:129 +0xb8
github.com/minio/minio/cmd.doesSignatureMatch(0xc000e92240, 0x40, 0xc000e9c300, 0x0, 0x0, 0x1db1223, 0x2, 0x0)
	/home/kp/code/src/github.com/minio/minio/cmd/signature-v4.go:352 +0x18f
github.com/minio/minio/cmd.reqSignatureV4Verify(0xc000e9c300, 0x0, 0x0, 0x1db1223, 0x2, 0x625d53)
	/home/kp/code/src/github.com/minio/minio/cmd/auth-handler.go:415 +0x178
github.com/minio/minio/cmd.isReqAuthenticated(0x20ef060, 0xc000454780, 0xc000e9c300, 0x0, 0x0, 0x1db1223, 0x2, 0x0)
	/home/kp/code/src/github.com/minio/minio/cmd/auth-handler.go:425 +0x77
github.com/minio/minio/cmd.checkRequestAuthTypeToAccessKey(0x20ef060, 0xc000454780, 0xc000e9c300, 0x1dd01a9, 0x14, 0xc000e26365, 0x6, 0x0, 0x0, 0x0, ...)
	/home/kp/code/src/github.com/minio/minio/cmd/auth-handler.go:299 +0x14e
github.com/minio/minio/cmd.checkRequestAuthType(...)
	/home/kp/code/src/github.com/minio/minio/cmd/auth-handler.go:273
github.com/minio/minio/cmd.objectAPIHandlers.GetBucketLocationHandler(0x1e4f2a0, 0x1e4f290, 0x20e2ee0, 0xc000dfa460, 0xc000e9c300)
	/home/kp/code/src/github.com/minio/minio/cmd/bucket-handlers.go:171 +0x21d
net/http.HandlerFunc.ServeHTTP(...)
	/usr/local/go/src/net/http/server.go:2042
github.com/minio/minio/cmd.httpTraceAll.func1(0x20e2ee0, 0xc000dfa460, 0xc000e9c300)
	/home/kp/code/src/github.com/minio/minio/cmd/handler-utils.go:353 +0x158
net/http.HandlerFunc.ServeHTTP(...)
	/usr/local/go/src/net/http/server.go:2042
github.com/minio/minio/cmd.collectAPIStats.func1(0x20e2ee0, 0xc000dfa1e0, 0xc000e9c300)
	/home/kp/code/src/github.com/minio/minio/cmd/handler-utils.go:380 +0xed
net/http.HandlerFunc.ServeHTTP(...)
```

## How to test this PR?
Run minio in gateway mode with credentials set in env; then do any mc operation on this endpoint with different credentials - correct response should be InvalidAccessKey error, not a panic.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) d6d770c1b16670771640d606690f05d63c5dbea4
- [ ] Documentation needed
- [ ] Unit tests needed
