### PR TITLE
Add dynamic reconfiguration of number of transition workers

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -92,8 +92,6 @@ func init() {
 		},
 	})
 
-	globalTransitionState = newTransitionState()
-
 	console.SetColor("Debug", fcolor.New())
 
 	gob.Register(StorageErr(""))

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -39,6 +39,7 @@ type apiConfig struct {
 	totalDriveCount          int
 	replicationWorkers       int
 	replicationFailedWorkers int
+	transitionWorkers        int
 }
 
 func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
@@ -87,6 +88,10 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 	}
 	t.replicationFailedWorkers = cfg.ReplicationFailedWorkers
 	t.replicationWorkers = cfg.ReplicationWorkers
+	if globalTransitionState != nil && cfg.TransitionWorkers != t.transitionWorkers {
+		globalTransitionState.UpdateWorkers(cfg.TransitionWorkers)
+	}
+	t.transitionWorkers = cfg.TransitionWorkers
 }
 
 func (t *apiConfig) getListQuorum() int {
@@ -172,4 +177,11 @@ func (t *apiConfig) getReplicationWorkers() int {
 	defer t.mu.RUnlock()
 
 	return t.replicationWorkers
+}
+
+func (t *apiConfig) getTransitionWorkers() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.transitionWorkers
 }

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -530,7 +530,6 @@ func serverMain(ctx *cli.Context) {
 	if globalIsErasure {
 		initAutoHeal(GlobalContext, newObject)
 		initHealMRF(GlobalContext, newObject)
-		initBackgroundTransition(GlobalContext, newObject)
 	}
 
 	initBackgroundExpiry(GlobalContext, newObject)
@@ -558,6 +557,7 @@ func serverMain(ctx *cli.Context) {
 
 	if globalIsErasure { // to be done after config init
 		initBackgroundReplication(GlobalContext, newObject)
+		initBackgroundTransition(GlobalContext, newObject)
 		globalTierJournal, err = initTierDeletionJournal(GlobalContext)
 		if err != nil {
 			logger.FatalIf(err, "Unable to initialize remote tier pending deletes journal")

--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -58,5 +58,11 @@ var (
 			Optional:    true,
 			Type:        "number",
 		},
+		config.HelpKV{
+			Key:         apiTransitionWorkers,
+			Description: `set the number of transition workers, defaults to 100`,
+			Optional:    true,
+			Type:        "number",
+		},
 	}
 )

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -289,4 +289,10 @@ Example 1:
 		"",
 		"MINIO_API_REPLICATION_WORKERS: should be > 0",
 	)
+
+	ErrInvalidTransitionWorkersValue = newErrFn(
+		"Invalid value for transition workers",
+		"",
+		"MINIO_API_TRANSITION_WORKERS: should be >= GOMAXPROCS/2",
+	)
 )


### PR DESCRIPTION
## Description
This change adds support for dynamically configuring number of transition workers per node.

## Motivation and Context
This would allow users to configure this number according to their transition workload.

## How to test this PR?
1. Configure remote tier, setup ILM policies on a bucket
2. `./mc admin config set minio-tier api transition_workers=95` 
3. Using `mc admin profile` you can confirm the number of `(*transitionState).worker` goroutines are running.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
