### PR TITLE
lock: Fix decision when a lock needs to be removed

### DIFF
--- a/internal/dsync/dsync_test.go
+++ b/internal/dsync/dsync_test.go
@@ -239,6 +239,10 @@ func TestTwoSimultaneousLocksForDifferentResources(t *testing.T) {
 // Test refreshing lock - refresh should always return true
 //
 func TestSuccessfulLockRefresh(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	dm := NewDRWMutex(ds, "aap")
 	contextCanceled := make(chan struct{})
 
@@ -266,6 +270,10 @@ func TestSuccessfulLockRefresh(t *testing.T) {
 
 // Test canceling context while quorum servers report lock not found
 func TestFailedRefreshLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	// Simulate Refresh RPC response to return no locking found
 	for i := range lockServers[:3] {
 		lockServers[i].setRefreshReply(false)
@@ -298,6 +306,10 @@ func TestFailedRefreshLock(t *testing.T) {
 
 // Test Unlock should not timeout
 func TestUnlockShouldNotTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	dm := NewDRWMutex(ds, "aap")
 
 	if !dm.GetLock(context.Background(), nil, id, source, Options{Timeout: 5 * time.Minute}) {


### PR DESCRIPTION
## Description
The code was not properly deciding if lock needs to be removed when it
doesn't have quorum anymore. After this commit, a lock will be
forcefully unlocked if nodes reporting they are not able to find a lock
internally breaks the quorum.

Simplify the code as well.


## Motivation and Context
Sometimes a lock is not cleared when it doesn't have a quorum

## How to test this PR?
Hard to test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
