### PR TITLE
start using t.SetEnv instead of os.Setenv

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,8 @@ linters:
     - varcheck
     - gocritic
     - gofumpt
+    - tenv
+    - durationcheck
 
 linters-settings:
   gofumpt:

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -115,19 +115,17 @@ func TestDownloadURL(t *testing.T) {
 		}
 	}
 
-	os.Setenv("KUBERNETES_SERVICE_HOST", "10.11.148.5")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.11.148.5")
 	durl = getDownloadURL(minioVersion1)
 	if durl != kubernetesDeploymentDoc {
 		t.Errorf("Expected %s, got %s", kubernetesDeploymentDoc, durl)
 	}
-	os.Unsetenv("KUBERNETES_SERVICE_HOST")
 
-	os.Setenv("MESOS_CONTAINER_NAME", "mesos-1111")
+	t.Setenv("MESOS_CONTAINER_NAME", "mesos-1111")
 	durl = getDownloadURL(minioVersion1)
 	if durl != mesosDeploymentDoc {
 		t.Errorf("Expected %s, got %s", mesosDeploymentDoc, durl)
 	}
-	os.Unsetenv("MESOS_CONTAINER_NAME")
 }
 
 // Tests user agent string.
@@ -162,10 +160,13 @@ func TestUserAgent(t *testing.T) {
 		sci := globalIsCICD
 		globalIsCICD = false
 
-		os.Setenv(testCase.envName, testCase.envValue)
-		if testCase.envName == "MESOS_CONTAINER_NAME" {
-			os.Setenv("MARATHON_APP_LABEL_DCOS_PACKAGE_VERSION", "mesos-1111")
+		if testCase.envName != "" {
+			t.Setenv(testCase.envName, testCase.envValue)
+			if testCase.envName == "MESOS_CONTAINER_NAME" {
+				t.Setenv("MARATHON_APP_LABEL_DCOS_PACKAGE_VERSION", "mesos-1111")
+			}
 		}
+
 		str := getUserAgent(testCase.mode)
 		expectedStr := testCase.expectedStr
 		if IsDocker() {
@@ -188,12 +189,11 @@ func TestIsDCOS(t *testing.T) {
 		globalIsCICD = sci
 	}()
 
-	os.Setenv("MESOS_CONTAINER_NAME", "mesos-1111")
+	t.Setenv("MESOS_CONTAINER_NAME", "mesos-1111")
 	dcos := IsDCOS()
 	if !dcos {
 		t.Fatalf("Expected %t, got %t", true, dcos)
 	}
-
 	os.Unsetenv("MESOS_CONTAINER_NAME")
 	dcos = IsDCOS()
 	if dcos {
@@ -209,12 +209,13 @@ func TestIsKubernetes(t *testing.T) {
 		globalIsCICD = sci
 	}()
 
-	os.Setenv("KUBERNETES_SERVICE_HOST", "10.11.148.5")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.11.148.5")
 	kubernetes := IsKubernetes()
 	if !kubernetes {
 		t.Fatalf("Expected %t, got %t", true, kubernetes)
 	}
 	os.Unsetenv("KUBERNETES_SERVICE_HOST")
+
 	kubernetes = IsKubernetes()
 	if kubernetes {
 		t.Fatalf("Expected %t, got %t", false, kubernetes)

--- a/internal/config/certs_test.go
+++ b/internal/config/certs_test.go
@@ -181,6 +181,9 @@ M9ofSEt/bdRD
 }
 
 func TestLoadX509KeyPair(t *testing.T) {
+	t.Cleanup(func() {
+		os.Unsetenv(EnvCertPassword)
+	})
 	for i, testCase := range loadX509KeyPairTests {
 		privateKey, err := createTempFile("private.key", testCase.privateKey)
 		if err != nil {
@@ -192,9 +195,8 @@ func TestLoadX509KeyPair(t *testing.T) {
 			t.Fatalf("Test %d: failed to create tmp certificate file: %v", i, err)
 		}
 
-		os.Unsetenv(EnvCertPassword)
 		if testCase.password != "" {
-			os.Setenv(EnvCertPassword, testCase.password)
+			t.Setenv(EnvCertPassword, testCase.password)
 		}
 		_, err = LoadX509KeyPair(certificate, privateKey)
 		if err != nil && !testCase.shouldFail {

--- a/internal/s3select/select_test.go
+++ b/internal/s3select/select_test.go
@@ -1655,8 +1655,7 @@ func TestCSVRanges(t *testing.T) {
 }
 
 func TestParquetInput(t *testing.T) {
-	os.Setenv("MINIO_API_SELECT_PARQUET", "on")
-	defer os.Setenv("MINIO_API_SELECT_PARQUET", "off")
+	t.Setenv("MINIO_API_SELECT_PARQUET", "on")
 
 	testTable := []struct {
 		requestXML     []byte
@@ -1757,8 +1756,7 @@ func TestParquetInput(t *testing.T) {
 }
 
 func TestParquetInputSchema(t *testing.T) {
-	os.Setenv("MINIO_API_SELECT_PARQUET", "on")
-	defer os.Setenv("MINIO_API_SELECT_PARQUET", "off")
+	t.Setenv("MINIO_API_SELECT_PARQUET", "on")
 
 	testTable := []struct {
 		requestXML []byte
@@ -1860,8 +1858,7 @@ func TestParquetInputSchema(t *testing.T) {
 }
 
 func TestParquetInputSchemaCSV(t *testing.T) {
-	os.Setenv("MINIO_API_SELECT_PARQUET", "on")
-	defer os.Setenv("MINIO_API_SELECT_PARQUET", "off")
+	t.Setenv("MINIO_API_SELECT_PARQUET", "on")
 
 	testTable := []struct {
 		requestXML []byte


### PR DESCRIPTION
## Description
start using t.SetEnv instead of os.Setenv

## Motivation and Context
just using more cleaner interfaces for tests

## How to test this PR?
Nothing should change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
