### PR TITLE
xl: CreateFile shouldn't prematurely timeout

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -337,7 +337,12 @@ func (client *storageRESTClient) CreateFile(ctx context.Context, volume, path st
 	values.Set(storageRESTFilePath, path)
 	values.Set(storageRESTLength, strconv.Itoa(int(size)))
 	respBody, err := client.call(ctx, storageRESTMethodCreateFile, values, ioutil.NopCloser(reader), size)
-	defer http.DrainBody(respBody)
+	if err != nil {
+		return err
+	}
+	waitReader, err := waitForHTTPResponse(respBody)
+	defer http.DrainBody(ioutil.NopCloser(waitReader))
+	defer respBody.Close()
 	return err
 }
 

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -290,7 +290,6 @@ func (s *storageRESTServer) CreateFileHandler(w http.ResponseWriter, r *http.Req
 
 	done := keepHTTPResponseAlive(w)
 	done(s.storage.CreateFile(r.Context(), volume, filePath, int64(fileSize), r.Body))
-	w.(http.Flusher).Flush()
 }
 
 // DeleteVersion delete updated metadata.

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -287,10 +287,10 @@ func (s *storageRESTServer) CreateFileHandler(w http.ResponseWriter, r *http.Req
 		s.writeErrorResponse(w, err)
 		return
 	}
-	err = s.storage.CreateFile(r.Context(), volume, filePath, int64(fileSize), r.Body)
-	if err != nil {
-		s.writeErrorResponse(w, err)
-	}
+
+	done := keepHTTPResponseAlive(w)
+	done(s.storage.CreateFile(r.Context(), volume, filePath, int64(fileSize), r.Body))
+	w.(http.Flusher).Flush()
 }
 
 // DeleteVersion delete updated metadata.


### PR DESCRIPTION

## Description
xl: CreateFile shouldn't prematurely timeout

## Motivation and Context
For large objects taking more than '3 minutes' response
times in a single PUT operation can timeout prematurely
as 'ResponseHeader' timeout hits for 3 minutes. Avoid
this by keeping the connection active during CreateFile
phase.

## How to test this PR?
upload a large single PUT object and expect it doesn't timeout in
a distributed setup.  This is a proper fix for PR #11854

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression a regression was introduced in #11854 
- [ ] Documentation updated
- [ ] Unit tests added/updated
