### PR TITLE
docs: add limits for bucket and object name length

### DIFF
--- a/docs/minio-limits.md
+++ b/docs/minio-limits.md
@@ -28,6 +28,10 @@
 | Maximum number of parts returned per list parts request                         | 10000                                         |
 | Maximum number of objects returned per list objects request                     | 4500                                          |
 | Maximum number of multipart uploads returned per list multipart uploads request | 1000                                          |
+| Maximum length for bucket names                                                 | 63                                            |
+| Maximum length for object names                                                 | 1024                                          |
+| Maximum length for '/' seperated object name segment                            | 255                                           |
+
 
 ### List of Amazon S3 API's not supported on MinIO
 We found the following APIs to be redundant or less useful outside of AWS S3. If you have a different view on any of the APIs we missed, please open a [GitHub issue](https://github.com/minio/minio/issues).


### PR DESCRIPTION
## Description
Bucket names are limited to 63 chars (according to AWS).
Object names are limited to 1024 chars (according to AWS).
A '/' seperated segment of an object id may not exceed 255 chars.

## Motivation and Context
The information is currently missing in the minio-limits.md, but good to know for the users.

## How to test this PR?
Create objects and buckets with appropriate names.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
