### PR TITLE
fix: TTFB prometheus metrics calculation

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -29,7 +29,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/logger"
@@ -379,12 +378,7 @@ func collectAPIStats(api string, f http.HandlerFunc) http.HandlerFunc {
 
 		f.ServeHTTP(statsWriter, r)
 
-		// Time duration in secs since the call started.
-		// We don't need to do nanosecond precision in this
-		// simply for the fact that it is not human readable.
-		durationSecs := time.Since(statsWriter.StartTime).Seconds()
-
-		globalHTTPStats.updateStats(api, r, statsWriter, durationSecs)
+		globalHTTPStats.updateStats(api, r, statsWriter)
 	}
 }
 

--- a/cmd/http-stats.go
+++ b/cmd/http-stats.go
@@ -161,7 +161,7 @@ func (st *HTTPStats) toServerHTTPStats() ServerHTTPStats {
 }
 
 // Update statistics from http request and response data
-func (st *HTTPStats) updateStats(api string, r *http.Request, w *logger.ResponseWriter, durationSecs float64) {
+func (st *HTTPStats) updateStats(api string, r *http.Request, w *logger.ResponseWriter) {
 	// A successful request has a 2xx response code
 	successReq := (w.StatusCode >= 200 && w.StatusCode < 300)
 
@@ -172,10 +172,8 @@ func (st *HTTPStats) updateStats(api string, r *http.Request, w *logger.Response
 		}
 	}
 
-	if r.Method == http.MethodGet {
-		// Increment the prometheus http request response histogram with appropriate label
-		httpRequestsDuration.With(prometheus.Labels{"api": api}).Observe(durationSecs)
-	}
+	// Increment the prometheus http request response histogram with appropriate label
+	httpRequestsDuration.With(prometheus.Labels{"api": api}).Observe(w.TimeToFirstByte.Seconds())
 }
 
 // Prepare new HTTPStats structure


### PR DESCRIPTION

## Description
fix: TTFB prometheus metrics calculation

## Motivation and Context
until now metrics was reporting the entire call
duration instead of ttfb's this PR fixes it

## How to test this PR?
Prometheus setup would be needed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
