### PR TITLE
pkg/lifecycle: Add SetPredictionHeaders method

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -309,8 +309,11 @@ func transitionObject(ctx context.Context, objectAPI ObjectLayer, oi ObjectInfo)
 // getLifeCycleTransitionTier returns storage class for transition target
 func getLifeCycleTransitionTier(ctx context.Context, lc *lifecycle.Lifecycle, bucket string, obj lifecycle.ObjectOpts) string {
 	for _, rule := range lc.FilterActionableRules(obj) {
-		if rule.Transition.StorageClass != "" {
+		if obj.IsLatest && rule.Transition.StorageClass != "" {
 			return rule.Transition.StorageClass
+		}
+		if !obj.IsLatest && rule.NoncurrentVersionTransition.StorageClass != "" {
+			return rule.NoncurrentVersionTransition.StorageClass
 		}
 	}
 	return ""
@@ -672,4 +675,22 @@ func isRestoredObjectOnDisk(meta map[string]string) (onDisk bool) {
 		}
 	}
 	return onDisk
+}
+
+// ToLifecycleOpts returns lifecycle.ObjectOpts value for oi.
+func (oi ObjectInfo) ToLifecycleOpts() lifecycle.ObjectOpts {
+	return lifecycle.ObjectOpts{
+		Name:                   oi.Name,
+		UserTags:               oi.UserTags,
+		VersionID:              oi.VersionID,
+		ModTime:                oi.ModTime,
+		IsLatest:               oi.IsLatest,
+		NumVersions:            oi.NumVersions,
+		DeleteMarker:           oi.DeleteMarker,
+		SuccessorModTime:       oi.SuccessorModTime,
+		RestoreOngoing:         oi.RestoreOngoing,
+		RestoreExpires:         oi.RestoreExpires,
+		TransitionStatus:       oi.TransitionStatus,
+		RemoteTiersImmediately: globalDebugRemoteTiersImmediately,
+	}
 }

--- a/cmd/bucket-lifecycle_test.go
+++ b/cmd/bucket-lifecycle_test.go
@@ -246,3 +246,40 @@ func TestValidateTransitionTier(t *testing.T) {
 		}
 	}
 }
+
+func TestGetLifecycleTransitionTier(t *testing.T) {
+	lc := lifecycle.Lifecycle{
+		Rules: []lifecycle.Rule{
+			{
+				ID:     "rule-1",
+				Status: "Enabled",
+				Transition: lifecycle.Transition{
+					Days:         lifecycle.TransitionDays(3),
+					StorageClass: "TIER-1",
+				},
+			},
+			{
+				ID:     "rule-2",
+				Status: "Enabled",
+				NoncurrentVersionTransition: lifecycle.NoncurrentVersionTransition{
+					NoncurrentDays: lifecycle.ExpirationDays(3),
+					StorageClass:   "TIER-2",
+				},
+			},
+		},
+	}
+
+	obj1 := lifecycle.ObjectOpts{
+		Name:     "obj1",
+		IsLatest: true,
+	}
+	obj2 := lifecycle.ObjectOpts{
+		Name: "obj2",
+	}
+	if got := getLifeCycleTransitionTier(context.TODO(), &lc, "bucket", obj1); got != "TIER-1" {
+		t.Fatalf("Expected TIER-1 but got %s", got)
+	}
+	if got := getLifeCycleTransitionTier(context.TODO(), &lc, "bucket", obj2); got != "TIER-2" {
+		t.Fatalf("Expected TIER-2 but got %s", got)
+	}
+}

--- a/internal/bucket/lifecycle/noncurrentversion.go
+++ b/internal/bucket/lifecycle/noncurrentversion.go
@@ -19,6 +19,7 @@ package lifecycle
 
 import (
 	"encoding/xml"
+	"time"
 )
 
 // NoncurrentVersionExpiration - an action for lifecycle configuration rule.
@@ -111,4 +112,15 @@ func (n NoncurrentVersionTransition) Validate() error {
 		return errXMLNotWellFormed
 	}
 	return nil
+}
+
+// NextDue returns upcoming NoncurrentVersionTransition date for obj if
+// applicable, returns false otherwise.
+func (n NoncurrentVersionTransition) NextDue(obj ObjectOpts) (time.Time, bool) {
+	switch {
+	case obj.IsLatest, n.IsDaysNull():
+		return time.Time{}, false
+	}
+
+	return ExpectedExpiryTime(obj.SuccessorModTime, int(n.NoncurrentDays)), true
 }

--- a/internal/bucket/lifecycle/transition.go
+++ b/internal/bucket/lifecycle/transition.go
@@ -163,3 +163,20 @@ func (t Transition) IsDateNull() bool {
 func (t Transition) IsNull() bool {
 	return t.IsDaysNull() && t.IsDateNull()
 }
+
+// NextDue returns upcoming transition date for obj and true if applicable,
+// returns false otherwise.
+func (t Transition) NextDue(obj ObjectOpts) (time.Time, bool) {
+	if !obj.IsLatest {
+		return time.Time{}, false
+	}
+
+	switch {
+	case !t.IsDateNull():
+		return t.Date.Time, true
+	case !t.IsDaysNull():
+		return ExpectedExpiryTime(obj.ModTime, int(t.Days)), true
+	}
+
+	return time.Time{}, false
+}


### PR DESCRIPTION
## Description

This method is used to add expected expiration and transition time for an object
in Get/Head Object response headers.

Also fixed bugs in lifecycle.PredictTransitionTime and
getLifecycleTransitionTier in handling current and non-current versions.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
