### PR TITLE
Refactor docker-compose, Use YAML variable for common minio configs

### DIFF
--- a/docs/orchestration/docker-compose/docker-compose.yaml
+++ b/docs/orchestration/docker-compose/docker-compose.yaml
@@ -1,84 +1,52 @@
 version: '3.7'
 
+# Settings and configurations that are common for all containers
+x-minio-common: &minio-common
+  image: minio/minio:RELEASE.2021-07-15T22-27-34Z
+  command: server --console-address ":9001" http://minio{1...4}/data{1...2}
+  expose:
+    - "9000"
+    - "9001"
+  environment:
+    MINIO_ROOT_USER: minio
+    MINIO_ROOT_PASSWORD: minio123
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+    interval: 30s
+    timeout: 20s
+    retries: 3
+
 # starts 4 docker containers running minio server instances.
 # using nginx reverse proxy, load balancing, you can access
 # it through port 9000.
 services:
   minio1:
-    image: minio/minio:RELEASE.2021-07-15T22-27-34Z
+    <<: *minio-common
     hostname: minio1
     volumes:
       - data1-1:/data1
       - data1-2:/data2
-    expose:
-      - "9000"
-      - "9001"
-    environment:
-      MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: minio123
-    command: server --console-address ":9001" http://minio{1...4}/data{1...2}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
 
   minio2:
-    image: minio/minio:RELEASE.2021-07-15T22-27-34Z
+    <<: *minio-common
     hostname: minio2
     volumes:
       - data2-1:/data1
       - data2-2:/data2
-    expose:
-      - "9000"
-      - "9001"
-    environment:
-      MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: minio123
-    command: server --console-address ":9001" http://minio{1...4}/data{1...2}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
 
   minio3:
-    image: minio/minio:RELEASE.2021-07-15T22-27-34Z
+    <<: *minio-common
     hostname: minio3
     volumes:
       - data3-1:/data1
       - data3-2:/data2
-    expose:
-      - "9000"
-      - "9001"
-    environment:
-      MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: minio123
-    command: server --console-address ":9001" http://minio{1...4}/data{1...2}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
 
   minio4:
-    image: minio/minio:RELEASE.2021-07-15T22-27-34Z
+    <<: *minio-common
     hostname: minio4
     volumes:
       - data4-1:/data1
       - data4-2:/data2
-    expose:
-      - "9000"
-      - "9001"
-    environment:
-      MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: minio123
-    command: server --console-address ":9001" http://minio{1...4}/data{1...2}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
 
   nginx:
     image: nginx:1.19.2-alpine


### PR DESCRIPTION
## Description
Refactor docker-compose and use YAML variable to share common configs with minio{1..4} 

## Motivation and Context
Reduce duplicated configuration and improve maintainability.  

## How to test this PR?
Run docker-compose and everything should be the same as before.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
