### PR TITLE
svcacct: Fix updating service account and add missing check

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1203,16 +1203,21 @@ func (sys *IAMSys) UpdateServiceAccount(ctx context.Context, accessKey string, o
 		return errNoSuchServiceAccount
 	}
 
-	if !auth.IsSecretKeyValid(opts.secretKey) {
-		return auth.ErrInvalidSecretKeyLength
-	}
-
 	if opts.secretKey != "" {
+		if !auth.IsSecretKeyValid(opts.secretKey) {
+			return auth.ErrInvalidSecretKeyLength
+		}
 		cr.SecretKey = opts.secretKey
 	}
 
-	if opts.status != "" {
+	switch opts.status {
+	// The caller did not ask to update status account, do nothing
+	case "":
+	// Update account status
+	case auth.AccountOn, auth.AccountOff:
 		cr.Status = opts.status
+	default:
+		return errors.New("unknown account status value")
 	}
 
 	if opts.sessionPolicy != nil {


### PR DESCRIPTION
## Description
UpdateServiceAccount ignores updating fields when not passed from upper
layer, such as empty policy, empty account status and empty secret key.

This PR will check for secret key only if it is empty and add more
check on the value of the account status.

Signed-off-by: Anis Elleuch <anis@min.io>

## Motivation and Context
Fix updating service account

## How to test this PR?
1. mc admin user svcacct add myminio/ <root-user>
2. mc admin policy info myminio readwrite >/tmp/readwrite.json
3. mc admin user svcacct set myminio <service-account-key> --policy /tmp/readwrite.json

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
