### PR TITLE
lifecycle: Remove a single delete marker with noncurrent expiry rule

### DIFF
--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -245,7 +245,19 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 					return DeleteVersionAction
 				}
 			}
+
+			if obj.VersionID != "" && obj.DeleteMarker && obj.NumVersions == 1 {
+				// From https: //docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-configuration-examples.html :
+				//   The NoncurrentVersionExpiration action in the same Lifecycle configuration removes noncurrent objects X days
+				//   after they become noncurrent. Thus, in this example, all object versions are permanently removed X days after
+				//   object creation. You will have expired object delete markers, but Amazon S3 detects and removes the expired
+				//   object delete markers for you.
+				if time.Now().After(ExpectedExpiryTime(obj.ModTime, int(rule.NoncurrentVersionExpiration.NoncurrentDays))) {
+					return DeleteVersionAction
+				}
+			}
 		}
+
 		if !rule.NoncurrentVersionTransition.IsDaysNull() {
 			if obj.VersionID != "" && !obj.IsLatest && !obj.SuccessorModTime.IsZero() && obj.TransitionStatus != TransitionComplete {
 				// Non current versions should be deleted if their age exceeds non current days configuration


### PR DESCRIPTION
## Description
NoncurrentVersionExpiry can remmove single delete markers according to
S3 spec:

```
The NoncurrentVersionExpiration action in the same Lifecycle
configuration removes noncurrent objects 30 days after they become
noncurrent. Thus, in this example, all object versions are permanently
removed 90 days after object creation. You will have expired object
delete markers, but Amazon S3 detects and removes the expired object
delete markers for you.
```

## Motivation and Context
Add minor missing feature to ILM

## How to test this PR?
1. Create a versioned bucket
2. Upload an object
3. Remove the object
4. Set up a lifecycle with non current expiry versions days set to 1
5. Change date/time to 3 days ahead
6. Check if the version and the delete marker is removed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
