### PR TITLE
Make storage class config dynamic

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,6 +169,7 @@ var SubSystemsDynamic = set.CreateStringSet(
 	LoggerWebhookSubSys,
 	AuditWebhookSubSys,
 	AuditKafkaSubSys,
+	StorageClassSubSys,
 )
 
 // SubSystemsSingleTargets - subsystems which only support single target.


### PR DESCRIPTION
## Description

Updating the storage class is already thread safe, so we can do this safely.

## How to test this PR?

Run locally. Use `mc admin config set myminio storage_class standard=EC:3`, copy file to cluster, use `xl-meta` to inspect metadata. Try different values.

Confirmed locally.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
