### PR TITLE
fix: reduce an extra readdir() attempted on non-legacy setups

### DIFF
--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -1719,7 +1719,7 @@ func TestXLStorageCheckFile(t *testing.T) {
 
 	for i, testCase := range testCases {
 		if err := xlStorage.CheckFile(context.Background(), testCase.srcVol, testCase.srcPath); err != testCase.expectedErr {
-			t.Fatalf("TestXLStorage case %d: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
+			t.Errorf("TestXLStorage case %d: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
 		}
 	}
 }


### PR DESCRIPTION


## Description
fix: reduce an extra readdir() attempted on non-legacy setups

## Motivation and Context
to verify moving content and preserving legacy content,
we have way to detect the objects through readdir()
this path is not necessary for most common cases on
newer setups, avoid readdir() to save multiple system
calls.

also fix the CheckFile behavior for most common
use case i.e without legacy format.

## How to test this PR?
Nothing special we should gain performance 
improvement with this change for all write
operations.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
