### PR TITLE
fix: regression from refactor in AMQP notification

### DIFF
--- a/internal/config/notify/parse.go
+++ b/internal/config/notify/parse.go
@@ -138,6 +138,12 @@ func fetchSubSysTargets(ctx context.Context, cfg config.Config,
 				}
 				_ = newTarget.Close()
 			}
+			if err = targetList.Add(newTarget); err != nil {
+				logger.LogIf(context.Background(), err)
+				if returnOnTargetError {
+					return targetsOffline, err
+				}
+			}
 		}
 	case config.NotifyESSubSys:
 		esTargets, err := GetNotifyES(cfg[config.NotifyESSubSys], transport)


### PR DESCRIPTION


## Description
fix: regression from refactor in AMQP notification

## Motivation and Context
fixes a regression introduced in #14269 that refactored
the notification registration logic, all the AMQP targets
however online will not be available for use anymore.

fixes #14451

## How to test this PR?
As per #14451 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression - yes from #14269
- [ ] Documentation updated
- [ ] Unit tests added/updated
