### PR TITLE
disable insecure DES ciphers when MINIO_API_SECURE_CIPHERS=off

### DIFF
--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -177,6 +177,18 @@ func NewServer(addrs []string, handler http.Handler, getCert certs.GetCertificat
 		if secureCiphers || fips.Enabled {
 			tlsConfig.CipherSuites = fips.CipherSuitesTLS()
 			tlsConfig.CurvePreferences = fips.EllipticCurvesTLS()
+		} else {
+			// This is temp. solution until we use Go 1.17 for releases.
+			// Go 1.17 disables the ciphers below by default.
+			for _, cipher := range tls.CipherSuites() {
+				if cipher.ID == tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA {
+					continue
+				}
+				if cipher.ID == tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA {
+					continue
+				}
+				tlsConfig.CipherSuites = append(tlsConfig.CipherSuites, cipher.ID)
+			}
 		}
 	}
 


### PR DESCRIPTION

## Description
This commit disables very old ciphers (considered insecure in Go 1.17)
when using the default Go cipher suites. Once switched to Go 1.17 this
change can be reverted.

This commit may be needed for clients that don't support
AES-GCM / ChaCha20Poly1305 ciphers but DES should also not be supported.

## Motivation and Context
TLS, legacy applications, compliance 

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
