### PR TITLE
allow multipart uploads for single part multipart

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -44,7 +44,7 @@ import (
 	"github.com/minio/console/restapi"
 	"github.com/minio/console/restapi/operations"
 	"github.com/minio/kes"
-	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/auth"
@@ -105,9 +105,10 @@ func init() {
 			},
 		},
 	}
-	// Set number of max retries to 1 for minio-go clients
-	minio.MaxRetry = 1
 
+	// All minio-go API operations shall be performed only once,
+	// another way to look at this is we are turning off retries.
+	minio.MaxRetry = 1
 }
 
 const consolePrefix = "CONSOLE_"

--- a/cmd/fs-v1-metadata.go
+++ b/cmd/fs-v1-metadata.go
@@ -29,6 +29,8 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/minio/minio/internal/crypto"
+	"github.com/minio/minio/internal/etag"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/lock"
 	"github.com/minio/minio/internal/logger"
@@ -167,6 +169,12 @@ func (m fsMetaV1) ToObjectInfo(bucket, object string, fi os.FileInfo) ObjectInfo
 	}
 
 	objInfo.ETag = extractETag(m.Meta)
+
+	et, e := etag.Parse(objInfo.ETag)
+	if e == nil {
+		objInfo.Multipart = et.IsMultipart()
+	}
+
 	objInfo.ContentType = m.Meta["content-type"]
 	objInfo.ContentEncoding = m.Meta["content-encoding"]
 	if storageClass, ok := m.Meta[xhttp.AmzStorageClass]; ok {
@@ -176,7 +184,6 @@ func (m fsMetaV1) ToObjectInfo(bucket, object string, fi os.FileInfo) ObjectInfo
 	}
 	var (
 		t time.Time
-		e error
 	)
 	if exp, ok := m.Meta["expires"]; ok {
 		if t, e = time.Parse(http.TimeFormat, exp); e == nil {
@@ -192,6 +199,14 @@ func (m fsMetaV1) ToObjectInfo(bucket, object string, fi os.FileInfo) ObjectInfo
 	// response headers. e.g, X-Minio-* or X-Amz-*.
 	// Tags have also been extracted, we remove that as well.
 	objInfo.UserDefined = cleanMetadata(m.Meta)
+
+	// Set multipart for encryption properly if
+	// not set already.
+	if !objInfo.Multipart {
+		if _, ok := crypto.IsEncrypted(objInfo.UserDefined); ok {
+			objInfo.Multipart = crypto.IsMultiPart(objInfo.UserDefined)
+		}
+	}
 
 	// All the parts per object.
 	objInfo.Parts = m.Parts

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -173,6 +173,8 @@ type ObjectInfo struct {
 
 	Legacy bool // indicates object on disk is in legacy data format
 
+	Multipart bool // indicates if object is multipart object.
+
 	// backendType indicates which backend filled this structure
 	backendType BackendType
 
@@ -193,6 +195,7 @@ func (o ObjectInfo) Clone() (cinfo ObjectInfo) {
 		Size:               o.Size,
 		IsDir:              o.IsDir,
 		ETag:               o.ETag,
+		Multipart:          o.Multipart,
 		InnerETag:          o.InnerETag,
 		VersionID:          o.VersionID,
 		IsLatest:           o.IsLatest,


### PR DESCRIPTION


## Description
allow multipart uploads for single part multipart

## Motivation and Context
it's possible that some multipart uploads would have
uploaded only single parts so relying on `len(o.Parts)`
alone is not sufficient, we need to look for ETag
pattern to be absolutely sure.

## How to test this PR?
Upload a single part multipart object, replication would
copy single part multipart object as non-multipart in the
master code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
