### PR TITLE
audit/logger: Increase http request timeout

### DIFF
--- a/cmd/logger/target/http/http.go
+++ b/cmd/logger/target/http/http.go
@@ -31,6 +31,9 @@ import (
 	"github.com/minio/minio/cmd/logger"
 )
 
+// Timeout for the webhook http call
+const webhookCallTimeout = 5 * time.Second
+
 // Target implements logger.Target and sends the json
 // format of a log entry to the configured http endpoint.
 // An internal buffer of logs is maintained but when the
@@ -62,7 +65,7 @@ func (h *Target) String() string {
 
 // Validate validate the http target
 func (h *Target) Validate() error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*webhookCallTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.endpoint, strings.NewReader(`{}`))
@@ -111,7 +114,7 @@ func (h *Target) startHTTPLogger() {
 				continue
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), webhookCallTimeout)
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 				h.endpoint, bytes.NewReader(logJSON))
 			if err != nil {


### PR DESCRIPTION
## Description
A configured audit logger or http logger is validated during MinIO
server startup. Relax the timeout to 10 seconds in that case, otherwise
both loggers won't be used.

1 second could be too low for a busy http endpoint.

## Motivation and Context
Fix issue seen by a user when audit is not working.

## How to test this PR?
Trivial change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
