### PR TITLE
fix incorrect http range in SelectObjectContentHandler

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -188,6 +188,10 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 			isSuffixLength = true
 		}
 
+		if length > 0 {
+			length--
+		}
+
 		rs := &HTTPRangeSpec{
 			IsSuffixLength: isSuffixLength,
 			Start:          offset,


### PR DESCRIPTION
## Description

This commit fix the HTTP range calculated in `SelectObjectContentHandler`.

## Motivation and Context

Without this commit, there will be no functionality issue, select object content works just fine. The problem is that HTTP header `Range` is off by 1 byte. So, for example, when selecting parquet object, the reader need to request an object with start offset 0 and length 1024 Bytes. The expected range should be `bytes=0-1023`, but get `bytes=0-1024` instead. Which means it is requested 1025 Bytes.

## How to test this PR?

Run MinIO as S3 gateway and then select object content with parquet format. Then, inspect variable `length` here: 
https://github.com/minio/minio/blob/c70240b8934dc127c3e7a22c8cbe8853ea654795/cmd/object-handlers.go#L194

and here:
https://github.com/minio/minio/blob/c70240b8934dc127c3e7a22c8cbe8853ea654795/cmd/gateway/s3/gateway-s3.go#L398

The value must be the same.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
