### PR TITLE
erasure: Set fi.IsLatest when adding a new version

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -950,6 +950,9 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 		}
 	}
 
+	// we are adding a new version to this object under the namespace lock, so this is the latest version.
+	fi.IsLatest = true
+
 	// Success, return object info.
 	return fi.ToObjectInfo(bucket, object), nil
 }

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -134,6 +134,8 @@ func (er erasureObjects) CopyObject(ctx context.Context, srcBucket, srcObject, d
 		return oi, toObjectErr(err, srcBucket, srcObject)
 	}
 
+	// we are adding a new version to this object under the namespace lock, so this is the latest version.
+	fi.IsLatest = true
 	return fi.ToObjectInfo(srcBucket, srcObject), nil
 }
 
@@ -1000,6 +1002,9 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 
 	fi.ReplicationState = opts.PutReplicationState()
 	online = countOnlineDisks(onlineDisks)
+
+	// we are adding a new version to this object under the namespace lock, so this is the latest version.
+	fi.IsLatest = true
 
 	return fi.ToObjectInfo(bucket, object), nil
 }


### PR DESCRIPTION
## Description
This change sets fi.IsLatest to true whenever we add a new version under the namespace lock, like in PutObject, CopyObject and CompleteMultipartUpload. Previously, we would return FileInfo values with IsLatest not indicating current status. E.g bucket lifecycle policy evaluation wouldn't have the complete picture of this version. 

## Motivation and Context
This is required for features that may need current FileInfo state as seen by the object layer.

## How to test this PR?
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
