### PR TITLE
Helm chart impovements

### DIFF
--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Multi-Cloud Object Storage
 name: minio
-version: 3.1.2
+version: 3.1.3
 appVersion: RELEASE.2021-09-09T21-37-07Z
 keywords:
   - minio

--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
+            {{- if .Values.metrics.serviceMonitor.public }}
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: "public"
+            {{- end}}
             {{- range $key, $val := .Values.environment }}
             - name: {{ $key }}
               value: {{ $val | quote }}

--- a/helm/minio/templates/gateway-deployment.yaml
+++ b/helm/minio/templates/gateway-deployment.yaml
@@ -91,6 +91,10 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
+            {{- if .Values.metrics.serviceMonitor.public }}
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: "public"
+            {{- end}}
             {{- range $key, $val := .Values.environment }}
             - name: {{ $key }}
               value: {{ $val | quote }}

--- a/helm/minio/templates/post-install-create-bucket-job.yaml
+++ b/helm/minio/templates/post-install-create-bucket-job.yaml
@@ -32,13 +32,13 @@ spec:
 {{- include "minio.imagePullSecrets" . | indent 6 }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.makeBucketJob.nodeSelector | indent 8 }}
 {{- end }}
-{{- with .Values.affinity }}
+{{- with .Values.makeBucketJob.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- with .Values.tolerations }}
+{{- with .Values.makeBucketJob.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/helm/minio/templates/post-install-create-user-job.yaml
+++ b/helm/minio/templates/post-install-create-user-job.yaml
@@ -32,13 +32,13 @@ spec:
 {{- include "minio.imagePullSecrets" . | indent 6 }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.makeUserJob.nodeSelector | indent 8 }}
 {{- end }}
-{{- with .Values.affinity }}
+{{- with .Values.makeUserJob.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- with .Values.tolerations }}
+{{- with .Values.makeUserJob.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
-            {{- if .Values.metrics.podMonitor.public }}
+            {{- if .Values.metrics.serviceMonitor.public }}
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: "public"
             {{- end}}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -269,6 +269,9 @@ makeUserJob:
   resources:
     requests:
       memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 ## List of buckets to be created after minio install
 ##
@@ -300,6 +303,9 @@ makeBucketJob:
   resources:
     requests:
       memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 ## Use this field to add environment variables relevant to MinIO server. These fields will be passed on to MinIO container(s)
 ## when Chart is deployed


### PR DESCRIPTION
## Description
Split toleration, nodeSelector and affinity from main pods and jobs. This is usefull, for example, when you want to run jobs on different nodes or use podAntiAffinity.
Fixed public monitoring from #13238: added env to deployment and gateway-deployment. Changed var in statefullSet

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
