### PR TITLE
re-use remote transports in Peer, Storage, Locker clients

### DIFF
--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -224,16 +223,7 @@ func newBootstrapRESTClient(endpoint Endpoint) *bootstrapRESTClient {
 		Path:   bootstrapRESTPath,
 	}
 
-	var tlsConfig *tls.Config
-	if globalIsSSL {
-		tlsConfig = &tls.Config{
-			ServerName: endpoint.Hostname(),
-			RootCAs:    globalRootCAs,
-		}
-	}
-
-	trFn := newInternodeHTTPTransport(tlsConfig, rest.DefaultTimeout)
-	restClient := rest.NewClient(serverURL, trFn, newAuthToken)
+	restClient := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken)
 	restClient.HealthCheckFn = nil
 
 	return &bootstrapRESTClient{endpoint: endpoint, restClient: restClient}

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -840,7 +840,7 @@ func getOnlineProxyEndpointIdx() int {
 }
 
 // GetProxyEndpoints - get all endpoints that can be used to proxy list request.
-func GetProxyEndpoints(endpointServerSets EndpointServerSets) ([]ProxyEndpoint, error) {
+func GetProxyEndpoints(endpointServerSets EndpointServerSets) []ProxyEndpoint {
 	var proxyEps []ProxyEndpoint
 
 	proxyEpSet := set.NewStringSet()
@@ -874,7 +874,7 @@ func GetProxyEndpoints(endpointServerSets EndpointServerSets) ([]ProxyEndpoint, 
 			})
 		}
 	}
-	return proxyEps, nil
+	return proxyEps
 }
 
 func updateDomainIPs(endPoints set.StringSet) {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"crypto/x509"
+	"net/http"
 	"os"
 	"time"
 
@@ -274,6 +275,8 @@ var (
 	globalFSOSync bool
 
 	globalProxyEndpoints []ProxyEndpoint
+
+	globalInternodeTransport http.RoundTripper
 
 	globalDNSCache *xhttp.DNSCache
 	// Add new variable global values here.

--- a/cmd/lock-rest-client_test.go
+++ b/cmd/lock-rest-client_test.go
@@ -29,6 +29,7 @@ func TestLockRESTlient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
+
 	lkClient := newlockRESTClient(endpoint)
 	if !lkClient.IsOnline() {
 		t.Fatalf("unexpected error. connection failed")

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -300,14 +300,12 @@ func LogIf(ctx context.Context, err error, errKind ...interface{}) {
 		return
 	}
 
-	if errors.Is(err, context.Canceled) || errors.Is(err, http.ErrServerClosed) {
+	if errors.Is(err, context.Canceled) {
 		return
 	}
 
-	if e := errors.Unwrap(err); e != nil {
-		if e.Error() == "disk not found" {
-			return
-		}
+	if err.Error() == http.ErrServerClosed.Error() || err.Error() == "disk not found" {
+		return
 	}
 
 	logIf(ctx, err, errKind...)

--- a/cmd/logger/logonce.go
+++ b/cmd/logger/logonce.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"net/http"
 	"sync"
-
 	"time"
 )
 
@@ -83,14 +82,12 @@ func LogOnceIf(ctx context.Context, err error, id interface{}, errKind ...interf
 		return
 	}
 
-	if errors.Is(err, context.Canceled) || errors.Is(err, http.ErrServerClosed) {
+	if errors.Is(err, context.Canceled) {
 		return
 	}
 
-	if e := errors.Unwrap(err); e != nil {
-		if e.Error() == "disk not found" {
-			return
-		}
+	if err.Error() == http.ErrServerClosed.Error() || err.Error() == "disk not found" {
+		return
 	}
 
 	logOnce.logOnceIf(ctx, err, id, errKind...)

--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -164,10 +164,9 @@ func (c *Client) Close() {
 }
 
 // NewClient - returns new REST client.
-func NewClient(url *url.URL, newCustomTransport func() *http.Transport, newAuthToken func(aud string) string) *Client {
+func NewClient(url *url.URL, tr http.RoundTripper, newAuthToken func(aud string) string) *Client {
 	// Transport is exactly same as Go default in https://golang.org/pkg/net/http/#RoundTripper
 	// except custom DialContext and TLSClientConfig.
-	tr := newCustomTransport()
 	return &Client{
 		httpClient:          &http.Client{Transport: tr},
 		url:                 url,

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/gob"
 	"encoding/hex"
 	"errors"
@@ -670,22 +669,13 @@ func newStorageRESTClient(endpoint Endpoint, healthcheck bool) *storageRESTClien
 		Path:   path.Join(storageRESTPrefix, endpoint.Path, storageRESTVersion),
 	}
 
-	var tlsConfig *tls.Config
-	if globalIsSSL {
-		tlsConfig = &tls.Config{
-			ServerName: endpoint.Hostname(),
-			RootCAs:    globalRootCAs,
-		}
-	}
-
-	trFn := newInternodeHTTPTransport(tlsConfig, rest.DefaultTimeout)
-	restClient := rest.NewClient(serverURL, trFn, newAuthToken)
+	restClient := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken)
 	if healthcheck {
 		restClient.HealthCheckFn = func() bool {
 			ctx, cancel := context.WithTimeout(GlobalContext, restClient.HealthCheckTimeout)
 			// Instantiate a new rest client for healthcheck
 			// to avoid recursive healthCheckFn()
-			respBody, err := rest.NewClient(serverURL, trFn, newAuthToken).Call(ctx, storageRESTMethodHealth, nil, nil, -1)
+			respBody, err := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken).Call(ctx, storageRESTMethodHealth, nil, nil, -1)
 			xhttp.DrainBody(respBody)
 			cancel()
 			return !errors.Is(err, context.DeadlineExceeded) && toStorageErr(err) != errDiskNotFound

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/minio/minio/cmd/crypto"
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/cmd/rest"
 	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/bucket/policy"
 	"github.com/minio/minio/pkg/hash"
@@ -69,6 +70,7 @@ import (
 // TestMain to set up global env.
 func TestMain(m *testing.M) {
 	flag.Parse()
+
 	globalActiveCred = auth.Credentials{
 		AccessKey: auth.DefaultAccessKey,
 		SecretKey: auth.DefaultSecretKey,
@@ -106,6 +108,8 @@ func TestMain(m *testing.M) {
 	globalConsoleSys = NewConsoleLogger(context.Background())
 
 	globalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second)
+
+	globalInternodeTransport = newInternodeHTTPTransport(nil, rest.DefaultTimeout)()
 
 	initHelp()
 


### PR DESCRIPTION
## Description
re-use remote transports in Peer, Storage, Locker clients

## Motivation and Context
use one transport for internode communication

## How to test this PR?
A major change of sort for optimized connection usage

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
