### PR TITLE
implement putMetacacheObject() optimizing List operations

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -648,9 +648,8 @@ func (er *erasureObjects) saveMetaCacheStream(ctx context.Context, mc *metaCache
 		r, err := hash.NewReader(bytes.NewReader(b.data), int64(len(b.data)), "", "", int64(len(b.data)))
 		logger.LogIf(ctx, err)
 		custom := b.headerKV()
-		_, err = er.putObject(ctx, minioMetaBucket, o.objectPath(b.n), NewPutObjReader(r), ObjectOptions{
+		_, err = er.putMetacacheObject(ctx, o.objectPath(b.n), NewPutObjReader(r), ObjectOptions{
 			UserDefined: custom,
-			NoLock:      true, // No need to hold namespace lock, each prefix caches uniquely.
 		})
 		if err != nil {
 			mc.setErr(err.Error())


### PR DESCRIPTION

## Description
implement putMetacacheObject() optimizing List operations

## Motivation and Context
removes unexpected features from regular putObject() such as

- increasing parity when disks are down, avoids
  a lot of DiskInfo() calls.

- triggering MRF for metacache objects
  if disks are offline

- avoiding renames from the temporary location
  to an actual namespace, not needed since
  metacache files are unique.

## How to test this PR?
Nothing should change in functionality.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
