### PR TITLE
fix: parallelize getPoolIdx() for object lookup

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -458,7 +458,7 @@ func (er erasureObjects) getObjectInfo(ctx context.Context, bucket, object strin
 			objInfo.StorageClass = sc
 		}
 	}
-	if !fi.VersionPurgeStatus.Empty() {
+	if !fi.VersionPurgeStatus.Empty() && opts.VersionID != "" {
 		// Make sure to return object info to provide extra information.
 		return objInfo, toObjectErr(errMethodNotAllowed, bucket, object)
 	}


### PR DESCRIPTION
## Description
fix: parallelize getPoolIdx() for object lookup

## Motivation and Context
for new writes in multiple pools parallelize object lookups

## How to test this PR?
Nothing special, no new regressions should be present

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
