### PR TITLE
More lock fixes in 10-28 branch

### DIFF
--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -222,13 +222,24 @@ func (l *localLocker) ForceUnlock(ctx context.Context, args dsync.LockArgs) (rep
 	default:
 		l.mutex.Lock()
 		defer l.mutex.Unlock()
-		if len(args.UID) != 0 {
-			return false, fmt.Errorf("ForceUnlock called with non-empty UID: %s", args.UID)
+		if len(args.UID) == 0 {
+			for _, resource := range args.Resources {
+				delete(l.lockMap, resource) // Remove the lock (irrespective of write or read lock)
+			}
+			return true, nil
 		}
-		for _, resource := range args.Resources {
-			delete(l.lockMap, resource) // Remove the lock (irrespective of write or read lock)
+
+		lockUIDFound := false
+
+		for resource, lris := range l.lockMap {
+			for _, lri := range lris {
+				if lri.UID == args.UID {
+					l.removeEntry(resource, dsync.LockArgs{Owner: lri.Owner, UID: lri.UID}, &lris)
+					lockUIDFound = true
+				}
+			}
 		}
-		return true, nil
+		return lockUIDFound, nil
 	}
 }
 


### PR DESCRIPTION
## Description
- Refresh() should remove non refreshed locks in local node as well
- UID is not unique per lock. ForceUnlock should remove all locks with the given UID

## Motivation and Context
More lock fix in 10-28

## How to test this PR?
Usual manual testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
