### PR TITLE
Close stream on panic

### DIFF
--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -19,9 +19,11 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -357,6 +359,12 @@ func (s *storageRESTServer) WalkDirHandler(w http.ResponseWriter, r *http.Reques
 	prefix := r.Form.Get(storageRESTPrefixFilter)
 	forward := r.Form.Get(storageRESTForwardFilter)
 	writer := streamHTTPResponse(w)
+	defer func() {
+		if r := recover(); r != nil {
+			debug.PrintStack()
+			writer.CloseWithError(fmt.Errorf("panic: %v", r))
+		}
+	}()
 	writer.CloseWithError(s.storage.WalkDir(r.Context(), WalkDirOptions{
 		Bucket:         volume,
 		BaseDir:        dirPath,

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"os/user"
 	"path"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -177,6 +178,12 @@ func (s *storageRESTServer) NSScannerHandler(w http.ResponseWriter, r *http.Requ
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 	resp := streamHTTPResponse(w)
+	defer func() {
+		if r := recover(); r != nil {
+			debug.PrintStack()
+			resp.CloseWithError(fmt.Errorf("panic: %v", r))
+		}
+	}()
 	respW := msgp.NewWriter(resp)
 
 	// Collect updates, stream them before the full cache is sent.


### PR DESCRIPTION
## Description

Always close streamHTTPResponse on panic on main thread to avoid write/flush after response handler has returned.

## Motivation and Context

Avoid crash on lower panic.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
