### PR TITLE
Prefix-level versioning exclusion

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -44,7 +44,6 @@ import (
 	sse "github.com/minio/minio/internal/bucket/encryption"
 	objectlock "github.com/minio/minio/internal/bucket/object/lock"
 	"github.com/minio/minio/internal/bucket/replication"
-	"github.com/minio/minio/internal/bucket/versioning"
 	"github.com/minio/minio/internal/config/dns"
 	"github.com/minio/minio/internal/crypto"
 	"github.com/minio/minio/internal/event"
@@ -480,10 +479,6 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 	deleteResults := make([]deleteResult, len(deleteObjectsReq.Objects))
 
 	vc, _ := globalBucketVersioningSys.Get(bucket)
-	if vc == nil {
-		// versioning.Versioning's zero value represents versioning disabled
-		vc = &versioning.Versioning{}
-	}
 	oss := make([]*objSweeper, len(deleteObjectsReq.Objects))
 	for index, object := range deleteObjectsReq.Objects {
 		if apiErrCode := checkRequestAuthType(ctx, r, policy.DeleteObjectAction, bucket, object.ObjectName); apiErrCode != ErrNone {

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -330,7 +330,7 @@ const (
 // 2. when a transitioned object expires (based on an ILM rule).
 func expireTransitionedObject(ctx context.Context, objectAPI ObjectLayer, oi *ObjectInfo, lcOpts lifecycle.ObjectOpts, action expireAction) error {
 	var opts ObjectOptions
-	opts.Versioned = globalBucketVersioningSys.EnabledPrefix(oi.Bucket, oi.Name)
+	opts.Versioned = globalBucketVersioningSys.PrefixEnabled(oi.Bucket, oi.Name)
 	opts.VersionID = lcOpts.VersionID
 	opts.Expiration = ExpirationOptions{Expire: true}
 	switch action {
@@ -415,8 +415,8 @@ func transitionObject(ctx context.Context, objectAPI ObjectLayer, oi ObjectInfo)
 			ETag:   oi.ETag,
 		},
 		VersionID:        oi.VersionID,
-		Versioned:        globalBucketVersioningSys.EnabledPrefix(oi.Bucket, oi.Name),
-		VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(oi.Bucket, oi.Name),
+		Versioned:        globalBucketVersioningSys.PrefixEnabled(oi.Bucket, oi.Name),
+		VersionSuspended: globalBucketVersioningSys.PrefixSuspended(oi.Bucket, oi.Name),
 		MTime:            oi.ModTime,
 	}
 	return tier, objectAPI.TransitionObject(ctx, oi.Bucket, oi.Name, opts)
@@ -575,8 +575,8 @@ func (r *RestoreObjectRequest) validate(ctx context.Context, objAPI ObjectLayer)
 
 // postRestoreOpts returns ObjectOptions with version-id from the POST restore object request for a given bucket and object.
 func postRestoreOpts(ctx context.Context, r *http.Request, bucket, object string) (opts ObjectOptions, err error) {
-	versioned := globalBucketVersioningSys.EnabledPrefix(bucket, object)
-	versionSuspended := globalBucketVersioningSys.SuspendedPrefix(bucket, object)
+	versioned := globalBucketVersioningSys.PrefixEnabled(bucket, object)
+	versionSuspended := globalBucketVersioningSys.PrefixSuspended(bucket, object)
 	vid := strings.TrimSpace(r.Form.Get(xhttp.VersionID))
 	if vid != "" && vid != nullVersionID {
 		_, err := uuid.Parse(vid)
@@ -627,8 +627,8 @@ func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo O
 			meta[xhttp.AmzServerSideEncryption] = xhttp.AmzEncryptionAES
 		}
 		return ObjectOptions{
-			Versioned:        globalBucketVersioningSys.EnabledPrefix(bucket, object),
-			VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(bucket, object),
+			Versioned:        globalBucketVersioningSys.PrefixEnabled(bucket, object),
+			VersionSuspended: globalBucketVersioningSys.PrefixSuspended(bucket, object),
 			UserDefined:      meta,
 		}
 	}
@@ -640,8 +640,8 @@ func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo O
 	}
 
 	return ObjectOptions{
-		Versioned:        globalBucketVersioningSys.EnabledPrefix(bucket, object),
-		VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(bucket, object),
+		Versioned:        globalBucketVersioningSys.PrefixEnabled(bucket, object),
+		VersionSuspended: globalBucketVersioningSys.PrefixSuspended(bucket, object),
 		UserDefined:      meta,
 		VersionID:        objInfo.VersionID,
 		MTime:            objInfo.ModTime,

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -330,7 +330,7 @@ const (
 // 2. when a transitioned object expires (based on an ILM rule).
 func expireTransitionedObject(ctx context.Context, objectAPI ObjectLayer, oi *ObjectInfo, lcOpts lifecycle.ObjectOpts, action expireAction) error {
 	var opts ObjectOptions
-	opts.Versioned = globalBucketVersioningSys.Enabled(oi.Bucket)
+	opts.Versioned = globalBucketVersioningSys.EnabledPrefix(oi.Bucket, oi.Name)
 	opts.VersionID = lcOpts.VersionID
 	opts.Expiration = ExpirationOptions{Expire: true}
 	switch action {
@@ -415,7 +415,7 @@ func transitionObject(ctx context.Context, objectAPI ObjectLayer, oi ObjectInfo)
 			ETag:   oi.ETag,
 		},
 		VersionID:        oi.VersionID,
-		Versioned:        globalBucketVersioningSys.Enabled(oi.Bucket),
+		Versioned:        globalBucketVersioningSys.EnabledPrefix(oi.Bucket, oi.Name),
 		VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(oi.Bucket, oi.Name),
 		MTime:            oi.ModTime,
 	}
@@ -575,7 +575,7 @@ func (r *RestoreObjectRequest) validate(ctx context.Context, objAPI ObjectLayer)
 
 // postRestoreOpts returns ObjectOptions with version-id from the POST restore object request for a given bucket and object.
 func postRestoreOpts(ctx context.Context, r *http.Request, bucket, object string) (opts ObjectOptions, err error) {
-	versioned := globalBucketVersioningSys.Enabled(bucket)
+	versioned := globalBucketVersioningSys.EnabledPrefix(bucket, object)
 	versionSuspended := globalBucketVersioningSys.SuspendedPrefix(bucket, object)
 	vid := strings.TrimSpace(r.Form.Get(xhttp.VersionID))
 	if vid != "" && vid != nullVersionID {
@@ -627,7 +627,7 @@ func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo O
 			meta[xhttp.AmzServerSideEncryption] = xhttp.AmzEncryptionAES
 		}
 		return ObjectOptions{
-			Versioned:        globalBucketVersioningSys.Enabled(bucket),
+			Versioned:        globalBucketVersioningSys.EnabledPrefix(bucket, object),
 			VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(bucket, object),
 			UserDefined:      meta,
 		}
@@ -640,7 +640,7 @@ func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo O
 	}
 
 	return ObjectOptions{
-		Versioned:        globalBucketVersioningSys.Enabled(bucket),
+		Versioned:        globalBucketVersioningSys.EnabledPrefix(bucket, object),
 		VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(bucket, object),
 		UserDefined:      meta,
 		VersionID:        objInfo.VersionID,

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -416,7 +416,7 @@ func transitionObject(ctx context.Context, objectAPI ObjectLayer, oi ObjectInfo)
 		},
 		VersionID:        oi.VersionID,
 		Versioned:        globalBucketVersioningSys.Enabled(oi.Bucket),
-		VersionSuspended: globalBucketVersioningSys.Suspended(oi.Bucket),
+		VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(oi.Bucket, oi.Name),
 		MTime:            oi.ModTime,
 	}
 	return tier, objectAPI.TransitionObject(ctx, oi.Bucket, oi.Name, opts)
@@ -576,7 +576,7 @@ func (r *RestoreObjectRequest) validate(ctx context.Context, objAPI ObjectLayer)
 // postRestoreOpts returns ObjectOptions with version-id from the POST restore object request for a given bucket and object.
 func postRestoreOpts(ctx context.Context, r *http.Request, bucket, object string) (opts ObjectOptions, err error) {
 	versioned := globalBucketVersioningSys.Enabled(bucket)
-	versionSuspended := globalBucketVersioningSys.Suspended(bucket)
+	versionSuspended := globalBucketVersioningSys.SuspendedPrefix(bucket, object)
 	vid := strings.TrimSpace(r.Form.Get(xhttp.VersionID))
 	if vid != "" && vid != nullVersionID {
 		_, err := uuid.Parse(vid)
@@ -628,7 +628,7 @@ func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo O
 		}
 		return ObjectOptions{
 			Versioned:        globalBucketVersioningSys.Enabled(bucket),
-			VersionSuspended: globalBucketVersioningSys.Suspended(bucket),
+			VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(bucket, object),
 			UserDefined:      meta,
 		}
 	}
@@ -641,7 +641,7 @@ func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo O
 
 	return ObjectOptions{
 		Versioned:        globalBucketVersioningSys.Enabled(bucket),
-		VersionSuspended: globalBucketVersioningSys.Suspended(bucket),
+		VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(bucket, object),
 		UserDefined:      meta,
 		VersionID:        objInfo.VersionID,
 		MTime:            objInfo.ModTime,

--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -196,7 +196,7 @@ func (sys *BucketMetadataSys) Get(bucket string) (BucketMetadata, error) {
 func (sys *BucketMetadataSys) GetVersioningConfig(bucket string) (*versioning.Versioning, error) {
 	meta, err := sys.GetConfig(GlobalContext, bucket)
 	if err != nil {
-		return nil, err
+		return &versioning.Versioning{}, err
 	}
 	return meta.versioningConfig, nil
 }

--- a/cmd/bucket-replication-utils.go
+++ b/cmd/bucket-replication-utils.go
@@ -509,7 +509,7 @@ func getHealReplicateObjectInfo(objInfo ObjectInfo, rcfg replicationConfig) Repl
 				ObjectName: oi.Name,
 				VersionID:  oi.VersionID,
 			},
-		}, oi, ObjectOptions{}, nil)
+		}, oi, ObjectOptions{VersionSuspended: globalBucketVersioningSys.PrefixSuspended(oi.Bucket, oi.Name)}, nil)
 	} else {
 		dsc = mustReplicate(GlobalContext, oi.Bucket, oi.Name, getMustReplicateOptions(ObjectInfo{
 			UserDefined: oi.UserDefined,

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -457,8 +457,8 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 		VersionID:         versionID,
 		MTime:             dobj.DeleteMarkerMTime.Time,
 		DeleteReplication: drs,
-		Versioned:         globalBucketVersioningSys.EnabledPrefix(bucket, dobj.ObjectName),
-		VersionSuspended:  globalBucketVersioningSys.SuspendedPrefix(bucket, dobj.ObjectName),
+		Versioned:         globalBucketVersioningSys.PrefixEnabled(bucket, dobj.ObjectName),
+		VersionSuspended:  globalBucketVersioningSys.PrefixSuspended(bucket, dobj.ObjectName),
 	})
 	if err != nil && !isErrVersionNotFound(err) { // VersionNotFound would be reported by pool that object version is missing on.
 		logger.LogIf(ctx, fmt.Errorf("Unable to update replication metadata for %s/%s(%s): %s", bucket, dobj.ObjectName, versionID, err))

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -458,7 +458,7 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 		MTime:             dobj.DeleteMarkerMTime.Time,
 		DeleteReplication: drs,
 		Versioned:         globalBucketVersioningSys.Enabled(bucket),
-		VersionSuspended:  globalBucketVersioningSys.Suspended(bucket),
+		VersionSuspended:  globalBucketVersioningSys.SuspendedPrefix(bucket, dobj.ObjectName),
 	})
 	if err != nil && !isErrVersionNotFound(err) { // VersionNotFound would be reported by pool that object version is missing on.
 		logger.LogIf(ctx, fmt.Errorf("Unable to update replication metadata for %s/%s(%s): %s", bucket, dobj.ObjectName, versionID, err))

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -269,6 +269,11 @@ func checkReplicateDelete(ctx context.Context, bucket string, dobj ObjectToDelet
 	if delOpts.ReplicationRequest {
 		return
 	}
+	// Skip replication if this object's prefix is excluded from being
+	// versioned.
+	if delOpts.VersionSuspended {
+		return
+	}
 	opts := replication.ObjectOpts{
 		Name:         dobj.ObjectName,
 		SSEC:         crypto.SSEC.IsEncrypted(oi.UserDefined),

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -180,6 +180,11 @@ func mustReplicate(ctx context.Context, bucket, object string, mopts mustReplica
 		return
 	}
 
+	// Disable server-side replication on object prefixes which are excluded
+	// from versioning via the MinIO bucket versioning extension.
+	if globalBucketVersioningSys.PrefixSuspended(bucket, object) {
+		return
+	}
 	replStatus := mopts.ReplicationStatus()
 	if replStatus == replication.Replica && !mopts.isMetadataReplication() {
 		return

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -457,7 +457,7 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 		VersionID:         versionID,
 		MTime:             dobj.DeleteMarkerMTime.Time,
 		DeleteReplication: drs,
-		Versioned:         globalBucketVersioningSys.Enabled(bucket),
+		Versioned:         globalBucketVersioningSys.EnabledPrefix(bucket, dobj.ObjectName),
 		VersionSuspended:  globalBucketVersioningSys.SuspendedPrefix(bucket, dobj.ObjectName),
 	})
 	if err != nil && !isErrVersionNotFound(err) { // VersionNotFound would be reported by pool that object version is missing on.

--- a/cmd/bucket-versioning-handler.go
+++ b/cmd/bucket-versioning-handler.go
@@ -72,7 +72,7 @@ func (api objectAPIHandlers) PutBucketVersioningHandler(w http.ResponseWriter, r
 		return
 	}
 
-	if rcfg, _ := globalBucketObjectLockSys.Get(bucket); rcfg.LockEnabled && v.Suspended() {
+	if rcfg, _ := globalBucketObjectLockSys.Get(bucket); rcfg.LockEnabled && (v.Suspended() || v.PrefixesExcluded()) {
 		writeErrorResponse(ctx, w, APIError{
 			Code:           "InvalidBucketState",
 			Description:    "An Object Lock configuration is present on this bucket, so the versioning state cannot be changed.",

--- a/cmd/bucket-versioning.go
+++ b/cmd/bucket-versioning.go
@@ -31,6 +31,17 @@ func (sys *BucketVersioningSys) Enabled(bucket string) bool {
 	return vc.Enabled()
 }
 
+// EnabledPrefix returns true is versioning is enabled at bucket level and if
+// the given prefix doesn't match any suspended prefixes configured. This is
+// part of a MinIO versioning configuration extension.
+func (sys *BucketVersioningSys) EnabledPrefix(bucket, prefix string) bool {
+	vc, err := globalBucketMetadataSys.GetVersioningConfig(bucket)
+	if err != nil {
+		return false
+	}
+	return vc.EnabledPrefix(prefix)
+}
+
 // Suspended suspended versioning?
 func (sys *BucketVersioningSys) Suspended(bucket string) bool {
 	vc, err := globalBucketMetadataSys.GetVersioningConfig(bucket)

--- a/cmd/bucket-versioning.go
+++ b/cmd/bucket-versioning.go
@@ -40,6 +40,16 @@ func (sys *BucketVersioningSys) Suspended(bucket string) bool {
 	return vc.Suspended()
 }
 
+// SuspendedPrefix returns true if the given prefix is marked suspended.
+// This is part of a MinIO versioning configuration extension.
+func (sys *BucketVersioningSys) SuspendedPrefix(bucket, prefix string) bool {
+	vc, err := globalBucketMetadataSys.GetVersioningConfig(bucket)
+	if err != nil {
+		return false
+	}
+	return vc.SuspendedPrefix(prefix)
+}
+
 // Get returns stored bucket policy
 func (sys *BucketVersioningSys) Get(bucket string) (*versioning.Versioning, error) {
 	if globalIsGateway {

--- a/cmd/bucket-versioning.go
+++ b/cmd/bucket-versioning.go
@@ -32,7 +32,7 @@ func (sys *BucketVersioningSys) Enabled(bucket string) bool {
 }
 
 // EnabledPrefix returns true is versioning is enabled at bucket level and if
-// the given prefix doesn't match any suspended prefixes configured. This is
+// the given prefix doesn't match any excluded prefixes pattern. This is
 // part of a MinIO versioning configuration extension.
 func (sys *BucketVersioningSys) EnabledPrefix(bucket, prefix string) bool {
 	vc, err := globalBucketMetadataSys.GetVersioningConfig(bucket)
@@ -51,8 +51,8 @@ func (sys *BucketVersioningSys) Suspended(bucket string) bool {
 	return vc.Suspended()
 }
 
-// SuspendedPrefix returns true if the given prefix is marked suspended.
-// This is part of a MinIO versioning configuration extension.
+// SuspendedPrefix returns true if the given prefix matches an excluded prefix
+// pattern. This is part of a MinIO versioning configuration extension.
 func (sys *BucketVersioningSys) SuspendedPrefix(bucket, prefix string) bool {
 	vc, err := globalBucketMetadataSys.GetVersioningConfig(bucket)
 	if err != nil {

--- a/cmd/bucket-versioning.go
+++ b/cmd/bucket-versioning.go
@@ -31,15 +31,15 @@ func (sys *BucketVersioningSys) Enabled(bucket string) bool {
 	return vc.Enabled()
 }
 
-// EnabledPrefix returns true is versioning is enabled at bucket level and if
+// PrefixEnabled returns true is versioning is enabled at bucket level and if
 // the given prefix doesn't match any excluded prefixes pattern. This is
 // part of a MinIO versioning configuration extension.
-func (sys *BucketVersioningSys) EnabledPrefix(bucket, prefix string) bool {
+func (sys *BucketVersioningSys) PrefixEnabled(bucket, prefix string) bool {
 	vc, err := globalBucketMetadataSys.GetVersioningConfig(bucket)
 	if err != nil {
 		return false
 	}
-	return vc.EnabledPrefix(prefix)
+	return vc.PrefixEnabled(prefix)
 }
 
 // Suspended suspended versioning?
@@ -51,25 +51,19 @@ func (sys *BucketVersioningSys) Suspended(bucket string) bool {
 	return vc.Suspended()
 }
 
-// SuspendedPrefix returns true if the given prefix matches an excluded prefix
+// PrefixSuspended returns true if the given prefix matches an excluded prefix
 // pattern. This is part of a MinIO versioning configuration extension.
-func (sys *BucketVersioningSys) SuspendedPrefix(bucket, prefix string) bool {
+func (sys *BucketVersioningSys) PrefixSuspended(bucket, prefix string) bool {
 	vc, err := globalBucketMetadataSys.GetVersioningConfig(bucket)
 	if err != nil {
 		return false
 	}
-	return vc.SuspendedPrefix(prefix)
+
+	return vc.PrefixSuspended(prefix)
 }
 
 // Get returns stored bucket policy
 func (sys *BucketVersioningSys) Get(bucket string) (*versioning.Versioning, error) {
-	if globalIsGateway {
-		objAPI := newObjectLayerFn()
-		if objAPI == nil {
-			return nil, errServerNotInitialized
-		}
-		return nil, NotImplemented{}
-	}
 	return globalBucketMetadataSys.GetVersioningConfig(bucket)
 }
 

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1184,7 +1184,7 @@ func applyExpiryOnNonTransitionedObjects(ctx context.Context, objLayer ObjectLay
 		opts.VersionID = obj.VersionID
 	}
 	if opts.VersionID == "" {
-		opts.Versioned = globalBucketVersioningSys.Enabled(obj.Bucket)
+		opts.Versioned = globalBucketVersioningSys.EnabledPrefix(obj.Bucket, obj.Name)
 	}
 
 	obj, err := objLayer.DeleteObject(ctx, obj.Bucket, obj.Name, opts)

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1184,7 +1184,7 @@ func applyExpiryOnNonTransitionedObjects(ctx context.Context, objLayer ObjectLay
 		opts.VersionID = obj.VersionID
 	}
 	if opts.VersionID == "" {
-		opts.Versioned = globalBucketVersioningSys.EnabledPrefix(obj.Bucket, obj.Name)
+		opts.Versioned = globalBucketVersioningSys.PrefixEnabled(obj.Bucket, obj.Name)
 	}
 
 	obj, err := objLayer.DeleteObject(ctx, obj.Bucket, obj.Name, opts)

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1243,6 +1243,9 @@ func (i *scannerItem) objectPath() string {
 // healReplication will heal a scanned item that has failed replication.
 func (i *scannerItem) healReplication(ctx context.Context, o ObjectLayer, oi ObjectInfo, sizeS *sizeSummary) {
 	roi := getHealReplicateObjectInfo(oi, i.replication)
+	if !roi.Dsc.ReplicateAny() {
+		return
+	}
 
 	if oi.DeleteMarker || !oi.VersionPurgeStatus.Empty() {
 		// heal delete marker replication failure or versioned delete replication failure

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -107,7 +107,7 @@ func (fi FileInfo) IsValid() bool {
 func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 	object = decodeDirObject(object)
 	versionID := fi.VersionID
-	if (globalBucketVersioningSys.EnabledPrefix(bucket, object) || globalBucketVersioningSys.SuspendedPrefix(bucket, object)) && versionID == "" {
+	if (globalBucketVersioningSys.PrefixEnabled(bucket, object) || globalBucketVersioningSys.PrefixSuspended(bucket, object)) && versionID == "" {
 		versionID = nullVersionID
 	}
 

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -107,7 +107,7 @@ func (fi FileInfo) IsValid() bool {
 func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 	object = decodeDirObject(object)
 	versionID := fi.VersionID
-	if (globalBucketVersioningSys.Enabled(bucket) || globalBucketVersioningSys.Suspended(bucket)) && versionID == "" {
+	if (globalBucketVersioningSys.Enabled(bucket) || globalBucketVersioningSys.SuspendedPrefix(bucket, object)) && versionID == "" {
 		versionID = nullVersionID
 	}
 

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -107,7 +107,7 @@ func (fi FileInfo) IsValid() bool {
 func (fi FileInfo) ToObjectInfo(bucket, object string) ObjectInfo {
 	object = decodeDirObject(object)
 	versionID := fi.VersionID
-	if (globalBucketVersioningSys.Enabled(bucket) || globalBucketVersioningSys.SuspendedPrefix(bucket, object)) && versionID == "" {
+	if (globalBucketVersioningSys.EnabledPrefix(bucket, object) || globalBucketVersioningSys.SuspendedPrefix(bucket, object)) && versionID == "" {
 		versionID = nullVersionID
 	}
 

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1187,7 +1187,13 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 		// VersionID is not set means delete is not specific about
 		// any version, look for if the bucket is versioned or not.
 		if objects[i].VersionID == "" {
-			if opts.Versioned || opts.VersionSuspended {
+			// MinIO extension to bucket version configuration
+			suspended := opts.VersionSuspended
+			if opts.VersionSuspendedFn != nil {
+				suspended = opts.VersionSuspendedFn(objects[i].ObjectName)
+			}
+
+			if opts.Versioned || suspended {
 				// Bucket is versioned and no version was explicitly
 				// mentioned for deletes, create a delete marker instead.
 				vr.ModTime = UTCNow()

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1192,8 +1192,11 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 			if opts.VersionSuspendedFn != nil {
 				suspended = opts.VersionSuspendedFn(objects[i].ObjectName)
 			}
-
-			if opts.Versioned || suspended {
+			versioned := opts.Versioned
+			if opts.VersionedFn != nil {
+				versioned = opts.VersionedFn(objects[i].ObjectName)
+			}
+			if versioned || suspended {
 				// Bucket is versioned and no version was explicitly
 				// mentioned for deletes, create a delete marker instead.
 				vr.ModTime = UTCNow()

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1189,12 +1189,12 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 		if objects[i].VersionID == "" {
 			// MinIO extension to bucket version configuration
 			suspended := opts.VersionSuspended
-			if opts.VersionSuspendedFn != nil {
-				suspended = opts.VersionSuspendedFn(objects[i].ObjectName)
+			if opts.PrefixSuspendedFn != nil {
+				suspended = opts.PrefixSuspendedFn(objects[i].ObjectName)
 			}
 			versioned := opts.Versioned
-			if opts.VersionedFn != nil {
-				versioned = opts.VersionedFn(objects[i].ObjectName)
+			if opts.PrefixEnabledFn != nil {
+				versioned = opts.PrefixEnabledFn(objects[i].ObjectName)
 			}
 			if versioned || suspended {
 				// Bucket is versioned and no version was explicitly

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -619,7 +619,6 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 
 	parallelWorkers := make(chan struct{}, workerSize)
 
-	versioned := globalBucketVersioningSys.Enabled(bName)
 	for _, set := range pool.sets {
 		set := set
 		disks := set.getOnlineDisks()
@@ -629,6 +628,7 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 			continue
 		}
 
+		vc, _ := globalBucketVersioningSys.Get(bName)
 		decommissionEntry := func(entry metaCacheEntry) {
 			defer func() {
 				<-parallelWorkers
@@ -667,7 +667,7 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 						bName,
 						version.Name,
 						ObjectOptions{
-							Versioned:         versioned,
+							Versioned:         vc.EnabledPrefix(version.Name),
 							VersionID:         version.VersionID,
 							MTime:             version.ModTime,
 							DeleteReplication: version.ReplicationState,

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -667,7 +667,7 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 						bName,
 						version.Name,
 						ObjectOptions{
-							Versioned:         vc.EnabledPrefix(version.Name),
+							Versioned:         vc.PrefixEnabled(version.Name),
 							VersionID:         version.VersionID,
 							MTime:             version.ModTime,
 							DeleteReplication: version.ReplicationState,

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -77,6 +77,7 @@ type ObjectOptions struct {
 	Mutate        bool
 	WalkAscending bool // return Walk results in ascending order of versions
 
+	VersionedFn        func(prefix string) bool
 	VersionSuspendedFn func(prefix string) bool
 }
 

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -77,8 +77,8 @@ type ObjectOptions struct {
 	Mutate        bool
 	WalkAscending bool // return Walk results in ascending order of versions
 
-	VersionedFn        func(prefix string) bool
-	VersionSuspendedFn func(prefix string) bool
+	PrefixEnabledFn   func(prefix string) bool
+	PrefixSuspendedFn func(prefix string) bool
 }
 
 // ExpirationOptions represents object options for object expiration at objectLayer.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -76,6 +76,8 @@ type ObjectOptions struct {
 	// Mutate set to 'true' if the call is namespace mutation call
 	Mutate        bool
 	WalkAscending bool // return Walk results in ascending order of versions
+
+	VersionSuspendedFn func(prefix string) bool
 }
 
 // ExpirationOptions represents object options for object expiration at objectLayer.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -77,8 +77,8 @@ type ObjectOptions struct {
 	Mutate        bool
 	WalkAscending bool // return Walk results in ascending order of versions
 
-	PrefixEnabledFn   func(prefix string) bool
-	PrefixSuspendedFn func(prefix string) bool
+	PrefixEnabledFn   func(prefix string) bool // function which returns true if versioning is enabled on prefix
+	PrefixSuspendedFn func(prefix string) bool // function which returns true if versioning is suspended on prefix
 }
 
 // ExpirationOptions represents object options for object expiration at objectLayer.

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -70,7 +70,7 @@ func testListObjectsVersionedFolders(obj ObjectLayer, instanceType string, t1 Te
 		md5Bytes := md5.Sum([]byte(object.content))
 		_, err = obj.PutObject(context.Background(), object.parentBucket, object.name, mustGetPutObjReader(t, bytes.NewBufferString(object.content),
 			int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), ObjectOptions{
-			Versioned:   globalBucketVersioningSys.Enabled(object.parentBucket),
+			Versioned:   globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
 			UserDefined: object.meta,
 		})
 		if err != nil {
@@ -78,7 +78,7 @@ func testListObjectsVersionedFolders(obj ObjectLayer, instanceType string, t1 Te
 		}
 		if object.addDeleteMarker {
 			oi, err := obj.DeleteObject(context.Background(), object.parentBucket, object.name, ObjectOptions{
-				Versioned: globalBucketVersioningSys.Enabled(object.parentBucket),
+				Versioned: globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
 			})
 			if err != nil {
 				t.Fatalf("%s : %s", instanceType, err.Error())
@@ -380,7 +380,7 @@ func _testListObjects(obj ObjectLayer, instanceType string, t1 TestErrHandler, v
 		_, err = obj.PutObject(context.Background(), object.parentBucket, object.name,
 			mustGetPutObjReader(t, bytes.NewBufferString(object.content),
 				int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), ObjectOptions{
-				Versioned:   globalBucketVersioningSys.Enabled(object.parentBucket),
+				Versioned:   globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
 				UserDefined: object.meta,
 			})
 		if err != nil {
@@ -1065,7 +1065,7 @@ func testDeleteObjectVersion(obj ObjectLayer, instanceType string, t1 TestErrHan
 		_, err := obj.PutObject(context.Background(), object.parentBucket, object.name,
 			mustGetPutObjReader(t, bytes.NewBufferString(object.content),
 				int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), ObjectOptions{
-				Versioned:        globalBucketVersioningSys.Enabled(object.parentBucket),
+				Versioned:        globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
 				VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(object.parentBucket, object.name),
 				UserDefined:      object.meta,
 			})
@@ -1073,7 +1073,7 @@ func testDeleteObjectVersion(obj ObjectLayer, instanceType string, t1 TestErrHan
 			t.Fatalf("%s : %s", instanceType, err)
 		}
 		obj, err := obj.DeleteObject(context.Background(), object.parentBucket, object.name, ObjectOptions{
-			Versioned:        globalBucketVersioningSys.Enabled(object.parentBucket),
+			Versioned:        globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
 			VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(object.parentBucket, object.name),
 			VersionID:        object.versionID,
 		})

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -70,7 +70,7 @@ func testListObjectsVersionedFolders(obj ObjectLayer, instanceType string, t1 Te
 		md5Bytes := md5.Sum([]byte(object.content))
 		_, err = obj.PutObject(context.Background(), object.parentBucket, object.name, mustGetPutObjReader(t, bytes.NewBufferString(object.content),
 			int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), ObjectOptions{
-			Versioned:   globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
+			Versioned:   globalBucketVersioningSys.PrefixEnabled(object.parentBucket, object.name),
 			UserDefined: object.meta,
 		})
 		if err != nil {
@@ -78,7 +78,7 @@ func testListObjectsVersionedFolders(obj ObjectLayer, instanceType string, t1 Te
 		}
 		if object.addDeleteMarker {
 			oi, err := obj.DeleteObject(context.Background(), object.parentBucket, object.name, ObjectOptions{
-				Versioned: globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
+				Versioned: globalBucketVersioningSys.PrefixEnabled(object.parentBucket, object.name),
 			})
 			if err != nil {
 				t.Fatalf("%s : %s", instanceType, err.Error())
@@ -380,7 +380,7 @@ func _testListObjects(obj ObjectLayer, instanceType string, t1 TestErrHandler, v
 		_, err = obj.PutObject(context.Background(), object.parentBucket, object.name,
 			mustGetPutObjReader(t, bytes.NewBufferString(object.content),
 				int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), ObjectOptions{
-				Versioned:   globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
+				Versioned:   globalBucketVersioningSys.PrefixEnabled(object.parentBucket, object.name),
 				UserDefined: object.meta,
 			})
 		if err != nil {
@@ -1065,16 +1065,16 @@ func testDeleteObjectVersion(obj ObjectLayer, instanceType string, t1 TestErrHan
 		_, err := obj.PutObject(context.Background(), object.parentBucket, object.name,
 			mustGetPutObjReader(t, bytes.NewBufferString(object.content),
 				int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), ObjectOptions{
-				Versioned:        globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
-				VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(object.parentBucket, object.name),
+				Versioned:        globalBucketVersioningSys.PrefixEnabled(object.parentBucket, object.name),
+				VersionSuspended: globalBucketVersioningSys.PrefixSuspended(object.parentBucket, object.name),
 				UserDefined:      object.meta,
 			})
 		if err != nil {
 			t.Fatalf("%s : %s", instanceType, err)
 		}
 		obj, err := obj.DeleteObject(context.Background(), object.parentBucket, object.name, ObjectOptions{
-			Versioned:        globalBucketVersioningSys.EnabledPrefix(object.parentBucket, object.name),
-			VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(object.parentBucket, object.name),
+			Versioned:        globalBucketVersioningSys.PrefixEnabled(object.parentBucket, object.name),
+			VersionSuspended: globalBucketVersioningSys.PrefixSuspended(object.parentBucket, object.name),
 			VersionID:        object.versionID,
 		})
 		if err != nil {

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -1066,7 +1066,7 @@ func testDeleteObjectVersion(obj ObjectLayer, instanceType string, t1 TestErrHan
 			mustGetPutObjReader(t, bytes.NewBufferString(object.content),
 				int64(len(object.content)), hex.EncodeToString(md5Bytes[:]), ""), ObjectOptions{
 				Versioned:        globalBucketVersioningSys.Enabled(object.parentBucket),
-				VersionSuspended: globalBucketVersioningSys.Suspended(object.parentBucket),
+				VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(object.parentBucket, object.name),
 				UserDefined:      object.meta,
 			})
 		if err != nil {
@@ -1074,7 +1074,7 @@ func testDeleteObjectVersion(obj ObjectLayer, instanceType string, t1 TestErrHan
 		}
 		obj, err := obj.DeleteObject(context.Background(), object.parentBucket, object.name, ObjectOptions{
 			Versioned:        globalBucketVersioningSys.Enabled(object.parentBucket),
-			VersionSuspended: globalBucketVersioningSys.Suspended(object.parentBucket),
+			VersionSuspended: globalBucketVersioningSys.SuspendedPrefix(object.parentBucket, object.name),
 			VersionID:        object.versionID,
 		})
 		if err != nil {

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -161,7 +161,7 @@ func getOpts(ctx context.Context, r *http.Request, bucket, object string) (Objec
 }
 
 func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts ObjectOptions, err error) {
-	versioned := globalBucketVersioningSys.Enabled(bucket)
+	versioned := globalBucketVersioningSys.EnabledPrefix(bucket, object)
 	opts, err = getOpts(ctx, r, bucket, object)
 	if err != nil {
 		return opts, err
@@ -203,7 +203,7 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 
 // get ObjectOptions for PUT calls from encryption headers and metadata
 func putOpts(ctx context.Context, r *http.Request, bucket, object string, metadata map[string]string) (opts ObjectOptions, err error) {
-	versioned := globalBucketVersioningSys.Enabled(bucket)
+	versioned := globalBucketVersioningSys.EnabledPrefix(bucket, object)
 	versionSuspended := globalBucketVersioningSys.SuspendedPrefix(bucket, object)
 
 	vid := strings.TrimSpace(r.Form.Get(xhttp.VersionID))

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -167,7 +167,7 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 		return opts, err
 	}
 	opts.Versioned = versioned
-	opts.VersionSuspended = globalBucketVersioningSys.Suspended(bucket)
+	opts.VersionSuspended = globalBucketVersioningSys.SuspendedPrefix(bucket, object)
 	delMarker := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarker))
 	if delMarker != "" {
 		switch delMarker {
@@ -204,7 +204,8 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 // get ObjectOptions for PUT calls from encryption headers and metadata
 func putOpts(ctx context.Context, r *http.Request, bucket, object string, metadata map[string]string) (opts ObjectOptions, err error) {
 	versioned := globalBucketVersioningSys.Enabled(bucket)
-	versionSuspended := globalBucketVersioningSys.Suspended(bucket)
+	versionSuspended := globalBucketVersioningSys.SuspendedPrefix(bucket, object)
+
 	vid := strings.TrimSpace(r.Form.Get(xhttp.VersionID))
 	if vid != "" && vid != nullVersionID {
 		_, err := uuid.Parse(vid)

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -161,12 +161,11 @@ func getOpts(ctx context.Context, r *http.Request, bucket, object string) (Objec
 }
 
 func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts ObjectOptions, err error) {
-	versioned := globalBucketVersioningSys.PrefixEnabled(bucket, object)
 	opts, err = getOpts(ctx, r, bucket, object)
 	if err != nil {
 		return opts, err
 	}
-	opts.Versioned = versioned
+	opts.Versioned = globalBucketVersioningSys.PrefixEnabled(bucket, object)
 	opts.VersionSuspended = globalBucketVersioningSys.PrefixSuspended(bucket, object)
 	delMarker := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarker))
 	if delMarker != "" {

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -161,13 +161,13 @@ func getOpts(ctx context.Context, r *http.Request, bucket, object string) (Objec
 }
 
 func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts ObjectOptions, err error) {
-	versioned := globalBucketVersioningSys.EnabledPrefix(bucket, object)
+	versioned := globalBucketVersioningSys.PrefixEnabled(bucket, object)
 	opts, err = getOpts(ctx, r, bucket, object)
 	if err != nil {
 		return opts, err
 	}
 	opts.Versioned = versioned
-	opts.VersionSuspended = globalBucketVersioningSys.SuspendedPrefix(bucket, object)
+	opts.VersionSuspended = globalBucketVersioningSys.PrefixSuspended(bucket, object)
 	delMarker := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarker))
 	if delMarker != "" {
 		switch delMarker {
@@ -203,8 +203,8 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 
 // get ObjectOptions for PUT calls from encryption headers and metadata
 func putOpts(ctx context.Context, r *http.Request, bucket, object string, metadata map[string]string) (opts ObjectOptions, err error) {
-	versioned := globalBucketVersioningSys.EnabledPrefix(bucket, object)
-	versionSuspended := globalBucketVersioningSys.SuspendedPrefix(bucket, object)
+	versioned := globalBucketVersioningSys.PrefixEnabled(bucket, object)
+	versionSuspended := globalBucketVersioningSys.PrefixSuspended(bucket, object)
 
 	vid := strings.TrimSpace(r.Form.Get(xhttp.VersionID))
 	if vid != "" && vid != nullVersionID {

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -275,8 +275,8 @@ func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toD
 		}
 		vc, _ := globalBucketVersioningSys.Get(bucket)
 		deletedObjs, errs := o.DeleteObjects(ctx, bucket, toDel, ObjectOptions{
-			VersionedFn:        vc.EnabledPrefix,
-			VersionSuspendedFn: vc.SuspendedPrefix,
+			PrefixEnabledFn:   vc.PrefixEnabled,
+			PrefixSuspendedFn: vc.PrefixSuspended,
 		})
 		var logged bool
 		for i, err := range errs {

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -266,7 +266,6 @@ func setPutObjHeaders(w http.ResponseWriter, objInfo ObjectInfo, delete bool) {
 }
 
 func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toDel []ObjectToDelete) {
-	versioned := globalBucketVersioningSys.Enabled(bucket)
 	for remaining := toDel; len(remaining) > 0; toDel = remaining {
 		if len(toDel) > maxDeleteList {
 			remaining = toDel[maxDeleteList:]
@@ -276,7 +275,7 @@ func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toD
 		}
 		vc, _ := globalBucketVersioningSys.Get(bucket)
 		deletedObjs, errs := o.DeleteObjects(ctx, bucket, toDel, ObjectOptions{
-			Versioned:          versioned,
+			VersionedFn:        vc.EnabledPrefix,
 			VersionSuspendedFn: vc.SuspendedPrefix,
 		})
 		var logged bool

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -267,7 +267,6 @@ func setPutObjHeaders(w http.ResponseWriter, objInfo ObjectInfo, delete bool) {
 
 func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toDel []ObjectToDelete) {
 	versioned := globalBucketVersioningSys.Enabled(bucket)
-	versionSuspended := globalBucketVersioningSys.Suspended(bucket)
 	for remaining := toDel; len(remaining) > 0; toDel = remaining {
 		if len(toDel) > maxDeleteList {
 			remaining = toDel[maxDeleteList:]
@@ -275,9 +274,10 @@ func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toD
 		} else {
 			remaining = nil
 		}
+		vc, _ := globalBucketVersioningSys.Get(bucket)
 		deletedObjs, errs := o.DeleteObjects(ctx, bucket, toDel, ObjectOptions{
-			Versioned:        versioned,
-			VersionSuspended: versionSuspended,
+			Versioned:          versioned,
+			VersionSuspendedFn: vc.SuspendedPrefix,
 		})
 		var logged bool
 		for i, err := range errs {

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3212,7 +3212,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 	}
 
 	versioned := globalBucketVersioningSys.Enabled(bucket)
-	suspended := globalBucketVersioningSys.Suspended(bucket)
+	suspended := globalBucketVersioningSys.SuspendedPrefix(bucket, object)
 	os := newObjSweeper(bucket, object).WithVersioning(versioned, suspended)
 	if !globalTierConfigMgr.Empty() {
 		// Get appropriate object info to identify the remote object to delete

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -204,7 +204,7 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 
 	objInfo, err := getObjectInfo(ctx, bucket, object, opts)
 	if err != nil {
-		if globalBucketVersioningSys.Enabled(bucket) {
+		if globalBucketVersioningSys.EnabledPrefix(bucket, object) {
 			// Versioning enabled quite possibly object is deleted might be delete-marker
 			// if present set the headers, no idea why AWS S3 sets these headers.
 			if objInfo.VersionID != "" && objInfo.DeleteMarker {
@@ -445,7 +445,7 @@ func (api objectAPIHandlers) getObjectHandler(ctx context.Context, objectAPI Obj
 				writeErrorResponse(ctx, w, toAPIError(ctx, proxy.Err), r.URL)
 				return
 			}
-			if globalBucketVersioningSys.Enabled(bucket) && gr != nil {
+			if globalBucketVersioningSys.EnabledPrefix(bucket, object) && gr != nil {
 				if !gr.ObjInfo.VersionPurgeStatus.Empty() {
 					// Shows the replication status of a permanent delete of a version
 					w.Header()[xhttp.MinIODeleteReplicationStatus] = []string{string(gr.ObjInfo.VersionPurgeStatus)}
@@ -673,7 +673,7 @@ func (api objectAPIHandlers) headObjectHandler(ctx context.Context, objectAPI Ob
 			}
 		}
 		if !proxy.Proxy {
-			if globalBucketVersioningSys.Enabled(bucket) {
+			if globalBucketVersioningSys.EnabledPrefix(bucket, object) {
 				switch {
 				case !objInfo.VersionPurgeStatus.Empty():
 					w.Header()[xhttp.MinIODeleteReplicationStatus] = []string{string(objInfo.VersionPurgeStatus)}
@@ -1087,7 +1087,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		if isErrPreconditionFailed(err) {
 			return
 		}
-		if globalBucketVersioningSys.Enabled(srcBucket) && gr != nil {
+		if globalBucketVersioningSys.EnabledPrefix(srcBucket, srcObject) && gr != nil {
 			// Versioning enabled quite possibly object is deleted might be delete-marker
 			// if present set the headers, no idea why AWS S3 sets these headers.
 			if gr.ObjInfo.VersionID != "" && gr.ObjInfo.DeleteMarker {
@@ -2480,7 +2480,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 		if isErrPreconditionFailed(err) {
 			return
 		}
-		if globalBucketVersioningSys.Enabled(srcBucket) && gr != nil {
+		if globalBucketVersioningSys.EnabledPrefix(srcBucket, srcObject) && gr != nil {
 			// Versioning enabled quite possibly object is deleted might be delete-marker
 			// if present set the headers, no idea why AWS S3 sets these headers.
 			if gr.ObjInfo.VersionID != "" && gr.ObjInfo.DeleteMarker {
@@ -3211,7 +3211,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 		w.Write(encodedErrorResponse)
 	}
 
-	versioned := globalBucketVersioningSys.Enabled(bucket)
+	versioned := globalBucketVersioningSys.EnabledPrefix(bucket, object)
 	suspended := globalBucketVersioningSys.SuspendedPrefix(bucket, object)
 	os := newObjSweeper(bucket, object).WithVersioning(versioned, suspended)
 	if !globalTierConfigMgr.Empty() {

--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -248,14 +248,20 @@ When Bucket Versioning with excluded prefixes are configured objects matching th
 
 ```
 <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <Status>Enabled</Status>
-  <ExcludedPrefixes>
-    <Prefix>prefix1/*</Prefix>
-  </ExcludedPrefixes>
-  <!-- .. up to 10 prefixes in all -->
+        <Status>Enabled</Status>
+        <ExcludePrefixMarker>true</ExcludePrefixMarker>
+
+        <ExcludedPrefixes>
+          <Prefix>app1-jobs/*/_temporary/</Prefix>
+        </ExcludedPrefixes>
+        <ExcludedPrefixes>
+          <Prefix>app2-jobs/_magic/</Prefix>
+        </ExcludedPrefixes>
+
+        <!-- .. up to 10 prefixes in all -->
 </VersioningConfiguration>
 ```
-In the above sample config, objects with key matching `prefix1/*` will neither be versioned nor replicated.
+In the above sample config, objects under prefixes matching any of the `ExcludedPrefixes` glob patterns will neither be versioned nor replicated.
 
 ## Explore Further
 

--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -249,7 +249,7 @@ When Bucket Versioning with excluded prefixes are configured objects matching th
 ```
 <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
         <Status>Enabled</Status>
-        <ExcludePrefixMarker>true</ExcludePrefixMarker>
+        <ExcludeFolders>true</ExcludeFolders>
 
         <ExcludedPrefixes>
           <Prefix>app1-jobs/*/_temporary/</Prefix>

--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -255,7 +255,7 @@ When Bucket Versioning with excluded prefixes are configured objects matching th
           <Prefix>app1-jobs/*/_temporary/</Prefix>
         </ExcludedPrefixes>
         <ExcludedPrefixes>
-          <Prefix>app2-jobs/_magic/</Prefix>
+          <Prefix>app2-jobs/*/_magic/</Prefix>
         </ExcludedPrefixes>
 
         <!-- .. up to 10 prefixes in all -->

--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -243,6 +243,20 @@ Replication from a source bucket to multiple destination buckets is supported. F
 
 Note that on the source side, the `X-Amz-Replication-Status` changes from `PENDING` to `COMPLETED` after replication succeeds to each of the targets. On the destination side, a `X-Amz-Replication-Status` status of `REPLICA` indicates that the object was replicated successfully. Any replication failures are automatically re-attempted during a periodic disk scanner cycle.
 
+### Interaction with extended Bucket Versioning configuration
+When Bucket Versioning with excluded prefixes are configured objects matching these prefixes are excluded from being versioned and replicated.
+
+```
+<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Status>Enabled</Status>
+  <ExcludedPrefixes>
+    <Prefix>prefix1/*</Prefix>
+  </ExcludedPrefixes>
+  <!-- .. up to 10 prefixes in all -->
+</VersioningConfiguration>
+```
+In the above sample config, objects with key matching `prefix1/*` will neither be versioned nor replicated.
+
 ## Explore Further
 
 - [MinIO Bucket Replication Design](https://github.com/minio/minio/blob/master/docs/bucket/replication/DESIGN.md)

--- a/docs/bucket/versioning/README.md
+++ b/docs/bucket/versioning/README.md
@@ -79,7 +79,7 @@ To exclude objects under a list of prefix (glob) patterns from being versioned, 
           <Prefix>app1-jobs/*/_temporary/</Prefix>
         </ExcludedPrefixes>
         <ExcludedPrefixes>
-          <Prefix>app2-jobs/_magic/</Prefix>
+          <Prefix>app2-jobs/*/_magic/</Prefix>
         </ExcludedPrefixes>
 
         <!-- .. up to 10 prefixes in all -->

--- a/docs/bucket/versioning/README.md
+++ b/docs/bucket/versioning/README.md
@@ -65,21 +65,24 @@ Similarly to suspend versioning set the configuration with Status set to `Suspen
 
 ## MinIO extension to Bucket Versioning
 ### Motivation
-Spark/Hadoop workloads which use FileOutputCommitter v1/v2 algorithm upload objects to a temporary prefix in a bucket. These objects are 'renamed' to a different prefix on Job commit. Object storage admins are forced to configure separate ILM policies to expire these objects and their versions to reclaim space.
+Spark/Hadoop workloads which use Hadoop MR Committer v1/v2 algorithm upload objects to a temporary prefix in a bucket. These objects are 'renamed' to a different prefix on Job commit. Object storage admins are forced to configure separate ILM policies to expire these objects and their versions to reclaim space.
 
 ### Solution
 To exclude objects under a list of prefix (glob) patterns from being versioned, you can send the following versioning configuration with Status set to `Enabled`.
 
 ```
 <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <Status>Enabled</Status>
-  <ExcludedPrefixes>
-    <Prefix>prefix1/*</Prefix>
-  </ExcludedPrefixes>
-  <ExcludedPrefixes>
-    <Prefix>spark/jobs/* </Prefix>
-  </ExcludedPrefixes>
-  <!-- .. up to 10 prefixes in all -->
+        <Status>Enabled</Status>
+        <ExcludePrefixMarker>true</ExcludePrefixMarker>
+
+        <ExcludedPrefixes>
+          <Prefix>app1-jobs/*/_temporary/</Prefix>
+        </ExcludedPrefixes>
+        <ExcludedPrefixes>
+          <Prefix>app2-jobs/_magic/</Prefix>
+        </ExcludedPrefixes>
+
+        <!-- .. up to 10 prefixes in all -->
 </VersioningConfiguration>
 ```
 

--- a/docs/bucket/versioning/README.md
+++ b/docs/bucket/versioning/README.md
@@ -73,7 +73,7 @@ To exclude objects under a list of prefix (glob) patterns from being versioned, 
 ```
 <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
         <Status>Enabled</Status>
-        <ExcludePrefixMarker>true</ExcludePrefixMarker>
+        <ExcludeFolders>true</ExcludeFolders>
 
         <ExcludedPrefixes>
           <Prefix>app1-jobs/*/_temporary/</Prefix>

--- a/docs/bucket/versioning/README.md
+++ b/docs/bucket/versioning/README.md
@@ -63,6 +63,28 @@ Similarly to suspend versioning set the configuration with Status set to `Suspen
 </VersioningConfiguration>
 ```
 
+## MinIO extension to Bucket Versioning
+### Motivation
+Spark/Hadoop workloads which use FileOutputCommitter v1/v2 algorithm upload objects to a temporary prefix in a bucket. These objects are 'renamed' to a different prefix on Job commit. Object storage admins are forced to configure separate ILM policies to expire these objects and their versions to reclaim space.
+
+### Solution
+To exclude objects under a list of prefix (glob) patterns from being versioned, you can send the following versioning configuration with Status set to `Enabled`.
+
+```
+<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Status>Enabled</Status>
+  <ExcludedPrefixes>
+    <Prefix>prefix1/*</Prefix>
+  </ExcludedPrefixes>
+  <ExcludedPrefixes>
+    <Prefix>spark/jobs/* </Prefix>
+  </ExcludedPrefixes>
+  <!-- .. up to 10 prefixes in all -->
+</VersioningConfiguration>
+```
+
+Note: Objects matching these prefixes will behave as though versioning were suspended. These objects **will not** be replicated if replication is configured.
+
 Only users with explicit permissions or the root credential can configure the versioning state of any bucket.
 
 ## Examples of enabling bucket versioning using MinIO Java SDK

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -89,18 +89,20 @@ func (v Versioning) Enabled() bool {
 // PrefixEnabled - returns true if versioning is enabled at the bucket and given
 // prefix, false otherwise.
 func (v Versioning) PrefixEnabled(prefix string) bool {
-	if v.Status == Enabled {
-		if prefix == "" {
-			return true
-		}
-		for _, sprefix := range v.ExcludedPrefixes {
-			if matched := wildcard.MatchSimple(sprefix.Prefix, prefix); matched {
-				return false
-			}
-		}
+	if v.Status != Enabled {
+		return false
+	}
+
+	if prefix == "" {
 		return true
 	}
-	return false
+	for _, sprefix := range v.ExcludedPrefixes {
+		if matched := wildcard.MatchSimple(sprefix.Prefix, prefix); matched {
+			return false
+		}
+	}
+	return true
+
 }
 
 // Suspended - returns true if versioning is suspended

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -98,8 +98,9 @@ func (v Versioning) EnabledPrefix(prefix string) bool {
 				return false
 			}
 		}
+		return true
 	}
-	return true
+	return false
 }
 
 // Suspended - returns true if versioning is suspended

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -87,11 +87,29 @@ func (v Versioning) Enabled() bool {
 	return v.Status == Enabled
 }
 
+// EnabledPrefix - returns true if versioning is enabled at the bucket and given
+// prefix, false otherwise.
+func (v Versioning) EnabledPrefix(prefix string) bool {
+	if v.Status == Enabled {
+		if prefix == "" {
+			return true
+		}
+		for _, sprefix := range v.SuspendedPrefixes {
+			if matched, _ := filepath.Match(sprefix, prefix); matched {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // Suspended - returns true if versioning is suspended
 func (v Versioning) Suspended() bool {
 	return v.Status == Suspended
 }
 
+// SuspendedPrefix - returns true if versioning is suspended at the bucket level
+// or suspended on the given prefix.
 func (v Versioning) SuspendedPrefix(prefix string) bool {
 	if v.Status == Suspended {
 		return true

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -40,7 +40,7 @@ var (
 	errTooManyExcludedPrefixes    = Errorf("too many excluded prefixes")
 )
 
-// Prefix - holds individual prefixes excluded from being versioned.
+// ExcludedPrefix - holds individual prefixes excluded from being versioned.
 type ExcludedPrefix struct {
 	Prefix string
 }
@@ -58,7 +58,6 @@ type Versioning struct {
 
 // Validate - validates the versioning configuration
 func (v Versioning) Validate() error {
-
 	// Not supported yet
 	// switch v.MFADelete {
 	// case Enabled, Disabled:

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -39,6 +39,11 @@ var (
 	errTooManyExcludedPrefixes    = Errorf("too many excluded prefixes")
 )
 
+// Prefix - holds individual prefixes excluded from being versioned.
+type Prefix struct {
+	Prefix string
+}
+
 // Versioning - Configuration for bucket versioning.
 type Versioning struct {
 	XMLNS   string   `xml:"xmlns,attr,omitempty"`
@@ -47,7 +52,7 @@ type Versioning struct {
 	Status State `xml:"Status,omitempty"`
 	// MinIO extension - allows selective, prefix-level versioning exclusion.
 	// Requires versioning to be enabled
-	ExcludedPrefixes []string `xml:">Prefix,omitempty"`
+	ExcludedPrefixes []Prefix `xml:",omitempty"`
 }
 
 // Validate - validates the versioning configuration
@@ -67,8 +72,8 @@ func (v Versioning) Validate() error {
 		}
 		for _, sprefix := range v.ExcludedPrefixes {
 			// Use filepath.Match to check for bad patterns
-			if _, err := filepath.Match(sprefix, ""); err != nil {
-				return Errorf("invalid excluded prefix %s: %w", sprefix, err)
+			if _, err := filepath.Match(sprefix.Prefix, ""); err != nil {
+				return Errorf("invalid excluded prefix %s: %w", sprefix.Prefix, err)
 			}
 		}
 
@@ -95,7 +100,7 @@ func (v Versioning) EnabledPrefix(prefix string) bool {
 			return true
 		}
 		for _, sprefix := range v.ExcludedPrefixes {
-			if matched, _ := filepath.Match(sprefix, prefix); matched {
+			if matched, _ := filepath.Match(sprefix.Prefix, prefix); matched {
 				return false
 			}
 		}
@@ -119,7 +124,7 @@ func (v Versioning) SuspendedPrefix(prefix string) bool {
 			return false
 		}
 		for _, sprefix := range v.ExcludedPrefixes {
-			if matched, _ := filepath.Match(sprefix, prefix); matched {
+			if matched, _ := filepath.Match(sprefix.Prefix, prefix); matched {
 				return true
 			}
 		}

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -55,8 +55,8 @@ type Versioning struct {
 	Status State `xml:"Status,omitempty"`
 	// MinIO extension - allows selective, prefix-level versioning exclusion.
 	// Requires versioning to be enabled
-	ExcludedPrefixes    []ExcludedPrefix `xml:",omitempty"`
-	ExcludePrefixMarker bool             `xml:",omitempty"`
+	ExcludedPrefixes []ExcludedPrefix `xml:",omitempty"`
+	ExcludeFolders   bool             `xml:",omitempty"`
 }
 
 // Validate - validates the versioning configuration
@@ -104,7 +104,7 @@ func (v Versioning) PrefixEnabled(prefix string) bool {
 	if prefix == "" {
 		return true
 	}
-	if v.ExcludePrefixMarker && strings.HasSuffix(prefix, "/") {
+	if v.ExcludeFolders && strings.HasSuffix(prefix, "/") {
 		return false
 	}
 
@@ -134,7 +134,7 @@ func (v Versioning) PrefixSuspended(prefix string) bool {
 		if prefix == "" {
 			return false
 		}
-		if v.ExcludePrefixMarker && strings.HasSuffix(prefix, "/") {
+		if v.ExcludeFolders && strings.HasSuffix(prefix, "/") {
 			return true
 		}
 
@@ -150,9 +150,9 @@ func (v Versioning) PrefixSuspended(prefix string) bool {
 }
 
 // PrefixesExcluded returns true if v contains one or more excluded object
-// prefixes or if ExcludePrefixMarker is true.
+// prefixes or if ExcludeFolders is true.
 func (v Versioning) PrefixesExcluded() bool {
-	return len(v.ExcludedPrefixes) > 0 || v.ExcludePrefixMarker
+	return len(v.ExcludedPrefixes) > 0 || v.ExcludeFolders
 }
 
 // ParseConfig - parses data in given reader to VersioningConfiguration.

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -150,9 +150,9 @@ func (v Versioning) PrefixSuspended(prefix string) bool {
 }
 
 // PrefixesExcluded returns true if v contains one or more excluded object
-// prefixes.
+// prefixes or if ExcludePrefixMarker is true.
 func (v Versioning) PrefixesExcluded() bool {
-	return len(v.ExcludedPrefixes) > 0
+	return len(v.ExcludedPrefixes) > 0 || v.ExcludePrefixMarker
 }
 
 // ParseConfig - parses data in given reader to VersioningConfiguration.

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -97,6 +97,9 @@ func (v Versioning) SuspendedPrefix(prefix string) bool {
 		return true
 	}
 	if v.Status == Enabled {
+		if prefix == "" {
+			return false
+		}
 		for _, sprefix := range v.SuspendedPrefixes {
 			if matched, _ := filepath.Match(sprefix, prefix); matched {
 				return true

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -110,7 +110,7 @@ func (v Versioning) PrefixEnabled(prefix string) bool {
 
 	for _, sprefix := range v.ExcludedPrefixes {
 		// Note: all excluded prefix patterns end with `/` (See Validate)
-		sprefix.Prefix = sprefix.Prefix + "*"
+		sprefix.Prefix += "*"
 
 		if matched := wildcard.MatchSimple(sprefix.Prefix, prefix); matched {
 			return false
@@ -139,6 +139,8 @@ func (v Versioning) PrefixSuspended(prefix string) bool {
 		}
 
 		for _, sprefix := range v.ExcludedPrefixes {
+			// Note: all excluded prefix patterns end with `/` (See Validate)
+			sprefix.Prefix += "*"
 			if matched := wildcard.MatchSimple(sprefix.Prefix, prefix); matched {
 				return true
 			}

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -86,9 +86,9 @@ func (v Versioning) Enabled() bool {
 	return v.Status == Enabled
 }
 
-// EnabledPrefix - returns true if versioning is enabled at the bucket and given
+// PrefixEnabled - returns true if versioning is enabled at the bucket and given
 // prefix, false otherwise.
-func (v Versioning) EnabledPrefix(prefix string) bool {
+func (v Versioning) PrefixEnabled(prefix string) bool {
 	if v.Status == Enabled {
 		if prefix == "" {
 			return true
@@ -108,9 +108,9 @@ func (v Versioning) Suspended() bool {
 	return v.Status == Suspended
 }
 
-// SuspendedPrefix - returns true if versioning is suspended at the bucket level
+// PrefixSuspended - returns true if versioning is suspended at the bucket level
 // or suspended on the given prefix.
-func (v Versioning) SuspendedPrefix(prefix string) bool {
+func (v Versioning) PrefixSuspended(prefix string) bool {
 	if v.Status == Suspended {
 		return true
 	}

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -102,7 +102,6 @@ func (v Versioning) PrefixEnabled(prefix string) bool {
 		}
 	}
 	return true
-
 }
 
 // Suspended - returns true if versioning is suspended

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -128,6 +128,12 @@ func (v Versioning) PrefixSuspended(prefix string) bool {
 	return false
 }
 
+// PrefixesExcluded returns true if v contains one or more excluded object
+// prefixes.
+func (v Versioning) PrefixesExcluded() bool {
+	return len(v.ExcludedPrefixes) > 0
+}
+
 // ParseConfig - parses data in given reader to VersioningConfiguration.
 func ParseConfig(reader io.Reader) (*Versioning, error) {
 	var v Versioning

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -19,26 +19,26 @@ func TestParseConfig(t *testing.T) {
 		{
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                                   <Status>Enabled</Status>
-                                  <SuspendedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging </Prefix>
                                     <Prefix> path/to/my/workload/_temporary/ </Prefix>
-                                  </SuspendedPrefixes>
+                                  </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
 			err: nil,
 		},
 		{
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                                   <Status>Suspended</Status>
-                                  <SuspendedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging </Prefix>
-                                  </SuspendedPrefixes>
+                                  </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
-			err: errSuspendedPrefixNotSupported,
+			err: errExcludedPrefixNotSupported,
 		},
 		{
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                                   <Status>Enabled</Status>
-                                  <SuspendedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/ab </Prefix>
                                     <Prefix> path/to/my/workload/_staging/cd </Prefix>
                                     <Prefix> path/to/my/workload/_staging/ef </Prefix>
@@ -50,9 +50,9 @@ func TestParseConfig(t *testing.T) {
                                     <Prefix> path/to/my/workload/_staging/qr </Prefix>
                                     <Prefix> path/to/my/workload/_staging/st </Prefix>
                                     <Prefix> path/to/my/workload/_staging/uv </Prefix>
-                                  </SuspendedPrefixes>
+                                  </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
-			err: errTooManySuspendedPrefixes,
+			err: errTooManyExcludedPrefixes,
 		},
 	}
 

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -1,0 +1,77 @@
+package versioning
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	testcases := []struct {
+		input string
+		err   error
+	}{
+		{
+			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                  <Status>Enabled</Status>
+                                </VersioningConfiguration>`,
+			err: nil,
+		},
+		{
+			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                  <Status>Enabled</Status>
+                                  <SuspendedPrefixes>
+                                    <Prefix> path/to/my/workload/_staging </Prefix>
+                                    <Prefix> path/to/my/workload/_temporary/ </Prefix>
+                                  </SuspendedPrefixes>
+                                </VersioningConfiguration>`,
+			err: nil,
+		},
+		{
+			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                  <Status>Suspended</Status>
+                                  <SuspendedPrefixes>
+                                    <Prefix> path/to/my/workload/_staging </Prefix>
+                                  </SuspendedPrefixes>
+                                </VersioningConfiguration>`,
+			err: errSuspendedPrefixNotSupported,
+		},
+		{
+			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                  <Status>Enabled</Status>
+                                  <SuspendedPrefixes>
+                                    <Prefix> path/to/my/workload/_staging/ab </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/cd </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/ef </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/gh </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/ij </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/kl </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/mn </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/op </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/qr </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/st </Prefix>
+                                    <Prefix> path/to/my/workload/_staging/uv </Prefix>
+                                  </SuspendedPrefixes>
+                                </VersioningConfiguration>`,
+			err: errTooManySuspendedPrefixes,
+		},
+	}
+
+	for i, tc := range testcases {
+		var v *Versioning
+		var err error
+		v, err = ParseConfig(strings.NewReader(tc.input))
+		if tc.err != err {
+			t.Fatalf("Test %d: expected %v but got %v", i+1, tc.err, err)
+		}
+		if err != nil {
+			if tc.err == nil {
+				t.Fatalf("Test %d: failed due to %v", i+1, err)
+			}
+
+		} else {
+			if err := v.Validate(); tc.err != err {
+				t.Fatalf("Test %d: validation failed due to %v", i+1, err)
+			}
+		}
+	}
+}

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -25,10 +25,10 @@ import (
 
 func TestParseConfig(t *testing.T) {
 	testcases := []struct {
-		input               string
-		err                 error
-		excludedPrefixes    []string
-		excludePrefixMarker bool
+		input            string
+		err              error
+		excludedPrefixes []string
+		excludeFolders   bool
 	}{
 		{
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -100,7 +100,7 @@ func TestParseConfig(t *testing.T) {
 		{
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                                   <Status>Enabled</Status>
-                                  <ExcludePrefixMarker>true</ExcludePrefixMarker>
+                                  <ExcludeFolders>true</ExcludeFolders>
                                   <ExcludedPrefixes>
                                     <Prefix>path/to/my/workload/_staging/</Prefix>
                                   </ExcludedPrefixes>
@@ -108,9 +108,9 @@ func TestParseConfig(t *testing.T) {
                                     <Prefix>path/to/my/workload/_temporary/</Prefix>
                                   </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
-			err:                 nil,
-			excludedPrefixes:    []string{"path/to/my/workload/_staging/", "path/to/my/workload/_temporary/"},
-			excludePrefixMarker: true,
+			err:              nil,
+			excludedPrefixes: []string{"path/to/my/workload/_staging/", "path/to/my/workload/_temporary/"},
+			excludeFolders:   true,
 		},
 		{
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -155,8 +155,8 @@ func TestParseConfig(t *testing.T) {
 					t.Fatalf("Test %d: Expected excluded prefix %s but got %s", i+1, tc.excludedPrefixes[i], v.ExcludedPrefixes[i].Prefix)
 				}
 			}
-			if tc.excludePrefixMarker != v.ExcludePrefixMarker {
-				t.Fatalf("Test %d: Expected ExcludePrefixMarker=%v but got %v", i+1, tc.excludePrefixMarker, v.ExcludePrefixMarker)
+			if tc.excludeFolders != v.ExcludeFolders {
+				t.Fatalf("Test %d: Expected ExcludeFoldersr=%v but got %v", i+1, tc.excludeFolders, v.ExcludeFolders)
 			}
 		}
 	}
@@ -189,10 +189,10 @@ func TestVersioningZero(t *testing.T) {
 	}
 }
 
-func TestExcludePrefixMarker(t *testing.T) {
+func TestExcludeFolders(t *testing.T) {
 	v := Versioning{
-		Status:              Enabled,
-		ExcludePrefixMarker: true,
+		Status:         Enabled,
+		ExcludeFolders: true,
 	}
 	testPrefixes := []string{"jobs/output/_temporary/", "jobs/output/", "jobs/"}
 	for i, prefix := range testPrefixes {
@@ -206,8 +206,8 @@ func TestExcludePrefixMarker(t *testing.T) {
 		t.Fatalf("Expected versioning to be enabled for %s", prefix)
 	}
 
-	// Test when ExcludePrefixMarker is disabled
-	v.ExcludePrefixMarker = false
+	// Test when ExcludeFolders is disabled
+	v.ExcludeFolders = false
 	for i, prefix := range testPrefixes {
 		if !v.PrefixEnabled(prefix) || v.PrefixSuspended(prefix) {
 			t.Fatalf("Test %d: Expected versioning to be enabled for %s", i+1, prefix)

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -150,3 +150,13 @@ func TestMarshalXML(t *testing.T) {
 		t.Fatalf("XML shouldn't contain ExcludedPrefixes tag - %s", str)
 	}
 }
+
+func TestVersioningZero(t *testing.T) {
+	var v Versioning
+	if v.Enabled() {
+		t.Fatalf("Expected to be disabled but got enabled")
+	}
+	if v.Suspended() {
+		t.Fatalf("Expected to be disabled but got suspended")
+	}
+}

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -1,6 +1,7 @@
 package versioning
 
 import (
+	"encoding/xml"
 	"strings"
 	"testing"
 )
@@ -21,6 +22,8 @@ func TestParseConfig(t *testing.T) {
                                   <Status>Enabled</Status>
                                   <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_temporary/ </Prefix>
                                   </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
@@ -40,15 +43,35 @@ func TestParseConfig(t *testing.T) {
                                   <Status>Enabled</Status>
                                   <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/ab </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/cd </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/ef </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/gh </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/ij </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/kl </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/mn </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/op </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/qr </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/st </Prefix>
+                                  </ExcludedPrefixes>
+                                  <ExcludedPrefixes>
                                     <Prefix> path/to/my/workload/_staging/uv </Prefix>
                                   </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
@@ -74,4 +97,22 @@ func TestParseConfig(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestMarshalXML(t *testing.T) {
+	// Validates if Versioning with no excluded prefixes omits
+	// ExcludedPrefixes tags
+	v := Versioning{
+		Status: Enabled,
+	}
+	buf, err := xml.Marshal(v)
+	if err != nil {
+		t.Fatalf("Failed to marshal %v: %v", v, err)
+	}
+
+	str := string(buf)
+	if strings.Contains(str, "ExcludedPrefixes") {
+		t.Fatalf("XML shouldn't contain ExcludedPrefixes tag - %s", str)
+	}
+
 }

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -8,8 +8,9 @@ import (
 
 func TestParseConfig(t *testing.T) {
 	testcases := []struct {
-		input string
-		err   error
+		input            string
+		err              error
+		excludedPrefixes []string
 	}{
 		{
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -21,19 +22,20 @@ func TestParseConfig(t *testing.T) {
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                                   <Status>Enabled</Status>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_temporary/ </Prefix>
+                                    <Prefix>path/to/my/workload/_temporary/*</Prefix>
                                   </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
-			err: nil,
+			err:              nil,
+			excludedPrefixes: []string{"path/to/my/workload/_staging/*", "path/to/my/workload/_temporary/*"},
 		},
 		{
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                                   <Status>Suspended</Status>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging </Prefix>
+                                    <Prefix>path/to/my/workload/_staging</Prefix>
                                   </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
 			err: errExcludedPrefixNotSupported,
@@ -42,37 +44,37 @@ func TestParseConfig(t *testing.T) {
 			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
                                   <Status>Enabled</Status>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/ab </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/ab/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/cd </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/cd/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/ef </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/ef/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/gh </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/gh/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/ij </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/ij/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/kl </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/kl/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/mn </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/mn/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/op </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/op/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/qr </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/qr/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/st </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/st/*</Prefix>
                                   </ExcludedPrefixes>
                                   <ExcludedPrefixes>
-                                    <Prefix> path/to/my/workload/_staging/uv </Prefix>
+                                    <Prefix>path/to/my/workload/_staging/uv/*</Prefix>
                                   </ExcludedPrefixes>
                                 </VersioningConfiguration>`,
 			err: errTooManyExcludedPrefixes,
@@ -90,10 +92,26 @@ func TestParseConfig(t *testing.T) {
 			if tc.err == nil {
 				t.Fatalf("Test %d: failed due to %v", i+1, err)
 			}
-
 		} else {
 			if err := v.Validate(); tc.err != err {
 				t.Fatalf("Test %d: validation failed due to %v", i+1, err)
+			}
+			if len(tc.excludedPrefixes) > 0 {
+				var mismatch bool
+				if len(v.ExcludedPrefixes) != len(tc.excludedPrefixes) {
+					t.Fatalf("Test %d: Expected length of excluded prefixes %d but got %d", i+1, len(tc.excludedPrefixes), len(v.ExcludedPrefixes))
+				}
+				var i int
+				var eprefix string
+				for i, eprefix = range tc.excludedPrefixes {
+					if eprefix != v.ExcludedPrefixes[i].Prefix {
+						mismatch = true
+						break
+					}
+				}
+				if mismatch {
+					t.Fatalf("Test %d: Expected excluded prefix %s but got %s", i+1, tc.excludedPrefixes[i], v.ExcludedPrefixes[i].Prefix)
+				}
 			}
 		}
 	}
@@ -114,5 +132,4 @@ func TestMarshalXML(t *testing.T) {
 	if strings.Contains(str, "ExcludedPrefixes") {
 		t.Fatalf("XML shouldn't contain ExcludedPrefixes tag - %s", str)
 	}
-
 }

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -1,3 +1,20 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package versioning
 
 import (

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -214,3 +214,37 @@ func TestExcludePrefixMarker(t *testing.T) {
 		}
 	}
 }
+
+func TestExcludedPrefixesMatch(t *testing.T) {
+	v := Versioning{
+		Status:           Enabled,
+		ExcludedPrefixes: []ExcludedPrefix{{"*/_temporary/"}},
+	}
+
+	if err := v.Validate(); err != nil {
+		t.Fatalf("Invalid test versioning config %v: %v", v, err)
+	}
+	tests := []struct {
+		prefix   string
+		excluded bool
+	}{
+		{
+			prefix:   "app1-jobs/output/_temporary/attempt1/data.csv",
+			excluded: true,
+		},
+		{
+			prefix:   "app1-jobs/output/final/attempt1/data.csv",
+			excluded: false,
+		},
+	}
+
+	for i, test := range tests {
+		if v.PrefixSuspended(test.prefix) != test.excluded {
+			if test.excluded {
+				t.Fatalf("Test %d: Expected prefix %s to be excluded from versioning", i+1, test.prefix)
+			} else {
+				t.Fatalf("Test %d: Expected prefix %s to have versioning enabled", i+1, test.prefix)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description
### Motivation
Spark/Hadoop workloads which use Hadoop MR Committer v1/v2 algorithm upload objects to a temporary prefix in a bucket. These objects are 'renamed' to a different prefix on Job commit. Object storage admins are forced to configure separate ILM policies to expire these objects and their versions to reclaim space.

### Solution:
This can be avoided by simply marking objects under these prefixes to be excluded from versioning, as shown below. 
Consequently, these objects are excluded from replication, and don't require ILM policies to prune unnecessary versions.

#### MinIO Extension to Bucket Version Configuration
```xml
<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"> 
        <Status>Enabled</Status>
        <ExcludeFolders>true</ExcludeFolders>

        <ExcludedPrefixes>
          <Prefix>app1-jobs/*/_temporary/</Prefix>
        </ExcludedPrefixes>
        <ExcludedPrefixes>
          <Prefix>app2-jobs/*/_magic/</Prefix>
        </ExcludedPrefixes>

        <!-- .. up to 10 prefixes in all -->     
</VersioningConfiguration>
```
Note: `ExcludeFolders` excludes all folders in a bucket from versioning. This is required to prevent the parent folders from accumulating delete markers, especially those which are shared across spark workloads spanning projects/teams.

#### To enable version exclusion on a list of prefixes
```shell
mc version enable --excluded-prefixes "app1-jobs/*/_temporary/,app2-jobs/*/_magic," --exclude-prefix-marker myminio/test
```

#### To reset version exclusion on prefixes
```shell
mc version enable myminio/test

```

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [x] Unit tests added/updated
