### PR TITLE
Fix listing more than one file in Gateway SSE

### DIFF
--- a/cmd/gateway/s3/gateway-s3-sse.go
+++ b/cmd/gateway/s3/gateway-s3-sse.go
@@ -113,7 +113,7 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 			} else {
 				objects = append(objects, obj)
 			}
-			if len(objects) > maxKeys {
+			if maxKeys > 0 && len(objects) > maxKeys {
 				break
 			}
 		}
@@ -130,7 +130,7 @@ func (l *s3EncObjects) ListObjectsV2(ctx context.Context, bucket, prefix, contin
 				prefixes = append(prefixes, p)
 			}
 		}
-		if (len(objects) > maxKeys) || !loi.IsTruncated {
+		if (maxKeys > 0 && len(objects) > maxKeys) || !loi.IsTruncated {
 			break
 		}
 	}


### PR DESCRIPTION
## Description
`ListObjectsV2` from Gateway S3 SSE only returns one file when listing a prefix when `maxKeys` is set to `0`.
With this extra check, an unlimited amount of files is returned when `maxKeys` is `0`, which is the same behaviour as in the rest of the codebase.

## How to test this PR?
Call the ListObjectsV2 function on a MinIO S3 Gateway with SSE enabled with `maxKeys` is `0`. It will return just one file on `master`, with this PR it will return all files. This becomes more explicit when deleting files in the MinIO Browser, as the web-handler calls this function with `maxKeys = 0`.

## Additional remarks
Can the maintainers make sure this fix also moves to https://github.com/minio/ming if needed?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
