### PR TITLE
odd stripe sizes should choose (odd+1)/2 to get the correct quorum

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -547,8 +547,8 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions, resul
 
 	// Special case: ask all disks if the drive count is 4
 	if askDisks <= 0 || er.setDriveCount == 4 {
-		askDisks = len(disks)          // with 'strict' quorum list on all online disks.
-		listingQuorum = len(disks) / 2 // keep this such that we can list all objects with different quorum ratio.
+		askDisks = len(disks)                // with 'strict' quorum list on all online disks.
+		listingQuorum = (len(disks) + 1) / 2 // keep this such that we can list all objects with different quorum ratio.
 	}
 	if askDisks > 0 && len(disks) > askDisks {
 		rand.Shuffle(len(disks), func(i, j int) {


### PR DESCRIPTION
## Description
odd stripe sizes should choose (odd+1)/2 to get the correct quorum

## Motivation and Context
listing quorum was wrong with odd stripe set deployments. 

## How to test this PR?
Create an inconsistent state on the disk and observe the listing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
