### PR TITLE
Send deployment id and minio version in http header

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -161,7 +161,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	signal.Notify(globalOSSignalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	// This is only to uniquely identify each gateway deployments.
 	globalDeploymentID = env.Get("MINIO_GATEWAY_DEPLOYMENT_ID", mustGetUUID())
-	logger.SetDeploymentID(globalDeploymentID)
+	xhttp.SetDeploymentID(globalDeploymentID)
 
 	if gw == nil {
 		logger.FatalIf(errUnexpected, "Gateway implementation not initialized")

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -493,7 +493,8 @@ func serverMain(ctx *cli.Context) {
 		logFatalErrs(err, Endpoint{}, true)
 	}
 
-	logger.SetDeploymentID(globalDeploymentID)
+	xhttp.SetDeploymentID(globalDeploymentID)
+	xhttp.SetMinIOVersion(Version)
 
 	// Enable background operations for erasure coding
 	if globalIsErasure {

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -191,3 +191,9 @@ const (
 
 	UploadID = "uploadId"
 )
+
+// http headers sent to webhook targets
+const (
+	// Reports the version of MinIO server
+	MinIOVersion = "x-minio-version"
+)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -33,6 +33,12 @@ import (
 	humanize "github.com/dustin/go-humanize"
 )
 
+// GlobalMinIOVersion - is sent in the header to all http targets
+var GlobalMinIOVersion string
+
+// GlobalDeploymentID - is sent in the header to all http targets
+var GlobalDeploymentID string
+
 const (
 	serverShutdownPoll = 500 * time.Millisecond
 
@@ -195,4 +201,14 @@ func NewServer(addrs []string) *Server {
 	// This is not configurable for now.
 	httpServer.MaxHeaderBytes = DefaultMaxHeaderBytes
 	return httpServer
+}
+
+// SetMinIOVersion -- MinIO version from the main package is set here
+func SetMinIOVersion(minioVer string) {
+	GlobalMinIOVersion = minioVer
+}
+
+// SetDeploymentID -- Deployment Id from the main package is set here
+func SetDeploymentID(deploymentID string) {
+	GlobalDeploymentID = deploymentID
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -33,11 +33,13 @@ import (
 	humanize "github.com/dustin/go-humanize"
 )
 
-// GlobalMinIOVersion - is sent in the header to all http targets
-var GlobalMinIOVersion string
+var (
+	// GlobalMinIOVersion - is sent in the header to all http targets
+	GlobalMinIOVersion string
 
-// GlobalDeploymentID - is sent in the header to all http targets
-var GlobalDeploymentID string
+	// GlobalDeploymentID - is sent in the header to all http targets
+	GlobalDeploymentID string
+)
 
 const (
 	serverShutdownPoll = 500 * time.Millisecond

--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/gzhttp"
+	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger/message/audit"
 )
 
@@ -146,7 +147,7 @@ func GetAuditEntry(ctx context.Context) *audit.Entry {
 		}
 		r = &audit.Entry{
 			Version:      audit.Version,
-			DeploymentID: globalDeploymentID,
+			DeploymentID: xhttp.GlobalDeploymentID,
 			Time:         time.Now().UTC(),
 		}
 		SetAuditEntry(ctx, r)
@@ -170,7 +171,7 @@ func AuditLog(ctx context.Context, w http.ResponseWriter, r *http.Request, reqCl
 			return
 		}
 
-		entry = audit.ToEntry(w, r, reqClaims, globalDeploymentID)
+		entry = audit.ToEntry(w, r, reqClaims, xhttp.GlobalDeploymentID)
 		// indicates all requests for this API call are inbound
 		entry.Trigger = "incoming"
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/minio/highwayhash"
 	"github.com/minio/minio-go/v7/pkg/set"
+	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger/message/log"
 )
 
@@ -52,8 +53,6 @@ const (
 )
 
 var trimStrings []string
-
-var globalDeploymentID string
 
 // TimeFormat - logging time format.
 const TimeFormat string = "15:04:05 MST 01/02/2006"
@@ -128,11 +127,6 @@ func uniqueEntries(paths []string) []string {
 		}
 	}
 	return m.ToSlice()
-}
-
-// SetDeploymentID -- Deployment Id from the main package is set here
-func SetDeploymentID(deploymentID string) {
-	globalDeploymentID = deploymentID
 }
 
 // Init sets the trimStrings to possible GOPATHs
@@ -319,7 +313,7 @@ func logIf(ctx context.Context, err error, errKind ...interface{}) {
 	// Get the cause for the Error
 	message := fmt.Sprintf("%v (%T)", err, err)
 	if req.DeploymentID == "" {
-		req.DeploymentID = globalDeploymentID
+		req.DeploymentID = xhttp.GlobalDeploymentID
 	}
 
 	objects := make([]log.ObjectVersion, 0, len(req.Objects))

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -144,6 +144,8 @@ func (h *Target) logEntry(entry interface{}) {
 		return
 	}
 	req.Header.Set(xhttp.ContentType, "application/json")
+	req.Header.Set(xhttp.MinIOVersion, xhttp.GlobalMinIOVersion)
+	req.Header.Set(xhttp.MinioDeploymentID, xhttp.GlobalDeploymentID)
 
 	// Set user-agent to indicate MinIO release
 	// version to the configured log endpoint


### PR DESCRIPTION
## Description

Send deployment id and minio version in the http headers
`x-minio-version` and `x-minio-deployment-id` respectively.

## Motivation and Context

Going forward, these can be used by the webhook targets to
- uniquely identify the cluster
- use the minio version to understand the payload format (in cases where the format has changed between versions)

## How to test this PR?

- Configure a logger webhook (where you can inspect headers of the webhook payload e.g. https://webhook.site/)
- Simulate an event in the cluster that triggers the webhook call
- Verify that the webhook request contains the two new headers

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
