### PR TITLE
fix: use common logging implementation for DNSCache

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -51,7 +51,7 @@ func init() {
 	logger.RegisterError(config.FmtError)
 
 	rand.Seed(time.Now().UTC().UnixNano())
-	globalDNSCache = xhttp.NewDNSCache(10*time.Second, 10*time.Second)
+	globalDNSCache = xhttp.NewDNSCache(10*time.Second, 10*time.Second, logger.LogOnceIf)
 
 	initGlobalContext()
 

--- a/cmd/http/dial_dnscache_test.go
+++ b/cmd/http/dial_dnscache_test.go
@@ -31,9 +31,13 @@ var (
 	testDefaultLookupTimeout = 1 * time.Second
 )
 
+func logOnce(ctx context.Context, err error, id interface{}, errKind ...interface{}) {
+	// no-op
+}
+
 func testDNSCache(t *testing.T) *DNSCache {
 	t.Helper() // skip printing file and line information from this function
-	return NewDNSCache(testFreq, testDefaultLookupTimeout)
+	return NewDNSCache(testFreq, testDefaultLookupTimeout, logOnce)
 }
 
 func TestDialContextWithDNSCache(t *testing.T) {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -107,7 +107,7 @@ func TestMain(m *testing.M) {
 	// Initialize globalConsoleSys system
 	globalConsoleSys = NewConsoleLogger(context.Background())
 
-	globalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second)
+	globalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second, logger.LogOnceIf)
 
 	globalInternodeTransport = newInternodeHTTPTransport(nil, rest.DefaultTimeout)()
 


### PR DESCRIPTION
## Description
fix: use common logging implementation for DNSCache

## Motivation and Context
avoid using `log.Println`  in main code paths

## How to test this PR?
Manually if the DNS service is down

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
