### PR TITLE
use expected MinIO URLs for console

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ For deployments behind a load balancer, proxy, or ingress rule where the MinIO h
 
 For example, consider a MinIO deployment behind a proxy `https://minio.example.net`, `https://console.minio.example.net` with rules for forwarding traffic on port :9000 and :9001 to MinIO and the MinIO Console respectively on the internal network. Set `MINIO_BROWSER_REDIRECT_URL` to `https://console.minio.example.net` to ensure the browser receives a valid reachable URL.
 
+If your TLS certs do not have IP SANs enabled then this can cause issues with console when MinIO server is configured with TLS directly, use `MINIO_SERVER_URL` environment variable pointing to `https://minio.example.net` this would allow MinIO Console UI to talk to MinIO API with proper TLS certs.
+
 | Dashboard                                                                                   | Creating a bucket                                                                           |
 | -------------                                                                               | -------------                                                                               |
 | ![Dashboard](https://github.com/minio/minio/blob/master/docs/screenshots/pic1.png?raw=true) | ![Dashboard](https://github.com/minio/minio/blob/master/docs/screenshots/pic2.png?raw=true) |

--- a/README.md
+++ b/README.md
@@ -216,7 +216,10 @@ For deployments behind a load balancer, proxy, or ingress rule where the MinIO h
 
 For example, consider a MinIO deployment behind a proxy `https://minio.example.net`, `https://console.minio.example.net` with rules for forwarding traffic on port :9000 and :9001 to MinIO and the MinIO Console respectively on the internal network. Set `MINIO_BROWSER_REDIRECT_URL` to `https://console.minio.example.net` to ensure the browser receives a valid reachable URL.
 
-If your TLS certs do not have IP SANs enabled then this can cause issues with console when MinIO server is configured with TLS directly, use `MINIO_SERVER_URL` environment variable pointing to `https://minio.example.net` this would allow MinIO Console UI to talk to MinIO API with proper TLS certs.
+Similarly, if your TLS certificates do not have the IP SAN for the MinIO server host, the MinIO Console may fail to validate the connection to the server. Use the `MINIO_SERVER_URL` environment variable  and specify the proxy-accessible hostname of the MinIO server to allow the Console to use the MinIO server API using the TLS certificate.
+
+For example: `export MINIO_SERVER_URL="https://minio.example.net"`
+
 
 | Dashboard                                                                                   | Creating a bucket                                                                           |
 | -------------                                                                               | -------------                                                                               |

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -245,7 +245,7 @@ func (l *EndpointServerPools) Add(zeps PoolEndpoints) error {
 func (l EndpointServerPools) Localhost() string {
 	for _, ep := range l {
 		for _, endpoint := range ep.Endpoints {
-			if endpoint.IsLocal {
+			if endpoint.IsLocal && endpoint.Host != "" {
 				u := &url.URL{
 					Scheme: endpoint.Scheme,
 					Host:   endpoint.Host,
@@ -254,7 +254,11 @@ func (l EndpointServerPools) Localhost() string {
 			}
 		}
 	}
-	return ""
+	host := globalMinioHost
+	if host == "" {
+		host = sortIPs(localIP4.ToSlice())[0]
+	}
+	return fmt.Sprintf("%s://%s", getURLScheme(globalIsTLS), net.JoinHostPort(host, globalMinioPort))
 }
 
 // LocalDisksPaths returns the disk paths of the local disks

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -209,14 +209,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	// To avoid this error situation we check for port availability.
 	logger.FatalIf(checkPortAvailability(globalMinioHost, globalMinioPort), "Unable to start the gateway")
 
-	globalMinioEndpoint = func() string {
-		host := globalMinioHost
-		if host == "" {
-			host = sortIPs(localIP4.ToSlice())[0]
-		}
-		return fmt.Sprintf("%s://%s", getURLScheme(globalIsTLS), net.JoinHostPort(host, globalMinioPort))
-	}()
-
 	// Handle gateway specific env
 	gatewayHandleEnvVars()
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -459,14 +459,6 @@ func serverMain(ctx *cli.Context) {
 	// Initialize all sub-systems
 	newAllSubsystems()
 
-	globalMinioEndpoint = func() string {
-		host := globalMinioHost
-		if host == "" {
-			host = sortIPs(localIP4.ToSlice())[0]
-		}
-		return fmt.Sprintf("%s://%s", getURLScheme(globalIsTLS), net.JoinHostPort(host, globalMinioPort))
-	}()
-
 	// Is distributed setup, error out if no certificates are found for HTTPS endpoints.
 	if globalIsDistErasure {
 		if globalEndpoints.HTTPS() && !globalIsTLS {

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -37,6 +37,7 @@ const (
 	EnvArgs       = "MINIO_ARGS"
 	EnvDNSWebhook = "MINIO_DNS_WEBHOOK_ENDPOINT"
 
+	EnvMinIOServerURL          = "MINIO_SERVER_URL"
 	EnvMinIOBrowserRedirectURL = "MINIO_BROWSER_REDIRECT_URL"
 	EnvRootDiskThresholdSize   = "MINIO_ROOTDISK_THRESHOLD_SIZE"
 


### PR DESCRIPTION


## Description
use expected MinIO URLs for console

## Motivation and Context
when TLS is configured using IPs directly
might interfere and not work properly when
the server is configured with TLS certs but
the certs only have domain certs.

Also additionally allow users to specify
a public accessible URL for console to talk
to MinIO i.e `MINIO_SERVER_URL` this would
allow them to use an external ingress domain
to talk to MinIO. This internally fixes few
problems such as presigned URL generation on
the console UI etc.

This needs to be done additionally for any
MinIO deployments that might have a much more
stricter requirement when running in standalone
mode such as FS or standalone erasure code.

## How to test this PR?
Setup MinIO with TLS certs using only certs
for let's say domain names `minio1, minio2, ...`
Console won't allow login to MinIO with TLS
errors, this PR will fix this behavior.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
