### PR TITLE
add unauthenticated lookup-bind mode to LDAP identity

### DIFF
--- a/cmd/config/identity/ldap/config.go
+++ b/cmd/config/identity/ldap/config.go
@@ -180,6 +180,9 @@ func getGroups(conn *ldap.Conn, sreq *ldap.SearchRequest) ([]string, error) {
 }
 
 func (l *Config) lookupBind(conn *ldap.Conn) error {
+	if l.LookupBindPassword == "" {
+		return conn.UnauthenticatedBind(l.LookupBindDN)
+	}
 	return conn.Bind(l.LookupBindDN, l.LookupBindPassword)
 }
 
@@ -422,7 +425,7 @@ func Lookup(kvs config.KVS, rootCAs *x509.CertPool) (l Config, err error) {
 	// Lookup bind user configuration
 	lookupBindDN := env.Get(EnvLookupBindDN, kvs.Get(LookupBindDN))
 	lookupBindPassword := env.Get(EnvLookupBindPassword, kvs.Get(LookupBindPassword))
-	if lookupBindDN != "" && lookupBindPassword != "" {
+	if lookupBindDN != "" {
 		l.LookupBindDN = lookupBindDN
 		l.LookupBindPassword = lookupBindPassword
 		l.isUsingLookupBind = true

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -85,6 +85,8 @@ MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN  (string)    Base LDAP DN to search f
 MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER   (string)    Search filter to lookup user DN
 ```
 
+If you set an empty lookup bind password, the lookup bind will use the unauthenticated authentication mechanism, as described in [RFC 4513 Section 5.1.2](https://tools.ietf.org/html/rfc4513#section-5.1.2).
+
 #### Username-Format Mode ####
 
 In this mode, the server does not use a separate LDAP service account. Instead, the username and password provided in the STS API call are used to login to the LDAP server and also to lookup the user's groups. This mode preserves older behavior for compatibility, but users are encouraged to use the Lookup-Bind mode.


### PR DESCRIPTION
Closes #11646

## Description
Add unauthenticated lookup-bind mode to LDAP identity

## Motivation and Context
Unauthenticated bind is described in [RFC 4513 Section 5.1.1 and 5.1.2](https://tools.ietf.org/html/rfc4513#section-5.1.1).

## How to test this PR?
Use empty username and/or password for LDAP lookup-bind mode.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] Added docs