### PR TITLE
do not use dataDir to reference inline data use versionID

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -279,37 +279,6 @@ func pickValidFileInfo(ctx context.Context, metaArr []FileInfo, modTime time.Tim
 	return findFileInfoInQuorum(ctx, metaArr, modTime, quorum)
 }
 
-// Rename metadata content to destination location for each disk concurrently.
-func renameFileInfo(ctx context.Context, disks []StorageAPI, srcBucket, srcEntry, dstBucket, dstEntry string, quorum int) ([]StorageAPI, error) {
-	ignoredErr := []error{errFileNotFound}
-
-	g := errgroup.WithNErrs(len(disks))
-
-	// Rename file on all underlying storage disks.
-	for index := range disks {
-		index := index
-		g.Go(func() error {
-			if disks[index] == nil {
-				return errDiskNotFound
-			}
-			if err := disks[index].RenameData(ctx, srcBucket, srcEntry, "", dstBucket, dstEntry); err != nil {
-				if !IsErrIgnored(err, ignoredErr...) {
-					return err
-				}
-			}
-			return nil
-		}, index)
-	}
-
-	// Wait for all renames to finish.
-	errs := g.Wait()
-
-	// We can safely allow RenameData errors up to len(er.getDisks()) - writeQuorum
-	// otherwise return failure. Cleanup successful renames.
-	err := reduceWriteQuorumErrs(ctx, errs, objectOpIgnoredErrs, quorum)
-	return evalDisks(disks, errs), err
-}
-
 // writeUniqueFileInfo - writes unique `xl.meta` content for each disk concurrently.
 func writeUniqueFileInfo(ctx context.Context, disks []StorageAPI, bucket, prefix string, files []FileInfo, quorum int) ([]StorageAPI, error) {
 	g := errgroup.WithNErrs(len(disks))

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -83,7 +83,17 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, data bool) (F
 		if !data || err != nil {
 			return fi, err
 		}
-		fi.Data = xlMeta.data.find(fi.DataDir)
+		versionID := fi.VersionID
+		if versionID == "" {
+			versionID = nullVersionID
+		}
+		fi.Data = xlMeta.data.find(versionID)
+		if len(fi.Data) == 0 {
+			// PR #11758 used DataDir, preserve it
+			// for users who might have used master
+			// branch
+			fi.Data = xlMeta.data.find(fi.DataDir)
+		}
 		return fi, nil
 	}
 

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -702,9 +702,10 @@ func (z *xlMetaV2) AddVersion(fi FileInfo) error {
 				ventry.ObjectV2.MetaUser[k] = v
 			}
 		}
+
 		// If asked to save data.
 		if len(fi.Data) > 0 || fi.Size == 0 {
-			z.data.replace(dd.String(), fi.Data)
+			z.data.replace(fi.VersionID, fi.Data)
 		}
 	}
 

--- a/cmd/xl-storage-format-v2_test.go
+++ b/cmd/xl-storage-format-v2_test.go
@@ -88,50 +88,50 @@ func TestXLV2FormatData(t *testing.T) {
 		t.Fatalf("want 1 entry, got %d", len(list))
 	}
 
