### PR TITLE
Fix delete marker replication propagation

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -500,7 +500,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 			replicate, repsync := checkReplicateDelete(ctx, bucket, ObjectToDelete{
 				ObjectName: object.ObjectName,
 				VersionID:  object.VersionID,
-			}, goi, gerr)
+			}, ObjectOptions{}, goi, gerr)
 			replicateSync = repsync
 			if replicate {
 				if apiErrCode := checkRequestAuthType(ctx, r, policy.ReplicateDeleteAction, bucket, object.ObjectName); apiErrCode != ErrNone {
@@ -604,7 +604,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 
 		if replicateDeletes {
 			if dobj.DeleteMarkerReplicationStatus == string(replication.Pending) || dobj.VersionPurgeStatus == Pending {
-				dv := DeletedObjectVersionInfo{
+				dv := DeletedObjectReplicationInfo{
 					DeletedObject: dobj,
 					Bucket:        bucket,
 				}

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1138,7 +1138,7 @@ func (i *scannerItem) healReplicationDeletes(ctx context.Context, o ObjectLayer,
 		} else {
 			versionID = oi.VersionID
 		}
-		globalReplicationPool.queueReplicaDeleteTask(ctx, DeletedObjectVersionInfo{
+		globalReplicationPool.queueReplicaDeleteTask(ctx, DeletedObjectReplicationInfo{
 			DeletedObject: DeletedObject{
 				ObjectName:                    oi.Name,
 				DeleteMarkerVersionID:         dmVersionID,
@@ -1149,6 +1149,7 @@ func (i *scannerItem) healReplicationDeletes(ctx context.Context, o ObjectLayer,
 				VersionPurgeStatus:            oi.VersionPurgeStatus,
 			},
 			Bucket: oi.Bucket,
+			OpType: replication.HealReplicationType,
 		})
 	}
 }

--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -331,6 +331,10 @@ func ErrorRespToObjectError(err error, params ...string) error {
 	case "EntityTooSmall":
 		err = PartTooSmall{}
 	}
+	switch minioErr.StatusCode {
+	case http.StatusMethodNotAllowed:
+		err = toObjectErr(errMethodNotAllowed, bucket, object)
+	}
 
 	return err
 }

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -58,7 +58,9 @@ type ObjectOptions struct {
 
 	// Use the maximum parity (N/2), used when
 	// saving server configuration files
-	MaxParity bool
+	MaxParity          bool
+	ReplicationRequest bool // only set for replica side
+
 }
 
 // BucketOptions represents bucket options for ObjectLayer bucket operations

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -70,6 +70,9 @@ func getDefaultOpts(header http.Header, copySource bool, metadata map[string]str
 		opts.ProxyHeaderSet = true
 		opts.ProxyRequest = strings.Join(v, "") == "true"
 	}
+	if _, ok := header[xhttp.MinIOSourceReplicationRequest]; ok {
+		opts.ReplicationRequest = true
+	}
 	return
 }
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3170,7 +3170,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		})
 	}
 
-	replicateDel, replicateSync := checkReplicateDelete(ctx, bucket, ObjectToDelete{ObjectName: object, VersionID: opts.VersionID}, goi, gerr)
+	replicateDel, replicateSync := checkReplicateDelete(ctx, bucket, ObjectToDelete{ObjectName: object, VersionID: opts.VersionID}, opts, goi, gerr)
 	if replicateDel {
 		if opts.VersionID != "" {
 			opts.VersionPurgeStatus = Pending
@@ -3260,7 +3260,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		} else {
 			versionID = objInfo.VersionID
 		}
-		dobj := DeletedObjectVersionInfo{
+		dobj := DeletedObjectReplicationInfo{
 			DeletedObject: DeletedObject{
 				ObjectName:                    object,
 				VersionID:                     versionID,

--- a/cmd/web-handlers.go
+++ b/cmd/web-handlers.go
@@ -770,7 +770,7 @@ next:
 				if replicateDel, replicateSync = checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{
 					ObjectName: objectName,
 					VersionID:  goi.VersionID,
-				}, goi, gerr); replicateDel {
+				}, opts, goi, gerr); replicateDel {
 					opts.DeleteMarkerReplicationStatus = string(replication.Pending)
 					opts.DeleteMarker = true
 				}
@@ -809,7 +809,7 @@ next:
 			})
 
 			if replicateDel {
-				dobj := DeletedObjectVersionInfo{
+				dobj := DeletedObjectReplicationInfo{
 					DeletedObject: DeletedObject{
 						ObjectName:                    objectName,
 						DeleteMarkerVersionID:         oi.VersionID,
@@ -903,7 +903,7 @@ next:
 						}
 					}
 				}
-				replicateDel, _ := checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{ObjectName: obj.Name, VersionID: obj.VersionID}, obj, nil)
+				replicateDel, _ := checkReplicateDelete(ctx, args.BucketName, ObjectToDelete{ObjectName: obj.Name, VersionID: obj.VersionID}, opts, obj, nil)
 				// since versioned delete is not available on web browser, yet - this is a simple DeleteMarker replication
 				objToDel := ObjectToDelete{ObjectName: obj.Name}
 				if replicateDel {
@@ -952,7 +952,7 @@ next:
 					Host:       sourceIP,
 				})
 				if dobj.DeleteMarkerReplicationStatus == string(replication.Pending) || dobj.VersionPurgeStatus == Pending {
-					dv := DeletedObjectVersionInfo{
+					dv := DeletedObjectReplicationInfo{
 						DeletedObject: dobj,
 						Bucket:        args.BucketName,
 					}


### PR DESCRIPTION
This backport is based on various fixes/changes in PR#12932, PR#12880 and
PR#12109 to properly propagate DeleteMarkers when the primary's
replication status could not be updated after the delete replication
finished. In this situation, RemoveObject call on the already replicated
delete marker would return `MethodNotAllowed` causing incorrect logging
and retries.

## Description


## Motivation and Context


## How to test this PR?
Cant be repro'd directly -  commented out the replication status update section of delete replication to recreate this situation.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
