### PR TITLE
avoid updating nsswitch.conf for redhat UBI images

### DIFF
--- a/Dockerfile.cicd
+++ b/Dockerfile.cicd
@@ -31,8 +31,7 @@ COPY --from=builder /go/minio/dockerscripts/docker-entrypoint.sh /usr/bin/
 RUN  \
     microdnf update --nodocs && \
     microdnf install curl ca-certificates shadow-utils util-linux --nodocs && \
-    microdnf clean all && \
-    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+    microdnf clean all
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,7 +19,6 @@ RUN  \
     microdnf update --nodocs && \
     microdnf install curl ca-certificates shadow-utils util-linux --nodocs && \
     microdnf clean all && \
-    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
     chmod +x /usr/bin/minio  && \
     chmod +x /usr/bin/docker-entrypoint.sh
 

--- a/Dockerfile.dev.browser
+++ b/Dockerfile.dev.browser
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:20.04
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
 


### PR DESCRIPTION
## Description
avoid updating nsswitch.conf for RedHat UBI images

## Motivation and Context
RedHat UBI images have systemd managed name
resolution we do not need to update it for mDNS instead

## How to test this PR?
Nothing special

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
