### PR TITLE
Add support for TCP_QUICKACK

### DIFF
--- a/cmd/http/dial_linux.go
+++ b/cmd/http/dial_linux.go
@@ -38,6 +38,10 @@ func setInternalTCPParameters(c syscall.RawConn) error {
 		// since Linux 4.11.
 		_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_FASTOPEN_CONNECT, 1)
 
+		// Enable TCP quick ACK, John Nagle says
+		// "Set TCP_QUICKACK. If you find a case where that makes things worse, let me know."
+		_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_QUICKACK, 1)
+
 		// The time (in seconds) the connection needs to remain idle before
 		// TCP starts sending keepalive probes, set this to 5 secs
 		// system defaults to 7200 secs!!!
@@ -52,6 +56,7 @@ func setInternalTCPParameters(c syscall.RawConn) error {
 		// ~ cat /proc/sys/net/ipv4/tcp_keepalive_intvl (defaults to 75 secs, we reduce it to 3 secs)
 		// 75
 		_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, 3)
+
 	})
 }
 
@@ -86,6 +91,10 @@ func NewCustomDialContext(dialTimeout time.Duration) DialContext {
 					// the TCP fast open connect. This feature is supported
 					// since Linux 4.11.
 					_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_FASTOPEN_CONNECT, 1)
+
+					// Enable TCP quick ACK, John Nagle says
+					// "Set TCP_QUICKACK. If you find a case where that makes things worse, let me know."
+					_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_QUICKACK, 1)
 				})
 			},
 		}


### PR DESCRIPTION
## Description
Add support for TCP_QUICKACK

## Motivation and Context
TCP_QUICKACK is a setting that allows TCP endpoints
to acknowledge the receipt of data instantly in situations
where they would normally wait to see if more data
would be arriving.

https://assets.extrahop.com/whitepapers/TCP-Optimization-Guide-by-ExtraHop.pdf

## How to test this PR?
Nothing specific will be doing benchmarks with this change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
