### PR TITLE
xl: Remove non needed check for empty dir

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1977,12 +1977,6 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath, dataDir,
 		s.deleteFile(srcVolumeDir, parentDir, false)
 	}
 
-	if srcDataPath != "" {
-		if parentDir := pathutil.Dir(srcDataPath); isDirEmpty(parentDir) {
-			s.deleteFile(srcVolumeDir, parentDir, false)
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description
RenameData renames xl.meta and data dir and removes the parent directory
if empty, however there is duplicate check for empty dir, since the
parent dir of xl.meta is always the same as the data-dir.

## Motivation and Context
Fix after code review

## How to test this PR?
No testing, trivial.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
