### PR TITLE
Fix leaked healing goroutines

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1848,7 +1848,15 @@ func (z *erasureServerPools) HealObjects(ctx context.Context, bucket, prefix str
 		}
 		wg.Wait()
 	}()
-	return <-errCh
+	var err error
+	for e := range errCh {
+		// Save first non-nil error.
+		if e != nil && err != nil {
+			err = e
+			cancel()
+		}
+	}
+	return err
 }
 
 func (z *erasureServerPools) HealObject(ctx context.Context, bucket, object, versionID string, opts madmin.HealOpts) (madmin.HealResultItem, error) {


### PR DESCRIPTION
## Description

Only the first `listAndHeal` would ever be able to write on errCh, blocking all others indefinitely.

Instead read all errors but return the first non-nil, if any.

The intention appears to be that this should cancel on any error, so that part is kept. Not sure I completely understand that.

Regression from #13990

## How to test this PR?

Check goroutines on running server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Fixes a regression  #13990
