### PR TITLE
Add update retry limit and compare error by string instead

### DIFF
--- a/cmd/metacache-server-sets.go
+++ b/cmd/metacache-server-sets.go
@@ -197,7 +197,7 @@ func (z *erasureServerSets) listPath(ctx context.Context, o listPathOptions) (en
 			allAtEOF = false
 			continue
 		}
-		if err == io.EOF {
+		if err.Error() == io.EOF.Error() {
 			continue
 		}
 		logger.LogIf(ctx, err)

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -319,7 +319,7 @@ func (r *metacacheReader) filter(o listPathOptions) (entries metaCacheEntriesSor
 			entries.o = append(entries.o, entry)
 			return entries.len() < o.Limit
 		})
-		if err != nil && err.Error() == io.EOF.Error() || pastPrefix || r.nextEOF() {
+		if (err != nil && err.Error() == io.EOF.Error()) || pastPrefix || r.nextEOF() {
 			return entries, io.EOF
 		}
 		return entries, err

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -663,10 +663,10 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 				if err == nil {
 					break
 				}
-				switch err {
-				case ObjectNotFound{}:
+				switch err.(type) {
+				case ObjectNotFound:
 					return err
-				case InsufficientReadQuorum{}:
+				case InsufficientReadQuorum:
 				default:
 					logger.LogIf(ctx, err)
 				}

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -319,7 +319,7 @@ func (r *metacacheReader) filter(o listPathOptions) (entries metaCacheEntriesSor
 			entries.o = append(entries.o, entry)
 			return entries.len() < o.Limit
 		})
-		if err == io.EOF || pastPrefix || r.nextEOF() {
+		if err != nil && err.Error() == io.EOF.Error() || pastPrefix || r.nextEOF() {
 			return entries, io.EOF
 		}
 		return entries, err
@@ -632,6 +632,9 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 			}
 		}()
 
+		const retryDelay = 200 * time.Millisecond
+		const maxTries = 10
+
 		// Write results to disk.
 		bw := newMetacacheBlockWriter(cacheCh, func(b *metacacheBlock) error {
 			if debugPrint {
@@ -654,13 +657,24 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 				return nil
 			}
 			// Update block 0 metadata.
+			var retries int
 			for {
 				err := er.updateObjectMeta(ctx, minioMetaBucket, o.objectPath(0), b.headerKV(), ObjectOptions{})
 				if err == nil {
 					break
 				}
-				logger.LogIf(ctx, err)
-				time.Sleep(100 * time.Millisecond)
+				switch err {
+				case ObjectNotFound{}:
+					return err
+				case InsufficientReadQuorum{}:
+				default:
+					logger.LogIf(ctx, err)
+				}
+				if retries >= maxTries {
+					return err
+				}
+				retries++
+				time.Sleep(retryDelay)
 			}
 			return nil
 		})


### PR DESCRIPTION
## Description

Fixes for errors seen in Subnet no 1073

Add max update attempts to caches.

If 'Object not found' return at once.

Strangely a non-equal `io.EOF`, but with similar text occurred. Added some checks for that.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
