### PR TITLE
Redact sensitive values from config in health data

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1564,6 +1564,7 @@ func (a adminAPIHandlers) HealthInfoHandler(w http.ResponseWriter, r *http.Reque
 					Error: err.Error(),
 				}
 			} else {
+				config.RedactSensitiveInfo()
 				healthInfo.Minio.Config = madmin.MinioConfig{
 					Config: config,
 				}

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1564,9 +1564,8 @@ func (a adminAPIHandlers) HealthInfoHandler(w http.ResponseWriter, r *http.Reque
 					Error: err.Error(),
 				}
 			} else {
-				config.RedactSensitiveInfo()
 				healthInfo.Minio.Config = madmin.MinioConfig{
-					Config: config,
+					Config: config.RedactSensitiveInfo(),
 				}
 			}
 			partialWrite(healthInfo)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -343,6 +343,40 @@ func (c Config) ReadConfig(r io.Reader) (dynOnly bool, err error) {
 	return dynOnly, nil
 }
 
+// RedactSensitiveInfo - removes sensitive information
+// like urls and credentials from the configuration
+func (c Config) RedactSensitiveInfo() {
+	sensitiveConfigKeys := map[string][]string{
+		"notify_amqp":          {"url", "routing_key"},
+		"notify_nsq":           {"nsqd_address"},
+		"notify_postgres":      {"connection_string"},
+		"notify_kafka":         {"sasl_username", "sasl_password", "client_tls_cert", "client_tls_key"},
+		"notify_redis":         {"address", "key", "password"},
+		"notify_mqtt":          {"broker", "password", "username"},
+		"notify_mysql":         {"dsn_string"},
+		"notify_webhook":       {"endpoint", "client_cert", "client_key"},
+		"notify_elasticsearch": {"url", "username", "password"},
+		"notify_nats":          {"address", "username", "password", "token", "cert_authority", "client_cert", "client_key"},
+	}
+
+	for configName, configVals := range c {
+		sensitiveKeys, isSensitiveConfig := sensitiveConfigKeys[configName]
+		if isSensitiveConfig {
+			for name, kvs := range configVals {
+				for _, sensitiveKey := range sensitiveKeys {
+					for i := range kvs {
+						if kvs[i].Key == sensitiveKey && len(kvs[i].Value) > 0 {
+							kvs[i].Value = "*redacted*"
+						}
+					}
+				}
+				configVals[name] = kvs
+			}
+			c[configName] = configVals
+		}
+	}
+}
+
 type configWriteTo struct {
 	Config
 	filterByKey string

--- a/internal/config/etcd/help.go
+++ b/internal/config/etcd/help.go
@@ -26,6 +26,7 @@ var (
 			Key:         Endpoints,
 			Description: `comma separated list of etcd endpoints e.g. "http://localhost:2379"`,
 			Type:        "csv",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         PathPrefix,
@@ -44,12 +45,14 @@ var (
 			Description: `client cert for mTLS authentication`,
 			Optional:    true,
 			Type:        "path",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         ClientCertKey,
 			Description: `client cert key for mTLS authentication`,
 			Optional:    true,
 			Type:        "path",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.Comment,

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -25,6 +25,10 @@ type HelpKV struct {
 	Description string `json:"description"`
 	Optional    bool   `json:"optional"`
 
+	// Indicates if the value contains sensitive info
+	// that shouldn't be exposed in certain apis
+	Sensitive bool `json:"sensitive"`
+
 	// Indicates if sub-sys supports multiple targets.
 	MultipleTargets bool `json:"multipleTargets"`
 }

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -26,6 +26,7 @@ var (
 			Key:         ServerAddr,
 			Description: `AD/LDAP server address e.g. "myldapserver.com:636"`,
 			Type:        "address",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         STSExpiry,
@@ -38,12 +39,14 @@ var (
 			Description: `DN for LDAP read-only service account used to perform DN and group lookups`,
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         LookupBindPassword,
 			Description: `Password for LDAP read-only service account used to perform DN and group lookups`,
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         UserDNSearchBaseDN,
@@ -62,6 +65,7 @@ var (
 			Description: `";" separated list of username bind DNs e.g. "uid=%s,cn=accounts,dc=myldapserver,dc=com"`,
 			Optional:    true,
 			Type:        "list",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         GroupSearchFilter,

--- a/internal/config/notify/help.go
+++ b/internal/config/notify/help.go
@@ -35,12 +35,14 @@ var (
 			Key:         target.WebhookEndpoint,
 			Description: "webhook server endpoint e.g. http://localhost:8080/minio/events",
 			Type:        "url",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.WebhookAuthToken,
 			Description: "opaque string or JWT authorization token",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.WebhookQueueDir,
@@ -65,12 +67,14 @@ var (
 			Description: "client cert for Webhook mTLS auth",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.WebhookClientKey,
 			Description: "client cert key for Webhook mTLS auth",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 	}
 
@@ -79,6 +83,7 @@ var (
 			Key:         target.AmqpURL,
 			Description: "AMQP server endpoint e.g. `amqp://myuser:mypassword@localhost:5672`",
 			Type:        "url",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.AmqpExchange,
@@ -97,6 +102,7 @@ var (
 			Description: "routing key for publishing",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.AmqpMandatory,
@@ -171,12 +177,14 @@ var (
 			Description: "username for SASL/PLAIN or SASL/SCRAM authentication",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.KafkaSASLPassword,
 			Description: "password for SASL/PLAIN or SASL/SCRAM authentication",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.KafkaSASLMechanism,
@@ -213,12 +221,14 @@ var (
 			Description: "path to client certificate for mTLS auth",
 			Optional:    true,
 			Type:        "path",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.KafkaClientTLSKey,
 			Description: "path to client key for mTLS auth",
 			Optional:    true,
 			Type:        "path",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.KafkaQueueDir,
@@ -251,6 +261,7 @@ var (
 			Key:         target.MqttBroker,
 			Description: "MQTT server endpoint e.g. `tcp://localhost:1883`",
 			Type:        "uri",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.MqttTopic,
@@ -262,12 +273,14 @@ var (
 			Description: "MQTT username",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.MqttPassword,
 			Description: "MQTT password",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.MqttQoS,
@@ -312,6 +325,7 @@ var (
 			Key:         target.PostgresConnectionString,
 			Description: `Postgres server connection-string e.g. "host=localhost port=5432 dbname=minio_events user=postgres password=password sslmode=disable"`,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.PostgresTable,
@@ -355,6 +369,7 @@ var (
 			Description: `MySQL data-source-name connection string e.g. "<user>:<password>@tcp(<host>:<port>)/<database>"`,
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.MySQLTable,
@@ -397,6 +412,7 @@ var (
 			Key:         target.NATSAddress,
 			Description: "NATS server address e.g. '0.0.0.0:4222'",
 			Type:        "address",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.NATSSubject,
@@ -408,18 +424,21 @@ var (
 			Description: "NATS username",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.NATSPassword,
 			Description: "NATS password",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.NATSToken,
 			Description: "NATS token",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.NATSTLS,
@@ -468,18 +487,21 @@ var (
 			Description: "path to certificate chain of the target NATS server",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.NATSClientCert,
 			Description: "client cert for NATS mTLS auth",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.NATSClientKey,
 			Description: "client cert key for NATS mTLS auth",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.NATSQueueDir,
@@ -506,6 +528,7 @@ var (
 			Key:         target.NSQAddress,
 			Description: "NSQ server address e.g. '127.0.0.1:4150'",
 			Type:        "address",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.NSQTopic,
@@ -549,6 +572,7 @@ var (
 			Key:         target.ElasticURL,
 			Description: "Elasticsearch server's address, with optional authentication info",
 			Type:        "url",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.ElasticIndex,
@@ -577,12 +601,14 @@ var (
 			Description: "username for Elasticsearch basic-auth",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.ElasticPassword,
 			Description: "password for Elasticsearch basic-auth",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.Comment,
@@ -597,11 +623,13 @@ var (
 			Key:         target.RedisAddress,
 			Description: "Redis server's address. For example: `localhost:6379`",
 			Type:        "address",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.RedisKey,
 			Description: "Redis key to store/update events, key is auto-created",
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.RedisFormat,
@@ -613,6 +641,7 @@ var (
 			Description: "Redis server password",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         target.RedisQueueDir,

--- a/internal/config/policy/opa/help.go
+++ b/internal/config/policy/opa/help.go
@@ -26,12 +26,14 @@ var (
 			Key:         URL,
 			Description: `[DEPRECATED] OPA HTTP(s) endpoint e.g. "http://localhost:8181/v1/data/httpapi/authz/allow"`,
 			Type:        "url",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         AuthToken,
 			Description: "[DEPRECATED] authorization token for OPA endpoint",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.Comment,

--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -28,12 +28,14 @@ var (
 			Key:         Endpoint,
 			Description: `HTTP(s) endpoint e.g. "http://localhost:8080/minio/logs/server"`,
 			Type:        "url",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         AuthToken,
 			Description: `opaque string or JWT authorization token`,
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.Comment,
@@ -48,12 +50,14 @@ var (
 			Key:         Endpoint,
 			Description: `HTTP(s) endpoint e.g. "http://localhost:8080/minio/logs/audit"`,
 			Type:        "url",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         AuthToken,
 			Description: `opaque string or JWT authorization token`,
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.Comment,
@@ -66,12 +70,14 @@ var (
 			Description: "mTLS certificate for Audit Webhook authentication",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         ClientKey,
 			Description: "mTLS certificate key for Audit Webhook authentication",
 			Optional:    true,
 			Type:        "string",
+			Sensitive:   true,
 		},
 	}
 )


### PR DESCRIPTION
## Description

The health api returns the server configuration details. Redact
sensitive values from the config values like URLs and credentials.

## Motivation and Context

Prevent sensitive info from leaking out through healthinfo api

## How to test this PR?

- Configure a bucket notification e.g. `notify_webhook`
- Generate health report using `mc admin subnet health {alias}`
- Verify that sensitve information like URLs/keys/certs are shown as `*redacted*` in the generated report

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
