### PR TITLE
allow MakeBucketLocation to work for metaBucket

### DIFF
--- a/cmd/erasure-bucket.go
+++ b/cmd/erasure-bucket.go
@@ -39,8 +39,10 @@ func (er erasureObjects) MakeBucketWithLocation(ctx context.Context, bucket stri
 	defer NSUpdated(bucket, slashSeparator)
 
 	// Verify if bucket is valid.
-	if err := s3utils.CheckValidBucketNameStrict(bucket); err != nil {
-		return BucketNameInvalid{Bucket: bucket}
+	if !isMinioMetaBucketName(bucket) {
+		if err := s3utils.CheckValidBucketNameStrict(bucket); err != nil {
+			return BucketNameInvalid{Bucket: bucket}
+		}
 	}
 
 	storageDisks := er.getDisks()

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -962,8 +962,11 @@ func (z *erasureServerPools) StartDecommission(ctx context.Context, idx int) (er
 		pathJoin(minioMetaBucket, minioConfigPrefix),
 		pathJoin(minioMetaBucket, bucketMetaPrefix),
 	} {
+		var bucketExists BucketExists
 		if err = z.MakeBucketWithLocation(ctx, metaBucket, BucketOptions{}); err != nil {
-			return err
+			if !errors.As(err, &bucketExists) {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
allow MakeBucketLocation to work for metaBucket

## Motivation and Context
decommission would fail to start due to failure
in MakeBucketLocation() error on .minio.sys/ bucket
creation.

Allow these special buckets.

## How to test this PR?
Start multiple pool setup and perform `mc admin decom start ..` 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression from #14497
- [ ] Documentation updated
- [ ] Unit tests added/updated
