### PR TITLE
ilm: Close warmBackend GetObject reader

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -341,7 +341,10 @@ func getTransitionedObjectReader(ctx context.Context, bucket, object string, rs 
 	if err != nil {
 		return nil, err
 	}
-	return fn(reader, h, opts.CheckPrecondFn)
+	closer := func() {
+		reader.Close()
+	}
+	return fn(reader, h, opts.CheckPrecondFn, closer)
 }
 
 // RestoreRequestType represents type of restore.


### PR DESCRIPTION
## Description
Closes warmBackend's readCloser to release resources that may be held by warmBackend drivers.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
