### PR TITLE
Always get the actual object size in bulk SSE-S3

### DIFF
--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -163,6 +163,8 @@ func DecryptETags(ctx context.Context, KMS kms.KMS, objects []ObjectInfo, batchS
 			if err != nil {
 				return err
 			}
+			objects[i].Size = size
+
 			ETag, err := etag.Parse(objects[i].ETag)
 			if err != nil {
 				return err
@@ -173,7 +175,6 @@ func DecryptETags(ctx context.Context, KMS kms.KMS, objects []ObjectInfo, batchS
 					return err
 				}
 				ETag = etag.ETag(tag)
-				objects[i].Size = size
 				objects[i].ETag = ETag.String()
 			}
 		}


### PR DESCRIPTION
## Description
In bulk ETag decryption, do not rely on the etag to check if it is
encrypted or not to decide if we should set the actual object size in
ObjectInfo. The reason is that multipart objects ETags are not
encrypted.

Always get the actual object size in that case.

## Motivation and Context
Fix size in listing of multipart objects when SSE-S3 is enabled

## How to test this PR?
Create a MinIO deployment with one bucket with SSE-S3 as default encryption
Upload a multipart object and check its size with mc ls command

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
