### PR TITLE
Remove `omitempty` from DeploymentID

### DIFF
--- a/internal/logger/message/log/entry.go
+++ b/internal/logger/message/log/entry.go
@@ -52,7 +52,7 @@ type API struct {
 
 // Entry - defines fields and values of each log entry.
 type Entry struct {
-	DeploymentID string    `json:"deploymentid,omitempty"`
+	DeploymentID string    `json:"deploymentid"`
 	Level        string    `json:"level"`
 	LogKind      string    `json:"errKind"`
 	Time         time.Time `json:"time"`


### PR DESCRIPTION
## Description

As deployment id must always be present.

## Motivation and Context

Since deployment id is always present, the log entry JSON must always contain it,
and it should never have a missing `deploymentid` node.

## How to test this PR?

No impact on minio functionality as such. Only implication is that consumers of
the logger webhook won't need to handle a scenario where the `deploymentid` node
is missing in the JSON.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
