### PR TITLE
fix: svc accounts cannot have same name as parent/targetUser

### DIFF
--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -82,7 +82,7 @@ var errGroupNotEmpty = errors.New("Specified group is not empty - cannot remove 
 var errNoSuchPolicy = errors.New("Specified canned policy does not exist")
 
 // error returned in IAM subsystem when an external users systems is configured.
-var errIAMActionNotAllowed = errors.New("Specified IAM action is not allowed with LDAP configuration")
+var errIAMActionNotAllowed = errors.New("Specified IAM action is not allowed")
 
 // error returned in IAM subsystem when IAM sub-system is still being initialized.
 var errIAMNotInitialized = errors.New("IAM sub-system is being initialized, please try again")


### PR DESCRIPTION

## Description
fix: svc accounts cannot have same name as parent/targetUser

## Motivation and Context
Currently in master this can cause existing
parent users to stop working and lead to
credentials getting overwritten.

```
~ mc admin user add alias/ minio123 minio123456
```

```
~ mc admin user svcacct add alias/ minio123 \
    --access-key minio123 --secret-key minio123456
```

This PR rejects all such scenarios.


## How to test this PR?
As per the motivation

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
