### PR TITLE
Allow bootstrapping policies with special characters in Helm

### DIFF
--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Multi-Cloud Object Storage
 name: minio
-version: 3.5.7
+version: 3.5.6
 appVersion: RELEASE.2022-02-18T01-50-10Z
 keywords:
   - minio

--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Multi-Cloud Object Storage
 name: minio
-version: 3.5.6
+version: 3.5.7
 appVersion: RELEASE.2022-02-18T01-50-10Z
 keywords:
   - minio

--- a/helm/minio/templates/_helper_create_policy.txt
+++ b/helm/minio/templates/_helper_create_policy.txt
@@ -43,17 +43,19 @@ checkPolicyExists() {
   return $?
 }
 
-# createPolicy($name)
+# createPolicy($name, $filename)
 createPolicy () {
   NAME=$1
+  FILENAME=$2
 
   # Create the name if it does not exist
+  echo "Checking policy: $NAME (in /config/$FILENAME.json)"
   if ! checkPolicyExists $NAME ; then
     echo "Creating policy '$NAME'"
   else
     echo "Policy '$NAME' already exists."
   fi
-  ${MC} admin policy add myminio $NAME /config/$NAME.json
+  ${MC} admin policy add myminio $NAME /config/$FILENAME.json
 
 }
 
@@ -67,7 +69,7 @@ connectToMinio $scheme
 
 {{ if .Values.policies }}
 # Create the policies
-{{- range .Values.policies }}
-createPolicy {{ .name }}
+{{- range $idx, $policy := .Values.policies }}
+createPolicy {{ $policy.name }} policy_{{ $idx }}
 {{- end }}
 {{- end }}

--- a/helm/minio/templates/configmap.yaml
+++ b/helm/minio/templates/configmap.yaml
@@ -15,8 +15,9 @@ data:
 {{ include (print $.Template.BasePath "/_helper_create_user.txt") . | indent 4 }}
   add-policy: |-
 {{ include (print $.Template.BasePath "/_helper_create_policy.txt") . | indent 4 }}
-{{- range .Values.policies }}
-  {{ .name }}.json: |-
+{{- range $idx, $policy := .Values.policies }}
+  # {{ $policy.name }}
+  policy_{{ $idx }}.json: |-
 {{ include (print $.Template.BasePath "/_helper_policy.tpl") . | indent 4 }}
 {{ end }}
   custom-command: |-


### PR DESCRIPTION
## Description
MinIO is great and I'm lazy and want to use Dex in my lab to authn/authz to MinIO. I can use Dex + github/gitlab as a lightweight IdP but they don't give me a ton of control over the groups (out of the box).

MinIO supports policies named `foo:admins` and `foo/admins` but the bootstrap script fails because Kubernetes ConfigMaps cannot have keys with non-dns names in them:

```
Error: UPGRADE FAILED: cannot patch "minio" with kind ConfigMap: ConfigMap "minio" is invalid:
[data[foo/admins.json]: Invalid value: "foo/admins.json": a valid config key must consist of alphanumeric
characters, '-', '_' or '.' (e.g. 'key.name',  or 'KEY_NAME',  or 'key-name', regex used for validation is
'[-._a-zA-Z0-9]+'), data[foo:admins.json]: Invalid value: "foo:admins.json": a valid config key must consist
of alphanumeric characters, '-', '_' or '.' (e.g. 'key.name',  or 'KEY_NAME',  or 'key-name', regex used for
validation is '[-._a-zA-Z0-9]+')]
```

## Motivation and Context

My IdP (Github and Gitlab via Dex) place a `:` (github) and a `/` (gitlab) in the JWT `groups` claim which I'm using as the policy. These policies `foo:admins` and `foo/admins` work fine in MinIO, but the bootstrap fails.

## How to test this PR?

Run `helm install -f values.yaml minio minio/minio` with this as a `values.yaml` file:

```yaml
policies:
  - name: foo:admins # GitHub OIDC login
    statements:
      - actions:
          - "admin:*"
      - actions:
          - "s3:*"
        resources: 
          - 'arn:aws:s3:::*'
  - name: foo/admins # Gitlab OIDC login
    statements:
      - actions:
          - "admin:*"
      - actions:
          - "s3:*"
        resources: 
          - 'arn:aws:s3:::*'
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated

Fixes #14355 