### PR TITLE
kes: add support for encrypted private keys

### DIFF
--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -120,6 +120,20 @@ Encrypted :
   X-Amz-Server-Side-Encryption: AES256
 ```
 
+## Encrypted Private Key
+
+MinIO supports encrypted KES client private keys. Therefore, you can use
+an password-protected private keys for `MINIO_KMS_KES_KEY_FILE`. 
+
+When using password-protected private keys for accessing KES you need to
+provide the password via:
+```
+export MINIO_KMS_KES_KEY_PASSWORD=<your-password>
+``` 
+
+Note that MinIO only supports encrypted private keys - not encrypted certificates.
+Certificates are no secrets and sent in plaintext as part of the TLS handshake.
+
 ## Explore Further
 
 - [Use `mc` with MinIO Server](https://docs.min.io/docs/minio-client-quickstart-guide)

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -62,13 +62,14 @@ const (
 
 	EnvUpdate = "MINIO_UPDATE"
 
-	EnvKMSSecretKey     = "MINIO_KMS_SECRET_KEY"
-	EnvKMSSecretKeyFile = "MINIO_KMS_SECRET_KEY_FILE"
-	EnvKESEndpoint      = "MINIO_KMS_KES_ENDPOINT"
-	EnvKESKeyName       = "MINIO_KMS_KES_KEY_NAME"
-	EnvKESClientKey     = "MINIO_KMS_KES_KEY_FILE"
-	EnvKESClientCert    = "MINIO_KMS_KES_CERT_FILE"
-	EnvKESServerCA      = "MINIO_KMS_KES_CAPATH"
+	EnvKMSSecretKey      = "MINIO_KMS_SECRET_KEY"
+	EnvKMSSecretKeyFile  = "MINIO_KMS_SECRET_KEY_FILE"
+	EnvKESEndpoint       = "MINIO_KMS_KES_ENDPOINT"
+	EnvKESKeyName        = "MINIO_KMS_KES_KEY_NAME"
+	EnvKESClientKey      = "MINIO_KMS_KES_KEY_FILE"
+	EnvKESClientPassword = "MINIO_KMS_KES_KEY_PASSWORD"
+	EnvKESClientCert     = "MINIO_KMS_KES_CERT_FILE"
+	EnvKESServerCA       = "MINIO_KMS_KES_CAPATH"
 
 	EnvEndpoints  = "MINIO_ENDPOINTS"   // legacy
 	EnvWorm       = "MINIO_WORM"        // legacy


### PR DESCRIPTION
## Description
This commit adds support for encrypted KES
client private keys.

Now, it is possible to encrypt the KES client
private key (`MINIO_KMS_KES_KEY_FILE`) with
a password.

For example, KES CLI already supports the
creation of encrypted private keys:
```
kes identity new --encrypt --key client.key --cert client.crt MinIO
```

To decrypt an encrypted private key, the password
needs to be provided:
```
MINIO_KMS_KES_KEY_PASSWORD=<password>
```

## Motivation and Context
KMS, KES

## How to test this PR?
1. Point KES CLI to play:
   ```sh
   export KES_SERVER=https://play.min.io:7373 
   export KES_CLIENT_CERT=root.cert 
   export KES_CLIENT_KEY=root.key
   ```
   > You can download the `root.key` and `root.cert` via:
   >  ```sh
   >  curl -sSL --tlsv1.2 \ 
   >       -O 'https://raw.githubusercontent.com/minio/kes/master/root.key' \
   >       -O 'https://raw.githubusercontent.com/minio/kes/master/root.cert'
   > ```
2.  Generate encrypted client private key and certificate:
     ```sh
     kes identity new --encrypt --key /tmp/client.key --cert /tmp/client.crt MinIO
     ```
3. Assign the printed identity to the MinIO policy:
   ```sh
   kes policy assign minio <your-identity>
   ```
4. Start MinIO
   ```
   export MINIO_ROOT_USER=minio 
   export MINIO_ROOT_PASSWORD=minio123 
   export MINIO_KMS_KES_ENDPOINT=https://127.0.0.1:7373 
   export MINIO_KMS_KES_KEY_FILE=/tmp/client.key 
   export MINIO_KMS_KES_CERT_FILE=/tmp/client.crt 
   export MINIO_KMS_KES_KEY_NAME=my-minio-key
   
   export MINIO_KMS_KES_KEY_PASSWORD=<your-password>
   ```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
