### PR TITLE
add delete-marker proactively in DeleteObject()

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1365,6 +1365,11 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 	fvID := mustGetUUID()
 	if markDelete {
 		if opts.Versioned || opts.VersionSuspended {
+			if !deleteMarker {
+				// versioning suspended means we add `null` version as
+				// delete marker, if its not decided already.
+				deleteMarker = opts.VersionSuspended && opts.VersionID == ""
+			}
 			fi := FileInfo{
 				Name:             object,
 				Deleted:          deleteMarker,
@@ -1381,10 +1386,10 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 					fi.VersionID = opts.VersionID
 				}
 			}
-			// versioning suspended means we add `null`
-			// version as delete marker
-			// Add delete marker, since we don't have any version specified explicitly.
-			// Or if a particular version id needs to be replicated.
+			// versioning suspended means we add `null` version as
+			// delete marker. Add delete marker, since we don't have
+			// any version specified explicitly. Or if a particular
+			// version id needs to be replicated.
 			if err = er.deleteObjectVersion(ctx, bucket, object, writeQuorum, fi, opts.DeleteMarker); err != nil {
 				return objInfo, toObjectErr(err, bucket, object)
 			}

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -647,6 +647,10 @@ func (z *erasureServerPools) MakeBucketWithLocation(ctx context.Context, bucket 
 		meta.ObjectLockConfigXML = enabledBucketObjectLockConfig
 	}
 
+	if opts.VersioningEnabled {
+		meta.VersioningConfigXML = enabledBucketVersioningConfig
+	}
+
 	if err := meta.Save(context.Background(), z); err != nil {
 		return toObjectErr(err, bucket)
 	}

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -1190,7 +1190,7 @@ func (x *xlMetaV2) DeleteVersion(fi FileInfo) (string, bool, error) {
 			}
 			return "", len(x.versions) == 0, err
 		case ObjectType:
-			if updateVersion {
+			if updateVersion && !fi.Deleted {
 				ver, err := x.getIdx(i)
 				if err != nil {
 					return "", false, err

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -954,11 +954,11 @@ func (s *xlStorage) DeleteVersion(ctx context.Context, volume, path string, fi F
 		if err != errFileNotFound {
 			return err
 		}
+		metaDataPoolPut(buf) // Never used, return it
 		if fi.Deleted && forceDelMarker {
 			// Create a new xl.meta with a delete marker in it
 			return s.WriteMetadata(ctx, volume, path, fi)
 		}
-		metaDataPoolPut(buf) // Never used, return it
 
 		buf, err = s.ReadAll(ctx, volume, pathJoin(path, xlStorageFormatFileV1))
 		if err != nil {
@@ -1016,6 +1016,7 @@ func (s *xlStorage) DeleteVersion(ctx context.Context, volume, path string, fi F
 			}
 		}
 	}
+
 	if !lastVersion {
 		buf, err = xlMeta.AppendTo(metaDataPoolGet())
 		defer metaDataPoolPut(buf)


### PR DESCRIPTION

## Description
add delete-marker proactively in DeleteObject()

## Motivation and Context
single object delete was not working properly
on a bucket when versioning was suspended,
current version 'null' object was never removed.

added unit tests to cover the behavior

fixes #13783


## How to test this PR?
Unit tests cover the situation

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes but not sure when - must have been here since the replication feature was introduced. 
- [ ] Documentation updated
- [ ] Unit tests added/updated
