### PR TITLE
Kafka: Check if connected

### DIFF
--- a/pkg/event/target/kafka.go
+++ b/pkg/event/target/kafka.go
@@ -160,6 +160,9 @@ func (target *KafkaTarget) Save(eventData event.Event) error {
 
 // send - sends an event to the kafka.
 func (target *KafkaTarget) send(eventData event.Event) error {
+	if target.producer == nil {
+		return errNotConnected
+	}
 	objectName, err := url.QueryUnescape(eventData.S3.Object.Key)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Check if Kafka producer is connected before sending.

Fixes #11576

## How to test this PR?

The producer is lazy, so may be initialized later, or not.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
