### PR TITLE
fix: creating steep directory structure on trash folder

### DIFF
--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -98,12 +98,7 @@ func formatErasureCleanupTmp(diskPath string) {
 			err))
 	}
 
-	if err := renameAll(tmpOld, pathJoin(diskPath, minioMetaTmpDeletedBucket, tmpID)); err != nil && !errors.Is(err, errFileNotFound) {
-		logger.LogIf(GlobalContext, fmt.Errorf("unable to rename (%s -> %s) %w, drive may be faulty please investigate",
-			pathJoin(diskPath, minioMetaTmpBucket),
-			tmpOld,
-			osErrToFileErr(err)))
-	}
+	go removeAll(tmpOld)
 
 	// Renames and schedules for purging all bucket metacache.
 	renameAllBucketMetacache(diskPath)


### PR DESCRIPTION
## Description
fix: creating steep directory structure on trash folder

## Motivation and Context
weird directory structures get created on the '.trash'
folder upon server restarts, this PR fixes this.

## How to test this PR?
Startup and restart MinIO distributed setups.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression - yes introduced here #14148
- [ ] Documentation updated
- [ ] Unit tests added/updated
