### PR TITLE
add missing wait groups for certain io.Pipe() usage

### DIFF
--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -357,22 +357,28 @@ func (c *cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	}
 
 	// Initialize pipe.
-	pipeReader, pipeWriter := io.Pipe()
-	teeReader := io.TeeReader(bkReader, pipeWriter)
+	pr, pw := io.Pipe()
+	var wg sync.WaitGroup
+	teeReader := io.TeeReader(bkReader, pw)
 	userDefined := getMetadata(bkReader.ObjInfo)
+	wg.Add(1)
 	go func() {
 		_, putErr := dcache.Put(ctx, bucket, object,
-			io.LimitReader(pipeReader, bkReader.ObjInfo.Size),
+			io.LimitReader(pr, bkReader.ObjInfo.Size),
 			bkReader.ObjInfo.Size, rs, ObjectOptions{
 				UserDefined: userDefined,
 			}, false)
-		// close the write end of the pipe, so the error gets
-		// propagated to getObjReader
-		pipeWriter.CloseWithError(putErr)
+		// close the read end of the pipe, so the error gets
+		// propagated to teeReader
+		pr.CloseWithError(putErr)
+		wg.Done()
 	}()
-	cleanupBackend := func() { bkReader.Close() }
-	cleanupPipe := func() { pipeWriter.Close() }
-	return NewGetObjectReaderFromReader(teeReader, bkReader.ObjInfo, opts, cleanupBackend, cleanupPipe)
+	cleanupBackend := func() {
+		bkReader.Close()
+		pw.CloseWithError(nil)
+		wg.Wait()
+	}
+	return NewGetObjectReaderFromReader(teeReader, bkReader.ObjInfo, opts, cleanupBackend)
 }
 
 // Returns ObjectInfo from cache if available.

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -374,8 +374,7 @@ func (c *cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 		wg.Done()
 	}()
 	cleanupBackend := func() {
-		bkReader.Close()
-		pw.CloseWithError(nil)
+		pw.CloseWithError(bkReader.Close())
 		wg.Wait()
 	}
 	return NewGetObjectReaderFromReader(teeReader, bkReader.ObjInfo, opts, cleanupBackend)

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -36,6 +36,7 @@ import (
 	"github.com/minio/minio/pkg/bucket/replication"
 	"github.com/minio/minio/pkg/event"
 	"github.com/minio/minio/pkg/hash"
+	xioutil "github.com/minio/minio/pkg/ioutil"
 	"github.com/minio/minio/pkg/mimedb"
 	"github.com/minio/minio/pkg/sync/errgroup"
 )
@@ -197,14 +198,17 @@ func (er erasureObjects) GetObjectNInfo(ctx context.Context, bucket, object stri
 		return nil, err
 	}
 	unlockOnDefer = false
-	pr, pw := io.Pipe()
+
+	pr, pw := xioutil.WaitPipe()
 	go func() {
 		pw.CloseWithError(er.getObjectWithFileInfo(ctx, bucket, object, off, length, pw, fi, metaArr, onlineDisks))
 	}()
 
 	// Cleanup function to cause the go routine above to exit, in
 	// case of incomplete read.
-	pipeCloser := func() { pr.Close() }
+	pipeCloser := func() {
+		pr.CloseWithError(nil)
+	}
 
 	return fn(pr, h, opts.CheckPrecondFn, pipeCloser, nsUnlocker)
 }
@@ -1359,17 +1363,18 @@ func (er erasureObjects) TransitionObject(ctx context.Context, bucket, object st
 		return err
 	}
 
-	pr, pw := io.Pipe()
+	pr, pw := xioutil.WaitPipe()
 	go func() {
 		err := er.getObjectWithFileInfo(ctx, bucket, object, 0, fi.Size, pw, fi, metaArr, onlineDisks)
 		pw.CloseWithError(err)
 	}()
-	if err = tgtClient.Put(ctx, destObj, pr, fi.Size); err != nil {
-		pr.Close()
+
+	err = tgtClient.Put(ctx, destObj, pr, fi.Size)
+	pr.CloseWithError(err)
+	if err != nil {
 		logger.LogIf(ctx, fmt.Errorf("Unable to transition %s/%s(%s) to %s tier: %w", bucket, object, opts.VersionID, opts.Transition.Tier, err))
 		return err
 	}
-	pr.Close()
 	fi.TransitionStatus = lifecycle.TransitionComplete
 	fi.TransitionedObjName = destObj
 	fi.TransitionTier = opts.Transition.Tier

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -909,9 +909,9 @@ func CleanMinioInternalMetadataKeys(metadata map[string]string) map[string]strin
 // client closed the stream prematurely.
 func newS2CompressReader(r io.Reader, on int64) io.ReadCloser {
 	pr, pw := io.Pipe()
-	comp := s2.NewWriter(pw)
 	// Copy input to compressor
 	go func() {
+		comp := s2.NewWriter(pw)
 		cn, err := io.Copy(comp, r)
 		if err != nil {
 			comp.Close()
@@ -926,12 +926,7 @@ func newS2CompressReader(r io.Reader, on int64) io.ReadCloser {
 			return
 		}
 		// Close the stream.
-		if err = comp.Close(); err != nil {
-			pw.CloseWithError(err)
-			return
-		}
-		// Everything ok, do regular close.
-		pw.Close()
+		pw.CloseWithError(comp.Close())
 	}()
 	return pr
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -208,11 +208,10 @@ func (client *storageRESTClient) NSScanner(ctx context.Context, cache dataUsageC
 	}()
 	respBody, err := client.call(ctx, storageRESTMethodNSScanner, url.Values{}, pr, -1)
 	defer xhttp.DrainBody(respBody)
+	pr.CloseWithError(err)
 	if err != nil {
-		pr.Close()
 		return cache, err
 	}
-	pr.Close()
 
 	var newCache dataUsageCache
 	pr, pw = io.Pipe()

--- a/pkg/ioutil/wait_pipe.go
+++ b/pkg/ioutil/wait_pipe.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Forked from golang.org/pkg/os.ReadFile with NOATIME support.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the https://golang.org/LICENSE file.
+
+package ioutil
+
+import (
+	"io"
+	"sync"
+)
+
+// PipeWriter is similar to io.PipeWriter with wait group
+type PipeWriter struct {
+	*io.PipeWriter
+	done func()
+}
+
+// CloseWithError close with supplied error the writer end.
+func (w *PipeWriter) CloseWithError(err error) error {
+	err = w.PipeWriter.CloseWithError(err)
+	w.done()
+	return err
+}
+
+// PipeReader is similar to io.PipeReader with wait group
+type PipeReader struct {
+	*io.PipeReader
+	wait func()
+}
+
+// CloseWithError close with supplied error the reader end
+func (r *PipeReader) CloseWithError(err error) error {
+	err = r.PipeReader.CloseWithError(err)
+	r.wait()
+	return err
+}
+
+// WaitPipe implements wait-group backend io.Pipe to provide
+// synchronization between read() end with write() end.
+func WaitPipe() (*PipeReader, *PipeWriter) {
+	r, w := io.Pipe()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	return &PipeReader{
+			PipeReader: r,
+			wait:       wg.Wait,
+		}, &PipeWriter{
+			PipeWriter: w,
+			done:       wg.Done,
+		}
+}


### PR DESCRIPTION


## Description
add missing wait groups for certain io.Pipe() usage

## Motivation and Context
wait groups are necessary with io.Pipes() to avoid
races when a blocking function may not be expected
and a Write() -> Close() before Read() races on each
other. We should avoid such situations.

## How to test this PR?
Nothing special this is just a code-review fix

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
