### PR TITLE
fix the hang problem with command ls recursive

### DIFF
--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -238,7 +238,7 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 	}(*o)
 
 	entries, err = filteredResults()
-	cancelList()
+	defer cancelList()
 	wg.Wait()
 	if listErr != nil && !errors.Is(listErr, context.Canceled) {
 		return entries, listErr
@@ -324,7 +324,7 @@ func (z *erasureServerPools) listMerged(ctx context.Context, o listPathOptions, 
 		return len(oMeta.versions) > len(eMeta.versions)
 	})
 
-	cancelList()
+	//cancelList()
 	wg.Wait()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
when i use the command mc ls -r xxx. the programe always hangs. 
With too many dirs and files in my cluster, but the command mc ls --versions works well for me.
After debugging, I found that the program is often stuck in the method erasureServerPools.listMerged
when range pool.sets the goroutine is always end with the cancel context

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)