### PR TITLE
replication: Fix replica stats during crawling

### DIFF
--- a/cmd/data-usage_test.go
+++ b/cmd/data-usage_test.go
@@ -615,6 +615,11 @@ func TestDataUsageCacheSerialize(t *testing.T) {
 	}
 	for wkey, wval := range want.Cache {
 		gotv := got.Cache[wkey]
+		// FIXME: the following block is needed because msgp:tuple will
+		// deserializes a nil map to a initialized empty map
+		if len(gotv.ReplicationStats.Targets) == 0 {
+			gotv.ReplicationStats.Targets = nil
+		}
 		if !equalAsJSON(gotv, wval) {
 			t.Errorf("deserialize mismatch, key %v\nwant: %#v\ngot:  %#v", wkey, wval, gotv)
 		}

--- a/cmd/data-usage_test.go
+++ b/cmd/data-usage_test.go
@@ -615,11 +615,6 @@ func TestDataUsageCacheSerialize(t *testing.T) {
 	}
 	for wkey, wval := range want.Cache {
 		gotv := got.Cache[wkey]
-		// FIXME: the following block is needed because msgp:tuple will
-		// deserializes a nil map to a initialized empty map
-		if len(gotv.ReplicationStats.Targets) == 0 {
-			gotv.ReplicationStats.Targets = nil
-		}
 		if !equalAsJSON(gotv, wval) {
 			t.Errorf("deserialize mismatch, key %v\nwant: %#v\ngot:  %#v", wkey, wval, gotv)
 		}

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1459,6 +1459,12 @@ func getBucketUsageMetrics() MetricsGroup {
 					VariableLabels: map[string]string{"bucket": bucket},
 				})
 
+				metrics = append(metrics, Metric{
+					Description:    getBucketRepReceivedBytesMD(),
+					Value:          float64(stats.ReplicaSize),
+					VariableLabels: map[string]string{"bucket": bucket},
+				})
+
 				if stats.hasReplicationUsage() {
 					for arn, stat := range stats.Stats {
 						metrics = append(metrics, Metric{
@@ -1469,11 +1475,6 @@ func getBucketUsageMetrics() MetricsGroup {
 						metrics = append(metrics, Metric{
 							Description:    getBucketRepSentBytesMD(),
 							Value:          float64(stat.ReplicatedSize),
-							VariableLabels: map[string]string{"bucket": bucket, "targetArn": arn},
-						})
-						metrics = append(metrics, Metric{
-							Description:    getBucketRepReceivedBytesMD(),
-							Value:          float64(stat.ReplicaSize),
 							VariableLabels: map[string]string{"bucket": bucket, "targetArn": arn},
 						})
 						metrics = append(metrics, Metric{

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -456,8 +456,8 @@ func getLatestReplicationStats(bucket string, u BucketUsageInfo) (s BucketReplic
 
 	// add initial usage stat to cluster stats
 	usageStat := globalReplicationStats.GetInitialUsage(bucket)
+	totReplicaSize += usageStat.ReplicaSize
 	if usageStat.Stats != nil {
-		totReplicaSize += usageStat.ReplicaSize
 		for arn, stat := range usageStat.Stats {
 			st := stats[arn]
 			if st == nil {


### PR DESCRIPTION
Also show replica stats with an ARN in prometheous output.

## Description
Also show replica stats with an ARN in prometheous output.


## Motivation and Context
Fix bytes received replica stats in prometheus in mc replicate status 

## How to test this PR?
Create two sites and enable bucket replication from site 1 to site 2 and then run `mc replicate status <alias> bucket`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
