### PR TITLE
Fix formatting disks in a test environment

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,3 +32,4 @@ jobs:
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0
           make verify
+          make verify-healing

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,4 +32,3 @@ jobs:
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0
           make verify
-          make verify-healing

--- a/buildscripts/verify-healing.sh
+++ b/buildscripts/verify-healing.sh
@@ -86,16 +86,14 @@ function __init__()
 }
 
 function perform_test() {
-    start_minio_3_node 120
+    start_minio_3_node 60
 
     echo "Testing Distributed Erasure setup healing of drives"
     echo "Remove the contents of the disks belonging to '${1}' erasure set"
 
-    set -x
-
     rm -rf ${WORK_DIR}/${1}/*/
 
-    start_minio_3_node 200
+    start_minio_3_node 60
 
     rv=$(check_online)
     if [ "$rv" == "1" ]; then

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -298,10 +298,9 @@ func (client *storageRESTClient) DiskInfo(ctx context.Context) (info DiskInfo, e
 		client.diskInfoCache.Update = client.diskInfo
 	})
 	val, err := client.diskInfoCache.Get()
-	if err == nil {
-		info = val.(DiskInfo)
+	if val != nil {
+		return val.(DiskInfo), err
 	}
-
 	return info, err
 }
 


### PR DESCRIPTION
## Description
markRootDisksAsDown() relies on disk info even if the disk is unformatted.
Therefore, we should always return DiskInfo data even when DiskInfo
storage API returns errUnformattedDisk

## Motivation and Context
Fix disks formatting in a test environment

## How to test this PR?
Run a distributed setup of 4 nodes and notice the existance of format.json in the first disk
of the first node.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
