### PR TITLE
Add support for mTLS for Audit log target

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -553,7 +553,7 @@ If you need help to migrate smoothly visit: https://min.io/pricing`
 					http.WithAuthToken(l.AuthToken),
 					http.WithUserAgent(loggerUserAgent),
 					http.WithLogKind(string(logger.All)),
-					http.WithTransport(NewGatewayHTTPTransport()),
+					http.WithTransport(NewGatewayHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)),
 				),
 			); err != nil {
 				logger.LogIf(ctx, fmt.Errorf("Unable to initialize audit HTTP target: %w", err))

--- a/cmd/config/certs.go
+++ b/cmd/config/certs.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"io/ioutil"
 
 	"github.com/minio/minio/pkg/env"
@@ -112,4 +113,13 @@ func LoadX509KeyPair(certFile, keyFile string) (tls.Certificate, error) {
 		}
 	}
 	return cert, nil
+}
+
+// EnsureCertAndKey checks if both client certificate and key paths are provided
+func EnsureCertAndKey(ClientCert, ClientKey string) error {
+	if (ClientCert != "" && ClientKey == "") ||
+		(ClientCert == "" && ClientKey != "") {
+		return errors.New("cert and key must be specified as a pair")
+	}
+	return nil
 }

--- a/cmd/logger/help.go
+++ b/cmd/logger/help.go
@@ -16,7 +16,9 @@
 
 package logger
 
-import "github.com/minio/minio/cmd/config"
+import (
+	"github.com/minio/minio/cmd/config"
+)
 
 // Help template for logger http and audit
 var (
@@ -57,6 +59,18 @@ var (
 			Description: config.DefaultComment,
 			Optional:    true,
 			Type:        "sentence",
+		},
+		config.HelpKV{
+			Key:         ClientCert,
+			Description: "mTLS certificate for Audit Webhook authentication",
+			Optional:    true,
+			Type:        "string",
+		},
+		config.HelpKV{
+			Key:         ClientKey,
+			Description: "mTLS certificate key for Audit Webhook authentication",
+			Optional:    true,
+			Type:        "string",
 		},
 	}
 )

--- a/docs/logging/README.md
+++ b/docs/logging/README.md
@@ -38,7 +38,7 @@ minio server /mnt/data
 Assuming `mc` is already [configured](https://docs.min.io/docs/minio-client-quickstart-guide.html)
 ```
 mc admin config get myminio/ audit_webhook
-audit_webhook:name1 auth_token="" endpoint=""
+audit_webhook:name1 enable=off endpoint= auth_token= client_cert= client_key= 
 ```
 
 ```
@@ -53,6 +53,8 @@ MinIO also honors environment variable for HTTP target Audit logging as shown be
 export MINIO_AUDIT_WEBHOOK_ENABLE_target1="on"
 export MINIO_AUDIT_WEBHOOK_AUTH_TOKEN_target1="token"
 export MINIO_AUDIT_WEBHOOK_ENDPOINT_target1=http://localhost:8080/minio/logs
+export MINIO_AUDIT_WEBHOOK_CLIENT_CERT="/tmp/cert.pem"
+export MINIO_AUDIT_WEBHOOK_CLIENT_KEY=="/tmp/key.pem"
 minio server /mnt/data
 ```
 


### PR DESCRIPTION
## Description
Add support for mTLS for Audit log target

## Motivation and Context
Webhook servers can use mTLS for connections.

## How to test this PR?
- Generate certificates using the following command with CN set to "localhost". And copy them to `/tmp/` (Or) any location.
```
openssl req -newkey rsa:2048 \
  -new -nodes -x509 \
  -days 3650 \
  -out cert.pem \
  -keyout key.pem \
  -subj "/C=US/ST=California/L=Mountain View/O=Your Organization/OU=Your Unit/CN=localhost"
```
- Use the following script to run webhook server

```
package main

import (
	"encoding/json"
	"fmt"
	"github.com/minio/minio/pkg/event"
	"io/ioutil"
	"log"
	"net/http"
	"crypto/tls"
	"crypto/x509"
	//"io"
)

func main() {

	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		b, err := ioutil.ReadAll(r.Body)
		defer r.Body.Close()
		if err != nil {
			fmt.Println(err)
			log.Fatal(err)
			return
		}
		if len(b) > 0 {
			var msg event.Log
			err = json.Unmarshal(b, &msg)
			if err != nil {
				log.Fatal(err)
				return
			}
			fmt.Println("**********New-Message****************")
			fmt.Println(string(b))
			w.WriteHeader(200)
		} else {
			fmt.Println("****PINGREQ*****")
		}
		w.Write([]byte("ping"))
	})

	// Create a CA certificate pool and add cert.pem to it
	caCert, err := ioutil.ReadFile("/tmp/cert.pem")
	if err != nil {
		log.Fatal(err)
	}
	caCertPool := x509.NewCertPool()
	caCertPool.AppendCertsFromPEM(caCert)

	// Create the TLS Config with the CA pool and enable Client certificate validation
	tlsConfig := &tls.Config{
		ClientCAs: caCertPool,
		ClientAuth: tls.RequireAndVerifyClientCert,
		//InsecureSkipVerify: true,
	}
	tlsConfig.BuildNameToCertificate()

	// Create a Server instance to listen on port 8443 with the TLS config
	server := &http.Server{
		Addr:      ":8443",
		TLSConfig: tlsConfig,
	}

	log.Printf("listening on https://%s/", "localhost:8443")
	// Listen to HTTPS connections with the server certificate and wait
	log.Fatal(server.ListenAndServeTLS("/tmp/cert.pem", "/tmp/key.pem"))
}

```
- Copy the cert.pem to ~/.minio/certs/CAs/public.crt
- We can use the same key pairs for both the client and server as they are in same host. 
- Start the MinIO server
- Set the client_cert and client_key in the audit webhook config. 
`mc admin config set myminio/ audit_webhook:1 endpoint="https://localhost:8443/" client_cert="/tmp/cert.pem" client_key="/tmp/key.pem"`
- Start watching for events.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
