### PR TITLE
fix: replication deleteObject() regression and CopyObject() behavior

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1118,10 +1118,10 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	var chStorageClass bool
-	if dstSc != "" {
+	if dstSc != "" && dstSc != srcInfo.StorageClass {
 		chStorageClass = true
 		srcInfo.metadataOnly = false
-	}
+	} // no changes in storage-class expected so its a metadataonly operation.
 
 	var reader io.Reader = gr
 


### PR DESCRIPTION


## Description
fix: replication deleteObject() regression and CopyObject() behavior

## Motivation and Context
This PR fixes two issues

- The first fix is a regression from #14555, the fix itself in #14555
  is correct but the interpretation of that information by the
  object layer code for "replication" was not correct. This PR
  tries to fix this situation by making sure the "Delete" replication
  works as expected when "VersionPurgeStatus" is already set.

  Without this fix, there is a DELETE marker created incorrectly on
  the source where the "DELETE" was triggered.

- The second fix is perhaps an older problem started since we inlined-data
  on the disk for small objects, CopyObject() incorrectly inline's
  a non-inlined data. This is due to the fact that we have code where
  we read the `part.1` under certain conditions where the size of the
  `part.1` is less than the specific "threshold".

  This eventually causes problems when we are "deleting" the data that
  is only inlined, which means dataDir is ignored leaving such
  dataDir on the disk, that looks like an inconsistent content on
  the namespace.

fixes #14767

## How to test this PR?
```sh
#!/bin/bash

export CI=true

rm -rf /tmp/xl*
pkill minio

(minio server --address ":9000" /tmp/xl{1...4})&

(minio server --address ":9001" /tmp/xl{5...8})&

sleep 5

export MC_HOST_minio1=http://minioadmin:minioadmin@localhost:9000
export MC_HOST_minio2=http://minioadmin:minioadmin@localhost:9001

mc admin replicate add minio1 minio2

base64 /dev/urandom | head -c 50000 > test-obj.txt

mc mb minio1/test-replication-bucket
mc cp test-obj.txt minio1/test-replication-bucket/
mc tag set --versions minio1/test-replication-bucket/test-obj.txt "mytag=testtag"

sleep 5

mc rm -r --force --versions minio1/test-replication-bucket/

mc ls --versions --json minio2/test-replication-bucket/
mc ls --versions --json minio1/test-replication-bucket/
```

This script reproduces the problem with the master branch

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
