### PR TITLE
Removing a tier is not supported

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -192,7 +192,6 @@ func registerAdminRouter(router *mux.Router, enableConfigOps, enableIAMOps bool)
 			adminRouter.Methods(http.MethodPut).Path(adminVersion + "/tier").HandlerFunc(httpTraceHdrs(adminAPI.AddTierHandler))
 			adminRouter.Methods(http.MethodPost).Path(adminVersion + "/tier/{tier}").HandlerFunc(httpTraceHdrs(adminAPI.EditTierHandler))
 			adminRouter.Methods(http.MethodGet).Path(adminVersion + "/tier").HandlerFunc(httpTraceHdrs(adminAPI.ListTierHandler))
-			adminRouter.Methods(http.MethodDelete).Path(adminVersion + "/tier/{tier}").HandlerFunc(httpTraceHdrs(adminAPI.RemoveTierHandler))
 		}
 
 		if globalIsDistErasure {

--- a/cmd/tier-handlers.go
+++ b/cmd/tier-handlers.go
@@ -72,37 +72,6 @@ func (api adminAPIHandlers) AddTierHandler(w http.ResponseWriter, r *http.Reques
 	writeSuccessNoContent(w)
 }
 
-func (api adminAPIHandlers) RemoveTierHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := newContext(r, w, "RemoveTier")
-
-	defer logger.AuditLog(ctx, w, r, mustGetClaimsFromToken(r))
-
-	objectAPI, _ := validateAdminUsersReq(ctx, w, r, iampolicy.RemoveTierAction)
-	if objectAPI == nil || globalNotificationSys == nil || globalTierConfigMgr == nil {
-		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrServerNotInitialized), r.URL)
-		return
-	}
-
-	var vars = mux.Vars(r)
-	scName := vars["tier"]
-
-	// Refresh from the disk in case we had missed notifications about edits from peers.
-	if err := loadGlobalTransitionTierConfig(); err != nil {
-		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
-		return
-	}
-
-	globalTierConfigMgr.RemoveTier(scName)
-	err := saveGlobalTierConfig()
-	if err != nil {
-		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
-		return
-	}
-	globalNotificationSys.LoadTransitionTierConfig(ctx)
-
-	writeSuccessNoContent(w)
-}
-
 func (api adminAPIHandlers) ListTierHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "ListTier")
 

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -161,17 +161,6 @@ func (config *TierConfigMgr) Edit(tierName string, creds madmin.TierCreds) error
 	return nil
 }
 
-func (config *TierConfigMgr) RemoveTier(name string) {
-	config.Lock()
-	defer config.Unlock()
-
-	// FIXME: check if the SC is used by any of the ILM policies.
-
-	delete(config.S3, name)
-	delete(config.Azure, name)
-	delete(config.GCS, name)
-}
-
 func (config *TierConfigMgr) Bytes() ([]byte, error) {
 	config.Lock()
 	defer config.Unlock()

--- a/docs/bucket/lifecycle/README.md
+++ b/docs/bucket/lifecycle/README.md
@@ -109,7 +109,7 @@ To transition objects in a bucket to a destination bucket on a different cluster
 ```
  mc admin tier add azure source AZURETIER --endpoint https://blob.core.windows.net --access-key AZURE_ACCOUNT_NAME --secret-key AZURE_ACCOUNT_KEY  --bucket azurebucket --prefix testprefix1/
 ```
-> The admin user running this command needs the "admin:SetTier", "admin:ListTier","admin:RemoveTier" permissions if not running as root.
+> The admin user running this command needs the "admin:SetTier" and "admin:ListTier" permissions if not running as root.
 
 Using above tier, set up a lifecycle rule with transition:
 ```

--- a/pkg/iam/policy/admin-action.go
+++ b/pkg/iam/policy/admin-action.go
@@ -123,8 +123,6 @@ const (
 
 	// SetTierAction - allow adding/editing a remote tier
 	SetTierAction = "admin:SetTier"
-	// RemoveTierAction - allow removing a remote tier
-	RemoveTierAction = "admin:RemoveTier"
 	// ListTierAction - allow listing remote tiers
 	ListTierAction = "admin:ListTier"
 
@@ -171,7 +169,6 @@ var supportedAdminActions = map[AdminAction]struct{}{
 	SetBucketTargetAction:          {},
 	GetBucketTargetAction:          {},
 	SetTierAction:                  {},
-	RemoveTierAction:               {},
 	ListTierAction:                 {},
 	AllAdminActions:                {},
 }
@@ -221,6 +218,5 @@ var adminActionConditionKeyMap = map[Action]condition.KeySet{
 	SetBucketTargetAction:          condition.NewKeySet(condition.AllSupportedAdminKeys...),
 	GetBucketTargetAction:          condition.NewKeySet(condition.AllSupportedAdminKeys...),
 	SetTierAction:                  condition.NewKeySet(condition.AllSupportedAdminKeys...),
-	RemoveTierAction:               condition.NewKeySet(condition.AllSupportedAdminKeys...),
 	ListTierAction:                 condition.NewKeySet(condition.AllSupportedAdminKeys...),
 }

--- a/pkg/madmin/tier.go
+++ b/pkg/madmin/tier.go
@@ -118,23 +118,3 @@ func (adm *AdminClient) EditTier(ctx context.Context, tierName string, creds Tie
 
 	return nil
 }
-
-func (adm *AdminClient) RemoveTier(ctx context.Context, tierName string) error {
-	reqData := requestData{
-		relPath: strings.Join([]string{adminAPIPrefix, TierAPI, tierName}, "/"),
-	}
-
-	// Execute DELETE on /minio/admin/v3/tier/tierName" to remove a tier
-	// configured.
-	resp, err := adm.executeMethod(ctx, http.MethodDelete, reqData)
-	defer closeResponse(resp)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusNoContent {
-		return httpRespToErrorResponse(resp)
-	}
-
-	return nil
-}


### PR DESCRIPTION
## Description
Supporting safe removal of a remote tier involves,
- ensuring there are no transitioned objects to this tier
- ensuring that there are no active ILM rules referring this tier (through storage-class tag)

The cost of supporting remove tier outweighs its benefits. Later we could provide support for disabling a remote tier to avoid transitioning newer objects to a remote tier which is being 'retired'/'decommissioned'.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
