### PR TITLE
Remove logging info from OBDInfoHandler

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1299,12 +1299,6 @@ func (a adminAPIHandlers) OBDInfoHandler(w http.ResponseWriter, r *http.Request)
 	go func() {
 		defer close(obdInfoCh)
 
-		if log := query.Get("log"); log == "true" {
-			obdInfo.Logging.ServersLog = append(obdInfo.Logging.ServersLog, getLocalLogOBD(deadlinedCtx, r))
-			obdInfo.Logging.ServersLog = append(obdInfo.Logging.ServersLog, globalNotificationSys.LogOBDInfo(deadlinedCtx)...)
-			partialWrite(obdInfo)
-		}
-
 		if cpu := query.Get("syscpu"); cpu == "true" {
 			cpuInfo := getLocalCPUOBDInfo(deadlinedCtx, r)
 

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1113,36 +1113,6 @@ func (sys *NotificationSys) ProcOBDInfo(ctx context.Context) []madmin.ServerProc
 	return reply
 }
 
-// LogOBDInfo - Logs OBD information
-func (sys *NotificationSys) LogOBDInfo(ctx context.Context) []madmin.ServerLogOBDInfo {
-	reply := make([]madmin.ServerLogOBDInfo, len(sys.peerClients))
-
-	g := errgroup.WithNErrs(len(sys.peerClients))
-	for index, client := range sys.peerClients {
-		if client == nil {
-			continue
-		}
-		index := index
-		g.Go(func() error {
-			var err error
-			reply[index], err = sys.peerClients[index].LogOBDInfo(ctx)
-			return err
-		}, index)
-	}
-
-	for index, err := range g.Wait() {
-		if err != nil {
-			addr := sys.peerClients[index].host.String()
-			reqInfo := (&logger.ReqInfo{}).AppendTags("remotePeer", addr)
-			ctx := logger.SetReqInfo(GlobalContext, reqInfo)
-			logger.LogIf(ctx, err)
-			reply[index].Addr = addr
-			reply[index].Error = err.Error()
-		}
-	}
-	return reply
-}
-
 // ServerInfo - calls ServerInfo RPC call on all peers.
 func (sys *NotificationSys) ServerInfo() []madmin.ServerProperties {
 	reply := make([]madmin.ServerProperties, len(sys.peerClients))

--- a/cmd/obdinfo.go
+++ b/cmd/obdinfo.go
@@ -148,19 +148,6 @@ func getLocalMemOBD(ctx context.Context, r *http.Request) madmin.ServerMemOBDInf
 	}
 }
 
