### PR TITLE
Change SetRemoteTarget API to allow editing remote target

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -165,14 +165,44 @@ func (a adminAPIHandlers) SetRemoteTargetHandler(w http.ResponseWriter, r *http.
 	}
 
 	target.SourceBucket = bucket
-	if !update {
+	var ops []madmin.TargetUpdateType
+	if update {
+		ops = madmin.GetTargetUpdateOps(r.URL.Query())
+	} else {
 		target.Arn = globalBucketTargetSys.getRemoteARN(bucket, &target)
 	}
 	if target.Arn == "" {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErrWithErr(ErrAdminConfigBadJSON, err), r.URL)
 		return
 	}
-
+	if update {
+		// overlay the updates on existing target
+		tgt := globalBucketTargetSys.GetRemoteBucketTargetByArn(ctx, bucket, target.Arn)
+		if tgt.Empty() {
+			writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErrWithErr(ErrRemoteTargetNotFoundError, err), r.URL)
+			return
+		}
+		for _, op := range ops {
+			switch op {
+			case madmin.CredentialsUpdateType:
+				tgt.Credentials = target.Credentials
+				tgt.TargetBucket = target.TargetBucket
+				tgt.Secure = target.Secure
+				tgt.Endpoint = target.Endpoint
+			case madmin.SyncUpdateType:
+				tgt.ReplicationSync = target.ReplicationSync
+			case madmin.ProxyUpdateType:
+				tgt.DisableProxy = target.DisableProxy
+			case madmin.PathUpdateType:
+				tgt.Path = target.Path
+			case madmin.BandwidthLimitUpdateType:
+				tgt.BandwidthLimit = target.BandwidthLimit
+			case madmin.HealthCheckDurationUpdateType:
+				tgt.HealthCheckDuration = target.HealthCheckDuration
+			}
+		}
+		target = tgt
+	}
 	if err = globalBucketTargetSys.SetTarget(ctx, bucket, &target, update); err != nil {
 		switch err.(type) {
 		case BucketRemoteConnectionErr:

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -1049,7 +1049,10 @@ func proxyHeadToRepTarget(ctx context.Context, bucket, object string, opts Objec
 	if tgt == nil || tgt.isOffline() {
 		return nil, oi, false, fmt.Errorf("target is offline or not configured")
 	}
-
+	// if proxying explicitly disabled on remote target
+	if tgt.disableProxy {
+		return nil, oi, false, nil
+	}
 	gopts := miniogo.GetObjectOptions{
 		VersionID:            opts.VersionID,
 		ServerSideEncryption: opts.ServerSideEncryption,

--- a/pkg/madmin/remote-target-commands_test.go
+++ b/pkg/madmin/remote-target-commands_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package madmin
+
+import (
+	"net/url"
+	"testing"
+)
+
+func isOpsEqual(op1 []TargetUpdateType, op2 []TargetUpdateType) bool {
+	if len(op1) != len(op2) {
+		return false
+	}
+	for _, o1 := range op1 {
+		found := false
+		for _, o2 := range op2 {
+			if o2 == o1 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// TestGetTargetUpdateOps tests GetTargetUpdateOps
+func TestGetTargetUpdateOps(t *testing.T) {
+	testCases := []struct {
+		values      url.Values
+		expectedOps []TargetUpdateType
+	}{
+		{values: url.Values{
+			"update": []string{"true"}},
+			expectedOps: []TargetUpdateType{},
+		},
+		{values: url.Values{
+			"update": []string{"false"},
+			"path":   []string{"true"},
+		},
+			expectedOps: []TargetUpdateType{},
+		},
+		{values: url.Values{
+			"update": []string{"true"},
+			"path":   []string{""},
+		},
+			expectedOps: []TargetUpdateType{},
+		},
+		{values: url.Values{
+			"update": []string{"true"},
+			"path":   []string{"true"},
+			"bzzzz":  []string{"true"},
+		},
+			expectedOps: []TargetUpdateType{PathUpdateType},
+		},
+
+		{values: url.Values{
+			"update":      []string{"true"},
+			"path":        []string{"true"},
+			"creds":       []string{"true"},
+			"sync":        []string{"true"},
+			"proxy":       []string{"true"},
+			"bandwidth":   []string{"true"},
+			"healthcheck": []string{"true"},
+		},
+			expectedOps: []TargetUpdateType{
+				PathUpdateType, CredentialsUpdateType, SyncUpdateType, ProxyUpdateType, BandwidthLimitUpdateType, HealthCheckDurationUpdateType},
+		},
+	}
+	for i, test := range testCases {
+		gotOps := GetTargetUpdateOps(test.values)
+		if !isOpsEqual(gotOps, test.expectedOps) {
+			t.Fatalf("test %d: expected %v got %v", i+1, test.expectedOps, gotOps)
+		}
+	}
+}


### PR DESCRIPTION
more flexibly.

- Previously only credentials could be updated with
`mc admin bucket remote edit`. Change this to allow updating
synchronous replication flag, path, bandwidth and healthcheck

Add a flag to allow disabling proxying in active-active replication

## Description


## Motivation and Context


## How to test this PR?
with https://github.com/minio/mc/pull/3701

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
