### PR TITLE
Fix TrafficMeter data race

### DIFF
--- a/internal/http/stats/http-traffic-recorder.go
+++ b/internal/http/stats/http-traffic-recorder.go
@@ -38,7 +38,7 @@ func (r *IncomingTrafficMeter) Read(p []byte) (n int, err error) {
 }
 
 // BytesCount returns the number of transferred bytes
-func (r IncomingTrafficMeter) BytesCount() int64 {
+func (r *IncomingTrafficMeter) BytesCount() int64 {
 	return atomic.LoadInt64(&r.countBytes)
 }
 
@@ -62,6 +62,6 @@ func (w *OutgoingTrafficMeter) Flush() {
 }
 
 // BytesCount returns the number of transferred bytes
-func (w OutgoingTrafficMeter) BytesCount() int64 {
+func (w *OutgoingTrafficMeter) BytesCount() int64 {
 	return atomic.LoadInt64(&w.countBytes)
 }


### PR DESCRIPTION
## Description

When reading `TrafficMeter` values, there was a value receiver.

This means that receivers are copied unsafely when invoked.

Fixes race seen with `-race` build.

## How to test this PR?

Build with `-race`, execute mint test or similar.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
