### PR TITLE
Fix divide by zero error in notificationsys

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1276,6 +1276,9 @@ func (sys *NotificationSys) restClientFromHash(s string) (client *peerRESTClient
 		return nil
 	}
 	peerClients := sys.getOnlinePeers()
+	if len(peerClients) == 0 {
+		return nil
+	}
 	idx := xxhash.Sum64String(s) % uint64(len(peerClients))
 	return peerClients[idx]
 }


### PR DESCRIPTION
Check if number of peers online > 0 before getting peerclient

## Description
panic: runtime error: integer divide by zero

goroutine 69453 [running]:
github.com/minio/minio/cmd.(*NotificationSys).restClientFromHash(0xc00197a070, 0xc0020497a5, 0x3, 0x3)
	/home/kp/code/src/github.com/minio/minio/cmd/notification.go:1279 +0xa9
github.com/minio/minio/cmd.(*erasureObjects).listPath(0xc0004c9940, 0x229fc20, 0xc002051410, 0xc002036840, 0x24, 0xc0020497a5, 0x3, 0x0, 0x0, 0xc0020497ee, ...)
	/home/kp/code/src/github.com/minio/minio/cmd/metacache-set.go:572 +0x35d
github.com/minio/minio/cmd.(*erasureServerPools).listPath.func1(0xc002495430, 0x229fc20, 0xc002051410, 0xc001cc9e40, 0xc002495428, 0xc00249543c, 0xc0024da0e0, 0xc002051860, 0x0, 0xc0004c9940)
	/home/kp/code/src/github.com/minio/minio/cmd/metacache-server-pool.go:157 +0x118
created by github.com/minio/minio/cmd.(*erasureServerPools).listPath
	/home/kp/code/src/github.com/minio/minio/cmd/metacache-server-pool.go:155 +0x525



## Motivation and Context


## How to test this PR?
Bring some of the nodes down in a distributed cluster, and was able to see this bug while bringing back some node

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
