### PR TITLE
disksWithAllParts should use parts if present

### DIFF
--- a/cmd/erasure-healing-common.go
+++ b/cmd/erasure-healing-common.go
@@ -223,7 +223,7 @@ func disksWithAllParts(ctx context.Context, onlineDisks []StorageAPI, partsMetad
 		}
 
 		// Always check data, if we got it.
-		if len(meta.Data) > 0 || meta.Size == 0 {
+		if (len(meta.Data) > 0 || meta.Size == 0) && len(meta.Parts) > 0 {
 			checksumInfo := meta.Erasure.GetChecksumInfo(meta.Parts[0].Number)
 			dataErrs[i] = bitrotVerify(bytes.NewBuffer(meta.Data),
 				int64(len(meta.Data)),


### PR DESCRIPTION
## Description
disksWithAllParts should use parts if present

## Motivation and Context
fixes a crash if when Parts are empty for delete marker. 

## How to test this PR?
Attempt a heal on the delete marker

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in #11758 
- [ ] Documentation updated
- [ ] Unit tests added/updated
