### PR TITLE
s3: Return correct error XML tag in case of copy object

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1035,6 +1035,10 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 				w.Header()[xhttp.AmzDeleteMarker] = []string{strconv.FormatBool(gr.ObjInfo.DeleteMarker)}
 			}
 		}
+		// Update context bucket & object names for correct S3 XML error response
+		reqInfo := logger.GetReqInfo(ctx)
+		reqInfo.BucketName = srcBucket
+		reqInfo.ObjectName = srcObject
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
 	}


### PR DESCRIPTION
## Description
In Copy Object S3 API, the server does not return correct bucket &
object names when the source bucket/object does not exist, this commit
fixes it.

## Motivation and Context
Fix xml error response in copy object handler

## How to test this PR?
```
$ mc mb myminio/testbucket myminio/foobucket/
$ aws --debug --profile minio --endpoint-url http://localhost:9000 s3api copy-object --bucket foobucket --key copy --copy-source testbucket/notfound`
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
