### PR TITLE
fix: New disks healing should pick unformatted disks as well

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,3 +32,4 @@ jobs:
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0
           make verify
+          make verify-healing

--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -705,7 +705,7 @@ func saveUnformattedFormat(ctx context.Context, storageDisks []StorageAPI, forma
 		if format == nil {
 			continue
 		}
-		if storageDisks[index] != nil && storageDisks[index].IsOnline() {
+		if storageDisks[index] != nil {
 			if err := saveFormatErasure(storageDisks[index], format, true); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description
A recent regression caused new disks not being re-formatted. In the old
code, a disk needed be 'online' to be chosen to be formatted but the
disk has to be already formatted for XL storage IsOnline() function to
return true.

It is enough to check if XL storage is nil or not if we want to avoid
formatting root disks.

## Motivation and Context
Fix formatting new disks

## How to test this PR?
Start a distributed setup (4 nodes/4 disks), remove all the content of one disk an wait.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
