### PR TITLE
config: fix typo in KES CA path env. variable

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -47,7 +47,7 @@ const (
 	EnvKESKeyName    = "MINIO_KMS_KES_KEY_NAME"
 	EnvKESClientKey  = "MINIO_KMS_KES_KEY_FILE"
 	EnvKESClientCert = "MINIO_KMS_KES_CERT_FILE"
-	EnvKESServerCA   = "MINIO_KMS_KES_CAPATH"
+	EnvKESServerCA   = "MINIO_KMS_KES_CA_PATH"
 
 	EnvEndpoints = "MINIO_ENDPOINTS" // legacy
 	EnvWorm      = "MINIO_WORM"      // legacy


### PR DESCRIPTION
## Description
This commit fixes a typo in the KES CA path
environment variable.

The CA certificate / directory for verifying
the KES server certificate should be specified
as `MINIO_KMS_KES_CA_PATH`.

## Motivation and Context
KES

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
