### PR TITLE
[10-28.sets] Always deduplicate folders in listing

### DIFF
--- a/cmd/erasure-server-sets.go
+++ b/cmd/erasure-server-sets.go
@@ -1008,6 +1008,12 @@ func lexicallySortedEntryZone(zoneEntryChs [][]FileInfoCh, zoneEntries [][]FileI
 				continue
 			}
 
+			// Always deduplicate prefixes
+			if lentry.Name == zoneEntries[i][j].Name && strings.HasSuffix(lentry.Name, slashSeparator) {
+				lexicallySortedEntryCount++
+				continue
+			}
+
 			// Entries are duplicated across disks,
 			// we should simply skip such entries.
 			if lentry.Name == zoneEntries[i][j].Name && lentry.ModTime.Equal(zoneEntries[i][j].ModTime) && setIndex == zoneEntryChs[i][j].SetIndex {
@@ -1099,6 +1105,12 @@ func lexicallySortedEntryZoneVersions(zoneEntryChs [][]FileInfoVersionsCh, zoneE
 	for i, entriesValid := range zoneEntriesValid {
 		for j, valid := range entriesValid {
 			if !valid {
+				continue
+			}
+
+			// Always deduplicate prefixes
+			if lentry.Name == zoneEntries[i][j].Name && strings.HasSuffix(lentry.Name, slashSeparator) {
+				lexicallySortedEntryCount++
 				continue
 			}
 


### PR DESCRIPTION
## Description
When a prefix with a trailing slash is found, always deduplicate it.

## Motivation and Context
Found an issu with a duplicated prefix when page listing size is 1

## How to test this PR?
Having multiple folders in different sets, then
`aws --profile minio --endpoint-url http://localhost:9000 s3 ls s3://testbucket/basefolder1/subfolder1/ --page-size 1`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
