### PR TITLE
fix: invalid parentUser id on OIDC auto expiration

### DIFF
--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -1450,11 +1450,11 @@ func (store *IAMStoreSys) DeleteUsers(ctx context.Context, users []string) error
 
 // GetAllParentUsers - returns all distinct "parent-users" associated with STS or service
 // credentials.
-func (store *IAMStoreSys) GetAllParentUsers() []string {
+func (store *IAMStoreSys) GetAllParentUsers() map[string]string {
 	cache := store.rlock()
 	defer store.runlock()
 
-	res := set.NewStringSet()
+	res := map[string]string{}
 	for _, cred := range cache.iamUsersMap {
 		if cred.IsServiceAccount() || cred.IsTemp() {
 			parentUser := cred.ParentUser
@@ -1470,11 +1470,13 @@ func (store *IAMStoreSys) GetAllParentUsers() []string {
 					}
 				}
 			}
-			res.Add(parentUser)
+			if _, ok := res[parentUser]; !ok {
+				res[parentUser] = cred.ParentUser
+			}
 		}
 	}
 
-	return res.ToSlice()
+	return res
 }
 
 // SetUserStatus - sets current user status.

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1003,7 +1003,7 @@ func (sys *IAMSys) SetUserSecretKey(ctx context.Context, accessKey string, secre
 func (sys *IAMSys) purgeExpiredCredentialsForExternalSSO(ctx context.Context) {
 	parentUsers := sys.store.GetAllParentUsers()
 	var expiredUsers []string
-	for _, parentUser := range parentUsers {
+	for parentUser, expiredUser := range parentUsers {
 		u, err := globalOpenIDConfig.LookupUser(parentUser)
 		if err != nil {
 			logger.LogIf(GlobalContext, err)
@@ -1012,7 +1012,7 @@ func (sys *IAMSys) purgeExpiredCredentialsForExternalSSO(ctx context.Context) {
 		// If user is set to "disabled", we will remove them
 		// subsequently.
 		if !u.Enabled {
-			expiredUsers = append(expiredUsers, parentUser)
+			expiredUsers = append(expiredUsers, expiredUser)
 		}
 	}
 
@@ -1025,12 +1025,12 @@ func (sys *IAMSys) purgeExpiredCredentialsForExternalSSO(ctx context.Context) {
 func (sys *IAMSys) purgeExpiredCredentialsForLDAP(ctx context.Context) {
 	parentUsers := sys.store.GetAllParentUsers()
 	var allDistNames []string
-	for _, parentUser := range parentUsers {
+	for parentUser, expiredUser := range parentUsers {
 		if !globalLDAPConfig.IsLDAPUserDN(parentUser) {
 			continue
 		}
 
-		allDistNames = append(allDistNames, parentUser)
+		allDistNames = append(allDistNames, expiredUser)
 	}
 
 	expiredUsers, err := globalLDAPConfig.GetNonEligibleUserDistNames(allDistNames)


### PR DESCRIPTION
## Description
This commit should fix a bug that was introduced in
`f6d13f57bb1218b60db8808a15ae5485f1ef362b` where the wrong
parentUserId was used for deletion of expired OIDC users

## Motivation and Context
Keycloak IDP user removal did not delete any expired users since `DeleteUser` method on `IAMStoreSys` was
called with Keycloak user ids instead of Minio's internal user id.

## How to test this PR?
You could setup a Minio deployment with Keycloak as its IDP. After that some service accounts should be created in Minio using a Keycloak user. If this user gets disabled or deleted in Keycloak, the services accounts still exists in Minio and can be used to access the system.
For now I did not implement any unit tests since I'm not 100% sure if implementation satisfies your general implementation/coding strategy in Minio. Please let me know if implementation approach is ok for you
I can implement the missing unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
