### PR TITLE
Fix WalkDir fallback hot loop

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -882,7 +882,11 @@ func listPathRaw(ctx context.Context, opts listPathRawOptions) (err error) {
 			}
 
 			// fallback only when set.
-			for fd := fallback(werr); fd != nil; {
+			for {
+				fd := fallback(werr)
+				if fd == nil {
+					break
+				}
 				// This fallback is only set when
 				// askDisks is less than total
 				// number of disks per set.


### PR DESCRIPTION
## Description

`fd` was never refreshed, leading to an infinite hot loop if a disk failed and the fallback disk fails as well.

Fix & simplify retry loop.

Fixes #14960

## How to test this PR?

Multiple failing disks and one with storage and one with network error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

