### PR TITLE
fips: always enable AES in FIPS mode when using madmin

### DIFF
--- a/pkg/madmin/encrypt.go
+++ b/pkg/madmin/encrypt.go
@@ -51,7 +51,7 @@ func EncryptData(password string, data []byte) ([]byte, error) {
 		err    error
 		stream *sio.Stream
 	)
-	if sioutil.NativeAES() { // Only use AES-GCM if we can use an optimized implementation
+	if useAES() { // Only use AES-GCM if we can use an optimized implementation
 		id = aesGcm
 		stream, err = sio.AES_256_GCM.Stream(key)
 	} else {

--- a/pkg/madmin/encrypt_fips.go
+++ b/pkg/madmin/encrypt_fips.go
@@ -1,0 +1,22 @@
+// MinIO Cloud Storage, (C) 2021 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build fips
+
+package madmin
+
+// useAES always returns true since AES is the only
+// option out of AES-GCM and ChaCha20-Poly1305 that
+// is approved by the NIST.
+func useAES() bool { return true }

--- a/pkg/madmin/encrypt_nofips.go
+++ b/pkg/madmin/encrypt_nofips.go
@@ -1,0 +1,24 @@
+// MinIO Cloud Storage, (C) 2021 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !fips
+
+package madmin
+
+import "github.com/secure-io/sio-go/sioutil"
+
+// useAES returns true if the executing CPU provides
+// AES-GCM hardware instructions and an optimized
+// assembler implementation is available.
+func useAES() bool { return sioutil.NativeAES() }


### PR DESCRIPTION
## Description
This commit adds FIPS-specifc build tags to the madmin
package. When madmin is compiled with `--tags "fips"`
it will always use AES-GCM for encryption - not just
when an optimized AES implementation is available.

## Motivation and Context
FIPS 140-2

## How to test this PR?
No server behavior should change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
