### PR TITLE
xl: Always set root disk to true in tests environments

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,6 @@ jobs:
         env:
           CGO_ENABLED: 0
           GO111MODULE: on
-          MINIO_CI_CD: 1
         run: |
           go build --ldflags="-s -w" -o %GOPATH%\bin\minio.exe
           go test -v --timeout 50m ./...
@@ -35,7 +34,6 @@ jobs:
         env:
           CGO_ENABLED: 0
           GO111MODULE: on
-          MINIO_CI_CD: 1
         run: |
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -115,6 +115,8 @@ func TestMain(m *testing.M) {
 
 	resetTestGlobals()
 
+	os.Setenv("MINIO_CI_CD", "ci")
+
 	os.Exit(m.Run())
 }
 

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -240,9 +240,14 @@ func newXLStorage(ep Endpoint) (*xlStorage, error) {
 		return nil, err
 	}
 
-	rootDisk, err := disk.IsRootDisk(path, "/")
-	if err != nil {
-		return nil, err
+	var rootDisk bool
+	if env.Get("MINIO_CI_CD", "") != "" {
+		rootDisk = true
+	} else {
+		rootDisk, err = disk.IsRootDisk(path, "/")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	p := &xlStorage{


### PR DESCRIPTION
## Description
Tests environments (go test or manual testing) should always consider
the passed disks are root disks and should not rely on disk.IsRootDisk()
function. The reason is that this latter can return a false negative
when called in a busy system. However, returning a false negative will
only occur in a testing environment and not in a production, so we can
accept this trade-off for now.


## Motivation and Context
go test is weirdly failing in my machine

## How to test this PR?
go test .


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
