### PR TITLE
fix: A possible crash when fi.Erasure.Distribution is empty

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -90,9 +90,12 @@ func (fi FileInfo) IsValid() bool {
 	}
 	dataBlocks := fi.Erasure.DataBlocks
 	parityBlocks := fi.Erasure.ParityBlocks
+	correctIndexes := (fi.Erasure.Index > 0 &&
+		fi.Erasure.Index <= dataBlocks+parityBlocks &&
+		len(fi.Erasure.Distribution) == (dataBlocks+parityBlocks))
 	return ((dataBlocks >= parityBlocks) &&
 		(dataBlocks != 0) && (parityBlocks != 0) &&
-		(fi.Erasure.Index > 0 && fi.Erasure.Distribution != nil))
+		correctIndexes)
 }
 
 // ToObjectInfo - Converts metadata to object info.


### PR DESCRIPTION
## Description
fix: A possible crash when fi.Erasure.Distribution is empty

## Motivation and Context
rare but possible seen in a customer environment

## How to test this PR?
No real way to reproduce this issue has been found

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
