### PR TITLE
cmd/os-readdir_other.go - fix variable name

### DIFF
--- a/cmd/os-readdir_other.go
+++ b/cmd/os-readdir_other.go
@@ -96,7 +96,7 @@ func readDirWithOpts(dirPath string, opts readDirOpts) (entries []string, err er
 
 	maxEntries := 1000
 	if opts.count > 0 && opts.count < maxEntries {
-		maxEntries = count
+		maxEntries = opts.count
 	}
 
 	done := false


### PR DESCRIPTION
## Description
Fix for build error `cmd/os-readdir_other.go:99:16: undefined: count`

## Motivation and Context
While building on omnios (an illumos distribution) I encounter the following error:
```
# github.com/minio/minio/cmd
cmd/os-readdir_other.go:99:16: undefined: count
gmake: *** [Makefile:62: build] Error 2
```

## How to test this PR?
Build on any illumos based operating system should be sufficient.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression https://github.com/minio/minio/pull/12668
- [ ] Documentation updated
- [ ] Unit tests added/updated
