### PR TITLE
heal legacy objects when versioning is enabled after upgrade

### DIFF
--- a/cmd/xl-storage-format-v1.go
+++ b/cmd/xl-storage-format-v1.go
@@ -199,7 +199,9 @@ func (m *xlMetaV1Object) ToFileInfo(volume, path string) (FileInfo, error) {
 		Erasure:   m.Erasure,
 		VersionID: m.VersionID,
 		DataDir:   m.DataDir,
+		XLV1:      true,
 	}
+
 	return fi, nil
 }
 


### PR DESCRIPTION

## Description
heal legacy objects when versioning is enabled after upgrade

## Motivation and Context
legacy objects in 'xl.json' after upgrade, should have
following sequence of events - bucket should have versioning
enabled and the object should have been overwritten with
another version of an object.

this situation was not handled, which would lead to older
objects to stay perpetually with "legacy" dataDir, however
these objects were readable by all means - there weren't
converted to the newer format.

This PR fixes this situation properly.

## How to test this PR?
Will be adding tests to this PR this is pending

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
