### PR TITLE
fix: make sure to delete dangling objects during heal

### DIFF
--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -84,7 +84,7 @@ var (
 		},
 		config.KV{
 			Key:   apiListQuorum,
-			Value: "optimal",
+			Value: "strict",
 		},
 		config.KV{
 			Key:   apiReplicationWorkers,


### PR DESCRIPTION


## Description
fix: make sure to delete dangling objects during heal

## Motivation and Context
heal with --remove was not removing dangling versions
on versioned buckets, this PR fixes this properly.

this is a regression introduced in PR #12617

## How to test this PR?
Add tests to cover multiple scenarios

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression in #12617
- [ ] Documentation updated
- [x] Unit tests added/updated
