### PR TITLE
Add a CI/CD Dockerfile

### DIFF
--- a/Dockerfile.cicd
+++ b/Dockerfile.cicd
@@ -1,0 +1,36 @@
+FROM golang:1.15-alpine as builder
+
+LABEL maintainer="MinIO Inc <dev@min.io>"
+
+ENV GOPATH /go
+ENV CGO_ENABLED 0
+ENV GO111MODULE on
+
+RUN  \
+  apk add --no-cache git && \
+  git clone https://github.com/minio/minio && cd minio && \
+  git checkout master && go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)"
+
+FROM alpine:3.12
+
+ENV MINIO_ACCESS_KEY_FILE=access_key \
+  MINIO_SECRET_KEY_FILE=secret_key \
+  MINIO_KMS_MASTER_KEY_FILE=kms_master_key \
+  MINIO_SSE_MASTER_KEY_FILE=sse_master_key \
+  MINIO_UPDATE_MINISIGN_PUBKEY="RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"
+
+EXPOSE 9000
+
+COPY --from=builder /go/bin/minio /usr/bin/minio
+COPY --from=builder /go/minio/CREDITS /third_party/
+COPY --from=builder /go/minio/dockerscripts/docker-entrypoint.sh /usr/bin/
+
+RUN  \
+  apk add --no-cache ca-certificates 'curl>7.61.0' 'su-exec>=0.2' && \
+  echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+
+VOLUME ["/data"]
+
+CMD ["minio", "server", "/data"]


### PR DESCRIPTION
## Description

This PR adds a Dockerfile intended to be used inside CI/CD pipelines. The only difference to the standard Dockerfile is that the server is started right away.

## Motivation and Context

I would like to use MinIO inside Azure Pipelines as a so called container resource. Sadly there is no way to pass command / arguments to these container resources … You can read more about it in [issue #10745](https://github.com/minio/minio/issues/10745)

## How to test this PR?

I've build this Dockerfile locally and ran it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
