### PR TITLE
remove unnecessary logging and move to log once

### DIFF
--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"go/build"
 	"hash"
+	"net/http"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -299,9 +300,17 @@ func LogIf(ctx context.Context, err error, errKind ...interface{}) {
 		return
 	}
 
-	if !errors.Is(err, context.Canceled) {
-		logIf(ctx, err, errKind...)
+	if errors.Is(err, context.Canceled) || errors.Is(err, http.ErrServerClosed) {
+		return
 	}
+
+	if e := errors.Unwrap(err); e != nil {
+		if e.Error() == "disk not found" {
+			return
+		}
+	}
+
+	logIf(ctx, err, errKind...)
 }
 
 // logIf prints a detailed error message during

--- a/cmd/metacache-bucket.go
+++ b/cmd/metacache-bucket.go
@@ -398,7 +398,7 @@ func (b *bucketMetacache) deleteAll() {
 		wg.Add(1)
 		go func(cache metacache) {
 			defer wg.Done()
-			logger.LogIf(ctx, ez.deleteAll(ctx, minioMetaBucket, metacachePrefixForID(cache.bucket, cache.id)))
+			ez.deleteAll(ctx, minioMetaBucket, metacachePrefixForID(cache.bucket, cache.id))
 		}(b.caches[id])
 		delete(b.caches, id)
 	}
@@ -426,6 +426,6 @@ func (b *bucketMetacache) deleteCache(id string) {
 			logger.LogIf(ctx, errors.New("bucketMetacache: expected objAPI to be *erasureServerSets"))
 			return
 		}
-		logger.LogIf(ctx, ez.deleteAll(ctx, minioMetaBucket, metacachePrefixForID(c.bucket, c.id)))
+		ez.deleteAll(ctx, minioMetaBucket, metacachePrefixForID(c.bucket, c.id))
 	}
 }

--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -27,8 +27,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/minio/minio/cmd/logger"
-
 	xhttp "github.com/minio/minio/cmd/http"
 	xnet "github.com/minio/minio/pkg/net"
 )
@@ -119,7 +117,6 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if xnet.IsNetworkOrHostDown(err, c.ExpectTimeouts) {
-			logger.LogIf(ctx, err, "marking disk offline")
 			c.MarkOffline()
 		}
 		return nil, &NetworkError{err}
@@ -149,7 +146,6 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 		b, err := ioutil.ReadAll(io.LimitReader(resp.Body, c.MaxErrResponseSize))
 		if err != nil {
 			if xnet.IsNetworkOrHostDown(err, c.ExpectTimeouts) {
-				logger.LogIf(ctx, err, "marking disk offline")
 				c.MarkOffline()
 			}
 			return nil, err


### PR DESCRIPTION
## Description
remove unnecessary logging and move to log once

## Motivation and Context
the current master logs way too much when a node
is down, instead log once and move on. 

## How to test this PR?
run a distributed setup and take one or more servers down

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
