### PR TITLE
Heal restored object contents on disk

### DIFF
--- a/cmd/erasure-healing-common.go
+++ b/cmd/erasure-healing-common.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/minio/madmin-go"
-	"github.com/minio/minio/pkg/bucket/lifecycle"
 )
 
 // commonTime returns a maximally occurring time from a list of time.
@@ -280,11 +279,11 @@ func disksWithAllParts(ctx context.Context, onlineDisks []StorageAPI, partsMetad
 			// disk has a valid xl.meta but may not have all the
 			// parts. This is considered an outdated disk, since
 			// it needs healing too.
-			if partsMetadata[i].TransitionStatus != lifecycle.TransitionComplete {
+			if !partsMetadata[i].IsRemote() {
 				dataErrs[i] = onlineDisk.VerifyFile(ctx, bucket, object, partsMetadata[i])
 			}
 		case madmin.HealNormalScan:
-			if partsMetadata[i].TransitionStatus != lifecycle.TransitionComplete {
+			if !partsMetadata[i].IsRemote() {
 				dataErrs[i] = onlineDisk.CheckParts(ctx, bucket, object, partsMetadata[i])
 			}
 		}

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -213,7 +213,7 @@ func shouldHealObjectOnDisk(erErr, dataErr error, meta FileInfo, quorumModTime t
 		return true
 	}
 	if erErr == nil {
-		if meta.TransitionStatus != lifecycle.TransitionComplete {
+		if !meta.IsRemote() {
 			// If xl.meta was read fine but there may be problem with the part.N files.
 			if IsErr(dataErr, []error{
 				errFileNotFound,
@@ -271,7 +271,6 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 
 	// List of disks having all parts as per latest er.meta.
 	availableDisks, dataErrs := disksWithAllParts(ctx, latestDisks, partsMetadata, errs, bucket, object, scanMode)
-
 	// Loop to find number of disks with valid data, per-drive
 	// data state and a list of outdated disks on which data needs
 	// to be healed.
@@ -367,7 +366,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 		nfi := fi
 		nfi.Erasure.Index = 0
 		nfi.Erasure.Checksums = nil
-		if fi.TransitionStatus != lifecycle.TransitionComplete {
+		if fi.IsRemote() {
 			nfi.Parts = nil
 		}
 		return nfi
@@ -401,7 +400,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 		inlineBuffers = make([]*bytes.Buffer, len(outDatedDisks))
 	}
 
-	if !latestMeta.Deleted && latestMeta.TransitionStatus != lifecycle.TransitionComplete {
+	if !latestMeta.Deleted && !latestMeta.IsRemote() {
 		result.DataBlocks = latestMeta.Erasure.DataBlocks
 		result.ParityBlocks = latestMeta.Erasure.ParityBlocks
 


### PR DESCRIPTION
## Description
Restore-object downloads a copy of an object version's contents on to disk. Restored contents are present on disks for a fixed amount of time. This fix ensures that MinIO's automatic healing applies to restored contents too.

## Motivation and Context
MinIO's automatic healing should apply to restored contents too.

## How to test this PR?
0. Configure a remote tier and setup ILM rules on a bucket
1. Upload an object (multipart) to this bucket
2. Wait until object is tiered
3. Perform restore-object; You can confirm that the contents are back on the disks
4. Now remove one or more parts of this object from backend - to simulate missing parts
5. Call admin-heal-object on this object.
6. Heal operation should add back the removed parts.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
