### PR TITLE
fix: make sure to convert the error properly in HealBucket()

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -1367,11 +1367,11 @@ func (s *erasureSets) HealBucket(ctx context.Context, bucket string, opts madmin
 		SetCount:  s.setCount,
 	}
 
-	for _, s := range s.sets {
+	for _, set := range s.sets {
 		var healResult madmin.HealResultItem
-		healResult, err = s.HealBucket(ctx, bucket, opts)
+		healResult, err = set.HealBucket(ctx, bucket, opts)
 		if err != nil {
-			return result, err
+			return result, toObjectErr(err, bucket)
 		}
 		result.Before.Drives = append(result.Before.Drives, healResult.Before.Drives...)
 		result.After.Drives = append(result.After.Drives, healResult.After.Drives...)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -311,6 +311,8 @@ func initServer(ctx context.Context, newObject ObjectLayer) error {
 		if errors.Is(err, errDiskNotFound) ||
 			errors.Is(err, errConfigNotFound) ||
 			errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, errErasureWriteQuorum) ||
+			errors.Is(err, errErasureReadQuorum) ||
 			errors.As(err, &rquorum) ||
 			errors.As(err, &wquorum) ||
 			isErrBucketNotFound(err) {
@@ -355,14 +357,12 @@ func initAllSubsystems(ctx context.Context, newObject ObjectLayer) (err error) {
 		for index := range buckets {
 			index := index
 			g.Go(func() error {
-				if _, berr := newObject.HealBucket(ctx, buckets[index].Name, madmin.HealOpts{Recreate: true}); berr != nil {
-					return fmt.Errorf("Unable to list buckets to heal: %w", berr)
-				}
-				return nil
+				_, berr := newObject.HealBucket(ctx, buckets[index].Name, madmin.HealOpts{Recreate: true})
+				return berr
 			}, index)
 		}
 		if err := g.WaitErr(); err != nil {
-			return err
+			return fmt.Errorf("Unable to list buckets to heal: %w", err)
 		}
 	}
 
@@ -371,6 +371,8 @@ func initAllSubsystems(ctx context.Context, newObject ObjectLayer) (err error) {
 		if errors.Is(err, errDiskNotFound) ||
 			errors.Is(err, errConfigNotFound) ||
 			errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, errErasureWriteQuorum) ||
+			errors.Is(err, errErasureReadQuorum) ||
 			errors.As(err, &rquorum) ||
 			errors.As(err, &wquorum) ||
 			isErrBucketNotFound(err) {


### PR DESCRIPTION

## Description
fix: make sure to convert the error properly in HealBucket()

## Motivation and Context
server startup code expects the object layer to properly
convert error into a proper type, so that in situations when
servers are coming up and quorum is not available servers
wait on each other.

## How to test this PR?
A simple local 2 node setup can easily reproduce this

```bash
#!/usr/bin/env bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
for i in {01..01}; do
    minio server --address ":90${i}" https://127.0.0.1:9001/home/harsha/disk{01..02} https://127.0.0.1:9002/home/harsha/disk{03..04} &
done
```

and then start 

```
minio server --address ":9002" https://127.0.0.1:9001/home/harsha/disk{01..02} https://127.0.0.1:9002/home/harsha/disk{03..04}
```

You need to make sure the setup has been already formatted prior to this test and you create a fake bucket on disk01, disk02

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
