### PR TITLE
fix: use buffers only when necessary for io.Copy()

### DIFF
--- a/buildscripts/race.sh
+++ b/buildscripts/race.sh
@@ -3,5 +3,5 @@
 set -e
 
 for d in $(go list ./... | grep -v browser); do
-    CGO_ENABLED=1 go test -v -race --timeout 50m "$d"
+    CGO_ENABLED=1 go test -v -race --timeout 100m "$d"
 done

--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -271,8 +271,8 @@ func fsOpenFile(ctx context.Context, readPath string, offset int64) (io.ReadClos
 	return fr, st.Size(), nil
 }
 
-// Creates a file and copies data from incoming reader. Staging buffer is used by io.CopyBuffer.
-func fsCreateFile(ctx context.Context, filePath string, reader io.Reader, buf []byte, fallocSize int64) (int64, error) {
+// Creates a file and copies data from incoming reader.
+func fsCreateFile(ctx context.Context, filePath string, reader io.Reader, fallocSize int64) (int64, error) {
 	if filePath == "" || reader == nil {
 		logger.LogIf(ctx, errInvalidArgument)
 		return 0, errInvalidArgument
@@ -317,21 +317,10 @@ func fsCreateFile(ctx context.Context, filePath string, reader io.Reader, buf []
 		}
 	}
 
-	var bytesWritten int64
-	if buf != nil {
-		bytesWritten, err = io.CopyBuffer(writer, reader, buf)
-		if err != nil {
-			if err != io.ErrUnexpectedEOF {
-				logger.LogIf(ctx, err)
-			}
-			return 0, err
-		}
-	} else {
-		bytesWritten, err = io.Copy(writer, reader)
-		if err != nil {
-			logger.LogIf(ctx, err)
-			return 0, err
-		}
+	bytesWritten, err := io.Copy(writer, reader)
+	if err != nil {
+		logger.LogIf(ctx, err)
+		return 0, err
 	}
 
 	return bytesWritten, nil

--- a/cmd/fs-v1-helpers_test.go
+++ b/cmd/fs-v1-helpers_test.go
@@ -75,7 +75,7 @@ func TestFSStats(t *testing.T) {
 	}
 
 	var reader = bytes.NewReader([]byte("Hello, world"))
-	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file"), reader, nil, 0); err != nil {
+	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file"), reader, 0); err != nil {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 	// Seek back.
@@ -85,7 +85,7 @@ func TestFSStats(t *testing.T) {
 		t.Fatal("Unexpected error", err)
 	}
 
-	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "path/to/success-file"), reader, nil, 0); err != nil {
+	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "path/to/success-file"), reader, 0); err != nil {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 	// Seek back.
@@ -192,7 +192,7 @@ func TestFSCreateAndOpen(t *testing.T) {
 		t.Fatalf("Unable to create directory, %s", err)
 	}
 
-	if _, err = fsCreateFile(GlobalContext, "", nil, nil, 0); err != errInvalidArgument {
+	if _, err = fsCreateFile(GlobalContext, "", nil, 0); err != errInvalidArgument {
 		t.Fatal("Unexpected error", err)
 	}
 
@@ -201,7 +201,7 @@ func TestFSCreateAndOpen(t *testing.T) {
 	}
 
 	var reader = bytes.NewReader([]byte("Hello, world"))
-	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file"), reader, nil, 0); err != nil {
+	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file"), reader, 0); err != nil {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 	// Seek back.
@@ -229,7 +229,7 @@ func TestFSCreateAndOpen(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		_, err = fsCreateFile(GlobalContext, pathJoin(path, testCase.srcVol, testCase.srcPath), reader, nil, 0)
+		_, err = fsCreateFile(GlobalContext, pathJoin(path, testCase.srcVol, testCase.srcPath), reader, 0)
 		if err != testCase.expectedErr {
 			t.Errorf("Test case %d: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
 		}
@@ -258,9 +258,8 @@ func TestFSDeletes(t *testing.T) {
 		t.Fatalf("Unable to create directory, %s", err)
 	}
 
-	var buf = make([]byte, 4096)
 	var reader = bytes.NewReader([]byte("Hello, world"))
-	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file"), reader, buf, reader.Size()); err != nil {
+	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file"), reader, reader.Size()); err != nil {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 	// Seek back.
@@ -396,13 +395,13 @@ func TestFSRemoves(t *testing.T) {
 	}
 
 	var reader = bytes.NewReader([]byte("Hello, world"))
-	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file"), reader, nil, 0); err != nil {
+	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file"), reader, 0); err != nil {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 	// Seek back.
 	reader.Seek(0, 0)
 
-	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file-new"), reader, nil, 0); err != nil {
+	if _, err = fsCreateFile(GlobalContext, pathJoin(path, "success-vol", "success-file-new"), reader, 0); err != nil {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 	// Seek back.
@@ -515,7 +514,7 @@ func TestFSRemoveMeta(t *testing.T) {
 	filePath := pathJoin(fsPath, "success-vol", "success-file")
 
 	var reader = bytes.NewReader([]byte("Hello, world"))
-	if _, err = fsCreateFile(GlobalContext, filePath, reader, nil, 0); err != nil {
+	if _, err = fsCreateFile(GlobalContext, filePath, reader, 0); err != nil {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 

--- a/cmd/fs-v1-multipart.go
+++ b/cmd/fs-v1-multipart.go
@@ -313,14 +313,8 @@ func (fs *FSObjects) PutObjectPart(ctx context.Context, bucket, object, uploadID
 		return pi, toObjectErr(err, bucket, object)
 	}
 
-	bufSize := int64(readSizeV1)
-	if size := data.Size(); size > 0 && bufSize > size {
-		bufSize = size
-	}
-	buf := make([]byte, bufSize)
-
 	tmpPartPath := pathJoin(fs.fsPath, minioMetaTmpBucket, fs.fsUUID, uploadID+"."+mustGetUUID()+"."+strconv.Itoa(partID))
-	bytesWritten, err := fsCreateFile(ctx, tmpPartPath, data, buf, data.Size())
+	bytesWritten, err := fsCreateFile(ctx, tmpPartPath, data, data.Size())
 
 	// Delete temporary part in case of failure. If
 	// PutObjectPart succeeds then there would be nothing to

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -57,7 +57,7 @@ func (t *apiConfig) init(cfg api.Config, setDriveCount int) {
 		// max requests per node is calculated as
 		// total_ram / ram_per_request
 		// ram_per_request is 4MiB * setDriveCount + 2 * 10MiB (default erasure block size)
-		apiRequestsMaxPerNode = int(stats.TotalRAM / uint64(setDriveCount*readBlockSize+blockSizeV1*2))
+		apiRequestsMaxPerNode = int(stats.TotalRAM / uint64(setDriveCount*(writeBlockSize+readBlockSize)+blockSizeV1*2))
 	} else {
 		apiRequestsMaxPerNode = cfg.RequestsMax
 		if len(globalEndpoints.Hostnames()) > 0 {

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -31,9 +31,6 @@ const (
 	// Block size used for all internal operations version 1.
 	blockSizeV1 = 10 * humanize.MiByte
 
-	// Staging buffer read size for all internal operations version 1.
-	readSizeV1 = 1 * humanize.MiByte
-
 	// Buckets meta prefix.
 	bucketMetaPrefix = "buckets"
 

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -515,15 +515,7 @@ func (s *storageRESTServer) ReadFileStreamHandler(w http.ResponseWriter, r *http
 	defer rc.Close()
 
 	w.Header().Set(xhttp.ContentLength, strconv.Itoa(length))
-
-	if length >= readBlockSize {
-		bufp := s.storage.pool.Get().(*[]byte)
-		defer s.storage.pool.Put(bufp)
-
-		io.CopyBuffer(w, rc, *bufp)
-	} else {
-		io.Copy(w, rc)
-	}
+	io.Copy(w, rc)
 	w.(http.Flusher).Flush()
 }
 

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -703,8 +703,8 @@ func TestXLStorageListVols(t *testing.T) {
 	}
 }
 
-// TestXLStorageXlStorageListDir -  TestXLStorages validate the directory listing functionality provided by xlStorage.ListDir .
-func TestXLStorageXlStorageListDir(t *testing.T) {
+// TestXLStorageListDir -  TestXLStorages validate the directory listing functionality provided by xlStorage.ListDir .
+func TestXLStorageListDir(t *testing.T) {
 	// create xlStorage test setup
 	xlStorage, path, err := newXLStorageTestSetup()
 	if err != nil {
@@ -1692,8 +1692,9 @@ func TestXLStorageVerifyFile(t *testing.T) {
 	w := newStreamingBitrotWriter(xlStorage, volName, fileName, size, algo, shardSize)
 	reader := bytes.NewReader(data)
 	for {
-		// Using io.CopyBuffer instead of this loop will not work for us as io.CopyBuffer
-		// will use bytes.Buffer.ReadConfig() which will not do shardSize'ed writes causing error.
+		// Using io.Copy instead of this loop will not work for us as io.Copy
+		// will use bytes.Reader.WriteTo() which will not do shardSize'ed writes
+		// causing error.
 		n, err := reader.Read(shard)
 		w.Write(shard[:n])
 		if err == nil {

--- a/docs/shared-backend/DESIGN.md
+++ b/docs/shared-backend/DESIGN.md
@@ -90,7 +90,7 @@ GetObject() holds a read lock on `fs.json`.
 
 ... you can perform other operations here ...
 
-	_, err = io.CopyBuffer(writer, reader, buf)
+	_, err = io.Copy(writer, reader)
 
 ... after successful copy operation unlocks the read lock ...
 ```

--- a/docs/zh_CN/shared-backend/DESIGN.md
+++ b/docs/zh_CN/shared-backend/DESIGN.md
@@ -38,7 +38,7 @@ minio server /path/to/nfs-volume
 
 ### Windows 2012 Server
 
-示例1: 运行Minio实例在持载在`\\remote-server\cifs`路径下的共享后端存储。 
+示例1: 运行Minio实例在持载在`\\remote-server\cifs`路径下的共享后端存储。
 
 On windows server1
 ```cmd
@@ -94,7 +94,7 @@ GetObject()持有`fs.json`的一个读锁。
 
 ... you can perform other operations here ...
 
-	_, err = io.CopyBuffer(writer, reader, buf)
+	_, err = io.Copy(writer, reader)
 
 ... after successful copy operation unlocks the read lock ...
 ```

--- a/pkg/ioutil/append-file_nix.go
+++ b/pkg/ioutil/append-file_nix.go
@@ -40,8 +40,6 @@ func AppendFile(dst string, src string, osync bool) error {
 		return err
 	}
 	defer srcFile.Close()
-	// Allocate staging buffer.
-	var buf = make([]byte, defaultAppendBufferSize)
-	_, err = io.CopyBuffer(appendFile, srcFile, buf)
+	_, err = io.Copy(appendFile, srcFile)
 	return err
 }

--- a/pkg/ioutil/append-file_windows.go
+++ b/pkg/ioutil/append-file_windows.go
@@ -36,8 +36,6 @@ func AppendFile(dst string, src string, osync bool) error {
 		return err
 	}
 	defer srcFile.Close()
-	// Allocate staging buffer.
-	var buf = make([]byte, defaultAppendBufferSize)
-	_, err = io.CopyBuffer(appendFile, srcFile, buf)
+	_, err = io.Copy(appendFile, srcFile)
 	return err
 }

--- a/pkg/ioutil/ioutil.go
+++ b/pkg/ioutil/ioutil.go
@@ -22,12 +22,8 @@ import (
 	"io"
 	"os"
 
-	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/minio/pkg/disk"
 )
-
-// defaultAppendBufferSize - Default buffer size for the AppendFile
-const defaultAppendBufferSize = humanize.MiByte
 
 // WriteOnCloser implements io.WriteCloser and always
 // executes at least one write operation if it is closed.
@@ -186,7 +182,7 @@ const directioAlignSize = 4096
 // 4K page boundaries. Without passing aligned buffer may cause
 // this function to return error.
 //
-// This code is similar in spirit to io.CopyBuffer but it is only to be
+// This code is similar in spirit to io.Copy but it is only to be
 // used with DIRECT I/O based file descriptor and it is expected that
 // input writer *os.File not a generic io.Writer. Make sure to have
 // the file opened for writes with syscall.O_DIRECT flag.


### PR DESCRIPTION
## Description
fix: use buffers only when necessary for io.Copy()

## Motivation and Context
 Use separate sync.Pool for writes/reads
    
Avoid passing buffers for io.CopyBuffer()
if the writer or reader implement io.WriteTo or io.ReadFrom
respectively then it's useless for sync.Pool to allocate
buffers on its own since that will be completely ignored
by the io.CopyBuffer Go implementation.

Improve this wherever we see this to be optimal.

This allows us to be more efficient on memory usage.
```
   385  // copyBuffer is the actual implementation of Copy and CopyBuffer.
   386  // if buf is nil, one is allocated.
   387  func copyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
   388  	// If the reader has a WriteTo method, use it to do the copy.
   389  	// Avoids an allocation and a copy.
   390  	if wt, ok := src.(WriterTo); ok {
   391  		return wt.WriteTo(dst)
   392  	}
   393  	// Similarly, if the writer has a ReadFrom method, use it to do the copy.
   394  	if rt, ok := dst.(ReaderFrom); ok {
   395  		return rt.ReadFrom(src)
   396  	}
```

From readahead package
```
// WriteTo writes data to w until there's no more data to write or when an error occurs.
// The return value n is the number of bytes written.
// Any error encountered during the write is also returned.
func (a *reader) WriteTo(w io.Writer) (n int64, err error) {
	if a.err != nil {
		return 0, a.err
	}
	n = 0
	for {
		err = a.fill()
		if err != nil {
			return n, err
		}
		n2, err := w.Write(a.cur.buffer())
		a.cur.inc(n2)
		n += int64(n2)
		if err != nil {
			return n, err
		}
```


## How to test this PR?
Testing overall memory growth while doing 

- `mc admin heal --scan deep`
- fs mode `mc cp` allocation 1MiB buffer
- also contention between single sync.Pool for writes/reads

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
