### PR TITLE
kes: remove unnecessary error conversion

### DIFF
--- a/cmd/admin-handler-utils.go
+++ b/cmd/admin-handler-utils.go
@@ -22,8 +22,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/minio/minio/internal/kms"
-
+	"github.com/minio/kes"
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config"
@@ -145,7 +144,7 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 				Description:    "The policy cannot be removed, as it is in use",
 				HTTPStatusCode: http.StatusBadRequest,
 			}
-		case kms.KeyExists(err):
+		case errors.Is(err, kes.ErrKeyExists):
 			apiErr = APIError{
 				Code:           "XMinioKMSKeyExists",
 				Description:    err.Error(),

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -820,7 +820,7 @@ func handleCommonEnvVars() {
 		// This implicitly checks that we can communicate to KES. We don't treat
 		// a policy error as failure condition since MinIO may not have the permission
 		// to create keys - just to generate/decrypt data encryption keys.
-		if err = KMS.CreateKey(defaultKeyID); err != nil && !kms.KeyExists(err) && !errors.Is(err, kes.ErrNotAllowed) {
+		if err = KMS.CreateKey(defaultKeyID); err != nil && !errors.Is(err, kes.ErrKeyExists) && !errors.Is(err, kes.ErrNotAllowed) {
 			logger.Fatal(err, "Unable to initialize a connection to KES as specified by the shell environment")
 		}
 		GlobalKMS = KMS

--- a/internal/kms/kes.go
+++ b/internal/kms/kes.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"net/http"
 	"time"
 
 	"github.com/minio/kes"
@@ -140,11 +139,4 @@ func (c *kesClient) DecryptKey(keyID string, ciphertext []byte, ctx Context) ([]
 		return nil, err
 	}
 	return c.client.Decrypt(context.Background(), keyID, ciphertext, ctxBytes)
-}
-
-// KeyExists returns if key exists on KMS based on the provided error type
-func KeyExists(err error) bool {
-	// legacyKeyExists will be used to maintain compatibility with KES versions older than v0.18.0
-	legacyKeyExists := kes.NewError(http.StatusBadRequest, "key does already exist")
-	return errors.Is(err, kes.ErrKeyExists) || errors.Is(err, legacyKeyExists)
 }


### PR DESCRIPTION
## Description
This commit removes some duplicate code that
converts KES API errors.

This code was added since KES `0.18.0` changed
some exported API errors. However, the KES SDK
handles this error conversion itself.
Therefore, it is not necessary to duplicate this
behavior in MinIO.

See: https://github.com/minio/kes/blob/21555fa624420def4aa4766686baa553b692010a/error.go#L94

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
