### PR TITLE
fix: allow authToken for webhook to support Splunk

### DIFF
--- a/internal/event/target/webhook.go
+++ b/internal/event/target/webhook.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/minio/minio/internal/event"
@@ -163,7 +164,15 @@ func (target *WebhookTarget) send(eventData event.Event) error {
 		return err
 	}
 
-	if target.args.AuthToken != "" {
+	// Verify if the authToken already contains
+	// <Key> <Token> like format, if this is
+	// already present we can blindly use the
+	// authToken as is instead of adding 'Bearer'
+	tokens := strings.Fields(target.args.AuthToken)
+	switch len(tokens) {
+	case 2:
+		req.Header.Set("Authorization", target.args.AuthToken)
+	case 1:
 		req.Header.Set("Authorization", "Bearer "+target.args.AuthToken)
 	}
 


### PR DESCRIPTION
## Description
fix: allow authToken for webhook to support Splunk

## Motivation and Context
authToken would only support "bearer" token,
instead, support raw tokens as well

## How to test this PR?
Just configure auth_token to be of some format like `auth_token="Splunk hec"` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
