### PR TITLE
use crypto/sha256 only for FIPS 140-2 compliance

### DIFF
--- a/cmd/bitrot.go
+++ b/cmd/bitrot.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -27,6 +26,7 @@ import (
 	"io"
 
 	"github.com/minio/highwayhash"
+	"github.com/minio/minio/internal/hash/sha256"
 	"golang.org/x/crypto/blake2b"
 
 	xioutil "github.com/minio/minio/internal/ioutil"

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -28,6 +27,7 @@ import (
 	"time"
 
 	"github.com/minio/minio/internal/bucket/replication"
+	"github.com/minio/minio/internal/hash/sha256"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/minio/internal/sync/errgroup"

--- a/cmd/hasher.go
+++ b/cmd/hasher.go
@@ -19,8 +19,9 @@ package cmd
 
 import (
 	"crypto/md5"
-	"crypto/sha256"
 	"encoding/hex"
+
+	"github.com/minio/minio/internal/hash/sha256"
 )
 
 // getSHA256Hash returns SHA-256 hash in hex encoding of given data.

--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"bytes"
 	"crypto/hmac"
-	"crypto/sha256"
 	"encoding/hex"
 	"io"
 	"io/ioutil"
@@ -29,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/minio/minio/internal/auth"
+	"github.com/minio/minio/internal/hash/sha256"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 )

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -27,7 +27,6 @@ package cmd
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"net/http"
@@ -40,6 +39,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/auth"
+	"github.com/minio/minio/internal/hash/sha256"
 	xhttp "github.com/minio/minio/internal/http"
 )
 

