### PR TITLE
If role policy is configured, require that role ARN be set in STS

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"math/rand"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -338,12 +339,14 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer, etcdClient *etc
 
 // Prints IAM role ARNs.
 func (sys *IAMSys) printIAMRoles() {
-	arns := sys.GetRoleARNs()
-
-	if len(arns) == 0 {
+	if len(sys.rolesMap) == 0 {
 		return
 	}
-
+	var arns []string
+	for arn := range sys.rolesMap {
+		arns = append(arns, arn.String())
+	}
+	sort.Strings(arns)
 	msgs := make([]string, 0, len(arns))
 	for _, arn := range arns {
 		msgs = append(msgs, color.Bold(arn))
@@ -430,13 +433,9 @@ func (sys *IAMSys) loadWatchedEvent(ctx context.Context, event iamWatchEvent) (e
 	return err
 }
 
-// GetRoleARNs - returns a list of enabled role ARNs.
-func (sys *IAMSys) GetRoleARNs() []string {
-	var res []string
-	for arn := range sys.rolesMap {
-		res = append(res, arn.String())
-	}
-	return res
+// HasRolePolicy - returns if a role policy is configured for IAM.
+func (sys *IAMSys) HasRolePolicy() bool {
+	return len(sys.rolesMap) > 0
 }
 
 // GetRolePolicy - returns policies associated with a role ARN.

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -394,8 +394,8 @@ func (sts *stsAPIHandlers) AssumeRoleWithSSO(w http.ResponseWriter, r *http.Requ
 	}
 
 	var policyName string
-	roleArn := r.Form.Get(stsRoleArn)
-	if roleArn != "" {
+	if globalIAMSys.HasRolePolicy() {
+		roleArn := r.Form.Get(stsRoleArn)
 		_, err := globalIAMSys.GetRolePolicy(roleArn)
 		if err != nil {
 			writeSTSErrorResponse(ctx, w, true, ErrSTSInvalidParameterValue,
@@ -406,10 +406,10 @@ func (sts *stsAPIHandlers) AssumeRoleWithSSO(w http.ResponseWriter, r *http.Requ
 		// associated policy when credentials are used.
 		m[roleArnClaim] = roleArn
 	} else {
-		// JWT has requested a custom claim with policy value set.
-		// This is a MinIO STS API specific value, this value should
-		// be set and configured on your identity provider as part of
-		// JWT custom claims.
+		// If no role policy is configured, then we use claims from the
+		// JWT. This is a MinIO STS API specific value, this value
+		// should be set and configured on your identity provider as
+		// part of JWT custom claims.
 		policySet, ok := iampolicy.GetPoliciesFromClaims(m, iamPolicyClaimNameOpenID())
 		policies := strings.Join(policySet.ToSlice(), ",")
 		if ok {


### PR DESCRIPTION

## Motivation and Context
Remove the existing fallback behavior. If role arn is configured in the sever, role arn will be required in the STS API call.



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
