### PR TITLE
add deadlines for DiskInfo calls

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -284,7 +284,7 @@ func getLocalDisksToHeal() (disksToHeal Endpoints) {
 			}
 			// Try to connect to the current endpoint
 			// and reformat if the current disk is not formatted
-			disk, _, err := connectEndpoint(endpoint)
+			disk, _, err := connectEndpoint(GlobalContext, endpoint)
 			if errors.Is(err, errUnformattedDisk) {
 				disksToHeal = append(disksToHeal, endpoint)
 			} else if err == nil && disk != nil && disk.Healing() != nil {
@@ -345,7 +345,7 @@ func monitorLocalDisksAndHeal(ctx context.Context, z *erasureServerPools, bgSeq 
 
 			// heal only if new disks found.
 			for _, endpoint := range healDisks {
-				disk, format, err := connectEndpoint(endpoint)
+				disk, format, err := connectEndpoint(ctx, endpoint)
 				if err != nil {
 					printEndpointError(endpoint, err, true)
 					continue

--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -873,7 +873,7 @@ func initFormatErasure(ctx context.Context, storageDisks []StorageAPI, setCount,
 	}
 
 	// Mark all root disks down
-	markRootDisksAsDown(storageDisks, sErrs)
+	markRootDisksAsDown(ctx, storageDisks, sErrs)
 
 	// Save formats `format.json` across all disks.
 	if err := saveFormatErasureAll(ctx, storageDisks, formats); err != nil {

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -139,7 +138,7 @@ func setRedirectHandler(h http.Handler) http.Handler {
 		// to any other online servers to avoid 503 for any incoming
 		// API calls.
 		if idx := getOnlineProxyEndpointIdx(); idx >= 0 {
-			proxyRequest(context.TODO(), w, r, globalProxyEndpoints[idx])
+			proxyRequest(r.Context(), w, r, globalProxyEndpoints[idx])
 			return
 		}
 		h.ServeHTTP(w, r)

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -283,7 +283,7 @@ func connectLoadInitFormats(retryCount int, firstDisk bool, endpoints Endpoints,
 	}
 
 	// Mark all root disks down
-	markRootDisksAsDown(storageDisks, sErrs)
+	markRootDisksAsDown(GlobalContext, storageDisks, sErrs)
 
 	// Following function is added to fix a regressions which was introduced
 	// in release RELEASE.2018-03-16T22-52-12Z after migrating v1 to v2 to v3.

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -241,7 +241,7 @@ func (client *storageRESTClient) DiskInfo(ctx context.Context) (info DiskInfo, e
 	client.diskInfoCache.Once.Do(func() {
 		client.diskInfoCache.TTL = time.Second
 		client.diskInfoCache.Update = func() (interface{}, error) {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()
 			respBody, err := client.call(ctx, storageRESTMethodDiskInfo, nil, nil, -1)
 			if err != nil {


### PR DESCRIPTION
## Description
add deadlines for DiskInfo calls

## Motivation and Context
add missing deadlines for DiskInfo calls by caller

## How to test this PR?
Nothing special but the caller sets a proper context 
for DiskInfo, instead of context.TODO()

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
