### PR TITLE
Add MaxNoncurrentVersions support to NoncurrentVersionExpiration

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -96,7 +96,8 @@ func (es *expiryState) queueExpiryTask(oi ObjectInfo, rmVersion bool) {
 }
 
 var (
-	globalExpiryState *expiryState
+	globalExpiryState      *expiryState
+	globalNoncurrentExpiry *noncurrentExpiry
 )
 
 func newExpiryState() *expiryState {
@@ -112,6 +113,7 @@ func initBackgroundExpiry(ctx context.Context, objectAPI ObjectLayer) {
 			applyExpiryRule(ctx, objectAPI, t.objInfo, false, t.versionExpiry)
 		}
 	}()
+	initBackgroundNoncurrentExpiry(ctx, objectAPI)
 }
 
 type transitionState struct {
@@ -672,4 +674,40 @@ func isRestoredObjectOnDisk(meta map[string]string) (onDisk bool) {
 		}
 	}
 	return onDisk
+}
+
+type noncurrentExpiryTask struct {
+	bucket   string
+	versions []ObjectToDelete
+}
+
+type noncurrentExpiry struct {
+	once sync.Once
+	ch   chan noncurrentExpiryTask
+}
+
+func (nc *noncurrentExpiry) enqueue(bucket string, toDel []ObjectToDelete) {
+	select {
+	case <-GlobalContext.Done():
+		nc.once.Do(func() {
+			close(nc.ch)
+		})
+	case nc.ch <- noncurrentExpiryTask{bucket: bucket, versions: toDel}:
+	default:
+	}
+}
+
+func newNoncurrentExpiryState() *noncurrentExpiry {
+	return &noncurrentExpiry{
+		ch: make(chan noncurrentExpiryTask, 10000),
+	}
+}
+
+func initBackgroundNoncurrentExpiry(ctx context.Context, objectAPI ObjectLayer) {
+	globalNoncurrentExpiry = newNoncurrentExpiryState()
+	go func() {
+		for t := range globalNoncurrentExpiry.ch {
+			deleteObjectVersions(ctx, objectAPI, t.bucket, t.versions)
+		}
+	}()
 }

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1443,6 +1443,8 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		UserAgent:    r.UserAgent(),
 		Host:         handlers.GetSourceIP(r),
 	})
+
+	ilmLimitNoncurrentVersions(objectAPI, dstBucket, dstObject)
 }
 
 // PutObjectHandler - PUT Object
@@ -1778,6 +1780,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		UserAgent:    r.UserAgent(),
 		Host:         handlers.GetSourceIP(r),
 	})
+	ilmLimitNoncurrentVersions(objectAPI, bucket, object)
 }
 
 // PutObjectExtractHandler - PUT Object extract is an extended API
@@ -3182,6 +3185,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 		UserAgent:    r.UserAgent(),
 		Host:         handlers.GetSourceIP(r),
 	})
+	ilmLimitNoncurrentVersions(objectAPI, bucket, object)
 }
 
 /// Delete objectAPIHandlers

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -476,6 +476,13 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 			return sizeSummary{}, errSkipFile
 		}
 		sizeS := sizeSummary{}
+		fivs.Versions, err = item.applyVersionActions(ctx, objAPI, fivs.Versions, &sizeS)
+		if err != nil {
+			if intDataUpdateTracker.debug {
+				console.Debugf(color.Green("scannerBucket:")+" applying version actions failed: %v: %w\n", item.Path, err)
+			}
+			return sizeSummary{}, errSkipFile
+		}
 		for _, version := range fivs.Versions {
 			oi := version.ToObjectInfo(item.bucket, item.objectPath())
 			sz := item.applyActions(ctx, objAPI, actionMeta{

--- a/internal/bucket/lifecycle/expiration.go
+++ b/internal/bucket/lifecycle/expiration.go
@@ -23,11 +23,12 @@ import (
 )
 
 var (
-	errLifecycleInvalidDate         = Errorf("Date must be provided in ISO 8601 format")
-	errLifecycleInvalidDays         = Errorf("Days must be positive integer when used with Expiration")
-	errLifecycleInvalidExpiration   = Errorf("Exactly one of Days (positive integer) or Date (positive ISO 8601 format) should be present inside Expiration.")
-	errLifecycleInvalidDeleteMarker = Errorf("Delete marker cannot be specified with Days or Date in a Lifecycle Expiration Policy")
-	errLifecycleDateNotMidnight     = Errorf("'Date' must be at midnight GMT")
+	errLifecycleInvalidDate                 = Errorf("Date must be provided in ISO 8601 format")
+	errLifecycleInvalidDays                 = Errorf("Days must be positive integer when used with Expiration")
+	errLifecycleInvalidExpiration           = Errorf("Exactly one of Days (positive integer) or Date (positive ISO 8601 format) should be present inside Expiration.")
+	errLifecycleInvalidDeleteMarker         = Errorf("Delete marker cannot be specified with Days or Date in a Lifecycle Expiration Policy")
+	errLifecycleDateNotMidnight             = Errorf("'Date' must be at midnight GMT")
+	errLifecycleInvalidNoncurrentExpiration = Errorf("Exactly one of NoncurrentDays (positive integer) or MaxNoncurrentVersions should be specified in a NoncurrentExpiration rule.")
 )
 
 // ExpirationDays is a type alias to unmarshal Days in Expiration

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -50,6 +50,7 @@ const (
 	EnvAPISecureCiphers            = "MINIO_API_SECURE_CIPHERS"
 	EnvAPIReplicationWorkers       = "MINIO_API_REPLICATION_WORKERS"
 	EnvAPIReplicationFailedWorkers = "MINIO_API_REPLICATION_FAILED_WORKERS"
+	EnvAPIILMInline                = "MINIO_API_ILM_INLINE"
 )
 
 // Deprecated key and ENVs


### PR DESCRIPTION
## Description
This allows users to limit the maximum number of noncurrent verisons for an
object via ILM rules.

e.g To enable this rule,
```
cat <<EOF | ./mc ilm import myminio/mybucket
{
    "Rules": [
        {
            "ID": "test-max-noncurrent",
            "Status": "Enabled",
            "Filter": {
                "Prefix": "user-uploads/"
            },
            "NoncurrentVersionExpiration": {
                "MaxNoncurrentVersions": 5
            }
        }
    ]
}
EOF
```

## Motivation and Context
To keep the number of noncurrent versions of an object under a limit when applications upload objects to the same name many times within its lifetime.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
