### PR TITLE
fix: do not heal when disks are down

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -433,6 +433,12 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 		return fi, nil, nil, err
 	}
 
+	// if one of the disk is offline, return right here no need
+	// to attempt a heal on the object.
+	if countErrs(errs, errDiskNotFound) > 0 {
+		return fi, metaArr, onlineDisks, nil
+	}
+
 	var missingBlocks int
 	for i, err := range errs {
 		if err != nil && errors.Is(err, errFileNotFound) {


### PR DESCRIPTION
## Description
fix: do not heal when disks are down

## Motivation and Context
HeadObject() was erroneously attempting
a heal when disks are down, avoid it. 

## How to test this PR?
Take nodes down and attempt `HeadObject()`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
