### PR TITLE
fips build tag uses relevant binary link for updates

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -400,7 +400,7 @@ func (sys *NotificationSys) DownloadProfilingData(ctx context.Context, writer io
 }
 
 // ServerUpdate - updates remote peers.
-func (sys *NotificationSys) ServerUpdate(ctx context.Context, u *url.URL, sha256Sum []byte, lrTime time.Time) []NotificationPeerErr {
+func (sys *NotificationSys) ServerUpdate(ctx context.Context, u *url.URL, sha256Sum []byte, lrTime time.Time, releaseInfo string) []NotificationPeerErr {
 	ng := WithNPeers(len(sys.peerClients))
 	for idx, client := range sys.peerClients {
 		if client == nil {
@@ -408,7 +408,7 @@ func (sys *NotificationSys) ServerUpdate(ctx context.Context, u *url.URL, sha256
 		}
 		client := client
 		ng.Go(ctx, func() error {
-			return client.ServerUpdate(ctx, u, sha256Sum, lrTime)
+			return client.ServerUpdate(ctx, u, sha256Sum, lrTime, releaseInfo)
 		}, idx, *client.host)
 	}
 	return ng.Wait()

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -599,19 +599,21 @@ func (client *peerRESTClient) LoadGroup(group string) error {
 }
 
 type serverUpdateInfo struct {
-	URL       *url.URL
-	Sha256Sum []byte
-	Time      time.Time
+	URL         *url.URL
+	Sha256Sum   []byte
+	Time        time.Time
+	ReleaseInfo string
 }
 
 // ServerUpdate - sends server update message to remote peers.
-func (client *peerRESTClient) ServerUpdate(ctx context.Context, u *url.URL, sha256Sum []byte, lrTime time.Time) error {
+func (client *peerRESTClient) ServerUpdate(ctx context.Context, u *url.URL, sha256Sum []byte, lrTime time.Time, releaseInfo string) error {
 	values := make(url.Values)
 	var reader bytes.Buffer
 	if err := gob.NewEncoder(&reader).Encode(serverUpdateInfo{
-		URL:       u,
-		Sha256Sum: sha256Sum,
-		Time:      lrTime,
+		URL:         u,
+		Sha256Sum:   sha256Sum,
+		Time:        lrTime,
+		ReleaseInfo: releaseInfo,
 	}); err != nil {
 		return err
 	}

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -771,7 +771,7 @@ func (s *peerRESTServer) ServerUpdateHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if _, err = updateServer(info.URL, info.Sha256Sum, info.Time, getMinioMode()); err != nil {
+	if _, err = updateServer(info.URL, info.Sha256Sum, info.Time, info.ReleaseInfo, getMinioMode()); err != nil {
 		s.writeErrorResponse(w, err)
 		return
 	}

--- a/cmd/update_fips.go
+++ b/cmd/update_fips.go
@@ -1,0 +1,24 @@
+// +build fips
+
+/*
+ * MinIO Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+var (
+	// Newer official download info URLs appear earlier below.
+	minioReleaseInfoURL = minioReleaseURL + "minio.fips.sha256sum"
+)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -298,22 +298,25 @@ func TestDownloadReleaseData(t *testing.T) {
 func TestParseReleaseData(t *testing.T) {
 	releaseTime, _ := releaseTagToReleaseTime("RELEASE.2016-10-07T01-16-39Z")
 	testCases := []struct {
-		data              string
-		expectedResult    time.Time
-		expectedSha256hex string
-		expectedErr       bool
+		data                string
+		expectedResult      time.Time
+		expectedSha256hex   string
+		expectedReleaseInfo string
+		expectedErr         bool
 	}{
-		{"more than two fields", time.Time{}, "", true},
-		{"more than", time.Time{}, "", true},
-		{"more than.two.fields", time.Time{}, "", true},
-		{"more minio.RELEASE.fields", time.Time{}, "", true},
-		{"more minio.RELEASE.2016-10-07T01-16-39Z", time.Time{}, "", true},
-		{"fbe246edbd382902db9a4035df7dce8cb441357d minio.RELEASE.2016-10-07T01-16-39Z\n", releaseTime, "fbe246edbd382902db9a4035df7dce8cb441357d", false},
-		{"fbe246edbd382902db9a4035df7dce8cb441357d minio.RELEASE.2016-10-07T01-16-39Z.customer-hotfix\n", releaseTime, "fbe246edbd382902db9a4035df7dce8cb441357d", false},
+		{"more than two fields", time.Time{}, "", "", true},
+		{"more than", time.Time{}, "", "", true},
+		{"more than.two.fields", time.Time{}, "", "", true},
+		{"more minio.RELEASE.fields", time.Time{}, "", "", true},
+		{"more minio.RELEASE.2016-10-07T01-16-39Z", time.Time{}, "", "", true},
+		{"fbe246edbd382902db9a4035df7dce8cb441357d minio.RELEASE.2016-10-07T01-16-39Z\n", releaseTime, "fbe246edbd382902db9a4035df7dce8cb441357d",
+			"minio.RELEASE.2016-10-07T01-16-39Z", false},
+		{"fbe246edbd382902db9a4035df7dce8cb441357d minio.RELEASE.2016-10-07T01-16-39Z.customer-hotfix\n", releaseTime, "fbe246edbd382902db9a4035df7dce8cb441357d",
+			"minio.RELEASE.2016-10-07T01-16-39Z.customer-hotfix", false},
 	}
 
 	for i, testCase := range testCases {
-		sha256Sum, result, err := parseReleaseData(testCase.data)
+		sha256Sum, result, releaseInfo, err := parseReleaseData(testCase.data)
 		if !testCase.expectedErr {
 			if err != nil {
 				t.Errorf("error case %d: expected no error, got: %v", i+1, err)
@@ -327,6 +330,9 @@ func TestParseReleaseData(t *testing.T) {
 			}
 			if !testCase.expectedResult.Equal(result) {
 				t.Errorf("case %d: result: expected: %v, got: %v", i+1, testCase.expectedResult, result)
+			}
+			if testCase.expectedReleaseInfo != releaseInfo {
+				t.Errorf("case %d: result: expected: %v, got: %v", i+1, testCase.expectedReleaseInfo, releaseInfo)
 			}
 		}
 	}


### PR DESCRIPTION

## Description
fips build tag uses relevant binary link for updates

## Motivation and Context
This code is necessary for `mc admin update` command
to work with fips compiled binaries, with fips tags
the releaseInfo will automatically point to fips
specific binaries.


## How to test this PR?
Not easy to test, this is tested locally in a simulated environment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
