### PR TITLE
mrf: Avoid rare data race and more simplification

### DIFF
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -68,17 +68,6 @@ func newBgHealSequence() *healSequence {
 	}
 }
 
-func getCurrentMRFStatus() madmin.MRFStatus {
-	mrfInfo := globalMRFState.getCurrentMRFRoundInfo()
-	return madmin.MRFStatus{
-		BytesHealed: mrfInfo.bytesHealed,
-		ItemsHealed: mrfInfo.itemsHealed,
-		TotalItems:  mrfInfo.itemsHealed + mrfInfo.pendingItems,
-		TotalBytes:  mrfInfo.bytesHealed + mrfInfo.pendingBytes,
-		Started:     mrfInfo.triggeredAt,
-	}
-}
-
 // getBackgroundHealStatus will return the
 func getBackgroundHealStatus(ctx context.Context, o ObjectLayer) (madmin.BgHealState, bool) {
 	if globalBackgroundHealState == nil {
@@ -94,9 +83,9 @@ func getBackgroundHealStatus(ctx context.Context, o ObjectLayer) (madmin.BgHealS
 		ScannedItemsCount: bgSeq.getScannedItemsCount(),
 	}
 
-	if globalMRFState != nil {
+	if globalMRFState.initialized() {
 		status.MRF = map[string]madmin.MRFStatus{
-			globalLocalNodeName: getCurrentMRFStatus(),
+			globalLocalNodeName: globalMRFState.getCurrentMRFRoundInfo(),
 		}
 	}
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -293,7 +293,7 @@ var (
 	globalBackgroundHealRoutine *healRoutine
 	globalBackgroundHealState   *allHealState
 
-	globalMRFState *mrfState
+	globalMRFState mrfState
 
 	// If writes to FS backend should be O_SYNC.
 	globalFSOSync bool


### PR DESCRIPTION
## Description
This change avoids a rare data race and simplify the function that
returns MRF last activity information.

## Motivation and Context
```
WARNING: DATA RACE
Write at 0x0000077a0cf8 by main goroutine:
  github.com/minio/minio/cmd.initHealMRF()
      github.com/minio/minio/cmd/mrf.go:233 +0x1e9
  github.com/minio/minio/cmd.serverMain()
      github.com/minio/minio/cmd/server-main.go:532 +0xe44
  github.com/minio/cli.HandleAction()
      github.com/minio/cli@v1.22.0/app.go:500 +0x103
  github.com/minio/cli.Command.Run()
      github.com/minio/cli@v1.22.0/command.go:225 +0xdc5
  github.com/minio/cli.(*App).Run()
      github.com/minio/cli@v1.22.0/app.go:261 +0xab3
  github.com/minio/minio/cmd.Main()
      github.com/minio/minio/cmd/main.go:168 +0xa8
  main.main()
      github.com/minio/minio/main.go:30 +0x64
Previous read at 0x0000077a0cf8 by goroutine 121:
  [failed to restore the stack]
```

## How to test this PR?
Hard to catch the race warning, a normal MRF testing will be good

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
