### PR TITLE
tracing: Support older admin tracing API

### DIFF
--- a/pkg/madmin/service-commands.go
+++ b/pkg/madmin/service-commands.go
@@ -80,6 +80,8 @@ type ServiceTraceInfo struct {
 
 // ServiceTraceOpts holds tracing options
 type ServiceTraceOpts struct {
+	All bool // Deprecated
+
 	S3         bool
 	Internal   bool
 	Storage    bool
@@ -97,11 +99,17 @@ func (adm AdminClient) ServiceTrace(ctx context.Context, opts ServiceTraceOpts) 
 		for {
 			urlValues := make(url.Values)
 			urlValues.Set("err", strconv.FormatBool(opts.OnlyErrors))
-			urlValues.Set("s3", strconv.FormatBool(opts.S3))
-			urlValues.Set("internal", strconv.FormatBool(opts.Internal))
-			urlValues.Set("storage", strconv.FormatBool(opts.Storage))
-			urlValues.Set("os", strconv.FormatBool(opts.OS))
 			urlValues.Set("threshold", opts.Threshold.String())
+
+			if opts.All {
+				// Deprecated flag
+				urlValues.Set("all", "true")
+			} else {
+				urlValues.Set("s3", strconv.FormatBool(opts.S3))
+				urlValues.Set("internal", strconv.FormatBool(opts.Internal))
+				urlValues.Set("storage", strconv.FormatBool(opts.Storage))
+				urlValues.Set("os", strconv.FormatBool(opts.OS))
+			}
 			reqData := requestData{
 				relPath:     adminAPIPrefix + "/trace",
 				queryValues: urlValues,

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -25,12 +25,12 @@ import (
 type Type int
 
 const (
+	// HTTP tracing (MinIO S3 & Internode)
+	HTTP Type = iota
 	// OS tracing (Golang os package calls)
-	OS Type = iota
+	OS
 	// Storage tracing (MinIO Storage Layer)
 	Storage
-	// HTTP tracing (MinIO S3 & Internode)
-	HTTP
 )
 
 // Info - represents a trace record, additionally


### PR DESCRIPTION
## Description
mc admin trace does not work with older MinIO versions because if an
incompability with older trace admin API. This commit changes madmin for
better backward compatibility with server admin API.

## Motivation and Context
Add backward compatibility with older trace admin API

## How to test this PR?
mc admin trace

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
