### PR TITLE
Clean up metadata cache when deleting bucket

### DIFF
--- a/cmd/metacache-manager.go
+++ b/cmd/metacache-manager.go
@@ -128,6 +128,18 @@ func (m *metacacheManager) getBucket(ctx context.Context, bucket string) *bucket
 	return b
 }
 
+// deleteBucketCache will delete the bucket cache if it exists.
+func (m *metacacheManager) deleteBucketCache(bucket string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.buckets[bucket]
+	if !ok {
+		return
+	}
+	b.deleteAll()
+	delete(m.buckets, bucket)
+}
+
 // deleteAll will delete all caches.
 func (m *metacacheManager) deleteAll() {
 	m.mu.Lock()

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -675,6 +675,9 @@ func (sys *NotificationSys) LoadBucketMetadata(ctx context.Context, bucketName s
 // DeleteBucketMetadata - calls DeleteBucketMetadata call on all peers
 func (sys *NotificationSys) DeleteBucketMetadata(ctx context.Context, bucketName string) {
 	globalBucketMetadataSys.Remove(bucketName)
+	if localMetacacheMgr != nil {
+		localMetacacheMgr.deleteBucketCache(bucketName)
+	}
 
 	ng := WithNPeers(len(sys.peerClients))
 	for idx, client := range sys.peerClients {

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -538,7 +538,9 @@ func (s *peerRESTServer) DeleteBucketMetadataHandler(w http.ResponseWriter, r *h
 	}
 
 	globalBucketMetadataSys.Remove(bucketName)
-	w.(http.Flusher).Flush()
+	if localMetacacheMgr != nil {
+		localMetacacheMgr.deleteBucketCache(bucketName)
+	}
 }
 
 // LoadBucketMetadataHandler - reloads in memory bucket metadata


### PR DESCRIPTION
## Description

Metadata caches were left behind when deleting a bucket.

## How to test this PR?

Create a bucket. Put in some content. Do a listing. Delete the bucket.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
