### PR TITLE
tls: Avoid 3DES ciphers

### DIFF
--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -179,8 +179,14 @@ func NewServer(addrs []string, handler http.Handler, getCert certs.GetCertificat
 		}
 
 		if secureCiphers || fips.Enabled {
+			// Hardened ciphers
 			tlsConfig.CipherSuites = fips.CipherSuitesTLS()
 			tlsConfig.CurvePreferences = fips.EllipticCurvesTLS()
+		} else {
+			// Default ciphers while excluding those with security issues
+			for _, cipher := range tls.CipherSuites() {
+				tlsConfig.CipherSuites = append(tlsConfig.CipherSuites, cipher.ID)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
3DES is enabled by default in Golang, this commit will use
tls.CipherSuites() which returns all ciphers excluding those with
security issues, such as 3DES.


## Motivation and Context
Some security scanners tools flag 3DES being enabled in MinIO

## How to test this PR?
Trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
