### PR TITLE
Added set keyword in the command set to enable encryption on buckets

### DIFF
--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -77,7 +77,7 @@ Auto-Encryption is useful when MinIO administrator wants to ensure that all data
 ### Using `mc encrypt` (recommended)
 MinIO automatically encrypts all objects on buckets if KMS is successfully configured and bucket encryption configuration is enabled for each bucket as shown below:
 ```
-mc encrypt sse-s3 myminio/bucket/
+mc encrypt set sse-s3 myminio/bucket/
 ```
 
 Verify if MinIO has `sse-s3` enabled


### PR DESCRIPTION

## Description
Added set keyword in the command set to enable encryption on buckets


## Motivation and Context
missing set keyword identified while I was trying to encrypt the buckets

## How to test this PR?
by running the command against an existing bucket

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
