### PR TITLE
sts: add support for certificate-based authentication

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -417,6 +417,8 @@ func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Reques
 				off = !openid.Enabled(kv)
 			case config.IdentityLDAPSubSys:
 				off = !xldap.Enabled(kv)
+			case config.IdentityTLSSubSys:
+				off = !globalSTSTLSConfig.Enabled
 			}
 			if off {
 				s.WriteString(config.KvComment)

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -38,6 +38,7 @@ import (
 	"github.com/minio/minio/internal/config/dns"
 	xldap "github.com/minio/minio/internal/config/identity/ldap"
 	"github.com/minio/minio/internal/config/identity/openid"
+	xtls "github.com/minio/minio/internal/config/identity/tls"
 	"github.com/minio/minio/internal/config/policy/opa"
 	"github.com/minio/minio/internal/config/storageclass"
 	xhttp "github.com/minio/minio/internal/http"
@@ -188,6 +189,7 @@ var (
 	globalStorageClass storageclass.Config
 	globalLDAPConfig   xldap.Config
 	globalOpenIDConfig openid.Config
+	globalSTSTLSConfig xtls.Config
 
 	// CA root certificates, a nil value means system certs pool will be used
 	globalRootCAs *x509.CertPool

--- a/cmd/sts-datatypes.go
+++ b/cmd/sts-datatypes.go
@@ -191,3 +191,15 @@ type AssumeRoleWithLDAPResponse struct {
 type LDAPIdentityResult struct {
 	Credentials auth.Credentials `xml:",omitempty"`
 }
+
+// AssumeRoleWithCertificateResponse contains the result of
+// a successful AssumeRoleWithCertificate request.
+type AssumeRoleWithCertificateResponse struct {
+	XMLName xml.Name `xml:"https://sts.amazonaws.com/doc/2011-06-15/ AssumeRoleWithCertificateResponse" json:"-"`
+	Result  struct {
+		Credentials auth.Credentials `xml:"Credentials,omitempty"`
+	} `xml:"AssumeRoleWithCertificateResult"`
+	Metadata struct {
+		RequestID string `xml:"RequestId,omitempty"`
+	} `xml:"ResponseMetadata,omitempty"`
+}

--- a/cmd/sts-errors.go
+++ b/cmd/sts-errors.go
@@ -93,6 +93,8 @@ const (
 	ErrSTSClientGrantsExpiredToken
 	ErrSTSInvalidClientGrantsToken
 	ErrSTSMalformedPolicyDocument
+	ErrSTSInsecureConnection
+	ErrSTSInvalidClientCertificate
 	ErrSTSNotInitialized
 	ErrSTSInternalError
 )
@@ -143,6 +145,16 @@ var stsErrCodes = stsErrorCodeMap{
 	ErrSTSMalformedPolicyDocument: {
 		Code:           "MalformedPolicyDocument",
 		Description:    "The request was rejected because the policy document was malformed.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrSTSInsecureConnection: {
+		Code:           "InsecureConnection",
+		Description:    "The request was made over a plain HTTP connection. A TLS connection is required.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrSTSInvalidClientCertificate: {
+		Code:           "InvalidClientCertificate",
+		Description:    "The provided client certificate is invalid. Retry with a different certificate.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrSTSNotInitialized: {

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -703,7 +703,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithCertificate(w http.ResponseWriter, r *h
 		}
 	}
 
-	// We set the expiry of the temp. credentials to the minumim of the
+	// We set the expiry of the temp. credentials to the minimum of the
 	// configured expiry and the duration until the certificate itself
 	// expires.
 	// We must not issue credentials that out-live the certificate.

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -723,7 +723,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithCertificate(w http.ResponseWriter, r *h
 	// We map the X.509 subject common name to the policy. So, a client
 	// with the common name "foo" will be associated with the policy "foo".
 	// Other mapping functions - e.g. public-key hash based mapping - are
-	// possible but not implement.
+	// possible but not implemented.
 	//
 	// Group mapping is not possible with standard X.509 certificates.
 	if err = globalIAMSys.SetTempUser(tmpCredentials.AccessKey, tmpCredentials, certificate.Subject.CommonName); err != nil {

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -726,6 +726,11 @@ func (sts *stsAPIHandlers) AssumeRoleWithCertificate(w http.ResponseWriter, r *h
 	// possible but not implemented.
 	//
 	// Group mapping is not possible with standard X.509 certificates.
+	if certificate.Subject.CommonName == "" {
+		writeSTSErrorResponse(ctx, w, true, ErrSTSMissingParameter, errors.New("The certificate subject CN is empty"))
+		return
+	}
+	tmpCredentials.ParentUser = "tls:" + certificate.Subject.CommonName // Associate any service accounts to the certificate CN
 	if err = globalIAMSys.SetTempUser(tmpCredentials.AccessKey, tmpCredentials, certificate.Subject.CommonName); err != nil {
 		writeSTSErrorResponse(ctx, w, true, ErrSTSInternalError, err)
 		return

--- a/cmd/stserrorcode_string.go
+++ b/cmd/stserrorcode_string.go
@@ -16,13 +16,15 @@ func _() {
 	_ = x[ErrSTSClientGrantsExpiredToken-5]
 	_ = x[ErrSTSInvalidClientGrantsToken-6]
 	_ = x[ErrSTSMalformedPolicyDocument-7]
-	_ = x[ErrSTSNotInitialized-8]
-	_ = x[ErrSTSInternalError-9]
+	_ = x[ErrSTSInsecureConnection-8]
+	_ = x[ErrSTSInvalidClientCertificate-9]
+	_ = x[ErrSTSNotInitialized-10]
+	_ = x[ErrSTSInternalError-11]
 }
 
-const _STSErrorCode_name = "STSNoneSTSAccessDeniedSTSMissingParameterSTSInvalidParameterValueSTSWebIdentityExpiredTokenSTSClientGrantsExpiredTokenSTSInvalidClientGrantsTokenSTSMalformedPolicyDocumentSTSNotInitializedSTSInternalError"
+const _STSErrorCode_name = "STSNoneSTSAccessDeniedSTSMissingParameterSTSInvalidParameterValueSTSWebIdentityExpiredTokenSTSClientGrantsExpiredTokenSTSInvalidClientGrantsTokenSTSMalformedPolicyDocumentSTSInsecureConnectionSTSInvalidClientCertificateSTSNotInitializedSTSInternalError"
 
-var _STSErrorCode_index = [...]uint8{0, 7, 22, 41, 65, 91, 118, 145, 171, 188, 204}
+var _STSErrorCode_index = [...]uint8{0, 7, 22, 41, 65, 91, 118, 145, 171, 192, 219, 236, 252}
 
 func (i STSErrorCode) String() string {
 	if i < 0 || i >= STSErrorCode(len(_STSErrorCode_index)-1) {

--- a/docs/sts/tls.md
+++ b/docs/sts/tls.md
@@ -1,0 +1,126 @@
+# AssumeRoleWithCertificate [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
+
+## Introduction
+
+MinIO provides a custom STS API that allows authentication with client X.509 / TLS certificates.
+
+A major advantage of certificate-based authentication compared to other STS authentication methods,
+like OpenID Connect or LDAP/AD, is that client authentication works without any additional/external
+component that must be constantly available. Therefore, certificate-based authentication may provide
+better availability / lower operational complexity.
+
+The MinIO TLS STS API can be configured via MinIO's standard configuration API (i.e. using `mc admin config set/get`).
+Further, it can be configured via the following environment variables:
+
+```
+mc admin config set myminio identity_tls --env
+KEY:
+identity_tls  enable X.509 TLS certificate SSO support
+
+ARGS:
+MINIO_IDENTITY_TLS_STS_EXPIRY   (duration)  temporary credentials validity duration in s,m,h,d. Default is "1h"
+MINIO_IDENTITY_TLS_SKIP_VERIFY  (on|off)    trust client certificates without verification. Defaults to "off" (verify)
+```
+
+The MinIO TLS STS API is enabled by default. However, it can be completely *disabled* by setting:
+```
+MINIO_IDENTITY_TLS_ENABLE=off
+```
+
+## Example
+
+MinIO exposes a custom S3 STS API endpoint as `Action=AssumeRoleWithCertificate`. A client has to send an HTTP `POST`
+request to `https://<host>:<port>?Action=AssumeRoleWithCertificate&Version=2011-06-15`. Since the authentication and
+authorization happens via X.509 certificates the client has to send the request over **TLS** and has to provide
+a client certificate.
+
+The following curl example shows how to authenticate to a MinIO server with client certificate and obtain temp. S3
+access/secret key credentials. 
+
+```curl
+curl -X POST --key private.key --cert public.crt "https://minio:9000?Action=AssumeRoleWithCertificate&Version=2011-06-15"
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<AssumeRoleWithCertificateResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+   <AssumeRoleWithCertificateResult>
+      <Credentials>
+         <AccessKeyId>YC12ZBHUVW588BQAE5BM</AccessKeyId>
+         <SecretAccessKey>Zgl9+zdE0pZ88+hLqtfh0ocLN+WQTJixHouCkZkW</SecretAccessKey>
+         <Expiration>2021-07-19T20:10:45Z</Expiration
+         <SessionToken>eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiJZQzEyWkJIVVZXNTg4QlFBRTVCTSIsImV4cCI6MTYyNjcyNTQ0NX0.wvMUf3w_x16qpVWgua8WxnV1Sgtv1jOnSu03vbrwOMzV3cI4q3_9WZD9LwlP-34DTsvbsg7gCBGh6YNriMMiQw</SessionToken>
+      </Credentials>
+   </AssumeRoleWithCertificateResult>
+   <ResponseMetadata>
+      <RequestId>169339CD8B3A6948</RequestId>
+   </ResponseMetadata>
+</AssumeRoleWithCertificateResponse>
+```
+
+## Authentication Flow
+
+A client can request temp. S3 credentials via the STS API. It can authenticate via a client certificate and
+obtain a access/secret key pair as well as a session token. These credentials are associated to an S3 policy
+at the MinIO server.
+
+In case of certificate-based authentication, MinIO has to map the client-provided certificate to an S3 policy.
+MinIO does this via the subject common name field of the X.509 certificate. So, MinIO will associate a certificate
+with a subject `CN = foobar` to a S3 policy named `foobar`.
+
+The following self-signed certificate is issued for `consoleAdmin`. So, MinIO would associate it with the
+pre-defined `consoleAdmin` policy.
+```
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            35:ac:60:46:ad:8d:de:18:dc:0b:f6:98:14:ee:89:e8
+        Signature Algorithm: ED25519
+        Issuer: CN = consoleAdmin
+        Validity
+            Not Before: Jul 19 15:08:44 2021 GMT
+            Not After : Aug 18 15:08:44 2021 GMT
+        Subject: CN = consoleAdmin
+        Subject Public Key Info:
+            Public Key Algorithm: ED25519
+                ED25519 Public-Key:
+                pub:
+                    5a:91:87:b8:77:fe:d4:af:d9:c7:c7:ce:55:ae:74:
+                    aa:f3:f1:fe:04:63:9b:cb:20:97:61:97:90:94:fa:
+                    12:8b
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ED25519
+         7e:aa:be:ed:47:4d:b9:2f:fc:ed:7f:5a:fc:6b:c0:05:5b:f5:
+         a0:31:fe:86:e3:8e:3f:49:af:6d:d5:ac:c7:c4:57:47:ce:97:
+         7d:ab:b8:e9:75:ec:b4:39:fb:c8:cf:53:16:5b:1f:15:b6:7f:
+         5a:d1:35:2d:fc:31:3a:10:e7:0c
+```
+> Observe the `Subject: CN = consoleAdmin` field.
+
+Also, note that the certificate has to contain the `Extended Key Usage: TLS Web Client Authentication`.
+Otherwise, MinIO would not accept the certificate as client certificate.
+
+Now, the STS certificate-based authentication happens in 4 steps:
+ 1. Client sends HTTP `POST` request over a TLS connection hitting the MinIO TLS STS API.
+ 2. MinIO verifies that the client certificate is valid.
+ 3. MinIO tries to find a policy that matches the `CN` of the client certificate.
+ 4. MinIO returns temp. S3 credentials associated to the found policy.
+
+The returned credentials expiry after a certain period of time that can be configured via
+`MINIO_IDENTITY_TLS_STS_EXPIRY` - for example: `export MINIO_IDENTITY_TLS_STS_EXPIRY=30m`.
+By default, the temp. S3 credentials are valid for 1 hour. The minimum expiration is 15 minutes.
+
+Further, the temp. S3 credentials will never out-live the client certificate. For example,
+if the `MINIO_IDENTITY_TLS_STS_EXPIRY` is 7 days but the certificate itself is only valid
+for the next 3 days, then MinIO will return S3 credentials that are valid for 3 days only.
+
+## Explore Further
+- [MinIO Admin Complete Guide](https://docs.min.io/docs/minio-admin-complete-guide.html)
+- [The MinIO documentation website](https://docs.min.io)

--- a/docs/sts/tls.md
+++ b/docs/sts/tls.md
@@ -1,16 +1,11 @@
 # AssumeRoleWithCertificate [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
 ## Introduction
-
 MinIO provides a custom STS API that allows authentication with client X.509 / TLS certificates.
 
-A major advantage of certificate-based authentication compared to other STS authentication methods,
-like OpenID Connect or LDAP/AD, is that client authentication works without any additional/external
-component that must be constantly available. Therefore, certificate-based authentication may provide
-better availability / lower operational complexity.
+A major advantage of certificate-based authentication compared to other STS authentication methods, like OpenID Connect or LDAP/AD, is that client authentication works without any additional/external component that must be constantly available. Therefore, certificate-based authentication may provide better availability / lower operational complexity.
 
-The MinIO TLS STS API can be configured via MinIO's standard configuration API (i.e. using `mc admin config set/get`).
-Further, it can be configured via the following environment variables:
+The MinIO TLS STS API can be configured via MinIO's standard configuration API (i.e. using `mc admin config set/get`). Further, it can be configured via the following environment variables:
 
 ```
 mc admin config set myminio identity_tls --env
@@ -18,7 +13,6 @@ KEY:
 identity_tls  enable X.509 TLS certificate SSO support
 
 ARGS:
-MINIO_IDENTITY_TLS_STS_EXPIRY   (duration)  temporary credentials validity duration in s,m,h,d. Default is "1h"
 MINIO_IDENTITY_TLS_SKIP_VERIFY  (on|off)    trust client certificates without verification. Defaults to "off" (verify)
 ```
 
@@ -28,17 +22,13 @@ MINIO_IDENTITY_TLS_ENABLE=off
 ```
 
 ## Example
-
-MinIO exposes a custom S3 STS API endpoint as `Action=AssumeRoleWithCertificate`. A client has to send an HTTP `POST`
-request to `https://<host>:<port>?Action=AssumeRoleWithCertificate&Version=2011-06-15`. Since the authentication and
-authorization happens via X.509 certificates the client has to send the request over **TLS** and has to provide
+MinIO exposes a custom S3 STS API endpoint as `Action=AssumeRoleWithCertificate`. A client has to send an HTTP `POST` request to `https://<host>:<port>?Action=AssumeRoleWithCertificate&Version=2011-06-15`. Since the authentication and authorization happens via X.509 certificates the client has to send the request over **TLS** and has to provide
 a client certificate.
 
-The following curl example shows how to authenticate to a MinIO server with client certificate and obtain temp. S3
-access/secret key credentials. 
+The following curl example shows how to authenticate to a MinIO server with client certificate and obtain STS access credentials.
 
 ```curl
-curl -X POST --key private.key --cert public.crt "https://minio:9000?Action=AssumeRoleWithCertificate&Version=2011-06-15"
+curl -X POST --key private.key --cert public.crt "https://minio:9000?Action=AssumeRoleWithCertificate&Version=2011-06-15&DurationSeconds=3600"
 ```
 
 ```xml
@@ -60,16 +50,11 @@ curl -X POST --key private.key --cert public.crt "https://minio:9000?Action=Assu
 
 ## Authentication Flow
 
-A client can request temp. S3 credentials via the STS API. It can authenticate via a client certificate and
-obtain a access/secret key pair as well as a session token. These credentials are associated to an S3 policy
-at the MinIO server.
+A client can request temp. S3 credentials via the STS API. It can authenticate via a client certificate and obtain a access/secret key pair as well as a session token. These credentials are associated to an S3 policy at the MinIO server.
 
-In case of certificate-based authentication, MinIO has to map the client-provided certificate to an S3 policy.
-MinIO does this via the subject common name field of the X.509 certificate. So, MinIO will associate a certificate
-with a subject `CN = foobar` to a S3 policy named `foobar`.
+In case of certificate-based authentication, MinIO has to map the client-provided certificate to an S3 policy. MinIO does this via the subject common name field of the X.509 certificate. So, MinIO will associate a certificate with a subject `CN = foobar` to a S3 policy named `foobar`.
 
-The following self-signed certificate is issued for `consoleAdmin`. So, MinIO would associate it with the
-pre-defined `consoleAdmin` policy.
+The following self-signed certificate is issued for `consoleAdmin`. So, MinIO would associate it with the pre-defined `consoleAdmin` policy.
 ```
 Certificate:
     Data:
@@ -104,22 +89,18 @@ Certificate:
 ```
 > Observe the `Subject: CN = consoleAdmin` field.
 
-Also, note that the certificate has to contain the `Extended Key Usage: TLS Web Client Authentication`.
-Otherwise, MinIO would not accept the certificate as client certificate.
+Also, note that the certificate has to contain the `Extended Key Usage: TLS Web Client Authentication`. Otherwise, MinIO would not accept the certificate as client certificate.
 
 Now, the STS certificate-based authentication happens in 4 steps:
- 1. Client sends HTTP `POST` request over a TLS connection hitting the MinIO TLS STS API.
- 2. MinIO verifies that the client certificate is valid.
- 3. MinIO tries to find a policy that matches the `CN` of the client certificate.
- 4. MinIO returns temp. S3 credentials associated to the found policy.
 
-The returned credentials expiry after a certain period of time that can be configured via
-`MINIO_IDENTITY_TLS_STS_EXPIRY` - for example: `export MINIO_IDENTITY_TLS_STS_EXPIRY=30m`.
-By default, the temp. S3 credentials are valid for 1 hour. The minimum expiration is 15 minutes.
+- Client sends HTTP `POST` request over a TLS connection hitting the MinIO TLS STS API.
+- MinIO verifies that the client certificate is valid.
+- MinIO tries to find a policy that matches the `CN` of the client certificate.
+- MinIO returns temp. S3 credentials associated to the found policy.
 
-Further, the temp. S3 credentials will never out-live the client certificate. For example,
-if the `MINIO_IDENTITY_TLS_STS_EXPIRY` is 7 days but the certificate itself is only valid
-for the next 3 days, then MinIO will return S3 credentials that are valid for 3 days only.
+The returned credentials expiry after a certain period of time that can be configured via `&DurationSeconds=3600`. By default, the STS credentials are valid for 1 hour. The minimum expiration allowed is 15 minutes.
+
+Further, the temp. S3 credentials will never out-live the client certificate. For example, if the `MINIO_IDENTITY_TLS_STS_EXPIRY` is 7 days but the certificate itself is only valid for the next 3 days, then MinIO will return S3 credentials that are valid for 3 days only.
 
 ## Explore Further
 - [MinIO Admin Complete Guide](https://docs.min.io/docs/minio-admin-complete-guide.html)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,7 @@ const (
 	PolicyOPASubSys      = "policy_opa"
 	IdentityOpenIDSubSys = "identity_openid"
 	IdentityLDAPSubSys   = "identity_ldap"
+	IdentityTLSSubSys    = "identity_tls"
 	CacheSubSys          = "cache"
 	RegionSubSys         = "region"
 	EtcdSubSys           = "etcd"
@@ -113,6 +114,7 @@ var SubSystems = set.CreateStringSet(
 	PolicyOPASubSys,
 	IdentityLDAPSubSys,
 	IdentityOpenIDSubSys,
+	IdentityTLSSubSys,
 	ScannerSubSys,
 	HealSubSys,
 	NotifyAMQPSubSys,
@@ -147,6 +149,7 @@ var SubSystemsSingleTargets = set.CreateStringSet([]string{
 	PolicyOPASubSys,
 	IdentityLDAPSubSys,
 	IdentityOpenIDSubSys,
+	IdentityTLSSubSys,
 	HealSubSys,
 	ScannerSubSys,
 }...)

--- a/internal/config/identity/tls/config.go
+++ b/internal/config/identity/tls/config.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tls
+
+import (
+	"errors"
+	"time"
+
+	"github.com/minio/minio/internal/config"
+	"github.com/minio/pkg/env"
+)
+
+const (
+	// EnvEnabled is an environment variable that controls whether the X.509
+	// TLS STS API is enabled. By default, if not set, it is enabled.
+	EnvEnabled = "MINIO_IDENTITY_TLS_ENABLE"
+
+	// EnvSTSExpiry is an environment variable for the expiry of temp.
+	// generated STS credentials. Its minimum value is 15 minutes and
+	// defaults to 1 hour, if not set.
+	EnvSTSExpiry = "MINIO_IDENTITY_TLS_STS_EXPIRY"
+
+	// EnvSkipVerify is an environment variable that controls whether
+	// MinIO verifies the client certificate present by the client
+	// when requesting temp. credentials.
+	// By default, MinIO always verify the client certificate.
+	//
+	// The client certificate verification should only be skipped
+	// when debugging or testing a setup since it allows arbitrary
+	// clients to obtain temp. credentials with arbitrary policy
+	// permissions - including admin permissions.
+	EnvSkipVerify = "MINIO_IDENTITY_TLS_SKIP_VERIFY"
+)
+
+// Config contains the STS TLS configuration for generating temp.
+// credentials and mapping client certificates to S3 policies.
+type Config struct {
+	Enabled bool `json:"enabled"`
+
+	// STSExpiry is the expiry duration of generated credentials.
+	STSExpiry time.Duration `json:"sts_expiry"`
+
+	// InsecureSkipVerify, if set to true, disables the client
+	// certificate verification. It should only be set for
+	// debugging or testing purposes.
+	InsecureSkipVerify bool `json:"skip_verify"`
+}
+
+// Lookup returns a new Config by merging the given K/V config
+// system with environment variables.
+func Lookup(kvs config.KVS) (Config, error) {
+	if err := config.CheckValidKeys(config.IdentityTLSSubSys, kvs, DefaultKVS); err != nil {
+		return Config{}, err
+	}
+	expiry, err := time.ParseDuration(env.Get(EnvSTSExpiry, kvs.Get(stsExpiry)))
+	if err != nil {
+		return Config{}, err
+	}
+	if expiry < 0 {
+		return Config{}, errors.New("tls: STS expiry must not be negative")
+	}
+	if expiry == 0 {
+		expiry = 1 * time.Hour // Set default expiry, if empty
+	}
+	if expiry < 15*time.Minute {
+		expiry = 15 * time.Minute // The minimal expiry duration is 15 minutes
+	}
+	insecureSkipVerify, err := config.ParseBool(env.Get(EnvSkipVerify, kvs.Get(skipVerify)))
+	if err != nil {
+		return Config{}, err
+	}
+	enabled, err := config.ParseBool(env.Get(EnvEnabled, "on"))
+	if err != nil {
+		return Config{}, err
+	}
+	return Config{
+		Enabled:            enabled,
+		STSExpiry:          expiry,
+		InsecureSkipVerify: insecureSkipVerify,
+	}, nil
+}
+
+const (
+	stsExpiry  = "sts_expiry"
+	skipVerify = "skip_verify"
+)
+
+// DefaultKVS is the the default K/V config system for
+// the STS TLS API.
+var DefaultKVS = config.KVS{
+	config.KV{
+		Key:   stsExpiry,
+		Value: (1 * time.Hour).String(),
+	},
+	config.KV{
+		Key:   skipVerify,
+		Value: "off",
+	},
+}
+
+// Help is the help and description for the STS API K/V configuration.
+var Help = config.HelpKVS{
+	config.HelpKV{
+		Key:         stsExpiry,
+		Description: `temporary credentials validity duration in s,m,h,d. Default is "1h"`,
+		Optional:    true,
+		Type:        "duration",
+	},
+	config.HelpKV{
+		Key:         skipVerify,
+		Description: `trust client certificates without verification. Defaults to "off" (verify)`,
+		Optional:    true,
+		Type:        "on|off",
+	},
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -172,6 +172,7 @@ func NewServer(addrs []string, handler http.Handler, getCert certs.GetCertificat
 			MinVersion:               tls.VersionTLS12,
 			NextProtos:               []string{"http/1.1", "h2"},
 			GetCertificate:           getCert,
+			ClientAuth:               tls.RequestClientCert,
 		}
 		if secureCiphers || fips.Enabled {
 			tlsConfig.CipherSuites = fips.CipherSuitesTLS()


### PR DESCRIPTION

## Description
This commit adds a new STS API for X.509 certificate
authentication.

A client can make a HTTP POST request over a TLS connection
and MinIO will verify the provided client certificate,
map it to a S3 policy and return temp. S3 credentials to the
client.

So, this STS API allows clients to authenticate with X.509
certificates over TLS and obtain temp. S3 credentials.

For more details and examples refer to the docs/sts/tls.md
documentation.

## Motivation and Context
TLS, STS

## How to test this PR?
See the docs/sts/tls.md

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
