### PR TITLE
update license verifier to use updated keys

### DIFF
--- a/pkg/licverifier/verifier.go
+++ b/pkg/licverifier/verifier.go
@@ -89,7 +89,7 @@ func toLicenseInfo(claims jwt.MapClaims) (LicenseInfo, error) {
 	}
 	plan, ok := claims[plan].(string)
 	if !ok {
-		return LicenseInfo{}, errors.New("Invalid service type in claims")
+		return LicenseInfo{}, errors.New("Invalid plan in claims")
 	}
 	return LicenseInfo{
 		Email:           email,

--- a/pkg/licverifier/verifier.go
+++ b/pkg/licverifier/verifier.go
@@ -43,11 +43,11 @@ type LicenseInfo struct {
 
 // license key JSON field names
 const (
-	accountID    = "accountId"
+	accountID    = "aid"
 	sub          = "sub"
 	expiresAt    = "exp"
-	organization = "organization"
-	capacity     = "capacity"
+	organization = "org"
+	capacity     = "cap"
 	plan         = "plan"
 )
 

--- a/pkg/licverifier/verifier.go
+++ b/pkg/licverifier/verifier.go
@@ -34,21 +34,21 @@ type LicenseVerifier struct {
 // LicenseInfo holds customer metadata present in the license key.
 type LicenseInfo struct {
 	Email           string    // Email of the license key requestor
-	TeamName        string    // Subnet team name
+	Organization    string    // Subnet organization name
 	AccountID       int64     // Subnet account id
 	StorageCapacity int64     // Storage capacity used in TB
-	ServiceType     string    // Subnet service type
+	Plan            string    // Subnet plan
 	ExpiresAt       time.Time // Time of license expiry
 }
 
 // license key JSON field names
 const (
-	accountID   = "accountId"
-	sub         = "sub"
-	expiresAt   = "exp"
-	teamName    = "teamName"
-	capacity    = "capacity"
-	serviceType = "serviceType"
+	accountID    = "accountId"
+	sub          = "sub"
+	expiresAt    = "exp"
+	organization = "organization"
+	capacity     = "capacity"
+	plan         = "plan"
 )
 
 // NewLicenseVerifier returns an initialized license verifier with the given
@@ -79,24 +79,24 @@ func toLicenseInfo(claims jwt.MapClaims) (LicenseInfo, error) {
 		return LicenseInfo{}, errors.New("Invalid time of expiry in claims")
 	}
 	expiresAt := time.Unix(int64(expiryTS), 0)
-	tName, ok := claims[teamName].(string)
+	orgName, ok := claims[organization].(string)
 	if !ok {
-		return LicenseInfo{}, errors.New("Invalid team name in claims")
+		return LicenseInfo{}, errors.New("Invalid organization in claims")
 	}
 	storageCap, ok := claims[capacity].(float64)
 	if !ok {
 		return LicenseInfo{}, errors.New("Invalid storage capacity in claims")
 	}
-	sType, ok := claims[serviceType].(string)
+	plan, ok := claims[plan].(string)
 	if !ok {
 		return LicenseInfo{}, errors.New("Invalid service type in claims")
 	}
 	return LicenseInfo{
 		Email:           email,
-		TeamName:        tName,
+		Organization:    orgName,
 		AccountID:       int64(accID),
 		StorageCapacity: int64(storageCap),
-		ServiceType:     sType,
+		Plan:            plan,
 		ExpiresAt:       expiresAt,
 	}, nil
 

--- a/pkg/licverifier/verifier_test.go
+++ b/pkg/licverifier/verifier_test.go
@@ -55,20 +55,20 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 		expectedLicInfo LicenseInfo
 		shouldPass      bool
 	}{{"", LicenseInfo{}, false},
-		{"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrYW5hZ2FyYWorYzFAbWluaW8uaW8iLCJleHAiOjEuNjQwOTQwMjQ1OTM3ODM5NzQ1ZTksInBsYW4iOiJTVEFOREFSRCIsImlzcyI6InN1Ym5ldEBtaW4uaW8iLCJjYXBhY2l0eSI6NTAsImlhdCI6MS42MDk0MDQyNDU5Mzc4Mzk3NDVlOSwiYWNjb3VudElkIjoxLCJvcmdhbml6YXRpb24iOiJHcmluZ290dHMgSW5jLiJ9.xflbObKf7J0GE9ljZz_r0yoir4L8MnhZ0N-oIkdivzRgL_CbnqaaLDJdn5xFY3LhRysTbn3JPnOmBrzEfVIuYDCoJm7htC3vOi0AjYr0pufsNPsKzJWzh-2pv8SeM0As", LicenseInfo{
+		{"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrYW5hZ2FyYWorYzFAbWluaW8uaW8iLCJjYXAiOjUwLCJvcmciOiJHcmluZ290dHMgSW5jLiIsImV4cCI6MS42NDE0NDYxNjkwMDExOTg4OTRlOSwicGxhbiI6IlNUQU5EQVJEIiwiaXNzIjoic3VibmV0QG1pbi5pbyIsImFpZCI6MSwiaWF0IjoxLjYwOTkxMDE2OTAwMTE5ODg5NGU5fQ.EhTL2xwMHnUoLQF4UR-5bjUCja3whseLU5mb9XEj7PvAae6HEIDCOMEF8Hhh20DN_v_LRE283j2ZlA5zulcXSZXS0CLcrKqbVy6QLvZfvvLuerOjJI-NBa9dSJWJ0WoN", LicenseInfo{
 			Email:           "kanagaraj+c1@minio.io",
 			Organization:    "Gringotts Inc.",
 			AccountID:       1,
 			StorageCapacity: 50,
 			Plan:            "STANDARD",
-			ExpiresAt:       time.Date(2021, time.December, 31, 8, 44, 5, 0, time.UTC),
+			ExpiresAt:       time.Date(2022, time.January, 6, 5, 16, 9, 0, time.UTC),
 		}, true},
 	}
 
 	for i, tc := range testCases {
-		// Fixing the jwt.TimeFunc at 2020-12-31 08:58:20 +0000 UTC to
+		// Fixing the jwt.TimeFunc at 2021-01-06 05:16:09 +0000 UTC to
 		// ensure that the license JWT doesn't expire ever.
-		at(time.Unix(int64(1609405100), 0), func() {
+		at(time.Unix(int64(1609910169), 0), func() {
 			licInfo, err := lv.Verify(tc.lic)
 			if err != nil && tc.shouldPass {
 				t.Fatalf("%d: Expected license to pass verification but failed with %s", i+1, err)
@@ -100,7 +100,7 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 		fmt.Println("Failed to create license verifier", err)
 	}
 
-	licenseKey := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrYW5hZ2FyYWorYzFAbWluaW8uaW8iLCJleHAiOjEuNjQwOTQwMjQ1OTM3ODM5NzQ1ZTksInBsYW4iOiJTVEFOREFSRCIsImlzcyI6InN1Ym5ldEBtaW4uaW8iLCJjYXBhY2l0eSI6NTAsImlhdCI6MS42MDk0MDQyNDU5Mzc4Mzk3NDVlOSwiYWNjb3VudElkIjoxLCJvcmdhbml6YXRpb24iOiJHcmluZ290dHMgSW5jLiJ9.xflbObKf7J0GE9ljZz_r0yoir4L8MnhZ0N-oIkdivzRgL_CbnqaaLDJdn5xFY3LhRysTbn3JPnOmBrzEfVIuYDCoJm7htC3vOi0AjYr0pufsNPsKzJWzh-2pv8SeM0As"
+	licenseKey := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrYW5hZ2FyYWorYzFAbWluaW8uaW8iLCJjYXAiOjUwLCJvcmciOiJHcmluZ290dHMgSW5jLiIsImV4cCI6MS42NDE0NDYxNjkwMDExOTg4OTRlOSwicGxhbiI6IlNUQU5EQVJEIiwiaXNzIjoic3VibmV0QG1pbi5pbyIsImFpZCI6MSwiaWF0IjoxLjYwOTkxMDE2OTAwMTE5ODg5NGU5fQ.EhTL2xwMHnUoLQF4UR-5bjUCja3whseLU5mb9XEj7PvAae6HEIDCOMEF8Hhh20DN_v_LRE283j2ZlA5zulcXSZXS0CLcrKqbVy6QLvZfvvLuerOjJI-NBa9dSJWJ0WoN"
 	licInfo, err := lv.Verify(licenseKey)
 	if err != nil {
 		fmt.Println("Failed to verify license key", err)

--- a/pkg/licverifier/verifier_test.go
+++ b/pkg/licverifier/verifier_test.go
@@ -32,7 +32,7 @@ func at(t time.Time, f func()) {
 }
 
 func areEqLicenseInfo(a, b LicenseInfo) bool {
-	if a.Email == b.Email && a.TeamName == b.TeamName && a.AccountID == b.AccountID && a.ServiceType == b.ServiceType && a.StorageCapacity == b.StorageCapacity && a.ExpiresAt.Equal(b.ExpiresAt) {
+	if a.Email == b.Email && a.Organization == b.Organization && a.AccountID == b.AccountID && a.Plan == b.Plan && a.StorageCapacity == b.StorageCapacity && a.ExpiresAt.Equal(b.ExpiresAt) {
 		return true
 	}
 	return false
@@ -55,20 +55,20 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 		expectedLicInfo LicenseInfo
 		shouldPass      bool
 	}{{"", LicenseInfo{}, false},
-		{"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrcCtjMUBtaW5pby5pbyIsInRlYW1OYW1lIjoiR3JpbmdvdHRzIEluYy4iLCJleHAiOjEuNjI4MjAxODYyNjgwNzM3Nzc1ZTksImNhcGFjaXR5Ijo1MCwiaWF0IjoxLjU5NjY2NTg2MjY4MDczNzc3NWU5LCJhY2NvdW50SWQiOjEsInNlcnZpY2VUeXBlIjoiU1RBTkRBUkQifQ._2EgZpjVGo3hRacO2MNavDqZoaP-hwDQ745Z-t-N6lKDwhHOzwhENb9UhiubOQ_yTJ9Ia5EqMhQrC1QCrk8-ThiftmjFGKTyYw5j7gvox_5L-R8HIegACynVlmBlF6IV", LicenseInfo{
-			Email:           "kp+c1@minio.io",
-			TeamName:        "Gringotts Inc.",
+		{"eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrYW5hZ2FyYWorYzFAbWluaW8uaW8iLCJleHAiOjEuNjQwOTQwMjQ1OTM3ODM5NzQ1ZTksInBsYW4iOiJTVEFOREFSRCIsImlzcyI6InN1Ym5ldEBtaW4uaW8iLCJjYXBhY2l0eSI6NTAsImlhdCI6MS42MDk0MDQyNDU5Mzc4Mzk3NDVlOSwiYWNjb3VudElkIjoxLCJvcmdhbml6YXRpb24iOiJHcmluZ290dHMgSW5jLiJ9.xflbObKf7J0GE9ljZz_r0yoir4L8MnhZ0N-oIkdivzRgL_CbnqaaLDJdn5xFY3LhRysTbn3JPnOmBrzEfVIuYDCoJm7htC3vOi0AjYr0pufsNPsKzJWzh-2pv8SeM0As", LicenseInfo{
+			Email:           "kanagaraj+c1@minio.io",
+			Organization:    "Gringotts Inc.",
 			AccountID:       1,
 			StorageCapacity: 50,
-			ServiceType:     "STANDARD",
-			ExpiresAt:       time.Date(2021, time.August, 5, 15, 17, 42, 0, time.FixedZone("PDT", -7*60*60)),
+			Plan:            "STANDARD",
+			ExpiresAt:       time.Date(2021, time.December, 31, 8, 44, 5, 0, time.UTC),
 		}, true},
 	}
 
 	for i, tc := range testCases {
-		// Fixing the jwt.TimeFunc at 2020-08-05 22:17:43 +0000 UTC to
+		// Fixing the jwt.TimeFunc at 2020-12-31 08:58:20 +0000 UTC to
 		// ensure that the license JWT doesn't expire ever.
-		at(time.Unix(int64(1596665863), 0), func() {
+		at(time.Unix(int64(1609405100), 0), func() {
 			licInfo, err := lv.Verify(tc.lic)
 			if err != nil && tc.shouldPass {
 				t.Fatalf("%d: Expected license to pass verification but failed with %s", i+1, err)
@@ -100,7 +100,7 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 		fmt.Println("Failed to create license verifier", err)
 	}
 
-	licenseKey := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrcCtjMUBtaW5pby5pbyIsInRlYW1OYW1lIjoiR3JpbmdvdHRzIEluYy4iLCJleHAiOjEuNjI4MjAxODYyNjgwNzM3Nzc1ZTksImNhcGFjaXR5Ijo1MCwiaWF0IjoxLjU5NjY2NTg2MjY4MDczNzc3NWU5LCJhY2NvdW50SWQiOjEsInNlcnZpY2VUeXBlIjoiU1RBTkRBUkQifQ._2EgZpjVGo3hRacO2MNavDqZoaP-hwDQ745Z-t-N6lKDwhHOzwhENb9UhiubOQ_yTJ9Ia5EqMhQrC1QCrk8-ThiftmjFGKTyYw5j7gvox_5L-R8HIegACynVlmBlF6IV"
+	licenseKey := "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJrYW5hZ2FyYWorYzFAbWluaW8uaW8iLCJleHAiOjEuNjQwOTQwMjQ1OTM3ODM5NzQ1ZTksInBsYW4iOiJTVEFOREFSRCIsImlzcyI6InN1Ym5ldEBtaW4uaW8iLCJjYXBhY2l0eSI6NTAsImlhdCI6MS42MDk0MDQyNDU5Mzc4Mzk3NDVlOSwiYWNjb3VudElkIjoxLCJvcmdhbml6YXRpb24iOiJHcmluZ290dHMgSW5jLiJ9.xflbObKf7J0GE9ljZz_r0yoir4L8MnhZ0N-oIkdivzRgL_CbnqaaLDJdn5xFY3LhRysTbn3JPnOmBrzEfVIuYDCoJm7htC3vOi0AjYr0pufsNPsKzJWzh-2pv8SeM0As"
 	licInfo, err := lv.Verify(licenseKey)
 	if err != nil {
 		fmt.Println("Failed to verify license key", err)


### PR DESCRIPTION
## Description

The following keys are updated based on the changes in Subnet license.
ServiceType -> Plan
TeamName -> Organization

## Motivation and Context
Verifier should be able to verify the new subnet license.

## How to test this PR?
Run the tests in `pkg/licverifier/verifier_test.go`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
