### PR TITLE
ldap: Reevalute filter when searching for non eligible users

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1606,7 +1606,7 @@ func (sys *IAMSys) purgeExpiredCredentialsForLDAP(ctx context.Context) {
 	}
 	sys.store.unlock()
 
-	expiredUsers, err := globalLDAPConfig.GetNonExistentUserDistNames(parentUsers)
+	expiredUsers, err := globalLDAPConfig.GetNonEligibleUserDistNames(parentUsers)
 	if err != nil {
 		// Log and return on error - perhaps it'll work the next time.
 		logger.LogIf(GlobalContext, err)

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -478,9 +478,9 @@ func (l Config) IsLDAPUserDN(user string) bool {
 	return strings.HasSuffix(user, ","+l.UserDNSearchBaseDN)
 }
 
-// GetNonExistentUserDistNames - find user accounts (DNs) that are no longer
-// present in the LDAP server.
-func (l *Config) GetNonExistentUserDistNames(userDistNames []string) ([]string, error) {
+// GetNonEligibleUserDistNames - find user accounts (DNs) that are no longer
+// present in the LDAP server or do not meet filter criteria anymore
+func (l *Config) GetNonEligibleUserDistNames(userDistNames []string) ([]string, error) {
 	if !l.isUsingLookupBind {
 		return nil, errors.New("current LDAP configuration does not permit looking for expired user accounts")
 	}
@@ -496,12 +496,15 @@ func (l *Config) GetNonExistentUserDistNames(userDistNames []string) ([]string, 
 		return nil, err
 	}
 
+	// Evaluate the filter again with generic wildcard instead of  specific values
+	filter := strings.Replace(l.UserDNSearchFilter, "%s", "*", -1)
+
 	nonExistentUsers := []string{}
 	for _, dn := range userDistNames {
 		searchRequest := ldap.NewSearchRequest(
 			dn,
 			ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
-			"(objectclass=*)",
+			filter,
 			[]string{}, // only need DN, so no pass no attributes here
 			nil,
 		)


### PR DESCRIPTION
## Description
The previous code removes SVC/STS accounts for ldap users that do not
exist anymore in LDAP server. This commit will actually re-evaluate
filter as well if it is changed and remove all local SVC/STS accounts
beloning to the ldap user if the latter is not eligible for the
search filter anymore.

For example: the filter selects enabled users among other criteras in
the LDAP database, if one ldap user changes his status to disabled
later, then associated SVC/STS accounts will be removed because that user
does not meet the filter search anymore.


## Motivation and Context
Remove disabled users in MSFT Active Directory

## How to test this PR?
1. Run openldap
2. Setup MinIO to connect with ldap, use an attribute to indicate the status of the user in the search filter 
3. Create an ldap user with an attribute which indicates the status of a user
4. Create an STS account from that ldap user
5. Disable the user in LDAP (change attribute status to disabled)
6. Wait for 5 minutes and test the STS account

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
