### PR TITLE
fix: use key.Ciphertext for DecryptKey in KeyStatus

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1304,6 +1304,7 @@ func (a adminAPIHandlers) KMSKeyStatusHandler(w http.ResponseWriter, r *http.Req
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrKMSNotConfigured), r.URL)
 		return
 	}
+
 	stat, err := GlobalKMS.Stat()
 	if err != nil {
 		writeCustomErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrInternalError), err.Error(), r.URL)
@@ -1333,7 +1334,7 @@ func (a adminAPIHandlers) KMSKeyStatusHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	// 2. Verify that we can indeed decrypt the (encrypted) key
-	decryptedKey, err := GlobalKMS.DecryptKey(key.KeyID, key.Plaintext, kmsContext)
+	decryptedKey, err := GlobalKMS.DecryptKey(key.KeyID, key.Ciphertext, kmsContext)
 	if err != nil {
 		response.DecryptionErr = err.Error()
 		resp, err := json.Marshal(response)
@@ -1798,10 +1799,6 @@ func fetchKMSStatus() madmin.KMS {
 	}
 	if len(stat.Endpoints) == 0 {
 		kmsStat.Status = stat.Name
-		return kmsStat
-	}
-	if err := checkConnection(stat.Endpoints[0], 15*time.Second); err != nil {
-		kmsStat.Status = string(madmin.ItemOffline)
 		return kmsStat
 	}
 	kmsStat.Status = string(madmin.ItemOnline)

--- a/pkg/kms/kes.go
+++ b/pkg/kms/kes.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"time"
 
 	"github.com/minio/kes"
 )
@@ -79,6 +80,11 @@ var _ KMS = (*kesClient)(nil) // compiler check
 // Stat returns the current KES status containing a
 // list of KES endpoints and the default key ID.
 func (c *kesClient) Stat() (Status, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := c.client.Version(ctx); err != nil {
+		return Status{}, err
+	}
 	var endpoints = make([]string, len(c.client.Endpoints))
 	copy(endpoints, c.client.Endpoints)
 	return Status{


### PR DESCRIPTION


## Description
fix: use key.Ciphertext for DecryptKey in KeyStatus

## Motivation and Context
enhance GlobalKMS.Stat() for kes to actually perform
a network call to check Version() of kes and also
implicitly that it's reachable.

## How to test this PR?
Using `mc admin kms key status` - Decryption part was failing, 
also enhance Stat() to actually verify if KES is reachable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes this bug was introduced in the recent KMS refactor
- [ ] Documentation updated
- [ ] Unit tests added/updated
