### PR TITLE
Add audit log for decommissioning

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -561,7 +561,7 @@ func (z *erasureServerPools) decommissionObject(ctx context.Context, bucket stri
 	defer func() {
 		gr.Close()
 		if err == nil {
-			auditLogDecom(ctx, "CopyData", objInfo.Bucket, objInfo.Name, objInfo.VersionID)
+			auditLogDecom(ctx, "DecomCopyData", objInfo.Bucket, objInfo.Name, objInfo.VersionID)
 		}
 	}()
 
@@ -747,7 +747,7 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 				if err != nil {
 					logger.LogIf(ctx, err)
 				} else {
-					auditLogDecom(ctx, "DeleteObject", bName, entry.name, "")
+					auditLogDecom(ctx, "DecomDeleteObject", bName, entry.name, "")
 				}
 			}
 			z.poolMetaMutex.Lock()

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -556,8 +556,15 @@ func (z *erasureServerPools) Init(ctx context.Context) error {
 }
 
 func (z *erasureServerPools) decommissionObject(ctx context.Context, bucket string, gr *GetObjectReader) (err error) {
-	defer gr.Close()
 	objInfo := gr.ObjInfo
+
+	defer func() {
+		gr.Close()
+		if err == nil {
+			auditLogDecom(ctx, "CopyData", objInfo.Bucket, objInfo.Name, objInfo.VersionID)
+		}
+	}()
+
 	if objInfo.isMultipart() {
 		uploadID, err := z.NewMultipartUpload(ctx, bucket, objInfo.Name, ObjectOptions{
 			VersionID:   objInfo.VersionID,
@@ -618,6 +625,8 @@ func (v versionsSorter) reverse() {
 }
 
 func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool *erasureSets, bName string) error {
+	ctx = logger.SetReqInfo(ctx, &logger.ReqInfo{})
+
 	var wg sync.WaitGroup
 	wStr := env.Get("_MINIO_DECOMMISSION_WORKERS", strconv.Itoa(len(pool.sets)))
 	workerSize, err := strconv.Atoi(wStr)
@@ -728,13 +737,18 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 
 			// if all versions were decommissioned, then we can delete the object versions.
 			if decommissionedCount == len(fivs.Versions) {
-				set.DeleteObject(ctx,
+				_, err := set.DeleteObject(ctx,
 					bName,
 					entry.name,
 					ObjectOptions{
 						DeletePrefix: true, // use prefix delete to delete all versions at once.
 					},
 				)
+				if err != nil {
+					logger.LogIf(ctx, err)
+				} else {
+					auditLogDecom(ctx, "DeleteObject", bName, entry.name, "")
+				}
 			}
 			z.poolMetaMutex.Lock()
 			z.poolMeta.TrackCurrentBucketObject(idx, bName, entry.name)
@@ -818,6 +832,9 @@ func (z *erasureServerPools) doDecommissionInRoutine(ctx context.Context, idx in
 	var dctx context.Context
 	dctx, z.decommissionCancelers[idx] = context.WithCancel(GlobalContext)
 	z.poolMetaMutex.Unlock()
+
+	// Generate an empty request info so it can be directly modified later by audit
+	dctx = logger.SetReqInfo(dctx, &logger.ReqInfo{})
 
 	if err := z.decommissionInBackground(dctx, idx); err != nil {
 		logger.LogIf(GlobalContext, err)
@@ -1089,4 +1106,12 @@ func (z *erasureServerPools) StartDecommission(ctx context.Context, idx int) (er
 	}
 	globalNotificationSys.ReloadPoolMeta(ctx)
 	return nil
+}
+
+func auditLogDecom(ctx context.Context, apiName, bucket, object, versionID string) {
+	auditLogInternal(ctx, bucket, object, AuditLogOptions{
+		Trigger:   "decommissioning",
+		APIName:   apiName,
+		VersionID: versionID,
+	})
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1019,12 +1019,14 @@ type AuditLogOptions struct {
 	APIName   string
 	Status    string
 	VersionID string
+	Error     string
 }
 
 // sends audit logs for internal subsystem activity
 func auditLogInternal(ctx context.Context, bucket, object string, opts AuditLogOptions) {
 	entry := audit.NewEntry(globalDeploymentID)
 	entry.Trigger = opts.Trigger
+	entry.Error = opts.Error
 	entry.API.Name = opts.APIName
 	entry.API.Bucket = bucket
 	entry.API.Object = object

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1033,6 +1033,11 @@ func auditLogInternal(ctx context.Context, bucket, object string, opts AuditLogO
 		entry.ReqQuery[xhttp.VersionID] = opts.VersionID
 	}
 	entry.API.Status = opts.Status
+	// Merge tag information if found - this is currently needed for tags
+	// set during decommissioning.
+	if reqInfo := logger.GetReqInfo(ctx); reqInfo != nil {
+		entry.Tags = reqInfo.GetTagsMap()
+	}
 	ctx = logger.SetAuditEntry(ctx, &entry)
 	logger.AuditLog(ctx, nil, nil, nil)
 }

--- a/internal/logger/message/audit/entry.go
+++ b/internal/logger/message/audit/entry.go
@@ -61,6 +61,8 @@ type Entry struct {
 	ReqHeader  map[string]string      `json:"requestHeader,omitempty"`
 	RespHeader map[string]string      `json:"responseHeader,omitempty"`
 	Tags       map[string]interface{} `json:"tags,omitempty"`
+
+	Error string `json:"error,omitempty"`
 }
 
 // NewEntry - constructs an audit entry object with some fields filled


### PR DESCRIPTION
## Description
Copying data to a new pool and removing them in the decommissioned pool
will be sent to the audit logging subsystem.

Also move the code that stores audit erasure set information to
erasure set level to ensure that we are not missing logging any
erasure set operation.

Example of JSON audit log:
```json
{
  "version": "1",
  "deploymentid": "c44e166e-9e9e-40f0-86fb-1ac9831649b5",
  "time": "2022-05-03T19:07:37.965056Z",
  "trigger": "decommissioning",
  "api": {
    "name": "DeleteObject",
    "bucket": ".minio.sys/buckets",
    "object": "testbucket/.metadata.bin",
    "rx": 0,
    "tx": 0
  },
  "tags": {
    "objectErasureMap": {
      "testbucket/.metadata.bin": {
        "poolId": 1,
        "setId": 1,
        "disks": [
          "http://localhost:9001/tmp/xl/1/1",
          "http://localhost:9001/tmp/xl/1/2",
          "http://localhost:9001/tmp/xl/1/3",
          "http://localhost:9001/tmp/xl/1/4",
          "http://localhost:9001/tmp/xl/1/5",
          "http://localhost:9001/tmp/xl/1/6",
          "http://localhost:9001/tmp/xl/1/7",
          "http://localhost:9001/tmp/xl/1/8"
        ]
      }
    }
  }
}
```


## Motivation and Context
Send decomissiong operations to audit logs

## How to test this PR?
1. Run an audit webhook
2. Run a MinIO setups with two zones
3. Copy some data and decommission one zone

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
