### PR TITLE
read-health check endpoint returns success if cluster can serve read

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1623,3 +1623,9 @@ func (fs *FSObjects) Health(ctx context.Context, opts HealthOptions) HealthResul
 		Healthy: newObjectLayerFn() != nil,
 	}
 }
+
+// ReadHealth returns "read" health of the object layer
+func (fs *FSObjects) ReadHealth(ctx context.Context) bool {
+	_, err := os.Stat(fs.fsPath)
+	return err == nil
+}

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -254,3 +254,8 @@ func (a GatewayUnsupported) IsCompressionSupported() bool {
 func (a GatewayUnsupported) Health(_ context.Context, _ HealthOptions) HealthResult {
 	return HealthResult{}
 }
+
+// ReadHealth - No Op.
+func (a GatewayUnsupported) ReadHealth(_ context.Context) bool {
+	return true
+}

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -216,7 +216,8 @@ func guessIsHealthCheckReq(req *http.Request) bool {
 	return aType == authTypeAnonymous && (req.Method == http.MethodGet || req.Method == http.MethodHead) &&
 		(req.URL.Path == healthCheckPathPrefix+healthCheckLivenessPath ||
 			req.URL.Path == healthCheckPathPrefix+healthCheckReadinessPath ||
-			req.URL.Path == healthCheckPathPrefix+healthCheckClusterPath)
+			req.URL.Path == healthCheckPathPrefix+healthCheckClusterPath ||
+			req.URL.Path == healthCheckPathPrefix+healthCheckClusterReadPath)
 }
 
 // guessIsMetricsReq - returns true if incoming request looks

--- a/cmd/healthcheck-router.go
+++ b/cmd/healthcheck-router.go
@@ -23,11 +23,12 @@ import (
 )
 
 const (
-	healthCheckPath          = "/health"
-	healthCheckLivenessPath  = "/live"
-	healthCheckReadinessPath = "/ready"
-	healthCheckClusterPath   = "/cluster"
-	healthCheckPathPrefix    = minioReservedBucketPath + healthCheckPath
+	healthCheckPath            = "/health"
+	healthCheckLivenessPath    = "/live"
+	healthCheckReadinessPath   = "/ready"
+	healthCheckClusterPath     = "/cluster"
+	healthCheckClusterReadPath = "/cluster/read"
+	healthCheckPathPrefix      = minioReservedBucketPath + healthCheckPath
 )
 
 // registerHealthCheckRouter - add handler functions for liveness and readiness routes.
@@ -38,6 +39,7 @@ func registerHealthCheckRouter(router *mux.Router) {
 
 	// Cluster check handler to verify cluster is active
 	healthRouter.Methods(http.MethodGet).Path(healthCheckClusterPath).HandlerFunc(httpTraceAll(ClusterCheckHandler))
+	healthRouter.Methods(http.MethodGet).Path(healthCheckClusterReadPath).HandlerFunc(httpTraceAll(ClusterReadCheckHandler))
 
 	// Liveness handler
 	healthRouter.Methods(http.MethodGet).Path(healthCheckLivenessPath).HandlerFunc(httpTraceAll(LivenessCheckHandler))

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -155,6 +155,7 @@ type ObjectLayer interface {
 
 	// Returns health of the backend
 	Health(ctx context.Context, opts HealthOptions) HealthResult
+	ReadHealth(ctx context.Context) bool
 
 	// ObjectTagging operations
 	PutObjectTags(context.Context, string, string, string, ObjectOptions) (ObjectInfo, error)

--- a/docs/metrics/healthcheck/README.md
+++ b/docs/metrics/healthcheck/README.md
@@ -20,10 +20,29 @@ livenessProbe:
 ```
 
 ### Cluster probe
-This probe is not useful in almost all cases, this is meant for administrators to see if quorum is available in any given cluster. The reply is '200 OK' if cluster has quorum if not it returns '503 Service Unavailable'.
+#### Cluster-writeable probe
+This probe is not useful in almost all cases, this is meant for administrators to see if write quorum is available in any given cluster. The reply is '200 OK' if cluster has write quorum if not it returns '503 Service Unavailable'.
 
 ```
 curl http://minio1:9001/minio/health/cluster
+HTTP/1.1 503 Service Unavailable
+Accept-Ranges: bytes
+Content-Length: 0
+Content-Security-Policy: block-all-mixed-content
+Server: MinIO/GOGET.GOGET
+Vary: Origin
+X-Amz-Bucket-Region: us-east-1
+X-Minio-Write-Quorum: 3
+X-Amz-Request-Id: 16239D6AB80EBECF
+X-Xss-Protection: 1; mode=block
+Date: Tue, 21 Jul 2020 00:36:14 GMT
+```
+
+#### Clustr-readable probe
+This probe is not useful in almost all cases, this is meant for administrators to see if read quorum is available in any given cluster. The reply is '200 OK' if cluster has read quorum if not it returns '503 Service Unavailable'.
+
+```
+curl http://minio1:9001/minio/health/cluster/read
 HTTP/1.1 503 Service Unavailable
 Accept-Ranges: bytes
 Content-Length: 0


### PR DESCRIPTION

## Description
Customer request for sidekick feature such that sidekick should route requests to faileover site even if it's read-only.

Related sidekick PR: https://github.com/minio/sidekick/pull/51

## How to test this PR?
Have two sites. Use sidekick to test. As:
```
  5. Two sites, each site having two zones, each zone having 4 servers. After failover, allow read requests to site2 even if it has just read quorum:
     $ sidekick --health-path=/minio/health/cluster --read-health-path=/minio/health/cluster/read  http://site1-minio{1...4}:9000,http://site1-minio{5...8}:9000 \
               http://site2-minio{1...4}:9000,http://site2-minio{5...8}:9000
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
