### PR TITLE
metrics: Add a metric to count failed RPC requests (10-28 branch)

### DIFF
--- a/cmd/rest/client.go
+++ b/cmd/rest/client.go
@@ -40,6 +40,19 @@ const (
 	closed
 )
 
+// Hold the number of failed RPC calls due to networking errors
+var networkErrsCounter uint64
+
+// GetNetworkErrsCounter returns the number of failed RPC requests
+func GetNetworkErrsCounter() uint64 {
+	return atomic.LoadUint64(&networkErrsCounter)
+}
+
+// ResetNetworkErrsCounter resets the number of failed RPC requests
+func ResetNetworkErrsCounter() {
+	atomic.StoreUint64(&networkErrsCounter, 0)
+}
+
 // NetworkError - error type in case of errors related to http/transport
 // for ex. connection refused, connection reset, dns resolution failure etc.
 // All errors returned by storage-rest-server (ex errFileNotFound, errDiskNotFound) are not considered to be network errors.
@@ -118,6 +131,7 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if xnet.IsNetworkOrHostDown(err, c.ExpectTimeouts) {
+			atomic.AddUint64(&networkErrsCounter, 1)
 			c.MarkOffline()
 		}
 		return nil, &NetworkError{err}


### PR DESCRIPTION
## Description
internode_failed_requests helps to see the number of failed internode
requests due to networking issues.

Signed-off-by: Anis Elleuch <anis@min.io>

## Motivation and Context
Having an idea about internode requests issues

## How to test this PR?
Trivial

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
