### PR TITLE
fix: possible wrong path composition for keycloak user lookups

### DIFF
--- a/internal/config/identity/openid/provider/keycloak.go
+++ b/internal/config/identity/openid/provider/keycloak.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"sync"
 )
@@ -83,11 +84,12 @@ func (k *KeycloakProvider) LoginWithClientID(clientID, clientSecret string) erro
 
 // LookupUser lookup user by their userid.
 func (k *KeycloakProvider) LookupUser(userid string) (User, error) {
-	lookupUserID := k.adminURL + "/realms" + k.realm + "/users/" + userid
-	req, err := http.NewRequest(http.MethodGet, lookupUserID, nil)
+	req, err := http.NewRequest(http.MethodGet, k.adminURL, nil)
 	if err != nil {
 		return User{}, err
 	}
+	req.URL.Path = path.Join(req.URL.Path, "realms", k.realm, "users", userid)
+
 	k.Lock()
 	accessToken := k.accessToken
 	k.Unlock()


### PR DESCRIPTION
## Description
`LookupUser` method in `internal/config/identity/openid/provider/keycloak.go` misses out a separation slash in URL path composition.

## Motivation and Context
In case that a user defined a value for the `MINIO_IDENTITY_OPENID_KEYCLOAK_REALM` environment
variable, but did not prefixed the value with a slash, the API path for the keycloak user
lookups was not composited correctly. This was also the case if the user did not specify any realm at all since Minio
used realm `master` as default in such cases

## How to test this PR?
For now I did not implement any unit tests since I'm not 100% sure if implementation satisfies your general implementation/coding strategy in Minio. Please let me know if implementation approach is ok for you
I can implement the missing unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
