### PR TITLE
tests: Remove RPC wording from the code

### DIFF
--- a/internal/dsync/dsync-server_test.go
+++ b/internal/dsync/dsync-server_test.go
@@ -148,13 +148,13 @@ func (lh *lockServerHandler) RLockHandler(w http.ResponseWriter, r *http.Request
 	}
 }
 
-func stopRPCServers() {
+func stopLockServers() {
 	for i := 0; i < numberOfNodes; i++ {
 		nodes[i].Close()
 	}
 }
 
-func startRPCServers() {
+func startLockServers() {
 	for i := 0; i < numberOfNodes; i++ {
 		lsrv := &lockServer{
 			mutex:   sync.Mutex{},

--- a/internal/dsync/dsync_test.go
+++ b/internal/dsync/dsync_test.go
@@ -30,9 +30,9 @@ import (
 
 // TestMain initializes the testing framework
 func TestMain(m *testing.M) {
-	startRPCServers()
+	startLockServers()
 
-	// Initialize net/rpc clients for dsync.
+	// Initialize locker clients for dsync.
 	var clnts []NetLocker
 	for i := 0; i < len(nodes); i++ {
 		clnts = append(clnts, newClient(nodes[i].URL))
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 	}
 
 	code := m.Run()
-	stopRPCServers()
+	stopLockServers()
 	os.Exit(code)
 }
 
@@ -224,7 +224,7 @@ func TestFailedRefreshLock(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	// Simulate Refresh RPC response to return no locking found
+	// Simulate Refresh response to return no locking found
 	for i := range lockServers[:3] {
 		lockServers[i].setRefreshReply(false)
 		defer lockServers[i].setRefreshReply(true)


### PR DESCRIPTION
## Description
Lock was using RPC in the past but it got replaced with a REST API. This
commit will fix function names/comments to avoid confusion.

## Motivation and Context
Code cleanup

## How to test this PR?
Trivial, no testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
