### PR TITLE
fix: do not overwrite error on fallback.

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1077,7 +1077,7 @@ func (s *xlStorage) ReadVersion(ctx context.Context, volume, path, versionID str
 		buf, err = s.readMetadata(ctx, pathJoin(volumeDir, path, xlStorageFormatFile))
 		if err != nil {
 			if osIsNotExist(err) {
-				if err = Access(volumeDir); err != nil && osIsNotExist(err) {
+				if aerr := Access(volumeDir); aerr != nil && osIsNotExist(aerr) {
 					return fi, errVolumeNotFound
 				}
 			}


### PR DESCRIPTION


## Description
fix: do not overwrite errors on fallback.

## Motivation and Context
older content was returning '404' upon headObject()
due to swallowing of the error, make sure the
error in handling independently.

fixes #13397
## How to test this PR?
As per #13397 upgrade from an older release from say 

```
~ ./minio.RELEASE.2019-12-30T05-45-39Z server /tmp/xl{1...4}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
