### PR TITLE
fix: s3select tests with new minio-py SDK

### DIFF
--- a/mint/run/core/minio-go/go.mod
+++ b/mint/run/core/minio-go/go.mod
@@ -1,3 +1,5 @@
 module mint.minio.io/minio-go
 
 go 1.14
+
+require github.com/minio/minio-go/v7 v7.0.6 // indirect

--- a/mint/run/core/s3select/csv.py
+++ b/mint/run/core/s3select/csv.py
@@ -19,9 +19,13 @@ import io
 import os
 
 from minio import Minio
-from minio.select.options import (CSVInput, CSVOutput, InputSerialization,
-                                  JSONOutput, OutputSerialization,
-                                  RequestProgress, SelectObjectOptions)
+from minio.selectrequest import (COMPRESSION_TYPE_NONE, FILE_HEADER_INFO_NONE,
+                                 JSON_TYPE_DOCUMENT, QUOTE_FIELDS_ALWAYS,
+                                 QUOTE_FIELDS_ASNEEDED, CSVInputSerialization,
+                                 CSVOutputSerialization,
+                                 JSONInputSerialization,
+                                 JSONOutputSerialization, SelectRequest)
+
 from utils import *
 
 
@@ -93,26 +97,22 @@ def test_csv_input_custom_quote_char(client, log_output):
 
     try:
         for idx, (quote_char, escape_char, data, expected_output) in enumerate(tests):
-            sql_opts = SelectObjectOptions(
-                expression="select * from s3object",
-                input_serialization=InputSerialization(
-                    compression_type="NONE",
-                    csv=CSVInput(file_header_info="NONE",
-                                 record_delimiter="\n",
-                                 field_delimiter=",",
-                                 quote_character=quote_char,
-                                 quote_escape_character=escape_char,
-                                 comments="#",
-                                 allow_quoted_record_delimiter="FALSE",),
+            sql_opts = SelectRequest(
+                "select * from s3object",
+                CSVInputSerialization(
+                    compression_type=COMPRESSION_TYPE_NONE,
+                    file_header_info=FILE_HEADER_INFO_NONE,
+                    record_delimiter="\n",
+                    field_delimiter=",",
+                    quote_character=quote_char,
+                    quote_escape_character=escape_char,
+                    comments="#",
+                    allow_quoted_record_delimiter="FALSE",
                 ),
-                output_serialization=OutputSerialization(
-                    json=JSONOutput(
-                        record_delimiter="\n",
-                    )
+                JSONOutputSerialization(
+                    record_delimiter="\n",
                 ),
-                request_progress=RequestProgress(
-                    enabled="False"
-                )
+                request_progress=False,
             )
 
             test_sql_api(f'test_{idx}', client, bucket_name,
@@ -150,30 +150,26 @@ def test_csv_output_custom_quote_char(client, log_output):
 
     try:
         for idx, (quote_char, escape_char, input_data, expected_output) in enumerate(tests):
-            sql_opts = SelectObjectOptions(
-                expression="select * from s3object",
-                input_serialization=InputSerialization(
-                    compression_type="NONE",
-                    csv=CSVInput(file_header_info="NONE",
-                                 record_delimiter="\n",
-                                 field_delimiter=",",
-                                 quote_character='"',
-                                 quote_escape_character='"',
-                                 comments="#",
-                                 allow_quoted_record_delimiter="FALSE",
-                                 ),
+            sql_opts = SelectRequest(
+                "select * from s3object",
+                CSVInputSerialization(
+                    compression_type=COMPRESSION_TYPE_NONE,
+                    file_header_info=FILE_HEADER_INFO_NONE,
+                    record_delimiter="\n",
+                    field_delimiter=",",
+                    quote_character='"',
+                    quote_escape_character='"',
+                    comments="#",
+                    allow_quoted_record_delimiter="FALSE",
                 ),
-                output_serialization=OutputSerialization(
-                    csv=CSVOutput(quote_fields="ALWAYS",
-                                  record_delimiter="\n",
-                                  field_delimiter=",",
-                                  quote_character=quote_char,
-                                  quote_escape_character=escape_char,
-                                  )
+                CSVOutputSerialization(
+                    quote_fields=QUOTE_FIELDS_ALWAYS,
+                    record_delimiter="\n",
+                    field_delimiter=",",
+                    quote_character=quote_char,
+                    quote_escape_character=escape_char,
                 ),
-                request_progress=RequestProgress(
-                    enabled="False"
-                )
+                request_progress=False,
             )
 
             test_sql_api(f'test_{idx}', client, bucket_name,

--- a/mint/run/core/s3select/tests.py
+++ b/mint/run/core/s3select/tests.py
@@ -21,6 +21,7 @@ from csv import (test_csv_input_custom_quote_char,
                  test_csv_output_custom_quote_char)
 
 from minio import Minio
+
 from sql_ops import (test_sql_datatypes, test_sql_functions_agg_cond_conv,
                      test_sql_functions_date, test_sql_functions_string,
                      test_sql_operators, test_sql_operators_precedence,


### PR DESCRIPTION
## Description
fix: s3select tests with new minio-py SDK

## Motivation and Context
update with new API changes and update go.mod

## How to test this PR?
Build `docker build . -t minio/mint:edge -f Dockerfile.mint` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
