### PR TITLE
fix: do not return an error for successfully deleted dangling objects

### DIFF
--- a/cmd/erasure-object_test.go
+++ b/cmd/erasure-object_test.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -257,7 +258,7 @@ func TestErasureDeleteObjectDiskNotFound(t *testing.T) {
 	z.serverSets[0].erasureDisksMu.Unlock()
 	_, err = obj.DeleteObject(ctx, bucket, object, ObjectOptions{})
 	// since majority of disks are not available, metaquorum is not achieved and hence errErasureWriteQuorum error
-	if err != toObjectErr(errErasureWriteQuorum, bucket, object) {
+	if !errors.Is(err, errErasureWriteQuorum) {
 		t.Errorf("Expected deleteObject to fail with %v, but failed with %v", toObjectErr(errErasureWriteQuorum, bucket, object), err)
 	}
 }
@@ -381,7 +382,7 @@ func TestPutObjectNoQuorum(t *testing.T) {
 		z.serverSets[0].erasureDisksMu.Unlock()
 		// Upload new content to same object "object"
 		_, err = obj.PutObject(ctx, bucket, object, mustGetPutObjReader(t, bytes.NewReader([]byte("abcd")), int64(len("abcd")), "", ""), opts)
-		if err != toObjectErr(errErasureWriteQuorum, bucket, object) {
+		if !errors.Is(err, errErasureWriteQuorum) {
 			t.Errorf("Expected putObject to fail with %v, but failed with %v", toObjectErr(errErasureWriteQuorum, bucket, object), err)
 		}
 	}

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -130,9 +130,27 @@ func toObjectErr(err error, params ...string) error {
 			}
 		}
 	case errErasureReadQuorum:
-		err = InsufficientReadQuorum{}
+		if len(params) == 1 {
+			err = InsufficientReadQuorum{
+				Bucket: params[0],
+			}
+		} else if len(params) >= 2 {
+			err = InsufficientReadQuorum{
+				Bucket: params[0],
+				Object: params[1],
+			}
+		}
 	case errErasureWriteQuorum:
-		err = InsufficientWriteQuorum{}
+		if len(params) == 1 {
+			err = InsufficientWriteQuorum{
+				Bucket: params[0],
+			}
+		} else if len(params) >= 2 {
+			err = InsufficientWriteQuorum{
+				Bucket: params[0],
+				Object: params[1],
+			}
+		}
 	case io.ErrUnexpectedEOF, io.ErrShortWrite:
 		err = IncompleteBody{}
 	case context.Canceled, context.DeadlineExceeded:
@@ -163,10 +181,10 @@ func (e SlowDown) Error() string {
 }
 
 // InsufficientReadQuorum storage cannot satisfy quorum for read operation.
-type InsufficientReadQuorum struct{}
+type InsufficientReadQuorum GenericError
 
 func (e InsufficientReadQuorum) Error() string {
-	return "Storage resources are insufficient for the read operation."
+	return "Storage resources are insufficient for the read operation " + e.Bucket + "/" + e.Object
 }
 
 // Unwrap the error.
@@ -175,10 +193,10 @@ func (e InsufficientReadQuorum) Unwrap() error {
 }
 
 // InsufficientWriteQuorum storage cannot satisfy quorum for write operation.
-type InsufficientWriteQuorum struct{}
+type InsufficientWriteQuorum GenericError
 
 func (e InsufficientWriteQuorum) Error() string {
-	return "Storage resources are insufficient for the write operation."
+	return "Storage resources are insufficient for the write operation " + e.Bucket + "/" + e.Object
 }
 
 // Unwrap the error.
@@ -192,6 +210,11 @@ type GenericError struct {
 	Object    string
 	VersionID string
 	Err       error
+}
+
+// Unwrap the error to its underlying error.
+func (e GenericError) Unwrap() error {
+	return e.Err
 }
 
 // InvalidArgument incorrect input argument

--- a/cmd/object-api-putobject_test.go
+++ b/cmd/object-api-putobject_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path"
@@ -296,7 +297,7 @@ func testObjectAPIPutObjectDiskNotFound(obj ObjectLayer, instanceType string, di
 		int64(len("mnop")),
 		false,
 		"",
-		InsufficientWriteQuorum{},
+		errErasureWriteQuorum,
 	}
 
 	_, actualErr := obj.PutObject(context.Background(), testCase.bucketName, testCase.objName, mustGetPutObjReader(t, bytes.NewReader(testCase.inputData), testCase.intputDataSize, testCase.inputMeta["etag"], sha256sum), ObjectOptions{UserDefined: testCase.inputMeta})
@@ -305,7 +306,7 @@ func testObjectAPIPutObjectDiskNotFound(obj ObjectLayer, instanceType string, di
 	}
 	// Failed as expected, but does it fail for the expected reason.
 	if actualErr != nil && !testCase.shouldPass {
-		if testCase.expectedError.Error() != actualErr.Error() {
+		if !errors.Is(actualErr, testCase.expectedError) {
 			t.Errorf("Test %d: %s: Expected to fail with error \"%s\", but instead failed with error \"%s\" instead.", len(testCases)+1, instanceType, testCase.expectedError.Error(), actualErr.Error())
 		}
 	}

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -118,6 +118,7 @@ type HealResultItem struct {
 	Type         HealItemType `json:"type"`
 	Bucket       string       `json:"bucket"`
 	Object       string       `json:"object"`
+	VersionID    string       `json:"versionId"`
 	Detail       string       `json:"detail"`
 	ParityBlocks int          `json:"parityBlocks,omitempty"`
 	DataBlocks   int          `json:"dataBlocks,omitempty"`


### PR DESCRIPTION


## Description
fix: do not return an error for successfully deleted dangling objects

## Motivation and Context
dangling objects when removed `mc admin heal -r` or crawler
auto-heal would incorrectly return error - this can interfere
with usage calculation as the entry size for this would be
returned as `0`, instead of upon success use the resultant
object size to calculate the final size for the object
and avoid reporting this in the log messages

Also do not set ObjectSize in healResultItem to be '-1'
this has an effect on crawler metrics calculating 1 byte
less for objects which seem to be missing their `xl.meta`

## How to test this PR?
Manually creating dangling objects

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
