### PR TITLE
Fix service account privilege escalation

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -605,7 +605,6 @@ func (a adminAPIHandlers) AddServiceAccount(w http.ResponseWriter, r *http.Reque
 			ConditionValues: getConditionValues(r, "", cred.AccessKey, claims),
 			IsOwner:         owner,
 			Claims:          claims,
-			DenyOnly:        true,
 		}) {
 			writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrAccessDenied), r.URL)
 			return

--- a/cmd/admin-handlers-users_test.go
+++ b/cmd/admin-handlers-users_test.go
@@ -890,6 +890,9 @@ func (s *TestSuiteIAM) TestServiceAccountOpsByUser(c *check) {
 
 	// 5. Check that service account can be deleted.
 	c.assertSvcAccDeletion(ctx, s, userAdmClient, accessKey, bucket)
+
+	// 6. Check that service account cannot be created for some other user.
+	c.mustNotCreateSvcAccount(ctx, globalActiveCred.AccessKey, userAdmClient)
 }
 
 func (s *TestSuiteIAM) TestServiceAccountOpsByAdmin(c *check) {

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -625,6 +625,9 @@ func (s *TestSuiteIAM) TestLDAPSTSServiceAccounts(c *check) {
 
 	// 5. Check that service account can be deleted.
 	c.assertSvcAccDeletion(ctx, s, userAdmClient, value.AccessKeyID, bucket)
+
+	// 6. Check that service account cannot be created for some other user.
+	c.mustNotCreateSvcAccount(ctx, globalActiveCred.AccessKey, userAdmClient)
 }
 
 // In this test, the parent users gets their permissions from a group, rather
@@ -725,6 +728,9 @@ func (s *TestSuiteIAM) TestLDAPSTSServiceAccountsWithGroups(c *check) {
 
 	// 5. Check that service account can be deleted.
 	c.assertSvcAccDeletion(ctx, s, userAdmClient, value.AccessKeyID, bucket)
+
+	// 6. Check that service account cannot be created for some other user.
+	c.mustNotCreateSvcAccount(ctx, globalActiveCred.AccessKey, userAdmClient)
 }
 
 func (s *TestSuiteIAM) TestOpenIDSTS(c *check) {
@@ -979,6 +985,9 @@ func (s *TestSuiteIAM) TestOpenIDServiceAcc(c *check) {
 
 	// 5. Check that service account can be deleted.
 	c.assertSvcAccDeletion(ctx, s, userAdmClient, value.AccessKeyID, bucket)
+
+	// 6. Check that service account cannot be created for some other user.
+	c.mustNotCreateSvcAccount(ctx, globalActiveCred.AccessKey, userAdmClient)
 }
 
 var testAppParams = OpenIDClientAppParams{


### PR DESCRIPTION
## Description

- Ensure that a regular unprivileged user is unable to create service accounts
for other users/root.

This fix includes tests to check this scenario is not possible.

## Motivation and Context

Fixes a security issue where an unprivileged user is able to create service accounts for root or other user and then is able to assume their access policies via the generated credentials.

This is a regression that has existed since version RELEASE.2021-12-09T06-19-41Z.

## How to test this PR?

```
mc admin user add myminio foo foobar123
mc admin policy set myminio readonly user=foo
MC_HOST_foo=http://foo:foobar123@localhost:9000 mc admin user svcacct add foo someOtherUser
```

The last command above should fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (introduced in https://github.com/minio/minio/pull/13849)
- [ ] Documentation updated
- [x] Unit tests added/updated
