### PR TITLE
fix: bucket / object count and size returned as 0

### DIFF
--- a/pkg/madmin/health.go
+++ b/pkg/madmin/health.go
@@ -256,18 +256,6 @@ func (adm *AdminClient) ServerHealthInfo(ctx context.Context, healthDataTypes []
 		var healthInfoMessage HealthInfo
 		healthInfoMessage.TimeStamp = time.Now()
 
-		if v.Get(string(HealthDataTypeMinioInfo)) == "true" {
-			info, err := adm.ServerInfo(ctx)
-			if err != nil {
-				respChan <- HealthInfo{
-					Error: err.Error(),
-				}
-				return
-			}
-			healthInfoMessage.Minio.Info = info
-			respChan <- healthInfoMessage
-		}
-
 		resp, err := adm.executeMethod(ctx, "GET", requestData{
 			relPath:     adminAPIPrefix + "/healthinfo",
 			queryValues: v,
@@ -308,10 +296,22 @@ func (adm *AdminClient) ServerHealthInfo(ctx context.Context, healthDataTypes []
 		}
 
 		respChan <- healthInfoMessage
+
+		if v.Get(string(HealthDataTypeMinioInfo)) == "true" {
+			info, err := adm.ServerInfo(ctx)
+			if err != nil {
+				respChan <- HealthInfo{
+					Error: err.Error(),
+				}
+				return
+			}
+			healthInfoMessage.Minio.Info = info
+			respChan <- healthInfoMessage
+		}
+
 		close(respChan)
 	}()
 	return respChan
-
 }
 
 // GetTotalCapacity gets the total capacity a server holds.


### PR DESCRIPTION
## Description

The ServerHealthInfo was first populating healthInfoMessage by calling
adm.ServerInfo() and then decoding the JSON response of /healthinfo into
the same struct. In this process, the uint values inside the Buckets,
Objects and Usage structs were getting overwritten with zero.

Reversed the logic by calling adm.ServerInfo() after /healthinfo to
avoid this and ensure that the bucket/object data is retained in the
health report.

## Motivation and Context

Values related to bucket count, object count and object size (usage) are being
returned as zero in the health report. This PR should fix the same.

## How to test this PR?

- Build `mc` with dependency on this PR
- Generate a health report (`mc admin subnet health {alias}`) (ensure that the cluster has some objects in it)
- Verify that the following nodes have proper data and are not zero
  - software -> minio -> info -> buckets -> count
  - software -> minio -> info -> objects -> count
  - software -> minio -> info -> usage -> size

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (PR #11493)
- [ ] Documentation updated
- [ ] Unit tests added/updated
