### PR TITLE
fix: properly send group unset policy

### DIFF
--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -129,8 +129,8 @@ func (s *peerRESTServer) LoadPolicyMappingHandler(w http.ResponseWriter, r *http
 		s.writeErrorResponse(w, errors.New("user-or-group is missing"))
 		return
 	}
-	_, isGroup := vars[peerRESTIsGroup]
 
+	_, isGroup := r.URL.Query()[peerRESTIsGroup]
 	if err := globalIAMSys.LoadPolicyMapping(objAPI, userOrGroup, isGroup); err != nil {
 		s.writeErrorResponse(w, err)
 		return
@@ -384,7 +384,6 @@ func (s *peerRESTServer) NetInfoHandler(w http.ResponseWriter, r *http.Request) 
 	}
 	if n != r.ContentLength {
 		err := fmt.Errorf("Subnet health: short read: expected %d found %d", r.ContentLength, n)
-
 		logger.LogIf(ctx, err)
 		w.Header().Set("FinalStatus", err.Error())
 		return


### PR DESCRIPTION
## Description
fix: properly send group unset policy

## Motivation and Context
In distributed setups `mc admin group unset`
was not correctly working due to incorrect
handling of query parameters between peers.

## How to test this PR?
```sh
export MINIO_ACCESS_KEY=minio
export MINIO_SECRET_KEY=minio123
export MINIO_ERASURE_SET_DRIVE_COUNT=6
export MINIO_PROMETHEUS_AUTH_TYPE=public
export MINIO_ENDPOINTS="http://127.0.0.1:9001/home/harsha/disk01 http://127.0.0.1:9002/home/harsha/disk02 http://127.0.0.1:9003/home/harsha/disk03 http://127.0.0.1:9004/home/harsha/disk04 http://127.0.0.1:9001/home/harsha/disk05 http://127.0.0.1:9002/home/harsha/disk06 http://127.0.0.1:9003/home/harsha/disk07 http://127.0.0.1:9004/home/harsha/disk08 http://127.0.0.1:9001/home/harsha/disk09 http://127.0.0.1:9002/home/harsha/disk10 http://127.0.0.1:9003/home/harsha/disk11 http://127.0.0.1:9004/home/harsha/disk12"
export MINIO_SCANNER_CYCLE=10s
for i in {01..04}; do
    /home/harsha/mygo/src/github.com/minio/minio/minio server --address ":90${i}" &
done
```

and attempt a 

```
~ mc admin policy set alias/ policyName group=groupName
```

```
~ mc admin policy unset alias/ policyName group=groupName
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
