### PR TITLE
etag: add FromContentMD5 to parse content-md5 as ETag

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"bufio"
 	"context"
-	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -1405,8 +1404,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	// Get Content-Md5 sent by client and verify if valid
-	md5Bytes, err := checkValidMD5(r.Header)
+	clientETag, err := etag.FromContentMD5(r.Header)
 	if err != nil {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDigest), r.URL, guessIsBrowserReq(r))
 		return
@@ -1460,7 +1458,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	var (
-		md5hex              = hex.EncodeToString(md5Bytes)
+		md5hex              = clientETag.String()
 		sha256hex           = ""
 		reader    io.Reader = r.Body
 		s3Err     APIErrorCode
@@ -2156,8 +2154,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	// get Content-Md5 sent by client and verify if valid
-	md5Bytes, err := checkValidMD5(r.Header)
+	clientETag, err := etag.FromContentMD5(r.Header)
 	if err != nil {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidDigest), r.URL, guessIsBrowserReq(r))
 		return
@@ -2208,7 +2205,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	}
 
 	var (
-		md5hex              = hex.EncodeToString(md5Bytes)
+		md5hex              = clientETag.String()
 		sha256hex           = ""
 		reader    io.Reader = r.Body
 		s3Error   APIErrorCode

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -139,18 +138,6 @@ func xmlDecoder(body io.Reader, v interface{}, size int64) error {
 	// Ignore any encoding set in the XML body
 	d.CharsetReader = nopCharsetConverter
 	return d.Decode(v)
-}
-
-// checkValidMD5 - verify if valid md5, returns md5 in bytes.
-func checkValidMD5(h http.Header) ([]byte, error) {
-	md5B64, ok := h[xhttp.ContentMD5]
-	if ok {
-		if md5B64[0] == "" {
-			return nil, fmt.Errorf("Content-Md5 header set to empty value")
-		}
-		return base64.StdEncoding.Strict().DecodeString(md5B64[0])
-	}
-	return []byte{}, nil
 }
 
 // hasContentMD5 returns true if Content-MD5 header is set.


### PR DESCRIPTION
## Description
This commit adds the `FromContentMD5` function to
parse a client-provided content-md5 as ETag.

Further, it also adds multipart ETag computation
for future needs.

## Motivation and Context
ETag

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
