### PR TITLE
remove replicate set fallback behavior

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -71,7 +71,7 @@ func init() {
 	logger.Init(GOPATH, GOROOT)
 	logger.RegisterError(config.FmtError)
 
-	if IsKubernetes() || IsDocker() || IsBOSH() || IsDCOS() || IsKubernetesReplicaSet() || IsPCFTile() {
+	if IsKubernetes() || IsDocker() || IsBOSH() || IsDCOS() || IsPCFTile() {
 		// 30 seconds matches the orchestrator DNS TTLs, have
 		// a 5 second timeout to lookup from DNS servers.
 		globalDNSCache = xhttp.NewDNSCache(30*time.Second, 5*time.Second, logger.LogOnceIf)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -150,11 +150,6 @@ func IsDCOS() bool {
 	return false
 }
 
-// IsKubernetesReplicaSet returns true if minio is running in kubernetes replica set.
-func IsKubernetesReplicaSet() bool {
-	return IsKubernetes() && (env.Get("KUBERNETES_REPLICA_SET", "") != "")
-}
-
 // IsKubernetes returns true if minio is running in kubernetes.
 func IsKubernetes() bool {
 	if env.Get("MINIO_CI_CD", "") == "" {


### PR DESCRIPTION

## Description
remove replicate set fallback behavior

## Motivation and Context
replica set deployment style is an incorrect
style of distributed MinIO deployment, since
statefulsets have been around for many releases
in k8s now.

## How to test this PR?
Nothing special we are removing support for REPLICA_SET

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
