### PR TITLE
Fix DeleteMultipleObjectsHandler to process deleted objects correctly

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -547,7 +547,6 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 		dindex := objectsToDelete[ObjectToDelete{
 			ObjectName:                    dObjects[i].ObjectName,
 			VersionID:                     dObjects[i].VersionID,
-			DeleteMarkerVersionID:         dObjects[i].DeleteMarkerVersionID,
 			VersionPurgeStatus:            dObjects[i].VersionPurgeStatus,
 			DeleteMarkerReplicationStatus: dObjects[i].DeleteMarkerReplicationStatus,
 			PurgeTransitioned:             dObjects[i].PurgeTransitioned,


### PR DESCRIPTION
DeleteMarkerVersion which is returned by lower layer should not be
used in the key to lookup ObjectToDelete map

## Description


## Motivation and Context
Some delete marker creation events were dropped or reported with missing object name etc due to incorrect comparison.
With master, only one delete marker creation event is returned as the map indexes always to 0 given that DeleteMarker version was not part of the map key while constructing, but used in the lookup

## How to test this PR?
```
➜   mc cp  /etc/issue adest/bucket/xd1 
.../issue:  26 B / 26 B ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 663 B/s 0s
➜   mc cp  /etc/issue adest/bucket/xd 
.../issue:  26 B / 26 B ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 622 B/s 0s
➜  mc rm adest/bucket/xd --force --r 
Removing `adest/bucket/xd`.
Removing `adest/bucket/xd1`.
```
```
[2021-02-11T06:10:47.667Z]        s3:ObjectRemoved:DeleteMarkerCreated http://localhost:9009/bucket/xd
[2021-02-11T06:10:47.667Z]        s3:ObjectRemoved:DeleteMarkerCreated http://localhost:9009/bucket/xd1
[2021-02-11T06:10:47.727Z]        s3:Replication:OperationCompletedReplication http://localhost:9009/bucket/xd
[2021-02-11T06:10:47.731Z]        s3:Replication:OperationCompletedReplication http://localhost:9009/bucket/xd1

```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
