### PR TITLE
Remove Connections from SysProcess struct

### DIFF
--- a/cmd/healthinfo.go
+++ b/cmd/healthinfo.go
@@ -204,7 +204,7 @@ func getLocalProcInfo(ctx context.Context, r *http.Request) madmin.ServerProcInf
 		if err != nil {
 			return errProcInfo(err)
 		}
-		sysProc.Connections = conns
+		sysProc.ConnectionCount = len(conns)
 
 		createTime, err := proc.CreateTimeWithContext(ctx)
 		if err != nil {

--- a/pkg/madmin/health.go
+++ b/pkg/madmin/health.go
@@ -65,36 +65,36 @@ type ServerProcInfo struct {
 
 // SysProcess - Includes process lvl information about a single process
 type SysProcess struct {
-	Pid            int32                       `json:"pid"`
-	Background     bool                        `json:"background,omitempty"`
-	CPUPercent     float64                     `json:"cpupercent,omitempty"`
-	Children       []int32                     `json:"children,omitempty"`
-	CmdLine        string                      `json:"cmd,omitempty"`
-	Connections    []nethw.ConnectionStat      `json:"connections,omitempty"`
-	CreateTime     int64                       `json:"createtime,omitempty"`
-	Cwd            string                      `json:"cwd,omitempty"`
-	Exe            string                      `json:"exe,omitempty"`
-	Gids           []int32                     `json:"gids,omitempty"`
-	IOCounters     *process.IOCountersStat     `json:"iocounters,omitempty"`
-	IsRunning      bool                        `json:"isrunning,omitempty"`
-	MemInfo        *process.MemoryInfoStat     `json:"meminfo,omitempty"`
-	MemMaps        *[]process.MemoryMapsStat   `json:"memmaps,omitempty"`
-	MemPercent     float32                     `json:"mempercent,omitempty"`
-	Name           string                      `json:"name,omitempty"`
-	NetIOCounters  []nethw.IOCountersStat      `json:"netiocounters,omitempty"`
-	Nice           int32                       `json:"nice,omitempty"`
-	NumCtxSwitches *process.NumCtxSwitchesStat `json:"numctxswitches,omitempty"`
-	NumFds         int32                       `json:"numfds,omitempty"`
-	NumThreads     int32                       `json:"numthreads,omitempty"`
-	PageFaults     *process.PageFaultsStat     `json:"pagefaults,omitempty"`
-	Parent         int32                       `json:"parent,omitempty"`
-	Ppid           int32                       `json:"ppid,omitempty"`
-	Rlimit         []process.RlimitStat        `json:"rlimit,omitempty"`
-	Status         string                      `json:"status,omitempty"`
-	Tgid           int32                       `json:"tgid,omitempty"`
-	Times          *cpu.TimesStat              `json:"cputimes,omitempty"`
-	Uids           []int32                     `json:"uids,omitempty"`
-	Username       string                      `json:"username,omitempty"`
+	Pid             int32                       `json:"pid"`
+	Background      bool                        `json:"background,omitempty"`
+	CPUPercent      float64                     `json:"cpupercent,omitempty"`
+	Children        []int32                     `json:"children,omitempty"`
+	CmdLine         string                      `json:"cmd,omitempty"`
+	ConnectionCount int                         `json:"connection_count,omitempty"`
+	CreateTime      int64                       `json:"createtime,omitempty"`
+	Cwd             string                      `json:"cwd,omitempty"`
+	Exe             string                      `json:"exe,omitempty"`
+	Gids            []int32                     `json:"gids,omitempty"`
+	IOCounters      *process.IOCountersStat     `json:"iocounters,omitempty"`
+	IsRunning       bool                        `json:"isrunning,omitempty"`
+	MemInfo         *process.MemoryInfoStat     `json:"meminfo,omitempty"`
+	MemMaps         *[]process.MemoryMapsStat   `json:"memmaps,omitempty"`
+	MemPercent      float32                     `json:"mempercent,omitempty"`
+	Name            string                      `json:"name,omitempty"`
+	NetIOCounters   []nethw.IOCountersStat      `json:"netiocounters,omitempty"`
+	Nice            int32                       `json:"nice,omitempty"`
+	NumCtxSwitches  *process.NumCtxSwitchesStat `json:"numctxswitches,omitempty"`
+	NumFds          int32                       `json:"numfds,omitempty"`
+	NumThreads      int32                       `json:"numthreads,omitempty"`
+	PageFaults      *process.PageFaultsStat     `json:"pagefaults,omitempty"`
+	Parent          int32                       `json:"parent,omitempty"`
+	Ppid            int32                       `json:"ppid,omitempty"`
+	Rlimit          []process.RlimitStat        `json:"rlimit,omitempty"`
+	Status          string                      `json:"status,omitempty"`
+	Tgid            int32                       `json:"tgid,omitempty"`
+	Times           *cpu.TimesStat              `json:"cputimes,omitempty"`
+	Uids            []int32                     `json:"uids,omitempty"`
+	Username        string                      `json:"username,omitempty"`
 }
 
 // ServerMemInfo - Includes host virtual and swap mem information


### PR DESCRIPTION
## Description

The connections info of the processes takes up a huge amount of space,
and is not important for adding any useful health checks. Removing it
will significantly reduce the size of the subnet health report.

## Motivation and Context

To reduce size of subnet health report

## How to test this PR?

- Build minio with this PR code and start the server
- Run `mc admin subnet health <alias>` with an existing/older version of `mc`.
  - Verify that the generated report doesn't contain `connections` node for any process under `procinfos -> processes`
- Build `mc` with dependency on this PR (modify `go.mod` to replace the `minio` path to the local minio having this PR code)
- Generate the health report using this newly built `mc`
  - Verify that this report contains a new node `connection_count` for each process under `procinfos -> processes`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
