### PR TITLE
fix: attempt to drain the ReadFileStream for connection pooling

### DIFF
--- a/cmd/http/close.go
+++ b/cmd/http/close.go
@@ -32,12 +32,13 @@ func DrainBody(respBody io.ReadCloser) {
 	// If resp.Body is not closed, the Client's underlying RoundTripper
 	// (typically Transport) may not be able to re-use a persistent TCP
 	// connection to the server for a subsequent "keep-alive" request.
+	maxSplurpSize := int64(2 << 10)
 	if respBody != nil {
 		// Drain any remaining Body and then close the connection.
 		// Without this closing connection would disallow re-using
 		// the same connection for future uses.
 		//  - http://stackoverflow.com/a/17961593/4465767
 		defer respBody.Close()
-		io.Copy(ioutil.Discard, respBody)
+		io.CopyN(ioutil.Discard, respBody, maxSplurpSize)
 	}
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -208,17 +208,17 @@ func (client *storageRESTClient) NSScanner(ctx context.Context, cache dataUsageC
 	}()
 	respBody, err := client.call(ctx, storageRESTMethodNSScanner, url.Values{}, pr, -1)
 	defer xhttp.DrainBody(respBody)
+	pr.Close()
 	if err != nil {
-		pr.Close()
 		return cache, err
 	}
-	pr.Close()
 
 	var newCache dataUsageCache
 	pr, pw = io.Pipe()
 	go func() {
 		pw.CloseWithError(waitForHTTPStream(respBody, pw))
 	}()
+
 	err = newCache.deserialize(pr)
 	pr.CloseWithError(err)
 	return newCache, err

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -453,6 +453,7 @@ func newInternodeHTTPTransport(tlsConfig *tls.Config, dialTimeout time.Duration)
 	tr := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           xhttp.DialContextWithDNSCache(globalDNSCache, xhttp.NewInternodeDialContext(dialTimeout)),
+		MaxIdleConns:          1024,
 		MaxIdleConnsPerHost:   1024,
 		WriteBufferSize:       32 << 10, // 32KiB moving up from 4KiB default
 		ReadBufferSize:        32 << 10, // 32KiB moving up from 4KiB default
@@ -500,6 +501,7 @@ func newCustomHTTPProxyTransport(tlsConfig *tls.Config, dialTimeout time.Duratio
 	tr := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           xhttp.DialContextWithDNSCache(globalDNSCache, xhttp.NewInternodeDialContext(dialTimeout)),
+		MaxIdleConns:          1024,
 		MaxIdleConnsPerHost:   1024,
 		WriteBufferSize:       16 << 10, // 16KiB moving up from 4KiB default
 		ReadBufferSize:        16 << 10, // 16KiB moving up from 4KiB default
@@ -525,6 +527,7 @@ func newCustomHTTPTransportWithHTTP2(tlsConfig *tls.Config, dialTimeout time.Dur
 	tr := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           xhttp.DialContextWithDNSCache(globalDNSCache, xhttp.NewInternodeDialContext(dialTimeout)),
+		MaxIdleConns:          1024,
 		MaxIdleConnsPerHost:   1024,
 		IdleConnTimeout:       15 * time.Second,
 		ResponseHeaderTimeout: 1 * time.Minute,
@@ -564,6 +567,7 @@ func newCustomHTTPTransport(tlsConfig *tls.Config, dialTimeout time.Duration) fu
 	tr := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           xhttp.DialContextWithDNSCache(globalDNSCache, xhttp.NewInternodeDialContext(dialTimeout)),
+		MaxIdleConns:          1024,
 		MaxIdleConnsPerHost:   1024,
 		WriteBufferSize:       16 << 10, // 16KiB moving up from 4KiB default
 		ReadBufferSize:        16 << 10, // 16KiB moving up from 4KiB default
@@ -650,6 +654,7 @@ func NewRemoteTargetHTTPTransport() *http.Transport {
 			Timeout:   15 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
+		MaxIdleConns:          1024,
 		MaxIdleConnsPerHost:   1024,
 		WriteBufferSize:       16 << 10, // 16KiB moving up from 4KiB default
 		ReadBufferSize:        16 << 10, // 16KiB moving up from 4KiB default


### PR DESCRIPTION


## Description
fix: attempt to drain the ReadFileStream for connection pooling

## Motivation and Context
avoid time_wait build up with getObject requests if there are
pending callers and their timeout can lead to time_wait states

## How to test this PR?
not easy to test the PR, requires a production setup with busy
workload.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
