### PR TITLE
Disallow deletion of arn when active replication config

### DIFF
--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -201,7 +201,7 @@ func (sys *BucketTargetSys) RemoveTarget(ctx context.Context, bucket, arnStr str
 		// reject removal of remote target if replication configuration is present
 		rcfg, err := getReplicationConfig(ctx, bucket)
 		if err == nil {
-			for _, tgtArn := range rcfg.FilterTargetArns(replication.ObjectOpts{}) {
+			for _, tgtArn := range rcfg.FilterTargetArns(replication.ObjectOpts{OpType: replication.AllReplicationType}) {
 				if err == nil && (tgtArn == arnStr || rcfg.RoleArn == arnStr) {
 					sys.RLock()
 					_, ok := sys.arnRemotesMap[arnStr]

--- a/internal/bucket/replication/replication.go
+++ b/internal/bucket/replication/replication.go
@@ -124,6 +124,7 @@ const (
 	HealReplicationType
 	ExistingObjectReplicationType
 	ResyncReplicationType
+	AllReplicationType
 )
 
 // Valid returns true if replication type is set
@@ -148,7 +149,7 @@ type ObjectOpts struct {
 // FilterActionableRules returns the rules actions that need to be executed
 // after evaluating prefix/tag filtering
 func (c Config) FilterActionableRules(obj ObjectOpts) []Rule {
-	if obj.Name == "" && obj.OpType != ResyncReplicationType {
+	if obj.Name == "" && !(obj.OpType == ResyncReplicationType || obj.OpType == AllReplicationType) {
 		return nil
 	}
 	var rules []Rule
@@ -160,8 +161,8 @@ func (c Config) FilterActionableRules(obj ObjectOpts) []Rule {
 		if obj.TargetArn != "" && rule.Destination.ARN != obj.TargetArn && c.RoleArn != obj.TargetArn {
 			continue
 		}
-		// Ignore other object level and prefix filters for resyncing target
-		if obj.OpType == ResyncReplicationType {
+		// Ignore other object level and prefix filters for resyncing target/listing bucket targets
+		if obj.OpType == ResyncReplicationType || obj.OpType == AllReplicationType {
 			rules = append(rules, rule)
 			continue
 		}


### PR DESCRIPTION
is present. Regression from #12880

## Description


## Motivation and Context
Target should not be deleted when in use by replication.

## How to test this PR?
Try deleting a target arn with `mc admin bucket remote rm` when this arn is in a replication config

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) #12880
- [ ] Documentation updated
- [ ] Unit tests added/updated
