### PR TITLE
Get the BackendInfo to fill the apporpriate struct fields

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -805,6 +805,7 @@ func (z *erasureServerPools) getDecommissionPoolSpaceInfo(idx int) (pi poolSpace
 		return pi, errInvalidArgument
 	}
 	info, _ := z.serverPools[idx].StorageInfo(context.Background())
+	info.Backend = z.BackendInfo()
 	for _, disk := range info.Disks {
 		if disk.Healing {
 			return pi, decomError{


### PR DESCRIPTION
I had removed the line added in this PR by mistake in the previous PR https://github.com/minio/minio/pull/14656/commits/6184a03b4a387954e17628b8051b5f750db7524e


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated