### PR TITLE
keep blockSizeV1 buffer for existing content

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -69,8 +69,11 @@ type erasureObjects struct {
 	// Locker mutex map.
 	nsMutex *nsLockMap
 
-	// Byte pools used for temporary i/o buffers.
+	// Byte pools used for temporary i/o buffers
 	bp *bpool.BytePoolCap
+
+	// Byte pools used for temporary i/o buffers (existing objects)
+	bpLegacy *bpool.BytePoolCap
 
 	mrfOpCh chan partialOperation
 


### PR DESCRIPTION
## Description
keep blockSizeV1 buffer for existing content

## Motivation and Context
need to keep blockSizeV1 buffer for existing
content to avoid unexpected overallocation
spikes.

## How to test this PR?
Upgrade existing cluster with the previous content
with blockSizeV1, verify that it uses a different buffer 
pool

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
