### PR TITLE
support site replication to replicate IAM users,groups

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -214,7 +214,7 @@ func getDisksInfo(disks []StorageAPI, endpoints []Endpoint) (disksInfo []madmin.
 				}
 			}
 			di.Metrics = &madmin.DiskMetrics{
-				APILatencies: make(map[string]string),
+				APILatencies: make(map[string]interface{}),
 				APICalls:     make(map[string]uint64),
 			}
 			for k, v := range info.Metrics.APILatencies {

--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -1486,7 +1486,8 @@ func (store *IAMStoreSys) SetUserStatus(ctx context.Context, accessKey string, s
 		AccessKey: accessKey,
 		SecretKey: cred.SecretKey,
 		Status: func() string {
-			if status == madmin.AccountEnabled {
+			switch string(status) {
+			case string(madmin.AccountEnabled), string(auth.AccountOn):
 				return auth.AccountOn
 			}
 			return auth.AccountOff
@@ -1555,6 +1556,10 @@ func (store *IAMStoreSys) UpdateServiceAccount(ctx context.Context, accessKey st
 	switch opts.status {
 	// The caller did not ask to update status account, do nothing
 	case "":
+	case string(madmin.AccountEnabled):
+		cr.Status = auth.AccountOn
+	case string(madmin.AccountDisabled):
+		cr.Status = auth.AccountOff
 	// Update account status
 	case auth.AccountOn, auth.AccountOff:
 		cr.Status = opts.status
@@ -1633,7 +1638,8 @@ func (store *IAMStoreSys) AddUser(ctx context.Context, accessKey string, ureq ma
 		AccessKey: accessKey,
 		SecretKey: ureq.SecretKey,
 		Status: func() string {
-			if ureq.Status == madmin.AccountEnabled {
+			switch string(ureq.Status) {
+			case string(madmin.AccountEnabled), string(auth.AccountOn):
 				return auth.AccountOn
 			}
 			return auth.AccountOff

--- a/docs/site-replication/run-multi-site-minio-idp.sh
+++ b/docs/site-replication/run-multi-site-minio-idp.sh
@@ -42,23 +42,40 @@ export MC_HOST_minio1=http://minio:minio123@localhost:9001
 export MC_HOST_minio2=http://minio:minio123@localhost:9002
 export MC_HOST_minio3=http://minio:minio123@localhost:9003
 
-./mc admin replicate add minio1 minio2 minio3
+./mc admin replicate add minio1 minio2
 
 ./mc admin user add minio1 foobar foo12345
+
+## add foobar-g group with foobar
+./mc admin group add minio2 foobar-g foobar
+
 ./mc admin policy set minio1 consoleAdmin user=foobar
 sleep 5
 
 ./mc admin user info minio2 foobar
-./mc admin user info minio3 foobar
+
+./mc admin group info minio1 foobar-g
+
 ./mc admin policy add minio1 rw ./docs/site-replication/rw.json
 
 sleep 5
 ./mc admin policy info minio2 rw >/dev/null 2>&1
+
+./mc admin replicate status minio1
+
+## Add a new empty site
+./mc admin replicate add minio1 minio2 minio3
+
+sleep 10
+
 ./mc admin policy info minio3 rw >/dev/null 2>&1
 
 ./mc admin policy remove minio3 rw
 
+./mc admin replicate status minio3
+
 sleep 10
+
 ./mc admin policy info minio1 rw
 if [ $? -eq 0 ]; then
     echo "expecting the command to fail, exiting.."
@@ -71,21 +88,33 @@ if [ $? -eq 0 ]; then
     exit_1;
 fi
 
+./mc admin policy info minio3 rw
+if [ $? -eq 0 ]; then
+    echo "expecting the command to fail, exiting.."
+    exit_1;
+fi
+
 ./mc admin user info minio1 foobar
 if [ $? -ne 0 ]; then
-    echo "policy mapping missing, exiting.."
+    echo "policy mapping missing on 'minio1', exiting.."
     exit_1;
 fi
 
 ./mc admin user info minio2 foobar
 if [ $? -ne 0 ]; then
-    echo "policy mapping missing, exiting.."
+    echo "policy mapping missing on 'minio2', exiting.."
     exit_1;
 fi
 
 ./mc admin user info minio3 foobar
 if [ $? -ne 0 ]; then
-    echo "policy mapping missing, exiting.."
+    echo "policy mapping missing on 'minio3', exiting.."
+    exit_1;
+fi
+
+./mc admin group info minio3 foobar-g
+if [ $? -ne 0 ]; then
+    echo "group mapping missing on 'minio3', exiting.."
     exit_1;
 fi
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/minio/csvparser v1.0.0
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.14.0
-	github.com/minio/madmin-go v1.2.4
+	github.com/minio/madmin-go v1.2.6
 	github.com/minio/minio-go/v7 v7.0.20
 	github.com/minio/parquet-go v1.1.0
 	github.com/minio/pkg v1.1.14

--- a/go.sum
+++ b/go.sum
@@ -1092,8 +1092,8 @@ github.com/minio/kes v0.14.0/go.mod h1:OUensXz2BpgMfiogslKxv7Anyx/wj+6bFC6qA7BQc
 github.com/minio/madmin-go v1.0.12/go.mod h1:BK+z4XRx7Y1v8SFWXsuLNqQqnq5BO/axJ8IDJfgyvfs=
 github.com/minio/madmin-go v1.1.15/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
 github.com/minio/madmin-go v1.1.23/go.mod h1:wv8zCroSCnpjjQdmgsdJEkFH2oD4w9J40OZqbhxjiJ4=
-github.com/minio/madmin-go v1.2.4 h1:o+0X6ENO/AtkRxCbD4FXT6YCRIH7HgDGb+WzfJFDzMQ=
-github.com/minio/madmin-go v1.2.4/go.mod h1:/rOfQv4ohkXJ+7EaSnhg9IJEX7cobX08zkSLfh8G3Ks=
+github.com/minio/madmin-go v1.2.6 h1:k4q5I+6nV/r7QBFZtvlPWMJh8uOo5AbEMx/39VXP7kg=
+github.com/minio/madmin-go v1.2.6/go.mod h1:/rOfQv4ohkXJ+7EaSnhg9IJEX7cobX08zkSLfh8G3Ks=
 github.com/minio/mc v0.0.0-20211207230606-23a05f5a17f2 h1:xocb1RGyrDJ8PxkNn0NSbaBlfdU6J/Ag9QK62pb7nR8=
 github.com/minio/mc v0.0.0-20211207230606-23a05f5a17f2/go.mod h1:siI9jWTzj1KsNXgz6NOL/S7OTaAUM0OMi+zEkF08gnA=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=


### PR DESCRIPTION


## Description
support site replication to replicate IAM users,groups

## Motivation and Context
- Site replication was missing replicating users,
  groups when an empty site was added.

- Add site replication for groups and users when they
  are disabled and enabled.

- Add support for replicating bucket quota config.

## How to test this PR?
Tests included in the PR

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
