### PR TITLE
Do not wait for results when listing is canceled

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -189,7 +189,11 @@ func (o *listPathOptions) gatherResults(ctx context.Context, in <-chan metaCache
 		}
 		if resCh != nil {
 			resErr = io.EOF
-			resCh <- results
+			select {
+			case <-ctx.Done():
+				// Nobody wants it.
+			case resCh <- results:
+			}
 		}
 	}()
 	return func() (metaCacheEntriesSorted, error) {


### PR DESCRIPTION
## Description

When canceled nobody may be listening for the results.

Prevents memory buildup from cancelled requests.

## How to test this PR?

Issue listing requests, do not read then even if available and close the connection.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
