### PR TITLE
Allow OIDC user to query user info if policies permit

### DIFF
--- a/cmd/admin-handlers-users_test.go
+++ b/cmd/admin-handlers-users_test.go
@@ -844,6 +844,14 @@ func (c *check) mustCreateIAMUser(ctx context.Context, admClnt *madmin.AdminClie
 	}
 }
 
+func (c *check) mustGetIAMUserInfo(ctx context.Context, admClnt *madmin.AdminClient, accessKey string) madmin.UserInfo {
+	ui, err := admClnt.GetUserInfo(ctx, accessKey)
+	if err != nil {
+		c.Fatalf("should be able to get user info: %v", err)
+	}
+	return ui
+}
+
 func (c *check) mustNotCreateIAMUser(ctx context.Context, admClnt *madmin.AdminClient) {
 	randUser := mustGetUUID()
 	randPass := mustGetUUID()

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -712,7 +712,10 @@ func (s *TestSuiteIAM) TestOpenIDSTSAddUser(c *check) {
 		c.Fatalf("policy add error: %v", err)
 	}
 
-	c.mustCreateIAMUser(ctx, userAdmClient)
+	cr := c.mustCreateIAMUser(ctx, userAdmClient)
+
+	userInfo := c.mustGetIAMUserInfo(ctx, userAdmClient, cr.AccessKey)
+	c.Assert(userInfo.Status, madmin.AccountEnabled)
 }
 
 func (s *TestSuiteIAM) TestOpenIDServiceAcc(c *check) {


### PR DESCRIPTION
## Motivation and Context

Bug reported by @Alevsk - console gets a 403 error. Fixed here.

## How to test this PR?

Login via OIDC and try to get user info by clicking on users in console. Browser networks requests shows 403 error, UI does not show the expected enabled status for enabled accounts.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
