### PR TITLE
fix: add /usr/bin symlink

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -39,6 +39,7 @@ RUN \
      chmod +x /opt/bin/minio && \
      chmod +x /usr/bin/docker-entrypoint.sh && \
      chmod +x /usr/bin/verify-minio.sh && \
+     ln -s /opt/bin/minio /usr/bin/minio && \
      /usr/bin/verify-minio.sh
 
 EXPOSE 9000

--- a/Dockerfile.release.fips
+++ b/Dockerfile.release.fips
@@ -39,6 +39,7 @@ RUN \
      chmod +x /opt/bin/minio && \
      chmod +x /usr/bin/docker-entrypoint.sh && \
      chmod +x /usr/bin/verify-minio.sh && \
+     ln -s /opt/bin/minio /usr/bin/minio && \
      /usr/bin/verify-minio.sh
 
 EXPOSE 9000

--- a/dockerscripts/verify-minio.sh
+++ b/dockerscripts/verify-minio.sh
@@ -8,6 +8,11 @@ if [ ! -x "/opt/bin/minio" ]; then
     exit 1
 fi
 
+if [ ! -x "/usr/bin/minio" ]; then
+    echo "minio executable binary not found at old location refusing to proceed"
+    exit 1
+fi
+
 verify_sha256sum() {
     echo "verifying binary checksum"
     echo "$(awk '{print $1}' /opt/bin/minio.sha256sum)  /opt/bin/minio" | sha256sum -c


### PR DESCRIPTION
## Description

Add a symlink from `/usr/bin/minio` to `/opt/bin/minio` to avoid breaking change.

Fixes #13181.

## Motivation and Context

The Minio executable was moved from `/usr/bin/minio` to `/opt/bin/minio`, which caused environments with custom entrypoints to break.

## How to test this PR?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
