### PR TITLE
iam: Return a slice of policies for a group

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1563,11 +1563,7 @@ func (sys *IAMSys) GetGroupDescription(group string) (gd madmin.GroupDesc, err e
 		return gd, err
 	}
 
-	// A group may be mapped to at most one policy.
-	policy := ""
-	if len(ps) > 0 {
-		policy = ps[0]
-	}
+	policy := strings.Join(ps, ",")
 
 	if sys.usersSysType != MinIOUsersSysType {
 		return madmin.GroupDesc{
@@ -1681,7 +1677,7 @@ func (sys *IAMSys) policyDBSet(name, policyName string, userType IAMUserType, is
 
 // PolicyDBGet - gets policy set on a user or group. Since a user may
 // be a member of multiple groups, this function returns an array of
-// applicable policies (each group is mapped to at most one policy).
+// applicable policies
 func (sys *IAMSys) PolicyDBGet(name string, isGroup bool) ([]string, error) {
 	if !sys.Initialized() {
 		return nil, errServerNotInitialized
@@ -1739,17 +1735,6 @@ func (sys *IAMSys) policyDBGet(name string, isGroup bool) ([]string, error) {
 	policies = append(policies, mp.toSlice()...)
 
 	for _, group := range sys.iamUserGroupMemberships[name].ToSlice() {
-		// Skip missing or disabled groups
-		gi, ok := sys.iamGroupsMap[group]
-		if !ok || gi.Status == statusDisabled {
-			continue
-		}
-
-		p := sys.iamGroupPolicyMap[group]
-		policies = append(policies, p.toSlice()...)
-	}
-
-	for _, group := range u.Groups {
 		// Skip missing or disabled groups
 		gi, ok := sys.iamGroupsMap[group]
 		if !ok || gi.Status == statusDisabled {


### PR DESCRIPTION
## Description
A group can have multiple policies, a user subscribed to readwrite &
diagnostics can perform S3 operations & admin operations as well.
However, the current code only returns one policy for one group.

This PR also fixes a redundant policy accumulation from groups in
policyGetDB()

## Motivation and Context
Fix returning the list of policies for a given group

## How to test this PR?
mc admin user add myminio console console123
mc admin group add myminio/ consolegroup console
mc admin group info myminio/ consolegroup


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
