### PR TITLE
add code to parse secrets natively instead of shell scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM minio/minio:latest
 
 COPY ./minio /opt/bin/minio
+COPY dockerscripts/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,7 @@
 FROM minio/minio:latest
 
 COPY ./minio /opt/bin/minio
+COPY dockerscripts/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 

--- a/dockerscripts/docker-entrypoint.sh
+++ b/dockerscripts/docker-entrypoint.sh
@@ -8,79 +8,6 @@ if [ "${1}" != "minio" ]; then
     fi
 fi
 
-## look for specific a `config.env` file to load all the
-## minio settings from
-docker_minio_env() {
-    if [ -f "$MINIO_CONFIG_ENV_FILE" ]; then
-        config_env_file="${MINIO_CONFIG_ENV_FILE}"
-    else
-        config_env_file="/run/secrets/${MINIO_CONFIG_ENV_FILE}"
-    fi
-    if [ -f "$config_env_file" ]; then
-        # shellcheck source=/dev/null
-        . "${config_env_file}"
-    fi
-}
-
-## Look for docker secrets at given absolute path or in default documented location.
-docker_secrets_env_old() {
-    if [ -f "$MINIO_ACCESS_KEY_FILE" ]; then
-        ACCESS_KEY_FILE="$MINIO_ACCESS_KEY_FILE"
-    else
-        ACCESS_KEY_FILE="/run/secrets/$MINIO_ACCESS_KEY_FILE"
-    fi
-    if [ -f "$MINIO_SECRET_KEY_FILE" ]; then
-        SECRET_KEY_FILE="$MINIO_SECRET_KEY_FILE"
-    else
-        SECRET_KEY_FILE="/run/secrets/$MINIO_SECRET_KEY_FILE"
-    fi
-
-    if [ -f "$ACCESS_KEY_FILE" ]; then
-        MINIO_ACCESS_KEY="$(cat "$ACCESS_KEY_FILE")"
-        export MINIO_ACCESS_KEY
-    fi
-    if [ -f "$SECRET_KEY_FILE" ]; then
-        MINIO_SECRET_KEY="$(cat "$SECRET_KEY_FILE")"
-        export MINIO_SECRET_KEY
-    fi
-}
-
-docker_secrets_env() {
-    if [ -f "$MINIO_ROOT_USER_FILE" ]; then
-        ROOT_USER_FILE="$MINIO_ROOT_USER_FILE"
-    else
-        ROOT_USER_FILE="/run/secrets/$MINIO_ROOT_USER_FILE"
-    fi
-    if [ -f "$MINIO_ROOT_PASSWORD_FILE" ]; then
-        ROOT_PASSWORD_FILE="$MINIO_ROOT_PASSWORD_FILE"
-    else
-        ROOT_PASSWORD_FILE="/run/secrets/$MINIO_ROOT_PASSWORD_FILE"
-    fi
-
-    if [ -f "$ROOT_USER_FILE" ]; then
-        MINIO_ROOT_USER="$(cat "$ROOT_USER_FILE")"
-        export MINIO_ROOT_USER
-    fi
-    if [ -f "$ROOT_PASSWORD_FILE" ]; then
-        MINIO_ROOT_PASSWORD="$(cat "$ROOT_PASSWORD_FILE")"
-        export MINIO_ROOT_PASSWORD
-    fi
-}
-
-## Set KMS_SECRET_KEY from docker secrets if provided
-docker_kms_secret_encryption_env() {
-    if [ -f "$MINIO_KMS_SECRET_KEY_FILE" ]; then
-        KMS_SECRET_KEY_FILE="$MINIO_KMS_SECRET_KEY_FILE"
-    else
-        KMS_SECRET_KEY_FILE="/run/secrets/$MINIO_KMS_SECRET_KEY_FILE"
-    fi
-
-    if [ -f "$KMS_SECRET_KEY_FILE" ]; then
-        MINIO_KMS_SECRET_KEY="$(cat "$KMS_SECRET_KEY_FILE")"
-        export MINIO_KMS_SECRET_KEY
-    fi
-}
-
 # su-exec to requested user, if service cannot run exec will fail.
 docker_switch_user() {
     if [ -n "${MINIO_USERNAME}" ] && [ -n "${MINIO_GROUPNAME}" ]; then
@@ -97,20 +24,6 @@ docker_switch_user() {
         exec "$@"
     fi
 }
-
-## Set access env from secrets if necessary. Legacy
-docker_secrets_env_old
-
-## Set access env from secrets if necessary. Override
-docker_secrets_env
-
-## Set kms encryption from secrets if necessary. Override
-docker_kms_secret_encryption_env
-
-## Set all config environment variables from 'config.env' if necessary.
-## Overrides all previous settings and also overrides all
-## environment values passed from 'podman run -e ENV=value'
-docker_minio_env
 
 ## Switch to user if applicable.
 docker_switch_user "$@"

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -29,6 +29,20 @@ const (
 	EnvRootUser     = "MINIO_ROOT_USER"
 	EnvRootPassword = "MINIO_ROOT_PASSWORD"
 
+	// Legacy files
+	EnvAccessKeyFile = "MINIO_ACCESS_KEY_FILE"
+	EnvSecretKeyFile = "MINIO_SECRET_KEY_FILE"
+
+	// Current files
+	EnvRootUserFile     = "MINIO_ROOT_USER_FILE"
+	EnvRootPasswordFile = "MINIO_ROOT_PASSWORD_FILE"
+
+	// Set all config environment variables from 'config.env'
+	// if necessary. Overrides all previous settings and also
+	// overrides all environment values passed from
+	// 'podman run -e ENV=value'
+	EnvConfigEnvFile = "MINIO_CONFIG_ENV_FILE"
+
 	EnvBrowser    = "MINIO_BROWSER"
 	EnvDomain     = "MINIO_DOMAIN"
 	EnvPublicIPs  = "MINIO_PUBLIC_IPS"
@@ -47,12 +61,13 @@ const (
 
 	EnvUpdate = "MINIO_UPDATE"
 
-	EnvKMSSecretKey  = "MINIO_KMS_SECRET_KEY"
-	EnvKESEndpoint   = "MINIO_KMS_KES_ENDPOINT"
-	EnvKESKeyName    = "MINIO_KMS_KES_KEY_NAME"
-	EnvKESClientKey  = "MINIO_KMS_KES_KEY_FILE"
-	EnvKESClientCert = "MINIO_KMS_KES_CERT_FILE"
-	EnvKESServerCA   = "MINIO_KMS_KES_CAPATH"
+	EnvKMSSecretKey     = "MINIO_KMS_SECRET_KEY"
+	EnvKMSSecretKeyFile = "MINIO_KMS_SECRET_KEY_FILE"
+	EnvKESEndpoint      = "MINIO_KMS_KES_ENDPOINT"
+	EnvKESKeyName       = "MINIO_KMS_KES_KEY_NAME"
+	EnvKESClientKey     = "MINIO_KMS_KES_KEY_FILE"
+	EnvKESClientCert    = "MINIO_KMS_KES_CERT_FILE"
+	EnvKESServerCA      = "MINIO_KMS_KES_CAPATH"
 
 	EnvEndpoints  = "MINIO_ENDPOINTS"   // legacy
 	EnvWorm       = "MINIO_WORM"        // legacy


### PR DESCRIPTION
## Description
add code to parse secrets natively instead of shell scripts

## Motivation and Context
Remove docker-entrypoint.sh based secrets loading

## How to test this PR?
Nothing special use `docker secrets` and use kubernetes
secrets to load the credentials/config properly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
