### PR TITLE
listing: improve listing of encrypted objects

### DIFF
--- a/cmd/bucket-listobjects-handlers.go
+++ b/cmd/bucket-listobjects-handlers.go
@@ -19,12 +19,12 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
-	"github.com/minio/minio/internal/kms"
 	"github.com/minio/minio/internal/logger"
 
 	"github.com/minio/pkg/bucket/policy"
@@ -100,7 +100,8 @@ func (api objectAPIHandlers) ListObjectVersionsHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	if err = DecryptETags(ctx, GlobalKMS, listObjectVersionsInfo.Objects, kms.BatchSize()); err != nil {
+	if err = DecryptETags(ctx, GlobalKMS, listObjectVersionsInfo.Objects); err != nil {
+		logger.LogIf(ctx, fmt.Errorf("Failed to decrypt ETag: %v", err)) // TODO(aead): Remove once we are confident that decryption does not fail accidentially
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
@@ -165,7 +166,8 @@ func (api objectAPIHandlers) ListObjectsV2MHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if err = DecryptETags(ctx, GlobalKMS, listObjectsV2Info.Objects, kms.BatchSize()); err != nil {
+	if err = DecryptETags(ctx, GlobalKMS, listObjectsV2Info.Objects); err != nil {
+		logger.LogIf(ctx, fmt.Errorf("Failed to decrypt ETag: %v", err)) // TODO(aead): Remove once we are confident that decryption does not fail accidentially
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
@@ -243,7 +245,8 @@ func (api objectAPIHandlers) ListObjectsV2Handler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if err = DecryptETags(ctx, GlobalKMS, listObjectsV2Info.Objects, kms.BatchSize()); err != nil {
+	if err = DecryptETags(ctx, GlobalKMS, listObjectsV2Info.Objects); err != nil {
+		logger.LogIf(ctx, fmt.Errorf("Failed to decrypt ETag: %v", err)) // TODO(aead): Remove once we are confident that decryption does not fail accidentially
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
@@ -343,7 +346,8 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if err = DecryptETags(ctx, GlobalKMS, listObjectsInfo.Objects, kms.BatchSize()); err != nil {
+	if err = DecryptETags(ctx, GlobalKMS, listObjectsInfo.Objects); err != nil {
+		logger.LogIf(ctx, fmt.Errorf("Failed to decrypt ETag: %v", err)) // TODO(aead): Remove once we are confident that decryption does not fail accidentially
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -386,13 +386,13 @@ func getHostFromSrv(records []dns.SrvRecord) (host string) {
 }
 
 // IsCompressed returns true if the object is marked as compressed.
-func (o ObjectInfo) IsCompressed() bool {
+func (o *ObjectInfo) IsCompressed() bool {
 	_, ok := o.UserDefined[ReservedMetadataPrefix+"compression"]
 	return ok
 }
 
 // IsCompressedOK returns whether the object is compressed and can be decompressed.
-func (o ObjectInfo) IsCompressedOK() (bool, error) {
+func (o *ObjectInfo) IsCompressedOK() (bool, error) {
 	scheme, ok := o.UserDefined[ReservedMetadataPrefix+"compression"]
 	if !ok {
 		return false, nil
@@ -404,17 +404,8 @@ func (o ObjectInfo) IsCompressedOK() (bool, error) {
 	return true, fmt.Errorf("unknown compression scheme: %s", scheme)
 }
 
-// GetActualETag - returns the actual etag of the stored object
-// decrypts SSE objects.
-func (o ObjectInfo) GetActualETag(h http.Header) string {
-	if _, ok := crypto.IsEncrypted(o.UserDefined); !ok {
-		return o.ETag
-	}
-	return getDecryptedETag(h, o, false)
-}
-
 // GetActualSize - returns the actual size of the stored object
-func (o ObjectInfo) GetActualSize() (int64, error) {
+func (o *ObjectInfo) GetActualSize() (int64, error) {
 	if o.IsCompressed() {
 		sizeStr, ok := o.UserDefined[ReservedMetadataPrefix+"actual-size"]
 		if !ok {

--- a/internal/crypto/sse-s3.go
+++ b/internal/crypto/sse-s3.go
@@ -92,7 +92,7 @@ func (s3 sses3) UnsealObjectKey(KMS kms.KMS, metadata map[string]string, bucket,
 // keys.
 //
 // The metadata, buckets and objects slices must have the same length.
-func (s3 sses3) UnsealObjectKeys(KMS kms.KMS, metadata []map[string]string, buckets, objects []string) ([]ObjectKey, error) {
+func (s3 sses3) UnsealObjectKeys(ctx context.Context, KMS kms.KMS, metadata []map[string]string, buckets, objects []string) ([]ObjectKey, error) {
 	if KMS == nil {
 		return nil, Errorf("KMS not configured")
 	}
@@ -124,7 +124,7 @@ func (s3 sses3) UnsealObjectKeys(KMS kms.KMS, metadata []map[string]string, buck
 		for i := range buckets {
 			contexts = append(contexts, kms.Context{buckets[i]: path.Join(buckets[i], objects[i])})
 		}
-		unsealKeys, err := KMS.DecryptAll(keyIDs[0], kmsKeys, contexts)
+		unsealKeys, err := KMS.DecryptAll(ctx, keyIDs[0], kmsKeys, contexts)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/kms/kes.go
+++ b/internal/kms/kes.go
@@ -162,7 +162,7 @@ func (c *kesClient) DecryptKey(keyID string, ciphertext []byte, ctx Context) ([]
 	return c.client.Decrypt(context.Background(), keyID, ciphertext, ctxBytes)
 }
 
-func (c *kesClient) DecryptAll(keyID string, ciphertexts [][]byte, contexts []Context) ([][]byte, error) {
+func (c *kesClient) DecryptAll(ctx context.Context, keyID string, ciphertexts [][]byte, contexts []Context) ([][]byte, error) {
 	if c.bulkAvailable {
 		CCPs := make([]kes.CCP, 0, len(ciphertexts))
 		for i := range ciphertexts {
@@ -175,7 +175,7 @@ func (c *kesClient) DecryptAll(keyID string, ciphertexts [][]byte, contexts []Co
 				Context:    bCtx,
 			})
 		}
-		PCPs, err := c.client.DecryptAll(context.Background(), keyID, CCPs...)
+		PCPs, err := c.client.DecryptAll(ctx, keyID, CCPs...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -18,12 +18,11 @@
 package kms
 
 import (
+	"context"
 	"encoding"
 	"encoding/json"
-	"strconv"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/minio/pkg/env"
 )
 
 // KMS is the generic interface that abstracts over
@@ -57,19 +56,7 @@ type KMS interface {
 	// DecryptAll decrypts all ciphertexts with the key referenced
 	// by the key ID. The contexts must match the context value
 	// used to generate the ciphertexts.
-	DecryptAll(keyID string, ciphertext [][]byte, context []Context) ([][]byte, error)
-}
-
-// BatchSize returns the size of the batches that should be used during
-// KES bulk decryption API calls.
-func BatchSize() int {
-	const DefaultBatchSize = 500
-	v := env.Get("MINIO_KMS_KES_BULK_API_BATCH_SIZE", strconv.Itoa(DefaultBatchSize))
-	n, err := strconv.Atoi(v)
-	if err != nil {
-		return DefaultBatchSize
-	}
-	return n
+	DecryptAll(ctx context.Context, keyID string, ciphertext [][]byte, context []Context) ([][]byte, error)
 }
 
 // Status describes the current state of a KMS.

--- a/internal/kms/single-key.go
+++ b/internal/kms/single-key.go
@@ -18,6 +18,7 @@
 package kms
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
@@ -224,7 +225,7 @@ func (kms secretKey) DecryptKey(keyID string, ciphertext []byte, context Context
 	return plaintext, nil
 }
 
-func (kms secretKey) DecryptAll(keyID string, ciphertexts [][]byte, contexts []Context) ([][]byte, error) {
+func (kms secretKey) DecryptAll(_ context.Context, keyID string, ciphertexts [][]byte, contexts []Context) ([][]byte, error) {
 	plaintexts := make([][]byte, 0, len(ciphertexts))
 	for i := range ciphertexts {
 		plaintext, err := kms.DecryptKey(keyID, ciphertexts[i], contexts[i])


### PR DESCRIPTION
## Description    
This commit improves the listing of encrypted objects:
   - Use `etag.Format` and `etag.Decrypt`
   - Detect SSE-S3 single-part objects in a single iteration
   - Fix batch size to `250`
   - Pass request context to `DecryptAll` to not waste resources
     when a client cancels the operation.

## Motivation and Context
SSE-S3, ETags

## How to test this PR?
No behavior should have changed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
