### PR TITLE
fix: do not ignore delete-marker directories in ListObjects()

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1118,12 +1118,15 @@ func (z *erasureServerPools) ListObjects(ctx context.Context, bucket, prefix, ma
 	}
 
 	opts := listPathOptions{
-		Bucket:      bucket,
-		Prefix:      prefix,
-		Separator:   delimiter,
-		Limit:       maxKeysPlusOne(maxKeys, marker != ""),
-		Marker:      marker,
-		InclDeleted: false,
+		Bucket:    bucket,
+		Prefix:    prefix,
+		Separator: delimiter,
+		Limit:     maxKeysPlusOne(maxKeys, marker != ""),
+		Marker:    marker,
+		// When delimiter is set make sure to include delete markers
+		// necessary to capture proper CommonPrefixes as expected
+		// in the response as per AWS S3.
+		InclDeleted: delimiter != "",
 		AskDisks:    globalAPIConfig.getListQuorum(),
 	}
 	merged, err := z.listPath(ctx, &opts)


### PR DESCRIPTION

## Description
fix: do not ignore delete-marker directories in ListObjects()

## Motivation and Context
Following scenarios such as objects that exist inside a
prefix say `folder/` must be included in the listObjects()
response.

```
2aa16073-387e-492c-9d59-b4b0b7b6997a v2 DEL folder/
a5b9ce68-7239-4921-90ab-20aed402c7a2 v1 PUT folder/
f2211798-0eeb-4d9e-9184-fcfeae27d069 v1 PUT folder/1.txt
```

The current master does not handle this scenario, because it
ignores the top-level delete-marker on folders. This is
however unexpected. It is expected that list objects return
the top-level prefix in this situation.

```
aws s3api list-objects --bucket harshavardhana --prefix unique/ \
     --delimiter / --profile minio --endpoint-url http://localhost:9000
{
    "CommonPrefixes": [
        {
            "Prefix": "unique/folder/"
        }
    ]
}
```

There are applications in the wild such as the Hadoop s3a connector
that exploit this behavior and expect the folder to be present
in the response.

This also makes the behavior consistent with AWS S3.

## How to test this PR?
Unit tests cover the cases supported

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
