### PR TITLE
fix: remove unnecessary limit for queueStore

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -506,7 +506,6 @@ func (c Config) Merge() Config {
 				rnSubSys, ok := renamedSubsys[subSys]
 				if !ok {
 					// A config subsystem was removed or server was downgraded.
-					Logger.Info("config: ignoring unknown subsystem config %q\n", subSys)
 					continue
 				}
 				// Copy over settings from previous sub-system

--- a/internal/config/notify/help.go
+++ b/internal/config/notify/help.go
@@ -141,6 +141,12 @@ var (
 			Type:        "number",
 		},
 		config.HelpKV{
+			Key:         target.AmqpPublisherConfirms,
+			Description: "enable consumer acknowlegement and publisher confirms, use this along with queue_dir for guaranteed delivery of all events",
+			Optional:    true,
+			Type:        "on|off",
+		},
+		config.HelpKV{
 			Key:         target.AmqpQueueDir,
 			Description: queueDirComment,
 			Optional:    true,

--- a/internal/config/notify/parse.go
+++ b/internal/config/notify/parse.go
@@ -1702,6 +1702,10 @@ var (
 			Value: "0",
 		},
 		config.KV{
+			Key:   target.AmqpPublisherConfirms,
+			Value: config.EnableOff,
+		},
+		config.KV{
 			Key:   target.AmqpQueueLimit,
 			Value: "0",
 		},
@@ -1779,6 +1783,10 @@ func GetNotifyAMQP(amqpKVS map[string]config.KVS) (map[string]target.AMQPArgs, e
 		if k != config.Default {
 			autoDeletedEnv = autoDeletedEnv + config.Default + k
 		}
+		publisherConfirmsEnv := target.EnvAMQPPublisherConfirms
+		if k != config.Default {
+			publisherConfirmsEnv = publisherConfirmsEnv + config.Default + k
+		}
 		queueDirEnv := target.EnvAMQPQueueDir
 		if k != config.Default {
 			queueDirEnv = queueDirEnv + config.Default + k
@@ -1792,20 +1800,21 @@ func GetNotifyAMQP(amqpKVS map[string]config.KVS) (map[string]target.AMQPArgs, e
 			return nil, err
 		}
 		amqpArgs := target.AMQPArgs{
-			Enable:       enabled,
-			URL:          *url,
-			Exchange:     env.Get(exchangeEnv, kv.Get(target.AmqpExchange)),
-			RoutingKey:   env.Get(routingKeyEnv, kv.Get(target.AmqpRoutingKey)),
-			ExchangeType: env.Get(exchangeTypeEnv, kv.Get(target.AmqpExchangeType)),
-			DeliveryMode: uint8(deliveryMode),
-			Mandatory:    env.Get(mandatoryEnv, kv.Get(target.AmqpMandatory)) == config.EnableOn,
-			Immediate:    env.Get(immediateEnv, kv.Get(target.AmqpImmediate)) == config.EnableOn,
-			Durable:      env.Get(durableEnv, kv.Get(target.AmqpDurable)) == config.EnableOn,
-			Internal:     env.Get(internalEnv, kv.Get(target.AmqpInternal)) == config.EnableOn,
-			NoWait:       env.Get(noWaitEnv, kv.Get(target.AmqpNoWait)) == config.EnableOn,
-			AutoDeleted:  env.Get(autoDeletedEnv, kv.Get(target.AmqpAutoDeleted)) == config.EnableOn,
-			QueueDir:     env.Get(queueDirEnv, kv.Get(target.AmqpQueueDir)),
-			QueueLimit:   queueLimit,
+			Enable:            enabled,
+			URL:               *url,
+			Exchange:          env.Get(exchangeEnv, kv.Get(target.AmqpExchange)),
+			RoutingKey:        env.Get(routingKeyEnv, kv.Get(target.AmqpRoutingKey)),
+			ExchangeType:      env.Get(exchangeTypeEnv, kv.Get(target.AmqpExchangeType)),
+			DeliveryMode:      uint8(deliveryMode),
+			Mandatory:         env.Get(mandatoryEnv, kv.Get(target.AmqpMandatory)) == config.EnableOn,
+			Immediate:         env.Get(immediateEnv, kv.Get(target.AmqpImmediate)) == config.EnableOn,
+			Durable:           env.Get(durableEnv, kv.Get(target.AmqpDurable)) == config.EnableOn,
+			Internal:          env.Get(internalEnv, kv.Get(target.AmqpInternal)) == config.EnableOn,
+			NoWait:            env.Get(noWaitEnv, kv.Get(target.AmqpNoWait)) == config.EnableOn,
+			AutoDeleted:       env.Get(autoDeletedEnv, kv.Get(target.AmqpAutoDeleted)) == config.EnableOn,
+			PublisherConfirms: env.Get(publisherConfirmsEnv, kv.Get(target.AmqpPublisherConfirms)) == config.EnableOn,
+			QueueDir:          env.Get(queueDirEnv, kv.Get(target.AmqpQueueDir)),
+			QueueLimit:        queueLimit,
 		}
 		if err = amqpArgs.Validate(); err != nil {
 			return nil, err

--- a/internal/event/target/queuestore.go
+++ b/internal/event/target/queuestore.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	"github.com/minio/minio/internal/event"
-	"github.com/minio/pkg/sys"
 )
 
 const (
@@ -47,14 +46,6 @@ type QueueStore struct {
 func NewQueueStore(directory string, limit uint64) Store {
 	if limit == 0 {
 		limit = defaultLimit
-		_, maxRLimit, err := sys.GetMaxOpenFileLimit()
-		if err == nil {
-			// Limit the maximum number of entries
-			// to maximum open file limit
-			if maxRLimit < limit {
-				limit = maxRLimit
-			}
-		}
 	}
 
 	return &QueueStore{


### PR DESCRIPTION


## Description
fix: remove unnecessary limit for queueStore

## Motivation and Context
there is no good reason to limit ourselves
to max_open_fd for queue_store

## How to test this PR?
Not easy, just a cursory view that it's not useful for us.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
