### PR TITLE
Storage-class headers should depend only on ObjectInfo state

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -184,12 +184,13 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 		w.Header()[xhttp.AmzBucketReplicationStatus] = []string{objInfo.ReplicationStatus.String()}
 	}
 
+	if objInfo.IsRemote() {
+		// Check if object is being restored. For more information on x-amz-restore header see
+		// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax
+		w.Header()[xhttp.AmzStorageClass] = []string{objInfo.TransitionTier}
+	}
+
 	if lc, err := globalLifecycleSys.Get(objInfo.Bucket); err == nil {
-		if objInfo.IsRemote() {
-			// Check if object is being restored. For more information on x-amz-restore header see
-			// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax
-			w.Header()[xhttp.AmzStorageClass] = []string{objInfo.TransitionTier}
-		}
 		lc.SetPredictionHeaders(w, objInfo.ToLifecycleOpts())
 	}
 


### PR DESCRIPTION
## Description
X-Amz-StorageClass header must be set if an object has transitioned, independent of whether any lifecycle rules are configured on its bucket.

## How to test this PR?
1. Set ILM rules for transition on a bucket.
2. Upload objects into this bucket and wait until they are transitioned per ILM rules
3. Remove ILM rules from this bucket.
4. `./mc stat` on one of the transitioned objects must have X-Amz-StorageClass header set to its remote tier.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
