### PR TITLE
rest: healthcheck should not update failure metrics

### DIFF
--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -161,6 +161,7 @@ func newlockRESTClient(endpoint Endpoint) *lockRESTClient {
 	// Use a separate client to avoid recursive calls.
 	healthClient := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken)
 	healthClient.ExpectTimeouts = true
+	healthClient.NoMetrics = true
 	restClient.HealthCheckFn = func() bool {
 		ctx, cancel := context.WithTimeout(context.Background(), restClient.HealthCheckTimeout)
 		defer cancel()

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -919,6 +919,7 @@ func newPeerRESTClient(peer *xnet.Host) *peerRESTClient {
 	// Use a separate client to avoid recursive calls.
 	healthClient := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken)
 	healthClient.ExpectTimeouts = true
+	healthClient.NoMetrics = true
 
 	// Construct a new health function.
 	restClient.HealthCheckFn = func() bool {

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -704,6 +704,7 @@ func newStorageRESTClient(endpoint Endpoint, healthcheck bool) *storageRESTClien
 		// Use a separate client to avoid recursive calls.
 		healthClient := rest.NewClient(serverURL, globalInternodeTransport, newAuthToken)
 		healthClient.ExpectTimeouts = true
+		healthClient.NoMetrics = true
 		restClient.HealthCheckFn = func() bool {
 			ctx, cancel := context.WithTimeout(context.Background(), restClient.HealthCheckTimeout)
 			defer cancel()


### PR DESCRIPTION
## Description
healthcheck should not update failure metrics, otherwise, we can see high numbers
of networking issues when a node is down.

## Motivation and Context
Avoid high number of minio_inter_node_traffic_errors_total metric

## How to test this PR?
1. Run four nodes with MINIO_PROMETHEUS_AUTH_TYPE="public"
2. Kill one node and get prometheus output:
`curl http://localhost:9001/minio/v2/metrics/node 2>/dev/null | grep minio_inter_node_traffic_errors_total`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
