### PR TITLE
Fix user listing with LDAP

### DIFF
--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -1099,15 +1099,6 @@ func (store *IAMStoreSys) GetUsers() map[string]madmin.UserInfo {
 		}
 	}
 
-	if store.getUsersSysType() == LDAPUsersSysType {
-		for k, v := range cache.iamUserPolicyMap {
-			result[k] = madmin.UserInfo{
-				PolicyName: v.Policies,
-				Status:     madmin.AccountEnabled,
-			}
-		}
-	}
-
 	return result
 }
 

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -297,6 +297,15 @@ func (s *TestSuiteIAM) TestLDAPSTS(c *check) {
 		c.Fatalf("Error initializing client: %v", err)
 	}
 
+	// Validate that user listing does not return any entries
+	usersList, err := s.adm.ListUsers(ctx)
+	if err != nil {
+		c.Fatalf("list users should not fail: %v", err)
+	}
+	if len(usersList) > 0 {
+		c.Fatalf("expected listing to be empty: %v", usersList)
+	}
+
 	// Validate that the client from sts creds can access the bucket.
 	c.mustListObjects(ctx, minioClient, bucket)
 


### PR DESCRIPTION
## Description

Users listing was showing just a weird policy mapping output which does not
make sense here:

```
$ mc admin user list myminio
enabled    uid=dillon,ou=peo...  consoleAdmin
```

Since all credentials with LDAP enabled, are currently either STS or service accounts (or root), we return an empty result for this API.

## Motivation and Context

Fix a bug.

## How to test this PR?

As described.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (not sure when introduced)
- [ ] Documentation updated
- [ ] Unit tests added/updated
