### PR TITLE
Data usage should account for transitioned objects

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -896,7 +896,11 @@ func (i *scannerItem) applyActions(ctx context.Context, o ObjectLayer, meta acti
 	}
 
 	if applied {
-		return 0
+		switch action {
+		case lifecycle.TransitionAction, lifecycle.TransitionVersionAction:
+		default: // for all lifecycle actions that remove data
+			return 0
+		}
 	}
 	return size
 }
@@ -1039,7 +1043,7 @@ func applyExpiryRule(ctx context.Context, objLayer ObjectLayer, obj ObjectInfo, 
 	return applyExpiryOnNonTransitionedObjects(ctx, objLayer, obj, applyOnVersion)
 }
 
-// Perform actions (removal of transitioning of objects), return true the action is successfully performed
+// Perform actions (removal or transitioning of objects), return true the action is successfully performed
 func applyLifecycleAction(ctx context.Context, action lifecycle.Action, objLayer ObjectLayer, obj ObjectInfo) (success bool) {
 	switch action {
 	case lifecycle.DeleteVersionAction, lifecycle.DeleteAction:

--- a/pkg/bucket/lifecycle/lifecycle.go
+++ b/pkg/bucket/lifecycle/lifecycle.go
@@ -44,7 +44,7 @@ type Action int
 //go:generate stringer -type Action $GOFILE
 
 const (
-	// NoneAction means no action required after evaluting lifecycle rules
+	// NoneAction means no action required after evaluating lifecycle rules
 	NoneAction Action = iota
 	// DeleteAction means the object needs to be removed after evaluating lifecycle rules
 	DeleteAction


### PR DESCRIPTION
## Description
Data scanner ignores size of transitioning objects along with expiring one while calculating bucket usage.

## How to test this PR?
1. Setup ILM transition on a bucket
2. Upload objects to this bucket; wait until an object transitions.
3. With this fix, you should *not* notice any change in bucket usage at the time of object transition.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
