### PR TITLE
Fix network policies in modern kubernetes versions

### DIFF
--- a/helm/minio/templates/_helpers.tpl
+++ b/helm/minio/templates/_helpers.tpl
@@ -37,8 +37,10 @@ Return the appropriate apiVersion for networkpolicy.
 {{- define "minio.networkPolicy.apiVersion" -}}
 {{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.Version -}}
+{{- else if semverCompare ">=1.7-0, <1.16-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else if semverCompare "^1.16-0" .Capabilities.KubeVersion.Version -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## Description
Network policies should use the stable API since 1.16 (source: https://groups.google.com/g/kubernetes-dev/c/je0rjyfTVyc )

## Motivation and Context
v1beta1 has been removed in modern k8s versions and therefore network policies are no longer installed and instead error out.

## How to test this PR?
Install a network policy on kube 1.20 or higher and you can't

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) https://github.com/minio/minio/issues/14029
- [ ] Documentation updated
- [ ] Unit tests added/updated
