### PR TITLE
fix: speedtest should exit upon errors cleanly

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1078,10 +1078,7 @@ func speedTest(ctx context.Context, opts speedTestOpts) chan madmin.SpeedTestRes
 				break
 			}
 
-			doBreak := false
-			if float64(totalGet-throughputHighestGet)/float64(totalGet) < 0.025 {
-				doBreak = true
-			}
+			doBreak := float64(totalGet-throughputHighestGet)/float64(totalGet) < 0.025
 
 			throughputHighestGet = totalGet
 			throughputHighestResults = results
@@ -1092,12 +1089,19 @@ func speedTest(ctx context.Context, opts speedTestOpts) chan madmin.SpeedTestRes
 				break
 			}
 
-			if !opts.autotune {
-				sendResult()
-				break
+			for _, result := range results {
+				if result.Error != "" {
+					// Break out on errors.
+					sendResult()
+					return
+				}
 			}
 
 			sendResult()
+			if !opts.autotune {
+				break
+			}
+
 			// Try with a higher concurrency to see if we get better throughput
 			concurrency += (concurrency + 1) / 2
 		}


### PR DESCRIPTION


## Description
fix: speedtest should exit upon errors cleanly

## Motivation and Context
- deleteBucket() should be called for cleanup
  if client abruptly disconnects

- out of disk errors should be sent to client
  properly and also cancel the calls

- limit concurrency to available MAXPROCS not
  32 for auto-tuned setup, if procs are beyond
  32 then continue normally. this is to handle
  smaller setups.

fixes #13834

## How to test this PR?
Use smaller setups, run on laptops. Speedtest shouldn't kill
these systems and in turn run under the constraints.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
