### PR TITLE
tagging: Add event notif for PUT object tagging

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1542,59 +1542,59 @@ func (z *erasureServerPools) Health(ctx context.Context, opts HealthOptions) Hea
 }
 
 // PutObjectTags - replace or add tags to an existing object
-func (z *erasureServerPools) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) error {
+func (z *erasureServerPools) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) (ObjectInfo, error) {
 	object = encodeDirObject(object)
 	if z.SinglePool() {
 		return z.serverPools[0].PutObjectTags(ctx, bucket, object, tags, opts)
 	}
 
 	for _, pool := range z.serverPools {
-		err := pool.PutObjectTags(ctx, bucket, object, tags, opts)
+		objInfo, err := pool.PutObjectTags(ctx, bucket, object, tags, opts)
 		if err != nil {
 			if isErrObjectNotFound(err) || isErrVersionNotFound(err) {
 				continue
 			}
-			return err
+			return ObjectInfo{}, err
 		}
-		return nil
+		return objInfo, nil
 	}
 	if opts.VersionID != "" {
-		return VersionNotFound{
+		return ObjectInfo{}, VersionNotFound{
 			Bucket:    bucket,
 			Object:    object,
 			VersionID: opts.VersionID,
 		}
 	}
-	return ObjectNotFound{
+	return ObjectInfo{}, ObjectNotFound{
 		Bucket: bucket,
 		Object: object,
 	}
 }
 
 // DeleteObjectTags - delete object tags from an existing object
-func (z *erasureServerPools) DeleteObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) error {
+func (z *erasureServerPools) DeleteObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
 	object = encodeDirObject(object)
 	if z.SinglePool() {
 		return z.serverPools[0].DeleteObjectTags(ctx, bucket, object, opts)
 	}
 	for _, pool := range z.serverPools {
-		err := pool.DeleteObjectTags(ctx, bucket, object, opts)
+		objInfo, err := pool.DeleteObjectTags(ctx, bucket, object, opts)
 		if err != nil {
 			if isErrObjectNotFound(err) || isErrVersionNotFound(err) {
 				continue
 			}
-			return err
+			return ObjectInfo{}, err
 		}
-		return nil
+		return objInfo, nil
 	}
 	if opts.VersionID != "" {
-		return VersionNotFound{
+		return ObjectInfo{}, VersionNotFound{
 			Bucket:    bucket,
 			Object:    object,
 			VersionID: opts.VersionID,
 		}
 	}
-	return ObjectNotFound{
+	return ObjectInfo{}, ObjectNotFound{
 		Bucket: bucket,
 		Object: object,
 	}

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -1384,13 +1384,13 @@ func (s *erasureSets) HealObject(ctx context.Context, bucket, object, versionID 
 }
 
 // PutObjectTags - replace or add tags to an existing object
-func (s *erasureSets) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) error {
+func (s *erasureSets) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) (ObjectInfo, error) {
 	er := s.getHashedSet(object)
 	return er.PutObjectTags(ctx, bucket, object, tags, opts)
 }
 
 // DeleteObjectTags - delete object tags from an existing object
-func (s *erasureSets) DeleteObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) error {
+func (s *erasureSets) DeleteObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
 	er := s.getHashedSet(object)
 	return er.DeleteObjectTags(ctx, bucket, object, opts)
 }

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -208,9 +208,9 @@ func (a GatewayUnsupported) GetMetrics(ctx context.Context) (*BackendMetrics, er
 }
 
 // PutObjectTags - not implemented.
-func (a GatewayUnsupported) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) error {
+func (a GatewayUnsupported) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) (ObjectInfo, error) {
 	logger.LogIf(ctx, NotImplemented{})
-	return NotImplemented{}
+	return ObjectInfo{}, NotImplemented{}
 }
 
 // GetObjectTags - not implemented.
@@ -220,9 +220,9 @@ func (a GatewayUnsupported) GetObjectTags(ctx context.Context, bucket, object st
 }
 
 // DeleteObjectTags - not implemented.
-func (a GatewayUnsupported) DeleteObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) error {
+func (a GatewayUnsupported) DeleteObjectTags(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
 	logger.LogIf(ctx, NotImplemented{})
-	return NotImplemented{}
+	return ObjectInfo{}, NotImplemented{}
 }
 
 // IsNotificationSupported returns whether bucket notification is applicable for this layer.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -157,7 +157,7 @@ type ObjectLayer interface {
 	Health(ctx context.Context, opts HealthOptions) HealthResult
 
 	// ObjectTagging operations
-	PutObjectTags(context.Context, string, string, string, ObjectOptions) error
+	PutObjectTags(context.Context, string, string, string, ObjectOptions) (ObjectInfo, error)
 	GetObjectTags(context.Context, string, string, ObjectOptions) (*tags.Tags, error)
-	DeleteObjectTags(context.Context, string, string, ObjectOptions) error
+	DeleteObjectTags(context.Context, string, string, ObjectOptions) (ObjectInfo, error)
 }

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3293,7 +3293,7 @@ func (api objectAPIHandlers) PutObjectTaggingHandler(w http.ResponseWriter, r *h
 	sendEvent(eventArgs{
 		EventName:    event.ObjectCreatedPutTagging,
 		BucketName:   bucket,
-		Object:       ObjectInfo{Bucket: bucket, Name: object, VersionID: objInfo.VersionID, UserTags: tagsStr},
+		Object:       objInfo,
 		ReqParams:    extractReqParams(r),
 		RespElements: extractRespElements(w),
 		UserAgent:    r.UserAgent(),
@@ -3346,11 +3346,13 @@ func (api objectAPIHandlers) DeleteObjectTaggingHandler(w http.ResponseWriter, r
 		opts.UserDefined = make(map[string]string)
 		opts.UserDefined[xhttp.AmzBucketReplicationStatus] = replication.Pending.String()
 	}
+
 	// Delete object tags
 	if err = objAPI.DeleteObjectTags(ctx, bucket, object, opts); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}
+	oi.UserTags = ""
 
 	if opts.VersionID != "" {
 		w.Header()[xhttp.AmzVersionID] = []string{opts.VersionID}
@@ -3365,7 +3367,7 @@ func (api objectAPIHandlers) DeleteObjectTaggingHandler(w http.ResponseWriter, r
 	sendEvent(eventArgs{
 		EventName:    event.ObjectCreatedDeleteTagging,
 		BucketName:   bucket,
-		Object:       ObjectInfo{Bucket: bucket, Name: object, VersionID: oi.VersionID, UserTags: ""},
+		Object:       oi,
 		ReqParams:    extractReqParams(r),
 		RespElements: extractRespElements(w),
 		UserAgent:    r.UserAgent(),

--- a/pkg/event/name.go
+++ b/pkg/event/name.go
@@ -41,6 +41,8 @@ const (
 	ObjectCreatedPut
 	ObjectCreatedPutRetention
 	ObjectCreatedPutLegalHold
+	ObjectCreatedPutTagging
+	ObjectCreatedDeleteTagging
 	ObjectRemovedAll
 	ObjectRemovedDelete
 	ObjectRemovedDeleteMarkerCreated
@@ -77,6 +79,7 @@ func (name Name) Expand() []Name {
 			ObjectCreatedCompleteMultipartUpload, ObjectCreatedCopy,
 			ObjectCreatedPost, ObjectCreatedPut,
 			ObjectCreatedPutRetention, ObjectCreatedPutLegalHold,
+			ObjectCreatedPutTagging, ObjectCreatedDeleteTagging,
 			ObjectReplicationComplete, ObjectReplicationFailed,
 		}
 	case ObjectRemovedAll:
@@ -134,6 +137,10 @@ func (name Name) String() string {
 		return "s3:ObjectCreated:Post"
 	case ObjectCreatedPut:
 		return "s3:ObjectCreated:Put"
+	case ObjectCreatedPutTagging:
+		return "s3:ObjectCreated:PutTagging"
+	case ObjectCreatedDeleteTagging:
+		return "s3:ObjectCreated:DeleteTagging"
 	case ObjectCreatedPutRetention:
 		return "s3:ObjectCreated:PutRetention"
 	case ObjectCreatedPutLegalHold:
@@ -244,6 +251,10 @@ func ParseName(s string) (Name, error) {
 		return ObjectCreatedPutRetention, nil
 	case "s3:ObjectCreated:PutLegalHold":
 		return ObjectCreatedPutLegalHold, nil
+	case "s3:ObjectCreated:PutTagging":
+		return ObjectCreatedPutTagging, nil
+	case "s3:ObjectCreated:DeleteTagging":
+		return ObjectCreatedDeleteTagging, nil
 	case "s3:ObjectRemoved:*":
 		return ObjectRemovedAll, nil
 	case "s3:ObjectRemoved:Delete":

--- a/pkg/event/name_test.go
+++ b/pkg/event/name_test.go
@@ -31,8 +31,9 @@ func TestNameExpand(t *testing.T) {
 		{BucketCreated, []Name{BucketCreated}},
 		{BucketRemoved, []Name{BucketRemoved}},
 		{ObjectAccessedAll, []Name{ObjectAccessedGet, ObjectAccessedHead, ObjectAccessedGetRetention, ObjectAccessedGetLegalHold}},
-		{ObjectCreatedAll, []Name{ObjectCreatedCompleteMultipartUpload, ObjectCreatedCopy,
-			ObjectCreatedPost, ObjectCreatedPut, ObjectCreatedPutRetention, ObjectCreatedPutLegalHold, ObjectReplicationComplete, ObjectReplicationFailed}},
+		{ObjectCreatedAll, []Name{ObjectCreatedCompleteMultipartUpload, ObjectCreatedCopy, ObjectCreatedPost, ObjectCreatedPut,
+			ObjectCreatedPutRetention, ObjectCreatedPutLegalHold, ObjectCreatedPutTagging, ObjectCreatedDeleteTagging,
+			ObjectReplicationComplete, ObjectReplicationFailed}},
 		{ObjectRemovedAll, []Name{ObjectRemovedDelete, ObjectRemovedDeleteMarkerCreated}},
 		{ObjectAccessedHead, []Name{ObjectAccessedHead}},
 	}


### PR DESCRIPTION
## Description
mc mirror needs to detect put object tagging event to replicate it in destination in --watch mode

## Motivation and Context
mc mirror replication

## How to test this PR?
1. `mc admin trace -v -a myminio/`
2. `mc watch myminio/testbucket/`
3. `mc tag set myminio/testbucket/object key=val and kill mc watch command to see the trace`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
