### PR TITLE
config: enforce AES-GCM in FIPS mode

### DIFF
--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -173,7 +173,7 @@ func NewServer(addrs []string, handler http.Handler, getCert certs.GetCertificat
 			NextProtos:               []string{"http/1.1", "h2"},
 			GetCertificate:           getCert,
 		}
-		if secureCiphers || fips.Enabled() {
+		if secureCiphers || fips.Enabled {
 			tlsConfig.CipherSuites = fips.CipherSuitesTLS()
 			tlsConfig.CurvePreferences = fips.EllipticCurvesTLS()
 		}

--- a/pkg/fips/api.go
+++ b/pkg/fips/api.go
@@ -34,14 +34,13 @@ package fips
 
 import "crypto/tls"
 
-// Enabled returns true if and only if FIPS 140-2 support
-// is enabled.
+// Enabled indicates whether cryptographic primitives,
+// like AES or SHA-256, are implemented using a FIPS 140
+// certified module.
 //
-// FIPS 140-2 requires that only specifc cryptographic
-// primitives, like AES or SHA-256, are used and that
-// those primitives are implemented by a FIPS 140-2
-// certified cryptographic module.
-func Enabled() bool { return enabled }
+// If FIPS-140 is enabled no non-NIST/FIPS approved
+// primitives must be used.
+const Enabled = enabled
 
 // CipherSuitesDARE returns the supported cipher suites
 // for the DARE object encryption.

--- a/pkg/fips/fips.go
+++ b/pkg/fips/fips.go
@@ -1,5 +1,3 @@
-// +build fips
-
 // Copyright (c) 2015-2021 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
@@ -17,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// +build fips,linux,amd64
+
 package fips
 
 import (
@@ -25,7 +25,7 @@ import (
 	"github.com/minio/sio"
 )
 
-var enabled = true
+const enabled = true
 
 func cipherSuitesDARE() []byte {
 	return []byte{sio.AES_256_GCM}

--- a/pkg/fips/no_fips.go
+++ b/pkg/fips/no_fips.go
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// +build !fips
+
 package fips
 
 import (
@@ -23,7 +25,7 @@ import (
 	"github.com/minio/sio"
 )
 
-var enabled = false
+const enabled = false
 
 func cipherSuitesDARE() []byte {
 	return []byte{sio.AES_256_GCM, sio.CHACHA20_POLY1305}


### PR DESCRIPTION
## Description
This commit enforces the usage of AES-256
for config and IAM data en/decryption in FIPS
mode.

Further, it improves the implementation of
`fips.Enabled` by making it a compile time
constant. Now, the compiler is able to evaluate
the any `if fips.Enabled { ... }` at compile time
and eliminate unused code.


## Motivation and Context
FIPS, IAM/config

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
