### PR TITLE
fix: some races when accessing ldap/openid config globally

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -218,7 +218,7 @@ func getClaimsFromTokenWithSecret(token, secret string) (map[string]interface{},
 	}
 
 	// If AuthZPlugin is set, return without any further checks.
-	if globalAuthZPlugin != nil {
+	if newGlobalAuthZPluginFn() != nil {
 		return claims.Map(), nil
 	}
 

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -558,7 +558,8 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 			authZPluginCfg.CloseRespFn = opaCfg.CloseRespFn
 		}
 	}
-	globalAuthZPlugin = polplugin.New(authZPluginCfg)
+
+	setGlobalAuthZPlugin(polplugin.New(authZPluginCfg))
 
 	globalLDAPConfig, err = xldap.Lookup(s[config.IdentityLDAPSubSys][config.Default],
 		globalRootCAs)

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -359,4 +359,18 @@ var (
 	// Add new variable global values here.
 )
 
+var globalAuthZPluginMutex sync.Mutex
+
+func newGlobalAuthZPluginFn() *polplugin.AuthZPlugin {
+	globalAuthZPluginMutex.Lock()
+	defer globalAuthZPluginMutex.Unlock()
+	return globalAuthZPlugin
+}
+
+func setGlobalAuthZPlugin(authz *polplugin.AuthZPlugin) {
+	globalAuthZPluginMutex.Lock()
+	globalAuthZPlugin = authz
+	globalAuthZPluginMutex.Unlock()
+}
+
 var errSelfTestFailure = errors.New("self test failed. unsafe to start server")

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -62,6 +62,31 @@ type Config struct {
 	rootCAs           *x509.CertPool
 }
 
+// Clone returns a cloned copy of LDAP config.
+func (l *Config) Clone() Config {
+	if l == nil {
+		return Config{}
+	}
+	cfg := Config{
+		Enabled:                   l.Enabled,
+		ServerAddr:                l.ServerAddr,
+		UserDNSearchBaseDistName:  l.UserDNSearchBaseDistName,
+		UserDNSearchBaseDistNames: l.UserDNSearchBaseDistNames,
+		UserDNSearchFilter:        l.UserDNSearchFilter,
+		GroupSearchBaseDistName:   l.GroupSearchBaseDistName,
+		GroupSearchBaseDistNames:  l.GroupSearchBaseDistNames,
+		GroupSearchFilter:         l.GroupSearchFilter,
+		LookupBindDN:              l.LookupBindDN,
+		LookupBindPassword:        l.LookupBindPassword,
+		stsExpiryDuration:         l.stsExpiryDuration,
+		tlsSkipVerify:             l.tlsSkipVerify,
+		serverInsecure:            l.serverInsecure,
+		serverStartTLS:            l.serverStartTLS,
+		rootCAs:                   l.rootCAs,
+	}
+	return cfg
+}
+
 // LDAP keys and envs.
 const (
 	ServerAddr         = "server_addr"

--- a/internal/config/identity/openid/openid.go
+++ b/internal/config/identity/openid/openid.go
@@ -164,6 +164,32 @@ type Config struct {
 	closeRespFn func(io.ReadCloser)
 }
 
+// Clone returns a cloned copy of OpenID config.
+func (r *Config) Clone() Config {
+	if r == nil {
+		return Config{}
+	}
+	cfg := Config{
+		Enabled:            r.Enabled,
+		arnProviderCfgsMap: make(map[arn.ARN]*providerCfg, len(r.arnProviderCfgsMap)),
+		ProviderCfgs:       make(map[string]*providerCfg, len(r.ProviderCfgs)),
+		pubKeys:            r.pubKeys,
+		roleArnPolicyMap:   make(map[arn.ARN]string, len(r.roleArnPolicyMap)),
+		transport:          r.transport,
+		closeRespFn:        r.closeRespFn,
+	}
+	for k, v := range r.arnProviderCfgsMap {
+		cfg.arnProviderCfgsMap[k] = v
+	}
+	for k, v := range r.ProviderCfgs {
+		cfg.ProviderCfgs[k] = v
+	}
+	for k, v := range r.roleArnPolicyMap {
+		cfg.roleArnPolicyMap[k] = v
+	}
+	return cfg
+}
+
 // LookupConfig lookup jwks from config, override with any ENVs.
 func LookupConfig(kvsMap map[string]config.KVS, transport http.RoundTripper, closeRespFn func(io.ReadCloser), serverRegion string) (c Config, err error) {
 	openIDClientTransport := http.DefaultTransport


### PR DESCRIPTION
## Description
fix: some races when accessing ldap/openid config globally

## Motivation and Context
mainly to avoid races during CI/CD tests

## How to test this PR?
CI/CD should cover it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
