### PR TITLE
Update mysql key name length, character set and collation

### DIFF
--- a/internal/event/target/mysql.go
+++ b/internal/event/target/mysql.go
@@ -37,8 +37,10 @@ import (
 
 const (
 	mysqlTableExists          = `SELECT 1 FROM %s;`
-	mysqlCreateNamespaceTable = `CREATE TABLE %s (key_name VARCHAR(2048), value JSON, PRIMARY KEY (key_name));`
-	mysqlCreateAccessTable    = `CREATE TABLE %s (event_time DATETIME NOT NULL, event_data JSON);`
+	mysqlCreateNamespaceTable = `CREATE TABLE %s (key_name VARCHAR(4096), value JSON, PRIMARY KEY (key_name))
+                                       CHARACTER SET = utf8mb4 COLLATE = utf8mb4_bin ROW_FORMAT = Dynamic;`
+	mysqlCreateAccessTable = `CREATE TABLE %s (event_time DATETIME NOT NULL, event_data JSON)
+                                    ROW_FORMAT = Dynamic;`
 
 	mysqlUpdateRow = `INSERT INTO %s (key_name, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value=VALUES(value);`
 	mysqlDeleteRow = `DELETE FROM %s WHERE key_name = ?;`


### PR DESCRIPTION
## Description
Fixes #13227


## Motivation and Context

Increase allowed key length (mysql does not permit VARCHAR type without a length), and specify utf8 character set encoding as this is the encoding appropriate for s3 object keys which are utf8 encoded.

Also optimize table storage with row_format specifier.

## How to test this PR?
According to:
https://docs.min.io/docs/minio-bucket-notification-guide.html#MySQL

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
