### PR TITLE
Transition without re-reading object info

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -921,6 +921,9 @@ func (i *scannerItem) applyLifecycle(ctx context.Context, o ObjectLayer, oi Obje
 	switch action {
 	case lifecycle.DeleteAction, lifecycle.DeleteVersionAction:
 	case lifecycle.TransitionAction, lifecycle.TransitionVersionAction:
+		// Apply without re-reading object info.
+		// This is done by the worker.
+		return applyLifecycleAction(ctx, action, o, oi), size
 	case lifecycle.DeleteRestoredAction, lifecycle.DeleteRestoredVersionAction:
 	default:
 		// No action.


### PR DESCRIPTION
## Description

Queue objects for transition without reading consistent object info, but do that in the worker instead.

This gives faster scanner operation and more up-to-date metadata for the transition operation.

@krisis I don't know if we should re-run the checks against the lifecycle, or if there is enough checks for state changes for it to not do something weird, if some state changed.

Since it is an async process it *should* be rechecking, and I can see it fairly quickly [re-reads the metadata](https://github.com/minio/minio/blob/bbf3576f70390309c4ff73f7f15a20223b383764/cmd/erasure-object.go#L1489), so I assume this is safe.

It might even be safe enough without re-reading in `worker`, but I wanted to double check before doing that.

## How to test this PR?

Regular transition setup.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
