### PR TITLE
Add server pool reserved space

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -342,7 +342,7 @@ func (z *erasureServerPools) getServerPoolsAvailableSpace(ctx context.Context, b
 			available += disk.Total - disk.Used
 
 			// set maxUsedPct to the value from the disk with the least space percentage.
-			if pctUsed := int(available * 100 / disk.Total); pctUsed > maxUsedPct {
+			if pctUsed := int(disk.Used * 100 / disk.Total); pctUsed > maxUsedPct {
 				maxUsedPct = pctUsed
 			}
 		}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -113,6 +113,10 @@ const (
 	// diskFillFraction is the fraction of a disk we allow to be filled.
 	diskFillFraction = 0.99
 
+	// diskReserveFraction is the fraction of a disk where we will fill other server pools first.
+	// If all pools reach this, we will use all pools with regular placement.
+	diskReserveFraction = 0.15
+
 	// diskAssumeUnknownSize is the size to assume when an unknown size upload is requested.
 	diskAssumeUnknownSize = 1 << 30
 


### PR DESCRIPTION
## Description

If one or more pools reach 85% usage in a set, we will only use pools that have less for new objects.

In case all pools are above 85% we allow all to be used with the regular distribution.

## Motivation and Context

Disk performance start degrading at high utilization and it will leave more space for adding versions to existing objects or overwrites.

A few numbers between 75 and 90% was thrown around, so 85% seems like a reasonable limit to stop placing objects in a pool.


## How to test this PR?


## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
