### PR TITLE
standardize config help defaults

### DIFF
--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -21,82 +21,86 @@ import "github.com/minio/minio/internal/config"
 
 // Help template for storageclass feature.
 var (
+	defaultHelpPostfix = func(key string) string {
+		return config.DefaultHelpPostfix(DefaultKVS, key)
+	}
+
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         apiRequestsMax,
-			Description: `set the maximum number of concurrent requests, e.g. "1600"`,
+			Description: `set the maximum number of concurrent requests` + defaultHelpPostfix(apiRequestsMax),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         apiRequestsDeadline,
-			Description: `set the deadline for API requests waiting to be processed e.g. "1m"`,
+			Description: `set the deadline for API requests waiting to be processed` + defaultHelpPostfix(apiRequestsDeadline),
 			Optional:    true,
 			Type:        "duration",
 		},
 		config.HelpKV{
 			Key:         apiClusterDeadline,
-			Description: `set the deadline for cluster readiness check e.g. "10s"`,
+			Description: `set the deadline for cluster readiness check` + defaultHelpPostfix(apiClusterDeadline),
 			Optional:    true,
 			Type:        "duration",
 		},
 		config.HelpKV{
 			Key:         apiCorsAllowOrigin,
-			Description: `set comma separated list of origins allowed for CORS requests e.g. "https://example1.com,https://example2.com"`,
+			Description: `set comma separated list of origins allowed for CORS requests` + defaultHelpPostfix(apiCorsAllowOrigin),
 			Optional:    true,
 			Type:        "csv",
 		},
 		config.HelpKV{
 			Key:         apiRemoteTransportDeadline,
-			Description: `set the deadline for API requests on remote transports while proxying between federated instances e.g. "2h"`,
+			Description: `set the deadline for API requests on remote transports while proxying between federated instances e.g. "2h"` + defaultHelpPostfix(apiRemoteTransportDeadline),
 			Optional:    true,
 			Type:        "duration",
 		},
 		config.HelpKV{
 			Key:         apiListQuorum,
-			Description: `set the acceptable quorum expected for list operations e.g. "optimal", "reduced", "disk", "strict", defaults to "strict"`,
+			Description: `set the acceptable quorum expected for list operations e.g. "optimal", "reduced", "disk", "strict"` + defaultHelpPostfix(apiListQuorum),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         apiReplicationWorkers,
-			Description: `set the number of replication workers, defaults to 100`,
+			Description: `set the number of replication workers` + defaultHelpPostfix(apiReplicationWorkers),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         apiReplicationFailedWorkers,
-			Description: `set the number of replication workers for recently failed replicas, defaults to 4`,
+			Description: `set the number of replication workers for recently failed replicas` + defaultHelpPostfix(apiReplicationFailedWorkers),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         apiTransitionWorkers,
-			Description: `set the number of transition workers, defaults to 100`,
+			Description: `set the number of transition workers` + defaultHelpPostfix(apiTransitionWorkers),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         apiStaleUploadsExpiry,
-			Description: `set to expire stale multipart uploads older than this value, defaults to 24 hours`,
+			Description: `set to expire stale multipart uploads older than this values` + defaultHelpPostfix(apiStaleUploadsExpiry),
 			Optional:    true,
 			Type:        "duration",
 		},
 		config.HelpKV{
 			Key:         apiStaleUploadsCleanupInterval,
-			Description: `set to change intervals when stale multipart uploads are expired, defaults to every 6 hours`,
+			Description: `set to change intervals when stale multipart uploads are expired` + defaultHelpPostfix(apiStaleUploadsCleanupInterval),
 			Optional:    true,
 			Type:        "duration",
 		},
 		config.HelpKV{
 			Key:         apiDeleteCleanupInterval,
-			Description: `set to change intervals when deleted objects are permanently deleted from ".trash" folder, defaults to every 5 minutes`,
+			Description: `set to change intervals when deleted objects are permanently deleted from ".trash" folder` + defaultHelpPostfix(apiDeleteCleanupInterval),
 			Optional:    true,
 			Type:        "duration",
 		},
 		config.HelpKV{
 			Key:         apiDisableODirect,
-			Description: "set to disable O_DIRECT for reads under special conditions. NOTE: it is not recommended to disable O_DIRECT without prior testing.",
+			Description: "set to disable O_DIRECT for reads under special conditions. NOTE: it is not recommended to disable O_DIRECT without prior testing." + defaultHelpPostfix(apiDisableODirect),
 			Optional:    true,
 			Type:        "boolean",
 		},

