### PR TITLE
fix: incorrect O_DIRECT behavior for reads

### DIFF
--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -30,8 +30,6 @@ import (
 	"strings"
 	"syscall"
 	"testing"
-
-	"github.com/minio/minio/internal/config/storageclass"
 )
 
 func TestCheckPathLength(t *testing.T) {
@@ -1152,10 +1150,6 @@ func TestXLStorageReadFile(t *testing.T) {
 	}
 
 	for l := 0; l < 2; l++ {
-		// 1st loop tests with dma=write, 2nd loop tests with dma=read-write.
-		if l == 1 {
-			globalStorageClass.DMA = storageclass.DMAReadWrite
-		}
 		// Following block validates all ReadFile test cases.
 		for i, testCase := range testCases {
 			var n int64
@@ -1212,9 +1206,6 @@ func TestXLStorageReadFile(t *testing.T) {
 			}
 		}
 	}
-
-	// Reset the flag.
-	globalStorageClass.DMA = storageclass.DMAWrite
 
 	// TestXLStorage for permission denied.
 	if runtime.GOOS != globalWindowsOSName {

--- a/internal/config/storageclass/help.go
+++ b/internal/config/storageclass/help.go
@@ -35,12 +35,6 @@ var (
 			Type:        "string",
 		},
 		config.HelpKV{
-			Key:         ClassDMA,
-			Description: `enable O_DIRECT for both read and write, defaults to "write" e.g. "read+write"`,
-			Optional:    true,
-			Type:        "string",
-		},
-		config.HelpKV{
 			Key:         config.Comment,
 			Description: config.DefaultComment,
 			Optional:    true,


### PR DESCRIPTION

## Description
fix: incorrect O_DIRECT behavior for reads

## Motivation and Context
O_DIRECT behavior was broken and it was still
caching all the reads, this change properly fixes
this behavior.

## How to test this PR?
Need to test on Linux kernel to observe the 
reads and page-cache build up upon re-reads.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
