### PR TITLE
s3: Fix GET with partNumber specified

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -157,19 +157,13 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 	}
 
 	if opts.PartNumber > 0 {
-		var start, end int64
-		for i := 0; i < len(objInfo.Parts) && i < opts.PartNumber; i++ {
-			start = end
-			end = start + objInfo.Parts[i].ActualSize - 1
-		}
-		rs = &HTTPRangeSpec{Start: start, End: end}
-		rangeLen = end - start + 1
-	} else {
-		// for providing ranged content
-		start, rangeLen, err = rs.GetOffsetLength(totalObjectSize)
-		if err != nil {
-			return err
-		}
+		rs = partNumberToRangeSpec(objInfo, opts.PartNumber)
+	}
+
+	// For providing ranged content
+	start, rangeLen, err = rs.GetOffsetLength(totalObjectSize)
+	if err != nil {
+		return err
 	}
 
 	// Set content length.


### PR DESCRIPTION
## Description
partNumber was miscalculting the start and end of parts when partNumber
query is specified in the GET request. This commit fixes it and also
fixes the ContentRange header in that case.


## Motivation and Context
Fix https://github.com/minio/minio/issues/11025

## How to test this PR?
1. dd if=/dev/urandom of=file.1 count=$[128] bs=$[1024*1024]
2. dd if=/dev/urandom of=file.2 count=$[128] bs=$[1024*1024]
3. cat file1 file2 >file
4. mc cp file myminio/testbucket/
5. aws --profile minio --endpoint-url http://localhost:9000 s3api get-object --bucket testbucket --key file --part-number 2 /tmp/out
6. md5sum file.2 /tmp/out

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
