### PR TITLE
Fix multi delete when using S3 Gateway with SSE

### DIFF
--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -407,6 +407,20 @@ func (l *s3EncObjects) DeleteObject(ctx context.Context, bucket string, object s
 	return l.deleteGWMetadata(ctx, bucket, getDareMetaPath(object))
 }
 
+func (l *s3EncObjects) DeleteObjects(ctx context.Context, bucket string, objects []minio.ObjectToDelete, opts minio.ObjectOptions) ([]minio.DeletedObject, []error) {
+	errs := make([]error, len(objects))
+	dobjects := make([]minio.DeletedObject, len(objects))
+	for idx, object := range objects {
+		_, errs[idx] = l.DeleteObject(ctx, bucket, object.ObjectName, opts)
+		if errs[idx] == nil {
+			dobjects[idx] = minio.DeletedObject{
+				ObjectName: object.ObjectName,
+			}
+		}
+	}
+	return dobjects, errs
+}
+
 // ListMultipartUploads lists all multipart uploads.
 func (l *s3EncObjects) ListMultipartUploads(ctx context.Context, bucket string, prefix string, keyMarker string, uploadIDMarker string, delimiter string, maxUploads int) (lmi minio.ListMultipartsInfo, e error) {
 


### PR DESCRIPTION
## Description
When using MinIO in Gateway S3 mode with SSE enabled, files are not deleted when using the multi delete feature.
Files **are** deleted successfully when deleting one file at a time. This led me to believe the `DeleteObjects` function was missing from the `gateway-s3-sse.go` file, and lo and behold: it was :)

By adding the `DeleteObjects` function, the SSE gateway shadows the normal gateway function, making sure the SSE `DeleteObject` function is called correctly instead of the normal `DeleteObject` function.

The `DeleteObjects` function is copied as-is from `cmd/gateway/s3/gateway-s3.go`.

## How to test this PR?
Run `mc rm --force --recursive local/bucket/folder` against a folder on a MinIO S3 Gateway with SSE enabled.
Works for this PR, doesn't work on `master`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
