### PR TITLE
Include transition/replication fields in FileInfo quorum calculation

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -278,6 +278,18 @@ func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.
 			h.Write([]byte(fmt.Sprintf("%v", meta.Erasure.Distribution)))
 			// make sure that length of Data is same
 			h.Write([]byte(fmt.Sprintf("%v", len(meta.Data))))
+
+			// ILM transition fields
+			h.Write([]byte(meta.TransitionStatus))
+			h.Write([]byte(meta.TransitionTier))
+			h.Write([]byte(meta.TransitionedObjName))
+			h.Write([]byte(meta.TransitionVersionID))
+
+			// Server-side replication fields
+			h.Write([]byte(fmt.Sprintf("%v", meta.MarkDeleted)))
+			h.Write([]byte(meta.DeleteMarkerReplicationStatus))
+			h.Write([]byte(meta.VersionPurgeStatus))
+			h.Write([]byte(meta.Metadata[xhttp.AmzBucketReplicationStatus]))
 			metaHashes[i] = hex.EncodeToString(h.Sum(nil))
 			h.Reset()
 		}


### PR DESCRIPTION
## Description
This PR includes ILM transition and server-side replication related fields into the metadata quorum calculation. Existing checks don't capture differences in metadata in these fields.

## How to test this PR?
1. Setup a remote tier
2. Upload an object
3. Bring down a disk before the object is transitioned 
4. Bring back this disk once the object is transitioned
5. GetObject should work fine. Without this PR, GetObject would fail at erasure decode layer.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
