### PR TITLE
allow disabling strict sha256 validation with some broken clients

### DIFF
--- a/cmd/fs-v1-multipart_test.go
+++ b/cmd/fs-v1-multipart_test.go
@@ -58,9 +58,9 @@ func TestFSCleanupMultipartUploadsInRoutine(t *testing.T) {
 	}, obj.SetDriveCounts())
 
 	defer func() {
-		globalAPIConfig = apiConfig{
-			listQuorum: 3,
-		}
+		globalAPIConfig.init(api.Config{
+			ListQuorum: "optimal",
+		}, obj.SetDriveCounts())
 	}()
 
 	var cleanupWg sync.WaitGroup

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -587,6 +587,10 @@ func serverMain(ctx *cli.Context) {
 		logStartupMessage(color.RedBold(msg))
 	}
 
+	if !globalCLIContext.StrictS3Compat {
+		logStartupMessage(color.RedBold("WARNING: Strict AWS S3 compatible incoming PUT, POST content payload validation is turned off, caution is advised do not use in production"))
+	}
+
 	if globalBrowserEnabled {
 		globalConsoleSrv, err = initConsoleServer()
 		if err != nil {

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -50,7 +50,7 @@ const (
 	EnvAPICorsAllowOrigin          = "MINIO_API_CORS_ALLOW_ORIGIN"
 	EnvAPIRemoteTransportDeadline  = "MINIO_API_REMOTE_TRANSPORT_DEADLINE"
 	EnvAPIListQuorum               = "MINIO_API_LIST_QUORUM"
-	EnvAPISecureCiphers            = "MINIO_API_SECURE_CIPHERS"
+	EnvAPISecureCiphers            = "MINIO_API_SECURE_CIPHERS" // default "on"
 	EnvAPIReplicationWorkers       = "MINIO_API_REPLICATION_WORKERS"
 	EnvAPIReplicationFailedWorkers = "MINIO_API_REPLICATION_FAILED_WORKERS"
 	EnvAPITransitionWorkers        = "MINIO_API_TRANSITION_WORKERS"


### PR DESCRIPTION


## Description
allow disabling strict sha256 validation with some broken clients

## Motivation and Context
with some broken clients allow non-strict validation
of sha256 when ContentLength > 0, it has been found in
the wild some applications that need this behavior. This
shall be only allowed if `--no-compat` is used.

## How to test this PR?
Nothing special, there are few proprietary clients that
have this behavior.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
