### PR TITLE
fix: migrate users properly from older releases to newer

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -149,7 +149,6 @@ func runDataScanner(pctx context.Context, objAPI ObjectLayer) {
 			bf, err := globalNotificationSys.updateBloomFilter(ctx, nextBloomCycle)
 			logger.LogIf(ctx, err)
 			err = objAPI.NSScanner(ctx, bf, results)
-			close(results)
 			logger.LogIf(ctx, err)
 			if err == nil {
 				// Store new cycle...

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -408,6 +408,9 @@ func (z *erasureServerPools) StorageInfo(ctx context.Context) (StorageInfo, []er
 }
 
 func (z *erasureServerPools) NSScanner(ctx context.Context, bf *bloomFilter, updates chan<- madmin.DataUsageInfo) error {
+	// Updates must be closed before we return.
+	defer close(updates)
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION

## Description
fix: migrate users properly from older releases to newer

## Motivation and Context
Bonus: stream saved lists directly to decode in listObjects
instead of using bytes.Buffer, as it can lead to memory usage
as well as high latency on servers.

## How to test this PR?
Migrate users from 2019 release to latest master and release will fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
