### PR TITLE
Make number of replication workers configurable.

### DIFF
--- a/cmd/config/api/help.go
+++ b/cmd/config/api/help.go
@@ -45,5 +45,11 @@ var (
 			Optional:    true,
 			Type:        "duration",
 		},
+		config.HelpKV{
+			Key:         apiReplicationWorkers,
+			Description: `set the number of replication workers, defaults to 100`,
+			Optional:    true,
+			Type:        "number",
+		},
 	}
 )

--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -281,4 +281,10 @@ Example 1:
 		"",
 		"Refer to https://docs.min.io/docs/minio-kms-quickstart-guide.html for setting up SSE",
 	)
+
+	ErrInvalidReplicationWorkersValue = newErrFn(
+		"Invalid value for replication workers",
+		"",
+		"MINIO_API_REPLICATION_WORKERS: should be > 0",
+	)
 )

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -36,7 +36,8 @@ type apiConfig struct {
 	extendListLife   time.Duration
 	corsAllowOrigins []string
 	// total drives per erasure set across pools.
-	totalDriveCount int
+	totalDriveCount    int
+	replicationWorkers int
 }
 
 func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
@@ -78,6 +79,7 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 	t.requestsDeadline = cfg.RequestsDeadline
 	t.listQuorum = cfg.GetListQuorum()
 	t.extendListLife = cfg.ExtendListLife
+	t.replicationWorkers = cfg.ReplicationWorkers
 }
 
 func (t *apiConfig) getListQuorum() int {
@@ -151,4 +153,11 @@ func maxClients(f http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 	}
+}
+
+func (t *apiConfig) getReplicationWorkers() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.replicationWorkers
 }

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -492,7 +492,6 @@ func serverMain(ctx *cli.Context) {
 	// Enable background operations for erasure coding
 	if globalIsErasure {
 		initAutoHeal(GlobalContext, newObject)
-		initBackgroundReplication(GlobalContext, newObject)
 		initBackgroundTransition(GlobalContext, newObject)
 		initBackgroundExpiry(GlobalContext, newObject)
 	}
@@ -513,6 +512,9 @@ func serverMain(ctx *cli.Context) {
 		}
 	}
 
+	if globalIsErasure { // to be done after config init
+		initBackgroundReplication(GlobalContext, newObject)
+	}
 	if globalCacheConfig.Enabled {
 		// initialize the new disk cache objects.
 		var cacheAPI CacheObjectLayer


### PR DESCRIPTION
MINIO_API_REPLICATION_WORKERS env.var and
`mc admin config set api` allow number of replication
workers to be configurable. Defaults to half the number
of cpus available.

## Description


## Motivation and Context


## How to test this PR?
`mc admin config set alias  api`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
