### PR TITLE
snowball: return errors on failures

### DIFF
--- a/cmd/untar.go
+++ b/cmd/untar.go
@@ -144,7 +144,7 @@ func untar(r io.Reader, putObject func(reader io.Reader, info os.FileInfo, name 
 		case err != nil:
 			extra := ""
 			if n > 0 {
-				extra = fmt.Sprintf(" after %d successful object(s)")
+				extra = fmt.Sprintf(" after %d successful object(s)", n)
 			}
 			return fmt.Errorf("tar file error: %w%s", err, extra)
 

--- a/cmd/untar.go
+++ b/cmd/untar.go
@@ -97,7 +97,7 @@ var magicHeaders = []struct {
 	},
 }
 
-func untar(r io.Reader, putObject func(reader io.Reader, info os.FileInfo, name string)) error {
+func untar(r io.Reader, putObject func(reader io.Reader, info os.FileInfo, name string) error) error {
 	bf := bufio.NewReader(r)
 	switch f := detect(bf); f {
 	case formatGzip:
@@ -130,6 +130,7 @@ func untar(r io.Reader, putObject func(reader io.Reader, info os.FileInfo, name 
 		return fmt.Errorf("Unsupported format %s", f)
 	}
 	tarReader := tar.NewReader(r)
+	n := 0
 	for {
 		header, err := tarReader.Next()
 
@@ -141,7 +142,11 @@ func untar(r io.Reader, putObject func(reader io.Reader, info os.FileInfo, name 
 
 		// return any other error
 		case err != nil:
-			return err
+			extra := ""
+			if n > 0 {
+				extra = fmt.Sprintf(" after %d successful object(s)")
+			}
+			return fmt.Errorf("tar file error: %w%s", err, extra)
 
 		// if the header is nil, just skip it (not sure how this happens)
 		case header == nil:
@@ -155,9 +160,15 @@ func untar(r io.Reader, putObject func(reader io.Reader, info os.FileInfo, name 
 
 		switch header.Typeflag {
 		case tar.TypeDir: // = directory
-			putObject(tarReader, header.FileInfo(), trimLeadingSlash(pathJoin(name, slashSeparator)))
+			if err := putObject(tarReader, header.FileInfo(), trimLeadingSlash(pathJoin(name, slashSeparator))); err != nil {
+				return err
+			}
+			n++
 		case tar.TypeReg, tar.TypeChar, tar.TypeBlock, tar.TypeFifo, tar.TypeGNUSparse: // = regular
-			putObject(tarReader, header.FileInfo(), trimLeadingSlash(path.Clean(name)))
+			if err := putObject(tarReader, header.FileInfo(), trimLeadingSlash(path.Clean(name))); err != nil {
+				return err
+			}
+			n++
 		default:
 			// ignore symlink'ed
 			continue


### PR DESCRIPTION
## Description

Return errors when untar fails at once.

Fixes #13832

## Motivation and Context

Current error handling was quite a mess. Errors are written to the stream, but processing continues.

Instead return errors when they occur and transform internal errors to bad request errors, since it is likely a problem with the input.

## How to test this PR?

Upload content that is expected to fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
