### PR TITLE
federation: Redirect Lifecycle PUT request by bucket name

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -634,7 +634,7 @@ func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	// For browser requests, when federation is setup we need to
 	// specifically handle download and upload for browser requests.
-	if guessIsBrowserReq(r) && globalDNSConfig != nil && len(globalDomainNames) > 0 {
+	if globalDNSConfig != nil && len(globalDomainNames) > 0 && guessIsBrowserReq(r) {
 		var bucket, _ string
 		switch r.Method {
 		case http.MethodPut:
@@ -689,7 +689,7 @@ func (f bucketForwardingHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	// MakeBucket requests should be handled at current endpoint
-	if r.Method == http.MethodPut && bucket != "" && object == "" {
+	if r.Method == http.MethodPut && bucket != "" && object == "" && r.URL.RawQuery == "" {
 		f.handler.ServeHTTP(w, r)
 		return
 	}


### PR DESCRIPTION
## Description
The bucket forwarder handler considers MakeBucket to be always local but
it mistakenly thinks that PUT bucket lifecycle to be a MakeBucket call.

Fix the check of the MakeBucket call by ensuring that the query is empty
in the PUT url.


## Motivation and Context
PUT lifecycle bucket does not work in path style mode in a federated setup

## How to test this PR?
1. Create a new docker image based on this PR
2. Deploy a federated setup: https://github.com/krisis/minio-federated-setup with the generated docker image
3. mc mb cluster1/testbucket/
4. mc ilm add --expiry-days 1 cluster2/testbucket/



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
