### PR TITLE
fix aggressive expiration detection

### DIFF
--- a/cmd/http/dial_dnscache.go
+++ b/cmd/http/dial_dnscache.go
@@ -44,7 +44,9 @@ func DialContextWithDNSCache(cache *DNSCache, baseDialCtx DialContext) DialConte
 		baseDialCtx = (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
+			// If zero, Go defaults to '300ms', we will default to 100ms instead.
+			// https://tools.ietf.org/html/rfc6555
+			FallbackDelay: 100 * time.Millisecond,
 		}).DialContext
 	}
 	return func(ctx context.Context, network, host string) (net.Conn, error) {

--- a/cmd/http/dial_linux.go
+++ b/cmd/http/dial_linux.go
@@ -68,6 +68,9 @@ func NewInternodeDialContext(dialTimeout time.Duration) DialContext {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		dialer := &net.Dialer{
 			Timeout: dialTimeout,
+			// If zero, Go defaults to '300ms', we will default to 100ms instead.
+			// https://tools.ietf.org/html/rfc6555
+			FallbackDelay: 100 * time.Millisecond,
 			Control: func(network, address string, c syscall.RawConn) error {
 				return setInternalTCPParameters(c)
 			},
@@ -81,6 +84,9 @@ func NewCustomDialContext(dialTimeout time.Duration) DialContext {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		dialer := &net.Dialer{
 			Timeout: dialTimeout,
+			// If zero, Go defaults to '300ms', we will default to 100ms instead.
+			// https://tools.ietf.org/html/rfc6555
+			FallbackDelay: 100 * time.Millisecond,
 			Control: func(network, address string, c syscall.RawConn) error {
 				return c.Control(func(fdPtr uintptr) {
 					// got socket file descriptor to set parameters.

--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -258,7 +258,7 @@ func (l *localLocker) Expired(ctx context.Context, args dsync.LockArgs) (expired
 				ep := globalRemoteEndpoints[args.Owner]
 				if !ep.IsLocal {
 					// check if the owner is online
-					return isServerResolvable(ep, 250*time.Millisecond) != nil, nil
+					return isServerResolvable(ep, 1*time.Second) != nil, nil
 				}
 				return false, nil
 			}

--- a/cmd/lock-rest-server.go
+++ b/cmd/lock-rest-server.go
@@ -302,7 +302,7 @@ func lockMaintenance(ctx context.Context, interval time.Duration) error {
 		for _, c := range lockers {
 			go func(lrip lockRequesterInfo, c dsync.NetLocker) {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(GlobalContext, 3*time.Second)
+				ctx, cancel := context.WithTimeout(GlobalContext, 5*time.Second)
 
 				// Call back to all participating servers, verify
 				// if each of those servers think lock is still

--- a/pkg/madmin/transport.go
+++ b/pkg/madmin/transport.go
@@ -30,8 +30,9 @@ var DefaultTransport = func(secure bool) http.RoundTripper {
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   5 * time.Second,
-			KeepAlive: 15 * time.Second,
+			Timeout:       5 * time.Second,
+			KeepAlive:     15 * time.Second,
+			FallbackDelay: 100 * time.Millisecond,
 		}).DialContext,
 		MaxIdleConns:          1024,
 		MaxIdleConnsPerHost:   1024,


### PR DESCRIPTION


## Description
fix aggressive expiration detection

## Motivation and Context
for some flaky networks, this may be too fast of a value
choose a defensive value, and let this be addressed
properly in a new refactor of dsync with renewal logic.

## How to test this PR?
Nothing special, you need a flaky network

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
