### PR TITLE
Honor MINIO_REGION env in gateway

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -194,10 +194,15 @@ func (g *S3) new(creds madmin.Credentials, transport http.RoundTripper) (*miniog
 		chainCreds = NewChainCredentials(defaultProviders)
 	}
 
+	region := s3utils.GetRegionFromURL(*u)
+	if region == "" {
+		region = os.Getenv(config.EnvRegion)
+	}
+
 	optionsStaticCreds := &miniogo.Options{
 		Creds:        credentials.NewStaticV4(creds.AccessKey, creds.SecretKey, creds.SessionToken),
 		Secure:       secure,
-		Region:       s3utils.GetRegionFromURL(*u),
+		Region:       region,
 		BucketLookup: miniogo.BucketLookupAuto,
 		Transport:    transport,
 	}
@@ -205,7 +210,7 @@ func (g *S3) new(creds madmin.Credentials, transport http.RoundTripper) (*miniog
 	optionsChainCreds := &miniogo.Options{
 		Creds:        chainCreds,
 		Secure:       secure,
-		Region:       s3utils.GetRegionFromURL(*u),
+		Region:       region,
 		BucketLookup: miniogo.BucketLookupAuto,
 		Transport:    transport,
 	}


### PR DESCRIPTION
## Description

Honor MINIO_REGION env in S3 gateway

## Motivation and Context

Allows to gateway S3 providers with a specific region.
Fixes #7702 #7044 #12886

## How to test this PR?

Using another Minio server as backend which has region configured.

~ export MINIO_ACCESS_KEY=minio
~ export MINIO_SECRET_KEY=minio123
~ export MINIO_REGION=custom-region
~ minio server ~/data --address ":9001"

~ export MINIO_ACCESS_KEY=minio
~ export MINIO_SECRET_KEY=minio123
~ export MINIO_REGION=custom-region
~ minio gateway s3 http://localhost:9001

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
