### PR TITLE
fix: deleting objects was not working after upgrades

### DIFF
--- a/cmd/config-common.go
+++ b/cmd/config-common.go
@@ -57,7 +57,9 @@ type objectDeleter interface {
 }
 
 func deleteConfig(ctx context.Context, objAPI objectDeleter, configFile string) error {
-	_, err := objAPI.DeleteObject(ctx, minioMetaBucket, configFile, ObjectOptions{})
+	_, err := objAPI.DeleteObject(ctx, minioMetaBucket, configFile, ObjectOptions{
+		DeletePrefix: true,
+	})
 	if err != nil && isErrObjectNotFound(err) {
 		return errConfigNotFound
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -96,7 +96,9 @@ func listServerConfigHistory(ctx context.Context, objAPI ObjectLayer, withData b
 
 func delServerConfigHistory(ctx context.Context, objAPI ObjectLayer, uuidKV string) error {
 	historyFile := pathJoin(minioConfigHistoryPrefix, uuidKV+kvPrefix)
-	_, err := objAPI.DeleteObject(ctx, minioMetaBucket, historyFile, ObjectOptions{})
+	_, err := objAPI.DeleteObject(ctx, minioMetaBucket, historyFile, ObjectOptions{
+		DeletePrefix: true,
+	})
 	return err
 }
 


### PR DESCRIPTION

## Description
fix: deleting objects was not working after upgrades

## Motivation and Context
DeleteObject() on existing objects before `xl.json` to
`xl.meta` change were not working, not sure when this
regression was added. This PR fixes this properly.

Also this PR ensures that we perform rename of xl.json
to xl.meta only during "write" phase of the call i.e
either during Healing or PutObject() overwrites.

Also handles few other scenarios during migration where
`backendEncryptedFile` was missing deleteConfig() will
fail with `configNotFound` this case was not ignored,
which can lead to failure during upgrades.

## How to test this PR?
Start a setup with 2020-05-01 and then copy a bunch of files, now upgrade with the latest release using the same script. `mc rm -r --force` would not delete the objects at all. 

```sh
export MINIO_ACCESS_KEY=minio
export MINIO_SECRET_KEY=minio123
export MINIO_ERASURE_SET_DRIVE_COUNT=6
export MINIO_ENDPOINTS="http://127.0.0.1:9001/home/harsha/disk01 http://127.0.0.1:9002/home/harsha/disk02 http://127.0.0.1:9003/home/harsha/disk03 http://127.0.0.1:9004/home/harsha/disk04 http://127.0.0.1:9001/home/harsha/disk05 http://127.0.0.1:9002/home/harsha/disk06 http://127.0.0.1:9003/home/harsha/disk07 http://127.0.0.1:9004/home/harsha/disk08 http://127.0.0.1:9001/home/harsha/disk09 http://127.0.0.1:9002/home/harsha/disk10 http://127.0.0.1:9003/home/harsha/disk11 http://127.0.0.1:9004/home/harsha/disk12"
export MINIO_SCANNER_CYCLE=10s
#export _MINIO_SERVER_DEBUG=on
for i in {01..04}; do
    /home/harsha/mygo/src/github.com/minio/minio/minio.RELEASE.2020-05-01T22-19-14Z server --address ":90${i}" &
    #/home/harsha/mygo/src/github.com/minio/minio/minio server --address ":90${i}" &
done
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression not sure when, but this is a regression.
- [ ] Documentation updated
- [ ] Unit tests added/updated
