### PR TITLE
Ignore disks with 0 total space

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -336,7 +336,7 @@ func (z *erasureServerPools) getServerPoolsAvailableSpace(ctx context.Context, b
 		}
 		var maxUsedPct int
 		for _, disk := range zinfo {
-			if disk == nil {
+			if disk == nil || disk.Total == 0 {
 				continue
 			}
 			available += disk.Total - disk.Used


### PR DESCRIPTION
## Motivation and Context

Not observed, but mainly defensive to ensure no `/0` in percent calculation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
