### PR TITLE
fix: skip disks that are offline when healing the drives

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -705,8 +705,10 @@ func saveUnformattedFormat(ctx context.Context, storageDisks []StorageAPI, forma
 		if format == nil {
 			continue
 		}
-		if err := saveFormatErasure(storageDisks[index], format, true); err != nil {
-			return err
+		if storageDisks[index] != nil && storageDisks[index].IsOnline() {
+			if err := saveFormatErasure(storageDisks[index], format, true); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description
fix: skip disks that are offline when healing the drives

## Motivation and Context
combination of disks that are 'root disk'  and actual healable 
disks cause healable disks to be not healed. 

## How to test this PR?
bring some actual drives, remove some drives to make them
root disks.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
