### PR TITLE
Translate empty versionID string to null version where appropriate

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -102,7 +102,7 @@ func (fi FileInfo) IsValid() bool {
 func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 	object = decodeDirObject(object)
 	versionID := fi.VersionID
-	if globalBucketVersioningSys.Enabled(bucket) && versionID == "" {
+	if (globalBucketVersioningSys.Enabled(bucket) || globalBucketVersioningSys.Suspended(bucket)) && versionID == "" {
 		versionID = nullVersionID
 	}
 


### PR DESCRIPTION

## Description
We store the null version as empty string. We should translate it to null
version for bucket with version suspended too.

## Motivation and Context
ILM transition subsystem doesn't apply `NoncurrentVersionTransition` action on an object with empty version id. To address this
we need to translate the empty version id string to null version id (constant) if the bucket has versioning enabled or suspended.

## How to test this PR?
1. Make a bucket with versioning enabled
2. Enable ilm policy on this bucket with NoncurrentVersionTransition action configured.
e.g
```
cat > test-ilm.json <<EOF
{
    "Rules": [
        {
            "ID": "c0qpv6va7c2ef34p0dc0",
            "Filter": {
                "And": {},
                "Tag": {}
            },
            "NoncurrentVersionTransition": {
                "NoncurrentDays": 1,
                "StorageClass": "S3TIER-1"
            },
            "Status": "Enabled",
            "Transition": {
                "StorageClass": "S3TIER-1",
                "Days": 1
            }
        }
    ]
}
EOF
./mc ilm import $ALIAS/mybucket < test-ilm.json
```
2. Upload an object
3. Suspend versioning on the bucket
4. Upload contents to the same object, this creates the null version

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
