### PR TITLE
update ctx usage;

### DIFF
--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -1153,7 +1153,7 @@ func (c *cacheObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 	if err == nil {
 		// fill cache in the background
 		go func() {
-			_, err := dcache.CompleteMultipartUpload(GlobalContext, bucket, object, uploadID, uploadedParts, oi, opts)
+			_, err := dcache.CompleteMultipartUpload(bgContext(ctx), bucket, object, uploadID, uploadedParts, oi, opts)
 			if err != nil {
 				// fill cache in the background
 				bReader, bErr := c.InnerGetObjectNInfoFn(GlobalContext, bucket, object, nil, http.Header{}, readLock, ObjectOptions{})

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -1153,7 +1153,7 @@ func (c *cacheObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 	if err == nil {
 		// fill cache in the background
 		go func() {
-			_, err := dcache.CompleteMultipartUpload(ctx, bucket, object, uploadID, uploadedParts, oi, opts)
+			_, err := dcache.CompleteMultipartUpload(GlobalContext, bucket, object, uploadID, uploadedParts, oi, opts)
 			if err != nil {
 				// fill cache in the background
 				bReader, bErr := c.InnerGetObjectNInfoFn(GlobalContext, bucket, object, nil, http.Header{}, readLock, ObjectOptions{})


### PR DESCRIPTION
## Description
some file multipart can not move to /cache/sha256(bucket+objectkey) from /cache/sha256(bucket+objectkey)/uploadId/, and this problem may result in a waste of disk space.

## Motivation and Context
golang version:1.17.5

## How to test this PR?
1. MINIO_CACHE="on"；
2. upload with FPutObject method；
3.Repeat the second step until the problem occurs；
