### PR TITLE
metacache: Make very small requests transient

### DIFF
--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -707,7 +707,7 @@ func (z *erasureServerPools) ListObjectVersions(ctx context.Context, bucket, pre
 	// more objects matching the prefix.
 	ri := logger.GetReqInfo(ctx)
 	if ri != nil && strings.Contains(ri.UserAgent, `1.0 Veeam/1.0 Backup`) && strings.HasSuffix(prefix, ".blk") {
-		opts.singleObject = true
+		opts.discardResult = true
 		opts.Transient = true
 	}
 


### PR DESCRIPTION
## Description

For recursive requests that only wants less than 10 results do a transient listing.

Attempts to avoid expensive listings to run for a long while when clients aren't interested in results.

If the client DOES resume the listing a full cache will be generated due to the marker without ID.

## Motivation and Context

If a client just want to check if a path exists, they may trigger a full recursive listing.

## How to test this PR?

Do a recursive listing with a low limit. The returned marker should not contain a `[minio_cache:` part.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
