### PR TITLE
Mint - Add environment variable RUN_ON_FAIL

### DIFF
--- a/mint/README.md
+++ b/mint/README.md
@@ -44,6 +44,7 @@ Below environment variables are required to be passed to the docker container. S
 | `MINT_MODE` | (Optional) Set mode indicating what category of tests to be run by values `core`, `full`. Defaults to `core` | `full` |
 | `DOMAIN` | (Optional) Value of MINIO_DOMAIN environment variable used in Minio server | `myminio.com` |
 | `ENABLE_VIRTUAL_STYLE` | (Optional) Set `1` to indicate virtual style access . Defaults to `0` (Path style) | `1` |
+| `RUN_ON_FAIL` | (Optional) Set `1` to indicate execute all tests independent of failures (currently implemented for minio-go and minio-java) . Defaults to `0` (Path style) | `1` |
 
 
 ### Test virtual style access against Minio server

--- a/mint/mint.sh
+++ b/mint/mint.sh
@@ -21,6 +21,7 @@ MINT_MODE=${MINT_MODE:-core}
 SERVER_REGION=${SERVER_REGION:-us-east-1}
 ENABLE_HTTPS=${ENABLE_HTTPS:-0}
 ENABLE_VIRTUAL_STYLE=${ENABLE_VIRTUAL_STYLE:-0}
+RUN_ON_FAIL=${RUN_ON_FAIL:-0}
 GO111MODULE=on
 
 if [ -z "$SERVER_ENDPOINT" ]; then
@@ -136,6 +137,7 @@ function main()
     export ENABLE_HTTPS
     export SERVER_REGION
     export ENABLE_VIRTUAL_STYLE
+    export RUN_ON_FAIL
     export GO111MODULE
 
     echo "Running with"
@@ -147,6 +149,7 @@ function main()
     echo "MINT_DATA_DIR:        $MINT_DATA_DIR"
     echo "MINT_MODE:            $MINT_MODE"
     echo "ENABLE_VIRTUAL_STYLE: $ENABLE_VIRTUAL_STYLE"
+    echo "RUN_ON_FAIL:          $RUN_ON_FAIL"
     echo
     echo "To get logs, run 'docker cp ${CONTAINER_ID}:/mint/log /tmp/mint-logs'"
     echo

--- a/mint/run/core/minio-go/README.md
+++ b/mint/run/core/minio-go/README.md
@@ -5,7 +5,7 @@ This directory serves as the location for Mint tests using `minio-go`.  Top leve
 New tests are added in functional tests of minio-go.  Please check https://github.com/minio/minio-go
 
 ## Running tests manually
-- Set environment variables `MINT_DATA_DIR`, `MINT_MODE`, `SERVER_ENDPOINT`, `ACCESS_KEY`, `SECRET_KEY`, `SERVER_REGION` and `ENABLE_HTTPS`
+- Set environment variables `MINT_DATA_DIR`, `MINT_MODE`, `SERVER_ENDPOINT`, `ACCESS_KEY`, `SECRET_KEY`, `SERVER_REGION`, `ENABLE_HTTPS` and `RUN_ON_FAIL`
 - Call `run.sh` with output log file and error log file. for example
 ```bash
 export MINT_DATA_DIR=~/my-mint-dir
@@ -15,5 +15,6 @@ export ACCESS_KEY="Q3AM3UQ867SPQQA43P2F"
 export SECRET_KEY="zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
 export ENABLE_HTTPS=1
 export SERVER_REGION=us-east-1
+export RUN_ON_FAIL=1
 ./run.sh /tmp/output.log /tmp/error.log
 ```

--- a/mint/run/core/minio-java/README.md
+++ b/mint/run/core/minio-java/README.md
@@ -5,7 +5,7 @@ This directory serves as the location for Mint tests using `minio-java`.  Top le
 New tests is added in functional tests of minio-java.  Please check https://github.com/minio/minio-java
 
 ## Running tests manually
-- Set environment variables `MINT_DATA_DIR`, `MINT_MODE`, `SERVER_ENDPOINT`, `ACCESS_KEY`, `SECRET_KEY`, `SERVER_REGION` and `ENABLE_HTTPS`
+- Set environment variables `MINT_DATA_DIR`, `MINT_MODE`, `SERVER_ENDPOINT`, `ACCESS_KEY`, `SECRET_KEY`, `SERVER_REGION`, `ENABLE_HTTPS` and `RUN_ON_FAIL`
 - Call `run.sh` with output log file and error log file. for example
 ```bash
 export MINT_DATA_DIR=~/my-mint-dir
@@ -15,5 +15,6 @@ export ACCESS_KEY="Q3AM3UQ867SPQQA43P2F"
 export SECRET_KEY="zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
 export ENABLE_HTTPS=1
 export SERVER_REGION=us-east-1
+export RUN_ON_FAIL=1
 ./run.sh /tmp/output.log /tmp/error.log
 ```

--- a/mint/run/core/minio-java/run.sh
+++ b/mint/run/core/minio-java/run.sh
@@ -31,4 +31,4 @@ if [ "$ENABLE_HTTPS" -eq 1 ]; then
 fi
 
 java -Xmx4096m -Xms256m -cp "/mint/run/core/minio-java/*:." FunctionalTest \
-    "$endpoint" "$ACCESS_KEY" "$SECRET_KEY" "$SERVER_REGION" 1>>"$output_log_file" 2>"$error_log_file"
+    "$endpoint" "$ACCESS_KEY" "$SECRET_KEY" "$SERVER_REGION" "$RUN_ON_FAIL" 1>>"$output_log_file" 2>"$error_log_file"


### PR DESCRIPTION
Refering to https://github.com/minio/minio/issues/11996

## Description
By setting the variable `RUN_ON_FAIL` all tests from all packages (currently implemented for minio-go and minio-java) are executed independent of failures.

 

## Motivation and Context
Whenever the Mint test suite is executed, a single failing test from one of the test packages causes all the remaining tests from that package to be skipped.

 

## How to test this PR?

`RUN_ON_FAIL=1`
At least two tests from a package must fail.

`RUN_ON_FAIL=0`
The behavior is not changed if the environment variable is not set or equals 0.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Optimization (provides speedup with no functional changes)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

 

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)

- [x] Documentation updated

- [ ] Unit tests added/updated