### PR TITLE
claim exp should be integer

### DIFF
--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -287,8 +287,7 @@ func updateClaimsExpiry(dsecs string, claims map[string]interface{}) error {
 		defaultExpiryDuration = time.Unix(expAt, 0).UTC().Sub(time.Now().UTC())
 	} // else honor the specified expiry duration.
 
-	expiry := time.Now().UTC().Add(defaultExpiryDuration).Unix()
-	claims["exp"] = strconv.FormatInt(expiry, 10) // update with new expiry.
+	claims["exp"] = time.Now().UTC().Add(defaultExpiryDuration).Unix() // update with new expiry.
 	return nil
 }
 


### PR DESCRIPTION
## Description
Updated expiration claim should be numeric as per https://openid.net/specs/openid-connect-core-1_0.html#IDToken.

## Motivation and Context
Currently it's not possible to login to console with Oauth. Console unable to parse generated STS token since 'exp' claim encoded as string and it treated as expired.

## How to test this PR?
Try to login with Oauth

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
