### PR TITLE
Add IsRemote method on FileInfo, ObjectInfo

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -201,12 +201,10 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 				}
 			}
 		}
-		if objInfo.TransitionStatus == lifecycle.TransitionComplete {
+		if objInfo.IsRemote() {
 			// Check if object is being restored. For more information on x-amz-restore header see
 			// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax
-			if onDisk := isRestoredObjectOnDisk(objInfo.UserDefined); !onDisk {
-				w.Header()[xhttp.AmzStorageClass] = []string{objInfo.TransitionTier}
-			}
+			w.Header()[xhttp.AmzStorageClass] = []string{objInfo.TransitionTier}
 		}
 		ruleID, transitionTime := lc.PredictTransitionTime(lifecycle.ObjectOpts{
 			Name:             objInfo.Name,

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -550,6 +550,24 @@ func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo O
 
 var errRestoreHDRMalformed = fmt.Errorf("x-amz-restore header malformed")
 
+// IsRemote returns true if this object version's contents are in its remote
+// tier.
+func (fi FileInfo) IsRemote() bool {
+	if fi.TransitionStatus != lifecycle.TransitionComplete {
+		return false
+	}
+	return !isRestoredObjectOnDisk(fi.Metadata)
+}
+
+// IsRemote returns true if this object version's contents are in its remote
+// tier.
+func (oi ObjectInfo) IsRemote() bool {
+	if oi.TransitionStatus != lifecycle.TransitionComplete {
+		return false
+	}
+	return !isRestoredObjectOnDisk(oi.UserDefined)
+}
+
 // restoreObjStatus represents a restore-object's status. It can be either
 // ongoing or completed.
 type restoreObjStatus struct {

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -509,7 +509,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 
 		// dataDir should be empty when
 		// - transitionStatus is complete and not in restored state
-		if partsMetadata[i].TransitionStatus == lifecycle.TransitionComplete && !isRestoredObjectOnDisk(partsMetadata[i].Metadata) {
+		if partsMetadata[i].IsRemote() {
 			partsMetadata[i].DataDir = ""
 		}
 		// Attempt a rename now from healed data to final location.


### PR DESCRIPTION
## Description

Provides a convenient method to know if an object's contents are in its remote
tier.

## Motivation and Context
Encapsulate ILM transition specific knowledge via methods on FileInfo, ObjectInfo.

## How to test this PR?
PR must pass CI. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
