### PR TITLE
use fadvise to control Linux page-cache

### DIFF
--- a/cmd/os-readdir_unix.go
+++ b/cmd/os-readdir_unix.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/minio/minio/internal/disk"
 	"golang.org/x/sys/unix"
 )
 
@@ -110,6 +111,11 @@ func readDirFn(dirPath string, fn func(name string, typ os.FileMode) error) erro
 		}
 		return osErrToFileErr(err)
 	}
+	if err := disk.Fadvise(f, disk.FadvSequential); err != nil {
+		return err
+	}
+
+	defer disk.Fadvise(f, disk.FadvNoReuse)
 	defer f.Close()
 
 	bufp := direntPool.Get().(*[]byte)
@@ -185,6 +191,12 @@ func readDirWithOpts(dirPath string, opts readDirOpts) (entries []string, err er
 	if err != nil {
 		return nil, osErrToFileErr(err)
 	}
+
+	if err := disk.Fadvise(f, disk.FadvSequential); err != nil {
+		return nil, err
+	}
+
+	defer disk.Fadvise(f, disk.FadvNoReuse)
 	defer f.Close()
 
 	bufp := direntPool.Get().(*[]byte)

--- a/internal/disk/fdatasync_linux.go
+++ b/internal/disk/fdatasync_linux.go
@@ -23,6 +23,8 @@ package disk
 import (
 	"os"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // Fdatasync - fdatasync() is similar to fsync(), but does not flush modified metadata
@@ -37,4 +39,16 @@ import (
 // do not require all metadata to be synchronized with the disk.
 func Fdatasync(f *os.File) error {
 	return syscall.Fdatasync(int(f.Fd()))
+}
+
+// fdavise advice constants
+const (
+	FadvSequential = unix.FADV_SEQUENTIAL
+	FadvNoReuse    = unix.FADV_NOREUSE
+)
+
+// Fadvise implements possibility of choosing
+// offset: 0, length: 0
+func Fadvise(f *os.File, advice int) error {
+	return unix.Fadvise(int(f.Fd()), 0, 0, advice)
 }

--- a/internal/disk/fdatasync_unix.go
+++ b/internal/disk/fdatasync_unix.go
@@ -29,3 +29,15 @@ import (
 func Fdatasync(f *os.File) error {
 	return syscall.Fsync(int(f.Fd()))
 }
+
+// fdavise advice constants
+const (
+	FadvSequential = 0
+	FadvNoReuse    = 0
+)
+
+// Fadvise implements possibility of choosing
+// offset: 0, length: 0
+func Fadvise(f *os.File, advice int) error {
+	return nil
+}

--- a/internal/disk/fdatasync_unsupported.go
+++ b/internal/disk/fdatasync_unsupported.go
@@ -28,3 +28,15 @@ import (
 func Fdatasync(f *os.File) error {
 	return nil
 }
+
+// fdavise advice constants
+const (
+	FadvSequential = 0
+	FadvNoReuse    = 0
+)
+
+// Fadvise implements possibility of choosing
+// offset: 0, length: 0
+func Fadvise(f *os.File, advice int) error {
+	return nil
+}

--- a/internal/ioutil/read_file.go
+++ b/internal/ioutil/read_file.go
@@ -20,6 +20,8 @@ package ioutil
 import (
 	"io"
 	"os"
+
+	"github.com/minio/minio/internal/disk"
 )
 
 // ReadFile reads the named file and returns the contents.
@@ -33,6 +35,10 @@ func ReadFile(name string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := disk.Fadvise(f, disk.FadvSequential); err != nil {
+		return nil, err
+	}
+	defer disk.Fadvise(f, disk.FadvNoReuse)
 	defer f.Close()
 	st, err := f.Stat()
 	if err != nil {


### PR DESCRIPTION

## Description
use fadvise to control Linux page-cache

## Motivation and Context
This PR brings two optimizations mainly
for page-cache build-up and how to avoid
getting OOM killed in the process. Although
these memories are reclaimable Linux is not
fast enough to reclaim them as needed on a
very busy system. fadvise is a system call
implemented in Linux to advise page-cache to
avoid overload as we get significant amount
of requests on the server.

- FADV_SEQUENTIAL tells that all I/O from now
  is going to be sequential, allowing for more
  resposive throughput.

- FADV_NOREUSE tells kernel to start removing
  things for this 'fd' from page-cache.

## How to test this PR?
A Linux system and observe the page-cache build-up with various S3 calls. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
