### PR TITLE
fix(probe): readinness probe should return an error during init

### DIFF
--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -89,7 +89,7 @@ func ClusterReadCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 // ReadinessCheckHandler Checks if the process is up. Always returns success.
 func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
-	if shouldProxy() || !globalIAMSys.isConfigLoaded() {
+	if shouldProxy() {
 		// Service not initialized yet
 		w.Header().Set(xhttp.MinIOServerStatus, unavailable)
 		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -89,9 +89,11 @@ func ClusterReadCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 // ReadinessCheckHandler Checks if the process is up. Always returns success.
 func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
-	if shouldProxy() {
+	if shouldProxy() || !globalIAMSys.isConfigLoaded() {
 		// Service not initialized yet
 		w.Header().Set(xhttp.MinIOServerStatus, unavailable)
+		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
+		return
 	}
 
 	writeResponse(w, http.StatusOK, nil, mimeNone)

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -444,18 +444,6 @@ func (sys *IAMSys) Initialized() bool {
 	return sys.store != nil
 }
 
-func (sys *IAMSys) isConfigLoaded() bool {
-	if !sys.Initialized() {
-		return false
-	}
-	select {
-	case <-sys.configLoaded:
-		return true
-	default:
-		return false
-	}
-}
-
 // Load - loads all credentials
 func (sys *IAMSys) Load(ctx context.Context, store IAMStorageAPI) error {
 	iamUsersMap := make(map[string]auth.Credentials)

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -444,6 +444,18 @@ func (sys *IAMSys) Initialized() bool {
 	return sys.store != nil
 }
 
+func (sys *IAMSys) isConfigLoaded() bool {
+	if !sys.Initialized() {
+		return false
+	}
+	select {
+	case <-sys.configLoaded:
+		return true
+	default:
+		return false
+	}
+}
+
 // Load - loads all credentials
 func (sys *IAMSys) Load(ctx context.Context, store IAMStorageAPI) error {
 	iamUsersMap := make(map[string]auth.Credentials)


### PR DESCRIPTION
## Description
Implemented the readiness probe to return an error code during the IAM initialization phase.

## Motivation and Context
fixes #11862 

## How to test this PR?
create 1000 users
restart minio
curl -v http://localhost:9000/minio/health/ready
and check is returns `503 Service Unavailable` during the initialization phase

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
