### PR TITLE
listing: Don't log errFileNotFound and friends

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -696,6 +696,8 @@ func (er *erasureObjects) saveMetaCacheStream(ctx context.Context, mc *metaCache
 			switch err.(type) {
 			case ObjectNotFound:
 				return err
+			case StorageErr:
+				return err
 			case InsufficientReadQuorum:
 			default:
 				logger.LogIf(ctx, err)


### PR DESCRIPTION
## Description

`errFileNotFound` can happen when a cache outlives its usefulness.

## Types of changes
- [x] Cleanup
