### PR TITLE
fix: optimize parentDirIsObject by moving isObject to storage layer

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -774,6 +774,9 @@ func (s *erasureSets) GetObject(ctx context.Context, bucket, object string, star
 }
 
 func (s *erasureSets) parentDirIsObject(ctx context.Context, bucket, parent string) bool {
+	if parent == "." {
+		return false
+	}
 	return s.getHashedSet(parent).parentDirIsObject(ctx, bucket, parent)
 }
 

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -1657,6 +1657,10 @@ func TestXLStorageCheckFile(t *testing.T) {
 		t.Fatalf("Unable to create file, %s", err)
 	}
 
+	if err := xlStorage.MakeVol(context.Background(), "success-vol/path/to/"+xlStorageFormatFile); err != nil {
+		t.Fatalf("Unable to create path, %s", err)
+	}
+
 	testCases := []struct {
 		srcVol      string
 		srcPath     string
@@ -1695,7 +1699,7 @@ func TestXLStorageCheckFile(t *testing.T) {
 		{
 			srcVol:      "success-vol",
 			srcPath:     "path",
-			expectedErr: errFileNotFound,
+			expectedErr: errPathNotFound,
 		},
 		// TestXLStorage case - 6.
 		// TestXLStorage case with non existent volume.
@@ -1703,6 +1707,13 @@ func TestXLStorageCheckFile(t *testing.T) {
 			srcVol:      "non-existent-vol",
 			srcPath:     "success-file",
 			expectedErr: errPathNotFound,
+		},
+		// TestXLStorage case - 7.
+		// TestXLStorage case with file with directory.
+		{
+			srcVol:      "success-vol",
+			srcPath:     "path/to",
+			expectedErr: errFileNotFound,
 		},
 	}
 


### PR DESCRIPTION
## Description
fix: optimize parentDirIsObject by moving isObject to storage layer

## Motivation and Context
For objects with `N` prefix depth, this PR reduces `N` such network
operations by converting `CheckFile` into a single bulk operation.

Reduction in chattiness here would allow disks to be utilized more
cleanly, while maintaining the same functionality along with one
extra volume check stat() call is removed.

## How to test this PR?
Update tests to test multiple sets scenario

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
