### PR TITLE
Fixes Gateway S3 SSE pagination

### DIFF
--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -65,8 +65,8 @@ type s3EncObjects struct {
 
 // ListObjects lists all blobs in S3 bucket filtered by prefix
 func (l *s3EncObjects) ListObjects(ctx context.Context, bucket string, prefix string, marker string, delimiter string, maxKeys int) (loi minio.ListObjectsInfo, e error) {
-	var continuationToken, startAfter string
-	res, err := l.ListObjectsV2(ctx, bucket, prefix, continuationToken, delimiter, maxKeys, false, startAfter)
+	var startAfter string
+	res, err := l.ListObjectsV2(ctx, bucket, prefix, marker, delimiter, maxKeys, false, startAfter)
 	if err != nil {
 		return loi, err
 	}
@@ -91,10 +91,12 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 		if e != nil {
 			return loi, minio.ErrorRespToObjectError(e, bucket)
 		}
+
+		continuationToken = loi.NextContinuationToken
+		isTruncated = loi.IsTruncated
+
 		for _, obj := range loi.Objects {
 			startAfter = obj.Name
-			continuationToken = loi.NextContinuationToken
-			isTruncated = loi.IsTruncated
 
 			if !isGWObject(obj.Name) {
 				continue


### PR DESCRIPTION
## Description
Fixes #10838 and an additional bug that causes an endless loop when the data returned from the S3 backend contains only prefixes and no objects. Moving the assignment of the `continuationToken` to outside of the object-loop fixes this issue.

## Motivation and Context
See #10838. This fixes pagination issues with both the ListObjectV1 and ListObjectV2 APIs for the S3 Gateway with SSE.

## How to test this PR?
Run `mc ls` against an S3 Gateway with SSE enabled. With previous versions, listing a folder with >1000 prefixes (but without any actual leaf objects) will hang indefinitely. With this PR, `mc ls` will actually work.

Furthermore, the Python script in #10838 is successfully able to complete with this PR.
 
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
