### PR TITLE
update new name for MINIO_POLICY_OPA_URL

### DIFF
--- a/docs/iam/access-management-plugin.md
+++ b/docs/iam/access-management-plugin.md
@@ -22,7 +22,7 @@ In another terminal start MinIO:
 export MINIO_CI_CD=1
 export MINIO_ROOT_USER=minio
 export MINIO_ROOT_PASSWORD=minio123
-export MINIO_POLICY_OPA_URL=http://localhost:8080/
+export MINIO_POLICY_PLUGIN_URL=http://localhost:8080/
 minio server /tmp/disk{1...4}
 ```
 


### PR DESCRIPTION
Update new name for `MINIO_POLICY_OPA_URL` in access-management-plugin.md example to `MINIO_POLICY_PLUGIN_URL`.

## Description

Update one missed spot in the Access Management Plugin documentation markdown that still references the old environment variable name `MINIO_POLICY_OPA_URL` to `MINIO_POLICY_PLUGIN_URL`.

## Motivation and Context

example code to run plugin is misleading.

## How to test this PR?

N/A: minor documentation change only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
