### PR TITLE
listobjectversions: Add shortcut for Veeam blocks

### DIFF
--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -680,7 +680,6 @@ func (z *erasureServerSets) ListObjectVersions(ctx context.Context, bucket, pref
 	// more objects matching the prefix.
 	ri := logger.GetReqInfo(ctx)
 	if ri != nil && strings.Contains(ri.UserAgent, `1.0 Veeam/1.0 Backup`) && strings.HasSuffix(prefix, ".blk") {
-		logger.Info("Veeam shortcut for %s", prefix)
 		opts.singleObject = true
 		opts.Transient = true
 	}

--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -662,7 +663,8 @@ func (z *erasureServerSets) ListObjectVersions(ctx context.Context, bucket, pref
 	if marker == "" && versionMarker != "" {
 		return loi, NotImplemented{}
 	}
-	merged, err := z.listPath(ctx, listPathOptions{
+
+	opts := listPathOptions{
 		Bucket:      bucket,
 		Prefix:      prefix,
 		Separator:   delimiter,
@@ -670,7 +672,20 @@ func (z *erasureServerSets) ListObjectVersions(ctx context.Context, bucket, pref
 		Marker:      marker,
 		InclDeleted: true,
 		AskDisks:    globalAPIConfig.getListQuorum(),
-	})
+	}
+
+	// Shortcut for APN/1.0 Veeam/1.0 Backup/10.0
+	// It requests unique blocks with a specific prefix.
+	// We skip scanning the parent directory for
+	// more objects matching the prefix.
+	ri := logger.GetReqInfo(ctx)
+	if ri != nil && strings.Contains(ri.UserAgent, `1.0 Veeam/1.0 Backup`) && strings.HasSuffix(prefix, ".blk") {
+		logger.Info("Veeam shortcut for %s", prefix)
+		opts.singleObject = true
+		opts.Transient = true
+	}
+
+	merged, err := z.listPath(ctx, opts)
 	if err != nil && err != io.EOF {
 		return loi, err
 	}

--- a/cmd/metacache-server-sets.go
+++ b/cmd/metacache-server-sets.go
@@ -83,6 +83,10 @@ func (z *erasureServerSets) listPath(ctx context.Context, o listPathOptions) (en
 		o.ID = mustGetUUID()
 	}
 	o.BaseDir = baseDirFromPrefix(o.Prefix)
+	if o.singleObject {
+		// Override for single object.
+		o.BaseDir = o.Prefix
+	}
 
 	var cache metacache
 	// If we don't have a list id we must ask the server if it has a cache or create a new.

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -87,6 +87,9 @@ type listPathOptions struct {
 	// This means the cache metadata will not be persisted on disk.
 	// A transient result will never be returned from the cache so knowing the list id is required.
 	Transient bool
+
+	// singleObject will assume that prefix refers to an exact single object.
+	singleObject bool
 }
 
 func init() {

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -545,7 +545,7 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 		console.Printf("listPath with options: %#v\n", o)
 	}
 	// See if we have the listing stored.
-	if !o.Create {
+	if !o.Create && !o.singleObject {
 		entries, err := er.streamMetadataParts(ctx, o)
 		switch err {
 		case nil, io.EOF, context.Canceled, context.DeadlineExceeded:
@@ -665,6 +665,10 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 
 		// Write results to disk.
 		bw := newMetacacheBlockWriter(cacheCh, func(b *metacacheBlock) error {
+			if o.singleObject {
+				// Don't save single object listings.
+				return nil
+			}
 			if debugPrint {
 				console.Println("listPath: saving block", b.n, "to", o.objectPath(b.n))
 			}

--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -116,7 +116,7 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			// If root was an object return it as such.
 			if HasSuffix(entry, xlStorageFormatFile) {
 				var meta metaCacheEntry
-				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, opts.BaseDir, meta.name, xlStorageFormatFile))
+				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, opts.BaseDir, entry))
 				if err != nil {
 					logger.LogIf(ctx, err)
 					continue
@@ -131,12 +131,12 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			// Check legacy.
 			if HasSuffix(entry, xlStorageFormatFileV1) {
 				var meta metaCacheEntry
-				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, opts.BaseDir, meta.name, xlStorageFormatFileV1))
+				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, opts.BaseDir, entry))
 				if err != nil {
 					logger.LogIf(ctx, err)
 					continue
 				}
-				meta.name = strings.TrimSuffix(meta.name, xlStorageFormatFileV1)
+				meta.name = strings.TrimSuffix(entry, xlStorageFormatFileV1)
 				meta.name = strings.TrimSuffix(meta.name, SlashSeparator)
 				meta.name = pathJoin(opts.BaseDir, meta.name)
 				out <- meta

--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -116,14 +116,14 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			// If root was an object return it as such.
 			if HasSuffix(entry, xlStorageFormatFile) {
 				var meta metaCacheEntry
-				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, opts.BaseDir, entry))
+				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, current, entry))
 				if err != nil {
 					logger.LogIf(ctx, err)
 					continue
 				}
