### PR TITLE
fix: capture disks when entire peer is offline

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1218,6 +1218,21 @@ func (sys *NotificationSys) ProcInfo(ctx context.Context) []madmin.ServerProcInf
 	return reply
 }
 
+func getOfflineDisks(offlineHost string, endpoints EndpointServerPools) []madmin.Disk {
+	var offlineDisks []madmin.Disk
+	for _, pool := range endpoints {
+		for _, ep := range pool.Endpoints {
+			if offlineHost == ep.Host {
+				offlineDisks = append(offlineDisks, madmin.Disk{
+					Endpoint: ep.String(),
+					State:    string(madmin.ItemOffline),
+				})
+			}
+		}
+	}
+	return offlineDisks
+}
+
 // ServerInfo - calls ServerInfo RPC call on all peers.
 func (sys *NotificationSys) ServerInfo() []madmin.ServerProperties {
 	reply := make([]madmin.ServerProperties, len(sys.peerClients))
@@ -1233,6 +1248,7 @@ func (sys *NotificationSys) ServerInfo() []madmin.ServerProperties {
 			if err != nil {
 				info.Endpoint = client.host.String()
 				info.State = string(madmin.ItemOffline)
+				info.Disks = getOfflineDisks(info.Endpoint, globalEndpoints)
 			} else {
 				info.State = string(madmin.ItemOnline)
 			}


### PR DESCRIPTION


## Description
fix: capture disks when entire peer is offline

## Motivation and Context
currently when one of the peer is down, the
drives from that peer are reported as '0/0'
offline instead we should capture/filter the
drives from the peer and populate it appropriately
such that `mc admin info` displays correct info.

## How to test this PR?
```bash

#!/usr/bin/env bash

export MINIO_ACCESS_KEY="minio"
export MINIO_SECRET_KEY="minio123"
export MINIO_ERASURE_SET_DRIVE_COUNT=4
export MINIO_PROMETHEUS_AUTH_TYPE=public
#rm -rf /tmp/disk{01..12}
export MINIO_ENDPOINTS="http://127.0.0.1:9001/home/harsha/disk01 http://127.0.0.1:9001/home/harsha/disk02 http://127.0.0.1:9002/home/harsha/disk03 http://127.0.0.1:9002/home/harsha/disk04 http://127.0.0.1:9001/home/harsha/disk05 http://127.0.0.1:9001/home/harsha/disk06 http://127.0.0.1:9002/home/harsha/disk07 http://127.0.0.1:9002/home/harsha/disk08"
export MINIO_KMS_AUTO_ENCRYPTION=off
for i in {01..02}; do
    minio server --address ":90${i}" &
done
```

and run `mc admin info alias/` after taking down peer on port `9001` 

Correct values should be 
```
mc admin info myminio-local2/
●  127.0.0.1:9001
   Uptime: offline
   Drives: 0/4 OK 

●  127.0.0.1:9002
   Uptime: 41 seconds 
   Version: 2021-03-04T02:19:32Z
   Network: 1/2 OK 
   Drives: 4/4 OK 

2.7 GiB Used, 2 Buckets, 4,089 Objects
4 drives online, 4 drives offline
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
