### PR TITLE
Minor improvements to newXLStorage

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -40,6 +40,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	fcolor "github.com/fatih/color"
 	"github.com/go-openapi/loads"
 	"github.com/inconshreveable/mousetrap"
@@ -651,6 +652,16 @@ func handleCommonEnvVars() {
 	if err != nil {
 		logger.Fatal(config.ErrInvalidFSOSyncValue(err), "Invalid MINIO_FS_OSYNC value in environment variable")
 	}
+
+	if rootDiskSize := env.Get(config.EnvRootDiskThresholdSize, ""); rootDiskSize != "" {
+		size, err := humanize.ParseBytes(rootDiskSize)
+		if err != nil {
+			logger.Fatal(err, fmt.Sprintf("Invalid %s value in environment variable", config.EnvRootDiskThresholdSize))
+		}
+		globalRootDiskThreshold = size
+	}
+
+	globalIsCICD = env.Get("MINIO_CI_CD", "") != ""
 
 	domains := env.Get(config.EnvDomain, "")
 	if len(domains) != 0 {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -341,6 +341,10 @@ var (
 	// List of local drives to this node, this is only set during server startup.
 	globalLocalDrives []StorageAPI
 
+	// Is MINIO_CI_CD set?
+	globalIsCICD bool
+
+	globalRootDiskThreshold uint64
 	// Add new variable global values here.
 )
 

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -41,12 +41,10 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/minio/minio/internal/bucket/lifecycle"
 	"github.com/minio/minio/internal/color"
-	"github.com/minio/minio/internal/config"
 	"github.com/minio/minio/internal/disk"
 	xioutil "github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/console"
-	"github.com/minio/pkg/env"
 	"github.com/yargevad/filepathx"
 )
 
@@ -215,38 +213,32 @@ func newXLStorage(ep Endpoint) (s *xlStorage, err error) {
 	}
 
 	var rootDisk bool
-	if env.Get("MINIO_CI_CD", "") != "" {
+	if globalIsCICD {
 		rootDisk = true
 	} else {
 		rootDisk, err = disk.IsRootDisk(path, SlashSeparator)
 		if err != nil {
 			return nil, err
 		}
-		if !rootDisk {
-			// If for some reason we couldn't detect the
-			// root disk use - MINIO_ROOTDISK_THRESHOLD_SIZE
-			// to figure out if the disk is root disk or not.
-			if rootDiskSize := env.Get(config.EnvRootDiskThresholdSize, ""); rootDiskSize != "" {
-				info, err := disk.GetInfo(path)
-				if err != nil {
-					return nil, err
-				}
-				size, err := humanize.ParseBytes(rootDiskSize)
-				if err != nil {
-					return nil, err
-				}
-				// size of the disk is less than the threshold or
-				// equal to the size of the disk at path, treat
-				// such disks as rootDisks and reject them.
-				rootDisk = info.Total <= size
+		if !rootDisk && globalRootDiskThreshold > 0 {
+			// If for some reason we couldn't detect the root disk
+			// use - MINIO_ROOTDISK_THRESHOLD_SIZE to figure out if
+			// this disk is a root disk.
+			info, err := disk.GetInfo(path)
+			if err != nil {
+				return nil, err
 			}
+
+			// treat those disks with size less than or equal to the
+			// threshold as rootDisks.
+			rootDisk = info.Total <= globalRootDiskThreshold
 		}
 	}
 
 	s = &xlStorage{
 		diskPath:   path,
 		endpoint:   ep,
-		globalSync: env.Get(config.EnvFSOSync, config.EnableOff) == config.EnableOn,
+		globalSync: globalFSOSync,
 		rootDisk:   rootDisk,
 		poolIndex:  -1,
 		setIndex:   -1,
@@ -1422,8 +1414,8 @@ func (s *xlStorage) ReadAll(ctx context.Context, volume string, path string) (bu
 	// Specific optimization to avoid re-read from the drives for `format.json`
 	// in-case the caller is a network operation.
 	if volume == minioMetaBucket && path == formatConfigFile {
-		formatData := make([]byte, len(s.formatData))
 		s.RLock()
+		formatData := make([]byte, len(s.formatData))
 		copy(formatData, s.formatData)
 		s.RUnlock()
 		if len(formatData) > 0 {


### PR DESCRIPTION
## Description
- Create internal erasure volumes only if disk is unformatted
- Return a copy of format data in xlStorage.ReadAll
- Avoid repeated syscalls to lookup env vars in newXLStorage

## Motivation and Context
In setups with large number of disks per node, avoiding repetitive work on a single disk can result huge savings.

## How to test this PR?
Existing unit/functional tests should cover.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
