### PR TITLE
Bring back listing LDAP users temporarly

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -130,6 +130,18 @@ func (a adminAPIHandlers) ListUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Add ldap users which have mapped policies if in LDAP mode
+	// FIXME(vadmeste): move this to policy info in the future
+	ldapUsers, err := globalIAMSys.ListLDAPUsers()
+	if err != nil && err != errIAMActionNotAllowed {
+		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
+		return
+	}
+	for k, v := range ldapUsers {
+		allCredentials[k] = v
+	}
+
+	// Marshal the response
 	data, err := json.Marshal(allCredentials)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)

--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -1184,6 +1184,18 @@ func (store *IAMStoreSys) GetUsers() map[string]madmin.UserInfo {
 	return result
 }
 
+// GetUsersWithMappedPolicies - safely returns the name of access keys with associated policies
+func (store *IAMStoreSys) GetUsersWithMappedPolicies() map[string]string {
+	cache := store.rlock()
+	defer store.runlock()
+
+	result := make(map[string]string)
+	for k, v := range cache.iamUserPolicyMap {
+		result[k] = v.Policies
+	}
+	return result
+}
+
 // GetUserInfo - get info on a user.
 func (store *IAMStoreSys) GetUserInfo(name string) (u madmin.UserInfo, err error) {
 	if name == "" {

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -694,6 +694,28 @@ func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
 	return sys.store.GetUsers(), nil
 }
 
+// ListLDAPUsers - list LDAP users which has
+func (sys *IAMSys) ListLDAPUsers() (map[string]madmin.UserInfo, error) {
+	if !sys.Initialized() {
+		return nil, errServerNotInitialized
+	}
+
+	if sys.usersSysType != LDAPUsersSysType {
+		return nil, errIAMActionNotAllowed
+	}
+
+	<-sys.configLoaded
+
+	ldapUsers := make(map[string]madmin.UserInfo)
+	for user, policy := range sys.store.GetUsersWithMappedPolicies() {
+		ldapUsers[user] = madmin.UserInfo{
+			PolicyName: policy,
+			Status:     madmin.AccountEnabled,
+		}
+	}
+	return ldapUsers, nil
+}
+
 // IsTempUser - returns if given key is a temporary user.
 func (sys *IAMSys) IsTempUser(name string) (bool, string, error) {
 	if !sys.Initialized() {

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -476,8 +476,12 @@ func (s *TestSuiteIAM) TestLDAPSTS(c *check) {
 	if err != nil {
 		c.Fatalf("list users should not fail: %v", err)
 	}
-	if len(usersList) > 0 {
-		c.Fatalf("expected listing to be empty: %v", usersList)
+	if len(usersList) != 1 {
+		c.Fatalf("expected user listing output: %v", usersList)
+	}
+	uinfo := usersList[userDN]
+	if uinfo.PolicyName != policy || uinfo.Status != madmin.AccountEnabled {
+		c.Fatalf("expected user listing content: %v", uinfo)
 	}
 
 	// Validate that the client from sts creds can access the bucket.


### PR DESCRIPTION
## Description
In previous releases, mc admin user list would return the list of users
that have policies mapped in IAM database. However, this was removed but
this commit will bring it back until we revmap this.


## Motivation and Context
Revert back mc admin user list to list LDAP users with associated policies

## How to test this PR?
- Have an LDAP server with a user in it
- Start MinIO with a configured LDAP
- List users with mc admin user list myminio

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
