### PR TITLE
fix: missing path in admin trace

### DIFF
--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -218,11 +218,16 @@ func Trace(f http.HandlerFunc, logBody bool, w http.ResponseWriter, r *http.Requ
 		Time:     now,
 		Proto:    r.Proto,
 		Method:   r.Method,
-		Path:     r.URL.RawPath,
 		RawQuery: redactLDAPPwd(r.URL.RawQuery),
 		Client:   handlers.GetSourceIP(r),
 		Headers:  reqHeaders,
 	}
+
+	path := r.URL.RawPath
+	if path == "" {
+		path = r.URL.Path
+	}
+	rq.Path = path
 
 	rw := logger.NewResponseWriter(w)
 	rw.LogErrBody = true


### PR DESCRIPTION
## Description
fix: missing path in admin trace

## Motivation and Context
PR #12360 introduced a change that seems to have
added a regression, the RawPath in r.URL seems to
be empty, if it is fallback to r.URL.Path instead.

## How to test this PR?
Just do `mc admin trace`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression in #12360
- [ ] Documentation updated
- [ ] Unit tests added/updated
