### PR TITLE
fix: drive state not added in health report

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -226,6 +226,7 @@ func (fs *FSObjects) StorageInfo(ctx context.Context) (StorageInfo, []error) {
 	storageInfo := StorageInfo{
 		Disks: []madmin.Disk{
 			{
+				State:          madmin.DriveStateOk,
 				TotalSpace:     di.Total,
 				UsedSpace:      di.Used,
 				AvailableSpace: di.Free,


### PR DESCRIPTION
## Description

In case of FS mode, the drive state was not being added in the health
report. Fixed by hard coding it to "ok".

## Motivation and Context

Drive state is a basic field in the health data and is expected to be present
in all modes. Not having it in the report can cause errors on `health-analyzer`

## How to test this PR?

- Generate the health report (`mc admin subnet health {alias}`) for a cluster in FS mode
- Verify that under `minio -> info -> servers -> drives` the `state` field is present for the drive and it's value is `ok`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
