### PR TITLE
Add size info to s3:ObjectRemoved:Delete events

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1355,6 +1355,7 @@ func (args eventArgs) ToEvent(escape bool) event.Event {
 				Key:       keyName,
 				VersionID: args.Object.VersionID,
 				Sequencer: uniqueID,
+				Size:      args.Object.Size,
 			},
 		},
 		Source: event.Source{
@@ -1365,7 +1366,6 @@ func (args eventArgs) ToEvent(escape bool) event.Event {
 
 	if args.EventName != event.ObjectRemovedDelete && args.EventName != event.ObjectRemovedDeleteMarkerCreated {
 		newEvent.S3.Object.ETag = args.Object.ETag
-		newEvent.S3.Object.Size = args.Object.Size
 		newEvent.S3.Object.ContentType = args.Object.ContentType
 		newEvent.S3.Object.UserMetadata = make(map[string]string, len(args.Object.UserDefined))
 		for k, v := range args.Object.UserDefined {

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3455,6 +3455,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 	}
 
 	// Notify object deleted event.
+	objInfo.Size = goi.Size
 	sendEvent(eventArgs{
 		EventName:    eventName,
 		BucketName:   bucket,


### PR DESCRIPTION
Delete events are missing object size information, which is valuable.
This PR adds size information.