### PR TITLE
Fix multipart restore to remove part match

### DIFF
--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -505,6 +505,11 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 		// record the index of the updated disks
 		partsMetadata[i].Erasure.Index = i + 1
 
+		// dataDir should be empty when
+		// - transitionStatus is complete and not in restored state
+		if partsMetadata[i].TransitionStatus == lifecycle.TransitionComplete && !isRestoredObjectOnDisk(partsMetadata[i].Metadata) {
+			partsMetadata[i].DataDir = ""
+		}
 		// Attempt a rename now from healed data to final location.
 		if err = disk.RenameData(ctx, minioMetaTmpBucket, tmpID, partsMetadata[i], bucket, object); err != nil {
 			logger.LogIf(ctx, err)

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -575,7 +575,7 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 		PartNumber:   partID,
 		ETag:         md5hex,
 		LastModified: fi.ModTime,
-		Size:         fi.Size,
+		Size:         n,
 		ActualSize:   data.ActualSize(),
 	}, nil
 }

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -495,7 +495,7 @@ func (e TransitionStorageClassNotFound) Error() string {
 type InvalidObjectState GenericError
 
 func (e InvalidObjectState) Error() string {
-	return "The operation is not valid for the current state of the object" + e.Bucket + "/" + e.Object
+	return "The operation is not valid for the current state of the object " + e.Bucket + "/" + e.Object + "(" + e.VersionID + ")"
 }
 
 /// Bucket related errors.

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1858,8 +1858,7 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 	var srcDataPath string
 	var dstDataPath string
 	dataDir := retainSlash(fi.DataDir)
-	// no need to rename dataDir paths for objects that are in transitionComplete state.
-	if dataDir != "" && fi.TransitionStatus != lifecycle.TransitionComplete {
+	if dataDir != "" {
 		srcDataPath = retainSlash(pathJoin(srcVolumeDir, srcPath, dataDir))
 		// make sure to always use path.Join here, do not use pathJoin as
 		// it would additionally add `/` at the end and it comes in the


### PR DESCRIPTION
Part ETags are not available after multipart finalizes, removing this
check as not useful.

## Description


## Motivation and Context


## How to test this PR?
restore on a tiered multipart object

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
