### PR TITLE
Require clear header naming for prefix deletion

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -970,7 +970,7 @@ func (api objectAPIHandlers) DeleteBucketHandler(w http.ResponseWriter, r *http.
 	}
 
 	forceDelete := false
-	if value := r.Header.Get(xhttp.MinIOForceDelete); value != "" {
+	if value := r.Header.Get(xhttp.MinIOForceBucketDeletion); value != "" {
 		var err error
 		forceDelete, err = strconv.ParseBool(value)
 		if err != nil {

--- a/cmd/http/headers.go
+++ b/cmd/http/headers.go
@@ -119,7 +119,8 @@ const (
 	MinIOServerStatus = "x-minio-server-status"
 
 	// Delete special flag to force delete a bucket
-	MinIOForceDelete = "x-minio-force-delete"
+	MinIOForceBucketDeletion = "x-minio-force-bucket-deletion"
+	MinIOForcePrefixDeletion = "x-minio-force-prefix-deletion"
 
 	// Header indicates if the mtime should be preserved by client
 	MinIOSourceMTime = "x-minio-source-mtime"

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -117,7 +117,7 @@ func getOpts(ctx context.Context, r *http.Request, bucket, object string) (Objec
 	}
 
 	deletePrefix := false
-	if d := r.Header.Get("x-minio-force-delete"); d != "" {
+	if d := r.Header.Get(xhttp.MinIOForcePrefixDeletion); d != "" {
 		if b, err := strconv.ParseBool(d); err != nil {
 			return opts, err
 		} else {


### PR DESCRIPTION

## Description
DELETE a bucket & object uses similar HTTP requests. It is possible that
a user playing with lowlevel requests to send a DELETE request with
x-minio-force-delete with an empty object name, which means the whole
bucket could be removed accidentely.

Make the intention more clear in headers by renaming x-minio-force-delete to
x-minio-force-bucket-deletion and x-minio-force-prefix-deletion.


## Motivation and Context
More safeguards when playing with force delete

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
