### PR TITLE
lock: Timeout Unlock RPC call

### DIFF
--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -109,7 +109,7 @@ func (l *localLocker) Lock(ctx context.Context, args dsync.LockArgs) (reply bool
 	return true, nil
 }
 
-func (l *localLocker) Unlock(args dsync.LockArgs) (reply bool, err error) {
+func (l *localLocker) Unlock(_ context.Context, args dsync.LockArgs) (reply bool, err error) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
@@ -177,7 +177,7 @@ func (l *localLocker) RLock(ctx context.Context, args dsync.LockArgs) (reply boo
 	return reply, nil
 }
 
-func (l *localLocker) RUnlock(args dsync.LockArgs) (reply bool, err error) {
+func (l *localLocker) RUnlock(_ context.Context, args dsync.LockArgs) (reply bool, err error) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	var lri []lockRequesterInfo

--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -122,8 +122,8 @@ func (client *lockRESTClient) Lock(ctx context.Context, args dsync.LockArgs) (re
 }
 
 // RUnlock calls read unlock REST API.
-func (client *lockRESTClient) RUnlock(args dsync.LockArgs) (reply bool, err error) {
-	return client.restCall(context.Background(), lockRESTMethodRUnlock, args)
+func (client *lockRESTClient) RUnlock(ctx context.Context, args dsync.LockArgs) (reply bool, err error) {
+	return client.restCall(ctx, lockRESTMethodRUnlock, args)
 }
 
 // RUnlock calls read unlock REST API.
@@ -132,8 +132,8 @@ func (client *lockRESTClient) Refresh(ctx context.Context, args dsync.LockArgs) 
 }
 
 // Unlock calls write unlock RPC.
-func (client *lockRESTClient) Unlock(args dsync.LockArgs) (reply bool, err error) {
-	return client.restCall(context.Background(), lockRESTMethodUnlock, args)
+func (client *lockRESTClient) Unlock(ctx context.Context, args dsync.LockArgs) (reply bool, err error) {
+	return client.restCall(ctx, lockRESTMethodUnlock, args)
 }
 
 // ForceUnlock calls force unlock handler to forcibly unlock an active lock.

--- a/cmd/lock-rest-client_test.go
+++ b/cmd/lock-rest-client_test.go
@@ -47,12 +47,12 @@ func TestLockRESTlient(t *testing.T) {
 		t.Fatal("Expected for Lock to fail")
 	}
 
-	_, err = lkClient.RUnlock(dsync.LockArgs{})
+	_, err = lkClient.RUnlock(context.Background(), dsync.LockArgs{})
 	if err == nil {
 		t.Fatal("Expected for RUnlock to fail")
 	}
 
-	_, err = lkClient.Unlock(dsync.LockArgs{})
+	_, err = lkClient.Unlock(context.Background(), dsync.LockArgs{})
 	if err == nil {
 		t.Fatal("Expected for Unlock to fail")
 	}

--- a/cmd/lock-rest-server.go
+++ b/cmd/lock-rest-server.go
@@ -156,7 +156,7 @@ func (l *lockRESTServer) UnlockHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = l.ll.Unlock(args)
+	_, err = l.ll.Unlock(context.Background(), args)
 	// Ignore the Unlock() "reply" return value because if err == nil, "reply" is always true
 	// Consequently, if err != nil, reply is always false
 	if err != nil {
@@ -203,7 +203,7 @@ func (l *lockRESTServer) RUnlockHandler(w http.ResponseWriter, r *http.Request) 
 
 	// Ignore the RUnlock() "reply" return value because if err == nil, "reply" is always true.
 	// Consequently, if err != nil, reply is always false
-	if _, err = l.ll.RUnlock(args); err != nil {
+	if _, err = l.ll.RUnlock(context.Background(), args); err != nil {
 		l.writeErrorResponse(w, err)
 		return
 	}

--- a/pkg/dsync/drwmutex.go
+++ b/pkg/dsync/drwmutex.go
@@ -49,7 +49,7 @@ const drwMutexAcquireTimeout = 1 * time.Second // 1 second.
 const drwMutexRefreshCallTimeout = 5 * time.Second
 
 // dRWMutexUnlockTimeout - timeout for the unlock call
-const drwMutexUnlockCallTimeout = 20 * time.Second
+const drwMutexUnlockCallTimeout = 30 * time.Second
 
 // dRWMutexRefreshInterval - the interval between two refresh calls
 const drwMutexRefreshInterval = 10 * time.Second

--- a/pkg/dsync/drwmutex.go
+++ b/pkg/dsync/drwmutex.go
@@ -46,7 +46,10 @@ func log(format string, data ...interface{}) {
 const drwMutexAcquireTimeout = 1 * time.Second // 1 second.
 
 // dRWMutexRefreshTimeout - timeout for the refresh call
-const drwMutexRefreshTimeout = 5 * time.Second
+const drwMutexRefreshCallTimeout = 5 * time.Second
+
+// dRWMutexUnlockTimeout - timeout for the unlock call
+const drwMutexUnlockCallTimeout = 20 * time.Second
 
 // dRWMutexRefreshInterval - the interval between two refresh calls
 const drwMutexRefreshInterval = 10 * time.Second
@@ -275,7 +278,7 @@ func refresh(ctx context.Context, ds *Dsync, id, source string, quorum int, lock
 				Quorum:    quorum,
 			}
 
-			ctx, cancel := context.WithTimeout(ctx, drwMutexRefreshTimeout)
+			ctx, cancel := context.WithTimeout(ctx, drwMutexRefreshCallTimeout)
 			defer cancel()
 
 			refreshed, err := c.Refresh(ctx, args)
@@ -613,13 +616,16 @@ func sendRelease(ds *Dsync, c NetLocker, owner string, uid string, isReadLock bo
 		Resources: names,
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), drwMutexUnlockCallTimeout)
+	defer cancel()
+
 	if isReadLock {
-		if _, err := c.RUnlock(args); err != nil {
+		if _, err := c.RUnlock(ctx, args); err != nil {
 			log("dsync: Unable to call RUnlock failed with %s for %#v at %s\n", err, args, c)
 			return false
 		}
 	} else {
-		if _, err := c.Unlock(args); err != nil {
+		if _, err := c.Unlock(ctx, args); err != nil {
 			log("dsync: Unable to call Unlock failed with %s for %#v at %s\n", err, args, c)
 			return false
 		}

--- a/pkg/dsync/drwmutex_test.go
+++ b/pkg/dsync/drwmutex_test.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package dsync_test
+package dsync
 
 import (
 	"context"
@@ -24,8 +24,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	. "github.com/minio/minio/pkg/dsync"
 )
 
 const (

--- a/pkg/dsync/rpc-client-impl_test.go
+++ b/pkg/dsync/rpc-client-impl_test.go
@@ -105,12 +105,12 @@ func (rpcClient *ReconnectRPCClient) Lock(ctx context.Context, args LockArgs) (s
 	return status, err
 }
 
-func (rpcClient *ReconnectRPCClient) RUnlock(args LockArgs) (status bool, err error) {
+func (rpcClient *ReconnectRPCClient) RUnlock(ctx context.Context, args LockArgs) (status bool, err error) {
 	err = rpcClient.Call("Dsync.RUnlock", &args, &status)
 	return status, err
 }
 
-func (rpcClient *ReconnectRPCClient) Unlock(args LockArgs) (status bool, err error) {
+func (rpcClient *ReconnectRPCClient) Unlock(ctx context.Context, args LockArgs) (status bool, err error) {
 	err = rpcClient.Call("Dsync.Unlock", &args, &status)
 	return status, err
 }

--- a/pkg/dsync/rpc-client-impl_test.go
+++ b/pkg/dsync/rpc-client-impl_test.go
@@ -15,14 +15,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package dsync_test
+package dsync
 
 import (
 	"context"
 	"net/rpc"
 	"sync"
-
-	. "github.com/minio/minio/pkg/dsync"
 )
 
 // ReconnectRPCClient is a wrapper type for rpc.Client which provides reconnect on first failure.

--- a/pkg/dsync/rpc-client-interface.go
+++ b/pkg/dsync/rpc-client-interface.go
@@ -54,12 +54,12 @@ type NetLocker interface {
 	// Do read unlock for given LockArgs. It should return
 	// * a boolean to indicate success/failure of the operation
 	// * an error on failure of unlock request operation.
-	RUnlock(args LockArgs) (bool, error)
+	RUnlock(ctx context.Context, args LockArgs) (bool, error)
 
 	// Do write unlock for given LockArgs. It should return
 	// * a boolean to indicate success/failure of the operation
 	// * an error on failure of unlock request operation.
-	Unlock(args LockArgs) (bool, error)
+	Unlock(ctx context.Context, args LockArgs) (bool, error)
 
 	// Refresh the given lock to prevent it from becoming stale
 	Refresh(ctx context.Context, args LockArgs) (bool, error)

--- a/pkg/dsync/rpc-client-interface.go
+++ b/pkg/dsync/rpc-client-interface.go
@@ -54,11 +54,15 @@ type NetLocker interface {
 	// Do read unlock for given LockArgs. It should return
 	// * a boolean to indicate success/failure of the operation
 	// * an error on failure of unlock request operation.
+	// Canceling the context will abort the remote call.
+	// In that case, the resource may or may not be unlocked.
 	RUnlock(ctx context.Context, args LockArgs) (bool, error)
 
 	// Do write unlock for given LockArgs. It should return
 	// * a boolean to indicate success/failure of the operation
 	// * an error on failure of unlock request operation.
+	// Canceling the context will abort the remote call.
+	// In that case, the resource may or may not be unlocked.
 	Unlock(ctx context.Context, args LockArgs) (bool, error)
 
 	// Refresh the given lock to prevent it from becoming stale


### PR DESCRIPTION
## Description
RPC unlock call needs to be timeouted otherwise this can block
indefintely.

## Motivation and Context
Some reports that the scanner lock is not there and no server is sleeping to wait for
acquiring the scanner lock. I reviewed the code and it seems the only way that this happens
is that those nodes are blocked in GetLock() call and blocks in sendRelease() call because
this latter does not have any timeout.

Internode REST client has a header timeout (15m) but I also think it is better if we do
not rely completely on it.

## How to test this PR?
No easy way to reproduce the failure, only testing is to check if there is no regression

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
