### PR TITLE
re-use rand.New() do not repeat allocate.

### DIFF
--- a/internal/dsync/drwmutex_test.go
+++ b/internal/dsync/drwmutex_test.go
@@ -306,6 +306,9 @@ func TestRUnlockPanic2(t *testing.T) {
 
 // Borrowed from rwmutex_test.go
 func benchmarkRWMutex(b *testing.B, localWork, writeRatio int) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
 	rwm := NewDRWMutex(ds, "test")
 	b.RunParallel(func(pb *testing.PB) {
 		foo := 0

--- a/internal/dsync/dsync_test.go
+++ b/internal/dsync/dsync_test.go
@@ -325,6 +325,9 @@ func TestMutex(t *testing.T) {
 }
 
 func BenchmarkMutexUncontended(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
 	type PaddedMutex struct {
 		*DRWMutex
 	}
@@ -338,6 +341,9 @@ func BenchmarkMutexUncontended(b *testing.B) {
 }
 
 func benchmarkMutex(b *testing.B, slack, work bool) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
 	mu := NewDRWMutex(ds, "")
 	if slack {
 		b.SetParallelism(10)
@@ -375,6 +381,9 @@ func BenchmarkMutexWorkSlack(b *testing.B) {
 }
 
 func BenchmarkMutexNoSpin(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
 	// This benchmark models a situation where spinning in the mutex should be
 	// non-profitable and allows to confirm that spinning does not do harm.
 	// To achieve this we create excess of goroutines most of which do local work.
@@ -409,6 +418,9 @@ func BenchmarkMutexNoSpin(b *testing.B) {
 }
 
 func BenchmarkMutexSpin(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
 	// This benchmark models a situation where spinning in the mutex should be
 	// profitable. To achieve this we create a goroutine per-proc.
 	// These goroutines access considerable amount of local data so that

--- a/internal/dsync/locked_rand.go
+++ b/internal/dsync/locked_rand.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dsync
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// lockedRandSource provides protected rand source, implements rand.Source interface.
+type lockedRandSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+// Int63 returns a non-negative pseudo-random 63-bit integer as an int64.
+func (r *lockedRandSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+// Seed uses the provided seed value to initialize the generator to a
+// deterministic state.
+func (r *lockedRandSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
+}


### PR DESCRIPTION

## Description
re-use rand.New() do not repeat allocate.

## Motivation and Context
also simplify readerLocks to be just like
writeLocks, DRWMutex() is never shared
and there are order guarantees that need
for such a thing to work for RLock's

## How to test this PR?
Nothing special everything works as expected
we are simply reducing memory allocations for
rand.New() and readerLocks()

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
