### PR TITLE
Fix: non-existent policy cannot be set on a user/group

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1191,7 +1191,7 @@ func (sys *IAMSys) PolicyDBSet(ctx context.Context, name, policy string, isGroup
 
 	err := sys.store.PolicyDBSet(ctx, name, policy, userType, isGroup)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// Notify all other MinIO peers to reload policy

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -277,7 +277,13 @@ func (s *TestSuiteIAM) TestLDAPSTS(c *check) {
 		c.Fatalf("Expected to fail to create STS cred with no associated policy!")
 	}
 
+	// Attempting to set a non-existent policy should fail.
 	userDN := "uid=dillon,ou=people,ou=swengg,dc=min,dc=io"
+	err = s.adm.SetPolicy(ctx, policy+"x", userDN, false)
+	if err == nil {
+		c.Fatalf("should not be able to set non-existent policy")
+	}
+
 	err = s.adm.SetPolicy(ctx, policy, userDN, false)
 	if err != nil {
 		c.Fatalf("Unable to set policy: %v", err)


### PR DESCRIPTION

## Motivation and Context

Bug fix.

## How to test this PR?

Try to set a non-existent policy with mc like:

```
mc admin policy set myminio doesnotexist user=foo
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
