### PR TITLE
fix: use renameAll instead of deleteObject() for purging temporary files

### DIFF
--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -547,7 +547,7 @@ func (er erasureObjects) healObject(ctx context.Context, bucket string, object s
 
 	}
 
-	defer er.deleteObject(context.Background(), minioMetaTmpBucket, tmpID, len(storageDisks)/2+1)
+	defer er.renameAll(context.Background(), minioMetaTmpBucket, tmpID)
 
 	// Rename from tmp location to the actual location.
 	for i, disk := range outDatedDisks {


### PR DESCRIPTION
## Description
fix: use renameAll instead of deleteObject() for purging temporary files

## Motivation and Context
This PR simplifies few things

- Multipart parts are renamed, upon failure are unrenamed() keep this
  multipart-specific behavior is needed and works fine.

- AbortMultipart should blindly delete once the lock is acquired instead
  of reading metadata and calculating quorum, abort is a delete()
  operation and client have no business looking for errors on this.

  In S3 its an idempotent operation with no real error that needs
  to be returned, as it's a temporary location anyways.

- Skip Access() calls to folders that are operating on
  `.minio.sys/multipart` folder as well.

## How to test this PR?
Our unit and functional tests cover all areas here.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
