### PR TITLE
xl: Avoid listing empty directories (2020-10-28 branch)

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1081,7 +1081,10 @@ func (s *xlStorage) Walk(ctx context.Context, volume, dirPath, marker string, re
 		dirObjects := make(map[string]struct{})
 		for walkResult := range walkResultCh {
 			var fi FileInfo
-			if HasSuffix(walkResult.entry, SlashSeparator) && !walkResult.emptyDir {
+			if HasSuffix(walkResult.entry, SlashSeparator) && walkResult.emptyDir {
+				// Avoid listing empty directory, they are not supposed to exist
+				continue
+			} else if HasSuffix(walkResult.entry, SlashSeparator) && !walkResult.emptyDir {
 				_, dirObj := dirObjects[walkResult.entry]
 				if dirObj {
 					continue


### PR DESCRIPTION
## Description
After the introduction of __XLDIR__ with xl.meta inside them, we don't
have to list empty directories anymore.

## Motivation and Context
Avoid listing empty directories from each disk

## How to test this PR?
```
minio server /tmp/xl/{1..4}/
mc mb myminio/testbucket/
mc cp testfile myminio/testbucket/dir/
Remove only testfile in all disks
mc ls myminio/testbucket/
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
