### PR TITLE
Fix versionID and MTime for restored object

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1518,7 +1518,12 @@ func (er erasureObjects) restoreTransitionedObject(ctx context.Context, bucket s
 		return setRestoreHeaderFn(oi, InvalidObjectState{Bucket: bucket, Object: object})
 	}
 
-	_, err = er.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, opts)
+	_, err = er.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, ObjectOptions{
+		VersionID:        oi.VersionID,
+		MTime:            oi.ModTime,
+		Versioned:        globalBucketVersioningSys.Enabled(bucket),
+		VersionSuspended: globalBucketVersioningSys.Suspended(bucket),
+	})
 	if err != nil {
 		return setRestoreHeaderFn(oi, toObjectErr(err, minioMetaMultipartBucket, uploadIDPath))
 	}


### PR DESCRIPTION
Signed-off-by: Poorna Krishnamoorthy <poorna@minio.io>

## Description
After switching to use CompleteMultipartUpload, version and mtime need to be passed down to ensure restore does not change version id or mtime.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
