### PR TITLE
Reverting TOC due to gluegun incompatibility. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,6 @@ MinIO is a High Performance Object Storage released under Apache License v2.0. I
 This README provides quickstart instructions on running MinIO on baremetal hardware, including Docker-based installations. For Kubernetes environments, 
 use the [MinIO Kubernetes Operator](https://github.com/minio/operator/blob/master/README.md). 
 
-**Table of Contents**
-
-- [Docker Installation](#docker-installation)
-- [macOS Installation](#macos)
-- [GNU/Linux Installation](#gnulinux)
-- [Windows Installation](#microsoft-windows)
-- [FreeBSD Installation](#freebsd)
-- [Source Installation](#install-from-source)
-- [Deployment Recommendations](#deployment-recommendations)
-- [Test Connectivity to MinIO](#test-minio-connectivity)
-- [Upgrade MinIO](#upgrading-minio)
-- [Explore Further](#explore-further)
-- [Contribute to MinIO](#contribute-to-minio-project)
-- [License](#license)
-
 # Docker Installation
 
 Use the following commands to run a standalone MinIO server on a Docker container. 


### PR DESCRIPTION
Nothing we can do in the short term to fix Gluegun to render the TOC using github semantics.

Revert this commit once we migrate to new docs site, as the github readme can stand alone and no longer will have external dependencies

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation-only fix

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [X] Documentation updated
- [ ] Unit tests added/updated
