### PR TITLE
return appropriate errors upon parseErrors

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3533,9 +3533,11 @@ func (api objectAPIHandlers) PutObjectLegalHoldHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	legalHold, err := objectlock.ParseObjectLegalHold(r.Body)
+	legalHold, err := objectlock.ParseObjectLegalHold(io.LimitReader(r.Body, r.ContentLength))
 	if err != nil {
-		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
+		apiErr := errorCodes.ToAPIErr(ErrMalformedXML)
+		apiErr.Description = err.Error()
+		writeErrorResponse(ctx, w, apiErr, r.URL)
 		return
 	}
 

--- a/internal/bucket/object/lock/lock.go
+++ b/internal/bucket/object/lock/lock.go
@@ -535,7 +535,7 @@ func (l *ObjectLegalHold) IsEmpty() bool {
 func ParseObjectLegalHold(reader io.Reader) (hold *ObjectLegalHold, err error) {
 	hold = &ObjectLegalHold{}
 	if err = xml.NewDecoder(reader).Decode(hold); err != nil {
-		return
+		return nil, err
 	}
 
 	if !hold.Status.Valid() {


### PR DESCRIPTION
## Description
return appropriate errors upon parseErrors

## Motivation and Context
parseErrors don't return appropriate errors.

## How to test this PR?
Run versioning mint tests and observe
the server does not print random logs,
without this PR they do.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
