### PR TITLE
fix: multiple fixes in prefix exclude the implementation

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -271,7 +271,7 @@ func checkReplicateDelete(ctx context.Context, bucket string, dobj ObjectToDelet
 	}
 	// Skip replication if this object's prefix is excluded from being
 	// versioned.
-	if delOpts.VersionSuspended {
+	if !delOpts.Versioned {
 		return
 	}
 	opts := replication.ObjectOpts{

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1189,9 +1189,6 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 		if objects[i].VersionID == "" {
 			// MinIO extension to bucket version configuration
 			suspended := opts.VersionSuspended
-			if opts.PrefixSuspendedFn != nil {
-				suspended = opts.PrefixSuspendedFn(objects[i].ObjectName)
-			}
 			versioned := opts.Versioned
 			if opts.PrefixEnabledFn != nil {
 				versioned = opts.PrefixEnabledFn(objects[i].ObjectName)
@@ -1204,7 +1201,7 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 				// Versioning suspended means that we add a `null` version
 				// delete marker, if not add a new version for this delete
 				// marker.
-				if opts.Versioned {
+				if versioned {
 					vr.VersionID = mustGetUUID()
 				}
 			}

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -77,8 +77,7 @@ type ObjectOptions struct {
 	Mutate        bool
 	WalkAscending bool // return Walk results in ascending order of versions
 
-	PrefixEnabledFn   func(prefix string) bool // function which returns true if versioning is enabled on prefix
-	PrefixSuspendedFn func(prefix string) bool // function which returns true if versioning is suspended on prefix
+	PrefixEnabledFn func(prefix string) bool // function which returns true if versioning is enabled on prefix
 }
 
 // ExpirationOptions represents object options for object expiration at objectLayer.

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -166,7 +166,7 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 		return opts, err
 	}
 	opts.Versioned = globalBucketVersioningSys.PrefixEnabled(bucket, object)
-	opts.VersionSuspended = globalBucketVersioningSys.PrefixSuspended(bucket, object)
+	opts.VersionSuspended = globalBucketVersioningSys.Suspended(bucket)
 	delMarker := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarker))
 	if delMarker != "" {
 		switch delMarker {

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -275,8 +275,8 @@ func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toD
 		}
 		vc, _ := globalBucketVersioningSys.Get(bucket)
 		deletedObjs, errs := o.DeleteObjects(ctx, bucket, toDel, ObjectOptions{
-			PrefixEnabledFn:   vc.PrefixEnabled,
-			PrefixSuspendedFn: vc.PrefixSuspended,
+			PrefixEnabledFn:  vc.PrefixEnabled,
+			VersionSuspended: vc.Suspended(),
 		})
 		var logged bool
 		for i, err := range errs {

--- a/docs/bucket/versioning/README.md
+++ b/docs/bucket/versioning/README.md
@@ -65,6 +65,8 @@ Similarly to suspend versioning set the configuration with Status set to `Suspen
 
 ## MinIO extension to Bucket Versioning
 ### Motivation
+**PLEASE READ: This feature is meant for advanced usecases only where the setup is using bucket versioning or with replicated buckets, use this feature to optimize versioning behavior for some specific applications. MinIO experts will evaluate and guide on the benefits for your application, please reach out to us on https://subnet.min.io.**
+
 Spark/Hadoop workloads which use Hadoop MR Committer v1/v2 algorithm upload objects to a temporary prefix in a bucket. These objects are 'renamed' to a different prefix on Job commit. Object storage admins are forced to configure separate ILM policies to expire these objects and their versions to reclaim space.
 
 ### Solution
@@ -76,19 +78,23 @@ To exclude objects under a list of prefix (glob) patterns from being versioned, 
         <ExcludeFolders>true</ExcludeFolders>
 
         <ExcludedPrefixes>
-          <Prefix>app1-jobs/*/_temporary/</Prefix>
+          <Prefix>*/_temporary</Prefix>
         </ExcludedPrefixes>
         <ExcludedPrefixes>
-          <Prefix>app2-jobs/*/_magic/</Prefix>
+          <Prefix>*/__magic</Prefix>
+        </ExcludedPrefixes>
+        <ExcludedPrefixes>
+          <Prefix>*/_staging</Prefix>
         </ExcludedPrefixes>
 
         <!-- .. up to 10 prefixes in all -->
 </VersioningConfiguration>
 ```
 
-Note: Objects matching these prefixes will behave as though versioning were suspended. These objects **will not** be replicated if replication is configured.
-
-Only users with explicit permissions or the root credential can configure the versioning state of any bucket.
+### Features
+- Objects matching these prefixes will behave as though versioning were suspended. These objects **will not** be replicated if bucket has replication configured.
+- Objects matching these prefixes will also not leave delete markers, dramatically reduces namespace pollution while keeping the benefits of replication.
+- Users with explicit permissions or the root credential can configure the versioning state of any bucket.
 
 ## Examples of enabling bucket versioning using MinIO Java SDK
 

--- a/internal/bucket/versioning/versioning.go
+++ b/internal/bucket/versioning/versioning.go
@@ -39,7 +39,6 @@ const (
 var (
 	errExcludedPrefixNotSupported = Errorf("excluded prefixes extension supported only when versioning is enabled")
 	errTooManyExcludedPrefixes    = Errorf("too many excluded prefixes")
-	errInvalidPrefixPattern       = Errorf("invalid prefix pattern")
 )
 
 // ExcludedPrefix - holds individual prefixes excluded from being versioned.
@@ -72,11 +71,6 @@ func (v Versioning) Validate() error {
 		const maxExcludedPrefixes = 10
 		if len(v.ExcludedPrefixes) > maxExcludedPrefixes {
 			return errTooManyExcludedPrefixes
-		}
-		for _, sprefix := range v.ExcludedPrefixes {
-			if !strings.HasSuffix(sprefix.Prefix, "/") {
-				return errInvalidPrefixPattern
-			}
 		}
 
 	case Suspended:

--- a/internal/bucket/versioning/versioning_test.go
+++ b/internal/bucket/versioning/versioning_test.go
@@ -112,15 +112,6 @@ func TestParseConfig(t *testing.T) {
 			excludedPrefixes: []string{"path/to/my/workload/_staging/", "path/to/my/workload/_temporary/"},
 			excludeFolders:   true,
 		},
-		{
-			input: `<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                                  <Status>Enabled</Status>
-                                  <ExcludedPrefixes>
-                                    <Prefix>path/to/my/workload/_staging</Prefix>
-                                  </ExcludedPrefixes>
-                                </VersioningConfiguration>`,
-			err: errInvalidPrefixPattern,
-		},
 	}
 
 	for i, tc := range testcases {


### PR DESCRIPTION

## Description
fix: multiple fixes in prefix exclude the implementation

## Motivation and Context
- do not need to restrict prefix exclusions that do not
  have `/` as suffix, relax this requirement as spark.

- multiple delete objects were incorrectly creating a
  null delete marker on a versioned bucket instead of
  creating a proper versioned delete marker.

- do not suspend paths on the excluded prefixes during
  delete operations to avoid creating `null` delete markers,
  honor suspension of versioning only are bucket level for
  delete markers.

## How to test this PR?
Multiple site setup
```
#!/bin/bash

set -x

export MINIO_ROOT_USER=minio
export MINIO_ROOT_PASSWORD=minio123

export MC_HOST_minio1=http://minio:minio123@localhost:9001/
export MC_HOST_minio2=http://minio:minio123@localhost:9002

rm -rf /tmp/xl*
pkill -9 minio

(minio server --address ":9001" /tmp/xl{1...4})&
pid1=$!

(minio server --address ":9002" /tmp/xl{5...8})&
pid2=$!

sleep 5

mc admin replicate add minio1 minio2

mc mb minio1/spark-bucket
mc version enable minio1/spark-bucket --excluded-prefixes "*/_temporary,*/_staging" --exclude-folders
```

```scala
import org.apache.spark.sql._
import org.apache.spark.sql.types._

object app {
  def main() {

    val spark: SparkSession = SparkSession.builder()
      .master("local[1]")
      .appName("SparkByExamples.com")
      .getOrCreate()

    // Replace Key with your AWS account key (You can find this on IAM
    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.access.key", "minio")

    // Replace Key with your AWS secret key (You can find this on IAM
    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.secret.key", "minio123")

    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.endpoint", "http://localhost:9001")

    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")

    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")

    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.path.style.access", "true")
    
    val data = Seq(
      ("James ","","Smith","36636","M",3000),
      ("Michael ","Rose","","40288","M",4000),
      ("Robert ","","Williams","42114","M",4000),
      ("Maria ","Anne","Jones","39192","F",4000),
      ("Jen","Mary","Brown","","F",-1)
    )

    val columns = Seq("firstname","middlename","lastname","dob","gender","salary")
    import spark.sqlContext.implicits._
    val df = data.toDF(columns:_*)

    df.write.parquet("s3a://spark-bucket/spark-job/newdata/people.parquet")
  }
}
```

```
./bin/spark-shell --packages com.amazonaws:aws-java-sdk:1.11.375,org.apache.hadoop:hadoop-aws:3.2.2 -i min.scala

spark> app.main()
```

You should be able to see the new feature work properly by not replicating content.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
