### PR TITLE
xl: CreateFile shouldn't prematurely timeout

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	dataScannerSleepPerFolder = time.Millisecond // Time to wait between folders.
-	dataScannerStartDelay     = 1 * time.Minute  // Time to wait on startup and between cycles.
+	dataScannerStartDelay     = 5 * time.Minute  // Time to wait on startup and between cycles.
 	dataUsageUpdateDirCycles  = 16               // Visit all folders every n cycles.
 
 	healDeleteDangling    = true

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -337,8 +337,10 @@ func (client *storageRESTClient) CreateFile(ctx context.Context, volume, path st
 	values.Set(storageRESTFilePath, path)
 	values.Set(storageRESTLength, strconv.Itoa(int(size)))
 	respBody, err := client.call(ctx, storageRESTMethodCreateFile, values, ioutil.NopCloser(reader), size)
-	defer http.DrainBody(respBody)
-	return err
+	if err != nil {
+		return err
+	}
+	return waitForHTTPStream(respBody, ioutil.Discard)
 }
 
 func (client *storageRESTClient) WriteMetadata(ctx context.Context, volume, path string, fi FileInfo) error {

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -287,10 +287,10 @@ func (s *storageRESTServer) CreateFileHandler(w http.ResponseWriter, r *http.Req
 		s.writeErrorResponse(w, err)
 		return
 	}
-	err = s.storage.CreateFile(r.Context(), volume, filePath, int64(fileSize), r.Body)
-	if err != nil {
-		s.writeErrorResponse(w, err)
-	}
+
+	done := keepHTTPResponseAlive(w)
+	done(s.storage.CreateFile(r.Context(), volume, filePath, int64(fileSize), r.Body))
+	w.(http.Flusher).Flush()
 }
 
 // DeleteVersion delete updated metadata.


### PR DESCRIPTION

## Description
xl: CreateFile shouldn't prematurely timeout

## Motivation and Context
For large objects taking more than '3 minutes' response
times in a single PUT operation can timeout prematurely
as 'ResponseHeader' timeout hits for 3 minutes. Avoid
this by keeping the connection active during CreateFile
phase.

## How to test this PR?
Upload a really large file such as 200GiB in a single stream
and see how much time it takes for CreateFile response
times, if in the writing phase takes more than 3minutes all writes
will fail with 503 errors. 

This is not seen in the wild because most users use multipart
operations and each multipart operation somehow completes
with in the 3minute window. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
