### PR TITLE
Set ownerid/ownerdisplayname through envoirnment variables 

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -418,8 +418,8 @@ func generateListBucketsResponse(buckets []BucketInfo) ListBucketsResponse {
 	listbuckets := make([]Bucket, 0, len(buckets))
 	data := ListBucketsResponse{}
 	owner := Owner{
-		ID:          globalMinioDefaultOwnerID,
-		DisplayName: "minio",
+		ID:          globalMinioOwnerID,
+		DisplayName: globalMinioOwnerDisplayName,
 	}
 
 	for _, bucket := range buckets {
@@ -439,8 +439,8 @@ func generateListBucketsResponse(buckets []BucketInfo) ListBucketsResponse {
 func generateListVersionsResponse(bucket, prefix, marker, versionIDMarker, delimiter, encodingType string, maxKeys int, resp ListObjectVersionsInfo) ListVersionsResponse {
 	versions := make([]ObjectVersion, 0, len(resp.Objects))
 	owner := Owner{
-		ID:          globalMinioDefaultOwnerID,
-		DisplayName: "minio",
+		ID:          globalMinioOwnerID,
+		DisplayName: globalMinioOwnerDisplayName,
 	}
 	data := ListVersionsResponse{}
 
@@ -497,8 +497,8 @@ func generateListVersionsResponse(bucket, prefix, marker, versionIDMarker, delim
 func generateListObjectsV1Response(bucket, prefix, marker, delimiter, encodingType string, maxKeys int, resp ListObjectsInfo) ListObjectsResponse {
 	contents := make([]Object, 0, len(resp.Objects))
 	owner := Owner{
-		ID:          globalMinioDefaultOwnerID,
-		DisplayName: "minio",
+		ID:          globalMinioOwnerID,
+		DisplayName: globalMinioOwnerDisplayName,
 	}
 	data := ListObjectsResponse{}
 
@@ -546,8 +546,8 @@ func generateListObjectsV1Response(bucket, prefix, marker, delimiter, encodingTy
 func generateListObjectsV2Response(bucket, prefix, token, nextToken, startAfter, delimiter, encodingType string, fetchOwner, isTruncated bool, maxKeys int, objects []ObjectInfo, prefixes []string, metadata bool) ListObjectsV2Response {
 	contents := make([]Object, 0, len(objects))
 	owner := Owner{
-		ID:          globalMinioDefaultOwnerID,
-		DisplayName: "minio",
+		ID:          globalMinioOwnerID,
+		DisplayName: globalMinioOwnerDisplayName,
 	}
 	data := ListObjectsV2Response{}
 
@@ -662,12 +662,12 @@ func generateListPartsResponse(partsInfo ListPartsInfo, encodingType string) Lis
 
 	// Dumb values not meaningful
 	listPartsResponse.Initiator = Initiator{
-		ID:          globalMinioDefaultOwnerID,
-		DisplayName: globalMinioDefaultOwnerID,
+		ID:          globalMinioOwnerID,
+		DisplayName: globalMinioOwnerID,
 	}
 	listPartsResponse.Owner = Owner{
-		ID:          globalMinioDefaultOwnerID,
-		DisplayName: globalMinioDefaultOwnerID,
+		ID:          globalMinioOwnerID,
+		DisplayName: globalMinioOwnerID,
 	}
 
 	listPartsResponse.MaxParts = partsInfo.MaxParts

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -418,8 +418,8 @@ func generateListBucketsResponse(buckets []BucketInfo) ListBucketsResponse {
 	listbuckets := make([]Bucket, 0, len(buckets))
 	data := ListBucketsResponse{}
 	owner := Owner{
-		ID:          globalMinioOwnerID,
-		DisplayName: globalMinioOwnerDisplayName,
+		ID:          globalOwnerID,
+		DisplayName: globalOwnerDisplayName,
 	}
 
 	for _, bucket := range buckets {
@@ -439,8 +439,8 @@ func generateListBucketsResponse(buckets []BucketInfo) ListBucketsResponse {
 func generateListVersionsResponse(bucket, prefix, marker, versionIDMarker, delimiter, encodingType string, maxKeys int, resp ListObjectVersionsInfo) ListVersionsResponse {
 	versions := make([]ObjectVersion, 0, len(resp.Objects))
 	owner := Owner{
-		ID:          globalMinioOwnerID,
-		DisplayName: globalMinioOwnerDisplayName,
+		ID:          globalOwnerID,
+		DisplayName: globalOwnerDisplayName,
 	}
 	data := ListVersionsResponse{}
 
@@ -497,8 +497,8 @@ func generateListVersionsResponse(bucket, prefix, marker, versionIDMarker, delim
 func generateListObjectsV1Response(bucket, prefix, marker, delimiter, encodingType string, maxKeys int, resp ListObjectsInfo) ListObjectsResponse {
 	contents := make([]Object, 0, len(resp.Objects))
 	owner := Owner{
-		ID:          globalMinioOwnerID,
-		DisplayName: globalMinioOwnerDisplayName,
+		ID:          globalOwnerID,
+		DisplayName: globalOwnerDisplayName,
 	}
 	data := ListObjectsResponse{}
 
@@ -546,8 +546,8 @@ func generateListObjectsV1Response(bucket, prefix, marker, delimiter, encodingTy
 func generateListObjectsV2Response(bucket, prefix, token, nextToken, startAfter, delimiter, encodingType string, fetchOwner, isTruncated bool, maxKeys int, objects []ObjectInfo, prefixes []string, metadata bool) ListObjectsV2Response {
 	contents := make([]Object, 0, len(objects))
 	owner := Owner{
-		ID:          globalMinioOwnerID,
-		DisplayName: globalMinioOwnerDisplayName,
+		ID:          globalOwnerID,
+		DisplayName: globalOwnerDisplayName,
 	}
 	data := ListObjectsV2Response{}
 
@@ -662,12 +662,12 @@ func generateListPartsResponse(partsInfo ListPartsInfo, encodingType string) Lis
 
 	// Dumb values not meaningful
 	listPartsResponse.Initiator = Initiator{
-		ID:          globalMinioOwnerID,
-		DisplayName: globalMinioOwnerID,
+		ID:          globalOwnerID,
+		DisplayName: globalOwnerID,
 	}
 	listPartsResponse.Owner = Owner{
-		ID:          globalMinioOwnerID,
-		DisplayName: globalMinioOwnerID,
+		ID:          globalOwnerID,
+		DisplayName: globalOwnerID,
 	}
 
 	listPartsResponse.MaxParts = partsInfo.MaxParts

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -660,6 +660,9 @@ func handleCommonEnvVars() {
 		logger.Fatal(config.ErrInvalidFSOSyncValue(err), "Invalid MINIO_FS_OSYNC value in environment variable")
 	}
 
+	globalMinioOwnerID = env.Get(config.EnvMinioOwnerId, globalMinioDefaultOwnerID)
+	globalMinioOwnerDisplayName = env.Get(config.EnvMinioOwnerDisplayName, globalMinioDefaultOwnerDisplayName)
+
 	if rootDiskSize := env.Get(config.EnvRootDiskThresholdSize, ""); rootDiskSize != "" {
 		size, err := humanize.ParseBytes(rootDiskSize)
 		if err != nil {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -660,6 +660,9 @@ func handleCommonEnvVars() {
 		logger.Fatal(config.ErrInvalidFSOSyncValue(err), "Invalid MINIO_FS_OSYNC value in environment variable")
 	}
 
+	globalOwnerID = env.Get(config.EnvOwnerId, globalMinioDefaultOwnerID)
+	globalOwnerDisplayName = env.Get(config.EnvOwnerDisplayName, globalMinioDefaultOwnerDisplayName)
+
 	if rootDiskSize := env.Get(config.EnvRootDiskThresholdSize, ""); rootDiskSize != "" {
 		size, err := humanize.ParseBytes(rootDiskSize)
 		if err != nil {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -68,16 +68,17 @@ const (
 	//    It is 64-character obfuscated version of the account ID.
 	// ```
 	// http://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example4.html
-	globalMinioDefaultOwnerID      = "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
-	globalMinioDefaultStorageClass = "STANDARD"
-	globalWindowsOSName            = "windows"
-	globalMacOSName                = "darwin"
-	globalMinioModeFS              = "mode-server-fs"
-	globalMinioModeErasure         = "mode-server-xl"
-	globalMinioModeDistErasure     = "mode-server-distributed-xl"
-	globalMinioModeGatewayPrefix   = "mode-gateway-"
-	globalDirSuffix                = "__XLDIR__"
-	globalDirSuffixWithSlash       = globalDirSuffix + slashSeparator
+	globalMinioDefaultOwnerID          = "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
+	globalMinioDefaultOwnerDisplayName = "minio"
+	globalMinioDefaultStorageClass     = "STANDARD"
+	globalWindowsOSName                = "windows"
+	globalMacOSName                    = "darwin"
+	globalMinioModeFS                  = "mode-server-fs"
+	globalMinioModeErasure             = "mode-server-xl"
+	globalMinioModeDistErasure         = "mode-server-distributed-xl"
+	globalMinioModeGatewayPrefix       = "mode-gateway-"
+	globalDirSuffix                    = "__XLDIR__"
+	globalDirSuffixWithSlash           = globalDirSuffix + slashSeparator
 
 	// Add new global values here.
 )
@@ -347,9 +348,10 @@ var (
 	globalRootDiskThreshold uint64
 
 	// Used for collecting stats for netperf
-	globalNetPerfMinDuration = time.Second * 10
-	globalNetPerfRX          netPerfRX
-
+	globalNetPerfMinDuration    = time.Second * 10
+	globalNetPerfRX             netPerfRX
+	globalMinioOwnerID          = globalMinioDefaultOwnerID
+	globalMinioOwnerDisplayName = globalMinioDefaultOwnerDisplayName
 	// Add new variable global values here.
 )
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -68,16 +68,17 @@ const (
 	//    It is 64-character obfuscated version of the account ID.
 	// ```
 	// http://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example4.html
-	globalMinioDefaultOwnerID      = "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
-	globalMinioDefaultStorageClass = "STANDARD"
-	globalWindowsOSName            = "windows"
-	globalMacOSName                = "darwin"
-	globalMinioModeFS              = "mode-server-fs"
-	globalMinioModeErasure         = "mode-server-xl"
-	globalMinioModeDistErasure     = "mode-server-distributed-xl"
-	globalMinioModeGatewayPrefix   = "mode-gateway-"
-	globalDirSuffix                = "__XLDIR__"
-	globalDirSuffixWithSlash       = globalDirSuffix + slashSeparator
+	globalMinioDefaultOwnerID          = "02d6176db174dc93cb1b899f7c6078f08654445fe8cf1b6ce98d8855f66bdbf4"
+	globalMinioDefaultOwnerDisplayName = "minio"
+	globalMinioDefaultStorageClass     = "STANDARD"
+	globalWindowsOSName                = "windows"
+	globalMacOSName                    = "darwin"
+	globalMinioModeFS                  = "mode-server-fs"
+	globalMinioModeErasure             = "mode-server-xl"
+	globalMinioModeDistErasure         = "mode-server-distributed-xl"
+	globalMinioModeGatewayPrefix       = "mode-gateway-"
+	globalDirSuffix                    = "__XLDIR__"
+	globalDirSuffixWithSlash           = globalDirSuffix + slashSeparator
 
 	// Add new global values here.
 )
@@ -350,6 +351,9 @@ var (
 	globalNetPerfMinDuration = time.Second * 10
 	globalNetPerfRX          netPerfRX
 
+	//Use to set custom owner id and display name
+	globalOwnerID          = globalMinioDefaultOwnerID
+	globalOwnerDisplayName = globalMinioDefaultOwnerDisplayName
 	// Add new variable global values here.
 )
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -74,4 +74,7 @@ const (
 	EnvWorm       = "MINIO_WORM"        // legacy
 	EnvRegion     = "MINIO_REGION"      // legacy
 	EnvRegionName = "MINIO_REGION_NAME" // legacy
+
+	EnvOwnerId          = "MINIO_OWNER_ID"
+	EnvOwnerDisplayName = "MINIO_OWNER_DISPLAY_NAME"
 )

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -74,4 +74,7 @@ const (
 	EnvWorm       = "MINIO_WORM"        // legacy
 	EnvRegion     = "MINIO_REGION"      // legacy
 	EnvRegionName = "MINIO_REGION_NAME" // legacy
+
+	EnvMinioOwnerId          = "MINIO_OWNER_ID"
+	EnvMinioOwnerDisplayName = "MINIO_OWNER_DISPLAY_NAME"
 )


### PR DESCRIPTION
## Description
Set custom owner id and display name through environment variables. The following two variables are used for this purpose:
MINIO_OWNER_ID
MINIO_OWNER_DISPLAY_NAME 

## Motivation and Context
Hardcoded OwnerId is almost useless in the current scenario. Providing method, just in case someone wants to set a custom owner id 

## How to test this PR?
export MINIO_OWNER_ID="{UUID of 64 lenght}"
export MINIO_OWNER_DISPLAY_NAME="test"
minio server /data

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
