### PR TITLE
xl: Dedup common prefixes entries

### DIFF
--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -1319,11 +1319,15 @@ func (z *erasureServerSets) listObjectVersions(ctx context.Context, bucket, pref
 		loi.NextMarker = entries.FilesVersions[len(entries.FilesVersions)-1].Name
 	}
 
+	var prevPrefix string
 	for _, entry := range entries.FilesVersions {
 		for _, version := range entry.Versions {
 			objInfo := version.ToObjectInfo(bucket, entry.Name)
 			if HasSuffix(objInfo.Name, SlashSeparator) && !recursive {
-				loi.Prefixes = append(loi.Prefixes, objInfo.Name)
+				if objInfo.Name != prevPrefix {
+					loi.Prefixes = append(loi.Prefixes, objInfo.Name)
+					prevPrefix = objInfo.Name
+				}
 				continue
 			}
 			loi.Objects = append(loi.Objects, objInfo)


### PR DESCRIPTION
## Description
Since the support of empty directory __XLDIR__, the walk code in listing
can return two duplicated entries, one as a real diretory, the second as
the empty object with a trailing slash.

The fix deduplicates entries in CommonPrefixes when that happens.


## Motivation and Context
Fix duplication in mc ls --versions when an empty directory has multiple versions

## How to test this PR?
mc mb myminio/testbucket/
mc version enable myminio/testbucket/
mc mb myminio/testbucket/dir/
mc mb myminio/testbucket/dir/
mc ls --versions myminio/testbucket/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
