### PR TITLE
fix: change defaults for DNS cache dialer

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -51,7 +51,7 @@ func init() {
 	logger.RegisterError(config.FmtError)
 
 	rand.Seed(time.Now().UTC().UnixNano())
-	globalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second)
+	globalDNSCache = xhttp.NewDNSCache(10*time.Second, 3*time.Second)
 
 	initGlobalContext()
 


### PR DESCRIPTION
## Description
fix: change defaults for DNS cache dialer

## Motivation and Context
simplify DNS cache dialer

## How to test this PR?
mainly when servers are down allow
DNS resolvers to fail faster. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
