### PR TITLE
Fix regression in AssumeRole session policy handling (fixes #12756)

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -2353,13 +2353,6 @@ func isAllowedBySessionPolicy(args iampolicy.Args) (hasSessionPolicy bool, isAll
 		return
 	}
 
-	policyBytes, err := base64.StdEncoding.DecodeString(spolicyStr)
-	if err != nil {
-		// Got a malformed base64 string
-		return
-	}
-	spolicyStr = string(policyBytes)
-
 	// Check if policy is parseable.
 	subPolicy, err := iampolicy.ParseConfig(bytes.NewReader([]byte(spolicyStr)))
 	if err != nil {


### PR DESCRIPTION

## How to test this PR?

Use assume role to create temp creds for a user (see `docs/sts/assume-role.md`):

```
aws --profile foobar --endpoint-url http://localhost:9000 sts assume-role --policy '{"Version":"2012-10-17","Statement":[{"Sid":"Stmt1","Effect":"Allow","Action":"s3:*","Resource":"arn:aws:s3:::*"}]}' --role-arn arn:xxx:xxx:xxx:xxxx --role-session-name anything
```

Check that generated creds works:

```
MC_HOST_ftmp=http://access_key:secret_key:session_token@localhost:9000 mc ls ftmp
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (introduced in eae9c2f65bade4d9de2aac42f188114bf6dbe555)
- [ ] Documentation updated
- [ ] Unit tests added/updated
