### PR TITLE
fix: new disk healing complete too early

### DIFF
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -282,6 +282,11 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []BucketIn
 			},
 			finished: nil,
 		})
+		
+		if err != nil {
+			logger.LogIf(ctx, err)
+			return err
+		}		
 
 		select {
 		// If context is canceled don't mark as done...

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -282,11 +282,11 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []BucketIn
 			},
 			finished: nil,
 		})
-		
+
 		if err != nil {
 			logger.LogIf(ctx, err)
 			return err
-		}		
+		}
 
 		select {
 		// If context is canceled don't mark as done...


### PR DESCRIPTION
## Description

fix: new disk auto healing complete too early when error occurs

## Motivation and Context

MinIO's auto healing for new disk completed too early when there was an error occurred. The bucket is marked as done, and the healing track file will be deleted. Then the disk is marked as healed. 

## How to test this PR?

1. unmount a disk and format it to clean all data
2. remount the clean disk, and create necessary directories
3. ensure that MinIO's auto healing for this disk is triggered
4. use a debugger to let metacache-set.go:listPathRaw function to return error
5. check that the .minio.sys/buckets/.healing.bin file on the disk is not removed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
