### PR TITLE
add filesystem group change policy for large minio deployments

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -60,6 +60,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
 {{- end }}
 {{ if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -60,7 +60,9 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor 20) }}
         fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+        {{- end }}
 {{- end }}
 {{ if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -87,7 +87,9 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor 20) }}
         fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+        {{- end }}
 {{- end }}
 {{ if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -87,6 +87,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
 {{- end }}
 {{ if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -237,6 +237,7 @@ securityContext:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # Additational pod annotations
 podAnnotations: {}


### PR DESCRIPTION
## Description
This change adds `fsGroupChangePolicy: onRootMismatch` for helm based minio deployments. This basically allows minio to skip checking the fsgroup changes - which can be rather slow operation

## Motivation and Context
When using minio helm chart to deploy minio in Kubernetes cluster, if we have a large number of files in minio - e.g. greater than 300Gb, minio pod fails to come up due to PVC failing to get mounted.

We see below warning in kubelet logs for that node where pod is assigned:
```
W1220 05:32:58.485516    8703 volume_linux.go:52] Setting volume ownership for /var/lib/kubelet/pods/408ef833-2757-4807-a213-596706ddb0c5/volumes/kubernetes.io~vsphere-volume/pvc-573193ec-093a-4cd0-9f15-eed87faa3079 and fsGroup set. If the volume has a lot of files then setting volume ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699
```

Going through https://github.com/kubernetes/kubernetes/issues/69699 as suggested and [linked documentation](https://kubernetes.io/blog/2020/12/14/kubernetes-release-1.20-fsgroupchangepolicy-fsgrouppolicy/) - it is suggested that we should set below setting for minio container.

      securityContext:
        fsGroupChangePolicy: "OnRootMismatch"



## How to test this PR?
Deploy minio with a LOT of files in storage in kubernetes and delete the worker node so that minio is forced to move to different node.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
