### PR TITLE
Update minio/pkg to v1.1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/minio/madmin-go v1.3.4
 	github.com/minio/minio-go/v7 v7.0.23
 	github.com/minio/parquet-go v1.1.0
-	github.com/minio/pkg v1.1.16
+	github.com/minio/pkg v1.1.17
 	github.com/minio/selfupdate v0.4.0
 	github.com/minio/sha256-simd v1.0.0
 	github.com/minio/simdjson-go v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -844,8 +844,8 @@ github.com/minio/operator v0.0.0-20220110040724-a5d59a342b7f/go.mod h1:k00quEXDt
 github.com/minio/parquet-go v1.1.0 h1:j2Fn1/h7Ts/0qzdMZU9oCUKr0IJwRTD9Hg9QJyVaN6A=
 github.com/minio/parquet-go v1.1.0/go.mod h1:nnAkbt2CG/DCQ3trcV3uyvwns4VjyoINF5vMqF5efOE=
 github.com/minio/pkg v1.0.3/go.mod h1:obU54TZ9QlMv0TRaDgQ/JTzf11ZSXxnSfLrm4tMtBP8=
-github.com/minio/pkg v1.1.16 h1:wx+h71SWrSqb1I4BHe66dU2rNbPJu5dkteOZxtdrqkY=
-github.com/minio/pkg v1.1.16/go.mod h1:dj3rI8IXrE1xIQIF1M5Qbk5GqFcoxnwKexYNolUsVGs=
+github.com/minio/pkg v1.1.17 h1:THs4HFHBi00J4KmOJC6wxYTI7hJGfjI4pwU3DhqSArk=
+github.com/minio/pkg v1.1.17/go.mod h1:dj3rI8IXrE1xIQIF1M5Qbk5GqFcoxnwKexYNolUsVGs=
 github.com/minio/selfupdate v0.3.1/go.mod h1:b8ThJzzH7u2MkF6PcIra7KaXO9Khf6alWPvMSyTDCFM=
 github.com/minio/selfupdate v0.4.0 h1:A7t07pN4Ch1tBTIRStW0KhUVyykz+2muCqFsITQeEW8=
 github.com/minio/selfupdate v0.4.0/go.mod h1:mcDkzMgq8PRcpCRJo/NlPY7U45O5dfYl2Y0Rg7IustY=


### PR DESCRIPTION
## Description
Fix for admin policy validation of KMSCreateKey

## Motivation and Context
Adding IAM policies containing `admin:KMSCreateKey` action incorrectly failed.

## How to test this PR?
Try adding an IAM policy containing `admin:KMSCreateKey` action. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
