### PR TITLE
docs: Update README.md

### DIFF
--- a/docs/orchestration/kubernetes/README.md
+++ b/docs/orchestration/kubernetes/README.md
@@ -6,9 +6,9 @@ MinIO is a high performance distributed object storage server, designed for larg
 
 There are multiple options to deploy MinIO on Kubernetes:
 
-- MinIO-Operator: Operator offers seamless way to create and update highly available distributed MinIO clusters. Refer [MinIO Operator documentation](https://github.com/minio/minio-operator/blob/master/README.md) for more details.
+- MinIO-Operator: Operator offers seamless way to create and update highly available distributed MinIO clusters. Refer to [MinIO Operator documentation](https://github.com/minio/minio-operator/blob/master/README.md) for more details.
 
-- Helm Chart: MinIO Helm Chart offers customizable and easy MinIO deployment with a single command. Refer [MinIO Helm Chart documentation](https://github.com/minio/charts) for more details.
+- Helm Chart: MinIO operator-based Helm Chart offers customizable and easy MinIO deployment with a single command. Refer to [MinIO Helm Chart documentation](https://github.com/minio/operator/tree/master/helm/minio-operator) for more details.
 
 ## Monitoring MinIO in Kubernetes
 


### PR DESCRIPTION
## Description
This PR replaces the (archived) link https://github.com/minio/charts with a link to https://github.com/minio/operator/tree/master/helm/minio-operator (which the archived repo points to).


## Motivation and Context

The link to `MinIO Helm Chart documentation` points to a repo that has been archived. The archived repo directs users to https://github.com/minio/operator/tree/master/helm/minio-operator. 

Disclaimer: I don't know the difference between https://github.com/minio/minio-operator (mentioned in the preceding bullet point in the file modified by this PR) and https://github.com/minio/operator or if the description of the changed link remains accurate.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
