### PR TITLE
select: Fix leak on compressed files

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -243,6 +243,7 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 		}
 		return
 	}
+	defer s3Select.Close()
 
 	if err = s3Select.Open(getObject); err != nil {
 		if serr, ok := err.(s3select.SelectError); ok {
@@ -281,7 +282,6 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 	}
 
 	s3Select.Evaluate(w)
-	s3Select.Close()
 
 	// Notify object accessed via a GET request.
 	sendEvent(eventArgs{


### PR DESCRIPTION
## Description

Properly close gzip reader when done reading.

Fixes #11300

## How to test this PR?

Upload 1000 gzipped files to a prefix. Execute `mc sql -query="select * from S3Object limit 1" local2/bucket/prefix/`, observe memory usage slowly rise.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
