### PR TITLE
ci: Always set disks as non root disks

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -212,21 +212,23 @@ func newXLStorage(ep Endpoint) (s *xlStorage, err error) {
 	}
 
 	var rootDisk bool
-	if globalRootDiskThreshold > 0 {
-		// Use MINIO_ROOTDISK_THRESHOLD_SIZE to figure out if
-		// this disk is a root disk.
-		info, err := disk.GetInfo(path)
-		if err != nil {
-			return nil, err
-		}
+	if !globalIsCICD {
+		if globalRootDiskThreshold > 0 {
+			// Use MINIO_ROOTDISK_THRESHOLD_SIZE to figure out if
+			// this disk is a root disk.
+			info, err := disk.GetInfo(path)
+			if err != nil {
+				return nil, err
+			}
 
-		// treat those disks with size less than or equal to the
-		// threshold as rootDisks.
-		rootDisk = info.Total <= globalRootDiskThreshold
-	} else {
-		rootDisk, err = disk.IsRootDisk(path, SlashSeparator)
-		if err != nil {
-			return nil, err
+			// treat those disks with size less than or equal to the
+			// threshold as rootDisks.
+			rootDisk = info.Total <= globalRootDiskThreshold
+		} else {
+			rootDisk, err = disk.IsRootDisk(path, SlashSeparator)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
In the testing mode, reformatting disks will fail because the healing
code will complain if one disk is in root mode. This commit will
automatically set all disks as non-root if MINIO_CI_CD is set.

## Motivation and Context
Facilitate healing testing in a CI environment

## How to test this PR?
1. Deploy a distributed setup in the local machine
2. Remove one disk content and wait to see if it is healed or not

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
