### PR TITLE
Deprecate caching for erasure/distributed mode

### DIFF
--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -706,7 +706,7 @@ func (c *cacheObjects) PutObject(ctx context.Context, bucket, object string, r *
 				oi, _, err := dcache.Stat(GlobalContext, bucket, object)
 				// avoid cache overwrite if another background routine filled cache
 				if err != nil || oi.ETag != bReader.ObjInfo.ETag {
-					dcache.Put(GlobalContext, bucket, object, bReader, bReader.ObjInfo.Size, nil, ObjectOptions{UserDefined: getMetadata(bReader.ObjInfo)}, false, true)
+					dcache.Put(GlobalContext, bucket, object, bReader, bReader.ObjInfo.Size, nil, ObjectOptions{UserDefined: getMetadata(bReader.ObjInfo)}, false, false)
 				}
 			}()
 		}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -591,8 +591,11 @@ func serverMain(ctx *cli.Context) {
 		}
 	}
 
+	// initialize the new disk cache objects.
 	if globalCacheConfig.Enabled {
-		// initialize the new disk cache objects.
+		if globalIsErasure {
+			logStartupMessage(color.Yellow("WARNING: Disk caching is deprecated for single/multi drive MinIO setups. Please migrate to using MinIO S3 gateway instead of disk caching"))
+		}
 		var cacheAPI CacheObjectLayer
 		cacheAPI, err = newServerCacheObjects(GlobalContext, globalCacheConfig)
 		logger.FatalIf(err, "Unable to initialize disk caching")

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -593,9 +593,7 @@ func serverMain(ctx *cli.Context) {
 
 	// initialize the new disk cache objects.
 	if globalCacheConfig.Enabled {
-		if globalIsErasure {
-			logStartupMessage(color.Yellow("WARNING: Disk caching is deprecated for single/multi drive MinIO setups. Please migrate to using MinIO S3 gateway instead of disk caching"))
-		}
+		logStartupMessage(color.Yellow("WARNING: Disk caching is deprecated for single/multi drive MinIO setups. Please migrate to using MinIO S3 gateway instead of disk caching"))
 		var cacheAPI CacheObjectLayer
 		cacheAPI, err = newServerCacheObjects(GlobalContext, globalCacheConfig)
 		logger.FatalIf(err, "Unable to initialize disk caching")

--- a/internal/config/cache/lookup.go
+++ b/internal/config/cache/lookup.go
@@ -56,7 +56,6 @@ const (
 	DefaultAfter         = "0"
 	DefaultWaterMarkLow  = "70"
 	DefaultWaterMarkHigh = "80"
-	DefaultCacheCommit   = WriteThrough
 )
 
 // DefaultKVS - default KV settings for caching.
@@ -96,7 +95,7 @@ var (
 		},
 		config.KV{
 			Key:   Commit,
-			Value: DefaultCacheCommit,
+			Value: "",
 		},
 	}
 )


### PR DESCRIPTION
Fixes: #13907

Also removing default value of `writethrough` for cache commit
which was interefering with cache_after setting

## Description


## Motivation and Context
caching not useful in dist/erasure mode.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