--- a/cmd/streaming-signature-v4.go
+++ b/cmd/streaming-signature-v4.go
@@ -22,7 +22,6 @@ package cmd
 import (
 	"bufio"
 	"bytes"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"hash"
@@ -32,6 +31,7 @@ import (
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/minio/internal/auth"
+	"github.com/minio/minio/internal/hash/sha256"
 	xhttp "github.com/minio/minio/internal/http"
 )
 

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
@@ -34,6 +33,7 @@ import (
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config/identity/openid"
+	"github.com/minio/minio/internal/hash/sha256"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	iampolicy "github.com/minio/pkg/iam/policy"

--- a/internal/config/identity/openid/openid.go
+++ b/internal/config/identity/openid/openid.go
@@ -20,7 +20,6 @@ package openid
 import (
 	"crypto"
 	"crypto/sha1"
-	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"io"
@@ -36,6 +35,7 @@ import (
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config"
 	"github.com/minio/minio/internal/config/identity/openid/provider"
+	"github.com/minio/minio/internal/hash/sha256"
 	"github.com/minio/pkg/env"
 	iampolicy "github.com/minio/pkg/iam/policy"
 	xnet "github.com/minio/pkg/net"

--- a/internal/crypto/key.go
+++ b/internal/crypto/key.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"io"
 	"path"
 
 	"github.com/minio/minio/internal/fips"
+	"github.com/minio/minio/internal/hash/sha256"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/sio"
 )

--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -110,7 +110,6 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/md5"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -120,6 +119,7 @@ import (
 	"strings"
 
 	"github.com/minio/minio/internal/fips"
+	"github.com/minio/minio/internal/hash/sha256"
 	"github.com/minio/sio"
 )
 

--- a/internal/event/target/kafka_scram_client_contrib.go
+++ b/internal/event/target/kafka_scram_client_contrib.go
@@ -17,11 +17,12 @@
 package target
 
 import (
-	"crypto/sha256"
 	"crypto/sha512"
 
 	"github.com/Shopify/sarama"
 	"github.com/xdg/scram"
+
+	"github.com/minio/minio/internal/hash/sha256"
 )
 
 func initScramClient(args KafkaArgs, config *sarama.Config) {

--- a/internal/hash/reader.go
+++ b/internal/hash/reader.go
@@ -26,6 +26,7 @@ import (
 	"io"
 
 	"github.com/minio/minio/internal/etag"
+	"github.com/minio/minio/internal/hash/sha256"
 )
 
 // A Reader wraps an io.Reader and computes the MD5 checksum
@@ -122,7 +123,7 @@ func NewReader(src io.Reader, size int64, md5Hex, sha256Hex string, actualSize i
 	}
 	var hash hash.Hash
 	if len(SHA256) != 0 {
-		hash = newSHA256()
+		hash = sha256.New()
 	}
 	return &Reader{
 		src:           src,

--- a/internal/hash/sha256/sh256_fips.go
+++ b/internal/hash/sha256/sh256_fips.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2022 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -18,15 +18,18 @@
 //go:build fips
 // +build fips
 
-package hash
+package sha256
 
 import (
-	"crypto/sha256"
+	fipsha256 "crypto/sha256"
 	"hash"
 )
 
-// newSHA256 returns a new hash.Hash computing the SHA256 checksum.
+// New returns a new hash.Hash computing the SHA256 checksum.
 // The SHA256 implementation is FIPS 140-2 compliant when the
 // boringcrypto branch of Go is used.
 // Ref: https://github.com/golang/go/tree/dev.boringcrypto
-func newSHA256() hash.Hash { return sha256.New() }
+func New() hash.Hash { return fipsha256.New() }
+
+// Sum256 returns the SHA256 checksum of the data.
+func Sum256(data []byte) [fipssha256.Size]byte { return fipssha256.Sum256(data) }

--- a/internal/hash/sha256/sh256_nofips.go
+++ b/internal/hash/sha256/sh256_nofips.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2022 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -18,14 +18,17 @@
 //go:build !fips
 // +build !fips
 
-package hash
+package sha256
 
 import (
 	"hash"
 
-	sha256 "github.com/minio/sha256-simd"
+	nofipssha256 "github.com/minio/sha256-simd"
 )
 
-// newSHA256 returns a new hash.Hash computing the SHA256 checksum.
+// New returns a new hash.Hash computing the SHA256 checksum.
 // The SHA256 implementation is not FIPS 140-2 compliant.
-func newSHA256() hash.Hash { return sha256.New() }
+func New() hash.Hash { return nofipssha256.New() }
+
+// Sum256 returns the SHA256 checksum of the data.
+func Sum256(data []byte) [nofipssha256.Size]byte { return nofipssha256.Sum256(data) }

--- a/internal/kms/single-key.go
+++ b/internal/kms/single-key.go
@@ -22,7 +22,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
-	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -33,6 +32,8 @@ import (
 	"github.com/secure-io/sio-go/sioutil"
 	"golang.org/x/crypto/chacha20"
 	"golang.org/x/crypto/chacha20poly1305"
+
+	"github.com/minio/minio/internal/hash/sha256"
 )
 
 // Parse parses s as single-key KMS. The given string

--- a/internal/logger/target/kafka/kafka_scram_client_contrib.go
+++ b/internal/logger/target/kafka/kafka_scram_client_contrib.go
@@ -18,11 +18,12 @@
 package kafka
 
 import (
-	"crypto/sha256"
 	"crypto/sha512"
 
 	"github.com/Shopify/sarama"
 	"github.com/xdg/scram"
+
+	"github.com/minio/minio/internal/hash/sha256"
 )
 
 func initScramClient(cfg Config, config *sarama.Config) {


### PR DESCRIPTION

## Description
use crypto/sha256 only for FIPS 140-2 compliance

## Motivation and Context
It would seem like the PR #11623 had chewed more
than it wanted to, non-fips build shouldn't really
be forced to use slower crypto/sha256 even for
presumed "non-performance" codepaths. In MinIO
there are really no "non-performance" codepaths.
This assumption seems to have had an adverse 
effect in certain areas of CPU usage.

This PR ensures that we stick to sha256-simd
on all non-FIPS builds, our most common build
to ensure we get the best out of the CPU at
any given point in time.

## How to test this PR?
Requires CPU profiling with many concurrent PUT operations.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
