### PR TITLE
Newer noncurrent versions

### DIFF
--- a/cmd/bucket-lifecycle-handlers.go
+++ b/cmd/bucket-lifecycle-handlers.go
@@ -80,13 +80,13 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	// Disallow MaxNoncurrentVersions if bucket has object locking enabled
+	// Disallow NewerNoncurrentVersions if bucket has object locking enabled
 	var rCfg lock.Retention
 	if rCfg, err = globalBucketObjectLockSys.Get(bucket); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
-	if rCfg.LockEnabled && bucketLifecycle.HasMaxNoncurrentVersions() {
+	if rCfg.LockEnabled && bucketLifecycle.HasNewerNoncurrentVersions() {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidLifecycleWithObjectLock), r.URL)
 		return
 	}

--- a/cmd/bucket-lifecycle-handlers.go
+++ b/cmd/bucket-lifecycle-handlers.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/minio/minio/internal/bucket/lifecycle"
-	"github.com/minio/minio/internal/bucket/object/lock"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/bucket/policy"
@@ -77,17 +76,6 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 	// Validate the received bucket policy document
 	if err = bucketLifecycle.Validate(); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
-		return
-	}
-
-	// Disallow NewerNoncurrentVersions if bucket has object locking enabled
-	var rCfg lock.Retention
-	if rCfg, err = globalBucketObjectLockSys.Get(bucket); err != nil {
-		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
-		return
-	}
-	if rCfg.LockEnabled && bucketLifecycle.HasNewerNoncurrentVersions() {
-		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidLifecycleWithObjectLock), r.URL)
 		return
 	}
 

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -972,9 +972,9 @@ func (i *scannerItem) applyTierObjSweep(ctx context.Context, o ObjectLayer, oi O
 
 }
 
-// applyMaxNoncurrentVersionLimit removes noncurrent versions older than the most recent MaxNoncurrentVersions configured.
+// applyNewerNoncurrentVersionLimit removes noncurrent versions older than the most recent NewerNoncurrentVersions configured.
 // Note: This function doesn't update sizeSummary since it always removes versions that it doesn't return.
-func (i *scannerItem) applyMaxNoncurrentVersionLimit(ctx context.Context, o ObjectLayer, fivs []FileInfo) ([]FileInfo, error) {
+func (i *scannerItem) applyNewerNoncurrentVersionLimit(ctx context.Context, o ObjectLayer, fivs []FileInfo) ([]FileInfo, error) {
 	if i.lifeCycle == nil {
 		return fivs, nil
 	}
@@ -1008,14 +1008,14 @@ func (i *scannerItem) applyMaxNoncurrentVersionLimit(ctx context.Context, o Obje
 		})
 	}
 
-	globalExpiryState.enqueueByMaxNoncurrent(i.bucket, toDel)
+	globalExpiryState.enqueueByNewerNoncurrent(i.bucket, toDel)
 	return fivs, nil
 }
 
 // applyVersionActions will apply lifecycle checks on all versions of a scanned item. Returns versions that remain
 // after applying lifecycle checks configured.
 func (i *scannerItem) applyVersionActions(ctx context.Context, o ObjectLayer, fivs []FileInfo) ([]FileInfo, error) {
-	return i.applyMaxNoncurrentVersionLimit(ctx, o, fivs)
+	return i.applyNewerNoncurrentVersionLimit(ctx, o, fivs)
 }
 
 // applyActions will apply lifecycle checks on to a scanned item.

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1008,7 +1008,7 @@ func (i *scannerItem) applyNewerNoncurrentVersionLimit(ctx context.Context, _ Ob
 		}
 
 		// NoncurrentDays not passed yet.
