### PR TITLE
cache: in writeback mode skip etag verification

### DIFF
--- a/cmd/disk-cache-backend.go
+++ b/cmd/disk-cache-backend.go
@@ -808,10 +808,6 @@ func (c *diskCache) GetLockContext(ctx context.Context, bucket, object string) (
 
 // Caches the object to disk
 func (c *diskCache) Put(ctx context.Context, bucket, object string, data io.Reader, size int64, rs *HTTPRangeSpec, opts ObjectOptions, incHitsOnly, writeback bool) (oi ObjectInfo, err error) {
-	if !c.diskSpaceAvailable(size) {
-		io.Copy(ioutil.Discard, data)
-		return oi, errDiskFull
-	}
 	cLock, lkctx, err := c.GetLockContext(ctx, bucket, object)
 	if err != nil {
 		return oi, err

--- a/cmd/disk-cache-utils.go
+++ b/cmd/disk-cache-utils.go
@@ -581,3 +581,14 @@ func (t *multiWriter) Write(p []byte) (n int, err error) {
 func cacheMultiWriter(w1 io.Writer, w2 *io.PipeWriter) io.Writer {
 	return &multiWriter{backendWriter: w1, cacheWriter: w2}
 }
+
+// skipETagVerification returns true if writeback commit is not complete
+func skipETagVerification(m map[string]string) bool {
+	if v, ok := m[writeBackStatusHeader]; ok {
+		switch cacheCommitStatus(v) {
+		case CommitPending, CommitFailed:
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
if the commit is still in pending or failed status

This PR also does some minor code cleanup

## Description


## Motivation and Context


## How to test this PR?
Set up cache drives with `MINIO_CACHE_COMMIT` set to writeback - for single uploads even if the backend is down/slow and commit is in pending/failed status the content should be served

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
