### PR TITLE
tests: Avoid running TestNSRace in short test mode

### DIFF
--- a/cmd/namespace-lock_test.go
+++ b/cmd/namespace-lock_test.go
@@ -41,6 +41,10 @@ func TestGetSource(t *testing.T) {
 
 // Test lock race
 func TestNSLockRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	ctx := context.Background()
 
 	for i := 0; i < 10000; i++ {


### PR DESCRIPTION
## Description
TestNSRace takes almost half of time than the entire tests, add the possibility to avoid it with go test -short command.

## Motivation and Context
Shorten go test time in developers machines

## How to test this PR?
```
go test -short .
```
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
