### PR TITLE
Support variable server pools

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -97,16 +97,9 @@ func initTestErasureObjLayer(ctx context.Context) (ObjectLayer, []string, error)
 	if err != nil {
 		return nil, nil, err
 	}
-	endpoints := mustGetNewEndpoints(erasureDirs...)
-	storageDisks, format, err := waitForFormatErasure(true, endpoints, 1, 1, 16, "")
-	if err != nil {
-		removeRoots(erasureDirs)
-		return nil, nil, err
-	}
-
+	endpoints := mustGetZoneEndpoints(erasureDirs...)
 	globalPolicySys = NewPolicySys()
-	objLayer := &erasureServerPools{serverPools: make([]*erasureSets, 1)}
-	objLayer.serverPools[0], err = newErasureSets(ctx, endpoints, storageDisks, format)
+	objLayer, err := newErasureServerPools(ctx, endpoints)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -342,7 +342,7 @@ func validateConfig(s config.Config, setDriveCount int) error {
 	return notify.TestNotificationTargets(GlobalContext, s, NewGatewayHTTPTransport(), globalNotificationSys.ConfiguredTargetIDs())
 }
 
-func lookupConfigs(s config.Config, setDriveCount int) {
+func lookupConfigs(s config.Config, minSetDriveCount int) {
 	ctx := GlobalContext
 
 	var err error
@@ -429,7 +429,7 @@ func lookupConfigs(s config.Config, setDriveCount int) {
 		logger.LogIf(ctx, fmt.Errorf("Invalid api configuration: %w", err))
 	}
 
-	globalAPIConfig.init(apiConfig, setDriveCount)
+	globalAPIConfig.init(apiConfig, minSetDriveCount)
 
 	// Initialize remote instance transport once.
 	getRemoteInstanceTransportOnce.Do(func() {
@@ -437,7 +437,7 @@ func lookupConfigs(s config.Config, setDriveCount int) {
 	})
 
 	if globalIsErasure {
-		globalStorageClass, err = storageclass.LookupConfig(s[config.StorageClassSubSys][config.Default], setDriveCount)
+		globalStorageClass, err = storageclass.LookupConfig(s[config.StorageClassSubSys][config.Default], minSetDriveCount)
 		if err != nil {
 			logger.LogIf(ctx, fmt.Errorf("Unable to initialize storage class config: %w", err))
 		}

--- a/cmd/config/storageclass/storage-class.go
+++ b/cmd/config/storageclass/storage-class.go
@@ -88,14 +88,13 @@ var (
 // StorageClass - holds storage class information
 type StorageClass struct {
 	Parity int
-	DMA    string
 }
 
 // Config storage class configuration
 type Config struct {
 	Standard StorageClass `json:"standard"`
 	RRS      StorageClass `json:"rrs"`
-	DMA      StorageClass `json:"dma"`
+	DMA      string       `json:"dma"`
 }
 
 // UnmarshalJSON - Validate SS and RRS parity when unmarshalling JSON.
@@ -112,7 +111,7 @@ func (sCfg *Config) UnmarshalJSON(data []byte) error {
 // IsValid - returns true if input string is a valid
 // storage class kind supported.
 func IsValid(sc string) bool {
-	return sc == RRS || sc == STANDARD || sc == DMA
+	return sc == RRS || sc == STANDARD
 }
 
 // UnmarshalText unmarshals storage class from its textual form into
@@ -120,14 +119,6 @@ func IsValid(sc string) bool {
 func (sc *StorageClass) UnmarshalText(b []byte) error {
 	scStr := string(b)
 	if scStr == "" {
-		return nil
-	}
-	if scStr == DMAWrite {
-		sc.DMA = DMAWrite
-		return nil
-	}
-	if scStr == DMAReadWrite {
-		sc.DMA = DMAReadWrite
 		return nil
 	}
 	s, err := parseStorageClass(scStr)
@@ -143,14 +134,14 @@ func (sc *StorageClass) MarshalText() ([]byte, error) {
 	if sc.Parity != 0 {
 		return []byte(fmt.Sprintf("%s:%d", schemePrefix, sc.Parity)), nil
 	}
-	return []byte(sc.DMA), nil
+	return []byte{}, nil
 }
 
 func (sc *StorageClass) String() string {
 	if sc.Parity != 0 {
 		return fmt.Sprintf("%s:%d", schemePrefix, sc.Parity)
 	}
-	return sc.DMA
+	return ""
 }
 
 // Parses given storageClassEnv and returns a storageClass structure.
@@ -218,14 +209,16 @@ func validateParity(ssParity, rrsParity, setDriveCount int) (err error) {
 }
 
 // GetParityForSC - Returns the data and parity drive count based on storage class
-// If storage class is set using the env vars MINIO_STORAGE_CLASS_RRS and MINIO_STORAGE_CLASS_STANDARD
-// or config.json fields
-// -- corresponding values are returned
-// If storage class is not set during startup, default values are returned
-// -- Default for Reduced Redundancy Storage class is, parity = 2 and data = N-Parity
-// -- Default for Standard Storage class is, parity = N/2, data = N/2
-// If storage class is empty
-// -- standard storage class is assumed and corresponding data and parity is returned
+// If storage class is set using the env vars MINIO_STORAGE_CLASS_RRS and
+// MINIO_STORAGE_CLASS_STANDARD or server config fields corresponding values are
+// returned.
+//
+// -- if input storage class is empty then standard is assumed
+// -- if input is RRS but RRS is not configured default '2' parity
+//    for RRS is assumed
+// -- if input is STANDARD but STANDARD is not configured '0' parity
+//    is returned, the caller is expected to choose the right parity
+//    at that point.
 func (sCfg Config) GetParityForSC(sc string) (parity int) {
 	switch strings.TrimSpace(sc) {
 	case RRS:
@@ -241,7 +234,7 @@ func (sCfg Config) GetParityForSC(sc string) (parity int) {
 
 // GetDMA - returns DMA configuration.
 func (sCfg Config) GetDMA() string {
-	return sCfg.DMA.DMA
+	return sCfg.DMA
 }
 
 // Enabled returns if etcd is enabled.
@@ -254,8 +247,6 @@ func Enabled(kvs config.KVS) bool {
 // LookupConfig - lookup storage class config and override with valid environment settings if any.
 func LookupConfig(kvs config.KVS, setDriveCount int) (cfg Config, err error) {
 	cfg = Config{}
-	cfg.Standard.Parity = setDriveCount / 2
-	cfg.RRS.Parity = defaultRRSParity
 
 	if err = config.CheckValidKeys(config.StorageClassSubSys, kvs, DefaultKVS); err != nil {
 		return Config{}, err
@@ -270,9 +261,6 @@ func LookupConfig(kvs config.KVS, setDriveCount int) (cfg Config, err error) {
 		if err != nil {
 			return Config{}, err
 		}
-	}
-	if cfg.Standard.Parity == 0 {
-		cfg.Standard.Parity = setDriveCount / 2
 	}
 
 	if rrsc != "" {
@@ -291,7 +279,7 @@ func LookupConfig(kvs config.KVS, setDriveCount int) (cfg Config, err error) {
 	if dma != DMAReadWrite && dma != DMAWrite {
 		return Config{}, errors.New(`valid dma values are "read-write" and "write"`)
 	}
-	cfg.DMA.DMA = dma
+	cfg.DMA = dma
 
 	// Validation is done after parsing both the storage classes. This is needed because we need one
 	// storage class value to deduce the correct value of the other storage class.

--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -276,7 +276,16 @@ func parseEndpointSet(customSetDriveCount uint64, args ...string) (ep endpointSe
 // specific set size.
 // For example: {1...64} is divided into 4 sets each of size 16.
 // This applies to even distributed setup syntax as well.
-func GetAllSets(customSetDriveCount uint64, args ...string) ([][]string, error) {
+func GetAllSets(args ...string) ([][]string, error) {
+	var customSetDriveCount uint64
+	if v := env.Get(EnvErasureSetDriveCount, ""); v != "" {
+		driveCount, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, config.ErrInvalidErasureSetSize(err)
+		}
+		customSetDriveCount = uint64(driveCount)
+	}
+
 	var setArgs [][]string
 	if !ellipses.HasEllipses(args...) {
 		var setIndexes [][]uint64
@@ -335,16 +344,8 @@ func createServerEndpoints(serverAddr string, args ...string) (
 		return nil, -1, errInvalidArgument
 	}
 
-	var setDriveCount int
-	if v := env.Get(EnvErasureSetDriveCount, ""); v != "" {
-		setDriveCount, err = strconv.Atoi(v)
-		if err != nil {
-			return nil, -1, config.ErrInvalidErasureSetSize(err)
-		}
-	}
-
 	if !ellipses.HasEllipses(args...) {
-		setArgs, err := GetAllSets(uint64(setDriveCount), args...)
+		setArgs, err := GetAllSets(args...)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -362,17 +363,22 @@ func createServerEndpoints(serverAddr string, args ...string) (
 	}
 
 	var foundPrevLocal bool
+	var commonParityDrives int
+
 	for _, arg := range args {
-		setArgs, err := GetAllSets(uint64(setDriveCount), arg)
+		setArgs, err := GetAllSets(arg)
 		if err != nil {
 			return nil, -1, err
 		}
+
+		parityDrives := ecDrivesNoConfig(len(setArgs[0]))
+		if commonParityDrives != 0 && commonParityDrives != parityDrives {
+			return nil, -1, fmt.Errorf("All serverPools should have same parity ratio - expected %d, got %d", commonParityDrives, parityDrives)
+		}
+
 		endpointList, gotSetupType, err := CreateEndpoints(serverAddr, foundPrevLocal, setArgs...)
 		if err != nil {
 			return nil, -1, err
-		}
-		if setDriveCount != 0 && setDriveCount != len(setArgs[0]) {
-			return nil, -1, fmt.Errorf("All serverPools should have same drive per set ratio - expected %d, got %d", setDriveCount, len(setArgs[0]))
 		}
 		if err = endpointServerPools.Add(ZoneEndpoints{
 			SetCount:     len(setArgs),
@@ -382,9 +388,10 @@ func createServerEndpoints(serverAddr string, args ...string) (
 			return nil, -1, err
 		}
 		foundPrevLocal = endpointList.atleastOneEndpointLocal()
-		if setDriveCount == 0 {
-			setDriveCount = len(setArgs[0])
+		if commonParityDrives == 0 {
+			commonParityDrives = ecDrivesNoConfig(len(setArgs[0]))
 		}
+
 		if setupType == UnknownSetupType {
 			setupType = gotSetupType
 		}

--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -277,8 +277,8 @@ func TestHealObjectCorrupted(t *testing.T) {
 
 	// Test 4: checks if HealObject returns an error when xl.meta is not found
 	// in more than read quorum number of disks, to create a corrupted situation.
-	for i := 0; i <= len(er.getDisks())/2; i++ {
-		er.getDisks()[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
+	for i := 0; i <= nfi.Erasure.DataBlocks; i++ {
+		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
 	}
 
 	// Try healing now, expect to receive errFileNotFound.

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -62,7 +62,7 @@ func (er erasureObjects) CopyObject(ctx context.Context, srcBucket, srcObject, d
 	metaArr, errs := readAllFileInfo(ctx, storageDisks, srcBucket, srcObject, srcOpts.VersionID, false)
 
 	// get Quorum for this object
-	readQuorum, writeQuorum, err := objectQuorumFromMeta(ctx, er, metaArr, errs)
+	readQuorum, writeQuorum, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
 	if err != nil {
 		return oi, toObjectErr(err, srcBucket, srcObject)
 	}
@@ -380,7 +380,7 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 	// Read metadata associated with the object from all disks.
 	metaArr, errs := readAllFileInfo(ctx, disks, bucket, object, opts.VersionID, readData)
 
-	readQuorum, _, err := objectQuorumFromMeta(ctx, er, metaArr, errs)
+	readQuorum, _, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
 	if err != nil {
 		return fi, nil, nil, err
 	}
@@ -595,8 +595,8 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 
 	// Get parity and data drive count based on storage class metadata
 	parityDrives := globalStorageClass.GetParityForSC(opts.UserDefined[xhttp.AmzStorageClass])
-	if parityDrives == 0 {
-		parityDrives = getDefaultParityBlocks(len(storageDisks))
+	if parityDrives <= 0 {
+		parityDrives = er.defaultParityCount
 	}
 	dataDrives := len(storageDisks) - parityDrives
 
@@ -604,7 +604,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	// writeQuorum is dataBlocks + 1
 	writeQuorum := dataDrives
 	if dataDrives == parityDrives {
-		writeQuorum = dataDrives + 1
+		writeQuorum++
 	}
 
 	// Delete temporary object in the event of failure.
@@ -1093,7 +1093,7 @@ func (er erasureObjects) PutObjectTags(ctx context.Context, bucket, object strin
 	// Read metadata associated with the object from all disks.
 	metaArr, errs := readAllFileInfo(ctx, disks, bucket, object, opts.VersionID, false)
 
-	readQuorum, writeQuorum, err := objectQuorumFromMeta(ctx, er, metaArr, errs)
+	readQuorum, writeQuorum, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
 	if err != nil {
 		return toObjectErr(err, bucket, object)
 	}
@@ -1154,7 +1154,7 @@ func (er erasureObjects) updateObjectMeta(ctx context.Context, bucket, object st
 	// Read metadata associated with the object from all disks.
 	metaArr, errs := readAllFileInfo(ctx, disks, bucket, object, opts.VersionID, false)
 
-	readQuorum, writeQuorum, err := objectQuorumFromMeta(ctx, er, metaArr, errs)
+	readQuorum, writeQuorum, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
 	if err != nil {
 		return toObjectErr(err, bucket, object)
 	}

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -48,7 +48,8 @@ type partialOperation struct {
 type erasureObjects struct {
 	GatewayUnsupported
 
-	setDriveCount int
+	setDriveCount      int
+	defaultParityCount int
 
 	// getDisks returns list of storageAPIs.
 	getDisks func() []StorageAPI

--- a/cmd/format-erasure_test.go
+++ b/cmd/format-erasure_test.go
@@ -43,7 +43,8 @@ func TestFixFormatV3(t *testing.T) {
 		}
 	}
 
-	format := newFormatErasureV3(1, 8, "CRCMOD")
+	format := newFormatErasureV3(1, 8)
+	format.Erasure.DistributionAlgo = formatErasureVersionV2DistributionAlgoV1
 	formats := make([]*formatErasureV3, 8)
 
 	for j := 0; j < 8; j++ {
@@ -77,7 +78,8 @@ func TestFixFormatV3(t *testing.T) {
 
 // tests formatErasureV3ThisEmpty conditions.
 func TestFormatErasureEmpty(t *testing.T) {
-	format := newFormatErasureV3(1, 16, "CRCMOD")
+	format := newFormatErasureV3(1, 16)
+	format.Erasure.DistributionAlgo = formatErasureVersionV2DistributionAlgoV1
 	formats := make([]*formatErasureV3, 16)
 
 	for j := 0; j < 16; j++ {
@@ -276,7 +278,8 @@ func TestGetFormatErasureInQuorumCheck(t *testing.T) {
 	setCount := 2
 	setDriveCount := 16
 
-	format := newFormatErasureV3(setCount, setDriveCount, "CRCMOD")
+	format := newFormatErasureV3(setCount, setDriveCount)
+	format.Erasure.DistributionAlgo = formatErasureVersionV2DistributionAlgoV1
 	formats := make([]*formatErasureV3, 32)
 
 	for i := 0; i < setCount; i++ {
@@ -342,7 +345,8 @@ func TestGetErasureID(t *testing.T) {
 	setCount := 2
 	setDriveCount := 8
 
-	format := newFormatErasureV3(setCount, setDriveCount, "CRCMOD")
+	format := newFormatErasureV3(setCount, setDriveCount)
+	format.Erasure.DistributionAlgo = formatErasureVersionV2DistributionAlgoV1
 	formats := make([]*formatErasureV3, 16)
 
 	for i := 0; i < setCount; i++ {
@@ -397,7 +401,8 @@ func TestNewFormatSets(t *testing.T) {
 	setCount := 2
 	setDriveCount := 16
 
-	format := newFormatErasureV3(setCount, setDriveCount, "CRCMOD")
+	format := newFormatErasureV3(setCount, setDriveCount)
+	format.Erasure.DistributionAlgo = formatErasureVersionV2DistributionAlgoV1
 	formats := make([]*formatErasureV3, 32)
 	errs := make([]error, 32)
 

--- a/cmd/object-api-getobject_test.go
+++ b/cmd/object-api-getobject_test.go
@@ -340,8 +340,8 @@ func testGetObjectDiskNotFound(obj ObjectLayer, instanceType string, disks []str
 		}
 	}
 
-	// Take 8 disks down before GetObject is called, one more we loose quorum on 16 disk node.
-	for _, disk := range disks[:8] {
+	// Take 4 disks down before GetObject is called, one more we loose quorum on 16 disk node.
+	for _, disk := range disks[:4] {
 		os.RemoveAll(disk)
 	}
 

--- a/cmd/object-api-putobject_test.go
+++ b/cmd/object-api-putobject_test.go
@@ -225,8 +225,8 @@ func testObjectAPIPutObjectDiskNotFound(obj ObjectLayer, instanceType string, di
 		t.Fatalf("%s : %s", instanceType, err.Error())
 	}
 
-	// Take 8 disks down, one more we loose quorum on 16 disk node.
-	for _, disk := range disks[:7] {
+	// Take 4 disks down, one more we loose quorum on 16 disk node.
+	for _, disk := range disks[:4] {
 		os.RemoveAll(disk)
 	}
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -276,7 +276,7 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 			humanize.Ordinal(poolCount), setCount, setDriveCount)
 
 		// Initialize erasure code format on disks
-		format, err = initFormatErasure(GlobalContext, storageDisks, setCount, setDriveCount, "", deploymentID, sErrs)
+		format, err = initFormatErasure(GlobalContext, storageDisks, setCount, setDriveCount, deploymentID, sErrs)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -92,21 +92,14 @@ func path2BucketObject(s string) (bucket, prefix string) {
 	return path2BucketObjectWithBasePath("", s)
 }
 
-func getDefaultParityBlocks(drive int) int {
-	return drive / 2
-}
-
-func getDefaultDataBlocks(drive int) int {
+func getReadQuorum(drive int) int {
 	return drive - getDefaultParityBlocks(drive)
 }
 
-func getReadQuorum(drive int) int {
-	return getDefaultDataBlocks(drive)
-}
-
 func getWriteQuorum(drive int) int {
-	quorum := getDefaultDataBlocks(drive)
-	if getDefaultParityBlocks(drive) == quorum {
+	parity := getDefaultParityBlocks(drive)
+	quorum := drive - parity
+	if quorum == parity {
 		quorum++
 	}
 	return quorum

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -571,7 +571,7 @@ func (s *xlStorage) GetDiskID() (string, error) {
 	s.Lock()
 	defer s.Unlock()
 	s.diskID = format.Erasure.This
-	s.formatLegacy = format.Erasure.DistributionAlgo == formatErasureVersionV2DistributionAlgoLegacy
+	s.formatLegacy = format.Erasure.DistributionAlgo == formatErasureVersionV2DistributionAlgoV1
 	s.formatFileInfo = fi
 	s.formatLastCheck = time.Now()
 	return s.diskID, nil

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -1152,7 +1152,7 @@ func TestXLStorageReadFile(t *testing.T) {
 	for l := 0; l < 2; l++ {
 		// 1st loop tests with dma=write, 2nd loop tests with dma=read-write.
 		if l == 1 {
-			globalStorageClass.DMA.DMA = storageclass.DMAReadWrite
+			globalStorageClass.DMA = storageclass.DMAReadWrite
 		}
 		// Following block validates all ReadFile test cases.
 		for i, testCase := range testCases {
@@ -1212,7 +1212,7 @@ func TestXLStorageReadFile(t *testing.T) {
 	}
 
 	// Reset the flag.
-	globalStorageClass.DMA.DMA = storageclass.DMAWrite
+	globalStorageClass.DMA = storageclass.DMAWrite
 
 	// TestXLStorage for permission denied.
 	if runtime.GOOS != globalWindowsOSName {

--- a/docs/bucket/versioning/README.md
+++ b/docs/bucket/versioning/README.md
@@ -26,7 +26,7 @@ GET requests by specifying a version ID as shown below, you can retrieve the spe
 
 ![get_version_id](https://raw.githubusercontent.com/minio/minio/master/docs/bucket/versioning/versioning_GET_versionEnabled_id.png)
 
-To permanently delete an object you need to specify the version you want to delete. Only the user with appropriate permissions can permanently delete a version.  As shown below, a DELETE request called with a specific version id permanently deletes an object from a bucket. A delete marker is not added for DELETE requests with version id.
+To permanently delete an object you need to specify the version you want to delete, only the user with appropriate permissions can permanently delete a version.  As shown below DELETE request called with a specific version id permanently deletes an object from a bucket. Delete marker is not added for DELETE requests with version id.
 
 ![delete_version_id](https://raw.githubusercontent.com/minio/minio/master/docs/bucket/versioning/versioning_DELETE_versionEnabled_id.png)
 

--- a/docs/distributed/DESIGN.md
+++ b/docs/distributed/DESIGN.md
@@ -94,20 +94,22 @@ Input for the key is the object name specified in `PutObject()`, returns a uniqu
 
 - MinIO does erasure coding at the object level not at the volume level, unlike other object storage vendors. This allows applications to choose different storage class by setting `x-amz-storage-class=STANDARD/REDUCED_REDUNDANCY` for each object uploads so effectively utilizing the capacity of the cluster. Additionally these can also be enforced using IAM policies to make sure the client uploads with correct HTTP headers.
 
-- MinIO also supports expansion of existing clusters in server pools. Each pool is a self contained entity with same SLA's (read/write quorum) for each object as original cluster. By using the existing namespace for lookup validation MinIO ensures conflicting objects are not created. When no such object exists then MinIO simply uses the least used pool.
+- MinIO also supports expansion of existing clusters in server pools. Each pool is a self contained entity with same SLA's (read/write quorum) for each object as original cluster. By using the existing namespace for lookup validation MinIO ensures conflicting objects are not created. When no such object exists then MinIO simply uses the least used pool to place new objects.
 
 __There are no limits on how many server pools can be combined__
 
 ```
-minio server http://host{1...32}/export{1...32} http://host{5...6}/export{1...8}
+minio server http://host{1...32}/export{1...32} http://host{1...12}/export{1...12}
 ```
 
 In above example there are two server pools
 
 - 32 * 32 = 1024 drives pool1
-- 2 * 8 = 16 drives pool2
+- 12 * 12 = 144 drives pool2
 
-> Notice the requirement of common SLA here original cluster had 1024 drives with 16 drives per erasure set, second pool is expected to have a minimum of 16 drives to match the original cluster SLA or it should be in multiples of 16.
+> Notice the requirement of common SLA here original cluster had 1024 drives with 16 drives per erasure set with default parity of '4', second pool is expected to have a minimum of 8 drives per erasure set to match the original cluster SLA (parity count) of '4'. '12' drives stripe per erasure set in the second pool satisfies the original pool's parity count.
+
+Refer to the sizing guide with details on the default parity count chosen for different erasure stripe sizes [here](https://github.com/minio/minio/blob/master/docs/distributed/SIZING.md)
 
 MinIO places new objects in server pools based on proportionate free space, per pool. Following pseudo code demonstrates this behavior.
 ```go

--- a/docs/distributed/README.md
+++ b/docs/distributed/README.md
@@ -14,9 +14,9 @@ Distributed MinIO provides protection against multiple node/drive failures and [
 
 A stand-alone MinIO server would go down if the server hosting the disks goes offline. In contrast, a distributed MinIO setup with _m_ servers and _n_ disks will have your data safe as long as _m/2_ servers or _m*n_/2 or more disks are online.
 
-For example, an 16-server distributed setup with 200 disks per node would continue serving files, even if up to 8 servers are offline in default configuration i.e around 1600 disks can down MinIO would continue service files. But, you'll need at least 9 servers online to create new objects.
+For example, an 16-server distributed setup with 200 disks per node would continue serving files, up to 4 servers can be offline in default configuration i.e around 800 disks down MinIO would continue to read and write objects.
 
-You can also use [storage classes](https://github.com/minio/minio/tree/master/docs/erasure/storage-class) to set custom parity distribution per object.
+Refer to sizing guide for more understanding on default values chosen depending on your erasure stripe size [here](https://github.com/minio/minio/blob/master/docs/distributed/SIZING.md). Parity settings can be changed using [storage classes](https://github.com/minio/minio/tree/master/docs/erasure/storage-class).
 
 ### Consistency Guarantees
 
@@ -38,14 +38,14 @@ __NOTE:__
 
 - All the nodes running distributed MinIO need to have same access key and secret key for the nodes to connect. To achieve this, it is __recommended__ to export access key and secret key as environment variables, `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`, on all the nodes before executing MinIO server command.
 - __MinIO creates erasure-coding sets of *4* to *16* drives per set.  The number of drives you provide in total must be a multiple of one of those numbers.__
-- __MinIO chooses the largest EC set size which divides into the total number of drives or total number of nodes given - making sure to keep the uniform distribution i.e each node participates equal number of drives per set.
+- __MinIO chooses the largest EC set size which divides into the total number of drives or total number of nodes given - making sure to keep the uniform distribution i.e each node participates equal number of drives per set__.
 - __Each object is written to a single EC set, and therefore is spread over no more than 16 drives.__
 - __All the nodes running distributed MinIO setup are recommended to be homogeneous, i.e. same operating system, same number of disks and same network interconnects.__
 - MinIO distributed mode requires __fresh directories__. If required, the drives can be shared with other applications. You can do this by using a sub-directory exclusive to MinIO. For example, if you have mounted your volume under `/export`, pass `/export/data` as arguments to MinIO server.
 - The IP addresses and drive paths below are for demonstration purposes only, you need to replace these with the actual IP addresses and drive paths/folders.
 - Servers running distributed MinIO instances should be less than 15 minutes apart. You can enable [NTP](http://www.ntp.org/) service as a best practice to ensure same times across servers.
 - `MINIO_DOMAIN` environment variable should be defined and exported for bucket DNS style support.
-- Running Distributed MinIO on __Windows__ operating system is experimental. Please proceed with caution.
+- Running Distributed MinIO on __Windows__ operating system is considered **experimental**. Please proceed with caution.
 
 Example 1: Start distributed MinIO instance on n nodes with m drives each mounted at `/export1` to `/exportm` (pictured below), by running this command on all the n nodes:
 
@@ -79,8 +79,7 @@ minio server http://host{1...4}/export{1...16} http://host{5...12}/export{1...16
 
 Now the server has expanded total storage by _(newly_added_servers\*m)_ more disks, taking the total count to _(existing_servers\*m)+(newly_added_servers\*m)_ disks. New object upload requests automatically start using the least used cluster. This expansion strategy works endlessly, so you can perpetually expand your clusters as needed.  When you restart, it is immediate and non-disruptive to the applications. Each group of servers in the command-line is called a pool. There are 2 server pools in this example. New objects are placed in server pools in proportion to the amount of free space in each pool. Within each pool, the location of the erasure-set of drives is determined based on a deterministic hashing algorithm.
 
-> __NOTE:__ __Each pool you add must have the same erasure coding set size as the original pool, so the same data redundancy SLA is maintained.__
-> For example, if your first pool was 8 drives, you could add further server pools of 16, 32 or 1024 drives each. All you have to make sure is deployment SLA is multiples of original data redundancy SLA i.e 8.
+> __NOTE:__ __Each pool you add must have the same erasure coding parity configuration as the original pool, so the same data redundancy SLA is maintained.__
 
 ## 3. Test your setup
 To test this setup, access the MinIO server via browser or [`mc`](https://docs.min.io/docs/minio-client-quickstart-guide).

--- a/docs/distributed/SIZING.md
+++ b/docs/distributed/SIZING.md
@@ -1,0 +1,34 @@
+## Erasure code sizing guide
+
+### Toy Setups
+
+Capacity constrained environments, MinIO will work but not recommended for production.
+
+| servers | drives (per node) | stripe_size | parity chosen (default) | tolerance for reads (servers) | tolerance for writes (servers) |
+|--------:|------------------:|------------:|------------------------:|------------------------------:|-------------------------------:|
+|       1 |                 1 |           1 |                       0 |                             0 |                              0 |
+|       1 |                 4 |           4 |                       2 |                             0 |                              0 |
+|       4 |                 1 |           4 |                       2 |                             2 |                              3 |
+|       5 |                 1 |           5 |                       2 |                             2 |                              2 |
+|       6 |                 1 |           6 |                       3 |                             3 |                              4 |
+|       7 |                 1 |           7 |                       3 |                             3 |                              3 |
+
+### Minimum System Configuration for Production
+
+| servers | drives (per node) | stripe_size | parity chosen (default) | tolerance for reads (servers) | tolerance for writes (servers) |
+|--------:|------------------:|------------:|------------------------:|------------------------------:|-------------------------------:|
+|       4 |                 2 |           8 |                       4 |                             2 |                              1 |
+|       5 |                 2 |          10 |                       4 |                             2 |                              2 |
+|       6 |                 2 |          12 |                       4 |                             2 |                              2 |
+|       7 |                 2 |          14 |                       4 |                             2 |                              2 |
+|       8 |                 1 |           8 |                       4 |                             4 |                              3 |
+|       8 |                 2 |          16 |                       4 |                             2 |                              2 |
+|       9 |                 2 |           9 |                       4 |                             4 |                              4 |
+|      10 |                 2 |          10 |                       4 |                             4 |                              4 |
+|      11 |                 2 |          11 |                       4 |                             4 |                              4 |
+|      12 |                 2 |          12 |                       4 |                             4 |                              4 |
+|      13 |                 2 |          13 |                       4 |                             4 |                              4 |
+|      14 |                 2 |          14 |                       4 |                             4 |                              4 |
+|      15 |                 2 |          15 |                       4 |                             4 |                              4 |
+|      16 |                 2 |          16 |                       4 |                             4 |                              4 |
+

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -57,8 +57,8 @@ The main difference between various MinIO-KMS deployments is the KMS implementat
 |:---------------------------------------------------------------------------------------------|:------------------------------------------------------------------|
 | [Hashicorp Vault](https://github.com/minio/kes/wiki/Hashicorp-Vault-Keystore)                | Local KMS. MinIO and KMS on-prem (**Recommended**)                |
 | [AWS-KMS + SecretsManager](https://github.com/minio/kes/wiki/AWS-SecretsManager)             | Cloud KMS. MinIO in combination with a managed KMS installation   |
-| [Gemalto KeySecure /Thales CipherTrust](https://github.com/minio/kes/wiki/Gemalto-KeySecure) | Local KMS. MinIO and KMS On-Premises.                 |
-| [Google Cloud Platform SecretManager](https://github.com/minio/kes/wiki/GCP-SecretManager)   | Cloud KMS. MinIO in combination with a managed KMS installation | 
+| [Gemalto KeySecure /Thales CipherTrust](https://github.com/minio/kes/wiki/Gemalto-KeySecure) | Local KMS. MinIO and KMS On-Premises.                             |
+| [Google Cloud Platform SecretManager](https://github.com/minio/kes/wiki/GCP-SecretManager)   | Cloud KMS. MinIO in combination with a managed KMS installation   |
 | [FS](https://github.com/minio/kes/wiki/Filesystem-Keystore)                                  | Local testing or development (**Not recommended for production**) |
 
 


### PR DESCRIPTION
## Description
Support variable server pools

## Motivation and Context
The current implementation requires server pools to have
same erasure stripe sizes, to facilitate same SLA
and expectations.

This PR allows server pools to be variadic, i.e they
do not have to be same erasure stripe sizes - instead
they should have SLA for parity ratio.

If the parity ratio cannot be guaranteed by the new
server pool, the deployment is rejected i.e server
pool expansion is not allowed.

## How to test this PR?
Test with the following example

```yaml

version: '2'

# starts 4 docker containers running minio server instances. Each
# minio server's web interface will be accessible on the host at port
# 9001 through 9004.
services:
 minio1:
  image: y4m4/minio:dev
  restart: always
  volumes:
   - /home/harsha/data1:/data
  ports:
   - "9001:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
 minio2:
  image: y4m4/minio:dev
  restart: always
  volumes:
   - /home/harsha/data2:/data
  ports:
   - "9002:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
 minio3:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data3:/data
  ports:
   - "9003:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
  restart: on-failure
 minio4:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data4:/data
  ports:
   - "9004:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
  restart: on-failure
 minio5:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data5:/data
  ports:
   - "9005:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
  restart: on-failure
 minio6:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data6:/data
  ports:
   - "9006:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
  restart: on-failure
 minio7:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data7:/data
  ports:
   - "9007:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
  restart: on-failure
 minio8:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data8:/data
  ports:
   - "9008:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data   
  restart: on-failure
 minio9:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data9:/data
  ports:
   - "9009:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
  restart: on-failure
 minio10:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data10:/data
  ports:
   - "9010:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
 minio10:
  image: y4m4/minio:dev
  volumes:
   - /home/harsha/data10:/data
  ports:
   - "9010:9000"
  environment:
   MINIO_ACCESS_KEY: minio
   MINIO_SECRET_KEY: minio123
  command: server http://minio{1...4}/data http://minio{5...10}/data
  restart: on-failure
```

```
$ docker-compose -f /tmp/docker-compose.yaml up
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
