### PR TITLE
simplify logger time and avoid possible crashes

### DIFF
--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -147,7 +147,7 @@ func GetAuditEntry(ctx context.Context) *audit.Entry {
 		r = &audit.Entry{
 			Version:      audit.Version,
 			DeploymentID: globalDeploymentID,
-			Time:         time.Now().UTC().Format(time.RFC3339Nano),
+			Time:         time.Now().UTC(),
 		}
 		SetAuditEntry(ctx, r)
 		return r

--- a/internal/logger/console.go
+++ b/internal/logger/console.go
@@ -80,7 +80,7 @@ func (f fatalMsg) json(msg string, args ...interface{}) {
 	logJSON, err := json.Marshal(&log.Entry{
 		Level:   FatalLvl.String(),
 		Message: message,
-		Time:    time.Now().UTC().Format(time.RFC3339Nano),
+		Time:    time.Now().UTC(),
 		Trace:   &log.Trace{Message: message, Source: []string{getSource(6)}},
 	})
 	if err != nil {
@@ -159,7 +159,7 @@ func (i infoMsg) json(msg string, args ...interface{}) {
 	logJSON, err := json.Marshal(&log.Entry{
 		Level:   InformationLvl.String(),
 		Message: message,
-		Time:    time.Now().UTC().Format(time.RFC3339Nano),
+		Time:    time.Now().UTC(),
 	})
 	if err != nil {
 		panic(err)
@@ -192,7 +192,7 @@ func (i errorMsg) json(msg string, args ...interface{}) {
 	logJSON, err := json.Marshal(&log.Entry{
 		Level:   ErrorLvl.String(),
 		Message: message,
-		Time:    time.Now().UTC().Format(time.RFC3339Nano),
+		Time:    time.Now().UTC(),
 		Trace:   &log.Trace{Message: message, Source: []string{getSource(6)}},
 	})
 	if err != nil {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -349,7 +349,7 @@ func logIf(ctx context.Context, err error, errKind ...interface{}) {
 		Host:         req.Host,
 		RequestID:    req.RequestID,
 		UserAgent:    req.UserAgent,
-		Time:         time.Now().UTC().Format(time.RFC3339Nano),
+		Time:         time.Now().UTC(),
 		API: &log.API{
 			Name: API,
 			Args: &log.Args{

--- a/internal/logger/message/audit/entry.go
+++ b/internal/logger/message/audit/entry.go
@@ -31,10 +31,10 @@ const Version = "1"
 
 // Entry - audit entry logs.
 type Entry struct {
-	Version      string `json:"version"`
-	DeploymentID string `json:"deploymentid,omitempty"`
-	Time         string `json:"time"`
-	Trigger      string `json:"trigger"`
+	Version      string    `json:"version"`
+	DeploymentID string    `json:"deploymentid,omitempty"`
+	Time         time.Time `json:"time"`
+	Trigger      string    `json:"trigger"`
 	API          struct {
 		Name            string `json:"name,omitempty"`
 		Bucket          string `json:"bucket,omitempty"`
@@ -61,7 +61,7 @@ func NewEntry(deploymentID string) Entry {
 	return Entry{
 		Version:      Version,
 		DeploymentID: deploymentID,
-		Time:         time.Now().UTC().Format(time.RFC3339Nano),
+		Time:         time.Now().UTC(),
 	}
 }
 

--- a/internal/logger/message/log/entry.go
+++ b/internal/logger/message/log/entry.go
@@ -17,7 +17,10 @@
 
 package log
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 // Args - defines the arguments for the API.
 type Args struct {
@@ -41,17 +44,17 @@ type API struct {
 
 // Entry - defines fields and values of each log entry.
 type Entry struct {
-	DeploymentID string `json:"deploymentid,omitempty"`
-	Level        string `json:"level"`
-	LogKind      string `json:"errKind"`
-	Time         string `json:"time"`
-	API          *API   `json:"api,omitempty"`
-	RemoteHost   string `json:"remotehost,omitempty"`
-	Host         string `json:"host,omitempty"`
-	RequestID    string `json:"requestID,omitempty"`
-	UserAgent    string `json:"userAgent,omitempty"`
-	Message      string `json:"message,omitempty"`
-	Trace        *Trace `json:"error,omitempty"`
+	DeploymentID string    `json:"deploymentid,omitempty"`
+	Level        string    `json:"level"`
+	LogKind      string    `json:"errKind"`
+	Time         time.Time `json:"time"`
+	API          *API      `json:"api,omitempty"`
+	RemoteHost   string    `json:"remotehost,omitempty"`
+	Host         string    `json:"host,omitempty"`
+	RequestID    string    `json:"requestID,omitempty"`
+	UserAgent    string    `json:"userAgent,omitempty"`
+	Message      string    `json:"message,omitempty"`
+	Trace        *Trace    `json:"error,omitempty"`
 }
 
 // Info holds console log messages

--- a/internal/logger/target/console/console.go
+++ b/internal/logger/target/console/console.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/minio/minio/internal/color"
 	"github.com/minio/minio/internal/logger"
@@ -81,15 +80,20 @@ func (c *Target) Send(e interface{}, logKind string) error {
 		}
 	}
 
-	apiString := "API: " + entry.API.Name + "("
-	if entry.API.Args != nil && entry.API.Args.Bucket != "" {
-		apiString = apiString + "bucket=" + entry.API.Args.Bucket
+	var apiString string
+	if entry.API != nil {
+		apiString = "API: " + entry.API.Name + "("
+		if entry.API.Args != nil && entry.API.Args.Bucket != "" {
+			apiString = apiString + "bucket=" + entry.API.Args.Bucket
+		}
+		if entry.API.Args != nil && entry.API.Args.Object != "" {
+			apiString = apiString + ", object=" + entry.API.Args.Object
+		}
+		apiString += ")"
+	} else {
+		apiString = "INTERNAL"
 	}
-	if entry.API.Args != nil && entry.API.Args.Object != "" {
-		apiString = apiString + ", object=" + entry.API.Args.Object
-	}
-	apiString += ")"
-	timeString := "Time: " + time.Now().Format(logger.TimeFormat)
+	timeString := "Time: " + entry.Time.Format(logger.TimeFormat)
 
 	var deploymentID string
 	if entry.DeploymentID != "" {


### PR DESCRIPTION


## Description
simplify logger time and avoid possible crashes

## Motivation and Context
time.Format() is not necessary prematurely for JSON
marshaling, since JSON marshaling indeed defaults
to RFC3339Nano.

This also ensures the 'time' is remembered until its
logged and it is the same time when the 'caller'
invoked 'log' functions.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
