### PR TITLE
Revert ignoring inlined objects for transition

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1396,11 +1396,6 @@ func (er erasureObjects) TransitionObject(ctx context.Context, bucket, object st
 		}
 	}
 
-	// object content is small enough that it's inlined, skipping transition
-	if fi.InlineData() {
-		return nil
-	}
-
 	destObj, err := genTransitionObjName(bucket)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
Backup applications tend to have object sizes less than 128KiB and still would like to be transitioned to a remote tier. This change ensures that even inlined objects are transitioned.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
