### PR TITLE
Deprecate root disk for disk caching

### DIFF
--- a/internal/config/cache/config.go
+++ b/internal/config/cache/config.go
@@ -20,12 +20,10 @@ package cache
 import (
 	"encoding/json"
 	"errors"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/minio/minio/internal/config"
-	"github.com/minio/minio/internal/disk"
 	"github.com/minio/pkg/ellipses"
 )
 
@@ -117,19 +115,9 @@ func parseCacheDrives(drives string) ([]string, error) {
 			endpoints = append(endpoints, d)
 		}
 	}
-	isCICD := os.Getenv("MINIO_CI_CD") != "" || os.Getenv("CI") != ""
 	for _, d := range endpoints {
 		if !filepath.IsAbs(d) {
 			return nil, config.ErrInvalidCacheDrivesValue(nil).Msg("cache dir should be absolute path: %s", d)
-		}
-		if !isCICD {
-			rootDsk, err := disk.IsRootDisk(d, "/")
-			if err != nil {
-				return nil, config.ErrInvalidCacheDrivesValue(nil).Msg("Invalid cache dir %s err : %s", d, err.Error())
-			}
-			if rootDsk {
-				return nil, config.ErrInvalidCacheDrivesValue(nil).Msg("cache dir cannot be part of root disk: %s", d)
-			}
 		}
 	}
 	return endpoints, nil


### PR DESCRIPTION
- This PR modifies #14513 to issue a deprecation
warning rather than reject settings on startup.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
