### PR TITLE
Use metadata reader in ReadVersion

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -860,7 +860,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 		}
 	}()
 
-	shardFileSize := erasure.ShardFileSize(data.Size())
+	shardFileSize := erasure.ShardFileSize(data.ActualSize())
 	writers := make([]io.Writer, len(onlineDisks))
 	var inlineBuffers []*bytes.Buffer
 	if shardFileSize >= 0 {

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -860,7 +860,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 		}
 	}()
 
-	shardFileSize := erasure.ShardFileSize(data.ActualSize())
+	shardFileSize := erasure.ShardFileSize(data.Size())
 	writers := make([]io.Writer, len(onlineDisks))
 	var inlineBuffers []*bytes.Buffer
 	if shardFileSize >= 0 {
@@ -869,6 +869,15 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 		} else if shardFileSize < smallFileThreshold/8 {
 			inlineBuffers = make([]*bytes.Buffer, len(onlineDisks))
 		}
+	} else {
+		// If compressed, use actual size to determine.
+		if sz := erasure.ShardFileSize(data.ActualSize()); sz > 0 {
+			if !opts.Versioned && sz < smallFileThreshold {
+				inlineBuffers = make([]*bytes.Buffer, len(onlineDisks))
+			} else if sz < smallFileThreshold/8 {
+				inlineBuffers = make([]*bytes.Buffer, len(onlineDisks))
+			}
+		}
 	}
 	for i, disk := range onlineDisks {
 		if disk == nil {
@@ -876,7 +885,11 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 		}
 
 		if len(inlineBuffers) > 0 {
-			inlineBuffers[i] = bytes.NewBuffer(make([]byte, 0, shardFileSize))
+			sz := shardFileSize
+			if sz < 0 {
+				sz = data.ActualSize()
+			}
+			inlineBuffers[i] = bytes.NewBuffer(make([]byte, 0, sz))
 			writers[i] = newStreamingBitrotWriterBuffer(inlineBuffers[i], DefaultBitrotAlgorithm, erasure.ShardSize())
 			continue
 		}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1074,7 +1074,7 @@ func (s *xlStorage) ReadVersion(ctx context.Context, volume, path, versionID str
 	} else {
 		buf, err = s.readMetadata(pathJoin(volumeDir, path, xlStorageFormatFile))
 		if err != nil {
-			if os.IsNotExist(err) {
+			if osIsNotExist(err) {
 				if err = Access(volumeDir); err != nil && osIsNotExist(err) {
 					return fi, errVolumeNotFound
 				}


### PR DESCRIPTION
## Description

Comparison of `λ warp stat --obj.size=60KB --duration=1m`:

```
λ warp cmp -analyze.op=STAT warp-stat-2021-08-12-master.csv.zst warp-stat-2021-08-12-new.csv.zst
304476 operations loaded... Done!
397301 operations loaded... Done!
-------------------
Operation: STAT
Operations: 294476 -> 387301
* Average: +31.52% (+1546.9) obj/s
* Fastest: +29.96% (+1559.1) obj/s
* 50% Median: +30.70% (+1514.7) obj/s
* Slowest: +46.17% (+1934.4) obj/s
```

All operations using `ReadVersion` or even `readAllFileInfo(readData=false)` will benefit from this.

Bonus: Compressed data was never inlined, use actual size for determining inlining.

## How to test this PR?

Described above.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
