### PR TITLE
Do not send 'sensitive' flag to client

### DIFF
--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -27,7 +27,7 @@ type HelpKV struct {
 
 	// Indicates if the value contains sensitive info
 	// that shouldn't be exposed in certain apis
-	Sensitive bool `json:"sensitive"`
+	Sensitive bool `json:"-"`
 
 	// Indicates if sub-sys supports multiple targets.
 	MultipleTargets bool `json:"multipleTargets"`


### PR DESCRIPTION
## Description

As it is server specific and is not required on client side.

## Motivation and Context

Sending this flag in the JSON response to client results in `mc admin config set` command failing with:

`Unable to get help for the sub-system: json: unknown field "sensitive".`

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (PR #12421)
- [ ] Documentation updated
- [ ] Unit tests added/updated
