### PR TITLE
config/iam: only first server should rotate keys

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -582,6 +582,11 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for {
+		// Only first node is responsible of migrating IAM data
+		if !globalEndpoints.FirstLocal() {
+			break
+		}
+
 		// let one of the server acquire the lock, if not let them timeout.
 		// which shall be retried again by this loop.
 		if _, err := txnLk.GetLock(retryCtx, iamLockTimeout); err != nil {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -308,33 +308,37 @@ func initServer(ctx context.Context, newObject ObjectLayer) error {
 			logger.Info("Waiting for all MinIO sub-systems to be initialized.. lock acquired")
 		}
 
-		// Migrate all backend configs to encrypted backend configs, optionally
-		// handles rotating keys for encryption, if there is any retriable failure
-		// that shall be retried if there is an error.
-		if err = handleEncryptedConfigBackend(newObject); err == nil {
-			// Upon success migrating the config, initialize all sub-systems
-			// if all sub-systems initialized successfully return right away
-			if err = initAllSubsystems(ctx, newObject); err == nil {
+		if globalEndpoints.FirstLocal() {
+			// Migrate all backend configs to encrypted backend configs, optionally
+			// handles rotating keys for encryption, if there is any retriable failure
+			// that shall be retried if there is an error.
+			if err = handleEncryptedConfigBackend(newObject); err != nil {
 				txnLk.Unlock()
-				// All successful return.
-				if globalIsDistErasure {
-					// These messages only meant primarily for distributed setup, so only log during distributed setup.
-					logger.Info("All MinIO sub-systems initialized successfully")
+				if configRetriableErrors(err) {
+					logger.Info("Waiting for all MinIO sub-systems to be initialized.. possible cause (%v)", err)
+					time.Sleep(time.Duration(r.Float64() * float64(5*time.Second)))
+					continue
 				}
-				return nil
+				return fmt.Errorf("Unable to migrate encrypted config: %w", err)
 			}
+		}
+
+		// Upon success migrating the config, initialize all sub-systems
+		// if all sub-systems initialized successfully return right away
+		if err = initAllSubsystems(ctx, newObject); err == nil {
+			txnLk.Unlock()
+			// All successful return.
+			if globalIsDistErasure {
+				// These messages only meant primarily for distributed setup, so only log during distributed setup.
+				logger.Info("All MinIO sub-systems initialized successfully")
+			}
+			return nil
 		}
 
 		txnLk.Unlock() // Unlock the transaction lock and allow other nodes to acquire the lock if possible.
 
-		if configRetriableErrors(err) {
-			logger.Info("Waiting for all MinIO sub-systems to be initialized.. possible cause (%v)", err)
-			time.Sleep(time.Duration(r.Float64() * float64(5*time.Second)))
-			continue
-		}
-
-		// Any other unhandled return right here.
-		return fmt.Errorf("Unable to initialize sub-systems: %w", err)
+		logger.Info("Waiting for all MinIO sub-systems to be initialized.. possible cause (%v)", err)
+		time.Sleep(time.Duration(r.Float64() * float64(5*time.Second)))
 	}
 }
 


### PR DESCRIPTION
## Description
Avoid parallel nodes (probably with different env variables and root access & secret keys)
to rotate config and IAM data encryption key.


## Motivation and Context
Fix issue when servers not able to decrypt IAM after a root access key rotation.

## How to test this PR?
Hard to test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
