### PR TITLE
canceled PUTs throw frivolous logs

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2039,7 +2039,8 @@ func skipAccessChecks(volume string) (ok bool) {
 // RenameData - rename source path to destination path atomically, metadata and data directory.
 func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string) (err error) {
 	defer func() {
-		if err != nil {
+		if err != nil && !contextCanceled(ctx) {
+			// Only log these errors if context is not yet canceled.
 			logger.LogIf(ctx, fmt.Errorf("srcVolume: %s, srcPath: %s, dstVolume: %s:, dstPath: %s - error %v",
 				srcVolume, srcPath,
 				dstVolume, dstPath,


### PR DESCRIPTION

## Description
canceled PUTs throw frivolous logs

## Motivation and Context
remote drives might throw frivolous logs,
if the caller canceled the PUT operation
in such scenarios there is no reason to log.


## How to test this PR?
Run `mc support perf object alias/`  on
a distributed setup. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
