### PR TITLE
make sure to preserve UUID from reference format

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -73,6 +73,8 @@ func initAutoHeal(ctx context.Context, objAPI ObjectLayer) {
 		}
 	}
 
+	go monitorLocalDisksInconsistentAndHeal(ctx, z, bgSeq)
+
 	go monitorLocalDisksAndHeal(ctx, z, bgSeq)
 }
 
@@ -96,12 +98,86 @@ func getLocalDisksToHeal() (disksToHeal Endpoints) {
 
 }
 
+func getLocalDisksToHealInconsistent() (refFormats []*formatErasureV3, diskFormats [][]*formatErasureV3, disksToHeal [][]StorageAPI) {
+	disksToHeal = make([][]StorageAPI, len(globalEndpoints))
+	diskFormats = make([][]*formatErasureV3, len(globalEndpoints))
+	refFormats = make([]*formatErasureV3, len(globalEndpoints))
+	for k, ep := range globalEndpoints {
+		disksToHeal[k] = make([]StorageAPI, len(ep.Endpoints))
+		diskFormats[k] = make([]*formatErasureV3, len(ep.Endpoints))
+		formats := make([]*formatErasureV3, len(ep.Endpoints))
+		storageDisks, _ := initStorageDisksWithErrors(ep.Endpoints)
+		for i, disk := range storageDisks {
+			if disk != nil {
+				format, err := loadFormatErasure(disk)
+				if err != nil {
+					// any error we don't care proceed.
+					continue
+				}
+				formats[i] = format
+			}
+		}
+		refFormat, err := getFormatErasureInQuorum(formats)
+		if err != nil {
+			logger.LogIf(GlobalContext, fmt.Errorf("No erasured disks are in quorum or too many disks are offline - please investigate immediately"))
+			continue
+		}
+		// We have obtained reference format - check if disks are inconsistent
+		for i, format := range formats {
+			if format == nil {
+				continue
+			}
+			if err := formatErasureV3Check(refFormat, format); err != nil {
+				if errors.Is(err, errInconsistentDisk) {
+					// Found inconsistencies - check which disk it is.
+					if storageDisks[i] != nil && storageDisks[i].IsLocal() {
+						disksToHeal[k][i] = storageDisks[i]
+					}
+				}
+			}
+		}
+		refFormats[k] = refFormat
+		diskFormats[k] = formats
+	}
+	return refFormats, diskFormats, disksToHeal
+}
+
 func initBackgroundHealing(ctx context.Context, objAPI ObjectLayer) {
 	// Run the background healer
 	globalBackgroundHealRoutine = newHealRoutine()
 	go globalBackgroundHealRoutine.run(ctx, objAPI)
 
 	globalBackgroundHealState.LaunchNewHealSequence(newBgHealSequence())
+}
+
+// monitorLocalDisksInconsistentAndHeal - ensures that inconsistent
+// disks are healed appropriately.
+func monitorLocalDisksInconsistentAndHeal(ctx context.Context, z *erasureServerSets, bgSeq *healSequence) {
+	// Perform automatic disk healing when a disk is found to be inconsistent.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(defaultMonitorNewDiskInterval):
+			waitForLowHTTPReq(int32(globalEndpoints.NEndpoints()), time.Second)
+
+			refFormats, diskFormats, localDisksHeal := getLocalDisksToHealInconsistent()
+			for k := range refFormats {
+				for j, disk := range localDisksHeal[k] {
+					if disk == nil {
+						continue
+					}
+					format := diskFormats[k][j].Clone()
+					format.Erasure.Sets = refFormats[k].Erasure.Sets
+					if err := saveFormatErasure(disk, format, true); err != nil {
+						logger.LogIf(ctx, fmt.Errorf("Unable fix inconsistent format for drive %s: %w", disk, err))
+						continue
+					}
+					globalBackgroundHealState.pushHealLocalDisks(disk.Endpoint())
+				}
+			}
+		}
+	}
 }
 
 // monitorLocalDisksAndHeal - ensures that detected new disks are healed
@@ -149,7 +225,10 @@ func monitorLocalDisksAndHeal(ctx context.Context, z *erasureServerSets, bgSeq *
 				}
 
 				// Calculate the set index where the current endpoint belongs
+				z.serverSets[zoneIdx].erasureDisksMu.RLock()
+				// Protect reading reference format.
 				setIndex, _, err := findDiskIndex(z.serverSets[zoneIdx].format, format)
