### PR TITLE
do not heal "backend-encrypted" out-of-band with migration

### DIFF
--- a/buildscripts/verify-healing.sh
+++ b/buildscripts/verify-healing.sh
@@ -67,7 +67,7 @@ function start_minio_3_node() {
 
 
 function check_online() {
-    if grep -q 'Server switching to safe mode' ${WORK_DIR}/dist-minio-*.log; then
+    if grep -q 'Unable to initialize sub-systems' ${WORK_DIR}/dist-minio-*.log; then
         echo "1"
     fi
 }

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -819,16 +819,6 @@ func (h *healSequence) healFromSourceCh() {
 }
 
 func (h *healSequence) healDiskMeta(objAPI ObjectLayer) error {
-	// Try to pro-actively heal backend-encrypted file.
-	if err := h.queueHealTask(healSource{
-		bucket: minioMetaBucket,
-		object: backendEncryptedFile,
-	}, madmin.HealItemBucketMetadata); err != nil {
-		if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
-			return err
-		}
-	}
-
 	// Start healing the config prefix.
 	return h.healMinioSysMeta(objAPI, minioConfigPrefix)()
 }

--- a/cmd/config-encrypted.go
+++ b/cmd/config-encrypted.go
@@ -183,5 +183,5 @@ func migrateConfigPrefixToEncrypted(objAPI ObjectLayer, encrypted bool) error {
 	if encrypted && GlobalKMS != nil {
 		logger.Info("Migration of encrypted config data completed. All config data is now encrypted.")
 	}
-	return deleteConfig(GlobalContext, globalObjectAPI, backendEncryptedFile)
+	return deleteConfig(GlobalContext, objAPI, backendEncryptedFile)
 }

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -158,13 +158,6 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []BucketIn
 		Name: pathJoin(minioMetaBucket, minioConfigPrefix),
 	})
 
-	// Try to pro-actively heal backend-encrypted file.
-	if _, err := er.HealObject(ctx, minioMetaBucket, backendEncryptedFile, "", madmin.HealOpts{}); err != nil {
-		if !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
-			logger.LogIf(ctx, err)
-		}
-	}
-
 	// Heal all buckets with all objects
 	for _, bucket := range buckets {
 		if tracker.isHealed(bucket.Name) {


### PR DESCRIPTION


## Description
do not heal "backend-encrypted" out-of-band with migration

## Motivation and Context
backend-encrypted doesn't need to be explicitly healed anymore
since this file is deleted upon upgrade and migration to the
KMS based encrypted config/IAM credentials.

## How to test this PR?
There is a slight possibility that backend-encrypted file might 
be left over successfully healed upon partial deletes(), causing slightly
confusing behavior for config migration. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
