### PR TITLE
Add `enable` key to logger webhook help

### DIFF
--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -25,6 +25,13 @@ import (
 var (
 	Help = config.HelpKVS{
 		config.HelpKV{
+			Key:         config.Enable,
+			Description: "set to 'on' to enable the logger webhook",
+			Optional:    true,
+			Type:        "on|off",
+			Sensitive:   false,
+		},
+		config.HelpKV{
 			Key:         Endpoint,
 			Description: `HTTP(s) endpoint e.g. "http://localhost:8080/minio/logs/server"`,
 			Type:        "url",


### PR DESCRIPTION
## Description

This key is supported by the logger webhook config, but is not returned
in the help.

## Motivation and Context

- option available on config, but not shown in help
- required for correct parsing of output of `config get` on client (mc) side

## How to test this PR?

- Start a cluster using minio built with this PR
- Run `./mc admin config set myminio logger_webhook`
- Verify that the help printed includes the `enable` key

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
