### PR TITLE
do not return error for usage-cache version v4

### DIFF
--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -798,7 +798,7 @@ func (d *dataUsageCache) deserialize(r io.Reader) error {
 	if n != 1 {
 		return io.ErrUnexpectedEOF
 	}
-	ver := b[0]
+	ver := int(b[0])
 	switch ver {
 	case dataUsageCacheVerV1:
 		return errors.New("cache version deprecated (will autoupdate)")
@@ -900,6 +900,7 @@ func (d *dataUsageCache) deserialize(r io.Reader) error {
 
 			d.Cache[k] = e
 		}
+		return nil
 	case dataUsageCacheVerCurrent:
 		// Zstd compressed.
 		dec, err := zstd.NewReader(r, zstd.WithDecoderConcurrency(2))
@@ -908,8 +909,9 @@ func (d *dataUsageCache) deserialize(r io.Reader) error {
 		}
 		defer dec.Close()
 		return d.DecodeMsg(msgp.NewReader(dec))
+	default:
+		return fmt.Errorf("dataUsageCache: unknown version: %d", ver)
 	}
-	return fmt.Errorf("dataUsageCache: unknown version: %d", int(ver))
 }
 
 // Trim this from start+end of hashes.


### PR DESCRIPTION
## Description
do not return an error for usage-cache version v4

## Motivation and Context
usage-cache version v4 is supported, so make sure
switch case handles it.

## How to test this PR?
upgrade from the latest release to master

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
