### PR TITLE
Avoid returning duplicated prefixes containing stale files

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -99,6 +99,8 @@ type erasureSets struct {
 
 	mrfMU         sync.Mutex
 	mrfOperations map[healSource]int
+
+	zoneIndex int
 }
 
 func isEndpointConnected(diskMap map[string]StorageAPI, endpoint string) bool {
@@ -832,10 +834,11 @@ func (s *erasureSets) CopyObject(ctx context.Context, srcBucket, srcObject, dstB
 
 // FileInfoVersionsCh - file info versions channel
 type FileInfoVersionsCh struct {
-	Ch       chan FileInfoVersions
-	Prev     FileInfoVersions
-	Valid    bool
-	SetIndex int
+	Ch        chan FileInfoVersions
+	Prev      FileInfoVersions
+	Valid     bool
+	SetIndex  int
+	ZoneIndex int
 }
 
 // Pop - pops a cached entry if any, or from the cached channel.
@@ -856,10 +859,11 @@ func (f *FileInfoVersionsCh) Push(fi FileInfoVersions) {
 
 // FileInfoCh - file info channel
 type FileInfoCh struct {
-	Ch       chan FileInfo
-	Prev     FileInfo
-	Valid    bool
-	SetIndex int
+	Ch        chan FileInfo
+	Prev      FileInfo
+	Valid     bool
+	SetIndex  int
+	ZoneIndex int
 }
 
 // Pop - pops a cached entry if any, or from the cached channel.
@@ -973,8 +977,9 @@ func (s *erasureSets) startMergeWalksVersionsN(ctx context.Context, bucket, pref
 
 				mutex.Lock()
 				entryChs = append(entryChs, FileInfoVersionsCh{
-					Ch:       entryCh,
-					SetIndex: i,
+					Ch:        entryCh,
+					SetIndex:  i,
+					ZoneIndex: s.zoneIndex,
 				})
 				mutex.Unlock()
 			}(i, disk)
@@ -1010,8 +1015,9 @@ func (s *erasureSets) startMergeWalksN(ctx context.Context, bucket, prefix, mark
 				}
 				mutex.Lock()
 				entryChs = append(entryChs, FileInfoCh{
-					Ch:       entryCh,
-					SetIndex: i,
+					Ch:        entryCh,
+					SetIndex:  i,
+					ZoneIndex: s.zoneIndex,
 				})
 				mutex.Unlock()
 			}(i, disk)


### PR DESCRIPTION
## Description
When a prefix is present in multiple sets and multiple zones, and it
only contains stale files, it will be shown as empty.

This fix reduces the chance of these use case appearing by testing on
set index & zone index of a found prefix:

If a prefix does not have a quorum in a given set, just do not attribute
it a quorum and push it again to visit it later since there is a chance
that it can have a quorum in another set or zone.

Now if the same prefix does not have quorum in any set in any zone, it
will never have a quourm and won't be shown.

But sometimes a prefix can have quorum because it contains stale
objects, this use case is not fixed.

## Motivation and Context
Hide empty directories due to stale files

## How to test this PR?
Not trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
