### PR TITLE
fix: decommission bugfixes found during migration of .minio.sys/config

### DIFF
--- a/cmd/admin-handler-utils.go
+++ b/cmd/admin-handler-utils.go
@@ -90,6 +90,18 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 		apiErr = errorCodes.ToAPIErrWithErr(e.Code, e.Cause)
 	default:
 		switch {
+		case errors.Is(err, errDecommissionAlreadyRunning):
+			apiErr = APIError{
+				Code:           "XMinioDecommissionNotAllowed",
+				Description:    err.Error(),
+				HTTPStatusCode: http.StatusBadRequest,
+			}
+		case errors.Is(err, errDecommissionComplete):
+			apiErr = APIError{
+				Code:           "XMinioDecommissionNotAllowed",
+				Description:    err.Error(),
+				HTTPStatusCode: http.StatusBadRequest,
+			}
 		case errors.Is(err, errConfigNotFound):
 			apiErr = APIError{
 				Code:           "XMinioConfigError",

--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -896,8 +896,17 @@ func makeFormatErasureMetaVolumes(disk StorageAPI) error {
 	if disk == nil {
 		return errDiskNotFound
 	}
+	volumes := []string{
+		minioMetaBucket,
+		minioMetaTmpBucket,
+		minioMetaMultipartBucket,
+		minioMetaTmpDeletedBucket,
+		dataUsageBucket,
+		pathJoin(minioMetaBucket, minioConfigPrefix),
+		minioMetaTmpBucket + "-old",
+	}
 	// Attempt to create MinIO internal buckets.
-	return disk.MakeVolBulk(context.TODO(), minioMetaBucket, minioMetaTmpBucket, minioMetaMultipartBucket, minioMetaTmpDeletedBucket, dataUsageBucket, minioMetaTmpBucket+"-old")
+	return disk.MakeVolBulk(context.TODO(), volumes...)
 }
 
 // Initialize a new set of set formats which will be written to all disks.

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -209,6 +209,9 @@ func (s *xlStorage) Sanitize() error {
 		return err
 	}
 
+	// Create any missing paths.
+	makeFormatErasureMetaVolumes(s)
+
 	return formatErasureCleanupTmp(s.diskPath)
 }
 


### PR DESCRIPTION
## Description
fix: decommission bugfixes found during migration of .minio.sys/config

## Motivation and Context
bugfixes in decommission

## How to test this PR?
```yaml
version: '3.7'

# Settings and configurations that are common for all containers
x-minio-common: &minio-common
  image: minio/minio:dev
  command: server --console-address ":9001" http://minio{1...4}/data{1...2} http://minio{1...4}/data{3...4}
  expose:
    - "9000"
    - "9001"
  environment:
    MINIO_ROOT_USER: minio
    MINIO_ROOT_PASSWORD: minio123
    _MINIO_SERVER_DEBUG: "on"
  healthcheck:
    test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
    interval: 30s
    timeout: 20s
    retries: 3

# starts 4 docker containers running minio server instances.
# using nginx reverse proxy, load balancing, you can access
# it through port 9000.
services:
  minio1:
    <<: *minio-common
    hostname: minio1
    volumes:
      - data1-1:/data1
      - data1-2:/data2
      - data1-3:/data3
      - data1-4:/data4

  minio2:
    <<: *minio-common
    hostname: minio2
    volumes:
      - data2-1:/data1
      - data2-2:/data2
      - data2-3:/data3
      - data2-4:/data4

  minio3:
    <<: *minio-common
    hostname: minio3
    volumes:
      - data3-1:/data1
      - data3-2:/data2
      - data3-3:/data3
      - data3-4:/data4

  minio4:
    <<: *minio-common
    hostname: minio4
    volumes:
      - data4-1:/data1
      - data4-2:/data2
      - data4-3:/data3
      - data4-4:/data4

  nginx:
    image: nginx:1.19.2-alpine
    hostname: nginx
    volumes:
      - ./nginx.conf:/etc/nginx/nginx.conf:ro
    ports:
      - "9000:9000"
      - "9001:9001"
    depends_on:
      - minio1
      - minio2
      - minio3
      - minio4

## By default this config uses default local driver,
## For custom volumes replace with volume driver configuration.
volumes:
  data1-1:
  data1-2:
  data1-3:
  data1-4:
  data2-1:
  data2-2:
  data2-3:
  data2-4:
  data3-1:
  data3-2:
  data3-3:
  data3-4:
  data4-1:
  data4-2:
  data4-3:
  data4-4:
```

You need to use `mc` from here https://github.com/minio/mc/pull/3769 

```
~ mc admin decom status nginx/
┌─────┬─────────────────────────────────┬─────────────────────────────────┬────────┐
│ ID  │ Pools                           │ Capacity                        │ Status │
│ 1st │ http://minio{1...4}/data{1...2} │ 68 GiB (used) / 376 GiB (total) │ Active │
│ 2nd │ http://minio{1...4}/data{3...4} │ 68 GiB (used) / 376 GiB (total) │ Active │
└─────┴─────────────────────────────────┴─────────────────────────────────┴────────┘
```

```
~ mc admin decom start nginx/ http://minio{1...4}/data{1...2}
~ mc admin decom status nginx/
┌─────┬─────────────────────────────────┬─────────────────────────────────┬──────────┐
│ ID  │ Pools                           │ Capacity                        │ Status   │
│ 1st │ http://minio{1...4}/data{1...2} │ 69 GiB (used) / 376 GiB (total) │ Complete │
│ 2nd │ http://minio{1...4}/data{3...4} │ 69 GiB (used) / 376 GiB (total) │ Active   │
└─────┴─────────────────────────────────┴─────────────────────────────────┴──────────┘
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
