### PR TITLE
Limit mySQL key size to 3K

### DIFF
--- a/internal/event/target/mysql.go
+++ b/internal/event/target/mysql.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	mysqlTableExists          = `SELECT 1 FROM %s;`
-	mysqlCreateNamespaceTable = `CREATE TABLE %s (key_name VARCHAR(4096), value JSON, PRIMARY KEY (key_name))
+	mysqlTableExists = `SELECT 1 FROM %s;`
+	// Some MySQL has a 3072 byte limit on key sizes.
+	mysqlCreateNamespaceTable = `CREATE TABLE %s (key_name VARCHAR(3072), value JSON, PRIMARY KEY (key_name))
                                        CHARACTER SET = utf8mb4 COLLATE = utf8mb4_bin ROW_FORMAT = Dynamic;`
 	mysqlCreateAccessTable = `CREATE TABLE %s (event_time DATETIME NOT NULL, event_data JSON)
                                     ROW_FORMAT = Dynamic;`


### PR DESCRIPTION
## Description

User is reporting `Error 1071 :Specified key was too long,max key length is 3072 bytes`.

Regression caused by #13414

## How to test this PR?

This seems to be the limit we can go to.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Fixes a regression #13414
