### PR TITLE
make sure to pass Lifecycle if set for List filtering

### DIFF
--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -291,9 +291,9 @@ func (z *erasureServerPools) listMerged(ctx context.Context, o listPathOptions, 
 	mu.Unlock()
 
 	// Do lifecycle filtering.
-	if o.lcFilter != nil {
+	if o.Lifecycle != nil {
 		filterIn := make(chan metaCacheEntry, 10)
-		go filterLifeCycle(ctx, o.Bucket, o.lcFilter, filterIn, results)
+		go filterLifeCycle(ctx, o.Bucket, o.Lifecycle, filterIn, results)
 		// Replace results.
 		results = filterIn
 	}
@@ -381,6 +381,8 @@ func filterLifeCycle(ctx context.Context, bucket string, lc *lifecycle.Lifecycle
 		action := evalActionFromLifecycle(ctx, *lc, objInfo, false)
 		switch action {
 		case lifecycle.DeleteVersionAction, lifecycle.DeleteAction:
+			fallthrough
+		case lifecycle.DeleteRestoredAction, lifecycle.DeleteRestoredVersionAction:
 			// Skip this entry.
 			continue
 		}

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -93,13 +93,13 @@ type listPathOptions struct {
 	// Versioned is this a ListObjectVersions call.
 	Versioned bool
 
-	// pool and set of where the cache is located.
-	pool, set int
-
-	// lcFilter performs filtering based on lifecycle.
+	// Lifecycle performs filtering based on lifecycle.
 	// This will filter out objects if the most recent version should be deleted by lifecycle.
 	// Is not transferred across request calls.
-	lcFilter *lifecycle.Lifecycle
+	Lifecycle *lifecycle.Lifecycle
+
+	// pool and set of where the cache is located.
+	pool, set int
 }
 
 func init() {


### PR DESCRIPTION

## Description
make sure to pass Lifecycle if set for List filtering

## Motivation and Context
PR #14606 never really passed the Lifecycle filter
down to the listing callers to ensure skipping the
entries.

## How to test this PR?
Expire some objects and set ILM

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
