### PR TITLE
ignore healing .trash, .metacache amd .multipart paths

### DIFF
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -27,6 +27,7 @@ import (
 	"github.com/minio/minio/pkg/color"
 	"github.com/minio/minio/pkg/console"
 	"github.com/minio/minio/pkg/madmin"
+	"github.com/minio/minio/pkg/wildcard"
 )
 
 const (
@@ -204,6 +205,20 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []BucketIn
 		healEntry := func(entry metaCacheEntry) {
 			if entry.isDir() {
 				return
+			}
+			// We might land at .metacache, .trash, .multipart
+			// no need to heal them skip, only when bucket
+			// is '.minio.sys'
+			if bucket.Name == minioMetaBucket {
+				if wildcard.Match("buckets/*/.metacache/*", entry.name) {
+					return
+				}
+				if wildcard.Match("tmp/.trash/*", entry.name) {
+					return
+				}
+				if wildcard.Match("multipart/*", entry.name) {
+					return
+				}
 			}
 			fivs, err := entry.fileInfoVersions(bucket.Name)
 			if err != nil {


### PR DESCRIPTION
## Description
ignore healing .trash, .metacache amd .multipart paths

## Motivation and Context
ignore healing of certain temporary objects

## How to test this PR?
Print in `healEntry` to see if the correct paths are ignored and not healed as 
part of `mc admin heal -r` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
