### PR TITLE
Strip off port for google endpoint

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -169,6 +169,9 @@ func (a adminAPIHandlers) SetRemoteTargetHandler(w http.ResponseWriter, r *http.
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErrWithErr(ErrAdminConfigBadJSON, err), r.URL)
 		return
 	}
+	if !target.Secure && port == "80" || target.Secure && port == "443" {
+		target.Endpoint = host
+	}
 	sameTarget, _ := isLocalHost(host, port, globalMinioPort)
 	if sameTarget && bucket == target.TargetBucket {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrBucketRemoteIdenticalToSource), r.URL)


### PR DESCRIPTION
## Description


## Motivation and Context
if storage.googleapis.com is used as a remote target, it rejects connections which specify default port in the endpoint.

## How to test this PR?
`mc admin bucket remote add`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
