### PR TITLE
fix: honor delimiter as per AWS S3 spec

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -301,6 +301,20 @@ func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, aft
 	prevPrefix := ""
 	for _, entry := range m.o {
 		if entry.isObject() {
+			if delimiter != "" {
+				idx := strings.Index(strings.TrimPrefix(entry.name, prefix), delimiter)
+				if idx >= 0 {
+					idx = len(prefix) + idx + len(delimiter)
+					currPrefix := entry.name[:idx]
+					if currPrefix == prevPrefix {
+						continue
+					}
+					prevPrefix = currPrefix
+					commonPrefixes = append(commonPrefixes, currPrefix)
+					continue
+				}
+			}
+
 			fiv, err := entry.fileInfoVersions(bucket)
 			if afterV != "" {
 				// Forward first entry to specified version
@@ -314,6 +328,7 @@ func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, aft
 			}
 			continue
 		}
+
 		if entry.isDir() {
 			if delimiter == "" {
 				continue
@@ -343,6 +358,20 @@ func (m *metaCacheEntriesSorted) fileInfos(bucket, prefix, delimiter string) (ob
 	prevPrefix := ""
 	for _, entry := range m.o {
 		if entry.isObject() {
+			if delimiter != "" {
+				idx := strings.Index(strings.TrimPrefix(entry.name, prefix), delimiter)
+				if idx >= 0 {
+					idx = len(prefix) + idx + len(delimiter)
+					currPrefix := entry.name[:idx]
+					if currPrefix == prevPrefix {
+						continue
+					}
+					prevPrefix = currPrefix
+					commonPrefixes = append(commonPrefixes, currPrefix)
+					continue
+				}
+			}
+
 			fi, err := entry.fileInfo(bucket)
 			if err == nil {
 				objects = append(objects, fi.ToObjectInfo(bucket, entry.name))


### PR DESCRIPTION
## Description
fix: honor delimiter as per AWS S3 spec

## Motivation and Context
custom delimiters were not honored as per AWS S3 spec
thanks to @krishnasrinivas for finding Splunk incompatible 
behavior

## How to test this PR?
Added unit tests to cover the scenarios.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
