### PR TITLE
Partially defined credential env vars cause "minio gateway s3" to fail

### DIFF
--- a/buildscripts/verify-build.sh
+++ b/buildscripts/verify-build.sh
@@ -31,6 +31,8 @@ FUNCTIONAL_TESTS="$WORK_DIR/functional-tests.sh"
 
 function start_minio_fs()
 {
+    export MINIO_ROOT_USER=$ACCESS_KEY
+    export MINIO_ROOT_PASSWORD=$SECRET_KEY
     "${MINIO[@]}" server "${WORK_DIR}/fs-disk" >"$WORK_DIR/fs-minio.log" 2>&1 &
     sleep 10
 }

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -318,47 +318,57 @@ func handleCommonEnvVars() {
 	globalInplaceUpdateDisabled = strings.EqualFold(env.Get(config.EnvUpdate, config.EnableOn), config.EnableOff)
 
 	// Check if the supported credential env vars, "MINIO_ROOT_USER" and
-	// "MINIO_ROOT_PASSWORD" is provided
-	if env.IsSet(config.EnvRootUser) && env.IsSet(config.EnvRootPassword) {
-		cred, err := auth.CreateCredentials(env.Get(config.EnvRootUser, ""), env.Get(config.EnvRootPassword, ""))
-		if err != nil {
-			logger.Fatal(config.ErrInvalidCredentials(err),
-				"Unable to validate credentials inherited from the shell environment")
+	// "MINIO_ROOT_PASSWORD" are provided
+	// Warn user if deprecated environment variables,
+	// "MINIO_ACCESS_KEY" and "MINIO_SECRET_KEY", are defined
+	// Check all error conditions first
+	if !env.IsSet(config.EnvRootUser) && env.IsSet(config.EnvRootPassword) {
+		logger.Fatal(config.ErrMissingEnvCredentialRootUser(nil), "Unable to start MinIO")
+	} else if env.IsSet(config.EnvRootUser) && !env.IsSet(config.EnvRootPassword) {
+		logger.Fatal(config.ErrMissingEnvCredentialRootPassword(nil), "Unable to start MinIO")
+	} else if !env.IsSet(config.EnvRootUser) && !env.IsSet(config.EnvRootPassword) {
+		if !env.IsSet(config.EnvAccessKey) && env.IsSet(config.EnvSecretKey) {
+			logger.Fatal(config.ErrMissingEnvCredentialAccessKey(nil), "Unable to start MinIO")
+		} else if env.IsSet(config.EnvAccessKey) && !env.IsSet(config.EnvSecretKey) {
+			logger.Fatal(config.ErrMissingEnvCredentialSecretKey(nil), "Unable to start MinIO")
 		}
-		globalActiveCred = cred
-	} else if env.IsSet(config.EnvAccessKey) && env.IsSet(config.EnvSecretKey) {
-		// If depracated "ACCESS_KEY" and "SECRET_KEY" env vars are provided,
-		// but there is also one of "MINIO_ROOT_*" env var is defined, then
-		// we reject trying deprecated env vars and ask for the missing "MINIO_ROOT_*"
-		if env.IsSet(config.EnvRootUser) {
-			logger.Fatal(config.ErrMissingEnvCredentialRootPassword(nil), "")
-		} else if env.IsSet(config.EnvRootPassword) {
-			logger.Fatal(config.ErrMissingEnvCredentialRootUser(nil), "")
-		}
+	}
 
-		// Try the deprecated "ACCESS_KEY" and "SECRET_KEY" env vars
-		cred, err := auth.CreateCredentials(env.Get(config.EnvAccessKey, ""), env.Get(config.EnvSecretKey, ""))
+	// At this point, either both environment variables
+	// are defined or both are not defined.
+	// Check both cases and authenticate them if correctly defined
+	var user, password string
+	haveRootCredentials := false
+	haveAccessCredentials := false
+	if env.IsSet(config.EnvRootUser) && env.IsSet(config.EnvRootPassword) {
+		user = env.Get(config.EnvRootUser, "")
+		password = env.Get(config.EnvRootPassword, "")
+		haveRootCredentials = true
+	} else if env.IsSet(config.EnvAccessKey) && env.IsSet(config.EnvSecretKey) {
+		user = env.Get(config.EnvAccessKey, "")
+		password = env.Get(config.EnvSecretKey, "")
+		haveAccessCredentials = true
+	}
+	if haveRootCredentials || haveAccessCredentials {
+		cred, err := auth.CreateCredentials(user, password)
 		if err != nil {
 			logger.Fatal(config.ErrInvalidCredentials(err),
 				"Unable to validate credentials inherited from the shell environment")
 		}
-		msg := fmt.Sprintf("%s and %s are deprecated.\nPlease use %s and %s",
-			config.EnvAccessKey, config.EnvSecretKey, config.EnvRootUser, config.EnvRootPassword)
-		logger.StartupMessage(color.RedString(msg))
+		if haveAccessCredentials {
+			msg := fmt.Sprintf("WARNING: %s and %s are deprecated.\n"+
+				"         Please use %s and %s",
+				config.EnvAccessKey, config.EnvSecretKey,
+				config.EnvRootUser, config.EnvRootPassword)
+			logger.StartupMessage(color.RedString(msg))
+		}
 		globalActiveCred = cred
-	} else {
-		if !env.IsSet(config.EnvRootUser) {
-			logger.Fatal(config.ErrMissingEnvCredentialRootUser(nil), "")
-		}
-		if !env.IsSet(config.EnvRootPassword) {
-			logger.Fatal(config.ErrMissingEnvCredentialRootPassword(nil), "")
-		}
-		if !env.IsSet(config.EnvAccessKey) {
-			logger.Fatal(config.ErrMissingEnvCredentialAccessKey(nil), "")
-		}
-		if !env.IsSet(config.EnvSecretKey) {
-			logger.Fatal(config.ErrMissingEnvCredentialSecretKey(nil), "")
-		}
+	}
+	if !haveRootCredentials && !haveAccessCredentials {
+		msg := "No credential environment variables defined. Going with the defaults.\n" +
+			"It is strongly recommended to define your own credentials" +
+			" via environment variables %s and %s instead of using default values"
+		logger.StartupMessage(color.RedString(msg, config.EnvRootUser, config.EnvRootPassword))
 	}
 
 	switch {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -318,21 +318,15 @@ func handleCommonEnvVars() {
 	globalInplaceUpdateDisabled = strings.EqualFold(env.Get(config.EnvUpdate, config.EnableOn), config.EnableOff)
 
 	if env.IsSet(config.EnvAccessKey) || env.IsSet(config.EnvSecretKey) {
-		cred, err := auth.CreateCredentials(env.Get(config.EnvAccessKey, ""), env.Get(config.EnvSecretKey, ""))
-		if err != nil {
-			logger.Fatal(config.ErrInvalidCredentials(err),
-				"Unable to validate credentials inherited from the shell environment")
-		}
-		globalActiveCred = cred
+		globalActiveCred, _ = auth.CreateCredentials(env.Get(config.EnvAccessKey, ""), env.Get(config.EnvSecretKey, ""))
 	}
 
 	if env.IsSet(config.EnvRootUser) || env.IsSet(config.EnvRootPassword) {
-		cred, err := auth.CreateCredentials(env.Get(config.EnvRootUser, ""), env.Get(config.EnvRootPassword, ""))
+		globalActiveCred, err = auth.CreateCredentials(env.Get(config.EnvRootUser, ""), env.Get(config.EnvRootPassword, ""))
 		if err != nil {
 			logger.Fatal(config.ErrInvalidCredentials(err),
 				"Unable to validate credentials inherited from the shell environment")
 		}
-		globalActiveCred = cred
 	}
 
 	switch {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -327,6 +327,16 @@ func handleCommonEnvVars() {
 		}
 		globalActiveCred = cred
 	} else if env.IsSet(config.EnvAccessKey) && env.IsSet(config.EnvSecretKey) {
+		// If depracated "ACCESS_KEY" and "SECRET_KEY" env vars are provided,
+		// but there is also one of "MINIO_ROOT_*" env var is defined, then
+		// we reject trying deprecated env vars and ask for the missing "MINIO_ROOT_*"
+		if env.IsSet(config.EnvRootUser) {
+			logger.Fatal(config.ErrMissingEnvCredentialRootPassword(nil), "")
+		} else if env.IsSet(config.EnvRootPassword) {
+			logger.Fatal(config.ErrMissingEnvCredentialRootUser(nil), "")
+		}
+
+		// Try the deprecated "ACCESS_KEY" and "SECRET_KEY" env vars
 		cred, err := auth.CreateCredentials(env.Get(config.EnvAccessKey, ""), env.Get(config.EnvSecretKey, ""))
 		if err != nil {
 			logger.Fatal(config.ErrInvalidCredentials(err),

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -139,6 +139,30 @@ var (
 		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
 	)
 
+	ErrMissingEnvCredentialRootUser = newErrFn(
+		"Env var \""+EnvRootUser+"\" is missing",
+		"Please set your credential env var, \""+EnvRootUser+"\"",
+		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
+	)
+
+	ErrMissingEnvCredentialRootPassword = newErrFn(
+		"Env var \""+EnvRootPassword+"\" is missing",
+		"Please set your credential env var, \""+EnvRootPassword+"\"",
+		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
+	)
+
+	ErrMissingEnvCredentialAccessKey = newErrFn(
+		"Env var \""+AccessKey+"\" is deprecated",
+		"Please set your credential env var, \""+EnvRootUser+"\"",
+		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
+	)
+
+	ErrMissingEnvCredentialSecretKey = newErrFn(
+		"Env var \""+SecretKey+"\" is deprecated",
+		"Please set your credential env var, \""+EnvRootPassword+"\"",
+		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
+	)
+
 	ErrInvalidErasureEndpoints = newErrFn(
 		"Invalid endpoint(s) in erasure mode",
 		"Please provide correct combination of local/remote paths",

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -133,34 +133,28 @@ var (
 		`Access key length should be at least 3, and secret key length at least 8 characters`,
 	)
 
-	ErrEnvCredentialsMissingGateway = newErrFn(
-		"Credentials missing",
-		"Please set your credentials in the environment",
-		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
-	)
-
 	ErrMissingEnvCredentialRootUser = newErrFn(
-		"Env var \""+EnvRootUser+"\" is missing",
-		"Please set your credential env var, \""+EnvRootUser+"\"",
-		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
+		"Missing credential environment variable, \""+EnvRootUser+"\"",
+		"Environment variable \""+EnvRootUser+"\" is missing",
+		`Root user name (access key) and root password (secret key) are expected to be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
 	)
 
 	ErrMissingEnvCredentialRootPassword = newErrFn(
-		"Env var \""+EnvRootPassword+"\" is missing",
-		"Please set your credential env var, \""+EnvRootPassword+"\"",
-		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
+		"Missing credential environment variable, \""+EnvRootPassword+"\"",
+		"Environment variable \""+EnvRootPassword+"\" is missing",
+		`Root user name (access key) and root password (secret key) are expected to be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
 	)
 
 	ErrMissingEnvCredentialAccessKey = newErrFn(
-		"Env var \""+AccessKey+"\" is deprecated",
-		"Please set your credential env var, \""+EnvRootUser+"\"",
-		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
+		"Missing credential environment variable, \""+EnvAccessKey+"\"",
+		"Environment variables \""+EnvAccessKey+"\" and \""+EnvSecretKey+"\" are deprecated",
+		`Root user name (access key) and root password (secret key) are expected to be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
 	)
 
 	ErrMissingEnvCredentialSecretKey = newErrFn(
-		"Env var \""+SecretKey+"\" is deprecated",
-		"Please set your credential env var, \""+EnvRootPassword+"\"",
-		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
+		"Missing credential environment variable, \""+EnvSecretKey+"\"",
+		"Environment variables \""+EnvSecretKey+"\" and \""+EnvAccessKey+"\" are deprecated",
+		`Root user name (access key) and root password (secret key) are expected to be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
 	)
 
 	ErrInvalidErasureEndpoints = newErrFn(


### PR DESCRIPTION
## Description
Fixes #12227

## Motivation and Context
Users were expected not to provide partially set credential env vars. The right behavior should have been to disregard the partially defined credentials env vars as long as the other credential env var set is fully defined.

## How to test this PR?
Start a gateway by setting 1 credential env var set partially and the other set fully.
Example:: 
```
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
