### PR TITLE
fix sse-kms context unmarshal failure

### DIFF
--- a/internal/crypto/sse-kms.go
+++ b/internal/crypto/sse-kms.go
@@ -210,8 +210,8 @@ func (ssekms) ParseMetadata(metadata map[string]string) (keyID string, kmsKey []
 			return keyID, kmsKey, sealedKey, ctx, Errorf("The internal KMS context is not base64-encoded")
 		}
 		var json = jsoniter.ConfigCompatibleWithStandardLibrary
-		if err = json.Unmarshal(b, ctx); err != nil {
-			return keyID, kmsKey, sealedKey, ctx, Errorf("The internal sealed KMS context is invalid")
+		if err = json.Unmarshal(b, &ctx); err != nil {
+			return keyID, kmsKey, sealedKey, ctx, Errorf("The internal sealed KMS context is invalid %w", err)
 		}
 	}
 


### PR DESCRIPTION


## Description
fix sse-kms context unmarshal failure

## Motivation and Context
json.Unmarshal expects a pointer receiver, otherwise
kms.Context unmarshal fails with lack of pointer receiver,
this becomes complicated due to type aliasing over
map[string]string - fix it properly.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
