### PR TITLE
fix: simplify diskMap usage to keep certain checks predictable

### DIFF
--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -18,7 +18,7 @@
 package cmd
 
 const (
-	storageRESTVersion       = "v36" // Changes to FileInfo for tier-journal
+	storageRESTVersion       = "v37" // cleanup behavior change at storage layer.
 	storageRESTVersionPrefix = SlashSeparator + storageRESTVersion
 	storageRESTPrefix        = minioReservedBucketPath + "/storage"
 )

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -233,6 +233,16 @@ func newLocalXLStorage(path string) (*xlStorage, error) {
 	})
 }
 
+// Sanitize - sanitizes the `format.json`, cleanup tmp.
+// all other future cleanups should be added here.
+func (s *xlStorage) Sanitize() error {
+	if err := formatErasureMigrate(s.diskPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return formatErasureCleanupTmp(s.diskPath)
+}
+
 // Initialize a new storage disk.
 func newXLStorage(ep Endpoint) (*xlStorage, error) {
 	path := ep.Path
@@ -301,14 +311,6 @@ func newXLStorage(ep Endpoint) (*xlStorage, error) {
 	}
 	w.Close()
 	Remove(filePath)
-
-	if err := formatErasureMigrate(p.diskPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return p, err
-	}
-
-	if err := formatErasureCleanupTmp(p.diskPath); err != nil {
-		return p, err
-	}
 
 	// Success.
 	return p, nil


### PR DESCRIPTION


## Description
fix: simplify diskMap usage to keep certain checks predictable

## Motivation and Context
Bonus: also make sure that we Sanitize() the drives only during
startup of the server, but not during disk reconnects.

## How to test this PR?
This can happen when diskPath --> absolute path 
and input endpoint is not an absolute path. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
