### PR TITLE
Server side fix to check locks on objects for mc issue #3674

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3523,6 +3523,11 @@ func (api objectAPIHandlers) GetObjectRetentionHandler(w http.ResponseWriter, r 
 		getObjectInfo = api.CacheAPI().GetObjectInfo
 	}
 
+	if rcfg, _ := globalBucketObjectLockSys.Get(bucket); !rcfg.LockEnabled {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidBucketObjectLockConfiguration), r.URL, guessIsBrowserReq(r))
+		return
+	}
+
 	opts, err := getOpts(ctx, r, bucket, object)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
@@ -3536,7 +3541,6 @@ func (api objectAPIHandlers) GetObjectRetentionHandler(w http.ResponseWriter, r 
 	}
 
 	retention := objectlock.GetObjectRetentionMeta(objInfo.UserDefined)
-
 	if !retention.Mode.Valid() {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrNoSuchObjectLockConfiguration), r.URL, guessIsBrowserReq(r))
 		return


### PR DESCRIPTION
This is an additional change required to complete PR minio/mc#3677, for issue minio/mc#3674.

## Motivation and Context
The lock features; retention, and legalhold are handled identically, but there is a missing check in `PutObjectRetentionHandler` function. This causes the locking features to fail with different error messages when there is no configuration yet. 
With this fix, both features behave the same and throw the same error message, which is the expectation on the mc side, minio/mc#3677.

## How to test this PR?
Create several locked and unlocked objects and prefixes, with retention and legalhold
Then try to `mc mv` them. If the object is locked, we should reject to move the item, otherwise, the move action should complete.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

