### PR TITLE
metrics: Avoid crash when fetching tier metrics

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1664,7 +1664,7 @@ func getClusterTierMetrics() *MetricsGroup {
 			return
 		}
 		// data usage has not captured any tier stats yet.
-		if dui.TiersStats == nil {
+		if dui.TierStats == nil {
 			return
 		}
 

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1663,8 +1663,8 @@ func getClusterTierMetrics() *MetricsGroup {
 		if err != nil {
 			return
 		}
-		// data usage has not captured any data yet.
-		if dui.LastUpdate.IsZero() {
+		// data usage has not captured any tier stats yet.
+		if dui.TiersStats == nil {
 			return
 		}
 


### PR DESCRIPTION
## Description
Data usage does not always contain tiering info even if the data usage
information is valid. Avoid a crash in that case.

(e.g. the scanner scanned the namespace, the user enables tiering,
prometheus scrapes the server before the scanner gets a chance to
update the data usage with new tiering information)

## Motivation and Context
Fix a crash

## How to test this PR?
Trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
