### PR TITLE
fix: delimiter based listing was broken without marker

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -309,7 +309,7 @@ func (m *metaCacheEntriesSorted) iterate(fn func(entry metaCacheEntry) (cont boo
 
 // fileInfoVersions converts the metadata to FileInfoVersions where possible.
 // Metadata that cannot be decoded is skipped.
-func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, afterV string) (versions []ObjectInfo, commonPrefixes []string) {
+func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, afterV string) (versions []ObjectInfo) {
 	versions = make([]ObjectInfo, 0, m.len())
 	prevPrefix := ""
 	for _, entry := range m.o {
@@ -323,7 +323,11 @@ func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, aft
 						continue
 					}
 					prevPrefix = currPrefix
-					commonPrefixes = append(commonPrefixes, currPrefix)
+					versions = append(versions, ObjectInfo{
+						IsDir:  true,
+						Bucket: bucket,
+						Name:   currPrefix,
+					})
 					continue
 				}
 			}
@@ -356,17 +360,20 @@ func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, aft
 				continue
 			}
 			prevPrefix = currPrefix
-			commonPrefixes = append(commonPrefixes, currPrefix)
-			continue
+			versions = append(versions, ObjectInfo{
+				IsDir:  true,
+				Bucket: bucket,
+				Name:   currPrefix,
+			})
 		}
 	}
 
-	return versions, commonPrefixes
+	return versions
 }
 
 // fileInfoVersions converts the metadata to FileInfoVersions where possible.
 // Metadata that cannot be decoded is skipped.
-func (m *metaCacheEntriesSorted) fileInfos(bucket, prefix, delimiter string) (objects []ObjectInfo, commonPrefixes []string) {
+func (m *metaCacheEntriesSorted) fileInfos(bucket, prefix, delimiter string) (objects []ObjectInfo) {
 	objects = make([]ObjectInfo, 0, m.len())
 	prevPrefix := ""
 	for _, entry := range m.o {
@@ -380,7 +387,11 @@ func (m *metaCacheEntriesSorted) fileInfos(bucket, prefix, delimiter string) (ob
 						continue
 					}
 					prevPrefix = currPrefix
-					commonPrefixes = append(commonPrefixes, currPrefix)
+					objects = append(objects, ObjectInfo{
+						IsDir:  true,
+						Bucket: bucket,
+						Name:   currPrefix,
+					})
 					continue
 				}
 			}
@@ -405,12 +416,15 @@ func (m *metaCacheEntriesSorted) fileInfos(bucket, prefix, delimiter string) (ob
 				continue
 			}
 			prevPrefix = currPrefix
-			commonPrefixes = append(commonPrefixes, currPrefix)
-			continue
+			objects = append(objects, ObjectInfo{
+				IsDir:  true,
+				Bucket: bucket,
+				Name:   currPrefix,
+			})
 		}
 	}
 
-	return objects, commonPrefixes
+	return objects
 }
 
 // forwardTo will truncate m so only entries that are s or after is in the list.

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -570,11 +570,13 @@ func (web *webAPIHandlers) ListObjects(r *http.Request, args *ListObjectsArgs, r
 	nextMarker := ""
 	// Fetch all the objects
 	for {
-		// Limit browser to 1000 batches to be more responsive, scrolling friendly.
-		lo, err := listObjects(ctx, args.BucketName, args.Prefix, nextMarker, SlashSeparator, 1000)
+		// Limit browser to defaults batches to be more responsive, scrolling friendly.
+		lo, err := listObjects(ctx, args.BucketName, args.Prefix, nextMarker, SlashSeparator, -1)
 		if err != nil {
 			return &json2.Error{Message: err.Error()}
 		}
+
+		nextMarker = lo.NextMarker
 		for i := range lo.Objects {
 			lo.Objects[i].Size, err = lo.Objects[i].GetActualSize()
 			if err != nil {
@@ -595,8 +597,6 @@ func (web *webAPIHandlers) ListObjects(r *http.Request, args *ListObjectsArgs, r
 				Key: prefix,
 			})
 		}
-
-		nextMarker = lo.NextMarker
 
 		// Return when there are no more objects
 		if !lo.IsTruncated {

--- a/mint/build/minio-py/install.sh
+++ b/mint/build/minio-py/install.sh
@@ -23,5 +23,5 @@ fi
 
 test_run_dir="$MINT_RUN_CORE_DIR/minio-py"
 pip3 install --user faker
-pip3 install minio==${MINIO_PY_VERSION}
+pip3 install minio=="${MINIO_PY_VERSION}"
 $WGET --output-document="$test_run_dir/tests.py" "https://raw.githubusercontent.com/minio/minio-py/${MINIO_PY_VERSION}/tests/functional/tests.py"

--- a/mint/mint.sh
+++ b/mint/mint.sh
@@ -183,7 +183,7 @@ function main()
     done
 
     ## Report when all tests in run_list are run
-    if [ $i -eq "$count" ]; then
+    if [ "$i" -eq "$count" ]; then
         echo -e "\nAll tests ran successfully"
     else
         echo -e "\nExecuted $i out of $count tests successfully."


### PR DESCRIPTION

## Description
fix: delimiter based listing was broken without a marker

## Motivation and Context
with missing nextMarker with delimiter based listing,
top-level prefixes beyond 4500 or max-keys value
wouldn't be sent back for the client to ask for the next
batch.

reproduced at a customer deployment, create prefixes
as shown below

```
for year in $(seq 2017 2020)
do
    for month in {01..12}
    do for day in {01..31}
       do
           mc -q cp file myminio/testbucket/dir/day_id=$year-$month-$day/;
       done
    done
done
```

Then perform

```
aws s3api --profile minio --endpoint-url http://localhost:9000 list-objects \
    --bucket testbucket --prefix dir/ --delimiter / --max-keys 1000
```

You shall see missing NextMarker, this would disallow listing beyond max-keys
requested and also disallow beyond 4500 (maxKeyObjectList) prefixes being listed
because the client wouldn't know the NextMarker available.

This PR addresses this situation properly by making the implementation
more spec compatible. i.e NextMarker in-fact can be either an object, a prefix
with delimiter depending on the input operation.

This issue was introduced after the list caching changes and has been present
for a while.

## How to test this PR?
```
for year in $(seq 2017 2020)
do
    for month in {01..12}
    do for day in {01..31}
       do
           mc -q cp file myminio/testbucket/dir/day_id=$year-$month-$day/;
       done
    done
done
```

Then perform

```
aws s3api --profile minio --endpoint-url http://localhost:9000 list-objects \
    --bucket testbucket --prefix dir/ --delimiter / --max-keys 1000
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes in-fact with list caching changes
- [ ] Documentation needed
- [x] Unit tests needed
