### PR TITLE
allow resetting and reapply config on broken clusters

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -178,16 +178,7 @@ func (a adminAPIHandlers) GetConfigKVHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	cfg := globalServerConfig
-	if newObjectLayerFn() == nil {
-		var err error
-		cfg, err = getValidConfig(objectAPI)
-		if err != nil {
-			writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
-			return
-		}
-	}
-
+	cfg := globalServerConfig.Clone()
 	vars := mux.Vars(r)
 	var buf = &bytes.Buffer{}
 	cw := config.NewConfigWriteTo(cfg, vars["key"])
@@ -421,11 +412,7 @@ func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	cfg, err := readServerConfig(ctx, objectAPI)
-	if err != nil {
-		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
-		return
-	}
+	cfg := globalServerConfig.Clone()
 
 	var s strings.Builder
 	hkvs := config.HelpSubSysMap[""]

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -575,6 +575,7 @@ func handleCommonEnvVars() {
 		}
 		GlobalKMS = KMS
 	}
+
 	if tiers := env.Get("_MINIO_DEBUG_REMOTE_TIERS_IMMEDIATELY", ""); tiers != "" {
 		globalDebugRemoteTiersImmediately = strings.Split(tiers, ",")
 	}

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -101,10 +101,6 @@ func initHelp() {
 			Description: "[DEPRECATED] enable external OPA for policy enforcement",
 		},
 		config.HelpKV{
-			Key:         config.KmsKesSubSys,
-			Description: "enable external MinIO key encryption service",
-		},
-		config.HelpKV{
 			Key:         config.APISubSys,
 			Description: "manage global HTTP API call specific features, such as throttling, authentication types, etc.",
 		},

--- a/cmd/config-encrypted.go
+++ b/cmd/config-encrypted.go
@@ -97,15 +97,17 @@ func migrateIAMConfigsEtcdToEncrypted(ctx context.Context, client *etcd.Client) 
 		if !utf8.Valid(data) {
 			pdata, err := madmin.DecryptData(globalActiveCred.String(), bytes.NewReader(data))
 			if err != nil {
-				pdata, err = config.DecryptBytes(GlobalKMS, data, kms.Context{
-					minioMetaBucket: path.Join(minioMetaBucket, string(kv.Key)),
-				})
-				if err != nil {
+				if GlobalKMS != nil {
 					pdata, err = config.DecryptBytes(GlobalKMS, data, kms.Context{
-						minioMetaBucket: string(kv.Key),
+						minioMetaBucket: path.Join(minioMetaBucket, string(kv.Key)),
 					})
 					if err != nil {
-						return fmt.Errorf("Decrypting IAM config failed %w, possibly credentials are incorrect", err)
+						pdata, err = config.DecryptBytes(GlobalKMS, data, kms.Context{
+							minioMetaBucket: string(kv.Key),
+						})
+						if err != nil {
+							return fmt.Errorf("Decrypting IAM config failed %w, possibly credentials are incorrect", err)
+						}
 					}
 				}
 			}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -845,22 +845,14 @@ var (
 // Returns a minio-go Client configured to access remote host described by destDNSRecord
 // Applicable only in a federated deployment
 var getRemoteInstanceClient = func(r *http.Request, host string) (*miniogo.Core, error) {
-	if newObjectLayerFn() == nil {
-		return nil, errServerNotInitialized
-	}
-
 	cred := getReqAccessCred(r, globalServerRegion)
 	// In a federated deployment, all the instances share config files
 	// and hence expected to have same credentials.
-	core, err := miniogo.NewCore(host, &miniogo.Options{
+	return miniogo.NewCore(host, &miniogo.Options{
 		Creds:     credentials.NewStaticV4(cred.AccessKey, cred.SecretKey, ""),
 		Secure:    globalIsTLS,
 		Transport: getRemoteInstanceTransport,
 	})
-	if err != nil {
-		return nil, err
-	}
-	return core, nil
 }
 
 // Check if the destination bucket is on a remote site, this code only gets executed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,6 @@ const (
 	StorageClassSubSys   = "storage_class"
 	APISubSys            = "api"
 	CompressionSubSys    = "compression"
-	KmsKesSubSys         = "kms_kes"
 	LoggerWebhookSubSys  = "logger_webhook"
 	AuditWebhookSubSys   = "audit_webhook"
 	HealSubSys           = "heal"
@@ -107,7 +106,6 @@ var SubSystems = set.CreateStringSet(
 	APISubSys,
 	StorageClassSubSys,
 	CompressionSubSys,
-	KmsKesSubSys,
 	LoggerWebhookSubSys,
 	AuditWebhookSubSys,
 	PolicyOPASubSys,
@@ -144,7 +142,6 @@ var SubSystemsSingleTargets = set.CreateStringSet([]string{
 	APISubSys,
 	StorageClassSubSys,
 	CompressionSubSys,
-	KmsKesSubSys,
 	PolicyOPASubSys,
 	IdentityLDAPSubSys,
 	IdentityOpenIDSubSys,


### PR DESCRIPTION
## Description
allow resetting and reapply config on broken clusters

## Motivation and Context
Bonus: remove kms_kes as sub-system, since it's ENV only. - also 
fixes a crash with etcd cluster without KMS configured and also 
if KMS decryption is missing.

## How to test this PR?
Try to manually corrupt `config.json`, and then perform operations using 
`mc admin config export/import` to reset the cluster to make it operational.

The main reason for this PR is for operational purposes to quickly
recover production systems. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
