### PR TITLE
fix: Use correct replication status in replication healing

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -839,7 +839,7 @@ func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI Obje
 		for k, v := range objInfo.UserDefined {
 			popts.UserDefined[k] = v
 		}
-		popts.UserDefined[xhttp.AmzBucketReplicationStatus] = replication.Completed.String()
+		popts.UserDefined[xhttp.AmzBucketReplicationStatus] = replicationStatus.String()
 		if objInfo.UserTags != "" {
 			popts.UserDefined[xhttp.AmzObjectTagging] = objInfo.UserTags
 		}


### PR DESCRIPTION
## Description
In case of replication healing, we always store completed status in the
object metadata, which is wrong because replication could fail in the
further retries.

## Motivation and Context
Fix replication status in some cases

## How to test this PR?
Setup replication & stop destination server then check for the status of the source object
when replication fails

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
