### PR TITLE
[branch 10-28] Fix crash in new healing simplification refactor

### DIFF
--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -1983,8 +1983,8 @@ func (z *erasureServerSets) HealObjects(ctx context.Context, bucket, prefix stri
 	var skipped int
 	for _, zone := range z.serverSets {
 		entryChs := zone.startMergeWalksVersions(ctx, bucket, prefix, "", true, ctx.Done())
-		entriesInfos := make([]FileInfoVersions, 0, len(entryChs))
-		entriesValid := make([]bool, 0, len(entryChs))
+		entriesInfos := make([]FileInfoVersions, len(entryChs))
+		entriesValid := make([]bool, len(entryChs))
 
 		for {
 			entry, quorumCount, ok := lexicallySortedEntryVersions(entryChs, entriesInfos, entriesValid)


### PR DESCRIPTION
## Description
HealObjects() will lead to a crash after recent refactor, fix it.


## Motivation and Context
Fix an occasional crash

## How to test this PR?
Run a 4 disks one node cluster, create a bucket, upload a file and wait.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
