### PR TITLE
audit: Add field to know who triggered the operation

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -342,6 +342,10 @@ func deleteTransitionedObject(ctx context.Context, objectAPI ObjectLayer, bucket
 	if err != nil {
 		return err
 	}
+
+	// Send audit for the lifecycle delete operation
+	auditLogLifecycle(ctx, bucket, object)
+
 	eventName := event.ObjectRemovedDelete
 	if lcOpts.DeleteMarker {
 		eventName = event.ObjectRemovedDeleteMarkerCreated


### PR DESCRIPTION
## Description
This is for now needed to know if an external S3 request deleted a file
or it was the scanner.

Signed-off-by: Anis Elleuch <anis@min.io>

## Motivation and Context
Add indication what triggered an operation in the audit

## How to test this PR?
1. Setup an audit endpoint
2. Create a bucket, upload a file, setup ILM with one day expiry, forward the clock and see the audit json when the file is removed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
