### PR TITLE
Validate tier manager is initialized in tier Empty() check

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1651,11 +1651,11 @@ func getClusterTierMetrics() *MetricsGroup {
 		cacheInterval: 10 * time.Second,
 	}
 	mg.RegisterRead(func(ctx context.Context) (metrics []Metric) {
-		if globalTierConfigMgr.Empty() {
-			return
-		}
 		objLayer := newObjectLayerFn()
 		if objLayer == nil || globalIsGateway {
+			return
+		}
+		if globalTierConfigMgr.Empty() {
 			return
 		}
 

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -148,6 +148,9 @@ func (config *TierConfigMgr) Verify(ctx context.Context, tier string) error {
 
 // Empty returns if tier targets are empty
 func (config *TierConfigMgr) Empty() bool {
+	if config == nil {
+		return true
+	}
 	return len(config.ListTiers()) == 0
 }
 


### PR DESCRIPTION
## Description


## Motivation and Context
SIGSEGV reported due to metrics being called before the tier manager is initialized

```
Mar 28 14:53:35 : panic: runtime error: invalid memory address or nil pointer dereference
Mar 28 14:53:35 : [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1e4d9f7]
Mar 28 14:53:35 : goroutine 168 [running]:
Mar 28 14:53:35 : github.com/minio/minio/cmd.(*TierConfigMgr).ListTiers(0x1ea1c7c)
Mar 28 14:53:35 :         github.com/minio/minio/cmd/tier.go:156 +0x57
Mar 28 14:53:35 : github.com/minio/minio/cmd.(*TierConfigMgr).Empty(...)
Mar 28 14:53:35 :         github.com/minio/minio/cmd/tier.go:151
Mar 28 14:53:35 : github.com/minio/minio/cmd.getClusterTierMetrics.func1({0x1e5b620, 0xc0012b4668})
Mar 28 14:53:35 :         github.com/minio/minio/cmd/metrics-v2.go:1654 +0x35
Mar 28 14:53:35 : github.com/minio/minio/cmd.(*MetricsGroup).RegisterRead.func1.1()
Mar 28 14:53:35 :         github.com/minio/minio/cmd/metrics-v2.go:235 +0x2b
Mar 28 14:53:35 : github.com/minio/minio/cmd.(*timedValue).Get(0xc0012b4620)
Mar 28 14:53:35 :         github.com/minio/minio/cmd/utils.go:948 +0x32
Mar 28 14:53:35 : github.com/minio/minio/cmd.(*MetricsGroup).Get(0x0)
Mar 28 14:53:35 :         github.com/minio/minio/cmd/metrics-v2.go:270 +0x3f
Mar 28 14:53:35 : github.com/minio/minio/cmd.populateAndPublish({0xc00004c580, 0xf, 0x0}, 0xc0013c7fa8)
Mar 28 14:53:35 :         github.com/minio/minio/cmd/metrics-v2.go:1924 +0x66
Mar 28 14:53:35 : github.com/minio/minio/cmd.ReportMetrics.func1()
Mar 28 14:53:35 :         github.com/minio/minio/cmd/metrics-v2.go:1889 +0x98
Mar 28 14:53:35 : created by github.com/minio/minio/cmd.ReportMetrics
Mar 28 14:53:35 :         github.com/minio/minio/cmd/metrics-v2.go:1887 +0xf0
```
## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
