### PR TITLE
fix: strict quorum in list should list on all drives

### DIFF
--- a/cmd/config/api/api.go
+++ b/cmd/config/api/api.go
@@ -113,8 +113,6 @@ func (sCfg *Config) UnmarshalJSON(data []byte) error {
 // acceptable quorum expected for list operations
 func (sCfg Config) GetListQuorum() int {
 	switch sCfg.ListQuorum {
-	case "optimal":
-		return 3
 	case "reduced":
 		return 2
 	case "disk":
@@ -123,7 +121,7 @@ func (sCfg Config) GetListQuorum() int {
 	case "strict":
 		return -1
 	}
-	// Defaults to 3 drives per set.
+	// Defaults to 3 drives per set, defaults to "optimal" value
 	return 3
 }
 

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -595,16 +595,11 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 	}()
 
 	askDisks := o.AskDisks
-	if askDisks == -1 {
-		askDisks = getReadQuorum(er.SetDriveCount())
-	}
-
 	listingQuorum := askDisks - 1
-
 	// Special case: ask all disks if the drive count is 4
-	if er.SetDriveCount() == 4 {
-		askDisks = len(disks)
-		listingQuorum = 2
+	if askDisks == -1 || er.SetDriveCount() == 4 {
+		askDisks = len(disks) // with 'strict' quorum list on all online disks.
+		listingQuorum = getReadQuorum(er.SetDriveCount())
 	}
 
 	if len(disks) < askDisks {


### PR DESCRIPTION


## Description
fix: strict quorum in list should list on all drives

## Motivation and Context
the current implementation was incorrect, it in-fact
assumed only read quorum number of disks. in-fact
that value is only meant for read quorum good entries
from all online disks.

This PR fixes this behavior properly.

## How to test this PR?
You need to set "strict" quorum

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
