### PR TITLE
Allow policy bootstrapping with nil "Resource" in Helm chart

### DIFF
--- a/helm/minio/templates/_helper_policy.tpl
+++ b/helm/minio/templates/_helper_policy.tpl
@@ -8,10 +8,10 @@
       "Effect": "Allow",
       "Action": [
 "{{ $statement.actions | join "\",\n\"" }}"
-      ],
+      ]{{ if $statement.resources }},
       "Resource": [
 "{{ $statement.resources | join "\",\n\"" }}"
-      ]
+      ]{{ end }}
     }{{ if lt $i $statements_length }},{{end }}
 {{- end }}
   ]


### PR DESCRIPTION
## Description

Some policies like an admin policy will not need a `Resource` key, but the chart currently always includes one.

This change removes the Resources clause if it's absent in the
template like so:

```yaml
policies:
  - name: my-admins
    statements:
      - actions:
          - "admin:*"
      - actions:
          - "s3:*"
        resources: 
          - 'arn:aws:s3:::*'
```

Previously this yaml would produce the following policy:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
"admin:*"
      ],
      "Resource": [
""
      ]
    },
    {
      "Effect": "Allow",
      "Action": [
"s3:*"
      ],
      "Resource": [
"arn:aws:s3:::*"
      ]
    }
  ]
}
```

When this policy is loaded via the bootstrap scripts, an error is encountered:

```
kubectl logs minio-make-policies-job-k8t8k
Connecting to MinIO server: http://minio:9000
Added `myminio` successfully.
Checking policy: my-admins (in /config/policy_0.json)
Creating policy 'my-admins'
mc: <ERROR> Unable to add new policy: invalid resource ''.
```

After this PR it produces:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
"admin:*"
      ]
    },
    {
      "Effect": "Allow",
      "Action": [
"s3:*"
      ],
      "Resource": [
"arn:aws:s3:::*"
      ]
    }
  ]
}
```

This policy is correctly loaded into MinIO via the bootstrap scripts in the chart 🚀 

## Motivation and Context

I'd like to be able to keep my entire MinIO lab config in git, which includes the policies, OIDC config, everything except the root secret and OIDC secret. This allows me to recover from disasters (likely in my lab...) very easily by just bootstrapping a new cluster with no setup!

## How to test this PR?

Create a values file (`minio-test.yaml`) with the following:

```yaml
policies:
  - name: my-admins
    statements:
      - actions:
          - "admin:*"
      - actions:
          - "s3:*"
        resources:
          - 'arn:aws:s3:::*'
```

Install it: `helm install -f minio-test.yaml -n minio-test minio minio/minio`

### Other Notes

The delta (via `helm diff` between `3.5.7`) and this PR looks like this:

```diff
    policy_0.json: |-
      {
        "Version": "2012-10-17",
        "Statement": [
          {
            "Effect": "Allow",
            "Action": [
      "admin:*"
-           ],
-           "Resource": [
-     ""
            ]
          },
          {
            "Effect": "Allow",
            "Action": [
      "s3:*"
            ],
            "Resource": [
      "arn:aws:s3:::*"
            ]
          }
        ]
      }
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
