### PR TITLE
reduceErrs to handle context.Canceled errors

### DIFF
--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -39,6 +39,11 @@ func reduceErrs(errs []error, ignoredErrs []error) (maxCount int, maxErr error) 
 		if IsErrIgnored(err, ignoredErrs...) {
 			continue
 		}
+		// Errors due to context cancelation may be wrapped - group them by context.Canceled.
+		if errors.Is(err, context.Canceled) {
+			errorCounts[context.Canceled]++
+			continue
+		}
 		errorCounts[err]++
 	}
 

--- a/cmd/erasure-metadata-utils_test.go
+++ b/cmd/erasure-metadata-utils_test.go
@@ -54,6 +54,10 @@ func TestDiskCount(t *testing.T) {
 // Test for reduceErrs, reduceErr reduces collection
 // of errors into a single maximal error with in the list.
 func TestReduceErrs(t *testing.T) {
+	canceledErrs := make([]error, 0, 5)
+	for i := 0; i < 5; i++ {
+		canceledErrs = append(canceledErrs, fmt.Errorf("error %d: %w", i, context.Canceled))
+	}
 	// List all of all test cases to validate various cases of reduce errors.
 	testCases := []struct {
 		errs        []error
@@ -86,6 +90,8 @@ func TestReduceErrs(t *testing.T) {
 		{[]error{errFileNotFound, errFileNotFound, errFileNotFound,
 			errFileNotFound, errFileNotFound, nil, nil, nil, nil, nil},
 			nil, nil},
+		// Checks if wrapped context cancelation errors are grouped as one.
+		{canceledErrs, nil, context.Canceled},
 	}
 	// Validates list of all the testcases for returning valid errors.
 	for i, testCase := range testCases {


### PR DESCRIPTION
## Description
With this change reduceErrs will group all errors due to a context cancelation as
the same.

e.g, Following are errors due to context cancellation seen from 3 remote disks.
Their error values are different but they are all caused due to the same context
cancellation.
```
['Post
"http://minio2:9000/minio/storage/data1/v37/statvol?disk-id=101cbc99-f5d2-4a9d-b18b-97e872b3e4a7&volume=mybucket":
context canceled',
 'Post
 "http://minio3:9000/minio/storage/data1/v37/statvol?disk-id=7a84474b-a4fd-4b80-8aab-d308a587c280&volume=mybucket":
 context canceled',
 'Post
 "http://minio4:9000/minio/storage/data1/v37/statvol?disk-id=d60d571a-83c8-487d-9e14-beebc94682d2&volume=mybucket":
 context canceled']
```
## Motivation and Context
Errors caused by context cancellation must be reduced to the same underlying error (viz. context.Canceled)

## How to test this PR?
Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
