### PR TITLE
fix: can not continue heal object from last healed when restart server

### DIFF
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -180,7 +180,7 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []BucketIn
 		// If we resume to the same bucket, forward to last known item.
 		if tracker.Bucket != "" {
 			if tracker.Bucket == bucket.Name {
-				forwardTo = tracker.Bucket
+				forwardTo = tracker.Object
 			} else {
 				// Reset to where last bucket ended if resuming.
 				tracker.resume()


### PR DESCRIPTION

## Description
fix: can not continue heal object from last healed when restart server

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
