### PR TITLE
feat: distributed setup can start now with default credentials

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -245,14 +245,7 @@ func handleCommonCmdArgs(ctx *cli.Context) {
 }
 
 func handleCommonEnvVars() {
-	wormEnabled, err := config.LookupWorm()
-	if err != nil {
-		logger.Fatal(config.ErrInvalidWormValue(err), "Invalid worm configuration")
-	}
-	if wormEnabled {
-		logger.Fatal(errors.New("WORM is deprecated"), "global MINIO_WORM support is removed, please downgrade your server or migrate to https://github.com/minio/minio/tree/master/docs/retention")
-	}
-
+	var err error
 	globalBrowserEnabled, err = config.ParseBool(env.Get(config.EnvBrowser, config.EnableOn))
 	if err != nil {
 		logger.Fatal(config.ErrInvalidBrowserValue(err), "Invalid MINIO_BROWSER value in environment variable")

--- a/cmd/config/errors.go
+++ b/cmd/config/errors.go
@@ -127,12 +127,6 @@ var (
 		`Detected encrypted config backend, correct access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD to be able to decrypt the MinIO config, user IAM and policies`,
 	)
 
-	ErrMissingCredentialsBackendEncrypted = newErrFn(
-		"Credentials missing",
-		"Please set your credentials in the environment",
-		`Detected encrypted config backend, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD to be able to decrypt the MinIO config, user IAM and policies`,
-	)
-
 	ErrInvalidCredentials = newErrFn(
 		"Invalid credentials",
 		"Please provide correct credentials",
@@ -143,12 +137,6 @@ var (
 		"Credentials missing",
 		"Please set your credentials in the environment",
 		`In Gateway mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
-	)
-
-	ErrEnvCredentialsMissingDistributed = newErrFn(
-		"Credentials missing",
-		"Please set your credentials in the environment",
-		`In distributed server mode, access and secret keys should be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively`,
 	)
 
 	ErrInvalidErasureEndpoints = newErrFn(

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -473,8 +473,7 @@ func serverMain(ctx *cli.Context) {
 	}
 
 	if !globalActiveCred.IsValid() && globalIsDistErasure {
-		logger.Fatal(config.ErrEnvCredentialsMissingDistributed(nil),
-			"Unable to initialize the server in distributed mode")
+		globalActiveCred = auth.DefaultCredentials
 	}
 
 	// Set system resources to maximum.
@@ -570,7 +569,7 @@ func serverMain(ctx *cli.Context) {
 	printStartupMessage(getAPIEndpoints(), err)
 
 	if globalActiveCred.Equal(auth.DefaultCredentials) {
-		msg := fmt.Sprintf("Detected default credentials '%s', please change the credentials immediately using 'MINIO_ROOT_USER' and 'MINIO_ROOT_PASSWORD'", globalActiveCred)
+		msg := fmt.Sprintf("Detected default credentials '%s', please change the credentials immediately by setting 'MINIO_ROOT_USER' and 'MINIO_ROOT_PASSWORD' environment values", globalActiveCred)
 		logger.StartupMessage(color.RedBold(msg))
 	}
 

--- a/docs/distributed/README.md
+++ b/docs/distributed/README.md
@@ -38,7 +38,7 @@ To start a distributed MinIO instance, you just need to pass drive locations as 
 
 __NOTE:__
 
-- All the nodes running distributed MinIO need to have same access key and secret key for the nodes to connect. To achieve this, it is __recommended__ to export access key and secret key as environment variables, `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`, on all the nodes before executing MinIO server command.
+- All the nodes running distributed MinIO should share a common root credentials, for the nodes to connect and trust each other. To achieve this, it is __recommended__ to export root user and root password as environment variables, `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`, on all the nodes before executing MinIO server command. If not exported, default `minioadmin/minioadmin` credentials shall be used.
 - __MinIO creates erasure-coding sets of *4* to *16* drives per set.  The number of drives you provide in total must be a multiple of one of those numbers.__
 - __MinIO chooses the largest EC set size which divides into the total number of drives or total number of nodes given - making sure to keep the uniform distribution i.e each node participates equal number of drives per set__.
 - __Each object is written to a single EC set, and therefore is spread over no more than 16 drives.__

--- a/docs/multi-tenancy/README.md
+++ b/docs/multi-tenancy/README.md
@@ -60,7 +60,7 @@ minio server --address :9003 http://192.168.10.1{1...4}/data/tenant3
 
 ![Example-3](https://github.com/minio/minio/blob/master/docs/screenshots/Example-3.jpg?raw=true)
 
-**Note**: On distributed systems, credentials must be defined and exported using the `MINIO_ROOT_USER` and  `MINIO_ROOT_PASSWORD` environment variables. If a domain is required, it must be specified by defining and exporting the `MINIO_DOMAIN` environment variable.
+**Note**: On distributed systems, root credentials are recommend to be defined by exporting the `MINIO_ROOT_USER` and  `MINIO_ROOT_PASSWORD` environment variables. If no value is set MinIO setup will assume `minioadmin/minioadmin` as default credentials. If a domain is required, it must be specified by defining and exporting the `MINIO_DOMAIN` environment variable.
 
 ## <a name="cloud-scale-deployment"></a>Cloud Scale Deployment
 


### PR DESCRIPTION
## Description
feat: distributed setup can start now with default credentials

## Motivation and Context
In lieu of new changes coming for server command line, this
change is to deprecate strict requirement for distributed setups
to provide root credentials.
    
Bonus: remove MINIO_WORM warning from April 2020, it is time to
remove this warning.

## How to test this PR?
Nothing special just the following distributed setup should run fine without explicit credentials.
```
#!/usr/bin/env bash

unset MINIO_KMS_KES_CERT_FILE
unset MINIO_KMS_KES_KEY_FILE
unset MINIO_KMS_KES_ENDPOINT
unset MINIO_KMS_KES_KEY_NAME
unset MINIO_KMS_AUTO_ENCRYPTION
unset MINIO_ACCESS_KEY
unset MINIO_SECRET_KEY
unset MINIO_ROOT_USER
unset MINIO_ROOT_PASSWORD

export MINIO_ERASURE_SET_DRIVE_COUNT=6
export MINIO_PROMETHEUS_AUTH_TYPE=public
export MINIO_ENDPOINTS="http://127.0.0.1:9001/home/harsha/disk01 http://127.0.0.1:9002/home/harsha/disk02 http://127.0.0.1:9003/home/harsha/disk03 http://127.0.0.1:9004/home/harsha/disk04 http://127.0.0.1:9001/home/harsha/disk05 http://127.0.0.1:9002/home/harsha/disk06 http://127.0.0.1:9003/home/harsha/disk07 http://127.0.0.1:9004/home/harsha/disk08 http://127.0.0.1:9001/home/harsha/disk09 http://127.0.0.1:9002/home/harsha/disk10 http://127.0.0.1:9003/home/harsha/disk11 http://127.0.0.1:9004/home/harsha/disk12"
export MINIO_SCANNER_CYCLE=10s
for i in {01..04}; do
    /home/harsha/mygo/src/github.com/minio/minio/minio server --address ":90${i}" &
done
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
