### PR TITLE
[WIP] Add obsd/amd64 to the OS/arch list to crosscompile

### DIFF
--- a/buildscripts/cross-compile.sh
+++ b/buildscripts/cross-compile.sh
@@ -9,7 +9,7 @@ function _init() {
     export CGO_ENABLED=0
 
     ## List of architectures and OS to test coss compilation.
-    SUPPORTED_OSARCH="linux/ppc64le linux/mips64 linux/arm64 linux/s390x darwin/arm64 darwin/amd64 freebsd/amd64 windows/amd64 linux/arm linux/386 netbsd/amd64 linux/mips"
+    SUPPORTED_OSARCH="linux/ppc64le linux/mips64 linux/arm64 linux/s390x darwin/arm64 darwin/amd64 freebsd/amd64 windows/amd64 linux/arm linux/386 netbsd/amd64 linux/mips openbsd/amd64"
 }
 
 function _build() {


### PR DESCRIPTION
Hi,

Second try after https://github.com/minio/minio/pull/12417. Recreating a PR instead of reopening the previous one, because git is hard™.

gopsutil has landed a commit that remove the need for CGO: https://github.com/shirou/gopsutil/commit/d6e0932b9668488dcc01da288da88a52c25e7b98

It seems minio/minio pulls gopsutil through:
github.com/minio/mc@v0.0.0-20210626002108-cebf3318546f github.com/shirou/gopsutil/v3@v3.21.4
github.com/minio/madmin-go@v1.0.6 github.com/shirou/gopsutil/v3@v3.21.4
github.com/minio/madmin-go@v1.0.12 github.com/shirou/gopsutil/v3@v3.21.4

The madmin-go@v1.0.6 is because minio/minio pulls github.com/minio/console v0.7.5-0.20210628223511-b51d5505f375
which pulls github.com/minio/operator@v0.0.0-20210616045941-65f31f5f78ae
which pulls github.com/minio/madmin-go@v1.0.6

Can you please update those deps? gopsutil v3.21.6 has the aforementioned commit: https://github.com/shirou/gopsutil/releases/tag/v3.21.6

Thanks,
Daniel