### PR TITLE
fix: inherit heal opts globally, including bitrot settings

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -677,10 +677,9 @@ func (h *healSequence) queueHealTask(source healSource, healType madmin.HealItem
 	}
 	if source.opts != nil {
 		task.opts = *source.opts
-	} else {
-		if opts.Bitrot {
-			task.opts.ScanMode = madmin.HealDeepScan
-		}
+	}
+	if opts.Bitrot {
+		task.opts.ScanMode = madmin.HealDeepScan
 	}
 
 	// Wait and proceed if there are active requests

--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -570,9 +570,6 @@ func (f *folderScanner) scanQueuedLevels(ctx context.Context, folders []cachedFo
 							bucket:    bucket,
 							object:    entry.name,
 							versionID: "",
-							opts: &madmin.HealOpts{
-								Remove: true,
-							},
 						}, madmin.HealItemObject)
 						if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
 							logger.LogIf(ctx, err)
@@ -588,9 +585,6 @@ func (f *folderScanner) scanQueuedLevels(ctx context.Context, folders []cachedFo
 							bucket:    bucket,
 							object:    fiv.Name,
 							versionID: ver.VersionID,
-							opts: &madmin.HealOpts{
-								Remove: true,
-							},
 						}, madmin.HealItemObject)
 						if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
 							logger.LogIf(ctx, err)

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -823,7 +823,7 @@ func listPathRaw(ctx context.Context, opts listPathRawOptions) (err error) {
 	defer cancel()
 
 	askDisks := len(disks)
-	var readers = make([]*metacacheReader, askDisks)
+	readers := make([]*metacacheReader, askDisks)
 	for i := range disks {
 		r, w := io.Pipe()
 		d := disks[i]

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -522,7 +522,10 @@ func (s *storageRESTServer) ReadFileStreamHandler(w http.ResponseWriter, r *http
 
 	w.Header().Set(xhttp.ContentLength, strconv.Itoa(length))
 
-	io.Copy(w, rc)
+	bufp := s.storage.pool.Get().(*[]byte)
+	defer s.storage.pool.Put(bufp)
+
+	io.CopyBuffer(w, rc, *bufp)
 	w.(http.Flusher).Flush()
 }
 


### PR DESCRIPTION

## Description
fix: inherit heal opts globally, including bitrot settings

## Motivation and Context
Bonus re-use ReadFileStream internal io.Copy buffers, fixes
lots of chatty allocations when reading metacache readers
with many sustained concurrent listing operations

```
   17.30GB  1.27% 84.80%    35.26GB  2.58%  io.copyBuffer
```

## How to test this PR?
Needs a large setup with lots of objects 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
