### PR TITLE
DeleteMultipleObjects: Finish even if cancelled + concurrent sets

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -576,6 +576,9 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 		return
 	}
 
+	// Disable timeouts and cancellation
+	ctx = bgContext(ctx)
+
 	deleteList := toNames(objectsToDelete)
 	dObjects, errs := deleteObjectsFn(ctx, bucket, deleteList, ObjectOptions{
 		Versioned:        versioned,

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -911,3 +911,32 @@ func contextCanceled(ctx context.Context) bool {
 		return false
 	}
 }
+
+// bgContext returns a context that can be used for async operations.
+// Cancellation/timeouts are removed, so parent cancellations/timeout will
+// not propagate from parent.
+// Context values are preserved.
+// This can be used for goroutines that live beyond the parent context.
+func bgContext(parent context.Context) context.Context {
+	return bgCtx{parent: parent}
+}
+
+type bgCtx struct {
+	parent context.Context
+}
+
+func (a bgCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (a bgCtx) Err() error {
+	return nil
+}
+
+func (a bgCtx) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (a bgCtx) Value(key interface{}) interface{} {
+	return a.parent.Value(key)
+}

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1197,6 +1197,12 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 					continue
 				}
 				for _, v := range dedupVersions[i].Versions {
+					if err == errFileNotFound || err == errFileVersionNotFound {
+						if !dobjects[v.Idx].DeleteMarker {
+							// Not delete marker, if not found, ok.
+							continue
+						}
+					}
 					delObjErrs[index][v.Idx] = err
 				}
 			}

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -159,10 +159,15 @@ func toObjectErr(err error, params ...string) error {
 			apiErr.Object = decodeDirObject(params[1])
 		}
 		return apiErr
-	case io.ErrUnexpectedEOF.Error(), io.ErrShortWrite.Error():
-		return IncompleteBody{}
-	case context.Canceled.Error(), context.DeadlineExceeded.Error():
-		return IncompleteBody{}
+	case io.ErrUnexpectedEOF.Error(), io.ErrShortWrite.Error(), context.Canceled.Error(), context.DeadlineExceeded.Error():
+		apiErr := IncompleteBody{}
+		if len(params) >= 1 {
+			apiErr.Bucket = params[0]
+		}
+		if len(params) >= 2 {
+			apiErr.Object = decodeDirObject(params[1])
+		}
+		return apiErr
 	}
 	return err
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -611,6 +611,9 @@ func (client *storageRESTClient) DeleteVersions(ctx context.Context, volume stri
 	respBody, err := client.call(ctx, storageRESTMethodDeleteVersions, values, &buffer, -1)
 	defer xhttp.DrainBody(respBody)
 	if err != nil {
+		if contextCanceled(ctx) {
+			err = ctx.Err()
+		}
 		for i := range errs {
 			errs[i] = err
 		}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -943,6 +943,10 @@ func (s *xlStorage) DeleteVersions(ctx context.Context, volume string, versions 
 	errs := make([]error, len(versions))
 
 	for i, fiv := range versions {
+		if contextCanceled(ctx) {
+			errs[i] = ctx.Err()
+			continue
+		}
 		if err := s.deleteVersions(ctx, volume, fiv.Name, fiv.Versions...); err != nil {
 			errs[i] = err
 		}


### PR DESCRIPTION
## Description

* Process sets concurrently.
* Disconnect context from request.
* Insert context cancellation checks.
* `errFileNotFound` and `errFileVersionNotFound` are ok, unless creating delete markers.

## Motivation and Context

Canceled `DeleteMultipleObjects` has some interesting properties.

Since it is operating independently in bulk, per disk, it tends to leave a lot of inconsistent objects, since each disk may be at a different places when the cancel is received. This leads to a lot of "file not found" on subsequent requests, leading to quorum errors, even if the object/version is deleted.

In overall terms cancelation on bulk requests are questionable, unless you do strictly serial processing. I have done some cleanups, which should make the current processing more stable. I will send this as a PR.

However, I think the correct solution is to disable cancelation propagation and always finish the bulk delete operation, even if the client disconnects while it is going on.

## How to test this PR?

Best test is warp:

λ warp delete --duration=1s --noclear --objects=1000000
(let it finish)

λ warp delete --duration=1s
(ctrl+c after a few seconds, repeat)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Optimization (provides speedup with no functional changes)
