### PR TITLE
return kubernetes info in health report

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1775,9 +1775,9 @@ func getKubernetesInfo() madmin.KubernetesInfo {
 
 	ki := madmin.KubernetesInfo{}
 
-	req, e := http.NewRequestWithContext(ctx, http.MethodGet, kubernetesVersionEndpoint, nil)
-	if e != nil {
-		ki.Error = e.Error()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, kubernetesVersionEndpoint, nil)
+	if err != nil {
+		ki.Error = err.Error()
 		return ki
 	}
 
@@ -1786,15 +1786,15 @@ func getKubernetesInfo() madmin.KubernetesInfo {
 		Timeout:   10 * time.Second,
 	}
 
-	resp, e := client.Do(req)
-	if e != nil {
-		ki.Error = e.Error()
+	resp, err := client.Do(req)
+	if err != nil {
+		ki.Error = err.Error()
 		return ki
 	}
 
 	decoder := json.NewDecoder(resp.Body)
-	if e := decoder.Decode(&ki); e != nil {
-		ki.Error = e.Error()
+	if err := decoder.Decode(&ki); err != nil {
+		ki.Error = err.Error()
 	}
 	return ki
 }

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1769,8 +1769,8 @@ func getServerInfo(ctx context.Context, r *http.Request) madmin.InfoMessage {
 	}
 }
 
-func getKubernetesInfo() madmin.KubernetesInfo {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func getKubernetesInfo(dctx context.Context) madmin.KubernetesInfo {
+	ctx, cancel := context.WithCancel(dctx)
 	defer cancel()
 
 	ki := madmin.KubernetesInfo{}
@@ -1888,7 +1888,7 @@ func (a adminAPIHandlers) HealthInfoHandler(w http.ResponseWriter, r *http.Reque
 
 	getAndWritePlatformInfo := func() {
 		if IsKubernetes() {
-			healthInfo.Sys.KubernetesInfo = getKubernetesInfo()
+			healthInfo.Sys.KubernetesInfo = getKubernetesInfo(deadlinedCtx)
 			partialWrite(healthInfo)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/minio/dperf v0.3.6
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.19.2
-	github.com/minio/madmin-go v1.3.12
+	github.com/minio/madmin-go v1.3.13
 	github.com/minio/minio-go/v7 v7.0.24
 	github.com/minio/pkg v1.1.23
 	github.com/minio/selfupdate v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLT
 github.com/minio/kes v0.19.2 h1:0kdMAgLMSkiDA33k8pMHC7d6erDuseuLrZF+N3017SM=
 github.com/minio/kes v0.19.2/go.mod h1:X2fMkDbAkjbSKDGOQZvyPkHxoG7nuzP6R78Jw+TzXtM=
 github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
-github.com/minio/madmin-go v1.3.12 h1:7SmK/KtT7+d3hn3VcYBqI/c4yETfXV9gRT1j+g/U1jE=
-github.com/minio/madmin-go v1.3.12/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
+github.com/minio/madmin-go v1.3.13 h1:157u3bFK9qh2EkkqjpJ/bwOw/5KonXUWqhKP3ZczAdY=
+github.com/minio/madmin-go v1.3.13/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/mc v0.0.0-20220419155441-cc4ff3a0cc82 h1:CiTaWFwpxzjd7A3sUQ0xZEX8sWfZh3/k2qbxuPip05s=
 github.com/minio/mc v0.0.0-20220419155441-cc4ff3a0cc82/go.mod h1:h6VCl43/2AUA3RP1GWUVMqcUiXq2NWJ4+dSei+ibf70=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=


### PR DESCRIPTION
## Description

return kubernetes info in health report

## Motivation and Context

Getting kubernetes info like platform and version would be useful for troubleshooting

## How to test this PR?

- Build `mc` with https://github.com/minio/mc/pull/4075
- Start a minio cluster in a k8s environment using the `minio` binary built with this PR
- Generate health report for the cluster using `mc support diag --airgap {alias}`
- Check that the generated report contains a new node `sys -> kubernetes` that contains information about the k8s version, build and platform

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
