### PR TITLE
feat: Add support for audit notifications for transition

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1354,6 +1354,8 @@ const (
 	ILMExpiry = "ilm:expiry"
 	// ILMFreeVersionDelete - audit trail for ILM free-version delete
 	ILMFreeVersionDelete = "ilm:free-version-delete"
+	// ILMTransition - audit trail for ILM transitioning.
+	ILMTransition = " ilm:transition"
 )
 
 func auditLogLifecycle(ctx context.Context, oi ObjectInfo, trigger string) {
@@ -1363,6 +1365,8 @@ func auditLogLifecycle(ctx context.Context, oi ObjectInfo, trigger string) {
 		apiName = "ILMExpiry"
 	case ILMFreeVersionDelete:
 		apiName = "ILMFreeVersionDelete"
+	case ILMTransition:
+		apiName = "ILMTransition"
 	}
 	auditLogInternal(ctx, oi.Bucket, oi.Name, AuditLogOptions{
 		Trigger:   trigger,

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1437,16 +1437,15 @@ func (er erasureObjects) TransitionObject(ctx context.Context, bucket, object st
 		er.addPartial(bucket, object, opts.VersionID, -1)
 		break
 	}
-	// Notify object deleted event.
+
+	objInfo := fi.ToObjectInfo(bucket, object)
 	sendEvent(eventArgs{
 		EventName:  eventName,
 		BucketName: bucket,
-		Object: ObjectInfo{
-			Name:      object,
-			VersionID: opts.VersionID,
-		},
-		Host: "Internal: [ILM-Transition]",
+		Object:     objInfo,
+		Host:       "Internal: [ILM-Transition]",
 	})
+	auditLogLifecycle(ctx, objInfo, ILMTransition)
 	return err
 }
 


### PR DESCRIPTION
## Description
feat: Add support for audit notifications for transition

## Motivation and Context
This PR adds audit notifications for transitioning objects,
similar to audit logging for expiration and replication
traffic.

## How to test this PR?
Setup audit HTTP target and configure MinIO with ILM transition

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
