### PR TITLE
svc: Disallow creating services accounts by root

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -491,6 +491,12 @@ func (a adminAPIHandlers) AddServiceAccount(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Disallow creating service accounts by root user.
+	if owner {
+		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrAdminAccountNotEligible), r.URL)
+		return
+	}
+
+	// Disallow creating service accounts for root user.
 	if createReq.TargetUser == globalActiveCred.AccessKey {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrAdminAccountNotEligible), r.URL)
 		return


### PR DESCRIPTION
## Description
svc: Disallow creating services accounts by root

## Motivation and Context
One recent change allowed root to create service accounts but this 
is not allowed since the root admin will die soon.

## How to test this PR?
mc admin user add myminio/ console console123
mc admin user svcadd add myminio/ console

where myminio/ uses root credentials.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
