### PR TITLE
healing: re-read metadata after lock

### DIFF
--- a/pkg/madmin/heal-commands.go
+++ b/pkg/madmin/heal-commands.go
@@ -48,7 +48,6 @@ type HealOpts struct {
 	DryRun    bool         `json:"dryRun"`
 	Remove    bool         `json:"remove"`
 	Recreate  bool         `json:"recreate"` // only used when bucket needs to be healed
-	NoLock    bool         `json:"-"`        // only used internally.
 	ScanMode  HealScanMode `json:"scanMode"`
 }
 


### PR DESCRIPTION
## Description

Do no use potentially wrong metadata from before acquiring lock.

Plus remove unused NoLock option.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
