### PR TITLE
Add node CPU & memory metrics to Prometheus cluster endpoint

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -120,6 +120,8 @@ const (
 	lastActivityTime = "last_activity_nano_seconds"
 	startTime        = "starttime_seconds"
 	upTime           = "uptime_seconds"
+	memory           = "resident_memory_bytes"
+	cpu              = "cpu_total_seconds"
 )
 
 const (
@@ -821,6 +823,24 @@ func getMinIOProcessUptimeMD() MetricDescription {
 		Type:      gaugeMetric,
 	}
 }
+func getMinIOProcessResidentMemory() MetricDescription {
+	return MetricDescription{
+		Namespace: nodeMetricNamespace,
+		Subsystem: processSubsystem,
+		Name:      memory,
+		Help:      "Resident memory size in bytes.",
+		Type:      gaugeMetric,
+	}
+}
+func getMinIOProcessCPUTime() MetricDescription {
+	return MetricDescription{
+		Namespace: nodeMetricNamespace,
+		Subsystem: processSubsystem,
+		Name:      cpu,
+		Help:      "Total user and system CPU time spent in seconds.",
+		Type:      counterMetric,
+	}
+}
 func getMinioProcMetrics() MetricsGroup {
 	return MetricsGroup{
 		id:         "MinioProcMetrics",
@@ -912,6 +932,16 @@ func getMinioProcMetrics() MetricsGroup {
 				Metric{
 					Description: getMinIOProcessUptimeMD(),
 					Value:       time.Since(globalBootTime).Seconds(),
+				})
+			metrics = append(metrics,
+				Metric{
+					Description: getMinIOProcessResidentMemory(),
+					Value:       float64(stat.ResidentMemory()),
+				})
+			metrics = append(metrics,
+				Metric{
+					Description: getMinIOProcessCPUTime(),
+					Value:       float64(stat.CPUTime()),
 				})
 			return
 		},


### PR DESCRIPTION
## Description
Add node CPU & memory metrics to Prometheus cluster endpoint

## Motivation and Context
This is required to streamline MinIO Grafana Dashboard, it requires only cluster endpoint.

## How to test this PR?
Start MinIO Server and look for Prometheus metrics `minio_node_process_cpu_total_seconds` and `minio_node_process_resident_memory_bytes` on the cluster endpoint.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
