### PR TITLE
fix: issues with handling delete markers in metacache

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -846,21 +846,21 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 	}
 
 	// Check if there is any offline disk and add it to the MRF list
-	for i, disk := range onlineDisks {
-		if disk == nil || storageDisks[i] == nil {
-			er.addPartial(bucket, object, fi.VersionID)
-			break
+	for _, disk := range onlineDisks {
+		if disk != nil && disk.IsOnline() {
+			continue
 		}
+		er.addPartial(bucket, object, fi.VersionID)
+		break
 	}
 
 	for i := 0; i < len(onlineDisks); i++ {
-		if onlineDisks[i] == nil {
-			continue
+		if onlineDisks[i] != nil && onlineDisks[i].IsOnline() {
+			// Object info is the same in all disks, so we can pick
+			// the first meta from online disk
+			fi = partsMetadata[i]
+			break
 		}
-		// Object info is the same in all disks, so we can pick
-		// the first meta from online disk
-		fi = partsMetadata[i]
-		break
 	}
 
 	// Success, return object info.

--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -147,13 +147,11 @@ func (z *erasureServerPools) listPath(ctx context.Context, o listPathOptions) (e
 	var wg sync.WaitGroup
 	var errs []error
 	allAtEOF := true
-	asked := 0
 	mu.Lock()
 	// Ask all sets and merge entries.
 	for _, zone := range z.serverPools {
 		for _, set := range zone.sets {
 			wg.Add(1)
-			asked++
 			go func(i int, set *erasureObjects) {
 				defer wg.Done()
 				e, err := set.listPath(ctx, o)

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -168,11 +168,9 @@ func (o *listPathOptions) gatherResults(in <-chan metaCacheEntry) func() (metaCa
 				o.debugln("not in dir", o.Prefix, o.Separator)
 				continue
 			}
-			if !o.InclDeleted && entry.isObject() {
-				if entry.isLatestDeletemarker() {
-					o.debugln("latest delete")
-					continue
-				}
+			if !o.InclDeleted && entry.isObject() && entry.isLatestDeletemarker() {
+				o.debugln("latest is delete marker")
+				continue
 			}
 			if o.Limit > 0 && results.len() >= o.Limit {
 				// We have enough and we have more.

--- a/cmd/metacache-stream.go
+++ b/cmd/metacache-stream.go
@@ -519,7 +519,7 @@ func (r *metacacheReader) readN(n int, inclDeleted, inclDirs bool, prefix string
 		if !inclDirs && meta.isDir() {
 			continue
 		}
-		if meta.isDir() && !inclDeleted && meta.isLatestDeletemarker() {
+		if !inclDeleted && meta.isLatestDeletemarker() {
 			continue
 		}
 		res = append(res, meta)


### PR DESCRIPTION

## Description
fix: issues with handling delete markers in metacache

## Motivation and Context
Additional cases handled

- fix address situations where healing is not
  triggered on failed writes and deletes.

- consider object exists during listing when
  metadata can be successfully decoded.

## How to test this PR?
Taking nodes offline and coming back up, MRF is not 
triggered in most common situations

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
