### PR TITLE
Skip 0 byte stream writes

### DIFF
--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -781,6 +781,10 @@ type httpStreamResponse struct {
 // Write part of the the streaming response.
 // Note that upstream errors are currently not forwarded, but may be in the future.
 func (h *httpStreamResponse) Write(b []byte) (int, error) {
+	if len(b) == 0 || h.err != nil {
+		// Ignore 0 length blocks
+		return 0, h.err
+	}
 	tmp := make([]byte, len(b))
 	copy(tmp, b)
 	h.block <- tmp


### PR DESCRIPTION
## Description

Don't send a packet when receiving 0 bytes or there is an error recorded.

Mostly just defensive programming.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
