### PR TITLE
fix: treat errVolumeNotFound as EOF error in listPathRaw

### DIFF
--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -33,6 +33,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/tags"
 	"github.com/minio/minio/cmd/config/storageclass"
 	"github.com/minio/minio/cmd/logger"
+	"github.com/minio/minio/pkg/color"
 	"github.com/minio/minio/pkg/dsync"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/sync/errgroup"
@@ -330,6 +331,12 @@ func (z *erasureServerPools) CrawlAndGetDataUsage(ctx context.Context, bf *bloom
 	allBuckets, err := z.ListBuckets(ctx)
 	if err != nil {
 		return err
+	}
+
+	if len(allBuckets) == 0 {
+		logger.Info(color.Green("data-crawl:") + " No buckets found, skipping crawl")
+		updates <- DataUsageInfo{} // no buckets found update data usage to reflect latest state
+		return nil
 	}
 
 	// Crawl latest allBuckets first.


### PR DESCRIPTION
## Description
fix: treat errVolumeNotFound as EOF error in listPathRaw

## Motivation and Context
if the bucket is removed listPathRaw shouldn't log errVolumeNotFound

## How to test this PR?
Remove buckets that are currently being scanned in the crawler cycle
and see the error messages popup. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
