### PR TITLE
Use ObjectInfo.ToLifecycleOpts instead of literal values

### DIFF
--- a/cmd/bucket-lifecycle-handlers.go
+++ b/cmd/bucket-lifecycle-handlers.go
@@ -80,7 +80,7 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 	}
 
 	// Validate the transition storage ARNs
-	if err = validateTransitionTier(ctx, bucketLifecycle); err != nil {
+	if err = validateTransitionTier(bucketLifecycle); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}

--- a/cmd/bucket-lifecycle_test.go
+++ b/cmd/bucket-lifecycle_test.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -240,46 +239,9 @@ func TestValidateTransitionTier(t *testing.T) {
 			t.Fatalf("Test %d: Failed to parse lifecycle config %v", i+1, err)
 		}
 
-		err = validateTransitionTier(context.Background(), lc)
+		err = validateTransitionTier(lc)
 		if err != tc.expectedErr {
 			t.Fatalf("Test %d: Expected %v but got %v", i+1, tc.expectedErr, err)
 		}
-	}
-}
-
-func TestGetLifecycleTransitionTier(t *testing.T) {
-	lc := lifecycle.Lifecycle{
-		Rules: []lifecycle.Rule{
-			{
-				ID:     "rule-1",
-				Status: "Enabled",
-				Transition: lifecycle.Transition{
-					Days:         lifecycle.TransitionDays(3),
-					StorageClass: "TIER-1",
-				},
-			},
-			{
-				ID:     "rule-2",
-				Status: "Enabled",
-				NoncurrentVersionTransition: lifecycle.NoncurrentVersionTransition{
-					NoncurrentDays: lifecycle.ExpirationDays(3),
-					StorageClass:   "TIER-2",
-				},
-			},
-		},
-	}
-
-	obj1 := lifecycle.ObjectOpts{
-		Name:     "obj1",
-		IsLatest: true,
-	}
-	obj2 := lifecycle.ObjectOpts{
-		Name: "obj2",
-	}
-	if got := getLifeCycleTransitionTier(context.TODO(), &lc, "bucket", obj1); got != "TIER-1" {
-		t.Fatalf("Expected TIER-1 but got %s", got)
-	}
-	if got := getLifeCycleTransitionTier(context.TODO(), &lc, "bucket", obj2); got != "TIER-2" {
-		t.Fatalf("Expected TIER-2 but got %s", got)
 	}
 }

--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -476,3 +476,16 @@ func (lc Lifecycle) SetPredictionHeaders(w http.ResponseWriter, obj ObjectOpts) 
 		}
 	}
 }
+
+// TransitionTier returns remote tier that applies to obj per ILM rules.
+func (lc Lifecycle) TransitionTier(obj ObjectOpts) string {
+	for _, rule := range lc.FilterActionableRules(obj) {
+		if obj.IsLatest && rule.Transition.StorageClass != "" {
+			return rule.Transition.StorageClass
+		}
+		if !obj.IsLatest && rule.NoncurrentVersionTransition.StorageClass != "" {
+			return rule.NoncurrentVersionTransition.StorageClass
+		}
+	}
+	return ""
+}

--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -516,3 +516,40 @@ func TestSetPredictionHeaders(t *testing.T) {
 		}
 	}
 }
+
+func TestTransitionTier(t *testing.T) {
+	lc := Lifecycle{
+		Rules: []Rule{
+			{
+				ID:     "rule-1",
+				Status: "Enabled",
+				Transition: Transition{
+					Days:         TransitionDays(3),
+					StorageClass: "TIER-1",
+				},
+			},
+			{
+				ID:     "rule-2",
+				Status: "Enabled",
+				NoncurrentVersionTransition: NoncurrentVersionTransition{
+					NoncurrentDays: ExpirationDays(3),
+					StorageClass:   "TIER-2",
+				},
+			},
+		},
+	}
+
+	obj1 := ObjectOpts{
+		Name:     "obj1",
+		IsLatest: true,
+	}
+	obj2 := ObjectOpts{
+		Name: "obj2",
+	}
+	if got := lc.TransitionTier(obj1); got != "TIER-1" {
+		t.Fatalf("Expected TIER-1 but got %s", got)
+	}
+	if got := lc.TransitionTier(obj2); got != "TIER-2" {
+		t.Fatalf("Expected TIER-2 but got %s", got)
+	}
+}


### PR DESCRIPTION
## Description
Promote getLifecycleTransitionTier to a method on lifecycle.Lifecycle.
Remove unnecessary context arguments

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
