### PR TITLE
Remove IOPS autotuning and simplify autotune code

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -952,11 +952,6 @@ func (a adminAPIHandlers) SpeedtestHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	throughputSize := size
-	iopsSize := size
-
-	if autotune {
-		iopsSize = 4 * humanize.KiByte
-	}
 
 	keepAliveTicker := time.NewTicker(500 * time.Millisecond)
 	defer keepAliveTicker.Stop()
@@ -982,7 +977,7 @@ func (a adminAPIHandlers) SpeedtestHandler(w http.ResponseWriter, r *http.Reques
 		}
 	}()
 
-	result, err := speedTest(ctx, throughputSize, iopsSize, concurrent, duration, autotune)
+	result, err := speedTest(ctx, throughputSize, concurrent, duration, autotune)
 	if <-endBlankRepliesCh != nil {
 		return
 	}


### PR DESCRIPTION
## Description
Remove IOPS autotuning as discussed.

Two additional changes:
1) Focus autotune loop only on GET workload. Doing PUT and GET autotuning makes the code complicated. Sometimes the loop seems to never end at all causing issues.
2) If the GET throughput is within 2.5% of the value of the previous run, break the loop since the performance is reaching peak.

## Motivation and Context
Improvements for speedtest.

## How to test this PR?
mc admin speedtest ALIAS

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
