### PR TITLE
Add small client TLS PSK cache

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -118,6 +118,9 @@ const (
 
 	// diskMinInodes is the minimum number of inodes we want free on a disk to perform writes.
 	diskMinInodes = 1000
+
+	// tlsClientSessionCacheSize is the cache size for client sessions.
+	tlsClientSessionCacheSize = 100
 )
 
 var globalCLIContext = struct {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -181,15 +181,17 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 
 	// allow transport to be HTTP/1.1 for proxying.
 	globalProxyTransport = newCustomHTTPProxyTransport(&tls.Config{
-		RootCAs:          globalRootCAs,
-		CipherSuites:     fips.CipherSuitesTLS(),
-		CurvePreferences: fips.EllipticCurvesTLS(),
+		RootCAs:            globalRootCAs,
+		CipherSuites:       fips.CipherSuitesTLS(),
+		CurvePreferences:   fips.EllipticCurvesTLS(),
+		ClientSessionCache: tls.NewLRUClientSessionCache(tlsClientSessionCacheSize),
 	}, rest.DefaultTimeout)()
 	globalProxyEndpoints = GetProxyEndpoints(globalEndpoints)
 	globalInternodeTransport = newInternodeHTTPTransport(&tls.Config{
-		RootCAs:          globalRootCAs,
-		CipherSuites:     fips.CipherSuitesTLS(),
-		CurvePreferences: fips.EllipticCurvesTLS(),
+		RootCAs:            globalRootCAs,
+		CipherSuites:       fips.CipherSuitesTLS(),
+		CurvePreferences:   fips.EllipticCurvesTLS(),
+		ClientSessionCache: tls.NewLRUClientSessionCache(tlsClientSessionCacheSize),
 	}, rest.DefaultTimeout)()
 
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -1642,7 +1642,8 @@ func newRemoteClusterHTTPTransport() *http.Transport {
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
-			RootCAs: globalRootCAs,
+			RootCAs:            globalRootCAs,
+			ClientSessionCache: tls.NewLRUClientSessionCache(tlsClientSessionCacheSize),
 		},
 	}
 	return tr

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -417,7 +417,8 @@ func getUpdateTransport(timeout time.Duration) http.RoundTripper {
 		TLSHandshakeTimeout:   timeout,
 		ExpectContinueTimeout: timeout,
 		TLSClientConfig: &tls.Config{
-			RootCAs: globalRootCAs,
+			RootCAs:            globalRootCAs,
+			ClientSessionCache: tls.NewLRUClientSessionCache(tlsClientSessionCacheSize),
 		},
 		DisableCompression: true,
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -613,7 +613,8 @@ func NewGatewayHTTPTransport() *http.Transport {
 
 func newGatewayHTTPTransport(timeout time.Duration) *http.Transport {
 	tr := newCustomHTTPTransport(&tls.Config{
-		RootCAs: globalRootCAs,
+		RootCAs:            globalRootCAs,
+		ClientSessionCache: tls.NewLRUClientSessionCache(100),
 	}, defaultDialTimeout)()
 
 	// Customize response header timeout for gateway transport.
@@ -639,7 +640,8 @@ func NewRemoteTargetHTTPTransport() *http.Transport {
 		TLSHandshakeTimeout:   5 * time.Second,
 		ExpectContinueTimeout: 5 * time.Second,
 		TLSClientConfig: &tls.Config{
-			RootCAs: globalRootCAs,
+			RootCAs:            globalRootCAs,
+			ClientSessionCache: tls.NewLRUClientSessionCache(tlsClientSessionCacheSize),
 		},
 		// Go net/http automatically unzip if content-type is
 		// gzip disable this feature, as we are always interested
@@ -1135,6 +1137,7 @@ func newTLSConfig(getCert certs.GetCertificateFunc) *tls.Config {
 		MinVersion:               tls.VersionTLS12,
 		NextProtos:               []string{"http/1.1", "h2"},
 		GetCertificate:           getCert,
+		ClientSessionCache:       tls.NewLRUClientSessionCache(tlsClientSessionCacheSize),
 	}
 
 	tlsClientIdentity := env.Get(xtls.EnvIdentityTLSEnabled, "") == config.EnableOn

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -614,7 +614,7 @@ func NewGatewayHTTPTransport() *http.Transport {
 func newGatewayHTTPTransport(timeout time.Duration) *http.Transport {
 	tr := newCustomHTTPTransport(&tls.Config{
 		RootCAs:            globalRootCAs,
-		ClientSessionCache: tls.NewLRUClientSessionCache(100),
+		ClientSessionCache: tls.NewLRUClientSessionCache(tlsClientSessionCacheSize),
 	}, defaultDialTimeout)()
 
 	// Customize response header timeout for gateway transport.


### PR DESCRIPTION
## Description

Added for non-transient TLS HTTP clients.

## Motivation and Context

Reduce CPU in some scenarios for inter-server connections.

## How to test this PR?

TLS should be enabled.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
