### PR TITLE
fix: various performance improvements to tiering

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -187,7 +187,7 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 	if objInfo.IsRemote() {
 		// Check if object is being restored. For more information on x-amz-restore header see
 		// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax
-		w.Header()[xhttp.AmzStorageClass] = []string{objInfo.TransitionTier}
+		w.Header()[xhttp.AmzStorageClass] = []string{objInfo.TransitionedObject.Tier}
 	}
 
 	if lc, err := globalLifecycleSys.Get(objInfo.Bucket); err == nil {

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -162,11 +162,13 @@ func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 		objInfo.ReplicationStatus = replication.StatusType(fi.DeleteMarkerReplicationStatus)
 	}
 
-	objInfo.TransitionStatus = fi.TransitionStatus
-	objInfo.transitionedObjName = fi.TransitionedObjName
-	objInfo.transitionVersionID = fi.TransitionVersionID
-	objInfo.tierFreeVersion = fi.TierFreeVersion()
-	objInfo.TransitionTier = fi.TransitionTier
+	objInfo.TransitionedObject = TransitionedObject{
+		Name:        fi.TransitionedObjName,
+		VersionID:   fi.TransitionVersionID,
+		Status:      fi.TransitionStatus,
+		FreeVersion: fi.TierFreeVersion(),
+		Tier:        fi.TransitionTier,
+	}
 
 	// etag/md5Sum has already been extracted. We need to
 	// remove to avoid it from appearing as part of

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -113,16 +113,8 @@ type ObjectInfo struct {
 	// to a delete marker on an object.
 	DeleteMarker bool
 
-	// tierFreeVersion is true if this is a free-version
-	tierFreeVersion bool
-	// TransitionStatus indicates if transition is complete/pending
-	TransitionStatus string
-	// Name of transitioned object on remote tier
-	transitionedObjName string
-	// VersionID on the the remote tier
-	transitionVersionID string
-	// Name of remote tier object has transitioned to
-	TransitionTier string
+	// Transitioned object information
+	TransitionedObject TransitionedObject
 
 	// RestoreExpires indicates date a restored object expires
 	RestoreExpires time.Time
@@ -200,7 +192,7 @@ func (o ObjectInfo) Clone() (cinfo ObjectInfo) {
 		VersionID:          o.VersionID,
 		IsLatest:           o.IsLatest,
 		DeleteMarker:       o.DeleteMarker,
-		TransitionStatus:   o.TransitionStatus,
+		TransitionedObject: o.TransitionedObject,
 		RestoreExpires:     o.RestoreExpires,
 		RestoreOngoing:     o.RestoreOngoing,
 		ContentType:        o.ContentType,
@@ -352,6 +344,15 @@ type ListMultipartsInfo struct {
 	CommonPrefixes []string
 
 	EncodingType string // Not supported yet.
+}
+
+// TransitionedObject transitioned object tier and status.
+type TransitionedObject struct {
+	Name        string
+	VersionID   string
+	Tier        string
+	FreeVersion bool
+	Status      string
 }
 
 // DeletedObjectInfo - container for list objects versions deleted objects.

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -219,6 +219,7 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 // get ObjectOptions for PUT calls from encryption headers and metadata
 func putOpts(ctx context.Context, r *http.Request, bucket, object string, metadata map[string]string) (opts ObjectOptions, err error) {
 	versioned := globalBucketVersioningSys.Enabled(bucket)
+	versionSuspended := globalBucketVersioningSys.Suspended(bucket)
 	vid := strings.TrimSpace(r.Form.Get(xhttp.VersionID))
 	if vid != "" && vid != nullVersionID {
 		_, err := uuid.Parse(vid)
@@ -266,6 +267,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 			UserDefined:          metadata,
 			VersionID:            vid,
 			Versioned:            versioned,
+			VersionSuspended:     versionSuspended,
 			MTime:                mtime,
 		}, nil
 	}
@@ -273,6 +275,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 		opts, err = getOpts(ctx, r, bucket, object)
 		opts.VersionID = vid
 		opts.Versioned = versioned
+		opts.VersionSuspended = versionSuspended
 		opts.UserDefined = metadata
 		return
 	}
@@ -290,6 +293,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 			UserDefined:          metadata,
 			VersionID:            vid,
 			Versioned:            versioned,
+			VersionSuspended:     versionSuspended,
 			MTime:                mtime,
 		}, nil
 	}
@@ -300,6 +304,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 	}
 	opts.VersionID = vid
 	opts.Versioned = versioned
+	opts.VersionSuspended = versionSuspended
 	opts.MTime = mtime
 	return opts, nil
 }

--- a/cmd/tier-sweeper.go
+++ b/cmd/tier-sweeper.go
@@ -18,11 +18,7 @@
 package cmd
 
 import (
-	"net/http"
-	"strings"
-
 	"github.com/minio/minio/internal/bucket/lifecycle"
-	xhttp "github.com/minio/minio/internal/http"
 )
 
 // objSweeper determines if a transitioned object needs to be removed from the remote tier.
