### PR TITLE
fix: solve the problem of setting openid through the console

### DIFF
--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -547,10 +547,12 @@ func LookupConfig(kvs config.KVS, transport *http.Transport, closeRespFn func(io
 	c = Config{
 		RWMutex:            &sync.RWMutex{},
 		ClaimName:          env.Get(EnvIdentityOpenIDClaimName, kvs.Get(ClaimName)),
-		ClaimUserinfo:      env.Get(EnvIdentityOpenIDClaimUserInfo, kvs.Get(ClaimUserinfo)) == config.EnableOn,
+		ClaimUserinfo:      env.Get(EnvIdentityOpenIDClaimUserInfo, kvs.Get(ClaimUserinfo)) == config.EnableOn ||
+			env.Get(EnvIdentityOpenIDClaimUserInfo, kvs.Get(ClaimUserinfo)) == "true",
 		ClaimPrefix:        env.Get(EnvIdentityOpenIDClaimPrefix, kvs.Get(ClaimPrefix)),
 		RedirectURI:        env.Get(EnvIdentityOpenIDRedirectURI, kvs.Get(RedirectURI)),
-		RedirectURIDynamic: env.Get(EnvIdentityOpenIDRedirectURIDynamic, kvs.Get(RedirectURIDynamic)) == config.EnableOn,
+		RedirectURIDynamic: env.Get(EnvIdentityOpenIDRedirectURIDynamic, kvs.Get(RedirectURIDynamic)) == config.EnableOn ||
+			env.Get(EnvIdentityOpenIDRedirectURIDynamic, kvs.Get(RedirectURIDynamic)) == "true",
 		publicKeys:         make(map[string]crypto.PublicKey),
 		ClientID:           env.Get(EnvIdentityOpenIDClientID, kvs.Get(ClientID)),
 		ClientSecret:       env.Get(EnvIdentityOpenIDClientSecret, kvs.Get(ClientSecret)),


### PR DESCRIPTION
## Description
When saving the `Openid Configuration`, Some properties do not take effect, such as: 'claim userinfo' and 'redirecturidynamic'. The Console will send the value of `'true'` to the back-end, but the back-end will judge that it will be true only when it is `'on'`. Therefore, setting the property of `Radio(on|off)` type through the console is invalid.

## Motivation and Context


## How to test this PR?
Open the `Console - > Setting - > Identity Openid` and click the `Claim Userinfo` option

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
