### PR TITLE
fix starttls fails when MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY=off

### DIFF
--- a/cmd/config/identity/ldap/config.go
+++ b/cmd/config/identity/ldap/config.go
@@ -382,6 +382,8 @@ func (l *Config) Bind(username, password string) (string, []string, error) {
 
 // Connect connect to ldap server.
 func (l *Config) Connect() (ldapConn *ldap.Conn, err error) {
+	var tlsConfig *tls.Config
+	var host string
 	if l == nil {
 		return nil, errors.New("LDAP is not configured")
 	}
@@ -400,10 +402,15 @@ func (l *Config) Connect() (ldapConn *ldap.Conn, err error) {
 		if err != nil {
 			return nil, err
 		}
-		err = conn.StartTLS(&tls.Config{
+		tlsConfig = &tls.Config{
 			InsecureSkipVerify: l.tlsSkipVerify,
 			RootCAs:            l.rootCAs,
-		})
+		}
+		if !l.tlsSkipVerify {
+			host, _, _ = net.SplitHostPort(l.ServerAddr)
+			tlsConfig.ServerName = host
+		}
+		err = conn.StartTLS(tlsConfig)
 		return conn, err
 	}
 


### PR DESCRIPTION
## Description
Fix the #12216

## Motivation and Context
StartTLS without skip verify will always fail because ServerName is not provided

## How to test this PR?
test with ldap server with starttls protocol

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
