### PR TITLE
Fix wrong part number in compressed decryption

### DIFF
--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -519,8 +519,9 @@ func TestGetCompressedOffsets(t *testing.T) {
 		offset            int64
 		startOffset       int64
 		snappyStartOffset int64
+		firstPart         int
 	}{
-		{
+		0: {
 			objInfo: ObjectInfo{
 				Parts: []ObjectPartInfo{
 					{
@@ -536,8 +537,9 @@ func TestGetCompressedOffsets(t *testing.T) {
 			offset:            79109865,
 			startOffset:       39235668,
 			snappyStartOffset: 12001001,
+			firstPart:         1,
 		},
-		{
+		1: {
 			objInfo: ObjectInfo{
 				Parts: []ObjectPartInfo{
 					{
@@ -554,7 +556,7 @@ func TestGetCompressedOffsets(t *testing.T) {
 			startOffset:       0,
 			snappyStartOffset: 19109865,
 		},
-		{
+		2: {
 			objInfo: ObjectInfo{
 				Parts: []ObjectPartInfo{
 					{
@@ -573,14 +575,18 @@ func TestGetCompressedOffsets(t *testing.T) {
 		},
 	}
 	for i, test := range testCases {
-		startOffset, snappyStartOffset := getCompressedOffsets(test.objInfo, test.offset)
+		startOffset, snappyStartOffset, firstPart := getCompressedOffsets(test.objInfo, test.offset)
 		if startOffset != test.startOffset {
 			t.Errorf("Test %d - expected startOffset %d but received %d",
-				i+1, test.startOffset, startOffset)
+				i, test.startOffset, startOffset)
 		}
 		if snappyStartOffset != test.snappyStartOffset {
 			t.Errorf("Test %d - expected snappyOffset %d but received %d",
-				i+1, test.snappyStartOffset, snappyStartOffset)
+				i, test.snappyStartOffset, snappyStartOffset)
+		}
+		if firstPart != test.firstPart {
+			t.Errorf("Test %d - expected firstPart %d but received %d",
+				i, test.firstPart, firstPart)
 		}
 	}
 }


### PR DESCRIPTION
## Description

When offsets were specified we relied on the first part number to be correct. This caused `sio` to be unable to decrypt.

Recalculate based on offset.

## How to test this PR?

Repro: https://gist.github.com/harshavardhana/16ff9fd75c63b024ee26c3cef24616c6

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
