### PR TITLE
add MINIO_CONFIG_ENCRYPTED to have the capacity to not encrypt configuration

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -283,7 +283,18 @@ func handleCommonEnvVars() {
 				"Unable to validate credentials inherited from the shell environment")
 		}
 		globalActiveCred = cred
-		globalConfigEncrypted = true
+		if env.IsSet(config.ConfigEncrypted) {
+			if env.Get(config.ConfigEncrypted, "true") == "true" {
+				globalConfigEncrypted = true
+			} else if env.Get(config.ConfigEncrypted, "true") == "false" {
+				globalConfigEncrypted = false
+			} else {
+				logger.Fatal(config.ErrInvalidCredentials(err),
+					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable. Only authorized values: true or false")
+			}
+		} else {
+			globalConfigEncrypted = true
+		}
 	}
 
 	if env.IsSet(config.EnvRootUser) || env.IsSet(config.EnvRootPassword) {
@@ -293,7 +304,19 @@ func handleCommonEnvVars() {
 				"Unable to validate credentials inherited from the shell environment")
 		}
 		globalActiveCred = cred
-		globalConfigEncrypted = true
+		if env.IsSet(config.ConfigEncrypted) {
+			if env.Get(config.ConfigEncrypted, "true") == "true" {
+				globalConfigEncrypted = true
+			} else if env.Get(config.ConfigEncrypted, "true") == "false" {
+				globalConfigEncrypted = false
+			} else {
+				logger.Fatal(config.ErrInvalidCredentials(err),
+					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable. Only authorized values: true or false")
+			}
+		} else {
+			globalConfigEncrypted = true
+		}
+
 	}
 
 	if env.IsSet(config.EnvAccessKeyOld) && env.IsSet(config.EnvSecretKeyOld) {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -290,7 +290,7 @@ func handleCommonEnvVars() {
 				globalConfigEncrypted = false
 			} else {
 				logger.Fatal(config.ErrInvalidConfigurationEncrypted(err),
-					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable")
+					"Unable to parse MINIO_CONFIG_ENCRYPTED variable")
 			}
 		} else {
 			globalConfigEncrypted = true
@@ -311,7 +311,7 @@ func handleCommonEnvVars() {
 				globalConfigEncrypted = false
 			} else {
 				logger.Fatal(config.ErrInvalidConfigurationEncrypted(err),
-					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable")
+					"Unable to arse MINIO_CONFIG_ENCRYPTED variable")
 			}
 		} else {
 			globalConfigEncrypted = true

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -289,8 +289,8 @@ func handleCommonEnvVars() {
 			} else if env.Get(config.ConfigEncrypted, "true") == "false" {
 				globalConfigEncrypted = false
 			} else {
-				logger.Fatal(config.ErrInvalidCredentials(err),
-					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable. Only authorized values: true or false")
+				logger.Fatal(config.ErrInvalidConfigurationEncrypted(err),
+					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable")
 			}
 		} else {
 			globalConfigEncrypted = true
@@ -310,7 +310,7 @@ func handleCommonEnvVars() {
 			} else if env.Get(config.ConfigEncrypted, "true") == "false" {
 				globalConfigEncrypted = false
 			} else {
-				logger.Fatal(config.ErrInvalidCredentials(err),
+				logger.Fatal(config.ErrInvalidConfigurationEncrypted(err),
 					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable. Only authorized values: true or false")
 			}
 		} else {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -311,7 +311,7 @@ func handleCommonEnvVars() {
 				globalConfigEncrypted = false
 			} else {
 				logger.Fatal(config.ErrInvalidConfigurationEncrypted(err),
-					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable. Only authorized values: true or false")
+					"Unable to Parse MINIO_CONFIG_ENCRYPTED variable")
 			}
 		} else {
 			globalConfigEncrypted = true

--- a/cmd/config/constants.go
+++ b/cmd/config/constants.go
@@ -38,6 +38,7 @@ const (
 	EnvFSOSync         = "MINIO_FS_OSYNC"
 	EnvArgs            = "MINIO_ARGS"
 	EnvDNSWebhook      = "MINIO_DNS_WEBHOOK_ENDPOINT"
+	ConfigEncrypted    = "MINIO_CONFIG_ENCRYPTED"
 
 	EnvUpdate = "MINIO_UPDATE"
 

--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -118,6 +118,11 @@ var (
 		"Please set correct rotating credentials in the environment for decryption",
 		`Detected encrypted config backend, correct old access and secret keys should be specified via environment variables MINIO_ROOT_USER_OLD and MINIO_ROOT_PASSWORD_OLD to be able to re-encrypt the MinIO config, user IAM and policies with new credentials`,
 	)
+	ErrInvalidConfigurationEncrypted = newErrFn(
+		"Invalid Configuraton Encrypted setting",
+		"Please check the passed value",
+		"MINIO_CONFIG_ENCRYPTED only allow `true` of `false` values",
+	)
 
 	ErrInvalidCredentialsBackendEncrypted = newErrFn(
 		"Invalid credentials",

--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -119,7 +119,7 @@ var (
 		`Detected encrypted config backend, correct old access and secret keys should be specified via environment variables MINIO_ROOT_USER_OLD and MINIO_ROOT_PASSWORD_OLD to be able to re-encrypt the MinIO config, user IAM and policies with new credentials`,
 	)
 	ErrInvalidConfigurationEncrypted = newErrFn(
-		"Invalid configuraton encrypted setting",
+		"Invalid configuration encrypted setting",
 		"Please check the passed value",
 		"MINIO_CONFIG_ENCRYPTED only allow `true` of `false` values",
 	)

--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -119,7 +119,7 @@ var (
 		`Detected encrypted config backend, correct old access and secret keys should be specified via environment variables MINIO_ROOT_USER_OLD and MINIO_ROOT_PASSWORD_OLD to be able to re-encrypt the MinIO config, user IAM and policies with new credentials`,
 	)
 	ErrInvalidConfigurationEncrypted = newErrFn(
-		"Invalid Configuraton Encrypted setting",
+		"Invalid configuraton encrypted setting",
 		"Please check the passed value",
 		"MINIO_CONFIG_ENCRYPTED only allow `true` of `false` values",
 	)

--- a/docs/federation/lookup/README.md
+++ b/docs/federation/lookup/README.md
@@ -43,6 +43,13 @@ a bucket `bucket1` created on current MinIO instance will be accessible as `buck
 - This field is optional for distributed deployments. If you don't set this field in a federated setup, we use the IP addresses of
 hosts passed to the MinIO server startup and use them for DNS entries.
 
+#### MINIO_CONFIG_ENCRYPTED
+
+This is an environment variable to define if the Configuration stored in ETCD is encrypted or not. If the value is not set the configuration is encrypted.
+2 values are allowed:
+- `true` to encrypt the configuration
+- `false` to not encrypt the configuration
+
 ### Run Multiple Clusters
 
 > cluster1


### PR DESCRIPTION
## Description

This feature allow to not encrypt the configuration in ETCD by adding a new environment variable (MINIO_CONFIG_ENCRYPTED). 
By default it keep it to true as it was before.

## Motivation and Context
We have a high number of user and policies and the encryption is causing error. (see #11305 )

## How to test this PR?
Set the MINIO_CONFIG_ENCRYPTED=true and the configuration will be encrypted
Set the MINIO_CONFIG_ENCRYPTED=false and the configuration will not be encrypted

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
