### PR TITLE
fix: use NumVersions for list resolver

### DIFF
--- a/cmd/erasure-common.go
+++ b/cmd/erasure-common.go
@@ -61,7 +61,6 @@ func (er erasureObjects) getOnlineDisks() (newDisks []StorageAPI) {
 			}
 			di, err := disks[i-1].DiskInfo(context.Background())
 			if err != nil || di.Healing {
-
 				// - Do not consume disks which are not reachable
 				//   unformatted or simply not accessible for some reason.
 				//

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -572,8 +572,11 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions) (entr
 	}()
 
 	askDisks := o.AskDisks
-	listingQuorum := askDisks - 1
-	// Special case: ask all disks if the drive count is 4
+	if askDisks == 0 {
+		askDisks = globalAPIConfig.getListQuorum()
+	}
+	// make sure atleast default '3' lists object is present.
+	listingQuorum := askDisks
 	if askDisks == -1 || er.setDriveCount == 4 {
 		askDisks = len(disks) // with 'strict' quorum list on all online disks.
 		listingQuorum = getReadQuorum(er.setDriveCount)


### PR DESCRIPTION


## Description
fix: use NumVersions for list resolver

## Motivation and Context
also do not incorrectly double count
objExists unless it's selected and it
matches with the previous entry.

Bonus: change listQuorum to match with
AskDisks to ensure that we atleast by
default choose all the "drives" that
we asked is consistent.

## How to test this PR?
Easy to reproduce when one of the object 
has inconsistent state with rest of the objects,
the object was incorrectly assumed to be good
by bumping up the objExists count.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
