### PR TITLE
avoid parsing MINIO_KMS_MASTER_KEY as base64

### DIFF
--- a/pkg/kms/single-key.go
+++ b/pkg/kms/single-key.go
@@ -28,9 +28,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unicode/utf8"
 
-	"github.com/minio/sio"
 	"github.com/secure-io/sio-go/sioutil"
 	"golang.org/x/crypto/chacha20"
 	"golang.org/x/crypto/chacha20poly1305"
@@ -170,37 +168,9 @@ func (kms secretKey) GenerateKey(keyID string, context Context) (DEK, error) {
 	}, nil
 }
 
-func (kms secretKey) legacyDecryptKey(keyID string, sealedKey []byte, ctx Context) ([]byte, error) {
-	var derivedKey = kms.deriveKey(keyID, ctx)
-
-	var key [32]byte
-	out, err := sio.DecryptBuffer(key[:0], sealedKey, sio.Config{Key: derivedKey[:]})
-	if err != nil || len(out) != 32 {
-		return nil, err // TODO(aead): upgrade sio to use sio.Error
-	}
-	return key[:], nil
-}
-
-func (kms secretKey) deriveKey(keyID string, context Context) (key [32]byte) {
-	if context == nil {
-		context = Context{}
-	}
-	ctxBytes, _ := context.MarshalText()
-
-	mac := hmac.New(sha256.New, kms.key[:])
-	mac.Write([]byte(keyID))
-	mac.Write(ctxBytes)
-	mac.Sum(key[:0])
-	return key
-}
-
 func (kms secretKey) DecryptKey(keyID string, ciphertext []byte, context Context) ([]byte, error) {
 	if keyID != kms.keyID {
 		return nil, fmt.Errorf("kms: key %q does not exist", keyID)
-	}
-
-	if !utf8.Valid(ciphertext) {
-		return kms.legacyDecryptKey(keyID, ciphertext, context)
 	}
 
 	var encryptedKey encryptedKey


### PR DESCRIPTION
## Description
This commit reverts a change that added support for
parsing base64-encoded keys set via `MINIO_KMS_MASTER_KEY`.

The env. variable `MINIO_KMS_MASTER_KEY` is deprecated and
should ONLY support parsing existing keys - not the new format.

Any new deployment should use `MINIO_KMS_SECRET_KEY`. The legacy
env. variable `MINIO_KMS_MASTER_KEY` will be removed at some point
in time.

## Motivation and Context
`MINIO_KMS_MASTER_KEY` was never documented as something to be used unless for testing. It is deprecated and
any deployment should move to either KES or `MINIO_KMS_SECRET_KEY`.

Adding backward support to MINIO_KMS_MASTER_KEY just defers the deprecation process.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
