### PR TITLE
add io.ErrUnexpectedEOF for config retriable errors

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"os"
@@ -264,6 +265,7 @@ func configRetriableErrors(err error) bool {
 		errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, errErasureWriteQuorum) ||
 		errors.Is(err, errErasureReadQuorum) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.As(err, &rquorum) ||
 		errors.As(err, &wquorum) ||
 		isErrBucketNotFound(err) ||


### PR DESCRIPTION
## Description
add io.ErrUnexpectedEOF for config retriable errors

## Motivation and Context
unexpected EOF might be sent from lower layers

## How to test this PR?
Upgrade from older to newer binary in rolling fashion

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
