### PR TITLE
Simplify connectDisks() convert it to be per set level

### DIFF
--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -140,6 +140,7 @@ func readAllFileInfo(ctx context.Context, disks []StorageAPI, bucket, object, ve
 					errVolumeNotFound,
 					errFileVersionNotFound,
 					errDiskNotFound,
+					errUnformattedDisk,
 				}...) {
 					logger.LogOnceIf(ctx, fmt.Errorf("Drive %s, path (%s/%s) returned an error (%w)",
 						disks[index], bucket, object, err),


### PR DESCRIPTION

## Description
Simplify connectDisks() convert it to be per set level

## Motivation and Context
- Avoids a lot of unnecessary maps and data structures
  such as a large disk map with 100's of entries.

- Avoid reloading format.json upon reconnect, if MRF
  trigger is necessary only trigger MRF do not need
  to reload 'format.json' again, this can lead to
  another disconnection event where the newly reloaded
  disk is re-replaced in its position.

## How to test this PR?
All tests should cover this

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
