### PR TITLE
fix ServiceMonitor scheme in helm chart

### DIFF
--- a/helm/minio/templates/servicemonitor.yaml
+++ b/helm/minio/templates/servicemonitor.yaml
@@ -18,8 +18,10 @@ spec:
   endpoints:
     {{- if .Values.tls.enabled }}
     - port: https
+      scheme: https
     {{ else }}
     - port: http
+      scheme: http
     {{- end }}
       path: /minio/v2/metrics/cluster
       {{- if .Values.metrics.serviceMonitor.interval }}


### PR DESCRIPTION
## Description

Added `scheme` to servicemonitor.yaml

## Motivation and Context

ServiceMonitor should be created with `scheme: https` when tls is enabled.

## How to test this PR?

Run `helm install` and check if the ServiceMonitor is created with the scheme.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
