### PR TITLE
Fix panic when input cannot be parsed

### DIFF
--- a/internal/s3select/select.go
+++ b/internal/s3select/select.go
@@ -369,7 +369,7 @@ func (s3Select *S3Select) Open(getReader func(offset, length int64) (io.ReadClos
 		return err
 	}
 
-	panic(fmt.Errorf("unknown input format '%v'", s3Select.Input.format))
+	return fmt.Errorf("unknown input format '%v'", s3Select.Input.format)
 }
 
 func (s3Select *S3Select) marshal(buf *bytes.Buffer, record sql.Record) error {
@@ -577,6 +577,9 @@ OuterLoop:
 
 // Close - closes opened S3 object.
 func (s3Select *S3Select) Close() error {
+	if s3Select.recordReader == nil {
+		return nil
+	}
 	return s3Select.recordReader.Close()
 }
 


### PR DESCRIPTION
## Description

Fix cases where `s3Select.Open` fails and doesn't set the recordReader.

Fixes #13786

## How to test this PR?

Empty input file for instance can fail csv.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
