### PR TITLE
Add periodic callhome functionality

### DIFF
--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -31,7 +31,10 @@ import (
 // local endpoints from given list of endpoints
 func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Request) madmin.ServerProperties {
 	var localEndpoints Endpoints
-	addr := r.Host
+	addr := globalLocalNodeName
+	if r != nil {
+		addr = r.Host
+	}
 	if globalIsDistErasure {
 		addr = globalLocalNodeName
 	}
@@ -40,7 +43,7 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 		for _, endpoint := range ep.Endpoints {
 			nodeName := endpoint.Host
 			if nodeName == "" {
-				nodeName = r.Host
+				nodeName = addr
 			}
 			if endpoint.IsLocal {
 				// Only proceed for local endpoints

--- a/cmd/callhome.go
+++ b/cmd/callhome.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/minio/madmin-go"
+	"github.com/minio/minio/internal/logger"
+)
+
+const (
+	// CallhomeSchemaVersion1 is callhome schema version 1
+	CallhomeSchemaVersion1 = "1"
+
+	// CallhomeSchemaVersion is current callhome schema version.
+	CallhomeSchemaVersion = CallhomeSchemaVersion1
+
+	// CallhomeCycleDefault is the default interval between two callhome cycles (24hrs)
+	CallhomeCycleDefault = 24 * time.Hour
+)
+
+// CallhomeInfo - Contains callhome information
+type CallhomeInfo struct {
+	SchemaVersion string             `json:"schema_version"`
+	AdminInfo     madmin.InfoMessage `json:"admin_info"`
+}
+
+var (
+	enableCallhome            = false
+	callhomeLeaderLockTimeout = newDynamicTimeout(30*time.Second, 10*time.Second)
+	callhomeFreq              = &safeDuration{t: CallhomeCycleDefault}
+)
+
+func updateCallhomeParams(ctx context.Context, objAPI ObjectLayer) {
+	alreadyEnabled := enableCallhome
+	enableCallhome = globalCallhomeConfig.Enable
+	callhomeFreq.Update(globalCallhomeConfig.Frequency)
+	if !alreadyEnabled && enableCallhome {
+		initCallhome(ctx, objAPI)
+	}
+}
+
+// initCallhome will start the callhome task in the background.
+func initCallhome(ctx context.Context, objAPI ObjectLayer) {
+	go func() {
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		// Leader node (that successfully acquires the lock inside runCallhome)
+		// will keep performing the callhome. If the leader goes down for some reason,
+		// the lock will be released and another node will acquire it and take over
+		// because of this loop.
+		for {
+			runCallhome(ctx, objAPI)
+			if !enableCallhome {
+				return
+			}
+
+			// callhome running on a different node.
+			// sleep for some time and try again.
+			duration := time.Duration(r.Float64() * float64(callhomeFreq.Get()))
+			if duration < time.Second {
+				// Make sure to sleep atleast a second to avoid high CPU ticks.
+				duration = time.Second
+			}
+			time.Sleep(duration)
+
+			if !enableCallhome {
+				return
+			}
+		}
+	}()
+}
+
+func runCallhome(pctx context.Context, objAPI ObjectLayer) {
+	// Make sure only 1 callhome is running on the cluster.
+	locker := objAPI.NewNSLock(minioMetaBucket, "callhome/runCallhome.lock")
+	lkctx, err := locker.GetLock(pctx, callhomeLeaderLockTimeout)
+	if err != nil {
+		return
+	}
+	defer locker.Unlock(lkctx.cancel)
+
+	ctx := lkctx.Context()
+	defer lkctx.Cancel()
+
+	callhomeTimer := time.NewTimer(callhomeFreq.Get())
+	defer callhomeTimer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-callhomeTimer.C:
+			if !enableCallhome {
+				// Stop the processing as callhome got disabled
+				return
+			}
+			// Reset the timer for next cycle.
+			callhomeTimer.Reset(callhomeFreq.Get())
+
+			go performCallhome(ctx)
+		}
+	}
+}
+
+func performCallhome(ctx context.Context) {
+	err := sendCallhomeInfo(
+		CallhomeInfo{
+			SchemaVersion: CallhomeSchemaVersion,
+			AdminInfo:     getServerInfo(ctx, nil),
+		})
+	if err != nil {
+		logger.LogIf(ctx, fmt.Errorf("Unable to perform callhome: %w", err))
+	}
+}

