### PR TITLE
helm: add namespace to StatefulSet

### DIFF
--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -38,6 +38,7 @@ apiVersion: {{ template "minio.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ template "minio.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}


### PR DESCRIPTION
## Description

Add namespace to StatefulSet generated by helm.

## Motivation and Context

Even if we specify the target namespace by `helm install --namespace`, the StatefulSet is created on the default namespace. Since this resource references the ServiceAccount created on the target namespace, pods are hindered to be created. To avoid this, we deploy the StatefulSet to the target namespace of helm.

## How to test this PR?

Generate manifest by like `helm template --namespace ns release .` and check the namespace of the StatefulSet resource.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
