### PR TITLE
disk location and command line arg might not be same

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -415,9 +415,6 @@ func newErasureSets(ctx context.Context, endpoints Endpoints, storageDisks []Sto
 			if err != nil {
 				continue
 			}
-			if m != i || n != j {
-				return nil, fmt.Errorf("found a disk in an unexpected location, pool: %d, found (set=%d, disk=%d) expected (set=%d, disk=%d): %s(%s)", poolIdx, m, n, i, j, disk, diskID)
-			}
 			disk.SetDiskLoc(s.poolIndex, m, n)
 			s.endpointStrings[m*setDriveCount+n] = disk.String()
 			s.erasureDisks[m][n] = disk


### PR DESCRIPTION
## Description
disk location and command-line arg might not be same

## Motivation and Context
For example in k8s environments a command line such as

```
minio server https://server{1...4}/disk
```

can change its position from `server1` while was the first
disk might get scheduled on another node that has a local
disk that originally belonged to first node in the arg.

remove this check to ensure that server behaves properly
in these situations, since we are supposed to handle these
situations.

## How to test this PR?
Deploy repeatedly in k8s environments you will see this problem
if the command line changes, i.e first disk from the first time may
report itself as invalid and fail - after an upgrade. We should handle
this situation properly. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes in #13326
- [ ] Documentation updated
- [ ] Unit tests added/updated
