### PR TITLE
fix: re-use er.getDisks() properly in certain calls

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -382,8 +382,10 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 		return pi, toObjectErr(err, bucket, object, uploadID)
 	}
 
+	storageDisks := er.getDisks()
+
 	// Read metadata associated with the object from all disks.
-	partsMetadata, errs = readAllFileInfo(ctx, er.getDisks(), minioMetaMultipartBucket,
+	partsMetadata, errs = readAllFileInfo(ctx, storageDisks, minioMetaMultipartBucket,
 		uploadIDPath, "")
 
 	// get Quorum for this object
@@ -398,7 +400,7 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 	}
 
 	// List all online disks.
-	onlineDisks, modTime := listOnlineDisks(er.getDisks(), partsMetadata, errs)
+	onlineDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
 	// Pick one from the first valid metadata.
 	fi, err := pickValidFileInfo(ctx, partsMetadata, modTime, writeQuorum)

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -608,7 +608,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	}
 
 	// Initialize parts metadata
-	partsMetadata := make([]FileInfo, len(er.getDisks()))
+	partsMetadata := make([]FileInfo, len(storageDisks))
 
 	fi := newFileInfo(object, dataDrives, parityDrives)
 
@@ -767,19 +767,18 @@ func (er erasureObjects) deleteObjectVersion(ctx context.Context, bucket, object
 // all the disks in parallel, including `xl.meta` associated with the
 // object.
 func (er erasureObjects) deleteObject(ctx context.Context, bucket, object string, writeQuorum int) error {
-	var disks []StorageAPI
 	var err error
 	defer ObjectPathUpdated(pathJoin(bucket, object))
 
 	tmpObj := mustGetUUID()
+	disks := er.getDisks()
 	if bucket == minioMetaTmpBucket {
 		tmpObj = object
-		disks = er.getDisks()
 	} else {
 		// Rename the current object while requiring write quorum, but also consider
 		// that a non found object in a given disk as a success since it already
 		// confirms that the object doesn't have a part in that disk (already removed)
-		disks, err = rename(ctx, er.getDisks(), bucket, object, minioMetaTmpBucket, tmpObj, true, writeQuorum,
+		disks, err = rename(ctx, disks, bucket, object, minioMetaTmpBucket, tmpObj, true, writeQuorum,
 			[]error{errFileNotFound})
 		if err != nil {
 			return toObjectErr(err, bucket, object)
@@ -787,7 +786,6 @@ func (er erasureObjects) deleteObject(ctx context.Context, bucket, object string
 	}
 
 	g := errgroup.WithNErrs(len(disks))
-
 	for index := range disks {
 		index := index
 		g.Go(func() error {

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -388,12 +388,13 @@ func newErasureSets(ctx context.Context, endpoints Endpoints, storageDisks []Sto
 
 		// Initialize erasure objects for a given set.
 		s.sets[i] = &erasureObjects{
-			getDisks:     s.GetDisks(i),
-			getLockers:   s.GetLockers(i),
-			getEndpoints: s.GetEndpoints(i),
-			nsMutex:      mutex,
-			bp:           bp,
-			mrfOpCh:      make(chan partialOperation, 10000),
+			setDriveCount: setDriveCount,
+			getDisks:      s.GetDisks(i),
+			getLockers:    s.GetLockers(i),
+			getEndpoints:  s.GetEndpoints(i),
+			nsMutex:       mutex,
+			bp:            bp,
+			mrfOpCh:       make(chan partialOperation, 10000),
 		}
 
 		go s.sets[i].cleanupStaleUploads(ctx,

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -48,6 +48,8 @@ type partialOperation struct {
 type erasureObjects struct {
 	GatewayUnsupported
 
+	setDriveCount int
+
 	// getDisks returns list of storageAPIs.
 	getDisks func() []StorageAPI
 
@@ -70,11 +72,6 @@ type erasureObjects struct {
 // NewNSLock - initialize a new namespace RWLocker instance.
 func (er erasureObjects) NewNSLock(bucket string, objects ...string) RWLocker {
 	return er.nsMutex.NewNSLock(er.getLockers, bucket, objects...)
-}
-
-// SetDriveCount returns the current drives per set.
-func (er erasureObjects) SetDriveCount() int {
-	return len(er.getDisks())
 }
 
 // Shutdown function for object storage interface.


### PR DESCRIPTION
## Description
fix: re-use er.getDisks() properly in certain calls

## Motivation and Context
optimize certain calls

## How to test this PR?
manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
