### PR TITLE
fix: ignore drained pool in Healing, hold lock additionally

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -727,6 +727,12 @@ func (z *erasureServerPools) doDecommissionInRoutine(ctx context.Context, idx in
 	logger.LogIf(GlobalContext, z.CompleteDecommission(dctx, idx))
 }
 
+func (z *erasureServerPools) IsSuspended(idx int) bool {
+	z.poolMetaMutex.Lock()
+	defer z.poolMetaMutex.Unlock()
+	return z.poolMeta.IsSuspended(idx)
+}
+
 // Decommission - start decommission session.
 func (z *erasureServerPools) Decommission(ctx context.Context, idx int) error {
 	if idx < 0 {


### PR DESCRIPTION
## Description
fix: ignore drained pool in Healing, hold lock additionally

## Motivation and Context
drained pools can be ignored in the healing path
eagerly hold the lock, when looking up if the pool
is being drained.

## How to test this PR?
Start pool drain and then attempt `mc admin heal` 
this should skip the pool being drained.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
