### PR TITLE
Fix double slash subpath for console

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -179,7 +179,14 @@ func minioConfigToConsoleFeatures() {
 	}
 	// pass the console subpath configuration
 	if value := env.Get(config.EnvMinIOBrowserRedirectURL, ""); value != "" {
-		os.Setenv("CONSOLE_SUBPATH", pathJoin(globalBrowserRedirectURL.Path, SlashSeparator))
+		subPath := ""
+		trimmedRedirectPath := strings.TrimSpace(globalBrowserRedirectURL.Path)
+		if trimmedRedirectPath != "" && trimmedRedirectPath != SlashSeparator {
+			subPath = pathJoin(trimmedRedirectPath, SlashSeparator)
+		}
+		if subPath != SlashSeparator {
+			os.Setenv("CONSOLE_SUBPATH", subPath)
+		}
 	}
 	// Enable if prometheus URL is set.
 	if value := env.Get("MINIO_PROMETHEUS_URL", ""); value != "" {

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -33,6 +33,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -179,11 +180,7 @@ func minioConfigToConsoleFeatures() {
 	}
 	// pass the console subpath configuration
 	if value := env.Get(config.EnvMinIOBrowserRedirectURL, ""); value != "" {
-		subPath := ""
-		trimmedRedirectPath := strings.TrimSpace(globalBrowserRedirectURL.Path)
-		if trimmedRedirectPath != "" && trimmedRedirectPath != SlashSeparator {
-			subPath = pathJoin(trimmedRedirectPath, SlashSeparator)
-		}
+		subPath := path.Clean(pathJoin(strings.TrimSpace(globalBrowserRedirectURL.Path), SlashSeparator))
 		if subPath != SlashSeparator {
 			os.Setenv("CONSOLE_SUBPATH", subPath)
 		}


### PR DESCRIPTION
Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>

## Description

Fixes a problem where the browser redirect URL would yield a `//` subpath and pass that to console which would make it not work properly

## How to test this PR?

Start MinIO with the following environment variables

```
export MINIO_BROWSER_REDIRECT_URL=http://localhost:9091
export MINIO_SERVER_URL=http://localhost:9001
```
visit MinIO or Console URL, console should come up, but if you test this on any release outside of this PR, you'll get an empty screen


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
