### PR TITLE
fix: ignore disks that are available but not writable

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -698,22 +698,6 @@ func initErasureMetaVolumesInLocalDisks(storageDisks []StorageAPI, formats []*fo
 	return nil
 }
 
-// saveUnformattedFormat - populates `format.json` on unformatted disks.
-// also adds `.healing.bin` on the disks which are being actively healed.
-func saveUnformattedFormat(ctx context.Context, storageDisks []StorageAPI, formats []*formatErasureV3) error {
-	for index, format := range formats {
-		if format == nil {
-			continue
-		}
-		if storageDisks[index] != nil {
-			if err := saveFormatErasure(storageDisks[index], format, true); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // saveFormatErasureAll - populates `format.json` on disks in its order.
 func saveFormatErasureAll(ctx context.Context, storageDisks []StorageAPI, formats []*formatErasureV3) error {
 	g := errgroup.WithNErrs(len(storageDisks))


### PR DESCRIPTION


## Description
fix: ignore disks that are available but not writable

## Motivation and Context
This is to allow replacing drives while some drives
while available are not writable,

## How to test this PR?
In a 4 disk setup change the permissions of one drive
after a successful format change and make sure that
reading return "errUnformattedDisk" while the write
fails.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
