### PR TITLE
fix: decodeDirObject in prefix usage function

### DIFF
--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -84,7 +84,8 @@ func loadPrefixUsageFromBackend(ctx context.Context, objAPI ObjectLayer, bucket 
 				}
 
 				for id, usageInfo := range cache.flattenChildrens(*root) {
-					prefix := strings.TrimPrefix(id, bucket+slashSeparator)
+					prefix := decodeDirObject(strings.TrimPrefix(id, bucket+slashSeparator))
+					// decodeDirObject to avoid any __XL_DIR__ objects
 					m[prefix] += uint64(usageInfo.Size)
 				}
 			}


### PR DESCRIPTION


## Description
fix: decodeDirObject in prefix usage function

## Motivation and Context
prefixes at top-level create such as

```
~ mc mb alias/bucket/prefix
```

The prefix/ incorrect appears as prefix__XL_DIR__/
in the accountInfo output, make sure to trim '__XL_DIR__'

## How to test this PR?
Create prefix as `mc mb` and observe the `AccountInfo` output in JSON 
shows up as an incorrect name in the output.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
