### PR TITLE
fix: use madmin.Credentials for gateway interface

### DIFF
--- a/cmd/gateway-interface.go
+++ b/cmd/gateway-interface.go
@@ -17,9 +17,7 @@
 
 package cmd
 
-import (
-	"github.com/minio/minio/internal/auth"
-)
+import "github.com/minio/madmin-go"
 
 // GatewayMinioSysTmp prefix is used in Azure/GCS gateway for save metadata sent by Initialize Multipart Upload API.
 const (
@@ -37,8 +35,5 @@ type Gateway interface {
 	Name() string
 
 	// NewGatewayLayer returns a new  ObjectLayer.
-	NewGatewayLayer(creds auth.Credentials) (ObjectLayer, error)
-
-	// Returns true if gateway is ready for production.
-	Production() bool
+	NewGatewayLayer(creds madmin.Credentials) (ObjectLayer, error)
 }

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -43,7 +43,6 @@ import (
 	"github.com/minio/madmin-go"
 	miniogopolicy "github.com/minio/minio-go/v7/pkg/policy"
 	minio "github.com/minio/minio/cmd"
-	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/bucket/policy"
 	"github.com/minio/pkg/bucket/policy/condition"
@@ -138,14 +137,14 @@ func (g *Azure) Name() string {
 }
 
 // NewGatewayLayer initializes azure blob storage client and returns AzureObjects.
-func (g *Azure) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) {
+func (g *Azure) NewGatewayLayer(creds madmin.Credentials) (minio.ObjectLayer, error) {
 	var err error
 
 	// Override credentials from the Azure storage environment variables if specified
 	if acc, key := env.Get("AZURE_STORAGE_ACCOUNT", creds.AccessKey), env.Get("AZURE_STORAGE_KEY", creds.SecretKey); acc != "" && key != "" {
-		creds, err = auth.CreateCredentials(acc, key)
-		if err != nil {
-			return nil, err
+		creds = madmin.Credentials{
+			AccessKey: acc,
+			SecretKey: key,
 		}
 	}
 
@@ -242,11 +241,6 @@ func parseStorageEndpoint(host string, accountName string) (*url.URL, error) {
 	}
 
 	return url.Parse(endpoint)
-}
-
-// Production - Azure gateway is production ready.
-func (g *Azure) Production() bool {
-	return true
 }
 
 // s3MetaToAzureProperties converts metadata meant for S3 PUT/COPY

--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -40,7 +40,6 @@ import (
 	"github.com/minio/madmin-go"
 	miniogopolicy "github.com/minio/minio-go/v7/pkg/policy"
 	minio "github.com/minio/minio/cmd"
-	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/bucket/policy"
 	"github.com/minio/pkg/bucket/policy/condition"
@@ -164,7 +163,7 @@ func (g *GCS) Name() string {
 }
 
 // NewGatewayLayer returns gcs ObjectLayer.
-func (g *GCS) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) {
+func (g *GCS) NewGatewayLayer(creds madmin.Credentials) (minio.ObjectLayer, error) {
 	ctx := minio.GlobalContext
 
 	var err error
@@ -204,11 +203,6 @@ func (g *GCS) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error)
 	// Start background process to cleanup old files in minio.sys.tmp
 	go gcs.CleanupGCSMinioSysTmp(ctx)
 	return gcs, nil
-}
-
-// Production - GCS gateway is production ready.
-func (g *GCS) Production() bool {
-	return true
 }
 
 // Stored in gcs.json - Contents of this file is not used anywhere. It can be

--- a/cmd/gateway/hdfs/gateway-hdfs.go
+++ b/cmd/gateway/hdfs/gateway-hdfs.go
@@ -41,7 +41,6 @@ import (
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	minio "github.com/minio/minio/cmd"
-	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/logger"
 	xnet "github.com/minio/minio/internal/net"
 	"github.com/minio/pkg/env"
@@ -158,7 +157,7 @@ func getKerberosClient() (*krb.Client, error) {
 }
 
 // NewGatewayLayer returns hdfs gatewaylayer.
-func (g *HDFS) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) {
+func (g *HDFS) NewGatewayLayer(creds madmin.Credentials) (minio.ObjectLayer, error) {
 	dialFunc := (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
@@ -221,11 +220,6 @@ func (g *HDFS) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error
 	}
 
 	return &hdfsObjects{clnt: clnt, subPath: commonPath, listPool: minio.NewTreeWalkPool(time.Minute * 30)}, nil
-}
-
-// Production - hdfs gateway is production ready.
-func (g *HDFS) Production() bool {
-	return true
 }
 
 func (n *hdfsObjects) Shutdown(ctx context.Context) error {

--- a/cmd/gateway/nas/gateway-nas.go
+++ b/cmd/gateway/nas/gateway-nas.go
@@ -22,7 +22,6 @@ import (
 	"github.com/minio/cli"
 	"github.com/minio/madmin-go"
 	minio "github.com/minio/minio/cmd"
-	"github.com/minio/minio/internal/auth"
 )
 
 func init() {
@@ -86,18 +85,13 @@ func (g *NAS) Name() string {
 }
 
 // NewGatewayLayer returns nas gatewaylayer.
-func (g *NAS) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) {
+func (g *NAS) NewGatewayLayer(creds madmin.Credentials) (minio.ObjectLayer, error) {
 	var err error
 	newObject, err := minio.NewFSObjectLayer(g.path)
 	if err != nil {
 		return nil, err
 	}
 	return &nasObjects{newObject}, nil
-}
-
-// Production - nas gateway is production ready.
-func (g *NAS) Production() bool {
-	return true
 }
 
 // IsListenSupported returns whether listen bucket notification is applicable for this gateway.

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -34,7 +34,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/minio-go/v7/pkg/tags"
 	minio "github.com/minio/minio/cmd"
-	"github.com/minio/minio/internal/auth"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/bucket/policy"
@@ -205,7 +204,7 @@ func newS3(urlStr string, tripper http.RoundTripper) (*miniogo.Core, error) {
 }
 
 // NewGatewayLayer returns s3 ObjectLayer.
-func (g *S3) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) {
+func (g *S3) NewGatewayLayer(creds madmin.Credentials) (minio.ObjectLayer, error) {
 	metrics := minio.NewMetrics()
 
 	t := &minio.MetricsTransport{
@@ -248,11 +247,6 @@ func (g *S3) NewGatewayLayer(creds auth.Credentials) (minio.ObjectLayer, error) 
 		return &encS, nil
 	}
 	return &s, nil
-}
-
-// Production - s3 gateway is production ready.
-func (g *S3) Production() bool {
-	return true
 }
 
 // s3Objects implements gateway for MinIO and S3 compatible object storage servers.


### PR DESCRIPTION

## Description
fix: use madmin.Credentials for gateway interface

## Motivation and Context
the main reason is to de-couple the project from
depending on MinIO's internal/auth package, other
changes will subsequently follow.

## How to test this PR?
Nothing special to test, just simplification. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
