### PR TITLE
Update link to helm charts

### DIFF
--- a/docs/orchestration/kubernetes/README.md
+++ b/docs/orchestration/kubernetes/README.md
@@ -8,7 +8,7 @@ There are multiple options to deploy MinIO on Kubernetes:
 
 - MinIO-Operator: Operator offers seamless way to create and update highly available distributed MinIO clusters. Refer [MinIO Operator documentation](https://github.com/minio/minio-operator/blob/master/README.md) for more details.
 
-- Helm Chart: MinIO Helm Chart offers customizable and easy MinIO deployment with a single command. Refer [MinIO Helm Chart documentation](https://github.com/minio/charts) for more details.
+- Helm Chart: MinIO Helm Chart offers customizable and easy MinIO deployment with a single command. Refer [MinIO Helm Chart documentation](https://github.com/minio/operator/tree/master/helm/minio-operator) for more details.
 
 ## Monitoring MinIO in Kubernetes
 


### PR DESCRIPTION
## Description
The Kubernetes documentation links to helm charts that were deprecated in April 2021.
This updates the link in documentation to point at the new operator based chart.

## Motivation and Context
The documentation links to outdated information

## How to test this PR?
None - Documentation Fix

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated