### PR TITLE
fix: avoid removing healed parts on dstDataPath

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2054,6 +2054,12 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 				// Purge the destination path as we are not preserving anything
 				// versioned object was not requested.
 				oldDstDataPath = pathJoin(dstVolumeDir, dstPath, ofi.DataDir)
+				// if old destination path is same as new destination path
+				// there is nothing to purge, this is true in case of healing
+				// avoid setting oldDstDataPath at that point.
+				if oldDstDataPath == dstDataPath {
+					oldDstDataPath = ""
+				}
 				xlMeta.data.remove(nullVersionID, ofi.DataDir)
 			}
 		}


### PR DESCRIPTION

## Description
fix: avoid removing healed parts on dstDataPath

## Motivation and Context
destination path and old path will be similar
when healing occurs, this can lead to healed
parts being again purged leading to always an
inconsistent state on an object which might
further cause reduction in quorum eventually.

## How to test this PR?
```
~ minio server /tmp/xl{1...4}
~ mc mb myminio/testbucket/
~ mc cp file-20m myminio/testbucket/
~ rm -rf /tmp/xl1/testbucket/file-20m/{uuid}/part.1
~ mc admin heal -r myminio/testbucket/
```
Would erroneously end up removing the entire `{uuid}` folder.

This PR fixes this properly by making sure to avoid purging
a properly healed content.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
