### PR TITLE
fix: hostname inside --console-address not anonymized

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1655,7 +1655,8 @@ func (a adminAPIHandlers) HealthInfoHandler(w http.ResponseWriter, r *http.Reque
 	anonymizeCmdLine := func(cmdLine string) string {
 		if !globalIsDistErasure {
 			// FS mode - single server - hard code to `server1`
-			return strings.Replace(cmdLine, globalLocalNodeName, "server1", -1)
+			anonCmdLine := strings.Replace(cmdLine, globalLocalNodeName, "server1", -1)
+			return strings.Replace(anonCmdLine, globalMinioConsoleHost, "server1", -1)
 		}
 
 		// Server start command regex groups:


### PR DESCRIPTION
## Description

In case of non-distributed setup, if the server start command contains a
`--console-address` flag and if its value contains a hostname, it is not
getting anonymized.

Fixed by replacing the console host also with `server1`

## Motivation and Context

Bugfix

## How to test this PR?

1) Start the minio server in FS mode, ensuring that the `console-address` flag is passed in the start command e.g.

`./minio server --address my.host.com:9000 --console-address my.host.com:9443 /data{1...4}`

2) Configure alias for this host in `mc`

3) Generate the health report for this alias (`mc admin subnet health {alias}`)

4) Verify that the generated report shows `--console-address server1:9443` in place of `--console-address my.host.com:9443` under `sys -> procinfo -> cmd_line`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
