### PR TITLE
No retries if minio server is down/connection refused err

### DIFF
--- a/pkg/madmin/api.go
+++ b/pkg/madmin/api.go
@@ -340,7 +340,6 @@ var successStatus = []int{
 // delayed manner using a standard back off algorithm.
 func (adm AdminClient) executeMethod(ctx context.Context, method string, reqData requestData) (res *http.Response, err error) {
 	var reqRetry = MaxRetry // Indicates how many times we can retry the request
-
 	defer func() {
 		if err != nil {
 			// close idle connections before returning, upon error.
@@ -365,6 +364,10 @@ func (adm AdminClient) executeMethod(ctx context.Context, method string, reqData
 		// Initiate the request.
 		res, err = adm.do(req)
 		if err != nil {
+			// Give up right away if it is a connection refused problem
+			if strings.HasSuffix(err.Error(), "connect: connection refused") {
+				return nil, err
+			}
 			if err == context.Canceled || err == context.DeadlineExceeded {
 				return nil, err
 			}

--- a/pkg/madmin/api.go
+++ b/pkg/madmin/api.go
@@ -34,6 +34,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -365,7 +366,7 @@ func (adm AdminClient) executeMethod(ctx context.Context, method string, reqData
 		res, err = adm.do(req)
 		if err != nil {
 			// Give up right away if it is a connection refused problem
-			if strings.HasSuffix(err.Error(), "connect: connection refused") {
+			if errors.Is(err, syscall.ECONNREFUSED) {
 				return nil, err
 			}
 			if err == context.Canceled || err == context.DeadlineExceeded {


### PR DESCRIPTION
Fixes the issue minio/mc#3630 filed against `mc`. (We need to transfer it to minio repo)
When minio server is down, we retry 10 times and it takes around 90 seconds to 2 minutes to get back to the user to tell that it is a connection failure problem.

## Motivation and Context
It takes close to 2 minutes since we retry 10 times with increasing intervals.

## How to test this PR?
Run command `mc admin info <alias>` where alias points to a down minio server

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

