### PR TITLE
Upgrade ubi8/ubi-minimal to 8.4

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG TARGETARCH
 

--- a/Dockerfile.release.fips
+++ b/Dockerfile.release.fips
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Description

Upgrades `ubi8/ubi-minimal `base image from 8.3 to 8.4

## Motivation and Context

Our Anchore Engine installation reports a number of vulnerabilities in the `ubi8/ubi-minimal:8.3` base image, including 1 high severity vulnerability:

```
CVE-2021-27219          glib2-2.56.4-8.el8                             High            0:2.56.4-10.el8_4        CVE-2021-27219        https://access.redhat.com/security/cve/CVE-2021-27219        rpm         rhel:8            pkgdb
```

as well as 50 medium and 30 low severity vulns.


The `ubi8/ubi-minimal:8.4` has no critical or high vulns, 21 medium vulns and 18 low vulns.

## How to test this PR?

I would love to build this image and run some tests myself. But I am unsure how to do that.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
