### PR TITLE
return correct context errors for locking operations

### DIFF
--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -170,6 +170,10 @@ func (di *distLockInstance) GetLock(ctx context.Context, timeout *dynamicTimeout
 	}) {
 		timeout.LogFailure()
 		cancel()
+		switch err := newCtx.Err(); err {
+		case context.Canceled:
+			return LockContext{ctx: ctx, cancel: func() {}}, err
+		}
 		return LockContext{ctx: ctx, cancel: func() {}}, OperationTimedOut{}
 	}
 	timeout.LogSuccess(UTCNow().Sub(start))
@@ -195,6 +199,10 @@ func (di *distLockInstance) GetRLock(ctx context.Context, timeout *dynamicTimeou
 	}) {
 		timeout.LogFailure()
 		cancel()
+		switch err := newCtx.Err(); err {
+		case context.Canceled:
+			return LockContext{ctx: ctx, cancel: func() {}}, err
+		}
 		return LockContext{ctx: ctx, cancel: func() {}}, OperationTimedOut{}
 	}
 	timeout.LogSuccess(UTCNow().Sub(start))
@@ -247,6 +255,10 @@ func (li *localLockInstance) GetLock(ctx context.Context, timeout *dynamicTimeou
 					li.ns.unlock(li.volume, li.paths[si], readLock)
 				}
 			}
+			switch err := ctx.Err(); err {
+			case context.Canceled:
+				return LockContext{}, err
+			}
 			return LockContext{}, OperationTimedOut{}
 		}
 		success[i] = 1
@@ -279,6 +291,10 @@ func (li *localLockInstance) GetRLock(ctx context.Context, timeout *dynamicTimeo
 				if sint == 1 {
 					li.ns.unlock(li.volume, li.paths[si], readLock)
 				}
+			}
+			switch err := ctx.Err(); err {
+			case context.Canceled:
+				return LockContext{}, err
 			}
 			return LockContext{}, OperationTimedOut{}
 		}


### PR DESCRIPTION


## Description
return correct context errors for locking operations

## Motivation and Context
if a context is canceled do not need to return a timeout error
instead, return the appropriate error for context canceled.

## How to test this PR?
Nothing special just special handling

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
