### PR TITLE
Detect multipart uploads correctly in unencrypted case

### DIFF
--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -75,7 +75,8 @@ func (o *ObjectInfo) isMultipart() bool {
 	if len(o.Parts) == 0 {
 		return false
 	}
-	if !crypto.IsMultiPart(o.UserDefined) {
+	_, encrypted := crypto.IsEncrypted(o.UserDefined)
+	if encrypted && !crypto.IsMultiPart(o.UserDefined) {
 		return false
 	}
 	for _, part := range o.Parts {


### PR DESCRIPTION
This is a fix building on #13171 to ensure objects
uploaded using multipart are replicated as multipart

## Description


## Motivation and Context
admin trace on target should show multipart being used for replication sync both for encrypted/unencrypted situation when multipart was used during initial upload to source.

## How to test this PR?
see test script in previous PR

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
