### PR TITLE
Make DeleteObject(s) api responses consistent

### DIFF
--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -666,6 +666,12 @@ func isErrVersionNotFound(err error) bool {
 	return errors.As(err, &versionNotFound)
 }
 
+// isErrInvalidVersionID - Check if error type is InvalidVersionID.
+func isErrInvalidVersionID(err error) bool {
+	var invalidVersionID InvalidVersionID
+	return errors.As(err, &invalidVersionID)
+}
+
 // PreConditionFailed - Check if copy precondition failed
 type PreConditionFailed struct{}
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2711,6 +2711,10 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 
 	opts, err := delOpts(ctx, r, bucket, object)
 	if err != nil {
+		if isErrInvalidVersionID(err) {
+			writeSuccessNoContent(w)
+			return
+		}
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}


### PR DESCRIPTION
Ignore invalid version id format error and return 200

## Description


## Motivation and Context
This fixes case where version-id format is not valid uuid format. In both DeleteObject and DeleteObjects api treat it similarly and return 200

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
