### PR TITLE
health-info: Add tags to errors

### DIFF
--- a/cmd/healthinfo.go
+++ b/cmd/healthinfo.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"sync"
@@ -41,7 +42,7 @@ func getLocalCPUInfo(ctx context.Context, r *http.Request) madmin.ServerCPUInfo 
 	if err != nil {
 		return madmin.ServerCPUInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("info: %v", err),
 		}
 	}
 
@@ -49,7 +50,7 @@ func getLocalCPUInfo(ctx context.Context, r *http.Request) madmin.ServerCPUInfo 
 	if err != nil {
 		return madmin.ServerCPUInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("times: %v", err),
 		}
 	}
 
@@ -72,7 +73,7 @@ func getLocalDrives(ctx context.Context, parallel bool, endpointServerPools Endp
 					// Since this drive is not available, add relevant details and proceed
 					drivesPerfInfo = append(drivesPerfInfo, madmin.DrivePerfInfo{
 						Path:  endpoint.Path,
-						Error: err.Error(),
+						Error: fmt.Sprintf("stat: %v", err),
 					})
 					continue
 				}
@@ -84,7 +85,7 @@ func getLocalDrives(ctx context.Context, parallel bool, endpointServerPools Endp
 					}
 					latency, throughput, err := disk.GetHealthInfo(ctx, path, pathJoin(path, measurePath))
 					if err != nil {
-						driveInfo.Error = err.Error()
+						driveInfo.Error = fmt.Sprintf("health-info: %v", err)
 					} else {
 						driveInfo.Latency = latency
 						driveInfo.Throughput = throughput
@@ -129,7 +130,7 @@ func getLocalMemInfo(ctx context.Context, r *http.Request) madmin.ServerMemInfo 
 	if err != nil {
 		return madmin.ServerMemInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("swap: %v", err),
 		}
 	}
 
@@ -137,7 +138,7 @@ func getLocalMemInfo(ctx context.Context, r *http.Request) madmin.ServerMemInfo 
 	if err != nil {
 		return madmin.ServerMemInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("virtual-mem: %v", err),
 		}
 	}
 
@@ -154,23 +155,20 @@ func getLocalProcInfo(ctx context.Context, r *http.Request) madmin.ServerProcInf
 		addr = GetLocalPeer(globalEndpoints)
 	}
 
-	errProcInfo := func(err error) madmin.ServerProcInfo {
+	errProcInfo := func(tag string, err error) madmin.ServerProcInfo {
 		return madmin.ServerProcInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("%s: %v", tag, err),
 		}
 	}
 
 	selfPid := int32(syscall.Getpid())
 	self, err := process.NewProcess(selfPid)
 	if err != nil {
-		return errProcInfo(err)
+		return errProcInfo("new-process", err)
 	}
 
 	processes := []*process.Process{self}
-	if err != nil {
-		return errProcInfo(err)
-	}
 
 	sysProcs := []madmin.SysProcess{}
 	for _, proc := range processes {
@@ -179,13 +177,13 @@ func getLocalProcInfo(ctx context.Context, r *http.Request) madmin.ServerProcInf
 
 		bg, err := proc.BackgroundWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("background", err)
 		}
 		sysProc.Background = bg
 
 		cpuPercent, err := proc.CPUPercentWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("cpu-percent", err)
 		}
 		sysProc.CPUPercent = cpuPercent
 
