### PR TITLE
policy: Add Merge API to merge policy documents

### DIFF
--- a/pkg/bucket/policy/actionset.go
+++ b/pkg/bucket/policy/actionset.go
@@ -93,8 +93,12 @@ func (actionSet ActionSet) ToSlice() []Action {
 	for action := range actionSet {
 		actions = append(actions, action)
 	}
-
 	return actions
+}
+
+// Clone clones ActionSet structure
+func (actionSet ActionSet) Clone() ActionSet {
+	return NewActionSet(actionSet.ToSlice()...)
 }
 
 // UnmarshalJSON - decodes JSON data to ActionSet.

--- a/pkg/bucket/policy/condition/func.go
+++ b/pkg/bucket/policy/condition/func.go
@@ -66,6 +66,42 @@ func (functions Functions) Keys() KeySet {
 	return keySet
 }
 
+// Clone clones Functions structure
+func (functions Functions) Clone() Functions {
+	funcs := []Function{}
+
+	for _, f := range functions {
+		vfn := conditionFuncMap[f.name()]
+		for key, values := range f.toMap() {
+			function, _ := vfn(key, values.Clone())
+			funcs = append(funcs, function)
+		}
+	}
+
+	return funcs
+}
+
+// Equals returns true if two Functions structures are equal
+func (functions Functions) Equals(funcs Functions) bool {
+	if len(functions) != len(funcs) {
+		return false
+	}
+	for _, fi := range functions {
+		fistr := fi.String()
+		found := false
+		for _, fj := range funcs {
+			if fistr == fj.String() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
 // MarshalJSON - encodes Functions to  JSON data.
 func (functions Functions) MarshalJSON() ([]byte, error) {
 	nm := make(map[name]map[Key]ValueSet)

--- a/pkg/bucket/policy/condition/valueset.go
+++ b/pkg/bucket/policy/condition/valueset.go
@@ -29,6 +29,15 @@ func (set ValueSet) Add(value Value) {
 	set[value] = struct{}{}
 }
 
+// ToSlice converts ValueSet to a slice of Value
+func (set ValueSet) ToSlice() []Value {
+	var values []Value
+	for k := range set {
+		values = append(values, k)
+	}
+	return values
+}
+
 // MarshalJSON - encodes ValueSet to JSON data.
 func (set ValueSet) MarshalJSON() ([]byte, error) {
 	var values []Value
@@ -71,6 +80,11 @@ func (set *ValueSet) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// Clone clones ValueSet structure
+func (set ValueSet) Clone() ValueSet {
+	return NewValueSet(set.ToSlice()...)
 }
 
 // NewValueSet - returns new value set containing given values.

--- a/pkg/bucket/policy/principal.go
+++ b/pkg/bucket/policy/principal.go
@@ -90,6 +90,12 @@ func (p *Principal) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Clone clones Principal structure
+func (p Principal) Clone() Principal {
+	return NewPrincipal(p.AWS.ToSlice()...)
+
+}
+
 // NewPrincipal - creates new Principal.
 func NewPrincipal(principals ...string) Principal {
 	return Principal{AWS: set.CreateStringSet(principals...)}

--- a/pkg/bucket/policy/resourceset.go
+++ b/pkg/bucket/policy/resourceset.go
@@ -154,6 +154,21 @@ func (resourceSet ResourceSet) Validate(bucketName string) error {
 	return nil
 }
 
+// ToSlice - returns slice of resources from the resource set.
+func (resourceSet ResourceSet) ToSlice() []Resource {
+	resources := []Resource{}
+	for resource := range resourceSet {
+		resources = append(resources, resource)
+	}
+
+	return resources
+}
+
+// Clone clones ResourceSet structure
+func (resourceSet ResourceSet) Clone() ResourceSet {
+	return NewResourceSet(resourceSet.ToSlice()...)
+}
+
 // NewResourceSet - creates new resource set.
 func NewResourceSet(resources ...Resource) ResourceSet {
 	resourceSet := make(ResourceSet)

--- a/pkg/bucket/policy/statement.go
+++ b/pkg/bucket/policy/statement.go
@@ -33,6 +33,26 @@ type Statement struct {
 	Conditions condition.Functions `json:"Condition,omitempty"`
 }
 
+// Equals checks if two statements are equal
+func (statement Statement) Equals(st Statement) bool {
+	if statement.Effect != st.Effect {
+		return false
+	}
+	if !statement.Principal.Equals(st.Principal) {
+		return false
+	}
+	if !statement.Actions.Equals(st.Actions) {
+		return false
+	}
+	if !statement.Resources.Equals(st.Resources) {
+		return false
+	}
+	if !statement.Conditions.Equals(st.Conditions) {
+		return false
+	}
+	return true
+}
+
 // IsAllowed - checks given policy args is allowed to continue the Rest API.
 func (statement Statement) IsAllowed(args Args) bool {
 	check := func() bool {
@@ -141,6 +161,12 @@ func (statement Statement) Validate(bucketName string) error {
 	}
 
 	return statement.Resources.Validate(bucketName)
+}
+
+// Clone clones Statement structure
+func (statement Statement) Clone() Statement {
+	return NewStatement(statement.Effect, statement.Principal.Clone(),
+		statement.Actions.Clone(), statement.Resources.Clone(), statement.Conditions.Clone())
 }
 
 // NewStatement - creates new statement.

--- a/pkg/iam/policy/actionset.go
+++ b/pkg/iam/policy/actionset.go
@@ -27,6 +27,11 @@ import (
 // ActionSet - set of actions.
 type ActionSet map[Action]struct{}
 
+// Clone clones ActionSet structure
+func (actionSet ActionSet) Clone() ActionSet {
+	return NewActionSet(actionSet.ToSlice()...)
+}
+
 // Add - add action to the set.
 func (actionSet ActionSet) Add(action Action) {
 	actionSet[action] = struct{}{}

--- a/pkg/iam/policy/policy.go
+++ b/pkg/iam/policy/policy.go
@@ -151,23 +151,30 @@ func (iamp Policy) isValid() error {
 	return nil
 }
 
+// Merge merges two policies documents and drop
+// duplicate statements if any.
+func (iamp Policy) Merge(input Policy) Policy {
+	var mergedPolicy Policy
+	if iamp.Version != "" {
+		mergedPolicy.Version = iamp.Version
+	} else {
+		mergedPolicy.Version = input.Version
+	}
+	for _, st := range iamp.Statements {
+		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
+	}
+	for _, st := range input.Statements {
+		mergedPolicy.Statements = append(mergedPolicy.Statements, st.Clone())
+	}
+	mergedPolicy.dropDuplicateStatements()
+	return mergedPolicy
+}
+
 func (iamp *Policy) dropDuplicateStatements() {
 redo:
 	for i := range iamp.Statements {
 		for j, statement := range iamp.Statements[i+1:] {
-			if iamp.Statements[i].Effect != statement.Effect {
-				continue
-			}
-
-			if !iamp.Statements[i].Actions.Equals(statement.Actions) {
-				continue
-			}
-
-			if !iamp.Statements[i].Resources.Equals(statement.Resources) {
-				continue
-			}
-
-			if iamp.Statements[i].Conditions.String() != statement.Conditions.String() {
+			if !iamp.Statements[i].Equals(statement) {
 				continue
 			}
 			iamp.Statements = append(iamp.Statements[:j], iamp.Statements[j+1:]...)

--- a/pkg/iam/policy/resourceset.go
+++ b/pkg/iam/policy/resourceset.go
@@ -154,6 +154,21 @@ func (resourceSet ResourceSet) Validate() error {
 	return nil
 }
 
+// ToSlice - returns slice of resources from the resource set.
+func (resourceSet ResourceSet) ToSlice() []Resource {
+	resources := []Resource{}
+	for resource := range resourceSet {
+		resources = append(resources, resource)
+	}
+
+	return resources
+}
+
+// Clone clones ResourceSet structure
+func (resourceSet ResourceSet) Clone() ResourceSet {
+	return NewResourceSet(resourceSet.ToSlice()...)
+}
+
 // NewResourceSet - creates new resource set.
 func NewResourceSet(resources ...Resource) ResourceSet {
 	resourceSet := make(ResourceSet)

--- a/pkg/iam/policy/statement.go
+++ b/pkg/iam/policy/statement.go
@@ -129,6 +129,29 @@ func (statement Statement) Validate() error {
 	return statement.isValid()
 }
 
+// Equals checks if two statements are equal
+func (statement Statement) Equals(st Statement) bool {
+	if statement.Effect != st.Effect {
+		return false
+	}
+	if !statement.Actions.Equals(st.Actions) {
+		return false
+	}
+	if !statement.Resources.Equals(st.Resources) {
+		return false
+	}
+	if !statement.Conditions.Equals(st.Conditions) {
+		return false
+	}
+	return true
+}
+
+// Clone clones Statement structure
+func (statement Statement) Clone() Statement {
+	return NewStatement(statement.Effect, statement.Actions.Clone(),
+		statement.Resources.Clone(), statement.Conditions.Clone())
+}
+
 // NewStatement - creates new statement.
 func NewStatement(effect policy.Effect, actionSet ActionSet, resourceSet ResourceSet, conditions condition.Functions) Statement {
 	return Statement{


### PR DESCRIPTION
## Description
This commit adds a new API in pkg/bucket/policy package called
Merge() to merge multiple policies of a user or a group into one
policy document.

## Motivation and Context
mc admin user policy command should show one policy document which contains
all policies combined in one single JSON

## How to test this PR?
Not trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
