### PR TITLE
remove short circuited healing optimization

### DIFF
--- a/cmd/erasure-healing-common.go
+++ b/cmd/erasure-healing-common.go
@@ -189,35 +189,6 @@ func getLatestFileInfo(ctx context.Context, partsMetadata []FileInfo, errs []err
 	return latestFileInfo, nil
 }
 
-// fileInfoConsistent whether all fileinfos are consistent with each other.
-// Will return false if any fileinfo mismatches.
-func fileInfoConsistent(ctx context.Context, partsMetadata []FileInfo, errs []error) bool {
-	// There should be atleast half correct entries, if not return failure
-	if reducedErr := reduceReadQuorumErrs(ctx, errs, nil, len(partsMetadata)/2); reducedErr != nil {
-		return false
-	}
-	if len(partsMetadata) == 1 {
-		return true
-	}
-	// Reference
-	ref := partsMetadata[0]
-	if !ref.IsValid() {
-		return false
-	}
-	for _, meta := range partsMetadata[1:] {
-		if !meta.IsValid() {
-			return false
-		}
-		if !meta.ModTime.Equal(ref.ModTime) {
-			return false
-		}
-		if meta.DataDir != ref.DataDir {
-			return false
-		}
-	}
-	return true
-}
-
 // disksWithAllParts - This function needs to be called with
 // []StorageAPI returned by listOnlineDisks. Returns,
 //


### PR DESCRIPTION


## Description
remove short-circuited healing optimization

## Motivation and Context
this healing optimization caused multiple
regressions in healing

- delete-markers incorrectly missing
  heal and returning incorrect healing
  results to the client.

- missing individual 'parts' such
  as for restored object or simply
  for all objects just missing few parts.

This optimization is not necessary, we
should proceed to verify all cases possible
not just when metadata is inconsistent.

## How to test this PR?
All bigger objects simply delete their `part.1` and
observe the healing doesn't heal this situation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
