### PR TITLE
admin: Return exported errors with invalid access secret keys

### DIFF
--- a/pkg/auth/credentials.go
+++ b/pkg/auth/credentials.go
@@ -57,8 +57,8 @@ const (
 
 // Common errors generated for access and secret key validation.
 var (
-	ErrInvalidAccessKeyLength = fmt.Errorf("access key must be minimum %v or more characters long", accessKeyMinLen)
-	ErrInvalidSecretKeyLength = fmt.Errorf("secret key must be minimum %v or more characters long", secretKeyMinLen)
+	ErrInvalidAccessKeyLength = fmt.Errorf("access key length should be between %d and %d", accessKeyMinLen, accessKeyMaxLen)
+	ErrInvalidSecretKeyLength = fmt.Errorf("secret key length should be between %d and %d", secretKeyMinLen, secretKeyMaxLen)
 )
 
 // IsAccessKeyValid - validate access key for right length.
@@ -230,11 +230,11 @@ func GetNewCredentialsWithMetadata(m map[string]interface{}, tokenSecret string)
 // and generate a session token if a secret token is provided.
 func CreateNewCredentialsWithMetadata(accessKey, secretKey string, m map[string]interface{}, tokenSecret string) (cred Credentials, err error) {
 	if len(accessKey) < accessKeyMinLen || len(accessKey) > accessKeyMaxLen {
-		return Credentials{}, fmt.Errorf("access key length should be between %d and %d", accessKeyMinLen, accessKeyMaxLen)
+		return Credentials{}, ErrInvalidAccessKeyLength
 	}
 
 	if len(secretKey) < secretKeyMinLen || len(secretKey) > secretKeyMaxLen {
-		return Credentials{}, fmt.Errorf("secret key length should be between %d and %d", secretKeyMinLen, secretKeyMaxLen)
+		return Credentials{}, ErrInvalidSecretKeyLength
 	}
 
 	cred.AccessKey = accessKey


### PR DESCRIPTION
## Description
To avoid returning 5xx error from MinIO server and show a better error
message, we need to return ErrInvalidAccessKeyLength and ErrInvalidSecretKeyLength
when attempting to create a new credentials with invalid access or
secret keys.

Signed-off-by: Anis Elleuch <anis@min.io>

## Motivation and Context
Have a better error message when trying to create a service account
with invalid access or secret keys

## How to test this PR?
mc admin user svcacct add myminio/ minio --access-key mysvczzzzzzzzzzzzzzzzzzzzzzzzzzzz --secret-key 01234567890

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
