### PR TITLE
Add round-robin sharing of ILM transition tasks

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1065,7 +1065,10 @@ func applyTransitionAction(ctx context.Context, action lifecycle.Action, objLaye
 			return false
 		}
 	}
-	globalTransitionState.queueTransitionTask(obj)
+	if obj.InlineData {
+		return false
+	}
+	globalNotificationSys.EnqueueTransitionTask(ctx, obj)
 	return true
 
 }

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -124,6 +124,7 @@ func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 		ContentEncoding:  fi.Metadata["content-encoding"],
 		NumVersions:      fi.NumVersions,
 		SuccessorModTime: fi.SuccessorModTime,
+		InlineData:       fi.InlineData(),
 	}
 
 	// Update expires

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -182,6 +182,9 @@ type ObjectInfo struct {
 	NumVersions int
 	//  The modtime of the successor object version if any
 	SuccessorModTime time.Time
+
+	// True if object contents are inlined in xl.meta
+	InlineData bool
 }
 
 // Clone - Returns a cloned copy of current objectInfo

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -969,3 +969,16 @@ func (client *peerRESTClient) GetPeerMetrics(ctx context.Context) (<-chan Metric
 	}(ch)
 	return ch, nil
 }
+
+func (client *peerRESTClient) EnqueueTransitionTask(ctx context.Context, oi ObjectInfo) error {
+	params := make(url.Values)
+	params.Set(peerRESTBucket, oi.Bucket)
+	params.Set(peerRESTObject, oi.Name)
+	params.Set(peerRESTVersionID, oi.VersionID)
+	respBody, err := client.callWithContext(ctx, peerRESTMethodEnqueueTransitionTask, params, nil, -1)
+	if err != nil {
+		return err
+	}
+	http.DrainBody(respBody)
+	return nil
+}

--- a/cmd/peer-rest-common.go
+++ b/cmd/peer-rest-common.go
@@ -18,7 +18,7 @@
 package cmd
 
 const (
-	peerRESTVersion       = "v15" // Add LoadTransitionTierConfig
+	peerRESTVersion       = "v16" // Add EnqueueTransitionTask
 	peerRESTVersionPrefix = SlashSeparator + peerRESTVersion
 	peerRESTPrefix        = minioReservedBucketPath + "/peer"
 	peerRESTPath          = peerRESTPrefix + peerRESTVersionPrefix
@@ -62,11 +62,14 @@ const (
 	peerRESTMethodUpdateMetacacheListing   = "/updatemetacache"
 	peerRESTMethodGetPeerMetrics           = "/peermetrics"
 	peerRESTMethodLoadTransitionTierConfig = "/loadtransitiontierconfig"
+	peerRESTMethodEnqueueTransitionTask    = "/enqueuetransitiontask"
 )
 
 const (
 	peerRESTBucket         = "bucket"
 	peerRESTBuckets        = "buckets"
+	peerRESTObject         = "object"
+	peerRESTVersionID      = "versionID"
 	peerRESTUser           = "user"
 	peerRESTGroup          = "group"
 	peerRESTUserTemp       = "user-temp"

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -1110,6 +1110,11 @@ func (s *peerRESTServer) EnqueueTransitionTask(w http.ResponseWriter, r *http.Re
 	object := params.Get(peerRESTObject)
 	versionID := params.Get(peerRESTVersionID)
 	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		s.writeErrorResponse(w, errServerNotInitialized)
+		return
+	}
+
 	opts := ObjectOptions{
 		VersionID: versionID,
 	}
@@ -1118,9 +1123,12 @@ func (s *peerRESTServer) EnqueueTransitionTask(w http.ResponseWriter, r *http.Re
 		s.writeErrorResponse(w, err)
 		return
 	}
-	if globalTransitionState != nil {
-		globalTransitionState.queueTransitionTask(oi)
+	if globalTransitionState == nil {
+		s.writeErrorResponse(w, fmt.Errorf("transition state is not yet initialized"))
+		return
 	}
+	globalTransitionState.queueTransitionTask(oi)
+
 	w.(http.Flusher).Flush()
 }
 


### PR DESCRIPTION
## Description
This change implements a simple round robin scheme by which the MinIO server running the scanner distributes ILM transition tasks across all MinIO server nodes.

## Motivation and Context
ILM transition tasks are scheduled on the MinIO node where the scanner is running. This workload can be shared with other MinIO servers in the cluster thereby sharing the network bandwidth costs it entails.

## How to test this PR?
1. Setup objects for ILM transition
2. Run `./mc admin trace -a --funcname "internal.EnqueueTransitionTask" minio-tier`
You must see logs like the following with different MinIO server address indicating a round-robin distribution.
```
2021-07-23T15:18:43:000 [200 OK] internal.EnqueueTransitionTask minio2:9000/minio/peer/v16/enqueuetransitiontask?bucket=mybucket&object=obj-2&versionID=null  192.168.240.5     3.397ms      ↑ 65 B ↓ 0 B
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
