### PR TITLE
fix: move context timeout closer to network for Delete calls

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"path"
 	"sync"
-	"time"
 
 	"github.com/minio/minio-go/v7/pkg/tags"
 	xhttp "github.com/minio/minio/cmd/http"
@@ -774,13 +773,7 @@ func (er erasureObjects) deleteObject(ctx context.Context, bucket, object string
 			if disks[index] == nil {
 				return errDiskNotFound
 			}
-			tctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
-			err := cleanupDir(tctx, disks[index], minioMetaTmpBucket, tmpObj)
-			if err != nil && err != errVolumeNotFound {
-				return err
-			}
-			return nil
+			return cleanupDir(ctx, disks[index], minioMetaTmpBucket, tmpObj)
 		}, index)
 	}
 

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -137,7 +137,14 @@ func cleanupDir(ctx context.Context, storage StorageAPI, volume, dirPath string)
 		}
 		return nil
 	}
+
 	err := delFunc(retainSlash(pathJoin(dirPath)))
+	if IsErrIgnored(err, []error{
+		errVolumeNotFound,
+		errVolumeAccessDenied,
+	}...) {
+		return nil
+	}
 	return err
 }
 

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -323,7 +323,10 @@ func (client *storageRESTClient) DeleteVersion(ctx context.Context, volume, path
 		return err
 	}
 
-	respBody, err := client.call(ctx, storageRESTMethodDeleteVersion, values, &buffer, -1)
+	tctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	respBody, err := client.call(tctx, storageRESTMethodDeleteVersion, values, &buffer, -1)
 	defer http.DrainBody(respBody)
 	return err
 }
@@ -503,7 +506,9 @@ func (client *storageRESTClient) Delete(ctx context.Context, volume string, path
 	values.Set(storageRESTVolume, volume)
 	values.Set(storageRESTFilePath, path)
 	values.Set(storageRESTRecursive, strconv.FormatBool(recursive))
-	respBody, err := client.call(ctx, storageRESTMethodDeleteFile, values, nil, -1)
+	tctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	respBody, err := client.call(tctx, storageRESTMethodDeleteFile, values, nil, -1)
 	defer http.DrainBody(respBody)
 	return err
 }


### PR DESCRIPTION


## Description
fix: move context timeout closer to network for Delete calls

## Motivation and Context
allowing for disconnects to be limited to the drive
themselves instead of disconnecting all drives.

## How to test this PR?
Not easy to test would need an overloaded number of servers,
avoids a global timeout to avoid disconnecting all drives.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
