### PR TITLE
xl walk: Limit walk concurrent IO

### DIFF
--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -121,7 +121,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 		if contextCanceled(ctx) {
 			return ctx.Err()
 		}
+		s.walkMu.Lock()
 		entries, err := s.ListDir(ctx, opts.Bucket, current, -1)
+		s.walkMu.Unlock()
 		if err != nil {
 			// Folder could have gone away in-between
 			if err != errVolumeNotFound && err != errFileNotFound {
@@ -171,7 +173,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			// If root was an object return it as such.
 			if HasSuffix(entry, xlStorageFormatFile) {
 				var meta metaCacheEntry
+				s.walkMu.Lock()
 				meta.metadata, err = s.readMetadata(pathJoin(volumeDir, current, entry))
+				s.walkMu.Unlock()
 				if err != nil {
 					logger.LogIf(ctx, err)
 					continue
@@ -186,7 +190,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			// Check legacy.
 			if HasSuffix(entry, xlStorageFormatFileV1) {
 				var meta metaCacheEntry
+				s.walkMu.Lock()
 				meta.metadata, err = xioutil.ReadFile(pathJoin(volumeDir, current, entry))
+				s.walkMu.Unlock()
 				if err != nil {
 					logger.LogIf(ctx, err)
 					continue
@@ -242,7 +248,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 				meta.name = meta.name[:len(meta.name)-1] + globalDirSuffixWithSlash
 			}
 
+			s.walkMu.Lock()
 			meta.metadata, err = s.readMetadata(pathJoin(volumeDir, meta.name, xlStorageFormatFile))
+			s.walkMu.Unlock()
 			switch {
 			case err == nil:
 				// It was an object
@@ -251,7 +259,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 				}
 				out <- meta
 			case osIsNotExist(err):
+				s.walkMu.Lock()
 				meta.metadata, err = xioutil.ReadFile(pathJoin(volumeDir, meta.name, xlStorageFormatFileV1))
+				s.walkMu.Unlock()
 				if err == nil {
 					// It was an object
 					out <- meta

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -139,6 +139,9 @@ type xlStorage struct {
 
 	ctx context.Context
 	sync.RWMutex
+
+	// mutex to prevent concurrent read operations overloading walks.
+	walkMu sync.Mutex
 }
 
 // checkPathLength - returns error if given path name length more than 255


### PR DESCRIPTION
## Description

We are observing heavy system loads, potentially locking the system up for periods when concurrent listing operations are performed.

We place a per-disk lock on walk IO operations. This will minimize the impact of concurrent listing operations on the entire system and de-prioritize them compared to other operations since only 1 will be in IO queue at any time.

Single list operations should remain largely unaffected.

## How to test this PR?

@harshavardhana has a reproducing setup with spinning disks where this is most prevalent.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
