### PR TITLE
Don't autoheal if disks are healing

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -328,7 +328,9 @@ func (er erasureObjects) getObjectWithFileInfo(ctx context.Context, bucket, obje
 				}
 				if scan != madmin.HealUnknownScan {
 					healOnce.Do(func() {
-						go healObject(bucket, object, fi.VersionID, scan)
+						if _, healing := er.getOnlineDisksWithHealing(); !healing {
+							go healObject(bucket, object, fi.VersionID, scan)
+						}
 					})
 				}
 			}
@@ -438,7 +440,9 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 
 	// if missing metadata can be reconstructed, attempt to reconstruct.
 	if missingBlocks > 0 && missingBlocks < readQuorum {
-		go healObject(bucket, object, fi.VersionID, madmin.HealNormalScan)
+		if _, healing := er.getOnlineDisksWithHealing(); !healing {
+			go healObject(bucket, object, fi.VersionID, madmin.HealNormalScan)
+		}
 	}
 
 	return fi, metaArr, onlineDisks, nil


### PR DESCRIPTION
## Description

Don't spawn automatic healing ops if a disk is healing.

## Motivation and Context

Reduce the amount of queued heal requests.

## How to test this PR?

Replace disk, read should not trigger heals.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
