### PR TITLE
cmd/os-readdir_other.go - return nil with err

### DIFF
--- a/cmd/os-readdir_other.go
+++ b/cmd/os-readdir_other.go
@@ -126,7 +126,7 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 						isSysErrTooManySymlinks(err) {
 						continue
 					}
-					return err
+					return nil, err
 				}
 
 				// Ignore symlinked directories.


### PR DESCRIPTION
## Description
Fix for build error `cmd/os-readdir_other.go:129:6: not enough arguments to return `

## Motivation and Context

While building on omnios (an illumos distribution) I encounter the following error:
```
cmd/os-readdir_other.go:129:6: not enough arguments to return                             
>-------have (error)                       
>-------want ([]string, error)             
gmake: *** [Makefile:62: build] Error 2    
Build failed                               
```
As suggested in the error output, `nil` satisfies the demands of `want ([]string, error) `

## How to test this PR?

Build on any illumos based operating system should be sufficient.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression commit 8cad407e0b011e05e34f3aca8093dfdb4a2630dc
- [ ] Documentation updated
- [ ] Unit tests added/updated
