### PR TITLE
compression: mark ETag of compressed objects as multipart ETag

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -96,6 +96,12 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 
 	// Set Etag if available.
 	if objInfo.ETag != "" {
+		// The ETag of a compressed object is never its content MD5.
+		// Therefore, we add a "-1" if the ETag does not already have
+		// a "-X" suffix.
+		if objInfo.IsCompressed() && !strings.Contains(objInfo.ETag, "-") {
+			objInfo.ETag += "-1"
+		}
 		w.Header()[xhttp.ETag] = []string{"\"" + objInfo.ETag + "\""}
 	}
 


### PR DESCRIPTION
## Description
This commit ensures that the S3 ETag returned to the client is
always an S3 multipart ETag. An S3 multipart ETag has a `-X`
(`X` being the number of object parts) suffix.

The current behavior of the compression is to mark the
ETag of a compressed object as multipart ETag. This behavior
should be preserved for compressed + encrypted objects.

## Motivation and Context
#11447 

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
