### PR TITLE
MRF: Better detection of non stable disks

### DIFF
--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"io"
 	"sync"
+	"time"
 )
 
 // naughtyDisk wraps a POSIX disk and returns programmed errors
@@ -53,6 +54,10 @@ func (d *naughtyDisk) IsOnline() bool {
 		return err == errDiskNotFound
 	}
 	return d.disk.IsOnline()
+}
+
+func (d *naughtyDisk) LastConn() time.Time {
+	return d.disk.LastConn()
 }
 
 func (d *naughtyDisk) IsLocal() bool {

--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -75,6 +75,7 @@ func (n *NetworkError) Unwrap() error {
 // Client - http based RPC client.
 type Client struct {
 	connected int32 // ref: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	_         int32 // For 64 bits alignment
 	lastConn  int64
 
 	// HealthCheckFn is the function set to test for health.

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -30,7 +30,7 @@ type StorageAPI interface {
 
 	// Storage operations.
 	IsOnline() bool      // Returns true if disk is online.
-	LastConn() time.Time // Returns the last time of this disk (re)-connection
+	LastConn() time.Time // Returns the last time this disk (re)-connected
 
 	IsLocal() bool
 

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"io"
+	"time"
 )
 
 // StorageAPI interface.
@@ -29,6 +30,8 @@ type StorageAPI interface {
 
 	// Storage operations.
 	IsOnline() bool // Returns true if disk is online.
+	LastConn() time.Time
+
 	IsLocal() bool
 
 	Hostname() string   // Returns host name if remote host.

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -29,8 +29,8 @@ type StorageAPI interface {
 	String() string
 
 	// Storage operations.
-	IsOnline() bool // Returns true if disk is online.
-	LastConn() time.Time
+	IsOnline() bool      // Returns true if disk is online.
+	LastConn() time.Time // Returns the last time of this disk (re)-connection
 
 	IsLocal() bool
 

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -167,6 +167,11 @@ func (client *storageRESTClient) IsOnline() bool {
 	return client.restClient.IsOnline()
 }
 
+// LastConn - returns when the disk is seen to be connected the last time
+func (client *storageRESTClient) LastConn() time.Time {
+	return client.restClient.LastConn()
+}
+
 func (client *storageRESTClient) IsLocal() bool {
 	return false
 }

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -138,6 +138,10 @@ func (p *xlStorageDiskIDCheck) IsOnline() bool {
 	return storedDiskID == p.diskID
 }
 
+func (p *xlStorageDiskIDCheck) LastConn() time.Time {
+	return p.storage.LastConn()
+}
+
 func (p *xlStorageDiskIDCheck) IsLocal() bool {
 	return p.storage.IsLocal()
 }

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -342,6 +342,10 @@ func (s *xlStorage) IsOnline() bool {
 	return true
 }
 
+func (s *xlStorage) LastConn() time.Time {
+	return time.Time{}
+}
+
 func (s *xlStorage) IsLocal() bool {
 	return true
 }


### PR DESCRIPTION
## Description
MRF does not detect when a node is disconnected and reconnected quickly
this change will ensure that MRF is alerted by comparing the last disk
reconnection timestamp with the last MRF check time.

Signed-off-by: Anis Elleuch <anis@min.io>

## Motivation and Context
MRF does not work when there is a short node disconnection

## How to test this PR?
Contact me for a test script

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
