### PR TITLE
Identity LDAP: Allow multiple search base DNs

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -540,7 +540,7 @@ func (c *SiteReplicationSys) GetIDPSettings(ctx context.Context) madmin.IDPSetti
 	s := madmin.IDPSettings{}
 	s.LDAP = madmin.LDAPSettings{
 		IsLDAPEnabled:          globalLDAPConfig.Enabled,
-		LDAPUserDNSearchBase:   globalLDAPConfig.UserDNSearchBaseDN,
+		LDAPUserDNSearchBase:   globalLDAPConfig.UserDNSearchBaseDistName,
 		LDAPUserDNSearchFilter: globalLDAPConfig.UserDNSearchFilter,
 		LDAPGroupSearchBase:    globalLDAPConfig.GroupSearchBaseDistName,
 		LDAPGroupSearchFilter:  globalLDAPConfig.GroupSearchFilter,

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -37,7 +37,7 @@ ARGS:
 MINIO_IDENTITY_LDAP_SERVER_ADDR*            (address)   AD/LDAP server address e.g. "myldapserver.com:636"
 MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN          (string)    DN for LDAP read-only service account used to perform DN and group lookups
 MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD    (string)    Password for LDAP read-only service account used to perform DN and group lookups
-MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN  (string)    Base LDAP DN to search for user DN
+MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN  (string)    ";" separated list of user search base DNs e.g. "dc=myldapserver,dc=com"
 MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER   (string)    Search filter to lookup user DN
 MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER     (string)    search filter for groups e.g. "(&(objectclass=groupOfNames)(memberUid=%s))"
 MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN    (list)      ";" separated list of group search base DNs e.g. "dc=myldapserver,dc=com"

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -44,9 +44,9 @@ var (
 		},
 		config.HelpKV{
 			Key:         UserDNSearchBaseDN,
-			Description: `Base LDAP DN to search for user DN`,
+			Description: `";" separated list of user search base DNs e.g. "dc=myldapserver,dc=com"`,
 			Optional:    true,
-			Type:        "string",
+			Type:        "list",
 		},
 		config.HelpKV{
 			Key:         UserDNSearchFilter,


### PR DESCRIPTION
## Description

This change allows the MinIO server to lookup users in different directory
sub-trees by allowing specification of multiple search bases separated by
semicolons.


## Motivation and Context

Based on a customer requirement.

## How to test this PR?

Specify multiple base DNs separated by colons for `MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN` and try to login with users in each different base LDAP sub-tree.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
