### PR TITLE
fix: re-use bytes.Buffer using sync.Pool

### DIFF
--- a/cmd/metacache-bucket.go
+++ b/cmd/metacache-bucket.go
@@ -113,6 +113,7 @@ func loadBucketMetaCache(ctx context.Context, bucket string) (*bucketMetacache, 
 	// Use global context for this.
 	err := objAPI.GetObject(GlobalContext, minioMetaBucket, pathJoin("buckets", bucket, ".metacache", "index.s2"), 0, -1, w, "", ObjectOptions{})
 	logger.LogIf(ctx, w.CloseWithError(err))
+	wg.Wait()
 	if err != nil {
 		switch err.(type) {
 		case ObjectNotFound:
@@ -125,7 +126,6 @@ func loadBucketMetaCache(ctx context.Context, bucket string) (*bucketMetacache, 
 		}
 		return newBucketMetacache(bucket, false), err
 	}
-	wg.Wait()
 	if decErr != nil {
 		if errors.Is(err, context.Canceled) {
 			return newBucketMetacache(bucket, false), err


### PR DESCRIPTION
## Description
fix: re-use bytes.Buffer using sync.Pool

## Motivation and Context
memory optimization 

## How to test this PR?
large amounts of listing in parallel can
cause spike in memory usage, to reduce 
such a consumption reuse bytes.Buffer

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
