### PR TITLE
fix: parentDirIsObject() make it independent for parents

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -26,6 +26,7 @@ import (
 	"hash/crc32"
 	"math/rand"
 	"net/http"
+	"path"
 	"sort"
 	"sync"
 	"time"
@@ -879,10 +880,19 @@ func (s *erasureSets) GetObjectNInfo(ctx context.Context, bucket, object string,
 }
 
 func (s *erasureSets) parentDirIsObject(ctx context.Context, bucket, parent string) bool {
-	if parent == "." {
-		return false
+	var isParentDirObject func(string) bool
+	isParentDirObject = func(p string) bool {
+		if p == "." || p == SlashSeparator {
+			return false
+		}
+		if s.getHashedSet(p).parentDirIsObject(ctx, bucket, p) {
+			// If there is already a file at prefix "p", return true.
+			return true
+		}
+		// Check if there is a file as one of the parent paths.
+		return isParentDirObject(path.Dir(p))
 	}
-	return s.getHashedSet(parent).parentDirIsObject(ctx, bucket, parent)
+	return isParentDirObject(parent)
 }
 
 // PutObject - writes an object to hashedSet based on the object name.


### PR DESCRIPTION
## Description
fix: parentDirIsObject() make it independent for parents

## Motivation and Context
this is to ensure that if parents exist on different sets
we get to reject the creation of such prefixes. 

## How to test this PR?
You would need large enough sets with some 
conflicting object names

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
