### PR TITLE
fix: remove deprecated LDAP username format support

### DIFF
--- a/cmd/server-rlimit.go
+++ b/cmd/server-rlimit.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"runtime"
 	"runtime/debug"
 
 	"github.com/minio/minio/internal/logger"
@@ -42,7 +43,7 @@ func setMaxResources() (err error) {
 		return err
 	}
 
-	if maxLimit < 4096 {
+	if maxLimit < 4096 && runtime.GOOS != globalWindowsOSName {
 		logger.Info("WARNING: maximum file descriptor limit %d is too low for production servers. At least 4096 is recommended. Fix with \"ulimit -n 4096\"", maxLimit)
 	}
 

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -29,12 +29,6 @@ var (
 			Sensitive:   true,
 		},
 		config.HelpKV{
-			Key:         STSExpiry,
-			Description: `[DEPRECATED] temporary credentials validity duration in s,m,h,d. Default is "1h"`,
-			Optional:    true,
-			Type:        "duration",
-		},
-		config.HelpKV{
 			Key:         LookupBindDN,
 			Description: `DN for LDAP read-only service account used to perform DN and group lookups`,
 			Optional:    true,
@@ -59,13 +53,6 @@ var (
 			Description: `Search filter to lookup user DN`,
 			Optional:    true,
 			Type:        "string",
-		},
-		config.HelpKV{
-			Key:         UsernameFormat,
-			Description: `[DEPRECATED] ";" separated list of username bind DNs e.g. "uid=%s,cn=accounts,dc=myldapserver,dc=com"`,
-			Optional:    true,
-			Type:        "list",
-			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         GroupSearchFilter,

--- a/internal/config/identity/ldap/legacy.go
+++ b/internal/config/identity/ldap/legacy.go
@@ -31,14 +31,6 @@ func SetIdentityLDAP(s config.Config, ldapArgs Config) {
 			Value: ldapArgs.ServerAddr,
 		},
 		config.KV{
-			Key:   STSExpiry,
-			Value: ldapArgs.STSExpiryDuration,
-		},
-		config.KV{
-			Key:   UsernameFormat,
-			Value: ldapArgs.UsernameFormat,
-		},
-		config.KV{
 			Key:   GroupSearchFilter,
 			Value: ldapArgs.GroupSearchFilter,
 		},

--- a/internal/config/identity/tls/config.go
+++ b/internal/config/identity/tls/config.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config"
+	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/env"
 )
 
@@ -89,7 +90,10 @@ func Lookup(kvs config.KVS) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	enabled, err := config.ParseBool(env.Get(EnvEnabled, "on"))
+	if insecureSkipVerify {
+		logger.Info("CRITICAL: enabling MINIO_IDENTITY_TLS_SKIP_VERIFY is not recommended in a production environment")
+	}
+	enabled, err := config.ParseBool(env.Get(EnvEnabled, config.EnableOn))
 	if err != nil {
 		return Config{}, err
 	}


### PR DESCRIPTION
## Description
fix: remove deprecated LDAP username format support

## Motivation and Context
deprecate support for LDAP username format

## How to test this PR?
Nothing special all steps should work fine
with the removal of code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
