### PR TITLE
Simplify access to local node name

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -517,7 +517,7 @@ func (a adminAPIHandlers) StartProfilingHandler(w http.ResponseWriter, r *http.R
 
 	vars := mux.Vars(r)
 	profiles := strings.Split(vars["profilerType"], ",")
-	thisAddr, err := xnet.ParseHost(GetLocalPeer(globalEndpoints))
+	thisAddr, err := xnet.ParseHost(globalLocalNodeName)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return

--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -31,7 +31,7 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 	var localEndpoints Endpoints
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(endpointServerPools)
+		addr = globalLocalNodeName
 	}
 	network := make(map[string]string)
 	for _, ep := range endpointServerPools {

--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -40,17 +40,6 @@ type HTTPConsoleLoggerSys struct {
 	logBuf   *ring.Ring
 }
 
-func mustGetNodeName(endpointServerPools EndpointServerPools) (nodeName string) {
-	host, err := xnet.ParseHost(GetLocalPeer(endpointServerPools))
-	if err != nil {
-		logger.FatalIf(err, "Unable to start console logging subsystem")
-	}
-	if globalIsDistErasure {
-		nodeName = host.Name
-	}
-	return nodeName
-}
-
 // NewConsoleLogger - creates new HTTPConsoleLoggerSys with all nodes subscribed to
 // the console logging pub sub system
 func NewConsoleLogger(ctx context.Context) *HTTPConsoleLoggerSys {
@@ -63,8 +52,18 @@ func NewConsoleLogger(ctx context.Context) *HTTPConsoleLoggerSys {
 }
 
 // SetNodeName - sets the node name if any after distributed setup has initialized
-func (sys *HTTPConsoleLoggerSys) SetNodeName(endpointServerPools EndpointServerPools) {
-	sys.nodeName = mustGetNodeName(endpointServerPools)
+func (sys *HTTPConsoleLoggerSys) SetNodeName(nodeName string) {
+	if !globalIsDistErasure {
+		sys.nodeName = ""
+		return
+	}
+
+	host, err := xnet.ParseHost(globalLocalNodeName)
+	if err != nil {
+		logger.FatalIf(err, "Unable to start console logging subsystem")
+	}
+
+	sys.nodeName = host.Name
 }
 
 // HasLogListeners returns true if console log listeners are registered

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -761,7 +761,7 @@ func CreateEndpoints(serverAddr string, foundLocal bool, args ...[]string) (Endp
 // the first element from the set of peers which indicate that
 // they are local. There is always one entry that is local
 // even with repeated server endpoints.
-func GetLocalPeer(endpointServerPools EndpointServerPools) (localPeer string) {
+func GetLocalPeer(endpointServerPools EndpointServerPools, host, port string) (localPeer string) {
 	peerSet := set.NewStringSet()
 	for _, ep := range endpointServerPools {
 		for _, endpoint := range ep.Endpoints {
@@ -776,11 +776,11 @@ func GetLocalPeer(endpointServerPools EndpointServerPools) (localPeer string) {
 	if peerSet.IsEmpty() {
 		// Local peer can be empty in FS or Erasure coded mode.
 		// If so, return globalMinioHost + globalMinioPort value.
-		if globalMinioHost != "" {
-			return net.JoinHostPort(globalMinioHost, globalMinioPort)
+		if host != "" {
+			return net.JoinHostPort(host, port)
 		}
 
-		return net.JoinHostPort("127.0.0.1", globalMinioPort)
+		return net.JoinHostPort("127.0.0.1", port)
 	}
 	return peerSet.ToSlice()[0]
 }

--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -334,15 +334,6 @@ func TestCreateEndpoints(t *testing.T) {
 // So it means that if you have say localhost:9000 and localhost:9001 as endpointArgs then localhost:9001
 // is considered a remote service from localhost:9000 perspective.
 func TestGetLocalPeer(t *testing.T) {
-	tempGlobalMinioAddr := globalMinioAddr
-	tempGlobalMinioPort := globalMinioPort
-	defer func() {
-		globalMinioAddr = tempGlobalMinioAddr
-		globalMinioPort = tempGlobalMinioPort
-	}()
-	globalMinioAddr = ":9000"
-	globalMinioPort = "9000"
-
 	testCases := []struct {
 		endpointArgs   []string
 		expectedResult string
@@ -363,9 +354,9 @@ func TestGetLocalPeer(t *testing.T) {
 				t.Fatalf("error: expected = <nil>, got = %v", err)
 			}
 		}
-		remotePeer := GetLocalPeer(zendpoints)
-		if remotePeer != testCase.expectedResult {
-			t.Fatalf("Test %d: expected: %v, got: %v", i+1, testCase.expectedResult, remotePeer)
+		localPeer := GetLocalPeer(zendpoints, "", "9000")
+		if localPeer != testCase.expectedResult {
+			t.Fatalf("Test %d: expected: %v, got: %v", i+1, testCase.expectedResult, localPeer)
 		}
 	}
 }

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -355,7 +355,7 @@ func newErasureSets(ctx context.Context, endpoints Endpoints, storageDisks []Sto
 		sets:               make([]*erasureObjects, setCount),
 		erasureDisks:       make([][]StorageAPI, setCount),
 		erasureLockers:     make([][]dsync.NetLocker, setCount),
-		erasureLockOwner:   GetLocalPeer(globalEndpoints),
+		erasureLockOwner:   globalLocalNodeName,
 		endpoints:          endpoints,
 		endpointStrings:    endpointStrings,
 		setCount:           setCount,

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -194,6 +194,9 @@ var (
 
 	globalEndpoints EndpointServerPools
 
+	// The name of this local node, fetched from arguments
+	globalLocalNodeName string
+
 	globalRemoteEndpoints map[string]Endpoint
 
 	// Global server's network statistics

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -541,7 +541,7 @@ func errorResponseHandler(w http.ResponseWriter, r *http.Request) {
 // gets host name for current node
 func getHostName(r *http.Request) (hostName string) {
 	if globalIsDistErasure {
-		hostName = GetLocalPeer(globalEndpoints)
+		hostName = globalLocalNodeName
 	} else {
 		hostName = r.Host
 	}

--- a/cmd/healthinfo.go
+++ b/cmd/healthinfo.go
@@ -35,7 +35,7 @@ import (
 func getLocalCPUInfo(ctx context.Context, r *http.Request) madmin.ServerCPUInfo {
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(globalEndpoints)
+		addr = globalLocalNodeName
 	}
 
 	info, err := cpuhw.InfoWithContext(ctx)
@@ -106,7 +106,7 @@ func getLocalDrives(ctx context.Context, parallel bool, endpointServerPools Endp
 
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(endpointServerPools)
+		addr = globalLocalNodeName
 	}
 	if parallel {
 		return madmin.ServerDrivesInfo{
@@ -123,7 +123,7 @@ func getLocalDrives(ctx context.Context, parallel bool, endpointServerPools Endp
 func getLocalMemInfo(ctx context.Context, r *http.Request) madmin.ServerMemInfo {
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(globalEndpoints)
+		addr = globalLocalNodeName
 	}
 
 	swap, err := memhw.SwapMemoryWithContext(ctx)
@@ -152,7 +152,7 @@ func getLocalMemInfo(ctx context.Context, r *http.Request) madmin.ServerMemInfo 
 func getLocalProcInfo(ctx context.Context, r *http.Request) madmin.ServerProcInfo {
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(globalEndpoints)
+		addr = globalLocalNodeName
 	}
 
 	errProcInfo := func(tag string, err error) madmin.ServerProcInfo {

--- a/cmd/healthinfo_linux.go
+++ b/cmd/healthinfo_linux.go
@@ -34,7 +34,7 @@ import (
 func getLocalOsInfo(ctx context.Context, r *http.Request) madmin.ServerOsInfo {
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(globalEndpoints)
+		addr = globalLocalNodeName
 	}
 
 	srvrOsInfo := madmin.ServerOsInfo{Addr: addr}
@@ -65,7 +65,7 @@ func getLocalOsInfo(ctx context.Context, r *http.Request) madmin.ServerOsInfo {
 func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskHwInfo {
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(globalEndpoints)
+		addr = globalLocalNodeName
 	}
 
 	parts, err := diskhw.PartitionsWithContext(ctx, true)

--- a/cmd/healthinfo_nonlinux.go
+++ b/cmd/healthinfo_nonlinux.go
@@ -30,7 +30,7 @@ import (
 func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskHwInfo {
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(globalEndpoints)
+		addr = globalLocalNodeName
 	}
 
 	return madmin.ServerDiskHwInfo{
@@ -42,7 +42,7 @@ func getLocalDiskHwInfo(ctx context.Context, r *http.Request) madmin.ServerDiskH
 func getLocalOsInfo(ctx context.Context, r *http.Request) madmin.ServerOsInfo {
 	addr := r.Host
 	if globalIsDistErasure {
-		addr = GetLocalPeer(globalEndpoints)
+		addr = globalLocalNodeName
 	}
 
 	return madmin.ServerOsInfo{

--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -127,7 +127,7 @@ func WebTrace(ri *jsonrpc.RequestInfo) trace.Info {
 	t := trace.Info{FuncName: name}
 	t.NodeName = r.Host
 	if globalIsDistErasure {
-		t.NodeName = GetLocalPeer(globalEndpoints)
+		t.NodeName = globalLocalNodeName
 	}
 
 	// strip port from the host address
@@ -191,7 +191,7 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 	r.Body = ioutil.NopCloser(reqBodyRecorder)
 	t.NodeName = r.Host
 	if globalIsDistErasure {
-		t.NodeName = GetLocalPeer(globalEndpoints)
+		t.NodeName = globalLocalNodeName
 	}
 	// strip port from the host address
 	if host, _, err := net.SplitHostPort(t.NodeName); err == nil {

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1406,7 +1406,7 @@ func ReportMetrics(ctx context.Context, generators func() []MetricsGenerator) <-
 			if m.VariableLabels == nil {
 				m.VariableLabels = make(map[string]string)
 			}
-			m.VariableLabels[serverName] = GetLocalPeer(globalEndpoints)
+			m.VariableLabels[serverName] = globalLocalNodeName
 			for {
 				select {
 				case ch <- m:
@@ -1453,7 +1453,7 @@ func (c *minioCollectorV2) Collect(ch chan<- prometheus.Metric) {
 
 	populateAndPublish(c.generator, func(metric Metric) bool {
 		labels, values := getOrderedLabelValueArrays(metric.VariableLabels)
-		values = append(values, GetLocalPeer(globalEndpoints))
+		values = append(values, globalLocalNodeName)
 		labels = append(labels, serverName)
 
 		if metric.Description.Type == histogramMetric {

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -538,7 +538,7 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 	}
 
 	server := getLocalServerProperty(globalEndpoints, &http.Request{
-		Host: GetLocalPeer(globalEndpoints),
+		Host: globalLocalNodeName,
 	})
 
 	onlineDisks, offlineDisks := getOnlineOfflineDisksStats(server.Disks)

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -354,7 +354,7 @@ func (sys *NotificationSys) DownloadProfilingData(ctx context.Context, writer io
 	}
 
 	// Local host
-	thisAddr, err := xnet.ParseHost(GetLocalPeer(globalEndpoints))
+	thisAddr, err := xnet.ParseHost(globalLocalNodeName)
 	if err != nil {
 		logger.LogIf(ctx, err)
 		return profilingDataFound
@@ -889,7 +889,7 @@ func (sys *NotificationSys) NetInfo(ctx context.Context) madmin.ServerNetHealthI
 	}
 
 	for i := 0; i < len(sortedGlobalEndpoints); i++ {
-		if sortedGlobalEndpoints[i] != GetLocalPeer(globalEndpoints) {
+		if sortedGlobalEndpoints[i] != globalLocalNodeName {
 			continue
 		}
 		for j := 0; j < len(sortedGlobalEndpoints); j++ {
@@ -922,7 +922,7 @@ func (sys *NotificationSys) NetInfo(ctx context.Context) madmin.ServerNetHealthI
 	}
 	return madmin.ServerNetHealthInfo{
 		Net:  netInfos,
-		Addr: GetLocalPeer(globalEndpoints),
+		Addr: globalLocalNodeName,
 	}
 }
 
@@ -997,7 +997,7 @@ func (sys *NotificationSys) NetPerfParallelInfo(ctx context.Context) madmin.Serv
 	wg.Wait()
 	return madmin.ServerNetHealthInfo{
 		Net:  netInfos,
-		Addr: GetLocalPeer(globalEndpoints),
+		Addr: globalLocalNodeName,
 	}
 
 }


### PR DESCRIPTION
## Description
Local node name is heavily used in tracing, create a new global variable
to store it. Multiple goroutines can access to it since it won't be
changed later.

## Motivation and Context
Simplification

## How to test this PR?
Trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