--- a/cmd/callhome.go
+++ b/cmd/callhome.go
@@ -102,7 +102,7 @@ func runCallhome(ctx context.Context, objAPI ObjectLayer) {
 	}
 
 	ctx = lkctx.Context()
-	defer locker.Unlock(lkctx.cancel)
+	defer locker.Unlock(lkctx.Cancel)
 
 	callhomeTimer := time.NewTimer(callhomeFreq.Load())
 	defer callhomeTimer.Stop()

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -230,8 +230,8 @@ func minioConfigToConsoleFeatures() {
 	if globalSubnetConfig.APIKey != "" {
 		os.Setenv("CONSOLE_SUBNET_API_KEY", globalSubnetConfig.APIKey)
 	}
-	if globalSubnetConfig.Proxy != "" {
-		os.Setenv("CONSOLE_SUBNET_PROXY", globalSubnetConfig.Proxy)
+	if globalSubnetConfig.ProxyURL != nil {
+		os.Setenv("CONSOLE_SUBNET_PROXY", globalSubnetConfig.ProxyURL.String())
 	}
 }
 

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -662,7 +662,7 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 			return fmt.Errorf("Unable to apply scanner config: %w", err)
 		}
 		// update dynamic scanner values.
-		scannerCycle.Update(scannerCfg.Cycle)
+		scannerCycle.Store(scannerCfg.Cycle)
 		logger.LogIf(ctx, scannerSleeper.Update(scannerCfg.Delay, scannerCfg.MaxWait))
 	case config.LoggerWebhookSubSys:
 		loggerCfg, err := logger.LookupConfigForSubSys(s, config.LoggerWebhookSubSys)

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -28,6 +28,7 @@ import (
 	"github.com/minio/minio/internal/config"
 	"github.com/minio/minio/internal/config/api"
 	"github.com/minio/minio/internal/config/cache"
+	"github.com/minio/minio/internal/config/callhome"
 	"github.com/minio/minio/internal/config/compress"
 	"github.com/minio/minio/internal/config/dns"
 	"github.com/minio/minio/internal/config/etcd"
@@ -70,6 +71,7 @@ func initHelp() {
 		config.HealSubSys:           heal.DefaultKVS,
 		config.ScannerSubSys:        scanner.DefaultKVS,
 		config.SubnetSubSys:         subnet.DefaultKVS,
+		config.CallhomeSubSys:       callhome.DefaultKVS,
 	}
 	for k, v := range notify.DefaultNotificationKVS {
 		kvs[k] = v
@@ -201,6 +203,12 @@ func initHelp() {
 			Description: "set subnet config for the cluster e.g. api key",
 			Optional:    true,
 		},
+		config.HelpKV{
+			Key:         config.CallhomeSubSys,
+			Type:        "string",
+			Description: "enable callhome for the cluster",
+			Optional:    true,
+		},
 	}
 
 	if globalIsErasure {
@@ -243,6 +251,7 @@ func initHelp() {
 		config.NotifyWebhookSubSys:  notify.HelpWebhook,
 		config.NotifyESSubSys:       notify.HelpES,
 		config.SubnetSubSys:         subnet.HelpSubnet,
+		config.CallhomeSubSys:       callhome.HelpCallhome,
 	}
 
 	config.RegisterHelpSubSys(helpMap)
@@ -356,6 +365,10 @@ func validateSubSysConfig(s config.Config, subSys string, objAPI ObjectLayer) er
 		}
 	case config.SubnetSubSys:
 		if _, err := subnet.LookupConfig(s[config.SubnetSubSys][config.Default]); err != nil {
+			return err
+		}
+	case config.CallhomeSubSys:
+		if _, err := callhome.LookupConfig(s[config.CallhomeSubSys][config.Default]); err != nil {
 			return err
 		}
 	case config.PolicyOPASubSys:
@@ -718,6 +731,14 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 					globalStorageClass.Update(sc)
 				}
 			}
+		}
+	case config.CallhomeSubSys:
+		callhomeCfg, err := callhome.LookupConfig(s[config.CallhomeSubSys][config.Default])
+		if err != nil {
+			logger.LogIf(ctx, fmt.Errorf("Unable to load callhome config: %w", err))
+		} else {
+			globalCallhomeConfig = callhomeCfg
+			updateCallhomeParams(ctx, objAPI)
 		}
 	}
 	globalServerConfigMu.Lock()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -37,6 +37,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config/cache"
