### PR TITLE
fix: crash in single drive mode for lifecycle

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -516,9 +516,9 @@ func serverMain(ctx *cli.Context) {
 	if globalIsErasure {
 		initAutoHeal(GlobalContext, newObject)
 		initBackgroundTransition(GlobalContext, newObject)
-		initBackgroundExpiry(GlobalContext, newObject)
 	}
 
+	initBackgroundExpiry(GlobalContext, newObject)
 	initDataScanner(GlobalContext, newObject)
 
 	if err = initServer(GlobalContext, newObject); err != nil {


### PR DESCRIPTION
## Description
fix: crash in single drive mode for lifecycle

## Motivation and Context
also, make sure to close the channel on the producer
side, not in a separate go-routine, this can lead
to races between a writer and a closer.

## How to test this PR?
fixes #12073

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
