### PR TITLE
s3: Force a prefix removal using a special header

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1039,8 +1039,7 @@ func (er erasureObjects) deletePrefix(ctx context.Context, bucket, prefix string
 // response to the client request.
 func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	if opts.DeletePrefix {
-		err := er.deletePrefix(ctx, bucket, object)
-		return ObjectInfo{}, err
+		return ObjectInfo{}, toObjectErr(er.deletePrefix(ctx, bucket, object), bucket, object)
 	}
 
 	versionFound := true

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -793,9 +793,24 @@ func (z *erasureServerPools) PutObject(ctx context.Context, bucket string, objec
 	return z.serverPools[idx].PutObject(ctx, bucket, object, data, opts)
 }
 
+func (z *erasureServerPools) deletePrefix(ctx context.Context, bucket string, prefix string) error {
+	for _, zone := range z.serverPools {
+		_, err := zone.DeleteObject(ctx, bucket, prefix, ObjectOptions{DeletePrefix: true})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (z *erasureServerPools) DeleteObject(ctx context.Context, bucket string, object string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	if err = checkDelObjArgs(ctx, bucket, object); err != nil {
 		return objInfo, err
+	}
+
+	if opts.DeletePrefix {
+		err := z.deletePrefix(ctx, bucket, object)
+		return ObjectInfo{}, err
 	}
 
 	object = encodeDirObject(object)

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -919,10 +919,25 @@ func (s *erasureSets) GetObjectInfo(ctx context.Context, bucket, object string, 
 	return set.GetObjectInfo(ctx, bucket, object, opts)
 }
 
+func (s *erasureSets) deletePrefix(ctx context.Context, bucket string, prefix string) error {
+	for _, s := range s.sets {
+		_, err := s.DeleteObject(ctx, bucket, prefix, ObjectOptions{DeletePrefix: true})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DeleteObject - deletes an object from the hashedSet based on the object name.
 func (s *erasureSets) DeleteObject(ctx context.Context, bucket string, object string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
 	set := s.getHashedSet(object)
 	auditObjectErasureSet(ctx, object, set)
+
+	if opts.DeletePrefix {
+		err := s.deletePrefix(ctx, bucket, object)
+		return ObjectInfo{}, err
+	}
 	return set.DeleteObject(ctx, bucket, object, opts)
 }
 

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -58,6 +58,8 @@ type ObjectOptions struct {
 	ProxyHeaderSet bool                                                  // only set for GET/HEAD in active-active replication scenario
 	ParentIsObject func(ctx context.Context, bucket, parent string) bool // Used to verify if parent is an object.
 
+	DeletePrefix bool //  set true to enforce a prefix deletion, only application for DeleteObject API,
+
 	// Use the maximum parity (N/2), used when saving server configuration files
 	MaxParity bool
 }

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -121,11 +121,21 @@ func getOpts(ctx context.Context, r *http.Request, bucket, object string) (Objec
 		}, nil
 	}
 
+	deletePrefix := false
+	if d := r.Header.Get(xhttp.MinIOForceDelete); d != "" {
+		if b, err := strconv.ParseBool(d); err == nil {
+			deletePrefix = b
+		} else {
+			return opts, err
+		}
+	}
+
 	// default case of passing encryption headers to backend
 	opts, err = getDefaultOpts(r.Header, false, nil)
 	if err != nil {
 		return opts, err
 	}
+	opts.DeletePrefix = deletePrefix
 	opts.PartNumber = partNumber
 	opts.VersionID = vid
 	delMarker := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarker))

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -3270,6 +3271,10 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 
 	apiErr := ErrNone
 	if rcfg, _ := globalBucketObjectLockSys.Get(bucket); rcfg.LockEnabled {
+		if opts.DeletePrefix {
+			writeErrorResponse(ctx, w, toAPIError(ctx, errors.New("force-delete is forbidden in a locked-enabled bucket")), r.URL, guessIsBrowserReq(r))
+			return
+		}
 		if vID != "" {
 			apiErr = enforceRetentionBypassForDelete(ctx, r, bucket, ObjectToDelete{
 				ObjectName: object,

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -141,7 +141,7 @@ const (
 	// Server-Status
 	MinIOServerStatus = "x-minio-server-status"
 
-	// Delete special flag to force delete a bucket
+	// Delete special flag to force delete a bucket or a prefix
 	MinIOForceDelete = "x-minio-force-delete"
 
 	// Header indicates if the mtime should be preserved by client


### PR DESCRIPTION
## Description
An S3 client can send x-minio-force-delete to remove a prefix.


## Motivation and Context
Help the user to quickly remove a prefix, this is a MinIO extension

## How to test this PR?
```
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
#!/usr/bin/env python3

def remove_prefix(self, bucket, prefix):
    if bucket is None or bucket == "":
        raise Exception('bucket name is invalid')
    if prefix is None or prefix == "":
        raise Exception('prefix name is invalid')
    self._execute('DELETE', bucket, prefix, headers={'x-minio-force-delete': 'true'})

from minio import Minio
setattr(Minio, "remove_prefix", remove_prefix)

minioClient = Minio(
        'localhost:9000',
        access_key='minio',
        secret_key='minio123',
        secure=False
        )

minioClient.remove_prefix('testbucket', 'prefix/')
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
