### PR TITLE
Make logger webhook config dynamic

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -574,18 +574,6 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 		logger.LogIf(ctx, fmt.Errorf("Unable to initialize logger/audit targets: %w", err))
 	}
 
-	for _, l := range loggerCfg.HTTP {
-		if l.Enabled {
-			l.LogOnce = logger.LogOnceIf
-			l.UserAgent = loggerUserAgent
-			l.Transport = NewGatewayHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)
-			// Enable http logging
-			if err = logger.AddTarget(http.New(l)); err != nil {
-				logger.LogIf(ctx, fmt.Errorf("Unable to initialize server logger HTTP target: %w", err))
-			}
-		}
-	}
-
 	for _, l := range loggerCfg.AuditWebhook {
 		if l.Enabled {
 			l.LogOnce = logger.LogOnceIf

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -657,11 +657,12 @@ func applyDynamicConfig(ctx context.Context, objAPI ObjectLayer, s config.Config
 		logger.LogIf(ctx, fmt.Errorf("Unable to load logger webhook config: %w", err))
 	}
 	userAgent := getUserAgent(getMinioMode())
-	for _, l := range loggerCfg.HTTP {
+	for n, l := range loggerCfg.HTTP {
 		if l.Enabled {
 			l.LogOnce = logger.LogOnceIf
 			l.UserAgent = userAgent
 			l.Transport = NewGatewayHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)
+			loggerCfg.HTTP[n] = l
 		}
 	}
 	err = logger.UpdateTargets(loggerCfg)

--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -150,6 +150,10 @@ func (sys *HTTPConsoleLoggerSys) Content() (logs []log.Entry) {
 	return
 }
 
+// Cancel - cancels the target
+func (sys *HTTPConsoleLoggerSys) Cancel() {
+}
+
 // Send log message 'e' to console and publish to console
 // log pubsub system
 func (sys *HTTPConsoleLoggerSys) Send(e interface{}, logKind string) error {

--- a/cmd/data-update-tracker_test.go
+++ b/cmd/data-update-tracker_test.go
@@ -55,6 +55,9 @@ func (t *testingLogger) Init() error {
 	return nil
 }
 
+func (t *testingLogger) Cancel() {
+}
+
 func (t *testingLogger) Send(entry interface{}, errKind string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,7 @@ var SubSystemsDynamic = set.CreateStringSet(
 	HealSubSys,
 	SubnetSubSys,
 	LoggerWebhookSubSys,
+	AuditWebhookSubSys,
 )
 
 // SubSystemsSingleTargets - subsystems which only support single target.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,6 +166,7 @@ var SubSystemsDynamic = set.CreateStringSet(
 	ScannerSubSys,
 	HealSubSys,
 	SubnetSubSys,
+	LoggerWebhookSubSys,
 )
 
 // SubSystemsSingleTargets - subsystems which only support single target.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,7 +167,6 @@ var SubSystemsDynamic = set.CreateStringSet(
 	HealSubSys,
 	SubnetSubSys,
 	LoggerWebhookSubSys,
-	AuditWebhookSubSys,
 )
 
 // SubSystemsSingleTargets - subsystems which only support single target.

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -197,6 +197,10 @@ func (h *Target) Init() error {
 	return nil
 }
 
+// Cancel - cancels the target
+func (h *Target) Cancel() {
+}
+
 // New initializes a new logger target which
 // sends log over http to the specified endpoint
 func New(config Config) *Target {

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -113,7 +113,7 @@ func AddTarget(t Target) error {
 }
 
 func cancelAllTargets() {
-	for _, tgt := range Targets() {
+	for _, tgt := range targets {
 		tgt.Cancel()
 	}
 }
@@ -133,13 +133,13 @@ func initTargets(cfg Config) (tgts []Target, err error) {
 
 // UpdateTargets swaps targets with newly loaded ones from the cfg
 func UpdateTargets(cfg Config) error {
-	cancelAllTargets() // cancel running targets
 	updated, err := initTargets(cfg)
 	if err != nil {
 		return err
 	}
 
 	swapMu.Lock()
+	cancelAllTargets() // cancel running targets
 	targets = updated
 	atomic.StoreInt32(&nTargets, int32(len(updated)))
 	swapMu.Unlock()

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -139,9 +139,9 @@ func UpdateTargets(cfg Config) error {
 	}
 
 	swapMu.Lock()
+	atomic.StoreInt32(&nTargets, int32(len(updated)))
 	cancelAllTargets() // cancel running targets
 	targets = updated
-	atomic.StoreInt32(&nTargets, int32(len(updated)))
 	swapMu.Unlock()
 	return nil
 }


### PR DESCRIPTION
## Description

It should not be required to restart the server after setting the logger
webhook config.

## Motivation and Context

After enabling/disabling the logs option of callhome (that internally
configures the logger webhook), currently the system asks the user
to restart the MinIO server, which is unnecessary.

## How to test this PR?
- Build minio with this PR and start the server
- Configure a logger webhook using `mc admin config set {alias} logger_webhook` or enable/disable the logs option of callhome using `mc support callhome set {alias} logs=on|off`
- Verify that the output doesn't ask the user to restart the server

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
