### PR TITLE
fix: add offline StorageAPI to avoid unexpected crashes

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -750,18 +750,19 @@ func closeStorageDisks(storageDisks []StorageAPI) {
 	}
 }
 
-func initStorageDisksWithErrorsWithoutHealthCheck(endpoints Endpoints) ([]StorageAPI, []error) {
+func initStorageDisksWithoutHealthCheck(endpoints Endpoints) []StorageAPI {
 	// Bootstrap disks.
 	storageDisks := make([]StorageAPI, len(endpoints))
 	g := errgroup.WithNErrs(len(endpoints))
 	for index := range endpoints {
 		index := index
 		g.Go(func() (err error) {
-			storageDisks[index], err = newStorageAPIWithoutHealthCheck(endpoints[index])
-			return err
+			storageDisks[index] = newStorageAPIWithoutHealthCheck(endpoints[index])
+			return nil
 		}, index)
 	}
-	return storageDisks, g.Wait()
+	g.Wait()
+	return storageDisks
 }
 
 // Initialize storage disks for each endpoint.

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -123,7 +123,7 @@ func NewFSObjectLayer(fsPath string) (ObjectLayer, error) {
 	}
 
 	var err error
-	if fsPath, err = getValidPath(fsPath, false); err != nil {
+	if fsPath, err = getValidPath(fsPath); err != nil {
 		if err == errMinDiskSize {
 			return nil, config.ErrUnableToWriteInBackend(err).Hint(err.Error())
 		}

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -54,16 +54,16 @@ func isObjectDir(object string, size int64) bool {
 	return HasSuffix(object, SlashSeparator) && size == 0
 }
 
-func newStorageAPIWithoutHealthCheck(endpoint Endpoint) (storage StorageAPI, err error) {
+func newStorageAPIWithoutHealthCheck(endpoint Endpoint) (storage StorageAPI) {
 	if endpoint.IsLocal {
 		storage, err := newXLStorage(endpoint)
 		if err != nil {
-			return nil, err
+			return storage
 		}
-		return &xlStorageDiskIDCheck{storage: storage}, nil
+		return &xlStorageDiskIDCheck{storage: storage}
 	}
 
-	return newStorageRESTClient(endpoint, false), nil
+	return newStorageRESTClient(endpoint, false)
 }
 
 // Depending on the disk type network or local, initialize storage API.
@@ -71,7 +71,7 @@ func newStorageAPI(endpoint Endpoint) (storage StorageAPI, err error) {
 	if endpoint.IsLocal {
 		storage, err := newXLStorage(endpoint)
 		if err != nil {
-			return nil, err
+			return newOfflineDisk(endpoint, err), err
 		}
 		return &xlStorageDiskIDCheck{storage: storage}, nil
 	}

--- a/cmd/offline-storage.go
+++ b/cmd/offline-storage.go
@@ -1,0 +1,175 @@
+/*
+ * MinIO Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"io"
+)
+
+// offlineDisk is a dummy disk used instead of 'nil' to avoid code crashes
+type offlineDisk struct {
+	endpoint Endpoint
+	err      error
+}
+
+func newOfflineDisk(ep Endpoint, err error) StorageAPI {
+	return &offlineDisk{endpoint: ep, err: err}
+}
+
+func (d *offlineDisk) String() string {
+	return d.endpoint.String()
+}
+
+func (d *offlineDisk) IsOnline() bool {
+	return false
+}
+
+func (d *offlineDisk) IsLocal() bool {
+	return d.endpoint.IsLocal
+}
+
+func (d *offlineDisk) Endpoint() Endpoint {
+	return d.endpoint
+}
+
+func (d *offlineDisk) Hostname() string {
+	return d.endpoint.Host
+}
+
+func (d *offlineDisk) Healing() bool {
+	return false
+}
+
+func (d *offlineDisk) Close() (err error) {
+	return nil
+}
+
+func (d *offlineDisk) GetDiskID() (string, error) {
+	return "", d.err
+}
+
+func (d *offlineDisk) SetDiskID(id string) {
+	// no-op
+}
+
+func (d *offlineDisk) CrawlAndGetDataUsage(ctx context.Context, cache dataUsageCache) (info dataUsageCache, err error) {
+	return info, d.err
+}
+
+func (d *offlineDisk) DiskInfo(ctx context.Context) (info DiskInfo, err error) {
+	return info, d.err
+}
+
+func (d *offlineDisk) MakeVolBulk(ctx context.Context, volumes ...string) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) MakeVol(ctx context.Context, volume string) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) ListVols(ctx context.Context) (vols []VolInfo, err error) {
+	return vols, d.err
+}
+
+func (d *offlineDisk) StatVol(ctx context.Context, volume string) (vol VolInfo, err error) {
+	return vol, d.err
+}
+func (d *offlineDisk) DeleteVol(ctx context.Context, volume string, forceDelete bool) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writer) error {
+	return d.err
+}
+
+func (d *offlineDisk) WalkVersions(ctx context.Context, volume, dirPath, marker string, recursive bool, endWalkCh <-chan struct{}) (chan FileInfoVersions, error) {
+	return nil, d.err
+}
+
+func (d *offlineDisk) ListDir(ctx context.Context, volume, dirPath string, count int) (entries []string, err error) {
+	return nil, d.err
+}
+
+func (d *offlineDisk) ReadFile(ctx context.Context, volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
+	return 0, d.err
+}
+
+func (d *offlineDisk) ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error) {
+	return nil, d.err
+}
+
+func (d *offlineDisk) CreateFile(ctx context.Context, volume, path string, size int64, reader io.Reader) error {
+	return d.err
+}
+
+func (d *offlineDisk) AppendFile(ctx context.Context, volume string, path string, buf []byte) error {
+	return d.err
+}
+
+func (d *offlineDisk) RenameData(ctx context.Context, srcVolume, srcPath, dataDir, dstVolume, dstPath string) error {
+	return d.err
+}
+
+func (d *offlineDisk) RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) error {
+	return d.err
+}
+
+func (d *offlineDisk) CheckParts(ctx context.Context, volume string, path string, fi FileInfo) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) CheckFile(ctx context.Context, volume string, path string) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) Delete(ctx context.Context, volume string, path string, recursive bool) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) DeleteVersions(ctx context.Context, volume string, versions []FileInfo) []error {
+	errs := make([]error, len(versions))
+	for i := range errs {
+		errs[i] = d.err
+	}
+	return errs
+}
+
+func (d *offlineDisk) WriteMetadata(ctx context.Context, volume, path string, fi FileInfo) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) DeleteVersion(ctx context.Context, volume, path string, fi FileInfo) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) ReadVersion(ctx context.Context, volume, path, versionID string, readData bool) (fi FileInfo, err error) {
+	return fi, d.err
+}
+
+func (d *offlineDisk) WriteAll(ctx context.Context, volume string, path string, b []byte) (err error) {
+	return d.err
+}
+
+func (d *offlineDisk) ReadAll(ctx context.Context, volume string, path string) (buf []byte, err error) {
+	return nil, d.err
+}
+
+func (d *offlineDisk) VerifyFile(ctx context.Context, volume, path string, fi FileInfo) error {
+	return d.err
+}

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -240,11 +240,8 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 
 	for i, err := range errs {
 		if err != nil {
-			if err != errDiskNotFound {
-				return nil, nil, fmt.Errorf("Disk %s: %w", endpoints[i], err)
-			}
-			if retryCount >= 5 {
-				logger.Info("Unable to connect to %s: %v\n", endpoints[i], isServerResolvable(endpoints[i]))
+			if retryCount >= 3 {
+				logger.Info("Unable to connect to %s: %v %w\n", endpoints[i], isServerResolvable(endpoints[i]), fmt.Errorf("Disk %s: %w", endpoints[i], err))
 			}
 		}
 	}
@@ -254,7 +251,7 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 	// Check if we have
 	for i, sErr := range sErrs {
 		// print the error, nonetheless, which is perhaps unhandled
-		if sErr != errUnformattedDisk && sErr != errDiskNotFound && retryCount >= 5 {
+		if sErr != errUnformattedDisk && sErr != errDiskNotFound && retryCount >= 3 {
 			if sErr != nil {
 				logger.Info("Unable to read 'format.json' from %s: %v\n", endpoints[i], sErr)
 			}

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -82,8 +82,8 @@ func testStorageAPIListVols(t *testing.T, storage StorageAPI) {
 		expectedResult []VolInfo
 		expectErr      bool
 	}{
-		{nil, []VolInfo{}, false},
-		{[]string{"foo"}, []VolInfo{{Name: "foo"}}, false},
+		{nil, []VolInfo{{Name: ".minio.sys"}}, false},
+		{[]string{"foo"}, []VolInfo{{Name: ".minio.sys"}, {Name: "foo"}}, false},
 	}
 
 	for i, testCase := range testCases {

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -128,10 +128,6 @@ func newXLStorageTestSetup() (*xlStorageDiskIDCheck, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	err = storage.MakeVol(context.Background(), minioMetaBucket)
-	if err != nil {
-		return nil, "", err
-	}
 	// Create a sample format.json file
 	err = storage.WriteAll(context.Background(), minioMetaBucket, formatConfigFile, []byte(`{"version":"1","format":"xl","id":"592a41c2-b7cc-4130-b883-c4b5cb15965b","xl":{"version":"3","this":"da017d62-70e3-45f1-8a1a-587707e69ad1","sets":[["e07285a6-8c73-4962-89c6-047fb939f803","33b8d431-482d-4376-b63c-626d229f0a29","cff6513a-4439-4dc1-bcaa-56c9e880c352","da017d62-70e3-45f1-8a1a-587707e69ad1","9c9f21d5-1f15-4737-bce6-835faa0d9626","0a59b346-1424-4fc2-9fa2-a2e80541d0c1","7924a3dc-b69a-4971-9a2e-014966d6aebb","4d2b8dd9-4e48-444b-bdca-c89194b26042"]],"distributionAlgo":"CRCMOD"}}`))
 	if err != nil {
@@ -258,7 +254,7 @@ func TestXLStorageReadVersion(t *testing.T) {
 	// create xlStorage test setup
 	xlStorage, path, err := newXLStorageTestSetup()
 	if err != nil {
-		t.Fatalf("Unable to create xlStorage test setup, %s", err)
+		t.Fatalf("Unable to cfgreate xlStorage test setup, %s", err)
 	}
 
 	defer os.RemoveAll(path)
@@ -539,7 +535,7 @@ func TestXLStorageMakeVol(t *testing.T) {
 
 		// Initialize xlStorage storage layer for permission denied error.
 		_, err = newLocalXLStorage(permDeniedDir)
-		if err != nil && err != errFileAccessDenied {
+		if err != nil && err != errDiskAccessDenied {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
@@ -638,7 +634,7 @@ func TestXLStorageDeleteVol(t *testing.T) {
 
 		// Initialize xlStorage storage layer for permission denied error.
 		_, err = newLocalXLStorage(permDeniedDir)
-		if err != nil && err != errFileAccessDenied {
+		if err != nil && err != errDiskAccessDenied {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
@@ -890,7 +886,7 @@ func TestXLStorageListDir(t *testing.T) {
 
 		// Initialize xlStorage storage layer for permission denied error.
 		_, err = newLocalXLStorage(permDeniedDir)
-		if err != nil && err != errFileAccessDenied {
+		if err != nil && err != errDiskAccessDenied {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
@@ -1014,7 +1010,7 @@ func TestXLStorageDeleteFile(t *testing.T) {
 
 		// Initialize xlStorage storage layer for permission denied error.
 		_, err = newLocalXLStorage(permDeniedDir)
-		if err != nil && err != errFileAccessDenied {
+		if err != nil && err != errDiskAccessDenied {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
@@ -1221,7 +1217,7 @@ func TestXLStorageReadFile(t *testing.T) {
 
 		// Initialize xlStorage storage layer for permission denied error.
 		_, err = newLocalXLStorage(permDeniedDir)
-		if err != nil && err != errFileAccessDenied {
+		if err != nil && err != errDiskAccessDenied {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
@@ -1391,7 +1387,7 @@ func TestXLStorageAppendFile(t *testing.T) {
 		var xlStoragePermStorage StorageAPI
 		// Initialize xlStorage storage layer for permission denied error.
 		_, err = newLocalXLStorage(permDeniedDir)
-		if err != nil && err != errFileAccessDenied {
+		if err != nil && err != errDiskAccessDenied {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 


### PR DESCRIPTION

## Description
fix: add offline StorageAPI to avoid unexpected crashes

## Motivation and Context
Additionally also add O_DIRECT checks for read and writes,
In-case user enables O_DIRECT for reads and backend does
not support it we shall proceed to turn it off instead
and print a warning. This validation is necessary to avoid
unexpected downtime with user mistakes.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
