### PR TITLE
Update Replication README to point at new docs

### DIFF
--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -2,6 +2,8 @@
 
 Bucket replication is designed to replicate selected objects in a bucket to a destination bucket.
 
+The contents of this page have been migrated to the new [MinIO Baremetal Documentation: Bucket Replication](https://docs.min.io/minio/baremetal/replication/replication-overview.html#) page. The [Bucket Replication](https://docs.min.io/minio/baremetal/replication/replication-overview.html#) section includes dedicated tutorials for configuring one-way "Active-Passive" and two-way "Active-Active" bucket replication. Please update your bookmarks to use the new MinIO documentation, as this legacy documentation will be deprecated and removed in the future.
+
 To replicate objects in a bucket to a destination bucket on a target site either in the same cluster or a different cluster, start by enabling [versioning](https://docs.minio.io/docs/minio-bucket-versioning-guide.html) for both source and destination buckets. Finally, the target site and the destination bucket need to be configured on the source MinIO server.
 
 ## Highlights


### PR DESCRIPTION
This is a minor change to call out the new documentation and warn users to change their bookmarks. Once we are ready to set up some redirects, we can remove this page from Gluegun TOC.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation-Only 

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x ] Documentation updated
- [ ] Unit tests added/updated
