### PR TITLE
fix: no need to proxy if IAM not initialized

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -166,10 +166,7 @@ func setBrowserRedirectHandler(h http.Handler) http.Handler {
 }
 
 func shouldProxy() bool {
-	if newObjectLayerFn() == nil {
-		return true
-	}
-	return !globalIAMSys.Initialized()
+	return newObjectLayerFn() == nil
 }
 
 // Fetch redirect location if urlPath satisfies certain

--- a/cmd/metacache-manager.go
+++ b/cmd/metacache-manager.go
@@ -60,8 +60,8 @@ func (m *metacacheManager) initManager() {
 			time.Sleep(time.Second)
 			objAPI = newObjectLayerFn()
 		}
+
 		if !globalIsErasure {
-			logger.Info("metacacheManager was initialized in non-erasure mode, skipping save")
 			return
 		}
 


### PR DESCRIPTION


## Description
fix: no need to proxy if IAM not initialized

## Motivation and Context
IAM not initialized doesn't mean we can't still
read the content from the disk, we should just
allow the request to go-through if object layer
is initialized.

## How to test this PR?
Need to manually block IAM loading and observe if requests 
get re-routed unnecessarily 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
