### PR TITLE
request only at max 1 version for latest version resolution

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -571,6 +571,13 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions, resul
 		bucket:    o.Bucket,
 	}
 
+	// Maximum versions requested for "latest" object
+	// resolution on versioned buckets, this is to be only
+	// used when o.Versioned is false
+	if !o.Versioned {
+		resolver.requestedVersions = 1
+	}
+
 	ctxDone := ctx.Done()
 	return listPathRaw(ctx, listPathRawOptions{
 		disks:         disks,


### PR DESCRIPTION

## Description
request only at max 1 version for latest version resolution

## Motivation and Context
ListObjects, ListObjectsV2 calls are being heavily taxed when
there are many versions of objects leftover from a previous
release or ILM was never set up to clean them up. Instead
of being absolutely correct at resolving the exact latest
version of an object, we simply rely on the topmost 1
version.

Once we have obtained the top most "1" version for
ListObject, ListObjectsV2 call we break out fast.

## How to test this PR?
CI/CD should cover the current unit tests. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
