### PR TITLE
readAllData: Reuse small file buffers

### DIFF
--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -501,6 +501,8 @@ func (s *storageRESTServer) ReadAllHandler(w http.ResponseWriter, r *http.Reques
 		s.writeErrorResponse(w, err)
 		return
 	}
+	// Reuse after return.
+	defer metaDataPoolPut(buf)
 	w.Header().Set(xhttp.ContentLength, strconv.Itoa(len(buf)))
 	w.Write(buf)
 	w.(http.Flusher).Flush()
@@ -540,6 +542,7 @@ func (s *storageRESTServer) ReadFileHandler(w http.ResponseWriter, r *http.Reque
 		verifier = NewBitrotVerifier(BitrotAlgorithmFromString(vars[storageRESTBitrotAlgo]), hash)
 	}
 	buf := make([]byte, length)
+	defer metaDataPoolPut(buf) // Reuse if we can.
 	_, err = s.storage.ReadFile(r.Context(), volume, filePath, int64(offset), buf, verifier)
 	if err != nil {
 		s.writeErrorResponse(w, err)

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1241,6 +1241,9 @@ func (s *xlStorage) readAllData(volumeDir string, filePath string) (buf []byte, 
 		buf, err = ioutil.ReadAll(r)
 		return buf, osErrToFileErr(err)
 	}
+	if stat.IsDir() {
+		return nil, errFileNotFound
+	}
 
 	// Read into appropriate buffer.
 	sz := stat.Size()

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -859,6 +859,8 @@ func (s *xlStorage) DeleteVersion(ctx context.Context, volume, path string, fi F
 			// Create a new xl.meta with a delete marker in it
 			return s.WriteMetadata(ctx, volume, path, fi)
 		}
+		metaDataPoolPut(buf) // Never used, return it
+
 		buf, err = s.ReadAll(ctx, volume, pathJoin(path, xlStorageFormatFileV1))
 		if err != nil {
 			if err == errFileNotFound && fi.VersionID != "" {
@@ -1232,12 +1234,26 @@ func (s *xlStorage) readAllData(volumeDir string, filePath string) (buf []byte, 
 		SmallFile: true,
 	}
 	defer r.Close()
-	buf, err = ioutil.ReadAll(r)
+
+	// Get size for precise allocation.
+	stat, err := f.Stat()
 	if err != nil {
-		err = osErrToFileErr(err)
+		buf, err = ioutil.ReadAll(r)
+		return buf, osErrToFileErr(err)
 	}
 
-	return buf, err
+	// Read into appropriate buffer.
+	sz := stat.Size()
+	if sz <= metaDataReadDefault {
+		buf = metaDataPoolGet()
+		buf = buf[:sz]
+	} else {
+		buf = make([]byte, sz)
+	}
+	// Read file...
+	_, err = io.ReadFull(r, buf)
+
+	return buf, osErrToFileErr(err)
 }
 
 // ReadAll reads from r until an error or EOF and returns the data it read.

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -443,7 +443,8 @@ func TestXLStorageReadAll(t *testing.T) {
 	for i, testCase := range testCases {
 		dataRead, err = xlStorage.ReadAll(context.Background(), testCase.volume, testCase.path)
 		if err != testCase.err {
-			t.Fatalf("TestXLStorage %d: Expected err \"%s\", got err \"%s\"", i+1, testCase.err, err)
+			t.Errorf("TestXLStorage %d: Expected err \"%v\", got err \"%v\"", i+1, testCase.err, err)
+			continue
 		}
 		if err == nil {
 			if string(dataRead) != string([]byte("Hello, World")) {


### PR DESCRIPTION
## Description

(Re)use small buffers for small readAllData operations.

## Motivation and Context

Decrease memory allocations for UpdateMetadata for instance.

## How to test this PR?

Load test PutObjectRetention.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
