### PR TITLE
Allow to specify secrets separately

### DIFF
--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -35,15 +35,13 @@ docker_secrets_env_old() {
         SECRET_KEY_FILE="/run/secrets/$MINIO_SECRET_KEY_FILE"
     fi
 
-    if [ -f "$ACCESS_KEY_FILE" ] && [ -f "$SECRET_KEY_FILE" ]; then
-        if [ -f "$ACCESS_KEY_FILE" ]; then
-            MINIO_ACCESS_KEY="$(cat "$ACCESS_KEY_FILE")"
-            export MINIO_ACCESS_KEY
-        fi
-        if [ -f "$SECRET_KEY_FILE" ]; then
-            MINIO_SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
-            export MINIO_SECRET_KEY
-        fi
+    if [ -f "$ACCESS_KEY_FILE" ]; then
+        MINIO_ACCESS_KEY="$(cat "$ACCESS_KEY_FILE")"
+        export MINIO_ACCESS_KEY
+    fi
+    if [ -f "$SECRET_KEY_FILE" ]; then
+        MINIO_SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
+        export MINIO_SECRET_KEY
     fi
 }
 
@@ -59,15 +57,13 @@ docker_secrets_env() {
         ROOT_PASSWORD_FILE="/run/secrets/$MINIO_ROOT_PASSWORD_FILE"
     fi
 
-    if [ -f "$ROOT_USER_FILE" ] && [ -f "$ROOT_PASSWORD_FILE" ]; then
-        if [ -f "$ROOT_USER_FILE" ]; then
-            MINIO_ROOT_USER="$(cat "$ROOT_USER_FILE")"
-            export MINIO_ROOT_USER
-        fi
-        if [ -f "$ROOT_PASSWORD_FILE" ]; then
-            MINIO_ROOT_PASSWORD="$(cat "$ROOT_PASSWORD_FILE")"
-            export MINIO_ROOT_PASSWORD
-        fi
+    if [ -f "$ROOT_USER_FILE" ]; then
+        MINIO_ROOT_USER="$(cat "$ROOT_USER_FILE")"
+        export MINIO_ROOT_USER
+    fi
+    if [ -f "$ROOT_PASSWORD_FILE" ]; then
+        MINIO_ROOT_PASSWORD="$(cat "$ROOT_PASSWORD_FILE")"
+        export MINIO_ROOT_PASSWORD
     fi
 }
 

--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -54,18 +54,18 @@ docker_secrets_env() {
         ROOT_USER_FILE="/run/secrets/$MINIO_ROOT_USER_FILE"
     fi
     if [ -f "$MINIO_ROOT_PASSWORD_FILE" ]; then
-        SECRET_KEY_FILE="$MINIO_ROOT_PASSWORD_FILE"
+        ROOT_PASSWORD_FILE="$MINIO_ROOT_PASSWORD_FILE"
     else
-        SECRET_KEY_FILE="/run/secrets/$MINIO_ROOT_PASSWORD_FILE"
+        ROOT_PASSWORD_FILE="/run/secrets/$MINIO_ROOT_PASSWORD_FILE"
     fi
 
-    if [ -f "$ROOT_USER_FILE" ] && [ -f "$SECRET_KEY_FILE" ]; then
+    if [ -f "$ROOT_USER_FILE" ] && [ -f "$ROOT_PASSWORD_FILE" ]; then
         if [ -f "$ROOT_USER_FILE" ]; then
             MINIO_ROOT_USER="$(cat "$ROOT_USER_FILE")"
             export MINIO_ROOT_USER
         fi
-        if [ -f "$SECRET_KEY_FILE" ]; then
-            MINIO_ROOT_PASSWORD="$(cat "$SECRET_KEY_FILE")"
+        if [ -f "$ROOT_PASSWORD_FILE" ]; then
+            MINIO_ROOT_PASSWORD="$(cat "$ROOT_PASSWORD_FILE")"
             export MINIO_ROOT_PASSWORD
         fi
     fi


### PR DESCRIPTION
## Description

It allows to set `*_FILE`-suffixed variable for `USER` or `PASSWORD` instead of both.

## Motivation and Context

Sometimes it is easier to hardcode username and use Docker secrets only for passwords:

```
storage:
    image: minio/minio
    environment:
        MINIO_ROOT_USER: storage_user
        MINIO_ROOT_PASSWORD_FILE: /run/secrets/storage_password
```

## How to test this PR?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
