### PR TITLE
audit/kafka: Fix quitting early after first logging

### DIFF
--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -179,11 +179,13 @@ func (h *Target) startHTTPLogger() {
 	go func() {
 		defer h.wg.Done()
 
-		select {
-		case entry := <-h.logCh:
-			h.logEntry(entry)
-		case <-h.doneCh:
-			return
+		for {
+			select {
+			case entry := <-h.logCh:
+				h.logEntry(entry)
+			case <-h.doneCh:
+				return
+			}
 		}
 	}()
 }

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -96,11 +96,13 @@ func (h *Target) startKakfaLogger() {
 	go func() {
 		defer h.wg.Done()
 
-		select {
-		case entry := <-h.logCh:
-			h.logEntry(entry)
-		case <-h.doneCh:
-			return
+		for {
+			select {
+			case entry := <-h.logCh:
+				h.logEntry(entry)
+			case <-h.doneCh:
+				return
+			}
 		}
 	}()
 }
@@ -230,6 +232,7 @@ func (h *Target) Cancel() {
 func New(config Config) *Target {
 	target := &Target{
 		logCh:   make(chan interface{}, 10000),
+		doneCh:  make(chan struct{}),
 		kconfig: config,
 	}
 	return target


### PR DESCRIPTION
## Description
A recent commit created some regressions:
- Kafka/Audit goroutines quit when the first log is sent
- Missing doneCh initialization in Kafka audit

## Motivation and Context
Fix a regression in the audit code

## How to test this PR?
1. Run MinIO with audit enabled
2. Run mc ls <alias> multiple and check if all audit events are sent

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
