### PR TITLE
Wait for updates collector when disk.NSScanner returns error

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -517,6 +517,11 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, bf
 					} else {
 						logger.LogIf(ctx, err)
 					}
+					// This ensures that we don't close
+					// bucketResults channel while the
+					// updates-collector goroutine still
+					// holds a reference to this.
+					wg.Wait()
 					continue
 				}
 


### PR DESCRIPTION
## Description
We don't wait for updates-collector goroutine when `disk.NSScanner` returns with a non-nil error. This could lead to a panic due to send on closed channel (`bucketResultsCh`).

## Motivation and Context
When a lot of disks are offline or are healing and don't have all data on them, scanner goroutine may panic due to send operation on a closed channel. 

## How to test this PR?
It was observed on a setup when a lot of disks that were being healed. All those disks that were being healed belonged to a single node.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
