### PR TITLE
azure: Specify different Azure storage in the shell env

### DIFF
--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -29,7 +29,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"sort"
 	"strconv"
@@ -177,7 +176,7 @@ func (g *Azure) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, erro
 	var err error
 
 	// Override credentials from the Azure storage environment variables if specified
-	if acc, key := os.Getenv("AZURE_STORAGE_ACCOUNT"), os.Getenv("AZURE_STORAGE_KEY"); acc != "" && key != "" {
+	if acc, key := env.Get("AZURE_STORAGE_ACCOUNT", creds.AccessKey), env.Get("AZURE_STORAGE_KEY", creds.SecretKey); acc != "" && key != "" {
 		creds, err = auth.CreateCredentials(acc, key)
 		if err != nil {
 			return nil, err

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -29,6 +29,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"sort"
 	"strconv"
@@ -173,6 +174,16 @@ func (g *Azure) Name() string {
 
 // NewGatewayLayer initializes azure blob storage client and returns AzureObjects.
 func (g *Azure) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) {
+	var err error
+
+	// Override credentials from the Azure storage environment variables if specified
+	if acc, key := os.Getenv("AZURE_STORAGE_ACCOUNT"), os.Getenv("AZURE_STORAGE_KEY"); acc != "" && key != "" {
+		creds, err = auth.CreateCredentials(acc, key)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	endpointURL, err := parseStorageEndpoint(g.host, creds.AccessKey)
 	if err != nil {
 		return nil, err

--- a/docs/gateway/azure.md
+++ b/docs/gateway/azure.md
@@ -36,6 +36,10 @@ mc ls myazure
 [2017-02-26 22:10:11 PST]     0B test-container1/
 ```
 
+### Use custom access/secret keys
+
+If you do not want to share the credentials of the Azure blob storage with your users/applications, you can set the original credentials in the shell environment using `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` variables and assign different access/secret keys to `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`.
+
 ### Known limitations
 Gateway inherits the following Azure limitations:
 


### PR DESCRIPTION
## Description
AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY are used in az cli to specifiy
the azure blob storage access & secret keys. With this commit, it is
possible to set them if you want from the gateway own credentials to be
different to the Azure blob credentials.

## Motivation and Context
Fixes https://github.com/minio/minio/issues/10746

## How to test this PR?
`AZURE_STORAGE_ACCOUNT=xxx AZURE_STORAGE_KEY=xxxxxx MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=minio123 minio gateway azure`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation needed
- [ ] Unit tests needed
