### PR TITLE
applyMaxNoncurrentVersionLimit: Fix remaining versions calculation

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -903,7 +903,7 @@ func (i *scannerItem) applyMaxNoncurrentVersionLimit(ctx context.Context, o Obje
 
 	overflowVersions := fivs[lim+1:]
 	// current version + most recent lim noncurrent versions
-	fivs = append(fivs[0:1], fivs[:lim+1]...)
+	fivs = fivs[:lim+1]
 
 	rcfg, _ := globalBucketObjectLockSys.Get(i.bucket)
 	toDel := make([]ObjectToDelete, 0, len(overflowVersions))


### PR DESCRIPTION
## Description
Fixes a bug in computing remaining object versions after applying MaxNoncurrentVersions rule on an object.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
