### PR TITLE
admin: ServerInfo returns info without object layer initialized

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1497,20 +1497,11 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 
 	defer logger.AuditLog(w, r, "ServerInfo", mustGetClaimsFromToken(r))
 
-	objectAPI, _ := validateAdminReq(ctx, w, r, iampolicy.ServerInfoAdminAction)
-	if objectAPI == nil {
+	// Validate request signature.
+	_, adminAPIErr := checkAdminRequestAuth(ctx, r, iampolicy.ServerInfoAdminAction, "")
+	if adminAPIErr != ErrNone {
+		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(adminAPIErr), r.URL)
 		return
-	}
-
-	buckets := madmin.Buckets{}
-	objects := madmin.Objects{}
-	usage := madmin.Usage{}
-
-	dataUsageInfo, err := loadDataUsageFromBackend(ctx, objectAPI)
-	if err == nil {
-		buckets = madmin.Buckets{Count: dataUsageInfo.BucketsCount}
-		objects = madmin.Objects{Count: dataUsageInfo.ObjectsTotalCount}
-		usage = madmin.Usage{Size: dataUsageInfo.ObjectsTotalSize}
 	}
 
 	vault := fetchVaultStatus()
@@ -1534,30 +1525,53 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 	// Get the notification target info
 	notifyTarget := fetchLambdaInfo()
 
-	// Fetching the Storage information, ignore any errors.
-	storageInfo, _ := objectAPI.StorageInfo(ctx, false)
-
-	var backend interface{}
-	if storageInfo.Backend.Type == BackendType(madmin.Erasure) {
-		backend = madmin.ErasureBackend{
-			Type:             madmin.ErasureType,
-			OnlineDisks:      storageInfo.Backend.OnlineDisks.Sum(),
-			OfflineDisks:     storageInfo.Backend.OfflineDisks.Sum(),
-			StandardSCData:   storageInfo.Backend.StandardSCData,
-			StandardSCParity: storageInfo.Backend.StandardSCParity,
-			RRSCData:         storageInfo.Backend.RRSCData,
-			RRSCParity:       storageInfo.Backend.RRSCParity,
-		}
-	} else {
-		backend = madmin.FSBackend{
-			Type: madmin.FsType,
-		}
-	}
-
-	mode := "online"
 	server := getLocalServerProperty(globalEndpoints, r)
 	servers := globalNotificationSys.ServerInfo()
 	servers = append(servers, server)
