### PR TITLE
do not flush if Write() failed

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -756,13 +756,17 @@ func (a adminAPIHandlers) HealHandler(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(200)
 				}
 				// Send whitespace and keep connection open
-				w.Write([]byte(" "))
+				if _, err := w.Write([]byte(" ")); err != nil {
+					return
+				}
 				w.(http.Flusher).Flush()
 			case hr := <-respCh:
 				switch hr.apiErr {
 				case noError:
 					if started {
-						w.Write(hr.respBytes)
+						if _, err := w.Write(hr.respBytes); err != nil {
+							return
+						}
 						w.(http.Flusher).Flush()
 					} else {
 						writeSuccessResponseJSON(w, hr.respBytes)
@@ -787,7 +791,9 @@ func (a adminAPIHandlers) HealHandler(w http.ResponseWriter, r *http.Request) {
 						w.Header().Set(xhttp.ContentType, string(mimeJSON))
 						w.WriteHeader(hr.apiErr.HTTPStatusCode)
 					}
-					w.Write(errorRespJSON)
+					if _, err := w.Write(errorRespJSON); err != nil {
+						return
+					}
 					w.(http.Flusher).Flush()
 				}
 				break forLoop
@@ -1194,10 +1200,10 @@ func (a adminAPIHandlers) ConsoleLogHandler(w http.ResponseWriter, r *http.Reque
 				if err := enc.Encode(log); err != nil {
 					return
 				}
-			}
-			if len(logCh) == 0 {
-				// Flush if nothing is queued
-				w.(http.Flusher).Flush()
+				if len(logCh) == 0 {
+					// Flush if nothing is queued
+					w.(http.Flusher).Flush()
+				}
 			}
 		case <-keepAliveTicker.C:
 			if len(logCh) > 0 {
@@ -1863,15 +1869,19 @@ func (a adminAPIHandlers) HealthInfoHandler(w http.ResponseWriter, r *http.Reque
 			if !ok {
 				return
 			}
-			logger.LogIf(ctx, enc.Encode(oinfo))
-			w.(http.Flusher).Flush()
+			if err := enc.Encode(oinfo); err != nil {
+				return
+			}
+			if len(healthInfoCh) == 0 {
+				// Flush if nothing is queued
+				w.(http.Flusher).Flush()
+			}
 		case <-ticker.C:
 			if _, err := w.Write([]byte(" ")); err != nil {
 				return
 			}
 			w.(http.Flusher).Flush()
 		case <-deadlinedCtx.Done():
-			w.(http.Flusher).Flush()
 			return
 		}
 	}
@@ -1940,10 +1950,12 @@ func (a adminAPIHandlers) BandwidthMonitorHandler(w http.ResponseWriter, r *http
 				return
 			}
 			if err := enc.Encode(report); err != nil {
-				writeErrorResponseJSON(ctx, w, toAPIError(ctx, err), r.URL)
 				return
 			}
-			w.(http.Flusher).Flush()
+			if len(reportCh) == 0 {
+				// Flush if nothing is queued
+				w.(http.Flusher).Flush()
+			}
 		case <-keepAliveTicker.C:
 			if _, err := w.Write([]byte(" ")); err != nil {
 				return

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/klauspost/compress/gzhttp"
+	"github.com/minio/console/restapi"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/wildcard"
@@ -39,6 +40,18 @@ func newHTTPServerFn() *xhttp.Server {
 func setHTTPServer(h *xhttp.Server) {
 	globalObjLayerMutex.Lock()
 	globalHTTPServer = h
+	globalObjLayerMutex.Unlock()
+}
+
+func newConsoleServerFn() *restapi.Server {
+	globalObjLayerMutex.RLock()
+	defer globalObjLayerMutex.RUnlock()
+	return globalConsoleSrv
+}
+
+func setConsoleSrv(srv *restapi.Server) {
+	globalObjLayerMutex.Lock()
+	globalConsoleSrv = srv
 	globalObjLayerMutex.Unlock()
 }
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3060,14 +3060,17 @@ func sendWhiteSpace(w http.ResponseWriter) <-chan bool {
 			case <-ticker.C:
 				// Write header if not written yet.
 				if !headerWritten {
-					w.Write([]byte(xml.Header))
-					headerWritten = true
+					_, err := w.Write([]byte(xml.Header))
+					headerWritten = err == nil
 				}
 
 				// Once header is written keep writing empty spaces
 				// which are ignored by client SDK XML parsers.
 				// This occurs when server takes long time to completeMultiPartUpload()
-				w.Write([]byte(" "))
+				_, err := w.Write([]byte(" "))
+				if err != nil {
+					return
+				}
 				w.(http.Flusher).Flush()
 			case doneCh <- headerWritten:
 				ticker.Stop()

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -821,7 +821,6 @@ func (s *peerRESTServer) SignalServiceHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	signal := serviceSignal(si)
-	defer w.(http.Flusher).Flush()
 	switch signal {
 	case serviceRestart:
 		globalServiceSignalCh <- signal
@@ -902,9 +901,6 @@ func (s *peerRESTServer) ListenHandler(w http.ResponseWriter, r *http.Request) {
 
 	rulesMap := event.NewRulesMap(eventNames, pattern, event.TargetID{ID: mustGetUUID()})
 
-	w.WriteHeader(http.StatusOK)
-	w.(http.Flusher).Flush()
-
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 
@@ -975,9 +971,6 @@ func (s *peerRESTServer) TraceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	w.(http.Flusher).Flush()
-
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 
@@ -1047,7 +1040,6 @@ func (s *peerRESTServer) ConsoleLogHandler(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Connection", "close")
 	w.WriteHeader(http.StatusOK)
-	w.(http.Flusher).Flush()
 
 	doneCh := make(chan struct{})
 	defer close(doneCh)
@@ -1091,8 +1083,6 @@ func (s *peerRESTServer) GetBandwidth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bucketsString := r.Form.Get("buckets")
-	w.WriteHeader(http.StatusOK)
-	w.(http.Flusher).Flush()
 
 	doneCh := make(chan struct{})
 	defer close(doneCh)
@@ -1112,8 +1102,6 @@ func (s *peerRESTServer) GetPeerMetrics(w http.ResponseWriter, r *http.Request) 
 	if !s.IsValid(w, r) {
 		s.writeErrorResponse(w, errors.New("invalid request"))
 	}
-	w.WriteHeader(http.StatusOK)
-	w.(http.Flusher).Flush()
 
 	doneCh := make(chan struct{})
 	defer close(doneCh)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -609,13 +609,15 @@ func serverMain(ctx *cli.Context) {
 	}
 
 	if globalBrowserEnabled {
-		globalConsoleSrv, err = initConsoleServer()
+		srv, err := initConsoleServer()
 		if err != nil {
 			logger.FatalIf(err, "Unable to initialize console service")
 		}
 
+		setConsoleSrv(srv)
+
 		go func() {
-			logger.FatalIf(globalConsoleSrv.Serve(), "Unable to initialize console server")
+			logger.FatalIf(newConsoleServerFn().Serve(), "Unable to initialize console server")
 		}()
 	}
 

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -66,8 +66,8 @@ func handleSignals() {
 			logger.LogIf(context.Background(), oerr)
 		}
 
-		if globalConsoleSrv != nil {
-			logger.LogIf(context.Background(), globalConsoleSrv.Shutdown())
+		if srv := newConsoleServerFn(); srv != nil {
+			logger.LogIf(context.Background(), srv.Shutdown())
 		}
 
 		return (err == nil && oerr == nil)

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -760,39 +760,51 @@ func keepHTTPReqResponseAlive(w http.ResponseWriter, r *http.Request) (resp func
 	doneCh := make(chan error)
 	ctx := r.Context()
 	go func() {
+		defer close(doneCh)
 		// Wait for body to be read.
 		select {
 		case <-ctx.Done():
+			return
 		case <-bodyDoneCh:
-		case err := <-doneCh:
+		case err, ok := <-doneCh:
+			if !ok {
+				return
+			}
 			if err != nil {
-				w.Write([]byte{1})
+				_, werr := w.Write([]byte{1})
+				if werr != nil {
+					return
+				}
 				w.Write([]byte(err.Error()))
 			} else {
 				w.Write([]byte{0})
 			}
-			close(doneCh)
 			return
 		}
-		defer close(doneCh)
 		// Initiate ticker after body has been read.
 		ticker := time.NewTicker(time.Second * 10)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
 				// Response not ready, write a filler byte.
-				_, err := w.Write([]byte{32})
-				if err == nil {
-					w.(http.Flusher).Flush()
+				if _, err := w.Write([]byte{32}); err != nil {
+					return
 				}
-			case err := <-doneCh:
+				w.(http.Flusher).Flush()
+			case err, ok := <-doneCh:
+				if !ok {
+					return
+				}
 				if err != nil {
-					w.Write([]byte{1})
+					_, werr := w.Write([]byte{1})
+					if werr != nil {
+						return
+					}
 					w.Write([]byte(err.Error()))
 				} else {
 					w.Write([]byte{0})
 				}
-				ticker.Stop()
 				return
 			}
 		}
@@ -827,22 +839,25 @@ func keepHTTPResponseAlive(w http.ResponseWriter) func(error) {
 	go func() {
 		defer close(doneCh)
 		ticker := time.NewTicker(time.Second * 10)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
 				// Response not ready, write a filler byte.
-				_, err := w.Write([]byte{32})
-				if err == nil {
-					w.(http.Flusher).Flush()
+				if _, err := w.Write([]byte{32}); err != nil {
+					return
 				}
+				w.(http.Flusher).Flush()
 			case err := <-doneCh:
 				if err != nil {
-					w.Write([]byte{1})
+					_, werr := w.Write([]byte{1})
+					if werr != nil {
+						return
+					}
 					w.Write([]byte(err.Error()))
 				} else {
 					w.Write([]byte{0})
 				}
-				ticker.Stop()
 				return
 			}
 		}
@@ -936,20 +951,24 @@ func streamHTTPResponse(w http.ResponseWriter) *httpStreamResponse {
 	blockCh := make(chan []byte)
 	h := httpStreamResponse{done: doneCh, block: blockCh}
 	go func() {
+		defer close(doneCh)
 		ticker := time.NewTicker(time.Second * 10)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
 				// Response not ready, write a filler byte.
 				_, err := w.Write([]byte{32})
-				if err == nil {
-					w.(http.Flusher).Flush()
-				}
-			case err := <-doneCh:
-				ticker.Stop()
-				defer close(doneCh)
 				if err != nil {
-					w.Write([]byte{1})
+					return
+				}
+				w.(http.Flusher).Flush()
+			case err := <-doneCh:
+				if err != nil {
+					_, werr := w.Write([]byte{1})
+					if werr != nil {
+						return
+					}
 					w.Write([]byte(err.Error()))
 				} else {
 					w.Write([]byte{0})

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -92,7 +92,6 @@ func (srv *Server) Start(ctx context.Context) (err error) {
 			w.Header().Set("Connection", "close")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte(http.ErrServerClosed.Error()))
-			w.(http.Flusher).Flush()
 			return
 		}
 


### PR DESCRIPTION


## Description
do not flush if Write() failed

## Motivation and Context
Go might reset the internal http.ResponseWriter() to `nil`
after Write() failure, so due to some timing by the time
we get to Flush() the underlying response writer might be
empty.

## How to test this PR?
Really hard to reproduce crash - this is the place https://github.com/golang/go/blob/a59e33224e42d60a97fa720a45e1b74eb6aaa3d0/src/net/http/server.go#L1697 that can get triggered by this situation. 

The theory is that w.Write() fails which in turn internally requires that `w` will be `nil` - this might have problems because once there is an error there is no need to further Flush() errors. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
