### PR TITLE
metrics: Add the number of requests in the queue

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -259,6 +259,7 @@ type ServerHTTPAPIStats struct {
 // ServerHTTPStats holds all type of http operations performed to/from the server
 // including their average execution time.
 type ServerHTTPStats struct {
+	S3RequestsInQueue int32              `json:"s3RequestsInQueue"`
 	CurrentS3Requests ServerHTTPAPIStats `json:"currentS3Requests"`
 	TotalS3Requests   ServerHTTPAPIStats `json:"totalS3Requests"`
 	TotalS3Errors     ServerHTTPAPIStats `json:"totalS3Errors"`

--- a/cmd/http-stats.go
+++ b/cmd/http-stats.go
@@ -137,23 +137,26 @@ func (stats *HTTPAPIStats) Load() map[string]int {
 // HTTPStats holds statistics information about
 // HTTP requests made by all clients
 type HTTPStats struct {
+	s3RequestsInQueue int32
 	currentS3Requests HTTPAPIStats
 	totalS3Requests   HTTPAPIStats
 	totalS3Errors     HTTPAPIStats
 }
 
+func (st *HTTPStats) addRequestsInQueue(i int32) {
+	atomic.AddInt32(&st.s3RequestsInQueue, i)
+}
+
 // Converts http stats into struct to be sent back to the client.
 func (st *HTTPStats) toServerHTTPStats() ServerHTTPStats {
 	serverStats := ServerHTTPStats{}
-
+	serverStats.S3RequestsInQueue = atomic.LoadInt32(&st.s3RequestsInQueue)
 	serverStats.CurrentS3Requests = ServerHTTPAPIStats{
 		APIStats: st.currentS3Requests.Load(),
 	}
-
 	serverStats.TotalS3Requests = ServerHTTPAPIStats{
 		APIStats: st.totalS3Requests.Load(),
 	}
-
 	serverStats.TotalS3Errors = ServerHTTPAPIStats{
 		APIStats: st.totalS3Errors.Load(),
 	}


### PR DESCRIPTION
## Description
We can use this metric to check if there are too many S3 clients in the
queue and could explain why some of those S3 clients are timing out.

```
minio_s3_requests_waiting_total{server="127.0.0.1:9000"} 9981
```

If max_requests is 10000 then there is a strong possiblity that clients
are timing out because of the queue deadline

## Motivation and Context
Add new metric showing the number of clients in the pipeline

## How to test this PR?
```
$ MINIO_PROMETHEUS_AUTH_TYPE="public" minio server /tmp/xl/{1...4}/
$ mc mb myminio/testbucket/
$ mc admin config set myminio/ api max_requests=10
$ mc cp -r /usr/share/ myminio/testbucket/
$ curl http://localhost:9000/minio/v2/metrics/cluster | grep wait 
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
