### PR TITLE
Remove notification from NotificationSys on bucket deletion

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -563,6 +563,7 @@ func (sys *NotificationSys) DeleteBucketMetadata(ctx context.Context, bucketName
 	globalReplicationStats.Delete(bucketName)
 	globalBucketMetadataSys.Remove(bucketName)
 	globalBucketTargetSys.Delete(bucketName)
+	globalNotificationSys.RemoveNotification(bucketName)
 	if localMetacacheMgr != nil {
 		localMetacacheMgr.deleteBucketCache(bucketName)
 	}


### PR DESCRIPTION
## Description


## Motivation and Context
Properly clean up notification sys on bucket deletion so that stale event targets will be removed from memory. Otherwise `mc admin config set alias notify_webhook` can fail.

## How to test this PR?
With master, create a notification webhook and configure a bucket to receive notifications via this webhook. When bucket is deleted, attempt to set a new endpoint with this webhook id will fail

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