--- a/internal/config/cache/help.go
+++ b/internal/config/cache/help.go
@@ -21,57 +21,61 @@ import "github.com/minio/minio/internal/config"
 
 // Help template for caching feature.
 var (
+	defaultHelpPostfix = func(key string) string {
+		return config.DefaultHelpPostfix(DefaultKVS, key)
+	}
+
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         Drives,
-			Description: `comma separated mountpoints e.g. "/optane1,/optane2"`,
+			Description: `comma separated mountpoints e.g. "/optane1,/optane2"` + defaultHelpPostfix(Drives),
 			Type:        "csv",
 		},
 		config.HelpKV{
 			Key:         Expiry,
-			Description: `cache expiry duration in days e.g. "90"`,
+			Description: `cache expiry duration in days` + defaultHelpPostfix(Expiry),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         Quota,
-			Description: `limit cache drive usage in percentage e.g. "90"`,
+			Description: `limit cache drive usage in percentage` + defaultHelpPostfix(Quota),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         Exclude,
-			Description: `exclude cache for following patterns e.g. "bucket/*.tmp,*.exe"`,
+			Description: `exclude cache for following patterns e.g. "bucket/*.tmp,*.exe"` + defaultHelpPostfix(Exclude),
 			Optional:    true,
 			Type:        "csv",
 		},
 		config.HelpKV{
 			Key:         After,
-			Description: `minimum number of access before caching an object`,
+			Description: `minimum number of access before caching an object` + defaultHelpPostfix(After),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         WatermarkLow,
-			Description: `% of cache use at which to stop cache eviction`,
+			Description: `% of cache use at which to stop cache eviction` + defaultHelpPostfix(WatermarkLow),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         WatermarkHigh,
-			Description: `% of cache use at which to start cache eviction`,
+			Description: `% of cache use at which to start cache eviction` + defaultHelpPostfix(WatermarkHigh),
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         Range,
-			Description: `set to "on" or "off" caching of independent range requests per object, defaults to "on"`,
+			Description: `set to "on" or "off" caching of independent range requests per object` + defaultHelpPostfix(Range),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         Commit,
-			Description: `set to control cache commit behavior, defaults to "writethrough"`,
+			Description: `set to control cache commit behavior` + defaultHelpPostfix(Commit),
 			Optional:    true,
 			Type:        "string",
 		},

--- a/internal/config/compress/help.go
+++ b/internal/config/compress/help.go
@@ -21,16 +21,20 @@ import "github.com/minio/minio/internal/config"
 
 // Help template for compress feature.
 var (
+	defaultHelpPostfix = func(key string) string {
+		return config.DefaultHelpPostfix(DefaultKVS, key)
+	}
+
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         Extensions,
-			Description: `comma separated file extensions e.g. ".txt,.log,.csv"`,
+			Description: `comma separated file extensions` + defaultHelpPostfix(Extensions),
 			Optional:    true,
 			Type:        "csv",
 		},
 		config.HelpKV{
 			Key:         MimeTypes,
-			Description: `comma separated wildcard mime-types e.g. "text/*,application/json,application/xml"`,
+			Description: `comma separated wildcard mime-types` + defaultHelpPostfix(MimeTypes),
 			Optional:    true,
 			Type:        "csv",
 		},

