### PR TITLE
kms: KES client should return non-nil error when GenerateKey fails

### DIFF
--- a/pkg/kms/kes.go
+++ b/pkg/kms/kes.go
@@ -115,7 +115,7 @@ func (c *kesClient) GenerateKey(keyID string, ctx Context) (DEK, error) {
 	}
 	dek, err := c.client.GenerateKey(context.Background(), keyID, ctxBytes)
 	if err != nil {
-		return DEK{}, nil
+		return DEK{}, err
 	}
 	return DEK{
 		KeyID:      keyID,


### PR DESCRIPTION

## Description
This commit fixes a bug in the KMS KES client integration.
The client should return a non-nil error when the key generation
fails.

## Motivation and Context
KMS, KES

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
