### PR TITLE
Recreate bucket metacache if corrupted

### DIFF
--- a/cmd/metacache-manager.go
+++ b/cmd/metacache-manager.go
@@ -45,7 +45,7 @@ const metacacheManagerTransientBucket = "**transient**"
 // initManager will start async saving the cache.
 func (m *metacacheManager) initManager() {
 	// Add a transient bucket.
-	tb := newBucketMetacache(metacacheManagerTransientBucket)
+	tb := newBucketMetacache(metacacheManagerTransientBucket, false)
 	tb.transient = true
 	m.buckets[metacacheManagerTransientBucket] = tb
 


### PR DESCRIPTION
## Description

If bucket metadata cannot be read, clean up existing and create a new.

## Motivation and Context

If bucket metadata ended up with a read quorum error there was no automatic recovery.

Cleanup will remove any leftover data from the lost cache information.

## How to test this PR?

Make the `.minio.sys/buckets/BUCKET/.metacache/index.s2` impossible to read.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
