### PR TITLE
erasure: Reduce the interval of cleaning up .trash folder

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -421,7 +421,7 @@ func newErasureSets(ctx context.Context, endpoints Endpoints, storageDisks []Sto
 	}
 
 	// cleanup ".trash/" folder every 30 minutes with sufficient sleep cycles.
-	const deletedObjectsCleanupInterval = 30 * time.Minute
+	const deletedObjectsCleanupInterval = 10 * time.Minute
 
 	// start cleanup stale uploads go-routine.
 	go s.cleanupStaleUploads(ctx, GlobalStaleUploadsCleanupInterval, GlobalStaleUploadsExpiry)


### PR DESCRIPTION
## Description
Reduce from 30 to 10 minutes.


## Motivation and Context
erasure: Reduce the interval of cleaning up .trash folder

## How to test this PR?
Create a bucket, upload some objects and check .trash folder after 10 minutes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
