### PR TITLE
support directory objects in listing in certain scenarios

### DIFF
--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -66,7 +66,7 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 	}
 
 	// Stat a volume entry.
-	_, err = os.Stat(volumeDir)
+	_, err = os.Lstat(volumeDir)
 	if err != nil {
 		if osIsNotExist(err) {
 			return errVolumeNotFound
@@ -76,13 +76,6 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 		return err
 	}
 
-	// Fast exit track to check if we are listing an object with
-	// a trailing slash, this will avoid to list the object content.
-	if HasSuffix(opts.BaseDir, SlashSeparator) {
-		if st, err := os.Stat(pathJoin(volumeDir, opts.BaseDir, xlStorageFormatFile)); err == nil && st.Mode().IsRegular() {
-			return errFileNotFound
-		}
-	}
 	// Use a small block size to start sending quickly
 	w := newMetacacheWriter(wr, 16<<10)
 	defer w.Close()
@@ -91,6 +84,27 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 		return err
 	}
 	defer close(out)
+
+	// Fast exit track to check if we are listing an object with
+	// a trailing slash, this will avoid to list the object content.
+	if HasSuffix(opts.BaseDir, SlashSeparator) {
+		metadata, err := ioutil.ReadFile(pathJoin(volumeDir,
+			opts.BaseDir[:len(opts.BaseDir)-1]+globalDirSuffix,
+			xlStorageFormatFile))
+		if err == nil {
+			// if baseDir is already a directory object, consider it
+			// as part of the list call, this is a AWS S3 specific
+			// behavior.
+			out <- metaCacheEntry{
+				name:     opts.BaseDir,
+				metadata: metadata,
+			}
+		} else {
+			if st, err := os.Lstat(pathJoin(volumeDir, opts.BaseDir, xlStorageFormatFile)); err == nil && st.Mode().IsRegular() {
+				return errFileNotFound
+			}
+		}
+	}
 
 	prefix := opts.FilterPrefix
 	var scanDir func(path string) error


### PR DESCRIPTION



## Description
support directory objects in listing in certain scenarios

## Motivation and Context
When a directory object is presented as a `prefix`
param our implementation tend to only list objects
present common to the `prefix` than the `prefix` itself,
to mimic AWS S3 like flat key behavior this PR ensures
that if `prefix` is directory object, it should be
automatically considered to be part of the eventual
listing result.

fixes #11370

## How to test this PR?
various nested scenarios can be tested

```
~ mc mb myminio/testbucket/new/
~ mc mb myminio/testbucket/new/new/
~ mc mb myminio/testbucket/new/new/new/
```

Now listing with AWS CLI would need to return the following result
```bash
~ aws s3api list-objects --endpoint-url http://localhost:9000 --profile minio --bucket testbucket-v --prefix new/
{
    "Contents": [
        {
            "Key": "new/",
            "LastModified": "2021-02-05T06:27:42.660Z",
            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
            "Size": 0,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
            }
        },
        {
            "Key": "new/new/",
            "LastModified": "2021-02-05T06:30:44.104Z",
            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
            "Size": 0,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
            }
        },
        {
            "Key": "new/new/new/",
            "LastModified": "2021-02-05T06:30:24.526Z",
            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
            "Size": 0,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "",
                "ID": "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
            }
        }
    ]
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
