### PR TITLE
metacache: Ask all disks when drive count is 4

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -549,6 +549,10 @@ func (er *erasureObjects) streamMetadataParts(ctx context.Context, o listPathOpt
 	}
 }
 
+func (er erasureObjects) SetDriveCount() int {
+	return er.setDriveCount
+}
+
 // Will return io.EOF if continuing would not yield more results.
 func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entries metaCacheEntriesSorted, err error) {
 	const debugPrint = false
@@ -610,6 +614,14 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 	askDisks := o.AskDisks
 	if askDisks == -1 {
 		askDisks = getReadQuorum(er.SetDriveCount())
+	}
+
+	listingQuorum := askDisks - 1
+
+	// Special case: ask all disks if the drive count is 4
+	if er.SetDriveCount() == 4 {
+		askDisks = len(disks)
+		listingQuorum = 2
 	}
 
 	if len(disks) < askDisks {
@@ -715,8 +727,8 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 
 		// How to resolve results.
 		resolver := metadataResolutionParams{
-			dirQuorum: askDisks - 1,
-			objQuorum: askDisks - 1,
+			dirQuorum: listingQuorum,
+			objQuorum: listingQuorum,
 			bucket:    o.Bucket,
 		}
 
@@ -726,7 +738,7 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 			path:         o.BaseDir,
 			recursive:    o.Recursive,
 			filterPrefix: o.FilterPrefix,
-			minDisks:     askDisks - 1,
+			minDisks:     listingQuorum,
 			agreed: func(entry metaCacheEntry) {
 				cacheCh <- entry
 				filterCh <- entry


### PR DESCRIPTION
## Description
In a set of 4 disks, metacache will list from all disks

## Motivation and Context
Enable full listing in case of 4 disks  per set

## How to reproduce the issue ?

1. `minio server /tmp/xl/{1..4}/ &`
2. `mc mb myminio/testbucket/`
3. `mc cp file myminio/testbucket/`
4. `rm /tmp/xl/{1..2}/testbucket/file/`
5. `mc ls myminio/testbucket/`

if `mc ls` shows 'file', remove `.metacache` from the backend and run `mc ls` again until you reproduce the issue.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
