### PR TITLE
fix validation for deletemarker replication

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2713,7 +2713,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			opts.DeleteMarkerReplicationStatus = string(replication.Pending)
 		}
 	}
-
+	replicaDel := false
 	if r.Header.Get(xhttp.AmzBucketReplicationStatus) == replication.Replica.String() {
 		// check if replica has permission to be deleted.
 		if apiErrCode := checkRequestAuthType(ctx, r, policy.ReplicateDeleteAction, bucket, object); apiErrCode != ErrNone {
@@ -2721,14 +2721,19 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			return
 		}
 		opts.DeleteMarkerReplicationStatus = replication.Replica.String()
+		replicaDel = true
 	}
-
+	vID := opts.VersionID
+	if replicaDel && opts.VersionPurgeStatus.Empty() {
+		// opts.VersionID holds delete marker version ID to replicate and not yet present on disk
+		vID = ""
+	}
 	apiErr := ErrNone
 	if rcfg, _ := globalBucketObjectLockSys.Get(bucket); rcfg.LockEnabled {
-		if opts.VersionID != "" {
+		if vID != "" {
 			apiErr = enforceRetentionBypassForDelete(ctx, r, bucket, ObjectToDelete{
 				ObjectName: object,
-				VersionID:  opts.VersionID,
+				VersionID:  vID,
 			}, getObjectInfo)
 			if apiErr != ErrNone && apiErr != ErrNoSuchKey {
 				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(apiErr), r.URL, guessIsBrowserReq(r))


### PR DESCRIPTION
of object locked bucket

## Description


## Motivation and Context


## How to test this PR?
Turn object locking on a bucket and enable delete marker replication. Should replicate the deletemarker/versioned delete.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
