### PR TITLE
enable SO_REUSEPORT sockets, allow cleaner reuse of time_waits

### DIFF
--- a/internal/http/listen_nix.go
+++ b/internal/http/listen_nix.go
@@ -27,11 +27,12 @@ import (
 )
 
 var cfg = &tcplisten.Config{
+	ReusePort:   true,
 	DeferAccept: true,
 	FastOpen:    true,
-	// Bump up the soMaxConn value from 128 to 4096 to
+	// Bump up the soMaxConn value from 128 to 65535 to
 	// handle large incoming concurrent requests.
-	Backlog: 4096,
+	Backlog: 65535,
 }
 
 // Unix listener with special TCP options.


### PR DESCRIPTION

## Description
enable SO_REUSEPORT sockets, allow cleaner reuse of time_waits

## Motivation and Context
Refer here https://lwn.net/Articles/542629/

## How to test this PR?
We already use SO_REUSEADDR, we are just enabling the
Linux only option for SO_REUSEPORT

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
