### PR TITLE
fix: use equalFold() instead of lower and compare

### DIFF
--- a/cmd/disk-cache-utils.go
+++ b/cmd/disk-cache-utils.go
@@ -110,7 +110,7 @@ func cacheControlOpts(o ObjectInfo) *cacheControl {
 
 	var headerVal string
 	for k, v := range m {
-		if strings.ToLower(k) == "cache-control" {
+		if strings.EqualFold(k, "cache-control") {
 			headerVal = v
 		}
 

--- a/cmd/warm-backend-azure.go
+++ b/cmd/warm-backend-azure.go
@@ -47,7 +47,7 @@ func (az *warmBackendAzure) getDest(object string) string {
 }
 func (az *warmBackendAzure) tier() azblob.AccessTierType {
 	for _, t := range azblob.PossibleAccessTierTypeValues() {
-		if strings.ToLower(az.StorageClass) == strings.ToLower(string(t)) {
+		if strings.EqualFold(az.StorageClass, string(t)) {
 			return t
 		}
 	}

--- a/internal/bucket/object/lock/lock.go
+++ b/internal/bucket/object/lock/lock.go
@@ -382,7 +382,7 @@ func IsObjectLockLegalHoldRequested(h http.Header) bool {
 
 // IsObjectLockGovernanceBypassSet returns true if object lock governance bypass header is set.
 func IsObjectLockGovernanceBypassSet(h http.Header) bool {
-	return strings.ToLower(h.Get(AmzObjectLockBypassRetGovernance)) == "true"
+	return strings.EqualFold(h.Get(AmzObjectLockBypassRetGovernance), "true")
 }
 
 // IsObjectLockRequested returns true if legal hold or object lock retention headers are requested.

--- a/internal/crypto/sse-s3.go
+++ b/internal/crypto/sse-s3.go
@@ -46,7 +46,8 @@ func (sses3) String() string { return "SSE-S3" }
 
 func (sses3) IsRequested(h http.Header) bool {
 	_, ok := h[xhttp.AmzServerSideEncryption]
-	return ok && strings.ToLower(h.Get(xhttp.AmzServerSideEncryption)) != xhttp.AmzEncryptionKMS // Return only true if the SSE header is specified and does not contain the SSE-KMS value
+	// Return only true if the SSE header is specified and does not contain the SSE-KMS value
+	return ok && !strings.EqualFold(h.Get(xhttp.AmzServerSideEncryption), xhttp.AmzEncryptionKMS)
 }
 
 // ParseHTTP parses the SSE-S3 related HTTP headers and checks

--- a/internal/s3select/select.go
+++ b/internal/s3select/select.go
@@ -387,7 +387,7 @@ func (s3Select *S3Select) marshal(buf *bytes.Buffer, record sql.Record) error {
 			FieldDelimiter: []rune(s3Select.Output.CSVArgs.FieldDelimiter)[0],
 			Quote:          []rune(s3Select.Output.CSVArgs.QuoteCharacter)[0],
 			QuoteEscape:    []rune(s3Select.Output.CSVArgs.QuoteEscapeCharacter)[0],
-			AlwaysQuote:    strings.ToLower(s3Select.Output.CSVArgs.QuoteFields) == "always",
+			AlwaysQuote:    strings.EqualFold(s3Select.Output.CSVArgs.QuoteFields, "always"),
 		}
 		err := record.WriteCSV(bufioWriter, opts)
 		if err != nil {

--- a/internal/s3select/sql/analysis.go
+++ b/internal/s3select/sql/analysis.go
@@ -179,7 +179,7 @@ func (e *PrimaryTerm) analyze(s *Select) (result qProp) {
 	case e.JPathExpr != nil:
 		// Check if the path expression is valid
 		if len(e.JPathExpr.PathExpr) > 0 {
-			if e.JPathExpr.BaseKey.String() != s.From.As && strings.ToLower(e.JPathExpr.BaseKey.String()) != baseTableName {
+			if e.JPathExpr.BaseKey.String() != s.From.As && !strings.EqualFold(e.JPathExpr.BaseKey.String(), baseTableName) {
 				result = qProp{err: errInvalidKeypath}
 				return
 			}

--- a/internal/s3select/sql/parser.go
+++ b/internal/s3select/sql/parser.go
@@ -31,7 +31,7 @@ type Boolean bool
 
 // Capture interface used by participle
 func (b *Boolean) Capture(values []string) error {
-	*b = strings.ToLower(values[0]) == "true"
+	*b = Boolean(strings.EqualFold(values[0], "true"))
 	return nil
 }
 

--- a/internal/s3select/sql/statement.go
+++ b/internal/s3select/sql/statement.go
@@ -118,7 +118,7 @@ func ParseSelectStatement(s string) (stmt SelectStatement, err error) {
 }
 
 func validateTableName(from *TableExpression) error {
-	if strings.ToLower(from.Table.BaseKey.String()) != baseTableName {
+	if !strings.EqualFold(from.Table.BaseKey.String(), baseTableName) {
 		return errBadTableName(errors.New("table name must be `s3object`"))
 	}
 

--- a/internal/s3select/sql/utils.go
+++ b/internal/s3select/sql/utils.go
@@ -44,7 +44,7 @@ func (e *JSONPath) StripTableAlias(tableAlias string) []*JSONPathElement {
 		return e.strippedPathExpr
 	}
 
-	hasTableAlias := e.BaseKey.String() == tableAlias || strings.ToLower(e.BaseKey.String()) == baseTableName
+	hasTableAlias := e.BaseKey.String() == tableAlias || strings.EqualFold(e.BaseKey.String(), baseTableName)
 	var pathExpr []*JSONPathElement
 	if hasTableAlias {
 		pathExpr = e.PathExpr


### PR DESCRIPTION
## Description
fix: use equalFold() instead of lower and compare

## Motivation and Context
avoid allocating based on strings.ToLower()
when we can.

## How to test this PR?
Nothing should change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
