### PR TITLE
speed up startup sequence for all operations

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -35,8 +35,8 @@ import (
 
 const (
 	minioConfigPrefix = "config"
-
-	kvPrefix = ".kv"
+	minioConfigBucket = minioMetaBucket + SlashSeparator + minioConfigPrefix
+	kvPrefix          = ".kv"
 
 	// Captures all the previous SetKV operations and allows rollback.
 	minioConfigHistoryPrefix = minioConfigPrefix + "/history"

--- a/cmd/format-erasure_test.go
+++ b/cmd/format-erasure_test.go
@@ -132,11 +132,12 @@ func TestFormatErasureMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = formatErasureMigrate(rootPath); err != nil {
+	formatData, _, err := formatErasureMigrate(rootPath)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	migratedVersion, err := formatGetBackendErasureVersion(pathJoin(rootPath, minioMetaBucket, formatConfigFile))
+	migratedVersion, err := formatGetBackendErasureVersion(formatData)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +180,7 @@ func TestFormatErasureMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = formatErasureMigrate(rootPath); err == nil {
+	if _, _, err = formatErasureMigrate(rootPath); err == nil {
 		t.Fatal("Expected to fail with unexpected backend format")
 	}
 
@@ -199,7 +200,7 @@ func TestFormatErasureMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = formatErasureMigrate(rootPath); err == nil {
+	if _, _, err = formatErasureMigrate(rootPath); err == nil {
 		t.Fatal("Expected to fail with unexpected backend format version number")
 	}
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -338,6 +338,9 @@ var (
 	globalServiceFreezeCnt int32
 	globalServiceFreezeMu  sync.Mutex // Updates.
 
+	// List of local drives to this node, this is only set during server startup.
+	globalLocalDrives []StorageAPI
+
 	// Add new variable global values here.
 )
 

--- a/cmd/tree-walk_test.go
+++ b/cmd/tree-walk_test.go
@@ -141,6 +141,8 @@ func TestTreeWalk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create tmp directory: %s", err)
 	}
+	defer os.RemoveAll(fsDir)
+
 	endpoints := mustGetNewEndpoints(fsDir)
 	disk, err := newStorageAPI(endpoints[0])
 	if err != nil {
@@ -175,11 +177,6 @@ func TestTreeWalk(t *testing.T) {
 
 	// Simple test when marker is set.
 	testTreeWalkMarker(t, listDir, isLeaf, isLeafDir)
-
-	err = os.RemoveAll(fsDir)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 // Test if tree walk go-routine exits cleanly if tree walk is aborted because of timeout.
@@ -188,6 +185,7 @@ func TestTreeWalkTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create tmp directory: %s", err)
 	}
+	defer os.RemoveAll(fsDir)
 	endpoints := mustGetNewEndpoints(fsDir)
 	disk, err := newStorageAPI(endpoints[0])
 	if err != nil {
@@ -250,10 +248,6 @@ func TestTreeWalkTimeout(t *testing.T) {
 	if ok {
 		t.Error("Tree-walk go routine has not exited after timeout.")
 	}
-	err = os.RemoveAll(fsDir)
-	if err != nil {
-		t.Error(err)
-	}
 }
 
 // TestRecursiveWalk - tests if treeWalk returns entries correctly with and
@@ -264,6 +258,7 @@ func TestRecursiveTreeWalk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create tmp directory: %s", err)
 	}
+	defer os.RemoveAll(fsDir1)
 
 	endpoints := mustGetNewEndpoints(fsDir1)
 	disk1, err := newStorageAPI(endpoints[0])
@@ -366,10 +361,6 @@ func TestRecursiveTreeWalk(t *testing.T) {
 			}
 		})
 	}
-	err = os.RemoveAll(fsDir1)
-	if err != nil {
-		t.Error(err)
-	}
 }
 
 func TestSortedness(t *testing.T) {
@@ -378,6 +369,7 @@ func TestSortedness(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create tmp directory: %s", err)
 	}
+	defer os.RemoveAll(fsDir1)
 
 	endpoints := mustGetNewEndpoints(fsDir1)
 	disk1, err := newStorageAPI(endpoints[0])
@@ -444,12 +436,6 @@ func TestSortedness(t *testing.T) {
 			t.Error(i+1, "Expected entries to be sort, but it wasn't")
 		}
 	}
-
-	// Remove directory created for testing
-	err = os.RemoveAll(fsDir1)
-	if err != nil {
-		t.Error(err)
-	}
 }
 
 func TestTreeWalkIsEnd(t *testing.T) {
@@ -458,6 +444,7 @@ func TestTreeWalkIsEnd(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create tmp directory: %s", err)
 	}
+	defer os.RemoveAll(fsDir1)
 
 	endpoints := mustGetNewEndpoints(fsDir1)
 	disk1, err := newStorageAPI(endpoints[0])
@@ -525,11 +512,5 @@ func TestTreeWalkIsEnd(t *testing.T) {
 		if !entry.end {
 			t.Errorf("Test %d: Last entry %s, doesn't have EOF marker set", i, entry.entry)
 		}
-	}
-
-	// Remove directory created for testing
-	err = os.RemoveAll(fsDir1)
-	if err != nil {
-		t.Error(err)
 	}
 }

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -625,7 +625,7 @@ func (s *xlStorage) GetDiskID() (string, error) {
 	fileInfo := s.formatFileInfo
 	lastCheck := s.formatLastCheck
 
-	// check if we have a valid disk ID that is less than 5 seconds old.
+	// check if we have a valid disk ID that is less than 1 seconds old.
 	if fileInfo != nil && diskID != "" && time.Since(lastCheck) <= 1*time.Second {
 		s.RUnlock()
 		return diskID, nil

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -128,13 +128,14 @@ func newXLStorageTestSetup() (*xlStorageDiskIDCheck, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
+
 	// Create a sample format.json file
-	err = storage.WriteAll(context.Background(), minioMetaBucket, formatConfigFile, []byte(`{"version":"1","format":"xl","id":"592a41c2-b7cc-4130-b883-c4b5cb15965b","xl":{"version":"3","this":"da017d62-70e3-45f1-8a1a-587707e69ad1","sets":[["e07285a6-8c73-4962-89c6-047fb939f803","33b8d431-482d-4376-b63c-626d229f0a29","cff6513a-4439-4dc1-bcaa-56c9e880c352","da017d62-70e3-45f1-8a1a-587707e69ad1","9c9f21d5-1f15-4737-bce6-835faa0d9626","0a59b346-1424-4fc2-9fa2-a2e80541d0c1","7924a3dc-b69a-4971-9a2e-014966d6aebb","4d2b8dd9-4e48-444b-bdca-c89194b26042"]],"distributionAlgo":"CRCMOD"}}`))
-	if err != nil {
+	if err = storage.WriteAll(context.Background(), minioMetaBucket, formatConfigFile, []byte(`{"version":"1","format":"xl","id":"592a41c2-b7cc-4130-b883-c4b5cb15965b","xl":{"version":"3","this":"da017d62-70e3-45f1-8a1a-587707e69ad1","sets":[["e07285a6-8c73-4962-89c6-047fb939f803","33b8d431-482d-4376-b63c-626d229f0a29","cff6513a-4439-4dc1-bcaa-56c9e880c352","da017d62-70e3-45f1-8a1a-587707e69ad1","9c9f21d5-1f15-4737-bce6-835faa0d9626","0a59b346-1424-4fc2-9fa2-a2e80541d0c1","7924a3dc-b69a-4971-9a2e-014966d6aebb","4d2b8dd9-4e48-444b-bdca-c89194b26042"]],"distributionAlgo":"CRCMOD"}}`)); err != nil {
 		return nil, "", err
 	}
+
 	disk := newXLStorageDiskIDCheck(storage)
-	disk.diskID = "da017d62-70e3-45f1-8a1a-587707e69ad1"
+	disk.SetDiskID("da017d62-70e3-45f1-8a1a-587707e69ad1")
 	return disk, diskPath, nil
 }
 

--- a/internal/ioutil/ioutil.go
+++ b/internal/ioutil/ioutil.go
@@ -238,10 +238,7 @@ func SameFile(fi1, fi2 os.FileInfo) bool {
 	if fi1.Mode() != fi2.Mode() {
 		return false
 	}
-	if fi1.Size() != fi2.Size() {
-		return false
-	}
-	return true
+	return fi1.Size() == fi2.Size()
 }
 
 // DirectioAlignSize - DirectIO alignment needs to be 4K. Defined here as

--- a/internal/ioutil/read_file.go
+++ b/internal/ioutil/read_file.go
@@ -19,10 +19,32 @@ package ioutil
 
 import (
 	"io"
+	"io/fs"
 	"os"
 
 	"github.com/minio/minio/internal/disk"
 )
+
+// ReadFileWithFileInfo reads the named file and returns the contents.
+// A successful call returns err == nil, not err == EOF.
+// Because ReadFile reads the whole file, it does not treat an EOF from Read
+// as an error to be reported, additionall returns os.FileInfo
+func ReadFileWithFileInfo(name string) ([]byte, fs.FileInfo, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dst := make([]byte, st.Size())
+	_, err = io.ReadFull(f, dst)
+	return dst, st, err
+}
 
 // ReadFile reads the named file and returns the contents.
 // A successful call returns err == nil, not err == EOF.


### PR DESCRIPTION


## Description
speed up startup sequence for all operations

## Motivation and Context
This speed-up is intended for faster startup times
for almost all MinIO operations. Changes here are

- Drives are not re-read for 'format.json' on a regular
  basis once read during init is remembered and refreshed
  at 5 second intervals.

- Do not do O_DIRECT tests on drives with existing 'format.json'
  only fresh setups need this check.

- Parallelize initializing erasureSets for multiple sets.

- Avoid re-reading format.json when migrating 'format.json'
  from really old V1->V2->V3

- Keep a copy of local drives for any given server in memory
  for the quick lookup.

## How to test this PR?
Should be tested with existing tests, might add some more 
while the reviews can come in. 

The overall benefit seen with this change is almost 3x for 
3000 drives per server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
