### PR TITLE
reduce allocations on multi-disk clusters

### DIFF
--- a/cmd/bitrot.go
+++ b/cmd/bitrot.go
@@ -164,7 +164,6 @@ func bitrotVerify(r io.Reader, wantSize, partSize int64, algo BitrotAlgorithm, w
 
 	h := algo.New()
 	hashBuf := make([]byte, h.Size())
-	buf := make([]byte, shardSize)
 	left := wantSize
 
 	// Calculate the size of the bitrot file and compare
@@ -172,6 +171,9 @@ func bitrotVerify(r io.Reader, wantSize, partSize int64, algo BitrotAlgorithm, w
 	if left != bitrotShardFileSize(partSize, shardSize, algo) {
 		return errFileCorrupt
 	}
+
+	bufp := xlPoolSmall.Get().(*[]byte)
+	defer xlPoolSmall.Put(bufp)
 
 	for left > 0 {
 		// Read expected hash...
@@ -186,13 +188,15 @@ func bitrotVerify(r io.Reader, wantSize, partSize int64, algo BitrotAlgorithm, w
 		if left < shardSize {
 			shardSize = left
 		}
-		read, err := io.CopyBuffer(h, io.LimitReader(r, shardSize), buf)
+
+		read, err := io.CopyBuffer(h, io.LimitReader(r, shardSize), *bufp)
 		if err != nil {
 			// Read's failed for object with right size, at different offsets.
-			return err
+			return errFileCorrupt
 		}
+
 		left -= read
-		if !bytes.Equal(h.Sum(nil), hashBuf) {
+		if !bytes.Equal(h.Sum(nil), hashBuf[:n]) {
 			return errFileCorrupt
 		}
 	}

--- a/cmd/erasure-healing-common.go
+++ b/cmd/erasure-healing-common.go
@@ -261,7 +261,7 @@ func disksWithAllParts(ctx context.Context, onlineDisks []StorageAPI, partsMetad
 		// Always check data, if we got it.
 		if (len(meta.Data) > 0 || meta.Size == 0) && len(meta.Parts) > 0 {
 			checksumInfo := meta.Erasure.GetChecksumInfo(meta.Parts[0].Number)
-			dataErrs[i] = bitrotVerify(bytes.NewBuffer(meta.Data),
+			dataErrs[i] = bitrotVerify(bytes.NewReader(meta.Data),
 				int64(len(meta.Data)),
 				meta.Erasure.ShardFileSize(meta.Size),
 				checksumInfo.Algorithm,


### PR DESCRIPTION
## Description
reduce allocations on multi-disk clusters

## Motivation and Context
multi-disk clusters initialize buffer pools
per disk, this is perhaps expensive and perhaps
not useful, for a running server instance. As this
may disallow re-use of buffers across sets,

this change ensures that buffers across sets
can be re-used at the drive level, this can reduce
quite a lot of memory on large drive setups.
reduce allocations in bitrotVerify

## How to test this PR?
Refer #12292 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
