### PR TITLE
Update S2 compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/json-iterator/go v1.1.10
-	github.com/klauspost/compress v1.11.7
-	github.com/klauspost/cpuid v1.3.1
+	github.com/klauspost/compress v1.11.12
+	github.com/klauspost/cpuid/v2 v2.0.4
 	github.com/klauspost/pgzip v1.2.5
 	github.com/klauspost/readahead v1.3.1
 	github.com/klauspost/reedsolomon v1.9.11

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaHeMeg=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.12 h1:famVnQVu7QwryBN4jNseQdUKES71ZAOnB6UQQJPZvqk=
+github.com/klauspost/compress v1.11.12/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=

--- a/pkg/s3select/select_test.go
+++ b/pkg/s3select/select_test.go
@@ -22,14 +22,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/klauspost/cpuid"
+	"github.com/klauspost/cpuid/v2"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/simdjson-go"
 )
@@ -363,11 +362,13 @@ func TestJSONQueries(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			// Hack cpuid to the CPU doesn't appear to support AVX2.
 			// Restore whatever happens.
-			defer func(f cpuid.Flags) {
-				cpuid.CPU.Features = f
-			}(cpuid.CPU.Features)
-			cpuid.CPU.Features &= math.MaxUint64 - cpuid.AVX2
-
+			if cpuid.CPU.Supports(cpuid.AVX2) {
+				cpuid.CPU.Disable(cpuid.AVX2)
+				defer cpuid.CPU.Enable(cpuid.AVX2)
+			}
+			if simdjson.SupportedCPU() {
+				t.Fatal("setup error: expected cpu to be unsupported")
+			}
 			testReq := testCase.requestXML
 			if len(testReq) == 0 {
 				var escaped bytes.Buffer


### PR DESCRIPTION
## Description

Relevant updates:

* Less allocations on decode: https://github.com/klauspost/compress/pull/322
* Fixed rare out-of-bounds write on amd64.
* ARM64 decompression assembly. Around 2x output speed. https://github.com/klauspost/compress/pull/324
* Speed up decompression on non-assembly platforms. https://github.com/klauspost/compress/pull/328

Upgrade cpuid to match simdjson.

## How to test this PR?

Existing tests should do checks.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
