### PR TITLE
fix: discarding results do not attempt in-memory metacache writer

### DIFF
--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -570,8 +570,13 @@ func (f *folderScanner) scanQueuedLevels(ctx context.Context, folders []cachedFo
 							bucket:    bucket,
 							object:    entry.name,
 							versionID: "",
+							opts: &madmin.HealOpts{
+								Remove: true,
+							},
 						}, madmin.HealItemObject)
-						logger.LogIf(ctx, err)
+						if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
+							logger.LogIf(ctx, err)
+						}
 						foundObjs = foundObjs || err == nil
 						return
 					}
@@ -583,8 +588,13 @@ func (f *folderScanner) scanQueuedLevels(ctx context.Context, folders []cachedFo
 							bucket:    bucket,
 							object:    fiv.Name,
 							versionID: ver.VersionID,
+							opts: &madmin.HealOpts{
+								Remove: true,
+							},
 						}, madmin.HealItemObject)
-						logger.LogIf(ctx, err)
+						if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
+							logger.LogIf(ctx, err)
+						}
 						foundObjs = foundObjs || err == nil
 					}
 				},

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -674,11 +674,13 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 		return ObjectInfo{}, IncompleteBody{Bucket: bucket, Object: object}
 	}
 
-	lk := er.NewNSLock(bucket, object)
-	if err := lk.GetLock(ctx, globalOperationTimeout); err != nil {
-		return ObjectInfo{}, err
+	if !opts.NoLock {
+		lk := er.NewNSLock(bucket, object)
+		if err := lk.GetLock(ctx, globalOperationTimeout); err != nil {
+			return ObjectInfo{}, err
+		}
+		defer lk.Unlock()
 	}
-	defer lk.Unlock()
 
 	for i, w := range writers {
 		if w == nil {

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -130,7 +130,9 @@ func healErasureSet(ctx context.Context, setIndex int, buckets []BucketInfo, dis
 		bucket: minioMetaBucket,
 		object: backendEncryptedFile,
 	}, madmin.HealItemMetadata); err != nil {
-		logger.LogIf(ctx, err)
+		if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
+			logger.LogIf(ctx, err)
+		}
 	}
 
 	// Heal all buckets with all objects
@@ -139,7 +141,9 @@ func healErasureSet(ctx context.Context, setIndex int, buckets []BucketInfo, dis
 		if err := bgSeq.queueHealTask(healSource{
 			bucket: bucket.Name,
 		}, madmin.HealItemBucket); err != nil {
-			logger.LogIf(ctx, err)
+			if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
+				logger.LogIf(ctx, err)
+			}
 		}
 
 		var entryChs []FileInfoVersionsCh
@@ -179,7 +183,9 @@ func healErasureSet(ctx context.Context, setIndex int, buckets []BucketInfo, dis
 					object:    version.Name,
 					versionID: version.VersionID,
 				}, madmin.HealItemObject); err != nil {
-					logger.LogIf(ctx, err)
+					if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
+						logger.LogIf(ctx, err)
+					}
 				}
 			}
 		}

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -51,6 +51,7 @@ type ObjectOptions struct {
 	DeleteMarkerReplicationStatus string                 // Is only set in DELETE operations
 	VersionPurgeStatus            VersionPurgeStatusType // Is only set in DELETE operations for delete marker version to be permanently deleted.
 	TransitionStatus              string                 // status of the transition
+	NoLock                        bool                   // indicates to lower layers if the caller is expecting to hold locks.
 }
 
 // BucketOptions represents bucket options for ObjectLayer bucket operations


### PR DESCRIPTION


## Description
fix: discarding results do not attempt in-memory metacache writer

## Motivation and Context
Optimizations include

- do not write the metacache block if the size of the
  block is '0' and it is the first block - where listing
  is attempted for a transient list. this helps to                                                                                                                                          
  avoid creating lots of empty metacache entries for                                                                                                                                          
  `minioMetaBucket`

- avoid the entire initialization sequence of cacheCh
  , metacacheBlockWriter if we are simply going to skip
  them when discardResults is set to true.

- No need to hold write locks while writing metacache
  blocks - each block is unique, per bucket, per prefix
  and also is written by a single node.

## How to test this PR?
Needs a large setup with lots of files in different prefixes, tested this
on a packet setup with major gains obtained with per-prefix listing.

This PR to address some performance problems observed with
spark workloads under very high concurrency.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
