### PR TITLE
re-implement pickValidInfo dataDir, move to quorum calculation

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/upgrade-ci-cd.yaml
+++ b/.github/workflows/upgrade-ci-cd.yaml
@@ -26,44 +26,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Start containers MinIO from 2019
+      - name: Start upgrade tests
         run: |
-          sudo apt install curl -y
-          export MINIO_VERSION=RELEASE.2019-12-19T22-52-26Z
-          docker-compose -f "buildscripts/upgrade-tests/compose.yml" up -d --build
-          export GOPATH=/tmp/gopath
-          export PATH=${PATH}:${GOPATH}/bin
-          go install -v github.com/minio/mc@latest
-          until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;
-          mc mb minio/minio-test/;
-          mc mirror /usr/sbin minio/minio-test/to-read/;
-          mc cp /etc/hosts minio/minio-test/to-read/hosts;
-          mc policy set download minio/minio-test;
-          curl -s http://127.0.0.1:9000/minio-test/to-read/hosts | sha256sum;
-
-      - name: Build on ${{ matrix.os }}
-        if: matrix.os == 'ubuntu-latest'
-        env:
-          CGO_ENABLED: 0
-          GO111MODULE: on
-        run: |
-          TAG=minio/minio:dev make docker
-
-      - name: Start containers MinIO current
-        run: |
-          sudo apt install curl -y
-          export MINIO_VERSION=RELEASE.2019-12-19T22-52-26Z
-          docker-compose -f "buildscripts/upgrade-tests/compose.yml" stop
-          export MINIO_VERSION=dev
-          export GOPATH=/tmp/gopath
-          export PATH=${PATH}:${GOPATH}/bin
-          docker-compose -f "buildscripts/upgrade-tests/compose.yml" up -d --build
-          until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;
-          sha256sum1=$(curl -s http://127.0.0.1:9000/minio-test/to-read/hosts | sha256sum);
-          mc mirror /usr/sbin minio/minio-test/to-read/;
-          mc admin heal -r minio/minio-test; # test after healing
-          mc mirror /usr/sbin minio/minio-test/to-read/;
-          sha256sum2=$(curl -s http://127.0.0.1:9000/minio-test/to-read/hosts | sha256sum);
-          if [ "${sha256sum1}" != "$${sha256sum2}" ]; then
-             exit 1;
-          fi
+          make test-upgrade

--- a/.github/workflows/upgrade-ci-cd.yaml
+++ b/.github/workflows/upgrade-ci-cd.yaml
@@ -1,0 +1,69 @@
+name: Upgrade old version tests
+
+on:
+  pull_request:
+    branches:
+    - master
+
+# This ensures that previous jobs for the PR are canceled when the PR is
+# updated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Go ${{ matrix.go-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Start containers MinIO from 2019
+        run: |
+          sudo apt install curl -y
+          export MINIO_VERSION=RELEASE.2019-12-19T22-52-26Z
+          docker-compose -f "buildscripts/upgrade-tests/compose.yml" up -d --build
+          export GOPATH=/tmp/gopath
+          export PATH=${PATH}:${GOPATH}/bin
+          go install -v github.com/minio/mc@latest
+          until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;
+          mc mb minio/minio-test/;
+          mc mirror /usr/sbin minio/minio-test/to-read/;
+          mc cp /etc/hosts minio/minio-test/to-read/hosts;
+          mc policy set download minio/minio-test;
+          curl -s http://127.0.0.1:9000/minio-test/to-read/hosts | sha256sum;
+
+      - name: Build on ${{ matrix.os }}
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          CGO_ENABLED: 0
+          GO111MODULE: on
+        run: |
+          TAG=minio/minio:dev make docker
+
+      - name: Start containers MinIO current
+        run: |
+          sudo apt install curl -y
+          export MINIO_VERSION=RELEASE.2019-12-19T22-52-26Z
+          docker-compose -f "buildscripts/upgrade-tests/compose.yml" stop
+          export MINIO_VERSION=dev
+          export GOPATH=/tmp/gopath
+          export PATH=${PATH}:${GOPATH}/bin
+          docker-compose -f "buildscripts/upgrade-tests/compose.yml" up -d --build
+          until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;
+          sha256sum1=$(curl -s http://127.0.0.1:9000/minio-test/to-read/hosts | sha256sum);
+          mc mirror /usr/sbin minio/minio-test/to-read/;
+          mc admin heal -r minio/minio-test; # test after healing
+          mc mirror /usr/sbin minio/minio-test/to-read/;
+          sha256sum2=$(curl -s http://127.0.0.1:9000/minio-test/to-read/hosts | sha256sum);
+          if [ "${sha256sum1}" != "$${sha256sum2}" ]; then
+             exit 1;
+          fi

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ test: verifiers build ## builds minio, runs linters, tests
 	@echo "Running unit tests"
 	@GO111MODULE=on CGO_ENABLED=0 go test -tags kqueue ./... 1>/dev/null
 
+test-upgrade: build
+	@echo "Running minio upgrade tests"
+	@(env bash $(PWD)/buildscripts/minio-upgrade.sh)
+
 test-race: verifiers build ## builds minio, runs linters, tests (race)
 	@echo "Running unit tests under -race"
 	@(env bash $(PWD)/buildscripts/race.sh)

--- a/buildscripts/minio-upgrade.sh
+++ b/buildscripts/minio-upgrade.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+__init__() {
+    sudo apt install curl -y
+    export GOPATH=/tmp/gopath
+    export PATH=${PATH}:${GOPATH}/bin
+
+    go install github.com/minio/mc@latest
+
+    TAG=minio/minio:dev make docker
+
+    export MINIO_VERSION=RELEASE.2019-12-19T22-52-26Z
+    docker-compose -f "buildscripts/upgrade-tests/compose.yml" up -d --build
+    until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin); do
+        echo "...waiting..." && sleep 5;
+    done
+
+    mc mb minio/minio-test/
+    mc cp ./minio minio/minio-test/to-read/
+    mc cp /etc/hosts minio/minio-test/to-read/hosts
+    mc policy set download minio/minio-test
+    mc cat minio/minio-test/to-read/minio | sha256sum
+    mc cat ./minio | sha256sum
+    curl -s http://127.0.0.1:9000/minio-test/to-read/hosts | sha256sum
+}
+
+verify_checksum_after_heal() {
+    sum1=$(curl -s "$2" | sha256sum);
+    mc admin heal --json -r "$1" >/dev/null; # test after healing
+    sum1_heal=$(curl -s "$2" | sha256sum);
+
+    if [ "${sum1_heal}" != "${sum1}" ]; then
+        echo "mismatch expected ${sum1_heal}, got ${sum1}"
+        exit 1;
+    fi
+}
+
+verify_checksum_mc() {
+    expected=$(mc cat "$1" | sha256sum)
+    got=$(mc cat "$2" | sha256sum)
+
+    if [ "${expected}" != "${got}" ]; then
+        echo "mismatch expected ${expected}, got ${got}"
+        exit 1;
+    fi
+}
+
+main() {
+    export MINIO_VERSION=RELEASE.2019-12-19T22-52-26Z
+    docker-compose -f "buildscripts/upgrade-tests/compose.yml" stop
+
+    export MINIO_VERSION=dev
+    docker-compose -f "buildscripts/upgrade-tests/compose.yml" up -d --build
+
+    until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin); do
+        echo "...waiting..." && sleep 5
+    done
+
+    verify_checksum_after_heal minio/minio-test http://127.0.0.1:9000/minio-test/to-read/hosts
+
+    verify_checksum_mc ./minio minio/minio-test/to-read/minio
+
+    verify_checksum_mc /etc/hosts minio/minio-test/to-read/hosts
+}
+
+( __init__ "$@" && main "$@" )

--- a/buildscripts/upgrade-tests/compose.yml
+++ b/buildscripts/upgrade-tests/compose.yml
@@ -1,0 +1,81 @@
+version: '3.7'
+
+# Settings and configurations that are common for all containers
+x-minio-common: &minio-common
+  image: minio/minio:${MINIO_VERSION}
+  command: server http://minio{1...4}/data{1...3}
+  env_file:
+    - ./minio.env
+  expose:
+    - "9000"
+    - "9001"
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+    interval: 30s
+    timeout: 20s
+    retries: 3
+
+# starts 4 docker containers running minio server instances.
+# using nginx reverse proxy, load balancing, you can access
+# it through port 9000.
+services:
+  minio1:
+    <<: *minio-common
+    hostname: minio1
+    volumes:
+      - data1-1:/data1
+      - data1-2:/data2
+      - data1-3:/data3
+
+  minio2:
+    <<: *minio-common
+    hostname: minio2
+    volumes:
+      - data2-1:/data1
+      - data2-2:/data2
+      - data2-3:/data3
+
+  minio3:
+    <<: *minio-common
+    hostname: minio3
+    volumes:
+      - data3-1:/data1
+      - data3-2:/data2
+      - data3-3:/data3
+
+  minio4:
+    <<: *minio-common
+    hostname: minio4
+    volumes:
+      - data4-1:/data1
+      - data4-2:/data2
+      - data4-3:/data3
+
+  nginx:
+    image: nginx:1.19.2-alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+    - "9000:9000"
+    - "9001:9001"
+    depends_on:
+      - minio1
+      - minio2
+      - minio3
+      - minio4
+
+## By default this config uses default local driver,
+## For custom volumes replace with volume driver configuration.
+volumes:
+  data1-1:
+  data1-2:
+  data1-3:
+  data2-1:
+  data2-2:
+  data2-3:
+  data3-1:
+  data3-2:
+  data3-3:
+  data4-1:
+  data4-2:
+  data4-3:

--- a/buildscripts/upgrade-tests/minio.env
+++ b/buildscripts/upgrade-tests/minio.env
@@ -1,0 +1,3 @@
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin
+MINIO_BROWSER=off

--- a/buildscripts/upgrade-tests/nginx.conf
+++ b/buildscripts/upgrade-tests/nginx.conf
@@ -1,0 +1,68 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    # include /etc/nginx/conf.d/*.conf;
+
+    upstream minio {
+        server minio1:9000;
+        server minio2:9000;
+        server minio3:9000;
+        server minio4:9000;
+    }
+
+    # main minio
+    server {
+        listen       9000;
+        listen  [::]:9000;
+        server_name  localhost;
+
+         # To allow special characters in headers
+         ignore_invalid_headers off;
+         # Allow any size file to be uploaded.
+         # Set to a value such as 1000m; to restrict file size to a specific value
+         client_max_body_size 0;
+         # To disable buffering
+         proxy_buffering off;
+
+        location / {
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 300;
+            # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            chunked_transfer_encoding off;
+
+            proxy_pass http://minio;
+        }
+    }
+}

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -294,15 +294,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 
 	// List of disks having latest version of the object er.meta
 	// (by modtime).
-	_, modTime, dataDir := listOnlineDisks(storageDisks, partsMetadata, errs)
-
-	// make sure all parts metadata dataDir is same as returned by listOnlineDisks()
-	// the reason is its possible that some of the disks might have stale data, for those
-	// we simply override them with maximally occurring 'dataDir' - this ensures that
-	// disksWithAllParts() verifies same dataDir across all drives.
-	for i := range partsMetadata {
-		partsMetadata[i].DataDir = dataDir
-	}
+	_, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
 	// List of disks having all parts as per latest metadata.
 	// NOTE: do not pass in latestDisks to diskWithAllParts since
@@ -318,7 +310,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 
 	// Latest FileInfo for reference. If a valid metadata is not
 	// present, it is as good as object not found.
-	latestMeta, err := pickValidFileInfo(ctx, partsMetadata, modTime, dataDir, result.DataBlocks)
+	latestMeta, err := pickValidFileInfo(ctx, partsMetadata, modTime, result.DataBlocks)
 	if err != nil {
 		return result, toObjectErr(err, bucket, object, versionID)
 	}
@@ -551,6 +543,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 		if disk == OfflineDisk {
 			continue
 		}
+
 		// record the index of the updated disks
 		partsMetadata[i].Erasure.Index = i + 1
 

--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -179,6 +179,10 @@ func shuffleDisksAndPartsMetadataByIndex(disks []StorageAPI, metaArr []FileInfo,
 			inconsistent++
 			continue
 		}
+		if meta.XLV1 != fi.XLV1 {
+			inconsistent++
+			continue
+		}
 		// check if erasure distribution order matches the index
 		// position if this is not correct we discard the disk
 		// and move to collect others
@@ -226,6 +230,9 @@ func shuffleDisksAndPartsMetadata(disks []StorageAPI, partsMetadata []FileInfo, 
 			// Check for length of data parts only when
 			// fi.ModTime is not empty - ModTime is always set,
 			// if object was ever written previously.
+			continue
+		}
+		if !init && fi.XLV1 != partsMetadata[index].XLV1 {
 			continue
 		}
 		blockIndex := distribution[index]

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -282,7 +282,7 @@ func (fi FileInfo) ObjectToPartOffset(ctx context.Context, offset int64) (partIn
 	return 0, 0, InvalidRange{}
 }
 
-func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.Time, dataDir string, quorum int) (FileInfo, error) {
+func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.Time, quorum int) (FileInfo, error) {
 	// with less quorum return error.
 	if quorum < 2 {
 		return FileInfo{}, errErasureReadQuorum
@@ -290,7 +290,9 @@ func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.
 	metaHashes := make([]string, len(metaArr))
 	h := sha256.New()
 	for i, meta := range metaArr {
-		if meta.IsValid() && meta.ModTime.Equal(modTime) && meta.DataDir == dataDir {
+		if meta.IsValid() && meta.ModTime.Equal(modTime) {
+			fmt.Fprintf(h, "%v", meta.XLV1)
+			fmt.Fprintf(h, "%v", meta.GetDataDir())
 			for _, part := range meta.Parts {
 				fmt.Fprintf(h, "part.%d", part.Number)
 			}
@@ -351,8 +353,8 @@ func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.
 
 // pickValidFileInfo - picks one valid FileInfo content and returns from a
 // slice of FileInfo.
-func pickValidFileInfo(ctx context.Context, metaArr []FileInfo, modTime time.Time, dataDir string, quorum int) (FileInfo, error) {
-	return findFileInfoInQuorum(ctx, metaArr, modTime, dataDir, quorum)
+func pickValidFileInfo(ctx context.Context, metaArr []FileInfo, modTime time.Time, quorum int) (FileInfo, error) {
+	return findFileInfoInQuorum(ctx, metaArr, modTime, quorum)
 }
 
 // writeUniqueFileInfo - writes unique `xl.meta` content for each disk concurrently.

--- a/cmd/erasure-metadata_test.go
+++ b/cmd/erasure-metadata_test.go
@@ -178,28 +178,24 @@ func TestFindFileInfoInQuorum(t *testing.T) {
 	tests := []struct {
 		fis            []FileInfo
 		modTime        time.Time
-		dataDir        string
 		expectedErr    error
 		expectedQuorum int
 	}{
 		{
 			fis:            getNFInfo(16, 16, 1603863445, "36a21454-a2ca-11eb-bbaa-93a81c686f21"),
 			modTime:        time.Unix(1603863445, 0),
-			dataDir:        "36a21454-a2ca-11eb-bbaa-93a81c686f21",
 			expectedErr:    nil,
 			expectedQuorum: 8,
 		},
 		{
 			fis:            getNFInfo(16, 7, 1603863445, "36a21454-a2ca-11eb-bbaa-93a81c686f21"),
 			modTime:        time.Unix(1603863445, 0),
-			dataDir:        "36a21454-a2ca-11eb-bbaa-93a81c686f21",
 			expectedErr:    errErasureReadQuorum,
 			expectedQuorum: 8,
 		},
 		{
 			fis:            getNFInfo(16, 16, 1603863445, "36a21454-a2ca-11eb-bbaa-93a81c686f21"),
 			modTime:        time.Unix(1603863445, 0),
-			dataDir:        "36a21454-a2ca-11eb-bbaa-93a81c686f21",
 			expectedErr:    errErasureReadQuorum,
 			expectedQuorum: 0,
 		},
@@ -208,7 +204,7 @@ func TestFindFileInfoInQuorum(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run("", func(t *testing.T) {
-			_, err := findFileInfoInQuorum(context.Background(), test.fis, test.modTime, test.dataDir, test.expectedQuorum)
+			_, err := findFileInfoInQuorum(context.Background(), test.fis, test.modTime, test.expectedQuorum)
 			if err != test.expectedErr {
 				t.Errorf("Expected %s, got %s", test.expectedErr, err)
 			}

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -67,10 +67,10 @@ func (er erasureObjects) checkUploadIDExists(ctx context.Context, bucket, object
 	}
 
 	// List all online disks.
-	_, modTime, dataDir := listOnlineDisks(disks, metaArr, errs)
+	_, modTime := listOnlineDisks(disks, metaArr, errs)
 
 	// Pick latest valid metadata.
-	_, err = pickValidFileInfo(ctx, metaArr, modTime, dataDir, readQuorum)
+	_, err = pickValidFileInfo(ctx, metaArr, modTime, readQuorum)
 	return err
 }
 
@@ -460,10 +460,10 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 	}
 
 	// List all online disks.
-	onlineDisks, modTime, dataDir := listOnlineDisks(storageDisks, partsMetadata, errs)
+	onlineDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
 	// Pick one from the first valid metadata.
-	fi, err := pickValidFileInfo(pctx, partsMetadata, modTime, dataDir, writeQuorum)
+	fi, err := pickValidFileInfo(pctx, partsMetadata, modTime, writeQuorum)
 	if err != nil {
 		return pi, err
 	}
@@ -568,10 +568,10 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 	}
 
 	// Get current highest version based on re-read partsMetadata.
-	onlineDisks, modTime, dataDir = listOnlineDisks(onlineDisks, partsMetadata, errs)
+	onlineDisks, modTime = listOnlineDisks(onlineDisks, partsMetadata, errs)
 
 	// Pick one from the first valid metadata.
-	fi, err = pickValidFileInfo(wctx, partsMetadata, modTime, dataDir, writeQuorum)
+	fi, err = pickValidFileInfo(wctx, partsMetadata, modTime, writeQuorum)
 	if err != nil {
 		return pi, err
 	}
@@ -656,10 +656,10 @@ func (er erasureObjects) GetMultipartInfo(ctx context.Context, bucket, object, u
 		return result, toObjectErr(reducedErr, minioMetaMultipartBucket, uploadIDPath)
 	}
 
-	_, modTime, dataDir := listOnlineDisks(storageDisks, partsMetadata, errs)
+	_, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
 	// Pick one from the first valid metadata.
-	fi, err := pickValidFileInfo(ctx, partsMetadata, modTime, dataDir, readQuorum)
+	fi, err := pickValidFileInfo(ctx, partsMetadata, modTime, readQuorum)
 	if err != nil {
 		return result, err
 	}
@@ -706,10 +706,10 @@ func (er erasureObjects) ListObjectParts(ctx context.Context, bucket, object, up
 		return result, toObjectErr(reducedErr, minioMetaMultipartBucket, uploadIDPath)
 	}
 
-	_, modTime, dataDir := listOnlineDisks(storageDisks, partsMetadata, errs)
+	_, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
 	// Pick one from the first valid metadata.
-	fi, err := pickValidFileInfo(ctx, partsMetadata, modTime, dataDir, writeQuorum)
+	fi, err := pickValidFileInfo(ctx, partsMetadata, modTime, writeQuorum)
 	if err != nil {
 		return result, err
 	}
@@ -801,10 +801,10 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 		return oi, toObjectErr(reducedErr, bucket, object)
 	}
 
-	onlineDisks, modTime, dataDir := listOnlineDisks(storageDisks, partsMetadata, errs)
+	onlineDisks, modTime := listOnlineDisks(storageDisks, partsMetadata, errs)
 
 	// Pick one from the first valid metadata.
-	fi, err := pickValidFileInfo(rctx, partsMetadata, modTime, dataDir, writeQuorum)
+	fi, err := pickValidFileInfo(rctx, partsMetadata, modTime, writeQuorum)
 	if err != nil {
 		return oi, err
 	}

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -700,7 +700,7 @@ func (er *erasureObjects) saveMetaCacheStream(ctx context.Context, mc *metaCache
 			for k, v := range meta {
 				fi.Metadata[k] = v
 			}
-			err := er.updateObjectMeta(ctx, minioMetaBucket, o.objectPath(0), fi)
+			err := er.updateObjectMeta(ctx, minioMetaBucket, o.objectPath(0), fi, er.getDisks())
 			if err == nil {
 				break
 			}

--- a/cmd/os-reliable.go
+++ b/cmd/os-reliable.go
@@ -136,7 +136,7 @@ func renameAll(srcFilePath, dstFilePath string) (err error) {
 		switch {
 		case isSysErrNotDir(err) && !osIsNotExist(err):
 			// Windows can have both isSysErrNotDir(err) and osIsNotExist(err) returning
-			// true if the source file path contains an inexistant directory. In that case,
+			// true if the source file path contains an non-existent directory. In that case,
 			// we want to return errFileNotFound instead, which will honored in subsequent
 			// switch cases
 			return errFileAccessDenied

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -186,6 +186,21 @@ type FileInfo struct {
 	Idx int `msg:"i"`
 }
 
+// GetDataDir returns an expected dataDir given FileInfo
+// - deleteMarker returns "delete-marker"
+// - returns "legacy" if FileInfo is XLV1 and DataDir is
+//   empty, returns DataDir otherwise
+// - returns "dataDir"
+func (fi FileInfo) GetDataDir() string {
+	if fi.Deleted {
+		return "delete-marker"
+	}
+	if fi.XLV1 && fi.DataDir == "" {
+		return "legacy"
+	}
+	return fi.DataDir
+}
+
 // InlineData returns true if object contents are inlined alongside its metadata.
 func (fi FileInfo) InlineData() bool {
 	_, ok := fi.Metadata[ReservedMetadataPrefixLower+"inline-data"]


### PR DESCRIPTION
## Description
re-implement pickValidInfo dataDir, move to quorum calculation

## Motivation and Context
dataDir loosely based on maxima is incorrect and does not
work in all situations such as disks in the following order
    
- xl.json migration to xl.meta there may be partial xl.json's
  leftover if some disks are not yet connected when disk
  is yet to come up, since xl.json mtime and xl.meta is
  same the dataDir maxima don't work properly leading to
  quorum issues.
    
- its also possible that XLV1 might be true among the disks 
  available, make sure to keep FileInfo based on common quorum
  and skip unexpected disks with the older data format.

## How to test this PR?
CI/CD will do the job for you 🍰 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
