### PR TITLE
doc: add console-address on all example

### DIFF
--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -109,7 +109,7 @@ docker run \
   -e "MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE" \
   -e "MINIO_ROOT_PASSWORD=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY" \
   -v ${HOME}/data:/data \
-  quay.io/minio/minio server /data
+  quay.io/minio/minio server /data --console-address ":9001"
 ```
 
 #### Windows (regular user)
@@ -127,7 +127,7 @@ docker run \
   -e "MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE" \
   -e "MINIO_ROOT_PASSWORD=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY" \
   -v D:\data:/data \
-  quay.io/minio/minio server /data
+  quay.io/minio/minio server /data --console-address ":9001"
 ```
 
 ### MinIO Custom Access and Secret Keys using Docker secrets


### PR DESCRIPTION
## Description
--console-address ":9001" is  missing on docker example for regular user.

## Motivation and Context
Other example got it and it makes sens to add it for a standard user

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [X] Documentation updated
- [ ] Unit tests added/updated
