### PR TITLE
fix: print errors only when metacache status has errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ checks:
 getdeps:
 	@mkdir -p ${GOPATH}/bin
 	@which golangci-lint 1>/dev/null || (echo "Installing golangci-lint" && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.27.0)
-	@which ruleguard 1>/dev/null || (echo "Installing ruleguard" && GO111MODULE=off go get github.com/quasilyte/go-ruleguard/...)
-	@which msgp 1>/dev/null || (echo "Installing msgp" && GO111MODULE=off go get github.com/tinylib/msgp)
-	@which stringer 1>/dev/null || (echo "Installing stringer" && GO111MODULE=off go get golang.org/x/tools/cmd/stringer)
+	@which ruleguard 1>/dev/null || (echo "Installing ruleguard" && go get github.com/quasilyte/go-ruleguard/cmd/ruleguard@v0.2.1)
+	@which msgp 1>/dev/null || (echo "Installing msgp" && go get github.com/tinylib/msgp@v1.1.3)
+	@which stringer 1>/dev/null || (echo "Installing stringer" && go get golang.org/x/tools/cmd/stringer)
 
 crosscompile:
 	@(env bash $(PWD)/buildscripts/cross-compile.sh)

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -654,11 +654,11 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 				meta.endedCycle = intDataUpdateTracker.current()
 				meta, err = o.updateMetacacheListing(meta, rpc)
 				if meta.status == scanStateError {
+					logger.LogIf(ctx, err)
 					cancel()
 					exit = true
 				}
 				metaMu.Unlock()
-				logger.LogIf(ctx, err)
 			}
 		}()
 
@@ -772,7 +772,7 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 				metaMu.Lock()
 				meta.error = err.Error()
 				meta.status = scanStateError
-				meta, err = o.updateMetacacheListing(meta, rpc)
+				meta, _ = o.updateMetacacheListing(meta, rpc)
 				metaMu.Unlock()
 			}
 		}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1478,7 +1478,7 @@ func (s *xlStorage) ReadFileStream(ctx context.Context, volume, path string, off
 	if offset == 0 && globalStorageClass.GetDMA() == storageclass.DMAReadWrite {
 		file, err = disk.OpenFileDirectIO(filePath, os.O_RDONLY, 0666)
 	} else {
-		// Open the fileile fileor reading.
+		// Open the file for reading.
 		file, err = os.Open(filePath)
 	}
 	if err != nil {

--- a/ruleguard.rules.go
+++ b/ruleguard.rules.go
@@ -350,7 +350,7 @@ func largeloopcopy(m fluent.Matcher) {
 	m.Match(
 		`for $_, $v := range $_ { $*_ }`,
 	).
-		Where(m["v"].Type.Size > 512).
+		Where(m["v"].Type.Size > 1024).
 		Report(`loop copies large value each iteration`)
 }
 


### PR DESCRIPTION
## Description
fix: print errors only when metacache status has errors

## Motivation and Context
avoid printing non-actionable errors for common situations

## How to test this PR?
hard to reproduce but seen in production setups

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
