### PR TITLE
re-use transport for AdminInfo() call

### DIFF
--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -50,7 +50,7 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 			}
 			_, present := network[nodeName]
 			if !present {
-				if err := isServerResolvable(endpoint, 2*time.Second); err == nil {
+				if err := isServerResolvable(endpoint, 5*time.Second); err == nil {
 					network[nodeName] = string(madmin.ItemOnline)
 				} else {
 					network[nodeName] = string(madmin.ItemOffline)

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -121,31 +120,9 @@ func isServerResolvable(endpoint Endpoint, timeout time.Duration) error {
 		Path:   pathJoin(healthCheckPathPrefix, healthCheckLivenessPath),
 	}
 
-	var tlsConfig *tls.Config
-	if globalIsTLS {
-		tlsConfig = &tls.Config{
-			RootCAs: globalRootCAs,
-		}
-	}
-
 	httpClient := &http.Client{
-		Transport:
-		// For more details about various values used here refer
-		// https://golang.org/pkg/net/http/#Transport documentation
-		&http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			DialContext:           xhttp.NewCustomDialContext(3 * time.Second),
-			ResponseHeaderTimeout: 3 * time.Second,
-			TLSHandshakeTimeout:   3 * time.Second,
-			ExpectContinueTimeout: 3 * time.Second,
-			TLSClientConfig:       tlsConfig,
-			// Go net/http automatically unzip if content-type is
-			// gzip disable this feature, as we are always interested
-			// in raw stream.
-			DisableCompression: true,
-		},
+		Transport: globalInternodeTransport,
 	}
-	defer httpClient.CloseIdleConnections()
 
 	ctx, cancel := context.WithTimeout(GlobalContext, timeout)
 

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -63,7 +63,6 @@ type StorageAPI interface {
 	// returns 'nil' once healing is complete or if the disk
 	// has never been replaced.
 	Healing() *healingTracker
-
 	DiskInfo(ctx context.Context) (info DiskInfo, err error)
 	NSScanner(ctx context.Context, cache dataUsageCache, updates chan<- dataUsageEntry) (dataUsageCache, error)
 

--- a/internal/config/dns/operator_dns.go
+++ b/internal/config/dns/operator_dns.go
@@ -155,7 +155,6 @@ func (c *OperatorDNS) DeleteRecord(record SrvRecord) error {
 
 // Close closes the internal http client
 func (c *OperatorDNS) Close() error {
-	c.httpClient.CloseIdleConnections()
 	return nil
 }
 

--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -471,7 +471,6 @@ func parseDiscoveryDoc(u *xnet.URL, transport *http.Transport, closeRespFn func(
 	}
 	resp, err := clnt.Do(req)
 	if err != nil {
-		clnt.CloseIdleConnections()
 		return d, err
 	}
 	defer closeRespFn(resp.Body)

--- a/internal/event/target/webhook.go
+++ b/internal/event/target/webhook.go
@@ -228,8 +228,6 @@ func (target *WebhookTarget) Send(eventKey string) error {
 
 // Close - does nothing and available for interface compatibility.
 func (target *WebhookTarget) Close() error {
-	// Close idle connection with "keep-alive" states
-	target.httpClient.CloseIdleConnections()
 	return nil
 }
 


### PR DESCRIPTION

## Description
re-use transport for AdminInfo() call

## Motivation and Context
avoids creating new transport for each `isServerResolvable`
request, instead re-use the available global transport and do
not try to forcibly close connections to avoid TIME_WAIT
build upon large clusters.

Never use httpClient.CloseIdleConnections() since that can have
a drastic effect on existing connections on the transport pool.

Remove it everywhere.

## How to test this PR?
No easier way, but a constant `mc admin info` call with many 
servers running you may potentially see delays because of
new transports being used as the newer connections that
get established on Linux become slower.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
