### PR TITLE
feat: treat /var/run/secrets/ on k8s as system cert directory

### DIFF
--- a/pkg/certs/ca-certs.go
+++ b/pkg/certs/ca-certs.go
@@ -38,7 +38,7 @@ func GetRootCAs(certsCAsDir string) (*x509.CertPool, error) {
 	if err != nil {
 		if os.IsNotExist(err) || os.IsPermission(err) {
 			// Return success if CA's directory is missing or permission denied.
-			err = nil
+			return rootCAs, nil
 		}
 		return rootCAs, err
 	}
@@ -46,11 +46,10 @@ func GetRootCAs(certsCAsDir string) (*x509.CertPool, error) {
 	// Load all custom CA files.
 	for _, fi := range fis {
 		caCert, err := ioutil.ReadFile(path.Join(certsCAsDir, fi.Name()))
-		if err != nil {
-			// ignore files which are not readable.
-			continue
+		if err == nil {
+			rootCAs.AppendCertsFromPEM(caCert)
 		}
-		rootCAs.AppendCertsFromPEM(caCert)
+		// ignore files which are not readable.
 	}
 
 	return rootCAs, nil

--- a/pkg/certs/cert_pool_nix.go
+++ b/pkg/certs/cert_pool_nix.go
@@ -18,8 +18,67 @@
 
 package certs
 
-import "crypto/x509"
+import (
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Possible directories with certificate files, this is an extended
+// list from https://golang.org/src/crypto/x509/root_unix.go?#L18
+// for k8s platform
+var certDirectories = []string{
+	"/var/run/secrets/kubernetes.io/serviceaccount",
+}
+
+// readUniqueDirectoryEntries is like ioutil.ReadDir but omits
+// symlinks that point within the directory.
+func readUniqueDirectoryEntries(dir string) ([]os.FileInfo, error) {
+	fis, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	uniq := fis[:0]
+	for _, fi := range fis {
+		if !isSameDirSymlink(fi, dir) {
+			uniq = append(uniq, fi)
+		}
+	}
+	return uniq, nil
+}
+
+// isSameDirSymlink reports whether fi in dir is a symlink with a
+// target not containing a slash.
+func isSameDirSymlink(fi os.FileInfo, dir string) bool {
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	target, err := os.Readlink(filepath.Join(dir, fi.Name()))
+	return err == nil && !strings.Contains(target, "/")
+}
 
 func loadSystemRoots() (*x509.CertPool, error) {
-	return x509.SystemCertPool()
+	caPool, err := x509.SystemCertPool()
+	if err != nil {
+		return caPool, err
+	}
+
+	for _, directory := range certDirectories {
+		fis, err := readUniqueDirectoryEntries(directory)
+		if err != nil {
+			if os.IsNotExist(err) || os.IsPermission(err) {
+				return caPool, nil
+			}
+			return caPool, err
+		}
+		for _, fi := range fis {
+			data, err := ioutil.ReadFile(directory + "/" + fi.Name())
+			if err == nil {
+				caPool.AppendCertsFromPEM(data)
+			}
+		}
+	}
+	return caPool, nil
 }


### PR DESCRIPTION
## Description
feat: treat /var/run/secrets/ on k8s as system cert directory

## Motivation and Context
consider `/var/run/secrets/kubernetes.io/serviceaccount` 
as system cert directory for containers

## How to test this PR?
Need k8s environment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
