### PR TITLE
Don't copy interesting ids, clean up logging

### DIFF
--- a/cmd/metacache-bucket_test.go
+++ b/cmd/metacache-bucket_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Benchmark_bucketMetacache_findCache(b *testing.B) {
+	bm := newBucketMetacache("", false)
+	const elements = 50000
+	const paths = 100
+	if elements%paths != 0 {
+		b.Fatal("elements must be divisible by the number of paths")
+	}
+	var pathNames [paths]string
+	for i := range pathNames[:] {
+		pathNames[i] = fmt.Sprintf("prefix/%d", i)
+	}
+	for i := 0; i < elements; i++ {
+		bm.findCache(listPathOptions{
+			ID:           mustGetUUID(),
+			Bucket:       "",
+			BaseDir:      pathNames[i%paths],
+			Prefix:       "",
+			FilterPrefix: "",
+			Marker:       "",
+			Limit:        0,
+			AskDisks:     0,
+			Recursive:    false,
+			Separator:    slashSeparator,
+			Create:       true,
+			CurrentCycle: uint64(i),
+			OldestCycle:  uint64(i - 1),
+		})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bm.findCache(listPathOptions{
+			ID:           mustGetUUID(),
+			Bucket:       "",
+			BaseDir:      pathNames[i%paths],
+			Prefix:       "",
+			FilterPrefix: "",
+			Marker:       "",
+			Limit:        0,
+			AskDisks:     0,
+			Recursive:    false,
+			Separator:    slashSeparator,
+			Create:       true,
+			CurrentCycle: uint64(i % elements),
+			OldestCycle:  uint64(0),
+		})
+	}
+}

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/console"
 	"github.com/minio/minio/pkg/hash"
@@ -122,11 +123,22 @@ func (o listPathOptions) newMetacache() metacache {
 	}
 }
 
