### PR TITLE
fix: obtaining a valid FileInfo in getLatestFileInfo

### DIFF
--- a/buildscripts/minio-upgrade.sh
+++ b/buildscripts/minio-upgrade.sh
@@ -10,6 +10,38 @@ cleanup() {
     docker volume prune -f
 }
 
+verify_checksum_after_heal() {
+    local sum1
+    sum1=$(curl -s "$2" | sha256sum);
+    mc admin heal --json -r "$1" >/dev/null; # test after healing
+    local sum1_heal
+    sum1_heal=$(curl -s "$2" | sha256sum);
+
+    if [ "${sum1_heal}" != "${sum1}" ]; then
+        echo "mismatch expected ${sum1_heal}, got ${sum1}"
+        exit 1;
+    fi
+}
+
+verify_checksum_mc() {
+    local expected
+    expected=$(mc cat "$1" | sha256sum)
+    local got
+    got=$(mc cat "$2" | sha256sum)
+
+    if [ "${expected}" != "${got}" ]; then
+        echo "mismatch - expected ${expected}, got ${got}"
+        exit 1;
+    fi
+    echo "matches - ${expected}, got ${got}"
+}
+
+add_alias() {
+    until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin); do
+        echo "...waiting... for 5secs" && sleep 5
+    done
+}
+
 __init__() {
     sudo apt install curl -y
     export GOPATH=/tmp/gopath
@@ -22,48 +54,25 @@ __init__() {
     MINIO_VERSION=RELEASE.2019-12-19T22-52-26Z docker-compose \
                  -f "buildscripts/upgrade-tests/compose.yml" \
                  up -d --build
-    until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin); do
-        echo "...waiting..." && sleep 5;
-    done
+
+    add_alias
 
     mc mb minio/minio-test/
     mc cp ./minio minio/minio-test/to-read/
     mc cp /etc/hosts minio/minio-test/to-read/hosts
     mc policy set download minio/minio-test
-    mc cat minio/minio-test/to-read/minio | sha256sum
-    mc cat ./minio | sha256sum
+
+    verify_checksum_mc ./minio minio/minio-test/to-read/minio
+
     curl -s http://127.0.0.1:9000/minio-test/to-read/hosts | sha256sum
 
     MINIO_VERSION=dev docker-compose -f "buildscripts/upgrade-tests/compose.yml" stop
 }
 
-verify_checksum_after_heal() {
-    sum1=$(curl -s "$2" | sha256sum);
-    mc admin heal --json -r "$1" >/dev/null; # test after healing
-    sum1_heal=$(curl -s "$2" | sha256sum);
-
-    if [ "${sum1_heal}" != "${sum1}" ]; then
-        echo "mismatch expected ${sum1_heal}, got ${sum1}"
-        exit 1;
-    fi
-}
-
-verify_checksum_mc() {
-    expected=$(mc cat "$1" | sha256sum)
-    got=$(mc cat "$2" | sha256sum)
-
-    if [ "${expected}" != "${got}" ]; then
-        echo "mismatch expected ${expected}, got ${got}"
-        exit 1;
-    fi
-}
-
 main() {
     MINIO_VERSION=dev docker-compose -f "buildscripts/upgrade-tests/compose.yml" up -d --build
 
-    until (mc alias set minio http://127.0.0.1:9000 minioadmin minioadmin); do
-        echo "...waiting..." && sleep 5
-    done
+    add_alias
 
     verify_checksum_after_heal minio/minio-test http://127.0.0.1:9000/minio-test/to-read/hosts
 

--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -416,7 +416,7 @@ func TestHealObjectCorrupted(t *testing.T) {
 	}
 
 	fileInfos, errs := readAllFileInfo(ctx, erasureDisks, bucket, object, "", false)
-	fi, err := getLatestFileInfo(ctx, fileInfos, errs, er.defaultParityCount)
+	fi, err := getLatestFileInfo(ctx, fileInfos, errs)
 	if err != nil {
 		t.Fatalf("Failed to getLatestFileInfo - %v", err)
 	}
@@ -441,7 +441,7 @@ func TestHealObjectCorrupted(t *testing.T) {
 	}
 
 	fileInfos, errs = readAllFileInfo(ctx, erasureDisks, bucket, object, "", false)
-	nfi, err := getLatestFileInfo(ctx, fileInfos, errs, er.defaultParityCount)
+	nfi, err := getLatestFileInfo(ctx, fileInfos, errs)
 	if err != nil {
 		t.Fatalf("Failed to getLatestFileInfo - %v", err)
 	}
@@ -467,7 +467,7 @@ func TestHealObjectCorrupted(t *testing.T) {
 	}
 
 	fileInfos, errs = readAllFileInfo(ctx, erasureDisks, bucket, object, "", false)
-	nfi, err = getLatestFileInfo(ctx, fileInfos, errs, er.defaultParityCount)
+	nfi, err = getLatestFileInfo(ctx, fileInfos, errs)
 	if err != nil {
 		t.Fatalf("Failed to getLatestFileInfo - %v", err)
 	}

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -390,13 +390,9 @@ func writeUniqueFileInfo(ctx context.Context, disks []StorageAPI, bucket, prefix
 // writeQuorum is the min required disks to write data.
 func objectQuorumFromMeta(ctx context.Context, partsMetaData []FileInfo, errs []error, defaultParityCount int) (objectReadQuorum, objectWriteQuorum int, err error) {
 	// get the latest updated Metadata and a count of all the latest updated FileInfo(s)
-	latestFileInfo, err := getLatestFileInfo(ctx, partsMetaData, errs, defaultParityCount)
+	latestFileInfo, err := getLatestFileInfo(ctx, partsMetaData, errs)
 	if err != nil {
 		return 0, 0, err
-	}
-
-	if !latestFileInfo.IsValid() {
-		return 0, 0, errErasureReadQuorum
 	}
 
 	parityBlocks := globalStorageClass.GetParityForSC(latestFileInfo.Metadata[xhttp.AmzStorageClass])


### PR DESCRIPTION
## Description
fix: obtaining a valid FileInfo in getLatestFileInfo

## Motivation and Context
FileInfo quorum shouldn't be passed down, instead
inferred after obtaining a maximally occurring FileInfo.

This PR also changes other functions that rely on
wrong quorum calculation.

Update tests as well to handle the proper requirement. All
these changes are needed when migrating from older deployments
where we used to set N/2 quorum for reads to EC:4 parity in
newer releases.

## How to test this PR?
You need specific situations to be tested when xl.json -> xl.meta
upgrade happens in the quorum, certain incompatible situations
can lead to unreadable objects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
