### PR TITLE
Don't add free-version on restore-object

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -477,6 +477,18 @@ func (fi *FileInfo) TierFreeVersion() bool {
 	return ok
 }
 
+// IsRestoreObjReq returns true if fi corresponds to a RestoreObject request.
+func (fi *FileInfo) IsRestoreObjReq() bool {
+	if restoreHdr, ok := fi.Metadata[xhttp.AmzRestore]; ok {
+		if restoreStatus, err := parseRestoreObjStatus(restoreHdr); err == nil {
+			if !restoreStatus.Ongoing() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // VersionPurgeStatus returns overall version purge status for this object version across targets
 func (fi *FileInfo) VersionPurgeStatus() VersionPurgeStatusType {
 	return fi.ReplicationState.CompositeVersionPurgeStatus()

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2241,7 +2241,13 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 		// suspended or disabled on this bucket. RenameData will replace
 		// the 'null' version. We add a free-version to track its tiered
 		// content for asynchronous deletion.
-		xlMeta.AddFreeVersion(fi)
+		if !fi.IsRestoreObjReq() {
+			// Note: Restore object request reuses PutObject/Multipart
+			// upload to copy back its data from the remote tier. This
+			// doesn't replace the existing version, so we don't need to add
+			// a free-version.
+			xlMeta.AddFreeVersion(fi)
+		}
 	}
 
 	// indicates if RenameData() is called by healing.


### PR DESCRIPTION
## Description
A Put-Object request in an version disabled or suspended bucket replaces existing `null` version, which means we need to 'free' the corresponding transitioned object from its remote tier. This is tracked using an internal version called tier-free-version.
Restore-Object reuses parts of Put-Object which lead to this bug, where we were incorrectly add a tier-free-version.
In this change, we skip adding of a tier-free-version if we know it is a Restore-Object request.

## Motivation and Context
Fixes #14327 

## How to test this PR?
See #14327 for test instructions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
