### PR TITLE
Clean up targets properly on bucket deletion

### DIFF
--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -84,6 +84,20 @@ func (sys *BucketTargetSys) ListBucketTargets(ctx context.Context, bucket string
 	return nil, BucketRemoteTargetNotFound{Bucket: bucket}
 }
 
+// Delete clears targets present for a bucket
+func (sys *BucketTargetSys) Delete(bucket string) {
+	sys.Lock()
+	defer sys.Unlock()
+	tgts, ok := sys.targetsMap[bucket]
+	if !ok {
+		return
+	}
+	for _, t := range tgts {
+		delete(sys.arnRemotesMap, t.Arn)
+	}
+	delete(sys.targetsMap, bucket)
+}
+
 // SetTarget - sets a new minio-go client target for this bucket.
 func (sys *BucketTargetSys) SetTarget(ctx context.Context, bucket string, tgt *madmin.BucketTarget, update bool) error {
 	if globalIsGateway {

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -607,6 +607,7 @@ func (sys *NotificationSys) LoadBucketMetadata(ctx context.Context, bucketName s
 func (sys *NotificationSys) DeleteBucketMetadata(ctx context.Context, bucketName string) {
 	globalReplicationStats.Delete(bucketName)
 	globalBucketMetadataSys.Remove(bucketName)
+	globalBucketTargetSys.Delete(bucketName)
 	if localMetacacheMgr != nil {
 		localMetacacheMgr.deleteBucketCache(bucketName)
 	}

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -521,6 +521,7 @@ func (s *peerRESTServer) DeleteBucketMetadataHandler(w http.ResponseWriter, r *h
 
 	globalReplicationStats.Delete(bucketName)
 	globalBucketMetadataSys.Remove(bucketName)
+	globalBucketTargetSys.Delete(bucketName)
 	if localMetacacheMgr != nil {
 		localMetacacheMgr.deleteBucketCache(bucketName)
 	}


### PR DESCRIPTION
## Description


## Motivation and Context
On bucket deletion, remote targets for the bucket linger around

## How to test this PR?
create remote targets for a versioned bucket with `mc admin bucket remote`
delete bucket, `mc admin bucket remote ls alias` should not show the target

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
