### PR TITLE
Adds missing pipe/redirection device check for colorization

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -124,8 +124,7 @@ var (
 
 	// Colorize prints message in a colorized form, dictated by the corresponding tag argument.
 	Colorize = func(tag string, data interface{}) string {
-		colorized, _ := Theme[tag]
-		return colorized.SprintFunc()(data)
+		return Theme[tag].SprintFunc()(data)
 	}
 
 	// Eraseline Print in new line and adjust to top so that we don't print over the ongoing progress bar.

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -124,13 +124,8 @@ var (
 
 	// Colorize prints message in a colorized form, dictated by the corresponding tag argument.
 	Colorize = func(tag string, data interface{}) string {
-		if isatty.IsTerminal(os.Stdout.Fd()) {
-			colorized, ok := Theme[tag]
-			if ok {
-				return colorized.SprintFunc()(data)
-			} // else: No theme found. Return as string.
-		}
-		return fmt.Sprint(data)
+		colorized, _ := Theme[tag]
+		return colorized.SprintFunc()(data)
 	}
 
 	// Eraseline Print in new line and adjust to top so that we don't print over the ongoing progress bar.

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -19,6 +19,7 @@ package console
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,7 +125,18 @@ var (
 
 	// Colorize prints message in a colorized form, dictated by the corresponding tag argument.
 	Colorize = func(tag string, data interface{}) string {
-		return Theme[tag].SprintFunc()(data)
+		fi, err := os.Stdout.Stat()
+		if err != nil {
+			log.Fatal(err)
+		}
+		// check if it is a terminal or a pipe/redirection
+		if isatty.IsTerminal(os.Stdout.Fd()) || fi.Mode()&os.ModeCharDevice == 0 {
+			colorized, ok := Theme[tag]
+			if ok {
+				return colorized.SprintFunc()(data)
+			} // else: No theme found. Return as string.
+		}
+		return fmt.Sprint(data)
 	}
 
 	// Eraseline Print in new line and adjust to top so that we don't print over the ongoing progress bar.

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -129,7 +129,7 @@ var (
 		if err != nil {
 			log.Fatal(err)
 		}
-		// check if it is a terminal or a pipe/redirection
+		// Check if Stdout is a terminal device or a pipe/redirection
 		if isatty.IsTerminal(os.Stdout.Fd()) || fi.Mode()&os.ModeCharDevice == 0 {
 			colorized, ok := Theme[tag]
 			if ok {


### PR DESCRIPTION
Fixes minio/mc#3632 together with mc PR#3655

Maintain colorized output when `mc` command Stdout is a pipe

## Motivation and Context
minio/mc#3632

## How to test this PR?
`mc admin info <allias> | tee /tmp/result`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
