### PR TITLE
Alloc less for metacache decompression

### DIFF
--- a/cmd/metacache-stream.go
+++ b/cmd/metacache-stream.go
@@ -230,7 +230,8 @@ func (w *metacacheWriter) Reset(out io.Writer) {
 }
 
 var s2DecPool = sync.Pool{New: func() interface{} {
-	return s2.NewReader(nil)
+	// Default alloc block for network transfer.
+	return s2.NewReader(nil, s2.ReaderAllocBlock(16<<10))
 }}
 
 // metacacheReader allows reading a cache stream.


### PR DESCRIPTION
## Description

Network streams are limited to 16K blocks. Don't alloc more upfront.

Signed-off-by: Klaus Post <klauspost@gmail.com>

## How to test this PR?

Have a lot of ongoing listings from a lot of disks.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
