### PR TITLE
fix: IAM not initialized then checkKeyValid() should return 503s

### DIFF
--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -73,6 +73,8 @@ func prepareAdminErasureTestBed(ctx context.Context) (*adminErasureTestBed, erro
 
 	initAllSubsystems(ctx, objLayer)
 
+	globalIAMSys.InitStore(objLayer)
+
 	// Setup admin mgmt REST API handlers.
 	adminRouter := mux.NewRouter()
 	registerAdminRouter(adminRouter, true, true)

--- a/cmd/auth-handler_test.go
+++ b/cmd/auth-handler_test.go
@@ -357,6 +357,12 @@ func TestIsReqAuthenticated(t *testing.T) {
 		t.Fatalf("unable initialize config file, %s", err)
 	}
 
+	newAllSubsystems()
+
+	initAllSubsystems(context.Background(), objLayer)
+
+	globalIAMSys.InitStore(objLayer)
+
 	creds, err := auth.CreateCredentials("myuser", "mypassword")
 	if err != nil {
 		t.Fatalf("unable create credential, %s", err)
@@ -441,6 +447,12 @@ func TestValidateAdminSignature(t *testing.T) {
 	if err = newTestConfig(globalMinioDefaultRegion, objLayer); err != nil {
 		t.Fatalf("unable initialize config file, %s", err)
 	}
+
+	newAllSubsystems()
+
+	initAllSubsystems(context.Background(), objLayer)
+
+	globalIAMSys.InitStore(objLayer)
 
 	creds, err := auth.CreateCredentials("admin", "mypassword")
 	if err != nil {

--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -121,6 +121,12 @@ func isValidRegion(reqRegion string, confRegion string) bool {
 // check if the access key is valid and recognized, additionally
 // also returns if the access key is owner/admin.
 func checkKeyValid(accessKey string) (auth.Credentials, bool, APIErrorCode) {
+	if !globalIAMSys.Initialized() && !globalIsGateway {
+		// Check if server has initialized, then only proceed
+		// to check for IAM users otherwise its okay for clients
+		// to retry with 503 errors when server is coming up.
+		return auth.Credentials{}, false, ErrServerNotInitialized
+	}
 	var owner = true
 	var cred = globalActiveCred
 	if cred.AccessKey != accessKey {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -352,6 +352,8 @@ func UnstartedTestServer(t TestErrHandler, instanceType string) TestServer {
 
 	initAllSubsystems(ctx, objLayer)
 
+	globalIAMSys.InitStore(objLayer)
+
 	return testServer
 }
 
@@ -1571,6 +1573,8 @@ func newTestObjectLayer(ctx context.Context, endpointServerPools EndpointServerP
 
 	initAllSubsystems(ctx, z)
 
+	globalIAMSys.InitStore(z)
+
 	return z, nil
 }
 
@@ -1616,6 +1620,8 @@ func initAPIHandlerTest(obj ObjectLayer, endpoints []string) (string, http.Handl
 	newAllSubsystems()
 
 	initAllSubsystems(context.Background(), obj)
+
+	globalIAMSys.InitStore(obj)
 
 	// get random bucket name.
 	bucketName := getRandomBucketName()
@@ -1909,6 +1915,8 @@ func ExecObjectLayerTest(t TestErrHandler, objTest objTestType) {
 
 	initAllSubsystems(ctx, objLayer)
 
+	globalIAMSys.InitStore(objLayer)
+
 	// Executing the object layer tests for single node setup.
 	objTest(objLayer, FSTestStr, t)
 
@@ -1927,6 +1935,8 @@ func ExecObjectLayerTest(t TestErrHandler, objTest objTestType) {
 	defer objLayer.Shutdown(context.Background())
 
 	initAllSubsystems(ctx, objLayer)
+
+	globalIAMSys.InitStore(objLayer)
 
 	defer removeRoots(append(fsDirs, fsDir))
 	// Executing the object layer tests for Erasure.


### PR DESCRIPTION


## Description
fix: IAM not initialized then checkKeyValid() should return 503s

## Motivation and Context
currently GetUser() returns 403 when IAM is not initialized
this can lead to applications crashing, instead return 503
so that the applications can retry and backoff.

fixes #12078

## How to test this PR?
Nothing special as such nodes going down and up
should behave by returning 503's instead of 403s

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
