### PR TITLE
Support dynamic reset of minio config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,6 +217,22 @@ func (kvs KVS) Empty() bool {
 	return len(kvs) == 0
 }
 
+// Clone - returns a copy of the KVS
+func (kvs KVS) Clone() KVS {
+	c := make(KVS, len(kvs))
+	copy(c, kvs)
+	return c
+}
+
+// GetWithDefault - returns default value if key not set
+func (kvs KVS) GetWithDefault(key string, defaultKVS KVS) string {
+	v := kvs.Get(key)
+	if len(v) == 0 {
+		return defaultKVS.Get(key)
+	}
+	return v
+}
+
 // Keys returns the list of keys for the current KVS
 func (kvs KVS) Keys() []string {
 	var keys = make([]string, len(kvs))
@@ -759,10 +775,12 @@ func (c Config) SetKVS(s string, defaultKVS map[string]KVS) (dynamic bool, err e
 		kvs.Set(Enable, EnableOn)
 	}
 
-	currKVS, ok := c[subSys][tgt]
+	var currKVS KVS
+	ck, ok := c[subSys][tgt]
 	if !ok {
-		currKVS = defaultKVS[subSys]
+		currKVS = defaultKVS[subSys].Clone()
 	} else {
+		currKVS = ck.Clone()
 		for _, kv := range defaultKVS[subSys] {
 			if _, ok = currKVS.Lookup(kv.Key); !ok {
 				currKVS.Set(kv.Key, kv.Value)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,9 +219,7 @@ func (kvs KVS) Empty() bool {
 
 // Clone - returns a copy of the KVS
 func (kvs KVS) Clone() KVS {
-	c := make(KVS, len(kvs))
-	copy(c, kvs)
-	return c
+	return append(make(KVS, 0, len(kvs)), kvs...)
 }
 
 // GetWithDefault - returns default value if key not set

--- a/internal/config/heal/heal.go
+++ b/internal/config/heal/heal.go
@@ -150,15 +150,15 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	if err = config.CheckValidKeys(config.HealSubSys, kvs, DefaultKVS); err != nil {
 		return cfg, err
 	}
-	cfg.Bitrot, err = config.ParseBool(env.Get(EnvBitrot, kvs.Get(Bitrot)))
+	cfg.Bitrot, err = config.ParseBool(env.Get(EnvBitrot, kvs.GetWithDefault(Bitrot, DefaultKVS)))
 	if err != nil {
 		return cfg, fmt.Errorf("'heal:bitrotscan' value invalid: %w", err)
 	}
-	cfg.Sleep, err = time.ParseDuration(env.Get(EnvSleep, kvs.Get(Sleep)))
+	cfg.Sleep, err = time.ParseDuration(env.Get(EnvSleep, kvs.GetWithDefault(Sleep, DefaultKVS)))
 	if err != nil {
 		return cfg, fmt.Errorf("'heal:max_sleep' value invalid: %w", err)
 	}
-	cfg.IOCount, err = strconv.Atoi(env.Get(EnvIOCount, kvs.Get(IOCount)))
+	cfg.IOCount, err = strconv.Atoi(env.Get(EnvIOCount, kvs.GetWithDefault(IOCount, DefaultKVS)))
 	if err != nil {
 		return cfg, fmt.Errorf("'heal:max_io' value invalid: %w", err)
 	}

--- a/internal/config/scanner/scanner.go
+++ b/internal/config/scanner/scanner.go
@@ -95,7 +95,7 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	}
 	delay := env.Get(EnvDelayLegacy, "")
 	if delay == "" {
-		delay = env.Get(EnvDelay, kvs.Get(Delay))
+		delay = env.Get(EnvDelay, kvs.GetWithDefault(Delay, DefaultKVS))
 	}
 	cfg.Delay, err = strconv.ParseFloat(delay, 64)
 	if err != nil {
@@ -103,14 +103,14 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	}
 	maxWait := env.Get(EnvMaxWaitLegacy, "")
 	if maxWait == "" {
-		maxWait = env.Get(EnvMaxWait, kvs.Get(MaxWait))
+		maxWait = env.Get(EnvMaxWait, kvs.GetWithDefault(MaxWait, DefaultKVS))
 	}
 	cfg.MaxWait, err = time.ParseDuration(maxWait)
 	if err != nil {
 		return cfg, err
 	}
 
-	cfg.Cycle, err = time.ParseDuration(env.Get(EnvCycle, kvs.Get(Cycle)))
+	cfg.Cycle, err = time.ParseDuration(env.Get(EnvCycle, kvs.GetWithDefault(Cycle, DefaultKVS)))
 	if err != nil {
 		return cfg, err
 	}


### PR DESCRIPTION
## Description

If a given minio config is dynamic (can be changed without restart),
ensure that it can be reset also without restart.

## Motivation and Context

Configs that are considered dynamic do not require restart on `changing` the values.
However, they currently require restart on `resetting` the values. This is not good, and
they would be truly dynamic if values can be reset also without requiring a restart.

## How to test this PR?

For the following list of configs
- api
- compression
- scanner
- heal

1) Set some config values using `mc admin config set`
2) Get the config using `mc admin config get` and verify that the changed values are in effect
3) Reset the config using `mc admin config reset`
4) Get the config using `mc admin config get` and verify that it has gone back to the default values


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
