### PR TITLE
fix: optimize metacache manager locking

### DIFF
--- a/buildscripts/verify-healing.sh
+++ b/buildscripts/verify-healing.sh
@@ -67,7 +67,7 @@ function start_minio_3_node() {
 
 
 function check_online() {
-    if grep -q 'Unable to initialize sub-systems' ${WORK_DIR}/dist-minio-*.log; then
+    if grep -q 'Unable to initialize' ${WORK_DIR}/dist-minio-*.log; then
         echo "1"
     fi
 }
@@ -88,22 +88,24 @@ function __init__()
 }
 
 function perform_test() {
-    start_minio_3_node 60
+    start_minio_3_node 90
 
     echo "Testing Distributed Erasure setup healing of drives"
     echo "Remove the contents of the disks belonging to '${1}' erasure set"
 
     rm -rf ${WORK_DIR}/${1}/*/
 
-    start_minio_3_node 60
+    start_minio_3_node 90
 
     rv=$(check_online)
     if [ "$rv" == "1" ]; then
-        pkill -9 minio
         for i in $(seq 1 3); do
             echo "server$i log:"
             cat "${WORK_DIR}/dist-minio-server$i.log"
         done
+        if ! pkill -9 minio; then
+            echo "no minio process running anymore, proceed."
+        fi
         echo "FAILED"
         purge "$WORK_DIR"
         exit 1

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -121,6 +121,8 @@ func (er erasureObjects) renameAll(ctx context.Context, bucket, prefix string) {
 		}
 		wg.Add(1)
 		go func(disk StorageAPI) {
+			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
 			defer wg.Done()
 			disk.RenameFile(ctx, bucket, prefix, minioMetaTmpDeletedBucket, mustGetUUID())
 		}(disk)
@@ -136,6 +138,8 @@ func (er erasureObjects) deleteAll(ctx context.Context, bucket, prefix string) {
 		}
 		wg.Add(1)
 		go func(disk StorageAPI) {
+			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
 			defer wg.Done()
 			disk.Delete(ctx, bucket, prefix, true)
 		}(disk)

--- a/cmd/metacache-manager.go
+++ b/cmd/metacache-manager.go
@@ -128,8 +128,8 @@ func (m *metacacheManager) getBucket(ctx context.Context, bucket string) *bucket
 	m.mu.Lock()
 	// See if someone else fetched it while we waited for the lock.
 	b, ok = m.buckets[bucket]
+	m.mu.Unlock()
 	if ok {
-		m.mu.Unlock()
 		if b.bucket != bucket {
 			logger.Info("getBucket: newly cached bucket %s does not match this bucket %s", b.bucket, bucket)
 			debug.PrintStack()
@@ -145,6 +145,7 @@ func (m *metacacheManager) getBucket(ctx context.Context, bucket string) *bucket
 	if b.bucket != bucket {
 		logger.LogIf(ctx, fmt.Errorf("getBucket: loaded bucket %s does not match this bucket %s", b.bucket, bucket))
 	}
+	m.mu.Lock()
 	m.buckets[bucket] = b
 	m.mu.Unlock()
 	return b


### PR DESCRIPTION


## Description
fix: optimize metacache manager locking

## Motivation and Context
- before making network calls avoid local
  locks filling in in-memory copies.
- cleanups should not hold large locks, instead
  keep it blocking after the locks are relinquished.

## How to test this PR?
Nothing should change, just making changes
to ensure any locks held to avoid goroutine
build-up.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
