### PR TITLE
fix: console logger regression with dynamic logger webhook registration

### DIFF
--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -129,7 +129,7 @@ func (sys *HTTPConsoleLoggerSys) Endpoint() string {
 
 // String - stringer function for interface compatibility
 func (sys *HTTPConsoleLoggerSys) String() string {
-	return "console+http"
+	return logger.ConsoleLoggerTgt
 }
 
 // Content returns the console stdout log

--- a/internal/logger/console.go
+++ b/internal/logger/console.go
@@ -29,6 +29,9 @@ import (
 	c "github.com/minio/pkg/console"
 )
 
+// ConsoleLoggerTgt is a stringified value to represent console logging
+const ConsoleLoggerTgt = "console+http"
+
 // Logger interface describes the methods that need to be implemented to satisfy the interface requirements.
 type Logger interface {
 	json(msg string, args ...interface{})

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -139,6 +139,14 @@ func UpdateTargets(cfg Config) error {
 	}
 
 	swapMu.Lock()
+	for _, tgt := range targets {
+		// Preserve console target when dynamically updating
+		// other HTTP targets, console target is always present.
+		if tgt.String() == ConsoleLoggerTgt {
+			updated = append(updated, tgt)
+			break
+		}
+	}
 	atomic.StoreInt32(&nTargets, int32(len(updated)))
 	cancelAllTargets() // cancel running targets
 	targets = updated


### PR DESCRIPTION

## Description
fix: console logger regression with dynamic logger webhook registration

## Motivation and Context
fixes a regression from #14289

## How to test this PR?
console logger does not log anymore without enabling
webhook-based logging with the latest release.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes introduced in #14289 
- [ ] Documentation updated
- [ ] Unit tests added/updated