+				z.serverSets[zoneIdx].erasureDisksMu.RUnlock()
 				if err != nil {
 					printEndpointError(endpoint, err, false)
 					continue
@@ -173,7 +252,7 @@ func monitorLocalDisksAndHeal(ctx context.Context, z *erasureServerSets, bgSeq *
 						logger.Info("Healing disk '%s' on %s zone complete", disk, humanize.Ordinal(i+1))
 
 						if err := disk.DeleteFile(ctx, pathJoin(minioMetaBucket, bucketMetaPrefix),
-							healingTrackerFilename); err != nil {
+							healingTrackerFilename); err != nil && !errors.Is(err, errFileNotFound) {
 							logger.LogIf(ctx, err)
 							continue
 						}

--- a/cmd/format-erasure_test.go
+++ b/cmd/format-erasure_test.go
@@ -27,7 +27,7 @@ import (
 
 // Test get offline/online uuids.
 func TestGetUUIDs(t *testing.T) {
-	fmtV2 := newFormatErasureV3(4, 16)
+	fmtV2 := newFormatErasureV3(4, 16, "CRCMOD")
 	formats := make([]*formatErasureV3, 64)
 
 	for i := 0; i < 4; i++ {
@@ -61,7 +61,12 @@ func TestGetUUIDs(t *testing.T) {
 		t.Errorf("Expected offline count '16', got '%d'", gotCount)
 	}
 
-	markUUIDsOffline(fmtV2, formats)
+	var errs []error
+	for i := 0; i < 4*16; i++ {
+		errs = append(errs, errUnformattedDisk)
+	}
+
+	markUUIDsOffline(fmtV2, formats, errs)
 	gotCount = 0
 	for i := range fmtV2.Erasure.Sets {
 		for j := range fmtV2.Erasure.Sets[i] {
@@ -93,7 +98,7 @@ func TestFixFormatV3(t *testing.T) {
 		}
 	}
 
-	format := newFormatErasureV3(1, 8)
+	format := newFormatErasureV3(1, 8, "CRCMOD")
 	formats := make([]*formatErasureV3, 8)
 
 	for j := 0; j < 8; j++ {
@@ -127,7 +132,7 @@ func TestFixFormatV3(t *testing.T) {
 
 // tests formatErasureV3ThisEmpty conditions.
 func TestFormatErasureEmpty(t *testing.T) {
-	format := newFormatErasureV3(1, 16)
+	format := newFormatErasureV3(1, 16, "CRCMOD")
 	formats := make([]*formatErasureV3, 16)
 
 	for j := 0; j < 16; j++ {
@@ -326,7 +331,7 @@ func TestGetFormatErasureInQuorumCheck(t *testing.T) {
 	setCount := 2
 	setDriveCount := 16
 
-	format := newFormatErasureV3(setCount, setDriveCount)
+	format := newFormatErasureV3(setCount, setDriveCount, "CRCMOD")
 	formats := make([]*formatErasureV3, 32)
 
 	for i := 0; i < setCount; i++ {
@@ -392,7 +397,7 @@ func TestGetErasureID(t *testing.T) {
 	setCount := 2
 	setDriveCount := 8
 
-	format := newFormatErasureV3(setCount, setDriveCount)
+	format := newFormatErasureV3(setCount, setDriveCount, "CRCMOD")
 	formats := make([]*formatErasureV3, 16)
 
 	for i := 0; i < setCount; i++ {
@@ -447,7 +452,7 @@ func TestNewFormatSets(t *testing.T) {
 	setCount := 2
 	setDriveCount := 16
 
-	format := newFormatErasureV3(setCount, setDriveCount)
+	format := newFormatErasureV3(setCount, setDriveCount, "CRCMOD")
 	formats := make([]*formatErasureV3, 32)
 	errs := make([]error, 32)
 

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -120,6 +120,12 @@ func healErasureSet(ctx context.Context, setIndex int, buckets []BucketInfo, dis
 		Name: pathJoin(minioMetaBucket, bucketConfigPrefix),
 	}) // add metadata .minio.sys/ bucket prefixes to heal
 
+	// Try to pro-actively heal backend-encrypted file.
+	bgSeq.sourceCh <- healSource{
+		bucket: minioMetaBucket,
+		object: backendEncryptedFile,
+	}
+
 	// Heal all buckets with all objects
 	for _, bucket := range buckets {
 		// Heal current bucket

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -278,7 +278,7 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 			humanize.Ordinal(zoneCount), setCount, setDriveCount)
 
 		// Initialize erasure code format on disks
-		format, err = initFormatErasure(GlobalContext, storageDisks, setCount, setDriveCount, deploymentID, sErrs)
+		format, err = initFormatErasure(GlobalContext, storageDisks, setCount, setDriveCount, "", deploymentID, sErrs)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -27,6 +27,9 @@ var errCorruptedFormat = StorageErr("corrupted backend format, specified disk mo
 // errUnformattedDisk - unformatted disk found.
 var errUnformattedDisk = StorageErr("unformatted disk found")
 
+// errInconsistentDisk - inconsistent disk found.
+var errInconsistentDisk = StorageErr("inconsistent disk found")
+
 // errUnsupporteDisk - when disk does not support O_DIRECT flag.
 var errUnsupportedDisk = StorageErr("disk does not support O_DIRECT")
 


### PR DESCRIPTION
## Description
make sure to preserve UUID from reference format

## Motivation and Context
reference format should be the source of truth
for inconsistent drives which reconnect,
add them back to their original position

## How to test this PR?
Requires taking the server down and bringing it up 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
