### PR TITLE
Return list request when canceled

### DIFF
--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -199,8 +199,8 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 	// Create filter for results.
 	o.debugln("Raw List", o)
 	filterCh := make(chan metaCacheEntry, o.Limit)
-	filteredResults := o.gatherResults(filterCh)
 	listCtx, cancelList := context.WithCancel(ctx)
+	filteredResults := o.gatherResults(listCtx, filterCh)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	var listErr error
@@ -343,7 +343,7 @@ func (z *erasureServerPools) listAndSave(ctx context.Context, o *listPathOptions
 	inCh := make(chan metaCacheEntry, metacacheBlockSize)
 	outCh := make(chan metaCacheEntry, o.Limit)
 
-	filteredResults := o.gatherResults(outCh)
+	filteredResults := o.gatherResults(ctx, outCh)
 
 	mc := o.newMetacache()
 	meta := metaCacheRPC{meta: &mc, cancel: cancel, rpc: globalNotificationSys.restClientFromHash(o.Bucket), o: *o}

--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -186,9 +186,11 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 			rpc := globalNotificationSys.restClientFromHash(o.Bucket)
 			ctx, cancel := context.WithTimeout(GlobalContext, 5*time.Second)
 			defer cancel()
-			if c, err := rpc.GetMetacacheListing(ctx, *o); err == nil {
+			c, err := rpc.GetMetacacheListing(ctx, *o)
+			if err == nil {
 				c.error = "no longer used"
 				c.status = scanStateError
+				rpc.UpdateMetacacheListing(ctx, *c)
 			}
 		}()
 		o.ID = ""


### PR DESCRIPTION
## Description

* Don't wait for results if request is canceled.
* If an error occurs, cancel the running listing.

## How to test this PR?

Issue a List command. Cancel the request. Observe if request returns.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
