### PR TITLE
Check if remote tier creds have sufficient permissions

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1014,37 +1014,43 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 		// Tier admin API errors
 		case errors.Is(err, madmin.ErrTierNameEmpty):
 			apiErr = APIError{
-				Code:           "XMinioTierNameEmpty",
+				Code:           "XMinioAdminTierNameEmpty",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}
 		case errors.Is(err, madmin.ErrTierInvalidConfig):
 			apiErr = APIError{
-				Code:           "XMinioTierInvalidConfig",
+				Code:           "XMinioAdminTierInvalidConfig",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}
 		case errors.Is(err, madmin.ErrTierInvalidConfigVersion):
 			apiErr = APIError{
-				Code:           "XMinioTierInvalidConfigVersion",
+				Code:           "XMinioAdminTierInvalidConfigVersion",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}
 		case errors.Is(err, madmin.ErrTierTypeUnsupported):
 			apiErr = APIError{
-				Code:           "XMinioTierTypeUnsupported",
+				Code:           "XMinioAdminTierTypeUnsupported",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}
-		case errors.Is(err, errWarmBackendInUse):
+		case errors.Is(err, errTierBackendInUse):
 			apiErr = APIError{
-				Code:           "XMinioWarmBackendInUse",
+				Code:           "XMinioAdminTierBackendInUse",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusConflict,
 			}
 		case errors.Is(err, errTierInsufficientCreds):
 			apiErr = APIError{
 				Code:           "XMinioAdminTierInsufficientCreds",
+				Description:    err.Error(),
+				HTTPStatusCode: http.StatusBadRequest,
+			}
+		case errIsTierPermError(err):
+			apiErr = APIError{
+				Code:           "XMinioAdminTierInsufficientPermissions",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -194,7 +194,7 @@ func validateTransitionDestination(sc string) error {
 	if err != nil {
 		return TransitionStorageClassNotFound{}
 	}
-	_, err = backend.Get(context.Background(), "probeobject", warmBackendGetOpts{})
+	_, err = backend.Get(context.Background(), "probeobject", WarmBackendGetOpts{})
 	if !isErrObjectNotFound(err) {
 		return err
 	}
@@ -326,7 +326,7 @@ func getTransitionedObjectReader(ctx context.Context, bucket, object string, rs 
 	if err != nil {
 		return nil, ErrorRespToObjectError(err, bucket, object)
 	}
-	gopts := warmBackendGetOpts{}
+	gopts := WarmBackendGetOpts{}
 
 	// get correct offsets for object
 	if off >= 0 && length >= 0 {

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	errTierInsufficientCreds = errors.New("insufficient tier credentials supplied")
-	errWarmBackendInUse      = errors.New("backend warm tier already in use")
+	errTierBackendInUse      = errors.New("remote tier backend already in use")
 	errTierTypeUnsupported   = errors.New("unsupported tier type")
 )
 
@@ -104,7 +104,7 @@ func (config *TierConfigMgr) Add(ctx context.Context, tier madmin.TierConfig) er
 		return err
 	}
 	if inUse {
-		return errWarmBackendInUse
+		return errTierBackendInUse
 	}
 
 	config.Tiers[tierName] = tier

--- a/cmd/warm-backend-azure.go
+++ b/cmd/warm-backend-azure.go
@@ -65,7 +65,7 @@ func (az *warmBackendAzure) Put(ctx context.Context, object string, r io.Reader,
 	return azureToObjectError(err, az.Bucket, object)
 }
 
-func (az *warmBackendAzure) Get(ctx context.Context, object string, opts warmBackendGetOpts) (r io.ReadCloser, err error) {
+func (az *warmBackendAzure) Get(ctx context.Context, object string, opts WarmBackendGetOpts) (r io.ReadCloser, err error) {
 	if opts.startOffset < 0 {
 		return nil, InvalidRange{}
 	}

--- a/cmd/warm-backend-gcs.go
+++ b/cmd/warm-backend-gcs.go
@@ -57,7 +57,7 @@ func (gcs *warmBackendGCS) Put(ctx context.Context, key string, data io.Reader, 
 	return w.Close()
 }
 
-func (gcs *warmBackendGCS) Get(ctx context.Context, key string, opts warmBackendGetOpts) (r io.ReadCloser, err error) {
+func (gcs *warmBackendGCS) Get(ctx context.Context, key string, opts WarmBackendGetOpts) (r io.ReadCloser, err error) {
 	// GCS storage decompresses a gzipped object by default and returns the data.
 	// Refer to https://cloud.google.com/storage/docs/transcoding#decompressive_transcoding
 	// Need to set `Accept-Encoding` header to `gzip` when issuing a GetObject call, to be able

--- a/cmd/warm-backend-s3.go
+++ b/cmd/warm-backend-s3.go
@@ -61,7 +61,7 @@ func (s3 *warmBackendS3) Put(ctx context.Context, object string, r io.Reader, le
 	return s3.ToObjectError(err, object)
 }
 
-func (s3 *warmBackendS3) Get(ctx context.Context, object string, opts warmBackendGetOpts) (io.ReadCloser, error) {
+func (s3 *warmBackendS3) Get(ctx context.Context, object string, opts WarmBackendGetOpts) (io.ReadCloser, error) {
 	gopts := minio.GetObjectOptions{}
 
 	if opts.startOffset >= 0 && opts.length > 0 {


### PR DESCRIPTION
## Description
This change checks if remote tier object storage credentials supplied have sufficient permissions to transition objects to it.

## Motivation and Context
With this change the user would be intimated of insufficient permissions at the time of adding a tier. 

## How to test this PR?
To test this I used another MinIO instance for remote tier. The following policy is required for the remote tier credentials.
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "s3:ListBucket"
      ],
      "Effect": "Allow",
      "Resource": [
        "arn:aws:s3:::testbucket"
      ],
      "Sid": ""
    },
    {
      "Action": [
        "s3:GetObject",
        "s3:PutObject",
        "s3:DeleteObject"
      ],
      "Effect": "Allow",
      "Resource": [
        "arn:aws:s3:::testbucket/*"
      ],
      "Sid": ""
    }
  ]
}

```
1. Make the remote tier bucket `testbucket`.
2. Add a user with the above policy 
3. Try adding a remote tier with the above user's credentials.
4. Remove allowed actions in the above IAM policy document to test for insufficient permissions error during `tier-add`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
