### PR TITLE
add STS LDAP node.js sample

### DIFF
--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -239,7 +239,9 @@ $ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN='dc=minioad,dc=local;dc=somedo
 $ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER='(&(objectclass=group)(member=%s))'
 $ minio server ~/test
 ```
-You can make sure it works appropriately using our [example program](https://raw.githubusercontent.com/minio/minio/master/docs/sts/ldap.go):
+You can make sure it works appropriately using [node example program](https://github.com/minio/minio/samples/sts-ldap-node.js/README.md)
+
+Our GO sample is not [actively maintained](https://github.com/minio/minio/issues/11806) for a moment [go example program](https://raw.githubusercontent.com/minio/minio/master/docs/sts/ldap.go):
 ```
 $ go run ldap.go -u foouser -p foopassword
 
@@ -258,3 +260,6 @@ $ go run ldap.go -u foouser -p foopassword
 ## Explore Further
 - [MinIO Admin Complete Guide](https://docs.min.io/docs/minio-admin-complete-guide.html)
 - [The MinIO documentation website](https://docs.min.io)
+
+
+[../../samples/sts-ldap-node.js/README.md]: ../.go

--- a/samples/sts-ldap-node.js/README.md
+++ b/samples/sts-ldap-node.js/README.md
@@ -1,0 +1,45 @@
+### 1. Run LDAP service
+`yarn run-docker-ldap-service`
+
+### 2. Add minio config for LDAP
+`mc config host add myminio http://127.0.0.1:9000 minioadmin minioadmin`
+
+```
+cat <<EOF> allaccess.json
+{
+  "Statement": [
+    {
+      "Resource": [
+        "arn:aws:s3:::*"
+      ],
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow"
+    }
+  ],
+  "Version": "2012-10-17"
+}
+EOF
+```
+
+`mc admin policy add myminio allaccess allaccess.json`
+
+`mc admin policy set myminio allaccess user='cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com'`
+
+`yarn enable-minio-identity-ldap`
+
+### 3. Start minio server
+
+`mkdir -p export/{bucket1,bucket2}`
+
+`touch export/{bucket1,bucket2}/emptyfile.txt`
+
+`minio server ./export`
+
+### 4. Run node.js STS client
+#### Install dependencies
+`yarn install`
+
+#### Run STS client
+`node ldap.js`

--- a/samples/sts-ldap-node.js/ldap.js
+++ b/samples/sts-ldap-node.js/ldap.js
@@ -1,0 +1,64 @@
+const axios = require('axios');
+
+const url = 'http://localhost:9000';
+const params = new URLSearchParams();
+params.append('Action', 'AssumeRoleWithLDAPIdentity');
+params.append('LDAPUsername', 'Philip J. Fry');
+params.append('LDAPPassword', 'fry');
+params.append('Version', '2011-06-15');
+
+const config = {
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded'
+  }
+};
+
+axios
+  .post(url, params, config)
+  .then(response => {
+    console.log(response);
+    // eslint-disable-next-line global-require
+    const xml2js = require('xml2js');
+    const parser = new xml2js.Parser({
+      explicitRoot: false,
+      explicitArray: false,
+      ignoreAttrs: true
+    });
+    parser
+      .parseStringPromise(response.data)
+      .then(result => {
+        console.dir(result);
+        const accessKeyId =
+          result.AssumeRoleWithLDAPIdentityResult.Credentials.AccessKeyId;
+        const secretAccessKey =
+          result.AssumeRoleWithLDAPIdentityResult.Credentials.SecretAccessKey;
+        const sessionToken =
+          result.AssumeRoleWithLDAPIdentityResult.Credentials.SessionToken;
+
+        // eslint-disable-next-line global-require
+        const Minio = require('minio');
+
+        const minioClient = new Minio.Client({
+          endPoint: 'localhost',
+          port: 9000,
+          useSSL: false,
+          accessKey: accessKeyId,
+          secretKey: secretAccessKey,
+          sessionToken
+        });
+
+        minioClient.listBuckets((err, buckets) => {
+          if (err) return console.log(err);
+          console.log('buckets :', buckets);
+        });
+
+        return true;
+      })
+      .catch(err => {
+        console.log(err);
+      });
+    return true;
+  })
+  .catch(error => {
+    console.log(error);
+  });

--- a/samples/sts-ldap-node.js/package.json
+++ b/samples/sts-ldap-node.js/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "minio-ldap",
+  "version": "1.0.0",
+  "description": "minio ldap repository",
+  "scripts": {
+    "run-docker-ldap-service": "docker, run --rm -p 10389:10389 -p 10636:10636 rroemhild/test-openldap",
+    "enable-minio-identity-ldap": "mc admin config set myminio identity_ldap server_addr=127.0.0.1:10389 username_format='uid=%s,ou=service,dc=planetexpress,dc=com' group_search_filter='(&(objectclass=account)(uid=%s))' group_search_base_dn=\"dc=planetexpress,dc=com\" sts_expiry=60h tls_skip_verify=on server_insecure=on server_starttls=off user_dn_search_base_dn= user_dn_search_filter= lookup_bind_dn= lookup_bind_password="
+  },
+  "dependencies": {
+    "axios": "^0.21.1",
+    "minio": "^7.0.18",
+    "xml2js": "^0.4.23"
+  }
+}


### PR DESCRIPTION
## Description
Add Node.js LDAP STS Client

## Motivation and Context
Currently GO STS LDAP Client is deprecated and not working (without changes) look at: https://github.com/minio/minio/issues/11806

