### PR TITLE
fix: missing cleanup of tmp folders in NAS gateway setup

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -345,18 +345,14 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	}
 
 	if globalBrowserEnabled {
-		consoleSrv, err := initConsoleServer()
+		globalConsoleSrv, err = initConsoleServer()
 		if err != nil {
 			logger.FatalIf(err, "Unable to initialize console service")
 		}
 
 		go func() {
-			<-globalOSSignalCh
-			consoleSrv.Shutdown()
+			logger.FatalIf(globalConsoleSrv.Serve(), "Unable to initialize console server")
 		}()
-
-		consoleSrv.Serve()
-	} else {
-		<-globalOSSignalCh
 	}
+	<-globalOSSignalCh
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/minio/console/restapi"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/bucket/bandwidth"
 	"github.com/minio/minio/internal/handlers"
@@ -314,6 +315,8 @@ var (
 	globalTierConfigMgr *TierConfigMgr
 
 	globalTierJournal *tierJournal
+
+	globalConsoleSrv *restapi.Server
 
 	globalDebugRemoteTiersImmediately []string
 	// Add new variable global values here.

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1453,6 +1453,9 @@ func (sys *NotificationSys) GetBandwidthReports(ctx context.Context, buckets ...
 
 // GetClusterMetrics - gets the cluster metrics from all nodes excluding self.
 func (sys *NotificationSys) GetClusterMetrics(ctx context.Context) chan Metric {
+	if sys == nil {
+		return nil
+	}
 	g := errgroup.WithNErrs(len(sys.peerClients))
 	peerChannels := make([]<-chan Metric, len(sys.peerClients))
 	for index := range sys.peerClients {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -582,20 +582,17 @@ func serverMain(ctx *cli.Context) {
 	}
 
 	if globalBrowserEnabled {
-		consoleSrv, err := initConsoleServer()
+		globalConsoleSrv, err = initConsoleServer()
 		if err != nil {
 			logger.FatalIf(err, "Unable to initialize console service")
 		}
 
 		go func() {
-			logger.FatalIf(consoleSrv.Serve(), "Unable to initialize console server")
+			logger.FatalIf(globalConsoleSrv.Serve(), "Unable to initialize console server")
 		}()
-
-		<-globalOSSignalCh
-		consoleSrv.Shutdown()
-	} else {
-		<-globalOSSignalCh
 	}
+
+	<-globalOSSignalCh
 }
 
 // Initialize object layer with the supplied disks, objectLayer is nil upon any error.

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -66,6 +66,10 @@ func handleSignals() {
 			logger.LogIf(context.Background(), oerr)
 		}
 
+		if globalConsoleSrv != nil {
+			logger.LogIf(context.Background(), globalConsoleSrv.Shutdown())
+		}
+
 		return (err == nil && oerr == nil)
 	}
 


### PR DESCRIPTION


## Description
fix: missing cleanup of tmp folders in NAS gateway setup

## Motivation and Context
console service should be shutdown last once all shutdown
sequences are complete, this is to ensure that we do not
prematurely kill the server before it cleans up the

`.minio.sys/tmp/uuid` folder.

NOTE: this only applies to NAS gateway setup.

## How to test this PR?
Just run `minio gateway nas /tmp/1` and shutdown check a UUID folder is left over at `/tmp/1/.minio.sys/tmp/uuid` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression perhaps since console was embedded into MinIO
- [ ] Documentation updated
- [ ] Unit tests added/updated
