### PR TITLE
Restore-object should accept version-id for version-suspended bucket

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3886,7 +3886,7 @@ func (api objectAPIHandlers) PostRestoreObjectHandler(w http.ResponseWriter, r *
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrEmptyRequestBody), r.URL, guessIsBrowserReq(r))
 		return
 	}
-	opts, err := postOpts(ctx, r, bucket, object)
+	opts, err := postRestoreOpts(ctx, r, bucket, object)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return


### PR DESCRIPTION
## Description

POST Restore-object should accept version-id from the request for version-suspended buckets too.

## How to test this PR?
1. Make a bucket, enable versioning and upload to an object a few times to create multiple versions.
2. Suspend versioning on this bucket.
3. Now, try restoring a specific version. e.g,
```
aws --endpoint-url=http://192.168.0.14:9000 s3api restore-object --bucket mybucket  --version-id 65ac2f4f-e54c-4663-8268-2a53b72a8124 \
--key obj-1 \
--restore-request Days=1
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
