### PR TITLE
madmin obd: Remove unused log constants

### DIFF
--- a/pkg/madmin/obd.go
+++ b/pkg/madmin/obd.go
@@ -185,7 +185,6 @@ const (
 	OBDDataTypeSysMem      OBDDataType = "sysmem"
 	OBDDataTypeSysNet      OBDDataType = "sysnet"
 	OBDDataTypeSysProcess  OBDDataType = "sysprocess"
-	OBDDataTypeLog         OBDDataType = "log"
 )
 
 // OBDDataTypesMap - Map of OBD datatypes
@@ -202,7 +201,6 @@ var OBDDataTypesMap = map[string]OBDDataType{
 	"sysmem":      OBDDataTypeSysMem,
 	"sysnet":      OBDDataTypeSysNet,
 	"sysprocess":  OBDDataTypeSysProcess,
-	"log":         OBDDataTypeLog,
 }
 
 // OBDDataTypesList - List of OBD datatypes
@@ -219,7 +217,6 @@ var OBDDataTypesList = []OBDDataType{
 	OBDDataTypeSysMem,
 	OBDDataTypeSysNet,
 	OBDDataTypeSysProcess,
-	OBDDataTypeLog,
 }
 
 // ServerOBDInfo - Connect to a minio server and call OBD Info Management API


### PR DESCRIPTION
## Description
Removing the unused constants from madmin package

## Motivation and Context
This shows up in mc as an optional value.

## How to test this PR?
when you run 
```
$ mc admin subnet health play --test
Incorrect Usage: invalid value "play" for flag -test: valid options include perfdrive,perfnet,minioinfo,minioconfig,syscpu,sysdiskhw,sysdocker,sysosinfo,sysload,sysmem,sysnet,sysprocess,log
```
it should not show log as an option

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
