### PR TITLE
Fix s3zip not returning data

### DIFF
--- a/cmd/s3-zip-handlers.go
+++ b/cmd/s3-zip-handlers.go
@@ -173,7 +173,8 @@ func (api objectAPIHandlers) getObjectInArchiveFileHandler(ctx context.Context, 
 	var rc io.ReadCloser
 
 	if file.UncompressedSize64 > 0 {
-		rs := &HTTPRangeSpec{Start: file.Offset, End: file.Offset + int64(file.UncompressedSize64) - 1}
+		// We do not know where the file ends, but the returned reader only returns UncompressedSize.
+		rs := &HTTPRangeSpec{Start: file.Offset, End: -1}
 		gr, err := objectAPI.GetObjectNInfo(ctx, bucket, zipPath, rs, nil, readLock, opts)
 		if err != nil {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/minio/sha256-simd v1.0.0
 	github.com/minio/simdjson-go v0.2.1
 	github.com/minio/sio v0.3.0
-	github.com/minio/zipindex v0.2.0
+	github.com/minio/zipindex v0.2.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/montanaflynn/stats v0.6.6
 	github.com/nats-io/nats-server/v2 v2.3.2

--- a/go.sum
+++ b/go.sum
@@ -1054,8 +1054,8 @@ github.com/minio/simdjson-go v0.2.1/go.mod h1:JPUSkRykfSPS+AhO0YPA1h0l5vY7NqrF4z
 github.com/minio/sio v0.2.1/go.mod h1:8b0yPp2avGThviy/+OCJBI6OMpvxoUuiLvE6F1lebhw=
 github.com/minio/sio v0.3.0 h1:syEFBewzOMOYVzSTFpp1MqpSZk8rUNbz8VIIc+PNzus=
 github.com/minio/sio v0.3.0/go.mod h1:8b0yPp2avGThviy/+OCJBI6OMpvxoUuiLvE6F1lebhw=
-github.com/minio/zipindex v0.2.0 h1:iqgIhPkYnZ6fNd6q8trtJc8+mtKJNFTaxXlNw4n0We8=
-github.com/minio/zipindex v0.2.0/go.mod h1:s+b/Qyw9JtSEnYfaM4ASOWNO2xGnXCfzQ+SWAzVkVZc=
+github.com/minio/zipindex v0.2.1 h1:A37vDQJ7Uyp4RHpQEEpintgiIxg0t3npH2CWjLT//u4=
+github.com/minio/zipindex v0.2.1/go.mod h1:s+b/Qyw9JtSEnYfaM4ASOWNO2xGnXCfzQ+SWAzVkVZc=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
## Description

We do not reliably know the length of compressed data, including headers.

Request until the end-of-stream. Results will still be properly truncated.

Fixes #13441

`zipindex` upgrade fixes CRC errors being written (not returned to users though).

## How to test this PR?

Mint test: https://github.com/minio/minio-go/pull/1570

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
