### PR TITLE
export globalConsoleSys for access from ming

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1202,7 +1202,7 @@ func (a adminAPIHandlers) ConsoleLogHandler(w http.ResponseWriter, r *http.Reque
 
 	peers, _ := newPeerRestClients(globalEndpoints)
 
-	globalConsoleSys.Subscribe(logCh, ctx.Done(), node, limitLines, logKind, nil)
+	GlobalConsoleSys.Subscribe(logCh, ctx.Done(), node, limitLines, logKind, nil)
 
 	for _, peer := range peers {
 		if peer == nil {

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1634,7 +1634,7 @@ func (api objectAPIHandlers) GetBucketReplicationMetricsHandler(w http.ResponseW
 		return
 	}
 
-	bucketStats := globalNotificationSys.GetClusterBucketStats(r.Context(), bucket)
+	bucketStats := GlobalNotificationSys.GetClusterBucketStats(r.Context(), bucket)
 	bucketReplStats := BucketReplicationStats{}
 
 	for _, bucketStat := range bucketStats {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -346,8 +346,8 @@ func HandleCommonEnvVars() {
 }
 
 func LogStartupMessage(msg string) {
-	if globalConsoleSys != nil {
-		globalConsoleSys.Send(msg, string(logger.All))
+	if GlobalConsoleSys != nil {
+		GlobalConsoleSys.Send(msg, string(logger.All))
 	}
 	logger.StartupMessage(msg)
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -198,7 +198,7 @@ var (
 
 	// global console system to send console logs to
 	// registered listeners
-	globalConsoleSys *HTTPConsoleLoggerSys
+	GlobalConsoleSys *HTTPConsoleLoggerSys
 
 	globalEndpoints EndpointServerPools
 

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -433,7 +433,7 @@ func networkMetricsPrometheus(ch chan<- prometheus.Metric) {
 
 // get the most current of in-memory replication stats  and data usage info from crawler.
 func getLatestReplicationStats(bucket string, u madmin.BucketUsageInfo) (s BucketReplicationStats) {
-	bucketStats := globalNotificationSys.GetClusterBucketStats(GlobalContext, bucket)
+	bucketStats := GlobalNotificationSys.GetClusterBucketStats(GlobalContext, bucket)
 
 	replStats := BucketReplicationStats{}
 	for _, bucketStat := range bucketStats {

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -1020,7 +1020,7 @@ func (s *peerRESTServer) ConsoleLogHandler(w http.ResponseWriter, r *http.Reques
 	defer close(doneCh)
 
 	ch := make(chan interface{}, 2000)
-	globalConsoleSys.Subscribe(ch, doneCh, "", 0, string(logger.All), nil)
+	GlobalConsoleSys.Subscribe(ch, doneCh, "", 0, string(logger.All), nil)
 
 	enc := gob.NewEncoder(w)
 	for {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -408,8 +408,8 @@ func serverMain(ctx *cli.Context) {
 	setDefaultProfilerRates()
 
 	// Initialize globalConsoleSys system
-	globalConsoleSys = NewConsoleLogger(GlobalContext)
-	logger.AddTarget(globalConsoleSys)
+	GlobalConsoleSys = NewConsoleLogger(GlobalContext)
+	logger.AddTarget(GlobalConsoleSys)
 
 	// Perform any self-tests
 	erasureSelfTest()
@@ -422,7 +422,7 @@ func serverMain(ctx *cli.Context) {
 	serverHandleEnvVars()
 
 	// Set node name, only set for distributed setup.
-	globalConsoleSys.SetNodeName(globalLocalNodeName)
+	GlobalConsoleSys.SetNodeName(globalLocalNodeName)
 
 	// Initialize all help
 	InitHelp()

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -106,7 +106,7 @@ func TestMain(m *testing.M) {
 	SetMaxResources()
 
 	// Initialize globalConsoleSys system
-	globalConsoleSys = NewConsoleLogger(context.Background())
+	GlobalConsoleSys = NewConsoleLogger(context.Background())
 
 	GlobalDNSCache = xhttp.NewDNSCache(3*time.Second, 10*time.Second, logger.LogOnceIf)
 


### PR DESCRIPTION
## Description
export GlobalConsoleSys since admin handlers uses it during console
channel listening.

Also fix compilation error with globalNotificationSys

## Motivation and Context
Fix crash when running `mc admin console` against ming

## How to test this PR?
```
$ ming nas /tmp/nas
$ mc admin console mynas
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
