### PR TITLE
feat: create service accounts with same claims as parent

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1171,8 +1171,7 @@ type newServiceAccountOpts struct {
 	accessKey     string
 	secretKey     string
 
-	// LDAP username
-	ldapUsername string
+	claims map[string]interface{}
 }
 
 // NewServiceAccount - create a new service account
@@ -1260,9 +1259,12 @@ func (sys *IAMSys) NewServiceAccount(ctx context.Context, parentUser string, gro
 		m[iamPolicyClaimNameSA()] = "inherited-policy"
 	}
 
-	// For LDAP service account, save the ldap username in the metadata.
-	if opts.ldapUsername != "" {
-		m[ldapUserN] = opts.ldapUsername
+	// Add all the necessary claims for the service accounts.
+	for k, v := range opts.claims {
+		_, ok := m[k]
+		if !ok {
+			m[k] = v
+		}
 	}
 
 	var (


### PR DESCRIPTION

## Description
feat: create service accounts with same claims as parent

## Motivation and Context
allow claims from LDAP/OIDC to be inherited to service
accounts as well to allow dynamic policies.

fixes #13325


## How to test this PR?
As per #13325


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
