### PR TITLE
fix: do not crash PutObjectTags when a node is down

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -819,10 +819,12 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 	// Update all erasure metadata, make sure to not modify fields like
 	// checksum which are different on each disks.
 	for index := range partsMetadata {
-		partsMetadata[index].Size = fi.Size
-		partsMetadata[index].ModTime = fi.ModTime
-		partsMetadata[index].Metadata = fi.Metadata
-		partsMetadata[index].Parts = fi.Parts
+		if partsMetadata[index].IsValid() {
+			partsMetadata[index].Size = fi.Size
+			partsMetadata[index].ModTime = fi.ModTime
+			partsMetadata[index].Metadata = fi.Metadata
+			partsMetadata[index].Parts = fi.Parts
+		}
 	}
 
 	// Write final `xl.meta` at uploadID location

--- a/pkg/bucket/lifecycle/action_string.go
+++ b/pkg/bucket/lifecycle/action_string.go
@@ -11,11 +11,15 @@ func _() {
 	_ = x[NoneAction-0]
 	_ = x[DeleteAction-1]
 	_ = x[DeleteVersionAction-2]
+	_ = x[TransitionAction-3]
+	_ = x[TransitionVersionAction-4]
+	_ = x[DeleteRestoredAction-5]
+	_ = x[DeleteRestoredVersionAction-6]
 }
 
-const _Action_name = "NoneActionDeleteActionDeleteVersionAction"
+const _Action_name = "NoneActionDeleteActionDeleteVersionActionTransitionActionTransitionVersionActionDeleteRestoredActionDeleteRestoredVersionAction"
 
-var _Action_index = [...]uint8{0, 10, 22, 41}
+var _Action_index = [...]uint8{0, 10, 22, 41, 57, 80, 100, 127}
 
 func (i Action) String() string {
 	if i < 0 || i >= Action(len(_Action_index)-1) {


### PR DESCRIPTION

## Description
fix: do not crash PutObjectTags when a node is down

## Motivation and Context
fixes #10939

## How to test this PR?
As per #10939 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
