### PR TITLE
validate service type of target in replication/ilm config

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -154,6 +154,9 @@ func validateTransitionDestination(ctx context.Context, bucket string, targetLab
 	if err != nil {
 		return false, "", BucketRemoteTargetNotFound{Bucket: bucket}
 	}
+	if arn.Type != madmin.ILMService {
+		return false, "", BucketRemoteArnTypeInvalid{}
+	}
 	clnt := globalBucketTargetSys.GetRemoteTargetClient(ctx, tgt.Arn)
 	if clnt == nil {
 		return false, "", BucketRemoteTargetNotFound{Bucket: bucket}

--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -125,8 +125,10 @@ func (sys *BucketTargetSys) SetTarget(ctx context.Context, bucket string, tgt *m
 
 	tgts := sys.targetsMap[bucket]
 	newtgts := make([]madmin.BucketTarget, len(tgts))
+	labels := make(map[string]struct{})
 	found := false
 	for idx, t := range tgts {
+		labels[t.Label] = struct{}{}
 		if t.Type == tgt.Type {
 			if t.Arn == tgt.Arn {
 				return BucketRemoteAlreadyExists{Bucket: t.TargetBucket}
@@ -139,6 +141,9 @@ func (sys *BucketTargetSys) SetTarget(ctx context.Context, bucket string, tgt *m
 			continue
 		}
 		newtgts[idx] = t
+	}
+	if _, ok := labels[tgt.Label]; ok {
+		return BucketRemoteLabelInUse{Bucket: tgt.TargetBucket}
 	}
 	if !found {
 		newtgts = append(newtgts, *tgt)


### PR DESCRIPTION
## Description


## Motivation and Context
Specifying ilm service ARN for replication should fail. Also validating label uniqueness
## How to test this PR?
`mc replicate add source/bucket --remote-bucket bucket --priority 5 --arn arn:minio:ilm:us-east-1:8a59c4fb-0209-4d87-a5ed-75b20659e968:bucket --replicate "delete,delete-marker"` should fail

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
