### PR TITLE
remove null version dataDir upon overwrites

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2041,11 +2041,12 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath, dataDir,
 			return err
 		}
 
+		if oldDstDataPath != "" {
+			renameAll(oldDstDataPath, pathutil.Join(s.diskPath, minioMetaTmpDeletedBucket, mustGetUUID()))
+		}
+
 		// renameAll only for objects that have xl.meta not saved inline.
 		if len(fi.Data) == 0 && fi.Size > 0 {
-			if oldDstDataPath != "" {
-				renameAll(oldDstDataPath, pathutil.Join(s.diskPath, minioMetaTmpDeletedBucket, mustGetUUID()))
-			}
 			renameAll(dstDataPath, pathutil.Join(s.diskPath, minioMetaTmpDeletedBucket, mustGetUUID()))
 			if err = renameAll(srcDataPath, dstDataPath); err != nil {
 				logger.LogIf(ctx, err)


### PR DESCRIPTION
## Description
remove null version dataDir upon overwrites

## Motivation and Context
overwrites were leaving stale dataDir behind
clean it up properly even with inline data

## How to test this PR?
Just migrate older legacy content to latest
master and run `mc admin heal -r`   - the 
content should be automatically fixed properly. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
