### PR TITLE
heal: Return ObjectNotFound in HealObject if the object is not found

### DIFF
--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -796,8 +796,12 @@ func (er erasureObjects) HealObject(ctx context.Context, bucket, object, version
 	partsMetadata, errs := readAllFileInfo(healCtx, storageDisks, bucket, object, versionID)
 
 	if isAllNotFound(errs) {
-		// Nothing to do, file is already gone.
-		return defaultHealResult(FileInfo{}, storageDisks, storageEndpoints, errs, bucket, object, versionID), nil
+		if versionID != "" {
+			err = errFileVersionNotFound
+		} else {
+			err = errFileNotFound
+		}
+		return defaultHealResult(FileInfo{}, storageDisks, storageEndpoints, errs, bucket, object, versionID), toObjectErr(err, bucket, object, versionID)
 	}
 
 	fi, err := getLatestFileInfo(healCtx, partsMetadata, errs)


### PR DESCRIPTION
## Description
erasureServeSets.HealObject() does not know in which set a given
object exists, so it relies on HealObject ObjectNotFound error to go to
the next set in order to find/heal the object. However this behavior
has been changed recently and we can see sometimes many gray objects
with mc admin heal command.

This commit reverts the original logic.

## Motivation and Context
Fix inexplicably many gray objects during healing

## How to test this PR?
1. minio server /tmp/xl/1/{1...4}/
2. Create a bucket and upload an object
3. Restart minio with this command: minio server /tmp/xl/2/{1...4}/ /tmp/xl/1/{1...4}/
4. mc admin heal -r myminio/


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