@@ -43,7 +39,7 @@ import (
 type objSweeper struct {
 	Object              string
 	Bucket              string
-	ReqVersion          string // version ID set by application, applies only to DeleteObject and DeleteObjects APIs
+	VersionID           string // version ID set by application, applies only to DeleteObject and DeleteObjects APIs
 	Versioned           bool
 	Suspended           bool
 	TransitionStatus    string
@@ -55,46 +51,22 @@ type objSweeper struct {
 // newObjSweeper returns an objSweeper for a given bucket and object.
 // It initializes the versioning information using bucket name.
 func newObjSweeper(bucket, object string) *objSweeper {
-	versioned := globalBucketVersioningSys.Enabled(bucket)
-	suspended := globalBucketVersioningSys.Suspended(bucket)
 	return &objSweeper{
-		Object:    object,
-		Bucket:    bucket,
-		Versioned: versioned,
-		Suspended: suspended,
+		Object: object,
+		Bucket: bucket,
 	}
 }
 
-// versionIDer interface is used to fetch object versionIDer from disparate sources
-// like http.Request and ObjectToDelete.
-type versionIDer interface {
-	GetVersionID() string
-}
-
-// multiDelete is a type alias for ObjectToDelete to implement versionID
-// interface
-type multiDelete ObjectToDelete
-
-// GetVersionID returns object version of an object to be deleted via
-// multi-delete API.
-func (md multiDelete) GetVersionID() string {
-	return md.VersionID
-}
-
-// singleDelete is a type alias for http.Request to implement versionID
-// interface
-type singleDelete http.Request
-
-// GetVersionID returns object version of an object to be deleted via (simple)
-// delete API. Note only when the versionID is set explicitly by the application
-// will we return a non-empty versionID.
-func (sd singleDelete) GetVersionID() string {
-	return strings.TrimSpace(sd.URL.Query().Get(xhttp.VersionID))
-}
-
 // WithVersion sets the version ID from v
-func (os *objSweeper) WithVersion(v versionIDer) *objSweeper {
-	os.ReqVersion = v.GetVersionID()
+func (os *objSweeper) WithVersion(vid string) *objSweeper {
+	os.VersionID = vid
+	return os
+}
+
+// WithVersioning sets bucket versioning for sweeper.
+func (os *objSweeper) WithVersioning(versioned, suspended bool) *objSweeper {
+	os.Versioned = versioned
+	os.Suspended = suspended
 	return os
 }
 
@@ -102,22 +74,22 @@ func (os *objSweeper) WithVersion(v versionIDer) *objSweeper {
 // overwritten or deleted depending on bucket versioning status.
 func (os *objSweeper) GetOpts() ObjectOptions {
 	opts := ObjectOptions{
-		VersionID:        os.ReqVersion,
+		VersionID:        os.VersionID,
 		Versioned:        os.Versioned,
 		VersionSuspended: os.Suspended,
 	}
-	if os.Suspended && os.ReqVersion == "" {
+	if os.Suspended && os.VersionID == "" {
 		opts.VersionID = nullVersionID
 	}
 	return opts
 }
 
 // SetTransitionState sets ILM transition related information from given info.
-func (os *objSweeper) SetTransitionState(info ObjectInfo) {
-	os.TransitionTier = info.TransitionTier
-	os.TransitionStatus = info.TransitionStatus
-	os.RemoteObject = info.transitionedObjName
-	os.TransitionVersionID = info.transitionVersionID
+func (os *objSweeper) SetTransitionState(info TransitionedObject) {
+	os.TransitionTier = info.Tier
+	os.TransitionStatus = info.Status
+	os.RemoteObject = info.Name
+	os.TransitionVersionID = info.VersionID
 }
 
 // shouldRemoveRemoteObject determines if a transitioned object should be
@@ -140,7 +112,7 @@ func (os *objSweeper) shouldRemoveRemoteObject() (jentry, bool) {
 	switch {
 	case !os.Versioned, os.Suspended: // 1, 2.a, 2.b
 		delTier = true
-	case os.Versioned && os.ReqVersion != "": // 3.a
+	case os.Versioned && os.VersionID != "": // 3.a
 		delTier = true
 	}
 	if delTier {

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -115,6 +115,11 @@ func (config *TierConfigMgr) Add(ctx context.Context, tier madmin.TierConfig) er
 	return nil
 }
 
+// Empty returns if tier targets are empty
+func (config *TierConfigMgr) Empty() bool {
+	return len(config.ListTiers()) == 0
+}
+
 // ListTiers lists remote tiers configured in this deployment.
 func (config *TierConfigMgr) ListTiers() []madmin.TierConfig {
 	config.RLock()


### PR DESCRIPTION

## Description
fix: various performance improvements to tiering

## Motivation and Context
- deletes should always Sweep() for tiering at the
  end
- puts, copy and multipart writes should conditionally
  do getObjectInfo() when tiering targets are configured
- introduce 'TransitionedObject' struct for ease of usage
  and understanding.

## How to test this PR?
All writes, deletes should have high-performance improvement. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
