### PR TITLE
fix: openid config provider not initialized correctly

### DIFF
--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -155,7 +155,7 @@ const (
 // InitializeProvider initializes if any additional vendor specific
 // information was provided, initialization will return an error
 // initial login fails.
-func (r Config) InitializeProvider(kvs config.KVS) error {
+func (r *Config) InitializeProvider(kvs config.KVS) error {
 	vendor := env.Get(EnvIdentityOpenIDVendor, kvs.Get(Vendor))
 	if vendor == "" {
 		return nil

--- a/internal/config/identity/openid/jwt_test.go
+++ b/internal/config/identity/openid/jwt_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	jwtg "github.com/golang-jwt/jwt/v4"
+	"github.com/minio/minio/internal/config"
 	jwtm "github.com/minio/minio/internal/jwt"
 	xnet "github.com/minio/pkg/net"
 )
@@ -228,5 +229,29 @@ func TestExpCorrect(t *testing.T) {
 	})
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestKeycloakProviderInitialization(t *testing.T) {
+	testConfig := Config{
+		DiscoveryDoc: DiscoveryDoc{
+			TokenEndpoint: "http://keycloak.test/token/endpoint",
+		},
+	}
+	testKvs := config.KVS{}
+	testKvs.Set(Vendor, "keycloak")
+	testKvs.Set(KeyCloakRealm, "TestRealm")
+	testKvs.Set(KeyCloakAdminURL, "http://keycloak.test/auth/admin")
+
+	if testConfig.provider != nil {
+		t.Errorf("Empty config cannot have any provider!")
+	}
+
+	if err := testConfig.InitializeProvider(testKvs); err != nil {
+		t.Error(err)
+	}
+
+	if testConfig.provider == nil {
+		t.Errorf("keycloak provider must be initialized!")
 	}
 }


### PR DESCRIPTION
## Description
Up until now `InitializeProvider` method of `Config` struct was
implemented on a value receiver which is why changes on `provider`
field where never reflected to method callers. In order to fix this
issue, the method was implemented on a pointer receiver.

## Motivation and Context
Keycloak IDP user removal job was never triggered because of wrong configuration initialization.

## How to test this PR?
Unit test was implemented in `internal/config/identity/openid/jwt_test.go`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
