### PR TITLE
bitrot: add selftest for server startup

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -413,6 +413,7 @@ func serverMain(ctx *cli.Context) {
 	logger.AddTarget(globalConsoleSys)
 
 	// Perform any self-tests
+	bitrotSelfTest()
 	erasureSelfTest()
 	compressSelfTest()
 


### PR DESCRIPTION
## Description
This commit adds a self-test for all bitrot algorithms:
 - SHA-256
 - BLAKE2b
 - HighwayHash

The self-test computes an incremental checksum of pseudo-random
messages. If a bitrot algorithm implementation stops working on
some CPU architecture or with a certain Go version this self-test
will prevent the server from starting and silently corrupting data.

## Motivation and Context

For additional context see: minio/highwayhash#19


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
