### PR TITLE
fix: avoid sending errors on missing objects on locked buckets

### DIFF
--- a/cmd/api-datatypes.go
+++ b/cmd/api-datatypes.go
@@ -32,11 +32,25 @@ type DeletedObject struct {
 	// Replication status of DeleteMarker
 	DeleteMarkerReplicationStatus string `xml:"DeleteMarkerReplicationStatus,omitempty"`
 	// MTime of DeleteMarker on source that needs to be propagated to replica
-	DeleteMarkerMTime time.Time `xml:"DeleteMarkerMTime,omitempty"`
+	DeleteMarkerMTime DeleteMarkerMTime `xml:"DeleteMarkerMTime,omitempty"`
 	// Status of versioned delete (of object or DeleteMarker)
 	VersionPurgeStatus VersionPurgeStatusType `xml:"VersionPurgeStatus,omitempty"`
 	// PurgeTransitioned is nonempty if object is in transition tier
 	PurgeTransitioned string `xml:"PurgeTransitioned,omitempty"`
+}
+
+// DeleteMarkerMTime is an embedded type containing time.Time for XML marshal
+type DeleteMarkerMTime struct {
+	time.Time
+}
+
+// MarshalXML encodes expiration date if it is non-zero and encodes
+// empty string otherwise
+func (t DeleteMarkerMTime) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+	if t.Time.IsZero() {
+		return nil
+	}
+	return e.EncodeElement(t.Time.Format(time.RFC3339), startElement)
 }
 
 // ObjectToDelete carries key name for the object to delete.

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -124,6 +124,7 @@ const (
 	ErrObjectRestoreAlreadyInProgress
 	ErrNoSuchKey
 	ErrNoSuchUpload
+	ErrInvalidVersionID
 	ErrNoSuchVersion
 	ErrNotImplemented
 	ErrPreconditionFailed
@@ -558,10 +559,15 @@ var errorCodes = errorCodeMap{
 		Description:    "The specified multipart upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
 		HTTPStatusCode: http.StatusNotFound,
 	},
-	ErrNoSuchVersion: {
+	ErrInvalidVersionID: {
 		Code:           "InvalidArgument",
 		Description:    "Invalid version id specified",
 		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrNoSuchVersion: {
+		Code:           "NoSuchVersion",
+		Description:    "The specified version does not exist.",
+		HTTPStatusCode: http.StatusNotFound,
 	},
 	ErrNotImplemented: {
 		Code:           "NotImplemented",
@@ -1886,6 +1892,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrNoSuchKey
 	case MethodNotAllowed:
 		apiErr = ErrMethodNotAllowed
+	case InvalidVersionID:
+		apiErr = ErrInvalidVersionID
 	case VersionNotFound:
 		apiErr = ErrNoSuchVersion
 	case ObjectAlreadyExists:

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -495,7 +495,6 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 	})
 	deletedObjects := make([]DeletedObject, len(deleteObjects.Objects))
 	for i := range errs {
-
 		dindex := objectsToDelete[ObjectToDelete{
 			ObjectName:                    dObjects[i].ObjectName,
 			VersionID:                     dObjects[i].VersionID,
@@ -504,7 +503,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 			DeleteMarkerReplicationStatus: dObjects[i].DeleteMarkerReplicationStatus,
 			PurgeTransitioned:             dObjects[i].PurgeTransitioned,
 		}]
-		if errs[i] == nil || isErrObjectNotFound(errs[i]) || isErrVersionNotFound(errs[i]) {
+		if errs[i] == nil || isErrObjectNotFound(errs[i]) {
 			if replicateDeletes {
 				dObjects[i].DeleteMarkerReplicationStatus = deleteList[i].DeleteMarkerReplicationStatus
 				dObjects[i].VersionPurgeStatus = deleteList[i].VersionPurgeStatus

--- a/cmd/bucket-object-lock.go
+++ b/cmd/bucket-object-lock.go
@@ -89,16 +89,15 @@ func enforceRetentionBypassForDelete(ctx context.Context, r *http.Request, bucke
 	}
 
 	opts.VersionID = object.VersionID
-
 	if gerr != nil { // error from GetObjectInfo
-		switch err.(type) {
+		switch gerr.(type) {
 		case MethodNotAllowed: // This happens usually for a delete marker
 			if oi.DeleteMarker {
 				// Delete marker should be present and valid.
 				return ErrNone
 			}
 		}
-		return toAPIErrorCode(ctx, err)
+		return toAPIErrorCode(ctx, gerr)
 	}
 
 	lhold := objectlock.GetObjectLegalHoldMeta(oi.UserDefined)

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -200,7 +200,7 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectVersionInfo, objectA
 		VersionID: versionID,
 		Internal: miniogo.AdvancedRemoveOptions{
 			ReplicationDeleteMarker: dobj.DeleteMarkerVersionID != "",
-			ReplicationMTime:        dobj.DeleteMarkerMTime,
+			ReplicationMTime:        dobj.DeleteMarkerMTime.Time,
 			ReplicationStatus:       miniogo.ReplicationStatusReplica,
 		},
 	})

--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -854,7 +854,7 @@ func (i *crawlItem) healReplicationDeletes(ctx context.Context, o ObjectLayer, m
 				DeleteMarkerVersionID:         dmVersionID,
 				VersionID:                     versionID,
 				DeleteMarkerReplicationStatus: string(meta.oi.ReplicationStatus),
-				DeleteMarkerMTime:             meta.oi.ModTime,
+				DeleteMarkerMTime:             DeleteMarkerMTime{meta.oi.ModTime},
 				DeleteMarker:                  meta.oi.DeleteMarker,
 				VersionPurgeStatus:            meta.oi.VersionPurgeStatus,
 			},

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -759,9 +759,7 @@ func (s *erasureSets) DeleteObjects(ctx context.Context, bucket string, objects 
 		dobjects, errs := s.getHashedSet(objsGroup[0].object.ObjectName).DeleteObjects(ctx, bucket, toNames(objsGroup), opts)
 		for i, obj := range objsGroup {
 			delErrs[obj.origIndex] = errs[i]
-			if delErrs[obj.origIndex] == nil {
-				delObjects[obj.origIndex] = dobjects[i]
-			}
+			delObjects[obj.origIndex] = dobjects[i]
 		}
 	}
 

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -255,7 +255,14 @@ func (e BucketNotEmpty) Error() string {
 	return "Bucket not empty: " + e.Bucket
 }
 
-// VersionNotFound object does not exist.
+// InvalidVersionID invalid version id
+type InvalidVersionID GenericError
+
+func (e InvalidVersionID) Error() string {
+	return "Invalid version id: " + e.Bucket + "/" + e.Object + "(" + e.VersionID + ")"
+}
+
+// VersionNotFound version does not exist.
 type VersionNotFound GenericError
 
 func (e VersionNotFound) Error() string {

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -93,7 +93,7 @@ func getOpts(ctx context.Context, r *http.Request, bucket, object string) (Objec
 		_, err := uuid.Parse(vid)
 		if err != nil {
 			logger.LogIf(ctx, err)
-			return opts, VersionNotFound{
+			return opts, InvalidVersionID{
 				Bucket:    bucket,
 				Object:    object,
 				VersionID: vid,
@@ -209,7 +209,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 		_, err := uuid.Parse(vid)
 		if err != nil {
 			logger.LogIf(ctx, err)
-			return opts, VersionNotFound{
+			return opts, InvalidVersionID{
 				Bucket:    bucket,
 				Object:    object,
 				VersionID: vid,

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2798,13 +2798,14 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 				VersionID:                     versionID,
 				DeleteMarkerVersionID:         dmVersionID,
 				DeleteMarkerReplicationStatus: string(objInfo.ReplicationStatus),
-				DeleteMarkerMTime:             objInfo.ModTime,
+				DeleteMarkerMTime:             DeleteMarkerMTime{objInfo.ModTime},
 				DeleteMarker:                  objInfo.DeleteMarker,
 				VersionPurgeStatus:            objInfo.VersionPurgeStatus,
 			},
 			Bucket: bucket,
 		})
 	}
+
 	if goi.TransitionStatus == lifecycle.TransitionComplete { // clean up transitioned tier
 		action := lifecycle.DeleteAction
 		if goi.VersionID != "" {
@@ -2819,6 +2820,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			IsLatest:         goi.IsLatest,
 		}, action, true)
 	}
+
 	setPutObjHeaders(w, objInfo, true)
 	writeSuccessNoContent(w)
 }

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -1765,7 +1765,7 @@ func testAPICopyObjectPartHandler(obj ObjectLayer, instanceType, bucketName stri
 			copySourceHeader:   url.QueryEscape(SlashSeparator+bucketName+SlashSeparator+objectName) + "?versionId=17",
 			accessKey:          credentials.AccessKey,
 			secretKey:          credentials.SecretKey,
-			expectedRespStatus: http.StatusBadRequest,
+			expectedRespStatus: http.StatusNotFound,
 		},
 	}
 
@@ -2135,7 +2135,7 @@ func testAPICopyObjectHandler(obj ObjectLayer, instanceType, bucketName string, 
 			copySourceHeader:   url.QueryEscape(SlashSeparator+bucketName+SlashSeparator+objectName) + "?versionId=17",
 			accessKey:          credentials.AccessKey,
 			secretKey:          credentials.SecretKey,
-			expectedRespStatus: http.StatusBadRequest,
+			expectedRespStatus: http.StatusNotFound,
 		},
 	}
 

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -761,7 +761,7 @@ next:
 						ObjectName:                    objectName,
 						DeleteMarkerVersionID:         oi.VersionID,
 						DeleteMarkerReplicationStatus: string(oi.ReplicationStatus),
-						DeleteMarkerMTime:             oi.ModTime,
+						DeleteMarkerMTime:             DeleteMarkerMTime{oi.ModTime},
 						DeleteMarker:                  oi.DeleteMarker,
 						VersionPurgeStatus:            oi.VersionPurgeStatus,
 					},

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -445,8 +445,12 @@ func (z *xlMetaV2) DeleteVersion(fi FileInfo) (string, bool, error) {
 	}
 
 	var uv uuid.UUID
+	var err error
 	if fi.VersionID != "" {
-		uv, _ = uuid.Parse(fi.VersionID)
+		uv, err = uuid.Parse(fi.VersionID)
+		if err != nil {
+			return "", false, errFileVersionNotFound
+		}
 	}
 
 	var ventry xlMetaV2Version
@@ -645,8 +649,11 @@ func (z xlMetaV2) ListVersions(volume, path string) (versions []FileInfo, modTim
 // for consumption across callers.
 func (z xlMetaV2) ToFileInfo(volume, path, versionID string) (fi FileInfo, err error) {
 	var uv uuid.UUID
-	if versionID != "" {
-		uv, _ = uuid.Parse(versionID)
+	if versionID != "" && versionID != nullVersionID {
+		uv, err = uuid.Parse(versionID)
+		if err != nil {
+			return FileInfo{}, errFileVersionNotFound
+		}
 	}
 
 	var latestModTime time.Time


### PR DESCRIPTION
## Description
fix: avoid sending errors on missing objects on locked buckets

## Motivation and Context
Compatible errors for Veeam like clients

## How to test this PR?
```
~ aws s3api delete-objects --profile minio --endpoint-url http://localhost:9000 --bucket testbucket1 --delete file:///tmp/delete.json

{
    "ResponseMetadata": {
        "RequestId": "164B78EF8B58B2FC",
        "HostId": "",
        "HTTPStatusCode": 200,
        "HTTPHeaders": {
            "accept-ranges": "bytes",
            "content-length": "268",
            "content-security-policy": "block-all-mixed-content",
            "content-type": "application/xml",
            "server": "MinIO",
            "vary": "Origin",
            "x-amz-request-id": "164B78EF8B58B2FC",
            "x-xss-protection": "1; mode=block",
            "date": "Fri, 27 Nov 2020 20:57:42 GMT"
        },
        "RetryAttempts": 0
    },
    "Errors": [
        {
            "Key": "hosts",
            "VersionId": "dfdfdfdfdfdfdfdf",
            "Code": "NoSuchVersion",
            "Message": "The specified version does not exist."
        }
    ]
}
```

```json
{
  "Objects": [
    {
      "Key": "hosts",
      "VersionId": "dfdfdfdfdfdfdfdf"
    }
  ],
  "Quiet": false
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
