### PR TITLE
Fix deadlock when error during metacache generation

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -599,7 +599,7 @@ type metaCacheRPC struct {
 
 func (m *metaCacheRPC) setErr(err string) {
 	m.mu.Lock()
-	defer m.mu.Lock()
+	defer m.mu.Unlock()
 	meta := *m.meta
 	if meta.status != scanStateError {
 		meta.error = err


### PR DESCRIPTION
## Description
A typo forgot to release a lock after acquiring it.


## Motivation and Context
Fix typo

## How to test this PR?
Not trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
