### PR TITLE
add release build-arg to docker multiarch builds

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -2,11 +2,13 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 ARG TARGETARCH
 
+ARG RELEASE
+
 LABEL name="MinIO" \
       vendor="MinIO Inc <dev@min.io>" \
       maintainer="MinIO Inc <dev@min.io>" \
-      version="RELEASE.2021-03-10T05-11-33Z" \
-      release="RELEASE.2021-03-10T05-11-33Z" \
+      version="${RELEASE}" \
+      release="${RELEASE}" \
       summary="MinIO is a High Performance Object Storage, API compatible with Amazon S3 cloud storage service." \
       description="MinIO object storage is fundamentally different. Designed for performance and the S3 API, it is 100% open-source. MinIO is ideal for large, private cloud environments with stringent security requirements and delivers mission-critical availability across a diverse range of workloads."
 
@@ -28,9 +30,9 @@ RUN \
      microdnf install curl ca-certificates shadow-utils util-linux --nodocs && \
      rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
      microdnf install minisign --nodocs && \
-     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/minio -o /usr/bin/minio && \
-     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/minio.sha256sum -o /usr/bin/minio.sha256sum && \
-     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/minio.minisig -o /usr/bin/minio.minisig && \
+     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE} -o /usr/bin/minio && \
+     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.sha256sum -o /usr/bin/minio.sha256sum && \
+     curl -s -q https://dl.min.io/server/minio/release/linux-${TARGETARCH}/archive/minio.${RELEASE}.minisig -o /usr/bin/minio.minisig && \
      microdnf clean all && \
      chmod +x /usr/bin/minio && \
      chmod +x /usr/bin/docker-entrypoint.sh && \

--- a/docker-buildx.sh
+++ b/docker-buildx.sh
@@ -2,15 +2,17 @@
 
 sudo sysctl net.ipv6.conf.wlp59s0.disable_ipv6=1
 
-docker buildx build --push --no-cache -t "minio/minio:latest" \
+release=$(git describe --abbrev=0 --tags)
+
+docker buildx build --push --no-cache \
+       --build-arg RELEASE="${release}" -t "minio/minio:latest" \
        --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x \
        -f Dockerfile.release .
 
 docker buildx prune -f
 
-release=$(git describe --abbrev=0 --tags)
-
-docker buildx build --push --no-cache -t "minio/minio:${release}" \
+docker buildx build --push --no-cache \
+       --build-arg RELEASE="${release}" -t "minio/minio:${release}" \
        --platform=linux/arm64,linux/amd64,linux/ppc64le,linux/s390x \
        -f Dockerfile.release .
 


### PR DESCRIPTION
## Description
add release build-arg to docker multiarch builds

## Motivation and Context
make docker builds more dynamic

## How to test this PR?
nothing specific just change the image name `minio/minio`  to your `dockerhubaccount/minio` to test the process

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
