### PR TITLE
svc: Fix evaluation with an empty policy

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1096,11 +1096,6 @@ func (sys *IAMSys) IsAllowedServiceAccount(args iampolicy.Args, parentUser strin
 		return false
 	}
 
-	// This can only happen if policy was set but with an empty JSON.
-	if subPolicy.Version == "" && len(subPolicy.Statements) == 0 {
-		return combinedPolicy.IsAllowed(parentArgs)
-	}
-
 	if subPolicy.Version == "" {
 		return false
 	}


### PR DESCRIPTION
## Description
For service accounts, it is clear how to test if an account has inherited
policy from a parent user or not by testing this claim:
   `embedded-policy` vs `inherited-policy`

We do not have to test if a policy is empty or not to ignore it and to
evaluate parent policy.

## Motivation and Context
Fix service accounts access with empty policy

## How to test this PR?
```
$ minio server /tmp/fs/
$ mc admin user add myminio/ tenant-x-user tenant-x-user
$ mc admin policy set myminio/ readwrite user=tenant-x-user
$ cat >/tmp/policy.json <<EOF
{
 "Version": "2012-10-17",
  "Statement": []
}
EOF
$ mc admin user svcacct add myminio/ tenant-x-user --access-key tenant-x-sa --secret-key tenant-x-sa --policy /tmp/policy.json
$ mc alias set local http://localhost:9000 tenant-x-sa tenant-x-sa
$ mc mb local/testbucket/
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
