### PR TITLE
allow in-memory persistence for gateway

### DIFF
--- a/cmd/iam-dummy-store.go
+++ b/cmd/iam-dummy-store.go
@@ -65,34 +65,80 @@ func (ids *iamDummyStore) migrateBackendFormat(context.Context) error {
 }
 
 func (ids *iamDummyStore) loadPolicyDoc(ctx context.Context, policy string, m map[string]iampolicy.Policy) error {
+	v, ok := ids.iamPolicyDocsMap[policy]
+	if !ok {
+		return errNoSuchPolicy
+	}
+	m[policy] = v
 	return nil
 }
 
 func (ids *iamDummyStore) loadPolicyDocs(ctx context.Context, m map[string]iampolicy.Policy) error {
+	for k, v := range ids.iamPolicyDocsMap {
+		m[k] = v
+	}
 	return nil
 }
 
 func (ids *iamDummyStore) loadUser(ctx context.Context, user string, userType IAMUserType, m map[string]auth.Credentials) error {
+	u, ok := ids.iamUsersMap[user]
+	if !ok {
+		return errNoSuchUser
+	}
+	ids.iamUsersMap[user] = u
 	return nil
 }
 
 func (ids *iamDummyStore) loadUsers(ctx context.Context, userType IAMUserType, m map[string]auth.Credentials) error {
+	for k, v := range ids.iamUsersMap {
+		m[k] = v
+	}
 	return nil
 }
 
 func (ids *iamDummyStore) loadGroup(ctx context.Context, group string, m map[string]GroupInfo) error {
+	g, ok := ids.iamGroupsMap[group]
+	if !ok {
+		return errNoSuchGroup
+	}
+	m[group] = g
 	return nil
 }
 
 func (ids *iamDummyStore) loadGroups(ctx context.Context, m map[string]GroupInfo) error {
+	for k, v := range ids.iamGroupsMap {
+		m[k] = v
+	}
 	return nil
 }
 
 func (ids *iamDummyStore) loadMappedPolicy(ctx context.Context, name string, userType IAMUserType, isGroup bool, m map[string]MappedPolicy) error {
+	if isGroup {
+		g, ok := ids.iamGroupPolicyMap[name]
+		if !ok {
+			return errNoSuchPolicy
+		}
+		m[name] = g
+	} else {
+		u, ok := ids.iamUserPolicyMap[name]
+		if !ok {
+			return errNoSuchPolicy
+		}
+		m[name] = u
+	}
 	return nil
 }
 
 func (ids *iamDummyStore) loadMappedPolicies(ctx context.Context, userType IAMUserType, isGroup bool, m map[string]MappedPolicy) error {
+	if !isGroup {
+		for k, v := range ids.iamUserPolicyMap {
+			m[k] = v
+		}
+	} else {
+		for k, v := range ids.iamGroupPolicyMap {
+			m[k] = v
+		}
+	}
 	return nil
 }
 

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -151,7 +151,13 @@ func (sys *IAMSys) initStore(objAPI ObjectLayer, etcdClient *etcd.Client) {
 
 	if etcdClient == nil {
 		if globalIsGateway {
-			sys.store = &IAMStoreSys{newIAMDummyStore(sys.usersSysType)}
+			if globalGatewayName == NASBackendGateway {
+				sys.store = &IAMStoreSys{newIAMObjectStore(objAPI, sys.usersSysType)}
+			} else {
+				sys.store = &IAMStoreSys{newIAMDummyStore(sys.usersSysType)}
+				logger.Info("WARNING: %s gateway is running in-memory IAM store, for persistence please configure etcd",
+					globalGatewayName)
+			}
 		} else {
 			sys.store = &IAMStoreSys{newIAMObjectStore(objAPI, sys.usersSysType)}
 		}


### PR DESCRIPTION


## Description
allow in-memory persistence for gateway

## Motivation and Context
NAS gateway would persist however with
or without etcd as before.

## How to test this PR?
Check `minio-java` functional tests with gateway deployments locally
```
~ ./gradlew -PendPoint=http://10.0.0.67:9000       \
   -PaccessKey=minio  \
   -PsecretKey=minio123  \
   -Pregion=us-east-1  \
   runFunctionalTest
...
addUser()
addCannedPolicy()
setPolicy()
listUsers()
listCannedPolicies()
deleteUser()
removeCannedPolicy()
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes NAS gateway lost persistence for its credentials
- [ ] Documentation updated
- [ ] Unit tests added/updated
