### PR TITLE
fix ServiceAccount creation in helm chart

### DIFF
--- a/helm/minio/templates/serviceaccount.yaml
+++ b/helm/minio/templates/serviceaccount.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "minio.serviceAccountName" . | quote }}
+  name: {{ .Values.serviceAccount.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end -}}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -324,8 +324,8 @@ podDisruptionBudget:
 serviceAccount:
   create: true
   ## The name of the service account to use. If 'create' is 'true', a service account with that name
-  ## will be created. Otherwise, a name will be auto-generated.
-  name:
+  ## will be created.
+  name: "minio-sa"
 
 metrics:
   serviceMonitor:


### PR DESCRIPTION
## Description

Fixed the variable name on the templated and added name.

## Motivation and Context

helm install is failing with the following error

```
helm.go:81: [debug] template: minio/templates/serviceaccount.yaml:5:11: executing "minio/templates/serviceaccount.yaml" at <include "minio.serviceAccountName" .>: error calling include: template: no template "minio.serviceAccountName" associated with template "gotpl"
```

## How to test this PR?
```
helm install --namespace minio --set rootUser=rootuser,rootPassword=rootpass123 --generate-name ./helm/minio/ 
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
