### PR TITLE
Clean up cpuio profiling

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -320,8 +320,7 @@ func startProfiler(profilerType string) (minioProfiler, error) {
 			defer os.RemoveAll(dirPath)
 			return ioutil.ReadFile(fn)
 		}
-		// TODO(klauspost): Replace with madmin.ProfilerCPUIO on next update.
-	case "cpuio":
+	case madmin.ProfilerCPUIO:
 		// at 10k or more goroutines fgprof is likely to become
 		// unable to maintain its sampling rate and to significantly
 		// degrade the performance of your application
@@ -339,10 +338,6 @@ func startProfiler(profilerType string) (minioProfiler, error) {
 			return nil, err
 		}
 		stop := fgprof.Start(f, fgprof.FormatPprof)
-		err = pprof.StartCPUProfile(f)
-		if err != nil {
-			return nil, err
-		}
 		prof.stopFn = func() ([]byte, error) {
 			err := stop()
 			if err != nil {


### PR DESCRIPTION
## Description

Don't start regular cpu profile as well. Use madmin const.

This seems to prevent multiple invocations.

## How to test this PR?

Test running cpuio multiple times.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
