### PR TITLE
[IDP:LDAP] Cleanup creds for removed LDAP user entries

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1597,7 +1597,7 @@ func (sys *IAMSys) purgeExpiredCredentialsForLDAP(ctx context.Context) {
 	}
 	sys.store.unlock()
 
-	expiredUsers, err := globalLDAPConfig.GetNonExistentUserDNs(parentUsers)
+	expiredUsers, err := globalLDAPConfig.GetNonExistentUserDNS(parentUsers)
 	if err != nil {
 		// Log and return on error - perhaps it'll work the next time.
 		logger.LogIf(GlobalContext, err)

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -457,9 +457,9 @@ func (l Config) IsLDAPUserDN(user string) bool {
 	return strings.HasSuffix(user, ","+l.UserDNSearchBaseDN)
 }
 
-// GetNonExistentUserDNs - find user accounts that are no longer present in the
+// GetNonExistentUserDNS - find user accounts that are no longer present in the
 // LDAP server.
-func (l *Config) GetNonExistentUserDNS(userDNs []string) ([]string, error) {
+func (l *Config) GetNonExistentUserDNS(userDNS []string) ([]string, error) {
 	if !l.isUsingLookupBind {
 		return nil, errors.New("current LDAP configuration does not permit looking for expired user accounts")
 	}
@@ -476,7 +476,7 @@ func (l *Config) GetNonExistentUserDNS(userDNs []string) ([]string, error) {
 	}
 
 	nonExistentUsers := []string{}
-	for _, dn := range userDNs {
+	for _, dn := range userDNS {
 		searchRequest := ldap.NewSearchRequest(
 			dn,
 			ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -452,6 +452,62 @@ func (l Config) testConnection() error {
 	return fmt.Errorf("LDAP connection test error: %w", err)
 }
 
+// IsLDAPUserDN determines if the given string could be a user DN from LDAP.
+func (l Config) IsLDAPUserDN(user string) bool {
+	return strings.HasSuffix(user, ","+l.UserDNSearchBaseDN)
+}
+
+// GetNonExistentUserDNs - find user accounts that are no longer present in the
+// LDAP server.
+func (l *Config) GetNonExistentUserDNs(userDNs []string) ([]string, error) {
+	if !l.isUsingLookupBind {
+		return nil, errors.New("current LDAP configuration does not permit looking for expired user accounts")
+	}
+
+	conn, err := l.Connect()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	// Bind to the lookup user account
+	if err = l.lookupBind(conn); err != nil {
+		return nil, err
+	}
+
+	nonExistentUsers := []string{}
+	for _, dn := range userDNs {
+		searchRequest := ldap.NewSearchRequest(
+			dn,
+			ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
+			"(objectclass=*)",
+			[]string{}, // only need DN, so no pass no attributes here
+			nil,
+		)
+
+		searchResult, err := conn.Search(searchRequest)
+		if err != nil {
+			// Object does not exist error?
+			if ldap.IsErrorWithCode(err, 32) {
+				nonExistentUsers = append(nonExistentUsers, dn)
+				continue
+			}
+			return nil, err
+		}
+		if len(searchResult.Entries) == 0 {
+			// DN was not found - this means this user account is
+			// expired.
+			nonExistentUsers = append(nonExistentUsers, dn)
+		}
+	}
+	return nonExistentUsers, nil
+}
+
+// EnabledWithLookupBind - checks if ldap IDP is enabled in lookup bind mode.
+func (l Config) EnabledWithLookupBind() bool {
+	return l.Enabled && l.isUsingLookupBind
+}
+
 // Enabled returns if jwks is enabled.
 func Enabled(kvs config.KVS) bool {
 	return kvs.Get(ServerAddr) != ""

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -459,7 +459,7 @@ func (l Config) IsLDAPUserDN(user string) bool {
 
 // GetNonExistentUserDNs - find user accounts that are no longer present in the
 // LDAP server.
-func (l *Config) GetNonExistentUserDNs(userDNs []string) ([]string, error) {
+func (l *Config) GetNonExistentUserDNS(userDNs []string) ([]string, error) {
 	if !l.isUsingLookupBind {
 		return nil, errors.New("current LDAP configuration does not permit looking for expired user accounts")
 	}


### PR DESCRIPTION
## Description
This change lets the server poll the LDAP service periodically to check for LDAP
accounts with associated MinIO access credentials that have been removed. It
deletes any access credentials for such removed LDAP users.

## Motivation and Context

Remove credentials for users no longer part of the LDAP org.


## How to test this PR?

Use https://github.com/donatello/minio-ldap-testing to setup a test ldap server. Create some credentials for a user and delete the ldap entry using `ldapdelete` (see readme). After about 5 minutes, the credentials will be automatically purged.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
