### PR TITLE
simplify audit logging for replication and ILM

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -235,7 +235,7 @@ func expireTransitionedObject(ctx context.Context, objectAPI ObjectLayer, oi *Ob
 		}
 
 		// Send audit for the lifecycle delete operation
-		auditLogLifecycle(ctx, oi.Bucket, oi.Name, oi.VersionID, ILMExpiryActivity)
+		auditLogLifecycle(ctx, *oi, ILMExpiry)
 
 		eventName := event.ObjectRemovedDelete
 		if lcOpts.DeleteMarker {

--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -142,7 +142,11 @@ func GetAuditEntry(ctx context.Context) *audit.Entry {
 		if ok {
 			return r
 		}
-		r = &audit.Entry{}
+		r = &audit.Entry{
+			Version:      audit.Version,
+			DeploymentID: globalDeploymentID,
+			Time:         time.Now().UTC().Format(time.RFC3339Nano),
+		}
 		SetAuditEntry(ctx, r)
 		return r
 	}
@@ -165,7 +169,8 @@ func AuditLog(ctx context.Context, w http.ResponseWriter, r *http.Request, reqCl
 		}
 
 		entry = audit.ToEntry(w, r, reqClaims, globalDeploymentID)
-		entry.Trigger = "external-request"
+		// indicates all requests for this API call are inbound
+		entry.Trigger = "incoming"
 
 		for _, filterKey := range filterKeys {
 			delete(entry.ReqClaims, filterKey)


### PR DESCRIPTION
## Description
simplify audit logging for replication and ILM

## Motivation and Context
auditLog should be attempted right before the
return of the function and not multiple times
per function, this ensures that we only trigger
it once per function call.

## How to test this PR?
Configure audit logging and enable replication

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
