### PR TITLE
svc: Display the correct policy of a particular service account

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -727,14 +727,14 @@ func (a adminAPIHandlers) InfoServiceAccount(w http.ResponseWriter, r *http.Requ
 
 	// If policy is empty, check for policy of the parent user
 	if !impliedPolicy {
-		svcAccountPolicy.Merge(*policy)
+		svcAccountPolicy = svcAccountPolicy.Merge(*policy)
 	} else {
 		policiesNames, err := globalIAMSys.PolicyDBGet(svcAccount.AccessKey, false)
 		if err != nil {
 			writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 			return
 		}
-		svcAccountPolicy.Merge(globalIAMSys.GetCombinedPolicy(policiesNames...))
+		svcAccountPolicy = svcAccountPolicy.Merge(globalIAMSys.GetCombinedPolicy(policiesNames...))
 	}
 
 	policyJSON, err := json.Marshal(svcAccountPolicy)

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1136,7 +1136,7 @@ func (sys *IAMSys) NewServiceAccount(ctx context.Context, parentUser string, gro
 	}
 	cred.ParentUser = parentUser
 	cred.Groups = groups
-	cred.Status = string(madmin.AccountEnabled)
+	cred.Status = string(auth.AccountOn)
 
 	u := newUserIdentity(cred)
 
@@ -1255,10 +1255,13 @@ func (sys *IAMSys) GetServiceAccount(ctx context.Context, accessKey string) (aut
 		pt, ptok := jwtClaims.Lookup(iamPolicyClaimNameSA())
 		sp, spok := jwtClaims.Lookup(iampolicy.SessionPolicyName)
 		if ptok && spok && pt == "embedded-policy" {
-			p, err := iampolicy.ParseConfig(bytes.NewReader([]byte(sp)))
+			policyBytes, err := base64.StdEncoding.DecodeString(sp)
 			if err == nil {
-				embeddedPolicy = &iampolicy.Policy{}
-				embeddedPolicy.Merge(*p)
+				p, err := iampolicy.ParseConfig(bytes.NewReader(policyBytes))
+				if err == nil {
+					policy := iampolicy.Policy{}.Merge(*p)
+					embeddedPolicy = &policy
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
For InfoServiceAccount API, calculating the policy before showing it to
the user was not correctly done (only UX issue, not a security issue)

This commit fixes it.

## Motivation and Context
Fix mc admin user svcacct info --policy

## How to test this PR?
 mc admin user svcacct info --policy


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
