### PR TITLE
Use context from requests instead of context.Background()

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -195,7 +195,7 @@ func getClaimsFromToken(r *http.Request, token string) (map[string]interface{}, 
 		return claims.Map(), nil
 	}
 
-	stsTokenCallback := func(claims *xjwt.MapClaims) ([]byte, error) {
+	stsTokenCallback := func(ctx context.Context, claims *xjwt.MapClaims) ([]byte, error) {
 		// JWT token for x-amz-security-token is signed with admin
 		// secret key, temporary credentials become invalid if
 		// server admin credentials change. This is done to ensure
@@ -207,7 +207,7 @@ func getClaimsFromToken(r *http.Request, token string) (map[string]interface{}, 
 		return []byte(globalActiveCred.SecretKey), nil
 	}
 
-	if err := xjwt.ParseWithClaims(token, claims, stsTokenCallback); err != nil {
+	if err := xjwt.ParseWithClaims(r.Context(), token, claims, stsTokenCallback); err != nil {
 		return nil, errAuthentication
 	}
 

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -751,7 +751,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	}
 
 	// Verify policy signature.
-	errCode := doesPolicySignatureMatch(formValues)
+	errCode := doesPolicySignatureMatch(r.Context(), formValues)
 	if errCode != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(errCode), r.URL, guessIsBrowserReq(r))
 		return

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -212,7 +212,7 @@ func getReqAccessCred(r *http.Request, region string) (cred auth.Credentials) {
 			return globalActiveCred
 		}
 		if claims != nil {
-			cred, _ = globalIAMSys.GetUser(claims.AccessKey)
+			cred, _ = globalIAMSys.GetUser(r.Context(), claims.AccessKey)
 		}
 	}
 	return cred

--- a/cmd/iam-etcd-store.go
+++ b/cmd/iam-etcd-store.go
@@ -638,7 +638,7 @@ func (ies *IAMEtcdStore) watch(ctx context.Context, sys *IAMSys) {
 				}
 				for _, event := range watchResp.Events {
 					ies.lock()
-					ies.reloadFromEvent(sys, event)
+					ies.reloadFromEvent(ctx, sys, event)
 					ies.unlock()
 				}
 			}
@@ -647,7 +647,7 @@ func (ies *IAMEtcdStore) watch(ctx context.Context, sys *IAMSys) {
 }
 
 // sys.RLock is held by caller.
