### PR TITLE
fix: use browser redirect URL for IDP callback

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -428,6 +428,7 @@ func handleCommonEnvVars() {
 				err := fmt.Errorf("URL contains unexpected resources, expected URL to be of http(s)://minio.example.com format: %v", u)
 				logger.Fatal(err, "Invalid MINIO_BROWSER_REDIRECT value is environment variable")
 			}
+			u.Path = "" // remove any path component such as `/`
 			globalBrowserRedirectURL = u
 		}
 	}

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -157,6 +157,9 @@ func sortIPs(ipList []string) []string {
 }
 
 func getConsoleEndpoints() (consoleEndpoints []string) {
+	if globalBrowserRedirectURL != nil {
+		return []string{globalBrowserRedirectURL.String()}
+	}
 	var ipList []string
 	if globalMinioConsoleHost == "" {
 		ipList = sortIPs(mustGetLocalIP4().ToSlice())


### PR DESCRIPTION

## Description
fix: use browser redirect URL for IDP callback

## Motivation and Context
if browser_redirect_url is set use that for IDP callback
automatically, if we do not have to set REDIRECT_URI
for OpenID callback URL.

## How to test this PR?
Nothing special this is an enhancement

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
