### PR TITLE
dsync: use refresh timer properly to avoid leaks

### DIFF
--- a/pkg/dsync/drwmutex.go
+++ b/pkg/dsync/drwmutex.go
@@ -220,11 +220,17 @@ func (dm *DRWMutex) startContinousLockRefresh(lockLossCallback func(), id, sourc
 
 	go func() {
 		defer cancel()
+
+		refreshTimer := time.NewTimer(drwMutexRefreshInterval)
+		defer refreshTimer.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.NewTimer(drwMutexRefreshInterval).C:
+			case <-refreshTimer.C:
+				refreshTimer.Reset(drwMutexRefreshInterval)
+
 				refreshed, err := refresh(ctx, dm.clnt, id, source, quorum, dm.Names...)
 				if err == nil && !refreshed {
 					if lockLossCallback != nil {


### PR DESCRIPTION
## Description
dsync: use refresh timer properly to avoid leaks

## Motivation and Context
timer pattern should always involve a
'Stop()/Reset()' otherwise `time.NewTimer(duration).C`
will always leak.

## How to test this PR?
not easy to test, but the leaks can be observed over 
a long period of time, for long-running held locks such
as `runDataScanner.lock` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
