### PR TITLE
[deps]: update jwt-go dependency

### DIFF
--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
-	jwtreq "github.com/dgrijalva/jwt-go/request"
+	jwtgo "github.com/golang-jwt/jwt"
+	jwtreq "github.com/golang-jwt/jwt/request"
 	"github.com/minio/minio/internal/auth"
 	xjwt "github.com/minio/minio/internal/jwt"
 	"github.com/minio/minio/internal/logger"

--- a/cmd/jwt_test.go
+++ b/cmd/jwt_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 	"github.com/minio/minio/internal/auth"
 	xjwt "github.com/minio/minio/internal/jwt"
 )

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/tinylib/msgp/msgp"
 
-	jwtreq "github.com/dgrijalva/jwt-go/request"
+	jwtreq "github.com/golang-jwt/jwt/request"
 	"github.com/gorilla/mux"
 	"github.com/minio/minio/internal/config"
 	xhttp "github.com/minio/minio/internal/http"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/colinmarc/hdfs/v2 v2.2.0
 	github.com/coredns/coredns v1.4.0
 	github.com/dchest/siphash v1.2.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/djherbis/atime v1.0.0
 	github.com/dswarbrick/smart v0.0.0-20190505152634-909a45200d6d
 	github.com/dustin/go-humanize v1.0.0
@@ -27,6 +26,7 @@ require (
 	github.com/go-ldap/ldap/v3 v3.2.4
 	github.com/go-openapi/loads v0.20.2
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -533,6 +533,8 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/internal/auth/credentials.go
+++ b/internal/auth/credentials.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 	"github.com/minio/minio/internal/jwt"
 )
 

--- a/internal/config/dns/operator_dns.go
+++ b/internal/config/dns/operator_dns.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/minio/minio/internal/config"
 	xhttp "github.com/minio/minio/internal/http"
 )

--- a/internal/config/identity/openid/ecdsa-sha3_contrib.go
+++ b/internal/config/identity/openid/ecdsa-sha3_contrib.go
@@ -18,7 +18,7 @@ package openid
 import (
 	"crypto"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	// Needed for SHA3 to work - See: https://golang.org/src/crypto/crypto.go?s=1034:1288
 	_ "golang.org/x/crypto/sha3" // There is no SHA-3 FIPS-140 2 compliant implementation

--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config"
 	"github.com/minio/pkg/env"

--- a/internal/config/identity/openid/rsa-sha3_contrib.go
+++ b/internal/config/identity/openid/rsa-sha3_contrib.go
@@ -19,7 +19,7 @@ package openid
 import (
 	"crypto"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 
 	// Needed for SHA3 to work - See: https://golang.org/src/crypto/crypto.go?s=1034:1288
 	_ "golang.org/x/crypto/sha3" // There is no SHA-3 FIPS-140 2 compliant implementation

--- a/internal/jwt/parser.go
+++ b/internal/jwt/parser.go
@@ -19,8 +19,8 @@ package jwt
 
 // This file is a re-implementation of the original code here with some
 // additional allocation tweaks reproduced using GODEBUG=allocfreetrace=1
-// original file https://github.com/dgrijalva/jwt-go/blob/master/parser.go
-// borrowed under MIT License https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+// original file https://github.com/golang-jwt/jwt/blob/main/parser.go
+// borrowed under MIT License https://github.com/golang-jwt/jwt/blob/main/LICENSE
 
 import (
 	"crypto"
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"time"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
+	jwtgo "github.com/golang-jwt/jwt"
 	jsoniter "github.com/json-iterator/go"
 )
 
@@ -117,7 +117,7 @@ func (c *StandardClaims) SetAccessKey(accessKey string) {
 	c.AccessKey = accessKey
 }
 
-// Valid - implements https://godoc.org/github.com/dgrijalva/jwt-go#Claims compatible
+// Valid - implements https://godoc.org/github.com/golang-jwt/jwt#Claims compatible
 // claims interface, additionally validates "accessKey" fields.
 func (c *StandardClaims) Valid() error {
 	if err := c.StandardClaims.Valid(); err != nil {
@@ -162,7 +162,7 @@ func (c *MapClaims) SetAccessKey(accessKey string) {
 	c.MapClaims["accessKey"] = accessKey
 }
 
-// Valid - implements https://godoc.org/github.com/dgrijalva/jwt-go#Claims compatible
+// Valid - implements https://godoc.org/github.com/golang-jwt/jwt#Claims compatible
 // claims interface, additionally validates "accessKey" fields.
 func (c *MapClaims) Valid() error {
 	if err := c.MapClaims.Valid(); err != nil {

--- a/internal/jwt/parser_test.go
+++ b/internal/jwt/parser_test.go
@@ -19,15 +19,15 @@ package jwt
 
 // This file is a re-implementation of the original code here with some
 // additional allocation tweaks reproduced using GODEBUG=allocfreetrace=1
-// original file https://github.com/dgrijalva/jwt-go/blob/master/parser.go
-// borrowed under MIT License https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+// original file https://github.com/golang-jwt/jwt/blob/main/parser.go
+// borrowed under MIT License https://github.com/golang-jwt/jwt/blob/main/LICENSE
 
 import (
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 )
 
 var (


### PR DESCRIPTION
## Description

jwt-go has been renamed to jwt and has a new home. See
https://github.com/dgrijalva/jwt-go/issues/462

## Checklist:
- [x] Documentation updated

