### PR TITLE
Mark SUBNET credentials as sensitive

### DIFF
--- a/internal/config/subnet/api-key.go
+++ b/internal/config/subnet/api-key.go
@@ -48,18 +48,21 @@ var (
 			Type:        "string",
 			Description: "[DEPRECATED use api_key] Subnet license token for the cluster",
 			Optional:    true,
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.APIKey,
 			Type:        "string",
 			Description: "Subnet api key for the cluster",
 			Optional:    true,
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.Proxy,
 			Type:        "string",
 			Description: "HTTP(S) proxy URL to use for connecting to SUBNET",
 			Optional:    true,
+			Sensitive:   true,
 		},
 	}
 )


### PR DESCRIPTION
## Description

Mark SUBNET credentials as sensitive, so
that they are redacted in the health report

## Motivation and Context

Ensure sensitive information is redacted in health report

## How to test this PR?

- Start a cluster using minio built with this PR
- Register the cluster with SUBNET using `mc support register {alias}` (use `--dev` flag if testing with subnet local devenv)
- Generate the health report using `mc support diag --airgap`
- Open the generated report and verify that value of `api_key` under `config -> subnet` is `*redacted*`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
