### PR TITLE
usage cache:Avoid logging replication config missing error

### DIFF
--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -1076,6 +1076,10 @@ func (d *dataUsageCache) deserialize(r io.Reader) error {
 				}
 				cfg, err := getReplicationConfig(GlobalContext, d.Info.Name)
 				if err != nil {
+					// avoid logging replication config not found error
+					if _, ok := err.(BucketReplicationConfigNotFound); ok {
+						return nil
+					}
 					return err
 				}
 				due.ReplicationStats.ReplicaSize = v.ReplicaSize


### PR DESCRIPTION
Some stale entries can be reported on startup - avoid logging these.
```
API: SYSTEM()
Time: 12:24:04 PST 11/19/2021
DeploymentID: d9db8746-70ee-47b3-96b2-d9247a8da126
Error: The replication configuration was not found: / (cmd.BucketReplicationConfigNotFound)
       5: internal/logger/logonce.go:52:logger.(*logOnceType).logOnceIf()
       4: internal/logger/logonce.go:92:logger.LogOnceIf()
       3: cmd/data-usage-cache.go:941:cmd.(*dataUsageCache).load()
       2: cmd/erasure.go:366:cmd.erasureObjects.nsScanner()
       1: cmd/erasure-server-pool.go:533:cmd.(*erasureServerPools).NSScanner.func2()
```

## Description


## Motivation and Context
Avoid printing unactionable logs.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
