### PR TITLE
gateway: Add debug env variable to print S3 requests to backend

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -280,7 +280,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		SecretKey: globalActiveCred.SecretKey,
 	})
 	if err != nil {
-		globalHTTPServer.Shutdown()
 		logger.FatalIf(err, "Unable to initialize gateway backend")
 	}
 	newObject = NewGatewayLayerWithLocker(newObject)

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -34,9 +35,11 @@ import (
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/minio-go/v7/pkg/tags"
 	minio "github.com/minio/minio/cmd"
+	"github.com/minio/minio/internal/config"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/bucket/policy"
+	"github.com/minio/pkg/env"
 )
 
 func init() {
@@ -198,6 +201,10 @@ func newS3(urlStr string, tripper http.RoundTripper) (*miniogo.Core, error) {
 	clnt, err := miniogo.New(endpoint, options)
 	if err != nil {
 		return nil, err
+	}
+
+	if env.Get("_MINIO_GATEWAY_DEBUG", config.EnableOff) == config.EnableOn {
+		clnt.TraceOn(os.Stderr)
 	}
 
 	return &miniogo.Core{Client: clnt}, nil


### PR DESCRIPTION
## Description
If _MINIO_DEBUG_GATEWAY is set ton 'on'. The S3 gateway will print
minio-go S3 requests sent to the S3 backend server.

## Motivation and Context
Fixes https://github.com/minio/minio/issues/13089

## How to test this PR?
_MINIO_GATEWAY_DEBUG=on MINIO_ACCESS_KEY=s3-access-key MINIO_SECRET_KEY=s3-secret-key minio gateway s3

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
