### PR TITLE
allow configuring scanner cycles dynamically

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -624,6 +624,8 @@ func applyDynamicConfig(ctx context.Context, objAPI ObjectLayer, s config.Config
 	globalHealConfig = healCfg
 	globalHealConfigMu.Unlock()
 
+	// update dynamic scanner values.
+	scannerCycle.Update(scannerCfg.Cycle)
 	logger.LogIf(ctx, scannerSleeper.Update(scannerCfg.Delay, scannerCfg.MaxWait))
 
 	// Update all dynamic config values in memory.

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -44,7 +44,6 @@ import (
 
 const (
 	dataScannerSleepPerFolder = time.Millisecond // Time to wait between folders.
-	dataScannerStartDelay     = 1 * time.Minute  // Time to wait on startup and between cycles.
 	dataUsageUpdateDirCycles  = 16               // Visit all folders every n cycles.
 
 	healDeleteDangling    = true
@@ -59,11 +58,29 @@ var (
 	dataScannerLeaderLockTimeout = newDynamicTimeout(30*time.Second, 10*time.Second)
 	// Sleeper values are updated when config is loaded.
 	scannerSleeper = newDynamicSleeper(10, 10*time.Second)
+	scannerCycle   = &safeDuration{}
 )
 
 // initDataScanner will start the scanner in the background.
 func initDataScanner(ctx context.Context, objAPI ObjectLayer) {
 	go runDataScanner(ctx, objAPI)
+}
+
+type safeDuration struct {
+	sync.Mutex
+	t time.Duration
+}
+
+func (s *safeDuration) Update(t time.Duration) {
+	s.Lock()
+	defer s.Unlock()
+	s.t = t
+}
+
+func (s *safeDuration) Get() time.Duration {
+	s.Lock()
+	defer s.Unlock()
+	return s.t
 }
 
 // runDataScanner will start a data scanner.
@@ -77,7 +94,7 @@ func runDataScanner(ctx context.Context, objAPI ObjectLayer) {
 	for {
 		ctx, err = locker.GetLock(ctx, dataScannerLeaderLockTimeout)
 		if err != nil {
-			time.Sleep(time.Duration(r.Float64() * float64(dataScannerStartDelay)))
+			time.Sleep(time.Duration(r.Float64() * float64(scannerCycle.Get())))
 			continue
 		}
 		break
@@ -101,7 +118,7 @@ func runDataScanner(ctx context.Context, objAPI ObjectLayer) {
 		br.Close()
 	}
 
-	scannerTimer := time.NewTimer(dataScannerStartDelay)
+	scannerTimer := time.NewTimer(scannerCycle.Get())
 	defer scannerTimer.Stop()
 
 	for {
@@ -110,7 +127,7 @@ func runDataScanner(ctx context.Context, objAPI ObjectLayer) {
 			return
 		case <-scannerTimer.C:
 			// Reset the timer for next cycle.
-			scannerTimer.Reset(dataScannerStartDelay)
+			scannerTimer.Reset(scannerCycle.Get())
 
 			if intDataUpdateTracker.debug {
 				console.Debugln("starting scanner cycle")

--- a/cmd/logger/target/http/http.go
+++ b/cmd/logger/target/http/http.go
@@ -130,8 +130,8 @@ func (h *Target) startHTTPLogger() {
 			resp, err := h.client.Do(req)
 			cancel()
 			if err != nil {
-				logger.LogIf(ctx, fmt.Errorf("%s returned '%w', please check your endpoint configuration\n",
-					h.endpoint, err))
+				logger.LogOnceIf(ctx, fmt.Errorf("%s returned '%w', please check your endpoint configuration",
+					h.endpoint, err), h.endpoint)
 				continue
 			}
 
@@ -141,11 +141,11 @@ func (h *Target) startHTTPLogger() {
 			if resp.StatusCode != http.StatusOK {
 				switch resp.StatusCode {
 				case http.StatusForbidden:
-					logger.LogIf(ctx, fmt.Errorf("%s returned '%s', please check if your auth token is correctly set",
-						h.endpoint, resp.Status))
+					logger.LogOnceIf(ctx, fmt.Errorf("%s returned '%s', please check if your auth token is correctly set",
+						h.endpoint, resp.Status), h.endpoint)
 				default:
-					logger.LogIf(ctx, fmt.Errorf("%s returned '%s', please check your endpoint configuration",
-						h.endpoint, resp.Status))
+					logger.LogOnceIf(ctx, fmt.Errorf("%s returned '%s', please check your endpoint configuration",
+						h.endpoint, resp.Status), h.endpoint)
 				}
 			}
 		}


### PR DESCRIPTION
## Description
allow configuring scanner cycles dynamically

## Motivation and Context
This allows us to speed up or slow down sleeps
between multiple scanner cycles, helps in testing
as well as some deployments might want to run
scanner more frequently.
    
This change is also dynamic can be applied on
a running cluster, subsequent cycles pickup
the newly set value.

## How to test this PR?
```
mc admin config set myminio/ scanner cycle=5s
```

and observe using `mc admin trace -a` to see new cycles
get affected - are run more frequently.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
