### PR TITLE
xl: Avoid empty endpoints

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -349,6 +349,12 @@ func newErasureSets(ctx context.Context, endpoints Endpoints, storageDisks []Sto
 
 	endpointStrings := make([]string, len(endpoints))
 
+	// Fill endpointString with the same order of endpoints passed as
+	// arguments but it will be reordered later according to disks order
+	for i, endpoint := range endpoints {
+		endpointStrings[i] = endpoint.String()
+	}
+
 	// Initialize the erasure sets instance.
 	s := &erasureSets{
 		sets:               make([]*erasureObjects, setCount),


### PR DESCRIPTION
## Description
An endpoint can be empty when a disk is offline or something wrong with
it. Avoid it by filling erasureSets.endpointStrings with values from
arguments.

## Motivation and Context
mc admin info <alias> can return some erreouns data when one disk is offline.
This PR fixes its behavior.

## How to test this PR?
1. Initialize a distributed setup
2. Kill all nodes and then run `chmod 000 /path/to/one/disk`
3. Start the distributed setup again and run `mc admin heal <alias>`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
