### PR TITLE
Remove bootstrap platform check (#12202)

### DIFF
--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -58,10 +58,6 @@ type ServerSystemConfig struct {
 
 // Diff - returns error on first difference found in two configs.
 func (s1 ServerSystemConfig) Diff(s2 ServerSystemConfig) error {
-	if s1.MinioPlatform != s2.MinioPlatform {
-		return fmt.Errorf("Expected platform '%s', found to be running '%s'",
-			s1.MinioPlatform, s2.MinioPlatform)
-	}
 	if s1.MinioEndpoints.NEndpoints() != s2.MinioEndpoints.NEndpoints() {
 		return fmt.Errorf("Expected number of endpoints %d, seen %d", s1.MinioEndpoints.NEndpoints(),
 			s2.MinioEndpoints.NEndpoints())


### PR DESCRIPTION
## Description

This removes a platform check preventing use of mixed hardware platforms (e.g. ARM64 and AMD64) in a distributed MinIO setup.

This check was originally introduced in #8550 (Add bootstrap REST handler for verifying server config) about 18 months ago (Nov, 2019).

As noted in a performance benchmark posted on https://blog.min.io/intel_vs_gravitron/ (June, 2020):

> [...] what is clear is that the ARM architecture, with the introduction of the Graviton2 processor by AWS, has closed the performance gap to Intel and even surpassed it for multi-core performance

So let's drop it.

## Motivation and Context

See #12202.

## How to test this PR?

Follow the instructions in https://docs.min.io/docs/distributed-minio-quickstart-guide.html and bring up MinIO on three nodes:

- two on AMD64 based hardware platforms (e.g. your PC)
- one on a different hardware platform (e.g. Raspberry Pi 4 with a 64-bit OS)

After the initial setup, restart MinIO one the nodes and confirm that none of them no longer fails with e.g.:

> incorrect configuration: Expected platform 'OS: linux | Arch: arm64', found to be running 'OS: linux | Arch: amd64'

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
