### PR TITLE
initialize forwarder after init() to avoid crashes

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -30,7 +30,6 @@ import (
 	xhttp "github.com/minio/minio/cmd/http"
 	"github.com/minio/minio/cmd/http/stats"
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/pkg/handlers"
 )
 
 // Adds limiting body size middleware
@@ -532,14 +531,6 @@ func setRequestValidityHandler(h http.Handler) http.Handler {
 	})
 }
 
-var fwd = handlers.NewForwarder(&handlers.Forwarder{
-	PassHost:     true,
-	RoundTripper: newGatewayHTTPTransport(1 * time.Hour),
-	Logger: func(err error) {
-		logger.LogIf(GlobalContext, err)
-	},
-})
-
 // setBucketForwardingHandler middleware forwards the path style requests
 // on a bucket to the right bucket location, bucket to IP configuration
 // is obtained from centralized etcd configuration service.
@@ -589,7 +580,7 @@ func setBucketForwardingHandler(h http.Handler) http.Handler {
 					r.URL.Scheme = "https"
 				}
 				r.URL.Host = getHostFromSrv(sr)
-				fwd.ServeHTTP(w, r)
+				globalForwarder.ServeHTTP(w, r)
 				return
 			}
 			h.ServeHTTP(w, r)
@@ -639,7 +630,7 @@ func setBucketForwardingHandler(h http.Handler) http.Handler {
 				r.URL.Scheme = "https"
 			}
 			r.URL.Host = getHostFromSrv(sr)
-			fwd.ServeHTTP(w, r)
+			globalForwarder.ServeHTTP(w, r)
 			return
 		}
 		h.ServeHTTP(w, r)

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/pkg/bucket/bandwidth"
+	"github.com/minio/minio/pkg/handlers"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/minio/cmd/config/cache"
@@ -285,6 +286,8 @@ var (
 	globalProxyTransport http.RoundTripper
 
 	globalDNSCache *xhttp.DNSCache
+
+	globalForwarder *handlers.Forwarder
 	// Add new variable global values here.
 )
 


### PR DESCRIPTION


## Description
initialize forwarder after init() to avoid crashes

## Motivation and Context
DNSCache dialer is a global value initialized in
init(), whereas `go` keeps `var =` before `init()`
, also we don't need to keep proxy routers as
global entities - register the forwarder as
necessary to avoid crashes.

## How to test this PR?
Run MinIO in federation setup

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
