### PR TITLE
fs: Update object modtime when metadata is updated

### DIFF
--- a/cmd/fs-v1-helpers.go
+++ b/cmd/fs-v1-helpers.go
@@ -24,6 +24,7 @@ import (
 	pathutil "path"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/minio/minio/internal/lock"
 	"github.com/minio/minio/internal/logger"
@@ -166,6 +167,25 @@ func fsStat(ctx context.Context, statLoc string) (os.FileInfo, error) {
 	}
 
 	return fi, nil
+}
+
+// fsTouch updates a file access & modtime with current time
+func fsTouch(ctx context.Context, statLoc string) error {
+	if statLoc == "" {
+		logger.LogIf(ctx, errInvalidArgument)
+		return errInvalidArgument
+	}
+	if err := checkPathLength(statLoc); err != nil {
+		logger.LogIf(ctx, err)
+		return err
+	}
+	now := time.Now()
+	if err := os.Chtimes(statLoc, now, now); err != nil {
+		logger.LogIf(ctx, err)
+		return err
+	}
+
+	return nil
 }
 
 // Lookup if volume exists, returns volume attributes upon success.

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -682,8 +682,15 @@ func (fs *FSObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBu
 			return oi, toObjectErr(err, srcBucket, srcObject)
 		}
 
-		// Stat the file to get file size.
-		fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, srcBucket, srcObject))
+		fsObjectPath := pathJoin(fs.fsPath, srcBucket, srcObject)
+
+		// Update object modtime
+		err = fsTouch(ctx, fsObjectPath)
+		if err != nil {
+			return oi, toObjectErr(err, srcBucket, srcObject)
+		}
+		// Stat the file to get object info
+		fi, err := fsStatFile(ctx, fsObjectPath)
 		if err != nil {
 			return oi, toObjectErr(err, srcBucket, srcObject)
 		}


### PR DESCRIPTION
## Description
Follow S3 behavior of updating object modtime when object metadata is
updated.

## Motivation and Context
Fixes https://github.com/minio/minio/issues/12777

## How to test this PR?
`aws --endpoint-url http://localhost:9000 --profile minio s3 cp s3://testbucket/testobject s3://testbucket/testobject --metadata-directive=REPLACE` should update object modtime

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
