### PR TITLE
reload certs from disk upon SIGHUP

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -34,6 +34,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	fcolor "github.com/fatih/color"
@@ -718,6 +719,10 @@ func getTLSConfig() (x509Certs []*x509.Certificate, manager *certs.Manager, secu
 		}
 	}
 	secureConn = true
+
+	// syscall.SIGHUP to reload the certs.
+	manager.ReloadOnSignal(syscall.SIGHUP)
+
 	return x509Certs, manager, secureConn, nil
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -40,6 +40,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -597,6 +598,7 @@ func NewGatewayHTTPTransportWithClientCerts(clientCert, clientKey string) *http.
 				err.Error()))
 		}
 		if c != nil {
+			c.ReloadOnSignal(syscall.SIGHUP) // allow reloads upon SIGHUP
 			transport.TLSClientConfig.GetClientCertificate = c.GetClientCertificate
 		}
 	}

--- a/internal/event/target/webhook.go
+++ b/internal/event/target/webhook.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/minio/minio/internal/event"
@@ -238,6 +239,7 @@ func NewWebhookTarget(ctx context.Context, id string, args WebhookArgs, loggerOn
 		if err != nil {
 			return target, err
 		}
+		manager.ReloadOnSignal(syscall.SIGHUP) // allow reloads upon SIGHUP
 		transport.TLSClientConfig.GetClientCertificate = manager.GetClientCertificate
 	}
 	target.httpClient = &http.Client{Transport: transport}


### PR DESCRIPTION
## Description
reload certs from disk upon SIGHUP

## Motivation and Context
Simpler to use SIGHUP to reload certs

## How to test this PR?
Run `minio` with TLS certs expire them, then 
regenerate and replace them locally - try to connect
and it will fail. Send `kill -HUP $(pidof minio)`  and 
connect again it will succeed. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
