### PR TITLE
fix: allow S3 gateway passthrough for SSE-S3 header on copy object

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -872,9 +872,18 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if _, ok := crypto.IsRequested(r.Header); !objectAPI.IsEncryptionSupported() && ok {
-		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL, guessIsBrowserReq(r))
-		return
+	if _, ok := crypto.IsRequested(r.Header); ok {
+		if globalIsGateway {
+			if crypto.SSEC.IsRequested(r.Header) && !objectAPI.IsEncryptionSupported() {
+				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL, guessIsBrowserReq(r))
+				return
+			}
+		} else {
+			if !objectAPI.IsEncryptionSupported() {
+				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL, guessIsBrowserReq(r))
+				return
+			}
+		}
 	}
 
 	vars := mux.Vars(r)


### PR DESCRIPTION
## Description
this is a follow up on the https://github.com/minio/ming/issues/2

fix: allow S3 gateway passthrough for SSE-S3 header (on Object-Copy)

Motivation and Context
only in the case of S3 gateway we have a case where we
need to allow for SSE-S3 headers as passthrough,

If SSE-C headers are passed then they are rejected
if KMS is not configured.

How to test this PR?
Just run locally

aws --profile=minio s3api copy-object \
  --endpoint-url=http://localhost:9000 \
  --copy-source=sourcebucket/sourcefile \
  --bucket=destinationbucket \
  --key=destinationfile \
  --server-side-encryption=AES256


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
