### PR TITLE
Add prefixes usage in Accounting Usage Info

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -72,6 +72,8 @@ func registerAdminRouter(router *mux.Router, enableConfigOps bool) {
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/storageinfo").HandlerFunc(gz(httpTraceAll(adminAPI.StorageInfoHandler)))
 		// DataUsageInfo operations
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/datausageinfo").HandlerFunc(gz(httpTraceAll(adminAPI.DataUsageInfoHandler)))
+		// PrefixUsageInfo operations
+		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/prefixusageinfo").HandlerFunc(gz(httpTraceAll(adminAPI.PrefixUsageInfoHandler)))
 
 		if globalIsDistErasure || globalIsErasure {
 			/// Heal operations

--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -530,6 +530,18 @@ func (h dataUsageHash) Key() string {
 	return string(h)
 }
 
+func (d *dataUsageCache) flattenChildrens(root dataUsageEntry) (m map[string]dataUsageEntry) {
+	m = make(map[string]dataUsageEntry)
+	for id := range root.Children {
+		e := d.Cache[id]
+		if len(e.Children) > 0 {
+			e = d.flatten(e)
+		}
+		m[id] = e
+	}
+	return m
+}
+
 // flatten all children of the root into the root element and return it.
 func (d *dataUsageCache) flatten(root dataUsageEntry) dataUsageEntry {
 	for id := range root.Children {

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -76,11 +76,16 @@ func loadPrefixUsageFromBackend(ctx context.Context, objAPI ObjectLayer, bucket 
 		for _, er := range pool.sets {
 			// Load bucket usage prefixes
 			if err := cache.load(ctx, er, bucket+slashSeparator+dataUsageCacheName); err == nil {
-				if root := cache.find(bucket); root != nil {
-					for id, usageInfo := range cache.flattenChildrens(*root) {
-						prefix := strings.TrimPrefix(id, bucket+slashSeparator)
-						m[prefix] += uint64(usageInfo.Size)
-					}
+				root := cache.find(bucket)
+				if root == nil {
+					// We dont have usage information for this bucket in this
+					// set, go to the next set
+					continue
+				}
+
+				for id, usageInfo := range cache.flattenChildrens(*root) {
+					prefix := strings.TrimPrefix(id, bucket+slashSeparator)
+					m[prefix] += uint64(usageInfo.Size)
 				}
 			}
 		}


### PR DESCRIPTION
## Description
Add a new admin handler to return first level prefix usage of
a given bucket.

A simple code example which will be added in madmin-go/

```
package main

import (
        "context"
        "log"

        "github.com/minio/madmin-go"
)

func main() {
        madmClnt, err := madmin.New("localhost:9000", "minio", "minio123", false)
        if err != nil {
                log.Fatalln(err)
        }

        prefixUsageInfo, err := madmClnt.PrefixUsageInfo(context.Background(), "testbucket")
        if err != nil {
                log.Fatalln(err)
        }
        log.Println(prefixUsageInfo)
}
```

## Motivation and Context
Add prefix usage reporting

## How to test this PR?
Ask me

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
