### PR TITLE
Compress profiling data

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -335,6 +335,7 @@ func (sys *NotificationSys) DownloadProfilingData(ctx context.Context, writer io
 				logger.LogIf(ctx, zerr)
 				continue
 			}
+			header.Method = zip.Deflate
 			zwriter, zerr := zipWriter.CreateHeader(header)
 			if zerr != nil {
 				reqInfo := (&logger.ReqInfo{}).AppendTags("peerAddress", client.host.String())
@@ -381,6 +382,7 @@ func (sys *NotificationSys) DownloadProfilingData(ctx context.Context, writer io
 		if zerr != nil {
 			return profilingDataFound
 		}
+		header.Method = zip.Deflate
 
 		zwriter, zerr := zipWriter.CreateHeader(header)
 		if zerr != nil {


### PR DESCRIPTION
## Description

Trace data can be rather large and compresses fine.

Compress profile data in zip files. 1 minute sample with trace enabled:

```
277.895.314 before.profiles.zip
152.800.318 after.profiles.zip
```

## How to test this PR?

Enable `mc admin profile start -type=trace myminio` profiling and compare download sizes.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
