### PR TITLE
avoid atomics for self contained reader/writers

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -354,11 +354,11 @@ func setHTTPStatsHandler(h http.Handler) http.Handler {
 		h.ServeHTTP(meteredResponse, r)
 
 		if strings.HasPrefix(r.URL.Path, minioReservedBucketPath) {
-			globalConnStats.incInputBytes(meteredRequest.BytesCount())
-			globalConnStats.incOutputBytes(meteredResponse.BytesCount())
+			globalConnStats.incInputBytes(meteredRequest.BytesRead())
+			globalConnStats.incOutputBytes(meteredResponse.BytesWritten())
 		} else {
-			globalConnStats.incS3InputBytes(meteredRequest.BytesCount())
-			globalConnStats.incS3OutputBytes(meteredResponse.BytesCount())
+			globalConnStats.incS3InputBytes(meteredRequest.BytesRead())
+			globalConnStats.incS3OutputBytes(meteredResponse.BytesWritten())
 		}
 	})
 }

--- a/internal/http/stats/http-traffic-recorder.go
+++ b/internal/http/stats/http-traffic-recorder.go
@@ -20,7 +20,6 @@ package stats
 import (
 	"io"
 	"net/http"
-	"sync/atomic"
 )
 
 // IncomingTrafficMeter counts the incoming bytes from the underlying request.Body.
@@ -32,14 +31,14 @@ type IncomingTrafficMeter struct {
 // Read calls the underlying Read and counts the transferred bytes.
 func (r *IncomingTrafficMeter) Read(p []byte) (n int, err error) {
 	n, err = r.ReadCloser.Read(p)
-	atomic.AddInt64(&r.countBytes, int64(n))
+	r.countBytes += int64(n)
 
 	return n, err
 }
 
-// BytesCount returns the number of transferred bytes
-func (r *IncomingTrafficMeter) BytesCount() int64 {
-	return atomic.LoadInt64(&r.countBytes)
+// BytesRead returns the number of transferred bytes
+func (r *IncomingTrafficMeter) BytesRead() int64 {
+	return r.countBytes
 }
 
 // OutgoingTrafficMeter counts the outgoing bytes through the responseWriter.
@@ -52,7 +51,7 @@ type OutgoingTrafficMeter struct {
 // Write calls the underlying write and counts the output bytes
 func (w *OutgoingTrafficMeter) Write(p []byte) (n int, err error) {
 	n, err = w.ResponseWriter.Write(p)
-	atomic.AddInt64(&w.countBytes, int64(n))
+	w.countBytes += int64(n)
 	return n, err
 }
 
@@ -61,7 +60,7 @@ func (w *OutgoingTrafficMeter) Flush() {
 	w.ResponseWriter.(http.Flusher).Flush()
 }
 
-// BytesCount returns the number of transferred bytes
-func (w *OutgoingTrafficMeter) BytesCount() int64 {
-	return atomic.LoadInt64(&w.countBytes)
+// BytesWritten returns the number of transferred bytes
+func (w *OutgoingTrafficMeter) BytesWritten() int64 {
+	return w.countBytes
 }


### PR DESCRIPTION
## Description
avoid atomics for self contained reader/writers

## Motivation and Context
read/writers are not concurrent in handlers
and self contained - no need to use atomics 
on them. 

avoids unnecessary contentions where it's not
required.

## How to test this PR?
Nothing special, nothing changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
