### PR TITLE
Lifecycle: Accept empty <Filter> tag in XML documents

### DIFF
--- a/pkg/bucket/lifecycle/filter.go
+++ b/pkg/bucket/lifecycle/filter.go
@@ -28,6 +28,7 @@ var (
 // Filter - a filter for a lifecycle configuration Rule.
 type Filter struct {
 	XMLName xml.Name `xml:"Filter"`
+	set     bool
 
 	Prefix Prefix
 
@@ -68,6 +69,7 @@ func (f Filter) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // UnmarshalXML - decodes XML data.
 func (f *Filter) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (err error) {
+	f.set = true
 	for {
 		// Read tokens from the XML document in a stream.
 		t, err := d.Token()
@@ -111,12 +113,12 @@ func (f *Filter) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (err error
 
 // IsEmpty returns true if Filter is not specified in the XML
 func (f Filter) IsEmpty() bool {
-	return !f.Prefix.set && !f.andSet && !f.tagSet
+	return !f.set
 }
 
 // Validate - validates the filter element
 func (f Filter) Validate() error {
-	if !f.Prefix.set && !f.andSet && !f.tagSet {
+	if f.IsEmpty() {
 		return errXMLNotWellFormed
 	}
 	// A Filter must have exactly one of Prefix, Tag, or And specified.

--- a/pkg/bucket/lifecycle/lifecycle_test.go
+++ b/pkg/bucket/lifecycle/lifecycle_test.go
@@ -86,9 +86,15 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 			expectedParsingErr:    nil,
 			expectedValidationErr: errXMLNotWellFormed,
 		},
-		// Legitimate lifecycle
+		// Lifecycle with the deprecated Prefix tag
 		{
 			inputConfig:           `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>rule</ID><Prefix /><Status>Enabled</Status><Expiration><Days>1</Days></Expiration></Rule></LifecycleConfiguration>`,
+			expectedParsingErr:    nil,
+			expectedValidationErr: nil,
+		},
+		// Lifecycle with empty Filter tag
+		{
+			inputConfig:           `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>rule</ID><Filter></Filter><Status>Enabled</Status><Expiration><Days>1</Days></Expiration></Rule></LifecycleConfiguration>`,
 			expectedParsingErr:    nil,
 			expectedValidationErr: nil,
 		},


### PR DESCRIPTION
## Description
Follow S3 to accept empty filter tag inside an XML document.

<Filter> needs to be specified but it doesn't have to contain any other
xml tags inside it.


## Motivation and Context
Fixes https://github.com/minio/minio/issues/11893

## How to test this PR?
There is no easy way, you need to manually edit minio-go code for testing purposes:
```
diff --git a/api-bucket-lifecycle.go b/api-bucket-lifecycle.go
index e1fac81..206af53 100644
--- a/api-bucket-lifecycle.go
+++ b/api-bucket-lifecycle.go
@@ -46,6 +46,8 @@ func (c Client) SetBucketLifecycle(ctx context.Context, bucketName string, confi
                return err
        }
 
+       buf = []byte("<LifecycleConfiguration><Rule><ID>b245fc03-99d8-a666-3e74-dd7103a0866b</ID><Filter></Filter><Status>Enabled</Status><Expiration><Days>1</Days></Expiration></Rule></LifecycleConfiguration>")
+
        // Save the updated lifecycle.
        return c.putBucketLifecycle(ctx, bucketName, buf)
 }
```

Then run setbucketlifecycle.go in minio-go/examples/s3/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
