### PR TITLE
Resize replication pool dynamically after config update

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -73,7 +73,6 @@ func init() {
 		},
 	})
 
-	globalReplicationState = newReplicationState()
 	globalTransitionState = newTransitionState()
 
 	console.SetColor("Debug", color.New())

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1076,10 +1076,10 @@ func (i *scannerItem) healReplication(ctx context.Context, o ObjectLayer, oi Obj
 	switch oi.ReplicationStatus {
 	case replication.Pending:
 		sizeS.pendingSize += oi.Size
-		globalReplicationState.queueReplicaTask(oi)
+		globalReplicationPool.queueReplicaTask(oi)
 	case replication.Failed:
 		sizeS.failedSize += oi.Size
-		globalReplicationState.queueReplicaTask(oi)
+		globalReplicationPool.queueReplicaTask(oi)
 	case replication.Completed, "COMPLETE":
 		sizeS.replicatedSize += oi.Size
 	case replication.Replica:
@@ -1098,7 +1098,7 @@ func (i *scannerItem) healReplicationDeletes(ctx context.Context, o ObjectLayer,
 		} else {
 			versionID = oi.VersionID
 		}
-		globalReplicationState.queueReplicaDeleteTask(DeletedObjectVersionInfo{
+		globalReplicationPool.queueReplicaDeleteTask(DeletedObjectVersionInfo{
 			DeletedObject: DeletedObject{
 				ObjectName:                    oi.Name,
 				DeleteMarkerVersionID:         dmVersionID,

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -80,6 +80,10 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 	t.requestsDeadline = cfg.RequestsDeadline
 	t.listQuorum = cfg.GetListQuorum()
 	t.extendListLife = cfg.ExtendListLife
+	if globalReplicationPool != nil &&
+		cfg.ReplicationWorkers != t.replicationWorkers {
+		globalReplicationPool.Resize(cfg.ReplicationWorkers)
+	}
 	t.replicationWorkers = cfg.ReplicationWorkers
 }
 


### PR DESCRIPTION
## Description


## Motivation and Context
resize number of replication workers dynamically as per configuration

## How to test this PR?
`mc admin config set alias api` change number of replication workers to scale up/down the number of workers needed,

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
