### PR TITLE
fix: honor storage class uniformity for multiple pools

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/cmd/config/storageclass"
 	"github.com/minio/minio/cmd/logger"
 	"github.com/minio/minio/pkg/color"
@@ -908,7 +909,8 @@ func getDefaultParityBlocks(drive int) int {
 // ecDrivesNoConfig returns the erasure coded drives in a set if no config has been set.
 // It will attempt to read it from env variable and fall back to drives/2.
 func ecDrivesNoConfig(setDriveCount int) int {
-	ecDrives := globalStorageClass.GetParityForSC(storageclass.STANDARD)
+	sc, _ := storageclass.LookupConfig(config.KVS{}, setDriveCount)
+	ecDrives := sc.GetParityForSC(storageclass.STANDARD)
 	if ecDrives <= 0 {
 		ecDrives = getDefaultParityBlocks(setDriveCount)
 	}


### PR DESCRIPTION
## Description
fix: honor storage class uniformity for multiple pools

## Motivation and Context
newer server pool expansion

## How to test this PR?
```
~ docker-compose -f /tmp/t.yaml up
```

```yaml
version: '3.7'
# starts 4 docker containers running minio server instances.
# using nginx reverse proxy, load balancing, you can access
# it through port 9000.
services:
  minio1:
    image: y4m4/minio:dev
    expose:
      - "9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
      MINIO_STORAGE_CLASS_STANDARD: "EC:2"
    command: server http://minio{1...4}/data{1...2} http://minio{5...6}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio2:
    image: y4m4/minio:dev
    expose:
      - "9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
      MINIO_STORAGE_CLASS_STANDARD: "EC:2"
    command: server http://minio{1...4}/data{1...2} http://minio{5...6}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio3:
    image: y4m4/minio:dev
    expose:
      - "9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
      MINIO_STORAGE_CLASS_STANDARD: "EC:2"
    command: server http://minio{1...4}/data{1...2} http://minio{5...6}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio4:
    image: y4m4/minio:dev
    expose:
      - "9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
      MINIO_STORAGE_CLASS_STANDARD: "EC:2"
    command: server http://minio{1...4}/data{1...2} http://minio{5...6}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio5:
    image: y4m4/minio:dev
    expose:
      - "9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
      MINIO_STORAGE_CLASS_STANDARD: "EC:2"
    command: server http://minio{1...4}/data{1...2} http://minio{5...6}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
  minio6:
    image: y4m4/minio:dev
    expose:
      - "9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
      MINIO_STORAGE_CLASS_STANDARD: "EC:2"
    command: server http://minio{1...4}/data{1...2} http://minio{5...6}/data{1...2}
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
