### PR TITLE
fix: atomic.Value should be a concrete type to avoid panics

### DIFF
--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -228,7 +228,7 @@ func (t *apiConfig) getRequestsPool() (chan struct{}, time.Duration) {
 func maxClients(f http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if val := globalServiceFreeze.Load(); val != nil {
-			if unlock, ok := val.(chan struct{}); ok {
+			if unlock, ok := val.(chan struct{}); ok && unlock != nil {
 				// Wait until unfrozen.
 				<-unlock
 			}


### PR DESCRIPTION

## Description
fix: atomic.Value should be a concrete type to avoid panics

## Motivation and Context
Go's atomic.Value does not support `nil` type,
concrete type is necessary to avoid any panics with
the current implementation.

Also remove boolean to turn-off tracking of freezeCount.

## How to test this PR?
Nothing special `mc admin speedtest` would reproduce the crash anyways.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression was an implementation issue in #13707
- [ ] Documentation updated
- [ ] Unit tests added/updated
