### PR TITLE
fix: retain the previous UUID for newly replaced drives

### DIFF
--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -235,16 +234,7 @@ func newBootstrapRESTClient(endpoint Endpoint) *bootstrapRESTClient {
 
 	trFn := newInternodeHTTPTransport(tlsConfig, rest.DefaultTimeout)
 	restClient := rest.NewClient(serverURL, trFn, newAuthToken)
-	restClient.HealthCheckFn = func() bool {
-		ctx, cancel := context.WithTimeout(GlobalContext, restClient.HealthCheckTimeout)
-		// Instantiate a new rest client for healthcheck
-		// to avoid recursive healthCheckFn()
-		respBody, err := rest.NewClient(serverURL, trFn, newAuthToken).Call(ctx, bootstrapRESTMethodHealth, nil, nil, -1)
-		xhttp.DrainBody(respBody)
-		cancel()
-		var ne *rest.NetworkError
-		return !errors.Is(err, context.DeadlineExceeded) && !errors.As(err, &ne)
-	}
+	restClient.HealthCheckFn = nil
 
 	return &bootstrapRESTClient{endpoint: endpoint, restClient: restClient}
 }

--- a/cmd/erasure-decode_test.go
+++ b/cmd/erasure-decode_test.go
@@ -203,8 +203,9 @@ func TestErasureDecode(t *testing.T) {
 // This test is t.Skip()ed as it a long time to run, hence should be run
 // explicitly after commenting out t.Skip()
 func TestErasureDecodeRandomOffsetLength(t *testing.T) {
-	// Comment the following line to run this test.
-	t.SkipNow()
+	if testing.Short() {
+		t.Skip()
+	}
 	// Initialize environment needed for the test.
 	dataBlocks := 7
 	parityBlocks := 7

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -133,7 +133,7 @@ func (s *erasureSets) getDiskMap() map[string]StorageAPI {
 // Initializes a new StorageAPI from the endpoint argument, returns
 // StorageAPI and also `format` which exists on the disk.
 func connectEndpoint(endpoint Endpoint) (StorageAPI, *formatErasureV3, error) {
-	disk, err := newStorageAPI(endpoint)
+	disk, err := newStorageAPIWithoutHealthCheck(endpoint)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -221,7 +221,7 @@ func (s *erasureSets) connectDisks() {
 				}
 				return
 			}
-			if endpoint.IsLocal && disk.Healing() {
+			if disk.IsLocal() && disk.Healing() {
 				globalBackgroundHealState.pushHealLocalDisks(disk.Endpoint())
 				logger.Info(fmt.Sprintf("Found the drive %s that needs healing, attempting to heal...", disk))
 			}
@@ -232,13 +232,24 @@ func (s *erasureSets) connectDisks() {
 				printEndpointError(endpoint, err, false)
 				return
 			}
-			disk.SetDiskID(format.Erasure.This)
 
 			s.erasureDisksMu.Lock()
 			if s.erasureDisks[setIndex][diskIndex] != nil {
 				s.erasureDisks[setIndex][diskIndex].Close()
 			}
-			s.erasureDisks[setIndex][diskIndex] = disk
+			if disk.IsLocal() {
+				disk.SetDiskID(format.Erasure.This)
+				s.erasureDisks[setIndex][diskIndex] = disk
+			} else {
+				// Enable healthcheck disk for remote endpoint.
+				disk, err = newStorageAPI(endpoint)
+				if err != nil {
+					printEndpointError(endpoint, err, false)
+					return
+				}
+				disk.SetDiskID(format.Erasure.This)
+				s.erasureDisks[setIndex][diskIndex] = disk
+			}
 			s.endpointStrings[setIndex*s.setDriveCount+diskIndex] = disk.String()
 			s.erasureDisksMu.Unlock()
 			go func(setIndex int) {
@@ -1132,7 +1143,7 @@ func formatsToDrivesInfo(endpoints Endpoints, formats []*formatErasureV3, sErrs 
 // Reloads the format from the disk, usually called by a remote peer notifier while
 // healing in a distributed setup.
 func (s *erasureSets) ReloadFormat(ctx context.Context, dryRun bool) (err error) {
-	storageDisks, errs := initStorageDisksWithErrors(s.endpoints)
+	storageDisks, errs := initStorageDisksWithErrorsWithoutHealthCheck(s.endpoints)
 	for i, err := range errs {
 		if err != nil && err != errDiskNotFound {
 			return fmt.Errorf("Disk %s: %w", s.endpoints[i], err)
@@ -1182,6 +1193,15 @@ func (s *erasureSets) ReloadFormat(ctx context.Context, dryRun bool) (err error)
 		}
 
 		s.endpointStrings[m*s.setDriveCount+n] = disk.String()
+		if !disk.IsLocal() {
+			// Enable healthcheck disk for remote endpoint.
+			disk, err = newStorageAPI(disk.Endpoint())
+			if err != nil {
+				continue
+			}
+			disk.SetDiskID(diskID)
+		}
+
 		s.erasureDisks[m][n] = disk
 	}
 
@@ -1249,7 +1269,7 @@ func markRootDisksAsDown(storageDisks []StorageAPI, errs []error) {
 
 // HealFormat - heals missing `format.json` on fresh unformatted disks.
 func (s *erasureSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.HealResultItem, err error) {
-	storageDisks, errs := initStorageDisksWithErrors(s.endpoints)
+	storageDisks, errs := initStorageDisksWithErrorsWithoutHealthCheck(s.endpoints)
 	for i, derr := range errs {
 		if derr != nil && derr != errDiskNotFound {
 			return madmin.HealResultItem{}, fmt.Errorf("Disk %s: %w", s.endpoints[i], derr)
@@ -1298,39 +1318,8 @@ func (s *erasureSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.H
 		return res, errNoHealRequired
 	}
 
-	// Mark all UUIDs which might be offline, use list
-	// of formats to mark them appropriately.
-	markUUIDsOffline(refFormat, formats, sErrs)
-
 	// Initialize a new set of set formats which will be written to disk.
 	newFormatSets := newHealFormatSets(refFormat, s.setCount, s.setDriveCount, formats, sErrs)
-
-	// Look for all offline/unformatted disks in our reference format,
-	// such that we can fill them up with new UUIDs, this looping also
-	// ensures that the replaced disks allocated evenly across all sets.
-	// Making sure that the redundancy is not lost.
-	for i := range refFormat.Erasure.Sets {
-		for j := range refFormat.Erasure.Sets[i] {
-			if refFormat.Erasure.Sets[i][j] == offlineDiskUUID {
-				for l := range newFormatSets[i] {
-					if newFormatSets[i][l] == nil {
-						continue
-					}
-					if newFormatSets[i][l].Erasure.This == "" {
-						newFormatSets[i][l].Erasure.This = mustGetUUID()
-						refFormat.Erasure.Sets[i][j] = newFormatSets[i][l].Erasure.This
-						for m, v := range res.After.Drives {
-							if v.Endpoint == s.endpoints.GetString(i*s.setDriveCount+l) {
-								res.After.Drives[m].UUID = newFormatSets[i][l].Erasure.This
-								res.After.Drives[m].State = madmin.DriveStateOk
-							}
-						}
-						break
-					}
-				}
-			}
-		}
-	}
 
 	if !dryRun {
 		var tmpNewFormats = make([]*formatErasureV3, s.setCount*s.setDriveCount)
@@ -1339,8 +1328,9 @@ func (s *erasureSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.H
 				if newFormatSets[i][j] == nil {
 					continue
 				}
+				res.After.Drives[i*s.setDriveCount+j].UUID = newFormatSets[i][j].Erasure.This
+				res.After.Drives[i*s.setDriveCount+j].State = madmin.DriveStateOk
 				tmpNewFormats[i*s.setDriveCount+j] = newFormatSets[i][j]
-				tmpNewFormats[i*s.setDriveCount+j].Erasure.Sets = refFormat.Erasure.Sets
 			}
 		}
 
@@ -1382,7 +1372,16 @@ func (s *erasureSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.H
 			}
 
 			s.endpointStrings[m*s.setDriveCount+n] = disk.String()
+			if !disk.IsLocal() {
+				// Enable healthcheck disk for remote endpoint.
+				disk, err = newStorageAPI(disk.Endpoint())
+				if err != nil {
+					continue
+				}
+				disk.SetDiskID(diskID)
+			}
 			s.erasureDisks[m][n] = disk
+
 		}
 
 		s.erasureDisksMu.Unlock()

--- a/cmd/lock-rest-server.go
+++ b/cmd/lock-rest-server.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// Lock maintenance interval.
-	lockMaintenanceInterval = 15 * time.Second
+	lockMaintenanceInterval = 30 * time.Second
 
 	// Lock validity check interval.
 	lockValidityCheckInterval = 5 * time.Second
@@ -311,12 +311,8 @@ func lockMaintenance(ctx context.Context, interval time.Duration) error {
 
 			// less than the quorum, we have locks expired.
 			if nlripsMap[nlrip.name].locks < nlrip.lri.Quorum {
-				// The lock is no longer active at server that originated
-				// the lock, attempt to remove the lock.
-				globalLockServers[lendpoint].mutex.Lock()
 				// Purge the stale entry if it exists.
 				globalLockServers[lendpoint].removeEntryIfExists(nlrip)
-				globalLockServers[lendpoint].mutex.Unlock()
 			}
 
 		}

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -57,6 +57,18 @@ func isObjectDir(object string, size int64) bool {
 	return HasSuffix(object, SlashSeparator) && size == 0
 }
 
+func newStorageAPIWithoutHealthCheck(endpoint Endpoint) (storage StorageAPI, err error) {
+	if endpoint.IsLocal {
+		storage, err := newXLStorage(endpoint)
+		if err != nil {
+			return nil, err
+		}
+		return &xlStorageDiskIDCheck{storage: storage}, nil
+	}
+
+	return newStorageRESTClient(endpoint, false), nil
+}
+
 // Depending on the disk type network or local, initialize storage API.
 func newStorageAPI(endpoint Endpoint) (storage StorageAPI, err error) {
 	if endpoint.IsLocal {
@@ -67,7 +79,7 @@ func newStorageAPI(endpoint Endpoint) (storage StorageAPI, err error) {
 		return &xlStorageDiskIDCheck{storage: storage}, nil
 	}
 
-	return newStorageRESTClient(endpoint), nil
+	return newStorageRESTClient(endpoint, true), nil
 }
 
 // Cleanup a directory recursively.

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -454,7 +454,7 @@ func newStorageRESTHTTPServerClient(t *testing.T) (*httptest.Server, *storageRES
 	globalServerConfig = newServerConfig()
 	lookupConfigs(globalServerConfig, 0)
 
-	restClient := newStorageRESTClient(endpoint)
+	restClient := newStorageRESTClient(endpoint, false)
 
 	return httpServer, restClient, prevGlobalServerConfig, endpointPath
 }


### PR DESCRIPTION
## Description
fix: retain the previous UUID for newly replaced drives

## Motivation and Context
only newly replaced drives get the new `format.json`,
this avoids disks reloading their in-memory reference
format, ensures that drives are online without
reloading the in-memory reference format.
    
keeping reference format in-tact means UUIDs
never change once they are formatted.

## How to test this PR?
```
#!/usr/bin/env bash

export MINIO_ENDPOINTS="http://localhost:9001/tmp/fs-new1 http://localhost:9002/tmp/fs-new2 http://localhost:9003/tmp/fs-new3 http://localhost:9004/tmp/fs-new4 http://localhost:9005/tmp/fs-new5 http://localhost:9006/tmp/fs-new6 http://localhost:9007/tmp/fs-new7 http://localhost:9008/tmp/fs-new8"

for i in {01..08}; do
    "${GOPATH}/bin/minio" server --address ":90${i}" &
done
```
Take 5,6,7,8 down and delete `8th` backend and observe UUID is preserved. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
