### PR TITLE
Add deployment-id and source bucket to transitioned object name

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -269,13 +269,13 @@ func expireTransitionedObject(ctx context.Context, objectAPI ObjectLayer, oi *Ob
 }
 
 // generate an object name for transitioned object
-func genTransitionObjName() (string, error) {
+func genTransitionObjName(bucket string) (string, error) {
 	u, err := uuid.NewRandom()
 	if err != nil {
 		return "", err
 	}
 	us := u.String()
-	obj := fmt.Sprintf("%s/%s/%s", us[0:2], us[2:4], us)
+	obj := fmt.Sprintf("%s/%s/%s/%s/%s", globalDeploymentID, bucket, us[0:2], us[2:4], us)
 	return obj, nil
 }
 

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1399,7 +1399,7 @@ func (er erasureObjects) TransitionObject(ctx context.Context, bucket, object st
 		return nil
 	}
 
-	destObj, err := genTransitionObjName()
+	destObj, err := genTransitionObjName(bucket)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

## Description
This allows remote bucket admin to identify the origin of transitioned
objects by simply inspecting the object prefixes.

e.g let's take a remote tier TIER-1 pointing to a remote bucket (prefix)
testbucket/testprefix-1. The remote bucket admin can list all transitioned objects
from a MinIO deployment identified by '2e78e906-1c5d-4f94-8689-9df44cafde39' and
source bucket 'mybucket' like so,

$ ./mc ls -r minio-tier-target/testbucket/testprefix-1/2e78e906-1c5d-4f94-8689-9df44cafde39/mybucket/
[2021-07-12 17:15:50 PDT]   160B 48/fb/48fbc0e6-3a73-458b-9337-8e722c619ca4
[2021-07-12 16:58:46 PDT]   160B 7d/1c/7d1c96bd-031a-48d4-99ea-b1304e870830


## Motivation and Context
Allow a remote bucket admin to identify transitioned objects from a deleted MinIO deployment. 

## How to test this PR?
Listing on remote bucket (of a remote tier) should show deployment ID and source bucket. Additionally, objects tiered prior to this change must still be accessible.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
