### PR TITLE
Simplify remote tier validation in lifecycle rule validation

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1814,6 +1814,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrAdminInvalidAccessKey
 	case auth.ErrInvalidSecretKeyLength:
 		apiErr = ErrAdminInvalidSecretKey
+	case errInvalidStorageClass:
+		apiErr = ErrInvalidStorageClass
 	// SSE errors
 	case errInvalidEncryptionParameters:
 		apiErr = ErrInvalidEncryptionParameters

--- a/cmd/bucket-lifecycle-handlers.go
+++ b/cmd/bucket-lifecycle-handlers.go
@@ -80,7 +80,7 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 	}
 
 	// Validate the transition storage ARNs
-	if err = validateLifecycleTransition(ctx, bucket, bucketLifecycle); err != nil {
+	if err = validateTransitionTier(ctx, bucketLifecycle); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}

--- a/pkg/bucket/lifecycle/transition.go
+++ b/pkg/bucket/lifecycle/transition.go
@@ -129,7 +129,7 @@ func (t *Transition) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement)
 	return nil
 }
 
-// Validate - validates the "Expiration" element
+// Validate - validates the "Transition" element
 func (t Transition) Validate() error {
 	if !t.set {
 		return nil


### PR DESCRIPTION
## Description
Simplify storage class validation as part of bucket lifecycle document validation in PUT bucket lifecycle configuration API.

## Motivation and Context
Currently, MinIO checks remote tier access as part of storage class validation. This is unnecessary since this check is (already) performed at the time of adding a tier.

## How to test this PR?
1. Add a bucket
2. Try to configure bucket lifecycle for a bucket with a non-existent storage-class.
3. Should receive the following error,
```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidStorageClass</Code><Message>Invalid storage class.</Message><BucketName>mybucket</BucketName><Resource>/mybucket/</Resource><RequestId>1680933ADE609036</RequestId><HostId>8c07f841-d583-4761-a879-d08e6852d243</HostId></Error>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