-func getLocalLogOBD(ctx context.Context, r *http.Request) madmin.ServerLogOBDInfo {
-	addr := r.Host
-	if globalIsDistErasure {
-		addr = GetLocalPeer(globalEndpoints)
-	}
-
-	log := globalConsoleSys.Content()
-	return madmin.ServerLogOBDInfo{
-		Addr:    addr,
-		Entries: log,
-	}
-}
-
 func getLocalProcOBD(ctx context.Context, r *http.Request) madmin.ServerProcOBDInfo {
 	addr := r.Host
 	if globalIsDistErasure {

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -407,17 +407,6 @@ func (client *peerRESTClient) ProcOBDInfo(ctx context.Context) (info madmin.Serv
 	return info, err
 }
 
-// LogOBDInfo - fetch Log OBD information for a remote node.
-func (client *peerRESTClient) LogOBDInfo(ctx context.Context) (info madmin.ServerLogOBDInfo, err error) {
-	respBody, err := client.callWithContext(ctx, peerRESTMethodLogOBDInfo, nil, nil, -1)
-	if err != nil {
-		return
-	}
-	defer http.DrainBody(respBody)
-	err = gob.NewDecoder(respBody).Decode(&info)
-	return info, err
-}
-
 // StartProfiling - Issues profiling command on the peer node.
 func (client *peerRESTClient) StartProfiling(profiler string) error {
 	values := make(url.Values)

--- a/cmd/peer-rest-common.go
+++ b/cmd/peer-rest-common.go
@@ -33,7 +33,6 @@ const (
 	peerRESTMethodOsInfoOBDInfo         = "/osinfoobdinfo"
 	peerRESTMethodMemOBDInfo            = "/memobdinfo"
 	peerRESTMethodProcOBDInfo           = "/procobdinfo"
-	peerRESTMethodLogOBDInfo            = "/logobdinfo"
 	peerRESTMethodDispatchNetOBDInfo    = "/dispatchnetobdinfo"
 	peerRESTMethodDeleteBucketMetadata  = "/deletebucketmetadata"
 	peerRESTMethodLoadBucketMetadata    = "/loadbucketmetadata"

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -506,22 +506,6 @@ func (s *peerRESTServer) ProcOBDInfoHandler(w http.ResponseWriter, r *http.Reque
 	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
 }
 
-// LogOBDInfoHandler - returns Log OBD info.
-func (s *peerRESTServer) LogOBDInfoHandler(w http.ResponseWriter, r *http.Request) {
-	if !s.IsValid(w, r) {
-		s.writeErrorResponse(w, errors.New("Invalid request"))
-		return
-	}
-
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-
-	info := getLocalLogOBD(ctx, r)
-
-	defer w.(http.Flusher).Flush()
-	logger.LogIf(ctx, gob.NewEncoder(w).Encode(info))
-}
-
 // MemOBDInfoHandler - returns Mem OBD info.
 func (s *peerRESTServer) MemOBDInfoHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.IsValid(w, r) {
@@ -1040,7 +1024,6 @@ func registerPeerRESTHandlers(router *mux.Router) {
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodGetLocks).HandlerFunc(httpTraceHdrs(server.GetLocksHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodServerInfo).HandlerFunc(httpTraceHdrs(server.ServerInfoHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodProcOBDInfo).HandlerFunc(httpTraceHdrs(server.ProcOBDInfoHandler))
-	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodLogOBDInfo).HandlerFunc(httpTraceHdrs(server.LogOBDInfoHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodMemOBDInfo).HandlerFunc(httpTraceHdrs(server.MemOBDInfoHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodOsInfoOBDInfo).HandlerFunc(httpTraceHdrs(server.OsOBDInfoHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodDiskHwOBDInfo).HandlerFunc(httpTraceHdrs(server.DiskHwOBDInfoHandler))

--- a/pkg/madmin/obd.go
+++ b/pkg/madmin/obd.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/minio/minio/cmd/logger/message/log"
 	"github.com/minio/minio/pkg/disk"
 	"github.com/minio/minio/pkg/net"
 
@@ -43,19 +42,6 @@ type OBDInfo struct {
 	Perf      PerfOBDInfo  `json:"perf,omitempty"`
 	Minio     MinioOBDInfo `json:"minio,omitempty"`
 	Sys       SysOBDInfo   `json:"sys,omitempty"`
-	Logging   LogOBDInfo   `json:"logging,omitempty"`
-}
-
-// LogOBDInfo holds different type of logs of all clusters
-type LogOBDInfo struct {
-	ServersLog []ServerLogOBDInfo `json:"serverLogs"`
-}
-
-// ServerLogOBDInfo holds server's stdout log
-type ServerLogOBDInfo struct {
-	Addr    string      `json:"nodeName"`
-	Entries []log.Entry `json:"entries"`
-	Error   string      `json:"error,omitempty"`
 }
 
 // SysOBDInfo - Includes hardware and system information of the MinIO cluster


### PR DESCRIPTION
## Description

Remove logging info from OBDInfoHandler

## Motivation and Context

A lot of logging data is counterproductive. A better implementation with precise useful log data can be introduced later.

## How to test this PR?

`mc admin subnet health` command should not add `logging` node in the health report.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
