### PR TITLE
Add Dockerfile based on Red Hat UBI

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,0 +1,49 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+
+ARG TARGETARCH
+
+LABEL name="MinIO" \
+      vendor="MinIO Inc <dev@min.io>" \
+      maintainer="MinIO Inc <dev@min.io>" \
+      version="RELEASE.2020-11-25T22-36-25Z" \
+      release="RELEASE.2020-11-25T22-36-25Z" \
+      summary="MinIO is a High Performance Object Storage, API compatible with Amazon S3 cloud storage service." \
+      description="MinIO object storage is fundamentally different. Designed for performance and the S3 API, it is 100% open-source. MinIO is ideal for large, private cloud environments with stringent security requirements and delivers mission-critical availability across a diverse range of workloads."
+
+ENV MINIO_ACCESS_KEY_FILE=access_key \
+    MINIO_SECRET_KEY_FILE=secret_key \
+    MINIO_KMS_MASTER_KEY_FILE=kms_master_key \
+    MINIO_SSE_MASTER_KEY_FILE=sse_master_key \
+    MINIO_UPDATE_MINISIGN_PUBKEY="RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav" 
+
+COPY dockerscripts/verify-minio.sh /usr/bin/verify-minio.sh
+COPY dockerscripts/docker-entrypoint.ubi.sh /usr/bin/docker-entrypoint.ubi.sh
+COPY CREDITS /licenses/CREDITS
+COPY LICENSE /licenses/LICENSE
+
+RUN \
+     microdnf update --nodocs && \
+     microdnf install curl ca-certificates shadow-utils --nodocs && \
+     curl -s -q https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -o epel-release.rpm && \
+     rpm -ivh epel-release.rpm && microdnf install minisign --nodocs && \
+     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/minio -o /usr/bin/minio && \
+     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/minio.sha256sum -o /usr/bin/minio.sha256sum && \
+     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/minio.minisig -o /usr/bin/minio.minisig && \
+     microdnf clean all && \
+     chmod +x /usr/bin/minio && \
+     chmod +x /usr/bin/docker-entrypoint.ubi.sh && \
+     chmod +x /usr/bin/verify-minio.sh && \
+     /usr/bin/verify-minio.sh && \
+     groupadd --gid 1000 minio && \
+     useradd -M --uid 1000 --gid 1000 --home /usr/share/minio minio && \
+     mkdir -p /data && chown -R minio:minio /usr/bin /data
+
+EXPOSE 9000
+
+USER minio
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.ubi.sh"]
+
+VOLUME ["/data"]
+
+CMD ["minio"]

--- a/dockerscripts/docker-entrypoint.ubi.sh
+++ b/dockerscripts/docker-entrypoint.ubi.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+#
+# MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# If command starts with an option, prepend minio in UBI container image
+if [ "${1}" != "minio" ]; then
+    if [ -n "${1}" ]; then
+        set -- minio "$@"
+    fi
+fi
+
+## Look for docker secrets at given absolute path or in default documented location.
+docker_secrets_env() {
+    if [ -f "$MINIO_ACCESS_KEY_FILE" ]; then
+        ACCESS_KEY_FILE="$MINIO_ACCESS_KEY_FILE"
+    else
+        ACCESS_KEY_FILE="/run/secrets/$MINIO_ACCESS_KEY_FILE"
+    fi
+    if [ -f "$MINIO_SECRET_KEY_FILE" ]; then
+        SECRET_KEY_FILE="$MINIO_SECRET_KEY_FILE"
+    else
+        SECRET_KEY_FILE="/run/secrets/$MINIO_SECRET_KEY_FILE"
+    fi
+
+    if [ -f "$ACCESS_KEY_FILE" ] && [ -f "$SECRET_KEY_FILE" ]; then
+        if [ -f "$ACCESS_KEY_FILE" ]; then
+            MINIO_ACCESS_KEY="$(cat "$ACCESS_KEY_FILE")"
+            export MINIO_ACCESS_KEY
+        fi
+        if [ -f "$SECRET_KEY_FILE" ]; then
+            MINIO_SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
+            export MINIO_SECRET_KEY
+        fi
+    fi
+}
+
+## Set KMS_MASTER_KEY from docker secrets if provided
+docker_kms_encryption_env() {
+    if [ -f "$MINIO_KMS_MASTER_KEY_FILE" ]; then
+        KMS_MASTER_KEY_FILE="$MINIO_KMS_MASTER_KEY_FILE"
+    else
+        KMS_MASTER_KEY_FILE="/run/secrets/$MINIO_KMS_MASTER_KEY_FILE"
+    fi
+
+    if [ -f "$KMS_MASTER_KEY_FILE" ]; then
+        MINIO_KMS_MASTER_KEY="$(cat "$KMS_MASTER_KEY_FILE")"
+        export MINIO_KMS_MASTER_KEY
+    fi
+}
+
+## Legacy
+## Set SSE_MASTER_KEY from docker secrets if provided
+docker_sse_encryption_env() {
+    SSE_MASTER_KEY_FILE="/run/secrets/$MINIO_SSE_MASTER_KEY_FILE"
+
+    if [ -f "$SSE_MASTER_KEY_FILE" ]; then
+        MINIO_SSE_MASTER_KEY="$(cat "$SSE_MASTER_KEY_FILE")"
+        export MINIO_SSE_MASTER_KEY
+    fi
+}
+
+## Set access env from secrets if necessary.
+docker_secrets_env
+
+## Set kms encryption from secrets if necessary.
+docker_kms_encryption_env
+
+## Set sse encryption from secrets if necessary. Legacy
+docker_sse_encryption_env
+
+exec "$@"


### PR DESCRIPTION
## Description
Add a new Dockerfile with [UBI](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) as the base image.

## Motivation and Context
See https://connect.redhat.com/zones/containers/container-certification-policy-guide
for details

## How to test this PR?
Build the Docker image locally using `docker build -t minio/minio:ubi -f Dockerfile.ubi .`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