-				meta.name = strings.TrimSuffix(meta.name, xlStorageFormatFile)
+				meta.name = strings.TrimSuffix(entry, xlStorageFormatFile)
 				meta.name = strings.TrimSuffix(meta.name, SlashSeparator)
-				meta.name = pathJoin(opts.BaseDir, meta.name)
+				meta.name = pathJoin(current, meta.name)
 				meta.name = decodeDirObject(meta.name)
 				out <- meta
 				return nil
@@ -131,14 +131,14 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			// Check legacy.
 			if HasSuffix(entry, xlStorageFormatFileV1) {
 				var meta metaCacheEntry
-				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, opts.BaseDir, entry))
+				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, current, entry))
 				if err != nil {
 					logger.LogIf(ctx, err)
 					continue
 				}
 				meta.name = strings.TrimSuffix(entry, xlStorageFormatFileV1)
 				meta.name = strings.TrimSuffix(meta.name, SlashSeparator)
-				meta.name = pathJoin(opts.BaseDir, meta.name)
+				meta.name = pathJoin(current, meta.name)
 				out <- meta
 				return nil
 			}

--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -116,13 +116,14 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			// If root was an object return it as such.
 			if HasSuffix(entry, xlStorageFormatFile) {
 				var meta metaCacheEntry
-				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, meta.name, xlStorageFormatFile))
+				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, opts.BaseDir, meta.name, xlStorageFormatFile))
 				if err != nil {
 					logger.LogIf(ctx, err)
 					continue
 				}
 				meta.name = strings.TrimSuffix(meta.name, xlStorageFormatFile)
 				meta.name = strings.TrimSuffix(meta.name, SlashSeparator)
+				meta.name = pathJoin(opts.BaseDir, meta.name)
 				meta.name = decodeDirObject(meta.name)
 				out <- meta
 				return nil
@@ -130,13 +131,14 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			// Check legacy.
 			if HasSuffix(entry, xlStorageFormatFileV1) {
 				var meta metaCacheEntry
-				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, meta.name, xlStorageFormatFileV1))
+				meta.metadata, err = ioutil.ReadFile(pathJoin(volumeDir, opts.BaseDir, meta.name, xlStorageFormatFileV1))
 				if err != nil {
 					logger.LogIf(ctx, err)
 					continue
 				}
 				meta.name = strings.TrimSuffix(meta.name, xlStorageFormatFileV1)
 				meta.name = strings.TrimSuffix(meta.name, SlashSeparator)
+				meta.name = pathJoin(opts.BaseDir, meta.name)
 				out <- meta
 				return nil
 			}


### PR DESCRIPTION
## Description

Add shortcut for `APN/1.0 Veeam/1.0 Backup/10.0`

It requests unique blocks with a specific prefix.
We skip scanning the parent directory for more objects matching the prefix.
We do not save caches for these operations.

## Motivation and Context

Due to how Veeam structures data there can be huge delays while listing the prefix level.

## How to test this PR?

Requires Veeam client useragent or modifying the code.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
