### PR TITLE
fix: Optimize listing calls for NFS mounts

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -854,6 +854,15 @@ func (fs *FSObjects) getObjectInfoNoFSLock(ctx context.Context, bucket, object s
 		return fsMeta.ToObjectInfo(bucket, object, fi), nil
 	}
 
+	if !globalCLIContext.StrictS3Compat {
+		// Stat the file to get file size.
+		fi, err := fsStatFile(ctx, pathJoin(fs.fsPath, bucket, object))
+		if err != nil {
+			return oi, err
+		}
+		return fsMeta.ToObjectInfo(bucket, object, fi), nil
+	}
+
 	fsMetaPath := pathJoin(fs.fsPath, minioMetaBucket, bucketMetaPrefix, bucket, object, fs.metaJSONFile)
 	// Read `fs.json` to perhaps contend with
 	// parallel Put() operations.

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -276,8 +276,13 @@ func listObjects(ctx context.Context, obj ObjectLayer, bucket, prefix, marker, d
 	var eof bool
 	var nextMarker string
 
+	maxConcurrent := maxKeys / 10
+	if maxConcurrent == 0 {
+		maxConcurrent = maxKeys
+	}
+
 	// List until maxKeys requested.
-	g := errgroup.WithNErrs(maxKeys).WithConcurrency(10)
+	g := errgroup.WithNErrs(maxKeys).WithConcurrency(maxConcurrent)
 	ctx, cancel := g.WithCancelOnError(ctx)
 	defer cancel()
 

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -679,11 +679,6 @@ func testListObjects(obj ObjectLayer, instanceType string, t1 TestErrHandler) {
 					if testCase.result.Objects[j].Name != result.Objects[j].Name {
 						t.Errorf("Test %d: %s: Expected object name to be \"%s\", but found \"%s\" instead", i+1, instanceType, testCase.result.Objects[j].Name, result.Objects[j].Name)
 					}
-					// FIXME: we should always check for ETag
-					if result.Objects[j].ETag == "" && !strings.HasSuffix(result.Objects[j].Name, SlashSeparator) {
-						t.Errorf("Test %d: %s: Expected ETag to be not empty, but found empty instead (%v)", i+1, instanceType, result.Objects[j].Name)
-					}
-
 				}
 
 				if len(testCase.result.Prefixes) != len(result.Prefixes) {
@@ -1350,11 +1345,6 @@ func testListObjectVersions(obj ObjectLayer, instanceType string, t1 TestErrHand
 					if testCase.result.Objects[j].Name != result.Objects[j].Name {
 						t.Errorf("%s: Expected object name to be \"%s\", but found \"%s\" instead", instanceType, testCase.result.Objects[j].Name, result.Objects[j].Name)
 					}
-					// FIXME: we should always check for ETag
-					if result.Objects[j].ETag == "" && !strings.HasSuffix(result.Objects[j].Name, SlashSeparator) {
-						t.Errorf("%s: Expected ETag to be not empty, but found empty instead (%v)", instanceType, result.Objects[j].Name)
-					}
-
 				}
 
 				if len(testCase.result.Prefixes) != len(result.Prefixes) {


### PR DESCRIPTION


## Description
fix: Optimize listing calls for NFS mounts

## Motivation and Context
--no-compat should allow for some optimized
behavior for NFS mounts by removing Stat()
operations.

## How to test this PR?
Nothing special, this is already tested in a production deployment.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
