### PR TITLE
Display storage-class of transitioned object in HEAD

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -198,6 +198,9 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 				fmt.Sprintf(`expiry-date="%s", rule-id="%s"`, expiryTime.Format(http.TimeFormat), ruleID),
 			}
 		}
+		if objInfo.TransitionStatus == lifecycle.TransitionComplete {
+			w.Header()[xhttp.AmzStorageClass] = []string{objInfo.StorageClass}
+		}
 	}
 
 	return nil

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -165,6 +165,23 @@ func validateTransitionDestination(ctx context.Context, bucket string, targetLab
 	return sameTarget, arn.Bucket, nil
 }
 
+// transitionSC returns storage class label for this bucket
+func transitionSC(ctx context.Context, bucket string) string {
+	cfg, err := globalBucketMetadataSys.GetLifecycleConfig(bucket)
+	if err != nil {
+		return ""
+	}
+	for _, rule := range cfg.Rules {
+		if rule.Status == Disabled {
+			continue
+		}
+		if rule.Transition.StorageClass != "" {
+			return rule.Transition.StorageClass
+		}
+	}
+	return ""
+}
+
 // return true if ARN representing transition storage class is present in a active rule
 // for the lifecycle configured on this bucket
 func transitionSCInUse(ctx context.Context, lfc *lifecycle.Lifecycle, bucket, arnStr string) bool {

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -417,8 +417,14 @@ func (er erasureObjects) getObjectInfo(ctx context.Context, bucket, object strin
 		// Make sure to return object info to provide extra information.
 		return objInfo, toObjectErr(errMethodNotAllowed, bucket, object)
 	}
-
-	return fi.ToObjectInfo(bucket, object), nil
+	oi := fi.ToObjectInfo(bucket, object)
+	if oi.TransitionStatus == lifecycle.TransitionComplete {
+		// overlay storage class for transitioned objects with transition tier SC Label
+		if sc := transitionSC(ctx, bucket); sc != "" {
+			oi.StorageClass = sc
+		}
+	}
+	return oi, nil
 }
 
 func undoRename(disks []StorageAPI, srcBucket, srcEntry, dstBucket, dstEntry string, isDir bool, errs []error) {


### PR DESCRIPTION
## Description


## Motivation and Context
AWS shows current storage class specified in lifecycle rule after transition. We currently have no visible indication of object being moved to transition tier otherwise

## How to test this PR?
Setup transition and do a HEAD after object transitions - it should show storage class label associated with transition target.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
