### PR TITLE
isServerResolvable its sufficient to check server is reachable

### DIFF
--- a/cmd/lock-rest-server.go
+++ b/cmd/lock-rest-server.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// Lock maintenance interval.
-	lockMaintenanceInterval = 15 * time.Second
+	lockMaintenanceInterval = 1 * time.Minute
 
 	// Lock validity check interval.
 	lockValidityCheckInterval = 30 * time.Second
@@ -353,7 +353,7 @@ func startLockMaintenance(ctx context.Context) {
 		break
 	}
 
-	// Initialize a new ticker with 15secs between each ticks.
+	// Initialize a new ticker with 1 minute between each ticks.
 	lkTimer := time.NewTimer(lockMaintenanceInterval)
 	// Stop the timer upon returning.
 	defer lkTimer.Stop()
@@ -362,8 +362,7 @@ func startLockMaintenance(ctx context.Context) {
 
 	// Start with random sleep time, so as to avoid
 	// "synchronous checks" between servers
-	duration := time.Duration(r.Float64() * float64(lockMaintenanceInterval))
-	time.Sleep(duration)
+	time.Sleep(time.Duration(r.Float64() * float64(lockMaintenanceInterval)))
 
 	for {
 		// Verifies every minute for locks held more than 2 minutes.

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -205,14 +205,6 @@ func isServerResolvable(endpoint Endpoint, timeout time.Duration) error {
 	}
 	xhttp.DrainBody(resp.Body)
 
-	if resp.StatusCode != http.StatusOK {
-		return StorageErr(resp.Status)
-	}
-
-	if resp.Header.Get(xhttp.MinIOServerStatus) == unavailable {
-		return StorageErr(unavailable)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description
isServerResolvable its sufficient to check server is reachable

## Motivation and Context
using isServerResolvable for expiration can lead to chicken
and egg problems, a lock might expire knowingly when server
is booting up causing perpetual locks getting expired.

## How to test this PR?
harder to reproduce but it's possible in sufficiently slower setups

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
