### PR TITLE
reduce the number of middleware handlers

### DIFF
--- a/cmd/crossdomain-xml-handler.go
+++ b/cmd/crossdomain-xml-handler.go
@@ -25,29 +25,21 @@ const crossDomainXML = `<?xml version="1.0"?><!DOCTYPE cross-domain-policy SYSTE
 // Standard path where an app would find cross domain policy information.
 const crossDomainXMLEntity = "/crossdomain.xml"
 
-// Cross domain policy implements http.Handler interface, implementing a custom ServerHTTP.
-type crossDomainPolicy struct {
-	handler http.Handler
-}
-
 // A cross-domain policy file is an XML document that grants a web client, such as Adobe Flash Player
 // or Adobe Acrobat (though not necessarily limited to these), permission to handle data across domains.
 // When clients request content hosted on a particular source domain and that content make requests
 // directed towards a domain other than its own, the remote domain needs to host a cross-domain
 // policy file that grants access to the source domain, allowing the client to continue the transaction.
 func setCrossDomainPolicy(h http.Handler) http.Handler {
-	return crossDomainPolicy{handler: h}
-}
-
-func (c crossDomainPolicy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Look for 'crossdomain.xml' in the incoming request.
-	switch r.URL.Path {
-	case crossDomainXMLEntity:
-		// Write the standard cross domain policy xml.
-		w.Write([]byte(crossDomainXML))
-		// Request completed, no need to serve to other handlers.
-		return
-	}
-	// Continue to serve the request further.
-	c.handler.ServeHTTP(w, r)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Look for 'crossdomain.xml' in the incoming request.
+		switch r.URL.Path {
+		case crossDomainXMLEntity:
+			// Write the standard cross domain policy xml.
+			w.Write([]byte(crossDomainXML))
+			// Request completed, no need to serve to other handlers.
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
 }

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -269,7 +269,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		addrs = append(addrs, globalMinioAddr)
 	}
 
-	httpServer := xhttp.NewServer(addrs, criticalErrorHandler{corsHandler(router)}, getCert)
+	httpServer := xhttp.NewServer(addrs, setCriticalErrorHandler(corsHandler(router)), getCert)
 	httpServer.BaseContext = func(listener net.Listener) context.Context {
 		return GlobalContext
 	}

--- a/cmd/generic-handlers_test.go
+++ b/cmd/generic-handlers_test.go
@@ -155,7 +155,7 @@ func TestSSETLSHandler(t *testing.T) {
 		r.Header = test.Header
 		r.URL = test.URL
 
-		h := setSSETLSHandler(okHandler)
+		h := setRequestValidityHandler(okHandler)
 		h.ServeHTTP(w, r)
 
 		switch {

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -28,6 +28,10 @@ import (
 
 const unavailable = "offline"
 
+func shouldProxy() bool {
+	return newObjectLayerFn() == nil
+}
+
 // ClusterCheckHandler returns if the server is ready for requests.
 func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 	if globalIsGateway {

--- a/cmd/routers.go
+++ b/cmd/routers.go
@@ -40,41 +40,24 @@ func registerDistErasureRouters(router *mux.Router, endpointServerPools Endpoint
 
 // List of some generic handlers which are applied for all incoming requests.
 var globalHandlers = []mux.MiddlewareFunc{
-	// filters HTTP headers which are treated as metadata and are reserved
-	// for internal use only.
-	filterReservedMetadata,
-	// Enforce rules specific for TLS requests
-	setSSETLSHandler,
 	// Auth handler verifies incoming authorization headers and
 	// routes them accordingly. Client receives a HTTP error for
 	// invalid/unsupported signatures.
-	setAuthHandler,
+	//
 	// Validates all incoming requests to have a valid date header.
-	setTimeValidityHandler,
-	// Validates if incoming request is for restricted buckets.
-	setReservedBucketHandler,
+	setAuthHandler,
 	// Redirect some pre-defined browser request paths to a static location prefix.
 	setBrowserRedirectHandler,
 	// Adds 'crossdomain.xml' policy handler to serve legacy flash clients.
 	setCrossDomainPolicy,
-	// Limits all header sizes to a maximum fixed limit
-	setRequestHeaderSizeLimitHandler,
-	// Limits all requests size to a maximum fixed limit
-	setRequestSizeLimitHandler,
+	// Limits all body and header sizes to a maximum fixed limit
+	setRequestLimitHandler,
 	// Network statistics
 	setHTTPStatsHandler,
 	// Validate all the incoming requests.
 	setRequestValidityHandler,
-	// Forward path style requests to actual host in a bucket federated setup.
-	setBucketForwardingHandler,
-	// set HTTP security headers such as Content-Security-Policy.
-	addSecurityHeaders,
 	// set x-amz-request-id header.
 	addCustomHeaders,
-	// add redirect handler to redirect
-	// requests when object layer is not
-	// initialized.
-	setRedirectHandler,
 	// Add new handlers here.
 }
 
@@ -104,6 +87,10 @@ func configureServerHandler(endpointServerPools EndpointServerPools) (http.Handl
 	// Add API router
 	registerAPIRouter(router)
 
+	// Enable bucket forwarding handler only if bucket federation is enabled.
+	if globalDNSConfig != nil && globalBucketFederation {
+		globalHandlers = append(globalHandlers, setBucketForwardingHandler)
+	}
 	router.Use(globalHandlers...)
 
 	return router, nil

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -511,7 +511,7 @@ func serverMain(ctx *cli.Context) {
 		addrs = append(addrs, globalMinioAddr)
 	}
 
-	httpServer := xhttp.NewServer(addrs, criticalErrorHandler{corsHandler(handler)}, getCert)
+	httpServer := xhttp.NewServer(addrs, setCriticalErrorHandler(corsHandler(handler)), getCert)
 	httpServer.BaseContext = func(listener net.Listener) context.Context {
 		return GlobalContext
 	}

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -334,7 +334,7 @@ func UnstartedTestServer(t TestErrHandler, instanceType string) TestServer {
 	}
 
 	// Run TestServer.
-	testServer.Server = httptest.NewUnstartedServer(criticalErrorHandler{corsHandler(httpHandler)})
+	testServer.Server = httptest.NewUnstartedServer(setCriticalErrorHandler(corsHandler(httpHandler)))
 
 	globalObjLayerMutex.Lock()
 	globalObjectAPI = objLayer


### PR DESCRIPTION

## Description
reduce the number of middleware handlers

## Motivation and Context
- combine similar-looking functionalities into single
  handlers, and remove unnecessary proxying of the
  requests at the handler layer.

- remove bucket forwarding handler as part of the 
  default setup adds it only if bucket federation is enabled.

Improvements observed for 1kiB object writes and reads

```
-------------------
Operation: PUT
Duration: 53s -> 51s
* Average: +3.78% (+0.4 MiB/s) throughput, +3.78% (+424.8) obj/s
* Fastest: +3.44% (+0.4 MiB/s) throughput, +3.44% (+393.4) obj/s
* 50% Median: +3.87% (+0.4 MiB/s) throughput, +3.87% (+435.9) obj/s
```

```
-------------------
Operation: GET
Operations: 4538555 -> 4595804
* Average: +1.26% (+0.2 MiB/s) throughput, +1.26% (+190.2) obj/s
* Fastest: +4.67% (+0.7 MiB/s) throughput, +4.67% (+739.8) obj/s
* 50% Median: +1.15% (+0.2 MiB/s) throughput, +1.15% (+173.9) obj/s
```

## How to test this PR?
Nothing should change in terms of functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
