### PR TITLE
avoid double CORS headers in federation

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/gob"
 	"errors"
@@ -61,7 +62,9 @@ func init() {
 		PassHost:     true,
 		RoundTripper: newGatewayHTTPTransport(1 * time.Hour),
 		Logger: func(err error) {
-			logger.LogIf(GlobalContext, err)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				logger.LogIf(GlobalContext, err)
+			}
 		},
 	})
 

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -580,6 +580,11 @@ func setBucketForwardingHandler(h http.Handler) http.Handler {
 					r.URL.Scheme = "https"
 				}
 				r.URL.Host = getHostFromSrv(sr)
+				// Make sure we remove any existing headers before
+				// proxying the request to another node.
+				for k := range w.Header() {
+					w.Header().Del(k)
+				}
 				globalForwarder.ServeHTTP(w, r)
 				return
 			}
@@ -630,6 +635,11 @@ func setBucketForwardingHandler(h http.Handler) http.Handler {
 				r.URL.Scheme = "https"
 			}
 			r.URL.Host = getHostFromSrv(sr)
+			// Make sure we remove any existing headers before
+			// proxying the request to another node.
+			for k := range w.Header() {
+				w.Header().Del(k)
+			}
 			globalForwarder.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
## Description
avoid double CORS headers in federation

## Motivation and Context
CORS proxying adds double headers one
by the receiving server, one by proxied
server. Remove them before proxying
when 'Origin' header is found. 

## How to test this PR?
Need federation based setup

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
