### PR TITLE
fix: Mention GetBucketyPolicy in S3 gateway docs policy

### DIFF
--- a/docs/gateway/s3.md
+++ b/docs/gateway/s3.md
@@ -54,6 +54,7 @@ Minimum permissions required if you wish to provide restricted access with your 
             "Sid": "readonly",
             "Effect": "Allow",
             "Action": [
+                "s3:GetBucketPolicy",
                 "s3:HeadBucket",
                 "s3:ListBucket"
             ],


### PR DESCRIPTION
That action is needed for the gateway to obtain the policy
setting for public access.

Resolves: https://github.com/minio/minio/issues/12638

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
