### PR TITLE
fix: osinfos incomplete in case of warnings

### DIFF
--- a/cmd/healthinfo_linux.go
+++ b/cmd/healthinfo_linux.go
@@ -38,7 +38,10 @@ func getLocalOsInfo(ctx context.Context, r *http.Request) madmin.ServerOsInfo {
 		addr = GetLocalPeer(globalEndpoints)
 	}
 
-	info, err := host.InfoWithContext(ctx)
+	srvrOsInfo := madmin.ServerOsInfo{Addr: addr}
+	var err error
+
+	srvrOsInfo.Info, err = host.InfoWithContext(ctx)
 	if err != nil {
 		return madmin.ServerOsInfo{
 			Addr:  addr,
@@ -46,23 +49,18 @@ func getLocalOsInfo(ctx context.Context, r *http.Request) madmin.ServerOsInfo {
 		}
 	}
 
-	sensors, err := host.SensorsTemperaturesWithContext(ctx)
+	srvrOsInfo.Sensors, err = host.SensorsTemperaturesWithContext(ctx)
 	if err != nil {
-		return madmin.ServerOsInfo{
-			Addr:  addr,
-			Error: fmt.Sprintf("sensors-temp: %v", err),
+		// Set error only when it's not of WARNINGS type
+		if _, isWarning := err.(*host.Warnings); !isWarning {
+			srvrOsInfo.Error = fmt.Sprintf("sensors-temp: %v", err)
 		}
 	}
 
 	// ignore user err, as it cannot be obtained reliably inside containers
-	users, _ := host.UsersWithContext(ctx)
+	srvrOsInfo.Users, _ = host.UsersWithContext(ctx)
 
-	return madmin.ServerOsInfo{
-		Addr:    addr,
-		Info:    info,
-		Sensors: sensors,
-		Users:   users,
-	}
+	return srvrOsInfo
 }
 
 func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskHwInfo {


### PR DESCRIPTION
## Description

The function used for getting host information
(host.SensorsTemperaturesWithContext) returns warnings in some cases.

Returning with error in such cases means we miss out on the other useful
information already fetched (os info).

If the OS info has been succesfully fetched, it should always be
included in the output irrespective of whether the other data (CPU
sensors, users) could be fetched or not.

## Motivation and Context

Bugfix

## How to test this PR?

Health report generation (`mc admin subnet health alias`) should work fine,
and should include the `osinfos -> info` in the output even when there are
warnings or errors in fetching the CPU sensors info.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
