### PR TITLE
Return version-id header in DeleteObject response

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -943,6 +943,7 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 // response to the client request.
 func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	versionFound := true
+	objInfo = ObjectInfo{VersionID: opts.VersionID} // version id needed in Delete API response.
 	goi, gerr := er.GetObjectInfo(ctx, bucket, object, opts)
 	if gerr != nil && goi.Name == "" {
 		switch gerr.(type) {


### PR DESCRIPTION
even when the object version is non-existent

- To make this consistent with aws behavior.

## Description
delete-object was returning a 200 with no response headers earlier when version-id does not exist, whereas aws does return version id in the response.
Expected behavior:
```
➜  aws s3api delete-object --bucket bucket  --endpoint-url http://localhost:9008 --profile minio --key xblock/8100 --version-id 4885ffca-b924-4ba9-9a27-57c6310fd632  
{
    "VersionId": "4885ffca-b924-4ba9-9a27-57c6310fd632"
}
```
Actual
```
➜  aws s3api delete-object --bucket bucket  --endpoint-url http://localhost:9008 --profile minio --key xblock/8100 --version-id 4885ffca-b924-4ba9-9a27-57c6310fd632  
➜  
```
## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
