### PR TITLE
LDAP config: fix substitution variables

### DIFF
--- a/cmd/config/identity/ldap/config.go
+++ b/cmd/config/identity/ldap/config.go
@@ -301,7 +301,8 @@ func (l *Config) Bind(username, password string) (string, []string, error) {
 	var groups []string
 	if l.GroupSearchFilter != "" {
 		for _, groupSearchBase := range l.GroupSearchBaseDistNames {
-			filter := strings.Replace(l.GroupSearchFilter, "%s", ldap.EscapeFilter(bindDN), -1)
+			filter := strings.Replace(l.GroupSearchFilter, "%s", ldap.EscapeFilter(username), -1)
+			filter = strings.Replace(filter, "%d", ldap.EscapeFilter(bindDN), -1)
 			searchRequest := ldap.NewSearchRequest(
 				groupSearchBase,
 				ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -123,7 +123,13 @@ export MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY=on
 
 ### Variable substitution in AD/LDAP configuration strings ###
 
-`%s` is replaced with *username* automatically for construction bind_dn, search_filter and group_search_filter.
+In the configuration variables, `%s` is substituted with the *username* from the STS request and `%d` is substituted with the *distinguished username (user DN)* of the LDAP user. Please see the following table for which configuration variables support these substitution variables:
+
+| Variable                                    | Supported substitutions |
+|---------------------------------------------|-------------------------|
+| `MINIO_IDENTITY_LDAP_USERNAME_FORMAT`       | `%s`                    |
+| `MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER` | `%s`                    |
+| `MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER`   | `%s` and `%d`           |
 
 ## Managing User/Group Access Policy
 


### PR DESCRIPTION
## Description

- In username search filter and username format variables we support %s for
replacing with the username.

- In group search filter we support %s for username and %d for the full DN of
the username.

Updates documentation as well.

## Motivation and Context

In LDAP configuration, for group search we sometimes need to be able to substitute in the username or the full user DN to find the groups of a user. We allow this now in this change. In the existing implementation `%s` was substituted with the DN in the group search filter and with the username in the user search filter/format variables. This change also makes it uniform so that `%s` is always replaced with the username and introduces `%d` (for group search filter) to replace with the full user DN.

## How to test this PR?

With LDAP setup e.g. https://github.com/donatello/minio-ldap-testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
