### PR TITLE
Reuse buffers when writing metadata

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -497,9 +497,7 @@ func (m *metaCacheEntriesSorted) forwardTo(s string) {
 	})
 	if m.reuse {
 		for i, entry := range m.o[:idx] {
-			if len(entry.metadata) >= metaDataReadDefault && len(entry.metadata) < metaDataReadDefault*4 {
-				metaDataPool.Put(entry.metadata)
-			}
+			metaDataPoolPut(entry.metadata)
 			m.o[i].metadata = nil
 		}
 	}
@@ -517,9 +515,7 @@ func (m *metaCacheEntriesSorted) forwardPast(s string) {
 	})
 	if m.reuse {
 		for i, entry := range m.o[:idx] {
-			if len(entry.metadata) >= metaDataReadDefault && len(entry.metadata) < metaDataReadDefault*4 {
-				metaDataPool.Put(entry.metadata)
-			}
+			metaDataPoolPut(entry.metadata)
 			m.o[i].metadata = nil
 		}
 	}
@@ -739,9 +735,7 @@ func (m *metaCacheEntriesSorted) truncate(n int) {
 	if len(m.o) > n {
 		if m.reuse {
 			for i, entry := range m.o[n:] {
-				if len(entry.metadata) >= metaDataReadDefault && len(entry.metadata) < metaDataReadDefault*4 {
-					metaDataPool.Put(entry.metadata)
-				}
+				metaDataPoolPut(entry.metadata)
 				m.o[n+i].metadata = nil
 			}
 		}

--- a/cmd/metacache-stream.go
+++ b/cmd/metacache-stream.go
@@ -358,7 +358,7 @@ func (r *metacacheReader) next() (metaCacheEntry, error) {
 		r.err = err
 		return m, err
 	}
-	m.metadata, err = r.mr.ReadBytes(metaDataPool.Get().([]byte)[:0])
+	m.metadata, err = r.mr.ReadBytes(metaDataPoolGet())
 	if err == io.EOF {
 		err = io.ErrUnexpectedEOF
 	}
@@ -518,7 +518,7 @@ func (r *metacacheReader) readN(n int, inclDeleted, inclDirs bool, prefix string
 			r.mr.R.Skip(1)
 			return metaCacheEntriesSorted{o: res}, io.EOF
 		}
-		if meta.metadata, err = r.mr.ReadBytes(metaDataPool.Get().([]byte)[:0]); err != nil {
+		if meta.metadata, err = r.mr.ReadBytes(metaDataPoolGet()); err != nil {
 			if err == io.EOF {
 				err = io.ErrUnexpectedEOF
 			}
@@ -577,7 +577,7 @@ func (r *metacacheReader) readAll(ctx context.Context, dst chan<- metaCacheEntry
 			r.err = err
 			return err
 		}
-		if meta.metadata, err = r.mr.ReadBytes(metaDataPool.Get().([]byte)[:0]); err != nil {
+		if meta.metadata, err = r.mr.ReadBytes(metaDataPoolGet()); err != nil {
 			if err == io.EOF {
 				err = io.ErrUnexpectedEOF
 			}

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -1437,6 +1437,13 @@ const metaDataReadDefault = 4 << 10
 // Return used metadata byte slices here.
 var metaDataPool = sync.Pool{New: func() interface{} { return make([]byte, 0, metaDataReadDefault) }}
 
+// metaDataPoolPut will put an unused small buffer.
+func metaDataPoolPut(buf []byte) {
+	if cap(buf) >= metaDataReadDefault && cap(buf) < metaDataReadDefault*4 {
+		metaDataPool.Put(buf)
+	}
+}
+
 // readXLMetaNoData will load the metadata, but skip data segments.
 // This should only be used when data is never interesting.
 // If data is not xlv2, it is returned in full.

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -1437,7 +1437,13 @@ const metaDataReadDefault = 4 << 10
 // Return used metadata byte slices here.
 var metaDataPool = sync.Pool{New: func() interface{} { return make([]byte, 0, metaDataReadDefault) }}
 
-// metaDataPoolPut will put an unused small buffer.
+// metaDataPoolGet will return a byte slice with capacity at least metaDataReadDefault.
+// It will be length 0.
+func metaDataPoolGet() []byte {
+	return metaDataPool.Get().([]byte)[:0]
+}
+
+// metaDataPoolPut will put an unused small buffer back into the pool.
 func metaDataPoolPut(buf []byte) {
 	if cap(buf) >= metaDataReadDefault && cap(buf) < metaDataReadDefault*4 {
 		metaDataPool.Put(buf)
@@ -1455,9 +1461,7 @@ func readXLMetaNoData(r io.Reader, size int64) ([]byte, error) {
 		hasFull = false
 	}
 
-	buf := metaDataPool.Get().([]byte)
-	buf = buf[:initial]
-
+	buf := metaDataPoolGet()[:initial]
 	_, err := io.ReadFull(r, buf)
 	if err != nil {
 		return nil, fmt.Errorf("readXLMetaNoData.ReadFull: %w", err)

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -903,7 +903,7 @@ func (s *xlStorage) DeleteVersion(ctx context.Context, volume, path string, fi F
 		}
 	}
 	if !lastVersion {
-		buf, err = xlMeta.AppendTo(metaDataPool.Get().([]byte)[:0])
+		buf, err = xlMeta.AppendTo(metaDataPoolGet())
 		defer metaDataPoolPut(buf)
 		if err != nil {
 			return err
@@ -971,7 +971,7 @@ func (s *xlStorage) WriteMetadata(ctx context.Context, volume, path string, fi F
 			logger.LogIf(ctx, err)
 			return err
 		}
-		buf, err := xlMeta.AppendTo(metaDataPool.Get().([]byte)[:0])
+		buf, err := xlMeta.AppendTo(metaDataPoolGet())
 		defer metaDataPoolPut(buf)
 		if err != nil {
 			logger.LogIf(ctx, err)
@@ -998,7 +998,7 @@ func (s *xlStorage) WriteMetadata(ctx context.Context, volume, path string, fi F
 			return err
 		}
 
-		buf, err = xlMeta.AppendTo(metaDataPool.Get().([]byte)[:0])
+		buf, err = xlMeta.AppendTo(metaDataPoolGet())
 		defer metaDataPoolPut(buf)
 		if err != nil {
 			logger.LogIf(ctx, err)
@@ -1015,7 +1015,7 @@ func (s *xlStorage) WriteMetadata(ctx context.Context, volume, path string, fi F
 			return err
 		}
 
-		buf, err = xlMeta.AppendTo(metaDataPool.Get().([]byte)[:0])
+		buf, err = xlMeta.AppendTo(metaDataPoolGet())
 		defer metaDataPoolPut(buf)
 		if err != nil {
 			logger.LogIf(ctx, err)


### PR DESCRIPTION
## Description

Simplify returning buffers.

Tested using `warp mixed --duration=1m --obj.size=100K`:

```
Operation: DELETE
Operations: 7148 -> 7642
* Average: +6.77% (+8.1) obj/s
-------------------
Operation: GET
Operations: 32200 -> 34403
* Average: +6.74% (+3.5 MiB/s) throughput, +6.74% (+36.2) obj/s
* First Byte: Average: -105.403µs (-3%), Median: -309µs (-11%), Best: -2.7µs (-0%), Worst: +3.5637ms (+3%)
-------------------
Operation: PUT
Operations: 10741 -> 11475
* Average: +6.78% (+1.2 MiB/s) throughput, +6.78% (+12.1) obj/s
-------------------
Operation: STAT
Operations: 21465 -> 22927
* Average: +6.71% (+24.0) obj/s
```

## How to test this PR?

Build with `-race`. Tested with warp (as above) and mint tests.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
