### PR TITLE
fix: backend not reachable should be more descriptive

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1362,8 +1362,8 @@ var errorCodes = errorCodeMap{
 	},
 	ErrBackendDown: {
 		Code:           "XMinioBackendDown",
-		Description:    "Object storage backend is unreachable",
-		HTTPStatusCode: http.StatusServiceUnavailable,
+		Description:    "Remote backend is unreachable",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrIncorrectContinuationToken: {
 		Code:           "InvalidArgument",
@@ -2127,6 +2127,11 @@ func toAPIError(ctx context.Context, err error) APIError {
 			}
 			return apiErr
 		}
+	}
+
+	if apiErr.Code == "XMinioBackendDown" {
+		apiErr.Description = fmt.Sprintf("%s (%v)", apiErr.Description, err)
+		return apiErr
 	}
 
 	if apiErr.Code == "InternalError" {

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -287,7 +287,7 @@ func ErrorRespToObjectError(err error, params ...string) error {
 	}
 
 	if xnet.IsNetworkOrHostDown(err, false) {
-		return BackendDown{}
+		return BackendDown{Err: err.Error()}
 	}
 
 	minioErr, ok := err.(minio.ErrorResponse)

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -645,10 +645,12 @@ func (e UnsupportedMetadata) Error() string {
 }
 
 // BackendDown is returned for network errors or if the gateway's backend is down.
-type BackendDown struct{}
+type BackendDown struct {
+	Err string
+}
 
 func (e BackendDown) Error() string {
-	return "Backend down"
+	return e.Err
 }
 
 // isErrBucketNotFound - Check if error type is BucketNotFound.

--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -50,6 +50,10 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 	var empty bytes.Reader
 	rv, err := w.Put(ctx, probeObject, &empty, 0)
 	if err != nil {
+		switch err.(type) {
+		case BackendDown:
+			return err
+		}
 		return tierPermErr{
 			Op:  tierPut,
 			Err: err,
@@ -58,6 +62,10 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 
 	_, err = w.Get(ctx, probeObject, rv, WarmBackendGetOpts{})
 	if err != nil {
+		switch err.(type) {
+		case BackendDown:
+			return err
+		}
 		switch {
 		case isErrBucketNotFound(err):
 			return errTierBucketNotFound
@@ -72,6 +80,10 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 	}
 
 	if err = w.Remove(ctx, probeObject, rv); err != nil {
+		switch err.(type) {
+		case BackendDown:
+			return err
+		}
 		return tierPermErr{
 			Op:  tierDelete,
 			Err: err,


### PR DESCRIPTION
## Description
fix: backend not reachable should be more descriptive

## Motivation and Context
more descriptive errors in the response when the 
backend is not reachable.  As an example

```
~ mc admin tier add s3 myminio/ S3TIER1 --endpoint https://s1.amazonaws.com --access-key xxxx --secret-key xxxxxx --bucket minios3iocl  
mc: <ERROR> Unable to configure remote tier target. Remote backend is unreachable (Get "https://s1.amazonaws.com/minios3iocl/?location=": lookup s1.amazonaws.com on 75.75.75.75:53: no such host).
```

## How to test this PR?
As written in motivation 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
