### PR TITLE
fix: fallback listing on drives that are unformatted, disconnected

### DIFF
--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -209,6 +209,10 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 			}
 		}()
 		o.ID = ""
+
+		if err != nil {
+			logger.LogIf(ctx, fmt.Errorf("Resuming listing from drives failed %w, proceeding to do raw listing", err))
+		}
 	}
 
 	// Do listing in-place.


### PR DESCRIPTION
## Description
fix: fallback listing on drives that are unformatted, disconnected

## Motivation and Context
Make sure to skip the offline disks appropriately.

## How to test this PR?
Nothing should change, generally an optimization. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
