### PR TITLE
fix: network shutdown was not handled properly

### DIFF
--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -27,7 +27,6 @@ import (
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/rest"
 	"github.com/minio/minio/pkg/dsync"
-	xnet "github.com/minio/minio/pkg/net"
 )
 
 // lockRESTClient is authenticable lock REST client
@@ -161,7 +160,7 @@ func newlockRESTClient(endpoint Endpoint) *lockRESTClient {
 		defer cancel()
 		respBody, err := healthClient.Call(ctx, lockRESTMethodHealth, nil, nil, -1)
 		xhttp.DrainBody(respBody)
-		return !xnet.IsNetworkOrHostDown(err, false)
+		return !isNetworkError(err)
 	}
 
 	return &lockRESTClient{endpoint: endpoint, restClient: restClient}

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -882,7 +882,7 @@ func newPeerRESTClient(peer *xnet.Host) *peerRESTClient {
 		defer cancel()
 		respBody, err := healthClient.Call(ctx, peerRESTMethodHealth, nil, nil, -1)
 		xhttp.DrainBody(respBody)
-		return !xnet.IsNetworkOrHostDown(err, false)
+		return !isNetworkError(err)
 	}
 
 	return &peerRESTClient{host: peer, restClient: restClient}

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -626,7 +626,7 @@ func newStorageRESTClient(endpoint Endpoint, healthcheck bool) *storageRESTClien
 			respBody, err := healthClient.Call(ctx, storageRESTMethodHealth, nil, nil, -1)
 			xhttp.DrainBody(respBody)
 			cancel()
-			return !xnet.IsNetworkOrHostDown(err, false) && toStorageErr(err) != errDiskNotFound
+			return toStorageErr(err) != errDiskNotFound
 		}
 	}
 

--- a/pkg/net/url.go
+++ b/pkg/net/url.go
@@ -147,12 +147,15 @@ func IsNetworkOrHostDown(err error, expectTimeouts bool) bool {
 	if err == nil {
 		return false
 	}
+
 	if errors.Is(err, context.Canceled) {
 		return false
 	}
+
 	if expectTimeouts && errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
+
 	// We need to figure if the error either a timeout
 	// or a non-temporary error.
 	e, ok := err.(net.Error)


### PR DESCRIPTION


## Description
fix: network shutdown was not handled properly

## Motivation and Context
fixes a regression introduced in #10859, due
to the error returned by rest.Client being typed
i.e *rest.NetworkError - IsNetworkHostDown function
didn't work as expected to detect network issues.

This in-turn aggravated the situations when nodes
are disconnected leading to performance loss.

## How to test this PR?
Run a local distributed setup and see healthchecks incorrectly 
return true for downed node. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
