### PR TITLE
heal: Fix first entry on dangling

### DIFF
--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -450,14 +450,17 @@ func TestHealingDanglingObject(t *testing.T) {
 		t.Fatalf("Expected versions 1, got %d", fileInfoPreHeal.NumVersions)
 	}
 
+	ch := make(chan struct{})
 	if err = objLayer.HealObjects(ctx, bucket, "", madmin.HealOpts{Remove: true},
 		func(bucket, object, vid string) error {
 			_, err := objLayer.HealObject(ctx, bucket, object, vid, madmin.HealOpts{Remove: true})
+			close(ch)
 			return err
 		}); err != nil {
 		t.Fatal(err)
 	}
 
+	<-ch
 	fileInfoPostHeal, err = disks[0].ReadVersion(context.Background(), bucket, object, "", false)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -382,6 +382,13 @@ func TestHealingDanglingObject(t *testing.T) {
 		copy(disks, newDisks)
 		objLayer.(*erasureServerPools).serverPools[0].erasureDisksMu.Unlock()
 	}
+	getDisk := func(n int) StorageAPI {
+		objLayer.(*erasureServerPools).serverPools[0].erasureDisksMu.Lock()
+		disk := disks[n]
+		objLayer.(*erasureServerPools).serverPools[0].erasureDisksMu.Unlock()
+		return disk
+	}
+
 	// Remove 4 disks.
 	setDisks(nil, nil, nil, nil)
 
@@ -440,8 +447,8 @@ func TestHealingDanglingObject(t *testing.T) {
 	}
 
 	setDisks(orgDisks[:4]...)
-
-	fileInfoPreHeal, err = disks[0].ReadVersion(context.Background(), bucket, object, "", false)
+	disk := getDisk(0)
+	fileInfoPreHeal, err = disk.ReadVersion(context.Background(), bucket, object, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +465,8 @@ func TestHealingDanglingObject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileInfoPostHeal, err = disks[0].ReadVersion(context.Background(), bucket, object, "", false)
+	disk = getDisk(0)
+	fileInfoPostHeal, err = disk.ReadVersion(context.Background(), bucket, object, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -488,7 +496,8 @@ func TestHealingDanglingObject(t *testing.T) {
 
 	setDisks(orgDisks[:4]...)
 
-	fileInfoPreHeal, err = disks[0].ReadVersion(context.Background(), bucket, object, "", false)
+	disk = getDisk(0)
+	fileInfoPreHeal, err = disk.ReadVersion(context.Background(), bucket, object, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +514,8 @@ func TestHealingDanglingObject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileInfoPostHeal, err = disks[0].ReadVersion(context.Background(), bucket, object, "", false)
+	disk = getDisk(0)
+	fileInfoPostHeal, err = disk.ReadVersion(context.Background(), bucket, object, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -450,17 +450,14 @@ func TestHealingDanglingObject(t *testing.T) {
 		t.Fatalf("Expected versions 1, got %d", fileInfoPreHeal.NumVersions)
 	}
 
-	ch := make(chan struct{})
 	if err = objLayer.HealObjects(ctx, bucket, "", madmin.HealOpts{Remove: true},
 		func(bucket, object, vid string) error {
 			_, err := objLayer.HealObject(ctx, bucket, object, vid, madmin.HealOpts{Remove: true})
-			close(ch)
 			return err
 		}); err != nil {
 		t.Fatal(err)
 	}
 
-	<-ch
 	fileInfoPostHeal, err = disks[0].ReadVersion(context.Background(), bucket, object, "", false)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -389,11 +389,11 @@ func (m metaCacheEntries) resolve(r *metadataResolutionParams) (selected *metaCa
 
 // firstFound returns the first found and the number of set entries.
 func (m metaCacheEntries) firstFound() (first *metaCacheEntry, n int) {
-	for _, entry := range m {
+	for i, entry := range m {
 		if entry.name != "" {
 			n++
 			if first == nil {
-				first = &entry
+				first = &m[i]
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Instead of the first, the last entry was returned to pointerizing the range value.

Problem when quorum > 1 - only in scanner.

## Motivation and Context

Dangling objects would not be detected by scanner.

## How to test this PR?

Create dangling objects, observe scanner healing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
