### PR TITLE
fallback quorum should be "strict" globally if config is not loaded

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -190,7 +190,7 @@ var (
 	globalBucketTargetSys    *BucketTargetSys
 	// globalAPIConfig controls S3 API requests throttling,
 	// healthcheck readiness deadlines and cors settings.
-	globalAPIConfig = apiConfig{listQuorum: 3}
+	globalAPIConfig = apiConfig{listQuorum: -1}
 
 	globalStorageClass storageclass.Config
 	globalLDAPConfig   xldap.Config


### PR DESCRIPTION
## Description
fallback quorum should be "strict" globally if config is not loaded

## Motivation and Context
"strict" should be set globally as well.

## How to test this PR?
in-case config is not loaded make sure we have expected defaults.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
