### PR TITLE
multi-delete: Avoid empty Delete tag in the response

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -724,9 +724,6 @@ func generateMultiDeleteResponse(quiet bool, deletedObjects []DeletedObject, err
 	if !quiet {
 		deleteResp.DeletedObjects = deletedObjects
 	}
-	if len(errs) == len(deletedObjects) {
-		deleteResp.DeletedObjects = nil
-	}
 	deleteResp.Errors = errs
 	return deleteResp
 }


### PR DESCRIPTION
## Description
When removing an object fails, such as when it is WORM protected, an
wrong <Delete> will still be in the response. The commit fixes it.

## Motivation and Context
Fix multi-delete response

## How to test this PR?
1. mc mb myminio/testbucket/ --with-lock
2. mc cp file myminio/testbucket/file1
3. mc cp file myminio/testbucket/file2
4. mc ls -r --versions myminio/testbucket/
5. aws --debug --endpoint-url http://localhost:9000 s3api delete-objects --bucket testbucket --delete 'Objects=[{Key=file1,VersionId=22a5183b-c547-498d-9f89-e83ba95874ac},{Key=file2,VersionId=ac1776cd-ae15-4c34-96a3-3b0302647b1c}],Quiet=false'

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
