### PR TITLE
fix ObjectInfo returned by CopyObject

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -101,7 +101,7 @@ func (er erasureObjects) CopyObject(ctx context.Context, srcBucket, srcObject, d
 		modTime = dstOpts.MTime
 		fi.ModTime = dstOpts.MTime
 	}
-
+	fi.Metadata = srcInfo.UserDefined
 	srcInfo.UserDefined["etag"] = srcInfo.ETag
 
 	// Update `xl.meta` content on each disks.


### PR DESCRIPTION
erasure CopyObject was returning old metadata

## Description


## Motivation and Context


## How to test this PR?
Update metadata with CopyObject - returned ObjectInfo is metadata before update

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
