### PR TITLE
fix: ReadFileStream should return an error when size mismatches

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -313,19 +313,28 @@ func (er erasureObjects) getObjectWithFileInfo(ctx context.Context, bucket, obje
 			// - attempt a heal to successfully heal them for future calls.
 			if written == partLength {
 				var scan madmin.HealScanMode
-				if errors.Is(err, errFileNotFound) {
+				switch {
+				case errors.Is(err, errFileNotFound):
 					scan = madmin.HealNormalScan
-					logger.Info("Healing required, attempting to heal missing shards for %s", pathJoin(bucket, object, fi.VersionID))
-				} else if errors.Is(err, errFileCorrupt) {
+					logger.Info("Healing required, triggering async heal missing shards for %s", pathJoin(bucket, object, fi.VersionID))
+				case errors.Is(err, errFileCorrupt):
 					scan = madmin.HealDeepScan
-					logger.Info("Healing required, attempting to heal bitrot for %s", pathJoin(bucket, object, fi.VersionID))
+					logger.Info("Healing required, triggering async heal bitrot for %s", pathJoin(bucket, object, fi.VersionID))
 				}
-				if scan == madmin.HealNormalScan || scan == madmin.HealDeepScan {
+				switch scan {
+				case madmin.HealNormalScan:
+					fallthrough
+				case madmin.HealDeepScan:
 					healOnce.Do(func() {
 						if _, healing := er.getOnlineDisksWithHealing(); !healing {
 							go healObject(bucket, object, fi.VersionID, scan)
 						}
 					})
+					// Healing is triggered and we have written
+					// successfully the content to client for
+					// the specific part, we should `nil` this error
+					// and proceed forward, instead of throwing errors.
+					err = nil
 				}
 			}
 			if err != nil {

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -322,9 +322,7 @@ func (er erasureObjects) getObjectWithFileInfo(ctx context.Context, bucket, obje
 					logger.Info("Healing required, triggering async heal bitrot for %s", pathJoin(bucket, object, fi.VersionID))
 				}
 				switch scan {
-				case madmin.HealNormalScan:
-					fallthrough
-				case madmin.HealDeepScan:
+				case madmin.HealNormalScan, madmin.HealDeepScan:
 					healOnce.Do(func() {
 						if _, healing := er.getOnlineDisksWithHealing(); !healing {
 							go healObject(bucket, object, fi.VersionID, scan)

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1454,6 +1454,13 @@ func (s *xlStorage) ReadFileStream(ctx context.Context, volume, path string, off
 		return nil, errIsNotRegular
 	}
 
+	if st.Size() < offset+length {
+		// Expected size cannot be satisfied for
+		// requested offset and length
+		file.Close()
+		return nil, errFileCorrupt
+	}
+
 	alignment := offset%xioutil.DirectioAlignSize == 0
 	if !alignment {
 		if err = disk.DisableDirectIO(file); err != nil {


### PR DESCRIPTION

## Description
fix: ReadFileStream should return an error when size mismatches

## Motivation and Context
offset+length should match the Size() of the individual parts
as 'errFileCorrupt', to trigger healing of individual parts,
do not error out prematurely when healing such bitrot's upon
successful parts being written to the client.

another issue this PR fixes is to not return and error to
the client if we have just triggered a heal on a specific
part of the object, instead continue to read all the content
and let the heal happen asynchronously later.

## How to test this PR?
```
~ minio server /tmp/xl{1...4} --console-address ":9001"      
```

```
# upload a big file such as 256MiB
~ >/tmp/xl3/testbucket/bigfile/b9d6ce79-e7f0-45ad-b5a6-807985082492/part.1
```

Empty the part file, you can notice that this part is never healed in-line during
GetObject call since 0byte is not considered an unexpected situation at the
lower layers, we should catch this as an error - as this PR fixes for both
local and remote situations.
                                   
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
