### PR TITLE
Ensure cache has finished deserializing

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -184,8 +184,11 @@ func (client *storageRESTClient) CrawlAndGetDataUsage(ctx context.Context, cache
 	pr.Close()
 
 	var newCache dataUsageCache
+	var wg sync.WaitGroup
+	wg.Add(1)
 	pr, pw = io.Pipe()
 	go func() {
+		defer wg.Done()
 		pr.CloseWithError(newCache.deserialize(pr))
 	}()
 	err = waitForHTTPStream(respBody, pw)
@@ -193,6 +196,7 @@ func (client *storageRESTClient) CrawlAndGetDataUsage(ctx context.Context, cache
 	if err != nil {
 		return cache, err
 	}
+	wg.Wait()
 	return newCache, nil
 }
 


### PR DESCRIPTION
## Description

Make sure that response has been fully deserialized before returning.

## Motivation and Context

Fixes race condition with returned cache.

## How to test this PR?

Tested with normal operation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Fixes a regression: #11600