### PR TITLE
heal: Decode object name in healing result

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1404,6 +1404,7 @@ func (z *erasureServerPools) HealObject(ctx context.Context, bucket, object, ver
 
 	for _, pool := range z.serverPools {
 		result, err := pool.HealObject(ctx, bucket, object, versionID, opts)
+		result.Object = decodeDirObject(result.Object)
 		if err != nil {
 			if isErrObjectNotFound(err) || isErrVersionNotFound(err) {
 				continue


### PR DESCRIPTION
## Description
The user can see __XLDIR__ prefix in mc admin heal when the command
heals an empty object with a trailing slash. This commit decodes the
name of the object before sending it back to the upper level.

## Motivation and Context
Fix mc admin heal output for xl dirs

## How to test this PR?
```
mc mb myminio/testbucket/emptydir/
mc --json admin heal -r myminio/ | jq . | grep name
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
