### PR TITLE
fix: handle redirects for specific resources

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -114,13 +114,16 @@ func minioConfigToConsoleFeatures() {
 	os.Setenv("CONSOLE_MINIO_SERVER", getAPIEndpoints()[0])
 	if value := env.Get("MINIO_LOG_QUERY_URL", ""); value != "" {
 		os.Setenv("CONSOLE_LOG_QUERY_URL", value)
-	}
-	if value := env.Get("MINIO_LOG_QUERY_AUTH_TOKEN", ""); value != "" {
-		os.Setenv("CONSOLE_LOG_QUERY_AUTH_TOKEN", value)
+		if value := env.Get("MINIO_LOG_QUERY_AUTH_TOKEN", ""); value != "" {
+			os.Setenv("CONSOLE_LOG_QUERY_AUTH_TOKEN", value)
+		}
 	}
 	// Enable if prometheus URL is set.
 	if value := env.Get("MINIO_PROMETHEUS_URL", ""); value != "" {
 		os.Setenv("CONSOLE_PROMETHEUS_URL", value)
+		if value := env.Get("MINIO_PROMETHEUS_JOB_ID", "minio-job"); value != "" {
+			os.Setenv("CONSOLE_PROMETHEUS_JOB_ID", value)
+		}
 	}
 	// Enable if LDAP is enabled.
 	if globalLDAPConfig.Enabled {
@@ -411,11 +414,6 @@ func handleCommonEnvVars() {
 	globalBrowserEnabled, err = config.ParseBool(env.Get(config.EnvBrowser, config.EnableOn))
 	if err != nil {
 		logger.Fatal(config.ErrInvalidBrowserValue(err), "Invalid MINIO_BROWSER value in environment variable")
-	}
-
-	globalBrowserRedirect, err = config.ParseBool(env.Get(config.EnvBrowserRedirect, config.EnableOn))
-	if err != nil {
-		logger.Fatal(config.ErrInvalidBrowserValue(err), "Invalid MINIO_BROWSER_REDIRECT value in environment variable")
 	}
 
 	globalFSOSync, err = config.ParseBool(env.Get(config.EnvFSOSync, config.EnableOff))

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -137,9 +137,6 @@ var (
 	// This flag is set to 'true' by default
 	globalBrowserEnabled = true
 
-	// This flag is set to 'true' by default.
-	globalBrowserRedirect = true
-
 	// This flag is set to 'true' when MINIO_UPDATE env is set to 'off'. Default is false.
 	globalInplaceUpdateDisabled = false
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -29,14 +29,13 @@ const (
 	EnvRootUser     = "MINIO_ROOT_USER"
 	EnvRootPassword = "MINIO_ROOT_PASSWORD"
 
-	EnvBrowser         = "MINIO_BROWSER"
-	EnvBrowserRedirect = "MINIO_BROWSER_REDIRECT"
-	EnvDomain          = "MINIO_DOMAIN"
-	EnvRegionName      = "MINIO_REGION_NAME"
-	EnvPublicIPs       = "MINIO_PUBLIC_IPS"
-	EnvFSOSync         = "MINIO_FS_OSYNC"
-	EnvArgs            = "MINIO_ARGS"
-	EnvDNSWebhook      = "MINIO_DNS_WEBHOOK_ENDPOINT"
+	EnvBrowser    = "MINIO_BROWSER"
+	EnvDomain     = "MINIO_DOMAIN"
+	EnvRegionName = "MINIO_REGION_NAME"
+	EnvPublicIPs  = "MINIO_PUBLIC_IPS"
+	EnvFSOSync    = "MINIO_FS_OSYNC"
+	EnvArgs       = "MINIO_ARGS"
+	EnvDNSWebhook = "MINIO_DNS_WEBHOOK_ENDPOINT"
 
 	EnvRootDiskThresholdSize = "MINIO_ROOTDISK_THRESHOLD_SIZE"
 


### PR DESCRIPTION
## Description
fix: handle redirects for specific resources

## Motivation and Context
do not attempt redirect for all resources,
instead handle redirects only when we think
It's a legacy browser request.

## How to test this PR?
Nothing special test with various requests such as 

```
~ curl -H "User-Agent: Mozilla" http://localhost:9000 - should redirect
~ curl -H "User-Agent: Mozilla" http://localhost:9000/testbucket - should not redirect
~ curl -H "User-Agent: Mozilla" http://localhost:9000/minio/testbucket - should redirect
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
