### PR TITLE
Remove redundant GetBucketLifecycleHandler call

### DIFF
--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -343,9 +343,6 @@ func registerAPIRouter(router *mux.Router) {
 		// GetBucketLoggingHandler - this is a dummy call.
 		router.Methods(http.MethodGet).HandlerFunc(
 			collectAPIStats("getbucketlogging", maxClients(httpTraceAll(api.GetBucketLoggingHandler)))).Queries("logging", "")
-		// GetBucketLifecycleHandler - this is a dummy call.
-		router.Methods(http.MethodGet).HandlerFunc(
-			collectAPIStats("getbucketlifecycle", maxClients(httpTraceAll(api.GetBucketLifecycleHandler)))).Queries("lifecycle", "")
 		// GetBucketTaggingHandler
 		router.Methods(http.MethodGet).HandlerFunc(
 			collectAPIStats("getbuckettagging", maxClients(httpTraceAll(api.GetBucketTaggingHandler)))).Queries("tagging", "")


### PR DESCRIPTION
## Description
The api.GetBucketLifecycleHandler is registered two times in the cmd/api-router.go.
One if the registration calls is commented with "this is a dummy call". 
But the GetBucketLifecycleHandler is not a dummy call. Maybe it was a dummy call in earlier days.
This PR removes this second, unnecessary registration call.

## Motivation and Context
Remove unnecessary code with a misleading comment. 

## How to test this PR?
The PR does not change the behavoir. All unit- and system tests should pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
