### PR TITLE
trace: NumSubscribers() to use atomic instead of mutex

### DIFF
--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -67,7 +67,7 @@ func waitForLowHTTPReq(maxIO int, maxWait time.Duration) {
 	// Bucket notification and http trace are not costly, it is okay to ignore them
 	// while counting the number of concurrent connections
 	maxIOFn := func() int {
-		return maxIO + globalHTTPListen.NumSubscribers() + globalHTTPTrace.NumSubscribers()
+		return maxIO + int(globalHTTPListen.NumSubscribers()) + int(globalHTTPTrace.NumSubscribers())
 	}
 
 	if httpServer := newHTTPServerFn(); httpServer != nil {

--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -70,7 +70,7 @@ func (sys *HTTPConsoleLoggerSys) SetNodeName(endpointServerPools EndpointServerP
 // HasLogListeners returns true if console log listeners are registered
 // for this node or peers
 func (sys *HTTPConsoleLoggerSys) HasLogListeners() bool {
-	return sys != nil && sys.pubsub.HasSubscribers()
+	return sys != nil && sys.pubsub.NumSubscribers() > 0
 }
 
 // Subscribe starts console logging for this node.

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -348,7 +348,7 @@ func extractPostPolicyFormValues(ctx context.Context, form *multipart.Form) (fil
 // Log headers and body.
 func httpTraceAll(f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !globalHTTPTrace.HasSubscribers() {
+		if globalHTTPTrace.NumSubscribers() == 0 {
 			f.ServeHTTP(w, r)
 			return
 		}
@@ -360,7 +360,7 @@ func httpTraceAll(f http.HandlerFunc) http.HandlerFunc {
 // Log only the headers.
 func httpTraceHdrs(f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !globalHTTPTrace.HasSubscribers() {
+		if globalHTTPTrace.NumSubscribers() == 0 {
 			f.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1375,7 +1375,7 @@ func sendEvent(args eventArgs) {
 		return
 	}
 
-	if globalHTTPListen.HasSubscribers() {
+	if globalHTTPListen.NumSubscribers() > 0 {
 		globalHTTPListen.Publish(args.ToEvent(false))
 	}
 

--- a/cmd/web-router.go
+++ b/cmd/web-router.go
@@ -85,7 +85,7 @@ func registerWebRouter(router *mux.Router) error {
 				"bucket": bucketName,
 				"object": objectName,
 			})
-			if globalHTTPTrace.HasSubscribers() {
+			if globalHTTPTrace.NumSubscribers() > 0 {
 				globalHTTPTrace.Publish(WebTrace(ri))
 			}
 			logger.AuditLog(ri.ResponseWriter, ri.Request, ri.Method, claims.Map())


### PR DESCRIPTION
## Description
globalSubscribers.NumSubscribers() is heavily used in S3 requests and it
uses mutex, use atomic.Load instead since it is faster


## Motivation and Context
Increase server's performance a little bit

## How to test this PR?
Trivial fix

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation needed
- [ ] Unit tests needed