+	"github.com/minio/minio/internal/config/callhome"
 	"github.com/minio/minio/internal/config/compress"
 	"github.com/minio/minio/internal/config/dns"
 	xldap "github.com/minio/minio/internal/config/identity/ldap"
@@ -242,6 +243,9 @@ var (
 
 	// The global subnet config
 	globalSubnetConfig subnet.Config
+
+	// The global callhome config
+	globalCallhomeConfig callhome.Config
 
 	globalRemoteEndpoints map[string]Endpoint
 

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/mattn/go-ieproxy"
+)
+
+const (
+	subnetRespBodyLimit = 1 << 20 // 1 MiB
+)
+
+func subnetAuthHeaders(authToken string) map[string]string {
+	return map[string]string{"Authorization": authToken}
+}
+
+func httpClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			Proxy: ieproxy.GetProxyFunc(),
+			TLSClientConfig: &tls.Config{
+				RootCAs: globalRootCAs,
+				// Can't use SSLv3 because of POODLE and BEAST
+				// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+				// Can't use TLSv1.1 because of RC4 cipher usage
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+}
+
+func subnetHTTPDo(req *http.Request) (*http.Response, error) {
+	client := httpClient(10 * time.Second)
+	if len(globalSubnetConfig.Proxy) > 0 {
+		proxyURL, err := url.Parse(globalSubnetConfig.Proxy)
+		if err != nil {
+			return nil, err
+		}
+		client.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyURL)
+	}
+	return client.Do(req)
+}
+
+func subnetReqDo(r *http.Request, headers map[string]string) (string, error) {
+	for k, v := range headers {
+		r.Header.Add(k, v)
+	}
+
+	ct := r.Header.Get("Content-Type")
+	if len(ct) == 0 {
+		r.Header.Add("Content-Type", "application/json")
+	}
+
+	resp, err := subnetHTTPDo(r)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+	respBytes, err := ioutil.ReadAll(io.LimitReader(resp.Body, subnetRespBodyLimit))
+	if err != nil {
+		return "", err
+	}
+	respStr := string(respBytes)
+
+	if resp.StatusCode == http.StatusOK {
+		return respStr, nil
+	}
+	return respStr, fmt.Errorf("SUBNET request failed with code %d and error: %s", resp.StatusCode, respStr)
+}
+
+func subnetPostReq(reqURL string, payload interface{}, headers map[string]string) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	r, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	return subnetReqDo(r, headers)
+}
+
+func subnetBaseURL() string {
+	if globalIsCICD {
+		return "http://localhost:9000"
+	}
+
+	return "https://subnet.min.io"
+}
+
+func subnetCallhomeURL() string {
+	return subnetBaseURL() + "/api/callhome"
+}
+
+func sendCallhomeInfo(ch CallhomeInfo) error {
+	if len(globalSubnetConfig.APIKey) == 0 {
+		return errors.New("Cluster is not registered with SUBNET.")
+	}
+	headers := subnetAuthHeaders(globalSubnetConfig.APIKey)
+	_, err := subnetPostReq(subnetCallhomeURL(), ch, headers)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/klauspost/readahead v1.4.0
 	github.com/klauspost/reedsolomon v1.9.15
 	github.com/lib/pq v1.10.4
-	github.com/mattn/go-ieproxy v0.0.1
 	github.com/miekg/dns v1.1.48
 	github.com/minio/cli v1.22.0
 	github.com/minio/console v0.18.0
@@ -160,6 +159,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/klauspost/readahead v1.4.0
 	github.com/klauspost/reedsolomon v1.9.15
 	github.com/lib/pq v1.10.4
+	github.com/mattn/go-ieproxy v0.0.1
 	github.com/miekg/dns v1.1.48
 	github.com/minio/cli v1.22.0
 	github.com/minio/console v0.18.0
@@ -159,7 +160,6 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/internal/config/callhome/callhome.go
+++ b/internal/config/callhome/callhome.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package callhome
+
+import (
+	"time"
+
+	"github.com/minio/minio/internal/config"
+	"github.com/minio/pkg/env"
+)
+
+// Callhome related keys
+const (
+	Enable    = "enable"
+	Frequency = "frequency"
+)
+
+// DefaultKVS - default KV config for subnet settings
+var DefaultKVS = config.KVS{
+	config.KV{
+		Key:   Enable,
+		Value: "off",
+	},
+	config.KV{
+		Key:   Frequency,
+		Value: "24h",
+	},
+}
+
+// Config represents the subnet related configuration
+type Config struct {
+	// Flag indicating whether callhome is enabled.
+	Enable bool `json:"enable"`
+
+	// The interval between callhome cycles
+	Frequency time.Duration `json:"frequency"`
+}
+
+// LookupConfig - lookup config and override with valid environment settings if any.
+func LookupConfig(kvs config.KVS) (cfg Config, err error) {
+	if err = config.CheckValidKeys(config.CallhomeSubSys, kvs, DefaultKVS); err != nil {
+		return cfg, err
+	}
+
+	cfg.Enable = env.Get(config.EnvMinIOCallhomeEnable,
+		kvs.GetWithDefault(Enable, DefaultKVS)) == "on"
+	cfg.Frequency, err = time.ParseDuration(env.Get(config.EnvMinIOCallhomeFrequency,
+		kvs.GetWithDefault(Frequency, DefaultKVS)))
+	return cfg, err
+}

--- a/internal/config/callhome/callhome.go
+++ b/internal/config/callhome/callhome.go
@@ -58,7 +58,7 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	}
 
 	cfg.Enable = env.Get(config.EnvMinIOCallhomeEnable,
-		kvs.GetWithDefault(Enable, DefaultKVS)) == "on"
+		kvs.GetWithDefault(Enable, DefaultKVS)) == config.EnableOn
 	cfg.Frequency, err = time.ParseDuration(env.Get(config.EnvMinIOCallhomeFrequency,
 		kvs.GetWithDefault(Frequency, DefaultKVS)))
 	return cfg, err

