### PR TITLE
lifcycle: Add more validation to the config

### DIFF
--- a/pkg/bucket/lifecycle/filter_test.go
+++ b/pkg/bucket/lifecycle/filter_test.go
@@ -35,7 +35,7 @@ func TestUnsupportedFilters(t *testing.T) {
 							<Prefix>key-prefix</Prefix>
 						</And>
 						</Filter>`,
-			expectedErr: nil,
+			expectedErr: errXMLNotWellFormed,
 		},
 		{ // Filter with Tag tags
 			inputXML: ` <Filter>
@@ -85,6 +85,7 @@ func TestUnsupportedFilters(t *testing.T) {
 		{ // Filter with And and multiple Tag tags
 			inputXML: ` <Filter>
 							<And>
+							<Prefix></Prefix>
 							<Tag>
 								<Key>key1</Key>
 								<Value>value1</Value>

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -79,16 +79,16 @@ func (lc Lifecycle) HasActiveRules(prefix string, recursive bool) bool {
 			continue
 		}
 
-		if len(prefix) > 0 && len(rule.Filter.Prefix) > 0 {
+		if len(prefix) > 0 && len(rule.GetPrefix()) > 0 {
 			if !recursive {
 				// If not recursive, incoming prefix must be in rule prefix
-				if !strings.HasPrefix(prefix, rule.Filter.Prefix) {
+				if !strings.HasPrefix(prefix, rule.GetPrefix()) {
 					continue
 				}
 			}
 			if recursive {
 				// If recursive, we can skip this rule if it doesn't match the tested prefix.
-				if !strings.HasPrefix(prefix, rule.Filter.Prefix) && !strings.HasPrefix(rule.Filter.Prefix, prefix) {
+				if !strings.HasPrefix(prefix, rule.GetPrefix()) && !strings.HasPrefix(rule.GetPrefix(), prefix) {
 					continue
 				}
 			}
@@ -167,7 +167,7 @@ func (lc Lifecycle) FilterActionableRules(obj ObjectOpts) []Rule {
 		if rule.Status == Disabled {
 			continue
 		}
-		if !strings.HasPrefix(obj.Name, rule.Prefix()) {
+		if !strings.HasPrefix(obj.Name, rule.GetPrefix()) {
 			continue
 		}
 		// Indicates whether MinIO will remove a delete marker with no

--- a/pkg/bucket/lifecycle/noncurrentversion.go
+++ b/pkg/bucket/lifecycle/noncurrentversion.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2019-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,7 @@ import (
 type NoncurrentVersionExpiration struct {
 	XMLName        xml.Name       `xml:"NoncurrentVersionExpiration"`
 	NoncurrentDays ExpirationDays `xml:"NoncurrentDays,omitempty"`
-}
-
-// NoncurrentVersionTransition - an action for lifecycle configuration rule.
-type NoncurrentVersionTransition struct {
-	NoncurrentDays ExpirationDays `xml:"NoncurrentDays"`
-	StorageClass   string         `xml:"StorageClass"`
+	set            bool
 }
 
 // MarshalXML if non-current days not set to non zero value
@@ -41,9 +36,41 @@ func (n NoncurrentVersionExpiration) MarshalXML(e *xml.Encoder, start xml.StartE
 	return e.EncodeElement(noncurrentVersionExpirationWrapper(n), start)
 }
 
+// UnmarshalXML decodes NoncurrentVersionExpiration
+func (n *NoncurrentVersionExpiration) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
+	type noncurrentVersionExpirationWrapper NoncurrentVersionExpiration
+	var val noncurrentVersionExpirationWrapper
+	err := d.DecodeElement(&val, &startElement)
+	if err != nil {
+		return err
+	}
+	*n = NoncurrentVersionExpiration(val)
+	n.set = true
+	return nil
+}
+
 // IsDaysNull returns true if days field is null
 func (n NoncurrentVersionExpiration) IsDaysNull() bool {
 	return n.NoncurrentDays == ExpirationDays(0)
+}
+
+// Validate returns an error with wrong value
+func (n NoncurrentVersionExpiration) Validate() error {
+	if !n.set {
+		return nil
+	}
+	val := int(n.NoncurrentDays)
+	if val <= 0 {
+		return errXMLNotWellFormed
+	}
+	return nil
+}
+
+// NoncurrentVersionTransition - an action for lifecycle configuration rule.
+type NoncurrentVersionTransition struct {
+	NoncurrentDays ExpirationDays `xml:"NoncurrentDays"`
+	StorageClass   string         `xml:"StorageClass"`
+	set            bool
 }
 
 // MarshalXML is extended to leave out
@@ -59,4 +86,28 @@ func (n NoncurrentVersionTransition) MarshalXML(e *xml.Encoder, start xml.StartE
 // IsDaysNull returns true if days field is null
 func (n NoncurrentVersionTransition) IsDaysNull() bool {
 	return n.NoncurrentDays == ExpirationDays(0)
+}
+
+// UnmarshalXML decodes NoncurrentVersionExpiration
+func (n *NoncurrentVersionTransition) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
+	type noncurrentVersionTransitionWrapper NoncurrentVersionTransition
+	var val noncurrentVersionTransitionWrapper
+	err := d.DecodeElement(&val, &startElement)
+	if err != nil {
+		return err
+	}
+	*n = NoncurrentVersionTransition(val)
+	n.set = true
+	return nil
+}
+
+// Validate returns an error with wrong value
+func (n NoncurrentVersionTransition) Validate() error {
+	if !n.set {
+		return nil
+	}
+	if int(n.NoncurrentDays) <= 0 || n.StorageClass == "" {
+		return errXMLNotWellFormed
+	}
+	return nil
 }

--- a/pkg/bucket/lifecycle/prefix.go
+++ b/pkg/bucket/lifecycle/prefix.go
@@ -1,0 +1,50 @@
+/*
+ * MinIO Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lifecycle
+
+import (
+	"encoding/xml"
+)
+
+// Prefix holds the prefix xml tag in <Rule> and <Filter>
+type Prefix struct {
+	string
+	set bool
+}
+
+// UnmarshalXML - decodes XML data.
+func (p *Prefix) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (err error) {
+	var s string
+	if err = d.DecodeElement(&s, &start); err != nil {
+		return err
+	}
+	*p = Prefix{string: s, set: true}
+	return nil
+}
+
+// MarshalXML - decodes XML data.
+func (p Prefix) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+	if !p.set {
+		return nil
+	}
+	return e.EncodeElement(p.string, startElement)
+}
+
+// String returns the prefix string
+func (p Prefix) String() string {
+	return p.string
+}

--- a/pkg/bucket/lifecycle/rule_test.go
+++ b/pkg/bucket/lifecycle/rule_test.go
@@ -38,6 +38,7 @@ func TestInvalidRules(t *testing.T) {
 		{ // Rule with empty ID
 			inputXML: `<Rule>
 							<ID></ID>
+							<Filter><Prefix></Prefix></Filter>
 							<Expiration>
 								<Days>365</Days>
 							</Expiration>


### PR DESCRIPTION
## Description
Also add "Prefix" of the deprecated lifecycle configuration document

## Motivation and Context
Fixes https://github.com/minio/minio/issues/10853

## How to test this PR?
Test with 'aws s3api put-bucket-lifecycle-configuration'

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
