### PR TITLE
[FEATURE] Add a region environment variable for all clouds

### DIFF
--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -194,7 +194,7 @@ func (g *S3) new(creds madmin.Credentials, transport http.RoundTripper) (*miniog
 		chainCreds = NewChainCredentials(defaultProviders)
 	}
 
-	var region = env.Get("MINIO_GATEWAY_DEFAULT_REGION", s3utils.GetRegionFromURL(*u))
+	region := env.Get("MINIO_GATEWAY_DEFAULT_REGION", s3utils.GetRegionFromURL(*u))
 
 	optionsStaticCreds := &miniogo.Options{
 		Creds:        credentials.NewStaticV4(creds.AccessKey, creds.SecretKey, creds.SessionToken),

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -193,7 +193,7 @@ func (g *S3) new(creds madmin.Credentials, transport http.RoundTripper) (*miniog
 	} else {
 		chainCreds = NewChainCredentials(defaultProviders)
 	}
-	
+
 	var region = env.Get("MINIO_GATEWAY_DEFAULT_REGION", s3utils.GetRegionFromURL(*u))
 
 	optionsStaticCreds := &miniogo.Options{

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -193,11 +193,13 @@ func (g *S3) new(creds madmin.Credentials, transport http.RoundTripper) (*miniog
 	} else {
 		chainCreds = NewChainCredentials(defaultProviders)
 	}
+	
+	var region = env.Get("MINIO_GATEWAY_DEFAULT_REGION", s3utils.GetRegionFromURL(*u))
 
 	optionsStaticCreds := &miniogo.Options{
 		Creds:        credentials.NewStaticV4(creds.AccessKey, creds.SecretKey, creds.SessionToken),
 		Secure:       secure,
-		Region:       s3utils.GetRegionFromURL(*u),
+		Region:       region,
 		BucketLookup: miniogo.BucketLookupAuto,
 		Transport:    transport,
 	}
@@ -205,7 +207,7 @@ func (g *S3) new(creds madmin.Credentials, transport http.RoundTripper) (*miniog
 	optionsChainCreds := &miniogo.Options{
 		Creds:        chainCreds,
 		Secure:       secure,
-		Region:       s3utils.GetRegionFromURL(*u),
+		Region:       region,
 		BucketLookup: miniogo.BucketLookupAuto,
 		Transport:    transport,
 	}

--- a/docs/gateway/s3.md
+++ b/docs/gateway/s3.md
@@ -84,6 +84,7 @@ Minimum permissions required if you wish to provide restricted access with your 
 ## Run MinIO Gateway for AWS S3 compatible services
 
 As a prerequisite to run MinIO S3 gateway on an AWS S3 compatible service, you need valid access key, secret key and service endpoint.
+If your S3 endpoint does not end with ``amazonaws.com``, you must set the ``MINIO_GATEWAY_DEFAULT_REGION`` so that the MinIO gateway knows which region you are using.
 
 ## Run MinIO Gateway with double-encryption
 


### PR DESCRIPTION
## Description
This commit adds an optional MINIO_GATEWAY_DEFAULT_REGION environment variable that users can set to use Minio Gateway on more cloud providers.

## Motivation and Context
s3utils.GetRegionFromURL cannot find regions for all types of S3 urls.
Here is the list of clouds for which s3 endpoints might not work :
- IBM : [https://s3.``public cloud region``.cloud-object-storage.appdomain.cloud]()
- Oracle : [https://``object_storage_namespace``.compat.objectstorage.``public cloud region``.oraclecloud.com]()
- OVH : [https://s3.``public cloud region``.cloud.ovh.net]()
- Scaleway : [https://s3.``public cloud region``.scw.cloud]()
- ...

## How to test this PR?
-

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
