### PR TITLE
fix: do not niladic p.writers upon failure

### DIFF
--- a/cmd/erasure-encode.go
+++ b/cmd/erasure-encode.go
@@ -42,13 +42,18 @@ func (p *parallelWriter) Write(ctx context.Context, blocks [][]byte) error {
 			p.errs[i] = errDiskNotFound
 			continue
 		}
-
+		if p.errs[i] != nil {
+			continue
+		}
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_, p.errs[i] = p.writers[i].Write(blocks[i])
-			if p.errs[i] != nil {
-				p.writers[i] = nil
+			var n int
+			n, p.errs[i] = p.writers[i].Write(blocks[i])
+			if p.errs[i] == nil {
+				if n != len(blocks[i]) {
+					p.errs[i] = io.ErrShortWrite
+				}
 			}
 		}(i)
 	}
@@ -58,12 +63,7 @@ func (p *parallelWriter) Write(ctx context.Context, blocks [][]byte) error {
 	// CreateFile with p.writeQuorum=1 to accommodate healing of single disk.
 	// i.e if we do no return here in such a case, reduceWriteQuorumErrs() would
 	// return a quorum error to HealFile().
-	nilCount := 0
-	for _, err := range p.errs {
-		if err == nil {
-			nilCount++
-		}
-	}
+	nilCount := countErrs(p.errs, nil)
 	if nilCount >= p.writeQuorum {
 		return nil
 	}


### PR DESCRIPTION


## Description
fix: do not niladic p.writers upon failure

## Motivation and Context
p.writers is a verbatim value of bitrotWriter
backed by a pipe() that should never be nil'ed,
instead use the captured errors to skip the writes.

additionally, detect also short writes, and reject
them as errors.

## How to test this PR?
Nothing special test with disks or servers going down for writes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