+func (o *listPathOptions) debugf(format string, data ...interface{}) {
+	if metacacheDebug {
+		console.Debugf(format, data...)
+	}
+}
+
+func (o *listPathOptions) debugln(data ...interface{}) {
+	if metacacheDebug {
+		console.Debugln(data...)
+	}
+}
+
 // gatherResults will collect all results on the input channel and filter results according to the options.
 // Caller should close the channel when done.
 // The returned function will return the results once there is enough or input is closed.
 func (o *listPathOptions) gatherResults(in <-chan metaCacheEntry) func() (metaCacheEntriesSorted, error) {
-	const debugPrint = false
 	var resultsDone = make(chan metaCacheEntriesSorted)
 	// Copy so we can mutate
 	resCh := resultsDone
@@ -142,32 +154,22 @@ func (o *listPathOptions) gatherResults(in <-chan metaCacheEntry) func() (metaCa
 			if !o.IncludeDirectories && entry.isDir() {
 				continue
 			}
-			if debugPrint {
-				console.Infoln("gather got:", entry.name)
-			}
+			o.debugln("gather got:", entry.name)
 			if o.Marker != "" && entry.name <= o.Marker {
-				if debugPrint {
-					console.Infoln("pre marker")
-				}
+				o.debugln("pre marker")
 				continue
 			}
 			if !strings.HasPrefix(entry.name, o.Prefix) {
-				if debugPrint {
-					console.Infoln("not in prefix")
-				}
+				o.debugln("not in prefix")
 				continue
 			}
 			if !o.Recursive && !entry.isInDir(o.Prefix, o.Separator) {
-				if debugPrint {
-					console.Infoln("not in dir", o.Prefix, o.Separator)
-				}
+				o.debugln("not in dir", o.Prefix, o.Separator)
 				continue
 			}
 			if !o.InclDeleted && entry.isObject() {
 				if entry.isLatestDeletemarker() {
-					if debugPrint {
-						console.Infoln("latest delete")
-					}
+					o.debugln("latest delete")
 					continue
 				}
 			}
@@ -181,9 +183,7 @@ func (o *listPathOptions) gatherResults(in <-chan metaCacheEntry) func() (metaCa
 				}
 				continue
 			}
-			if debugPrint {
-				console.Infoln("adding...")
-			}
+			o.debugln("adding...")
 			results.o = append(results.o, entry)
 		}
 		if resCh != nil {
@@ -207,19 +207,15 @@ func (o *listPathOptions) findFirstPart(fi FileInfo) (int, error) {
 	if search == "" {
 		return 0, nil
 	}
-	const debugPrint = false
-	if debugPrint {
-		console.Infoln("searching for ", search)
-	}
+	o.debugln("searching for ", search)
 	var tmp metacacheBlock
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	i := 0
 	for {
 		partKey := fmt.Sprintf("%s-metacache-part-%d", ReservedMetadataPrefixLower, i)
 		v, ok := fi.Metadata[partKey]
 		if !ok {
-			if debugPrint {
-				console.Infoln("no match in metadata, waiting")
-			}
+			o.debugln("no match in metadata, waiting")
 			return -1, io.ErrUnexpectedEOF
 		}
 		err := json.Unmarshal([]byte(v), &tmp)
@@ -231,27 +227,18 @@ func (o *listPathOptions) findFirstPart(fi FileInfo) (int, error) {
 			return 0, errFileNotFound
 		}
 		if tmp.First >= search {
-			if debugPrint {
-				console.Infoln("First >= search", v)
-			}
+			o.debugln("First >= search", v)
 			return i, nil
 		}
 		if tmp.Last >= search {
-			if debugPrint {
-
-				console.Infoln("Last >= search", v)
-			}
+			o.debugln("Last >= search", v)
 			return i, nil
 		}
 		if tmp.EOS {
-			if debugPrint {
-				console.Infoln("no match, at EOS", v)
-			}
+			o.debugln("no match, at EOS", v)
 			return -3, io.EOF
 		}
-		if debugPrint {
-			console.Infoln("First ", tmp.First, "<", search, " search", i)
-		}
+		o.debugln("First ", tmp.First, "<", search, " search", i)
 		i++
 	}
 }
@@ -312,7 +299,6 @@ func (o *listPathOptions) SetFilter() {
 // Will return io.EOF if there are no more entries with the same filter.
 // The last entry can be used as a marker to resume the listing.
 func (r *metacacheReader) filter(o listPathOptions) (entries metaCacheEntriesSorted, err error) {
-	const debugPrint = false
 	// Forward to prefix, if any
 	err = r.forwardTo(o.Prefix)
 	if err != nil {
@@ -334,9 +320,8 @@ func (r *metacacheReader) filter(o listPathOptions) (entries metaCacheEntriesSor
 			}
 		}
 	}
-	if debugPrint {
-		console.Infoln("forwarded to ", o.Prefix, "marker:", o.Marker, "sep:", o.Separator)
-	}
+	o.debugln("forwarded to ", o.Prefix, "marker:", o.Marker, "sep:", o.Separator)
+
 	// Filter
 	if !o.Recursive {
 		entries.o = make(metaCacheEntries, 0, o.Limit)
@@ -555,10 +540,7 @@ func (er erasureObjects) SetDriveCount() int {
 
 // Will return io.EOF if continuing would not yield more results.
 func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entries metaCacheEntriesSorted, err error) {
-	const debugPrint = false
-	if debugPrint {
-		console.Printf("listPath with options: %#v\n", o)
-	}
+	o.debugf("listPath with options: %#v\n", o)
 
 	// See if we have the listing stored.
 	if !o.Create && !o.singleObject {
@@ -584,9 +566,7 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 	rpc := globalNotificationSys.restClientFromHash(o.Bucket)
 	var metaMu sync.Mutex
 
-	if debugPrint {
-		console.Println("listPath: scanning bucket:", o.Bucket, "basedir:", o.BaseDir, "prefix:", o.Prefix, "marker:", o.Marker)
-	}
+	o.debugln("listPath: scanning bucket:", o.Bucket, "basedir:", o.BaseDir, "prefix:", o.Prefix, "marker:", o.Marker)
 
 	// Disconnect from call above, but cancel on exit.
 	ctx, cancel := context.WithCancel(GlobalContext)
@@ -594,9 +574,7 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 	disks := er.getOnlineDisks()
 
 	defer func() {
-		if debugPrint {
-			console.Println("listPath returning:", entries.len(), "err:", err)
-		}
+		o.debugln("listPath returning:", entries.len(), "err:", err)
 		if err != nil && !errors.Is(err, io.EOF) {
 			go func(err string) {
 				metaMu.Lock()
@@ -682,9 +660,7 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 				// Don't save single object listings.
 				return nil
 			}
-			if debugPrint {
-				console.Println("listPath: saving block", b.n, "to", o.objectPath(b.n))
-			}
+			o.debugln("listPath: saving block", b.n, "to", o.objectPath(b.n))
 			r, err := hash.NewReader(bytes.NewBuffer(b.data), int64(len(b.data)), "", "", int64(len(b.data)), false)
 			logger.LogIf(ctx, err)
 			custom := b.headerKV()

--- a/cmd/metacache.go
+++ b/cmd/metacache.go
@@ -46,6 +46,9 @@ const (
 	// Enabling this will make cache sharing more likely and cause less IO,
 	// but may cause additional latency to some calls.
 	metacacheSharePrefix = false
+
+	// metacacheDebug will enable debug printing
+	metacacheDebug = false
 )
 
 //go:generate msgp -file $GOFILE -unexported
@@ -71,6 +74,64 @@ type metacache struct {
 
 func (m *metacache) finished() bool {
 	return !m.ended.IsZero()
+}
+
+// matches returns whether the metacache matches the options given.
+func (m *metacache) matches(o *listPathOptions, extend time.Duration) bool {
+	if o == nil {
+		return false
+	}
+
+	// Never return transient caches if there is no id.
+	if m.status == scanStateError || m.status == scanStateNone || m.dataVersion != metacacheStreamVersion {
+		o.debugf("cache %s state or stream version mismatch", m.id)
+		return false
+	}
+	if m.startedCycle < o.OldestCycle {
+		o.debugf("cache %s cycle too old", m.id)
+		return false
+	}
+
+	// Root of what we are looking for must at least have the same
+	if !strings.HasPrefix(o.BaseDir, m.root) {
+		o.debugf("cache %s prefix mismatch, cached:%v, want:%v", m.id, m.root, o.BaseDir)
+		return false
+	}
+	if m.filter != "" && strings.HasPrefix(m.filter, o.FilterPrefix) {
+		o.debugf("cache %s cannot be used because of filter %s", m.id, m.filter)
+		return false
+	}
+
+	if o.Recursive && !m.recursive {
+		o.debugf("cache %s not recursive", m.id)
+		// If this is recursive the cached listing must be as well.
+		return false
+	}
+	if o.Separator != slashSeparator && !m.recursive {
+		o.debugf("cache %s not slashsep and not recursive", m.id)
+		// Non slash separator requires recursive.
+		return false
+	}
+	if !m.finished() && time.Since(m.lastUpdate) > metacacheMaxRunningAge {
+		o.debugf("cache %s not running, time: %v", m.id, time.Since(m.lastUpdate))
+		// Abandoned
+		return false
+	}
+
+	if m.finished() && m.endedCycle <= o.OldestCycle {
+		if extend <= 0 {
+			// If scan has ended the oldest requested must be less.
+			o.debugf("cache %s ended and cycle (%v) <= oldest allowed (%v)", m.id, m.endedCycle, o.OldestCycle)
+			return false
+		}
+		if time.Since(m.lastUpdate) > metacacheMaxRunningAge+extend {
+			// Cache ended within bloom cycle, but we can extend the life.
+			o.debugf("cache %s ended (%v) and beyond extended life (%v)", m.id, m.lastUpdate, extend+metacacheMaxRunningAge)
+			return false
+		}
+	}
+
+	return true
 }
 
 // worthKeeping indicates if the cache by itself is worth keeping.


### PR DESCRIPTION
## Description

When searching the caches don't copy the ids, instead inline the loop.

```
Benchmark_bucketMetacache_findCache-32    	   19200	     63490 ns/op	    8303 B/op	       5 allocs/op
Benchmark_bucketMetacache_findCache-32    	   20338	     58609 ns/op	     111 B/op	       4 allocs/op
```

Add a reasonable, but still simplistic benchmark.

## Motivation and Context

Generate less garbage.
Make logging look nicer.

Replaces #11058

## How to test this PR?


## Types of changes
- [x] Optimization
