### PR TITLE
Avoid reconnect of disk during startup sequence

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -106,7 +106,7 @@ func isEndpointConnectionStable(diskMap map[Endpoint]StorageAPI, endpoint Endpoi
 	if !disk.IsOnline() {
 		return false
 	}
-	if disk.LastConn().After(lastCheck) {
+	if !lastCheck.IsZero() && disk.LastConn().After(lastCheck) {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Description
For the first call of function connectDisks, lastCheck is zero value, this will lead to reconnect to the endpoint, it's not expected. Also reconnect to the endpoints would lead to close of the previous connect, may lead to offline of the drives with close REST Client of the endpoints; when healing objects in the dir of .minio.sys/config, may meet err: errDiskNotFound。Before the  version https://github.com/minio/minio/commit/b7c5e45fff935994791f89237a4891185c55b91f，the err: errDiskNotFound may trigger  `delete`，which will delete the policy files on the folder of `.minio.sys/config`。Also, I don't agree with that drives can come online lazily leads to errDiskNotFound in commit https://github.com/minio/minio/commit/b7c5e45fff935994791f89237a4891185c55b91f。All the drivers of the sets come online in the call of the function waitForFormatErasure。So，all the drivers come online before call of isObjectDangling。

## Motivation and Context
Fix the bug of that objects  on `.minio.sys/config`
folder deleted unexpectedly ,  due to healing unexpectedly deleting the
files as healObject due to meet errs:errDiskNotFound when call `readAllFileInfo`，because drive comes offline by unexpectedly 
 reconnect in first call connectDisks。 

## How to test this PR?
For the latest verison，start the minio，the REST Clients of each drive be close and  reconnect after newErasureSets；

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
