### PR TITLE
fix: when parityDrives hits > len(storageDisks)/2, keep maxParity

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -32,6 +32,9 @@ import (
 	"github.com/minio/minio/pkg/sync/errgroup"
 )
 
+// Object was stored with additional erasure codes due to degraded system at upload time
+const minIOErasureUpgraded = "x-minio-internal-erasure-upgraded"
+
 const erasureAlgorithm = "rs-vandermonde"
 
 // byObjectPartNumber is a collection satisfying sort.Interface.

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -289,9 +289,10 @@ func (er erasureObjects) newMultipartUpload(ctx context.Context, bucket string, 
 		parityDrives = er.defaultParityCount
 	}
 
-	ecOrg := parityDrives
+	parityOrig := parityDrives
 	for _, disk := range onlineDisks {
 		if parityDrives >= len(onlineDisks)/2 {
+			parityDrives = len(onlineDisks) / 2
 			break
 		}
 		if disk == nil {
@@ -303,8 +304,8 @@ func (er erasureObjects) newMultipartUpload(ctx context.Context, bucket string, 
 			parityDrives++
 		}
 	}
-	if ecOrg != parityDrives {
-		opts.UserDefined[xhttp.MinIOErasureUpgraded] = fmt.Sprintf("%d->%d", ecOrg, parityDrives)
+	if parityOrig != parityDrives {
+		opts.UserDefined[minIOErasureUpgraded] = strconv.Itoa(parityOrig) + "->" + strconv.Itoa(parityDrives)
 	}
 
 	dataDrives := len(onlineDisks) - parityDrives

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -601,9 +602,10 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 		}
 
 		// If we have offline disks upgrade the number of erasure codes for this object.
-		ecOrg := parityDrives
+		parityOrig := parityDrives
 		for _, disk := range storageDisks {
 			if parityDrives >= len(storageDisks)/2 {
+				parityDrives = len(storageDisks) / 2
 				break
 			}
 			if disk == nil {
@@ -614,8 +616,8 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 				parityDrives++
 			}
 		}
-		if ecOrg != parityDrives {
-			opts.UserDefined[xhttp.MinIOErasureUpgraded] = fmt.Sprintf("%d->%d", ecOrg, parityDrives)
+		if parityOrig != parityDrives {
+			opts.UserDefined[minIOErasureUpgraded] = strconv.Itoa(parityOrig) + "->" + strconv.Itoa(parityDrives)
 		}
 	}
 	dataDrives := len(storageDisks) - parityDrives

--- a/cmd/http/headers.go
+++ b/cmd/http/headers.go
@@ -156,9 +156,6 @@ const (
 	// Reports number of drives currently healing
 	MinIOHealingDrives = "x-minio-healing-drives"
 
-	// Object was stored with additional erasure codes due to degraded system at upload time
-	MinIOErasureUpgraded = "x-minio-internal-erasure-upgraded"
-
 	// Header indicates if the delete marker should be preserved by client
 	MinIOSourceDeleteMarker = "x-minio-source-deletemarker"
 


### PR DESCRIPTION

## Description
fix: when parityDrives hits > len(storageDisks)/2, keep maxParity

## Motivation and Context
Additionally move out `x-minio-internal-erasure-upgraded` from HTTP headers
list, as it's an internal header, rename elsewhere accordingly.


## How to test this PR?
There is no possible way I think this bug is possible, but 
it is a defensive code to ensure that parity drives never 
exceed beyond half of the size of the number of disks 
per set `len(storageDisks)/2` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
