### PR TITLE
fix: do not make TLS strict based on serverName

### DIFF
--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -319,9 +319,8 @@ func (l *Config) Connect() (ldapConn *ldap.Conn, err error) {
 		return nil, errors.New("LDAP is not configured")
 	}
 
-	serverHost, _, err := net.SplitHostPort(l.ServerAddr)
+	_, _, err = net.SplitHostPort(l.ServerAddr)
 	if err != nil {
-		serverHost = l.ServerAddr
 		// User default LDAP port if none specified "636"
 		l.ServerAddr = net.JoinHostPort(l.ServerAddr, "636")
 	}
@@ -333,7 +332,6 @@ func (l *Config) Connect() (ldapConn *ldap.Conn, err error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: l.tlsSkipVerify,
 		RootCAs:            l.rootCAs,
-		ServerName:         serverHost,
 	}
 
 	if l.serverStartTLS {


### PR DESCRIPTION
## Description
fix: do not make TLS strict based on serverName

## Motivation and Context
LDAP TLS dialer shouldn't be strict with ServerName, there 
maybe many certs talking to common DNS endpoint it is
better to allow Dialer to choose appropriate public cert.

## How to test this PR?
Nothing special 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
