### PR TITLE
Use hw.physmem64 instead of hw.physmem for NetBSD in pkg/sys/getHwPhysmem 

### DIFF
--- a/pkg/sys/stats_bsd.go
+++ b/pkg/sys/stats_bsd.go
@@ -19,27 +19,27 @@
 package sys
 
 import (
-    "encoding/binary"
-    "syscall"
+	"encoding/binary"
+	"syscall"
 )
 
 func getHwPhysmem() (uint64, error) {
-    totalString, err := syscall.Sysctl("hw.physmem")
-    if err != nil {
-        return 0, err
-    }
+	totalString, err := syscall.Sysctl("hw.physmem")
+	if err != nil {
+		return 0, err
+	}
 
-    // syscall.sysctl() helpfully assumes the result is a null-terminated string and
-    // removes the last byte of the result if it's 0 :/
-    totalString += "\x00"
+	// syscall.sysctl() helpfully assumes the result is a null-terminated string and
+	// removes the last byte of the result if it's 0 :/
+	totalString += "\x00"
 
-    total := uint64(binary.LittleEndian.Uint64([]byte(totalString)))
+	total := uint64(binary.LittleEndian.Uint64([]byte(totalString)))
 
-    return total, nil
+	return total, nil
 }
 
 // GetStats - return system statistics for bsd.
 func GetStats() (stats Stats, err error) {
-    stats.TotalRAM, err = getHwPhysmem()
-    return stats, err
+	stats.TotalRAM, err = getHwPhysmem()
+	return stats, err
 }

--- a/pkg/sys/stats_netbsd.go
+++ b/pkg/sys/stats_netbsd.go
@@ -19,27 +19,27 @@
 package sys
 
 import (
-    "encoding/binary"
-    "syscall"
+	"encoding/binary"
+	"syscall"
 )
 
 func getHwPhysmem() (uint64, error) {
-    totalString, err := syscall.Sysctl("hw.physmem64")
-    if err != nil {
-        return 0, err
-    }
+	totalString, err := syscall.Sysctl("hw.physmem64")
+	if err != nil {
+		return 0, err
+	}
 
-    // syscall.sysctl() helpfully assumes the result is a null-terminated string and
-    // removes the last byte of the result if it's 0 :/
-    totalString += "\x00"
+	// syscall.sysctl() helpfully assumes the result is a null-terminated string and
+	// removes the last byte of the result if it's 0 :/
+	totalString += "\x00"
 
-    total := uint64(binary.LittleEndian.Uint64([]byte(totalString)))
+	total := uint64(binary.LittleEndian.Uint64([]byte(totalString)))
 
-    return total, nil
+	return total, nil
 }
 
 // GetStats - return system statistics for bsd.
 func GetStats() (stats Stats, err error) {
-    stats.TotalRAM, err = getHwPhysmem()
-    return stats, err
+	stats.TotalRAM, err = getHwPhysmem()
+	return stats, err
 }

--- a/pkg/sys/stats_netbsd.go
+++ b/pkg/sys/stats_netbsd.go
@@ -1,7 +1,7 @@
 // +build netbsd
 
 /*
- * MinIO Cloud Storage, (C) 2016,2017 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/sys/stats_netbsd.go
+++ b/pkg/sys/stats_netbsd.go
@@ -1,4 +1,4 @@
-// +build openbsd freebsd dragonfly
+// +build netbsd
 
 /*
  * MinIO Cloud Storage, (C) 2016,2017 MinIO, Inc.
@@ -24,7 +24,7 @@ import (
 )
 
 func getHwPhysmem() (uint64, error) {
-    totalString, err := syscall.Sysctl("hw.physmem")
+    totalString, err := syscall.Sysctl("hw.physmem64")
     if err != nil {
         return 0, err
     }


### PR DESCRIPTION
## Description

NetBSD has two sysctls for reporting the physical memory. 
"hw.physmem" only reports reasonable results on 32 bit systems and is 
kept to not break binary compatibility. On other systems, it reports
"-1". "hw.phymem64" reports reasonable results on all systems.

See also: http://mail-index.netbsd.org/netbsd-users/2017/02/16/msg019363.html

## Motivation and Context

Minio getHwPhysmem method currently uses the deprecated "hw.physmem"
key which results in a parse error (due to the -1). 

## How to test this PR?

The change was tested successfully on NetBSD/amd64 9.1, using the package from wip/minio and apply the patch manually (https://wip.pkgsrc.org/cgi-bin/gitweb.cgi?p=pkgsrc-wip.git;a=tree;f=minio;h=dc039c75d0a5f45c93df607b2ac3395595bb9055;hb=HEAD)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
