### PR TITLE
metacache: Always close block writer

### DIFF
--- a/cmd/metacache-stream_test.go
+++ b/cmd/metacache-stream_test.go
@@ -370,6 +370,7 @@ func Test_newMetacacheStream(t *testing.T) {
 	r := loadMetacacheSample(t)
 	var buf bytes.Buffer
 	w := newMetacacheWriter(&buf, 1<<20)
+	defer w.Close()
 	err := r.readFn(func(object metaCacheEntry) bool {
 		err := w.write(object)
 		if err != nil {


### PR DESCRIPTION
## Description

In some cases a writer could be left behind unclosed, leaking compression blocks.

Always close and set compression concurrency to 2 which should be fine to keep up.

## How to test this PR?

After serving list operations, servers would have leaked goroutines:

`#	0x139a384	github.com/klauspost/compress/s2.(*Writer).write.func1+0x284	github.com/klauspost/compress@v1.10.3/s2/encode.go:586` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
