### PR TITLE
Add extra environment variables from secret in Helm

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -126,6 +126,11 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end}}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.envFromSecret }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- with .Values.nodeSelector }}

--- a/helm/minio/templates/gateway-deployment.yaml
+++ b/helm/minio/templates/gateway-deployment.yaml
@@ -135,6 +135,11 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end}}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.envFromSecret }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- with .Values.nodeSelector }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -139,6 +139,11 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end}}
+          {{- if .Values.envFromSecret }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.envFromSecret }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -315,6 +315,10 @@ environment:
   ## MINIO_SUBNET_LICENSE: "License key obtained from https://subnet.min.io"
   ## MINIO_BROWSER: "off"
 
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for LDAP password, etc
+# envFromSecret: minio-extraenv
+
 networkPolicy:
   enabled: false
   allowExternal: true


### PR DESCRIPTION
## Description
Add ability to use extra environment variables from a secret.

## Motivation and Context
There are obvious cases when you don't want to commit some secrets in the values.yaml file, such as LDAP password, etc. For these use cases either you could create such secrets manually or use for example the external-secrets operator. This PR aims to cover these use-cases

## How to test this PR?
Create the secret where the key name (all caps) is the same as the required env var and set the secret name in the values.yaml file as documented.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
