### PR TITLE
Fix replication proxying for range GET requests

### DIFF
--- a/cmd/httprange.go
+++ b/cmd/httprange.go
@@ -174,3 +174,26 @@ func (h *HTTPRangeSpec) String(resourceSize int64) string {
 	}
 	return fmt.Sprintf("%d-%d", off, off+length-1)
 }
+
+// ToHeader returns the Range header value.
+func (h *HTTPRangeSpec) ToHeader() (string, error) {
+	if h == nil {
+		return "", nil
+	}
+	start := strconv.Itoa(int(h.Start))
+	end := strconv.Itoa(int(h.End))
+	switch {
+	case h.Start >= 0 && h.End >= 0:
+		if h.Start > h.End {
+			return "", errInvalidRange
+		}
+	case h.IsSuffixLength:
+		end = strconv.Itoa(int(h.Start * -1))
+		start = ""
+	case h.Start > -1:
+		end = ""
+	default:
+		return "", fmt.Errorf("does not have valid range value")
+	}
+	return fmt.Sprintf("bytes=%s-%s", start, end), nil
+}

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -698,3 +698,7 @@ func isErrMethodNotAllowed(err error) bool {
 	var methodNotAllowed MethodNotAllowed
 	return errors.As(err, &methodNotAllowed)
 }
+
+func isErrInvalidRange(err error) bool {
+	return errors.As(err, &errInvalidRange)
+}


### PR DESCRIPTION
to propagate error from proxy target correctly to
client if range GET is unsatisfiable.

## Description


## Motivation and Context


## How to test this PR?
Set up 1-way replication from minio1 -> minio2. 
Upload object to minio2 and send range GET request to minio1

```
➜  minio git:(master) aws s3api get-object --bucket bucket --key restaurant-scores-lives-standard.csv3 --endpoint-url http://minio4:9004 --range "bytes=30-50" --profile minio /tmp/adta 

An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist.
```
With this PR:
```
➜  minio git:(fxproxyheader) aws s3api get-object --bucket bucket --key restaurant-scores-lives-standard.csv3 --endpoint-url http://minio4:9004 --range "bytes=30-50" --profile minio /tmp/adta

An error occurred (InvalidRange) when calling the GetObject operation: The requested range is not satisfiable
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
