### PR TITLE
fix: pool number not added for one server

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1240,20 +1240,6 @@ func (sys *NotificationSys) ServerInfo() []madmin.ServerProperties {
 	}
 	wg.Wait()
 
-	for i := range reply {
-		for j := range globalEndpoints {
-			for _, endpoint := range globalEndpoints[j].Endpoints {
-				if reply[i].Endpoint == endpoint.Host {
-					reply[i].PoolNumber = j + 1
-				} else if host, err := xnet.ParseHost(reply[i].Endpoint); err == nil {
-					if host.Name == endpoint.Hostname() {
-						reply[i].PoolNumber = j + 1
-					}
-				}
-			}
-		}
-	}
-
 	return reply
 }
 


### PR DESCRIPTION
## Description

The previous code was iterating over replies from peers and assigning
pool numbers to them, thus missing to add it for the local server.

Fixed by iterating over the server properties of all the servers
including the local one.

## Motivation and Context

Ensure that pool number is available on all the servers in the health report

## How to test this PR?

- Build minio server using this PR
- Run the server for a cluster using server pools
- Build `mc` with dependency on this modified minio
- Generate health report (`mc admin subnet health {alias}`) for the cluster
- Verify that the `poolNumber` field is present on all the servers of the cluster

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
