### PR TITLE
add support to set subnet license for embedded console

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -152,6 +152,9 @@ func minioConfigToConsoleFeatures() {
 	}
 	os.Setenv("CONSOLE_MINIO_REGION", globalServerRegion)
 	os.Setenv("CONSOLE_CERT_PASSWD", env.Get("MINIO_CERT_PASSWD", ""))
+	if globalSubnetLicense != "" {
+		os.Setenv("CONSOLE_SUBNET_LICENSE", globalSubnetLicense)
+	}
 }
 
 func initConsoleServer() (*restapi.Server, error) {
@@ -596,6 +599,8 @@ func handleCommonEnvVars() {
 	if tiers := env.Get("_MINIO_DEBUG_REMOTE_TIERS_IMMEDIATELY", ""); tiers != "" {
 		globalDebugRemoteTiersImmediately = strings.Split(tiers, ",")
 	}
+
+	globalSubnetLicense = env.Get(config.EnvMinIOSubnetLicense, "")
 }
 
 func logStartupMessage(msg string) {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -216,6 +216,9 @@ var (
 	// The name of this local node, fetched from arguments
 	globalLocalNodeName string
 
+	// The global subnet license
+	globalSubnetLicense string
+
 	globalRemoteEndpoints map[string]Endpoint
 
 	// Global server's network statistics

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -37,6 +37,7 @@ const (
 	EnvArgs       = "MINIO_ARGS"
 	EnvDNSWebhook = "MINIO_DNS_WEBHOOK_ENDPOINT"
 
+	EnvMinIOSubnetLicense      = "MINIO_SUBNET_LICENSE"
 	EnvMinIOServerURL          = "MINIO_SERVER_URL"
 	EnvMinIOBrowserRedirectURL = "MINIO_BROWSER_REDIRECT_URL"
 	EnvRootDiskThresholdSize   = "MINIO_ROOTDISK_THRESHOLD_SIZE"


### PR DESCRIPTION
## Description
add support to set subnet license for embedded console

## Motivation and Context
to support subnet_license value for Console UI license page

## How to test this PR?
MINIO_SUBNET_LICENSE=...jwt-key minio server /tmp/disk{1...4}

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
