### PR TITLE
fix: grafana double counting for bucket usage, histrogram and objects

### DIFF
--- a/docs/metrics/prometheus/grafana/minio-overview.json
+++ b/docs/metrics/prometheus/grafana/minio-overview.json
@@ -307,7 +307,7 @@
       "pluginVersion": "7.2.0",
       "targets": [
         {
-          "expr": "sum without (bucket,instance) (bucket_usage_size)",
+          "expr": "topk(1, sum(bucket_usage_size) by (instance))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",
@@ -370,7 +370,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum without (bucket,instance) (bucket_usage_size)",
+          "expr": "topk(1, sum(bucket_usage_size) by (instance))",
           "interval": "",
           "legendFormat": "Total Storage Used",
           "refId": "A"
@@ -467,7 +467,7 @@
       "pluginVersion": "7.2.0",
       "targets": [
         {
-          "expr": "sum without (instance,bucket) (bucket_objects_histogram)",
+          "expr": "max by (object_size) (bucket_objects_histogram)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1136,7 +1136,7 @@
       "pluginVersion": "7.2.0",
       "targets": [
         {
-          "expr": "sum(bucket_objects_count)",
+          "expr": "topk(1, sum(bucket_objects_count) by (instance))",
           "format": "time_series",
           "instant": false,
           "interval": "1m",


### PR DESCRIPTION
## Description
fix: grafana double counting for bucket usage, histrogram and objects

## Motivation and Context
fixes double counting in a customer environment

## How to test this PR?
Setup prometheus in a large cluster

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
