### PR TITLE
fix: LDAP policy application on user policy

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1891,7 +1891,7 @@ func (sys *IAMSys) IsAllowedLDAPSTS(args iampolicy.Args, parentUser string) bool
 	}
 
 	// Check policy for this LDAP user.
-	ldapPolicies, err := sys.PolicyDBGetLDAP(args.AccountName, args.Groups...)
+	ldapPolicies, err := sys.PolicyDBGetLDAP(parentUser, args.Groups...)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## Description

Fix a bug where IAM policy application on user was not honored in the case of LDAP.

## How to test this PR?

With an LDAP setup. Apply policy on the user and not on any group. Check if the policies are honored. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