--- a/internal/config/etcd/help.go
+++ b/internal/config/etcd/help.go
@@ -21,35 +21,39 @@ import "github.com/minio/minio/internal/config"
 
 // etcd config documented in default config
 var (
+	defaultHelpPostfix = func(key string) string {
+		return config.DefaultHelpPostfix(DefaultKVS, key)
+	}
+
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         Endpoints,
-			Description: `comma separated list of etcd endpoints e.g. "http://localhost:2379"`,
+			Description: `comma separated list of etcd endpoints` + defaultHelpPostfix(Endpoints),
 			Type:        "csv",
 			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         PathPrefix,
-			Description: `namespace prefix to isolate tenants e.g. "customer1/"`,
+			Description: `namespace prefix to isolate tenants` + defaultHelpPostfix(PathPrefix),
 			Optional:    true,
 			Type:        "path",
 		},
 		config.HelpKV{
 			Key:         CoreDNSPath,
-			Description: `shared bucket DNS records, default is "/skydns"`,
+			Description: `shared bucket DNS records` + defaultHelpPostfix(CoreDNSPath),
 			Optional:    true,
 			Type:        "path",
 		},
 		config.HelpKV{
 			Key:         ClientCert,
-			Description: `client cert for mTLS authentication`,
+			Description: `client cert for mTLS authentication` + defaultHelpPostfix(ClientCert),
 			Optional:    true,
 			Type:        "path",
 			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         ClientCertKey,
-			Description: `client cert key for mTLS authentication`,
+			Description: `client cert key for mTLS authentication` + defaultHelpPostfix(ClientCertKey),
 			Optional:    true,
 			Type:        "path",
 			Sensitive:   true,

--- a/internal/config/heal/heal.go
+++ b/internal/config/heal/heal.go
@@ -115,45 +115,21 @@ func (opts *Config) Update(nopts Config) {
 	opts.cache.bitrotCycle, _ = parseBitrotConfig(nopts.Bitrot)
 }
 
-var (
-	// DefaultKVS - default KV config for heal settings
-	DefaultKVS = config.KVS{
-		config.KV{
-			Key:   Bitrot,
-			Value: config.EnableOff,
-		},
-		config.KV{
-			Key:   Sleep,
-			Value: "1s",
-		},
-		config.KV{
-			Key:   IOCount,
-			Value: "100",
-		},
-	}
-
-	// Help provides help for config values
-	Help = config.HelpKVS{
-		config.HelpKV{
-			Key:         Bitrot,
-			Description: `perform bitrot scan on disks when checking objects during scanner. e.g 6m`,
-			Optional:    true,
-			Type:        "on|off|duration",
-		},
-		config.HelpKV{
-			Key:         Sleep,
-			Description: `maximum sleep duration between objects to slow down heal operation. eg. 2s`,
-			Optional:    true,
-			Type:        "duration",
-		},
-		config.HelpKV{
-			Key:         IOCount,
-			Description: `maximum IO requests allowed between objects to slow down heal operation. eg. 3`,
-			Optional:    true,
-			Type:        "int",
-		},
-	}
-)
+// DefaultKVS - default KV config for heal settings
+var DefaultKVS = config.KVS{
+	config.KV{
+		Key:   Bitrot,
+		Value: config.EnableOff,
+	},
+	config.KV{
+		Key:   Sleep,
+		Value: "1s",
+	},
+	config.KV{
+		Key:   IOCount,
+		Value: "100",
+	},
+}
 
 const minimumBitrotCycleInMonths = 1
 

--- a/internal/config/heal/help.go
+++ b/internal/config/heal/help.go
@@ -15,35 +15,35 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package opa
+package heal
 
 import "github.com/minio/minio/internal/config"
 
-// Help template for OPA policy feature.
+// Help template for caching feature.
 var (
 	defaultHelpPostfix = func(key string) string {
 		return config.DefaultHelpPostfix(DefaultKVS, key)
 	}
 
+	// Help provides help for config values
 	Help = config.HelpKVS{
 		config.HelpKV{
-			Key:         URL,
-			Description: `[DEPRECATED] OPA HTTP(s) endpoint e.g. "http://localhost:8181/v1/data/httpapi/authz/allow"` + defaultHelpPostfix(URL),
-			Type:        "url",
-			Sensitive:   true,
+			Key:         Bitrot,
+			Description: `perform bitrot scan on disks when checking objects during scanner` + defaultHelpPostfix(Bitrot),
+			Optional:    true,
+			Type:        "on|off",
 		},
 		config.HelpKV{
-			Key:         AuthToken,
-			Description: "[DEPRECATED] authorization token for OPA endpoint" + defaultHelpPostfix(AuthToken),
+			Key:         Sleep,
+			Description: `maximum sleep duration between objects to slow down heal operation` + defaultHelpPostfix(Sleep),
 			Optional:    true,
-			Type:        "string",
-			Sensitive:   true,
+			Type:        "duration",
 		},
 		config.HelpKV{
-			Key:         config.Comment,
-			Description: config.DefaultComment,
+			Key:         IOCount,
+			Description: `maximum IO requests allowed between objects to slow down heal operation` + defaultHelpPostfix(IOCount),
 			Optional:    true,
-			Type:        "sentence",
+			Type:        "int",
 		},
 	}
 )

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -87,3 +87,12 @@ var (
 		},
 	}
 )
