### PR TITLE
fix the dashboard to use $rate_interval

### DIFF
--- a/docs/metrics/prometheus/grafana/minio-overview.json
+++ b/docs/metrics/prometheus/grafana/minio-overview.json
@@ -1834,7 +1834,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(minio_node_process_cpu_total_seconds[$__interval])",
+          "expr": "rate(minio_node_process_cpu_total_seconds[$__rate_interval])",
           "interval": "",
           "legendFormat": "CPU Usage Rate [{{server}}]",
           "refId": "A"
@@ -2445,7 +2445,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(minio_node_io_rchar_bytes[$__interval])",
+          "expr": "rate(minio_node_io_rchar_bytes[$__rate_interval])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2454,7 +2454,7 @@
         },
         {
           "exemplar": true,
-          "expr": "rate(minio_node_io_wchar_bytes[$__interval])",
+          "expr": "rate(minio_node_io_wchar_bytes[$__rate_interval])",
           "interval": "",
           "legendFormat": "Node WChar [{{server}}]",
           "refId": "B"
@@ -2544,5 +2544,5 @@
   "timezone": "",
   "title": "MinIO Overview",
   "uid": "pJnnS4hZz",
-  "version": 37
+  "version": 4
 }


### PR DESCRIPTION
## Description
Update the Grafana dashboard to use correct interval
variable.

## Motivation and Context
Refer https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/
for further information

## How to test this PR?
Setup MinIO + Prometheus + Grafana and observe rate() based metrics.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
