### PR TITLE
fix: upon failure attempt an undo for all calls in DeleteBucket()

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -842,9 +842,6 @@ func (s *erasureSets) DeleteBucket(ctx context.Context, bucket string, forceDele
 		}
 	}
 
-	// Delete all bucket metadata.
-	deleteBucketMetadata(ctx, s, bucket)
-
 	// Success.
 	return nil
 }


### PR DESCRIPTION


## Description
fix: upon failure attempt an undo for all calls in DeleteBucket()

## Motivation and Context
it's possible that, version might exist on the second pool such that
upon deleteBucket() might have deleted the bucket on pool1 successfully
since it doesn't have any objects, undo such operations properly in
all any error scenario.

Also, delete bucket metadata from pool layer rather than sets layer.

## How to test this PR?
mint tests already capture the error, this fix to ensure those pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
