### PR TITLE
copy bucket slice to avoid skipping .minio.sys/buckets

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1962,7 +1962,10 @@ func (s *xlStorage) Delete(ctx context.Context, volume string, path string, recu
 func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string) (err error) {
 	defer func() {
 		if err != nil {
-			logger.LogIf(ctx, err)
+			logger.LogIf(ctx, fmt.Errorf("srcVolume: %s, srcPath: %s, dstVolume: %s:, dstPath: %s - error %v",
+				srcVolume, srcPath,
+				dstVolume, dstPath,
+				err))
 		}
 		if err == nil {
 			if s.globalSync {


### PR DESCRIPTION
## Description
copy bucket slice to avoid skipping .minio.sys/buckets

## Motivation and Context
healing was skipping `.minio.sys/buckets` path 
so essentially not healing `.usage.json`. 

## How to test this PR?
```
~ minio server /tmp/xl{1...4} /tmp/xl{5...8}
```

Copy something to the drives  and then delete `rm -rf /tmp/xl7`  - let it heal, 
without this PR you will see that `/tmp/xl7/.minio.sys/buckets` is missing
and the next usage cycle complains about "RenameData() --> volume not found"


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression probably yes since we started passing around tracker.QueuedBuckets
- [ ] Documentation updated
- [ ] Unit tests added/updated
