### PR TITLE
Backporting fix to avoid repeated attempt at

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -497,10 +497,15 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 			object.PurgeTransitioned = goi.TransitionStatus
 		}
 		if replicateDeletes {
+			opts := ObjectOptions{
+				VersionID:        object.VersionID,
+				Versioned:        globalBucketVersioningSys.Enabled(bucket),
+				VersionSuspended: globalBucketVersioningSys.Suspended(bucket),
+			}
 			replicate, repsync := checkReplicateDelete(ctx, bucket, ObjectToDelete{
 				ObjectName: object.ObjectName,
 				VersionID:  object.VersionID,
-			}, goi, gerr)
+			}, opts, goi, gerr)
 			replicateSync = repsync
 			if replicate {
 				if apiErrCode := checkRequestAuthType(ctx, r, policy.ReplicateDeleteAction, bucket, object.ObjectName); apiErrCode != ErrNone {

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -177,10 +177,14 @@ func isStandardHeader(matchHeaderKey string) bool {
 }
 
 // returns whether object version is a deletemarker and if object qualifies for replication
-func checkReplicateDelete(ctx context.Context, bucket string, dobj ObjectToDelete, oi ObjectInfo, gerr error) (replicate, sync bool) {
+func checkReplicateDelete(ctx context.Context, bucket string, dobj ObjectToDelete, delOpts ObjectOptions, oi ObjectInfo, gerr error) (replicate, sync bool) {
 	rcfg, err := getReplicationConfig(ctx, bucket)
 	if err != nil || rcfg == nil {
 		return false, sync
+	}
+	// If incoming request is a replication request, it does not need to be re-replicated.
+	if delOpts.ReplicationRequest {
+		return
 	}
 	opts := replication.ObjectOpts{
 		Name:         dobj.ObjectName,

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1038,6 +1038,7 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 			return objInfo, gerr
 		}
 	}
+
 	// Acquire a write lock before deleting the object.
 	lk := er.NewNSLock(bucket, object)
 	ctx, err = lk.GetLock(ctx, globalDeleteOperationTimeout)

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -58,7 +58,8 @@ type ObjectOptions struct {
 
 	// Use the maximum parity (N/2), used when
 	// saving server configuration files
-	MaxParity bool
+	MaxParity          bool
+	ReplicationRequest bool
 }
 
 // BucketOptions represents bucket options for ObjectLayer bucket operations

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -70,6 +70,9 @@ func getDefaultOpts(header http.Header, copySource bool, metadata map[string]str
 		opts.ProxyHeaderSet = true
 		opts.ProxyRequest = strings.Join(v, "") == "true"
 	}
+	if _, ok := header[xhttp.MinIOSourceReplicationRequest]; ok {
+		opts.ReplicationRequest = true
+	}
 	return
 }
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3170,7 +3170,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		})
 	}
 
-	replicateDel, replicateSync := checkReplicateDelete(ctx, bucket, ObjectToDelete{ObjectName: object, VersionID: opts.VersionID}, goi, gerr)
+	replicateDel, replicateSync := checkReplicateDelete(ctx, bucket, ObjectToDelete{ObjectName: object, VersionID: opts.VersionID}, opts, goi, gerr)
 	if replicateDel {
 		if opts.VersionID != "" {
 			opts.VersionPurgeStatus = Pending

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -770,7 +770,7 @@ next:
 				if replicateDel, replicateSync = checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{
 					ObjectName: objectName,
 					VersionID:  goi.VersionID,
-				}, goi, gerr); replicateDel {
+				}, opts, goi, gerr); replicateDel {
 					opts.DeleteMarkerReplicationStatus = string(replication.Pending)
 					opts.DeleteMarker = true
 				}
@@ -903,7 +903,7 @@ next:
 						}
 					}
 				}
-				replicateDel, _ := checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{ObjectName: obj.Name, VersionID: obj.VersionID}, obj, nil)
+				replicateDel, _ := checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{ObjectName: obj.Name, VersionID: obj.VersionID}, opts, obj, nil)
 				// since versioned delete is not available on web browser, yet - this is a simple DeleteMarker replication
 				objToDel := ObjectToDelete{ObjectName: obj.Name}
 				if replicateDel {


### PR DESCRIPTION
delete marker replication

## Description


## Motivation and Context
Prevent multiple delete markers being created when object is deleted in a replicated setup

## How to test this PR?
In active active replication mode, `mc rm` repeatedly on same object should not set multiple delete markers

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
