### PR TITLE
do not crash when KMS is not enabled

### DIFF
--- a/internal/crypto/sse-kms.go
+++ b/internal/crypto/sse-kms.go
@@ -96,6 +96,10 @@ func (ssekms) IsEncrypted(metadata map[string]string) bool {
 // from the metadata using KMS and returns the decrypted object
 // key.
 func (s3 ssekms) UnsealObjectKey(KMS kms.KMS, metadata map[string]string, bucket, object string) (key ObjectKey, err error) {
+	if KMS == nil {
+		return key, Errorf("KMS not configured")
+	}
+
 	keyID, kmsKey, sealedKey, ctx, err := s3.ParseMetadata(metadata)
 	if err != nil {
 		return key, err

--- a/internal/crypto/sse-s3.go
+++ b/internal/crypto/sse-s3.go
@@ -72,6 +72,9 @@ func (sses3) IsEncrypted(metadata map[string]string) bool {
 // from the metadata using KMS and returns the decrypted object
 // key.
 func (s3 sses3) UnsealObjectKey(KMS kms.KMS, metadata map[string]string, bucket, object string) (key ObjectKey, err error) {
+	if KMS == nil {
+		return key, Errorf("KMS not configured")
+	}
 	keyID, kmsKey, sealedKey, err := s3.ParseMetadata(metadata)
 	if err != nil {
 		return key, err
@@ -90,6 +93,10 @@ func (s3 sses3) UnsealObjectKey(KMS kms.KMS, metadata map[string]string, bucket,
 //
 // The metadata, buckets and objects slices must have the same length.
 func (s3 sses3) UnsealObjectKeys(KMS kms.KMS, metadata []map[string]string, buckets, objects []string) ([]ObjectKey, error) {
+	if KMS == nil {
+		return nil, Errorf("KMS not configured")
+	}
+
 	if len(metadata) != len(buckets) || len(metadata) != len(objects) {
 		return nil, Errorf("invalid metadata/object count: %d != %d != %d", len(metadata), len(buckets), len(objects))
 	}


### PR DESCRIPTION
## Description
do not crash when KMS is not enabled

## Motivation and Context
KMS when not enabled might crash when listing
an object that previously had SSE-S3 enabled,
fail appropriately in such situations.

## How to test this PR?
Create some data when KMS was enabled and then disable KMS (list the content)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
