### PR TITLE
heal: Report skipping objects with normal healing mode

### DIFF
--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -644,7 +644,7 @@ func (f *folderScanner) scanQueuedLevels(ctx context.Context, folders []cachedFo
 							object:    object,
 							versionID: versionID,
 						}, madmin.HealItemObject)
-					})
+					}, nil)
 			}
 
 			wait()

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1549,7 +1549,7 @@ func (fs *FSObjects) Walk(ctx context.Context, bucket, prefix string, results ch
 }
 
 // HealObjects - no-op for fs. Valid only for Erasure.
-func (fs *FSObjects) HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn HealObjectFn) (e error) {
+func (fs *FSObjects) HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn1, fn2 HealObjectFn) (e error) {
 	logger.LogIf(ctx, NotImplemented{})
 	return NotImplemented{}
 }

--- a/cmd/fs-v1_test.go
+++ b/cmd/fs-v1_test.go
@@ -401,7 +401,7 @@ func TestFSHealObjects(t *testing.T) {
 	defer os.RemoveAll(disk)
 
 	obj := initFSObjects(disk, t)
-	err := obj.HealObjects(GlobalContext, "bucket", "prefix", madmin.HealOpts{}, nil)
+	err := obj.HealObjects(GlobalContext, "bucket", "prefix", madmin.HealOpts{}, nil, nil)
 	if err == nil || !isSameType(err, NotImplemented{}) {
 		t.Fatalf("Heal Object should return NotImplemented error ")
 	}

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -191,7 +191,7 @@ func (a GatewayUnsupported) Walk(ctx context.Context, bucket, prefix string, res
 }
 
 // HealObjects - Not implemented stub
-func (a GatewayUnsupported) HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn HealObjectFn) (e error) {
+func (a GatewayUnsupported) HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn1, fn2 HealObjectFn) (e error) {
 	return NotImplemented{}
 }
 

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -147,7 +147,7 @@ type ObjectLayer interface {
 	HealFormat(ctx context.Context, dryRun bool) (madmin.HealResultItem, error)
 	HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem, error)
 	HealObject(ctx context.Context, bucket, object, versionID string, opts madmin.HealOpts) (madmin.HealResultItem, error)
-	HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn HealObjectFn) error
+	HealObjects(ctx context.Context, bucket, prefix string, opts madmin.HealOpts, fn HealObjectFn, skipHealObjectCallBack HealObjectFn) error
 
 	// Backend related metrics
 	GetMetrics(ctx context.Context) (*BackendMetrics, error)

--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -121,6 +121,7 @@ type HealResultItem struct {
 	Object       string       `json:"object"`
 	VersionID    string       `json:"versionId"`
 	Detail       string       `json:"detail"`
+	Skipped      bool         `json:"skipped"`
 	ParityBlocks int          `json:"parityBlocks,omitempty"`
 	DataBlocks   int          `json:"dataBlocks,omitempty"`
 	DiskCount    int          `json:"diskCount"`


### PR DESCRIPTION
## Description
Normal healing mode skips objects that have full quorum in disks.
However, mc admin heal command does not receive any information about
these objects and users don't see any progress at all.

This PR adds a field Skipped to the item heal result structure for those
skipped objects. We call them skipped because we only check for their
presence in all disks and it is not deep healing.

## Motivation and Context
Better mc admin user experience when normal scanning is passed

## How to test this PR?
mc admin heal -r myminio/testbucket/, with and without this PR. (Actually mc still needs a little enhancement)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
