### PR TITLE
Fix resync replication of delete markers 

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1173,7 +1173,7 @@ func (i *scannerItem) healReplication(ctx context.Context, o ObjectLayer, oi Obj
 			return
 		}
 		// if replication status is Complete on DeleteMarker and existing object resync required
-		if existingObjResync && oi.ReplicationStatus == replication.Completed {
+		if existingObjResync && (oi.ReplicationStatus == replication.Completed) {
 			i.healReplicationDeletes(ctx, o, oi, existingObjResync)
 			return
 		}

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -441,7 +441,7 @@ func (er erasureObjects) getObjectInfo(ctx context.Context, bucket, object strin
 
 	}
 	objInfo = fi.ToObjectInfo(bucket, object)
-	if !fi.VersionPurgeStatus.Empty() {
+	if !fi.VersionPurgeStatus.Empty() && opts.VersionID != "" {
 		// Make sure to return object info to provide extra information.
 		return objInfo, toObjectErr(errMethodNotAllowed, bucket, object)
 	}

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -333,6 +333,10 @@ func ErrorRespToObjectError(err error, params ...string) error {
 		err = PartTooSmall{}
 	}
 
+	switch minioErr.StatusCode {
+	case http.StatusMethodNotAllowed:
+		err = toObjectErr(errMethodNotAllowed, bucket, object)
+	}
 	return err
 }
 

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -686,3 +686,9 @@ func isErrPreconditionFailed(err error) bool {
 	_, ok := err.(PreConditionFailed)
 	return ok
 }
+
+// isErrMethodNotAllowed - Check if error type is MethodNotAllowed.
+func isErrMethodNotAllowed(err error) bool {
+	var methodNotAllowed MethodNotAllowed
+	return errors.As(err, &methodNotAllowed)
+}


### PR DESCRIPTION
## Description

Fixes #12919 

Additionally fixing a regression in GetObjectInfo where delete replication metadata update was not happening in multiple server pools situation, because pool index was not returned correctly. This would cause the version to remain on disk in pending purge status

## Motivation and Context
Needs https://github.com/minio/minio-go/pull/1531

## How to test this PR?
As described in issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
