### PR TITLE
fix: getServerPoolsAvailableSpace() shouldn't crash

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -221,6 +221,9 @@ func (z *erasureServerPools) getServerPoolsAvailableSpace(ctx context.Context, b
 			continue
 		}
 		for _, disk := range zinfo {
+			if disk == nil {
+				continue
+			}
 			available += disk.Total - disk.Used
 		}
 		serverPools[i] = poolAvailableSpace{


### PR DESCRIPTION

## Description
fix: getServerPoolsAvailableSpace() shouldn't crash

## Motivation and Context
if one of the disks is offline then DiskInfo can be `nil`
and crash in the server pool.

## How to test this PR?
Easy to test, when the pool is coming up if the disk is 
offline this can happen. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
