### PR TITLE
do not expect 'speedtest' to be a bucket

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -978,8 +978,7 @@ func (a adminAPIHandlers) SpeedtestHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	deleteBucket := func() {
-		loc := pathJoin(minioMetaSpeedTestBucket, minioMetaSpeedTestBucketPrefix)
-		objectAPI.DeleteBucket(context.Background(), loc, DeleteBucketOptions{
+		objectAPI.DeleteBucket(context.Background(), pathJoin(minioMetaBucket, "speedtest"), DeleteBucketOptions{
 			Force:      true,
 			NoRecreate: true,
 		})

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -61,10 +61,7 @@ const (
 	// MinIO tmp meta prefix.
 	minioMetaTmpBucket = minioMetaBucket + "/tmp"
 	// MinIO tmp meta prefix for deleted objects.
-	minioMetaTmpDeletedBucket      = minioMetaTmpBucket + "/.trash"
-	minioMetaSpeedTestBucket       = minioMetaBucket + "/speedtest"
-	minioMetaSpeedTestBucketPrefix = "objects/"
-
+	minioMetaTmpDeletedBucket = minioMetaTmpBucket + "/.trash"
 	// DNS separator (period), used for bucket name validation.
 	dnsDelimiter = "."
 	// On compressed files bigger than this;

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -1168,7 +1168,6 @@ func selfSpeedtest(ctx context.Context, size, concurrent int, duration time.Dura
 	var totalBytesWritten uint64
 	var totalBytesRead uint64
 
-	bucket := minioMetaSpeedTestBucket
 	objCountPerThread := make([]uint64, concurrent)
 	uploadsCtx, uploadsCancel := context.WithCancel(context.Background())
 	defer uploadsCancel()
@@ -1178,7 +1177,7 @@ func selfSpeedtest(ctx context.Context, size, concurrent int, duration time.Dura
 		uploadsCancel()
 	}()
 
-	objNamePrefix := minioMetaSpeedTestBucketPrefix + uuid.New().String()
+	objNamePrefix := "speedtest/objects/" + uuid.New().String()
 
 	wg.Add(concurrent)
 	for i := 0; i < concurrent; i++ {
@@ -1198,7 +1197,7 @@ func selfSpeedtest(ctx context.Context, size, concurrent int, duration time.Dura
 					return
 				}
 				reader := NewPutObjReader(hashReader)
-				objInfo, err := objAPI.PutObject(uploadsCtx, bucket, fmt.Sprintf("%s.%d.%d",
+				objInfo, err := objAPI.PutObject(uploadsCtx, minioMetaBucket, fmt.Sprintf("%s.%d.%d",
 					objNamePrefix, i, objCountPerThread[i]), reader, ObjectOptions{
 					UserDefined: map[string]string{
 						xhttp.AmzStorageClass: storageClass,
@@ -1245,7 +1244,7 @@ func selfSpeedtest(ctx context.Context, size, concurrent int, duration time.Dura
 				if objCountPerThread[i] == j {
 					j = 0
 				}
-				r, err := objAPI.GetObjectNInfo(downloadsCtx, bucket, fmt.Sprintf("%s.%d.%d",
+				r, err := objAPI.GetObjectNInfo(downloadsCtx, minioMetaBucket, fmt.Sprintf("%s.%d.%d",
 					objNamePrefix, i, j), nil, nil, noLock, ObjectOptions{})
 				if err != nil {
 					if !contextCanceled(downloadsCtx) {


### PR DESCRIPTION

## Description
do not expect 'speedtest' to be a bucket

## Motivation and Context
fixes #14196

## How to test this PR?
A fresh setup run `mc admin speedtest`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression from 5a9f133491153b546982e4e140e87c7397799eb0
- [ ] Documentation updated
- [ ] Unit tests added/updated
