### PR TITLE
Allow decomission of pool even if a drive in it is down

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -804,13 +804,7 @@ func (z *erasureServerPools) getDecommissionPoolSpaceInfo(idx int) (pi poolSpace
 	if idx+1 > len(z.serverPools) {
 		return pi, errInvalidArgument
 	}
-	info, errs := z.serverPools[idx].StorageInfo(context.Background())
-	for _, err := range errs {
-		if err != nil {
-			return pi, errInvalidArgument
-		}
-	}
-	info.Backend = z.BackendInfo()
+	info, _ := z.serverPools[idx].StorageInfo(context.Background())
 	for _, disk := range info.Disks {
 		if disk.Healing {
 			return pi, decomError{


### PR DESCRIPTION
## Description
If a drive is down "mc admin decom status/list" fail on that pool.

## Motivation and Context
Allow decom of a pool even if a drive is failed.

## How to test this PR?
try:
mc admin decom status ALIAS
mc admin decom status ALIAS POOL


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
