### PR TITLE
Remove wrong "X-Amz-Bucket-Region" header

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -49,12 +49,6 @@ func setEventStreamHeaders(w http.ResponseWriter) {
 func setCommonHeaders(w http.ResponseWriter) {
 	// Set the "Server" http header.
 	w.Header().Set(xhttp.ServerInfo, "MinIO")
-
-	// Set `x-amz-bucket-region` only if region is set on the server
-	// by default minio uses an empty region.
-	if region := globalServerRegion; region != "" {
-		w.Header().Set(xhttp.AmzBucketRegion, region)
-	}
 	w.Header().Set(xhttp.AcceptRanges, "bytes")
 
 	// Remove sensitive information
@@ -194,4 +188,12 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 	}
 
 	return nil
+}
+
+// Write bucket region header
+func setBucketRegionHeader(w http.ResponseWriter, bucketRegion string) {
+	// Set `x-amz-bucket-region` only if bucketRegion is set
+	if bucketRegion != "" {
+		w.Header().Set(xhttp.AmzBucketRegion, bucketRegion)
+	}
 }

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1193,6 +1193,7 @@ func (api objectAPIHandlers) HeadBucketHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	setBucketRegionHeader(w, globalServerRegion)
 	writeSuccessResponseHeadersOnly(w)
 }
 


### PR DESCRIPTION
## Description
According to the aws s3 api ref(https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html), the X-Amz-Bucket-Region header is only included in the Head Bucket response.
However, in Minio, all responses include an X-Amz-Bucket-Region header.
https://github.com/minio/minio/blob/471b4fd0c93e0ec7e80018273e73f775dda67561/cmd/api-headers.go#L49-L62

When aws cli(s3) receives response 400 status code, it executes a region redirect to the aws address, so in the current PR, the header is included only when response status code is 200.

## Motivation and Context
For AWS S3 API compatibility

## How to test this PR?
go test(minio/cmd)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
