### PR TITLE
policy: Fix a typo when validating the list of policies

### DIFF
--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -805,7 +805,7 @@ func (store *IAMStoreSys) PolicyDBSet(ctx context.Context, name, policy string, 
 	// Handle policy mapping set/update
 	mp := newMappedPolicy(policy)
 	for _, p := range mp.toSlice() {
-		if _, found := cache.iamPolicyDocsMap[policy]; !found {
+		if _, found := cache.iamPolicyDocsMap[p]; !found {
 			logger.LogIf(GlobalContext, fmt.Errorf("%w: (%s)", errNoSuchPolicy, p))
 			return errNoSuchPolicy
 		}


### PR DESCRIPTION
## Description
When assigning two policies to a user using mc command, the server code
wrongly validates due to a typo in the code, the commit fixes it.

## Motivation and Context
Fix #13733 

## How to test this PR?
mc admin user add myminio foo foo12345
mc admin policy set myminio readwrite,consoleAdmin user=foo

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
