### PR TITLE
Add PVC annotations to StatefulSet PVC templates

### DIFF
--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -184,9 +184,9 @@ spec:
     {{- range $diskId := until $drivesPerNode}}
     - metadata:
         name: export-{{ $diskId }}
-      {{- if .Values.persistence.annotations }}
+      {{- if $.Values.persistence.annotations }}
         annotations:
-      {{ toYaml .Values.persistence.annotations | trimSuffix "\n" | indent 10 }}
+{{ toYaml $.Values.persistence.annotations | trimSuffix "\n" | indent 10 }}
       {{- end }}
       spec:
         accessModes: [ {{ $accessMode | quote }} ]
@@ -200,9 +200,9 @@ spec:
   {{- else }}
     - metadata:
         name: export
-      {{- if .Values.persistence.annotations }}
+      {{- if $.Values.persistence.annotations }}
         annotations:
-      {{ toYaml .Values.persistence.annotations | trimSuffix "\n" | indent 10 }}
+{{ toYaml $.Values.persistence.annotations | trimSuffix "\n" | indent 10 }}
       {{- end }}
       spec:
         accessModes: [ {{ $accessMode | quote }} ]

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -184,6 +184,10 @@ spec:
     {{- range $diskId := until $drivesPerNode}}
     - metadata:
         name: export-{{ $diskId }}
+      {{- if .Values.persistence.annotations }}
+        annotations:
+      {{ toYaml .Values.persistence.annotations | trimSuffix "\n" | indent 10 }}
+      {{- end }}
       spec:
         accessModes: [ {{ $accessMode | quote }} ]
         {{- if $storageClass }}
@@ -196,6 +200,10 @@ spec:
   {{- else }}
     - metadata:
         name: export
+      {{- if .Values.persistence.annotations }}
+        annotations:
+      {{ toYaml .Values.persistence.annotations | trimSuffix "\n" | indent 10 }}
+      {{- end }}
       spec:
         accessModes: [ {{ $accessMode | quote }} ]
         {{- if $storageClass }}


### PR DESCRIPTION
## Description
This is the continuation of https://github.com/minio/minio/pull/14793. That PR added the PVC annotations for the `standalone` mode, while this PR adds the functionality to the StatefulSet.

An example render:
```
  volumeClaimTemplates:
    - metadata:
        annotations:
          argocd.argoproj.io/sync-wave: '-1'
        name: export-0
      spec:
```

## Motivation and Context
- Same as in the previous PR, the annotations should be present in both modes.

## How to test this PR?


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
