### PR TITLE
Fix race in TestComputeActions test

### DIFF
--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -394,17 +394,17 @@ func TestComputeActions(t *testing.T) {
 		{
 			inputConfig:    `<BucketLifecycleConfiguration><Rule><Filter></Filter><Status>Enabled</Status><Transition><Days>0</Days><StorageClass>S3TIER-1</StorageClass></Transition></Rule></BucketLifecycleConfiguration>`,
 			objectName:     "foodir/fooobject",
-			objectModTime:  time.Now().UTC(), // Created now
+			objectModTime:  time.Now().Add(-1 * time.Nanosecond).UTC(), // Created now
 			expectedAction: TransitionAction,
 		},
 		// Should transition immediately when NoncurrentVersion Transition days is zero
 		{
 			inputConfig:            `<BucketLifecycleConfiguration><Rule><Filter></Filter><Status>Enabled</Status><NoncurrentVersionTransition><NoncurrentDays>0</NoncurrentDays><StorageClass>S3TIER-1</StorageClass></NoncurrentVersionTransition></Rule></BucketLifecycleConfiguration>`,
 			objectName:             "foodir/fooobject",
-			objectModTime:          time.Now().UTC(), // Created now
+			objectModTime:          time.Now().Add(-1 * time.Nanosecond).UTC(), // Created now
 			expectedAction:         TransitionVersionAction,
 			isNoncurrent:           true,
-			objectSuccessorModTime: time.Now().UTC(),
+			objectSuccessorModTime: time.Now().Add(-1 * time.Nanosecond).UTC(),
 			versionID:              uuid.New().String(),
 		},
 	}


### PR DESCRIPTION
## Description

=== RUN   TestComputeActions/#22
    lifecycle_test.go:429: Expected action: `TransitionAction`, got: `NoneAction`
=== RUN   TestComputeActions/#23
    lifecycle_test.go:429: Expected action: `TransitionVersionAction`, got: `NoneAction`
--- FAIL: TestComputeActions (0.00s)
## Motivation and Context

Not able to repro this with `go test -race -v -run TestComputeActions`. However this test is brittle and failing because ModTime (set to current time UTC) and UTC time compared [here](https://github.com/minio/minio/blob/master/internal/bucket/lifecycle/lifecycle.go#L340) are identical. 

## How to test this PR?
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
