### PR TITLE
fix: preserve shared dataDir during suspend overwrites

### DIFF
--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -974,6 +974,48 @@ func (j xlMetaV2Object) ToFileInfo(volume, path string) (FileInfo, error) {
 	return fi, nil
 }
 
+func (z *xlMetaV2) SharedDataDirCountStr(versionID, dataDir string) int {
+	var (
+		uv   uuid.UUID
+		ddir uuid.UUID
+		err  error
+	)
+	if versionID == nullVersionID {
+		versionID = ""
+	}
+	if versionID != "" {
+		uv, err = uuid.Parse(versionID)
+		if err != nil {
+			return 0
+		}
+	}
+	ddir, err = uuid.Parse(dataDir)
+	if err != nil {
+		return 0
+	}
+	return z.SharedDataDirCount(uv, ddir)
+}
+
+func (z *xlMetaV2) SharedDataDirCount(versionID [16]byte, dataDir [16]byte) int {
+	// v2 object is inlined, if it is skip dataDir share check.
+	if z.data.find(uuid.UUID(versionID).String()) != nil {
+		return 0
+	}
+	var sameDataDirCount int
+	for _, version := range z.Versions {
+		switch version.Type {
+		case ObjectType:
+			if version.ObjectV2.VersionID == versionID {
+				continue
+			}
+			if version.ObjectV2.DataDir == dataDir {
+				sameDataDirCount++
+			}
+		}
+	}
+	return sameDataDirCount
+}
+
 // DeleteVersion deletes the version specified by version id.
 // returns to the caller which dataDir to delete, also
 // indicates if this is the last version.
@@ -1081,23 +1123,6 @@ func (z *xlMetaV2) DeleteVersion(fi FileInfo) (string, bool, error) {
 		}
 	}
 
-	findDataDir := func(v2 *xlMetaV2Object, versions []xlMetaV2Version) int {
-		// v2 object is inlined, if it is skip dataDir share check.
-		if z.data.find(uuid.UUID(v2.VersionID).String()) != nil {
-			return 0
-		}
-		var sameDataDirCount int
-		for _, version := range versions {
-			switch version.Type {
-			case ObjectType:
-				if version.ObjectV2.DataDir == v2.DataDir {
-					sameDataDirCount++
-				}
-			}
-		}
-		return sameDataDirCount
-	}
-
 	for i, version := range z.Versions {
 		if !version.Valid() {
 			return "", false, errFileCorrupt
@@ -1110,7 +1135,7 @@ func (z *xlMetaV2) DeleteVersion(fi FileInfo) (string, bool, error) {
 					return uuid.UUID(version.ObjectV2.DataDir).String(), len(z.Versions) == 0, nil
 				}
 				z.Versions = append(z.Versions[:i], z.Versions[i+1:]...)
-				if findDataDir(version.ObjectV2, z.Versions) > 0 {
+				if z.SharedDataDirCount(version.ObjectV2.VersionID, version.ObjectV2.DataDir) > 0 {
 					if fi.Deleted {
 						z.Versions = append(z.Versions, ventry)
 					}
@@ -1243,7 +1268,6 @@ func (z xlMetaV2) ToFileInfo(volume, path, versionID string) (fi FileInfo, err e
 			fi.IsLatest = true
 			fi.NumVersions = len(orderedVersions)
 			return fi, err
-
 		}
 		return FileInfo{}, errFileNotFound
 	}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2020,9 +2020,11 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath, dataDir,
 		// return the latest "null" versionId info
 		ofi, err := xlMeta.ToFileInfo(dstVolume, dstPath, nullVersionID)
 		if err == nil && !ofi.Deleted {
-			// Purge the destination path as we are not preserving anything
-			// versioned object was not requested.
-			oldDstDataPath = pathJoin(dstVolumeDir, dstPath, ofi.DataDir)
+			if xlMeta.SharedDataDirCountStr(nullVersionID, ofi.DataDir) == 0 {
+				// Purge the destination path as we are not preserving anything
+				// versioned object was not requested.
+				oldDstDataPath = pathJoin(dstVolumeDir, dstPath, ofi.DataDir)
+			}
 		}
 	}
 


### PR DESCRIPTION


## Description
fix: preserve shared dataDir during suspend overwrites

## Motivation and Context
CopyObject() when shares dataDir needs to be preserved,
and upon versioning suspended overwrites should still
preserve the dataDir.

## How to test this PR?
```sh
#!/bin/bash

mc mb myminio/test
shred -s 4M /tmp/4m
mc cp /tmp/4m myminio/test
mc version enable myminio/test
mc cp myminio/test/4m myminio/test/ --attr "key=value"
mc ls --versions myminio/test/4m
mc version suspend myminio/test
mc cp /etc/issue myminio/test/4m
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
