### PR TITLE
validate if cached value is empty before use

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1210,7 +1210,7 @@ func (api objectAPIHandlers) HeadBucketHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	writeSuccessResponseHeadersOnly(w)
+	writeResponse(w, http.StatusOK, nil, mimeXML)
 }
 
 // DeleteBucketHandler - Delete bucket

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1131,7 +1131,9 @@ func (z *erasureServerPools) ListObjects(ctx context.Context, bucket, prefix, ma
 	}
 	merged, err := z.listPath(ctx, &opts)
 	if err != nil && err != io.EOF {
-		logger.LogIf(ctx, err)
+		if !isErrBucketNotFound(err) {
+			logger.LogIf(ctx, err)
+		}
 		return loi, err
 	}
 

--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -307,7 +307,7 @@ func (m metaCacheEntries) resolve(r *metadataResolutionParams) (selected *metaCa
 		// shallow decode.
 		xl, err := entry.xlmeta()
 		if err != nil {
-			logger.LogIf(context.Background(), err)
+			logger.LogIf(GlobalContext, err)
 			continue
 		}
 		objsValid++
@@ -339,9 +339,15 @@ func (m metaCacheEntries) resolve(r *metadataResolutionParams) (selected *metaCa
 	if objsValid < r.objQuorum {
 		return nil, false
 	}
+
 	// If all objects agree.
 	if selected != nil && objsAgree == objsValid {
 		return selected, true
+	}
+
+	// If cached is nil we shall skip the entry.
+	if selected.cached == nil {
+		return nil, false
 	}
 
 	// Merge if we have disagreement.


### PR DESCRIPTION

## Description
validate if cached value is empty before use

## Motivation and Context
fixes a crash reproduced while running hadoop tests

```
goroutine 201564 [running]:
github.com/minio/minio/cmd.metaCacheEntries.resolve({0xc0206ab7a0, 0x4, 0xc0015b1908}, 0xc0212a7040)
	github.com/minio/minio/cmd/metacache-entries.go:352 +0x58a
```


## How to test this PR?
Couldn't reproduce this with mint, but running 
hadoop tests reproduce this problem from hadoo-trunk
```
~ mvn verify -Dmarkers=delete -Dtest=none
```

To run all integration tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes after #13723
- [ ] Documentation updated
- [ ] Unit tests added/updated
