### PR TITLE
Update labels for object size histogram

### DIFF
--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -79,13 +79,13 @@ const (
 // ObjectsHistogramIntervals is the list of all intervals
 // of object sizes to be included in objects histogram.
 var ObjectsHistogramIntervals = []objectHistogramInterval{
-	{"LESS_THAN_1024_B", 0, humanize.KiByte - 1},
-	{"BETWEEN_1024_B_AND_1_MB", humanize.KiByte, humanize.MiByte - 1},
-	{"BETWEEN_1_MB_AND_10_MB", humanize.MiByte, humanize.MiByte*10 - 1},
-	{"BETWEEN_10_MB_AND_64_MB", humanize.MiByte * 10, humanize.MiByte*64 - 1},
-	{"BETWEEN_64_MB_AND_128_MB", humanize.MiByte * 64, humanize.MiByte*128 - 1},
-	{"BETWEEN_128_MB_AND_512_MB", humanize.MiByte * 128, humanize.MiByte*512 - 1},
-	{"GREATER_THAN_512_MB", humanize.MiByte * 512, math.MaxInt64},
+	{"< 1024B", 0, humanize.KiByte - 1},
+	{"> 1024B", humanize.KiByte, humanize.MiByte - 1},
+	{"> 1MB", humanize.MiByte, humanize.MiByte*10 - 1},
+	{"> 10MB", humanize.MiByte * 10, humanize.MiByte*64 - 1},
+	{"> 64MB", humanize.MiByte * 64, humanize.MiByte*128 - 1},
+	{"> 128MB", humanize.MiByte * 128, humanize.MiByte*512 - 1},
+	{"> 512MB", humanize.MiByte * 512, math.MaxInt64},
 }
 
 // BucketUsageInfo - bucket usage info provides

--- a/docs/metrics/prometheus/README.md
+++ b/docs/metrics/prometheus/README.md
@@ -165,13 +165,13 @@ Apart from above metrics, MinIO also exposes below mode specific metrics
 ### Bucket usage specific metrics
 All metrics are labeled by `bucket`, each metric is displayed per bucket. `buckets_objects_histogram` is additionally labeled by `object_size` string which is represented by any of the following values
 
-- *LESS_THAN_1024_B*
-- *BETWEEN_1024_B_AND_1_MB*
-- *BETWEEN_1_MB_AND_10_MB*
-- *BETWEEN_10_MB_AND_64_MB*
-- *BETWEEN_64_MB_AND_128_MB*
-- *BETWEEN_128_MB_AND_512_MB*
-- *GREATER_THAN_512_MB*
+- *< 1024B*
+- *> 1024B*
+- *> 1MB*
+- *> 10MB*
+- *> 64MB*
+- *> 128MB*
+- *> 512MB*
 
 
 Units defintions:


### PR DESCRIPTION
## Description
Use shorter labels for object size histogram

## Motivation and Context
This is required for the upcoming MinIO Grafana dashboard.

## How to test this PR?
Deploy MinIO + Prometheus and look for `buckets_objects_histogram` metric. It should show new labels.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
