### PR TITLE
Change SetRemoteTarget API to allow editing remote target

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -163,14 +163,44 @@ func (a adminAPIHandlers) SetRemoteTargetHandler(w http.ResponseWriter, r *http.
 	}
 
 	target.SourceBucket = bucket
-	if !update {
+	var ops []madmin.TargetUpdateType
+	if update {
+		ops = madmin.GetTargetUpdateOps(r.URL.Query())
+	} else {
 		target.Arn = globalBucketTargetSys.getRemoteARN(bucket, &target)
 	}
 	if target.Arn == "" {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErrWithErr(ErrAdminConfigBadJSON, err), r.URL)
 		return
 	}
-
+	if update {
+		// overlay the updates on existing target
+		tgt := globalBucketTargetSys.GetRemoteBucketTargetByArn(ctx, bucket, target.Arn)
+		if tgt.Empty() {
+			writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErrWithErr(ErrRemoteTargetNotFoundError, err), r.URL)
+			return
+		}
+		for _, op := range ops {
+			switch op {
+			case madmin.CredentialsUpdateType:
+				tgt.Credentials = target.Credentials
+				tgt.TargetBucket = target.TargetBucket
+				tgt.Secure = target.Secure
+				tgt.Endpoint = target.Endpoint
+			case madmin.SyncUpdateType:
+				tgt.ReplicationSync = target.ReplicationSync
+			case madmin.ProxyUpdateType:
+				tgt.DisableProxy = target.DisableProxy
+			case madmin.PathUpdateType:
+				tgt.Path = target.Path
+			case madmin.BandwidthLimitUpdateType:
+				tgt.BandwidthLimit = target.BandwidthLimit
+			case madmin.HealthCheckDurationUpdateType:
+				tgt.HealthCheckDuration = target.HealthCheckDuration
+			}
+		}
+		target = tgt
+	}
 	if err = globalBucketTargetSys.SetTarget(ctx, bucket, &target, update); err != nil {
 		switch err.(type) {
 		case BucketRemoteConnectionErr:

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -958,7 +958,10 @@ func proxyHeadToRepTarget(ctx context.Context, bucket, object string, opts Objec
 	if tgt == nil || tgt.isOffline() {
 		return nil, oi, false, fmt.Errorf("target is offline or not configured")
 	}
-
+	// if proxying explicitly disabled on remote target
+	if tgt.disableProxy {
+		return nil, oi, false, nil
+	}
 	gopts := miniogo.GetObjectOptions{
 		VersionID:            opts.VersionID,
 		ServerSideEncryption: opts.ServerSideEncryption,

--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -268,6 +268,21 @@ func (sys *BucketTargetSys) GetRemoteLabelWithArn(ctx context.Context, bucket, a
 	return ""
 }
 
+// GetRemoteBucketTargetByArn returns BucketTarget for a ARN
+func (sys *BucketTargetSys) GetRemoteBucketTargetByArn(ctx context.Context, bucket, arn string) madmin.BucketTarget {
+	sys.RLock()
+	defer sys.RUnlock()
+	var tgt madmin.BucketTarget
+	for _, t := range sys.targetsMap[bucket] {
+		if t.Arn == arn {
+			tgt = t.Clone()
+			tgt.Credentials = t.Credentials
+			return tgt
+		}
+	}
+	return tgt
+}
+
 // NewBucketTargetSys - creates new replication system.
 func NewBucketTargetSys() *BucketTargetSys {
 	return &BucketTargetSys{
@@ -377,6 +392,7 @@ func (sys *BucketTargetSys) getRemoteTargetClient(tcfg *madmin.BucketTarget) (*T
 		healthCheckDuration: hcDuration,
 		bucket:              tcfg.TargetBucket,
 		replicateSync:       tcfg.ReplicationSync,
+		disableProxy:        tcfg.DisableProxy,
 	}
 	go tc.healthCheck()
 	return tc, nil
@@ -451,6 +467,7 @@ type TargetClient struct {
 	healthCheckDuration time.Duration
 	bucket              string // remote bucket target
 	replicateSync       bool
+	disableProxy        bool
 }
 
 func (tc *TargetClient) isOffline() bool {

--- a/pkg/madmin/remote-target-commands.go
+++ b/pkg/madmin/remote-target-commands.go
@@ -101,6 +101,7 @@ type BucketTarget struct {
 	BandwidthLimit      int64             `json:"bandwidthlimit,omitempty"`
 	ReplicationSync     bool              `json:"replicationSync"`
 	HealthCheckDuration time.Duration     `json:"healthCheckDuration,omitempty"`
+	DisableProxy        bool              `json:"disableProxy"`
 }
 
 // Clone returns shallow clone of BucketTarget without secret key in credentials
@@ -112,7 +113,7 @@ func (t *BucketTarget) Clone() BucketTarget {
 		Credentials:         &auth.Credentials{AccessKey: t.Credentials.AccessKey},
 		Secure:              t.Secure,
 		Path:                t.Path,
-		API:                 t.Path,
+		API:                 t.API,
 		Arn:                 t.Arn,
 		Type:                t.Type,
 		Region:              t.Region,
@@ -120,6 +121,7 @@ func (t *BucketTarget) Clone() BucketTarget {
 		BandwidthLimit:      t.BandwidthLimit,
 		ReplicationSync:     t.ReplicationSync,
 		HealthCheckDuration: t.HealthCheckDuration,
+		DisableProxy:        t.DisableProxy,
 	}
 }
 
@@ -237,8 +239,54 @@ func (adm *AdminClient) SetRemoteTarget(ctx context.Context, bucket string, targ
 	return arn, nil
 }
 
+// TargetUpdateType -  type of update on the remote target
+type TargetUpdateType int
+
+const (
+	// CredentialsUpdateType update creds
+	CredentialsUpdateType TargetUpdateType = 1 + iota
+	// SyncUpdateType update synchronous replication setting
+	SyncUpdateType
+	// ProxyUpdateType update proxy setting
+	ProxyUpdateType
+	// BandwidthLimitUpdateType update bandwidth limit
+	BandwidthLimitUpdateType
+	// HealthCheckDurationUpdateType update health check duration
+	HealthCheckDurationUpdateType
+	// PathUpdateType update Path
+	PathUpdateType
+)
+
+// GetTargetUpdateOps returns a slice of update operations being
+// performed with `mc admin bucket remote edit`
+func GetTargetUpdateOps(values url.Values) []TargetUpdateType {
+	var ops []TargetUpdateType
+	if values.Get("update") != "true" {
+		return ops
+	}
+	if values.Get("creds") == "true" {
+		ops = append(ops, CredentialsUpdateType)
+	}
+	if values.Get("sync") == "true" {
+		ops = append(ops, SyncUpdateType)
+	}
+	if values.Get("proxy") == "true" {
+		ops = append(ops, ProxyUpdateType)
+	}
+	if values.Get("healthcheck") == "true" {
+		ops = append(ops, HealthCheckDurationUpdateType)
+	}
+	if values.Get("bandwidth") == "true" {
+		ops = append(ops, BandwidthLimitUpdateType)
+	}
+	if values.Get("path") == "true" {
+		ops = append(ops, PathUpdateType)
+	}
+	return ops
+}
+
 // UpdateRemoteTarget updates credentials for a remote bucket target
-func (adm *AdminClient) UpdateRemoteTarget(ctx context.Context, target *BucketTarget) (string, error) {
+func (adm *AdminClient) UpdateRemoteTarget(ctx context.Context, target *BucketTarget, ops ...TargetUpdateType) (string, error) {
 	if target == nil {
 		return "", fmt.Errorf("target cannot be nil")
 	}
@@ -253,6 +301,23 @@ func (adm *AdminClient) UpdateRemoteTarget(ctx context.Context, target *BucketTa
 	queryValues := url.Values{}
 	queryValues.Set("bucket", target.SourceBucket)
 	queryValues.Set("update", "true")
+
+	for _, op := range ops {
+		switch op {
+		case CredentialsUpdateType:
+			queryValues.Set("creds", "true")
+		case SyncUpdateType:
+			queryValues.Set("sync", "true")
+		case ProxyUpdateType:
+			queryValues.Set("proxy", "true")
+		case BandwidthLimitUpdateType:
+			queryValues.Set("bandwidth", "true")
+		case HealthCheckDurationUpdateType:
+			queryValues.Set("healthcheck", "true")
+		case PathUpdateType:
+			queryValues.Set("path", "true")
+		}
+	}
 
 	reqData := requestData{
 		relPath:     adminAPIPrefix + "/set-remote-target",

--- a/pkg/madmin/remote-target-commands_test.go
+++ b/pkg/madmin/remote-target-commands_test.go
@@ -1,0 +1,92 @@
+/*
+ * MinIO Cloud Storage, (C) 2018 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package madmin
+
+import (
+	"net/url"
+	"testing"
+)
+
+func isOpsEqual(op1 []TargetUpdateType, op2 []TargetUpdateType) bool {
+	if len(op1) != len(op2) {
+		return false
+	}
+	for _, o1 := range op1 {
+		found := false
+		for _, o2 := range op2 {
+			if o2 == o1 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// TestGetTargetUpdateOps tests GetTargetUpdateOps
+func TestGetTargetUpdateOps(t *testing.T) {
+	testCases := []struct {
+		values      url.Values
+		expectedOps []TargetUpdateType
+	}{
+		{values: url.Values{
+			"update": []string{"true"}},
+			expectedOps: []TargetUpdateType{},
+		},
+		{values: url.Values{
+			"update": []string{"false"},
+			"path":   []string{"true"},
+		},
+			expectedOps: []TargetUpdateType{},
+		},
+		{values: url.Values{
+			"update": []string{"true"},
+			"path":   []string{""},
+		},
+			expectedOps: []TargetUpdateType{},
+		},
+		{values: url.Values{
+			"update": []string{"true"},
+			"path":   []string{"true"},
+			"bzzzz":  []string{"true"},
+		},
+			expectedOps: []TargetUpdateType{PathUpdateType},
+		},
+
+		{values: url.Values{
+			"update":      []string{"true"},
+			"path":        []string{"true"},
+			"creds":       []string{"true"},
+			"sync":        []string{"true"},
+			"proxy":       []string{"true"},
+			"bandwidth":   []string{"true"},
+			"healthcheck": []string{"true"},
+		},
+			expectedOps: []TargetUpdateType{
+				PathUpdateType, CredentialsUpdateType, SyncUpdateType, ProxyUpdateType, BandwidthLimitUpdateType, HealthCheckDurationUpdateType},
+		},
+	}
+	for i, test := range testCases {
+		gotOps := GetTargetUpdateOps(test.values)
+		if !isOpsEqual(gotOps, test.expectedOps) {
+			t.Fatalf("test %d: expected %v got %v", i+1, test.expectedOps, gotOps)
+		}
+	}
+}


### PR DESCRIPTION
more flexibly.

- Previously only credentials could be updated with
`mc admin bucket remote edit`. Change this to allow updating
synchronous replication flag, path, bandwidth and healthcheck

Add a flag to allow disabling proxying in active-active replication

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
