### PR TITLE
docs: add QuickStart section to KMS encryption of IAM data

### DIFF
--- a/cmd/config-encrypted.go
+++ b/cmd/config-encrypted.go
@@ -94,8 +94,6 @@ func migrateIAMConfigsEtcdToEncrypted(ctx context.Context, client *etcd.Client) 
 				return err
 			}
 			logger.Info("Attempting to re-encrypt config, IAM users and policies on MinIO with %q (%s)", stat.DefaultKey, stat.Name)
-		} else {
-			logger.Info("Attempting to migrate encrypted config, IAM users and policies on MinIO to a plaintext format. To encrypt all MinIO config data a KMS is needed")
 		}
 	}
 
@@ -139,9 +137,7 @@ func migrateIAMConfigsEtcdToEncrypted(ctx context.Context, client *etcd.Client) 
 
 	if encrypted {
 		if GlobalKMS != nil {
-			logger.Info("Migration of encrypted config data completed. All config data is now encrypted with the KMS")
-		} else {
-			logger.Info("Migration of encrypted config data completed. All config data is now stored in plaintext")
+			logger.Info("Migration of encrypted config data completed. All config data is now encrypted.")
 		}
 	}
 	return deleteKeyEtcd(ctx, client, backendEncryptedFile)
@@ -158,8 +154,6 @@ func migrateConfigPrefixToEncrypted(objAPI ObjectLayer, encrypted bool) error {
 				return err
 			}
 			logger.Info("Attempting to re-encrypt config, IAM users and policies on MinIO with %q (%s)", stat.DefaultKey, stat.Name)
-		} else {
-			logger.Info("Attempting to migrate encrypted config, IAM users and policies on MinIO to a plaintext format. To encrypt all MinIO config data a KMS is needed")
 		}
 	}
 
@@ -201,9 +195,7 @@ func migrateConfigPrefixToEncrypted(objAPI ObjectLayer, encrypted bool) error {
 	}
 	if encrypted {
 		if GlobalKMS != nil {
-			logger.Info("Migration of encrypted config data completed. All config data is now encrypted with the KMS")
-		} else {
-			logger.Info("Migration of encrypted config data completed. All config data is now stored in plaintext")
+			logger.Info("Migration of encrypted config data completed. All config data is now encrypted.")
 		}
 	}
 	return deleteConfig(GlobalContext, globalObjectAPI, backendEncryptedFile)

--- a/docs/kms/IAM.md
+++ b/docs/kms/IAM.md
@@ -8,28 +8,75 @@ onwards, MinIO will use the KMS provided keys to encrypt the IAM data instead
 of the cluster root credentials. If the KMS is not enabled, MinIO will store
 the IAM data as plain text in its backend.
 
+### MinIO KMS Quick Start
+
+MinIO supports two ways of encrypting IAM and configuration data.
+You can either use KES - together with an external KMS - or, much simpler,
+set the env. variable `MINIO_KMS_SECRET_KEY` and start/restart the MinIO server. For more details about KES and how
+to set it up refer to our [KMS Guide](https://github.com/minio/minio/blob/master/docs/kms/README.md).
+
+Instead of configuring an external KMS you can start with a single key by
+setting the env. variable `MINIO_KMS_SECRET_KEY`. It expects the following
+format:
+```sh
+MINIO_KMS_SECRET_KEY=<key-name>:<base64-value>
+```
+
+First generate a 256 bit random key via:
+```sh
+$ cat /dev/urandom | head -c 32 | base64 -
+OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw=
+```
+
+Now, you can set `MINIO_KMS_SECRET_KEY` like this:
+```sh
+export MINIO_KMS_SECRET_KEY=my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw=
+```
+> You can choose an arbitrary name for the key - instead of `my-minio-key`.
+> Please note that loosing the `MINIO_KMS_SECRET_KEY` will cause data loss
+> since you will not be able to decrypt the IAM/configuration data anymore.
+For distributed MinIO deployments, specify the *same* `MINIO_KMS_SECRET_KEY` for each MinIO server process. 
+
+At any point in time you can switch from `MINIO_KMS_SECRET_KEY` to a full KMS
+deployment. You just need to import the generated key into KES - for example via
+the KES CLI once you have successfully setup KES:
+```sh
+kes key create my-minio-key OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw=
+```
+- For instructions on setting up KES, see the [KES Getting Started guide](https://github.com/minio/kes/wiki/Getting-Started) 
+
+- For instructions on using KES for encrypting the MinIO backend, follow the [KMS Quick Start](https://github.com/minio/minio/tree/master/docs/kms). The SSE-S3 configuration setup also supports MinIO KMS backend encryption.
+
 ### FAQ
 
-> Why is this change needed? Was the previous encryption not secure (enough)?
+> Why is this change needed?
 
-The previous mechanism of encryption using the cluster root credentials itself
-is secure. The purpose of this change is to improve the encryption key
-management by delegating it to the KMS. Once the cluster root credentials are no
-longer needed to decrypt persistent data at the backend, they can be rotated
-much more easily. By using a KMS to protect the IAM data a potential security or
-compliance team has much more control over how/when a MinIO cluster can be
-started.
+Before, there were two separate mechanisms - S3 objects got encrypted using a KMS,
+if present, and the IAM / configuration data got encrypted with the root credentials.
+Now, MinIO encrypts IAM / configuration and S3 objects with a KMS, if present. This
+change unified the key-management aspect within MinIO.
+
+The unified KMS-based approach has several advantages:
+ - Key management is now centralized. There is one way to change or rotate encryption keys.
+   There used to be two different mechanisms - one for regular S3 objects and one for IAM data.
+ - Reduced server startup time. For IAM encryption with the root credentials, MinIO had
+   to use a memory-hard function (Argon2) that (on purpose) consumes a lot of memory and CPU.
+   The new KMS-based approach can use a key derivation function that is orders of magnitudes
+   cheaper w.r.t. memory and CPU.
+ - Root credentials can now be changed easily. Before, a two-step process was required to
+   change the cluster root credentials since they were used to en/decrypt the IAM data.
+   So, both - the old and new credentials - had to be present at the same time during a rotation
+   and the old credentials had to be removed once the rotation completed. This process is now gone.
+   The root credentials can now be changed easily.
 
 > Does this mean I need an enterprise KMS setup to run MinIO (securely)?
 
 No, MinIO does not depend on any third-party KMS provider. You have three options here:
 
 - Run MinIO without a KMS. In this case all IAM data will be stored in plain-text.
-
 - Run MinIO with a single secret key. MinIO supports a static cryptographic key
   that can act as minimal KMS. With this method all IAM data will be stored
   encrypted. The encryption key has to be passed as environment variable.
-
 - Run MinIO with KES (minio/kes) in combination with any supported KMS as
   secure key store. For example, you can run MinIO + KES + Hashicorp Vault.
 


### PR DESCRIPTION
## Description
This commit enhances the docs about IAM encryption.
It adds a quick-start section that explains how to
get started quickly with `MINIO_KMS_SECRET_KEY`
instead of setting up KES.

## Motivation and Context
docs

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