-func (ies *IAMEtcdStore) reloadFromEvent(sys *IAMSys, event *etcd.Event) {
+func (ies *IAMEtcdStore) reloadFromEvent(ctx context.Context, sys *IAMSys, event *etcd.Event) {
 	eventCreate := event.IsModify() || event.IsCreate()
 	eventDelete := event.Type == etcd.EventTypeDelete
 	usersPrefix := strings.HasPrefix(string(event.Kv.Key), iamConfigUsersPrefix)

--- a/cmd/jwt/parser.go
+++ b/cmd/jwt/parser.go
@@ -22,6 +22,7 @@ package jwt
 // borrowed under MIT License https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
 
 import (
+	"context"
 	"crypto"
 	"crypto/hmac"
 	"encoding/base64"
@@ -274,7 +275,7 @@ func ParseUnverifiedStandardClaims(tokenString string, claims *StandardClaims, b
 }
 
 // ParseWithClaims - parse the token string, valid methods.
-func ParseWithClaims(tokenStr string, claims *MapClaims, fn func(*MapClaims) ([]byte, error)) error {
+func ParseWithClaims(ctx context.Context, tokenStr string, claims *MapClaims, fn func(context.Context, *MapClaims) ([]byte, error)) error {
 	// Key lookup function has to be provided.
 	if fn == nil {
 		// keyFunc was not provided, return error.
@@ -311,7 +312,7 @@ func ParseWithClaims(tokenStr string, claims *MapClaims, fn func(*MapClaims) ([]
 
 	// Lookup key from claims, claims may not be valid and may return
 	// invalid key which is okay as the signature verification will fail.
-	key, err := fn(claims)
+	key, err := fn(ctx, claims)
 	if err != nil {
 		return err
 	}

--- a/cmd/jwt/parser_test.go
+++ b/cmd/jwt/parser_test.go
@@ -22,6 +22,7 @@ package jwt
 // borrowed under MIT License https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -30,15 +31,17 @@ import (
 )
 
 var (
-	defaultKeyFunc = func(claim *MapClaims) ([]byte, error) { return []byte("HelloSecret"), nil }
-	emptyKeyFunc   = func(claim *MapClaims) ([]byte, error) { return nil, nil }
-	errorKeyFunc   = func(claim *MapClaims) ([]byte, error) { return nil, fmt.Errorf("error loading key") }
+	defaultKeyFunc = func(ctx context.Context, claim *MapClaims) ([]byte, error) { return []byte("HelloSecret"), nil }
+	emptyKeyFunc   = func(ctx context.Context, claim *MapClaims) ([]byte, error) { return nil, nil }
+	errorKeyFunc   = func(ctx context.Context, claim *MapClaims) ([]byte, error) {
+		return nil, fmt.Errorf("error loading key")
+	}
 )
 
 var jwtTestData = []struct {
 	name        string
 	tokenString string
-	keyfunc     func(*MapClaims) ([]byte, error)
+	keyfunc     func(context.Context, *MapClaims) ([]byte, error)
 	claims      jwt.Claims
 	valid       bool
 	errors      int32
@@ -186,7 +189,7 @@ func TestParserParse(t *testing.T) {
 				if data.tokenString == "" {
 					data.tokenString = mapClaimsToken(claims)
 				}
-				err = ParseWithClaims(data.tokenString, &MapClaims{}, data.keyfunc)
+				err = ParseWithClaims(context.Background(), data.tokenString, &MapClaims{}, data.keyfunc)
 			case *StandardClaims:
 				if data.tokenString == "" {
 					data.tokenString = standardClaimsToken(claims)

--- a/cmd/jwt_test.go
+++ b/cmd/jwt_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -41,6 +42,7 @@ func testAuthenticate(authType string, t *testing.T) {
 	}
 
 	globalActiveCred = cred
+	ctx := context.Background()
 
 	// Define test cases.
 	testCases := []struct {
@@ -64,9 +66,9 @@ func testAuthenticate(authType string, t *testing.T) {
 	for _, testCase := range testCases {
 		var err error
 		if authType == "web" {
-			_, err = authenticateWeb(testCase.accessKey, testCase.secretKey)
+			_, err = authenticateWeb(ctx, testCase.accessKey, testCase.secretKey)
 		} else if authType == "url" {
-			_, err = authenticateURL(testCase.accessKey, testCase.secretKey)
+			_, err = authenticateURL(ctx, testCase.accessKey, testCase.secretKey)
 		}
 
 		if testCase.expectedErr != nil {
@@ -193,7 +195,7 @@ func BenchmarkParseJWTMapClaims(b *testing.B) {
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			err = xjwt.ParseWithClaims(token, xjwt.NewMapClaims(), func(*xjwt.MapClaims) ([]byte, error) {
+			err = xjwt.ParseWithClaims(context.Background(), token, xjwt.NewMapClaims(), func(context.Context, *xjwt.MapClaims) ([]byte, error) {
 				return []byte(creds.SecretKey), nil
 			})
 			if err != nil {
@@ -235,6 +237,6 @@ func BenchmarkAuthenticateWeb(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		authenticateWeb(creds.AccessKey, creds.SecretKey)
+		authenticateWeb(context.Background(), creds.AccessKey, creds.SecretKey)
 	}
 }

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -192,7 +192,7 @@ func (s *peerRESTServer) LoadServiceAccountHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if err := globalIAMSys.LoadServiceAccount(accessKey); err != nil {
+	if err := globalIAMSys.LoadServiceAccount(r.Context(), accessKey); err != nil {
 		s.writeErrorResponse(w, err)
 		return
 	}
@@ -259,7 +259,7 @@ func (s *peerRESTServer) LoadUserHandler(w http.ResponseWriter, r *http.Request)
 		userType = stsUser
 	}
 
-	if err = globalIAMSys.LoadUser(objAPI, accessKey, userType); err != nil {
+	if err = globalIAMSys.LoadUser(r.Context(), objAPI, accessKey, userType); err != nil {
 		s.writeErrorResponse(w, err)
 		return
 	}

--- a/cmd/signature-v2.go
+++ b/cmd/signature-v2.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/subtle"
@@ -76,10 +77,10 @@ const (
 // AWS S3 Signature V2 calculation rule is give here:
 // http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationStringToSign
 
-func doesPolicySignatureV2Match(formValues http.Header) APIErrorCode {
+func doesPolicySignatureV2Match(ctx context.Context, formValues http.Header) APIErrorCode {
 	cred := globalActiveCred
 	accessKey := formValues.Get(xhttp.AmzAccessKeyID)
-	cred, _, s3Err := checkKeyValid(accessKey)
+	cred, _, s3Err := checkKeyValid(ctx, accessKey)
 	if s3Err != ErrNone {
 		return s3Err
 	}
@@ -154,7 +155,7 @@ func doesPresignV2SignatureMatch(r *http.Request) APIErrorCode {
 		return ErrInvalidQueryParams
 	}
 
-	cred, _, s3Err := checkKeyValid(accessKey)
+	cred, _, s3Err := checkKeyValid(r.Context(), accessKey)
 	if s3Err != ErrNone {
 		return s3Err
 	}
@@ -185,7 +186,7 @@ func doesPresignV2SignatureMatch(r *http.Request) APIErrorCode {
 
 func getReqAccessKeyV2(r *http.Request) (auth.Credentials, bool, APIErrorCode) {
 	if accessKey := r.URL.Query().Get(xhttp.AmzAccessKeyID); accessKey != "" {
-		return checkKeyValid(accessKey)
+		return checkKeyValid(r.Context(), accessKey)
 	}
 
 	// below is V2 Signed Auth header format, splitting on `space` (after the `AWS` string).
@@ -201,7 +202,7 @@ func getReqAccessKeyV2(r *http.Request) (auth.Credentials, bool, APIErrorCode) {
 		return auth.Credentials{}, false, ErrMissingFields
 	}
 
-	return checkKeyValid(keySignFields[0])
+	return checkKeyValid(r.Context(), keySignFields[0])
 }
 
 // Authorization = "AWS" + " " + AWSAccessKeyId + ":" + Signature;

--- a/cmd/signature-v2_test.go
+++ b/cmd/signature-v2_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -265,7 +266,7 @@ func TestDoesPolicySignatureV2Match(t *testing.T) {
 		formValues.Set("Awsaccesskeyid", test.accessKey)
 		formValues.Set("Signature", test.signature)
 		formValues.Set("Policy", test.policy)
-		errCode := doesPolicySignatureV2Match(formValues)
+		errCode := doesPolicySignatureV2Match(context.Background(), formValues)
 		if errCode != test.errCode {
 			t.Fatalf("(%d) expected to get %s, instead got %s", i+1, niceError(test.errCode), niceError(errCode))
 		}

--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -62,7 +62,7 @@ func getReqAccessKeyV4(r *http.Request, region string, stype serviceType) (auth.
 			return auth.Credentials{}, false, s3Err
 		}
 	}
-	return checkKeyValid(ch.accessKey)
+	return checkKeyValid(r.Context(), ch.accessKey)
 }
 
 // parse credentialHeader string into its structured form.

--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"encoding/hex"
 	"io"
@@ -120,13 +121,13 @@ func isValidRegion(reqRegion string, confRegion string) bool {
 
 // check if the access key is valid and recognized, additionally
 // also returns if the access key is owner/admin.
-func checkKeyValid(accessKey string) (auth.Credentials, bool, APIErrorCode) {
+func checkKeyValid(ctx context.Context, accessKey string) (auth.Credentials, bool, APIErrorCode) {
 	var owner = true
 	var cred = globalActiveCred
 	if cred.AccessKey != accessKey {
 		// Check if the access key is part of users credentials.
 		var ok bool
-		if cred, ok = globalIAMSys.GetUser(accessKey); !ok {
+		if cred, ok = globalIAMSys.GetUser(ctx, accessKey); !ok {
 			return cred, false, ErrInvalidAccessKeyID
 		}
 		owner = false

--- a/cmd/signature-v4_test.go
+++ b/cmd/signature-v4_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -84,7 +85,7 @@ func TestDoesPolicySignatureMatch(t *testing.T) {
 
 	// Run each test case individually.
 	for i, testCase := range testCases {
-		code := doesPolicySignatureMatch(testCase.form)
+		code := doesPolicySignatureMatch(context.Background(), testCase.form)
 		if code != testCase.expected {
 			t.Errorf("(%d) expected to get %s, instead got %s", i, niceError(testCase.expected), niceError(code))
 		}

--- a/cmd/streaming-signature-v4.go
+++ b/cmd/streaming-signature-v4.go
@@ -92,7 +92,7 @@ func calculateSeedSignature(r *http.Request) (cred auth.Credentials, signature s
 		return cred, "", "", time.Time{}, errCode
 	}
 
-	cred, _, errCode = checkKeyValid(signV4Values.Credential.accessKey)
+	cred, _, errCode = checkKeyValid(r.Context(), signV4Values.Credential.accessKey)
 	if errCode != ErrNone {
 		return cred, "", "", time.Time{}, errCode
 	}


### PR DESCRIPTION
## Description

Pass contexts from http.Request instead of using context.Background() in many places.

## Motivation and Context

This allows context management to work throughout the entire request, specifically within IAM stores.

## How to test this PR?

No functional changes to test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
