### PR TITLE
disable connectDisks loop under testing

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -485,7 +485,9 @@ func newErasureSets(ctx context.Context, endpoints PoolEndpoints, storageDisks [
 	go s.cleanupDeletedObjects(ctx)
 
 	// Start the disk monitoring and connect routine.
-	go s.monitorAndConnectEndpoints(ctx, defaultMonitorConnectEndpointInterval)
+	if !globalIsTesting {
+		go s.monitorAndConnectEndpoints(ctx, defaultMonitorConnectEndpointInterval)
+	}
 
 	return s, nil
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -139,6 +139,9 @@ var (
 	// Indicates if the running minio is in gateway mode.
 	globalIsGateway = false
 
+	// Indicates if server code should go through testing path.
+	globalIsTesting = false
+
 	// Name of gateway server, e.g S3, NAS etc
 	globalGatewayName = ""
 

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -73,6 +73,9 @@ import (
 func TestMain(m *testing.M) {
 	flag.Parse()
 
+	// set to 'true' when testing is invoked
+	globalIsTesting = true
+
 	globalActiveCred = auth.Credentials{
 		AccessKey: auth.DefaultAccessKey,
 		SecretKey: auth.DefaultSecretKey,


### PR DESCRIPTION
## Description
disable connectDisks loop under testing

## Motivation and Context
avoids races during tests, keeps tests predictable

## How to test this PR?
Reproduce races and errors without this change using following `go test`
```
go test -race -v -run TestHealingDanglingObject -count=1000
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
