### PR TITLE
api: Introduce metadata update APIs to update only metadata

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -452,7 +452,7 @@ func lookupConfigs(s config.Config, setDriveCounts []int) {
 			// if we validated all setDriveCounts and it was successful
 			// proceed to store the correct storage class globally.
 			if i == len(setDriveCounts)-1 {
-				globalStorageClass = sc
+				globalStorageClass.Update(sc)
 			}
 		}
 	}

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -96,7 +96,6 @@ func (er erasureObjects) CopyObject(ctx context.Context, srcBucket, srcObject, d
 	}
 
 	onlineDisks, metaArr = shuffleDisksAndPartsMetadataByIndex(onlineDisks, metaArr, fi)
-
 	versionID := srcInfo.VersionID
 	if srcInfo.versionOnly {
 		versionID = dstOpts.VersionID
@@ -1201,6 +1200,56 @@ func (er erasureObjects) addPartial(bucket, object, versionID string) {
 	}
 }
 
+func (er erasureObjects) PutObjectMetadata(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
+	var err error
+	// Lock the object before updating tags.
+	lk := er.NewNSLock(bucket, object)
+	ctx, err = lk.GetLock(ctx, globalOperationTimeout)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	defer lk.Unlock()
+
+	disks := er.getDisks()
+
+	// Read metadata associated with the object from all disks.
+	metaArr, errs := readAllFileInfo(ctx, disks, bucket, object, opts.VersionID, false)
+
+	readQuorum, _, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
+	if err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket, object)
+	}
+
+	// List all online disks.
+	_, modTime := listOnlineDisks(disks, metaArr, errs)
+
+	// Pick latest valid metadata.
+	fi, err := pickValidFileInfo(ctx, metaArr, modTime, readQuorum)
+	if err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket, object)
+	}
+	if fi.Deleted {
+		if opts.VersionID == "" {
+			return ObjectInfo{}, toObjectErr(errFileNotFound, bucket, object)
+		}
+		return ObjectInfo{}, toObjectErr(errMethodNotAllowed, bucket, object)
+	}
+
+	for k, v := range opts.UserDefined {
+		fi.Metadata[k] = v
+	}
+	fi.ModTime = opts.MTime
+	fi.VersionID = opts.VersionID
+
+	if err = er.updateObjectMeta(ctx, bucket, object, fi); err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket, object)
+	}
+
+	objInfo := fi.ToObjectInfo(bucket, object)
+	return objInfo, nil
+
+}
+
 // PutObjectTags - replace or add tags to an existing object
 func (er erasureObjects) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) (ObjectInfo, error) {
 	var err error
@@ -1215,15 +1264,15 @@ func (er erasureObjects) PutObjectTags(ctx context.Context, bucket, object strin
 	disks := er.getDisks()
 
 	// Read metadata associated with the object from all disks.
-	metaArr, errs := readAllFileInfo(ctx, disks, bucket, object, opts.VersionID, true)
+	metaArr, errs := readAllFileInfo(ctx, disks, bucket, object, opts.VersionID, false)
 
-	readQuorum, writeQuorum, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
+	readQuorum, _, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
 	if err != nil {
 		return ObjectInfo{}, toObjectErr(err, bucket, object)
 	}
 
 	// List all online disks.
-	onlineDisks, modTime := listOnlineDisks(disks, metaArr, errs)
+	_, modTime := listOnlineDisks(disks, metaArr, errs)
 
 	// Pick latest valid metadata.
 	fi, err := pickValidFileInfo(ctx, metaArr, modTime, readQuorum)
@@ -1237,118 +1286,43 @@ func (er erasureObjects) PutObjectTags(ctx context.Context, bucket, object strin
 		return ObjectInfo{}, toObjectErr(errMethodNotAllowed, bucket, object)
 	}
 
-	onlineDisks, metaArr = shuffleDisksAndPartsMetadataByIndex(onlineDisks, metaArr, fi)
-	for i, metaFi := range metaArr {
-		if metaFi.IsValid() {
-			// clean fi.Meta of tag key, before updating the new tags
-			delete(metaFi.Metadata, xhttp.AmzObjectTagging)
-			// Don't update for empty tags
-			if tags != "" {
-				metaFi.Metadata[xhttp.AmzObjectTagging] = tags
-			}
-			for k, v := range opts.UserDefined {
-				metaFi.Metadata[k] = v
-			}
-			metaArr[i].Metadata = metaFi.Metadata
-		}
-	}
-
-	tempObj := mustGetUUID()
-
-	var online int
-	// Cleanup in case of xl.meta writing failure
-	defer func() {
-		if online != len(onlineDisks) {
-			er.deleteObject(context.Background(), minioMetaTmpBucket, tempObj, writeQuorum)
-		}
-	}()
-
-	// Write unique `xl.meta` for each disk.
-	if onlineDisks, err = writeUniqueFileInfo(ctx, onlineDisks, minioMetaTmpBucket, tempObj, metaArr, writeQuorum); err != nil {
-		return ObjectInfo{}, toObjectErr(err, bucket, object)
-	}
-
-	// Atomically rename metadata from tmp location to destination for each disk.
-	if onlineDisks, err = renameFileInfo(ctx, onlineDisks, minioMetaTmpBucket, tempObj, bucket, object, writeQuorum); err != nil {
-		return ObjectInfo{}, toObjectErr(err, bucket, object)
-	}
-
-	online = countOnlineDisks(onlineDisks)
-
-	objInfo := fi.ToObjectInfo(bucket, object)
-	objInfo.UserTags = tags
-
-	return objInfo, nil
-}
-
-// updateObjectMeta will update the metadata of a file.
-func (er erasureObjects) updateObjectMeta(ctx context.Context, bucket, object string, meta map[string]string, opts ObjectOptions) error {
-	if len(meta) == 0 {
-		return nil
-	}
-	disks := er.getDisks()
-
-	// Read metadata associated with the object from all disks.
-	metaArr, errs := readAllFileInfo(ctx, disks, bucket, object, opts.VersionID, true)
-
-	readQuorum, writeQuorum, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
-	if err != nil {
-		return toObjectErr(err, bucket, object)
-	}
-
-	// List all online disks.
-	_, modTime := listOnlineDisks(disks, metaArr, errs)
-
-	// Pick latest valid metadata.
-	fi, err := pickValidFileInfo(ctx, metaArr, modTime, readQuorum)
-	if err != nil {
-		return toObjectErr(err, bucket, object)
-	}
-
-	// Update metadata
-	for k, v := range meta {
+	fi.Metadata[xhttp.AmzObjectTagging] = tags
+	for k, v := range opts.UserDefined {
 		fi.Metadata[k] = v
 	}
 
-	if fi.Deleted {
-		if opts.VersionID == "" {
-			return toObjectErr(errFileNotFound, bucket, object)
-		}
-		return toObjectErr(errMethodNotAllowed, bucket, object)
+	if err = er.updateObjectMeta(ctx, bucket, object, fi); err != nil {
+		return ObjectInfo{}, toObjectErr(err, bucket, object)
 	}
 
-	for i := range metaArr {
-		if errs[i] != nil {
-			// Avoid disks where loading metadata fail
-			continue
-		}
+	return fi.ToObjectInfo(bucket, object), nil
+}
 
-		metaArr[i].Metadata = fi.Metadata
+// updateObjectMeta will update the metadata of a file.
+func (er erasureObjects) updateObjectMeta(ctx context.Context, bucket, object string, fi FileInfo) error {
+	if len(fi.Metadata) == 0 {
+		return nil
 	}
 
-	tempObj := mustGetUUID()
+	disks := er.getDisks()
 
-	var online int
-	// Cleanup in case of xl.meta writing failure
-	defer func() {
-		if online != len(disks) {
-			er.deleteObject(context.Background(), minioMetaTmpBucket, tempObj, writeQuorum)
-		}
-	}()
+	g := errgroup.WithNErrs(len(disks))
 
-	// Write unique `xl.meta` for each disk.
-	if disks, err = writeUniqueFileInfo(ctx, disks, minioMetaTmpBucket, tempObj, metaArr, writeQuorum); err != nil {
-		return toObjectErr(err, bucket, object)
+	// Start writing `xl.meta` to all disks in parallel.
+	for index := range disks {
+		index := index
+		g.Go(func() error {
+			if disks[index] == nil {
+				return errDiskNotFound
+			}
+			return disks[index].UpdateMetadata(ctx, bucket, object, fi)
+		}, index)
 	}
 
-	// Atomically rename metadata from tmp location to destination for each disk.
-	if disks, err = renameFileInfo(ctx, disks, minioMetaTmpBucket, tempObj, bucket, object, writeQuorum); err != nil {
-		logger.LogIf(ctx, err)
-		return toObjectErr(err, bucket, object)
-	}
+	// Wait for all the routines.
+	mErrs := g.Wait()
 
-	online = countOnlineDisks(disks)
-	return nil
+	return reduceWriteQuorumErrs(ctx, mErrs, objectOpIgnoredErrs, getWriteQuorum(len(disks)))
 }
 
 // DeleteObjectTags - delete object tags from an existing object

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1778,6 +1778,22 @@ func (z *erasureServerPools) Health(ctx context.Context, opts HealthOptions) Hea
 	}
 }
 
+// PutObjectMetadata - replace or add tags to an existing object
+func (z *erasureServerPools) PutObjectMetadata(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
+	object = encodeDirObject(object)
+	if z.SinglePool() {
+		return z.serverPools[0].PutObjectMetadata(ctx, bucket, object, opts)
+	}
+
+	// We don't know the size here set 1GiB atleast.
+	idx, err := z.getPoolIdxExisting(ctx, bucket, object)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+
+	return z.serverPools[idx].PutObjectMetadata(ctx, bucket, object, opts)
+}
+
 // PutObjectTags - replace or add tags to an existing object
 func (z *erasureServerPools) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) (ObjectInfo, error) {
 	object = encodeDirObject(object)

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -1318,6 +1318,12 @@ func (s *erasureSets) HealObject(ctx context.Context, bucket, object, versionID 
 	return s.getHashedSet(object).HealObject(ctx, bucket, object, versionID, opts)
 }
 
+// PutObjectMetadata - replace or add metadata to an existing object/version
+func (s *erasureSets) PutObjectMetadata(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
+	er := s.getHashedSet(object)
+	return er.PutObjectMetadata(ctx, bucket, object, opts)
+}
+
 // PutObjectTags - replace or add tags to an existing object
 func (s *erasureSets) PutObjectTags(ctx context.Context, bucket, object string, tags string, opts ObjectOptions) (ObjectInfo, error) {
 	er := s.getHashedSet(object)

--- a/cmd/gateway-unsupported.go
+++ b/cmd/gateway-unsupported.go
@@ -52,6 +52,12 @@ func (a GatewayUnsupported) NSScanner(ctx context.Context, bf *bloomFilter, upda
 	return NotImplemented{}
 }
 
+// PutObjectMetadata - not implemented for gateway.
+func (a GatewayUnsupported) PutObjectMetadata(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
+	logger.CriticalIf(ctx, errors.New("not implemented"))
+	return ObjectInfo{}, NotImplemented{}
+}
+
 // NewNSLock is a dummy stub for gateway.
 func (a GatewayUnsupported) NewNSLock(bucket string, objects ...string) RWLocker {
 	logger.CriticalIf(context.Background(), errors.New("not implemented"))

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -686,7 +686,14 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 				// Update block 0 metadata.
 				var retries int
 				for {
-					err := er.updateObjectMeta(ctx, minioMetaBucket, o.objectPath(0), b.headerKV(), ObjectOptions{})
+					meta := b.headerKV()
+					fi := FileInfo{
+						Metadata: make(map[string]string, len(meta)),
+					}
+					for k, v := range meta {
+						fi.Metadata[k] = v
+					}
+					err := er.updateObjectMeta(ctx, minioMetaBucket, o.objectPath(0), fi)
 					if err == nil {
 						break
 					}

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -244,6 +244,13 @@ func (d *naughtyDisk) WriteMetadata(ctx context.Context, volume, path string, fi
 	return d.disk.WriteMetadata(ctx, volume, path, fi)
 }
 
+func (d *naughtyDisk) UpdateMetadata(ctx context.Context, volume, path string, fi FileInfo) (err error) {
+	if err := d.calcError(); err != nil {
+		return err
+	}
+	return d.disk.UpdateMetadata(ctx, volume, path, fi)
+}
+
 func (d *naughtyDisk) DeleteVersion(ctx context.Context, volume, path string, fi FileInfo, forceDelMarker bool) (err error) {
 	if err := d.calcError(); err != nil {
 		return err

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -161,6 +161,9 @@ type ObjectLayer interface {
 	Health(ctx context.Context, opts HealthOptions) HealthResult
 	ReadHealth(ctx context.Context) bool
 
+	// Metadata operations
+	PutObjectMetadata(context.Context, string, string, ObjectOptions) (ObjectInfo, error)
+
 	// ObjectTagging operations
 	PutObjectTags(context.Context, string, string, string, ObjectOptions) (ObjectInfo, error)
 	GetObjectTags(context.Context, string, string, ObjectOptions) (*tags.Tags, error)

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -55,6 +55,7 @@ type StorageAPI interface {
 	DeleteVersion(ctx context.Context, volume, path string, fi FileInfo, forceDelMarker bool) error
 	DeleteVersions(ctx context.Context, volume string, versions []FileInfo) []error
 	WriteMetadata(ctx context.Context, volume, path string, fi FileInfo) error
+	UpdateMetadata(ctx context.Context, volume, path string, fi FileInfo) error
 	ReadVersion(ctx context.Context, volume, path, versionID string, readData bool) (FileInfo, error)
 	RenameData(ctx context.Context, srcVolume, srcPath, dataDir, dstVolume, dstPath string) error
 

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -360,6 +360,21 @@ func (client *storageRESTClient) WriteMetadata(ctx context.Context, volume, path
 	return err
 }
 
+func (client *storageRESTClient) UpdateMetadata(ctx context.Context, volume, path string, fi FileInfo) error {
+	values := make(url.Values)
+	values.Set(storageRESTVolume, volume)
+	values.Set(storageRESTFilePath, path)
+
+	var reader bytes.Buffer
+	if err := msgp.Encode(&reader, &fi); err != nil {
+		return err
+	}
+
+	respBody, err := client.call(ctx, storageRESTMethodUpdateMetadata, values, &reader, -1)
+	defer http.DrainBody(respBody)
+	return err
+}
+
 func (client *storageRESTClient) DeleteVersion(ctx context.Context, volume, path string, fi FileInfo, forceDelMarker bool) error {
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -17,7 +17,7 @@
 package cmd
 
 const (
-	storageRESTVersion       = "v29" // Removed WalkVersions()
+	storageRESTVersion       = "v30" // Added UpdateMetadata()
 	storageRESTVersionPrefix = SlashSeparator + storageRESTVersion
 	storageRESTPrefix        = minioReservedBucketPath + "/storage"
 )
@@ -36,6 +36,7 @@ const (
 	storageRESTMethodCreateFile     = "/createfile"
 	storageRESTMethodWriteAll       = "/writeall"
 	storageRESTMethodWriteMetadata  = "/writemetadata"
+	storageRESTMethodUpdateMetadata = "/updatemetadata"
 	storageRESTMethodDeleteVersion  = "/deleteversion"
 	storageRESTMethodReadVersion    = "/readversion"
 	storageRESTMethodRenameData     = "/renamedata"

--- a/cmd/storagemetric_string.go
+++ b/cmd/storagemetric_string.go
@@ -29,14 +29,15 @@ func _() {
 	_ = x[storageMetricWriteAll-18]
 	_ = x[storageMetricDeleteVersion-19]
 	_ = x[storageMetricWriteMetadata-20]
-	_ = x[storageMetricReadVersion-21]
-	_ = x[storageMetricReadAll-22]
-	_ = x[storageMetricLast-23]
+	_ = x[storageMetricUpdateMetadata-21]
+	_ = x[storageMetricReadVersion-22]
+	_ = x[storageMetricReadAll-23]
+	_ = x[storageMetricLast-24]
 }
 
-const _storageMetric_name = "MakeVolBulkMakeVolListVolsStatVolDeleteVolWalkDirListDirReadFileAppendFileCreateFileReadFileStreamRenameFileRenameDataCheckPartsCheckFileDeleteDeleteVersionsVerifyFileWriteAllDeleteVersionWriteMetadataReadVersionReadAllLast"
+const _storageMetric_name = "MakeVolBulkMakeVolListVolsStatVolDeleteVolWalkDirListDirReadFileAppendFileCreateFileReadFileStreamRenameFileRenameDataCheckPartsCheckFileDeleteDeleteVersionsVerifyFileWriteAllDeleteVersionWriteMetadataUpdateMetadataReadVersionReadAllLast"
 
-var _storageMetric_index = [...]uint8{0, 11, 18, 26, 33, 42, 49, 56, 64, 74, 84, 98, 108, 118, 128, 137, 143, 157, 167, 175, 188, 201, 212, 219, 223}
+var _storageMetric_index = [...]uint8{0, 11, 18, 26, 33, 42, 49, 56, 64, 74, 84, 98, 108, 118, 128, 137, 143, 157, 167, 175, 188, 201, 215, 226, 233, 237}
 
 func (i storageMetric) String() string {
 	if i >= storageMetric(len(_storageMetric_index)-1) {

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -54,6 +54,7 @@ const (
 	storageMetricWriteAll
 	storageMetricDeleteVersion
 	storageMetricWriteMetadata
+	storageMetricUpdateMetadata
 	storageMetricReadVersion
 	storageMetricReadAll
 
@@ -539,6 +540,22 @@ func (p *xlStorageDiskIDCheck) DeleteVersion(ctx context.Context, volume, path s
 	}
 
 	return p.storage.DeleteVersion(ctx, volume, path, fi, forceDelMarker)
+}
+
+func (p *xlStorageDiskIDCheck) UpdateMetadata(ctx context.Context, volume, path string, fi FileInfo) (err error) {
+	defer p.updateStorageMetrics(storageMetricUpdateMetadata, volume, path)()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	if err = p.checkDiskStale(); err != nil {
+		return err
+	}
+
+	return p.storage.UpdateMetadata(ctx, volume, path, fi)
 }
 
 func (p *xlStorageDiskIDCheck) WriteMetadata(ctx context.Context, volume, path string, fi FileInfo) (err error) {

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -897,6 +897,44 @@ func (s *xlStorage) DeleteVersion(ctx context.Context, volume, path string, fi F
 	return err
 }
 
+// Updates only metadata for a given version.
+func (s *xlStorage) UpdateMetadata(ctx context.Context, volume, path string, fi FileInfo) error {
+	if len(fi.Metadata) == 0 {
+		return errInvalidArgument
+	}
+
+	buf, err := s.ReadAll(ctx, volume, pathJoin(path, xlStorageFormatFile))
+	if err != nil {
+		if err == errFileNotFound {
+			if fi.VersionID != "" {
+				return errFileVersionNotFound
+			}
+		}
+		return err
+	}
+
+	if !isXL2V1Format(buf) {
+		return errFileVersionNotFound
+	}
+
+	var xlMeta xlMetaV2
+	if err = xlMeta.Load(buf); err != nil {
+		logger.LogIf(ctx, err)
+		return err
+	}
+
+	if err = xlMeta.UpdateObjectVersion(fi); err != nil {
+		return err
+	}
+
+	buf, err = xlMeta.AppendTo(nil)
+	if err != nil {
+		return err
+	}
+
+	return s.WriteAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf)
+}
+
 // WriteMetadata - writes FileInfo metadata for path at `xl.meta`
 func (s *xlStorage) WriteMetadata(ctx context.Context, volume, path string, fi FileInfo) error {
 	buf, err := s.ReadAll(ctx, volume, pathJoin(path, xlStorageFormatFile))
@@ -936,7 +974,6 @@ func (s *xlStorage) WriteMetadata(ctx context.Context, volume, path string, fi F
 	}
 
 	return s.WriteAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf)
-
 }
 
 func (s *xlStorage) renameLegacyMetadata(volumeDir, path string) (err error) {
@@ -1044,7 +1081,7 @@ func (s *xlStorage) ReadVersion(ctx context.Context, volume, path, versionID str
 
 		// Reading data for small objects when
 		// - object has not yet transitioned
-		// - object size lesser than 32KiB
+		// - object size lesser than 128KiB
 		// - object has maximum of 1 parts
 		if fi.TransitionStatus == "" && fi.DataDir != "" && fi.Size <= smallFileThreshold && len(fi.Parts) == 1 {
 			// Enable O_DIRECT optionally only if drive supports it.
@@ -1891,7 +1928,7 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath, dataDir,
 		if isXL2V1Format(dstBuf) {
 			if err = xlMeta.Load(dstBuf); err != nil {
 				logger.LogIf(s.ctx, err)
-				return errFileCorrupt
+				return err
 			}
 		} else {
 			// This code-path is to preserve the legacy data.


### PR DESCRIPTION


## Description
api: Introduce metadata update APIs to update only metadata

## Motivation and Context
Current implementation heavily relies on readAllFileInfo
but with the advent of xl.meta inlined with data, we cannot
easily avoid reading data when we are only interested is
updating metadata, this leads to invariably write
amplification during metadata updates, repeatedly reading
data when we are only interested in updating metadata.

This PR ensures that we implement a metadata only update
API at storage layer, that handles updates to metadata alone
for any given version - given the version is valid and
present.

This helps reduce the chattiness for following calls..

- PutObjectTags
- DeleteObjectTags
- PutObjectLegalHold
- PutObjectRetention
- ReplicateObject (updates metadata on replication status)

## How to test this PR?
Run MinIO in erasure-coded setup locally and enable versioning on the bucket

```
~ minio server /tmp/xl{1...4}
```

Upload multiple objects in parallel
```
~ seq 1 1000 | parallel -j32 -I{} "echo {}; mc cp /etc/issue myminio/testbucket/issue --json"
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
