### PR TITLE
fix: delete/delete marker replication versions consistent

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3094,7 +3094,8 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			VersionID: opts.VersionID,
 		})
 	}
-	_, replicateDel, replicateSync := checkReplicateDelete(ctx, bucket, ObjectToDelete{ObjectName: object, VersionID: opts.VersionID}, goi, gerr)
+
+	replicateDel, replicateSync := checkReplicateDelete(ctx, bucket, ObjectToDelete{ObjectName: object, VersionID: opts.VersionID}, goi, gerr)
 	if replicateDel {
 		if opts.VersionID != "" {
 			opts.VersionPurgeStatus = Pending
@@ -3102,6 +3103,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			opts.DeleteMarkerReplicationStatus = string(replication.Pending)
 		}
 	}
+
 	vID := opts.VersionID
 	if r.Header.Get(xhttp.AmzBucketReplicationStatus) == replication.Replica.String() {
 		// check if replica has permission to be deleted.

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -767,7 +767,7 @@ next:
 			}
 			if hasReplicationRules(ctx, args.BucketName, []ObjectToDelete{{ObjectName: objectName}}) || hasLifecycleConfig {
 				goi, gerr = getObjectInfoFn(ctx, args.BucketName, objectName, opts)
-				if _, replicateDel, replicateSync = checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{
+				if replicateDel, replicateSync = checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{
 					ObjectName: objectName,
 					VersionID:  goi.VersionID,
 				}, goi, gerr); replicateDel {
@@ -903,7 +903,7 @@ next:
 						}
 					}
 				}
-				_, replicateDel, _ := checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{ObjectName: obj.Name, VersionID: obj.VersionID}, obj, nil)
+				replicateDel, _ := checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{ObjectName: obj.Name, VersionID: obj.VersionID}, obj, nil)
 				// since versioned delete is not available on web browser, yet - this is a simple DeleteMarker replication
 				objToDel := ObjectToDelete{ObjectName: obj.Name}
 				if replicateDel {


### PR DESCRIPTION


## Description
fix: delete/delete marker replication versions consistent

## Motivation and Context
replication didn't work as expected when deletion of
delete markers was requested in DeleteMultipleObjects
API, this is due to incorrect lookup elements being
used to look for delete markers.

## How to test this PR?
Two servers running locally
```
minio server --address ":9001" ~/xl1...4}
```

```
minio server --address ":9001" ~/xl-dr1...4}
```

```bash
#!/bin/bash

set -x
mc mb myminio/testbucket/
mc mb myminio-local1/testbucket/

mc version enable myminio/testbucket/
mc version enable myminio-local1/testbucket/

remote_arn=$(mc admin bucket remote add myminio/testbucket/ \
   http://minio:minio123@localhost:9001/testbucket \
   --service "replication" --json | jq -r ".RemoteARN")

mc replicate add myminio/testbucket/ \
   --arn ${remote_arn} --remote-bucket testbucket \
   --replicate "delete,delete-marker"
```

```
~ mc mirror /usr/sbin myminio/testbucket/
```

```
~ mc rm -r --force myminio/testbucket/
```

```
~ mc rm -r --versions --force myminio/testbucket/
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
