### PR TITLE
fix: nil pointer access in warmBackendAzure.Put

### DIFF
--- a/cmd/warm-backend-azure.go
+++ b/cmd/warm-backend-azure.go
@@ -66,7 +66,10 @@ func (az *warmBackendAzure) Put(ctx context.Context, object string, r io.Reader,
 		}
 	}
 	res, err := azblob.UploadStreamToBlockBlob(ctx, r, blobURL, azblob.UploadStreamToBlockBlobOptions{})
-	return remoteVersionID(res.Version()), azureToObjectError(err, az.Bucket, object)
+	if err != nil {
+		return "", azureToObjectError(err, az.Bucket, object)
+	}
+	return remoteVersionID(res.Version()), nil
 }
 
 func (az *warmBackendAzure) Get(ctx context.Context, object string, rv remoteVersionID, opts WarmBackendGetOpts) (r io.ReadCloser, err error) {


### PR DESCRIPTION
## Description
This change avoids fixes possible nil pointer dereference when warmBackendAzure.Put fails.

## Motivation and Context
To fix adding/editing of azure type remote tier.

## How to test this PR?
Try adding/editing azure type remote tier.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
