### PR TITLE
fix: remove inode free as part of SameDisk check

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -43,8 +43,8 @@ func SameDisk(di1, di2 Info) bool {
 		return false
 	}
 
-	// returns true only if Used, Free and number of free
-	// inodes are same, then its the same disk.
-	return di1.Used == di2.Used && di1.Free == di2.Free &&
-		di1.Ffree == di2.Ffree
+	// returns true only if Used, Free are same, then its the same disk.
+	// we are deliberately not using free inodes as that is unreliable
+	// due the fact that Ffree can vary even for temporary files
+	return di1.Used == di2.Used && di1.Free == di2.Free
 }


### PR DESCRIPTION
## Description
fix: remove inode free as part of SameDisk check

## Motivation and Context
attempts to reduce room for errors as inodes free
are rather not reliable on Linux

## How to test this PR?
Test with `minio server /tmp/disk{1...4}/export{1...4}`  where `/tmp` shares
the disk space with root disk `/`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
