### PR TITLE
Apply dynamic config at sub-system level

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -813,18 +813,16 @@ func GetSubSys(s string) (subSys string, inputs []string, tgt string, e error) {
 		return subSys, inputs, tgt, Errorf("input arguments cannot be empty")
 	}
 	inputs = strings.SplitN(s, KvSpaceSeparator, 2)
-	if len(inputs) <= 1 {
-		return subSys, inputs, tgt, Errorf("invalid number of arguments '%s'", s)
-	}
-	subSystemValue := strings.SplitN(inputs[0], SubSystemSeparator, 2)
-	if len(subSystemValue) == 0 {
-		return subSys, inputs, tgt, Errorf("invalid number of arguments %s", s)
-	}
 
-	if !SubSystems.Contains(subSystemValue[0]) {
+	subSystemValue := strings.SplitN(inputs[0], SubSystemSeparator, 2)
+	subSys = subSystemValue[0]
+	if !SubSystems.Contains(subSys) {
 		return subSys, inputs, tgt, Errorf("unknown sub-system %s", s)
 	}
-	subSys = subSystemValue[0]
+
+	if len(inputs) == 1 {
+		return subSys, inputs, tgt, nil
+	}
 
 	if SubSystemsSingleTargets.Contains(subSystemValue[0]) && len(subSystemValue) == 2 {
 		return subSys, inputs, tgt, Errorf("sub-system '%s' only supports single target", subSystemValue[0])


### PR DESCRIPTION
## Description

Currently, when applying any dynamic config, the system reloads and
re-applies the config of all the dynamic sub-systems.

This PR refactors the code in such a way that changing config of a given
dynamic sub-system will work on only that sub-system.

## Motivation and Context

There is no need to reload the configuration of all dynamic sub-systems
when setting/resetting config of a given sub-system.

## How to test this PR?

Test `set, get and reset` of all the dynamic configs using the
`mc admin config` command

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
