### PR TITLE
fix: remove deprecated MINIO_ACCESS_KEY, MINIO_SECRET_KEY envs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,7 @@ RUN  \
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
-ENV MINIO_ACCESS_KEY_FILE=access_key \
-    MINIO_SECRET_KEY_FILE=secret_key \
-    MINIO_ROOT_USER_FILE=access_key \
+ENV MINIO_ROOT_USER_FILE=access_key \
     MINIO_ROOT_PASSWORD_FILE=secret_key \
     MINIO_KMS_SECRET_KEY_FILE=kms_master_key \
     MINIO_UPDATE_MINISIGN_PUBKEY="RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"

--- a/Dockerfile.cicd
+++ b/Dockerfile.cicd
@@ -15,9 +15,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 ARG TARGETARCH
 
-ENV MINIO_ACCESS_KEY_FILE=access_key \
-    MINIO_SECRET_KEY_FILE=secret_key \
-    MINIO_ROOT_USER_FILE=access_key \
+ENV MINIO_ROOT_USER_FILE=access_key \
     MINIO_ROOT_PASSWORD_FILE=secret_key \
     MINIO_KMS_SECRET_KEY_FILE=kms_master_key \
     MINIO_UPDATE_MINISIGN_PUBKEY="RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,8 +8,6 @@ COPY dockerscripts/docker-entrypoint.sh /usr/bin/
 COPY minio /usr/bin/
 
 ENV MINIO_UPDATE=off \
-    MINIO_ACCESS_KEY_FILE=access_key \
-    MINIO_SECRET_KEY_FILE=secret_key \
     MINIO_ROOT_USER_FILE=access_key \
     MINIO_ROOT_PASSWORD_FILE=secret_key \
     MINIO_KMS_SECRET_KEY_FILE=kms_master_key

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -12,9 +12,7 @@ LABEL name="MinIO" \
       summary="MinIO is a High Performance Object Storage, API compatible with Amazon S3 cloud storage service." \
       description="MinIO object storage is fundamentally different. Designed for performance and the S3 API, it is 100% open-source. MinIO is ideal for large, private cloud environments with stringent security requirements and delivers mission-critical availability across a diverse range of workloads."
 
-ENV MINIO_ACCESS_KEY_FILE=access_key \
-    MINIO_SECRET_KEY_FILE=secret_key \
-    MINIO_ROOT_USER_FILE=access_key \
+ENV MINIO_ROOT_USER_FILE=access_key \
     MINIO_ROOT_PASSWORD_FILE=secret_key \
     MINIO_KMS_SECRET_KEY_FILE=kms_master_key \
     MINIO_UPDATE_MINISIGN_PUBKEY="RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -309,15 +309,6 @@ func handleCommonEnvVars() {
 	// in-place update is off.
 	globalInplaceUpdateDisabled = strings.EqualFold(env.Get(config.EnvUpdate, config.EnableOn), config.EnableOff)
 
-	if env.IsSet(config.EnvAccessKey) || env.IsSet(config.EnvSecretKey) {
-		cred, err := auth.CreateCredentials(env.Get(config.EnvAccessKey, ""), env.Get(config.EnvSecretKey, ""))
-		if err != nil {
-			logger.Fatal(config.ErrInvalidCredentials(err),
-				"Unable to validate credentials inherited from the shell environment")
-		}
-		globalActiveCred = cred
-	}
-
 	if env.IsSet(config.EnvRootUser) || env.IsSet(config.EnvRootPassword) {
 		cred, err := auth.CreateCredentials(env.Get(config.EnvRootUser, ""), env.Get(config.EnvRootPassword, ""))
 		if err != nil {

--- a/cmd/config/constants.go
+++ b/cmd/config/constants.go
@@ -24,8 +24,6 @@ const (
 
 // Top level common ENVs
 const (
-	EnvAccessKey    = "MINIO_ACCESS_KEY"
-	EnvSecretKey    = "MINIO_SECRET_KEY"
 	EnvRootUser     = "MINIO_ROOT_USER"
 	EnvRootPassword = "MINIO_ROOT_PASSWORD"
 

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -82,8 +82,8 @@ func TestMain(m *testing.M) {
 	// disable ENVs which interfere with tests.
 	for _, env := range []string{
 		crypto.EnvKMSAutoEncryption,
-		config.EnvAccessKey,
-		config.EnvSecretKey,
+		config.EnvRootUser,
+		config.EnvRootPassword,
 	} {
 		os.Unsetenv(env)
 	}

--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -8,31 +8,6 @@ if [ "${1}" != "minio" ]; then
     fi
 fi
 
-## Look for docker secrets at given absolute path or in default documented location.
-docker_secrets_env_old() {
-    if [ -f "$MINIO_ACCESS_KEY_FILE" ]; then
-        ACCESS_KEY_FILE="$MINIO_ACCESS_KEY_FILE"
-    else
-        ACCESS_KEY_FILE="/run/secrets/$MINIO_ACCESS_KEY_FILE"
-    fi
-    if [ -f "$MINIO_SECRET_KEY_FILE" ]; then
-        SECRET_KEY_FILE="$MINIO_SECRET_KEY_FILE"
-    else
-        SECRET_KEY_FILE="/run/secrets/$MINIO_SECRET_KEY_FILE"
-    fi
-
-    if [ -f "$ACCESS_KEY_FILE" ] && [ -f "$SECRET_KEY_FILE" ]; then
-        if [ -f "$ACCESS_KEY_FILE" ]; then
-            MINIO_ACCESS_KEY="$(cat "$ACCESS_KEY_FILE")"
-            export MINIO_ACCESS_KEY
-        fi
-        if [ -f "$SECRET_KEY_FILE" ]; then
-            MINIO_SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
-            export MINIO_SECRET_KEY
-        fi
-    fi
-}
-
 docker_secrets_env() {
     if [ -f "$MINIO_ROOT_USER_FILE" ]; then
         ROOT_USER_FILE="$MINIO_ROOT_USER_FILE"
@@ -97,9 +72,6 @@ docker_switch_user() {
         exec "$@"
     fi
 }
-
-## Set access env from secrets if necessary.
-docker_secrets_env_old
 
 ## Set access env from secrets if necessary.
 docker_secrets_env


### PR DESCRIPTION
## Description
fix: remove deprecated MINIO_ACCESS_KEY, MINIO_SECRET_KEY envs

## Motivation and Context
remove deprecated environment variables

## How to test this PR?
old keys should not be honored

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
