### PR TITLE
Ensure that role ARNs don't collide

### DIFF
--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -855,7 +855,7 @@ func TestIAMWithOpenIDWithRolePolicyServerSuite(t *testing.T) {
 }
 
 const (
-	testRoleARN = "arn:minio:iam:::role/127.0.0.1_minio-cl"
+	testRoleARN = "arn:minio:iam:::role/nOybJqMNzNmroqEKq5D0EUsRZw0"
 )
 
 func (s *TestSuiteIAM) TestOpenIDSTSWithRolePolicy(c *check) {

--- a/internal/arn/arn.go
+++ b/internal/arn/arn.go
@@ -59,9 +59,9 @@ type ARN struct {
 }
 
 var (
-	// Allows lower-case chars, numbers, '.', '-', '_' and '/'. Starts with
-	// a letter or digit. At least 1 character long.
-	validResourceIDRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9_/\.-]*$`)
+	// Allows english letters, numbers, '.', '-', '_' and '/'. Starts with a
+	// letter or digit. At least 1 character long.
+	validResourceIDRegex = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_/\.-]*$`)
 )
 
 // NewIAMRoleARN - returns an ARN for a role in MinIO.


### PR DESCRIPTION
## Description

- This is to prepare for multiple providers enhancement.

## Motivation and Context

When multiple providers are added, it will be needed to ensure that ARNs are unique. Existing implementation does not support this requirement.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
