### PR TITLE
add env variable to control if upgarde parity number

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -54,4 +54,6 @@ const (
 	EnvEndpoints = "MINIO_ENDPOINTS" // legacy
 	EnvWorm      = "MINIO_WORM"      // legacy
 	EnvRegion    = "MINIO_REGION"    // legacy
+
+	EnvUpgradeParityEnable = "MINIO_UPGRADE_PARITY_ENABLE"
 )


### PR DESCRIPTION
## Description
add env variable to control if upgarde parity number when some disks offline
https://github.com/minio/minio/discussions/13508
## Motivation and Context
1.In our scenario, we transfer large data from old oss to MinIO(more than 1PB each time), each transfer will last for several days. if some disk goes offline during this period, we may not be able to find this problem immediately, then it will cause some disks of that erasure set waste a lot of space(10% used more than other disks). 
2.sometimes we could need stable parity number for our MinIO cluster, because it's controllable.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides  #speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
