### PR TITLE
expire lockers if lockers are offline

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -178,7 +178,9 @@ func getDisksInfo(disks []StorageAPI, endpoints []string) (disksInfo []madmin.Di
 		}
 	}
 
-	if len(disksInfo) == rootDiskCount {
+	// Count offline disks as well to ensure consistent
+	// reportability of offline drives on local setups.
+	if len(disksInfo) == (rootDiskCount + offlineDisks.Sum()) {
 		// Success.
 		return disksInfo, errs, onlineDisks, offlineDisks
 	}

--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -35,6 +35,8 @@ type lockRequesterInfo struct {
 	// Owner represents the UUID of the owner who originally requested the lock
 	// useful in expiry.
 	Owner string
+	// Quorum represents the quorum required for this lock to be active.
+	Quorum int
 }
 
 // isWriteLock returns whether the lock is a write or read lock.
@@ -96,6 +98,7 @@ func (l *localLocker) Lock(ctx context.Context, args dsync.LockArgs) (reply bool
 				UID:           args.UID,
 				Timestamp:     UTCNow(),
 				TimeLastCheck: UTCNow(),
+				Quorum:        args.Quorum,
 			},
 		}
 	}
@@ -153,6 +156,7 @@ func (l *localLocker) RLock(ctx context.Context, args dsync.LockArgs) (reply boo
 		UID:           args.UID,
 		Timestamp:     UTCNow(),
 		TimeLastCheck: UTCNow(),
+		Quorum:        args.Quorum,
 	}
 	resource := args.Resources[0]
 	if lri, ok := l.lockMap[resource]; ok {

--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"io"
 	"net/url"
+	"strconv"
 
 	"github.com/minio/minio/cmd/http"
 	xhttp "github.com/minio/minio/cmd/http"
@@ -93,6 +94,7 @@ func (client *lockRESTClient) restCall(ctx context.Context, call string, args ds
 	values.Set(lockRESTUID, args.UID)
 	values.Set(lockRESTOwner, args.Owner)
 	values.Set(lockRESTSource, args.Source)
+	values.Set(lockRESTQuorum, strconv.Itoa(args.Quorum))
 	var buffer bytes.Buffer
 	for _, resource := range args.Resources {
 		buffer.WriteString(resource)

--- a/cmd/lock-rest-server-common.go
+++ b/cmd/lock-rest-server-common.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	lockRESTVersion       = "v3"
+	lockRESTVersion       = "v4" // Add Quorum query param
 	lockRESTVersionPrefix = SlashSeparator + lockRESTVersion
 	lockRESTPrefix        = minioReservedBucketPath + "/lock"
 )
@@ -43,6 +43,10 @@ const (
 	// Source contains the line number, function and file name of the code
 	// on the client node that requested the lock.
 	lockRESTSource = "source"
+
+	// Quroum value to be saved along lock requester info, useful
+	// in verifying stale locks
+	lockRESTQuorum = "quorum"
 )
 
 var (

--- a/pkg/dsync/drwmutex.go
+++ b/pkg/dsync/drwmutex.go
@@ -241,6 +241,7 @@ func lock(ctx context.Context, ds *Dsync, locks *[]string, id, source string, is
 				UID:       id,
 				Resources: lockNames,
 				Source:    source,
+				Quorum:    quorum,
 			}
 
 			var locked bool

--- a/pkg/dsync/rpc-client-interface.go
+++ b/pkg/dsync/rpc-client-interface.go
@@ -33,6 +33,9 @@ type LockArgs struct {
 	// Owner represents unique ID for this instance, an owner who originally requested
 	// the locked resource, useful primarily in figuring our stale locks.
 	Owner string
+
+	// Quorum represents the expected quorum for this lock type.
+	Quorum int
 }
 
 // NetLocker is dsync compatible locker interface.

--- a/pkg/madmin/top-commands.go
+++ b/pkg/madmin/top-commands.go
@@ -38,7 +38,8 @@ type LockEntry struct {
 	ServerList []string  `json:"serverlist"` // List of servers participating in the lock.
 	Owner      string    `json:"owner"`      // Owner UUID indicates server owns the lock.
 	ID         string    `json:"id"`         // UID to uniquely identify request of client.
-	Quorum     int       `json:"quorum"`     // represents quorum number of servers required to hold this lock, used to look for stale locks.
+	// Represents quorum number of servers required to hold this lock, used to look for stale locks.
+	Quorum int `json:"quorum"`
 }
 
 // LockEntries - To sort the locks


### PR DESCRIPTION

## Description
expire lockers if lockers are offline

## Motivation and Context
lockers currently might leave stale lockers,
in unknown ways waiting for downed lockers.

locker check interval is high enough to safely
cleanup stale locks.

## How to test this PR?
```sh
#!/usr/bin/env bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
export MINIO_ENDPOINTS="http://localhost:9001/tmp/fs-new1 http://localhost:9002/tmp/fs-new2 http://localhost:9003/tmp/fs-new3 http://localhost:9004/tmp/fs-new4 http://localhost:9005/tmp/fs-new5 http://localhost:9006/tmp/fs-new6 http://localhost:9007/tmp/fs-new7 http://localhost:9008/tmp/fs-new8"

for i in {01..08}; do
    "${GOPATH}/bin/minio" server --address ":90${i}" &
done
```

Run 8 servers and take down 5,6,7,8 and check `mc admin top locks --stale --json` - 
then bring back 8th server and then bring back 7th - with master we may lock forever
and never actually proceed to acquire locks.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
