### PR TITLE
fix: disallow invalid x-amz-security-token for root credentials

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1817,7 +1817,7 @@ func (sys *IAMSys) GetUser(accessKey string) (cred auth.Credentials, ok bool) {
 
 	if ok && cred.IsValid() {
 		if cred.IsServiceAccount() || cred.IsTemp() {
-			policies, err := sys.policyDBGet(cred.ParentUser, false)
+			policies, err := sys.policyDBGet(cred.AccessKey, false)
 			if err != nil {
 				// Reject if the policy map for user doesn't exist anymore.
 				logger.LogIf(context.Background(), fmt.Errorf("'%s' user does not have a policy present", cred.ParentUser))

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -767,11 +767,12 @@ func (sts *stsAPIHandlers) AssumeRoleWithCertificate(w http.ResponseWriter, r *h
 	parentUser := "tls:" + certificate.Subject.CommonName
 
 	tmpCredentials, err := auth.GetNewCredentialsWithMetadata(map[string]interface{}{
-		expClaim:    time.Now().UTC().Add(expiry).Unix(),
-		parentClaim: parentUser,
-		subClaim:    certificate.Subject.CommonName,
-		audClaim:    certificate.Subject.Organization,
-		issClaim:    certificate.Issuer.CommonName,
+		expClaim:                   time.Now().UTC().Add(expiry).Unix(),
+		parentClaim:                parentUser,
+		subClaim:                   certificate.Subject.CommonName,
+		audClaim:                   certificate.Subject.Organization,
+		issClaim:                   certificate.Issuer.CommonName,
+		iamPolicyClaimNameOpenID(): certificate.Subject.CommonName,
 	}, globalActiveCred.SecretKey)
 	if err != nil {
 		writeSTSErrorResponse(ctx, w, true, ErrSTSInternalError, err)


### PR DESCRIPTION


## Description
fix: disallow invalid x-amz-security-token for root credentials

## Motivation and Context
fixes #13335

This was a regression added in #12947 when this part of the
code was refactored to avoid privilege issues with service
accounts with session policy.

## How to test this PR?
Just do 
```
MC_HOST_local=http://minio:minio123:tk@localhost:9000/ mc ls local/
```

This shall not fail with the master branch but it should with this fix. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #12947
- [ ] Documentation updated
- [ ] Unit tests added/updated
