### PR TITLE
fix: multiple pool setup return incorrect DeleteMarker metadata

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -820,6 +820,11 @@ func (z *erasureServerPools) getLatestObjectInfoWithIdx(ctx context.Context, buc
 			// should be returned upwards.
 			return res.oi, res.zIdx, err
 		}
+		// When its a delete marker and versionID is empty
+		// we should simply return the error right away.
+		if res.oi.DeleteMarker && opts.VersionID == "" {
+			return res.oi, res.zIdx, err
+		}
 	}
 
 	object = decodeDirObject(object)


### PR DESCRIPTION
## Description
fix: multiple pool setup return incorrect DeleteMarker metadata

## Motivation and Context
DeleteMarker metadata returned is incorrect

## How to test this PR?
Create multiple pool setup and a versioned bucket with `delete-marker` created 
`mc stat --debug` would not return correct metadata. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression
- [ ] Documentation updated
- [ ] Unit tests added/updated
