### PR TITLE
Disallow delete replication for tag based rules

### DIFF
--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -178,6 +178,8 @@ When an object is deleted from the source bucket, the corresponding replica vers
 
 Note that due to this extension behavior, AWS SDK's may not support the extension functionality pertaining to replicating versioned deletes.
 
+Note that just like with [AWS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/delete-marker-replication.html), Delete marker replication is disallowed in MinIO when the replication rule has tags.
+
 To add a replication rule allowing both delete marker replication, versioned delete replication or both specify the --replicate flag with comma separated values as in the example below.
 
 Additional permission of "s3:ReplicateDelete" action would need to be specified on the access key configured for the target cluster if Delete Marker replication or versioned delete replication is enabled.

--- a/internal/bucket/replication/rule.go
+++ b/internal/bucket/replication/rule.go
@@ -153,6 +153,7 @@ var (
 	errDeleteReplicationMissing               = Errorf("Delete replication must be specified")
 	errInvalidDeleteReplicationStatus         = Errorf("Delete replication is either enable|disable")
 	errInvalidExistingObjectReplicationStatus = Errorf("Existing object replication status is invalid")
+	errTagsDeleteMarkerReplicationDisallowed  = Errorf("Delete marker replication is not supported if any Tag filter is specified")
 )
 
 // validateID - checks if ID is valid or not.
@@ -238,6 +239,9 @@ func (r Rule) Validate(bucket string, sameTarget bool) error {
 	}
 	if r.Destination.Bucket == bucket && sameTarget {
 		return errDestinationSourceIdentical
+	}
+	if !r.Filter.Tag.IsEmpty() && (r.DeleteMarkerReplication.Status == Enabled) {
+		return errTagsDeleteMarkerReplicationDisallowed
 	}
 	return r.ExistingObjectReplication.Validate()
 }


### PR DESCRIPTION
## Description


## Motivation and Context
Tag based rules are not replicated in AWS when delete marker is Enabled. Make MinIO implementation compliant with this behavior, since delete markers cannot have tags

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
