### PR TITLE
Add open FD and FD limit to cluster metrics

### DIFF
--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -31,6 +31,14 @@ These metrics can be from any MinIO server once per collection.
 |`minio_node_disk_free_bytes`                    |Total storage available on a disk.                                                                                           |
 |`minio_node_disk_total_bytes`                   |Total storage on a disk.                                                                                                     |
 |`minio_node_disk_used_bytes`                    |Total storage used on a disk.                                                                                                |
+|`minio_node_file_descriptor_limit_total`        |Limit on total number of open file descriptors for the MinIO Server process.                                                 |
+|`minio_node_file_descriptor_open_total`         |Total number of open file descriptors by the MinIO Server process.                                                           |
+|`minio_node_io_rchar_bytes`                     |Total bytes read by the process from the underlying storage system including cache, /proc/[pid]/io rchar                     |
+|`minio_node_io_read_bytes`                      |Total bytes read by the process from the underlying storage system, /proc/[pid]/io read_bytes                                |
+|`minio_node_io_wchar_bytes`                     |Total bytes written by the process to the underlying storage system including page cache, /proc/[pid]/io wchar               |
+|`minio_node_io_write_bytes`                     |Total bytes written by the process to the underlying storage system, /proc/[pid]/io write_bytes                              |
+|`minio_node_syscall_read_total`                 |Total read SysCalls to the kernel. /proc/[pid]/io syscr                                                                      |
+|`minio_node_syscall_write_total`                |Total write SysCalls to the kernel. /proc/[pid]/io syscw                                                                     |
 |`minio_s3_requests_error_total`                 |Total number S3 requests with errors                                                                                         |
 |`minio_s3_requests_inflight_total`              |Total number of S3 requests currently in flight.                                                                             |
 |`minio_s3_requests_total`                       |Total number S3 requests                                                                                                     |

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/procfs v0.2.0
 	github.com/rjeczalik/notify v0.9.2
 	github.com/rs/cors v1.7.0
 	github.com/secure-io/sio-go v0.3.0


### PR DESCRIPTION
## Description
This adds the open file descriptor count and limit to the cluster metrics reported.

## Motivation and Context
This has been useful for debugging and having a single URL to fetch the count and limit will be useful to estimate load or a problem with load.

## How to test this PR?
Start MinIO is distributed mode and `curl localhost:9004/minio/v2/metrics/cluster`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
