### PR TITLE
Fix negative STS IAM token TTL value

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -725,7 +725,7 @@ func (sys *IAMSys) SetTempUser(accessKey string, cred auth.Credentials, policyNa
 	sys.store.lock()
 	defer sys.store.unlock()
 
-	ttl := int64(UTCNow().Sub(cred.Expiration).Seconds())
+	ttl := int64(cred.Expiration.Sub(UTCNow()).Seconds())
 
 	// If OPA is not set we honor any policy claims for this
 	// temporary user which match with pre-configured canned


### PR DESCRIPTION
## Description
TTL value in STS tokens is negative, causing the token to expire early.

## Motivation and Context
Caused by #10828 

## How to test this PR?
Perform an AssumeRole with TTL (e.g. 15 minutes).
Token expires after a couple of seconds due to negative etcd lease TTL.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) #10828
- [ ] Documentation needed
- [ ] Unit tests needed
