### PR TITLE
DEPRECATION Warning: Avoid configuring default LDAP STS Expiry

### DIFF
--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -54,7 +54,6 @@ identity_ldap  enable LDAP SSO support
 
 ARGS:
 MINIO_IDENTITY_LDAP_SERVER_ADDR*            (address)   AD/LDAP server address e.g. "myldapserver.com:636"
-MINIO_IDENTITY_LDAP_STS_EXPIRY              (duration)  temporary credentials validity duration in s,m,h,d. Default is "1h"
 MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN          (string)    DN for LDAP read-only service account used to perform DN and group lookups
 MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD    (string)    Password for LDAP read-only service account used to perform DN and group lookups
 MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN  (string)    Base LDAP DN to search for user DN
@@ -123,11 +122,8 @@ export MINIO_IDENTITY_LDAP_SERVER_ADDR=myldapserver.com:636
 export MINIO_IDENTITY_LDAP_USERNAME_FORMAT="uid=%s,cn=accounts,dc=myldapserver,dc=com"
 export MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN="dc=myldapserver,dc=com"
 export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER="(&(objectclass=groupOfNames)(memberUid=%s)$)"
-export MINIO_IDENTITY_LDAP_STS_EXPIRY=720h
 export MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY=on
 ```
-
-> NOTE: In this example STS_EXPIRY is set to 1month, maximum expiry that can be set is 365 days.
 
 ### Variable substitution in AD/LDAP configuration strings ###
 

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -31,6 +31,7 @@ import (
 	ldap "github.com/go-ldap/ldap/v3"
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config"
+	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/env"
 )
 
@@ -553,6 +554,7 @@ func Lookup(kvs config.KVS, rootCAs *x509.CertPool) (l Config, err error) {
 	l.ServerAddr = ldapServer
 	l.stsExpiryDuration = defaultLDAPExpiry
 	if v := env.Get(EnvSTSExpiry, kvs.Get(STSExpiry)); v != "" {
+		logger.Info("DEPRECATION WARNING: Support for configuring the default LDAP credentials expiry duration will be removed in a future release. Please use the `DurationSeconds` parameter in the LDAP STS API instead.")
 		expDur, err := time.ParseDuration(v)
 		if err != nil {
 			return l, errors.New("LDAP expiry time err:" + err.Error())

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -30,7 +30,7 @@ var (
 		},
 		config.HelpKV{
 			Key:         STSExpiry,
-			Description: `temporary credentials validity duration in s,m,h,d. Default is "1h"`,
+			Description: `[DEPRECATED] temporary credentials validity duration in s,m,h,d. Default is "1h"`,
 			Optional:    true,
 			Type:        "duration",
 		},


### PR DESCRIPTION
## Description

- Show a notice when `MINIO_IDENTITY_LDAP_STS_EXPIRY` or the corresponding
configuration option is used at server startup.

- Once support is removed, the default will be fixed at 1 hour.

- Users may specify expiry directly in the STS API.

- Adds example in ldap.go to configure expiry in STS API.

## Motivation and Context

The parameter is now redundant.

## How to test this PR?

Use `docs/sts/ldap.go`. Needs https://github.com/minio/minio-go/pull/1521

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Proposed Breaking change 

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
