### PR TITLE
allow forcibly creating metadata on buckets

### DIFF
--- a/cmd/admin-handlers-site-replication.go
+++ b/cmd/admin-handlers-site-replication.go
@@ -115,10 +115,12 @@ func (a adminAPIHandlers) SRPeerBucketOps(w http.ResponseWriter, r *http.Request
 	case madmin.MakeWithVersioningBktOp:
 		_, isLockEnabled := r.Form["lockEnabled"]
 		_, isVersioningEnabled := r.Form["versioningEnabled"]
+		_, isForceCreate := r.Form["forceCreate"]
 		opts := BucketOptions{
 			Location:          r.Form.Get("location"),
 			LockEnabled:       isLockEnabled,
 			VersioningEnabled: isVersioningEnabled,
+			ForceCreate:       isForceCreate,
 		}
 		err = globalSiteReplicationSys.PeerBucketMakeWithVersioningHandler(ctx, bucket, opts)
 	case madmin.ConfigureReplBktOp:

--- a/cmd/erasure-bucket.go
+++ b/cmd/erasure-bucket.go
@@ -55,6 +55,11 @@ func (er erasureObjects) MakeBucketWithLocation(ctx context.Context, bucket stri
 		g.Go(func() error {
 			if storageDisks[index] != nil {
 				if err := storageDisks[index].MakeVol(ctx, bucket); err != nil {
+					if opts.ForceCreate && errors.Is(err, errVolumeExists) {
+						// No need to return error when force create was
+						// requested.
+						return nil
+					}
 					if !errors.Is(err, errVolumeExists) {
 						logger.LogIf(ctx, err)
 					}

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -98,6 +98,7 @@ type BucketOptions struct {
 	Location          string
 	LockEnabled       bool
 	VersioningEnabled bool
+	ForceCreate       bool // Create buckets even if they are already created.
 }
 
 // DeleteBucketOptions provides options for DeleteBucket calls.

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -625,6 +625,9 @@ func (c *SiteReplicationSys) MakeBucketHook(ctx context.Context, bucket string, 
 	if opts.VersioningEnabled {
 		optsMap["versioningEnabled"] = "true"
 	}
+	if opts.ForceCreate {
+		optsMap["forceCreate"] = "true"
+	}
 
 	// Create bucket and enable versioning on all peers.
 	makeBucketConcErr := c.concDo(

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -91,6 +91,9 @@ const (
 	AmzBucketReplicationStatus    = "X-Amz-Replication-Status"
 	AmzSnowballExtract            = "X-Amz-Meta-Snowball-Auto-Extract"
 
+	// Object lock enabled
+	AmzObjectLockEnabled = "x-amz-bucket-object-lock-enabled"
+
 	// Multipart parts count
 	AmzMpPartsCount = "x-amz-mp-parts-count"
 
@@ -143,6 +146,9 @@ const (
 
 	// Delete special flag to force delete a bucket or a prefix
 	MinIOForceDelete = "x-minio-force-delete"
+
+	// Create special flag to force create a bucket
+	MinIOForceCreate = "x-minio-force-create"
 
 	// Header indicates if the mtime should be preserved by client
 	MinIOSourceMTime = "x-minio-source-mtime"


### PR DESCRIPTION


## Description
allow forcibly creating metadata on buckets

## Motivation and Context
introduce x-minio-force-create environment variable
to force create a bucket and its metadata as required,
it is useful in some situations when bucket metadata
needs recovery.

## How to test this PR?
Will need to write custom code with MakeBucket call and set the relevant header.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