+
+// DefaultHelpPostfix - Helper function to add (default: $value) messages in config help
+func DefaultHelpPostfix(subsystem KVS, key string) string {
+	val, found := subsystem.Lookup(key)
+	if !found || val == "" {
+		return ""
+	}
+	return " (default: '" + val + "')"
+}

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -21,63 +21,70 @@ import "github.com/minio/minio/internal/config"
 
 // Help template for LDAP identity feature.
 var (
+	defaultHelpPostfix = func(key string) string {
+		return config.DefaultHelpPostfix(DefaultKVS, key)
+	}
+
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         ServerAddr,
-			Description: `AD/LDAP server address e.g. "myldapserver.com:636"`,
+			Description: `AD/LDAP server address e.g. "myldapserver.com:636"` + defaultHelpPostfix(ServerAddr),
 			Type:        "address",
 			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         LookupBindDN,
-			Description: `DN for LDAP read-only service account used to perform DN and group lookups`,
+			Description: `DN for LDAP read-only service account used to perform DN and group lookups` + defaultHelpPostfix(LookupBindDN),
+			Optional:    true,
 			Type:        "string",
 			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         LookupBindPassword,
-			Description: `Password for LDAP read-only service account used to perform DN and group lookups`,
+			Description: `Password for LDAP read-only service account used to perform DN and group lookups` + defaultHelpPostfix(LookupBindPassword),
 			Optional:    true,
 			Type:        "string",
 			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         UserDNSearchBaseDN,
-			Description: `";" separated list of user search base DNs e.g. "dc=myldapserver,dc=com"`,
+			Description: `";" separated list of user search base DNs e.g. "dc=myldapserver,dc=com"` + defaultHelpPostfix(UserDNSearchBaseDN),
+			Optional:    true,
 			Type:        "list",
 		},
 		config.HelpKV{
 			Key:         UserDNSearchFilter,
-			Description: `Search filter to lookup user DN`,
+			Description: `Search filter to lookup user DN` + defaultHelpPostfix(UserDNSearchFilter),
+			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         GroupSearchFilter,
-			Description: `search filter for groups e.g. "(&(objectclass=groupOfNames)(memberUid=%s))"`,
+			Description: `search filter for groups e.g. "(&(objectclass=groupOfNames)(memberUid=%s))"` + defaultHelpPostfix(GroupSearchFilter),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         GroupSearchBaseDN,
-			Description: `";" separated list of group search base DNs e.g. "dc=myldapserver,dc=com"`,
+			Description: `";" separated list of group search base DNs e.g. "dc=myldapserver,dc=com"` + defaultHelpPostfix(GroupSearchBaseDN),
 			Optional:    true,
 			Type:        "list",
 		},
 		config.HelpKV{
 			Key:         TLSSkipVerify,
-			Description: `trust server TLS without verification, defaults to "off" (verify)`,
+			Description: `trust server TLS without verification` + defaultHelpPostfix(TLSSkipVerify),
 			Optional:    true,
 			Type:        "on|off",
 		},
 		config.HelpKV{
 			Key:         ServerInsecure,
-			Description: `allow plain text connection to AD/LDAP server, defaults to "off"`,
+			Description: `allow plain text connection to AD/LDAP server` + defaultHelpPostfix(ServerInsecure),
 			Optional:    true,
 			Type:        "on|off",
 		},
 		config.HelpKV{
 			Key:         ServerStartTLS,
-			Description: `use StartTLS connection to AD/LDAP server, defaults to "off"`,
+			Description: `use StartTLS connection to AD/LDAP server` + defaultHelpPostfix(ServerStartTLS),
 			Optional:    true,
 			Type:        "on|off",
 		},

