### PR TITLE
avoid listing an empty dir without __XLDIR__

### DIFF
--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -209,7 +209,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 				// NOT an object, append to stack (with slash)
 				// If dirObject, but no metadata (which is unexpected) we skip it.
 				if !isDirObj {
-					dirStack = append(dirStack, meta.name+slashSeparator)
+					if !isDirEmpty(pathJoin(volumeDir, meta.name+slashSeparator)) {
+						dirStack = append(dirStack, meta.name+slashSeparator)
+					}
 				}
 			case isSysErrNotDir(err):
 				// skip


### PR DESCRIPTION
## Description
avoid listing an empty dir without __XLDIR__

## Motivation and Context
```
minio server /tmp/disk{1...4}
mc mb myminio/testbucket/
mkdir -p /tmp/disk{1..4}/testbucket/test-prefix/
```

This would end up being listed in the current
master, this PR fixes this situation.

If a directory is a leaf dir we should avoid it
being listed, since it cannot be deleted anymore
with DeleteObject, DeleteObjects() API calls
because we natively support directories now.

Avoid listing it and let healing purge this folder
eventually in the background.

## How to test this PR?
As written in the motivation and context

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
