### PR TITLE
Make HDFS gateway can only access subdir

### DIFF
--- a/cmd/gateway/hdfs/gateway-hdfs.go
+++ b/cmd/gateway/hdfs/gateway-hdfs.go
@@ -175,7 +175,7 @@ func (g *HDFS) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error
 	opts.DatanodeDialFunc = dialFunc
 
 	// Not addresses found, load it from command line.
-	var commonPath string
+	commonPath := env.Get("HDFS_GATEWAY_PREFIX", "")
 	if len(opts.Addresses) == 0 {
 		var addresses []string
 		for _, s := range g.args {
@@ -497,7 +497,7 @@ func (n *hdfsObjects) populateDirectoryListing(filePath string, fileInfos map[st
 	}
 
 	for _, fileInfo := range infos {
-		filePath := n.hdfsPathJoin(filePath, fileInfo.Name())
+		filePath := minio.PathJoin(filePath, fileInfo.Name())
 		fileInfos[filePath] = fileInfo
 	}
 

--- a/docs/gateway/hdfs.md
+++ b/docs/gateway/hdfs.md
@@ -30,6 +30,15 @@ docker run -p 9000:9000 \
  minio/minio gateway hdfs hdfs://namenode:8200
 ```
 
+### Subdirectory
+
+If you don't want to expose the entire HDFS, you can configure environment variable `HDFS_GATEWAY_PREFIX` to ensure that
+the gateway can only access specific subdirectories.
+
+```sh
+export HDFS_GATEWAY_PREFIX=/subdir
+```
+
 ### Setup Kerberos
 
 MinIO supports two kerberos authentication methods, keytab and ccache.


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>

## Description

Make the gateway can only access specific subdir (optional).

Note the `populateDirectoryListing` change.

`n.hdfsPathJoin` will concat the subPath, but the caller already concated the `subPath`, so the `populateDirectoryListing` shouldn't concat it again.

https://github.com/minio/minio/blob/55037e6e54e138836b84bf1d268378470f315b75/cmd/gateway/hdfs/gateway-hdfs.go#L410-L444

## Motivation and Context

Sometimes we don't want to expose the entire HDFS.

## How to test this PR?

Run `minio gateway hdfs` with env var `HDFS_GATEWAY_PREFIX=/some/subpath`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
