### PR TITLE
Disallow writeback caching with cache after

### DIFF
--- a/cmd/config/cache/lookup.go
+++ b/cmd/config/cache/lookup.go
@@ -222,6 +222,10 @@ func LookupConfig(kvs config.KVS) (Config, error) {
 		if err != nil {
 			return cfg, err
 		}
+		if cfg.After > 0 && cfg.CommitWriteback {
+			err := errors.New("cache after cannot be used with commit writeback")
+			return cfg, config.ErrInvalidCacheSetting(err)
+		}
 	}
 
 	return cfg, nil

--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -108,6 +108,11 @@ var (
 		"MINIO_CACHE_COMMIT: Valid expected value is `writeback` or `writethrough`",
 	)
 
+	ErrInvalidCacheSetting = newErrFn(
+		"Incompatible cache setting",
+		"Please check the passed value",
+		"MINIO_CACHE_AFTER cannot be used with MINIO_CACHE_COMMIT setting",
+	)
 	ErrInvalidRotatingCredentialsBackendEncrypted = newErrFn(
 		"Invalid rotating credentials",
 		"Please set correct rotating credentials in the environment for decryption",


### PR DESCRIPTION
Fixes :#10974

## Description


## Motivation and Context
cache_after is primarily intended for caching frequent GET's though still in use for uploads to delay caching. cache_commit is a upload only setting that doesn't make sense when used in conjunction with cache_after. 
 
## How to test this PR?
see issue desc.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
