### PR TITLE
fix: heal bucket metadata right before healing bucket

### DIFF
--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -102,7 +102,7 @@ func (h *healRoutine) run(ctx context.Context, objAPI ObjectLayer) {
 			case task.bucket == SlashSeparator:
 				res, err = healDiskFormat(ctx, objAPI, task.opts)
 			case task.bucket != "" && task.object == "":
-				res, err = objAPI.HealBucket(ctx, task.bucket, task.opts.DryRun, task.opts.Remove)
+				res, err = objAPI.HealBucket(ctx, task.bucket, task.opts)
 			case task.bucket != "" && task.object != "":
 				res, err = objAPI.HealObject(ctx, task.bucket, task.object, task.versionID, task.opts)
 			}

--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -46,16 +46,7 @@ func initAutoHeal(ctx context.Context, objAPI ObjectLayer) {
 
 	initBackgroundHealing(ctx, objAPI) // start quick background healing
 
-	var bgSeq *healSequence
-	var found bool
-
-	for {
-		bgSeq, found = globalBackgroundHealState.getHealSequenceByToken(bgHealingUUID)
-		if found {
-			break
-		}
-		time.Sleep(time.Second)
-	}
+	bgSeq := mustGetHealSequence(ctx)
 
 	globalBackgroundHealState.pushHealLocalDisks(getLocalDisksToHeal()...)
 

--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -440,6 +440,11 @@ func (sys *BucketMetadataSys) concurrentLoad(ctx context.Context, buckets []Buck
 	for index := range buckets {
 		index := index
 		g.Go(func() error {
+			if _, err := objAPI.HealBucket(ctx, buckets[index].Name, madmin.HealOpts{
+				Remove: true,
+			}); err != nil {
+				return err
+			}
 			meta, err := loadBucketMetadata(ctx, objAPI, buckets[index].Name)
 			if err != nil {
 				return err

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -48,6 +48,11 @@ func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
 	globalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second)
 
+	initGlobalContext()
+
+	globalReplicationState = newReplicationState()
+	globalTransitionState = newTransitionState()
+
 	gob.Register(StorageErr(""))
 }
 

--- a/cmd/erasure-bucket.go
+++ b/cmd/erasure-bucket.go
@@ -32,10 +32,15 @@ var bucketOpIgnoredErrs = append(baseIgnoredErrs, errDiskAccessDenied, errUnform
 var bucketMetadataOpIgnoredErrs = append(bucketOpIgnoredErrs, errVolumeNotFound)
 
 // MakeMultipleBuckets - create a list of buckets
-func (er erasureObjects) MakeMultipleBuckets(ctx context.Context, buckets ...string) error {
+func (er erasureObjects) MakeMultipleBuckets(ctx context.Context, bucketsInfo ...BucketInfo) error {
 	storageDisks := er.getDisks()
 
 	g := errgroup.WithNErrs(len(storageDisks))
+
+	buckets := make([]string, len(bucketsInfo))
+	for i := range bucketsInfo {
+		buckets[i] = bucketsInfo[i].Name
+	}
 
 	// Make a volume entry on all underlying storage disks.
 	for index := range storageDisks {

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -32,9 +32,9 @@ import (
 // Heals a bucket if it doesn't exist on one of the disks, additionally
 // also heals the missing entries for bucket metadata files
 // `policy.json, notification.xml, listeners.json`.
-func (er erasureObjects) HealBucket(ctx context.Context, bucket string, dryRun, remove bool) (
+func (er erasureObjects) HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (
 	result madmin.HealResultItem, err error) {
-	if !dryRun {
+	if !opts.DryRun {
 		defer ObjectPathUpdated(bucket)
 	}
 
@@ -45,7 +45,7 @@ func (er erasureObjects) HealBucket(ctx context.Context, bucket string, dryRun, 
 	writeQuorum := getWriteQuorum(len(storageDisks))
 
 	// Heal bucket.
-	return healBucket(ctx, storageDisks, storageEndpoints, bucket, writeQuorum, dryRun)
+	return healBucket(ctx, storageDisks, storageEndpoints, bucket, writeQuorum, opts.DryRun)
 }
 
 // Heal bucket - create buckets on disks where it does not exist.

--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -130,7 +130,10 @@ func TestHealing(t *testing.T) {
 		t.Fatal(err)
 	}
 	// This would create the bucket.
-	_, err = er.HealBucket(ctx, bucket, false, false)
+	_, err = er.HealBucket(ctx, bucket, madmin.HealOpts{
+		DryRun: false,
+		Remove: false,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -430,7 +430,7 @@ func (z *erasureServerPools) CrawlAndGetDataUsage(ctx context.Context, bf *bloom
 	return firstErr
 }
 
-func (z *erasureServerPools) MakeMultipleBuckets(ctx context.Context, buckets ...string) error {
+func (z *erasureServerPools) MakeMultipleBuckets(ctx context.Context, buckets ...BucketInfo) error {
 	g := errgroup.WithNErrs(len(z.serverPools))
 
 	// Create buckets in parallel across all sets.
@@ -1175,14 +1175,22 @@ func (z *erasureServerPools) HealFormat(ctx context.Context, dryRun bool) (madmi
 	return r, nil
 }
 
-func (z *erasureServerPools) HealBucket(ctx context.Context, bucket string, dryRun, remove bool) (madmin.HealResultItem, error) {
+func (z *erasureServerPools) HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem, error) {
 	var r = madmin.HealResultItem{
 		Type:   madmin.HealItemBucket,
 		Bucket: bucket,
 	}
 
+	// Ensure heal opts for bucket metadata be deep healed all the time.
+	opts.ScanMode = madmin.HealDeepScan
+
+	// Ignore the results on purpose.
+	if _, err := z.HealObject(ctx, minioMetaBucket, pathJoin(bucketConfigPrefix, bucket), "", opts); err != nil {
+		logger.LogIf(ctx, fmt.Errorf("Healing bucket metadata for %s failed", bucket))
+	}
+
 	for _, zone := range z.serverPools {
-		result, err := zone.HealBucket(ctx, bucket, dryRun, remove)
+		result, err := zone.HealBucket(ctx, bucket, opts)
 		if err != nil {
 			switch err.(type) {
 			case BucketNotFound:

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1540,7 +1540,7 @@ func (fs *FSObjects) HealObject(ctx context.Context, bucket, object, versionID s
 }
 
 // HealBucket - no-op for fs, Valid only for Erasure.
-func (fs *FSObjects) HealBucket(ctx context.Context, bucket string, dryRun, remove bool) (madmin.HealResultItem,
+func (fs *FSObjects) HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem,
 	error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return madmin.HealResultItem{}, NotImplemented{}
@@ -1561,10 +1561,9 @@ func (fs *FSObjects) HealObjects(ctx context.Context, bucket, prefix string, opt
 	return NotImplemented{}
 }
 
-// ListBucketsHeal - list all buckets to be healed. Valid only for Erasure
+// ListBucketsHeal - list all buckets to be healed. Valid only for Erasure, returns ListBuckets() in single drive mode.
 func (fs *FSObjects) ListBucketsHeal(ctx context.Context) ([]BucketInfo, error) {
-	logger.LogIf(ctx, NotImplemented{})
-	return []BucketInfo{}, NotImplemented{}
+	return fs.ListBuckets(ctx)
 }
 
 // GetMetrics - no op

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -52,7 +52,7 @@ func (a GatewayUnsupported) SetDriveCount() int {
 }
 
 // MakeMultipleBuckets is dummy stub for gateway.
-func (a GatewayUnsupported) MakeMultipleBuckets(ctx context.Context, buckets ...string) error {
+func (a GatewayUnsupported) MakeMultipleBuckets(ctx context.Context, buckets ...BucketInfo) error {
 	return NotImplemented{}
 }
 
@@ -171,7 +171,7 @@ func (a GatewayUnsupported) HealFormat(ctx context.Context, dryRun bool) (madmin
 }
 
 // HealBucket - Not implemented stub
-func (a GatewayUnsupported) HealBucket(ctx context.Context, bucket string, dryRun, remove bool) (madmin.HealResultItem, error) {
+func (a GatewayUnsupported) HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem, error) {
 	return madmin.HealResultItem{}, NotImplemented{}
 }
 

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -82,7 +82,7 @@ type ObjectLayer interface {
 	StorageInfo(ctx context.Context, local bool) (StorageInfo, []error) // local queries only local disks
 
 	// Bucket operations.
-	MakeMultipleBuckets(ctx context.Context, buckets ...string) error
+	MakeMultipleBuckets(ctx context.Context, bucketInfo ...BucketInfo) error
 	MakeBucketWithLocation(ctx context.Context, bucket string, opts BucketOptions) error
 	GetBucketInfo(ctx context.Context, bucket string) (bucketInfo BucketInfo, err error)
 	ListBuckets(ctx context.Context) (buckets []BucketInfo, err error)
@@ -122,7 +122,7 @@ type ObjectLayer interface {
 
 	// Healing operations.
 	HealFormat(ctx context.Context, dryRun bool) (madmin.HealResultItem, error)
-	HealBucket(ctx context.Context, bucket string, dryRun, remove bool) (madmin.HealResultItem, error)
+	HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem, error)
 	HealObject(ctx context.Context, bucket, object, versionID string, opts madmin.HealOpts) (madmin.HealResultItem, error)
 	HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn HealObjectFn) error
 	ListBucketsHeal(ctx context.Context) (buckets []BucketInfo, err error)

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -45,11 +45,6 @@ var GlobalContext context.Context
 // cancelGlobalContext can be used to indicate server shutdown.
 var cancelGlobalContext context.CancelFunc
 
-// Initialize service mutex once.
-func init() {
-	initGlobalContext()
-}
-
 func initGlobalContext() {
 	GlobalContext, cancelGlobalContext = context.WithCancel(context.Background())
 	GlobalServiceDoneCh = GlobalContext.Done()

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -640,9 +640,9 @@ func newStorageRESTClient(endpoint Endpoint, healthcheck bool) *storageRESTClien
 		healthClient.ExpectTimeouts = true
 		restClient.HealthCheckFn = func() bool {
 			ctx, cancel := context.WithTimeout(GlobalContext, restClient.HealthCheckTimeout)
+			defer cancel()
 			respBody, err := healthClient.Call(ctx, storageRESTMethodHealth, nil, nil, -1)
 			xhttp.DrainBody(respBody)
-			cancel()
 			return toStorageErr(err) != errDiskNotFound
 		}
 	}

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -428,7 +428,7 @@ func resetGlobalIsErasure() {
 func resetGlobalHealState() {
 	// Init global heal state
 	if globalAllHealState == nil {
-		globalAllHealState = newHealState()
+		globalAllHealState = newHealState(false)
 	} else {
 		globalAllHealState.Lock()
 		for _, v := range globalAllHealState.healSeqMap {
@@ -441,7 +441,7 @@ func resetGlobalHealState() {
 
 	// Init background heal state
 	if globalBackgroundHealState == nil {
-		globalBackgroundHealState = newHealState()
+		globalBackgroundHealState = newHealState(false)
 	} else {
 		globalBackgroundHealState.Lock()
 		for _, v := range globalBackgroundHealState.healSeqMap {


### PR DESCRIPTION

## Description
fix: heal bucket metadata right before healing bucket

## Motivation and Context
optimization mainly to avoid listing the entire
`.minio.sys/buckets/.minio.sys` directory, this
can get really huge and comes in the way of startup
routines, contents inside `.minio.sys/buckets/.minio.sys`
are rather transient and not necessary to be healed.


## How to test this PR?
All healing functionality should be the same and work properly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [x] Unit tests needed
