### PR TITLE
Check driver init error before using it

### DIFF
--- a/cmd/warm-backend-azure.go
+++ b/cmd/warm-backend-azure.go
@@ -74,7 +74,7 @@ func newWarmBackendAzure(conf madmin.TierAzure) (*warmBackendAzure, error) {
 		if _, ok := err.(base64.CorruptInputError); ok {
 			return nil, errors.New("invalid Azure credentials")
 		}
-		return &warmBackendAzure{}, err
+		return nil, err
 	}
 	p := azblob.NewPipeline(credential, azblob.PipelineOptions{})
 	u, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", conf.AccessKey))

--- a/pkg/madmin/tier.go
+++ b/pkg/madmin/tier.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"strings"
 )
 
@@ -39,13 +38,9 @@ func (adm *AdminClient) AddTier(ctx context.Context, cfg TierConfig) error {
 		return err
 	}
 
-	queryValues := url.Values{}
-	queryValues.Set("add", "")
-
 	reqData := requestData{
-		relPath:     strings.Join([]string{adminAPIPrefix, TierAPI}, "/"),
-		queryValues: queryValues,
-		content:     encData,
+		relPath: strings.Join([]string{adminAPIPrefix, TierAPI}, "/"),
+		content: encData,
 	}
 
 	// Execute PUT on /minio/admin/v3/tier to add a remote tier


### PR DESCRIPTION
## Description
Fixes crash in Azure warm tier driver at the time of adding ILM rules.

## Motivation and Context


## How to test this PR?
1. Add a remote tier 
2. Add an ILM rule referring to this tier
You should see no panic stack trace in MinIO logs

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
