### PR TITLE
sse-kms: fix single-part object decryption

### DIFF
--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -375,15 +375,14 @@ func decryptObjectInfo(key []byte, bucket, object string, metadata map[string]st
 // DecryptRequestWithSequenceNumberR - same as
 // DecryptRequestWithSequenceNumber but with a reader
 func DecryptRequestWithSequenceNumberR(client io.Reader, h http.Header, bucket, object string, seqNumber uint32, metadata map[string]string) (io.Reader, error) {
-	if crypto.S3.IsEncrypted(metadata) {
-		return newDecryptReader(client, nil, bucket, object, seqNumber, metadata)
+	if crypto.SSEC.IsEncrypted(metadata) {
+		key, err := ParseSSECustomerHeader(h)
+		if err != nil {
+			return nil, err
+		}
+		return newDecryptReader(client, key, bucket, object, seqNumber, metadata)
 	}
-
-	key, err := ParseSSECustomerHeader(h)
-	if err != nil {
-		return nil, err
-	}
-	return newDecryptReader(client, key, bucket, object, seqNumber, metadata)
+	return newDecryptReader(client, nil, bucket, object, seqNumber, metadata)
 }
 
 // DecryptCopyRequestR - same as DecryptCopyRequest, but with a


### PR DESCRIPTION

## Description
This commit fixes a bug in the single-part object decryption
that is triggered in case of SSE-KMS. Before, it was assumed
that the encryption is either SSE-C or SSE-S3. In case of SSE-KMS
the SSE-C branch was executed. This lead to an invalid SSE-C
algorithm error.

This commit fixes this by inverting the `if-else` logic.
Now, the SSE-C branch only gets executed when SSE-C headers
are present.

## Motivation and Context
SSE-KMS

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
