### PR TITLE
Let linux/mips and linux/mipsle 32bit architectures use 32bit source code

### DIFF
--- a/buildscripts/cross-compile.sh
+++ b/buildscripts/cross-compile.sh
@@ -9,7 +9,7 @@ function _init() {
     export CGO_ENABLED=0
 
     ## List of architectures and OS to test coss compilation.
-    SUPPORTED_OSARCH="linux/ppc64le linux/mips64 linux/arm64 linux/s390x darwin/arm64 darwin/amd64 freebsd/amd64 windows/amd64 linux/arm linux/386 netbsd/amd64"
+    SUPPORTED_OSARCH="linux/ppc64le linux/mips64 linux/arm64 linux/s390x darwin/arm64 darwin/amd64 freebsd/amd64 windows/amd64 linux/arm linux/386 linux/mips linux/mipsle netbsd/amd64"
 }
 
 function _build() {

--- a/pkg/disk/stat_linux.go
+++ b/pkg/disk/stat_linux.go
@@ -1,4 +1,4 @@
-// +build linux,!s390x,!arm,!386
+// +build linux,!s390x,!arm,!386,!mips,!mipsle
 
 /*
  * MinIO Cloud Storage, (C) 2015, 2016, 2017 MinIO, Inc.

--- a/pkg/disk/stat_linux_32bit.go
+++ b/pkg/disk/stat_linux_32bit.go
@@ -1,4 +1,4 @@
-// +build linux,arm linux,386
+// +build linux,arm linux,386 linux,mips linux,mipsle
 
 /*
  * MinIO Cloud Storage, (C) 2020 MinIO, Inc.

--- a/pkg/disk/type_linux.go
+++ b/pkg/disk/type_linux.go
@@ -1,4 +1,4 @@
-// +build linux,!s390x,!arm,!386
+// +build linux,!s390x,!arm,!386,!mips,!mipsle
 
 /*
  * MinIO Cloud Storage, (C) 2017 MinIO, Inc.

--- a/pkg/sys/stats_linux.go
+++ b/pkg/sys/stats_linux.go
@@ -1,4 +1,4 @@
-// +build linux,!arm,!386
+// +build linux,!arm,!386,!mips,!mipsle
 
 /*
  * MinIO Cloud Storage, (C) 2016,2017 MinIO, Inc.

--- a/pkg/sys/stats_linux_32bit.go
+++ b/pkg/sys/stats_linux_32bit.go
@@ -1,4 +1,4 @@
-// +build linux,arm linux,386
+// +build linux,arm linux,386 linux,mips linux,mipsle
 
 /*
  * MinIO Cloud Storage, (C) 2020 MinIO, Inc.


### PR DESCRIPTION
Currently the build fails because go tries to include 64bit source code.

## Description
This fixes #11768 by including also linux/mips and linux/mipsle in the architectures to be built with 32bit files.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
