### PR TITLE
fix: accountInfo should use parentUser

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -984,15 +984,18 @@ func (a adminAPIHandlers) AccountInfoHandler(w http.ResponseWriter, r *http.Requ
 	// Set delimiter value for "s3:delimiter" policy conditionals.
 	r.Header.Set("delimiter", SlashSeparator)
 
+	parentUser := cred.AccessKey
+	if cred.ParentUser != "" {
+		parentUser = cred.ParentUser
+	}
+
 	isAllowedAccess := func(bucketName string) (rd, wr bool) {
-		// Use the following trick to filter in place
-		// https://github.com/golang/go/wiki/SliceTricks#filter-in-place
 		if globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     cred.AccessKey,
+			AccountName:     parentUser,
 			Groups:          cred.Groups,
 			Action:          iampolicy.ListBucketAction,
 			BucketName:      bucketName,
-			ConditionValues: getConditionValues(r, "", cred.AccessKey, claims),
+			ConditionValues: getConditionValues(r, "", parentUser, claims),
 			IsOwner:         owner,
 			ObjectName:      "",
 			Claims:          claims,
@@ -1001,11 +1004,11 @@ func (a adminAPIHandlers) AccountInfoHandler(w http.ResponseWriter, r *http.Requ
 		}
 
 		if globalIAMSys.IsAllowed(iampolicy.Args{
-			AccountName:     cred.AccessKey,
+			AccountName:     parentUser,
 			Groups:          cred.Groups,
 			Action:          iampolicy.PutObjectAction,
 			BucketName:      bucketName,
-			ConditionValues: getConditionValues(r, "", cred.AccessKey, claims),
+			ConditionValues: getConditionValues(r, "", parentUser, claims),
 			IsOwner:         owner,
 			ObjectName:      "",
 			Claims:          claims,


### PR DESCRIPTION

## Description
fix: accountInfo should use parentUser

## Motivation and Context
parentUser is needed to make sure that
dynamic variables in policy work properly.

fixes #12651


## How to test this PR?

Verify these policies work properly

For `x.json`
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:*"
            ],
            "Resource": [
                "arn:aws:s3:::${aws:username}-*"
            ]
        }
    ]
}
```

and for `t.json`
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:ListAllMyBuckets",
                "s3:GetBucketLocation"
            ],
            "Resource": [
                "arn:aws:s3:::*"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:ListBucket",
                "s3:ListBucketMultipartUploads",
                "s3:ListMultipartUploadParts"
            ],
            "Resource": [
                "arn:aws:s3:::${aws:username}"
            ]
        },
        {
            "Effect": "Allow",
            "Action": [
                "s3:AbortMultipartUpload",
                "s3:GetObject",
                "s3:PutObject"
            ],
            "Resource": [
                "arn:aws:s3:::${aws:username}/*"
            ]
        }
    ]
}
```

```
10569  mc admin policy set myminio/ access user=minio1
10570  vim /tmp/t.json
10571  mc admin policy add myminio/ access /tmp/t.json
10572  vim /tmp/t.json
10573  emacsclient -t /tmp/t.json
10574  mc admin policy add myminio/ access /tmp/t.json
10575  mc admin user add myminio/ minio1 minio123
10576  mc admin group add myminio/ allcents minio1
10577  mc admin policy add myminio/ access /tmp/t.json
10578  mc admin policy set myminio/ access group=allcents
10579  mc mb myminio/minio1
10580  vim /tmp/x.json
10581  mc admin policy add myminio/ restrict /tmp/x.json
10582  mc admin user add myminio/ minio2 minio123
10583  mc admin policy set myminio/ restrict user=minio2
10584  mc mb myminio/minio2
10585  mc mb myminio/minio2-test
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes, accountInfo should work with dynamic policies
- [ ] Documentation updated
- [ ] Unit tests added/updated
