### PR TITLE
Add envVars for CLI arguments

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -51,23 +51,27 @@ import (
 // ServerFlags - server command specific flags
 var ServerFlags = []cli.Flag{
 	cli.StringFlag{
-		Name:  "address",
-		Value: ":" + GlobalMinioDefaultPort,
-		Usage: "bind to a specific ADDRESS:PORT, ADDRESS can be an IP or hostname",
+		Name:   "address",
+		Value:  ":" + GlobalMinioDefaultPort,
+		Usage:  "bind to a specific ADDRESS:PORT, ADDRESS can be an IP or hostname",
+		EnvVar: "MINIO_ADDRESS",
 	},
 	cli.IntFlag{
-		Name:  "listeners",
-		Value: 1,
-		Usage: "bind N number of listeners per ADDRESS:PORT",
+		Name:   "listeners",
+		Value:  1,
+		Usage:  "bind N number of listeners per ADDRESS:PORT",
+		EnvVar: "MINIO_LISTENERS",
 	},
 	cli.StringFlag{
-		Name:  "console-address",
-		Usage: "bind to a specific ADDRESS:PORT for embedded Console UI, ADDRESS can be an IP or hostname",
+		Name:   "console-address",
+		Usage:  "bind to a specific ADDRESS:PORT for embedded Console UI, ADDRESS can be an IP or hostname",
+		EnvVar: "MINIO_CONSOLE_ADDRESS",
 	},
 	cli.DurationFlag{
 		Name:   "shutdown-timeout",
 		Value:  xhttp.DefaultShutdownTimeout,
 		Usage:  "shutdown timeout to gracefully shutdown server",
+		EnvVar: "MINIO_SHUTDOWN_TIMEOUT",
 		Hidden: true,
 	},
 }


### PR DESCRIPTION

## Description
Add envVars for CLI arguments

## Motivation and Context
fixes #14107


## How to test this PR?
```
~ MINIO_CONSOLE_ADDRESS=":9090" MINIO_ADDRESS=":9001" minio server ~/test{1...4}
Verifying if 1 bucket is consistent across drives...
Automatically configured API requests per node based on available memory on the system: 139
Status:         4 Online, 0 Offline. 
API: http://10.0.0.185:9001  http://172.17.0.1:9001  http://172.19.0.1:9001  http://172.20.0.1:9001  http://127.0.0.1:9001                               
RootUser: minioadmin 
RootPass: minioadmin 

Console: http://10.0.0.185:9090 http://172.17.0.1:9090 http://172.19.0.1:9090 http://172.20.0.1:9090 http://127.0.0.1:9090                
RootUser: minioadmin 
RootPass: minioadmin 
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
