### PR TITLE
fix: return error for unexpected quorum in pickValidFileInfo

### DIFF
--- a/cmd/erasure-metadata_test.go
+++ b/cmd/erasure-metadata_test.go
@@ -176,29 +176,39 @@ func TestFindFileInfoInQuorum(t *testing.T) {
 	}
 
 	tests := []struct {
-		fis         []FileInfo
-		modTime     time.Time
-		dataDir     string
-		expectedErr error
+		fis            []FileInfo
+		modTime        time.Time
+		dataDir        string
+		expectedErr    error
+		expectedQuorum int
 	}{
 		{
-			fis:         getNFInfo(16, 16, 1603863445, "36a21454-a2ca-11eb-bbaa-93a81c686f21"),
-			modTime:     time.Unix(1603863445, 0),
-			dataDir:     "36a21454-a2ca-11eb-bbaa-93a81c686f21",
-			expectedErr: nil,
+			fis:            getNFInfo(16, 16, 1603863445, "36a21454-a2ca-11eb-bbaa-93a81c686f21"),
+			modTime:        time.Unix(1603863445, 0),
+			dataDir:        "36a21454-a2ca-11eb-bbaa-93a81c686f21",
+			expectedErr:    nil,
+			expectedQuorum: 8,
 		},
 		{
-			fis:         getNFInfo(16, 7, 1603863445, "36a21454-a2ca-11eb-bbaa-93a81c686f21"),
-			modTime:     time.Unix(1603863445, 0),
-			dataDir:     "36a21454-a2ca-11eb-bbaa-93a81c686f21",
-			expectedErr: errErasureReadQuorum,
+			fis:            getNFInfo(16, 7, 1603863445, "36a21454-a2ca-11eb-bbaa-93a81c686f21"),
+			modTime:        time.Unix(1603863445, 0),
+			dataDir:        "36a21454-a2ca-11eb-bbaa-93a81c686f21",
+			expectedErr:    errErasureReadQuorum,
+			expectedQuorum: 8,
+		},
+		{
+			fis:            getNFInfo(16, 16, 1603863445, "36a21454-a2ca-11eb-bbaa-93a81c686f21"),
+			modTime:        time.Unix(1603863445, 0),
+			dataDir:        "36a21454-a2ca-11eb-bbaa-93a81c686f21",
+			expectedErr:    errErasureReadQuorum,
+			expectedQuorum: 0,
 		},
 	}
 
 	for _, test := range tests {
 		test := test
 		t.Run("", func(t *testing.T) {
-			_, err := findFileInfoInQuorum(context.Background(), test.fis, test.modTime, test.dataDir, 8)
+			_, err := findFileInfoInQuorum(context.Background(), test.fis, test.modTime, test.dataDir, test.expectedQuorum)
 			if err != test.expectedErr {
 				t.Errorf("Expected %s, got %s", test.expectedErr, err)
 			}


### PR DESCRIPTION
## Description
fix: return error for unexpected quorum in pickValidFileInfo

## Motivation and Context
Return error if the input quorum is smaller than 
`< 2` minimum parity allowed.

## How to test this PR?
Only through various testcases

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
