### PR TITLE
fix: Remove repetitive IAM ready message

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -561,7 +561,6 @@ func (sys *IAMSys) Load(ctx context.Context, store IAMStorageAPI) error {
 	default:
 		close(sys.configLoaded)
 	}
-	logger.Info("IAM initialization complete")
 	return nil
 }
 
@@ -662,6 +661,8 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 	// Invalidate the old cred always, even upon error to avoid any leakage.
 	globalOldCred = auth.Credentials{}
 	go sys.store.watch(ctx, sys)
+
+	logger.Info("IAM initialization complete")
 }
 
 // DeletePolicy - deletes a canned policy from backend or etcd.


### PR DESCRIPTION
## Description
"IAM initialization complete" is printed each 5 minutes, avoid this by
printing it only during the first initialization of IAM.

## Motivation and Context
Remove repetitive annoying info message

## How to test this PR?
mc server /tmp/fs/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
