### PR TITLE
fix: safe update of the audit objectErasureMap

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -521,6 +522,21 @@ type auditObjectOp struct {
 	Disks []string `json:"disks"`
 }
 
+type auditObjectErasureMap struct {
+	sync.Map
+}
+
+// Define how to marshal auditObjectErasureMap so it can be
+// printed in the audit webhook notification request.
+func (a *auditObjectErasureMap) MarshalJSON() ([]byte, error) {
+	mapCopy := make(map[string]auditObjectOp)
+	a.Range(func(k, v interface{}) bool {
+		mapCopy[k.(string)] = v.(auditObjectOp)
+		return true
+	})
+	return json.Marshal(mapCopy)
+}
+
 func auditObjectErasureSet(ctx context.Context, object string, set *erasureObjects) {
 	if len(logger.AuditTargets) == 0 {
 		return
@@ -534,20 +550,20 @@ func auditObjectErasureSet(ctx context.Context, object string, set *erasureObjec
 		Disks: set.getEndpoints(),
 	}
 
-	var objectErasureSetTag map[string]auditObjectOp
+	var objectErasureSetTag *auditObjectErasureMap
 	reqInfo := logger.GetReqInfo(ctx)
 	for _, kv := range reqInfo.GetTags() {
 		if kv.Key == objectErasureMapKey {
-			objectErasureSetTag = kv.Val.(map[string]auditObjectOp)
+			objectErasureSetTag = kv.Val.(*auditObjectErasureMap)
 			break
 		}
 	}
 
 	if objectErasureSetTag == nil {
-		objectErasureSetTag = make(map[string]auditObjectOp)
+		objectErasureSetTag = &auditObjectErasureMap{}
 	}
 
-	objectErasureSetTag[object] = op
+	objectErasureSetTag.Store(object, op)
 	reqInfo.SetTags(objectErasureMapKey, objectErasureSetTag)
 }
 


### PR DESCRIPTION
## Description
objectErasureMap in the audit holds information about the objects
involved in the current S3 operation such as, pool index, set index and
disks endpoints. One user saw a crash due to concurrent update of
objectErasureMap information. Use sync.Map to prevent crash.

## Motivation and Context
Fixes #12476 

## How to test this PR?
Run MinIO server with audit webhook enabled.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
