### PR TITLE
Locker: Improve Refresh speed

### DIFF
--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -354,6 +354,7 @@ func (l *localLocker) expireOldLocks(interval time.Duration) {
 				if time.Since(lri.TimeLastRefresh) > interval {
 					l.removeEntry(lri.Name, dsync.LockArgs{Owner: lri.Owner, UID: lri.UID}, &lris)
 					found = true
+					break
 				}
 			}
 			// We did not find any more to expire.

--- a/cmd/lock-rest-server.go
+++ b/cmd/lock-rest-server.go
@@ -34,7 +34,7 @@ const (
 	lockMaintenanceInterval = 1 * time.Minute
 
 	// Lock validity duration
-	lockValidityDuration = 20 * time.Second
+	lockValidityDuration = 1 * time.Minute
 )
 
 // To abstract a node over network.

--- a/cmd/lock-rest-server_test.go
+++ b/cmd/lock-rest-server_test.go
@@ -44,13 +44,12 @@ func BenchmarkLockArgs(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	req := &http.Request{
-		Body: ioutil.NopCloser(bytes.NewReader(argBytes)),
-	}
+	req := &http.Request{}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		req.Body = ioutil.NopCloser(bytes.NewReader(argBytes))
 		getLockArgs(req)
 	}
 }
@@ -64,12 +63,12 @@ func BenchmarkLockArgsOld(b *testing.B) {
 
 	req := &http.Request{
 		Form: values,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`obj.txt`))),
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		req.Body = ioutil.NopCloser(bytes.NewReader([]byte(`obj.txt`)))
 		getLockArgsOld(req)
 	}
 }


### PR DESCRIPTION
## Description

Refresh was doing a linear scan of all locked resources. This was adding up to significant delays in locking on high load systems with long running requests.

Add a secondary index for O(log(n)) UID -> resource lookups. Multiple resources are stored in consecutive strings.

Bonus fixes:

 * On multiple Unlock entries unlock the write locks we can.
 * Fix `expireOldLocks` skipping checks on entry after expiring one.
 * Return fast on canTakeUnlock/canTakeLock.
 * Prealloc some places.
 * Expire locks after 1-2 minutes instead of 20s -> 1m20s.

## Motivation and Context

High mutex contention systems with long running requests.

## How to test this PR?

Should be covered by mint tests.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
