### PR TITLE
Fix replication of tag removal

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -769,7 +769,7 @@ func getReplicationAction(oi1 ObjectInfo, oi2 minio.ObjectInfo, opType replicati
 	}
 
 	t, _ := tags.ParseObjectTags(oi1.UserTags)
-	if !reflect.DeepEqual(oi2.UserTags, t.ToMap()) {
+	if !reflect.DeepEqual(oi2.UserTags, t.ToMap()) || (oi2.UserTagCount != len(t.ToMap())) {
 		return replicateMetadata
 	}
 

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1573,6 +1573,7 @@ func (er erasureObjects) PutObjectTags(ctx context.Context, bucket, object strin
 	filterOnlineDisksInplace(fi, metaArr, onlineDisks)
 
 	fi.Metadata[xhttp.AmzObjectTagging] = tags
+	fi.ReplicationState = opts.PutReplicationState()
 	for k, v := range opts.UserDefined {
 		fi.Metadata[k] = v
 	}

--- a/docs/site-replication/run-multi-site-ldap.sh
+++ b/docs/site-replication/run-multi-site-ldap.sh
@@ -166,6 +166,36 @@ if [ $? -ne 0 ]; then
     exit_1;
 fi
 
+vID=$(./mc stat minio2/newbucket/README.md --json | jq .versionID)
+if [ $? -ne 0 ]; then
+    echo "expecting object to be present. exiting.."
+    exit_1;
+fi
+./mc tag set --version-id "${vID}" minio2/newbucket/README.md "k=v"
+if [ $? -ne 0 ]; then
+    echo "expecting tag set to be successful. exiting.."
+    exit_1;
+fi
+sleep 5
+
+./mc tag remove --version-id "${vID}" minio2/newbucket/README.md
+if [ $? -ne 0 ]; then
+    echo "expecting tag removal to be successful. exiting.."
+    exit_1;
+fi
+sleep 5
+
+replStatus_minio2=$(./mc stat minio2/newbucket/README.md --json | jq -r .replicationStatus)
+if [ $? -ne 0 ]; then
+    echo "expecting object to be present. exiting.."
+    exit_1;
+fi
+
+if [ ${replStatus_minio2} != "COMPLETED" ]; then
+    echo "expected tag removal to have replicated, exiting..."
+    exit_1;
+fi
+
 ./mc rm minio3/newbucket/README.md
 sleep 5
 

--- a/docs/site-replication/run-multi-site-minio-idp.sh
+++ b/docs/site-replication/run-multi-site-minio-idp.sh
@@ -158,6 +158,36 @@ if [ $? -ne 0 ]; then
     exit_1;
 fi
 
+vID=$(./mc stat minio2/newbucket/README.md --json | jq .versionID)
+if [ $? -ne 0 ]; then
+    echo "expecting object to be present. exiting.."
+    exit_1;
+fi
+./mc tag set --version-id "${vID}" minio2/newbucket/README.md "k=v"
+if [ $? -ne 0 ]; then
+    echo "expecting tag set to be successful. exiting.."
+    exit_1;
+fi
+sleep 5
+
+./mc tag remove --version-id "${vID}" minio2/newbucket/README.md
+if [ $? -ne 0 ]; then
+    echo "expecting tag removal to be successful. exiting.."
+    exit_1;
+fi
+sleep 5
+
+replStatus_minio2=$(./mc stat minio2/newbucket/README.md --json | jq -r .replicationStatus )
+if [ $? -ne 0 ]; then
+    echo "expecting object to be present. exiting.."
+    exit_1;
+fi
+
+if [ ${replStatus_minio2} != "COMPLETED" ]; then
+    echo "expected tag removal to have replicated, exiting..."
+    exit_1;
+fi
+
 ./mc rm minio3/newbucket/README.md
 sleep 5
 


### PR DESCRIPTION
Currently tag removal leaves replication state as `PENDING` because
the `HEAD` api returns just a tag count but not the actual tags,
and this is treated as a no-op

## Description


## Motivation and Context
 

## How to test this PR?
Do a `mc tag set` followed by `mc tag remove` on an object version - Tag removal does not replicate 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
