### PR TITLE
locks: Ensure local lock removal after a failed refresh

### DIFF
--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -238,10 +238,11 @@ func (l *localLocker) ForceUnlock(ctx context.Context, args dsync.LockArgs) (rep
 			for _, lri := range lris {
 				if lri.UID == args.UID {
 					l.removeEntry(lri.Name, dsync.LockArgs{Owner: lri.Owner, UID: lri.UID}, &lris)
+					return true, nil
 				}
 			}
 		}
-		return true, nil
+		return false, nil
 	}
 }
 

--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -51,6 +51,9 @@ const drwMutexRefreshCallTimeout = 5 * time.Second
 // dRWMutexUnlockTimeout - timeout for the unlock call
 const drwMutexUnlockCallTimeout = 30 * time.Second
 
+// dRWMutexForceUnlockTimeout - timeout for the unlock call
+const drwMutexForceUnlockCallTimeout = 30 * time.Second
+
 // dRWMutexRefreshInterval - the interval between two refresh calls
 const drwMutexRefreshInterval = 10 * time.Second
 
@@ -237,6 +240,9 @@ func (dm *DRWMutex) startContinousLockRefresh(lockLossCallback func(), id, sourc
 
 				refreshed, err := refresh(ctx, dm.clnt, id, source, quorum, dm.Names...)
 				if err == nil && !refreshed {
+					// Clean the lock locally and in remote nodes
+					forceUnlock(ctx, dm.clnt, id)
+					// Execute the caller lock loss callback
 					if lockLossCallback != nil {
 						lockLossCallback()
 					}
@@ -245,6 +251,27 @@ func (dm *DRWMutex) startContinousLockRefresh(lockLossCallback func(), id, sourc
 			}
 		}
 	}()
+}
+
+func forceUnlock(ctx context.Context, ds *Dsync, id string) {
+	ctx, cancel := context.WithTimeout(ctx, drwMutexForceUnlockCallTimeout)
+	defer cancel()
+
+	restClnts, _ := ds.GetLockers()
+
+	var wg sync.WaitGroup
+	for index, c := range restClnts {
+		wg.Add(1)
+		// Send refresh request to all nodes
+		go func(index int, c NetLocker) {
+			defer wg.Done()
+			args := LockArgs{
+				UID: id,
+			}
+			c.ForceUnlock(ctx, args)
+		}(index, c)
+	}
+	wg.Wait()
 }
 
 type refreshResult struct {


### PR DESCRIPTION
## Description
In the event when a lock is not refreshed in the cluster, this latter
will be automatically removed in subsequent cleanup of non refreshed locks
routine, but it forgot to clean the local server, hence having same
weird stale locks present.

This commit will remove the lock locally also in remote nodes, if
removing a lock from a remote node will fail, it will be anyway removed
later in the locks cleanup routine.

## Motivation and Context
Fix occasional stale locks

## How to test this PR?
Fake code needs to be inserted, contact me.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
