### PR TITLE
fix: crash in hard quota enforcement

### DIFF
--- a/cmd/bucket-quota.go
+++ b/cmd/bucket-quota.go
@@ -89,7 +89,7 @@ func (sys *BucketQuotaSys) check(ctx context.Context, bucket string, size int64)
 			return err
 		}
 
-		dui := v.(madmin.DataUsageInfo)
+		dui := v.(DataUsageInfo)
 
 		bui, ok := dui.BucketsUsage[bucket]
 		if !ok {

--- a/cmd/bucket-quota.go
+++ b/cmd/bucket-quota.go
@@ -89,7 +89,10 @@ func (sys *BucketQuotaSys) check(ctx context.Context, bucket string, size int64)
 			return err
 		}
 
-		dui := v.(DataUsageInfo)
+		dui, ok := v.(DataUsageInfo)
+		if !ok {
+			return fmt.Errorf("internal error: Unexpected DUI data type: %T", v)
+		}
 
 		bui, ok := dui.BucketsUsage[bucket]
 		if !ok {


### PR DESCRIPTION
## Description
fix: crash in hard quota enforcement

## Motivation and Context
due to data structure change after multi-site 
replication, hard quota was broken due to
data structure change.

## How to test this PR?
Just set 
```
~ mc admin bucket quota alias/bucket --hard 19M
```

And then try to upload a 20MiB object using `mc cp --disable-multipart` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduce in multi-site replication.
- [ ] Documentation updated
- [ ] Unit tests added/updated
