### PR TITLE
Judge connection reset by peer error by opaque error

### DIFF
--- a/internal/event/target/store.go
+++ b/internal/event/target/store.go
@@ -90,11 +90,11 @@ func IsConnRefusedErr(err error) bool {
 
 // IsConnResetErr - Checks for connection reset errors.
 func IsConnResetErr(err error) bool {
-	if strings.Contains(err.Error(), "connection reset by peer") {
-		return true
+	operr, ok := err.(*net.OpError)
+	if !ok {
+		return false
 	}
-	// incase if error message is wrapped.
-	return errors.Is(err, syscall.ECONNRESET)
+	return errors.Is(operr, syscall.ECONNRESET)
 }
 
 // sendEvents - Reads events from the store and re-plays.

--- a/internal/event/target/store.go
+++ b/internal/event/target/store.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"syscall"
 	"time"


### PR DESCRIPTION
## Description
- Check `connection reset by peer` by `strings.Contains` is not elegant  
The original code to check `connection reset by peer` is this:
```go
func IsConnResetErr(err error) bool {
	if strings.Contains(err.Error(), "connection reset by peer") {
		return true
	}
	// incase if error message is wrapped.
	return errors.Is(err, syscall.ECONNRESET)
}
```
It's not so elegant and is a question asked in [stackoverflow](https://stackoverflow.com/questions/19929386/handling-connection-reset-errors-in-go)
So we can check it better with the help of type asset.  I upgraded it as this:
```go
// IsConnResetErr - Checks for connection reset errors.
func IsConnResetErr(err error) bool {
	operr, ok := err.(*net.OpError)
	if !ok {
		return false
	}
	return errors.Is(operr, syscall.ECONNRESET)
}
```

## Motivation and Context
This error checking for `connection reset by peer` can be more elegant.

## How to test this PR?
Just enhance the error-checking way and don't affect the business.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
