### PR TITLE
remove possible double locks in bandwidth monitor

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1921,8 +1921,6 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrSlowDown
 	case InsufficientReadQuorum:
 		apiErr = ErrSlowDown
-	case UnsupportedDelimiter:
-		apiErr = ErrNotImplemented
 	case InvalidMarkerPrefixCombination:
 		apiErr = ErrNotImplemented
 	case InvalidUploadIDKeyCombination:
@@ -2055,6 +2053,22 @@ func toAPIError(ctx context.Context, err error) APIError {
 	if ok {
 		code := toAPIErrorCode(ctx, e)
 		apiErr = errorCodes.ToAPIErrWithErr(code, e)
+	}
+
+	if apiErr.Code == "NotImplemented" {
+		switch e := err.(type) {
+		case NotImplemented:
+			desc := e.Error()
+			if desc == "" {
+				desc = apiErr.Description
+			}
+			apiErr = APIError{
+				Code:           apiErr.Code,
+				Description:    desc,
+				HTTPStatusCode: apiErr.HTTPStatusCode,
+			}
+			return apiErr
+		}
 	}
 
 	if apiErr.Code == "InternalError" {

--- a/cmd/api-errors_test.go
+++ b/cmd/api-errors_test.go
@@ -43,7 +43,6 @@ var toAPIErrorTests = []struct {
 	{err: InvalidPart{}, errCode: ErrInvalidPart},
 	{err: InsufficientReadQuorum{}, errCode: ErrSlowDown},
 	{err: InsufficientWriteQuorum{}, errCode: ErrSlowDown},
-	{err: UnsupportedDelimiter{}, errCode: ErrNotImplemented},
 	{err: InvalidMarkerPrefixCombination{}, errCode: ErrNotImplemented},
 	{err: InvalidUploadIDKeyCombination{}, errCode: ErrNotImplemented},
 	{err: MalformedUploadID{}, errCode: ErrNoSuchUpload},

--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -105,7 +105,7 @@ func (sys *BucketTargetSys) SetTarget(ctx context.Context, bucket string, tgt *m
 	}
 	if tgt.Type == madmin.ReplicationService {
 		if !globalIsErasure {
-			return NotImplemented{}
+			return NotImplemented{Message: "Replication is not implemented in " + getMinioMode()}
 		}
 		if !globalBucketVersioningSys.Enabled(bucket) {
 			return BucketReplicationSourceNotVersioned{Bucket: bucket}
@@ -116,6 +116,9 @@ func (sys *BucketTargetSys) SetTarget(ctx context.Context, bucket string, tgt *m
 		}
 		if vcfg.Status != string(versioning.Enabled) {
 			return BucketRemoteTargetNotVersioned{Bucket: tgt.TargetBucket}
+		}
+		if tgt.ReplicationSync && tgt.BandwidthLimit > 0 {
+			return NotImplemented{Message: "Synchronous replication does not support bandwidth limits"}
 		}
 	}
 	if tgt.Type == madmin.ILMService {
@@ -180,7 +183,7 @@ func (sys *BucketTargetSys) RemoveTarget(ctx context.Context, bucket, arnStr str
 	}
 	if arn.Type == madmin.ReplicationService {
 		if !globalIsErasure {
-			return NotImplemented{}
+			return NotImplemented{Message: "Replication is not implemented in " + getMinioMode()}
 		}
 		// reject removal of remote target if replication configuration is present
 		rcfg, err := getReplicationConfig(ctx, bucket)

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -332,15 +332,6 @@ func (e BucketExists) Error() string {
 	return "Bucket exists: " + e.Bucket
 }
 
-// UnsupportedDelimiter - unsupported delimiter.
-type UnsupportedDelimiter struct {
-	Delimiter string
-}
-
-func (e UnsupportedDelimiter) Error() string {
-	return fmt.Sprintf("delimiter '%s' is not supported. Only '/' is supported", e.Delimiter)
-}
-
 // InvalidUploadIDKeyCombination - invalid upload id and key marker combination.
 type InvalidUploadIDKeyCombination struct {
 	UploadIDMarker, KeyMarker string
@@ -638,14 +629,11 @@ func (e InvalidETag) Error() string {
 
 // NotImplemented If a feature is not implemented
 type NotImplemented struct {
-	API string
+	Message string
 }
 
 func (e NotImplemented) Error() string {
-	if e.API != "" {
-		return e.API + " is Not Implemented"
-	}
-	return "Not Implemented"
+	return e.Message
 }
 
 // UnsupportedMetadata - unsupported metadata


### PR DESCRIPTION

## Description
remove possible double locks in bandwidth monitor

## Motivation and Context
additionally, reject bandwidth limits with
synchronous replication for now.

## How to test this PR?
With two local sites

```
#!/bin/bash

set -x
mc mb myminio/testbucket/
mc mb myminio-local1/testbucket/

mc version enable myminio/testbucket/
mc version enable myminio-local1/testbucket/

remote_arn=$(mc admin bucket remote add myminio/testbucket/ \
   http://minio:minio123@localhost:9001/testbucket \
   --service "replication" --sync --bandwidth 10m --json | jq -r ".RemoteARN")

mc replicate add myminio/testbucket/ \
   --arn ${remote_arn} --remote-bucket testbucket \
   --replicate "delete,delete-marker"
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
