### PR TITLE
Return group DN instead of group name in LDAP STS

### DIFF
--- a/cmd/config/identity/ldap/help.go
+++ b/cmd/config/identity/ldap/help.go
@@ -69,12 +69,6 @@ var (
 			Type:        "string",
 		},
 		config.HelpKV{
-			Key:         GroupNameAttribute,
-			Description: `search attribute for group name e.g. "cn"`,
-			Optional:    true,
-			Type:        "string",
-		},
-		config.HelpKV{
 			Key:         GroupSearchBaseDN,
 			Description: `";" separated list of group search base DNs e.g. "dc=myldapserver,dc=com"`,
 			Optional:    true,

--- a/cmd/config/identity/ldap/legacy.go
+++ b/cmd/config/identity/ldap/legacy.go
@@ -42,10 +42,6 @@ func SetIdentityLDAP(s config.Config, ldapArgs Config) {
 			Value: ldapArgs.GroupSearchFilter,
 		},
 		config.KV{
-			Key:   GroupNameAttribute,
-			Value: ldapArgs.GroupNameAttribute,
-		},
-		config.KV{
 			Key:   GroupSearchBaseDN,
 			Value: ldapArgs.GroupSearchBaseDistName,
 		},


### PR DESCRIPTION
## Description

- Additionally, check if the user or their groups has a policy attached during
the STS call.

- Remove the group name attribute configuration value.

## Motivation and Context

Group DNs are used to disambiguate between groups with same name that may be present in both multiple hierarchies.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
