### PR TITLE
fix: use HealObject for cleaning up dangling objects

### DIFF
--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -611,18 +611,9 @@ func (f *folderScanner) scanQueuedLevels(ctx context.Context, folders []cachedFo
 				if f.dataUsageCrawlDebug {
 					logger.Info(color.Green("healObjects:")+" deleting dangling directory %s", prefix)
 				}
+
 				// If we have quorum, found directories, but no objects, issue heal to delete the dangling.
-				objAPI.HealObjects(ctx, bucket, prefix, madmin.HealOpts{Recursive: true, Remove: true},
-					func(bucket, object, versionID string) error {
-						// Wait for each heal as per crawler frequency.
-						wait()
-						wait = crawlerSleeper.Timer(ctx)
-						return bgSeq.queueHealTask(healSource{
-							bucket:    bucket,
-							object:    object,
-							versionID: versionID,
-						}, madmin.HealItemObject)
-					})
+				objAPI.HealObject(ctx, bucket, prefix, "", madmin.HealOpts{Recursive: true, Remove: true})
 			}
 
 			wait()


### PR DESCRIPTION

## Description
fix: use HealObject for cleaning up dangling objects

## Motivation and Context
main reason is that HealObjects starts a recursive listing
for each object, this can be a really really long time on
large namespaces instead avoid recursive listing just
perform HealObject() instead at the prefix.

delete's already handle purging dangling content, we
don't need to achieve this by doing recursive listing,
this in-turn can delay crawling significantly.

## How to test this PR?
Check for dangling objects and see how crawler cleanup
happens after every 5minute cycle.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
