### PR TITLE
[IDP:LDAP] Add root users and groups

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -312,6 +312,13 @@ func checkRequestAuthTypeCredential(ctx context.Context, r *http.Request, action
 		return cred, owner, s3Err
 	}
 
+	if !owner && globalLDAPConfig.Enabled {
+		// Check if user is configured as root/owner via LDAP
+		ldapUsername := claims[ldapUserN].(string)
+		groups := cred.Groups
+		owner = globalLDAPConfig.CheckForRootPrivilege(ldapUsername, groups)
+	}
+
 	// LocationConstraint is valid only for CreateBucketAction.
 	var locationConstraint string
 	if action == policy.CreateBucketAction {

--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -135,8 +135,8 @@ func checkKeyValid(accessKey string) (auth.Credentials, bool, APIErrorCode) {
 		if !ok {
 			return cred, false, ErrInvalidAccessKeyID
 		}
-		owner = cred.AccessKey == ucred.ParentUser
 		cred = ucred
+		owner = cred.AccessKey == ucred.ParentUser
 	}
 	return cred, owner, ErrNone
 }

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -532,13 +532,16 @@ func (sts *stsAPIHandlers) AssumeRoleWithLDAPIdentity(w http.ResponseWriter, r *
 		return
 	}
 
-	// Check if this user or their groups have a policy applied.
-	ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, false, groupDistNames...)
-	if len(ldapPolicies) == 0 && globalPolicyOPA == nil {
-		writeSTSErrorResponse(ctx, w, true, ErrSTSInvalidParameterValue,
-			fmt.Errorf("expecting a policy to be set for user `%s` or one of their groups: `%s` - rejecting this request",
-				ldapUserDN, strings.Join(groupDistNames, "`,`")))
-		return
+	// Root users do not need any policies to be applied.
+	if !globalLDAPConfig.CheckForRootPrivilege(ldapUsername, groupDistNames) {
+		// Check if this user or their groups have a policy applied.
+		ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, false, groupDistNames...)
+		if len(ldapPolicies) == 0 && globalPolicyOPA == nil {
+			writeSTSErrorResponse(ctx, w, true, ErrSTSInvalidParameterValue,
+				fmt.Errorf("expecting a policy to be set for user `%s` or one of their groups: `%s` - rejecting this request",
+					ldapUserDN, strings.Join(groupDistNames, "`,`")))
+			return
+		}
 	}
 
 	expiryDur := globalLDAPConfig.GetExpiryDuration()

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -401,6 +401,8 @@ func (l *Config) Bind(username, password string) (string, []string, error) {
 	return bindDN, groups, nil
 }
 
+// CheckForRootPrivilege checks if the given username and list of group
+// memberships allows for root privileges according to the LDAP configuration.
 func (l *Config) CheckForRootPrivilege(username string, groups []string) bool {
 	isRoot := l.RootUserNamesSet.Contains(username)
 	for _, group := range groups {

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -98,6 +98,18 @@ var (
 			Type:        "on|off",
 		},
 		config.HelpKV{
+			Key:         RootUserNames,
+			Type:        "list",
+			Description: `";" separated list of user names to be given full admin access to MinIO`,
+			Optional:    true,
+		},
+		config.HelpKV{
+			Key:         RootUserGroups,
+			Type:        "list",
+			Description: `";" separated list of LDAP group DNs whose members will get full admin access to MinIO`,
+			Optional:    true,
+		},
+		config.HelpKV{
 			Key:         config.Comment,
 			Description: config.DefaultComment,
 			Optional:    true,

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -50,13 +50,13 @@ var (
 		},
 		config.HelpKV{
 			Key:         UserDNSearchBaseDN,
-			Description: `Base LDAP DN to search for user DN`,
+			Description: `Base LDAP DN to search for user DN e.g. "cn=users,dc=myldapserver,dc=com`,
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         UserDNSearchFilter,
-			Description: `Search filter to lookup user DN`,
+			Description: `Search filter to lookup user DN e.g. "(uid=%s,cn=accounts,dc=myldapserver,dc=com)"`,
 			Optional:    true,
 			Type:        "string",
 		},


### PR DESCRIPTION
## Description

This change brings new configuration parameters to allow configuration of root
users and root user groups via LDAP integration.

## Motivation and Context

With external IDP, we are moving towards eliminating root user configuration when starting MinIO, instead root users configured via the IDP itself. This change is for LDAP.


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
