### PR TITLE
Add ability to mount extra minio env from secret

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -81,6 +81,10 @@ spec:
               subPath: "{{ .Values.persistence.subPath }}"
               {{- end }}
             {{- end }}
+            {{- if .Values.extraSecret }}
+            - name: extra-secret
+              mountPath: "/tmp/minio-config-env"
+            {{- end }}
             {{- include "minio.tlsKeysVolumeMount" . | indent 12 }}
           ports:
             - name: {{ $scheme }}
@@ -98,6 +102,10 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
+            {{- if .Values.extraSecret }}
+            - name: MINIO_CONFIG_ENV_FILE
+              value: "/tmp/minio-config-env/config.env"
+            {{- end}}
             {{- if .Values.metrics.serviceMonitor.public }}
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: "public"
@@ -148,6 +156,11 @@ spec:
             claimName: {{ .Values.persistence.existingClaim | default (include "minio.fullname" .) }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.extraSecret }}
+        - name: extra-secret
+          secret:
+            secretName: {{ .Values.extraSecret }}
         {{- end }}
         - name: minio-user
           secret:

--- a/helm/minio/templates/gateway-deployment.yaml
+++ b/helm/minio/templates/gateway-deployment.yaml
@@ -86,6 +86,10 @@ spec:
               subPath: "{{ .Values.persistence.subPath }}"
               {{- end }}
             {{- end }}
+            {{- if .Values.extraSecret }}
+            - name: extra-secret
+              mountPath: "/tmp/minio-config-env"
+            {{- end }}
             {{- include "minio.tlsKeysVolumeMount" . | indent 12 }}
           ports:
             - name: {{ $scheme }}
@@ -103,6 +107,10 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
+            {{- if .Values.extraSecret }}
+            - name: MINIO_CONFIG_ENV_FILE
+              value: "/tmp/minio-config-env/config.env"
+            {{- end}}
             {{- if eq .Values.gateway.type "gcs" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/tmp/credentials/service-account-file.json"
@@ -161,5 +169,10 @@ spec:
         - name: minio-user
           secret:
             secretName: {{ template "minio.secretName" . }}
+        {{- if .Values.extraSecret }}
+        - name: extra-secret
+          secret:
+            secretName: {{ .Values.extraSecret }}
+        {{- end }}
         {{- include "minio.tlsKeysVolume" . | indent 8 }}
 {{- end }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -114,6 +114,10 @@ spec:
               {{- end }}
             {{- end }}
             {{- end }}
+            {{- if .Values.extraSecret }}
+            - name: extra-secret
+              mountPath: "/tmp/minio-config-env"
+            {{- end }}
             {{- include "minio.tlsKeysVolumeMount" . | indent 12 }}
           ports:
             - name: {{ $scheme }}
@@ -131,6 +135,10 @@ spec:
                 secretKeyRef:
                   name: {{ template "minio.secretName" . }}
                   key: rootPassword
+            {{- if .Values.extraSecret }}
+            - name: MINIO_CONFIG_ENV_FILE
+              value: "/tmp/minio-config-env/config.env"
+            {{- end}}
             {{- if .Values.metrics.serviceMonitor.public }}
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: "public"
@@ -158,6 +166,11 @@ spec:
         - name: minio-user
           secret:
             secretName: {{ template "minio.secretName" . }}
+        {{- if .Values.extraSecret }}
+        - name: extra-secret
+          secret:
+            secretName: {{ .Values.extraSecret }}
+        {{- end }}
         {{- include "minio.tlsKeysVolume" . | indent 8 }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -315,6 +315,12 @@ environment:
   ## MINIO_SUBNET_LICENSE: "License key obtained from https://subnet.min.io"
   ## MINIO_BROWSER: "off"
 
+## The name of a secret in the same kubernetes namespace which contain secret values
+## This can be useful for LDAP password, etc
+## The key in the secret must be 'config.env'
+##
+# extraSecret: minio-extraenv
+
 networkPolicy:
   enabled: false
   allowExternal: true


### PR DESCRIPTION
## Description
As discussed in #14229, this solution would be the preferred way of adding extra configuration items to Minio.

I'm not sure about some naming conventions you guys are using, please let me know if something needs to be changed.

## Motivation and Context
In my use case, the value for `MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD` is not something I'm willing to commit ever as I store these secrets independently from my Helm values. 

## How to test this PR?
- Create a secret as below and test if `MINIO_CONFIG_ENV_FILE` is set to `/tmp/minio-config-env/config.env` in your pod as well as if it contains the value in your secret.

```
apiVersion: v1
data:
  config.env: <base64 encoded MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD="password">
immutable: false
kind: Secret
metadata:
  name: minio-extraenv
  namespace: minio
type: Opaque
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
