### PR TITLE
Add subnet proxy config

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -213,6 +213,9 @@ func minioConfigToConsoleFeatures() {
 	if globalSubnetConfig.APIKey != "" {
 		os.Setenv("CONSOLE_SUBNET_API_KEY", globalSubnetConfig.APIKey)
 	}
+	if globalSubnetConfig.Proxy != "" {
+		os.Setenv("CONSOLE_SUBNET_PROXY", globalSubnetConfig.Proxy)
+	}
 }
 
 func initConsoleServer() (*restapi.Server, error) {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -361,6 +361,10 @@ func validateConfig(s config.Config) error {
 		return err
 	}
 
+	if _, err = subnet.LookupConfig(s[config.SubnetSubSys][config.Default]); err != nil {
+		return err
+	}
+
 	return notify.TestNotificationTargets(GlobalContext, s, NewGatewayHTTPTransport(), globalNotificationSys.ConfiguredTargetIDs())
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ const (
 	SecretKey  = "secret_key"
 	License    = "license" // Deprecated Dec 2021
 	APIKey     = "api_key"
+	Proxy      = "proxy"
 )
 
 // Top level config constants.

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -55,6 +55,7 @@ const (
 
 	EnvMinIOSubnetLicense      = "MINIO_SUBNET_LICENSE" // Deprecated Dec 2021
 	EnvMinIOSubnetAPIKey       = "MINIO_SUBNET_API_KEY"
+	EnvMinIOSubnetProxy        = "MINIO_SUBNET_PROXY"
 	EnvMinIOServerURL          = "MINIO_SERVER_URL"
 	EnvMinIOBrowserRedirectURL = "MINIO_BROWSER_REDIRECT_URL"
 	EnvRootDiskThresholdSize   = "MINIO_ROOTDISK_THRESHOLD_SIZE"

--- a/internal/config/subnet/api-key.go
+++ b/internal/config/subnet/api-key.go
@@ -18,6 +18,8 @@
 package subnet
 
 import (
+	"net/url"
+
 	"github.com/minio/minio/internal/config"
 	"github.com/minio/pkg/env"
 )
@@ -31,6 +33,10 @@ var (
 		},
 		config.KV{
 			Key:   config.APIKey,
+			Value: "",
+		},
+		config.KV{
+			Key:   config.Proxy,
 			Value: "",
 		},
 	}
@@ -49,6 +55,12 @@ var (
 			Description: "Subnet api key for the cluster",
 			Optional:    true,
 		},
+		config.HelpKV{
+			Key:         config.Proxy,
+			Type:        "string",
+			Description: "HTTP(S) proxy URL to use for connecting to SUBNET",
+			Optional:    true,
+		},
 	}
 )
 
@@ -59,11 +71,20 @@ type Config struct {
 
 	// The subnet api key
 	APIKey string `json:"api_key"`
+
+	// The HTTP(S) proxy URL to use for connecting to SUBNET
+	Proxy string `json:"proxy"`
 }
 
 // LookupConfig - lookup config and override with valid environment settings if any.
 func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	if err = config.CheckValidKeys(config.SubnetSubSys, kvs, DefaultKVS); err != nil {
+		return cfg, err
+	}
+
+	cfg.Proxy = env.Get(config.EnvMinIOSubnetProxy, kvs.Get(config.Proxy))
+	_, err = url.Parse(cfg.Proxy)
+	if err != nil {
 		return cfg, err
 	}
 


### PR DESCRIPTION
## Description

Will store the HTTP(S) proxy URL to use for connecting to SUBNET.

## Motivation and Context

Refer [issue #464](https://github.com/miniohq/engineering/issues/464)

## How to test this PR?

- Build `minio` binary with this PR and start the cluster with it
- Test following `mc` commands against it:
```
mc admin config get {alias} subnet
mc admin config set {alias} subnet proxy={proxy}
mc admin config reset {alias} subnet
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
