### PR TITLE
ignore swapped drives instead of throwing errors

### DIFF
--- a/cmd/bucket-listobjects-handlers.go
+++ b/cmd/bucket-listobjects-handlers.go
@@ -32,8 +32,6 @@ import (
 
 func concurrentDecryptETag(ctx context.Context, objects []ObjectInfo) {
 	g := errgroup.WithNErrs(len(objects)).WithConcurrency(500)
-	_, cancel := g.WithCancelOnError(ctx)
-	defer cancel()
 	for index := range objects {
 		index := index
 		g.Go(func() error {
@@ -45,7 +43,7 @@ func concurrentDecryptETag(ctx context.Context, objects []ObjectInfo) {
 			return nil
 		}, index)
 	}
-	g.WaitErr()
+	g.Wait()
 }
 
 // Validate all the ListObjects query arguments, returns an APIErrorCode

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path"
 	"sort"
 	"strings"
@@ -222,18 +223,18 @@ func initConfig(objAPI ObjectLayer) error {
 	// If etcd is set then migrates /config/config.json
 	// to '<export_path>/.minio.sys/config/config.json'
 	if err := migrateConfigToMinioSys(objAPI); err != nil {
-		return err
+		return fmt.Errorf("migrateConfigToMinioSys: %w", err)
 	}
 
 	// Migrates backend '<export_path>/.minio.sys/config/config.json' to latest version.
 	if err := migrateMinioSysConfig(objAPI); err != nil {
-		return err
+		return fmt.Errorf("migrateMinioSysConfig: %w", err)
 	}
 
 	// Migrates backend '<export_path>/.minio.sys/config/config.json' to
 	// latest config format.
 	if err := migrateMinioSysConfigToKV(objAPI); err != nil {
-		return err
+		return fmt.Errorf("migrateMinioSysConfigToKV: %w", err)
 	}
 
 	return loadConfig(objAPI)

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -283,8 +283,6 @@ func listObjects(ctx context.Context, obj ObjectLayer, bucket, prefix, marker, d
 
 	// List until maxKeys requested.
 	g := errgroup.WithNErrs(maxKeys).WithConcurrency(maxConcurrent)
-	ctx, cancel := g.WithCancelOnError(ctx)
-	defer cancel()
 
 	objInfoFound := make([]*ObjectInfo, maxKeys)
 	var i int
@@ -345,8 +343,10 @@ func listObjects(ctx context.Context, obj ObjectLayer, bucket, prefix, marker, d
 			break
 		}
 	}
-	if err := g.WaitErr(); err != nil {
-		return loi, err
+	for _, err := range g.Wait() {
+		if err != nil {
+			return loi, err
+		}
 	}
 	// Copy found objects
 	objInfos := make([]ObjectInfo, 0, i+1)

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -86,46 +86,163 @@ type StorageAPI interface {
 	SetDiskLoc(poolIdx, setIdx, diskIdx int)    // Set location indexes.
 }
 
-// storageReader is an io.Reader view of a disk
-type storageReader struct {
-	storage      StorageAPI
-	volume, path string
-	offset       int64
+type unrecognizedDisk struct {
+	storage StorageAPI
 }
 
-func (r *storageReader) Read(p []byte) (n int, err error) {
-	nn, err := r.storage.ReadFile(context.TODO(), r.volume, r.path, r.offset, p, nil)
-	r.offset += nn
-	n = int(nn)
+func (p *unrecognizedDisk) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writer) (err error) {
+	return errDiskNotFound
+}
 
-	if err == io.ErrUnexpectedEOF && nn > 0 {
-		err = io.EOF
+func (p *unrecognizedDisk) String() string {
+	return p.storage.String()
+}
+
+func (p *unrecognizedDisk) IsOnline() bool {
+	return false
+}
+
+func (p *unrecognizedDisk) LastConn() time.Time {
+	return p.storage.LastConn()
+}
+
+func (p *unrecognizedDisk) IsLocal() bool {
+	return p.storage.IsLocal()
+}
+
+func (p *unrecognizedDisk) Endpoint() Endpoint {
+	return p.storage.Endpoint()
+}
+
+func (p *unrecognizedDisk) Hostname() string {
+	return p.storage.Hostname()
+}
+
+func (p *unrecognizedDisk) Healing() *healingTracker {
+	return nil
+}
+
+func (p *unrecognizedDisk) NSScanner(ctx context.Context, cache dataUsageCache, updates chan<- dataUsageEntry) (dataUsageCache, error) {
+	return dataUsageCache{}, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
+	return -1, -1, -1
+}
+
+func (p *unrecognizedDisk) SetDiskLoc(poolIdx, setIdx, diskIdx int) {
+}
+
+func (p *unrecognizedDisk) Close() error {
+	return p.storage.Close()
+}
+
+func (p *unrecognizedDisk) GetDiskID() (string, error) {
+	return "", errDiskNotFound
+}
+
+func (p *unrecognizedDisk) SetDiskID(id string) {
+}
+
+func (p *unrecognizedDisk) DiskInfo(ctx context.Context) (info DiskInfo, err error) {
+	return info, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) MakeVolBulk(ctx context.Context, volumes ...string) (err error) {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) MakeVol(ctx context.Context, volume string) (err error) {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) ListVols(ctx context.Context) ([]VolInfo, error) {
+	return nil, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) StatVol(ctx context.Context, volume string) (vol VolInfo, err error) {
+	return vol, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) DeleteVol(ctx context.Context, volume string, forceDelete bool) (err error) {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) ListDir(ctx context.Context, volume, dirPath string, count int) ([]string, error) {
+	return nil, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) ReadFile(ctx context.Context, volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error) {
+	return 0, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) AppendFile(ctx context.Context, volume string, path string, buf []byte) (err error) {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) CreateFile(ctx context.Context, volume, path string, size int64, reader io.Reader) error {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error) {
+	return nil, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) error {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string) error {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) CheckParts(ctx context.Context, volume string, path string, fi FileInfo) (err error) {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) Delete(ctx context.Context, volume string, path string, recursive bool) (err error) {
+	return errDiskNotFound
+}
+
+// DeleteVersions deletes slice of versions, it can be same object
+// or multiple objects.
+func (p *unrecognizedDisk) DeleteVersions(ctx context.Context, volume string, versions []FileInfoVersions) (errs []error) {
+	errs = make([]error, len(versions))
+
+	for i := range errs {
+		errs[i] = errDiskNotFound
 	}
-	return
+	return errs
 }
 
-// storageWriter is a io.Writer view of a disk.
-type storageWriter struct {
-	storage      StorageAPI
-	volume, path string
+func (p *unrecognizedDisk) VerifyFile(ctx context.Context, volume, path string, fi FileInfo) error {
+	return errDiskNotFound
 }
 
-func (w *storageWriter) Write(p []byte) (n int, err error) {
-	err = w.storage.AppendFile(context.TODO(), w.volume, w.path, p)
-	if err == nil {
-		n = len(p)
-	}
-	return
+func (p *unrecognizedDisk) WriteAll(ctx context.Context, volume string, path string, b []byte) (err error) {
+	return errDiskNotFound
 }
 
-// StorageWriter returns a new io.Writer which appends data to the file
-// at the given disk, volume and path.
-func StorageWriter(storage StorageAPI, volume, path string) io.Writer {
-	return &storageWriter{storage, volume, path}
+func (p *unrecognizedDisk) DeleteVersion(ctx context.Context, volume, path string, fi FileInfo, forceDelMarker bool) (err error) {
+	return errDiskNotFound
 }
 
-// StorageReader returns a new io.Reader which reads data to the file
-// at the given disk, volume, path and offset.
-func StorageReader(storage StorageAPI, volume, path string, offset int64) io.Reader {
-	return &storageReader{storage, volume, path, offset}
+func (p *unrecognizedDisk) UpdateMetadata(ctx context.Context, volume, path string, fi FileInfo) (err error) {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) WriteMetadata(ctx context.Context, volume, path string, fi FileInfo) (err error) {
+	return errDiskNotFound
+}
+
+func (p *unrecognizedDisk) ReadVersion(ctx context.Context, volume, path, versionID string, readData bool) (fi FileInfo, err error) {
+	return fi, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) ReadAll(ctx context.Context, volume string, path string) (buf []byte, err error) {
+	return nil, errDiskNotFound
+}
+
+func (p *unrecognizedDisk) StatInfoFile(ctx context.Context, volume, path string, glob bool) (stat []StatInfo, err error) {
+	return nil, errDiskNotFound
 }


### PR DESCRIPTION

## Description
ignore swapped drives instead of throwing errors

## Motivation and Context
- add checks such that swapped disks are detected
  and ignored - never used for normal operations.

- implement `unrecognizedDisk` to be ignored with
  all operations returning `errDiskNotFound`.

- also add checks such that we do not load unexpected
  disks while connecting automatically.

- additionally, humanize the values when printing the errors.

Bonus: fixes handling of non-quorum situations in
getLatestFileInfo(), that does not work when 2 drives
are down, currently, this function would return errors
incorrectly.

## How to test this PR?
Initialize a setup like this locally once and then swap the drives.
```
~ minio server /tmp/xl{1...4} /tmp/xl{5...8}
```

Swap the drives in this manner and start the server
```
~ mv /tmp/xl1 /tmp/xl1-old
~ mv /tmp/xl2 /tmp/xl1
~ mv /tmp/xl1-old /tmp/xl2
```

The server should print an error and report that drive is in the wrong place.
```
~ minio server /tmp/xl{1...4} /tmp/xl{5...8}  

API: SYSTEM()
Time: 20:38:43 PST 11/13/2021
Error: Detected unexpected disk ordering refusing to use the disk - poolID: 1st, found disk mounted at (set=1st, disk=2nd) expected mount at (set=1st, disk=1st): /tmp/xl1(82ab09f0-152b-4a7f-98c8-f3300f37ea30) (*errors.errorString)
       4: cmd/erasure-sets.go:430:cmd.newErasureSets()
       3: cmd/erasure-server-pool.go:111:cmd.newErasureServerPools()
       2: cmd/server-main.go:637:cmd.newObjectLayer()
       1: cmd/server-main.go:542:cmd.serverMain()

API: SYSTEM()
Time: 20:38:43 PST 11/13/2021
Error: Detected unexpected disk ordering refusing to use the disk - poolID: 1st, found disk mounted at (set=1st, disk=1st) expected mount at (set=1st, disk=2nd): /tmp/xl2(67132752-50a8-423d-af43-f84596310d2b) (*errors.errorString)
       4: cmd/erasure-sets.go:430:cmd.newErasureSets()
       3: cmd/erasure-server-pool.go:111:cmd.newErasureServerPools()
       2: cmd/server-main.go:637:cmd.newObjectLayer()
       1: cmd/server-main.go:542:cmd.serverMain()
Verifying if 2 buckets are consistent across drives...
Automatically configured API requests per node based on available memory on the system: 99
Use `mc admin info` to look for latest server/disk info
 Status:         6 Online, 2 Offline. 
API: http://10.0.0.67:9000  http://172.16.3.3:9000  http://172.17.0.1:9000  http://172.18.0.1:9000  http://127.0.0.1:9000                 
RootUser: minio 
RootPass: minio123 

Console: http://10.0.0.67:37543 http://172.16.3.3:37543 http://172.17.0.1:37543 http://172.18.0.1:37543 http://127.0.0.1:37543         
RootUser: minio 
RootPass: minio123 

Command-line: https://docs.min.io/docs/minio-client-quickstart-guide
   $ mc alias set myminio http://10.0.0.67:9000 minio minio123

Documentation: https://docs.min.io

WARNING: Console endpoint is listening on a dynamic port (37543), please use --console-address ":PORT" to choose a static port.

```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
