### PR TITLE
Don't set net.ipv6.conf.wlp59s0.disable_ipv6=1 on host in docker-buildx.sh

### DIFF
--- a/docker-buildx.sh
+++ b/docker-buildx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo sysctl net.ipv6.conf.wlp59s0.disable_ipv6=1
+sudo sysctl net.ipv6.conf.all.disable_ipv6=0
 
 release=$(git describe --abbrev=0 --tags)
 
@@ -44,4 +44,4 @@ docker buildx build --push --no-cache \
 
 docker buildx prune -f
 
-sudo sysctl net.ipv6.conf.wlp59s0.disable_ipv6=0
+sudo sysctl net.ipv6.conf.all.disable_ipv6=0


### PR DESCRIPTION
## Description
The build script assumes that the build host has a network interface `wlp59s0`, for which IPv6 is disabled during building. Without further context, I assume this is a slip from the contributor.

## Motivation and Context

Most contributors and users don't have any `wlp59s0` and it is unclear why having IPv6 enabled during build would be an issue.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
