### PR TITLE
parentDirIsObject() to return quickly with inexistant parent

### DIFF
--- a/cmd/erasure-common_test.go
+++ b/cmd/erasure-common_test.go
@@ -68,6 +68,10 @@ func TestErasureParentDirIsObject(t *testing.T) {
 		},
 		{
 			parentIsObject: false,
+			objectName:     "new-dir",
+		},
+		{
+			parentIsObject: false,
 			objectName:     "",
 		},
 		{

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -67,6 +67,9 @@ var errVolumeExists = StorageErr("volume already exists")
 // errIsNotRegular - not of regular file type.
 var errIsNotRegular = StorageErr("not of regular file type")
 
+// errPathNotFound - cannot find the path.
+var errPathNotFound = StorageErr("path not found")
+
 // errVolumeNotFound - cannot find the volume.
 var errVolumeNotFound = StorageErr("volume not found")
 

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -82,6 +82,8 @@ func toStorageErr(err error) error {
 		return errFileNameTooLong
 	case errFileAccessDenied.Error():
 		return errFileAccessDenied
+	case errPathNotFound.Error():
+		return errPathNotFound
 	case errIsNotRegular.Error():
 		return errIsNotRegular
 	case errVolumeNotEmpty.Error():

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1784,10 +1784,10 @@ func (s *xlStorage) CheckFile(ctx context.Context, volume string, path string) e
 	}
 
 	// Stat a volume entry.
-	_, err = os.Stat(volumeDir)
+	_, err = os.Stat(pathJoin(volumeDir, path))
 	if err != nil {
 		if osIsNotExist(err) {
-			return errVolumeNotFound
+			return errPathNotFound
 		}
 		return err
 	}

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -1596,14 +1596,14 @@ func TestXLStorageCheckFile(t *testing.T) {
 		{
 			srcVol:      "success-vol",
 			srcPath:     "nonexistent-file",
-			expectedErr: errFileNotFound,
+			expectedErr: errPathNotFound,
 		},
 		// TestXLStorage case - 4.
 		// TestXLStorage case with non-existent file path.
 		{
 			srcVol:      "success-vol",
 			srcPath:     "path/2/success-file",
-			expectedErr: errFileNotFound,
+			expectedErr: errPathNotFound,
 		},
 		// TestXLStorage case - 5.
 		// TestXLStorage case with path being a directory.
@@ -1617,7 +1617,7 @@ func TestXLStorageCheckFile(t *testing.T) {
 		{
 			srcVol:      "non-existent-vol",
 			srcPath:     "success-file",
-			expectedErr: errVolumeNotFound,
+			expectedErr: errPathNotFound,
 		},
 	}
 


### PR DESCRIPTION
## Description
Rewrite parentIsObject() function. Currently if a client uploads
a/b/c/d, we always check if c, b, a are actual object or not.

The new code will check with the reverse order and quickly quit if a
segment doesn't exist.

So if a, b, c in 'a/b/c' does not exist in the first place, then returns
false quickly.


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
