### PR TITLE
fix: rpc is nil if result is discarded

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -341,7 +341,10 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 	}
 
 	meta := o.newMetacache()
-	rpc := globalNotificationSys.restClientFromHash(o.Bucket)
+	var rpc *peerRESTClient
+	if !o.discardResult {
+		rpc = globalNotificationSys.restClientFromHash(o.Bucket)
+	}
 	var metaMu sync.Mutex
 
 	o.debugln(color.Green("listPath:")+" scanning bucket:", o.Bucket, "basedir:", o.BaseDir, "prefix:", o.Prefix, "marker:", o.Marker)

--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -153,7 +153,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 				var meta metaCacheEntry
 				meta.metadata, err = xioutil.ReadFile(pathJoin(volumeDir, current, entry))
 				if err != nil {
-					logger.LogIf(ctx, err)
+					if osErrToFileErr(err) != errFileNotFound {
+						logger.LogIf(ctx, err)
+					}
 					continue
 				}
 				meta.name = strings.TrimSuffix(entry, xlStorageFormatFile)
@@ -168,7 +170,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 				var meta metaCacheEntry
 				meta.metadata, err = xioutil.ReadFile(pathJoin(volumeDir, current, entry))
 				if err != nil {
-					logger.LogIf(ctx, err)
+					if osErrToFileErr(err) != errFileNotFound {
+						logger.LogIf(ctx, err)
+					}
 					continue
 				}
 				meta.name = strings.TrimSuffix(entry, xlStorageFormatFileV1)


### PR DESCRIPTION


## Description
fix: rpc is nil if the result is discarded

## Motivation and Context
this avoids sending unnecessary metacache updates
to peers for discarded results.

## How to test this PR?
Just start fresh MinIO installation there shall lot of 'errors' regarding volume 
not found and file not found, these are for discarded results which we shall
ignore by not performing those peer calls.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
