### PR TITLE
Update TLS README.md - fix command example

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -148,7 +148,7 @@ DNS.1 = localhost
 Run `openssl` by specifying the configuration file and enter a passphrase if prompted:
 
 ```sh
-openssl req -new -x509 -nodes -days 730 -key private.key -out public.crt -config openssl.conf
+openssl req -new -x509 -nodes -days 730 -keyout private.key -out public.crt -config openssl.conf
 ```
 
 ### <a name="using-gnu-tls"></a>3.3 Use GnuTLS (for Windows) to Generate a Certificate


### PR DESCRIPTION
In _3.2.3 Generate a self-signed certificate_  I think that the command example is not valid.

"-keyout" parameter should be used (as we want to generate a new private.key).
"-key" try to open the 'private.key' file (which does not exist in our case and lead to a 'No such file or directory:bss_file.c:402:fopen('private.key','r')' )

## Description
Update documentation

## Motivation and Context
Update documentation

## How to test this PR?
NA

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
