### PR TITLE
healObjects() should cancel() context before writing to errCh

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1640,8 +1640,8 @@ func (z *erasureServerPools) HealObjects(ctx context.Context, bucket, prefix str
 
 					disks, _ := set.getOnlineDisksWithHealing()
 					if len(disks) == 0 {
-						errCh <- errors.New("HealObjects: No non-healing disks found")
 						cancel()
+						errCh <- errors.New("HealObjects: No non-healing disks found")
 						return
 					}
 
@@ -1669,8 +1669,8 @@ func (z *erasureServerPools) HealObjects(ctx context.Context, bucket, prefix str
 						fivs, err := entry.fileInfoVersions(bucket)
 						if err != nil {
 							if err := healObject(bucket, entry.name, ""); err != nil {
-								errCh <- err
 								cancel()
+								errCh <- err
 								return
 							}
 							return
@@ -1678,8 +1678,8 @@ func (z *erasureServerPools) HealObjects(ctx context.Context, bucket, prefix str
 
 						for _, version := range fivs.Versions {
 							if err := healObject(bucket, version.Name, version.VersionID); err != nil {
-								errCh <- err
 								cancel()
+								errCh <- err
 								return
 							}
 						}
@@ -1718,9 +1718,10 @@ func (z *erasureServerPools) HealObjects(ctx context.Context, bucket, prefix str
 						},
 						finished: nil,
 					}
+
 					if err := listPathRaw(ctx, lopts); err != nil {
-						errCh <- fmt.Errorf("listPathRaw returned %w: opts(%#v)", err, lopts)
 						cancel()
+						errCh <- fmt.Errorf("listPathRaw returned %w: opts(%#v)", err, lopts)
 						return
 					}
 				}()


### PR DESCRIPTION
## Description
healObjects() should cancel() context before writing to errCh

## Motivation and Context
also remove HealObjects() code from dataScanner running another
listing from the data-scanner is super in-efficient and in-fact
this code is redundant since we already attempt to heal all
dangling objects anyways.

## How to test this PR?
Observe a running cluster and check if HealObjects() is called or not 
as this can get very expensive and not useful. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
