### PR TITLE
fix: enable AssumeRoleWithCertificate API only when asked

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -496,6 +496,10 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 		logger.LogIf(ctx, fmt.Errorf("Unable to initialize X.509/TLS STS API: %w", err))
 	}
 
+	if globalSTSTLSConfig.InsecureSkipVerify {
+		logger.Info("CRITICAL: enabling %s is not recommended in a production environment", xtls.EnvIdentityTLSSkipVerify)
+	}
+
 	globalOpenIDConfig, err = openid.LookupConfig(s[config.IdentityOpenIDSubSys][config.Default],
 		NewGatewayHTTPTransport(), xhttp.DrainBody)
 	if err != nil {

--- a/docs/sts/tls.md
+++ b/docs/sts/tls.md
@@ -16,9 +16,9 @@ ARGS:
 MINIO_IDENTITY_TLS_SKIP_VERIFY  (on|off)    trust client certificates without verification. Defaults to "off" (verify)
 ```
 
-The MinIO TLS STS API is enabled by default. However, it can be completely *disabled* by setting:
+The MinIO TLS STS API is disabled by default. However, it can be *enabled* by setting environment variable:
 ```
-MINIO_IDENTITY_TLS_ENABLE=off
+export MINIO_IDENTITY_TLS_ENABLE=on
 ```
 
 ## Example
@@ -101,6 +101,11 @@ Now, the STS certificate-based authentication happens in 4 steps:
 The returned credentials expiry after a certain period of time that can be configured via `&DurationSeconds=3600`. By default, the STS credentials are valid for 1 hour. The minimum expiration allowed is 15 minutes.
 
 Further, the temp. S3 credentials will never out-live the client certificate. For example, if the `MINIO_IDENTITY_TLS_STS_EXPIRY` is 7 days but the certificate itself is only valid for the next 3 days, then MinIO will return S3 credentials that are valid for 3 days only.
+
+## Caveat
+
+*Applications that use direct S3 API will work fine, however interactive users uploading content using (when POSTing to the presigned URL an app generates) a popup becomes visible on browser to provide client certs, you would have to manually cancel and continue. This may be annoying to use but there is no workaround for now.*
+
 
 ## Explore Further
 - [MinIO Admin Complete Guide](https://docs.min.io/docs/minio-admin-complete-guide.html)

--- a/internal/config/identity/tls/config.go
+++ b/internal/config/identity/tls/config.go
@@ -23,16 +23,15 @@ import (
 
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config"
-	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/env"
 )
 
 const (
-	// EnvEnabled is an environment variable that controls whether the X.509
+	// EnvIdentityTLSEnabled is an environment variable that controls whether the X.509
 	// TLS STS API is enabled. By default, if not set, it is enabled.
-	EnvEnabled = "MINIO_IDENTITY_TLS_ENABLE"
+	EnvIdentityTLSEnabled = "MINIO_IDENTITY_TLS_ENABLE"
 
-	// EnvSkipVerify is an environment variable that controls whether
+	// EnvIdentityTLSSkipVerify is an environment variable that controls whether
 	// MinIO verifies the client certificate present by the client
 	// when requesting temp. credentials.
 	// By default, MinIO always verify the client certificate.
@@ -41,7 +40,7 @@ const (
 	// when debugging or testing a setup since it allows arbitrary
 	// clients to obtain temp. credentials with arbitrary policy
 	// permissions - including admin permissions.
-	EnvSkipVerify = "MINIO_IDENTITY_TLS_SKIP_VERIFY"
+	EnvIdentityTLSSkipVerify = "MINIO_IDENTITY_TLS_SKIP_VERIFY"
 )
 
 // Config contains the STS TLS configuration for generating temp.
@@ -86,14 +85,11 @@ func Lookup(kvs config.KVS) (Config, error) {
 	if err := config.CheckValidKeys(config.IdentityTLSSubSys, kvs, DefaultKVS); err != nil {
 		return Config{}, err
 	}
-	insecureSkipVerify, err := config.ParseBool(env.Get(EnvSkipVerify, kvs.Get(skipVerify)))
+	insecureSkipVerify, err := config.ParseBool(env.Get(EnvIdentityTLSSkipVerify, kvs.Get(skipVerify)))
 	if err != nil {
 		return Config{}, err
 	}
-	if insecureSkipVerify {
-		logger.Info("CRITICAL: enabling MINIO_IDENTITY_TLS_SKIP_VERIFY is not recommended in a production environment")
-	}
-	enabled, err := config.ParseBool(env.Get(EnvEnabled, config.EnableOn))
+	enabled, err := config.ParseBool(env.Get(EnvIdentityTLSEnabled, ""))
 	if err != nil {
 		return Config{}, err
 	}


### PR DESCRIPTION


## Description
fix: enable AssumeRoleWithCertificate API only when asked

## Motivation and Context
This is a breaking change but we need to do this to avoid
issues discussed in #13409 based on discussions from #13371

fixes #13371
fixes #13409

## How to test this PR?
As per #13371 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
