### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/pkg/disk/directio_unsupported.go
+++ b/pkg/disk/directio_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!netbsd,!freebsd,!darwin,!openbsd
+// +build !linux,!netbsd,!freebsd,!darwin
 
 /*
  * Minio Cloud Storage, (C) 2019-2020 Minio, Inc.
@@ -61,9 +61,4 @@ func DisableDirectIO(f *os.File) error {
 // for systems that do not support DirectIO.
 func AlignedBlock(BlockSize int) []byte {
 	return make([]byte, BlockSize)
-}
-
-// Fdatasync is a no-op
-func Fdatasync(f *os.File) error {
-	return nil
 }

--- a/pkg/disk/fdatasync_unsupported.go
+++ b/pkg/disk/fdatasync_unsupported.go
@@ -1,0 +1,28 @@
+// +build !linux,!netbsd,!freebsd,!darwin,!openbsd
+
+/*
+ * Minio Cloud Storage, (C) 2020 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package disk
+
+import (
+	"os"
+)
+
+// Fdatasync is a no-op
+func Fdatasync(f *os.File) error {
+	return nil
+}


### PR DESCRIPTION
github.com/ncw/directio doesn't support OpenBSD, but OpenBSD has
syscall.Fsync. (It also has fdatasync:
https://man.openbsd.org/fdatasync
but apparently Golang can't call it).
