### PR TITLE
Helm - Ingress networking.k8s.io/v1

### DIFF
--- a/helm/minio/templates/_helpers.tpl
+++ b/helm/minio/templates/_helpers.tpl
@@ -70,8 +70,10 @@ Return the appropriate apiVersion for ingress.
 {{- define "minio.ingress.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 
@@ -81,8 +83,10 @@ Return the appropriate apiVersion for console ingress.
 {{- define "minio.consoleIngress.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/minio/templates/console-ingress.yaml
+++ b/helm/minio/templates/console-ingress.yaml
@@ -36,9 +36,18 @@ spec:
     - http:
         paths:
           - path: {{ $ingressPath }}
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $servicePort }}
+          {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
+          {{- end }}
       {{- if . }}
       host: {{ . | quote }}
       {{- end }}

--- a/helm/minio/templates/console-ingress.yaml
+++ b/helm/minio/templates/console-ingress.yaml
@@ -21,6 +21,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.consoleIngress.ingressClassName }}
+  ingressClassName: {{ .Values.consoleIngress.ingressClassName }}
+{{- end }}
 {{- if .Values.consoleIngress.tls }}
   tls:
   {{- range .Values.consoleIngress.tls }}

--- a/helm/minio/templates/ingress.yaml
+++ b/helm/minio/templates/ingress.yaml
@@ -21,6 +21,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/helm/minio/templates/ingress.yaml
+++ b/helm/minio/templates/ingress.yaml
@@ -36,9 +36,18 @@ spec:
     - http:
         paths:
           - path: {{ $ingressPath }}
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $servicePort }}
+          {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
+          {{- end }}
       {{- if . }}
       host: {{ . | quote }}
       {{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -169,6 +169,7 @@ service:
 
 ingress:
   enabled: false
+  # ingressClassName: ""
   labels: {}
     # node-role.kubernetes.io/ingress: platform
 
@@ -197,6 +198,7 @@ consoleService:
 
 consoleIngress:
   enabled: false
+  # ingressClassName: ""
   labels: {}
     # node-role.kubernetes.io/ingress: platform
 


### PR DESCRIPTION
## Description
Hi, I updated the Ingress resources of the helm chart & added the newer networking.k8s.io/v1 for kubernetes versions >= 1.19.


## Motivation and Context
The beta ingress API is deprecated and is removed in Kubernetes 1.22+ https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#what-to-do 
This change is required to deploy the chart on the newest Kubernetes Version.  
In addition the ingressClassName attribute was added

## How to test this PR?
It can be tested by deploying on Kubernetes Cluster with k8s version < 1.19 (to ensure the changes don't break anything) and a cluster running k8s 1.22

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
