### PR TITLE
Grab read lock while reading usage cache

### DIFF
--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -528,7 +528,7 @@ type objectIO interface {
 // Only backend errors are returned as errors.
 // If the object is not found or unable to deserialize d is cleared and nil error is returned.
 func (d *dataUsageCache) load(ctx context.Context, store objectIO, name string) error {
-	r, err := store.GetObjectNInfo(ctx, dataUsageBucket, name, nil, http.Header{}, noLock, ObjectOptions{})
+	r, err := store.GetObjectNInfo(ctx, dataUsageBucket, name, nil, http.Header{}, readLock, ObjectOptions{})
 	if err != nil {
 		switch err.(type) {
 		case ObjectNotFound:


### PR DESCRIPTION
## Description

Grab read lock while reading bucket usage.

## Motivation and Context

Prevent healing from interfering

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

Signed-off-by: Klaus Post <klauspost@gmail.com>
