### PR TITLE
heal: Heal bucket metadata when a fresh disk is inserted

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -375,6 +375,12 @@ func monitorLocalDisksAndHeal(ctx context.Context, z *erasureServerPools, bgSeq 
 				Name: pathJoin(minioMetaBucket, minioConfigPrefix),
 			})
 
+			// Buckets data are dispersed in multiple zones/sets, make
+			// sure to heal all bucket metadata configuration.
+			buckets = append(buckets, []BucketInfo{
+				{Name: pathJoin(minioMetaBucket, bucketMetaPrefix)},
+			}...)
+
 			// Heal latest buckets first.
 			sort.Slice(buckets, func(i, j int) bool {
 				a, b := strings.HasPrefix(buckets[i].Name, minioMetaBucket), strings.HasPrefix(buckets[j].Name, minioMetaBucket)


### PR DESCRIPTION
## Description
Replacing disk with a fresh one never heals bucket metadata (policy,
notification, etc..). This commit fixes the issue.

## Motivation and Context
Fix healing bucket metadata with new disks

## How to test this PR?
1. minio server /tmp/xl/{1...4}/
2. mc mb myminio/testbucket/
3. rm -r /tmp/xl/1/{.minio.sys,testbucket}/
4. Wait until MinIO server says the new disk is healed
5. ls /tmp/xl/1/.minio.sys/buckets/testbucket/.metadata.bin/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