+
+	var backend interface{}
+	mode := madmin.ObjectLayerInitializing
+
+	buckets := madmin.Buckets{}
+	objects := madmin.Objects{}
+	usage := madmin.Usage{}
+
+	objectAPI := newObjectLayerFn()
+	if objectAPI != nil {
+		mode = madmin.ObjectLayerOnline
+		// Load data usage
+		dataUsageInfo, err := loadDataUsageFromBackend(ctx, objectAPI)
+		if err == nil {
+			buckets = madmin.Buckets{Count: dataUsageInfo.BucketsCount}
+			objects = madmin.Objects{Count: dataUsageInfo.ObjectsTotalCount}
+			usage = madmin.Usage{Size: dataUsageInfo.ObjectsTotalSize}
+		}
+
+		// Fetching the backend information
+		backendInfo := objectAPI.BackendInfo()
+		if backendInfo.Type == BackendType(madmin.Erasure) {
+			// Calculate the number of online/offline disks of all nodes
+			var allDisks []madmin.Disk
+			for _, s := range servers {
+				allDisks = append(allDisks, s.Disks...)
+			}
+			onlineDisks, offlineDisks := getOnlineOfflineDisksStats(allDisks)
+
+			backend = madmin.ErasureBackend{
+				Type:             madmin.ErasureType,
+				OnlineDisks:      onlineDisks.Sum(),
+				OfflineDisks:     offlineDisks.Sum(),
+				StandardSCData:   backendInfo.StandardSCData,
+				StandardSCParity: backendInfo.StandardSCParity,
+				RRSCData:         backendInfo.RRSCData,
+				RRSCParity:       backendInfo.RRSCParity,
+			}
+		} else {
+			backend = madmin.FSBackend{
+				Type: madmin.FsType,
+			}
+		}
+	}
 
 	domain := globalDomainNames
 	services := madmin.Services{
@@ -1566,25 +1580,6 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 		Logger:        log,
 		Audit:         audit,
 		Notifications: notifyTarget,
-	}
-
-	// find all disks which belong to each respective endpoints
-	for i := range servers {
-		for _, disk := range storageInfo.Disks {
-			if strings.Contains(disk.Endpoint, servers[i].Endpoint) {
-				servers[i].Disks = append(servers[i].Disks, disk)
-			}
-		}
-	}
-
-	// add all the disks local to this server.
-	for _, disk := range storageInfo.Disks {
-		if disk.DrivePath == "" && disk.Endpoint == "" {
-			continue
-		}
-		if disk.Endpoint == disk.DrivePath {
-			servers[len(servers)-1].Disks = append(servers[len(servers)-1].Disks, disk)
-		}
 	}
 
 	infoMsg := madmin.InfoMessage{

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -353,6 +353,14 @@ func (endpoints Endpoints) GetString(i int) string {
 	return endpoints[i].String()
 }
 
+// GetAllStrings - returns allstring of all endpoints
+func (endpoints Endpoints) GetAllStrings() (all []string) {
+	for _, e := range endpoints {
+		all = append(all, e.String())
+	}
+	return
+}
+
 func hostResolveToLocalhost(endpoint Endpoint) bool {
 	hostIPs, err := getHostIP(endpoint.Hostname())
 	if err != nil {

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -491,8 +491,6 @@ func (s *erasureSets) StorageUsageInfo(ctx context.Context) StorageInfo {
 
 		for _, lstorageInfo := range storageInfos {
 			storageInfo.Disks = append(storageInfo.Disks, lstorageInfo.Disks...)
-			storageInfo.Backend.OnlineDisks = storageInfo.Backend.OnlineDisks.Merge(lstorageInfo.Backend.OnlineDisks)
-			storageInfo.Backend.OfflineDisks = storageInfo.Backend.OfflineDisks.Merge(lstorageInfo.Backend.OfflineDisks)
 		}
 
 		return storageInfo
@@ -530,8 +528,6 @@ func (s *erasureSets) StorageInfo(ctx context.Context, local bool) (StorageInfo,
 
 	for _, lstorageInfo := range storageInfos {
 		storageInfo.Disks = append(storageInfo.Disks, lstorageInfo.Disks...)
-		storageInfo.Backend.OnlineDisks = storageInfo.Backend.OnlineDisks.Merge(lstorageInfo.Backend.OnlineDisks)
-		storageInfo.Backend.OfflineDisks = storageInfo.Backend.OfflineDisks.Merge(lstorageInfo.Backend.OfflineDisks)
 	}
 
 	if local {

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -200,6 +200,11 @@ func (fs *FSObjects) Shutdown(ctx context.Context) error {
 	return fsRemoveAll(ctx, pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID))
 }
 
+// BackendInfo - returns backend information
+func (fs *FSObjects) BackendInfo() BackendInfo {
+	return BackendInfo{Type: BackendFS}
+}
+
 // StorageInfo - returns underlying storage statistics.
 func (fs *FSObjects) StorageInfo(ctx context.Context, _ bool) (StorageInfo, []error) {
 

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -34,6 +34,11 @@ import (
 // GatewayUnsupported list of unsupported call stubs for gateway.
 type GatewayUnsupported struct{}
 
+// BackendInfo returns the underlying backend information
+func (a GatewayUnsupported) BackendInfo() BackendInfo {
+	return BackendInfo{Type: BackendGateway}
+}
+
 // CrawlAndGetDataUsage - crawl is not implemented for gateway
 func (a GatewayUnsupported) CrawlAndGetDataUsage(ctx context.Context, bf *bloomFilter, updates chan<- DataUsageInfo) error {
 	logger.CriticalIf(ctx, errors.New("not implemented"))

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -500,8 +500,7 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 	// Fetch disk space info, ignore errors
 	storageInfo, _ := objLayer.StorageInfo(GlobalContext, true)
 
-	offlineDisks := storageInfo.Backend.OfflineDisks
-	onlineDisks := storageInfo.Backend.OnlineDisks
+	onlineDisks, offlineDisks := getOnlineOfflineDisksStats(storageInfo.Disks)
 	totalDisks := offlineDisks.Merge(onlineDisks)
 
 	// MinIO Offline Disks per node

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -42,26 +42,25 @@ const (
 	// Add your own backend.
 )
 
+// BackendInfo - contains info of the underlying backend
+type BackendInfo struct {
+	// Represents various backend types, currently on FS, Erasure and Gateway
+	Type BackendType
+
+	// Following fields are only meaningful if BackendType is Gateway.
+	GatewayOnline bool
+
+	// Following fields are only meaningful if BackendType is Erasure.
+	StandardSCData   int // Data disks for currently configured Standard storage class.
+	StandardSCParity int // Parity disks for currently configured Standard storage class.
+	RRSCData         int // Data disks for currently configured Reduced Redundancy storage class.
+	RRSCParity       int // Parity disks for currently configured Reduced Redundancy storage class.
+}
+
 // StorageInfo - represents total capacity of underlying storage.
 type StorageInfo struct {
-	Disks []madmin.Disk
-
-	// Backend type.
-	Backend struct {
-		// Represents various backend types, currently on FS, Erasure and Gateway
-		Type BackendType
-
-		// Following fields are only meaningful if BackendType is Gateway.
-		GatewayOnline bool
-
-		// Following fields are only meaningful if BackendType is Erasure.
-		OnlineDisks      madmin.BackendDisks // Online disks during server startup.
-		OfflineDisks     madmin.BackendDisks // Offline disks during server startup.
-		StandardSCData   int                 // Data disks for currently configured Standard storage class.
-		StandardSCParity int                 // Parity disks for currently configured Standard storage class.
-		RRSCData         int                 // Data disks for currently configured Reduced Redundancy storage class.
-		RRSCParity       int                 // Parity disks for currently configured Reduced Redundancy storage class.
-	}
+	Disks   []madmin.Disk
+	Backend BackendInfo
 }
 
 // objectHistogramInterval is an interval that will be

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -79,6 +79,8 @@ type ObjectLayer interface {
 	// Storage operations.
 	Shutdown(context.Context) error
 	CrawlAndGetDataUsage(ctx context.Context, bf *bloomFilter, updates chan<- DataUsageInfo) error
+
+	BackendInfo() BackendInfo
 	StorageInfo(ctx context.Context, local bool) (StorageInfo, []error) // local queries only local disks
 
 	// Bucket operations.

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -205,12 +205,13 @@ func printObjectAPIMsg() {
 func getStorageInfoMsg(storageInfo StorageInfo) string {
 	var msg string
 	var mcMessage string
+	onlineDisks, offlineDisks := getOnlineOfflineDisksStats(storageInfo.Disks)
 	if storageInfo.Backend.Type == BackendErasure {
-		if storageInfo.Backend.OfflineDisks.Sum() > 0 {
+		if offlineDisks.Sum() > 0 {
 			mcMessage = "Use `mc admin info` to look for latest server/disk info\n"
 		}
 
-		diskInfo := fmt.Sprintf(" %d Online, %d Offline. ", storageInfo.Backend.OnlineDisks.Sum(), storageInfo.Backend.OfflineDisks.Sum())
+		diskInfo := fmt.Sprintf(" %d Online, %d Offline. ", onlineDisks.Sum(), offlineDisks.Sum())
 		msg += color.Blue("Status:") + fmt.Sprintf(getFormatStr(len(diskInfo), 8), diskInfo)
 		if len(mcMessage) > 0 {
 			msg = fmt.Sprintf("%s %s", mcMessage, msg)

--- a/cmd/server-startup-msg_test.go
+++ b/cmd/server-startup-msg_test.go
@@ -28,9 +28,17 @@ import (
 // Tests if we generate storage info.
 func TestStorageInfoMsg(t *testing.T) {
 	infoStorage := StorageInfo{}
+	infoStorage.Disks = []madmin.Disk{
+		{Endpoint: "http://127.0.0.1:9000/data/1/", State: madmin.DriveStateOk},
+		{Endpoint: "http://127.0.0.1:9000/data/2/", State: madmin.DriveStateOk},
+		{Endpoint: "http://127.0.0.1:9000/data/3/", State: madmin.DriveStateOk},
+		{Endpoint: "http://127.0.0.1:9000/data/4/", State: madmin.DriveStateOk},
+		{Endpoint: "http://127.0.0.1:9001/data/1/", State: madmin.DriveStateOk},
+		{Endpoint: "http://127.0.0.1:9001/data/2/", State: madmin.DriveStateOk},
+		{Endpoint: "http://127.0.0.1:9001/data/3/", State: madmin.DriveStateOk},
+		{Endpoint: "http://127.0.0.1:9001/data/4/", State: madmin.DriveStateOffline},
+	}
 	infoStorage.Backend.Type = BackendErasure
-	infoStorage.Backend.OnlineDisks = madmin.BackendDisks{"127.0.0.1:9000": 4, "127.0.0.1:9001": 3}
-	infoStorage.Backend.OfflineDisks = madmin.BackendDisks{"127.0.0.1:9000": 0, "127.0.0.1:9001": 1}
 
 	if msg := getStorageInfoMsg(infoStorage); !strings.Contains(msg, "7 Online, 1 Offline") {
 		t.Fatal("Unexpected storage info message, found:", msg)

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -39,6 +39,16 @@ const (
 	// Add your own backend.
 )
 
+// ObjectLayerState - represents the status of the object layer
+type ObjectLayerState string
+
+const (
+	// ObjectLayerInitializing indicates that the object layer is still in initialization phase
+	ObjectLayerInitializing = ObjectLayerState("initializing")
+	// ObjectLayerOnline indicates that the object layer is ready
+	ObjectLayerOnline = ObjectLayerState("online")
+)
+
 // StorageInfo - represents total capacity of underlying storage.
 type StorageInfo struct {
 	Disks []Disk
@@ -163,7 +173,7 @@ func (adm *AdminClient) DataUsageInfo(ctx context.Context) (DataUsageInfo, error
 
 // InfoMessage container to hold server admin related information.
 type InfoMessage struct {
-	Mode         string             `json:"mode,omitempty"`
+	Mode         ObjectLayerState   `json:"mode,omitempty"`
 	Domain       []string           `json:"domain,omitempty"`
 	Region       string             `json:"region,omitempty"`
 	SQSARN       []string           `json:"sqsARN,omitempty"`


### PR DESCRIPTION
## Description
The only function change in this PR is the ability of madmin ServerInfo (mc admin info)
to return even the object layer is not initialized yet. Otherwise all changes are either
moving or code simplification.


Also when the cluster is not initialized yet, ServerInfo returns 'initializing' mode.


## Motivation and Context
Users should be able to call mc admin info when the cluster is in initialization phase.
This will at least shows network connection status between nodes and disks status
if available.

## How to test this PR?
1. Run one node / 4 nodes 
2. mc admin info node1

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
