### PR TITLE
Refactor replication,ilm handling in Delete api

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -165,12 +164,8 @@ func (a adminAPIHandlers) SetRemoteTargetHandler(w http.ResponseWriter, r *http.
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErrWithErr(ErrAdminConfigBadJSON, err), r.URL)
 		return
 	}
-	host, port, err := net.SplitHostPort(target.Endpoint)
-	if err != nil {
-		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErrWithErr(ErrAdminConfigBadJSON, err), r.URL)
-		return
-	}
-	sameTarget, _ := isLocalHost(host, port, globalMinioPort)
+
+	sameTarget, _ := isLocalHost(target.URL().Hostname(), target.URL().Port(), globalMinioPort)
 	if sameTarget && bucket == target.TargetBucket {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrBucketRemoteIdenticalToSource), r.URL)
 		return

--- a/cmd/api-datatypes.go
+++ b/cmd/api-datatypes.go
@@ -35,6 +35,8 @@ type DeletedObject struct {
 	DeleteMarkerMTime time.Time `xml:"DeleteMarkerMTime,omitempty"`
 	// Status of versioned delete (of object or DeleteMarker)
 	VersionPurgeStatus VersionPurgeStatusType `xml:"VersionPurgeStatus,omitempty"`
+	// PurgeTransitioned is nonempty if object is in transition tier
+	PurgeTransitioned string `xml:"PurgeTransitioned,omitempty"`
 }
 
 // ObjectToDelete carries key name for the object to delete.
@@ -47,6 +49,8 @@ type ObjectToDelete struct {
 	VersionPurgeStatus VersionPurgeStatusType `xml:"VersionPurgeStatus"`
 	// Version ID of delete marker
 	DeleteMarkerVersionID string `xml:"DeleteMarkerVersionId"`
+	// PurgeTransitioned is nonempty if object is in transition tier
+	PurgeTransitioned string `xml:"PurgeTransitioned"`
 }
 
 // createBucketConfiguration container for bucket configuration request from client.

