### PR TITLE
Mint: Strip the default port from SERVER_ENDPOINT in aws-sdk-go tests

### DIFF
--- a/mint/run/core/aws-sdk-go/main.go
+++ b/mint/run/core/aws-sdk-go/main.go
@@ -1046,6 +1046,12 @@ func main() {
 	accessKey := os.Getenv("ACCESS_KEY")
 	secretKey := os.Getenv("SECRET_KEY")
 	secure := os.Getenv("ENABLE_HTTPS")
+	if strings.HasSuffix(endpoint, ":443") {
+		endpoint = strings.ReplaceAll(endpoint, ":443", "")
+	}
+	if strings.HasSuffix(endpoint, ":80") {
+		endpoint = strings.ReplaceAll(endpoint, ":80", "")
+	}
 	sdkEndpoint := "http://" + endpoint
 	if secure == "1" {
 		sdkEndpoint = "https://" + endpoint


### PR DESCRIPTION
## Description

Remove default ports 80 or 443 from the SERVER_ENDPOINT environment variable before executing the aws-sdk-go tests.

## Motivation and Context

I noticed that when executing the Mint test suite against MinIO running on port 443 the aws-sdk-go would immediately fail. After a bit of digging I found out that this happens because default ports are stripped from the URL when calculating the signature, but the Host header will still contain the port number. MinIO will therefore compute a different signature and fail with a different error message than expected by the tests.

This prevented me from executing all tests in `aws-sdk-go/main.go`.

The underlying issue is the same as in #9169 and as discussed there should be fixed on the client's side, which in this case are the aws-sdk-go tests in Mint.

## How to test this PR?

I was able to reproduce this behavior with Docker, but only when using port 443. Sadly I was unable to use the vanialla MinIO docker image for this, because I needed to generate a valid SSL certificate.

Therefore in the following you will find a `Dockerfile` to build a custom container image with MinIO and an SSL certificate, as well as a `docker-compose.yml` which will run Mint tests against our custom MinIO container.

### Dockerfile for iternity/minio

I'm adding
- openssl to issue a self-signed certificate,
- wget to download the MinIO binary and
- curl to allow an easy healthcheck to see if MinIO is up and running.

```
FROM ubuntu

RUN apt-get update
RUN apt-get install openssl wget curl -y
RUN mkdir -p /root/.minio/certs
RUN openssl \
    req -x509 \
    -newkey rsa:4096 \
    -keyout /root/.minio/certs/private.key \
    -out /root/.minio/certs/public.crt \
    -days 365 \
    -nodes \
    -subj '/C=DE/ST=BW/L=Freiburg/O=iTernity GmbH/OU=Development/CN=minio' \
    -addext "subjectAltName = DNS:minio"

RUN wget https://dl.min.io/server/minio/release/linux-amd64/minio
RUN chmod +x minio

ENTRYPOINT [ "/minio" ]
```

### docker-compose.yml:

```yaml
version: "3.3"

services:

  minio:
    image: iternity/minio
    command: server /data --address :443
    ports:
      - 443:443
    environment:
      - MINIO_ACCESS_KEY=accessKey
      - MINIO_SECRET_KEY=secretKey
    volumes:
      - ./data:/data
    healthcheck:
      test: ["CMD", "curl", "-k", "https://localhost/minio/health/live"]
      interval: 5s
      timeout: 2s
      retries: 5

  mint:
    image: minio/mint
    depends_on:
      minio:
        condition: service_healthy
    environment:
      - MINT_MODE=full
      - SERVER_ENDPOINT=minio:443
      - ACCESS_KEY=accessKey
      - SECRET_KEY=secretKey
      - ENABLE_HTTPS=1
    volumes:
      - ./test-logs:/mint/log

```

The `healthcheck` ensures that the MinIO process is up and running before Mint starts running tests.

### Dockerfile for iternity/mint

This requires the `aws-sdk-go` binary in the workpath. I used this to verify my change.

```
FROM minio/mint

COPY aws-sdk-go /mint/run/core/aws-sdk-go/
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
