### PR TITLE
Make LDAP case-insensitive in DNs for username and group names

### DIFF
--- a/cmd/iam-dummy-store.go
+++ b/cmd/iam-dummy-store.go
@@ -45,6 +45,9 @@ func (ids *iamDummyStore) runlock() {
 	ids.RUnlock()
 }
 
+func (ids *iamDummyStore) setUsersSysType(u UsersSysType) {
+}
+
 func (ids *iamDummyStore) migrateBackendFormat(context.Context) error {
 	return nil
 }

--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -400,8 +400,13 @@ func (iamOS *IAMObjectStore) loadMappedPolicies(ctx context.Context, userType IA
 		policyFile := item.Item
 		userOrGroupName := strings.TrimSuffix(policyFile, ".json")
 		if iamOS.usersSysType == LDAPUsersSysType {
-			// Filter out lower-cased names - see comments above.
-			if userOrGroupName == strings.ToLower(userOrGroupName) {
+			standardDNStr, err := globalLDAPConfig.GetDNStr(userOrGroupName)
+			if err != nil {
+				continue
+			}
+			// Filter out names that are already standard DN string
+			// representations.
+			if userOrGroupName == standardDNStr {
 				continue
 			}
 		}

--- a/internal/config/identity/ldap/config_test.go
+++ b/internal/config/identity/ldap/config_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ldap
+
+import (
+	"testing"
+
+	ldap "github.com/go-ldap/ldap/v3"
+)
+
+func TestLDAPGetDNStr(t *testing.T) {
+	mainDNStr := "uid=dillon,ou=itdept,dc=example,dc=com"
+	// case-sensitive equal cases
+	equalCSVariations := []string{
+		"uid=dillon,ou=itdept,dc=example,dc=com",
+		"  uid=dillon ,ou=itdept,dc = example , dc=com  ",
+		"UID=dillon,ou=itdept,dc=example,dc=com",
+		"UID=dillon,OU=itdept,DC=example,DC=com",
+		"UID=dillon, OU=itdept  ,  DC = example,DC=   com",
+	}
+	// case-insensitive equal cases
+	equalCISVariations := []string{
+		"uid=DILLON,ou=itdept,dc=example,dc=com",
+		"uid=Dillon,ou=ITDept,dc=Example,dc=Com",
+		"uid=Dillon,ou=ITDept,dc=Example,dc=Com",
+		"UID=DILLON,OU=ITDEPT,DC=EXAMPLE,DC=COM",
+	}
+	// non-equal cases, regardless of casing
+	nonEqualVariations := []string{
+		"uid=dillon,ou=it dept,dc=example,dc=com",
+		"uid=dillon ,ou=itdept,dc = example , dc=in  ",
+		"UID=DILLON\\, III.,OU=ITDEPT,DC=EXAMPLE,DC=COM",
+		"UID=DILLON\\, III.+CN=xx,OU=ITDEPT,DC=EXAMPLE,DC=COM",
+	}
+
+	mainDN, err := ldap.ParseDN(mainDNStr)
+	if err != nil {
+		t.Fatalf("unexpected parse error")
+	}
+
+	mainDNCaseSensitive := GetDNStr(mainDN, true)
+	mainDNCaseInsensitive := GetDNStr(mainDN, false)
+
+	for _, s := range equalCSVariations {
+		dn, err := ldap.ParseDN(s)
+		if err != nil {
+			t.Fatalf("error parsing DN %s: %v", s, err)
+		}
+		if mainDNCaseSensitive != GetDNStr(dn, true) {
+			t.Errorf("[CaseSensitiveEquals] %s was not DN equal to %s", s, mainDNStr)
+		}
+	}
+
+	for _, s := range append(equalCSVariations, equalCISVariations...) {
+		dn, err := ldap.ParseDN(s)
+		if err != nil {
+			t.Fatalf("error parsing DN %s: %v", s, err)
+		}
+		if mainDNCaseInsensitive != GetDNStr(dn, false) {
+			t.Errorf("[CaseInsensitiveEquals] %s was not DN equal to %s", s, mainDNStr)
+		}
+	}
+
+	for _, s := range nonEqualVariations {
+		dn, err := ldap.ParseDN(s)
+		if err != nil {
+			t.Errorf("error parsing %s: %v", s, err)
+			continue
+		}
+		if mainDNCaseSensitive == GetDNStr(dn, true) {
+			t.Errorf("[CaseSensitiveNE] %s was DN equal to %s", s, mainDNStr)
+		}
+		if mainDNCaseInsensitive == GetDNStr(dn, false) {
+			t.Errorf("[CaseInsensitiveNE] %s was DN equal to %s", s, mainDNStr)
+		}
+	}
+}

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -80,6 +80,12 @@ var (
 			Type:        "list",
 		},
 		config.HelpKV{
+			Key:         DNCaseSensitive,
+			Description: "enable case-sensitive DN attributes comparison",
+			Optional:    true,
+			Type:        "on|off",
+		},
+		config.HelpKV{
 			Key:         TLSSkipVerify,
 			Description: `trust server TLS without verification, defaults to "off" (verify)`,
 			Optional:    true,


### PR DESCRIPTION
## Description
- Involves changes in loading policy mappings from IAM object store and IAM etcd
store

## How to test this PR?

For an LDAP setup use https://github.com/donatello/minio-ldap-testing

Use `mc admin policy set myminio consoleAdmin user=UID=liZA,ou=people,ou=swengg,dc=min,dc=io` with different casings for the user DN and check that it is case-insensitive.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
