### PR TITLE
fix: Prometheus metrics to re-use storage disks

### DIFF
--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -42,16 +42,16 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 			}
 			if endpoint.IsLocal {
 				// Only proceed for local endpoints
-				network[nodeName] = "online"
+				network[nodeName] = string(madmin.ItemOnline)
 				localEndpoints = append(localEndpoints, endpoint)
 				continue
 			}
 			_, present := network[nodeName]
 			if !present {
 				if err := isServerResolvable(endpoint, 2*time.Second); err == nil {
-					network[nodeName] = "online"
+					network[nodeName] = string(madmin.ItemOnline)
 				} else {
-					network[nodeName] = "offline"
+					network[nodeName] = string(madmin.ItemOffline)
 					// log once the error
 					logger.LogOnceIf(context.Background(), err, nodeName)
 				}
@@ -59,35 +59,21 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 		}
 	}
 
-	localDisks, _ := initStorageDisksWithErrors(localEndpoints)
-	defer closeStorageDisks(localDisks)
-
-	storageInfo, _ := getStorageInfo(localDisks, localEndpoints.GetAllStrings())
-
-	return madmin.ServerProperties{
-		State:    "ok",
+	props := madmin.ServerProperties{
+		State:    string(madmin.ItemInitializing),
 		Endpoint: addr,
 		Uptime:   UTCNow().Unix() - globalBootTime.Unix(),
 		Version:  Version,
 		CommitID: CommitID,
 		Network:  network,
-		Disks:    storageInfo.Disks,
-	}
-}
-
-func getLocalDisks(endpointServerPools EndpointServerPools) []madmin.Disk {
-	var localEndpoints Endpoints
-	for _, ep := range endpointServerPools {
-		for _, endpoint := range ep.Endpoints {
-			if !endpoint.IsLocal {
-				continue
-			}
-			localEndpoints = append(localEndpoints, endpoint)
-		}
 	}
 
-	localDisks, _ := initStorageDisksWithErrors(localEndpoints)
-	defer closeStorageDisks(localDisks)
-	storageInfo, _ := getStorageInfo(localDisks, localEndpoints.GetAllStrings())
-	return storageInfo.Disks
+	objLayer := newObjectLayerFn()
+	if objLayer != nil {
+		storageInfo, _ := objLayer.LocalStorageInfo(GlobalContext)
+		props.State = string(madmin.ItemOnline)
+		props.Disks = storageInfo.Disks
+	}
+
+	return props
 }

