### PR TITLE
ignore NoSuchVersion error in DeleteObjects API

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -503,7 +503,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 			DeleteMarkerReplicationStatus: dObjects[i].DeleteMarkerReplicationStatus,
 			PurgeTransitioned:             dObjects[i].PurgeTransitioned,
 		}]
-		if errs[i] == nil || isErrObjectNotFound(errs[i]) {
+		if errs[i] == nil || isErrObjectNotFound(errs[i]) || isErrVersionNotFound(errs[i]) {
 			if replicateDeletes {
 				dObjects[i].DeleteMarkerReplicationStatus = deleteList[i].DeleteMarkerReplicationStatus
 				dObjects[i].VersionPurgeStatus = deleteList[i].VersionPurgeStatus


### PR DESCRIPTION
Currently, the error response reports NoSuchVersion
for a non-existent version-id, whereas AWS ignores the error.

## Description


## Motivation and Context
```
aws s3api delete-objects --bucket bucket --delete Objects=[{Key=xblock/8100,VersionId=4dc2f16f-6b67-4307-9f91-550d1780ec3b}] --endpoint-url=http://localhost:9008 --profile minio
returns 
    "Errors": [
        {
            "Key": "xblock/8100",
            "VersionId": "4dc2f16f-6b67-4307-9f91-550d1780ec3b",
            "Code": "NoSuchVersion",
            "Message": "The specified version does not exist."
        }
    ]
```
whereas aws returns:
```
aws s3api delete-objects --bucket tbucket13 --delete "Objects=[{Key=small/e.txt,VersionId=zWzF8uUy1bvPjvIjOMofwFPXZoRcn8G9}]"
{
    "Deleted": [
        {
            "Key": "small/e.txt",
            "VersionId": "zWzF8uUy1bvPjvIjOMofwFPXZoRcn8G9"
        }
    ]
}
```

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
