### PR TITLE
browser: fix file uploads with '#' in the name

### DIFF
--- a/browser/app/js/uploads/__tests__/actions.test.js
+++ b/browser/app/js/uploads/__tests__/actions.test.js
@@ -138,9 +138,10 @@ describe("Uploads actions", () => {
         objects: { currentPrefix: "pre1/" }
       })
       store.dispatch(uploadsActions.uploadFile(file))
+      const objectPath = encodeURIComponent("pre1/file1")
       expect(open).toHaveBeenCalledWith(
         "PUT",
-        "https://localhost:8080/upload/test1/pre1/file1",
+        "https://localhost:8080/upload/test1/" + objectPath,
         true
       )
       expect(send).toHaveBeenCalledWith(file)

--- a/browser/app/js/uploads/actions.js
+++ b/browser/app/js/uploads/actions.js
@@ -94,7 +94,7 @@ export const uploadFile = file => {
       _filePath = _filePath.substring(1)
     }
     const filePath = _filePath
-    const objectName = `${currentPrefix}${filePath}`
+    const objectName = encodeURIComponent(`${currentPrefix}${filePath}`)
     const uploadUrl = `${
       window.location.origin
     }${minioBrowserPrefix}/upload/${currentBucket}/${objectName}`


### PR DESCRIPTION
## Description

Object path will be url encoded when the file is uploaded from the browser.

## Motivation and Context
When the file name or the prefix contains `#`,
whatever comes after is ingored.

This is fixed by encoding the object path using
encodeURIComponent.

Fixes #11112 

## How to test this PR?
Follow the steps mentioned in #11112 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