--- a/cmd/bucket-object-lock.go
+++ b/cmd/bucket-object-lock.go
@@ -82,7 +82,7 @@ func enforceRetentionForDeletion(ctx context.Context, objInfo ObjectInfo) (locke
 // For objects in "Governance" mode, overwrite is allowed if a) object retention date is past OR
 // governance bypass headers are set and user has governance bypass permissions.
 // Objects in "Compliance" mode can be overwritten only if retention date is past.
-func enforceRetentionBypassForDelete(ctx context.Context, r *http.Request, bucket string, object ObjectToDelete, getObjectInfoFn GetObjectInfoFn) APIErrorCode {
+func enforceRetentionBypassForDelete(ctx context.Context, r *http.Request, bucket string, object ObjectToDelete, oi ObjectInfo, gerr error) APIErrorCode {
 	opts, err := getOpts(ctx, r, bucket, object.ObjectName)
 	if err != nil {
 		return toAPIErrorCode(ctx, err)
@@ -90,8 +90,7 @@ func enforceRetentionBypassForDelete(ctx context.Context, r *http.Request, bucke
 
 	opts.VersionID = object.VersionID
 
-	oi, err := getObjectInfoFn(ctx, bucket, object.ObjectName, opts)
-	if err != nil {
+	if gerr != nil { // error from GetObjectInfo
 		switch err.(type) {
 		case MethodNotAllowed: // This happens usually for a delete marker
 			if oi.DeleteMarker {

--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -351,7 +351,7 @@ func (sys *BucketTargetSys) getRemoteTargetClient(tcfg *madmin.BucketTarget) (*m
 		getRemoteTargetInstanceTransport = newGatewayHTTPTransport(1 * time.Hour)
 	})
 
-	core, err := miniogo.NewCore(tcfg.Endpoint, &miniogo.Options{
+	core, err := miniogo.NewCore(tcfg.URL().Host, &miniogo.Options{
 		Creds:     creds,
 		Secure:    tcfg.Secure,
 		Transport: getRemoteTargetInstanceTransport,
@@ -366,7 +366,7 @@ func (sys *BucketTargetSys) getRemoteARN(bucket string, target *madmin.BucketTar
 	}
 	tgts := sys.targetsMap[bucket]
 	for _, tgt := range tgts {
-		if tgt.Type == target.Type && tgt.TargetBucket == target.TargetBucket && target.URL() == tgt.URL() {
+		if tgt.Type == target.Type && tgt.TargetBucket == target.TargetBucket && target.URL().String() == tgt.URL().String() {
 			return tgt.Arn
 		}
 	}

--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -772,7 +772,7 @@ func (i *crawlItem) applyActions(ctx context.Context, o ObjectLayer, meta action
 		return 0
 	}
 	if obj.TransitionStatus != "" {
-		if err := deleteTransitionedObject(ctx, o, i.bucket, i.objectPath(), obj, lcOpts, action); err != nil {
+		if err := deleteTransitionedObject(ctx, o, i.bucket, i.objectPath(), lcOpts, action, false); err != nil {
 			logger.LogIf(ctx, err)
 			return size
 		}

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -905,6 +905,7 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 					DeleteMarkerReplicationStatus: versions[objIndex].DeleteMarkerReplicationStatus,
 					ObjectName:                    versions[objIndex].Name,
 					VersionPurgeStatus:            versions[objIndex].VersionPurgeStatus,
+					PurgeTransitioned:             objects[objIndex].PurgeTransitioned,
 				}
 			} else {
 				dobjects[objIndex] = DeletedObject{
@@ -912,6 +913,7 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 					VersionID:                     versions[objIndex].VersionID,
 					VersionPurgeStatus:            versions[objIndex].VersionPurgeStatus,
 					DeleteMarkerReplicationStatus: versions[objIndex].DeleteMarkerReplicationStatus,
+					PurgeTransitioned:             objects[objIndex].PurgeTransitioned,
 				}
 			}
 		}

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -510,6 +510,9 @@ func (z *xlMetaV2) DeleteVersion(fi FileInfo) (string, bool, error) {
 				if updateVersion {
 					delete(z.Versions[i].DeleteMarker.MetaSys, xhttp.AmzBucketReplicationStatus)
 					delete(z.Versions[i].DeleteMarker.MetaSys, VersionPurgeStatusKey)
+					if z.Versions[i].DeleteMarker.MetaSys == nil {
+						z.Versions[i].DeleteMarker.MetaSys = make(map[string][]byte)
+					}
 					if fi.DeleteMarkerReplicationStatus != "" {
 						z.Versions[i].DeleteMarker.MetaSys[xhttp.AmzBucketReplicationStatus] = []byte(fi.DeleteMarkerReplicationStatus)
 					}

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -508,11 +508,11 @@ func (z *xlMetaV2) DeleteVersion(fi FileInfo) (string, bool, error) {
 		case DeleteType:
 			if bytes.Equal(version.DeleteMarker.VersionID[:], uv[:]) {
 				if updateVersion {
-					delete(z.Versions[i].DeleteMarker.MetaSys, xhttp.AmzBucketReplicationStatus)
-					delete(z.Versions[i].DeleteMarker.MetaSys, VersionPurgeStatusKey)
-					if z.Versions[i].DeleteMarker.MetaSys == nil {
+					if len(z.Versions[i].DeleteMarker.MetaSys) == 0 {
 						z.Versions[i].DeleteMarker.MetaSys = make(map[string][]byte)
 					}
+					delete(z.Versions[i].DeleteMarker.MetaSys, xhttp.AmzBucketReplicationStatus)
+					delete(z.Versions[i].DeleteMarker.MetaSys, VersionPurgeStatusKey)
 					if fi.DeleteMarkerReplicationStatus != "" {
 						z.Versions[i].DeleteMarker.MetaSys[xhttp.AmzBucketReplicationStatus] = []byte(fi.DeleteMarkerReplicationStatus)
 					}

--- a/pkg/madmin/remote-target-commands.go
+++ b/pkg/madmin/remote-target-commands.go
@@ -118,20 +118,15 @@ func (t *BucketTarget) Clone() BucketTarget {
 }
 
 // URL returns target url
-func (t BucketTarget) URL() string {
+func (t BucketTarget) URL() *url.URL {
 	scheme := "http"
 	if t.Secure {
 		scheme = "https"
 	}
-	urlStr := fmt.Sprintf("%s://%s", scheme, t.Endpoint)
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return urlStr
+	return &url.URL{
+		Scheme: scheme,
+		Host:   t.Endpoint,
 	}
-	if u.Port() == "80" || u.Port() == "443" {
-		u.Host = u.Hostname()
-	}
-	return u.String()
 }
 
 // Empty returns true if struct is empty.


### PR DESCRIPTION
## Description

GetObjectInfo is called multiple times for replication, locking enforcement and lifecycle in delete objects handler - Refactoring this, and also handling
- deletes of transitioned objects via DELETE api
- remote target url minor fix
- hand a unique ARN for a given bucket,region and target type to handle accidental deletes of a ARN. That would ensure any transitioned object is still accessible even if ARN was removed and re-added

Each of these is a separate commit for ease of review.
## Motivation and Context
## How to test this PR?
Set up ilm/replication and do `mc rm`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
