### PR TITLE
allow disabling O_DIRECT in certain environments for reads

### DIFF
--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -49,6 +49,7 @@ type apiConfig struct {
 	staleUploadsExpiry          time.Duration
 	staleUploadsCleanupInterval time.Duration
 	deleteCleanupInterval       time.Duration
+	disableODirect              bool
 }
 
 const cgroupLimitFile = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
@@ -150,6 +151,14 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 	t.staleUploadsExpiry = cfg.StaleUploadsExpiry
 	t.staleUploadsCleanupInterval = cfg.StaleUploadsCleanupInterval
 	t.deleteCleanupInterval = cfg.DeleteCleanupInterval
+	t.disableODirect = cfg.DisableODirect
+}
+
+func (t *apiConfig) isDisableODirect() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.disableODirect
 }
 
 func (t *apiConfig) getListQuorum() int {

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1652,7 +1652,7 @@ func (s *xlStorage) ReadFileStream(ctx context.Context, volume, path string, off
 	}
 
 	alignment := offset%xioutil.DirectioAlignSize == 0
-	if !alignment {
+	if !alignment || globalAPIConfig.isDisableODirect() {
 		if err = disk.DisableDirectIO(file); err != nil {
 			file.Close()
 			return nil, err

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -43,6 +43,7 @@ const (
 	apiStaleUploadsCleanupInterval = "stale_uploads_cleanup_interval"
 	apiStaleUploadsExpiry          = "stale_uploads_expiry"
 	apiDeleteCleanupInterval       = "delete_cleanup_interval"
+	apiDisableODirect              = "disable_odirect"
 
 	EnvAPIRequestsMax              = "MINIO_API_REQUESTS_MAX"
 	EnvAPIRequestsDeadline         = "MINIO_API_REQUESTS_DEADLINE"
@@ -59,6 +60,7 @@ const (
 	EnvAPIStaleUploadsExpiry          = "MINIO_API_STALE_UPLOADS_EXPIRY"
 	EnvAPIDeleteCleanupInterval       = "MINIO_API_DELETE_CLEANUP_INTERVAL"
 	EnvDeleteCleanupInterval          = "MINIO_DELETE_CLEANUP_INTERVAL"
+	EnvAPIDisableODirect              = "MINIO_API_DISABLE_ODIRECT"
 )
 
 // Deprecated key and ENVs
@@ -118,6 +120,10 @@ var (
 			Key:   apiDeleteCleanupInterval,
 			Value: "5m",
 		},
+		config.KV{
+			Key:   apiDisableODirect,
+			Value: "off",
+		},
 	}
 )
 
@@ -135,6 +141,7 @@ type Config struct {
 	StaleUploadsCleanupInterval time.Duration `json:"stale_uploads_cleanup_interval"`
 	StaleUploadsExpiry          time.Duration `json:"stale_uploads_expiry"`
 	DeleteCleanupInterval       time.Duration `json:"delete_cleanup_interval"`
+	DisableODirect              bool          `json:"disable_odirect"`
 }
 
 // UnmarshalJSON - Validate SS and RRS parity when unmarshalling JSON.
@@ -254,6 +261,8 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		return cfg, err
 	}
 
+	disableODirect := env.Get(EnvAPIDisableODirect, kvs.Get(apiDisableODirect)) == config.EnableOn
+
 	return Config{
 		RequestsMax:                 requestsMax,
 		RequestsDeadline:            requestsDeadline,
@@ -267,5 +276,6 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		StaleUploadsCleanupInterval: staleUploadsCleanupInterval,
 		StaleUploadsExpiry:          staleUploadsExpiry,
 		DeleteCleanupInterval:       deleteCleanupInterval,
+		DisableODirect:              disableODirect,
 	}, nil
 }

--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -94,5 +94,11 @@ var (
 			Optional:    true,
 			Type:        "duration",
 		},
+		config.HelpKV{
+			Key:         apiDisableODirect,
+			Description: "set to disable O_DIRECT for reads under special conditions. NOTE: it is not recommended to disable O_DIRECT without prior testing.",
+			Optional:    true,
+			Type:        "boolean",
+		},
 	}
 )


### PR DESCRIPTION
## Description
allow disabling O_DIRECT in certain environments for reads

## Motivation and Context
repeated reads on single large objects in HPC like
workloads, need the following option to disable
O_DIRECT for more effective usage of the kernel
page-cache.

However this option should be used in very specific
situations only, and shouldn't be enabled on all deployments.

NVMe servers benefit always from keeping O_DIRECT on.

## How to test this PR?
Needs a specific workload pattern, O_DIRECT won't 
be disabled in most environments. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