-	if !bytes.Equal(xl2.data.find("bffea160-ca7f-465f-98bc-9b4f1c3ba1ef"), data) {
-		t.Fatal("Find data returned", xl2.data.find("bffea160-ca7f-465f-98bc-9b4f1c3ba1ef"))
+	if !bytes.Equal(xl2.data.find("756100c6-b393-4981-928a-d49bbc164741"), data) {
+		t.Fatal("Find data returned", xl2.data.find("756100c6-b393-4981-928a-d49bbc164741"))
 	}
-	if !bytes.Equal(xl2.data.find(fi.DataDir), data2) {
-		t.Fatal("Find data returned", xl2.data.find(fi.DataDir))
+	if !bytes.Equal(xl2.data.find(fi.VersionID), data2) {
+		t.Fatal("Find data returned", xl2.data.find(fi.VersionID))
 	}
 
 	// Remove entry
-	xl2.data.remove(fi.DataDir)
+	xl2.data.remove(fi.VersionID)
 	failOnErr(xl2.data.validate())
-	if xl2.data.find(fi.DataDir) != nil {
-		t.Fatal("Data was not removed:", xl2.data.find(fi.DataDir))
+	if xl2.data.find(fi.VersionID) != nil {
+		t.Fatal("Data was not removed:", xl2.data.find(fi.VersionID))
 	}
 	if xl2.data.entries() != 1 {
 		t.Fatal("want 1 entry, got", xl2.data.entries())
 	}
 	// Re-add
-	xl2.data.replace(fi.DataDir, fi.Data)
+	xl2.data.replace(fi.VersionID, fi.Data)
 	failOnErr(xl2.data.validate())
 	if xl2.data.entries() != 2 {
 		t.Fatal("want 2 entries, got", xl2.data.entries())
 	}
 
 	// Replace entry
-	xl2.data.replace("bffea160-ca7f-465f-98bc-9b4f1c3ba1ef", data2)
+	xl2.data.replace("756100c6-b393-4981-928a-d49bbc164741", data2)
 	failOnErr(xl2.data.validate())
 	if xl2.data.entries() != 2 {
 		t.Fatal("want 2 entries, got", xl2.data.entries())
 	}
-	if !bytes.Equal(xl2.data.find("bffea160-ca7f-465f-98bc-9b4f1c3ba1ef"), data2) {
-		t.Fatal("Find data returned", xl2.data.find("bffea160-ca7f-465f-98bc-9b4f1c3ba1ef"))
+	if !bytes.Equal(xl2.data.find("756100c6-b393-4981-928a-d49bbc164741"), data2) {
+		t.Fatal("Find data returned", xl2.data.find("756100c6-b393-4981-928a-d49bbc164741"))
 	}
 
-	if !xl2.data.rename("bffea160-ca7f-465f-98bc-9b4f1c3ba1ef", "new-key") {
+	if !xl2.data.rename("756100c6-b393-4981-928a-d49bbc164741", "new-key") {
 		t.Fatal("old key was not found")
 	}
 	failOnErr(xl2.data.validate())
 	if !bytes.Equal(xl2.data.find("new-key"), data2) {
-		t.Fatal("Find data returned", xl2.data.find("bffea160-ca7f-465f-98bc-9b4f1c3ba1ef"))
+		t.Fatal("Find data returned", xl2.data.find("756100c6-b393-4981-928a-d49bbc164741"))
 	}
 	if xl2.data.entries() != 2 {
 		t.Fatal("want 2 entries, got", xl2.data.entries())
 	}
-	if !bytes.Equal(xl2.data.find(fi.DataDir), data2) {
+	if !bytes.Equal(xl2.data.find(fi.VersionID), data2) {
 		t.Fatal("Find data returned", xl2.data.find(fi.DataDir))
 	}
 


### PR DESCRIPTION


## Description
do not use dataDir to reference inline data use versionID

## Motivation and Context
versionID is the one that needs to be preserved and as
well as overwritten in case of replication, transition
etc - dataDir is an ephemeral entity that changes
during overwrites - make sure that versionID is used
to save the object content.

this would break things if you are already running
the latest master, please wipe your current content
and re-do your setup after this change.

## How to test this PR?
Test with current master 

```
~ minio server /tmp/xl{1...4}
```

Create a bucket and upload content multiple times to the same object - observe xl.meta
gets the appended value of the object content instead of overwriting, we should only add
if a new version is added otherwise the referenced version shall be overwritten. 

This PR fixes this - this is a major blocker and must have before we make a release.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression without this change all overwrites add new content to xl.meta
- [ ] Documentation updated
- [ ] Unit tests added/updated
