### PR TITLE
fix: regression in adding new replication targets

### DIFF
--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -129,11 +129,7 @@ func (sys *BucketTargetSys) SetTarget(ctx context.Context, bucket string, tgt *m
 	sys.Lock()
 	defer sys.Unlock()
 
-	tgts, ok := sys.targetsMap[bucket]
-	if !ok {
-		return BucketRemoteTargetNotFound{Bucket: bucket}
-	}
-
+	tgts := sys.targetsMap[bucket]
 	newtgts := make([]madmin.BucketTarget, len(tgts))
 	labels := make(map[string]struct{}, len(tgts))
 	found := false


### PR DESCRIPTION
## Description
fix: regression in adding new replication targets

## Motivation and Context
regression added in #11237

## How to test this PR?

Should succeed in adding new buckets 
```
mc admin bucket remote add m1/test http://minio:minio123@localhost:9001/test --service replication --region us-east-1
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in #11237
- [ ] Documentation updated
- [ ] Unit tests added/updated
