### PR TITLE
select: Allow lower case 'is'

### DIFF
--- a/internal/s3select/select_test.go
+++ b/internal/s3select/select_test.go
@@ -474,6 +474,13 @@ func TestJSONQueries(t *testing.T) {
 			wantResult: `{"Id":1,"Name":"Anshu","Address":"Templestowe","Car":"Jeep"}`,
 			withJSON:   `{ "person": [ { "Id": 1, "Name": "Anshu", "Address": "Templestowe", "Car": "Jeep" }, { "Id": 2, "Name": "Ben Mostafa", "Address": "Las Vegas", "Car": "Mustang" }, { "Id": 3, "Name": "Rohan Wood", "Address": "Wooddon", "Car": "VW" } ] }`,
 		},
+		{
+			name:       "lower-case-is",
+			query:      `select * from s3object[*] as s where s.request.header['User-Agent'] is not null`,
+			wantResult: `{"request":{"uri":"/1","header":{"User-Agent":"test"}}}`,
+			withJSON: `{"request":{"uri":"/1","header":{"User-Agent":"test"}}}
+{"request":{"uri":"/2","header":{}}}`,
+		},
 	}
 
 	defRequest := `<?xml version="1.0" encoding="UTF-8"?>

--- a/internal/s3select/sql/evaluate.go
+++ b/internal/s3select/sql/evaluate.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/bcicen/jstream"
 	"github.com/minio/simdjson-go"
@@ -134,7 +135,7 @@ func (e *ConditionOperand) evalNode(r Record, tableAlias string) (*Value, error)
 			return nil, cmpRErr
 		}
 
-		b, err := opVal.compareOp(e.ConditionRHS.Compare.Operator, cmpRight)
+		b, err := opVal.compareOp(strings.ToUpper(e.ConditionRHS.Compare.Operator), cmpRight)
 		return FromBool(b), err
 
 	case e.ConditionRHS.Between != nil:


### PR DESCRIPTION
## Description

Allow using lower case for `is` statement.

Ref: #14358


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Unit tests added/updated
