### PR TITLE
fix: server in shutdown should return 503 instead of 403

### DIFF
--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -90,7 +90,7 @@ func (srv *Server) Start(ctx context.Context) (err error) {
 		if atomic.LoadUint32(&srv.inShutdown) != 0 {
 			// To indicate disable keep-alives
 			w.Header().Set("Connection", "close")
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte(http.ErrServerClosed.Error()))
 			w.(http.Flusher).Flush()
 			return


### PR DESCRIPTION

## Description
fix: server in shutdown should return 503 instead of 403

## Motivation and Context
various situations where the client is retrying the request
server going through shutdown might incorrectly send 403
which is a non-retriable error, this PR allows for clients
when they retry an attempt to go to another healthy pod
or server in a distributed cluster - assuming it is a properly
load-balanced setup.

## How to test this PR?
Nothing special just have a retrying client, when the server
is going down you shall see new connection attempts are
receiving 403 which is wrong and should be changed to 503
instead.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
