### PR TITLE
site replication: heal missing/invalid replication config

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1636,7 +1636,7 @@ func (api objectAPIHandlers) PutBucketReplicationConfigHandler(w http.ResponseWr
 		writeErrorResponse(ctx, w, apiErr, r.URL)
 		return
 	}
-	sameTarget, apiErr := validateReplicationDestination(ctx, bucket, replicationConfig)
+	sameTarget, apiErr := validateReplicationDestination(ctx, bucket, replicationConfig, true)
 	if apiErr != noError {
 		writeErrorResponse(ctx, w, apiErr, r.URL)
 		return


### PR DESCRIPTION
Validate remote target ARN's and heal any stale rule in
the replication config

## Description


## Motivation and Context
Ensure remote targets present in replication config are valid and self heal as needed.

## How to test this PR?
mc admin replicate add sitea siteb
mc mb sitea/bucket
mc admin bucket remote rm sitea/bucket --arn <arn-currently-in-repl-config>
With this PR,  self heal should re-create the target and fix replication config
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
