### PR TITLE
env: Remove quotes when parsing a config env file

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -460,9 +460,21 @@ func parsEnvEntry(envEntry string) (envKV, error) {
 	if len(envTokens) != 2 {
 		return envKV{}, fmt.Errorf("envEntry malformed; %s, expected to be of form 'KEY=value'", envEntry)
 	}
+
+	key := envTokens[0]
+	val := envTokens[1]
+
+	// Remove quotes from the value if found
+	if len(val) >= 2 {
+		quote := val[0]
+		if (quote == '"' || quote == '\'') && val[len(val)-1] == quote {
+			val = val[1 : len(val)-1]
+		}
+	}
+
 	return envKV{
-		Key:   envTokens[0],
-		Value: envTokens[1],
+		Key:   key,
+		Value: val,
 	}, nil
 }
 

--- a/cmd/common-main_test.go
+++ b/cmd/common-main_test.go
@@ -45,6 +45,26 @@ export MINIO_ROOT_PASSWORD=minio123`,
 				},
 			},
 		},
+		// Value with double quotes
+		{`export MINIO_ROOT_USER="minio"`,
+			false,
+			[]envKV{
+				{
+					Key:   "MINIO_ROOT_USER",
+					Value: "minio",
+				},
+			},
+		},
+		// Value with single quotes
+		{`export MINIO_ROOT_USER='minio'`,
+			false,
+			[]envKV{
+				{
+					Key:   "MINIO_ROOT_USER",
+					Value: "minio",
+				},
+			},
+		},
 		{`
 MINIO_ROOT_USER=minio
 MINIO_ROOT_PASSWORD=minio123`,


### PR DESCRIPTION
## Description
The code parsing the config environment file does not remove quotes of
environment variables values. This commit adds this capability.

## Motivation and Context
Fix parsing parsing some env variables in the operator.

## How to test this PR?
Deploy a tenant with the operator

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
