### PR TITLE
etag: compute ETag as MD5 for compressed single-part objects

### DIFF
--- a/pkg/etag/etag_test.go
+++ b/pkg/etag/etag_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 )
 
+var _ Tagger = Wrap(nil, nil).(Tagger) // runtime check that wrapReader implements Tagger
+
 var parseTests = []struct {
 	String     string
 	ETag       ETag

--- a/pkg/etag/reader.go
+++ b/pkg/etag/reader.go
@@ -34,8 +34,10 @@ type wrapReader struct {
 	Tagger
 }
 
+var _ Tagger = wrapReader{} // compiler check
+
 // ETag returns the ETag of the underlying Tagger.
-func (r *wrapReader) ETag() ETag {
+func (r wrapReader) ETag() ETag {
 	if r.Tagger == nil {
 		return nil
 	}


### PR DESCRIPTION
## Description
This commit fixes a bug causing the MinIO server to compute
the ETag of a single-part object as MD5 of the compressed
content - not as MD5 of the actual content.

This usually does not affect clients since the MinIO appended
a `-1` to indicate that the ETag belongs to a multipart object.
However, this behavior was problematic since:
 - A S3 client being very strict should reject such an ETag since
   the client uploaded the object via single-part API but got
   a multipart ETag that is not the content MD5.
 - The MinIO server leaks (via the ETag) that it compressed the
   object.

This commit addresses both cases. Now, the MinIO server returns
an ETag equal to the content MD5 for single-part objects that got
compressed.

## Motivation and Context
ETag, Fixes #12337 

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
