### PR TITLE
populate additional claims for Prometheus endpoint

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -487,20 +487,7 @@ func setAuthHandler(h http.Handler) http.Handler {
 	// handler for validating incoming authorization headers.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		aType := getRequestAuthType(r)
-		if isSupportedS3AuthType(aType) {
-			// Let top level caller validate for anonymous and known signed requests.
-			h.ServeHTTP(w, r)
-			return
-		} else if aType == authTypeJWT {
-			// Validate Authorization header if its valid for JWT request.
-			if _, _, authErr := webRequestAuthenticate(r); authErr != nil {
-				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte(authErr.Error()))
-				return
-			}
-			h.ServeHTTP(w, r)
-			return
-		} else if aType == authTypeSTS {
+		if isSupportedS3AuthType(aType) || aType == authTypeJWT || aType == authTypeSTS {
 			h.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -213,15 +213,6 @@ func getReqAccessCred(r *http.Request, region string) (cred auth.Credentials) {
 	if cred.AccessKey == "" {
 		cred, _, _ = getReqAccessKeyV2(r)
 	}
-	if cred.AccessKey == "" {
-		claims, owner, _ := webRequestAuthenticate(r)
-		if owner {
-			return globalActiveCred
-		}
-		if claims != nil {
-			cred, _ = globalIAMSys.GetUser(claims.AccessKey)
-		}
-	}
 	return cred
 }
 


### PR DESCRIPTION
## Description
populate additional claims for Prometheus endpoint

## Motivation and Context
service accounts and STS provide additional claims for
policy authorization which needs to be verified along
with Prometheus issuer claim. 

## How to test this PR?
Use service accounts or STS credentials with an LDAP
setup and verify with a proper policy they are able to use
Prometheus endpoint. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
