### PR TITLE
Return data for disk info when the disk is unformatted

### DIFF
--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -109,7 +109,7 @@ func storageServerRequestValidate(r *http.Request) error {
 }
 
 // IsValid - To authenticate and verify the time difference.
-func (s *storageRESTServer) IsValid(w http.ResponseWriter, r *http.Request) bool {
+func (s *storageRESTServer) IsAuthValid(w http.ResponseWriter, r *http.Request) bool {
 	if s.storage == nil {
 		s.writeErrorResponse(w, errDiskNotFound)
 		return false
@@ -117,6 +117,15 @@ func (s *storageRESTServer) IsValid(w http.ResponseWriter, r *http.Request) bool
 
 	if err := storageServerRequestValidate(r); err != nil {
 		s.writeErrorResponse(w, err)
+		return false
+	}
+
+	return true
+}
+
+// IsValid - To authenticate and check if the disk-id in the request corresponds to the underlying disk.
+func (s *storageRESTServer) IsValid(w http.ResponseWriter, r *http.Request) bool {
+	if !s.IsAuthValid(w, r) {
 		return false
 	}
 
@@ -155,7 +164,7 @@ func (s *storageRESTServer) HealthHandler(w http.ResponseWriter, r *http.Request
 
 // DiskInfoHandler - returns disk info.
 func (s *storageRESTServer) DiskInfoHandler(w http.ResponseWriter, r *http.Request) {
-	if !s.IsValid(w, r) {
+	if !s.IsAuthValid(w, r) {
 		return
 	}
 	info, err := s.storage.DiskInfo(r.Context())


### PR DESCRIPTION
## Description
A DiskInfo REST call to an unformatted disk returns an error with no
disk information, such as the disk endpoint URL, which is unexpected.


## Motivation and Context
Fix wrong reporting of heal status when there is an unformatted disk (while the cluster is still online)

## How to test this PR?
- Start a distributed setup
- Manually remove one disk content and quickly run `mc admin heal <alias>`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
