### PR TITLE
Skip printing error if empty for reporting bandwidth

### DIFF
--- a/pkg/madmin/bandwidth.go
+++ b/pkg/madmin/bandwidth.go
@@ -29,8 +29,8 @@ import (
 
 // Report includes the bandwidth report or the error encountered.
 type Report struct {
-	Report bandwidth.Report
-	Err    error
+	Report bandwidth.Report `json:"report"`
+	Err    error            `json:"error,omitempty"`
 }
 
 // GetBucketBandwidth - Gets a channel reporting bandwidth measurements for replication buckets. If no buckets


### PR DESCRIPTION
## Description
Skip printing error field when empty. This is used by `mc` to report bandwidth.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
