### PR TITLE
fix: legacy objects with 10MiB blockSize should use right buffers

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -391,6 +391,14 @@ func newErasureSets(ctx context.Context, endpoints Endpoints, storageDisks []Sto
 	// setCount * setDriveCount with each memory upto blockSizeV2.
 	bp := bpool.NewBytePoolCap(n, blockSizeV2, blockSizeV2*2)
 
+	// Initialize byte pool for all sets, bpool size is set to
+	// setCount * setDriveCount with each memory upto blockSizeV1
+	//
+	// Number of buffers, max 10GiB
+	m := (10 * humanize.GiByte) / (blockSizeV1 * 2)
+
+	bpOld := bpool.NewBytePoolCap(m, blockSizeV1, blockSizeV1*2)
+
 	for i := 0; i < setCount; i++ {
 		s.erasureDisks[i] = make([]StorageAPI, setDriveCount)
 	}
@@ -440,6 +448,7 @@ func newErasureSets(ctx context.Context, endpoints Endpoints, storageDisks []Sto
 			deletedCleanupSleeper: newDynamicSleeper(10, 2*time.Second),
 			nsMutex:               mutex,
 			bp:                    bp,
+			bpOld:                 bpOld,
 			mrfOpCh:               make(chan partialOperation, 10000),
 		}
 	}

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -74,6 +74,10 @@ type erasureObjects struct {
 	// Byte pools used for temporary i/o buffers.
 	bp *bpool.BytePoolCap
 
+	// Byte pools used for temporary i/o buffers,
+	// legacy objects.
+	bpOld *bpool.BytePoolCap
+
 	mrfOpCh chan partialOperation
 
 	deletedCleanupSleeper *dynamicSleeper


### PR DESCRIPTION

## Description
fix: legacy objects with 10MiB blockSize should use right buffers

## Motivation and Context
healing code was using incorrect buffers to heal older
objects with 10MiB erasure blockSize, incorrect calculation
of such buffers can lead to incorrect premature closure of
io.Pipe() during healing.

fixes #12410

## How to test this PR?
Just upgrade from an older 2020 release and run `mc admin heal -r` on those objects. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
