### PR TITLE
fix: properly support versionIdMarker, allow marker without prefix

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -826,15 +826,15 @@ func (z *erasureServerPools) ListObjectVersions(ctx context.Context, bucket, pre
 	if marker == "" && versionMarker != "" {
 		return loi, NotImplemented{}
 	}
-
 	opts := listPathOptions{
-		Bucket:      bucket,
-		Prefix:      prefix,
-		Separator:   delimiter,
-		Limit:       maxKeys,
-		Marker:      marker,
-		InclDeleted: true,
-		AskDisks:    globalAPIConfig.getListQuorum(),
+		Bucket:        bucket,
+		Prefix:        prefix,
+		Separator:     delimiter,
+		Limit:         maxKeys,
+		Marker:        marker,
+		VersionMarker: versionMarker,
+		InclDeleted:   true,
+		AskDisks:      globalAPIConfig.getListQuorum(),
 	}
 
 	// Shortcut for APN/1.0 Veeam/1.0 Backup/10.0

--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -32,6 +32,12 @@ type metaCacheEntry struct {
 	// Entries without metadata will only be present in non-recursive scans.
 	metadata []byte
 
+	// this value is set to '-1' in most common scenarios,
+	// it is only set for this entry if the version needs
+	// to be skipped by the caller. check relevant code in
+	// fileInfoVersions() on how this is used.
+	versionIdx int
+
 	// cached contains the metadata if decoded.
 	cached *FileInfo
 }
@@ -335,12 +341,8 @@ func (m *metaCacheEntriesSorted) fileInfoVersions(bucket, prefix, delimiter, aft
 			}
 
 			fiVersions := fiv.Versions
-			if afterV != "" {
-				vidMarkerIdx := fiv.findVersionIndex(afterV)
-				if vidMarkerIdx >= 0 {
-					fiVersions = fiVersions[vidMarkerIdx+1:]
-				}
-				afterV = ""
+			if entry.versionIdx >= 0 {
+				fiVersions = fiVersions[entry.versionIdx+1:]
 			}
 
 			for _, version := range fiVersions {

--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -60,14 +60,6 @@ func (z *erasureServerPools) listPath(ctx context.Context, o listPathOptions) (e
 		return entries, err
 	}
 
-	// Marker is set validate pre-condition.
-	if o.Marker != "" && o.Prefix != "" {
-		// Marker not common with prefix is not implemented. Send an empty response
-		if !HasPrefix(o.Marker, o.Prefix) {
-			return entries, io.EOF
-		}
-	}
-
 	// With max keys of zero we have reached eof, return right here.
 	if o.Limit == 0 {
 		return entries, io.EOF


### PR DESCRIPTION

## Description
fix: properly support versionIdMarker, allow marker without prefix

## Motivation and Context
AWS S3 compatibility issue fix, such that versionIdMarker
is properly honored as a sub-marker for the actual KeyMarker,
KeyMarker should be present in the result, if the keyMarker
has more versions beyond the requested versionIdMarker.

## How to test this PR?
Use the versioning tests PR submitted by @vadmeste #11500 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
