### PR TITLE
add support for tuning healing to make healing more aggressive

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -124,8 +124,6 @@ wait:
 		case <-ctx.Done():
 			return
 		case <-time.After(defaultMonitorNewDiskInterval):
-			waitForLowHTTPReq(int32(globalEndpoints.NEndpoints()), time.Second)
-
 			var erasureSetInZoneDisksToHeal []map[int][]StorageAPI
 
 			healDisks := globalBackgroundHealState.getHealLocalDisks()

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -186,7 +186,10 @@ func deepHealObject(bucket, object, versionID string) {
 			bucket:    bucket,
 			object:    object,
 			versionID: versionID,
-			opts:      &madmin.HealOpts{ScanMode: madmin.HealDeepScan},
+			opts: &madmin.HealOpts{
+				Remove:   true, // if found dangling purge it.
+				ScanMode: madmin.HealDeepScan,
+			},
 		}
 	}
 }

--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -57,8 +57,8 @@ type Server struct {
 }
 
 // GetRequestCount - returns number of request in progress.
-func (srv *Server) GetRequestCount() int32 {
-	return atomic.LoadInt32(&srv.requestCount)
+func (srv *Server) GetRequestCount() int {
+	return int(atomic.LoadInt32(&srv.requestCount))
 }
 
 // Start - start HTTP server


### PR DESCRIPTION

## Description
add support for tuning healing to make healing more aggressive

## Motivation and Context
supports `mc admin config set <alias> heal max_sleep=100ms` to
enable more aggressive healing under certain times.

also optimize some areas that were doing extra checks than
necessary when bitrotscan was enabled, avoid double sleep
make healing more predictable.

fixes #10497

## How to test this PR?
Nothing special observe that healing to run at faster speeds
during active I/O if the heal.sleep times are reduced from the 
default 1sec

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
