### PR TITLE
Add option in readDir to enable symlink following of dirs

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -534,7 +534,7 @@ func (fs *FSObjects) ListBuckets(ctx context.Context) ([]BucketInfo, error) {
 		atomic.AddInt64(&fs.activeIOCount, -1)
 	}()
 
-	entries, err := readDir(fs.fsPath)
+	entries, err := readDirWithOpts(fs.fsPath, readDirOpts{count: -1, followDirSymlink: true})
 	if err != nil {
 		logger.LogIf(ctx, errDiskNotFound)
 		return nil, toObjectErr(errDiskNotFound)

--- a/cmd/os-readdir-common.go
+++ b/cmd/os-readdir-common.go
@@ -17,8 +17,11 @@
 
 package cmd
 
+// Options for readDir function call
 type readDirOpts struct {
-	count            int
+	// The maximum number of entries to return
+	count int
+	// Follow directory symlink
 	followDirSymlink bool
 }
 
@@ -27,6 +30,7 @@ func readDir(dirPath string) (entries []string, err error) {
 	return readDirWithOpts(dirPath, readDirOpts{count: -1})
 }
 
+// Return up to count entries at the directory dirPath.
 func readDirN(dirPath string, count int) (entries []string, err error) {
 	return readDirWithOpts(dirPath, readDirOpts{count: count})
 }

--- a/cmd/os-readdir-common.go
+++ b/cmd/os-readdir-common.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+type readDirOpts struct {
+	count            int
+	followDirSymlink bool
+}
+
+// Return all the entries at the directory dirPath.
+func readDir(dirPath string) (entries []string, err error) {
+	return readDirWithOpts(dirPath, readDirOpts{count: -1})
+}
+
+func readDirN(dirPath string, count int) (entries []string, err error) {
+	return readDirWithOpts(dirPath, readDirOpts{count: count})
+}

--- a/cmd/os-readdir_unix.go
+++ b/cmd/os-readdir_unix.go
@@ -98,11 +98,6 @@ func parseDirEnt(buf []byte) (consumed int, name []byte, typ os.FileMode, err er
 	return consumed, nameBuf[:nameLen], typ, nil
 }
 
-// Return all the entries at the directory dirPath.
-func readDir(dirPath string) (entries []string, err error) {
-	return readDirN(dirPath, -1)
-}
-
 // readDirFn applies the fn() function on each entries at dirPath, doesn't recurse into
 // the directory itself, if the dirPath doesn't exist this function doesn't return
 // an error.
@@ -184,7 +179,7 @@ func readDirFn(dirPath string, fn func(name string, typ os.FileMode) error) erro
 
 // Return count entries at the directory dirPath and all entries
 // if count is set to -1
-func readDirN(dirPath string, count int) (entries []string, err error) {
+func readDirWithOpts(dirPath string, opts readDirOpts) (entries []string, err error) {
 	f, err := Open(dirPath)
 	if err != nil {
 		return nil, osErrToFileErr(err)
@@ -201,6 +196,8 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 
 	boff := 0 // starting read position in buf
 	nbuf := 0 // end valid data in buf
+
+	count := opts.count
 
 	for count != 0 {
 		if boff >= nbuf {
@@ -242,7 +239,7 @@ func readDirN(dirPath string, count int) (entries []string, err error) {
 			}
 
 			// Ignore symlinked directories.
-			if typ&os.ModeSymlink == os.ModeSymlink && fi.IsDir() {
+			if !opts.followDirSymlink && typ&os.ModeSymlink == os.ModeSymlink && fi.IsDir() {
 				continue
 			}
 


### PR DESCRIPTION
## Description
We do not follow symlinked directories but we make this an exception in case of FS & NAS gateway


## Motivation and Context
Enable listing symlinked buckets

## How to test this PR?
1. Run `minio gateway nas /tmp/nas`
2. `mc mb myminio/testbucket`
3. `cd /tmp/nas/; ln -s testbucket -T symlink`
4. List buckets: `mc ls myminio/`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
