### PR TITLE
Fix link in README.md

### DIFF
--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -185,6 +185,6 @@ remote replication target using the `mc admin bucket remote add` command
 ```
 
 ## Explore Further
-- [MinIO Bucket Replication Design](https://raw.githubusercontent.com/minio/minio/master/docs/bucket/replication/DESIGN.md)
+- [MinIO Bucket Replication Design](https://github.com/minio/minio/blob/master/docs/bucket/replication/DESIGN.md)
 - [MinIO Bucket Versioning Implementation](https://docs.minio.io/docs/minio-bucket-versioning-guide.html)
 - [MinIO Client Quickstart Guide](https://docs.minio.io/docs/minio-client-quickstart-guide.html)


### PR DESCRIPTION
The link to `MinIO Bucket Replication Design` was using the raw view of the document which is hard to read. I have changed it to the user-friendly HTML view generated by GitHub for markdown files.