### PR TITLE
fix: empty buckets/objects nodes in new setup

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1582,9 +1582,13 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 		// Load data usage
 		dataUsageInfo, err := loadDataUsageFromBackend(ctx, objectAPI)
 		if err == nil {
-			buckets = madmin.Buckets{Count: &dataUsageInfo.BucketsCount}
-			objects = madmin.Objects{Count: &dataUsageInfo.ObjectsTotalCount}
-			usage = madmin.Usage{Size: &dataUsageInfo.ObjectsTotalSize}
+			buckets = madmin.Buckets{Count: dataUsageInfo.BucketsCount}
+			objects = madmin.Objects{Count: dataUsageInfo.ObjectsTotalCount}
+			usage = madmin.Usage{Size: dataUsageInfo.ObjectsTotalSize}
+		} else {
+			buckets = madmin.Buckets{Error: err.Error()}
+			objects = madmin.Objects{Error: err.Error()}
+			usage = madmin.Usage{Error: err.Error()}
 		}
 
 		// Fetching the backend information

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1582,9 +1582,9 @@ func (a adminAPIHandlers) ServerInfoHandler(w http.ResponseWriter, r *http.Reque
 		// Load data usage
 		dataUsageInfo, err := loadDataUsageFromBackend(ctx, objectAPI)
 		if err == nil {
-			buckets = madmin.Buckets{Count: dataUsageInfo.BucketsCount}
-			objects = madmin.Objects{Count: dataUsageInfo.ObjectsTotalCount}
-			usage = madmin.Usage{Size: dataUsageInfo.ObjectsTotalSize}
+			buckets = madmin.Buckets{Count: &dataUsageInfo.BucketsCount}
+			objects = madmin.Objects{Count: &dataUsageInfo.ObjectsTotalCount}
+			usage = madmin.Usage{Size: &dataUsageInfo.ObjectsTotalSize}
 		}
 
 		// Fetching the backend information

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -195,17 +195,20 @@ type Services struct {
 
 // Buckets contains the number of buckets
 type Buckets struct {
-	Count *uint64 `json:"count,omitempty"`
+	Count uint64 `json:"count"`
+	Error string `json:"error,omitempty"`
 }
 
 // Objects contains the number of objects
 type Objects struct {
-	Count *uint64 `json:"count,omitempty"`
+	Count uint64 `json:"count"`
+	Error string `json:"error,omitempty"`
 }
 
 // Usage contains the total size used
 type Usage struct {
-	Size *uint64 `json:"size,omitempty"`
+	Size  uint64 `json:"size"`
+	Error string `json:"error,omitempty"`
 }
 
 // KMS contains KMS status information

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -195,17 +195,17 @@ type Services struct {
 
 // Buckets contains the number of buckets
 type Buckets struct {
-	Count uint64 `json:"count,omitempty"`
+	Count *uint64 `json:"count,omitempty"`
 }
 
 // Objects contains the number of objects
 type Objects struct {
-	Count uint64 `json:"count,omitempty"`
+	Count *uint64 `json:"count,omitempty"`
 }
 
-// Usage contains the tottal size used
+// Usage contains the total size used
 type Usage struct {
-	Size uint64 `json:"size,omitempty"`
+	Size *uint64 `json:"size,omitempty"`
 }
 
 // KMS contains KMS status information


### PR DESCRIPTION
## Description

When the number of buckets/objects is zero, it gets omitted from the
health report json as `0` is considered an empty value by the json
marshaller.

Remove `omitempty` from the bucket/object count fields and add an
`error` field. When the count cannot be fetched because of any error,
the `error` field will be populated with the actual error message. (Note
that the count will also get populated with the default value of `0`).
  
The client should read the `count` value only if there is no error.

The new behavior will be as follows:

- non-zero (say 3) buckets

```json
"buckets": {
  "count": 3
},
```

- no buckets

```json
"buckets": {
  "count": 0
},
```

- bucket count cannot be fetched because of an error

```json
"buckets": {
  "count": 0,
  "error": "error message"
},
```

## Motivation and Context

Bugfix

## How to test this PR?

- Create a new minio cluster
- Build `mc` with dependency on this PR
- Generate the health report for this cluster (`./mc admin subnet health {alias]`)
- Check that the generated report contains values for `count` under `buckets` and `objects` as `0`
- Generate the report using a previous version of mc
- Verify that the report generation command doesn't fail, and that the `buckets` and `objects` nodes are empty (`{}`)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
