### PR TITLE
set a context timeout for prometheus metrics collectors

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1265,9 +1265,13 @@ func (c *minioClusterCollector) Collect(out chan<- prometheus.Metric) {
 		}
 	}
 
+	peerDeadlineCtx, pCancel := context.WithTimeout(GlobalContext, 5*time.Second)
+	defer pCancel()
+	reportDeadlineCtx, rCancel := context.WithTimeout(GlobalContext, 5*time.Second)
+	defer rCancel()
 	// Call peer api to fetch metrics
-	peerCh := globalNotificationSys.GetClusterMetrics(GlobalContext)
-	selfCh := ReportMetrics(GlobalContext, GetAllGenerators)
+	peerCh := globalNotificationSys.GetClusterMetrics(peerDeadlineCtx)
+	selfCh := ReportMetrics(reportDeadlineCtx, GetAllGenerators)
 	wg.Add(2)
 	go publish(peerCh)
 	go publish(selfCh)


### PR DESCRIPTION
This will avoid delays in returning available metrics if
the server is under load and all metric collectors do not
return info in a timely manner.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
