### PR TITLE
Update ldap.md: add a link to ldap.go

### DIFF
--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -235,7 +235,7 @@ $ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER='(&(objectclass=group)(member=%
 $ export MINIO_IDENTITY_LDAP_GROUP_NAME_ATTRIBUTE='cn'
 $ minio server ~/test
 ```
-You can make sure it works appropriately using our [Golang example program](ldap.go):
+You can make sure it works appropriately using our [example program](https://raw.githubusercontent.com/minio/minio/master/docs/sts/ldap.go):
 ```
 $ go run ldap.go -u foouser -p foopassword
 

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -235,7 +235,7 @@ $ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER='(&(objectclass=group)(member=%
 $ export MINIO_IDENTITY_LDAP_GROUP_NAME_ATTRIBUTE='cn'
 $ minio server ~/test
 ```
-
+You can make sure it works appropriately using our [Golang example program](ldap.go):
 ```
 $ go run ldap.go -u foouser -p foopassword
 


### PR DESCRIPTION
Hi there,

## Description
I updated this document because a lot of people, including myself, find it hard to follow this document.
I think a link to the `ldap.go`, which is just an example, will help readers to be able to test this feature more easily.

I think a link to the [minio-ldap-setting](https://github.com/donatello/minio-ldap-testing) can be helpful as well.
