### PR TITLE
avoid frequent DNS lookups for baremetal setups

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -59,7 +59,15 @@ func init() {
 	config.Logger.Info = logger.Info
 	config.Logger.LogIf = logger.LogIf
 
-	globalDNSCache = xhttp.NewDNSCache(10*time.Second, 10*time.Second, logger.LogOnceIf)
+	if IsKubernetes() || IsDocker() || IsBOSH() || IsDCOS() || IsKubernetesReplicaSet() || IsPCFTile() {
+		// 30 seconds matches the orchestrator DNS TTLs, have
+		// a 5 second timeout to lookup from DNS servers.
+		globalDNSCache = xhttp.NewDNSCache(30*time.Second, 5*time.Second, logger.LogOnceIf)
+	} else {
+		// On bare-metals DNS do not change often, so it is
+		// safe to assume a higher timeout upto 10 minutes.
+		globalDNSCache = xhttp.NewDNSCache(10*time.Minute, 5*time.Second, logger.LogOnceIf)
+	}
 
 	initGlobalContext()
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -219,6 +219,11 @@ func IsSourceBuild() bool {
 	return err != nil
 }
 
+// IsPCFTile returns if server is running in PCF
+func IsPCFTile() bool {
+	return env.Get("MINIO_PCF_TILE_VERSION", "") != ""
+}
+
 // DO NOT CHANGE USER AGENT STYLE.
 // The style should be
 //
@@ -284,9 +289,11 @@ func getUserAgent(mode string) string {
 		}
 	}
 
-	pcfTileVersion := env.Get("MINIO_PCF_TILE_VERSION", "")
-	if pcfTileVersion != "" {
-		uaAppend(" MinIO/pcf-tile-", pcfTileVersion)
+	if IsPCFTile() {
+		pcfTileVersion := env.Get("MINIO_PCF_TILE_VERSION", "")
+		if pcfTileVersion != "" {
+			uaAppend(" MinIO/pcf-tile-", pcfTileVersion)
+		}
 	}
 
 	return strings.Join(userAgentParts, "")


### PR DESCRIPTION
## Description
avoid frequent DNS lookups for bare-metal setups

## Motivation and Context
cache up-to 10 minutes

## How to test this PR?
Adding prints to see how regularly MinIO loads DNS. With a large set of servers
this may increase the load of the DNS if all of the refreshed simultaneously. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
