### PR TITLE
fix: remove parent dirs in RenameData upon failure

### DIFF
--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -356,10 +356,10 @@ func testStorageAPIDeleteFile(t *testing.T, storage StorageAPI) {
 		expectErr  bool
 	}{
 		{"foo", "myobject", false},
-		// should removed by above case.
-		{"foo", "myobject", true},
-		// file not found error
-		{"foo", "yourobject", true},
+		// file not found not returned
+		{"foo", "myobject", false},
+		// file not found not returned
+		{"foo", "yourobject", false},
 	}
 
 	for i, testCase := range testCases {

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -966,11 +966,11 @@ func TestXLStorageDeleteFile(t *testing.T) {
 			expectedErr: nil,
 		},
 		// TestXLStorage case - 2.
-		// The file was deleted in the last  case, so Delete should fail.
+		// The file was deleted in the last  case, so Delete should not fail.
 		{
 			srcVol:      "success-vol",
 			srcPath:     "success-file",
-			expectedErr: errFileNotFound,
+			expectedErr: nil,
 		},
 		// TestXLStorage case - 3.
 		// TestXLStorage case with segment of the volume name > 255.


### PR DESCRIPTION

## Description
fix: remove parent dirs in RenameData upon failure

## Motivation and Context
- it is possible that during I/O failures we might
  leave partially written directories, make sure
  we purge them after.

- rename current data-dir (null) versionId only after
  the newer xl.meta has been written fully.

- attempt removal once for minioMetaTmpBucket/uuid/
  as this folder is empty if all previous operations
  were successful, this allows avoiding recursive os.Remove()

## How to test this PR?
The situations in this PR are hard to reproduce
but they do happen in the wild, and cannot be
fixed easily. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
