### PR TITLE
fix: add missing deleted key element in multiObjectDelete

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -461,7 +461,10 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 
 	deletedObjects := make([]DeletedObject, len(deleteObjects.Objects))
 	for i := range errs {
-		dindex := objectsToDelete[deleteList[i]]
+		dindex := objectsToDelete[ObjectToDelete{
+			ObjectName: dObjects[i].ObjectName,
+			VersionID:  dObjects[i].VersionID,
+		}]
 		apiErr := toAPIError(ctx, errs[i])
 		if apiErr.Code == "" || apiErr.Code == "NoSuchKey" || apiErr.Code == "InvalidArgument" {
 			deletedObjects[dindex] = dObjects[i]


### PR DESCRIPTION

## Description
fix: add missing deleted key element in multiObjectDelete

## Motivation and Context
fixes #10832

## How to test this PR?
```
~  aws --profile minio --endpoint-url http://localhost:9001 s3api delete-objects --bucket testbucket --delete file:///tmp/del.json
{
    "Deleted": [
        {
            "Key": "dir1/"
        },
        {
            "Key": "dir2/"
        },
        {
            "Key": "dir2/7.jpg"
        }
    ]
}
```

```json
{
  "Objects": [
    {
      "Key": "dir1/"
    },
    {
      "Key": "dir2/"
    },
    {
      "Key": "dir2/7.jpg"
    }
  ],
  "Quiet": false
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
