### PR TITLE
fix: delete marker replication should support directories

### DIFF
--- a/cmd/api-datatypes.go
+++ b/cmd/api-datatypes.go
@@ -27,12 +27,14 @@ type DeletedObject struct {
 	DeleteMarkerVersionID string `xml:"DeleteMarkerVersionId,omitempty"`
 	ObjectName            string `xml:"Key,omitempty"`
 	VersionID             string `xml:"VersionId,omitempty"`
+
+	// MinIO extensions to support delete marker replication
 	// Replication status of DeleteMarker
-	DeleteMarkerReplicationStatus string
+	DeleteMarkerReplicationStatus string `xml:"DeleteMarkerReplicationStatus,omitempty"`
 	// MTime of DeleteMarker on source that needs to be propagated to replica
-	DeleteMarkerMTime time.Time
+	DeleteMarkerMTime time.Time `xml:"DeleteMarkerMTime,omitempty"`
 	// Status of versioned delete (of object or DeleteMarker)
-	VersionPurgeStatus VersionPurgeStatusType
+	VersionPurgeStatus VersionPurgeStatusType `xml:"VersionPurgeStatus,omitempty"`
 }
 
 // ObjectToDelete carries key name for the object to delete.
@@ -40,11 +42,11 @@ type ObjectToDelete struct {
 	ObjectName string `xml:"Key"`
 	VersionID  string `xml:"VersionId"`
 	// Replication status of DeleteMarker
-	DeleteMarkerReplicationStatus string
+	DeleteMarkerReplicationStatus string `xml:"DeleteMarkerReplicationStatus"`
 	// Status of versioned delete (of object or DeleteMarker)
-	VersionPurgeStatus VersionPurgeStatusType
+	VersionPurgeStatus VersionPurgeStatusType `xml:"VersionPurgeStatus"`
 	// Version ID of delete marker
-	DeleteMarkerVersionID string
+	DeleteMarkerVersionID string `xml:"DeleteMarkerVersionId"`
 }
 
 // createBucketConfiguration container for bucket configuration request from client.

--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"path"
 	"time"
 
 	"github.com/minio/minio/pkg/madmin"
@@ -95,9 +94,6 @@ func (h *healRoutine) run(ctx context.Context, objAPI ObjectLayer) {
 				res, err = objAPI.HealBucket(ctx, task.bucket, task.opts.DryRun, task.opts.Remove)
 			case task.bucket != "" && task.object != "":
 				res, err = objAPI.HealObject(ctx, task.bucket, task.object, task.versionID, task.opts)
-			}
-			if task.bucket != "" && task.object != "" {
-				ObjectPathUpdated(path.Join(task.bucket, task.object))
 			}
 			task.responseCh <- healResult{result: res, err: err}
 

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
 	"sync"
 	"time"
 
@@ -528,7 +527,7 @@ func (er erasureObjects) healObjectDir(ctx context.Context, bucket, object strin
 				}(index, disk)
 			}
 			wg.Wait()
-			ObjectPathUpdated(path.Join(bucket, object))
+			ObjectPathUpdated(pathJoin(bucket, object))
 		}
 	}
 

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -707,7 +707,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 		return oi, toObjectErr(errFileParentIsFile, bucket, object)
 	}
 
-	defer ObjectPathUpdated(path.Join(bucket, object))
+	defer ObjectPathUpdated(pathJoin(bucket, object))
 
 	// Calculate s3 compatible md5sum for complete multipart.
 	s3MD5 := getCompleteMultipartMD5(parts)

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -125,17 +125,20 @@ func getOpts(ctx context.Context, r *http.Request, bucket, object string) (Objec
 	opts.VersionID = vid
 	delMarker := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarker))
 	if delMarker != "" {
-		if delMarker != "true" && delMarker != "false" {
+		switch delMarker {
+		case "true":
+			opts.DeleteMarker = true
+		case "false":
+		default:
+			err = fmt.Errorf("Unable to parse %s, failed with %w", xhttp.MinIOSourceDeleteMarker, fmt.Errorf("DeleteMarker should be true or false"))
 			logger.LogIf(ctx, err)
 			return opts, InvalidArgument{
 				Bucket: bucket,
 				Object: object,
-				Err:    fmt.Errorf("Unable to parse %s, failed with %w", xhttp.MinIOSourceDeleteMarker, fmt.Errorf("DeleteMarker should be true or false")),
+				Err:    err,
 			}
 		}
-		if delMarker == "true" {
-			opts.DeleteMarker = true
-		}
+
 	}
 	return opts, nil
 }
@@ -150,31 +153,35 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 	opts.VersionSuspended = globalBucketVersioningSys.Suspended(bucket)
 	delMarker := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarker))
 	if delMarker != "" {
-		if delMarker != "true" && delMarker != "false" {
+		switch delMarker {
+		case "true":
+			opts.DeleteMarker = true
+		case "false":
+		default:
+			err = fmt.Errorf("Unable to parse %s, failed with %w", xhttp.MinIOSourceDeleteMarker, fmt.Errorf("DeleteMarker should be true or false"))
 			logger.LogIf(ctx, err)
 			return opts, InvalidArgument{
 				Bucket: bucket,
 				Object: object,
-				Err:    fmt.Errorf("Unable to parse %s, failed with %w", xhttp.MinIOSourceDeleteMarker, fmt.Errorf("DeleteMarker should be true or false")),
+				Err:    err,
 			}
-		}
-		if delMarker == "true" {
-			opts.DeleteMarker = true
 		}
 	}
 
 	purgeVersion := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarkerDelete))
 	if purgeVersion != "" {
-		if purgeVersion != "true" && purgeVersion != "false" {
+		switch purgeVersion {
+		case "true":
+			opts.VersionPurgeStatus = Complete
+		case "false":
+		default:
+			err = fmt.Errorf("Unable to parse %s, failed with %w", xhttp.MinIOSourceDeleteMarkerDelete, fmt.Errorf("DeleteMarkerPurge should be true or false"))
 			logger.LogIf(ctx, err)
 			return opts, InvalidArgument{
 				Bucket: bucket,
 				Object: object,
-				Err:    fmt.Errorf("Unable to parse %s, failed with %w", xhttp.MinIOSourceDeleteMarkerDelete, fmt.Errorf("DeleteMarkerPurge should be true or false")),
+				Err:    err,
 			}
-		}
-		if purgeVersion == "true" {
-			opts.VersionPurgeStatus = Complete
 		}
 	}
 


### PR DESCRIPTION
## Description
fix: delete marker replication should support directories

## Motivation and Context
allow directories to be replicated as well, along with
their delete markers in replication.
    
Bonus fix to fix bloom filter updates for directories
to be preserved.

## How to test this PR?
Nothing special create delete markers for directories and see
if they are replicated properly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
