### PR TITLE
Enhance the error checking for reset by peer, use errors.Is to check error in cmd/os-readdir_other.go

### DIFF
--- a/cmd/os-readdir_other.go
+++ b/cmd/os-readdir_other.go
@@ -21,6 +21,7 @@
 package cmd
 
 import (
+	"errors"
 	"io"
 	"os"
 	"syscall"
@@ -49,11 +50,11 @@ func readDirFn(dirPath string, filter func(name string, typ os.FileMode) error) 
 		// Read up to max number of entries.
 		fis, err := d.Readdir(maxEntries)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			err = osErrToFileErr(err)
-			if err == errFileNotFound {
+			if errors.Is(err, errFileNotFound) {
 				return nil
 			}
 			return err
@@ -77,7 +78,7 @@ func readDirFn(dirPath string, filter func(name string, typ os.FileMode) error) 
 					continue
 				}
 			}
-			if err = filter(fi.Name(), fi.Mode()); err == errDoneForNow {
+			if err = filter(fi.Name(), fi.Mode()); errors.Is(err, errDoneForNow) {
 				// filtering requested to return by caller.
 				return nil
 			}
@@ -106,7 +107,7 @@ func readDirWithOpts(dirPath string, opts readDirOpts) (entries []string, err er
 		// Read up to max number of entries.
 		fis, err := d.Readdir(maxEntries)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, osErrToFileErr(err)

--- a/internal/event/target/store.go
+++ b/internal/event/target/store.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"syscall"
 	"time"
@@ -90,11 +91,11 @@ func IsConnRefusedErr(err error) bool {
 
 // IsConnResetErr - Checks for connection reset errors.
 func IsConnResetErr(err error) bool {
-	if strings.Contains(err.Error(), "connection reset by peer") {
-		return true
+	operr, ok := err.(*net.OpError)
+	if !ok {
+		return false
 	}
-	// incase if error message is wrapped.
-	return errors.Is(err, syscall.ECONNRESET)
+	return errors.Is(operr, syscall.ECONNRESET)
 }
 
 // sendEvents - Reads events from the store and re-plays.


### PR DESCRIPTION
## Description
- Check `connection reset by peer` by `strings.Contains` is not elegant  
The original code to check `connection reset by peer` is this:
```go
func IsConnResetErr(err error) bool {
	if strings.Contains(err.Error(), "connection reset by peer") {
		return true
	}
	// incase if error message is wrapped.
	return errors.Is(err, syscall.ECONNRESET)
}
```
It's not so elegant and is a question asked in [stackoverflow](https://stackoverflow.com/questions/19929386/handling-connection-reset-errors-in-go)
So we can check it better with the help of type asset.  I upgraded it as this:
```go
// IsConnResetErr - Checks for connection reset errors.
func IsConnResetErr(err error) bool {
	operr, ok := err.(*net.OpError)
	if !ok {
		return false
	}
	return errors.Is(operr, syscall.ECONNRESET)
}
```
- As golang 1.13 introduced `errors.Is` to check error, so I think we can use it instead of `==` to make a better error judgement.


## Motivation and Context
N/A(sorry for unknowing how to write down here)

## How to test this PR?
Just fix the error checking way and don't affect the business.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
