### PR TITLE
avoid healObjects recursively healing at empty path

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1563,10 +1563,15 @@ func (z *erasureServerPools) HealObjects(ctx context.Context, bucket, prefix str
 						bucket:    bucket,
 					}
 
+					path := baseDirFromPrefix(prefix)
+					if path == "" {
+						path = prefix
+					}
+
 					if err := listPathRaw(ctx, listPathRawOptions{
 						disks:          disks,
 						bucket:         bucket,
-						path:           baseDirFromPrefix(prefix),
+						path:           path,
 						recursive:      true,
 						forwardTo:      "",
 						minDisks:       1,


### PR DESCRIPTION


## Description
avoid healObjects recursively healing at empty path

## Motivation and Context
baseDirFromPrefix(prefix) for object names without
parent directory incorrectly uses empty path, leading
to long listing at various paths that are not useful
for healing - avoid this listing completely if "baseDir"
returns empty simple use the "prefix" as is.

this improves startup performance significantly
## How to test this PR?
Upload a bunch of files and then `mc rm -r --force` the objects, 
restart the services and see the server is not waiting to heal `tmp/.trash` 
directory. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
