### PR TITLE
API: Disable rate limiting when MINIO_API_REQUESTS_MAX=0

### DIFF
--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -63,7 +63,7 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 	}
 
 	var apiRequestsMaxPerNode int
-	if cfg.RequestsMax <= 0 {
+	if cfg.RequestsMax < 0 {
 		var maxMem uint64
 		memStats, err := mem.VirtualMemory()
 		if err != nil {
@@ -90,7 +90,9 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 		}
 	}
 
-	if cap(t.requestsPool) < apiRequestsMaxPerNode {
+	if apiRequestsMaxPerNode == 0 {
+		t.requestsPool = nil
+	} else if cap(t.requestsPool) < apiRequestsMaxPerNode {
 		// Only replace if needed.
 		// Existing requests will use the previous limit,
 		// but new requests will use the new limit.


### PR DESCRIPTION
## Description

When 

```bash
export MINIO_API_REQUESTS_MAX=0
```

is used (and in fact by default) rate limiting should be disabled.

## Motivation and Context

See #13561 

## How to test this PR?

Debug MinIO and look at the values of `globalAPIConfig` or print them out using additional logging.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