--- a/internal/config/callhome/help.go
+++ b/internal/config/callhome/help.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package callhome
+
+import "github.com/minio/minio/internal/config"
+
+var (
+	defaultHelpPostfix = func(key string) string {
+		return config.DefaultHelpPostfix(DefaultKVS, key)
+	}
+
+	// HelpCallhome - provides help for callhome config
+	HelpCallhome = config.HelpKVS{
+		config.HelpKV{
+			Key:         Enable,
+			Type:        "boolean",
+			Description: "set to enable callhome" + defaultHelpPostfix(Enable),
+			Optional:    true,
+		},
+		config.HelpKV{
+			Key:         Frequency,
+			Type:        "duration",
+			Description: "time duration between callhome cycles e.g. 24h" + defaultHelpPostfix(Frequency),
+			Optional:    true,
+		},
+	}
+)

--- a/internal/config/callhome/help.go
+++ b/internal/config/callhome/help.go
@@ -28,7 +28,7 @@ var (
 	HelpCallhome = config.HelpKVS{
 		config.HelpKV{
 			Key:         Enable,
-			Type:        "boolean",
+			Type:        "on|off",
 			Description: "set to enable callhome" + defaultHelpPostfix(Enable),
 			Optional:    true,
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,7 @@ const (
 	ScannerSubSys        = "scanner"
 	CrawlerSubSys        = "crawler"
 	SubnetSubSys         = "subnet"
+	CallhomeSubSys       = "callhome"
 
 	// Add new constants here if you add new fields to config.
 )
@@ -161,6 +162,7 @@ var SubSystems = set.CreateStringSet(
 	NotifyRedisSubSys,
 	NotifyWebhookSubSys,
 	SubnetSubSys,
+	CallhomeSubSys,
 )
 
 // SubSystemsDynamic - all sub-systems that have dynamic config.
@@ -170,6 +172,7 @@ var SubSystemsDynamic = set.CreateStringSet(
 	ScannerSubSys,
 	HealSubSys,
 	SubnetSubSys,
+	CallhomeSubSys,
 	LoggerWebhookSubSys,
 	AuditWebhookSubSys,
 	AuditKafkaSubSys,

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -53,9 +53,13 @@ const (
 	EnvSiteName   = "MINIO_SITE_NAME"
 	EnvSiteRegion = "MINIO_SITE_REGION"
 
-	EnvMinIOSubnetLicense      = "MINIO_SUBNET_LICENSE" // Deprecated Dec 2021
-	EnvMinIOSubnetAPIKey       = "MINIO_SUBNET_API_KEY"
-	EnvMinIOSubnetProxy        = "MINIO_SUBNET_PROXY"
+	EnvMinIOSubnetLicense = "MINIO_SUBNET_LICENSE" // Deprecated Dec 2021
+	EnvMinIOSubnetAPIKey  = "MINIO_SUBNET_API_KEY"
+	EnvMinIOSubnetProxy   = "MINIO_SUBNET_PROXY"
+
+	EnvMinIOCallhomeEnable    = "MINIO_CALLHOME_ENABLE"
+	EnvMinIOCallhomeFrequency = "MINIO_CALLHOME_FREQUENCY"
+
 	EnvMinIOServerURL          = "MINIO_SERVER_URL"
 	EnvMinIOBrowserRedirectURL = "MINIO_BROWSER_REDIRECT_URL"
 	EnvRootDiskThresholdSize   = "MINIO_ROOTDISK_THRESHOLD_SIZE"

--- a/internal/config/subnet/api-key.go
+++ b/internal/config/subnet/api-key.go
@@ -18,10 +18,9 @@
 package subnet
 
 import (
-	"net/url"
-
 	"github.com/minio/minio/internal/config"
 	"github.com/minio/pkg/env"
+	xnet "github.com/minio/pkg/net"
 )
 
 // DefaultKVS - default KV config for subnet settings
@@ -49,7 +48,7 @@ type Config struct {
 	APIKey string `json:"api_key"`
 
 	// The HTTP(S) proxy URL to use for connecting to SUBNET
-	ProxyURL *url.URL `json:"proxy_url"`
+	ProxyURL *xnet.URL `json:"proxy_url"`
 }
 
 // LookupConfig - lookup config and override with valid environment settings if any.
@@ -60,7 +59,7 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 
 	proxy := env.Get(config.EnvMinIOSubnetProxy, kvs.Get(config.Proxy))
 	if len(proxy) > 0 {
-		cfg.ProxyURL, err = url.Parse(proxy)
+		cfg.ProxyURL, err = xnet.ParseHTTPURL(proxy)
 		if err != nil {
 			return cfg, err
 		}

--- a/internal/config/subnet/api-key.go
+++ b/internal/config/subnet/api-key.go
@@ -49,7 +49,7 @@ type Config struct {
 	APIKey string `json:"api_key"`
 
 	// The HTTP(S) proxy URL to use for connecting to SUBNET
-	Proxy string `json:"proxy"`
+	ProxyURL *url.URL `json:"proxy_url"`
 }
 
 // LookupConfig - lookup config and override with valid environment settings if any.
@@ -58,10 +58,12 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		return cfg, err
 	}
 
-	cfg.Proxy = env.Get(config.EnvMinIOSubnetProxy, kvs.Get(config.Proxy))
-	_, err = url.Parse(cfg.Proxy)
-	if err != nil {
-		return cfg, err
+	proxy := env.Get(config.EnvMinIOSubnetProxy, kvs.Get(config.Proxy))
+	if len(proxy) > 0 {
+		cfg.ProxyURL, err = url.Parse(proxy)
+		if err != nil {
+			return cfg, err
+		}
 	}
 
 	cfg.License = env.Get(config.EnvMinIOSubnetLicense, kvs.Get(config.License))


### PR DESCRIPTION
## Description

Periodically (every 24hrs by default), fetch callhome information and
upload it to SUBNET. As of now the callhome payload contains only
the `admin info` data. It will subsequently be enhanced to send other
useful information.
  
New config keys added under the new `callhome` subsystem:
  
`enable` - Set to `on` for enabling callhome. Default `off`
`frequency` - Interval between callhome cycles. Default `24h`

## Motivation and Context

Send callhome information to SUBNET for better supportability

## How to test this PR?

- For local testing, ensure that the env variable `MINIO_CI_CD` is set to `on`
- Start the `SUBNET` backend locally (it runs on `https://localhost:9000`)
- Start a cluster with `minio` built using this PR
- Enable callhome by running `mc admin config set {alias} callhome enable=on frequency=20s`
- Check that entries are getting created in the SUBNET local db every 20 seconds
`SELECT id, created_at, info from customer.callhome order by id desc LIMIT 10`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
