### PR TITLE
Set free-version id in case of version/version-suspended buckets

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1065,6 +1065,7 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 					DeleteMarkerReplicationStatus: objects[i].DeleteMarkerReplicationStatus,
 					VersionPurgeStatus:            objects[i].VersionPurgeStatus,
 				}
+				versions[i].SetTierFreeVersionID(mustGetUUID())
 				if opts.Versioned {
 					versions[i].VersionID = uuid
 				}


### PR DESCRIPTION
## Description
This free-version id may be used to track tiered object contents of the
object (version) being deleted.

## How to test this PR?
1. Add a remote tier
2. Set up bucket ILM policy to transition to the above tier
3. Enable bucket versioning on this bucket
4. Upload an object to this bucket
5. Delete this object using `mc rm ..` (which uses the multi-delete API)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
