### PR TITLE
fix: handle weird drives sporadic read O_DIRECT behavior

### DIFF
--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"hash/crc32"
 
 	"github.com/minio/minio/cmd/logger"
@@ -134,7 +135,8 @@ func readAllFileInfo(ctx context.Context, disks []StorageAPI, bucket, object, ve
 					errFileVersionNotFound,
 					errDiskNotFound,
 				}...) {
-					logger.LogOnceIf(ctx, err, disks[index].String())
+					logger.LogOnceIf(ctx, fmt.Errorf("Drive %s returned an error (%w)", disks[index], err),
+						disks[index].String())
 				}
 			}
 			return err

--- a/pkg/ioutil/ioutil_test.go
+++ b/pkg/ioutil/ioutil_test.go
@@ -50,14 +50,14 @@ func TestDeadlineWriter(t *testing.T) {
 	if err != context.Canceled {
 		t.Error("DeadlineWriter shouldn't be successful - should return context.Canceled")
 	}
-	w = NewDeadlineWriter(&sleepWriter{timeout: 500 * time.Millisecond}, 600*time.Millisecond)
+	w = NewDeadlineWriter(&sleepWriter{timeout: 100 * time.Millisecond}, 600*time.Millisecond)
 	n, err := w.Write([]byte("abcd"))
 	w.Close()
 	if err != nil {
 		t.Errorf("DeadlineWriter should succeed but failed with %s", err)
 	}
 	if n != 4 {
-		t.Errorf("DeadlineWriter should succeed but should have only written 0 bytes, but returned %d instead", n)
+		t.Errorf("DeadlineWriter should succeed but should have only written 4 bytes, but returned %d instead", n)
 	}
 }
 


### PR DESCRIPTION


## Description
fix: handle weird drives sporadic read O_DIRECT behavior

## Motivation and Context
on freshReads, if drive returns errInvalidArgument, we
should simply turn-off DirectIO and read normally, there
are situations in k8s like environments where the drives
behave sporadically in a single deployment and may not
have been implemented properly to handle O_DIRECT for
reads.

## How to test this PR?
In k8s ci/cd environment

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
