### PR TITLE
Add consoleAdmin as a default canned policy

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -2089,6 +2089,10 @@ func setDefaultCannedPolicies(policies map[string]iampolicy.Policy) {
 	if !ok {
 		policies["diagnostics"] = iampolicy.AdminDiagnostics
 	}
+	_, ok = policies["consoleAdmin"]
+	if !ok {
+		policies["consoleAdmin"] = iampolicy.ConsoleAdmin
+	}
 }
 
 // buildUserGroupMemberships - builds the memberships map. IMPORTANT:

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -2091,7 +2091,7 @@ func setDefaultCannedPolicies(policies map[string]iampolicy.Policy) {
 	}
 	_, ok = policies["consoleAdmin"]
 	if !ok {
-		policies["consoleAdmin"] = iampolicy.ConsoleAdmin
+		policies["consoleAdmin"] = iampolicy.Admin
 	}
 }
 

--- a/pkg/iam/policy/constants.go
+++ b/pkg/iam/policy/constants.go
@@ -82,6 +82,7 @@ var AdminDiagnostics = Policy{
 	},
 }
 
+// Admin - provides admin access for console and mc users.
 var Admin = Policy{
 	Version: DefaultVersion,
 	Statements: []Statement{

--- a/pkg/iam/policy/constants.go
+++ b/pkg/iam/policy/constants.go
@@ -82,7 +82,7 @@ var AdminDiagnostics = Policy{
 	},
 }
 
-var ConsoleAdmin = Policy{
+var Admin = Policy{
 	Version: DefaultVersion,
 	Statements: []Statement{
 		{

--- a/pkg/iam/policy/constants.go
+++ b/pkg/iam/policy/constants.go
@@ -18,6 +18,7 @@ package iampolicy
 
 import (
 	"github.com/minio/minio/pkg/bucket/policy"
+	"github.com/minio/minio/pkg/bucket/policy/condition"
 )
 
 // Policy claim constants
@@ -77,6 +78,26 @@ var AdminDiagnostics = Policy{
 				ServerInfoAdminAction, TopLocksAdminAction,
 				HealthInfoAdminAction, BandwidthMonitorAction),
 			Resources: NewResourceSet(NewResource("*", "")),
+		},
+	},
+}
+
+var ConsoleAdmin = Policy{
+	Version: DefaultVersion,
+	Statements: []Statement{
+		{
+			SID:        policy.ID(""),
+			Effect:     policy.Allow,
+			Actions:    NewActionSet(AllAdminActions),
+			Resources:  NewResourceSet(),
+			Conditions: condition.NewFunctions(),
+		},
+		{
+			SID:        policy.ID(""),
+			Effect:     policy.Allow,
+			Actions:    NewActionSet(AllActions),
+			Resources:  NewResourceSet(NewResource("*", "")),
+			Conditions: condition.NewFunctions(),
 		},
 	},
 }

--- a/pkg/iam/policy/constants.go
+++ b/pkg/iam/policy/constants.go
@@ -82,7 +82,7 @@ var AdminDiagnostics = Policy{
 	},
 }
 
-// Admin - provides admin access for console and mc users.
+// Admin - provides admin all-access canned policy
 var Admin = Policy{
 	Version: DefaultVersion,
 	Statements: []Statement{


### PR DESCRIPTION
## Description
This PR add a new default canned policy `consoleAdmin`. 

## Motivation and Context
The default console policy is important to use the MinIO Console. It is better have this policy configured by
default on MinIO.

## How to test this PR?
Build this PR and start MinIO server. Check for default policies using 

```
./mc admin policy list myminio
./mc admin policy info myminio consoleAdmin
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
