### PR TITLE
Update nginx.conf for large file uploads

### DIFF
--- a/docs/orchestration/docker-compose/nginx.conf
+++ b/docs/orchestration/docker-compose/nginx.conf
@@ -49,6 +49,7 @@ http {
         client_max_body_size 0;
         # To disable buffering
         proxy_buffering off;
+        proxy_request_buffering off;
 
         location / {
             proxy_set_header Host $http_host;
@@ -78,6 +79,7 @@ http {
         client_max_body_size 0;
         # To disable buffering
         proxy_buffering off;
+        proxy_request_buffering off;
 
         location / {
             proxy_set_header Host $http_host;


### PR DESCRIPTION
## Description
nginx shall not buffer HTTP POST File Uploads, this makes the transfer faster and allows to upload large files. In my envorinment, it was not possible to upload files >10GB if nginx buffered them. nginx ran into a timeout during his own upload to min.io.

## How to test this PR?
Upload large files 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
