### PR TITLE
fix: heal rejects objects with disk re-ordering issue

### DIFF
--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -221,6 +221,17 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 	partsMetadata []FileInfo, errs []error, latestFileInfo FileInfo,
 	dryRun bool, remove bool, scanMode madmin.HealScanMode) (result madmin.HealResultItem, err error) {
 
+	for i, metadata := range shufflePartsMetadata(partsMetadata, latestFileInfo.Erasure.Distribution) {
+		if !metadata.IsValid() {
+			continue
+		}
+		if i != metadata.Erasure.Index-1 {
+			// FIXME: fix in the next release for objects which erasure.Index does not match
+			// with expected distribution.
+			return result, fmt.Errorf("Unable to heal object %s, disk ordering issue detected", pathJoin(bucket, object))
+		}
+	}
+
 	dataBlocks := latestFileInfo.Erasure.DataBlocks
 
 	storageDisks := er.getDisks()


### PR DESCRIPTION

## Description
For objects with disk ordering issues, we will not heal them. Instead a proper fix will be done in the subsequent release

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
