### PR TITLE
Fix dockerfile.dev to create /opt/bin first

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,11 +4,13 @@ LABEL maintainer="MinIO Inc <dev@min.io>"
 
 ENV PATH=/opt/bin:$PATH
 
+RUN mkdir -p /opt/bin && chmod -R 777 /opt/bin
+
 COPY minio /opt/bin
+
 COPY dockerscripts/docker-entrypoint.sh /usr/bin/
 
-RUN mkdir -p /opt/bin && chmod -R 777 /opt/bin && \
-    chmod +x /opt/bin/minio && \
+RUN chmod +x /opt/bin/minio && \
     chmod +x /usr/bin/docker-entrypoint.sh
 
 EXPOSE 9000


### PR DESCRIPTION
before copying binary

## Description


## Motivation and Context
docker build fails with `chmod: cannot access '/opt/bin/minio': Not a directory`

## How to test this PR?
build the image with this docker file

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
