### PR TITLE
[Docs] Use `-new` during OpenSSL certificate generation

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -150,7 +150,7 @@ DNS.1 = localhost
 Run `openssl` by specifying the configuration file and enter a passphrase if prompted:
 
 ```sh
-openssl req -x509 -nodes -days 730 -key private.key -out public.crt -config openssl.conf
+openssl req -new -x509 -nodes -days 730 -key private.key -out public.crt -config openssl.conf
 ```
 
 ### <a name="using-gnu-tls"></a>3.3 Use GnuTLS (for Windows) to Generate a Certificate


### PR DESCRIPTION
## Description
As per https://stackoverflow.com/a/3758443/8156177, OpenSSL expects a certificate via standard input. `-new` will allow a new certificate to be generated instead.

## Motivation and Context
I was following the guide, and the command hung, so I looked it up and turns out I needed `-new`. Thought I'd propose a change to the docs.