### PR TITLE
Add initial usage in GetBucketReplicationMetrics API

### DIFF
--- a/cmd/bucket-replication-stats.go
+++ b/cmd/bucket-replication-stats.go
@@ -110,7 +110,7 @@ func (r *ReplicationStats) Update(bucket string, n int64, status, prevStatus rep
 	r.Unlock()
 }
 
-// GetInitialUsage gets initial usage from the time of cluster initialization
+// GetInitialUsage get replication metrics available at the time of cluster initialization
 func (r *ReplicationStats) GetInitialUsage(bucket string) BucketReplicationStats {
 	if r == nil {
 		return BucketReplicationStats{}
@@ -133,7 +133,7 @@ func (r *ReplicationStats) GetInitialUsage(bucket string) BucketReplicationStats
 	}
 }
 
-// Get total bytes pending replication for a bucket
+// Get replication metrics for a bucket from this node since this node came up.
 func (r *ReplicationStats) Get(bucket string) BucketReplicationStats {
 	if r == nil {
 		return BucketReplicationStats{}


### PR DESCRIPTION
## Description


## Motivation and Context
initial usage reported from scanner needs to be accounted in the metrics calculation.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
