### PR TITLE
fix: multi-pool setup make sure acquire locks properly

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -443,7 +443,7 @@ func (er erasureObjects) getObjectInfo(ctx context.Context, bucket, object strin
 
 	}
 	objInfo = fi.ToObjectInfo(bucket, object)
-	if !fi.VersionPurgeStatus().Empty() && opts.VersionID != "" {
+	if opts.VersionID != "" && !fi.VersionPurgeStatus().Empty() {
 		// Make sure to return object info to provide extra information.
 		return objInfo, toObjectErr(errMethodNotAllowed, bucket, object)
 	}

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -1492,9 +1492,9 @@ func readXLMetaNoData(r io.Reader, size int64) ([]byte, error) {
 		buf = append(buf, make([]byte, extra)...)
 		_, err := io.ReadFull(r, buf[has:])
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// Returned if we read nothing.
-				return io.ErrUnexpectedEOF
+				return fmt.Errorf("readXLMetaNoData.readMore: %w", io.ErrUnexpectedEOF)
 			}
 			return fmt.Errorf("readXLMetaNoData.readMore: %w", err)
 		}


### PR DESCRIPTION

## Description
fix: multi-pool setup make sure acquire locks properly

## Motivation and Context
This was a regression introduced in '14bb969782'
this has the potential to cause corruption when
there are concurrent overwrites attempting to update
the content on the namespace.

This PR adds a situation where PutObject(), CopyObject()
compete properly for the same locks with NewMultipartUpload()
however it ends up turning off competing locks for the actual
object with GetObject() and DeleteObject() - since they do not
compete due to concurrent I/O on a versioned bucket it can lead
to loss of versions.

This PR fixes this bug with multi-pool setup with replication
that causes corruption of inlined data due to lack of competing
locks in a multi-pool setup.

Instead CompleteMultipartUpload holds the necessary
locks when finishing the transaction, knowing the exact
location of an object to schedule the multipart upload
doesn't need to compete in this manner, a pool id location
for existing object.


## How to test this PR?
fix: multi-pool setup make sure acquire locks properly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes this was introduced in 14bb969782
- [ ] Documentation updated
- [ ] Unit tests added/updated
