### PR TITLE
fix: return quorum error upon decode failures

### DIFF
--- a/cmd/erasure-decode.go
+++ b/cmd/erasure-decode.go
@@ -198,6 +198,18 @@ func (p *parallelReader) Read(dst [][]byte) ([][]byte, error) {
 		return newBuf, nil
 	}
 
+	if countErrs(p.errs, nil) == len(p.errs) {
+		// We have success from all drives this can mean that
+		// all local drives succeeded, but all remote drives
+		// failed to read since p.readers[i] was already nil
+		// for such remote servers - this condition was missed
+		// we would return instead `nil, nil` from this
+		// function - it is safer to simply return Quorum error
+		// when all errs are nil but erasure coding cannot decode
+		// the content.
+		return nil, errErasureReadQuorum
+	}
+
 	return nil, reduceReadQuorumErrs(context.Background(), p.errs, objectOpIgnoredErrs, p.dataBlocks)
 }
 


### PR DESCRIPTION
## Description
fix: return quorum error upon decode failures

## Motivation and Context
when we are sure that decode failures can
happen, return an appropriate error.

## How to test this PR?
very hard to reproduce this situation but whenever this happens following cases
should happen

- 4 node setup
- 3 nodes go down during a GetObject() after a successful Lock()
- leading to nil bitrotReaders for remote servers

```
too few shards given (*fmt.wrapError)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
