### PR TITLE
fix: generating service accounts for group only LDAP accounts

### DIFF
--- a/cmd/config-encrypted.go
+++ b/cmd/config-encrypted.go
@@ -28,7 +28,6 @@ import (
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/cmd/config"
 	"github.com/minio/minio/cmd/logger"
-	"github.com/minio/minio/pkg/auth"
 	"github.com/minio/minio/pkg/kms"
 	etcd "go.etcd.io/etcd/clientv3"
 )
@@ -62,23 +61,6 @@ func checkBackendEncrypted(objAPI ObjectLayer) (bool, error) {
 		return false, err
 	}
 	return err == nil && bytes.Equal(data, backendEncryptedMigrationComplete), nil
-}
-
-// decryptData - decrypts input data with more that one credentials,
-func decryptData(edata []byte, creds ...auth.Credentials) ([]byte, error) {
-	var err error
-	var data []byte
-	for _, cred := range creds {
-		data, err = madmin.DecryptData(cred.String(), bytes.NewReader(edata))
-		if err != nil {
-			if err == madmin.ErrMaliciousData {
-				continue
-			}
-			return nil, err
-		}
-		break
-	}
-	return data, err
 }
 
 func migrateIAMConfigsEtcdToEncrypted(ctx context.Context, client *etcd.Client) error {
@@ -115,7 +97,7 @@ func migrateIAMConfigsEtcdToEncrypted(ctx context.Context, client *etcd.Client) 
 		}
 
 		if !utf8.Valid(data) {
-			data, err = decryptData(data, globalActiveCred)
+			data, err = madmin.DecryptData(globalActiveCred.String(), bytes.NewReader(data))
 			if err != nil {
 				return fmt.Errorf("Decrypting config failed %w, possibly credentials are incorrect", err)
 			}
@@ -170,7 +152,7 @@ func migrateConfigPrefixToEncrypted(objAPI ObjectLayer, encrypted bool) error {
 			}
 
 			if !utf8.Valid(data) {
-				data, err = decryptData(data, globalActiveCred)
+				data, err = madmin.DecryptData(globalActiveCred.String(), bytes.NewReader(data))
 				if err != nil {
 					return fmt.Errorf("Decrypting config failed %w, possibly credentials are incorrect", err)
 				}

--- a/cmd/config-encrypted_test.go
+++ b/cmd/config-encrypted_test.go
@@ -49,17 +49,17 @@ func TestDecryptData(t *testing.T) {
 
 	tests := []struct {
 		edata   []byte
-		creds   []auth.Credentials
+		cred    auth.Credentials
 		success bool
 	}{
-		{edata1, []auth.Credentials{cred1, cred2}, true},
-		{edata2, []auth.Credentials{cred1, cred2}, true},
-		{data, []auth.Credentials{cred1, cred2}, false},
+		{edata1, cred1, true},
+		{edata2, cred2, true},
+		{data, cred1, false},
 	}
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			ddata, err := decryptData(test.edata, test.creds...)
+			ddata, err := madmin.DecryptData(test.cred.String(), bytes.NewReader(test.edata))
 			if err != nil && test.success {
 				t.Errorf("Expected success, saw failure %v", err)
 			}

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1135,6 +1135,13 @@ func (sys *IAMSys) NewServiceAccount(ctx context.Context, parentUser string, gro
 	if err != nil {
 		return auth.Credentials{}, err
 	}
+	for _, group := range groups {
+		gpolicies, err := sys.policyDBGet(group, true)
+		if err != nil && err != errNoSuchGroup {
+			return auth.Credentials{}, err
+		}
+		policies = append(policies, gpolicies...)
+	}
 	if len(policies) == 0 {
 		return auth.Credentials{}, errNoSuchUser
 	}
@@ -1896,6 +1903,9 @@ func (sys *IAMSys) policyDBGet(name string, isGroup bool) (policies []string, er
 	var parentName string
 	u, ok := sys.iamUsersMap[name]
 	if ok {
+		if !u.IsValid() {
+			return nil, nil
+		}
 		parentName = u.ParentUser
 	}
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -545,6 +545,8 @@ func serverMain(ctx *cli.Context) {
 		if errors.Is(err, context.Canceled) {
 			logger.FatalIf(err, "Server startup canceled upon user request")
 		}
+
+		logger.LogIf(GlobalContext, err)
 	}
 
 	if globalIsErasure { // to be done after config init

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -236,7 +236,7 @@ $ export MINIO_ROOT_PASSWORD=minio123
 $ export MINIO_IDENTITY_LDAP_SERVER_ADDR='my.ldap-active-dir-server.com:636'
 $ export MINIO_IDENTITY_LDAP_USERNAME_FORMAT='cn=%s,ou=Users,ou=BUS1,ou=LOB,dc=somedomain,dc=com;cn=%s,ou=Users,ou=BUS2,ou=LOB,dc=somedomain,dc=com'
 $ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN='dc=minioad,dc=local;dc=somedomain,dc=com'
-$ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER='(&(objectclass=group)(member=%s))'
+$ export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER='(&(objectclass=groupOfNames)(member=%d))'
 $ minio server ~/test
 ```
 You can make sure it works appropriately using our [example program](https://raw.githubusercontent.com/minio/minio/master/docs/sts/ldap.go):


### PR DESCRIPTION
## Description
fix: generating service accounts for group only LDAP accounts

## Motivation and Context
fixes #12315

## How to test this PR?
Use the following LDIF file https://raw.githubusercontent.com/donatello/minio-ldap-testing/main/bootstrap.ldif and start MinIO 

```
MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN='cn=admin,dc=min,dc=io'
MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN=ou=hwengg,dc=min,dc=io;ou=swengg,dc=min,dc=io
MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD=admin
MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER=(&(objectclass=groupOfNames)(member=%d))
MINIO_IDENTITY_LDAP_SERVER_ADDR=localhost:389
MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN=dc=min,dc=io
MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER=(uid=%s)
MINIO_IDENTITY_LDAP_SERVER_INSECURE=on
MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN=cn=admin,dc=min,dc=io
```

Start LDAP service
```
docker run --rm  -p 389:389 -p 636:636 --name minio-ldap-server   --env LDAP_ORGANISATION="MinIO Inc"   --env LDAP_DOMAIN="min.io"   --env LDAP_ADMIN_PASSWORD="admin" --volume $PWD/bootstrap.ldif:/container/service/slapd/assets/config/bootstrap/ldif/50-bootstrap.ldif   --hostname minio-ldap-server osixia/openldap:1.4.0 --copy-service
```

Then proceed to `console` and log in.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
