### PR TITLE
MRF: Better detection of offline disks during deletion (10-28 branch)

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -95,18 +95,26 @@ type erasureSets struct {
 	poolSplunk   *MergeWalkPool
 	poolVersions *MergeWalkVersionsPool
 
-	mrfMU         sync.Mutex
-	mrfOperations map[healSource]int
+	lastConnectDisksOpTime time.Time
+	mrfMU                  sync.Mutex
+	mrfOperations          map[healSource]int
 
 	zoneIndex int
 }
 
-func isEndpointConnected(diskMap map[string]StorageAPI, endpoint string) bool {
+// Return false if endpoint is not connected or has been reconnected after last check
+func isEndpointConnectionStable(diskMap map[string]StorageAPI, endpoint string, lastCheck time.Time) bool {
 	disk := diskMap[endpoint]
 	if disk == nil {
 		return false
 	}
-	return disk.IsOnline()
+	if !disk.IsOnline() {
+		return false
+	}
+	if disk.LastConn().After(lastCheck) {
+		return false
+	}
+	return true
 }
 
 func (s *erasureSets) getDiskMap() map[string]StorageAPI {
@@ -198,6 +206,10 @@ func findDiskIndex(refFormat, format *formatErasureV3) (int, int, error) {
 // connectDisks - attempt to connect all the endpoints, loads format
 // and re-arranges the disks in proper position.
 func (s *erasureSets) connectDisks() {
+	defer func() {
+		s.lastConnectDisksOpTime = time.Now()
+	}()
+
 	var wg sync.WaitGroup
 	var setsJustConnected = make([]bool, s.setCount)
 	diskMap := s.getDiskMap()
@@ -206,7 +218,7 @@ func (s *erasureSets) connectDisks() {
 		if endpoint.IsLocal {
 			diskPath = endpoint.Path
 		}
-		if isEndpointConnected(diskMap, diskPath) {
+		if isEndpointConnectionStable(diskMap, diskPath, s.lastConnectDisksOpTime) {
 			continue
 		}
 		wg.Add(1)

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"sync"
+	"time"
 )
 
 // naughtyDisk wraps a POSIX disk and returns programmed errors
@@ -52,6 +53,10 @@ func (d *naughtyDisk) IsOnline() bool {
 		return err == errDiskNotFound
 	}
 	return d.disk.IsOnline()
+}
+
+func (d *naughtyDisk) LastConn() time.Time {
+	return d.disk.LastConn()
 }
 
 func (d *naughtyDisk) IsLocal() bool {

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"io"
+	"time"
 )
 
 // StorageAPI interface.
@@ -28,6 +29,8 @@ type StorageAPI interface {
 
 	// Storage operations.
 	IsOnline() bool // Returns true if disk is online.
+	LastConn() time.Time
+
 	IsLocal() bool
 
 	Hostname() string   // Returns host name if remote host.

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -29,6 +29,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/minio/minio/cmd/http"
 	xhttp "github.com/minio/minio/cmd/http"
@@ -142,6 +143,11 @@ func (client *storageRESTClient) String() string {
 // IsOnline - returns whether RPC client failed to connect or not.
 func (client *storageRESTClient) IsOnline() bool {
 	return client.restClient.IsOnline()
+}
+
+// LastConn - returns when the disk is seen to be connected the last time
+func (client *storageRESTClient) LastConn() time.Time {
+	return client.restClient.LastConn()
 }
 
 func (client *storageRESTClient) IsLocal() bool {

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"io"
+	"time"
 )
 
 // Detects change in underlying disk.
@@ -37,6 +38,10 @@ func (p *xlStorageDiskIDCheck) IsOnline() bool {
 		return false
 	}
 	return storedDiskID == p.diskID
+}
+
+func (p *xlStorageDiskIDCheck) LastConn() time.Time {
+	return p.storage.LastConn()
 }
 
 func (p *xlStorageDiskIDCheck) IsLocal() bool {

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -333,6 +333,10 @@ func (s *xlStorage) IsOnline() bool {
 	return true
 }
 
+func (s *xlStorage) LastConn() time.Time {
+	return time.Time{}
+}
+
 func (s *xlStorage) IsLocal() bool {
 	return true
 }


### PR DESCRIPTION
## Description
MRF with deletion does not work when a disk is offline for a short time,
because RPC will automatically reconnect disks and the MRF won't receive
any disk reconnection event.

This PR fixes it.


Signed-off-by: Anis Elleuch <anis@min.io>


## Motivation and Context
Fix MRF

## How to test this PR?
Contact me for a reproducer script

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
