### PR TITLE
select: Return early from bool AND, OR

### DIFF
--- a/internal/s3select/select_test.go
+++ b/internal/s3select/select_test.go
@@ -794,6 +794,14 @@ func TestCSVQueries2(t *testing.T) {
 			query:      `select * from S3object where _2 IS NOT ''`,
 			wantResult: `{"c1":"1","c2":"2","c3":"3"}`,
 		},
+		{
+			name: "select-is_not_string",
+			input: []byte(`c1,c2,c3
+1,2,3
+1,,3`),
+			query:      `select * from S3object where _2 != '' AND _2 > 1`,
+			wantResult: `{"c1":"1","c2":"2","c3":"3"}`,
+		},
 	}
 
 	defRequest := `<?xml version="1.0" encoding="UTF-8"?>

--- a/internal/s3select/sql/evaluate.go
+++ b/internal/s3select/sql/evaluate.go
@@ -69,6 +69,9 @@ func (e *Expression) evalNode(r Record, tableAlias string) (*Value, error) {
 		if !ok {
 			return nil, errExpectedBool
 		}
+		if b {
+			return FromBool(true), nil
+		}
 		result = result || b
 	}
 	return FromBool(result), nil
@@ -90,6 +93,9 @@ func (e *AndCondition) evalNode(r Record, tableAlias string) (*Value, error) {
 		b, ok := res.ToBool()
 		if !ok {
 			return nil, errExpectedBool
+		}
+		if !b {
+			return FromBool(false), nil
 		}
 		result = result && b
 	}


### PR DESCRIPTION
## Description

Return as soon as an AND fails and whenever an OR succeeds. Faster and more flexible.

For example makes `select * from S3object where _2 != '' AND _2 > 1` able to operate on empty fields.

Followup to #13900

## How to test this PR?

Unit test included

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [x] Unit tests added/updated
