### PR TITLE
Fix helm chart k8s version comparison

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-        {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor 20) }}
+        {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "20") }}
         fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
         {{- end }}
 {{- end }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -87,7 +87,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         runAsGroup: {{ .Values.securityContext.runAsGroup }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-        {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor 20) }}
+        {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "20") }}
         fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Fixes an issue with the helm chart trying to check the kubernetes version

## Motivation and Context

Bug was added here - https://github.com/minio/minio/pull/14528

The error message:

```
Error: template: charts/minio/templates/statefulset.yaml:90:61: executing "charts/minio/templates/statefulset.yaml" at <ge .Capabilities.KubeVersion.Minor 20>: error calling ge: incompatible types for comparison
```

## How to test this PR?

Deploy an instance of minio via the helm chart.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression - https://github.com/minio/minio/pull/14528
- [ ] Documentation updated
- [ ] Unit tests added/updated
