### PR TITLE
Add new `site` config sub-system intended to replace `region`

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1466,7 +1466,7 @@ func getServerInfo(ctx context.Context, r *http.Request) madmin.InfoMessage {
 	return madmin.InfoMessage{
 		Mode:         string(mode),
 		Domain:       domain,
-		Region:       globalServerRegion,
+		Region:       globalSite.Region,
 		SQSARN:       globalNotificationSys.GetARNList(false),
 		DeploymentID: globalDeploymentID,
 		Buckets:      buckets,

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -396,10 +396,10 @@ func (e errorCodeMap) ToAPIErrWithErr(errCode APIErrorCode, err error) APIError 
 	if err != nil {
 		apiErr.Description = fmt.Sprintf("%s (%s)", apiErr.Description, err)
 	}
-	if globalServerRegion != "" {
+	if globalSite.Region != "" {
 		switch errCode {
 		case ErrAuthorizationHeaderMalformed:
-			apiErr.Description = fmt.Sprintf("The authorization header is malformed; the region is wrong; expecting '%s'.", globalServerRegion)
+			apiErr.Description = fmt.Sprintf("The authorization header is malformed; the region is wrong; expecting '%s'.", globalSite.Region)
 			return apiErr
 		}
 	}
@@ -2286,7 +2286,7 @@ func getAPIErrorResponse(ctx context.Context, err APIError, resource, requestID,
 		BucketName: reqInfo.BucketName,
 		Key:        reqInfo.ObjectName,
 		Resource:   resource,
-		Region:     globalServerRegion,
+		Region:     globalSite.Region,
 		RequestID:  requestID,
 		HostID:     hostID,
 	}

--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -52,7 +52,7 @@ func setCommonHeaders(w http.ResponseWriter) {
 
 	// Set `x-amz-bucket-region` only if region is set on the server
 	// by default minio uses an empty region.
-	if region := globalServerRegion; region != "" {
+	if region := globalSite.Region; region != "" {
 		w.Header().Set(xhttp.AmzBucketRegion, region)
 	}
 	w.Header().Set(xhttp.AcceptRanges, "bytes")

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -790,9 +790,9 @@ func writeErrorResponse(ctx context.Context, w http.ResponseWriter, err APIError
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
 		w.Header().Set(xhttp.RetryAfter, "120")
 	case "InvalidRegion":
-		err.Description = fmt.Sprintf("Region does not match; expecting '%s'.", globalServerRegion)
+		err.Description = fmt.Sprintf("Region does not match; expecting '%s'.", globalSite.Region)
 	case "AuthorizationHeaderMalformed":
-		err.Description = fmt.Sprintf("The authorization header is malformed; the region is wrong; expecting '%s'.", globalServerRegion)
+		err.Description = fmt.Sprintf("The authorization header is malformed; the region is wrong; expecting '%s'.", globalSite.Region)
 	}
 
 	// Generate error response.

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -299,7 +299,7 @@ func checkRequestAuthTypeCredential(ctx context.Context, r *http.Request, action
 		}
 		cred, owner, s3Err = getReqAccessKeyV2(r)
 	case authTypeSigned, authTypePresigned:
-		region := globalServerRegion
+		region := globalSite.Region
 		switch action {
 		case policy.GetBucketLocationAction, policy.ListAllMyBucketsAction:
 			region = ""
@@ -529,7 +529,7 @@ func validateSignature(atype authType, r *http.Request) (auth.Credentials, bool,
 		}
 		cred, owner, s3Err = getReqAccessKeyV2(r)
 	case authTypePresigned, authTypeSigned:
-		region := globalServerRegion
+		region := globalSite.Region
 		if s3Err = isReqAuthenticated(GlobalContext, r, region, serviceS3); s3Err != ErrNone {
 			return cred, owner, s3Err
 		}
@@ -596,7 +596,7 @@ func isPutActionAllowed(ctx context.Context, atype authType, bucketName, objectN
 	case authTypeSignedV2, authTypePresignedV2:
 		cred, owner, s3Err = getReqAccessKeyV2(r)
 	case authTypeStreamingSigned, authTypePresigned, authTypeSigned:
-		region := globalServerRegion
+		region := globalSite.Region
 		cred, owner, s3Err = getReqAccessKeyV4(r, region, serviceS3)
 	}
 	if s3Err != ErrNone {

--- a/cmd/auth-handler_test.go
+++ b/cmd/auth-handler_test.go
@@ -397,7 +397,7 @@ func TestIsReqAuthenticated(t *testing.T) {
 
 	// Validates all testcases.
 	for i, testCase := range testCases {
-		s3Error := isReqAuthenticated(ctx, testCase.req, globalServerRegion, serviceS3)
+		s3Error := isReqAuthenticated(ctx, testCase.req, globalSite.Region, serviceS3)
 		if s3Error != testCase.s3Error {
 			if _, err := ioutil.ReadAll(testCase.req.Body); toAPIErrorCode(ctx, err) != testCase.s3Error {
 				t.Fatalf("Test %d: Unexpected S3 error: want %d - got %d (got after reading request %s)", i, testCase.s3Error, s3Error, toAPIError(ctx, err).Code)
@@ -435,7 +435,7 @@ func TestCheckAdminRequestAuthType(t *testing.T) {
 	}
 	ctx := context.Background()
 	for i, testCase := range testCases {
-		if _, s3Error := checkAdminRequestAuth(ctx, testCase.Request, iampolicy.AllAdminActions, globalServerRegion); s3Error != testCase.ErrCode {
+		if _, s3Error := checkAdminRequestAuth(ctx, testCase.Request, iampolicy.AllAdminActions, globalSite.Region); s3Error != testCase.ErrCode {
 			t.Errorf("Test %d: Unexpected s3error returned wanted %d, got %d", i, testCase.ErrCode, s3Error)
 		}
 	}

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -211,7 +211,7 @@ func (api objectAPIHandlers) GetBucketLocationHandler(w http.ResponseWriter, r *
 	// Generate response.
 	encodedSuccessResponse := encodeResponse(LocationResponse{})
 	// Get current region.
-	region := globalServerRegion
+	region := globalSite.Region
 	if region != globalMinioDefaultRegion {
 		encodedSuccessResponse = encodeResponse(LocationResponse{
 			Location: region,

--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -72,8 +72,8 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
-	config.SetRegion(globalServerRegion)
-	if err = config.Validate(globalServerRegion, globalNotificationSys.targetList); err != nil {
+	config.SetRegion(globalSite.Region)
+	if err = config.Validate(globalSite.Region, globalNotificationSys.targetList); err != nil {
 		arnErr, ok := err.(*event.ErrARNNotFound)
 		if ok {
 			for i, queue := range config.QueueList {
@@ -145,7 +145,7 @@ func (api objectAPIHandlers) PutBucketNotificationHandler(w http.ResponseWriter,
 		return
 	}
 
-	config, err := event.ParseConfig(io.LimitReader(r.Body, r.ContentLength), globalServerRegion, globalNotificationSys.targetList)
+	config, err := event.ParseConfig(io.LimitReader(r.Body, r.ContentLength), globalSite.Region, globalNotificationSys.targetList)
 	if err != nil {
 		apiErr := errorCodes.ToAPIErr(ErrMalformedXML)
 		if event.IsEventError(err) {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -187,7 +187,7 @@ func minioConfigToConsoleFeatures() {
 			os.Setenv("CONSOLE_IDP_CALLBACK", getConsoleEndpoints()[0]+"/oauth_callback")
 		}
 	}
-	os.Setenv("CONSOLE_MINIO_REGION", globalServerRegion)
+	os.Setenv("CONSOLE_MINIO_REGION", globalSite.Region)
 	os.Setenv("CONSOLE_CERT_PASSWD", env.Get("MINIO_CERT_PASSWD", ""))
 	if globalSubnetConfig.License != "" {
 		os.Setenv("CONSOLE_SUBNET_LICENSE", globalSubnetConfig.License)

--- a/cmd/config-common.go
+++ b/cmd/config-common.go
@@ -30,7 +30,6 @@ import (
 var errConfigNotFound = errors.New("config file not found")
 
 func readConfig(ctx context.Context, objAPI ObjectLayer, configFile string) ([]byte, error) {
-	// Read entire content by setting size to -1
 	r, err := objAPI.GetObjectNInfo(ctx, minioMetaBucket, configFile, nil, http.Header{}, readLock, ObjectOptions{})
 	if err != nil {
 		// Treat object not found as config not found.

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -36,18 +36,21 @@ func TestServerConfig(t *testing.T) {
 		t.Fatalf("Init Test config failed")
 	}
 
-	if globalServerRegion != globalMinioDefaultRegion {
-		t.Errorf("Expecting region `us-east-1` found %s", globalServerRegion)
+	if globalSite.Region != globalMinioDefaultRegion {
+		t.Errorf("Expecting region `us-east-1` found %s", globalSite.Region)
 	}
 
 	// Set new region and verify.
 	config.SetRegion(globalServerConfig, "us-west-1")
-	region, err := config.LookupRegion(globalServerConfig[config.RegionSubSys][config.Default])
+	site, err := config.LookupSite(
+		globalServerConfig[config.SiteSubSys][config.Default],
+		globalServerConfig[config.RegionSubSys][config.Default],
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if region != "us-west-1" {
-		t.Errorf("Expecting region `us-west-1` found %s", globalServerRegion)
+	if site.Region != "us-west-1" {
+		t.Errorf("Expecting region `us-west-1` found %s", globalSite.Region)
 	}
 
 	if err := saveServerConfig(context.Background(), objLayer, globalServerConfig); err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -186,11 +186,6 @@ func readServerConfig(ctx context.Context, objAPI ObjectLayer) (config.Config, e
 // ConfigSys - config system.
 type ConfigSys struct{}
 
-// Load - load config.json.
-func (sys *ConfigSys) Load(objAPI ObjectLayer) error {
-	return sys.Init(objAPI)
-}
-
 // Init - initializes config system from config.json.
 func (sys *ConfigSys) Init(objAPI ObjectLayer) error {
 	if objAPI == nil {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -29,6 +29,7 @@ import (
 	"github.com/minio/console/restapi"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/bucket/bandwidth"
+	"github.com/minio/minio/internal/config"
 	"github.com/minio/minio/internal/handlers"
 	"github.com/minio/minio/internal/kms"
 	"github.com/rs/dnscache"
@@ -148,8 +149,9 @@ var (
 	// This flag is set to 'true' when MINIO_UPDATE env is set to 'off'. Default is false.
 	globalInplaceUpdateDisabled = false
 
-	// This flag is set to 'us-east-1' by default
-	globalServerRegion = globalMinioDefaultRegion
+	globalSite = config.Site{
+		Region: globalMinioDefaultRegion,
+	}
 
 	// MinIO local server address (in `host:port` format)
 	globalMinioAddr = ""

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -58,7 +58,7 @@ func parseLocationConstraint(r *http.Request) (location string, s3Error APIError
 	} // else for both err as nil or io.EOF
 	location = locationConstraint.Location
 	if location == "" {
-		location = globalServerRegion
+		location = globalSite.Region
 	}
 	return location, ErrNone
 }
@@ -66,7 +66,7 @@ func parseLocationConstraint(r *http.Request) (location string, s3Error APIError
 // Validates input location is same as configured region
 // of MinIO server.
 func isValidLocation(location string) bool {
-	return globalServerRegion == "" || globalServerRegion == location
+	return globalSite.Region == "" || globalSite.Region == location
 }
 
 // Supported headers that needs to be extracted.
@@ -222,7 +222,7 @@ func extractReqParams(r *http.Request) map[string]string {
 		return nil
 	}
 
-	region := globalServerRegion
+	region := globalSite.Region
 	cred := getReqAccessCred(r, region)
 
 	principalID := cred.AccessKey

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -63,7 +63,7 @@ func (sys *NotificationSys) GetARNList(onlyActive bool) []string {
 	if sys == nil {
 		return arns
 	}
-	region := globalServerRegion
+	region := globalSite.Region
 	for targetID, target := range sys.targetList.TargetMap() {
 		// httpclient target is part of ListenNotification
 		// which doesn't need to be listed as part of the ARN list
@@ -643,8 +643,8 @@ func (sys *NotificationSys) set(bucket BucketInfo, meta BucketMetadata) {
 	if config == nil {
 		return
 	}
-	config.SetRegion(globalServerRegion)
-	if err := config.Validate(globalServerRegion, globalNotificationSys.targetList); err != nil {
+	config.SetRegion(globalSite.Region)
+	if err := config.Validate(globalSite.Region, globalNotificationSys.targetList); err != nil {
 		if _, ok := err.(*event.ErrARNNotFound); !ok {
 			logger.LogIf(GlobalContext, err)
 		}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -862,7 +862,7 @@ var (
 // Returns a minio-go Client configured to access remote host described by destDNSRecord
 // Applicable only in a federated deployment
 var getRemoteInstanceClient = func(r *http.Request, host string) (*miniogo.Core, error) {
-	cred := getReqAccessCred(r, globalServerRegion)
+	cred := getReqAccessCred(r, globalSite.Region)
 	// In a federated deployment, all the instances share config files
 	// and hence expected to have same credentials.
 	return miniogo.NewCore(host, &miniogo.Options{
@@ -1651,7 +1651,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		}
 
 	case authTypePresigned, authTypeSigned:
-		if s3Err = reqSignatureV4Verify(r, globalServerRegion, serviceS3); s3Err != ErrNone {
+		if s3Err = reqSignatureV4Verify(r, globalSite.Region, serviceS3); s3Err != ErrNone {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
 			return
 		}
@@ -1982,7 +1982,7 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 		}
 
 	case authTypePresigned, authTypeSigned:
-		if s3Err = reqSignatureV4Verify(r, globalServerRegion, serviceS3); s3Err != ErrNone {
+		if s3Err = reqSignatureV4Verify(r, globalSite.Region, serviceS3); s3Err != ErrNone {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
 			return
 		}
@@ -2739,7 +2739,7 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 			return
 		}
 	case authTypePresigned, authTypeSigned:
-		if s3Error = reqSignatureV4Verify(r, globalServerRegion, serviceS3); s3Error != ErrNone {
+		if s3Error = reqSignatureV4Verify(r, globalSite.Region, serviceS3); s3Error != ErrNone {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL)
 			return
 		}

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -126,7 +126,7 @@ func printServerCommonMsg(apiEndpoints []string) {
 	cred := globalActiveCred
 
 	// Get saved region.
-	region := globalServerRegion
+	region := globalSite.Region
 
 	apiEndpointStr := strings.Join(apiEndpoints, "  ")
 

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -173,7 +173,7 @@ func compareSignatureV4(sig1, sig2 string) bool {
 // returns ErrNone if the signature matches.
 func doesPolicySignatureV4Match(formValues http.Header) (auth.Credentials, APIErrorCode) {
 	// Server region.
-	region := globalServerRegion
+	region := globalSite.Region
 
 	// Parse credential tag.
 	credHeader, s3Err := parseCredentialHeader("Credential="+formValues.Get(xhttp.AmzCredential), region, serviceS3)

--- a/cmd/signature-v4_test.go
+++ b/cmd/signature-v4_test.go
@@ -107,7 +107,7 @@ func TestDoesPresignedSignatureMatch(t *testing.T) {
 	now := UTCNow()
 	credentialTemplate := "%s/%s/%s/s3/aws4_request"
 
-	region := globalServerRegion
+	region := globalSite.Region
 	accessKeyID := globalActiveCred.AccessKey
 	testCases := []struct {
 		queryParams map[string]string

--- a/cmd/streaming-signature-v4.go
+++ b/cmd/streaming-signature-v4.go
@@ -74,7 +74,7 @@ func calculateSeedSignature(r *http.Request) (cred auth.Credentials, signature s
 	v4Auth := req.Header.Get(xhttp.Authorization)
 
 	// Parse signature version '4' header.
-	signV4Values, errCode := parseSignV4(v4Auth, globalServerRegion, serviceS3)
+	signV4Values, errCode := parseSignV4(v4Auth, globalSite.Region, serviceS3)
 	if errCode != ErrNone {
 		return cred, "", "", time.Time{}, errCode
 	}

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -142,12 +142,12 @@ func checkAssumeRoleAuth(ctx context.Context, r *http.Request) (user auth.Creden
 	default:
 		return user, true, ErrSTSAccessDenied
 	case authTypeSigned:
-		s3Err := isReqAuthenticated(ctx, r, globalServerRegion, serviceSTS)
+		s3Err := isReqAuthenticated(ctx, r, globalSite.Region, serviceSTS)
 		if s3Err != ErrNone {
 			return user, false, STSErrorCode(s3Err)
 		}
 
-		user, _, s3Err = getReqAccessKeyV4(r, globalServerRegion, serviceSTS)
+		user, _, s3Err = getReqAccessKeyV4(r, globalSite.Region, serviceSTS)
 		if s3Err != ErrNone {
 			return user, false, STSErrorCode(s3Err)
 		}

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -725,7 +725,7 @@ func newTestStreamingRequest(method, urlStr string, dataLength, chunkSize int64,
 func assembleStreamingChunks(req *http.Request, body io.ReadSeeker, chunkSize int64,
 	secretKey, signature string, currTime time.Time) (*http.Request, error) {
 
-	regionStr := globalServerRegion
+	regionStr := globalSite.Region
 	var stream []byte
 	var buffer []byte
 	body.Seek(0, 0)
@@ -833,7 +833,7 @@ func preSignV4(req *http.Request, accessKeyID, secretAccessKey string, expires i
 		return errors.New("Presign cannot be generated without access and secret keys")
 	}
 
-	region := globalServerRegion
+	region := globalSite.Region
 	date := UTCNow()
 	scope := getScope(date, region)
 	credential := fmt.Sprintf("%s/%s", accessKeyID, scope)
@@ -961,7 +961,7 @@ func signRequestV4(req *http.Request, accessKey, secretKey string) error {
 	}
 	sort.Strings(headers)
 
-	region := globalServerRegion
+	region := globalSite.Region
 
 	// Get canonical headers.
 	var buf bytes.Buffer

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -40,30 +40,33 @@ export MINIO_ROOT_PASSWORD=minio13
 minio server /data
 ```
 
-#### Region
+#### Site
 ```
 KEY:
-region  label the location of the server
+site  label the server and its location
 
 ARGS:
-name     (string)    name of the location of the server e.g. "us-west-rack2"
+name     (string)    name for the site e.g. "cal-rack0"
+region   (string)    name of the location of the server e.g. "us-west-1"
 comment  (sentence)  optionally add a comment to this setting
 ```
 
 or environment variables
 ```
 KEY:
-region  label the location of the server
+site  label the server and its location
 
 ARGS:
-MINIO_REGION_NAME     (string)    name of the location of the server e.g. "us-west-rack2"
-MINIO_REGION_COMMENT  (sentence)  optionally add a comment to this setting
+MINIO_SITE_NAME     (string)    name for the site e.g. "cal-rack0"
+MINIO_SITE_REGION   (string)    name of the location of the server e.g. "us-west-1"
+MINIO_SITE_COMMENT  (sentence)  optionally add a comment to this setting
 ```
 
 Example:
 
 ```sh
-export MINIO_REGION_NAME="my_region"
+export MINIO_SITE_REGION="us-west-0"
+export MINIO_SITE_NAME="sfo-rack-1"
 minio server /data
 ```
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -31,11 +31,13 @@ const (
 
 	EnvBrowser    = "MINIO_BROWSER"
 	EnvDomain     = "MINIO_DOMAIN"
-	EnvRegionName = "MINIO_REGION_NAME"
 	EnvPublicIPs  = "MINIO_PUBLIC_IPS"
 	EnvFSOSync    = "MINIO_FS_OSYNC"
 	EnvArgs       = "MINIO_ARGS"
 	EnvDNSWebhook = "MINIO_DNS_WEBHOOK_ENDPOINT"
+
+	EnvSiteName   = "MINIO_SITE_NAME"
+	EnvSiteRegion = "MINIO_SITE_REGION"
 
 	EnvMinIOSubnetLicense      = "MINIO_SUBNET_LICENSE"
 	EnvMinIOServerURL          = "MINIO_SERVER_URL"
@@ -51,7 +53,8 @@ const (
 	EnvKESClientCert = "MINIO_KMS_KES_CERT_FILE"
 	EnvKESServerCA   = "MINIO_KMS_KES_CAPATH"
 
-	EnvEndpoints = "MINIO_ENDPOINTS" // legacy
-	EnvWorm      = "MINIO_WORM"      // legacy
-	EnvRegion    = "MINIO_REGION"    // legacy
+	EnvEndpoints  = "MINIO_ENDPOINTS"   // legacy
+	EnvWorm       = "MINIO_WORM"        // legacy
+	EnvRegion     = "MINIO_REGION"      // legacy
+	EnvRegionName = "MINIO_REGION_NAME" // legacy
 )

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -49,13 +49,34 @@ func (hkvs HelpKVS) Lookup(key string) (HelpKV, bool) {
 // DefaultComment used across all sub-systems.
 const DefaultComment = "optionally add a comment to this setting"
 
-// Region and Worm help is documented in default config
+// Region help is documented in default config
 var (
+	SiteHelp = HelpKVS{
+		HelpKV{
+			Key:         NameKey,
+			Type:        "string",
+			Description: `name for the site e.g. "cal-rack0"`,
+			Optional:    true,
+		},
+		HelpKV{
+			Key:         RegionKey,
+			Type:        "string",
+			Description: `name of the location of the server e.g. "us-west-1"`,
+			Optional:    true,
+		},
+		HelpKV{
+			Key:         Comment,
+			Type:        "sentence",
+			Description: DefaultComment,
+			Optional:    true,
+		},
+	}
+
 	RegionHelp = HelpKVS{
 		HelpKV{
 			Key:         RegionName,
 			Type:        "string",
-			Description: `name of the location of the server e.g. "us-west-rack2"`,
+			Description: `[DEPRECATED] name of the location of the server e.g. "us-west-rack2"`,
 			Optional:    true,
 		},
 		HelpKV{


### PR DESCRIPTION
## Description

- New sub-system has "region" and "name" fields.

- `region` subsystem is marked as deprecated, however still works, unless the
new region parameter under `site` is set - in this case, the region subsystem is
ignored. `region` subsystem is hidden from top-level help (i.e. from `mc admin
config set myminio`), but appears when specifically requested (i.e. with `mc
admin config set myminio region`).

- MINIO_REGION, MINIO_REGION_NAME are supported as legacy environment variables
for server region.

- Adds MINIO_SITE_REGION as the current environment variable to configure the
server region and MINIO_SITE_NAME for the site name.

## Motivation and Context

Allow a user configurable friendly site name for the MinIO deployment, handy when managing multiple deployments.

## How to test this PR?

```
mc admin config set|get myminio site
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
