### PR TITLE
[branch 10-28.sets] Listing: Do not include marker in CommonPrefixes

### DIFF
--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -913,6 +913,12 @@ func (z *erasureServerSets) listObjects(ctx context.Context, bucket, prefix, mar
 
 	for _, entry := range entries.Files {
 		objInfo := entry.ToObjectInfo(entry.Volume, entry.Name)
+		// Always avoid including the marker in the result, this is
+		// needed to avoid including dir__XLDIR__ and dir/ twice in
+		// different listing pages
+		if objInfo.Name == marker {
+			continue
+		}
 		if HasSuffix(objInfo.Name, SlashSeparator) && !recursive {
 			loi.Prefixes = append(loi.Prefixes, objInfo.Name)
 			continue
@@ -1324,6 +1330,12 @@ func (z *erasureServerSets) listObjectVersions(ctx context.Context, bucket, pref
 	for _, entry := range entries.FilesVersions {
 		for _, version := range entry.Versions {
 			objInfo := version.ToObjectInfo(bucket, entry.Name)
+			// Always avoid including the marker in the result, this is
+			// needed to avoid including dir__XLDIR__ and dir/ twice in
+			// different listing pages
+			if objInfo.Name == marker && objInfo.VersionID == versionMarker {
+				continue
+			}
 			if HasSuffix(objInfo.Name, SlashSeparator) && !recursive {
 				loi.Prefixes = append(loi.Prefixes, objInfo.Name)
 				continue


### PR DESCRIPTION
## Description
Walk() and Merge code can return dir__XLDIR__ as the last element 
on a page list and dir__XLDIR__ as the first element in the next list page.

dir__XLDIR__ is shown in the second-page list because the marker set to
dir/ is meant to skip dir/ and not dir__XLDIR__

To fix this, the code will avoid adding the marker itself to the listing
result.

## Motivation and Context
Fix duplicate prefix listing

## How to test this PR?
Contact me

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
