### PR TITLE
Writeall: Truncate files

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1619,7 +1619,7 @@ func (s *xlStorage) WriteAll(ctx context.Context, volume string, path string, b 
 		atomic.AddInt32(&s.activeIOCount, -1)
 	}()
 
-	w, err := s.openFile(volume, path, os.O_CREATE|os.O_WRONLY)
+	w, err := s.openFile(volume, path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

If the destination files exist and is larger junk data will be left at the end of the file.

Observed in multipart metadata files.

## How to test this PR?

CI should be fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
