### PR TITLE
Remove remote object if transition object fails

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1628,6 +1628,7 @@ func (er erasureObjects) TransitionObject(ctx context.Context, bucket, object st
 	}
 
 	if err = er.deleteObjectVersion(ctx, bucket, object, writeQuorum, fi, false); err != nil {
+		logger.LogIf(ctx, tgtClient.Remove(ctx, destObj, rv))
 		eventName = event.ObjectTransitionFailed
 	}
 


### PR DESCRIPTION
## Description
This change removes the remote object when object transition fails.

## Motivation and Context
To not leave behind remote objects with no reference from hot-tier.

## How to test this PR?
Have less than write quorum disks online when object transition is in progress. This should not leave behind unreferenced remote objects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