--- a/internal/config/identity/openid/help.go
+++ b/internal/config/identity/openid/help.go
@@ -21,80 +21,84 @@ import "github.com/minio/minio/internal/config"
 
 // Help template for OpenID identity feature.
 var (
+	defaultHelpPostfix = func(key string) string {
+		return config.DefaultHelpPostfix(DefaultKVS, key)
+	}
+
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         ConfigURL,
-			Description: `openid discovery document e.g. "https://accounts.google.com/.well-known/openid-configuration"`,
+			Description: `openid discovery document e.g. "https://accounts.google.com/.well-known/openid-configuration"` + defaultHelpPostfix(ConfigURL),
 			Type:        "url",
 		},
 		config.HelpKV{
 			Key:         ClientID,
-			Description: `unique public identifier for apps e.g. "292085223830.apps.googleusercontent.com"`,
+			Description: `unique public identifier for apps e.g. "292085223830.apps.googleusercontent.com"` + defaultHelpPostfix(ClientID),
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         ClientSecret,
-			Description: `secret for the unique public identifier for apps e.g.`,
+			Description: `secret for the unique public identifier for apps` + defaultHelpPostfix(ClientSecret),
 			Type:        "string",
 			Optional:    true,
 		},
 		config.HelpKV{
 			Key:         ClaimName,
-			Description: `JWT canned policy claim name, defaults to "policy"`,
+			Description: `JWT canned policy claim name` + defaultHelpPostfix(ClaimName),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         ClaimUserinfo,
-			Description: `Enable fetching claims from UserInfo Endpoint for authenticated user`,
+			Description: `Enable fetching claims from UserInfo Endpoint for authenticated user` + defaultHelpPostfix(ClaimUserinfo),
 			Optional:    true,
 			Type:        "on|off",
 		},
 		config.HelpKV{
 			Key:         RolePolicy,
-			Description: `Set the IAM access policies applicable to this client application and IDP e.g. "app-bucket-write,app-bucket-list"`,
+			Description: `Set the IAM access policies applicable to this client application and IDP e.g. "app-bucket-write,app-bucket-list"` + defaultHelpPostfix(RolePolicy),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         Scopes,
-			Description: `Comma separated list of OpenID scopes for server, defaults to advertised scopes from discovery document e.g. "email,admin"`,
+			Description: `Comma separated list of OpenID scopes for server, defaults to advertised scopes from discovery document e.g. "email,admin"` + defaultHelpPostfix(Scopes),
 			Optional:    true,
 			Type:        "csv",
 		},
 		config.HelpKV{
 			Key:         Vendor,
-			Description: `Specify vendor type for vendor specific behavior to checking validity of temporary credentials and service accounts on MinIO`,
+			Description: `Specify vendor type for vendor specific behavior to checking validity of temporary credentials and service accounts on MinIO` + defaultHelpPostfix(Vendor),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         KeyCloakRealm,
-			Description: `Specify Keycloak 'realm' name, only honored if vendor was set to 'keycloak' as value, if no realm is specified 'master' is default`,
+			Description: `Specify Keycloak 'realm' name, only honored if vendor was set to 'keycloak' as value, if no realm is specified 'master' is default` + defaultHelpPostfix(KeyCloakRealm),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         KeyCloakAdminURL,
-			Description: `Specify Keycloak 'admin' REST API endpoint e.g. http://localhost:8080/auth/admin/`,
+			Description: `Specify Keycloak 'admin' REST API endpoint e.g. http://localhost:8080/auth/admin/` + defaultHelpPostfix(KeyCloakAdminURL),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         RedirectURIDynamic,
-			Description: `Enable 'Host' header based dynamic redirect URI`,
+			Description: `Enable 'Host' header based dynamic redirect URI` + defaultHelpPostfix(RedirectURIDynamic),
 			Optional:    true,
 			Type:        "on|off",
 		},
 		config.HelpKV{
 			Key:         ClaimPrefix,
-			Description: `[DEPRECATED use 'claim_name'] JWT claim namespace prefix e.g. "customer1/"`,
+			Description: `[DEPRECATED use 'claim_name'] JWT claim namespace prefix e.g. "customer1/"` + defaultHelpPostfix(ClaimPrefix),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         RedirectURI,
-			Description: `[DEPRECATED use env 'MINIO_BROWSER_REDIRECT_URL'] Configure custom redirect_uri for OpenID login flow callback`,
+			Description: `[DEPRECATED use env 'MINIO_BROWSER_REDIRECT_URL'] Configure custom redirect_uri for OpenID login flow callback` + defaultHelpPostfix(RedirectURI),
 			Optional:    true,
 			Type:        "string",
 		},
