### PR TITLE
Avoid calling .Reset() on active timer

### DIFF
--- a/cmd/bucket-replication-stats.go
+++ b/cmd/bucket-replication-stats.go
@@ -169,19 +169,17 @@ func (r *ReplicationStats) loadInitialReplicationMetrics(ctx context.Context) {
 	)
 outer:
 	for {
-		rTimer.Reset(time.Minute)
 		select {
 		case <-ctx.Done():
 			return
 		case <-rTimer.C:
 			dui, err = loadDataUsageFromBackend(GlobalContext, newObjectLayerFn())
-			if err != nil {
-				continue
-			}
 			// If LastUpdate is set, data usage is available.
-			if !dui.LastUpdate.IsZero() {
+			if err == nil && !dui.LastUpdate.IsZero() {
 				break outer
 			}
+
+			rTimer.Reset(time.Minute)
 		}
 	}
 

--- a/cmd/mrf.go
+++ b/cmd/mrf.go
@@ -190,12 +190,12 @@ func (m *mrfState) healRoutine() {
 	}
 
 	for {
-		idler.Reset(mrfInfoResetInterval)
 		select {
 		case <-m.ctx.Done():
 			return
 		case <-idler.C:
 			m.resetMRFInfoIfNoPendingOps()
+			idler.Reset(mrfInfoResetInterval)
 		case setInfo := <-m.setReconnectEvent:
 			// Get the list of objects related the er.set
 			// to which the connected disk belongs.

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -3330,19 +3330,17 @@ func (c *SiteReplicationSys) startHealRoutine(ctx context.Context, objAPI Object
 	defer healTimer.Stop()
 
 	for {
-		healTimer.Reset(siteHealTimeInterval)
-
 		select {
 		case <-healTimer.C:
 			c.RLock()
 			enabled := c.enabled
 			c.RUnlock()
-			if !enabled {
-				continue
+			if enabled {
+				c.healIAMSystem(ctx, objAPI) // heal IAM system first
+				c.healBuckets(ctx, objAPI)   // heal buckets subsequently
 			}
+			healTimer.Reset(siteHealTimeInterval)
 
-			c.healIAMSystem(ctx, objAPI) // heal IAM system first
-			c.healBuckets(ctx, objAPI)   // heal buckets subsequently
 		case <-ctx.Done():
 			return
 		}

--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -255,8 +255,6 @@ func (dm *DRWMutex) startContinousLockRefresh(lockLossCallback func(), id, sourc
 		defer refreshTimer.Stop()
 
 		for {
-			refreshTimer.Reset(dm.refreshInterval)
-
 			select {
 			case <-ctx.Done():
 				return
@@ -271,6 +269,8 @@ func (dm *DRWMutex) startContinousLockRefresh(lockLossCallback func(), id, sourc
 					}
 					return
 				}
+
+				refreshTimer.Reset(dm.refreshInterval)
 			}
 		}
 	}()


### PR DESCRIPTION
## Description

.Reset() documentation states:

    For a Timer created with NewTimer, Reset should be invoked only on stopped
    or expired timers with drained channels.

This change is just to comply with this requirement as there might be some
runtime dependent situation that might lead to unexpected behavior.

## Motivation and Context

Noticed a potential issue while reviewing #14935 

## How to test this PR?

Nothing special to test here.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
