### PR TITLE
[10-28] locks: Top locks to build list of locks based on resource name

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -376,10 +376,10 @@ func topLockEntries(peerLocks []*PeerLocks, stale bool) madmin.LockEntries {
 		for _, locks := range peerLock.Locks {
 			for k, v := range locks {
 				for _, lockReqInfo := range v {
-					if val, ok := entryMap[lockReqInfo.UID]; ok {
+					if val, ok := entryMap[k]; ok {
 						val.ServerList = append(val.ServerList, peerLock.Addr)
 					} else {
-						entryMap[lockReqInfo.UID] = lriToLockEntry(lockReqInfo, k, peerLock.Addr)
+						entryMap[k] = lriToLockEntry(lockReqInfo, k, peerLock.Addr)
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Top locks fails to show resources of multi delete objects call because
this is about a single lock of multiple resources. This commit fixes it.

## Motivation and Context
Fix top locks issue with multi delete locks in 10-28

## How to test this PR?
Comment the line of the code which unlocks in DeleteObjects() in erasure-server-sets.go
Create a bucket, upload multiple objects
mc rm -r --force myminio/bucket/
mc admin top locks myminio/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
