### PR TITLE
s3: Put bucket tagging to return an error when bucket is not found

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1796,6 +1796,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 	}
 
 	switch err {
+	case errVolumeNotFound:
+		apiErr = ErrNoSuchBucket
 	case errInvalidArgument:
 		apiErr = ErrAdminInvalidArgument
 	case errNoSuchUser:

--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -123,6 +123,9 @@ func (b *BucketMetadata) Load(ctx context.Context, api ObjectLayer, name string)
 	configFile := path.Join(bucketConfigPrefix, name, bucketMetadataFile)
 	data, err := readConfig(ctx, api, configFile)
 	if err != nil {
+		if err == errConfigNotFound {
+			err = errVolumeNotFound
+		}
 		return err
 	}
 	if len(data) <= 4 {
@@ -149,7 +152,7 @@ func (b *BucketMetadata) Load(ctx context.Context, api ObjectLayer, name string)
 func loadBucketMetadata(ctx context.Context, objectAPI ObjectLayer, bucket string) (BucketMetadata, error) {
 	b := newBucketMetadata(bucket)
 	err := b.Load(ctx, objectAPI, b.Name)
-	if err != nil && !errors.Is(err, errConfigNotFound) {
+	if err != nil {
 		return b, err
 	}
 


### PR DESCRIPTION
## Description
loadBucketMetadata() should return an error when the bucket metadata
file doesn't exist. This should not cause a problem since the bucket metadata
file is always created already when a new bucket is created.

## Motivation and Context
PutBucketTagging handler should return bucket not found error when the bucket
doesn't exist.  

## How to test this PR?
aws s3api put-bucket-tagging --debug --endpoint http://localhost:9000 --profile minio --bucket testbucket  --tagging '{"TagSet": [{ "Key": "organization", "Value": "marketing" }]}'


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
