### PR TITLE
fix: allow an entire set to be dropped

### DIFF
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -201,7 +200,12 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []BucketIn
 
 		disks, _ := er.getOnlineDisksWithHealing()
 		if len(disks) == 0 {
-			return errors.New("healErasureSet: No non-healing disks found")
+			// all disks are healing in this set, this is allowed
+			// so we simply proceed to next bucket, marking the bucket
+			// as done as there are no objects to heal.
+			tracker.bucketDone(bucket.Name)
+			logger.LogIf(ctx, tracker.update(ctx))
+			continue
 		}
 
 		// Limit listing to 3 drives.


### PR DESCRIPTION


## Description
fix: allow an entire set to be dropped

## Motivation and Context
proceed to heal the cluster when all the
drives in a set have failed, this is extremely
rare occurrence but even if it happens we allow
the cluster to be functional.

## How to test this PR?
As per GitHub CI/CD `make verify-healing` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