--- a/cmd/erasure-common.go
+++ b/cmd/erasure-common.go
@@ -23,6 +23,16 @@ import (
 	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
+func (er erasureObjects) getLocalDisks() (localDisks []StorageAPI) {
+	disks := er.getDisks()
+	for _, disk := range disks {
+		if disk != nil && disk.IsLocal() {
+			localDisks = append(localDisks, disk)
+		}
+	}
+	return localDisks
+}
+
 func (er erasureObjects) getLoadBalancedLocalDisks() (newDisks []StorageAPI) {
 	disks := er.getDisks()
 	// Based on the random shuffling return back randomized disks.

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -601,6 +601,37 @@ func (s *erasureSets) StorageInfo(ctx context.Context) (StorageInfo, []error) {
 	return storageInfo, errs
 }
 
+// StorageInfo - combines output of StorageInfo across all erasure coded object sets.
+func (s *erasureSets) LocalStorageInfo(ctx context.Context) (StorageInfo, []error) {
+	var storageInfo StorageInfo
+
+	storageInfos := make([]StorageInfo, len(s.sets))
+	storageInfoErrs := make([][]error, len(s.sets))
+
+	g := errgroup.WithNErrs(len(s.sets))
+	for index := range s.sets {
+		index := index
+		g.Go(func() error {
+			storageInfos[index], storageInfoErrs[index] = s.sets[index].LocalStorageInfo(ctx)
+			return nil
+		}, index)
+	}
+
+	// Wait for the go routines.
+	g.Wait()
+
+	for _, lstorageInfo := range storageInfos {
+		storageInfo.Disks = append(storageInfo.Disks, lstorageInfo.Disks...)
+	}
+
+	var errs []error
+	for i := range s.sets {
+		errs = append(errs, storageInfoErrs[i]...)
+	}
+
+	return storageInfo, errs
+}
+
 // Shutdown shutsdown all erasure coded sets in parallel
 // returns error upon first error.
 func (s *erasureSets) Shutdown(ctx context.Context) error {

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -229,6 +229,18 @@ func (er erasureObjects) StorageInfo(ctx context.Context) (StorageInfo, []error)
 	return getStorageInfo(disks, endpoints)
 }
 
+// LocalStorageInfo - returns underlying local storage statistics.
+func (er erasureObjects) LocalStorageInfo(ctx context.Context) (StorageInfo, []error) {
+	disks := er.getLocalDisks()
+	endpoints := make([]string, len(disks))
+	for i, disk := range disks {
+		if disk != nil {
+			endpoints[i] = disk.String()
+		}
+	}
+	return getStorageInfo(disks, endpoints)
+}
+
 func (er erasureObjects) getOnlineDisksWithHealing() (newDisks []StorageAPI, healing bool) {
 	var wg sync.WaitGroup
 	disks := er.getDisks()

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -206,6 +206,11 @@ func (fs *FSObjects) BackendInfo() BackendInfo {
 	return BackendInfo{Type: BackendFS}
 }
 
+// LocalStorageInfo - returns underlying storage statistics.
+func (fs *FSObjects) LocalStorageInfo(ctx context.Context) (StorageInfo, []error) {
+	return fs.StorageInfo(ctx)
+}
+
 // StorageInfo - returns underlying storage statistics.
 func (fs *FSObjects) StorageInfo(ctx context.Context) (StorageInfo, []error) {
 	atomic.AddInt64(&fs.activeIOCount, 1)

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -39,6 +39,13 @@ func (a GatewayUnsupported) BackendInfo() BackendInfo {
 	return BackendInfo{Type: BackendGateway}
 }
 
+// LocalStorageInfo returns the local disks information, mainly used
+// in prometheus - for gateway this just a no-op
+func (a GatewayUnsupported) LocalStorageInfo(ctx context.Context) (StorageInfo, []error) {
+	logger.CriticalIf(ctx, errors.New("not implemented"))
+	return StorageInfo{}, nil
+}
+
 // NSScanner - scanner is not implemented for gateway
 func (a GatewayUnsupported) NSScanner(ctx context.Context, bf *bloomFilter, updates chan<- DataUsageInfo) error {
 	logger.CriticalIf(ctx, errors.New("not implemented"))

--- a/cmd/gateway/hdfs/gateway-hdfs.go
+++ b/cmd/gateway/hdfs/gateway-hdfs.go
@@ -232,6 +232,10 @@ func (n *hdfsObjects) Shutdown(ctx context.Context) error {
 	return n.clnt.Close()
 }
 
+func (n *hdfsObjects) LocalStorageInfo(ctx context.Context) (si minio.StorageInfo, errs []error) {
+	return n.StorageInfo(ctx)
+}
+
 func (n *hdfsObjects) StorageInfo(ctx context.Context) (si minio.StorageInfo, errs []error) {
 	fsInfo, err := n.clnt.StatFs()
 	if err != nil {

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -521,6 +521,10 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	if globalIsGateway {
+		return
+	}
+
 	server := getLocalServerProperty(globalEndpoints, &http.Request{
 		Host: GetLocalPeer(globalEndpoints),
 	})

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1231,9 +1231,9 @@ func (sys *NotificationSys) ServerInfo() []madmin.ServerProperties {
 			info, err := client.ServerInfo()
 			if err != nil {
 				info.Endpoint = client.host.String()
-				info.State = "offline"
+				info.State = string(madmin.ItemOffline)
 			} else {
-				info.State = "ok"
+				info.State = string(madmin.ItemOnline)
 			}
 			reply[idx] = info
 		}(client, i)
@@ -1306,7 +1306,7 @@ func GetPeerOnlineCount() (nodesOnline, nodesOffline int) {
 	nodesOffline = 0
 	servers := globalNotificationSys.ServerInfo()
 	for _, s := range servers {
-		if s.State == "ok" {
+		if s.State == string(madmin.ItemOnline) {
 			nodesOnline++
 			continue
 		}

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -90,7 +90,8 @@ type ObjectLayer interface {
 	NSScanner(ctx context.Context, bf *bloomFilter, updates chan<- DataUsageInfo) error
 
 	BackendInfo() BackendInfo
-	StorageInfo(ctx context.Context) (StorageInfo, []error) // local queries only local disks
+	StorageInfo(ctx context.Context) (StorageInfo, []error)
+	LocalStorageInfo(ctx context.Context) (StorageInfo, []error)
 
 	// Bucket operations.
 	MakeBucketWithLocation(ctx context.Context, bucket string, opts BucketOptions) error

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -295,7 +295,7 @@ func newXLStorage(ep Endpoint) (*xlStorage, error) {
 			return p, err
 		}
 		// error is unsupported disk, turn-off directIO for reads
-		logger.Info(fmt.Sprintf("Drive %s does not support O_DIRECT for reads, proceeding to use the drive without O_DIRECT", ep))
+		logger.LogOnceIf(GlobalContext, fmt.Errorf("Drive %s does not support O_DIRECT for reads, proceeding to use the drive without O_DIRECT", ep), ep.String())
 		p.readODirectSupported = false
 	}
 

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -39,14 +39,17 @@ const (
 	// Add your own backend.
 )
 
-// ObjectLayerState - represents the status of the object layer
-type ObjectLayerState string
+// ItemState - represents the status of any item in offline,init,online state
+type ItemState string
 
 const (
-	// ObjectLayerInitializing indicates that the object layer is still in initialization phase
-	ObjectLayerInitializing = ObjectLayerState("initializing")
-	// ObjectLayerOnline indicates that the object layer is ready
-	ObjectLayerOnline = ObjectLayerState("online")
+
+	// ItemOffline indicates that the item is offline
+	ItemOffline = ItemState("offline")
+	// ItemInitializing indicates that the item is still in initialization phase
+	ItemInitializing = ItemState("initializing")
+	// ItemOnline indicates that the item is online
+	ItemOnline = ItemState("online")
 )
 
 // StorageInfo - represents total capacity of underlying storage.
@@ -171,7 +174,7 @@ func (adm *AdminClient) DataUsageInfo(ctx context.Context) (DataUsageInfo, error
 
 // InfoMessage container to hold server admin related information.
 type InfoMessage struct {
-	Mode         ObjectLayerState   `json:"mode,omitempty"`
+	Mode         string             `json:"mode,omitempty"`
 	Domain       []string           `json:"domain,omitempty"`
 	Region       string             `json:"region,omitempty"`
 	SQSARN       []string           `json:"sqsARN,omitempty"`


### PR DESCRIPTION

## Description
fix: Prometheus metrics to re-use storage disks

## Motivation and Context
also re-use storage disks for all `mc admin server info`
calls as well, implement a new LocalStorageInfo() API
call at ObjectLayer to lookup local disks storageInfo

also fixes bugs where there were double calls to StorageInfo()

## How to test this PR?
As per issue #11643 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
