### PR TITLE
LDAP: Fix user DN filtering that causes some unnecessary logs

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -286,7 +286,7 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer, etcdClient *etc
 				}
 			}
 		}()
-	case globalLDAPConfig.EnabledWithLookupBind():
+	case globalLDAPConfig.Enabled:
 		go func() {
 			ticker := time.NewTicker(sys.iamRefreshInterval)
 			defer ticker.Stop()
@@ -843,7 +843,7 @@ func (sys *IAMSys) purgeExpiredCredentialsForLDAP(ctx context.Context) {
 		allDistNames = append(allDistNames, parentUser)
 	}
 
-	expiredUsers, err := globalLDAPConfig.GetNonEligibleUserDistNames(parentUsers)
+	expiredUsers, err := globalLDAPConfig.GetNonEligibleUserDistNames(allDistNames)
 	if err != nil {
 		// Log and return on error - perhaps it'll work the next time.
 		logger.LogIf(GlobalContext, err)


### PR DESCRIPTION
- Also remove unnecessary `isUsingLookupBind` field in LDAP struct

## Description

Fix unnecessary log printed with site replication and in some other situations:

```
API: SYSTEM()
Time: 11:56:11 PDT 11/04/2021
DeploymentID: f502e40b-470d-4601-88a6-e371e6a7bd4f
Error: LDAP Result Code 34 "Invalid DN Syntax": invalid DN (*ldap.Error)
       2: cmd/iam.go:850:cmd.(*IAMSys).purgeExpiredCredentialsForLDAP()
       1: cmd/iam.go:296:cmd.(*IAMSys).Init.func2()
```

## Motivation and Context

Found during some testing.

## How to test this PR?

No behavior change except for removing this log.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a minor regression (ecd54b4cba1bbda0744b0013324a746882bde246) 
- [ ] Documentation updated
- [ ] Unit tests added/updated
