### PR TITLE
fix: metacache should only rename entries during cleanup

### DIFF
--- a/cmd/bucket-listobjects-handlers.go
+++ b/cmd/bucket-listobjects-handlers.go
@@ -26,7 +26,6 @@ import (
 	"github.com/minio/minio/cmd/logger"
 
 	"github.com/minio/minio/pkg/bucket/policy"
-	"github.com/minio/minio/pkg/handlers"
 	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
@@ -295,10 +294,6 @@ func proxyRequestByNodeIndex(ctx context.Context, w http.ResponseWriter, r *http
 	return proxyRequest(ctx, w, r, ep)
 }
 
-func proxyRequestByStringHash(ctx context.Context, w http.ResponseWriter, r *http.Request, str string) (success bool) {
-	return proxyRequestByNodeIndex(ctx, w, r, crcHashMod(str, len(globalProxyEndpoints)))
-}
-
 // ListObjectsV1Handler - GET Bucket (List Objects) Version 1.
 // --------------------------
 // This implementation of the GET operation returns some or all (up to 10000)
@@ -334,15 +329,6 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 	// Validate all the query params before beginning to serve the request.
 	if s3Error := validateListObjectsArgs(marker, delimiter, encodingType, maxKeys); s3Error != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL, guessIsBrowserReq(r))
-		return
-	}
-
-	// Forward the request using Source IP or bucket
-	forwardStr := handlers.GetSourceIPFromHeaders(r)
-	if forwardStr == "" {
-		forwardStr = bucket
-	}
-	if proxyRequestByStringHash(ctx, w, r, forwardStr) {
 		return
 	}
 

--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -330,16 +330,23 @@ func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, aft
 			}
 
 			fiv, err := entry.fileInfoVersions(bucket)
+			if err != nil {
+				continue
+			}
+
+			fiVersions := fiv.Versions
 			if afterV != "" {
-				// Forward first entry to specified version
-				fiv.forwardPastVersion(afterV)
+				vidMarkerIdx := fiv.findVersionIndex(afterV)
+				if vidMarkerIdx >= 0 {
+					fiVersions = fiVersions[vidMarkerIdx+1:]
+				}
 				afterV = ""
 			}
-			if err == nil {
-				for _, version := range fiv.Versions {
-					versions = append(versions, version.ToObjectInfo(bucket, entry.name))
-				}
+
+			for _, version := range fiVersions {
+				versions = append(versions, version.ToObjectInfo(bucket, entry.name))
 			}
+
 			continue
 		}
 

--- a/cmd/metacache-manager.go
+++ b/cmd/metacache-manager.go
@@ -92,7 +92,6 @@ func (m *metacacheManager) initManager() {
 			}
 			m.mu.Unlock()
 		}
-		m.getTransient().deleteAll()
 	}()
 }
 
@@ -124,11 +123,11 @@ func (m *metacacheManager) updateCacheEntry(update metacache) (metacache, error)
 	}
 
 	b, ok := m.buckets[update.bucket]
+	m.mu.RUnlock()
 	if ok {
-		m.mu.RUnlock()
 		return b.updateCacheEntry(update)
 	}
-	m.mu.RUnlock()
+
 	// We should have either a trashed bucket or this
 	return metacache{}, errVolumeNotFound
 }

--- a/cmd/metacache.go
+++ b/cmd/metacache.go
@@ -123,7 +123,7 @@ func (m *metacache) matches(o *listPathOptions, extend time.Duration) bool {
 		}
 		if time.Since(m.lastUpdate) > metacacheMaxRunningAge+extend {
 			// Cache ended within bloom cycle, but we can extend the life.
-			o.debugf("cache %s ended (%v) and beyond extended life (%v)", m.id, m.lastUpdate, extend+metacacheMaxRunningAge)
+			o.debugf("cache %s ended (%v) and beyond extended life (%v)", m.id, m.lastUpdate, metacacheMaxRunningAge+extend)
 			return false
 		}
 	}
@@ -151,8 +151,8 @@ func (m *metacache) worthKeeping(currentCycle uint64) bool {
 		// Cycle is too old to be valuable.
 		return false
 	case cache.status == scanStateError || cache.status == scanStateNone:
-		// Remove failed listings after 10 minutes.
-		return time.Since(cache.lastUpdate) < 10*time.Minute
+		// Remove failed listings after 5 minutes.
+		return time.Since(cache.lastUpdate) < 5*time.Minute
 	}
 	return true
 }
@@ -170,8 +170,9 @@ func (m *metacache) canBeReplacedBy(other *metacache) bool {
 	if m.status == scanStateStarted && time.Since(m.lastUpdate) < metacacheMaxRunningAge {
 		return false
 	}
+
 	// Keep it around a bit longer.
-	if time.Since(m.lastHandout) < time.Hour || time.Since(m.lastUpdate) < metacacheMaxRunningAge {
+	if time.Since(m.lastHandout) < 30*time.Minute || time.Since(m.lastUpdate) < metacacheMaxRunningAge {
 		return false
 	}
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -125,16 +125,8 @@ func formatErasureCleanupTmpLocalEndpoints(endpoints Endpoints) error {
 					osErrToFileErr(err))
 			}
 
-			// Move .minio.sys/buckets/.minio.sys/metacache transient list cache
-			// folder to speed up startup routines.
-			tmpMetacacheOld := pathJoin(epPath, minioMetaTmpBucket+"-old", mustGetUUID())
-			if err := renameAll(pathJoin(epPath, minioMetaBucket, metacachePrefixForID(minioMetaBucket, "")),
-				tmpMetacacheOld); err != nil && err != errFileNotFound {
-				return fmt.Errorf("unable to rename (%s -> %s) %w",
-					pathJoin(epPath, minioMetaBucket+metacachePrefixForID(minioMetaBucket, "")),
-					tmpMetacacheOld,
-					osErrToFileErr(err))
-			}
+			// Renames and schedules for puring all bucket metacache.
+			renameAllBucketMetacache(epPath)
 
 			// Removal of tmp-old folder is backgrounded completely.
 			go removeAll(pathJoin(epPath, minioMetaTmpBucket+"-old"))

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -85,18 +85,18 @@ type FileInfoVersions struct {
 	Versions []FileInfo
 }
 
-// forwardPastVersion will truncate the result to only contain versions after 'v'.
-// If v is empty or the version isn't found no changes will be made.
-func (f *FileInfoVersions) forwardPastVersion(v string) {
-	if v == "" {
-		return
+// findVersionIndex will return the version index where the version
+// was found. Returns -1 if not found.
+func (f *FileInfoVersions) findVersionIndex(v string) int {
+	if f == nil || v == "" {
+		return -1
 	}
 	for i, ver := range f.Versions {
 		if ver.VersionID == v {
-			f.Versions = f.Versions[i+1:]
-			return
+			return i
 		}
 	}
+	return -1
 }
 
 // FileInfo - represents file stat information.


### PR DESCRIPTION

## Description
fix: metacache should only rename entries during cleanup

## Motivation and Context
To avoid large delays in metacache cleanup, use rename
instead of recursive delete calls, renames are cheaper
move the content to minioMetaTmpBucket and then cleanup
this folder once in 24hrs instead.

If the new cache can replace an existing one, we should
let it replace since that is currently being saved anyways,
this avoids pile-up of 1000's of metacache entires for
same listing calls that are not necessary to be stored
on disk.

## How to test this PR?
Create a bunch of content and invoke many parallel lists calls every 10secs
and observe the growth and shrinking of the `.metacache` entries

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
