### PR TITLE
fix: check for xl.meta as directory fallback

### DIFF
--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -258,7 +258,7 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 					meta.name = strings.TrimSuffix(meta.name, globalDirSuffixWithSlash) + slashSeparator
 				}
 				out <- meta
-			case osIsNotExist(err):
+			case osIsNotExist(err), isSysErrIsDir(err):
 				s.walkMu.Lock()
 				meta.metadata, err = xioutil.ReadFile(pathJoin(volumeDir, meta.name, xlStorageFormatFileV1))
 				s.walkMu.Unlock()

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -88,6 +88,7 @@ func testListObjects(obj ObjectLayer, instanceType string, t1 TestErrHandler) {
 		{testBuckets[5], "foo/201910/1112", "content", nil},
 		{testBuckets[5], "foo/201910/2112", "content", nil},
 		{testBuckets[5], "foo/201910_txt", "content", nil},
+		{testBuckets[5], "201910/foo/bar/xl.meta/1.txt", "content", nil},
 	}
 	for _, object := range testObjects {
 		md5Bytes := md5.Sum([]byte(object.content))
@@ -499,6 +500,13 @@ func testListObjects(obj ObjectLayer, instanceType string, t1 TestErrHandler) {
 				{Name: "foo/201910_txt"},
 			},
 		},
+		// ListObjectsResult-39 list with prefix match 1 level deep
+		{
+			IsTruncated: false,
+			Objects: []ObjectInfo{
+				{Name: "201910/foo/bar/xl.meta/1.txt"},
+			},
+		},
 	}
 
 	testCases := []struct {
@@ -627,6 +635,8 @@ func testListObjects(obj ObjectLayer, instanceType string, t1 TestErrHandler) {
 		// Test listing with prefix match
 		{testBuckets[5], "foo/201910/11", "", "", 1000, resultCases[37], nil, true},
 		{testBuckets[5], "foo/201910", "", "", 1000, resultCases[38], nil, true},
+		// Test listing with prefix match with 'xl.meta'
+		{testBuckets[5], "201910/foo/bar", "", "", 1000, resultCases[39], nil, true},
 	}
 
 	for i, testCase := range testCases {

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -34,6 +34,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -404,6 +405,13 @@ func (s *xlStorage) readMetadata(itemPath string) ([]byte, error) {
 	stat, err := f.Stat()
 	if err != nil {
 		return nil, err
+	}
+	if stat.IsDir() {
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: itemPath,
+			Err:  syscall.EISDIR,
+		}
 	}
 	return readXLMetaNoData(f, stat.Size())
 }


### PR DESCRIPTION

## Description
fix: check for xl.meta as directory fallback

## Motivation and Context
Objects uploaded in this format for example

```
mc cp /etc/hosts alias/bucket/foo/bar/xl.meta
mc ls -r alias/bucket/foo/bar
```

Won't list the object, handle this scenario.

## How to test this PR?
Manually as described in motivation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
