### PR TITLE
handle dns.ErrBucketConflict as BucketAlreadyExists

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -2004,6 +2004,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrKeyTooLongError
 	case dns.ErrInvalidBucketName:
 		apiErr = ErrInvalidBucketName
+	case dns.ErrBucketConflict:
+		apiErr = ErrBucketAlreadyExists
 	default:
 		var ie, iw int
 		// This work-around is to handle the issue golang/go#30648

--- a/cmd/config/dns/operator_dns.go
+++ b/cmd/config/dns/operator_dns.go
@@ -100,6 +100,10 @@ func (c *OperatorDNS) Put(bucket string) error {
 	xhttp.DrainBody(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		errorString := errorStringBuilder.String()
+		switch resp.StatusCode {
+		case http.StatusConflict:
+			return ErrBucketConflict(Error{bucket, errors.New(errorString)})
+		}
 		return newError(bucket, fmt.Errorf("service create for bucket %s, failed with status %s, error %s", bucket, resp.Status, errorString))
 	}
 	return nil

--- a/cmd/config/dns/store.go
+++ b/cmd/config/dns/store.go
@@ -26,10 +26,18 @@ type Error struct {
 type ErrInvalidBucketName Error
 
 func (e ErrInvalidBucketName) Error() string {
-	return "invalid bucket name error: " + e.Err.Error()
+	return e.Bucket + " invalid bucket name error: " + e.Err.Error()
 }
+
 func (e Error) Error() string {
 	return "dns related error: " + e.Err.Error()
+}
+
+// ErrBucketConflict for buckets that already exist
+type ErrBucketConflict Error
+
+func (e ErrBucketConflict) Error() string {
+	return e.Bucket + " bucket conflict error: " + e.Err.Error()
 }
 
 // Store dns record store


### PR DESCRIPTION
## Description
handle dns.ErrBucketConflict as BucketAlreadyExists

## Motivation and Context
DNS webhook can return 409 when bucket already 
exists return an appropriate error

## How to test this PR?
You need a customer DNS webhook endpoint that
returns 409 on bucket conflict

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
