### PR TITLE
fix: etcd IAM encryption fails due to incorrect kms.Context

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -317,14 +317,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(globalNotificationSys.Init(GlobalContext, buckets, newObject), "Unable to initialize notification system")
 	}
 
-	if globalEtcdClient != nil {
-		// ****  WARNING ****
-		// Migrating to encrypted backend on etcd should happen before initialization of
-		// IAM sub-systems, make sure that we do not move the above codeblock elsewhere.
-		logger.FatalIf(migrateIAMConfigsEtcdToEncrypted(GlobalContext, globalEtcdClient),
-			"Unable to handle encrypted backend for iam and policies")
-	}
-
 	if enableIAMOps {
 		// Initialize users credentials and policies in background.
 		globalIAMSys.InitStore(newObject)

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -212,9 +212,6 @@ var (
 
 	globalActiveCred auth.Credentials
 
-	// Hold the old server credentials passed by the environment
-	globalOldCred auth.Credentials
-
 	globalPublicCerts []*x509.Certificate
 
 	globalDomainNames []string      // Root domains for virtual host style requests

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -668,8 +668,6 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 		break
 	}
 
-	// Invalidate the old cred always, even upon error to avoid any leakage.
-	globalOldCred = auth.Credentials{}
 	go sys.store.watch(ctx, sys)
 
 	logger.Info("IAM initialization complete")

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -548,6 +548,9 @@ func serverMain(ctx *cli.Context) {
 		logger.LogIf(GlobalContext, err)
 	}
 
+	// Initialize users credentials and policies in background right after config has initialized.
+	go globalIAMSys.Init(GlobalContext, newObject)
+
 	initDataScanner(GlobalContext, newObject)
 
 	if globalIsErasure { // to be done after config init
@@ -566,9 +569,6 @@ func serverMain(ctx *cli.Context) {
 
 		setCacheObjectLayer(cacheAPI)
 	}
-
-	// Initialize users credentials and policies in background right after config has initialized.
-	go globalIAMSys.Init(GlobalContext, newObject)
 
 	// Prints the formatted startup message, if err is not nil then it prints additional information as well.
 	printStartupMessage(getAPIEndpoints(), err)


### PR DESCRIPTION

## Description
fix: etcd IAM encryption fails due to incorrect kms.Context

## Motivation and Context
Due to incorrect KMS context constructed, we need to add
additional fallbacks and also fix the original root cause
to fix already migrated deployments.

Bonus remove double migration is avoided in gateway mode
for etcd, instead do it once in iam.Init(), also simplify
the migration by not migrating STS users instead let the
clients regenerate them.

## How to test this PR?
- Install etcd
- Install release RELEASE.2021-04-22T15-44-28Z in gateway mode
- Update release to RELEASE.2021-05-11T23-27-41Z in gateway mode, with value MINIO_KMS_SECRET_KEY set.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes all etcd deployments are affected
- [ ] Documentation updated
- [ ] Unit tests added/updated