-		if time.Now().UTC().Before(obj.SuccessorModTime.AddDate(0, 0, days)) {
+		if time.Now().UTC().Before(lifecycle.ExpectedExpiryTime(obj.SuccessorModTime, days)) {
 			// add this version back to remaining versions for
 			// subsequent lifecycle policy applications
 			fivs = append(fivs, fi)

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -979,7 +979,7 @@ func (i *scannerItem) applyNewerNoncurrentVersionLimit(ctx context.Context, o Ob
 		return fivs, nil
 	}
 
-	lim := i.lifeCycle.NoncurrentVersionsExpirationLimit(lifecycle.ObjectOpts{Name: i.objectPath()})
+	_, days, lim := i.lifeCycle.NoncurrentVersionsExpirationLimit(lifecycle.ObjectOpts{Name: i.objectPath()})
 	if lim == 0 || len(fivs) <= lim+1 { // fewer than lim _noncurrent_ versions
 		return fivs, nil
 	}
@@ -1002,6 +1002,11 @@ func (i *scannerItem) applyNewerNoncurrentVersionLimit(ctx context.Context, o Ob
 			}
 			continue
 		}
+
+		if time.Now().UTC().Before(obj.SuccessorModTime.AddDate(0, 0, days)) {
+			continue
+		}
+
 		toDel = append(toDel, ObjectToDelete{
 			ObjectName: fi.Name,
 			VersionID:  fi.VersionID,

--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -501,17 +501,3 @@ func (lc Lifecycle) NoncurrentVersionsExpirationLimit(obj ObjectOpts) (string, i
 	}
 	return ruleID, days, lim
 }
-
-// HasNewerNoncurrentVersions returns true if there exists a rule with
-// NewerNoncurrentVersions limit set.
-func (lc Lifecycle) HasNewerNoncurrentVersions() bool {
-	for _, rule := range lc.Rules {
-		if rule.Status == Disabled {
-			continue
-		}
-		if rule.NoncurrentVersionExpiration.NewerNoncurrentVersions > 0 {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -310,6 +310,9 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 		}
 
 		if !rule.NoncurrentVersionExpiration.IsDaysNull() {
+			if !obj.IsLatest && rule.NoncurrentVersionExpiration.NewerNoncurrentVersions > 0 {
+				continue
+			}
 			if obj.VersionID != "" && !obj.IsLatest && !obj.SuccessorModTime.IsZero() {
 				// Non current versions should be deleted if their age exceeds non current days configuration
 				// https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions

--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -310,6 +310,9 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 		}
 
 		if !rule.NoncurrentVersionExpiration.IsDaysNull() {
+			// Skip rules with newer noncurrent versions specified.
+			// These are not handled at an individual version.
+			// ComputeAction applies to a specific version.
 			if !obj.IsLatest && rule.NoncurrentVersionExpiration.NewerNoncurrentVersions > 0 {
 				continue
 			}

--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -311,8 +311,9 @@ func (lc Lifecycle) ComputeAction(obj ObjectOpts) Action {
 
 		if !rule.NoncurrentVersionExpiration.IsDaysNull() {
 			// Skip rules with newer noncurrent versions specified.
-			// These are not handled at an individual version.
-			// ComputeAction applies to a specific version.
+			// These rules are not handled at an individual version
+			// level. ComputeAction applies only to a specific
+			// version.
 			if !obj.IsLatest && rule.NoncurrentVersionExpiration.NewerNoncurrentVersions > 0 {
 				continue
 			}

--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -394,6 +394,11 @@ func (lc Lifecycle) PredictExpiryTime(obj ObjectOpts) (string, time.Time) {
 	// Iterate over all actionable rules and find the earliest
 	// expiration date and its associated rule ID.
 	for _, rule := range lc.FilterActionableRules(obj) {
+		// We don't know the index of this version and hence can't
+		// reliably compute expected expiry time.
+		if !obj.IsLatest && rule.NoncurrentVersionExpiration.NewerNoncurrentVersions > 0 {
+			continue
+		}
 		if !rule.NoncurrentVersionExpiration.IsDaysNull() && !obj.IsLatest && obj.VersionID != "" {
 			return rule.ID, ExpectedExpiryTime(obj.SuccessorModTime, int(rule.NoncurrentVersionExpiration.NoncurrentDays))
 		}

--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -114,7 +114,7 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 		},
 		// Lifecycle with max noncurrent versions
 		{
-			inputConfig:           `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>rule</ID>><Status>Enabled</Status><Filter></Filter><NoncurrentVersionExpiration><MaxNoncurrentVersions>5</MaxNoncurrentVersions></NoncurrentVersionExpiration></Rule></LifecycleConfiguration>`,
+			inputConfig:           `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>rule</ID>><Status>Enabled</Status><Filter></Filter><NoncurrentVersionExpiration><NewerNoncurrentVersions>5</NewerNoncurrentVersions></NoncurrentVersionExpiration></Rule></LifecycleConfiguration>`,
 			expectedParsingErr:    nil,
 			expectedValidationErr: nil,
 		},
@@ -636,14 +636,14 @@ func TestNoncurrentVersionsLimit(t *testing.T) {
 			ID:     strconv.Itoa(i),
 			Status: "Enabled",
 			NoncurrentVersionExpiration: NoncurrentVersionExpiration{
-				MaxNoncurrentVersions: i,
+				NewerNoncurrentVersions: i,
 			},
 		})
 	}
 	lc := Lifecycle{
 		Rules: rules,
 	}
-	if lim := lc.NoncurrentVersionsExpirationLimit(ObjectOpts{Name: "obj"}); lim != 1 {
+	if lim := lc.NoncurrentVersionsExpirationLimit(ObjectOpts{Name: "obj"}); lim != 10 {
 		t.Fatalf("Expected max noncurrent versions limit to be 1 but got %d", lim)
 	}
 }

--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -637,13 +637,16 @@ func TestNoncurrentVersionsLimit(t *testing.T) {
 			Status: "Enabled",
 			NoncurrentVersionExpiration: NoncurrentVersionExpiration{
 				NewerNoncurrentVersions: i,
+				NoncurrentDays:          ExpirationDays(i),
 			},
 		})
 	}
 	lc := Lifecycle{
 		Rules: rules,
 	}
-	if lim := lc.NoncurrentVersionsExpirationLimit(ObjectOpts{Name: "obj"}); lim != 10 {
-		t.Fatalf("Expected max noncurrent versions limit to be 1 but got %d", lim)
+	if ruleID, days, lim := lc.NoncurrentVersionsExpirationLimit(ObjectOpts{Name: "obj"}); ruleID != "1" || days != 1 || lim != 10 {
+		t.Fatalf("Expected (ruleID, days, lim) to be (\"1\", 1, 10) but got (%s, %d, %d)", ruleID, days, lim)
+	} else {
+		fmt.Println(ruleID, days, lim)
 	}
 }

--- a/internal/bucket/lifecycle/noncurrentversion.go
+++ b/internal/bucket/lifecycle/noncurrentversion.go
@@ -24,10 +24,10 @@ import (
 
 // NoncurrentVersionExpiration - an action for lifecycle configuration rule.
 type NoncurrentVersionExpiration struct {
-	XMLName               xml.Name       `xml:"NoncurrentVersionExpiration"`
-	NoncurrentDays        ExpirationDays `xml:"NoncurrentDays,omitempty"`
-	MaxNoncurrentVersions int            `xml:"MaxNoncurrentVersions,omitempty"`
-	set                   bool
+	XMLName                 xml.Name       `xml:"NoncurrentVersionExpiration"`
+	NoncurrentDays          ExpirationDays `xml:"NoncurrentDays,omitempty"`
+	NewerNoncurrentVersions int            `xml:"NewerNoncurrentVersions,omitempty"`
+	set                     bool
 }
 
 // MarshalXML if non-current days not set to non zero value
@@ -54,7 +54,7 @@ func (n *NoncurrentVersionExpiration) UnmarshalXML(d *xml.Decoder, startElement 
 
 // IsNull returns if both NoncurrentDays and NoncurrentVersions are empty
 func (n NoncurrentVersionExpiration) IsNull() bool {
-	return n.IsDaysNull() && n.MaxNoncurrentVersions == 0
+	return n.IsDaysNull() && n.NewerNoncurrentVersions == 0
 }
 
 // IsDaysNull returns true if days field is null
@@ -69,15 +69,11 @@ func (n NoncurrentVersionExpiration) Validate() error {
 	}
 	val := int(n.NoncurrentDays)
 	switch {
-	case val == 0 && n.MaxNoncurrentVersions == 0:
+	case val == 0 && n.NewerNoncurrentVersions == 0:
 		// both fields can't be zero
 		return errXMLNotWellFormed
 
-	case val > 0 && n.MaxNoncurrentVersions > 0:
-		// both tags can't be non-zero simultaneously
-		return errLifecycleInvalidNoncurrentExpiration
-
-	case val < 0, n.MaxNoncurrentVersions < 0:
+	case val < 0, n.NewerNoncurrentVersions < 0:
 		// negative values are not supported
 	}
 	return nil

--- a/internal/bucket/lifecycle/noncurrentversion.go
+++ b/internal/bucket/lifecycle/noncurrentversion.go
@@ -90,6 +90,7 @@ func (n NoncurrentVersionExpiration) Validate() error {
 
 	case val < 0, n.NewerNoncurrentVersions < 0:
 		// negative values are not supported
+		return errXMLNotWellFormed
 	}
 	return nil
 }

--- a/internal/bucket/lifecycle/noncurrentversion_test.go
+++ b/internal/bucket/lifecycle/noncurrentversion_test.go
@@ -48,6 +48,21 @@ func Test_NoncurrentVersionsExpiration_Validation(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			n: NoncurrentVersionExpiration{
+				NoncurrentDays: -1,
+				set:            true,
+			},
+			err: errXMLNotWellFormed,
+		},
+		{
+			n: NoncurrentVersionExpiration{
+				NoncurrentDays:          90,
+				NewerNoncurrentVersions: -2,
+				set:                     true,
+			},
+			err: errXMLNotWellFormed,
+		},
 		// MinIO extension: supports zero NoncurrentDays when NewerNoncurrentVersions > 0
 		{
 			n: NoncurrentVersionExpiration{

--- a/internal/bucket/lifecycle/noncurrentversion_test.go
+++ b/internal/bucket/lifecycle/noncurrentversion_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package lifecycle
+
+import "testing"
+
+func Test_NoncurrentVersionsExpiration_Validation(t *testing.T) {
+	testcases := []struct {
+		n   NoncurrentVersionExpiration
+		err error
+	}{
+		{
+			n: NoncurrentVersionExpiration{
+				NoncurrentDays:          0,
+				NewerNoncurrentVersions: 0,
+				set:                     true,
+			},
+			err: errXMLNotWellFormed,
+		},
+		{
+			n: NoncurrentVersionExpiration{
+				NoncurrentDays:          90,
+				NewerNoncurrentVersions: 0,
+				set:                     true,
+			},
+			err: nil,
+		},
+		{
+			n: NoncurrentVersionExpiration{
+				NoncurrentDays:          90,
+				NewerNoncurrentVersions: 2,
+				set:                     true,
+			},
+			err: nil,
+		},
+		// MinIO extension: supports zero NoncurrentDays when NewerNoncurrentVersions > 0
+		{
+			n: NoncurrentVersionExpiration{
+				NoncurrentDays:          0,
+				NewerNoncurrentVersions: 5,
+				set:                     true,
+			},
+			err: nil,
+		},
+	}
+
+	for i, tc := range testcases {
+		if got := tc.n.Validate(); got != tc.err {
+			t.Fatalf("%d: expected %v but got %v", i+1, tc.err, got)
+		}
+	}
+}


### PR DESCRIPTION
## Description
Implement `NewerNoncurrentVersions` support for `NoncurrentVersionExpiration` action.

Things to note:
1. MinIO introduced MaxNoncurrentVersions a few weeks back. This was designed to remove 'excess' noncurrent versions as early as possible. i.e there are no object age based constraints like `NoncurrentDays` specified.

2. AWS S3's NewerNoncurrentVersions is designed to retain a given number of noncurrent versions. The 'excess' noncurrent versions are expired after the specified `NoncurrentDays`. 

To unify both these goals, MinIO allows NewerNoncurrentVersions with zero `NoncurrentDays`.

## Motivation and Context
https://docs.aws.amazon.com/AmazonS3/latest/API/API_NoncurrentVersionExpiration.html (see `NewerNoncurrentVersions`)

## How to test this PR?
Coming soon ...

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
