### PR TITLE
Fix byte range checks in CopyObjectPart when compressed

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2330,13 +2330,10 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 	defer gr.Close()
 	srcInfo := gr.ObjInfo
 
-	actualPartSize := srcInfo.Size
-	if _, ok := crypto.IsEncrypted(srcInfo.UserDefined); ok {
-		actualPartSize, err = srcInfo.GetActualSize()
-		if err != nil {
-			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
-			return
-		}
+	actualPartSize, err := srcInfo.GetActualSize()
+	if err != nil {
+		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
+		return
 	}
 
 	if err := enforceBucketQuota(ctx, dstBucket, actualPartSize); err != nil {


### PR DESCRIPTION
## Description

Always use `GetActualSize` to get the part size, not just when encrypted.

Fixes mint test io.minio.MinioClient.uploadPartCopy, error "Range specified is not valid for source object".

## How to test this PR?

mint.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
