### PR TITLE
Make audit webhook and kafka config dynamic

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2222,7 +2222,7 @@ func fetchKMSStatus() madmin.KMS {
 func fetchLoggerInfo() ([]madmin.Logger, []madmin.Audit) {
 	var loggerInfo []madmin.Logger
 	var auditloggerInfo []madmin.Audit
-	for _, target := range logger.Targets() {
+	for _, target := range logger.HTTPTargets() {
 		if target.Endpoint() != "" {
 			tgt := target.String()
 			err := checkConnection(target.Endpoint(), 15*time.Second)

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2222,7 +2222,7 @@ func fetchKMSStatus() madmin.KMS {
 func fetchLoggerInfo() ([]madmin.Logger, []madmin.Audit) {
 	var loggerInfo []madmin.Logger
 	var auditloggerInfo []madmin.Audit
-	for _, target := range logger.HTTPTargets() {
+	for _, target := range logger.SystemTargets() {
 		if target.Endpoint() != "" {
 			tgt := target.String()
 			err := checkConnection(target.Endpoint(), 15*time.Second)

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -632,7 +632,7 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 				loggerCfg.HTTP[n] = l
 			}
 		}
-		err = logger.UpdateHTTPTargets(loggerCfg)
+		err = logger.UpdateSystemTargets(loggerCfg)
 		if err != nil {
 			logger.LogIf(ctx, fmt.Errorf("Unable to update logger webhook config: %w", err))
 		}

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -632,7 +632,7 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 				loggerCfg.HTTP[n] = l
 			}
 		}
-		err = logger.UpdateTargets(loggerCfg)
+		err = logger.UpdateHTTPTargets(loggerCfg)
 		if err != nil {
 			logger.LogIf(ctx, fmt.Errorf("Unable to update logger webhook config: %w", err))
 		}

--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -77,7 +77,7 @@ func (sys *HTTPConsoleLoggerSys) HasLogListeners() bool {
 func (sys *HTTPConsoleLoggerSys) Subscribe(subCh chan interface{}, doneCh <-chan struct{}, node string, last int, logKind string, filter func(entry interface{}) bool) {
 	// Enable console logging for remote client.
 	if !sys.HasLogListeners() {
-		logger.AddTarget(sys)
+		logger.AddHTTPTarget(sys)
 	}
 
 	cnt := 0

--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -25,6 +25,7 @@ import (
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/minio/internal/logger/message/log"
 	"github.com/minio/minio/internal/logger/target/console"
+	"github.com/minio/minio/internal/logger/target/types"
 	"github.com/minio/minio/internal/pubsub"
 	xnet "github.com/minio/pkg/net"
 )
@@ -152,6 +153,11 @@ func (sys *HTTPConsoleLoggerSys) Content() (logs []log.Entry) {
 
 // Cancel - cancels the target
 func (sys *HTTPConsoleLoggerSys) Cancel() {
+}
+
+// Type - returns type of the target
+func (sys *HTTPConsoleLoggerSys) Type() types.TargetType {
+	return types.TargetConsole
 }
 
 // Send log message 'e' to console and publish to console

--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -77,7 +77,7 @@ func (sys *HTTPConsoleLoggerSys) HasLogListeners() bool {
 func (sys *HTTPConsoleLoggerSys) Subscribe(subCh chan interface{}, doneCh <-chan struct{}, node string, last int, logKind string, filter func(entry interface{}) bool) {
 	// Enable console logging for remote client.
 	if !sys.HasLogListeners() {
-		logger.AddHTTPTarget(sys)
+		logger.AddSystemTarget(sys)
 	}
 
 	cnt := 0

--- a/cmd/data-update-tracker_test.go
+++ b/cmd/data-update-tracker_test.go
@@ -76,7 +76,7 @@ func (t *testingLogger) Send(entry interface{}, errKind string) error {
 
 func addTestingLogging(t testLoggerI) func() {
 	tl := &testingLogger{t: t}
-	logger.AddTarget(tl)
+	logger.AddHTTPTarget(tl)
 	return func() {
 		tl.mu.Lock()
 		defer tl.mu.Unlock()

--- a/cmd/data-update-tracker_test.go
+++ b/cmd/data-update-tracker_test.go
@@ -76,7 +76,7 @@ func (t *testingLogger) Send(entry interface{}, errKind string) error {
 
 func addTestingLogging(t testLoggerI) func() {
 	tl := &testingLogger{t: t}
-	logger.AddHTTPTarget(tl)
+	logger.AddSystemTarget(tl)
 	return func() {
 		tl.mu.Lock()
 		defer tl.mu.Unlock()

--- a/cmd/data-update-tracker_test.go
+++ b/cmd/data-update-tracker_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/minio/internal/logger/message/log"
+	"github.com/minio/minio/internal/logger/target/types"
 )
 
 type testLoggerI interface {
@@ -56,6 +57,10 @@ func (t *testingLogger) Init() error {
 }
 
 func (t *testingLogger) Cancel() {
+}
+
+func (t *testingLogger) Type() types.TargetType {
+	return types.TargetHTTP
 }
 
 func (t *testingLogger) Send(entry interface{}, errKind string) error {

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -176,7 +176,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 
 	// Initialize globalConsoleSys system
 	globalConsoleSys = NewConsoleLogger(GlobalContext)
-	logger.AddHTTPTarget(globalConsoleSys)
+	logger.AddSystemTarget(globalConsoleSys)
 
 	// Handle common command args.
 	handleCommonCmdArgs(ctx)

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -176,7 +176,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 
 	// Initialize globalConsoleSys system
 	globalConsoleSys = NewConsoleLogger(GlobalContext)
-	logger.AddTarget(globalConsoleSys)
+	logger.AddHTTPTarget(globalConsoleSys)
 
 	// Handle common command args.
 	handleCommonCmdArgs(ctx)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -401,7 +401,7 @@ func serverMain(ctx *cli.Context) {
 
 	// Initialize globalConsoleSys system
 	globalConsoleSys = NewConsoleLogger(GlobalContext)
-	logger.AddTarget(globalConsoleSys)
+	logger.AddHTTPTarget(globalConsoleSys)
 
 	// Perform any self-tests
 	bitrotSelfTest()

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -401,7 +401,7 @@ func serverMain(ctx *cli.Context) {
 
 	// Initialize globalConsoleSys system
 	globalConsoleSys = NewConsoleLogger(GlobalContext)
-	logger.AddHTTPTarget(globalConsoleSys)
+	logger.AddSystemTarget(globalConsoleSys)
 
 	// Perform any self-tests
 	bitrotSelfTest()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,7 @@ var SubSystemsDynamic = set.CreateStringSet(
 	HealSubSys,
 	SubnetSubSys,
 	LoggerWebhookSubSys,
+	AuditWebhookSubSys,
 )
 
 // SubSystemsSingleTargets - subsystems which only support single target.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,6 +168,7 @@ var SubSystemsDynamic = set.CreateStringSet(
 	SubnetSubSys,
 	LoggerWebhookSubSys,
 	AuditWebhookSubSys,
+	AuditKafkaSubSys,
 )
 
 // SubSystemsSingleTargets - subsystems which only support single target.

--- a/internal/logger/config.go
+++ b/internal/logger/config.go
@@ -621,6 +621,7 @@ func lookupAuditWebhookConfig(scfg config.Config, cfg Config) (Config, error) {
 	return cfg, nil
 }
 
+// LookupConfigForSubSys - lookup logger config, override with ENVs if set, for the given sub-system
 func LookupConfigForSubSys(scfg config.Config, subSys string) (cfg Config, err error) {
 	switch subSys {
 	case config.LoggerWebhookSubSys:

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -358,7 +358,7 @@ func logIf(ctx context.Context, err error, errKind ...interface{}) {
 	}
 
 	// Iterate over all logger targets to send the log entry
-	for _, t := range Targets() {
+	for _, t := range HTTPTargets() {
 		if err := t.Send(entry, entry.LogKind); err != nil {
 			LogAlwaysIf(context.Background(), fmt.Errorf("event(%v) was not sent to Logger target (%v): %v", entry, t, err), entry.LogKind)
 		}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -358,7 +358,7 @@ func logIf(ctx context.Context, err error, errKind ...interface{}) {
 	}
 
 	// Iterate over all logger targets to send the log entry
-	for _, t := range HTTPTargets() {
+	for _, t := range SystemTargets() {
 		if err := t.Send(entry, entry.LogKind); err != nil {
 			LogAlwaysIf(context.Background(), fmt.Errorf("event(%v) was not sent to Logger target (%v): %v", entry, t, err), entry.LogKind)
 		}

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	xhttp "github.com/minio/minio/internal/http"
+	"github.com/minio/minio/internal/logger/target/types"
 )
 
 // Timeout for the webhook http call
@@ -221,4 +222,9 @@ func (h *Target) Cancel() {
 		close(h.logCh)
 	}
 	h.wg.Wait()
+}
+
+// Type - returns type of the target
+func (h *Target) Type() types.TargetType {
+	return types.TargetHTTP
 }

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2022 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -33,6 +33,9 @@ import (
 	"github.com/minio/minio/internal/logger/message/audit"
 	xnet "github.com/minio/pkg/net"
 )
+
+// KAFKA - the string returned as endpoint of kafka targets
+const KAFKA = "kafka"
 
 // Target - Kafka target.
 type Target struct {
@@ -137,12 +140,12 @@ func (k Config) pingBrokers() error {
 
 // Endpoint - return kafka target
 func (h *Target) Endpoint() string {
-	return "kafka"
+	return KAFKA
 }
 
 // String - kafka string
 func (h *Target) String() string {
-	return "kafka"
+	return KAFKA
 }
 
 // Init initialize kafka target

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -34,8 +34,8 @@ import (
 	xnet "github.com/minio/pkg/net"
 )
 
-// KAFKA - the string returned as endpoint of kafka targets
-const KAFKA = "kafka"
+// NAME - the string returned as endpoint of kafka targets
+const NAME = "kafka"
 
 // Target - Kafka target.
 type Target struct {
@@ -140,12 +140,12 @@ func (k Config) pingBrokers() error {
 
 // Endpoint - return kafka target
 func (h *Target) Endpoint() string {
-	return KAFKA
+	return NAME
 }
 
 // String - kafka string
 func (h *Target) String() string {
-	return KAFKA
+	return NAME
 }
 
 // Init initialize kafka target

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -31,11 +31,9 @@ import (
 	saramatls "github.com/Shopify/sarama/tools/tls"
 
 	"github.com/minio/minio/internal/logger/message/audit"
+	"github.com/minio/minio/internal/logger/target/types"
 	xnet "github.com/minio/pkg/net"
 )
-
-// NAME - the string returned as endpoint of kafka targets
-const NAME = "kafka"
 
 // Target - Kafka target.
 type Target struct {
@@ -140,12 +138,12 @@ func (k Config) pingBrokers() error {
 
 // Endpoint - return kafka target
 func (h *Target) Endpoint() string {
-	return NAME
+	return "kafka"
 }
 
 // String - kafka string
 func (h *Target) String() string {
-	return NAME
+	return "kafka"
 }
 
 // Init initialize kafka target
@@ -229,4 +227,9 @@ func New(config Config) *Target {
 		kconfig: config,
 	}
 	return target
+}
+
+// Type - returns type of the target
+func (h *Target) Type() types.TargetType {
+	return types.TargetKafka
 }

--- a/internal/logger/target/types/types.go
+++ b/internal/logger/target/types/types.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+// TargetType indicates type of the target e.g. console, http, kafka
+type TargetType uint8
+
+// Constants for target types
+const (
+	_ TargetType = iota
+	TargetConsole
+	TargetHTTP
+	TargetKafka
+)

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -40,22 +40,22 @@ var (
 	// swapMu must be held while reading slice info or swapping targets or auditTargets.
 	swapMu sync.Mutex
 
-	// targets is the set of enabled loggers.
+	// httpTargets is the set of enabled loggers.
 	// Must be immutable at all times.
 	// Can be swapped to another while holding swapMu
-	targets  = []Target{}
-	nTargets int32 // atomic count of len(targets)
+	httpTargets = []Target{}
+	nTargets    int32 // atomic count of len(targets)
 )
 
-// Targets returns active targets.
+// HTTPTargets returns active targets.
 // Returned slice may not be modified in any way.
-func Targets() []Target {
+func HTTPTargets() []Target {
 	if atomic.LoadInt32(&nTargets) == 0 {
 		// Lock free if none...
 		return nil
 	}
 	swapMu.Lock()
-	res := targets
+	res := httpTargets
 	swapMu.Unlock()
 	return res
 }
@@ -81,29 +81,29 @@ var (
 	nAuditTargets int32 // atomic count of len(auditTargets)
 )
 
-// AddTarget adds a new logger target to the
+// AddHTTPTarget adds a new logger target to the
 // list of enabled loggers
-func AddTarget(t Target) error {
+func AddHTTPTarget(t Target) error {
 	if err := t.Init(); err != nil {
 		return err
 	}
 	swapMu.Lock()
-	updated := append(make([]Target, 0, len(targets)+1), targets...)
+	updated := append(make([]Target, 0, len(httpTargets)+1), httpTargets...)
 	updated = append(updated, t)
-	targets = updated
+	httpTargets = updated
 	atomic.StoreInt32(&nTargets, int32(len(updated)))
 	swapMu.Unlock()
 
 	return nil
 }
 
-func cancelAllTargets() {
-	for _, tgt := range targets {
+func cancelAllHTTPTargets() {
+	for _, tgt := range httpTargets {
 		tgt.Cancel()
 	}
 }
 
-func initHttpTargets(cfgMap map[string]http.Config) (tgts []Target, err error) {
+func initHTTPTargets(cfgMap map[string]http.Config) (tgts []Target, err error) {
 	for _, l := range cfgMap {
 		if l.Enabled {
 			t := http.New(l)
@@ -129,15 +129,15 @@ func initKafkaTargets(cfgMap map[string]kafka.Config) (tgts []Target, err error)
 	return tgts, err
 }
 
-// UpdateTargets swaps targets with newly loaded ones from the cfg
-func UpdateTargets(cfg Config) error {
-	updated, err := initHttpTargets(cfg.HTTP)
+// UpdateHTTPTargets swaps targets with newly loaded ones from the cfg
+func UpdateHTTPTargets(cfg Config) error {
+	updated, err := initHTTPTargets(cfg.HTTP)
 	if err != nil {
 		return err
 	}
 
 	swapMu.Lock()
-	for _, tgt := range targets {
+	for _, tgt := range httpTargets {
 		// Preserve console target when dynamically updating
 		// other HTTP targets, console target is always present.
 		if tgt.String() == ConsoleLoggerTgt {
@@ -146,8 +146,8 @@ func UpdateTargets(cfg Config) error {
 		}
 	}
 	atomic.StoreInt32(&nTargets, int32(len(updated)))
-	cancelAllTargets() // cancel running targets
-	targets = updated
+	cancelAllHTTPTargets() // cancel running targets
+	httpTargets = updated
 	swapMu.Unlock()
 	return nil
 }
@@ -171,7 +171,7 @@ func cancelAuditKafkaTargets() {
 func existingAuditWebhookTargets() []Target {
 	awTgts := []Target{}
 	for _, tgt := range auditTargets {
-		if tgt.Endpoint() != "kafka" {
+		if tgt.Endpoint() != kafka.KAFKA {
 			awTgts = append(awTgts, tgt)
 		}
 	}
@@ -190,7 +190,7 @@ func existingAuditKafkaTargets() []Target {
 
 // UpdateAuditWebhookTargets swaps audit webhook targets with newly loaded ones from the cfg
 func UpdateAuditWebhookTargets(cfg Config) error {
-	updated, err := initHttpTargets(cfg.AuditWebhook)
+	updated, err := initHTTPTargets(cfg.AuditWebhook)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Make the audit webhook and kafka config dynamic

## Motivation and Context

These are similar to the logger webhook config which is dynamic,
and there is no reason for them to not be.

## How to test this PR?

- Test that changing value of an audit webhook or audit kafka config using `mc admin config set {alias} audit_webhook|audit_kafka` doesn't ask you to restart the server
- Test that `get, set and reset` of all configs is working fine

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
