### PR TITLE
fs: Return faster on no ListObjects results

### DIFF
--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"sync"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/minio/minio/internal/sync/errgroup"
 )
 
@@ -289,6 +289,7 @@ func listObjects(ctx context.Context, obj ObjectLayer, bucket, prefix, marker, d
 		if !ok {
 			// Closed channel.
 			eof = true
+			break
 		}
 
 		if HasSuffix(walkResult.entry, SlashSeparator) {


### PR DESCRIPTION
## Description

When no results are sent `result.end` is never sent, so the loop runs until the list is full.

Break immediately when channel is closed.

Fixes #12518

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
