### PR TITLE
Fix retention enforcement check for deleted object versions

### DIFF
--- a/cmd/bucket-object-lock.go
+++ b/cmd/bucket-object-lock.go
@@ -93,7 +93,7 @@ func enforceRetentionBypassForDelete(ctx context.Context, r *http.Request, bucke
 	if gerr != nil { // error from GetObjectInfo
 		switch gerr.(type) {
 		case MethodNotAllowed: // This happens usually for a delete marker
-			if oi.DeleteMarker {
+			if oi.DeleteMarker || !oi.VersionPurgeStatus.Empty() {
 				// Delete marker should be present and valid.
 				return ErrNone
 			}


### PR DESCRIPTION
if an object is pending version purge, it should be treated
as ErrNone in retention enforcement check

## Description


## Motivation and Context
When object version is in PENDING/FAILED delete replication state, erasure layer would return MethodNotAllowed. This should be treated similiar to delete marker and not flagged during retention enforcement.

## How to test this PR?
Turn on 1-way replication between 2 object lock enabled buckets from A->B. 
``` 
`mc cp` on A
delete replication rules on A 
kill  B
`mc rm --force --versions A/bucket`
bring B online
`mc rm --force --versions A/bucket` should now succeed 
 ```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
