### PR TITLE
scanner: Shuffle disks to scan

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -435,6 +435,11 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, bf
 		}
 	}()
 
+	// Shuffle disks to ensure a total randomness of bucket/disk association to ensure
+	// that objects that are not present in all disks are accounted and ILM applied.
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.Shuffle(len(disks), func(i, j int) { disks[i], disks[j] = disks[j], disks[i] })
+
 	// Start one scanner per disk
 	var wg sync.WaitGroup
 	wg.Add(len(disks))


### PR DESCRIPTION
## Description
Ensure random association between disk and bucket in each crawling
iteration to ensure that ILM applies correctly to objects no present in
all disks.

## Motivation and Context
Better scanning

## How to test this PR?
Enable MINIO_DISK_USAGE_SCANNER_DEBUG=on and see 
what disks are being scanned

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
