### PR TITLE
listObjects optimized to handle max-keys=1 when prefix is object

### DIFF
--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -188,7 +188,9 @@ func verifyServerSystemConfig(ctx context.Context, endpointServerPools EndpointS
 			// after 5 retries start logging that servers are not reachable yet
 			if retries >= 5 {
 				logger.Info(fmt.Sprintf("Waiting for atleast %d remote servers to be online for bootstrap check", len(clnts)/2))
-				logger.Info(fmt.Sprintf("Following servers are currently offline or unreachable %s", offlineEndpoints))
+				if len(offlineEndpoints) > 0 {
+					logger.Info(fmt.Sprintf("Following servers are currently offline or unreachable %s", offlineEndpoints))
+				}
 				retries = 0 // reset to log again after 5 retries.
 			}
 			offlineEndpoints = nil

--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -331,7 +331,7 @@ func (s *storageRESTServer) WalkDirHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	var reportNotFound bool
-	if v := vars[storageRESTReportNotFound]; v != "" {
+	if v := r.Form.Get(storageRESTReportNotFound); v != "" {
 		reportNotFound, err = strconv.ParseBool(v)
 		if err != nil {
 			s.writeErrorResponse(w, err)


### PR DESCRIPTION

## Description
listObjects optimized to handle max-keys=1 when prefix is object

## Motivation and Context
Some applications albeit poorly written rather than using headObject
rely on listObjects to check for the existence of an object, this unusual
request always has prefix=(to actual object) and max-keys=1

handle this situation specially such that we can avoid readdir()
on the top-level parent to avoid sorting and skipping, ensuring
that such type of listObjects() always behaves similar to a
headObject() call.

## How to test this PR?

Create a large nested hierarchy and use aws cli to check the difference in timing

```
~ aws s3api list-objects --bucket testbucket --prefix x/201910/1220 --max-keys=1 --profile minio --endpoint-url http://localhost:9000
{
    "IsTruncated": false,
    "Marker": "",
    "Contents": [
        {
            "Key": "x/201910/1220",
            "LastModified": "2021-08-18T03:10:41.980Z",
            "ETag": "\"92a46c640c0a622d9500d610a7cb1d50\"",
            "Size": 525,
            "StorageClass": "STANDARD",
            "Owner": {
                "DisplayName": "minio",
                "ID": "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
            }
        }
    ],
    "Name": "testbucket",
    "Prefix": "x/201910/1220",
    "Delimiter": "",
    "MaxKeys": 1,
    "EncodingType": "url"
}
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
