### PR TITLE
Skip transitioning of object versions if inlined

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -267,7 +267,7 @@ func (er erasureObjects) getObjectWithFileInfo(ctx context.Context, bucket, obje
 	// due to a bug in RenameData() the fi.Data is not niled leading to
 	// GetObject thinking that fi.Data is valid while fi.Size has
 	// changed already.
-	if _, ok := fi.Metadata[ReservedMetadataPrefixLower+"inline-data"]; ok {
+	if fi.InlineData() {
 		shardFileSize := erasure.ShardFileSize(fi.Size)
 		if shardFileSize >= 0 && shardFileSize >= smallFileThreshold {
 			for i := range metaArr {
@@ -816,7 +816,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	if len(inlineBuffers) > 0 {
 		// Set an additional header when data is inlined.
 		for index := range partsMetadata {
-			partsMetadata[index].Metadata[ReservedMetadataPrefixLower+"inline-data"] = "true"
+			partsMetadata[index].SetInlineData()
 		}
 	}
 
@@ -1390,7 +1390,7 @@ func (er erasureObjects) TransitionObject(ctx context.Context, bucket, object st
 	}
 
 	// object content is small enough that it's inlined, skipping transition
-	if _, ok := fi.Metadata[ReservedMetadataPrefixLower+"inline-data"]; ok {
+	if fi.InlineData() {
 		return nil
 	}
 

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1388,6 +1388,12 @@ func (er erasureObjects) TransitionObject(ctx context.Context, bucket, object st
 			return toObjectErr(err, bucket, object)
 		}
 	}
+
+	// object content is small enough that it's inlined, skipping transition
+	if _, ok := fi.Metadata[ReservedMetadataPrefixLower+"inline-data"]; ok {
+		return nil
+	}
+
 	destObj, err := genTransitionObjName()
 	if err != nil {
 		return err

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -181,6 +181,17 @@ type FileInfo struct {
 	SuccessorModTime time.Time
 }
 
+// InlineData returns true if object contents are inlined alongside its metadata.
+func (fi FileInfo) InlineData() bool {
+	_, ok := fi.Metadata[ReservedMetadataPrefixLower+"inline-data"]
+	return ok
+}
+
+// SetInlineData marks object (version) as inline.
+func (fi FileInfo) SetInlineData() {
+	fi.Metadata[ReservedMetadataPrefixLower+"inline-data"] = "true"
+}
+
 // VersionPurgeStatusKey denotes purge status in metadata
 const VersionPurgeStatusKey = "purgestatus"
 

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -968,7 +968,7 @@ func (j xlMetaV2DeleteMarker) ToFileInfo(volume, path string) (FileInfo, error) 
 
 // UsesDataDir returns true if this object version uses its data directory for
 // its contents and false otherwise.
-func (j *xlMetaV2Object) UsesDataDir() bool {
+func (j xlMetaV2Object) UsesDataDir() bool {
 	// Skip if this version is not transitioned, i.e it uses its data directory.
 	if !bytes.Equal(j.MetaSys[ReservedMetadataPrefixLower+TransitionStatus], []byte(lifecycle.TransitionComplete)) {
 		return true
@@ -976,6 +976,19 @@ func (j *xlMetaV2Object) UsesDataDir() bool {
 
 	// Check if this transitioned object has been restored on disk.
 	return isRestoredObjectOnDisk(j.MetaUser)
+}
+
+func (j *xlMetaV2Object) SetTransition(fi FileInfo) {
+	j.MetaSys[ReservedMetadataPrefixLower+TransitionStatus] = []byte(fi.TransitionStatus)
+	j.MetaSys[ReservedMetadataPrefixLower+TransitionedObjectName] = []byte(fi.TransitionedObjName)
+	j.MetaSys[ReservedMetadataPrefixLower+TransitionedVersionID] = []byte(fi.TransitionVersionID)
+	j.MetaSys[ReservedMetadataPrefixLower+TransitionTier] = []byte(fi.TransitionTier)
+}
+
+func (j *xlMetaV2Object) RemoveRestoreHdrs() {
+	delete(j.MetaUser, xhttp.AmzRestore)
+	delete(j.MetaUser, xhttp.AmzRestoreExpiryDays)
+	delete(j.MetaUser, xhttp.AmzRestoreRequestDate)
 }
 
 func (j xlMetaV2Object) ToFileInfo(volume, path string) (FileInfo, error) {
@@ -1209,14 +1222,11 @@ func (z *xlMetaV2) DeleteVersion(fi FileInfo) (string, bool, error) {
 			if version.ObjectV2.VersionID == uv {
 				switch {
 				case fi.ExpireRestored:
-					delete(z.Versions[i].ObjectV2.MetaUser, xhttp.AmzRestore)
-					delete(z.Versions[i].ObjectV2.MetaUser, xhttp.AmzRestoreExpiryDays)
-					delete(z.Versions[i].ObjectV2.MetaUser, xhttp.AmzRestoreRequestDate)
+					z.Versions[i].ObjectV2.RemoveRestoreHdrs()
+
 				case fi.TransitionStatus == lifecycle.TransitionComplete:
-					z.Versions[i].ObjectV2.MetaSys[ReservedMetadataPrefixLower+TransitionStatus] = []byte(fi.TransitionStatus)
-					z.Versions[i].ObjectV2.MetaSys[ReservedMetadataPrefixLower+TransitionedObjectName] = []byte(fi.TransitionedObjName)
-					z.Versions[i].ObjectV2.MetaSys[ReservedMetadataPrefixLower+TransitionedVersionID] = []byte(fi.TransitionVersionID)
-					z.Versions[i].ObjectV2.MetaSys[ReservedMetadataPrefixLower+TransitionTier] = []byte(fi.TransitionTier)
+					z.Versions[i].ObjectV2.SetTransition(fi)
+
 				default:
 					z.Versions = append(z.Versions[:i], z.Versions[i+1:]...)
 					// if uv has tiered content we add a

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1099,8 +1099,8 @@ func (s *xlStorage) ReadVersion(ctx context.Context, volume, path, versionID str
 	if readData {
 		if len(fi.Data) > 0 || fi.Size == 0 {
 			if len(fi.Data) > 0 {
-				if _, ok := fi.Metadata[ReservedMetadataPrefixLower+"inline-data"]; !ok {
-					fi.Metadata[ReservedMetadataPrefixLower+"inline-data"] = "true"
+				if !fi.InlineData() {
+					fi.SetInlineData()
 				}
 			}
 			return fi, nil


### PR DESCRIPTION
## Description
ILM subsystem will skip transitioning objects smaller than 128KiB. 

## Motivation and Context
S3 behavior compatibility and to avoid performance effects of transitioning very small objects.

## How to test this PR?
1. Upload a small object (< 128KiB)
2. Set ILM rules matching this object.
3. Notice that this object doesn't transition.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
