### PR TITLE
Change the default object content-type to binary/octet-stream

### DIFF
--- a/cmd/config/compress/compress.go
+++ b/cmd/config/compress/compress.go
@@ -45,7 +45,7 @@ const (
 
 	// Include-list for compression.
 	DefaultExtensions = ".txt,.log,.csv,.json,.tar,.xml,.bin"
-	DefaultMimeTypes  = "text/*,application/json,application/xml"
+	DefaultMimeTypes  = "text/*,application/json,application/xml,binary/octet-stream"
 )
 
 // DefaultKVS - default KV config for compression settings

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -128,7 +128,7 @@ func extractMetadata(ctx context.Context, r *http.Request) (metadata map[string]
 
 	// Set content-type to default value if it is not set.
 	if _, ok := metadata[strings.ToLower(xhttp.ContentType)]; !ok {
-		metadata[strings.ToLower(xhttp.ContentType)] = "application/octet-stream"
+		metadata[strings.ToLower(xhttp.ContentType)] = "binary/octet-stream"
 	}
 
 	// https://github.com/google/security-research/security/advisories/GHSA-76wf-9vgp-pj7w


### PR DESCRIPTION
## Description
According to S3 spec, the default content-type of an object when not specified
is binary/octet-stream and application/octet-stream.

## Motivation and Context
Make versioning tests suceed

## How to test this PR?
$ aws --endpoint-url http://localhost s3api put-object --bucket testbucket --key testobject
$ aws --endpoint-url http://localhost s3api head-object --bucket testbucket --key testobject

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
