### PR TITLE
Add configurable channel queue_size for audit/logger webhook targets

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -62,7 +62,7 @@ func initHelp() {
 		config.RegionSubSys:         config.DefaultRegionKVS,
 		config.APISubSys:            api.DefaultKVS,
 		config.CredentialsSubSys:    config.DefaultCredentialKVS,
-		config.LoggerWebhookSubSys:  logger.DefaultKVS,
+		config.LoggerWebhookSubSys:  logger.DefaultLoggerWebhookKVS,
 		config.AuditWebhookSubSys:   logger.DefaultAuditWebhookKVS,
 		config.AuditKafkaSubSys:     logger.DefaultAuditKafkaKVS,
 		config.HealSubSys:           heal.DefaultKVS,
@@ -543,7 +543,7 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 
 	loggerCfg, err := logger.LookupConfig(s)
 	if err != nil {
-		logger.LogIf(ctx, fmt.Errorf("Unable to initialize logger: %w", err))
+		logger.LogIf(ctx, fmt.Errorf("Unable to initialize logger/audit targets: %w", err))
 	}
 
 	for _, l := range loggerCfg.HTTP {
@@ -553,7 +553,7 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 			l.Transport = NewGatewayHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)
 			// Enable http logging
 			if err = logger.AddTarget(http.New(l)); err != nil {
-				logger.LogIf(ctx, fmt.Errorf("Unable to initialize console HTTP target: %w", err))
+				logger.LogIf(ctx, fmt.Errorf("Unable to initialize server logger HTTP target: %w", err))
 			}
 		}
 	}
@@ -565,7 +565,7 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 			l.Transport = NewGatewayHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)
 			// Enable http audit logging
 			if err = logger.AddAuditTarget(http.New(l)); err != nil {
-				logger.LogIf(ctx, fmt.Errorf("Unable to initialize audit HTTP target: %w", err))
+				logger.LogIf(ctx, fmt.Errorf("Unable to initialize server audit HTTP target: %w", err))
 			}
 		}
 	}
@@ -575,7 +575,7 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 			l.LogOnce = logger.LogOnceIf
 			// Enable Kafka audit logging
 			if err = logger.AddAuditTarget(kafka.New(l)); err != nil {
-				logger.LogIf(ctx, fmt.Errorf("Unable to initialize audit Kafka target: %w", err))
+				logger.LogIf(ctx, fmt.Errorf("Unable to initialize server audit Kafka target: %w", err))
 			}
 		}
 	}

--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -227,6 +227,8 @@ func AuditLog(ctx context.Context, w http.ResponseWriter, r *http.Request, reqCl
 
 	// Send audit logs only to http targets.
 	for _, t := range AuditTargets() {
-		_ = t.Send(entry, string(All))
+		if err := t.Send(entry, string(All)); err != nil {
+			LogAlwaysIf(context.Background(), fmt.Errorf("event(%v) was not sent to Audit target (%v): %v", entry, t, err), All)
+		}
 	}
 }

--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -38,6 +38,26 @@ var (
 			Sensitive:   true,
 		},
 		config.HelpKV{
+			Key:         ClientCert,
+			Description: "mTLS certificate for Logger Webhook authentication",
+			Optional:    true,
+			Type:        "string",
+			Sensitive:   true,
+		},
+		config.HelpKV{
+			Key:         ClientKey,
+			Description: "mTLS certificate key for Logger Webhook authentication",
+			Optional:    true,
+			Type:        "string",
+			Sensitive:   true,
+		},
+		config.HelpKV{
+			Key:         QueueSize,
+			Description: "configure channel queue size for Logger Webhook targets",
+			Optional:    true,
+			Type:        "number",
+		},
+		config.HelpKV{
 			Key:         config.Comment,
 			Description: config.DefaultComment,
 			Optional:    true,
@@ -72,6 +92,12 @@ var (
 			Optional:    true,
 			Type:        "string",
 			Sensitive:   true,
+		},
+		config.HelpKV{
+			Key:         QueueSize,
+			Description: "configure channel queue size for Audit Webhook targets",
+			Optional:    true,
+			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         config.Comment,

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -374,7 +374,10 @@ func logIf(ctx context.Context, err error, errKind ...interface{}) {
 
 	// Iterate over all logger targets to send the log entry
 	for _, t := range Targets() {
-		t.Send(entry, entry.LogKind)
+		if err := t.Send(entry, entry.LogKind); err != nil {
+			LogAlwaysIf(context.Background(), fmt.Errorf("event(%v) was not sent to Logger target (%v): %v", entry, t, err), entry.LogKind)
+		}
+
 	}
 }
 

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -42,6 +42,7 @@ type Config struct {
 	AuthToken  string            `json:"authToken"`
 	ClientCert string            `json:"clientCert"`
 	ClientKey  string            `json:"clientKey"`
+	QueueSize  int               `json:"queueSize"`
 	Transport  http.RoundTripper `json:"-"`
 
 	// Custom logger
@@ -133,6 +134,7 @@ func (h *Target) startHTTPLogger() {
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 				h.config.Endpoint, bytes.NewReader(logJSON))
 			if err != nil {
+				h.config.LogOnce(ctx, fmt.Errorf("%s returned '%w', please check your endpoint configuration", h.config.Endpoint, err), h.config.Endpoint)
 				cancel()
 				continue
 			}
@@ -173,7 +175,7 @@ func (h *Target) startHTTPLogger() {
 // sends log over http to the specified endpoint
 func New(config Config) *Target {
 	h := &Target{
-		logCh:  make(chan interface{}, 10000),
+		logCh:  make(chan interface{}, config.QueueSize),
 		config: config,
 	}
 


### PR DESCRIPTION

## Description
Add configurable channel queue_size for audit/logger webhook targets

## Motivation and Context
Also, log all the missed events and logs instead of silently
swallowing the events.

Bonus: Extend the logger webhook to support mTLS
similar to audit webhook target.

## How to test this PR?
Build locally and run
```
~ MINIO_AUDIT_WEBHOOK_ENABLE_test=on MINIO_AUDIT_WEBHOOK_ENDPOINT_test=https://test123.free.beeceptor.com MINIO_AUDIT_WEBHOOK_QUEUE_SIZE_test=10000 minio server /tmp/test{1...4}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
