### PR TITLE
fix: handle a crash when AskDisks is set to -1

### DIFF
--- a/cmd/data-update-tracker.go
+++ b/cmd/data-update-tracker.go
@@ -403,7 +403,7 @@ func (d *dataUpdateTracker) deserialize(src io.Reader, newerThan time.Time) erro
 		return err
 	}
 	switch tmp[0] {
-	case 1, 2:
+	case 1, 2, 3:
 		logger.Info(color.Green("dataUpdateTracker: ") + "deprecated data version, updating.")
 		return nil
 	case dataUpdateTrackerVersion:

--- a/cmd/metacache-server-sets.go
+++ b/cmd/metacache-server-sets.go
@@ -124,6 +124,9 @@ func (z *erasureServerSets) listPath(ctx context.Context, o listPathOptions) (en
 		case "disk":
 			// Ask single disk.
 			o.AskDisks = 1
+		default:
+			// By default asks at max 3 disks.
+			o.AskDisks = 3
 		}
 	}
 

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -542,17 +542,9 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 	// We need to ask disks.
 	disks := er.getOnlineDisks()
 
-	var askDisks = o.AskDisks
-	switch askDisks {
-	// 50% or at least 3.
-	case -1:
-		o.AskDisks = getReadQuorum(len(er.getDisks()))
-		if o.AskDisks < 3 {
-			o.AskDisks = 3
-		}
-	// Default is 3 disks.
-	case 0:
-		askDisks = 3
+	askDisks := o.AskDisks
+	if askDisks == -1 {
+		askDisks = getReadQuorum(er.SetDriveCount())
 	}
 
 	if len(disks) < askDisks {
@@ -565,10 +557,11 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 		return
 	}
 
-	// Select askDisks random disks, 3 is ok.
+	// Select askDisks random disks.
 	if len(disks) > askDisks {
 		disks = disks[:askDisks]
 	}
+
 	var readers = make([]*metacacheReader, askDisks)
 	for i := range disks {
 		r, w := io.Pipe()

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -852,6 +852,10 @@ func (client *peerRESTClient) ConsoleLog(logCh chan interface{}, doneCh <-chan s
 // but 'all' will contain nil entry for local client.
 // The 'all' slice will be in the same order across the cluster.
 func newPeerRestClients(endpoints EndpointServerSets) (remote, all []*peerRESTClient) {
+	if !globalIsDistErasure {
+		// Only useful in distributed setups
+		return nil, nil
+	}
 	hosts := endpoints.hostsSorted()
 	remote = make([]*peerRESTClient, 0, len(hosts))
 	all = make([]*peerRESTClient, len(hosts))


### PR DESCRIPTION
## Description
fix: handle a crash when AskDisks is set to -1

## Motivation and Context
fix a crash when MINIO_API_LIST_STRICT_QUORUM=on

## How to test this PR?
compile master and enable `MINIO_API_LIST_STRICT_QUORUM=on` start 
an erasure-coded setup

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
