### PR TITLE
select: Add more compression formats

### DIFF
--- a/docs/select/README.md
+++ b/docs/select/README.md
@@ -5,7 +5,8 @@ You can use the Select API to query objects with following features:
 
 - Objects must be in CSV, JSON, or Parquet(*) format. 
 - UTF-8 is the only encoding type the Select API supports.
-- GZIP or BZIP2 - CSV and JSON files can be compressed using GZIP or BZIP2. The Select API supports columnar compression for Parquet using GZIP, Snappy, LZ4. Whole object compression is not supported for Parquet objects.
+- GZIP or BZIP2 - CSV and JSON files can be compressed using GZIP, BZIP2, [ZSTD](https://facebook.github.io/zstd/), and streaming formats of [LZ4](https://lz4.github.io/lz4/), [S2](https://github.com/klauspost/compress/tree/master/s2#s2-compression) and [SNAPPY](http://google.github.io/snappy/). 
+- Parquet API supports columnar compression for  using GZIP, Snappy, LZ4. Whole object compression is not supported for Parquet objects.
 - Server-side encryption - The Select API supports querying objects that are protected with server-side encryption.
 
 Type inference and automatic conversion of values is performed based on the context when the value is un-typed (such as when reading CSV data). If present, the CAST function overrides automatic conversion.

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/json-iterator/go v1.1.11
-	github.com/klauspost/compress v1.13.4
+	github.com/klauspost/compress v1.13.5
 	github.com/klauspost/cpuid/v2 v2.0.4
 	github.com/klauspost/pgzip v1.2.5
 	github.com/klauspost/readahead v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,8 @@ github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.12/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.12.2/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
-github.com/klauspost/compress v1.13.4 h1:0zhec2I8zGnjWcKyLl6i3gPqKANCCn5e9xmviEEeX6s=
-github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.5 h1:9O69jUPDcsT9fEm74W92rZL9FQY7rCdaXVneq+yyzl4=
+github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=

--- a/internal/s3select/errors.go
+++ b/internal/s3select/errors.go
@@ -17,6 +17,8 @@
 
 package s3select
 
+import "strings"
+
 // SelectError - represents s3 select error specified in
 // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html#RESTObjectSELECTContent-responses-special-errors.
 type SelectError interface {
@@ -66,25 +68,16 @@ func errMalformedXML(err error) *s3Error {
 func errInvalidCompressionFormat(err error) *s3Error {
 	return &s3Error{
 		code:       "InvalidCompressionFormat",
-		message:    "The file is not in a supported compression format. Only GZIP and BZIP2 are supported.",
+		message:    "The file is not in a supported compression format. GZIP, BZIP2, ZSTD, LZ4, S2 and SNAPPY are supported.",
 		statusCode: 400,
 		cause:      err,
 	}
 }
 
-func errInvalidBZIP2CompressionFormat(err error) *s3Error {
+func errInvalidCompression(err error, t CompressionType) *s3Error {
 	return &s3Error{
 		code:       "InvalidCompressionFormat",
-		message:    "BZIP2 is not applicable to the queried object. Please correct the request and try again.",
-		statusCode: 400,
-		cause:      err,
-	}
-}
-
-func errInvalidGZIPCompressionFormat(err error) *s3Error {
-	return &s3Error{
-		code:       "InvalidCompressionFormat",
-		message:    "GZIP is not applicable to the queried object. Please correct the request and try again.",
+		message:    strings.ToUpper(string(t)) + " is not applicable to the queried object. Please correct the request and try again.",
 		statusCode: 400,
 		cause:      err,
 	}


### PR DESCRIPTION
## Description

Support Zstandard, LZ4, S2 and Snappy as additional compression formats for S3 Select.

When using gzip, speed and compression is significantly decreased due to format limitations in the file format.

Allow alternative compression methods. This extends S3 functionality.

## How to test this PR?

* Download [nyc-taxi-data-10M.csv.zst](https://files.klauspost.com/compress/nyc-taxi-data-10M.csv.zst)
* Upload to minio as `mybucket/nyc-taxi-data-10M.csv.zst`
* Example query: `mc sql --compression zstd --csv-input "rd=\n,fh=USE,fd=;" -query "select count(*) from S3Object" local2/testbucket/nyc-taxi-data-10M.csv.zst`

To generate snappy/s2 use s2c, download from [here](https://github.com/klauspost/compress/releases/tag/v1.13.5)

```
$ zstd -d -c nyc-taxi-data-10M.csv.zst|s2c -slower -o=nyc-taxi-data-10M.csv.s2 -
$ zstd -d -c nyc-taxi-data-10M.csv.zst|s2c -snappy -slower -o=nyc-taxi-data-10M.csv.snappy -
```
To generate lz4, use 

```
$ go install github.com/pierrec/lz4/v4/cmd/lz4c@latest
$ zstd -d -c nyc-taxi-data-10M.csv.zst|lz4c compress >nyc-taxi-data-10M.csv.lz4
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