@@ -103,18 +107,6 @@ var (
 			Description: config.DefaultComment,
 			Optional:    true,
 			Type:        "sentence",
-		},
-		config.HelpKV{
-			Key:         ClaimPrefix,
-			Description: `[DEPRECATED use 'claim_name'] JWT claim namespace prefix e.g. "customer1/"`,
-			Optional:    true,
-			Type:        "string",
-		},
-		config.HelpKV{
-			Key:         RedirectURI,
-			Description: `[DEPRECATED use env 'MINIO_BROWSER_REDIRECT_URL'] Configure custom redirect_uri for OpenID login flow callback`,
-			Optional:    true,
-			Type:        "string",
 		},
 	}
 )

--- a/internal/config/identity/tls/config.go
+++ b/internal/config/identity/tls/config.go
@@ -119,7 +119,7 @@ var DefaultKVS = config.KVS{
 var Help = config.HelpKVS{
 	config.HelpKV{
 		Key:         skipVerify,
-		Description: `trust client certificates without verification. Defaults to "off" (verify)`,
+		Description: `trust client certificates without verification (default: 'off')`,
 		Optional:    true,
 		Type:        "on|off",
 	},

--- a/internal/config/scanner/help.go
+++ b/internal/config/scanner/help.go
@@ -15,35 +15,34 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package opa
+package scanner
 
 import "github.com/minio/minio/internal/config"
 
-// Help template for OPA policy feature.
 var (
 	defaultHelpPostfix = func(key string) string {
 		return config.DefaultHelpPostfix(DefaultKVS, key)
 	}
 
+	// Help provides help for config values
 	Help = config.HelpKVS{
 		config.HelpKV{
-			Key:         URL,
-			Description: `[DEPRECATED] OPA HTTP(s) endpoint e.g. "http://localhost:8181/v1/data/httpapi/authz/allow"` + defaultHelpPostfix(URL),
-			Type:        "url",
-			Sensitive:   true,
+			Key:         Delay,
+			Description: `scanner delay multiplier` + defaultHelpPostfix(Delay),
+			Optional:    true,
+			Type:        "float",
 		},
 		config.HelpKV{
-			Key:         AuthToken,
-			Description: "[DEPRECATED] authorization token for OPA endpoint" + defaultHelpPostfix(AuthToken),
+			Key:         MaxWait,
+			Description: `maximum wait time between operations` + defaultHelpPostfix(MaxWait),
 			Optional:    true,
-			Type:        "string",
-			Sensitive:   true,
+			Type:        "duration",
 		},
 		config.HelpKV{
-			Key:         config.Comment,
-			Description: config.DefaultComment,
+			Key:         Cycle,
+			Description: `time duration between scanner cycles` + defaultHelpPostfix(Cycle),
 			Optional:    true,
-			Type:        "sentence",
+			Type:        "duration",
 		},
 	}
 )

--- a/internal/config/scanner/scanner.go
+++ b/internal/config/scanner/scanner.go
@@ -48,45 +48,21 @@ type Config struct {
 	Cycle time.Duration
 }
 
-var (
-	// DefaultKVS - default KV config for heal settings
-	DefaultKVS = config.KVS{
-		config.KV{
-			Key:   Delay,
-			Value: "10",
-		},
-		config.KV{
-			Key:   MaxWait,
-			Value: "15s",
-		},
-		config.KV{
-			Key:   Cycle,
-			Value: "1m",
-		},
-	}
-
-	// Help provides help for config values
-	Help = config.HelpKVS{
-		config.HelpKV{
-			Key:         Delay,
-			Description: `scanner delay multiplier, defaults to '10.0'`,
-			Optional:    true,
-			Type:        "float",
-		},
-		config.HelpKV{
-			Key:         MaxWait,
-			Description: `maximum wait time between operations, defaults to '15s'`,
-			Optional:    true,
-			Type:        "duration",
-		},
-		config.HelpKV{
-			Key:         Cycle,
-			Description: `time duration between scanner cycles, defaults to '1m'`,
-			Optional:    true,
-			Type:        "duration",
-		},
-	}
-)
+// DefaultKVS - default KV config for heal settings
+var DefaultKVS = config.KVS{
+	config.KV{
+		Key:   Delay,
+		Value: "10",
+	},
+	config.KV{
+		Key:   MaxWait,
+		Value: "15s",
+	},
+	config.KV{
+		Key:   Cycle,
+		Value: "1m",
+	},
+}
 
 // LookupConfig - lookup config and override with valid environment settings if any.
 func LookupConfig(kvs config.KVS) (cfg Config, err error) {

--- a/internal/config/storageclass/help.go
+++ b/internal/config/storageclass/help.go
@@ -21,16 +21,20 @@ import "github.com/minio/minio/internal/config"
 
 // Help template for storageclass feature.
 var (
+	defaultHelpPostfix = func(key string) string {
+		return config.DefaultHelpPostfix(DefaultKVS, key)
+	}
+
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         ClassStandard,
-			Description: `set the parity count for default standard storage class e.g. "EC:4"`,
+			Description: `set the parity count for default standard storage class` + defaultHelpPostfix(ClassStandard),
 			Optional:    true,
 			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         ClassRRS,
-			Description: `set the parity count for reduced redundancy storage class e.g. "EC:2"`,
+			Description: `set the parity count for reduced redundancy storage class` + defaultHelpPostfix(ClassRRS),
 			Optional:    true,
 			Type:        "string",
 		},

--- a/internal/config/subnet/api-key.go
+++ b/internal/config/subnet/api-key.go
@@ -24,48 +24,21 @@ import (
 	"github.com/minio/pkg/env"
 )
 
-var (
-	// DefaultKVS - default KV config for subnet settings
-	DefaultKVS = config.KVS{
-		config.KV{
-			Key:   config.License, // Deprecated Dec 2021
-			Value: "",
-		},
-		config.KV{
-			Key:   config.APIKey,
-			Value: "",
-		},
-		config.KV{
-			Key:   config.Proxy,
-			Value: "",
-		},
-	}
-
-	// HelpSubnet - provides help for subnet api key config
-	HelpSubnet = config.HelpKVS{
-		config.HelpKV{
-			Key:         config.License, // Deprecated Dec 2021
-			Type:        "string",
-			Description: "[DEPRECATED use api_key] Subnet license token for the cluster",
-			Optional:    true,
-			Sensitive:   true,
-		},
-		config.HelpKV{
-			Key:         config.APIKey,
-			Type:        "string",
-			Description: "Subnet api key for the cluster",
-			Optional:    true,
-			Sensitive:   true,
-		},
-		config.HelpKV{
-			Key:         config.Proxy,
-			Type:        "string",
-			Description: "HTTP(S) proxy URL to use for connecting to SUBNET",
-			Optional:    true,
-			Sensitive:   true,
-		},
-	}
-)
+// DefaultKVS - default KV config for subnet settings
+var DefaultKVS = config.KVS{
+	config.KV{
+		Key:   config.License, // Deprecated Dec 2021
+		Value: "",
+	},
+	config.KV{
+		Key:   config.APIKey,
+		Value: "",
+	},
+	config.KV{
+		Key:   config.Proxy,
+		Value: "",
+	},
+}
 
 // Config represents the subnet related configuration
 type Config struct {

--- a/internal/config/subnet/help.go
+++ b/internal/config/subnet/help.go
@@ -15,35 +15,34 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package opa
+package subnet
 
 import "github.com/minio/minio/internal/config"
 
-// Help template for OPA policy feature.
 var (
 	defaultHelpPostfix = func(key string) string {
 		return config.DefaultHelpPostfix(DefaultKVS, key)
 	}
 
-	Help = config.HelpKVS{
+	// HelpSubnet - provides help for subnet api key config
+	HelpSubnet = config.HelpKVS{
 		config.HelpKV{
-			Key:         URL,
-			Description: `[DEPRECATED] OPA HTTP(s) endpoint e.g. "http://localhost:8181/v1/data/httpapi/authz/allow"` + defaultHelpPostfix(URL),
-			Type:        "url",
-			Sensitive:   true,
-		},
-		config.HelpKV{
-			Key:         AuthToken,
-			Description: "[DEPRECATED] authorization token for OPA endpoint" + defaultHelpPostfix(AuthToken),
-			Optional:    true,
+			Key:         config.License, // Deprecated Dec 2021
 			Type:        "string",
-			Sensitive:   true,
+			Description: "[DEPRECATED use api_key] Subnet license token for the cluster" + defaultHelpPostfix(config.License),
+			Optional:    true,
 		},
 		config.HelpKV{
-			Key:         config.Comment,
-			Description: config.DefaultComment,
+			Key:         config.APIKey,
+			Type:        "string",
+			Description: "Subnet api key for the cluster" + defaultHelpPostfix(config.APIKey),
 			Optional:    true,
-			Type:        "sentence",
+		},
+		config.HelpKV{
+			Key:         config.Proxy,
+			Type:        "string",
+			Description: "HTTP(S) proxy URL to use for connecting to SUBNET" + defaultHelpPostfix(config.Proxy),
+			Optional:    true,
 		},
 	}
 )


### PR DESCRIPTION
This PR standardizes the help message that is shown from mc when `mc admin config ...` command is issued. Instead of hard-coding config defaults, this pulls the value from the DefaultKV datastructure and standardizes the default value presentation format