### PR TITLE
Add runtime mem stats to server info

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -271,21 +271,6 @@ type ServerHTTPStats struct {
 	TotalS3RejectedInvalid uint64             `json:"totalS3RejectedInvalid"`
 }
 
-// ServerInfoData holds storage, connections and other
-// information of a given server.
-type ServerInfoData struct {
-	ConnStats  ServerConnStats  `json:"network"`
-	HTTPStats  ServerHTTPStats  `json:"http"`
-	Properties ServerProperties `json:"server"`
-}
-
-// ServerInfo holds server information result of one node
-type ServerInfo struct {
-	Error string          `json:"error"`
-	Addr  string          `json:"addr"`
-	Data  *ServerInfoData `json:"data"`
-}
-
 // StorageInfoHandler - GET /minio/admin/v3/storageinfo
 // ----------
 // Get server information

--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/minio/minio/cmd/logger"
@@ -67,6 +68,7 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 		CommitID: CommitID,
 		Network:  network,
 	}
+	runtime.ReadMemStats(&props.MemStats)
 
 	objLayer := newObjectLayerFn()
 	if objLayer != nil && !globalIsGateway {

--- a/pkg/madmin/info-commands.go
+++ b/pkg/madmin/info-commands.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"runtime"
 	"time"
 )
 
@@ -316,6 +317,7 @@ type ServerProperties struct {
 	Network    map[string]string `json:"network,omitempty"`
 	Disks      []Disk            `json:"drives,omitempty"`
 	PoolNumber int               `json:"poolNumber,omitempty"`
+	MemStats   runtime.MemStats  `json:"mem_stats"`
 }
 
 // DiskMetrics has the information about XL Storage APIs


### PR DESCRIPTION
## Description

Adds information about runtime+gc memory use.

## Motivation and Context

Gives more debugging information

## How to test this PR?

`mc admin info --json myminio`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
