### PR TITLE
Remove default value of STSExpiry for LDAP

### DIFF
--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -144,7 +144,7 @@ var (
 		},
 		config.KV{
 			Key:   STSExpiry,
-			Value: "1h",
+			Value: "",
 		},
 		config.KV{
 			Key:   TLSSkipVerify,


### PR DESCRIPTION
## Description
This ensures that the deprecation warning is shown when the setting is actually
used in a configuration - instead of showing up whenever LDAP is enabled.

## How to test this PR?
Just start server with ldap configured.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
