### PR TITLE
fix: align atomic variables for 32bit arch

### DIFF
--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -60,6 +60,8 @@ func (n *NetworkError) Unwrap() error {
 
 // Client - http based RPC client.
 type Client struct {
+	connected int32 // ref: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+
 	// HealthCheckFn is the function set to test for health.
 	// If not set the client will not keep track of health.
 	// Calling this returns true or false if the target
@@ -84,7 +86,6 @@ type Client struct {
 	httpClient   *http.Client
 	url          *url.URL
 	newAuthToken func(audience string) string
-	connected    int32
 }
 
 // URL query separator constants

--- a/pkg/sync/errgroup/errgroup.go
+++ b/pkg/sync/errgroup/errgroup.go
@@ -27,10 +27,10 @@ import (
 //
 // A zero Group can be used if errors should not be tracked.
 type Group struct {
+	firstErr  int64 // ref: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	wg        sync.WaitGroup
 	bucket    chan struct{}
 	errs      []error
-	firstErr  int64
 	cancel    context.CancelFunc
 	ctxCancel <-chan struct{} // nil if no context.
 	ctxErr    func() error


### PR DESCRIPTION

## Description
fix: align atomic variables for 32bit arch

## Motivation and Context
fixes #11474 

## How to test this PR?
Go requires atomic variables to be aligned for 32-bit architecture 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
