### PR TITLE
initialize IAM store before Init() to avoid any crash

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -444,6 +444,9 @@ func (sys *IAMSys) Initialized() bool {
 
 // Init - initializes config system by reading entries from config/iam
 func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
+	// Initialize IAM store
+	sys.InitStore(objAPI)
+
 	retryCtx, cancel := context.WithCancel(ctx)
 
 	// Indicate to our routine to exit cleanly upon return.

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -356,9 +356,6 @@ func initAllSubsystems(ctx context.Context, newObject ObjectLayer) (err error) {
 		logger.LogIf(ctx, fmt.Errorf("Unable to initialize config, some features may be missing %w", err))
 	}
 
-	// Initialize IAM store
-	globalIAMSys.InitStore(newObject)
-
 	// Populate existing buckets to the etcd backend
 	if globalDNSConfig != nil {
 		// Background this operation.


### PR DESCRIPTION
## Description
initialize IAM store before Init() to avoid any crash

## Motivation and Context
if credentials are wrong at startup it's possible that IAMStore 
would crash and not initialize 

## How to test this PR?
Just set incorrect root credentials and start server

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
