### PR TITLE
Don't zero buffer if big enough

### DIFF
--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -658,7 +658,12 @@ func readXLMetaNoData(r io.Reader, size int64) ([]byte, error) {
 			return io.ErrUnexpectedEOF
 		}
 		extra := n - has
-		buf = append(buf, make([]byte, extra)...)
+		if int64(cap(buf)) >= n {
+			// Extend since we have enough space.
+			buf = buf[:n]
+		} else {
+			buf = append(buf, make([]byte, extra)...)
+		}
 		_, err := io.ReadFull(r, buf[has:])
 		if err != nil {
 			if errors.Is(err, io.EOF) {


### PR DESCRIPTION
## Description

Only append zeroed bytes when we don't have enough space anyway. Avoids memclr.

## How to test this PR?

Covered by regular tests.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
