### PR TITLE
metacache: Always close the s2 writer

### DIFF
--- a/cmd/metacache-stream_test.go
+++ b/cmd/metacache-stream_test.go
@@ -47,11 +47,6 @@ func loadMetacacheSampleEntries(t testing.TB) metaCacheEntriesSorted {
 	if err != io.EOF {
 		t.Fatal(err)
 	}
-	if false {
-		w := newMetacacheFile("testdata/metacache-new.s2")
-		w.write(entries.entries()...)
-		w.Close()
-	}
 
 	return entries
 }


### PR DESCRIPTION
## Description

The s2 writer could be leaked if there was an error.

Make sure it is always closed.

Remove file writer. No need for this unused, duplicate code.

## How to test this PR?

Check gouroutine dumps.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
