### PR TITLE
Reduce logging when peer is offline

### DIFF
--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -140,9 +140,8 @@ func readVersionFromDisks(ctx context.Context, disks []StorageAPI, bucket, objec
 			}
 			metadataArray[index], err = disks[index].ReadVersion(ctx, bucket, object, versionID, checkDataDir)
 			if err != nil {
-				if err != errFileNotFound && err != errVolumeNotFound && err != errFileVersionNotFound {
-					logger.GetReqInfo(ctx).AppendTags("disk", disks[index].String())
-					logger.LogIf(ctx, err)
+				if !IsErr(err, errFileNotFound, errVolumeNotFound, errFileVersionNotFound, errDiskNotFound) {
+					logger.LogOnceIf(ctx, err, disks[index].String())
 				}
 			}
 			return err


### PR DESCRIPTION
## Description
When a peer node is offline the logging is verbose and needs to be reduced.

## Motivation and Context
Eliminate redundant logging.

## How to test this PR?
Tested locally on laptop

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
