### PR TITLE
Tweak readall allocation

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2091,7 +2091,8 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 		return err
 	}
 
-	dstBuf, err = xlMeta.AppendTo(nil)
+	dstBuf, err = xlMeta.AppendTo(metaDataPoolGet())
+	defer metaDataPoolPut(dstBuf)
 	if err != nil {
 		logger.LogIf(ctx, err)
 		if legacyPreserved {

--- a/docs/bucket/versioning/xl-meta.go
+++ b/docs/bucket/versioning/xl-meta.go
@@ -135,7 +135,7 @@ GLOBAL FLAGS:
 				}
 				data = b
 			default:
-				return errors.New("unknown metadata version")
+				return fmt.Errorf("unknown metadata version %d", minor)
 			}
 
 			if c.Bool("data") {

--- a/internal/ioutil/read_file.go
+++ b/internal/ioutil/read_file.go
@@ -34,6 +34,11 @@ func ReadFile(name string) ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close()
-
-	return io.ReadAll(f)
+	st, err := f.Stat()
+	if err != nil {
+		return io.ReadAll(f)
+	}
+	dst := make([]byte, st.Size())
+	_, err = io.ReadFull(f, dst)
+	return dst, err
 }


### PR DESCRIPTION
## Description

Use a single allocation for reading the file, not the growing buffer of `io.ReadAll`.

Reuse the write buffer if we can when writing metadata in RenameData.

## How to test this PR?

Should be covered by regular tests.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
