### PR TITLE
Add missing keys to API config help

### DIFF
--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -54,7 +54,7 @@ var (
 		},
 		config.HelpKV{
 			Key:         apiListQuorum,
-			Description: `set the acceptable quorum expected for list operations e.g. "optimal", "reduced", "disk", "strict", defaults to "optimal"`,
+			Description: `set the acceptable quorum expected for list operations e.g. "optimal", "reduced", "disk", "strict", defaults to "strict"`,
 			Optional:    true,
 			Type:        "string",
 		},

--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -35,6 +35,12 @@ var (
 			Type:        "duration",
 		},
 		config.HelpKV{
+			Key:         apiClusterDeadline,
+			Description: `set the deadline for cluster readiness check e.g. "10s"`,
+			Optional:    true,
+			Type:        "duration",
+		},
+		config.HelpKV{
 			Key:         apiCorsAllowOrigin,
 			Description: `set comma separated list of origins allowed for CORS requests e.g. "https://example1.com,https://example2.com"`,
 			Optional:    true,
@@ -45,6 +51,12 @@ var (
 			Description: `set the deadline for API requests on remote transports while proxying between federated instances e.g. "2h"`,
 			Optional:    true,
 			Type:        "duration",
+		},
+		config.HelpKV{
+			Key:         apiListQuorum,
+			Description: `set the acceptable quorum expected for list operations e.g. "optimal", "reduced", "disk", "strict", defaults to "optimal"`,
+			Optional:    true,
+			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         apiReplicationWorkers,


### PR DESCRIPTION
Added missing `apiClusterDeadline` and `apiListQuorum` to API config.HelpKVS structure

## Description
Missing keys in the Help structure

## Motivation and Context
The MinIO Console relies on Help text to to parse key value options. So this is needed for this to work:
https://github.com/minio/console/issues/1062

## How to test this PR?


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
