### PR TITLE
fix range header to download empty file in s3

### DIFF
--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -800,6 +800,11 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, opts ObjectOptions, cl
 			return r, nil
 		}
 	}
+	
+	if oi.Size == 0 {
+		return fn, off, -1, nil
+	}
+	
 	return fn, off, length, nil
 }
 


### PR DESCRIPTION
## Description
gateway s3 will set range header even if get file with 0kb.
`
Range:bytes=-1
`
cause the 416 Requested Range Not Satisfiable err.

I'm not sure it's correct to fix here,so you can open a new PR and close this.

## Motivation and Context
downlaod 0kb file in s3 backend

## How to test this PR?
1.run minio with gateway s3
2.put file with 0kb
3.get file returns 200 ok.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
