### PR TITLE
increase readdir per block memory to facilitate faster WalkDir

### DIFF
--- a/cmd/os-readdir_unix.go
+++ b/cmd/os-readdir_unix.go
@@ -31,10 +31,10 @@ import (
 // refer https://github.com/golang/go/issues/24015
 const blockSize = 8 << 10 // 8192
 
-// By default atleast 20 entries in single getdents call
+// By default atleast 128 entries in single getdents call (1MiB buffer)
 var direntPool = sync.Pool{
 	New: func() interface{} {
-		buf := make([]byte, blockSize*20)
+		buf := make([]byte, blockSize*128)
 		return &buf
 	},
 }


### PR DESCRIPTION
## Description
increase readdir per block memory to facilitate faster WalkDir

## Motivation and Context
Currently, we use 160KiB, bump it to 1MiB instead

## How to test this PR?
Nothing special requires that you have lots of content at a prefix

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
