### PR TITLE
fail readiness if etcd is unhealthy in gateway mode

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -301,9 +301,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		logger.FatalIf(globalNotificationSys.Init(GlobalContext, buckets, newObject), "Unable to initialize notification system")
 	}
 
-	// Initialize users credentials and policies in background.
-	globalIAMSys.InitStore(newObject)
-
 	go globalIAMSys.Init(GlobalContext, newObject)
 
 	if globalCacheConfig.Enabled {

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -95,6 +95,17 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(xhttp.MinIOServerStatus, unavailable)
 	}
 
+	if globalIsGateway && globalEtcdClient != nil {
+		// Borrowed from https://github.com/etcd-io/etcd/blob/main/etcdctl/ctlv3/command/ep_command.go#L118
+		ctx, cancel := context.WithTimeout(r.Context(), defaultContextTimeout)
+		defer cancel()
+		// etcd unreachable throw an error for readiness.
+		if _, err := globalEtcdClient.Get(ctx, "health"); err != nil {
+			writeErrorResponse(r.Context(), w, toAPIError(r.Context(), err), r.URL)
+			return
+		}
+	}
+
 	writeResponse(w, http.StatusOK, nil, mimeNone)
 }
 
@@ -104,5 +115,17 @@ func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 		// Service not initialized yet
 		w.Header().Set(xhttp.MinIOServerStatus, unavailable)
 	}
+
+	if globalIsGateway && globalEtcdClient != nil {
+		// Borrowed from https://github.com/etcd-io/etcd/blob/main/etcdctl/ctlv3/command/ep_command.go#L118
+		ctx, cancel := context.WithTimeout(r.Context(), defaultContextTimeout)
+		defer cancel()
+		// etcd unreachable throw an error for readiness.
+		if _, err := globalEtcdClient.Get(ctx, "health"); err != nil {
+			writeErrorResponse(r.Context(), w, toAPIError(r.Context(), err), r.URL)
+			return
+		}
+	}
+
 	writeResponse(w, http.StatusOK, nil, mimeNone)
 }

--- a/docs/metrics/healthcheck/README.md
+++ b/docs/metrics/healthcheck/README.md
@@ -4,12 +4,29 @@ MinIO server exposes three un-authenticated, healthcheck endpoints liveness prob
 
 ### Liveness probe
 
-This probe always responds with '200 OK'. When liveness probe fails, Kubernetes like platforms restart the container.
+This probe always responds with '200 OK'. Only fails if 'etcd' is configured and unreachable. This behavior is specific to gateway. When liveness probe fails, Kubernetes like platforms restart the container.
 
 ```
 livenessProbe:
   httpGet:
     path: /minio/health/live
+    port: 9000
+    scheme: HTTP
+  initialDelaySeconds: 120
+  periodSeconds: 30
+  timeoutSeconds: 10
+  successThreshold: 1
+  failureThreshold: 3
+```
+
+### Readiness probe
+
+This probe always responds with '200 OK'. Only fails if 'etcd' is configured and unreachable. This behavior is specific to gateway. When readiness probe fails, Kubernetes like platforms turn-off routing to the container.
+
+```
+readinessProbe:
+  httpGet:
+    path: /minio/health/ready
     port: 9000
     scheme: HTTP
   initialDelaySeconds: 120


### PR DESCRIPTION
## Description
fail readiness if etcd is unhealthy in gateway mode

## Motivation and Context
etcd if unreachable at any point fail readiness
for such a gateway instance.

## How to test this PR?
Start gateway and then take down etcd, check 
the readiness endpoint will return an error with
the error returned by 'etcd' client.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
