### PR TITLE
fix: healing buckets during pool expansion

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -327,7 +327,7 @@ func initAllSubsystems(ctx context.Context, newObject ObjectLayer) (err error) {
 			}
 		}
 		for _, bucket := range buckets {
-			if _, err = newObject.HealBucket(ctx, bucket.Name, madmin.HealOpts{}); err != nil {
+			if _, err = newObject.HealBucket(ctx, bucket.Name, madmin.HealOpts{Recreate: true}); err != nil {
 				return fmt.Errorf("Unable to list buckets to heal: %w", err)
 			}
 		}

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -42,6 +42,7 @@ type HealOpts struct {
 	Recursive bool         `json:"recursive"`
 	DryRun    bool         `json:"dryRun"`
 	Remove    bool         `json:"remove"`
+	Recreate  bool         `json:"recreate"` // only used when bucket needs to be healed
 	ScanMode  HealScanMode `json:"scanMode"`
 }
 


### PR DESCRIPTION
## Description
fix: healing buckets during pool expansion

## Motivation and Context
fixes #11209


## How to test this PR?
As per #11209 start with 

```
~ minio server --address ":9001" http://localhost:9001/tmp/1/{1...4}
~ mc mb myminio-local1/testbucket
```

To expand the setup
```
~ minio server --address ":9001" http://localhost:9001/tmp/1/{1...4} http://localhost:9002/tmp/2/{1...4}
...
...
~ minio server --address ":9002" http://localhost:9001/tmp/1/{1...4} http://localhost:9002/tmp/2/{1...4}
...
...
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression this is a regression since some releases
- [ ] Documentation needed
- [ ] Unit tests needed
