### PR TITLE
Don't replace caches that are receiving updates

### DIFF
--- a/cmd/metacache-bucket.go
+++ b/cmd/metacache-bucket.go
@@ -372,24 +372,7 @@ func (b *bucketMetacache) updateCacheEntry(update metacache) (metacache, error) 
 		logger.Info("updateCacheEntry: bucket %s list id %v not found", b.bucket, update.id)
 		return update, errFileNotFound
 	}
-
-	existing.lastUpdate = UTCNow()
-
-	if existing.status == scanStateStarted && update.status == scanStateSuccess {
-		existing.ended = UTCNow()
-		existing.endedCycle = update.endedCycle
-	}
-
-	if existing.status == scanStateStarted && update.status != scanStateStarted {
-		existing.status = update.status
-	}
-
-	if existing.error == "" && update.error != "" {
-		existing.error = update.error
-		existing.status = scanStateError
-		existing.ended = UTCNow()
-	}
-	existing.fileNotFound = existing.fileNotFound || update.fileNotFound
+	existing.update(update)
 	b.caches[update.id] = existing
 	b.updated = true
 	return existing, nil


### PR DESCRIPTION
## Description

Keep caches while they are receiving updates.
Move update code to separate function.

## How to test this PR?

In huge cluster where listing speed isn't synchronized the first listing that completes will mark the cache as successful.

There may however still be other sets that are still listing, so we need to keep the cache while they are still providing updates.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
