### PR TITLE
fix: drive hw info incomplete when smartinfo fails

### DIFF
--- a/cmd/healthinfo_linux.go
+++ b/cmd/healthinfo_linux.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"syscall"
 
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/smart"
@@ -99,14 +98,7 @@ func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskH
 			paths = append(paths, path)
 			smartInfo, err := smart.GetInfo(device)
 			if err != nil {
-				if syscall.EACCES == err {
-					smartInfo.Error = fmt.Sprintf("smart: %v", err)
-				} else {
-					return madmin.ServerDiskHwInfo{
-						Addr:  addr,
-						Error: fmt.Sprintf("smart: %v", err),
-					}
-				}
+				smartInfo.Error = fmt.Sprintf("smart: %v", err)
 			}
 			partition := madmin.PartitionStat{
 				Device:     part.Device,


### PR DESCRIPTION
## Description

Collection of SMART information doesn't work in certain scenarios e.g.
in a container-based setup. In such cases, instead of returning an error
(without any data), set the error on the smartinfo struct, so that other
important drive hw info like device, mountpoint, etc is retained in the output.

## Motivation and Context

Bugfix

## How to test this PR?

- Create a docker/k8s based minio cluster
- Run `mc admin subnet health alias` against this cluster
- Verify that
  - `hardware -> servers -> drives` is not empty and contains important information like device, mountpoint, fs type, and options
  - the error related to fetching SMART info is set inside `hardware -> servers -> drives -> partitions -> smartInfo -> error`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
