### PR TITLE
Fix AccountInfo API for LDAP usage

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -162,6 +162,7 @@ func checkAdminRequestAuth(ctx context.Context, r *http.Request, action iampolic
 	}
 	if globalIAMSys.IsAllowed(iampolicy.Args{
 		AccountName:     cred.AccessKey,
+		Groups:          cred.Groups,
 		Action:          iampolicy.Action(action),
 		ConditionValues: getConditionValues(r, "", cred.AccessKey, claims),
 		IsOwner:         owner,


### PR DESCRIPTION
## Description

- Also ensure admin APIs auth uses the groups of the user.

AccountInfo API did not take LDAP mode into account previously. This fixes that.

## How to test this PR?

With LDAP setup and perhaps with Console.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
