### PR TITLE
fix: use getObjectNInfo to avoid bytes.Buffer usage

### DIFF
--- a/cmd/data-crawler.go
+++ b/cmd/data-crawler.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"math"
 	"math/rand"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -84,16 +85,19 @@ func runDataCrawler(ctx context.Context, objAPI ObjectLayer) {
 
 	// Load current bloom cycle
 	nextBloomCycle := intDataUpdateTracker.current() + 1
-	var buf bytes.Buffer
-	err := objAPI.GetObject(ctx, dataUsageBucket, dataUsageBloomName, 0, -1, &buf, "", ObjectOptions{})
+
+	br, err := objAPI.GetObjectNInfo(ctx, dataUsageBucket, dataUsageBloomName, nil, http.Header{}, readLock, ObjectOptions{})
 	if err != nil {
 		if !isErrObjectNotFound(err) && !isErrBucketNotFound(err) {
 			logger.LogIf(ctx, err)
 		}
 	} else {
-		if buf.Len() == 8 {
-			nextBloomCycle = binary.LittleEndian.Uint64(buf.Bytes())
+		if br.ObjInfo.Size == 8 {
+			if err = binary.Read(br, binary.LittleEndian, &nextBloomCycle); err != nil {
+				logger.LogIf(ctx, err)
+			}
 		}
+		br.Close()
 	}
 
 	crawlTimer := time.NewTimer(dataCrawlStartDelay)

--- a/cmd/metacache-bucket.go
+++ b/cmd/metacache-bucket.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
+	"net/http"
 	"path"
 	"runtime/debug"
 	"strings"
@@ -95,25 +95,19 @@ func loadBucketMetaCache(ctx context.Context, bucket string) (*bucketMetacache, 
 			logger.LogIf(ctx, fmt.Errorf("loadBucketMetaCache: object layer not ready. bucket: %q", bucket))
 		}
 	}
+
 	var meta bucketMetacache
 	var decErr error
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	r, w := io.Pipe()
-	go func() {
-		defer wg.Done()
+	// Use global context for this.
+	r, err := objAPI.GetObjectNInfo(GlobalContext, minioMetaBucket, pathJoin("buckets", bucket, ".metacache", "index.s2"), nil, http.Header{}, readLock, ObjectOptions{})
+	if err == nil {
 		dec := s2DecPool.Get().(*s2.Reader)
 		dec.Reset(r)
 		decErr = meta.DecodeMsg(msgp.NewReader(dec))
 		dec.Reset(nil)
+		r.Close()
 		s2DecPool.Put(dec)
-		r.CloseWithError(decErr)
-	}()
-	// Use global context for this.
-	err := objAPI.GetObject(GlobalContext, minioMetaBucket, pathJoin("buckets", bucket, ".metacache", "index.s2"), 0, -1, w, "", ObjectOptions{})
-	logger.LogIf(ctx, w.CloseWithError(err))
-	wg.Wait()
+	}
 	if err != nil {
 		switch err.(type) {
 		case ObjectNotFound:


### PR DESCRIPTION

## Description
fix: use getObjectNInfo to avoid bytes.Buffer usage

## Motivation and Context
few places were still using legacy call GetObject()
which was mainly designed for client response writer,
use GetObjectNInfo() for internal calls instead.

## How to test this PR?
Nothing should change in terms of functionality
reduces the occasional memory usage

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
