### PR TITLE
fix: copyObject on versioned bucket when updating metadata

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1424,6 +1424,10 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		srcInfo.metadataOnly = false
 	}
 
+	if srcInfo.metadataOnly {
+		gr.Close() // We are not interested in the reader stream at this point close it.
+	}
+
 	// Check if x-amz-metadata-directive or x-amz-tagging-directive was not set to REPLACE and source,
 	// destination are same objects. Apply this restriction also when
 	// metadataOnly is true indicating that we are not overwriting the object.


### PR DESCRIPTION

## Description
fix: copyObject on versioned bucket when updating metadata

## Motivation and Context
updating metadata with CopyObject on a versioned bucket
causes the latest version to be not readable, this PR fixes
this properly by handling the inline data bug fix introduced
in PR #14780.

This bug affects only inlined data.

## How to test this PR?
```bash
#!/bin/bash

make build || exit -1

rm -rf /tmp/xl/ /tmp/xz/

killall -9 minio minio.old

export CI=1
export MINIO_ACCESS_KEY=minio
export MINIO_SECRET_KEY=minio123
export MINIO_PROMETHEUS_AUTH_TYPE="public"

args=()
for i in $(seq 1 12); do
   args+=("http://localhost:$[9000+$i]/tmp/xl/$i/ ")
done

for i in $(seq 1 12); do
    ./minio server --address ":$[9000+$i]" ${args[@]} &
done

./minio server --address ":9100" /tmp/xz/{1...4}/ &
sleep 15

mc alias set myminioxl http://localhost:9005/ minio minio123
mc alias set myminioxz http://localhost:9100/ minio minio123

mc mb -l myminioxl/testbucket/

sleep 5
# S3 operations only in first site
mc cp README.md myminioxl/testbucket/file
mc cp --storage-class "STANDARD" myminioxl/testbucket/file myminioxl/testbucket/file
mc cat myminioxl/testbucket/file
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
