### PR TITLE
ignore typed errors correctly in list cache layer

### DIFF
--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -440,7 +440,11 @@ func (d *dataUsageCache) load(ctx context.Context, store objectIO, name string) 
 	var buf bytes.Buffer
 	err := store.GetObject(ctx, dataUsageBucket, name, 0, -1, &buf, "", ObjectOptions{})
 	if err != nil {
-		if !isErrObjectNotFound(err) && !isErrBucketNotFound(err) && !errors.Is(err, InsufficientReadQuorum{}) {
+		switch err.(type) {
+		case ObjectNotFound:
+		case BucketNotFound:
+		case InsufficientReadQuorum:
+		default:
 			return toObjectErr(err, dataUsageBucket, name)
 		}
 		*d = dataUsageCache{}

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/gob"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -29,8 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/minio/minio/cmd/config/storageclass"
-	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/console"
 	"github.com/minio/minio/pkg/hash"
@@ -386,16 +383,22 @@ func (er *erasureObjects) streamMetadataParts(ctx context.Context, o listPathOpt
 		// Read metadata associated with the object from all disks.
 		fi, metaArr, onlineDisks, err := er.getObjectFileInfo(ctx, minioMetaBucket, o.objectPath(0), ObjectOptions{})
 		if err != nil {
-			if err == errFileNotFound || errors.Is(err, errErasureReadQuorum) || errors.Is(err, InsufficientReadQuorum{}) {
+			switch toObjectErr(err, minioMetaBucket, o.objectPath(0)).(type) {
+			case ObjectNotFound:
 				retries++
 				time.Sleep(retryDelay)
 				continue
+			case InsufficientReadQuorum:
+				retries++
+				time.Sleep(retryDelay)
+				continue
+			default:
+				if debugPrint {
+					console.Infoln("first getObjectFileInfo", o.objectPath(0), "returned err:", err)
+					console.Infof("err type: %T\n", err)
+				}
+				return entries, err
 			}
-			if debugPrint {
-				console.Infoln("first getObjectFileInfo", o.objectPath(0), "returned err:", err)
-				console.Infof("err type: %T\n", err)
-			}
-			return entries, err
 		}
 		if fi.Deleted {
 			return entries, errFileNotFound
@@ -404,7 +407,7 @@ func (er *erasureObjects) streamMetadataParts(ctx context.Context, o listPathOpt
 		partN, err := o.findFirstPart(fi)
 		switch err {
 		case nil:
-		case io.ErrUnexpectedEOF, errErasureReadQuorum, InsufficientReadQuorum{}:
+		case io.ErrUnexpectedEOF:
 			if retries == 10 {
 				err := o.checkMetacacheState(ctx, rpc)
 				if debugPrint {
@@ -462,23 +465,17 @@ func (er *erasureObjects) streamMetadataParts(ctx context.Context, o listPathOpt
 				}
 				// Load first part metadata...
 				fi, metaArr, onlineDisks, err = er.getObjectFileInfo(ctx, minioMetaBucket, o.objectPath(partN), ObjectOptions{})
-				switch err {
-				case errFileNotFound, errErasureReadQuorum, InsufficientReadQuorum{}:
+				if err != nil {
 					time.Sleep(retryDelay)
 					retries++
 					continue
-				default:
-					time.Sleep(retryDelay)
-					retries++
-					continue
-				case nil:
-					loadedPart = partN
-					bi, err := getMetacacheBlockInfo(fi, partN)
-					logger.LogIf(ctx, err)
-					if err == nil {
-						if bi.pastPrefix(o.Prefix) {
-							return entries, io.EOF
-						}
+				}
+				loadedPart = partN
+				bi, err := getMetacacheBlockInfo(fi, partN)
+				logger.LogIf(ctx, err)
+				if err == nil {
+					if bi.pastPrefix(o.Prefix) {
+						return entries, io.EOF
 					}
 				}
 				if fi.Deleted {
@@ -487,15 +484,20 @@ func (er *erasureObjects) streamMetadataParts(ctx context.Context, o listPathOpt
 			}
 			buf.Reset()
 			err := er.getObjectWithFileInfo(ctx, minioMetaBucket, o.objectPath(partN), 0, fi.Size, &buf, fi, metaArr, onlineDisks)
-			switch err {
-			case errFileNotFound, errErasureReadQuorum, InsufficientReadQuorum{}:
-				time.Sleep(retryDelay)
-				retries++
-				continue
-			default:
-				logger.LogIf(ctx, err)
-				return entries, err
-			case nil:
+			if err != nil {
+				switch toObjectErr(err, minioMetaBucket, o.objectPath(partN)).(type) {
+				case ObjectNotFound:
+					retries++
+					time.Sleep(retryDelay)
+					continue
+				case InsufficientReadQuorum:
+					retries++
+					time.Sleep(retryDelay)
+					continue
+				default:
+					logger.LogIf(ctx, err)
+					return entries, err
+				}
 			}
 			tmp, err := newMetacacheReader(&buf)
 			if err != nil {
@@ -666,7 +668,6 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 			r, err := hash.NewReader(bytes.NewBuffer(b.data), int64(len(b.data)), "", "", int64(len(b.data)), false)
 			logger.LogIf(ctx, err)
 			custom := b.headerKV()
-			custom[xhttp.AmzStorageClass] = storageclass.RRS
 			_, err = er.putObject(ctx, minioMetaBucket, o.objectPath(b.n), NewPutObjReader(r, nil, nil), ObjectOptions{UserDefined: custom})
 			if err != nil {
 				metaMu.Lock()

--- a/cmd/metacache-stream.go
+++ b/cmd/metacache-stream.go
@@ -19,13 +19,13 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/s2"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/tinylib/msgp/msgp"
@@ -816,6 +816,7 @@ type metacacheBlock struct {
 }
 
 func (b metacacheBlock) headerKV() map[string]string {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	v, err := json.Marshal(b)
 	if err != nil {
 		logger.LogIf(context.Background(), err) // Unlikely


### PR DESCRIPTION


## Description
ignore typed errors correctly in the list cache layer

## Motivation and Context
bonus write bucket metadata cache with enough quorum

Possible fix for #10868

## How to test this PR?
Hard to reproduce errors from #10868, most probably
if the quorum is lost on the objects it's possible to see 
these errors. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
