### PR TITLE
fix: IAM reload should only list at config/iam/ precisely

### DIFF
--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -407,15 +407,15 @@ func (iamOS *IAMObjectStore) loadMappedPolicies(ctx context.Context, userType IA
 }
 
 var (
-	usersListKey                   = "/users/"
-	svcAccListKey                  = "/service-accounts/"
-	groupsListKey                  = "/groups/"
-	policiesListKey                = "/policies/"
-	stsListKey                     = "/sts/"
-	policyDBUsersListKey           = "/policydb/users/"
-	policyDBSTSUsersListKey        = "/policydb/sts-users/"
-	policyDBServiceAccountsListKey = "/policydb/service-accounts/"
-	policyDBGroupsListKey          = "/policydb/groups/"
+	usersListKey                   = "users/"
+	svcAccListKey                  = "service-accounts/"
+	groupsListKey                  = "groups/"
+	policiesListKey                = "policies/"
+	stsListKey                     = "sts/"
+	policyDBUsersListKey           = "policydb/users/"
+	policyDBSTSUsersListKey        = "policydb/sts-users/"
+	policyDBServiceAccountsListKey = "policydb/service-accounts/"
+	policyDBGroupsListKey          = "policydb/groups/"
 
 	allListKeys = []string{
 		usersListKey,
@@ -433,7 +433,7 @@ var (
 func (iamOS *IAMObjectStore) listAllIAMConfigItems(ctx context.Context) (map[string][]string, error) {
 	res := make(map[string][]string)
 
-	for item := range listIAMConfigItems(ctx, iamOS.objAPI, iamConfigPrefix) {
+	for item := range listIAMConfigItems(ctx, iamOS.objAPI, iamConfigPrefix+SlashSeparator) {
 		if item.Err != nil {
 			return nil, item.Err
 		}
@@ -448,7 +448,7 @@ func (iamOS *IAMObjectStore) listAllIAMConfigItems(ctx context.Context) (map[str
 			}
 		}
 
-		if !found && !(item.Item == "config/config.json" || item.Item == "/format.json" || strings.Contains(item.Item, "config/history/")) {
+		if !found && (item.Item != "format.json") {
 			logger.LogIf(ctx, fmt.Errorf("unknown type of IAM file listed: %v", item.Item))
 		}
 	}


### PR DESCRIPTION
## Description
fix: IAM reload should only list at config/iam/ precisely

## Motivation and Context
only list entries that are needed.

## How to test this PR?
Run IAM with tiering configured

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
