### PR TITLE
listcache: Add path index

### DIFF
--- a/cmd/metacache-bucket.go
+++ b/cmd/metacache-bucket.go
@@ -45,8 +45,8 @@ type bucketMetacache struct {
 
 	// caches indexed by id.
 	caches map[string]metacache
-	// caches indexed by with root paths
-	cachesRoot map[string][]string
+	// cache ids indexed by root paths
+	cachesRoot map[string][]string `msg:"-"`
 
 	// Internal state
 	mu        sync.RWMutex `msg:"-"`

--- a/cmd/metacache-bucket.go
+++ b/cmd/metacache-bucket.go
@@ -230,7 +230,6 @@ func (b *bucketMetacache) findCache(o listPathOptions) metacache {
 		// Create new
 		best := o.newMetacache()
 		b.caches[o.ID] = best
-		b.cachesRoot[best.root] = append(b.cachesRoot[best.root], best.id)
 		b.updated = true
 		if debugPrint {
 			console.Info("returning new cache %s, bucket: %v", best.id, best.bucket)


### PR DESCRIPTION
## Description

Add a root path index.

```
Before:
Benchmark_bucketMetacache_findCache-32    	   10000	    730737 ns/op

With excluded prints:
Benchmark_bucketMetacache_findCache-32    	   10000	    207100 ns/op

With root path:
Benchmark_bucketMetacache_findCache-32    	  705765	      1943 ns/op
```

Benchmark used (not linear):

```Go
func Benchmark_bucketMetacache_findCache(b *testing.B) {
	bm := newBucketMetacache("", false)
	for i := 0; i < b.N; i++ {
		bm.findCache(listPathOptions{
			ID:           mustGetUUID(),
			Bucket:       "",
			BaseDir:      "prefix/" + mustGetUUID(),
			Prefix:       "",
			FilterPrefix: "",
			Marker:       "",
			Limit:        0,
			AskDisks:     0,
			Recursive:    false,
			Separator:    slashSeparator,
			Create:       true,
			CurrentCycle: 0,
			OldestCycle:  0,
		})
	}
}
```

Replaces #11058


## How to test this PR?

See #10942

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
