### PR TITLE
expire stale locks when owner is down

### DIFF
--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -45,7 +45,7 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 			}
 			_, present := network[nodeName]
 			if !present {
-				if err := IsServerResolvable(endpoint); err == nil {
+				if err := isServerResolvable(endpoint); err == nil {
 					network[nodeName] = "online"
 				} else {
 					network[nodeName] = "offline"

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -192,6 +192,8 @@ var (
 
 	globalEndpoints EndpointServerPools
 
+	globalRemoteEndpoints map[string]Endpoint
+
 	// Global server's network statistics
 	globalConnStats = newConnStats()
 

--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -228,6 +228,11 @@ func (l *localLocker) Expired(ctx context.Context, args dsync.LockArgs) (expired
 				// Check whether uid is still active
 				for _, entry := range lri {
 					if entry.UID == args.UID && entry.Owner == args.Owner {
+						if ep, ok := globalRemoteEndpoints[args.Owner]; ok {
+							if err = isServerResolvable(ep); err != nil {
+								return true, nil
+							}
+						}
 						return false, nil
 					}
 				}

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -163,9 +163,9 @@ func formatErasureCleanupTmpLocalEndpoints(endpoints Endpoints) error {
 // https://github.com/minio/minio/issues/5667
 var errErasureV3ThisEmpty = fmt.Errorf("Erasure format version 3 has This field empty")
 
-// IsServerResolvable - checks if the endpoint is resolvable
+// isServerResolvable - checks if the endpoint is resolvable
 // by sending a naked HTTP request with liveness checks.
-func IsServerResolvable(endpoint Endpoint) error {
+func isServerResolvable(endpoint Endpoint) error {
 	serverURL := &url.URL{
 		Scheme: endpoint.Scheme,
 		Host:   endpoint.Host,
@@ -244,7 +244,7 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 				return nil, nil, fmt.Errorf("Disk %s: %w", endpoints[i], err)
 			}
 			if retryCount >= 5 {
-				logger.Info("Unable to connect to %s: %v\n", endpoints[i], IsServerResolvable(endpoints[i]))
+				logger.Info("Unable to connect to %s: %v\n", endpoints[i], isServerResolvable(endpoints[i]))
 			}
 		}
 	}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -139,6 +139,16 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 
 	globalMinioHost, globalMinioPort = mustSplitHostPort(globalMinioAddr)
 	globalEndpoints, setupType, err = createServerEndpoints(globalCLIContext.Addr, serverCmdArgs(ctx)...)
+
+	globalRemoteEndpoints = make(map[string]Endpoint)
+	for _, z := range globalEndpoints {
+		for _, ep := range z.Endpoints {
+			if ep.IsLocal {
+				continue
+			}
+			globalRemoteEndpoints[ep.Host] = ep
+		}
+	}
 	logger.FatalIf(err, "Invalid command line arguments")
 
 	// allow transport to be HTTP/1.1 for proxying.


### PR DESCRIPTION

## Description
expire stale locks when owner is down

## Motivation and Context
fixes #11246


## How to test this PR?
```
#!/usr/bin/env bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
export MINIO_ENDPOINTS="http://127.0.0.1:9001/tmp/disk01 http://127.0.0.1:9002/tmp/disk02 http://127.0.0.1:9003/tmp/disk03 http://127.0.0.1:9004/tmp/disk04 http://127.0.0.1:9005/tmp/disk05 http://127.0.0.1:9006/tmp/disk06 http://127.0.0.1:9007/tmp/disk07 http://127.0.0.1:9008/tmp/disk08"
export MINIO_KMS_AUTO_ENCRYPTION=off
export MINIO_STORAGE_CLASS_DMA="read+write"
for i in {01..08}; do
    minio server --address ":90${i}" &
done
```

Run this and check where does crawler is running `mc admin top locks --json` - once you capture the owner kill the respective server, once done check again 

```
~ mc admin top locks --json
```

To see new server acquires a new lock on a new server

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
