### PR TITLE
fix testMultipartUploadFailure to properly cleanup

### DIFF
--- a/mint/run/core/aws-sdk-php/quick-tests.php
+++ b/mint/run/core/aws-sdk-php/quick-tests.php
@@ -506,7 +506,15 @@ function testMultipartUploadFailure($s3Client, $params) {
             ],
         ],
     ];
-    runExceptionalTests($s3Client, 'completeMultipartUpload', 'getAwsErrorCode', $params);
+     try {
+        runExceptionalTests($s3Client, 'completeMultipartUpload', 'getAwsErrorCode', $params);
+    }finally {
+        $s3Client->abortMultipartUpload([
+            'Bucket' => $bucket,
+            'Key' => $object,
+            'UploadId' => $uploadId
+        ]);
+    }
 }
 
  /**


### PR DESCRIPTION
## Description
Make the test to cleanup pending multipart uploads

## Motivation and Context
Because we are using the same objet name and bucket name in all tests.
We need to clean up multipart upload properly so that each test doesn't
interfere with one another.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
