### PR TITLE
normalize users with double // in accessKeys

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"path"
 
 	"github.com/gorilla/mux"
 	"github.com/minio/minio/cmd/logger"
@@ -358,7 +359,7 @@ func (a adminAPIHandlers) AddUser(w http.ResponseWriter, r *http.Request) {
 	defer logger.AuditLog(w, r, "AddUser", mustGetClaimsFromToken(r))
 
 	vars := mux.Vars(r)
-	accessKey := vars["accessKey"]
+	accessKey := path.Clean(vars["accessKey"])
 
 	// Get current object layer instance.
 	objectAPI := newObjectLayerFn()

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -1005,7 +1006,7 @@ func (web *webAPIHandlers) SetAuth(r *http.Request, args *SetAuthArgs, reply *Se
 	}
 
 	// Throw error when wrong secret key is provided
-	if prevCred.SecretKey != args.CurrentSecretKey {
+	if subtle.ConstantTimeCompare([]byte(prevCred.SecretKey), []byte(args.CurrentSecretKey)) != 1 {
 		return errIncorrectCreds
 	}
 


### PR DESCRIPTION
## Description
normalize users with double // in accessKeys

## Motivation and Context
building upon #11127 normalize `//` keys such that
only user access keys with a single `/` would be preserved

Related to #11126 

## How to test this PR?
Both with and without etcd the behavior with `mc admin user list` 
is expected to be the same. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
