### PR TITLE
Add building option for MinIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ build: checks ## builds minio to $(PWD)
 	@echo "Building minio binary to './minio'"
 	@CGO_ENABLED=0 go build -tags kqueue -trimpath --ldflags "$(LDFLAGS)" -o $(PWD)/minio 1>/dev/null
 
+build-linux-amd64:
+	@echo "Building minio binary to './minio' for linux amd64"
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags kqueue -trimpath --ldflags "$(LDFLAGS)" -o $(PWD)/minio 1>/dev/null
+
 hotfix-vars:
 	$(eval LDFLAGS := $(shell MINIO_RELEASE="RELEASE" MINIO_HOTFIX="hotfix.$(shell git rev-parse --short HEAD)" go run buildscripts/gen-ldflags.go $(shell git describe --tags --abbrev=0 | \
     sed 's#RELEASE\.\([0-9]\+\)-\([0-9]\+\)-\([0-9]\+\)T\([0-9]\+\)-\([0-9]\+\)-\([0-9]\+\)Z#\1-\2-\3T\4:\5:\6Z#')))
@@ -117,6 +121,10 @@ docker-hotfix: hotfix-push checks ## builds minio docker container with hotfix t
 docker: build checks ## builds minio docker container
 	@echo "Building minio docker image '$(TAG)'"
 	@docker build -q --no-cache -t $(TAG) . -f Dockerfile
+
+docker-linux-amd64: build-linux-amd64
+	@echo "Building minio docker image '$(TAG)' for linux amd64"
+	@docker buildx build --platform linux/amd64 -q --no-cache -t $(TAG) . -f Dockerfile
 
 install: build ## builds minio and installs it to $GOPATH/bin.
 	@echo "Installing minio binary to '$(GOPATH)/bin/minio'"


### PR DESCRIPTION
## Description

Adding a build option to extend the capabilities of our Makefile to get a working binary for our GitHub Action architecture compiled from a MacBook Pro with M1 Chip

## Motivation and Context

Currently we have to manually perform this change when testing manually over console/operator repository. It would be a nice addition that can save us time by having this option, specially for those running on Apple's M1 chip.

## How to test this PR?

1. Change directory to MinIO Repository:

```sh
cd ~/minio
```

2. Set environment variable as below:

```sh
VERSION=`git rev-parse HEAD`;
```

3. Use Makefile to create the binary for our docker image:

```sh
make docker-linux-amd64 VERSION=$VERSION;
```

4. Execute the docker container, it should work on Mac M1 Chip:

```sh
VERSION="minio/minio:$VERSION";
echo $VERSION
docker run \
-v /data1 -v /data2 -v /data3 -v /data4 \
--name minio \
-p 9000:9000 -p 9001:9001 \
$VERSION server /data{1...4} --console-address ':9001'
```

5. Expected output is:

```sh
$ docker run \
-v /data1 -v /data2 -v /data3 -v /data4 \
--name minio \
-p 9000:9000 -p 9001:9001 \
$VERSION server /data{1...4} --console-address ':9001'
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Formatting 1st pool, 1 set(s), 4 drives per set.
WARNING: Host local has more than 2 drives of set. A host failure will result in data becoming unavailable.
Automatically configured API requests per node based on available memory on the system: 245
Finished loading IAM sub-system (took 0.0s of 0.1s to load data).
Status:         4 Online, 0 Offline. 
API: http://172.17.0.2:9000  http://127.0.0.1:9000 

Console: http://172.17.0.2:9001 http://127.0.0.1:9001 

Documentation: https://docs.min.io
```

<img width="1840" alt="Screen Shot 2022-05-30 at 4 38 33 PM" src="https://user-images.githubusercontent.com/6667358/171056797-4a71cbf9-a5cc-456d-814b-3d27291e3428.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
