### PR TITLE
use nAgreed in partial() listing to ignore quickly

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -100,12 +100,14 @@ func init() {
 		PersistOnFailure: false,
 	}
 
+	containers := IsKubernetes() || IsDocker() || IsBOSH() || IsDCOS() || IsPCFTile()
+
 	// Call to refresh will refresh names in cache. If you pass true, it will also
 	// remove cached names not looked up since the last call to Refresh. It is a good idea
 	// to call this method on a regular interval.
 	go func() {
 		var t *time.Ticker
-		if IsKubernetes() || IsDocker() || IsBOSH() || IsDCOS() || IsPCFTile() {
+		if containers {
 			t = time.NewTicker(1 * time.Minute)
 		} else {
 			t = time.NewTicker(10 * time.Minute)


### PR DESCRIPTION
## Description
use nAgreed in partial() listing to ignore quickly 

## Motivation and Context
no need to spend time resolving list entries
when nAgreed is already less than quorum.

## How to test this PR?
Optimization

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
