### PR TITLE
Add "enable" to config help

### DIFF
--- a/internal/config/compress/help.go
+++ b/internal/config/compress/help.go
@@ -27,6 +27,13 @@ var (
 
 	Help = config.HelpKVS{
 		config.HelpKV{
+			Key:         config.Enable,
+			Description: "Enable or disable object compression",
+			Type:        "on|off",
+			Optional:    true,
+			Sensitive:   false,
+		},
+		config.HelpKV{
 			Key:         Extensions,
 			Description: `comma separated file extensions` + defaultHelpPostfix(Extensions),
 			Optional:    true,

--- a/internal/config/identity/openid/help.go
+++ b/internal/config/identity/openid/help.go
@@ -27,6 +27,13 @@ var (
 
 	Help = config.HelpKVS{
 		config.HelpKV{
+			Key:         config.Enable,
+			Description: "Enable or disable OpenID",
+			Type:        "on|off",
+			Optional:    true,
+			Sensitive:   false,
+		},
+		config.HelpKV{
 			Key:         DisplayName,
 			Description: "Friendly display name for this Provider/App" + defaultHelpPostfix(DisplayName),
 			Optional:    true,

--- a/internal/config/notify/help.go
+++ b/internal/config/notify/help.go
@@ -28,9 +28,18 @@ const (
 	queueLimitComment = `maximum limit for undelivered messages, defaults to '100000'`
 )
 
+var enableHelp = config.HelpKV{
+	Key:         config.Enable,
+	Description: "Enable or disable notifications",
+	Type:        "on|off",
+	Sensitive:   false,
+	Optional:    true,
+}
+
 // Help template inputs for all notification targets
 var (
 	HelpWebhook = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.WebhookEndpoint,
 			Description: "webhook server endpoint e.g. http://localhost:8080/minio/events",
@@ -79,6 +88,7 @@ var (
 	}
 
 	HelpAMQP = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.AmqpURL,
 			Description: "AMQP server endpoint e.g. `amqp://myuser:mypassword@localhost:5672`",
@@ -167,6 +177,7 @@ var (
 	}
 
 	HelpKafka = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.KafkaBrokers,
 			Description: "comma separated list of Kafka broker addresses",
@@ -263,6 +274,7 @@ var (
 	}
 
 	HelpMQTT = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.MqttBroker,
 			Description: "MQTT server endpoint e.g. `tcp://localhost:1883`",
@@ -327,6 +339,7 @@ var (
 	}
 
 	HelpPostgres = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.PostgresConnectionString,
 			Description: `Postgres server connection-string e.g. "host=localhost port=5432 dbname=minio_events user=postgres password=password sslmode=disable"`,
@@ -370,6 +383,7 @@ var (
 	}
 
 	HelpMySQL = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.MySQLDSNString,
 			Description: `MySQL data-source-name connection string e.g. "<user>:<password>@tcp(<host>:<port>)/<database>"`,
@@ -414,6 +428,7 @@ var (
 	}
 
 	HelpNATS = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.NATSAddress,
 			Description: "NATS server address e.g. '0.0.0.0:4222'",
@@ -530,6 +545,7 @@ var (
 	}
 
 	HelpNSQ = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.NSQAddress,
 			Description: "NSQ server address e.g. '127.0.0.1:4150'",
@@ -574,6 +590,7 @@ var (
 	}
 
 	HelpES = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.ElasticURL,
 			Description: "Elasticsearch server's address, with optional authentication info",
@@ -625,6 +642,7 @@ var (
 	}
 
 	HelpRedis = config.HelpKVS{
+		enableHelp,
 		config.HelpKV{
 			Key:         target.RedisAddress,
 			Description: "Redis server's address. For example: `localhost:6379`",

--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -74,6 +74,13 @@ var (
 
 	HelpWebhook = config.HelpKVS{
 		config.HelpKV{
+			Key:         config.Enable,
+			Description: "set to 'on' to enable the audit logger",
+			Optional:    true,
+			Type:        "on|off",
+			Sensitive:   false,
+		},
+		config.HelpKV{
 			Key:         Endpoint,
 			Description: `HTTP(s) endpoint e.g. "http://localhost:8080/minio/logs/audit"`,
 			Type:        "url",
@@ -115,6 +122,13 @@ var (
 	}
 
 	HelpKafka = config.HelpKVS{
+		config.HelpKV{
+			Key:         config.Enable,
+			Description: "set to 'on' to enable kafka audit logging",
+			Optional:    true,
+			Type:        "on|off",
+			Sensitive:   false,
+		},
 		config.HelpKV{
 			Key:         KafkaBrokers,
 			Description: "comma separated list of Kafka broker addresses",


### PR DESCRIPTION
## Description

Most help sections were missing "enable", which means it is filtered out with `mc admin config get --json`.

Add it where missing.

## How to test this PR?

`mc admin config get --json ...` makes it easy to see.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
