### PR TITLE
Fix entries not cleared on resolve

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -262,7 +262,7 @@ func (m metaCacheEntries) resolve(r *metadataResolutionParams) (selected *metaCa
 			e *metaCacheEntry
 		}, 0, len(m))
 	}
-	r.candidates = r.candidates[0:]
+	r.candidates = r.candidates[:0]
 	for i := range m {
 		entry := &m[i]
 		if entry.name == "" {


### PR DESCRIPTION
## Description

This can cause old entries to be included (albeit unlikely) in resolution.

## How to test this PR?

Conflict resolution can cause an old entry to be most popular.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
