### PR TITLE
Fix waitgroup add after wait on config reload

### DIFF
--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -128,9 +128,6 @@ func acceptedResponseStatusCode(code int) bool {
 }
 
 func (h *Target) logEntry(entry interface{}) {
-	h.wg.Add(1)
-	defer h.wg.Done()
-
 	logJSON, err := json.Marshal(&entry)
 	if err != nil {
 		return
@@ -181,6 +178,8 @@ func (h *Target) startHTTPLogger() {
 	// Create a routine which sends json logs received
 	// from an internal channel.
 	go func() {
+		h.wg.Add(1)
+		defer h.wg.Done()
 		for entry := range h.logCh {
 			h.logEntry(entry)
 		}

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	sarama "github.com/Shopify/sarama"
+	"github.com/Shopify/sarama"
 	saramatls "github.com/Shopify/sarama/tools/tls"
 
 	"github.com/minio/minio/internal/logger/message/audit"
@@ -62,9 +62,6 @@ func (h *Target) Send(entry interface{}, errKind string) error {
 }
 
 func (h *Target) logEntry(entry interface{}) {
-	h.wg.Add(1)
-	defer h.wg.Done()
-
 	logJSON, err := json.Marshal(&entry)
 	if err != nil {
 		return
@@ -90,6 +87,8 @@ func (h *Target) startKakfaLogger() {
 	// Create a routine which sends json logs received
 	// from an internal channel.
 	go func() {
+		h.wg.Add(1)
+		defer h.wg.Done()
 		for entry := range h.logCh {
 			h.logEntry(entry)
 		}


### PR DESCRIPTION
## Description

Fix `panic: "POST /minio/peer/v21/signalservice?signal=2": sync: WaitGroup is reused before previous Wait has returned`

Log entries already on the channel would cause `logEntry` to increment the waitgroup when sending messages, after Cancel has been called.

Instead of tracking every single message, just check the send goroutine. Faster and safe, since it will not decrement until the channel is closed.

Regression from #14289

## How to test this PR?

Update audit targets on loaded, running system.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Fixes a regression #14289
