### PR TITLE
Fix global in-place update boolean check

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -407,7 +407,7 @@ func serverMain(ctx *cli.Context) {
 		}
 	}
 
-	if !globalCLIContext.Quiet && globalInplaceUpdateDisabled {
+	if !globalCLIContext.Quiet && !globalInplaceUpdateDisabled {
 		// Check for new updates from dl.min.io.
 		checkUpdate(getMinioMode())
 	}


### PR DESCRIPTION
## Description
PR #10752 introduced `MINIO_UPDATE` environment-variable check, but it incorrectly checks if positive.
Currently, if `MINIO_UPDATE=on`, updates are disabled.

Expected:
- `MINIO_UPDATE=off` - Disables update
- `MINIO_UPDATE=on` - Enable updates

## Motivation and Context
Bug

## How to test this PR?
Run `tcpdump` and start minio-server. Grep for `dl.min.io`, for example:
```sh
tcpdump -i ens33 -ttnnvvS | grep dl.min
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (PR #10752)
- [ ] Documentation needed
- [ ] Unit tests needed
