### PR TITLE
Fix mysql notification target

### DIFF
--- a/internal/event/target/mysql.go
+++ b/internal/event/target/mysql.go
@@ -38,13 +38,16 @@ import (
 const (
 	mysqlTableExists = `SELECT 1 FROM %s;`
 	// Some MySQL has a 3072 byte limit on key sizes.
-	mysqlCreateNamespaceTable = `CREATE TABLE %s (key_name VARCHAR(3072), value JSON, PRIMARY KEY (key_name))
-                                       CHARACTER SET = utf8mb4 COLLATE = utf8mb4_bin ROW_FORMAT = Dynamic;`
+	mysqlCreateNamespaceTable = `CREATE TABLE %s (
+             key_name VARCHAR(3072) NOT NULL,
+             key_hash CHAR(64) GENERATED ALWAYS AS (SHA2(key_name, 256)) STORED NOT NULL PRIMARY KEY,
+             value JSON)
+           CHARACTER SET = utf8mb4 COLLATE = utf8mb4_bin ROW_FORMAT = Dynamic;`
 	mysqlCreateAccessTable = `CREATE TABLE %s (event_time DATETIME NOT NULL, event_data JSON)
                                     ROW_FORMAT = Dynamic;`
 
 	mysqlUpdateRow = `INSERT INTO %s (key_name, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value=VALUES(value);`
-	mysqlDeleteRow = `DELETE FROM %s WHERE key_name = ?;`
+	mysqlDeleteRow = `DELETE FROM %s WHERE key_hash = SHA2(?, 256);`
 	mysqlInsertRow = `INSERT INTO %s (event_time, event_data) VALUES (?, ?);`
 )
 


### PR DESCRIPTION
## Description

- Add a generated hash column as primary key for key name as MySQL does not
allow indexes on long VARCHAR columns.

## Motivation and Context

Fix mysql notification target, fixing issue https://github.com/minio/minio/issues/14284

## How to test this PR?

Start mysql (as of writing version 8.x) in docker with:
```
docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -e MYSQL_DATABASE=test -e MYSQL_USER=user -e MYSQL_PASSWORD=password -it -p 3306:3306 mysql:latest
```

Start minio:

```
MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 ./minio server /tmp/disk
```

Configure bucket notifications:

```
mc admin config set myminio notify_mysql:1 table="minio_images" dsn_string='user:password@tcp(127.0.0.1:3306)/test'
mc admin service restart myminio

mc mb myminio/mybucket
mc event add  myminio/mybucket arn:minio:sqs::1:mysql --event put,delete,get
```

Create/update/delete some objects to generate notification events:

```
mc cp myfile myminio/mybucket/
```

Check the table in Mysql - it should contain one row per object existing in `myminio/mybucket`:

```
mysql -uuser -p -P3306 -h127.0.0.1 test
Password:
select * from minio_images;
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (https://github.com/minio/minio/pull/13414, https://github.com/minio/minio/pull/13974)
- [ ] Documentation updated
- [ ] Unit tests added/updated
