### PR TITLE
Allow sending headers in amqp event notification

### DIFF
--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -140,6 +140,8 @@ $ mc admin config set myminio/ notify_amqp:1 exchange="bucketevents" exchange_ty
 
 MinIO supports all the exchanges available in [RabbitMQ](https://www.rabbitmq.com/). For this setup, we are using `fanout` exchange.
 
+MinIO also sends with the notifications two headers: `minio-bucket` and `minio-event`. An exchange using the type "headers" can use this information to route the notifications to proper queues.
+
 Note that, you can add as many AMQP server endpoint configurations as needed by providing an identifier (like "1" in the example above) for the AMQP instance and an object of per-server configuration parameters.
 
 ### Step 2: Enable bucket notification using MinIO client


### PR DESCRIPTION
Signed-off-by: Ricardo Katz <rkatz@vmware.com>

## Description
This PR adds a feature to enable AMQP notifications to contain a header, with bucket and event name

## Motivation and Context
Minio allow sending notifications to AMQP compliant services (mostly notable RabbitMQ). The allowed ways of sending those notifications today demands the cluster admin to:
* Configure a notification that bucket owners can use in their own buckets, which might end on multiple users sending notifications to the same queue, due to this notification using the same routing key (or even being a fanout, and users receiving notifications from other users buckets)
* Configure a notification for each user and demanding multiple restarts of the environment (and this does not blocks users from sending notifications to the wrong exchanges)

With this PR, the exchange of type ["headers"](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchanges) can be used, and the header of the notification can be used to route messages.

On a simple way, users can configure their buckets to use the same single notification configuration, that will send to an exchange on RMQ that can use the metadata/headers to route, for example, messages with bucketname="ricardo" to a queue named "ricardo", and also allow the admins to route all messages containing "s3:PutObject" to an audit queue.

## How to test this PR?
* Run a simple RabbitMQ server, and configure an exchange of type headers and name "testexchange"
* Configure two bindings on this exchange: one with arguments: `bucket=bucket1` pointing to queue `bucket1` and other `bucket=bucket2` pointing to queue `bucket2`
* Run Minio with the following arguments:
```
MINIO_NOTIFY_AMQP_ADD_HEADERS_notifications="on"  
MINIO_NOTIFY_AMQP_ENABLE_notifications="on" MINIO_NOTIFY_AMQP_URL_notifications="amqp://guest:guest@localhost:5672" MINIO_NOTIFY_AMQP_EXCHANGE_TYPE_notifications="headers" MINIO_NOTIFY_AMQP_EXCHANGE_notifications="testexchange"
```

* Create bucket1 and bucket2 and configure both of them to point to `arn:minio:sqs::notifications:amqp` with all events. Generate some traffic (put, get objects)
* Verify in RMQ that notifications from bucket1 goes to queue bucket1, and bucket2 to queue bucket2
 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Documentation updated
- [ ] Unit tests added/updated
