### PR TITLE
crypto: simplify Context encoding

### DIFF
--- a/cmd/crypto/error.go
+++ b/cmd/crypto/error.go
@@ -81,8 +81,6 @@ var (
 
 	errInvalidInternalIV            = Errorf("The internal encryption IV is malformed")
 	errInvalidInternalSealAlgorithm = Errorf("The internal seal algorithm is invalid and not supported")
-
-	errMissingUpdatedKey = Errorf("The key update returned no error but also no sealed key")
 )
 
 var (

--- a/cmd/crypto/kes.go
+++ b/cmd/crypto/kes.go
@@ -181,7 +181,10 @@ func (kes *kesService) CreateKey(keyID string) error { return kes.client.CreateK
 // named key referenced by keyID. It also binds the generated key
 // cryptographically to the provided context.
 func (kes *kesService) GenerateKey(keyID string, ctx Context) (key [32]byte, sealedKey []byte, err error) {
-	context := ctx.AppendTo(make([]byte, 0, 128))
+	context, err := ctx.MarshalText()
+	if err != nil {
+		return key, nil, err
+	}
 
 	var plainKey []byte
 	plainKey, sealedKey, err = kes.client.GenerateDataKey(keyID, context)
@@ -203,7 +206,10 @@ func (kes *kesService) GenerateKey(keyID string, ctx Context) (key [32]byte, sea
 // The context must be same context as the one provided while
 // generating the plaintext key / sealedKey.
 func (kes *kesService) UnsealKey(keyID string, sealedKey []byte, ctx Context) (key [32]byte, err error) {
-	context := ctx.AppendTo(make([]byte, 0, 128))
+	context, err := ctx.MarshalText()
+	if err != nil {
+		return key, err
+	}
 
 	var plainKey []byte
 	plainKey, err = kes.client.DecryptDataKey(keyID, sealedKey, context)

--- a/cmd/crypto/kms.go
+++ b/cmd/crypto/kms.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"errors"
-	"fmt"
 	"io"
 	"sort"
 
@@ -33,74 +32,29 @@ import (
 // associated with a certain object.
 type Context map[string]string
 
-// WriteTo writes the context in a canonical from to w.
-// It returns the number of bytes and the first error
-// encounter during writing to w, if any.
-//
-// WriteTo sorts the context keys and writes the sorted
-// key-value pairs as canonical JSON object to w.
-// Sort order is based on the un-escaped keys.
-//
-// Note that neither keys nor values are escaped for JSON.
-func (c Context) WriteTo(w io.Writer) (n int64, err error) {
-	sortedKeys := make(sort.StringSlice, 0, len(c))
-	for k := range c {
-		sortedKeys = append(sortedKeys, k)
-	}
-	sort.Sort(sortedKeys)
+// MarshalText returns a canonical text representation of
+// the Context.
 
-	escape := func(s string) string {
-		buf := bytes.NewBuffer(make([]byte, 0, len(s)))
-		EscapeStringJSON(buf, s)
-		return buf.String()
-	}
-
-	nn, err := io.WriteString(w, "{")
-	if err != nil {
-		return n + int64(nn), err
-	}
-	n += int64(nn)
-	for i, k := range sortedKeys {
-		s := fmt.Sprintf("\"%s\":\"%s\",", escape(k), escape(c[k]))
-		if i == len(sortedKeys)-1 {
-			s = s[:len(s)-1] // remove last ','
-		}
-
-		nn, err = io.WriteString(w, s)
-		if err != nil {
-			return n + int64(nn), err
-		}
-		n += int64(nn)
-	}
-	nn, err = io.WriteString(w, "}")
-	return n + int64(nn), err
-}
-
-// AppendTo appends the context in a canonical from to dst.
-//
-// AppendTo sorts the context keys and writes the sorted
-// key-value pairs as canonical JSON object to w.
-// Sort order is based on the un-escaped keys.
-//
-// Note that neither keys nor values are escaped for JSON.
-func (c Context) AppendTo(dst []byte) (output []byte) {
+// MarshalText sorts the context keys and writes the sorted
+// key-value pairs as canonical JSON object. The sort order
+// is based on the un-escaped keys.
+func (c Context) MarshalText() ([]byte, error) {
 	if len(c) == 0 {
-		return append(dst, '{', '}')
+		return []byte{'{', '}'}, nil
 	}
 
-	// out should not escape.
-	out := bytes.NewBuffer(dst)
-
-	// No need to copy+sort
+	// Pre-allocate a buffer - 128 bytes is an arbitrary
+	// heuristic value that seems like a good starting size.
+	var b = bytes.NewBuffer(make([]byte, 0, 128))
 	if len(c) == 1 {
 		for k, v := range c {
-			out.WriteString(`{"`)
-			EscapeStringJSON(out, k)
-			out.WriteString(`":"`)
-			EscapeStringJSON(out, v)
-			out.WriteString(`"}`)
+			b.WriteString(`{"`)
+			EscapeStringJSON(b, k)
+			b.WriteString(`":"`)
+			EscapeStringJSON(b, v)
+			b.WriteString(`"}`)
 		}
-		return out.Bytes()
+		return b.Bytes(), nil
 	}
 
 	sortedKeys := make([]string, 0, len(c))
@@ -109,19 +63,19 @@ func (c Context) AppendTo(dst []byte) (output []byte) {
 	}
 	sort.Strings(sortedKeys)
 
-	out.WriteByte('{')
+	b.WriteByte('{')
 	for i, k := range sortedKeys {
-		out.WriteByte('"')
-		EscapeStringJSON(out, k)
-		out.WriteString(`":"`)
-		EscapeStringJSON(out, c[k])
-		out.WriteByte('"')
+		b.WriteByte('"')
+		EscapeStringJSON(b, k)
+		b.WriteString(`":"`)
+		EscapeStringJSON(b, c[k])
+		b.WriteByte('"')
 		if i < len(sortedKeys)-1 {
-			out.WriteByte(',')
+			b.WriteByte(',')
 		}
 	}
-	out.WriteByte('}')
-	return out.Bytes()
+	b.WriteByte('}')
+	return b.Bytes(), nil
 }
 
 // KMS represents an active and authenticted connection
@@ -225,9 +179,11 @@ func (kms *masterKeyKMS) deriveKey(keyID string, context Context) (key [32]byte)
 	if context == nil {
 		context = Context{}
 	}
+	ctxBytes, _ := context.MarshalText()
+
 	mac := hmac.New(sha256.New, kms.masterKey[:])
 	mac.Write([]byte(keyID))
-	mac.Write(context.AppendTo(make([]byte, 0, 128)))
+	mac.Write(ctxBytes)
 	mac.Sum(key[:0])
 	return key
 }


### PR DESCRIPTION
## Description
This commit adds a `MarshalText` implementation
to the `crypto.Context` type.
The `MarshalText` implementation replaces the
`WriteTo` and `AppendTo` implementation.

It is slightly slower than the `AppendTo` implementation
```
goos: darwin
goarch: arm64
pkg: github.com/minio/minio/cmd/crypto
BenchmarkContext_AppendTo/0-elems-8         	381475698	         2.892 ns/op	       0 B/op	       0 allocs/op
BenchmarkContext_AppendTo/1-elems-8         	17945088	        67.54 ns/op	       0 B/op	       0 allocs/op
BenchmarkContext_AppendTo/3-elems-8         	 5431770	       221.2 ns/op	      72 B/op	       2 allocs/op
BenchmarkContext_AppendTo/4-elems-8         	 3430684	       346.7 ns/op	      88 B/op	       2 allocs/op
```
vs.
```
goos: darwin
goarch: arm64
pkg: github.com/minio/minio/cmd/crypto
BenchmarkContext/0-elems-8         	136530691	         8.611 ns/op	       2 B/op	       1 allocs/op
BenchmarkContext/1-elems-8         	 6995516	       170.6 ns/op	     168 B/op	       5 allocs/op
BenchmarkContext/3-elems-8         	 4247020	       281.3 ns/op	     160 B/op	       6 allocs/op
BenchmarkContext/4-elems-8         	 2340092	       512.5 ns/op	     736 B/op	       9 allocs/op
```

However, the `AppendTo` benchmark used a pre-allocated buffer. While
this improves its performance it does not match the actual usage of
`crypto.Context` which is passed to a `KMS` and always encoded into
a newly allocated buffer.

Therefore, this change seems acceptable since it should not impact the
actual performance but reduces the overall code for Context marshaling.

## Motivation and Context
KMS

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
