### PR TITLE
DOCS: Remove http links in favor of HTTPS

### DIFF
--- a/docs/select/README.md
+++ b/docs/select/README.md
@@ -24,7 +24,7 @@ To enable Parquet set the environment variable `MINIO_API_SELECT_PARQUET=on`.
 # Example using Python API 
 
 ## 1. Prerequisites
-- Install MinIO Server from [here](http://docs.min.io/docs/minio-quickstart-guide).
+- Install MinIO Server from [here](https://docs.min.io/docs/minio-quickstart-guide).
 - Familiarity with AWS S3 API.
 - Familiarity with Python and installing dependencies.
 

--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -9,7 +9,7 @@ This guide explains how to configure MinIO Server with TLS certificates on Linux
 
 ## <a name="install-minio-server"></a>1. Install MinIO Server
 
-Install MinIO Server using the instructions in the [MinIO Quickstart Guide](http://docs.min.io/docs/minio-quickstart-guide).
+Install MinIO Server using the instructions in the [MinIO Quickstart Guide](https://docs.min.io/docs/minio-quickstart-guide).
 
 ## <a name="use-an-existing-key-and-certificate-with-minio"></a>2. Use an Existing Key and Certificate with MinIO
 


### PR DESCRIPTION
## Description

Via marketing sync, some http URLs may negatively impact google rankings. these readme files get pulled into the current site at https://docs.min.io. 

There might be other pages, but these are the only ones coming up in the SEO meeting. I don't think we need to go farther than what is popping up for now.

## Motivation and Context

Minor fix to mitigate potential SEO issues

## How to test this PR?

No testing required

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ x ] Documentation updated
- [ ] Unit tests added/updated
