### PR TITLE
Add riscv64 support

### DIFF
--- a/internal/kernel/kernel_utsname_uint8.go
+++ b/internal/kernel/kernel_utsname_uint8.go
@@ -15,8 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build (linux && arm) || (linux && ppc64) || (linux && ppc64le) || (linux && s390x)
-// +build linux,arm linux,ppc64 linux,ppc64le linux,s390x
+//go:build (linux && arm) || (linux && ppc64) || (linux && ppc64le) || (linux && s390x)|| (linux && riscv64)
+// +build linux,arm linux,ppc64 linux,ppc64le linux,s390x linux,riscv64
 
 package kernel
 


### PR DESCRIPTION
## Description

In riscv64, the `syscall.Uname` function will return a uint8 slice. This is tested in the Arch Linux RISC-V 64 QEMU environment.

```go
func main() {
      var buf syscall.Utsname
	  syscall.Uname(&buf)
      fmt.Printf("Buffer Type: %T\n", buf.Release)
}
```

```console
$ go build . && ./test
Buffer Type: [65]uint8
$ uname -m
riscv64
```

## Motivation and Context

I am now trying to make minio run on Arch Linux RISC-V, and this package fail to build because of the `utsnameStr` is not compile. This patch should help improve this issue.

## How to test this PR?

You can follow this instruction to setup a QEMU environment https://github.com/felixonmars/archriscv-packages/wiki/Setup-Arch-Linux-RISC-V-Development-Environment.

Then copy the source code into the qemu machine and run:

```console
pacman -Syu go
cd minio
go build .
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
