### PR TITLE
fix: for containers use root-disk detection cleverly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
 .git
 .github
+docs
+CREDITS
+default.etcd
+browser
+*.gz
+*.tar.gz
+*.bzip2
+*.zip

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,8 +6,6 @@ LABEL maintainer="MinIO Inc <dev@min.io>"
 
 COPY dockerscripts/docker-entrypoint.sh /usr/bin/
 COPY minio /usr/bin/
-COPY CREDITS /licenses/CREDITS
-COPY LICENSE /licenses/LICENSE
 
 ENV MINIO_UPDATE=off \
     MINIO_ACCESS_KEY_FILE=access_key \
@@ -17,10 +15,9 @@ ENV MINIO_UPDATE=off \
     MINIO_KMS_MASTER_KEY_FILE=kms_master_key \
     MINIO_SSE_MASTER_KEY_FILE=sse_master_key
 
-RUN  \
-    microdnf update --nodocs && \
-    microdnf install curl ca-certificates shadow-utils util-linux --nodocs && \
-    microdnf clean all && \
+RUN microdnf update --nodocs
+RUN microdnf install curl ca-certificates shadow-utils util-linux --nodocs
+RUN microdnf clean all && \
     chmod +x /usr/bin/minio  && \
     chmod +x /usr/bin/docker-entrypoint.sh
 

--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,8 @@ docker-hotfix: hotfix checks
 	@echo "Building minio docker image '$(TAG)'"
 	@docker build -t $(TAG) . -f Dockerfile.dev
 
-docker: checks
+docker: build checks
 	@echo "Building minio docker image '$(TAG)'"
-	@GOOS=linux GO111MODULE=on CGO_ENABLED=0 go build -tags kqueue -trimpath --ldflags "$(LDFLAGS)" -o $(PWD)/minio 1>/dev/null
 	@docker build -t $(TAG) . -f Dockerfile.dev
 
 # Builds minio and installs it to $GOPATH/bin.

--- a/pkg/disk/disk_unix.go
+++ b/pkg/disk/disk_unix.go
@@ -1,5 +1,7 @@
+// +build !windows
+
 /*
- * MinIO Cloud Storage, (C) 2018-2020 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2021 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +18,22 @@
 
 package disk
 
-// Info stat fs struct is container which holds following values
-// Total - total size of the volume / disk
-// Free - free size of the volume / disk
-// Files - total inodes available
-// Ffree - free inodes available
-// FSType - file system type
-type Info struct {
-	Total  uint64
-	Free   uint64
-	Used   uint64
-	Files  uint64
-	Ffree  uint64
-	FSType string
+import (
+	"syscall"
+)
+
+// SameDisk reports whether di1 and di2 describe the same disk.
+func SameDisk(disk1, disk2 string) (bool, error) {
+	st1 := syscall.Stat_t{}
+	st2 := syscall.Stat_t{}
+
+	if err := syscall.Stat(disk1, &st1); err != nil {
+		return false, err
+	}
+
+	if err := syscall.Stat(disk2, &st2); err != nil {
+		return false, err
+	}
+
+	return st1.Dev == st2.Dev, nil
 }

--- a/pkg/disk/disk_windows.go
+++ b/pkg/disk/disk_windows.go
@@ -1,5 +1,7 @@
+// +build windows
+
 /*
- * MinIO Cloud Storage, (C) 2018-2020 MinIO, Inc.
+ * MinIO Cloud Storage, (C) 2021 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +18,7 @@
 
 package disk
 
-// Info stat fs struct is container which holds following values
-// Total - total size of the volume / disk
-// Free - free size of the volume / disk
-// Files - total inodes available
-// Ffree - free inodes available
-// FSType - file system type
-type Info struct {
-	Total  uint64
-	Free   uint64
-	Used   uint64
-	Files  uint64
-	Ffree  uint64
-	FSType string
+// SameDisk reports whether di1 and di2 describe the same disk.
+func SameDisk(disk1, disk2 string) (bool, error) {
+	return false, nil
 }

--- a/pkg/disk/root_disk.go
+++ b/pkg/disk/root_disk.go
@@ -25,13 +25,5 @@ func IsRootDisk(diskPath string, rootDisk string) (bool, error) {
 		// On windows this function is not implemented.
 		return false, nil
 	}
-	info, err := GetInfo(diskPath)
-	if err != nil {
-		return false, err
-	}
-	rootInfo, err := GetInfo(rootDisk)
-	if err != nil {
-		return false, err
-	}
-	return SameDisk(info, rootInfo), nil
+	return SameDisk(diskPath, rootDisk)
 }


### PR DESCRIPTION

## Description
fix: for containers use root-disk detection cleverly

## Motivation and Context
root-disk implemented currently had issues where root
disk partitions getting modified might race and provide
incorrect results, to avoid this lets rely again back on
DeviceID and match it instead.

In-case of containers `/data` is one such extra entity that
needs to be verified for root disk, due to how 'overlay'
filesystem works and the 'overlay' presents a completely
different 'device' id - using `/data` as another entity
for fallback helps because our containers describe 'VOLUME'
parameter that allows containers to automatically have a
virtual `/data` that points to the container root path this
can either be at `/` or `/var/lib/` (on different partition)

## How to test this PR?
Deploy in `docker` containers, deploy in 'k8s' environments, 
This PR doesn't change any functionality for bare-metal setups.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
