### PR TITLE
Validate config before saving changes after config reset

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -74,6 +74,10 @@ func (a adminAPIHandlers) DelConfigKVHandler(w http.ResponseWriter, r *http.Requ
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
 	}
+	if err = validateConfig(cfg); err != nil {
+		writeCustomErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrAdminConfigBadJSON), err.Error(), r.URL)
+		return
+	}
 
 	if err = saveServerConfig(ctx, objectAPI, cfg); err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)

--- a/internal/config/notify/parse.go
+++ b/internal/config/notify/parse.go
@@ -82,7 +82,7 @@ func RegisterNotificationTargets(ctx context.Context, cfg config.Config, transpo
 		for _, targetID := range targetIDs {
 			if !targetList.Exists(targetID) {
 				return nil, config.Errorf(
-					"Unable to disable configured targets '%v'",
+					"Unable to disable currently configured targets '%v'",
 					targetID)
 			}
 		}


### PR DESCRIPTION
## Description


## Motivation and Context
`mc admin config reset alias notify_webhook` should fail when actively registered buckets exist. Currently, this succeeds but leaves behind stale bucket notification metadata on the registered buckets.  It would be cleaner to throw an error at the time of notify target reset so that `mc event remove` can be performed before removing the targets

## How to test this PR?
```
mc admin config set sitea notify_webhook enable=on endpoint=http://localhost:8080
mc admin service restart sitea
mc event add sitea/bucket
mc admin config reset sitea notify_webhook    
### with this PR, `reset` should report mc: <ERROR> Unable to reset 'notify_webhook:_' on the server. Unable to disable configured targets '_:webhook'.
### with master, this would succeed - an attempt to re-add the target fails 
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
