### PR TITLE
fix: remove the requirement for healing buckets in ListBucketsHeal

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -868,7 +868,7 @@ func (h *healSequence) healBuckets(objAPI ObjectLayer, bucketsOnly bool) error {
 		return h.healBucket(objAPI, h.bucket, bucketsOnly)
 	}
 
-	buckets, err := objAPI.ListBucketsHeal(h.ctx)
+	buckets, err := objAPI.ListBuckets(h.ctx)
 	if err != nil {
 		return errFnHealFromAPIErr(h.ctx, err)
 	}

--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -160,7 +160,7 @@ wait:
 				erasureSetInZoneDisksToHeal[zoneIdx][setIndex] = append(erasureSetInZoneDisksToHeal[zoneIdx][setIndex], disk)
 			}
 
-			buckets, _ := z.ListBucketsHeal(ctx)
+			buckets, _ := z.ListBuckets(ctx)
 			for i, setMap := range erasureSetInZoneDisksToHeal {
 				for setIndex, disks := range setMap {
 					for _, disk := range disks {

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1565,11 +1565,6 @@ func (fs *FSObjects) HealObjects(ctx context.Context, bucket, prefix string, opt
 	return NotImplemented{}
 }
 
-// ListBucketsHeal - list all buckets to be healed. Valid only for Erasure, returns ListBuckets() in single drive mode.
-func (fs *FSObjects) ListBucketsHeal(ctx context.Context) ([]BucketInfo, error) {
-	return fs.ListBuckets(ctx)
-}
-
 // GetMetrics - no op
 func (fs *FSObjects) GetMetrics(ctx context.Context) (*Metrics, error) {
 	logger.LogIf(ctx, NotImplemented{})

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -51,11 +51,6 @@ func (a GatewayUnsupported) SetDriveCount() int {
 	return 0
 }
 
-// MakeMultipleBuckets is dummy stub for gateway.
-func (a GatewayUnsupported) MakeMultipleBuckets(ctx context.Context, buckets ...BucketInfo) error {
-	return NotImplemented{}
-}
-
 // ListMultipartUploads lists all multipart uploads.
 func (a GatewayUnsupported) ListMultipartUploads(ctx context.Context, bucket string, prefix string, keyMarker string, uploadIDMarker string, delimiter string, maxUploads int) (lmi ListMultipartsInfo, err error) {
 	return lmi, NotImplemented{}
@@ -173,11 +168,6 @@ func (a GatewayUnsupported) HealFormat(ctx context.Context, dryRun bool) (madmin
 // HealBucket - Not implemented stub
 func (a GatewayUnsupported) HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem, error) {
 	return madmin.HealResultItem{}, NotImplemented{}
-}
-
-// ListBucketsHeal - Not implemented stub
-func (a GatewayUnsupported) ListBucketsHeal(ctx context.Context) (buckets []BucketInfo, err error) {
-	return nil, NotImplemented{}
 }
 
 // HealObject - Not implemented stub

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -277,8 +277,10 @@ func getMetacacheBlockInfo(fi FileInfo, block int) (*metacacheBlock, error) {
 	return &tmp, json.Unmarshal([]byte(v), &tmp)
 }
 
+const metacachePrefix = ".metacache"
+
 func metacachePrefixForID(bucket, id string) string {
-	return pathJoin("buckets", bucket, ".metacache", id)
+	return pathJoin(bucketMetaPrefix, bucket, metacachePrefix, id)
 }
 
 // objectPath returns the object path of the cache.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -82,7 +82,6 @@ type ObjectLayer interface {
 	StorageInfo(ctx context.Context, local bool) (StorageInfo, []error) // local queries only local disks
 
 	// Bucket operations.
-	MakeMultipleBuckets(ctx context.Context, bucketInfo ...BucketInfo) error
 	MakeBucketWithLocation(ctx context.Context, bucket string, opts BucketOptions) error
 	GetBucketInfo(ctx context.Context, bucket string) (bucketInfo BucketInfo, err error)
 	ListBuckets(ctx context.Context) (buckets []BucketInfo, err error)
@@ -125,7 +124,6 @@ type ObjectLayer interface {
 	HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem, error)
 	HealObject(ctx context.Context, bucket, object, versionID string, opts madmin.HealOpts) (madmin.HealResultItem, error)
 	HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn HealObjectFn) error
-	ListBucketsHeal(ctx context.Context) (buckets []BucketInfo, err error)
 
 	// Policy operations
 	SetBucketPolicy(context.Context, string, *policy.Policy) error

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -125,6 +125,17 @@ func formatErasureCleanupTmpLocalEndpoints(endpoints Endpoints) error {
 					osErrToFileErr(err))
 			}
 
+			// Move .minio.sys/buckets/.minio.sys/metacache transient list cache
+			// folder to speed up startup routines.
+			tmpMetacacheOld := pathJoin(epPath, minioMetaTmpBucket+"-old", mustGetUUID())
+			if err := renameAll(pathJoin(epPath, minioMetaBucket, metacachePrefixForID(minioMetaBucket, "")),
+				tmpMetacacheOld); err != nil && err != errFileNotFound {
+				return fmt.Errorf("unable to rename (%s -> %s) %w",
+					pathJoin(epPath, minioMetaBucket+metacachePrefixForID(minioMetaBucket, "")),
+					tmpMetacacheOld,
+					osErrToFileErr(err))
+			}
+
 			// Removal of tmp-old folder is backgrounded completely.
 			go removeAll(pathJoin(epPath, minioMetaTmpBucket+"-old"))
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -310,7 +310,7 @@ func initAllSubsystems(ctx context.Context, newObject ObjectLayer) (err error) {
 	rquorum := InsufficientReadQuorum{}
 	wquorum := InsufficientWriteQuorum{}
 
-	buckets, err := newObject.ListBucketsHeal(ctx)
+	buckets, err := newObject.ListBuckets(ctx)
 	if err != nil {
 		return fmt.Errorf("Unable to list buckets to heal: %w", err)
 	}


### PR DESCRIPTION

## Description
fix: remove the requirement for healing buckets in ListBucketsHeal

## Motivation and Context
With new refactor of bucket healing, healing bucket happens
automatically including its metadata, there is no need to
redundant heal buckets also in ListBucketsHeal remove
it.

## How to test this PR?
Nothing specific, check if buckets heal properly. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
