### PR TITLE
fix: rename error message for MINIO_BROWSER_REDIRECT_URL

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -419,14 +419,14 @@ func handleCommonEnvVars() {
 		if redirectURL := env.Get(config.EnvMinIOBrowserRedirectURL, ""); redirectURL != "" {
 			u, err := xnet.ParseHTTPURL(redirectURL)
 			if err != nil {
-				logger.Fatal(err, "Invalid MINIO_BROWSER_REDIRECT value in environment variable")
+				logger.Fatal(err, "Invalid MINIO_BROWSER_REDIRECT_URL value in environment variable")
 			}
 			// Look for if URL has invalid values and return error.
 			if !((u.Scheme == "http" || u.Scheme == "https") &&
 				(u.Path == "/" || u.Path == "") && u.Opaque == "" &&
 				!u.ForceQuery && u.RawQuery == "" && u.Fragment == "") {
 				err := fmt.Errorf("URL contains unexpected resources, expected URL to be of http(s)://minio.example.com format: %v", u)
-				logger.Fatal(err, "Invalid MINIO_BROWSER_REDIRECT value is environment variable")
+				logger.Fatal(err, "Invalid MINIO_BROWSER_REDIRECT_URL value is environment variable")
 			}
 			u.Path = "" // remove any path component such as `/`
 			globalBrowserRedirectURL = u


### PR DESCRIPTION
## Description

rename the error message for MINIO_BROWSER_REDIRECT_URL to match the field name

## Motivation and Context

I ran into such an error message and was first irritated that the variable `MINIO_BROWSER_REDIRECT` does not exist.
The variable is actually named `MINIO_BROWSER_REDIRECT_URL`.

## How to test this PR?

Set a wrong value to `MINIO_BROWSER_REDIRECT_URL`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