@@ -196,109 +194,109 @@ func getLocalProcInfo(ctx context.Context, r *http.Request) madmin.ServerProcInf
 		}
 		cmdLine, err := proc.CmdlineWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("cmdline", err)
 		}
 		sysProc.CmdLine = cmdLine
 
 		conns, err := proc.ConnectionsWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("conns", err)
 		}
 		sysProc.Connections = conns
 
 		createTime, err := proc.CreateTimeWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("create-time", err)
 		}
 		sysProc.CreateTime = createTime
 
 		cwd, err := proc.CwdWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("cwd", err)
 		}
 		sysProc.Cwd = cwd
 
 		exe, err := proc.ExeWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("exe", err)
 		}
 		sysProc.Exe = exe
 
 		gids, err := proc.GidsWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("gids", err)
 		}
 		sysProc.Gids = gids
 
 		ioCounters, err := proc.IOCountersWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("iocounters", err)
 		}
 		sysProc.IOCounters = ioCounters
 
 		isRunning, err := proc.IsRunningWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("is-running", err)
 		}
 		sysProc.IsRunning = isRunning
 
 		memInfo, err := proc.MemoryInfoWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("mem-info", err)
 		}
 		sysProc.MemInfo = memInfo
 
 		memMaps, err := proc.MemoryMapsWithContext(ctx, true)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("mem-maps", err)
 		}
 		sysProc.MemMaps = memMaps
 
 		memPercent, err := proc.MemoryPercentWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("mem-percent", err)
 		}
 		sysProc.MemPercent = memPercent
 
 		name, err := proc.NameWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("name", err)
 		}
 		sysProc.Name = name
 
 		netIOCounters, err := proc.NetIOCountersWithContext(ctx, false)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("netio-counters", err)
 		}
 		sysProc.NetIOCounters = netIOCounters
 
 		nice, err := proc.NiceWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("nice", err)
 		}
 		sysProc.Nice = nice
 
 		numCtxSwitches, err := proc.NumCtxSwitchesWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("num-ctx-switches", err)
 		}
 		sysProc.NumCtxSwitches = numCtxSwitches
 
 		numFds, err := proc.NumFDsWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("num-fds", err)
 		}
 		sysProc.NumFds = numFds
 
 		numThreads, err := proc.NumThreadsWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("num-threads", err)
 		}
 		sysProc.NumThreads = numThreads
 
 		pageFaults, err := proc.PageFaultsWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("page-faults", err)
 		}
 		sysProc.PageFaults = pageFaults
 
@@ -314,37 +312,37 @@ func getLocalProcInfo(ctx context.Context, r *http.Request) madmin.ServerProcInf
 
 		rlimit, err := proc.RlimitWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("rlimit", err)
 		}
 		sysProc.Rlimit = rlimit
 
 		status, err := proc.StatusWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("status", err)
 		}
 		sysProc.Status = status
 
 		tgid, err := proc.Tgid()
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("tgid", err)
 		}
 		sysProc.Tgid = tgid
 
 		times, err := proc.TimesWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("times", err)
 		}
 		sysProc.Times = times
 
 		uids, err := proc.UidsWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("uids", err)
 		}
 		sysProc.Uids = uids
 
 		username, err := proc.UsernameWithContext(ctx)
 		if err != nil {
-			return errProcInfo(err)
+			return errProcInfo("username", err)
 		}
 		sysProc.Username = username
 

--- a/cmd/healthinfo_linux.go
+++ b/cmd/healthinfo_linux.go
@@ -21,6 +21,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"syscall"
@@ -41,7 +42,7 @@ func getLocalOsInfo(ctx context.Context, r *http.Request) madmin.ServerOsInfo {
 	if err != nil {
 		return madmin.ServerOsInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("info: %v", err),
 		}
 	}
 
@@ -49,7 +50,7 @@ func getLocalOsInfo(ctx context.Context, r *http.Request) madmin.ServerOsInfo {
 	if err != nil {
 		return madmin.ServerOsInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("sensors-temp: %v", err),
 		}
 	}
 
@@ -74,7 +75,7 @@ func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskH
 	if err != nil {
 		return madmin.ServerDiskHwInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("partitions: %v", err),
 		}
 	}
 
@@ -99,11 +100,11 @@ func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskH
 			smartInfo, err := smart.GetInfo(device)
 			if err != nil {
 				if syscall.EACCES == err {
-					smartInfo.Error = err.Error()
+					smartInfo.Error = fmt.Sprintf("smart: %v", err)
 				} else {
 					return madmin.ServerDiskHwInfo{
 						Addr:  addr,
-						Error: err.Error(),
+						Error: fmt.Sprintf("smart: %v", err),
 					}
 				}
 			}
@@ -122,7 +123,7 @@ func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskH
 	if err != nil {
 		return madmin.ServerDiskHwInfo{
 			Addr:  addr,
-			Error: err.Error(),
+			Error: fmt.Sprintf("iocounters: %v", err),
 		}
 	}
 	usages := []*diskhw.UsageStat{}
@@ -131,7 +132,7 @@ func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskH
 		if err != nil {
 			return madmin.ServerDiskHwInfo{
 				Addr:  addr,
-				Error: err.Error(),
+				Error: fmt.Sprintf("usage: %v", err),
 			}
 		}
 		usages = append(usages, usage)


### PR DESCRIPTION
## Description
We use multiple libraries in health info, but the returned error does
not indicate exactly what library call is failing, hence adding named
tags to returned errors whenever applicable.

## Motivation and Context
Add little more descriptive errors in health info result

## How to test this PR?
Trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
