### PR TITLE
Reduce health check output

### DIFF
--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 	"net/url"
 	"strconv"
@@ -28,6 +27,7 @@ import (
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/rest"
 	"github.com/minio/minio/pkg/dsync"
+	xnet "github.com/minio/minio/pkg/net"
 )
 
 // lockRESTClient is authenticable lock REST client
@@ -153,15 +153,15 @@ func newlockRESTClient(endpoint Endpoint) *lockRESTClient {
 
 	restClient := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken)
 	restClient.ExpectTimeouts = true
+	// Use a separate client to avoid recursive calls.
+	healthClient := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken)
+	healthClient.ExpectTimeouts = true
 	restClient.HealthCheckFn = func() bool {
 		ctx, cancel := context.WithTimeout(GlobalContext, restClient.HealthCheckTimeout)
-		// Instantiate a new rest client for healthcheck
-		// to avoid recursive healthCheckFn()
-		respBody, err := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken).Call(ctx, lockRESTMethodHealth, nil, nil, -1)
+		defer cancel()
+		respBody, err := healthClient.Call(ctx, lockRESTMethodHealth, nil, nil, -1)
 		xhttp.DrainBody(respBody)
-		cancel()
-		var ne *rest.NetworkError
-		return !errors.Is(err, context.DeadlineExceeded) && !errors.As(err, &ne)
+		return !xnet.IsNetworkOrHostDown(err, false)
 	}
 
 	return &lockRESTClient{endpoint: endpoint, restClient: restClient}


### PR DESCRIPTION
## Description

This will make the health check clients 'silent'.
Use `IsNetworkOrHostDown` determine if network is ok so it mimics the functionality in the actual client.

## How to test this PR?

`TestNSLockRace` for instance print debug messages before.

## Types of changes
- [x] Clean up
