### PR TITLE
Allow only account-key updates for azure tier

### DIFF
--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -146,7 +146,7 @@ func (config *TierConfigMgr) Edit(ctx context.Context, tierName string, creds ma
 		return errTierNotFound
 	}
 
-	newCfg := config.Tiers[tierName]
+	cfg := config.Tiers[tierName]
 	switch tierType {
 	case madmin.S3:
 		if (creds.AccessKey == "" || creds.SecretKey == "") && !creds.AWSRole {
@@ -154,30 +154,29 @@ func (config *TierConfigMgr) Edit(ctx context.Context, tierName string, creds ma
 		}
 		switch {
 		case creds.AWSRole:
-			newCfg.S3.AWSRole = true
+			cfg.S3.AWSRole = true
 		default:
-			newCfg.S3.AccessKey = creds.AccessKey
-			newCfg.S3.SecretKey = creds.SecretKey
+			cfg.S3.AccessKey = creds.AccessKey
+			cfg.S3.SecretKey = creds.SecretKey
 		}
 	case madmin.Azure:
-		if creds.AccessKey == "" || creds.SecretKey == "" {
+		if creds.SecretKey == "" {
 			return errTierInsufficientCreds
 		}
-		newCfg.Azure.AccountName = creds.AccessKey
-		newCfg.Azure.AccountKey = creds.SecretKey
+		cfg.Azure.AccountKey = creds.SecretKey
 
 	case madmin.GCS:
 		if creds.CredsJSON == nil {
 			return errTierInsufficientCreds
 		}
-		newCfg.GCS.Creds = base64.URLEncoding.EncodeToString(creds.CredsJSON)
+		cfg.GCS.Creds = base64.URLEncoding.EncodeToString(creds.CredsJSON)
 	}
 
-	d, err := newWarmBackend(ctx, newCfg)
+	d, err := newWarmBackend(ctx, cfg)
 	if err != nil {
 		return err
 	}
-	config.Tiers[tierName] = newCfg
+	config.Tiers[tierName] = cfg
 	config.drivercache[tierName] = d
 	return nil
 }


### PR DESCRIPTION


## Description
Editing azure remote tier account-name could result in previously transitioned objects becoming inaccessible.
Edit-tier functionality is meant to only update secret key when they are rotated for this IAM user in the respective cloud storage. This changes removes the possibility of updating storage account name for an azure tier.


## Motivation and Context
To avoid user from accidentally changing azure tier's storage account leaving previously transtioned objects inaccessible.

## How to test this PR?
1. add an azure tier
2. edit this tier's account key (note: this requires an updated mc)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
