### PR TITLE
fix: dangling objects on actual namespace

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -373,7 +373,7 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 				// Remove the dangling object only when:
 				//  - This is a non versioned bucket
 				//  - This is a versioned bucket and the version ID is passed, the reason
-				//    is that it is hard to pick that particular version that is dangling
+				//    is that we cannot fetch the ID of the latest version when we don't trust xl.meta
 				if !opts.Versioned || opts.VersionID != "" {
 					er.deleteObjectVersion(ctx, bucket, object, 1, FileInfo{
 						Name:      object,

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -2242,9 +2242,15 @@ func generateTLSCertKey(host string) ([]byte, []byte, error) {
 
 func mustGetZoneEndpoints(args ...string) EndpointServerSets {
 	endpoints := mustGetNewEndpoints(args...)
+	drivesPerSet := len(args)
+	setCount := 1
+	if len(args) >= 16 {
+		drivesPerSet = 16
+		setCount = len(args) / 16
+	}
 	return []ZoneEndpoints{{
-		SetCount:     1,
-		DrivesPerSet: len(args),
+		SetCount:     setCount,
+		DrivesPerSet: drivesPerSet,
 		Endpoints:    endpoints,
 	}}
 }


### PR DESCRIPTION
## Description
fix: dangling objects on actual namespace

## Motivation and Context
continuation of PR #10765 but with protections 
to handle only objects on the actual namespace

## How to test this PR?
as per go unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
