### PR TITLE
fix: close the channel appropriately for dataUsageEntry

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -333,6 +333,8 @@ func (fs *FSObjects) NSScanner(ctx context.Context, bf *bloomFilter, updates cha
 // The updated cache for the bucket is returned.
 // A partially updated bucket may be returned.
 func (fs *FSObjects) scanBucket(ctx context.Context, bucket string, cache dataUsageCache) (dataUsageCache, error) {
+	defer close(cache.Info.updates)
+
 	// Get bucket policy
 	// Check if the current bucket has a configured lifecycle policy
 	lc, err := globalLifecycleSys.Get(bucket)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -531,7 +531,6 @@ func serverMain(ctx *cli.Context) {
 	}
 
 	initBackgroundExpiry(GlobalContext, newObject)
-	initDataScanner(GlobalContext, newObject)
 
 	if err = initServer(GlobalContext, newObject); err != nil {
 		var cerr config.Err
@@ -548,6 +547,8 @@ func serverMain(ctx *cli.Context) {
 
 		logger.LogIf(GlobalContext, err)
 	}
+
+	initDataScanner(GlobalContext, newObject)
 
 	if globalIsErasure { // to be done after config init
 		initBackgroundReplication(GlobalContext, newObject)


### PR DESCRIPTION

## Description
fix: close the channel appropriately for dataUsageEntry

## Motivation and Context
Bonus: initialize dataScanner routines after server
config has initialized.

fixes #12430

## How to test this PR?
FS mode never completes usage cycles anymore, this is a regression.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression most probably introduced in partial bucket updates PR
- [ ] Documentation updated
- [ ] Unit tests added/updated
