### PR TITLE
fix: keep a lookup table for constant idx conversions

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -39,7 +39,7 @@ const (
 	// RFC3339 a subset of the ISO8601 timestamp format. e.g 2014-04-29T18:30:38Z
 	iso8601TimeFormat = "2006-01-02T15:04:05.000Z" // Reply date format with nanosecond precision.
 	maxObjectList     = 1000                       // Limit number of objects in a listObjectsResponse/listObjectsVersionsResponse.
-	maxDeleteList     = 10000                      // Limit number of objects deleted in a delete call.
+	maxDeleteList     = 1000                       // Limit number of objects deleted in a delete call.
 	maxUploadsList    = 10000                      // Limit number of uploads in a listUploadsResponse.
 	maxPartsList      = 10000                      // Limit number of parts in a listPartsResponse.
 )

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -421,6 +421,14 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 		return
 	}
 
+	// AWS S3 returns error for number of objects > 1000
+	if len(deleteObjects.Objects) > maxDeleteList {
+		apiErr := errorCodes.ToAPIErr(ErrMalformedXML)
+		apiErr.Description = fmt.Sprintf("%s: input cannot have number of objects -> %d", apiErr.Description, maxDeleteList)
+		writeErrorResponse(ctx, w, apiErr, r.URL)
+		return
+	}
+
 	// Convert object name delete objects if it has `/` in the beginning.
 	for i := range deleteObjects.Objects {
 		deleteObjects.Objects[i].ObjectName = trimLeadingSlash(deleteObjects.Objects[i].ObjectName)


### PR DESCRIPTION

## Description
fix: keep a lookup table for constant idx conversions

## Motivation and Context
Any resources limit is limited to maxDeleteList()
for bulk locks, make sure we generate lookup table
based on this to avoid string allocations.

## How to test this PR?
Nothing should change, regular tests should cover it. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
