### PR TITLE
azure: Use default upload parameters to avoid consuming too much memory

### DIFF
--- a/cmd/gateway/azure/gateway-azure_test.go
+++ b/cmd/gateway/azure/gateway-azure_test.go
@@ -20,12 +20,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
-	"os"
 	"reflect"
-	"strconv"
 	"testing"
-
-	"github.com/dustin/go-humanize"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	minio "github.com/minio/minio/cmd"
@@ -267,37 +263,4 @@ func TestCheckAzureUploadID(t *testing.T) {
 			t.Fatalf("%s: expected: <nil>, got: %s", uploadID, err)
 		}
 	}
-}
-
-func TestParsingUploadChunkSize(t *testing.T) {
-	key := "MINIO_AZURE_CHUNK_SIZE_MB"
-	invalidValues := []string{
-		"",
-		"0,3",
-		"100.1",
-		"-1",
-	}
-
-	for i, chunkValue := range invalidValues {
-		os.Setenv(key, chunkValue)
-		result := getUploadChunkSizeFromEnv(key, strconv.Itoa(azureDefaultUploadChunkSize/humanize.MiByte))
-		if result != azureDefaultUploadChunkSize {
-			t.Errorf("Test %d: expected: %d, got: %d", i+1, azureDefaultUploadChunkSize, result)
-		}
-	}
-
-	validValues := []string{
-		"1",
-		"1.25",
-		"50",
-		"99",
-	}
-	for i, chunkValue := range validValues {
-		os.Setenv(key, chunkValue)
-		result := getUploadChunkSizeFromEnv(key, strconv.Itoa(azureDefaultUploadChunkSize/humanize.MiByte))
-		if result == azureDefaultUploadChunkSize {
-			t.Errorf("Test %d: expected: %d, got: %d", i+1, azureDefaultUploadChunkSize, result)
-		}
-	}
-
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -18,6 +18,7 @@
 package env
 
 import (
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -73,6 +74,16 @@ func Get(key, defaultValue string) string {
 		return v
 	}
 	return defaultValue
+}
+
+// GetInt returns an integer if found in the environment
+// and returns the default value otherwise.
+func GetInt(key string, defaultValue int) (int, error) {
+	v := Get(key, "")
+	if v == "" {
+		return defaultValue, nil
+	}
+	return strconv.Atoi(v)
 }
 
 // List all envs with a given prefix.


### PR DESCRIPTION
## Description
A lot of memory is consumed when uploading small files in parallel, use the Azure
 default upload parameters, therefore memory buffering will be decreased from 
25 MB to 1 MB.

This PR also adds  MINIO_AZURE_UPLOAD_CONCURRENCY for users to tweak,
the default value will be 4 to keep the old behavior.

## Motivation and Context
Reduce memory consumption with many concurrent uploads of small files

## How to test this PR?
1. Run minio gateway
2.
```go
func main() {
        s3Client, err := minio.New("localhost:9000", &minio.Options{Creds: credentials.NewStaticV4("x", "xxx", ""), Secure: false})
        if err != nil {
                log.Fatalln(err)
        }

        oneKB := bytes.Repeat([]byte{'A'}, 1024)

        wg := sync.WaitGroup{}
        for w := 0; w < 10; w++ {
                wg.Add(1)
                go func() {
                        for {
                                _, err := s3Client.PutObject(context.Background(), "bucketName", "objectName", bytes.NewReader(oneKB), int64(len(oneKB)), minio.PutObjectOptions{})
                                if err != nil {
                                        fmt.Print("!")
                                } else {
                                        fmt.Print(".")
                                }
                        }
                }()
        }

        wg.Wait()
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
