### PR TITLE
fix: read metadata in O_DIRECT if configured and supported

### DIFF
--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -143,7 +143,7 @@ func osErrToFileErr(err error) error {
 	if osIsPermission(err) {
 		return errFileAccessDenied
 	}
-	if isSysErrNotDir(err) {
+	if isSysErrNotDir(err) || isSysErrIsDir(err) {
 		return errFileNotFound
 	}
 	if isSysErrPathNotFound(err) {


### PR DESCRIPTION

## Description
fix: read metadata in O_DIRECT if configured and supported

## Motivation and Context
reduce the page-cache pressure completely by moving
the entire read-phase of our operations to O_DIRECT,
primarily this is going to be very useful for chatty
metadata operations such as listing, scanner, ILM, healing
like operations to avoid filling up the page-cache upon
repeated runs.

## How to test this PR?
Not trivial, requires a beefy setup. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x[ New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
