### PR TITLE
Make isIndexedMetaV2 return errors

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -168,8 +168,10 @@ func (e *metaCacheEntry) isLatestDeletemarker() bool {
 	if !isXL2V1Format(e.metadata) {
 		return false
 	}
-	if meta, _ := isIndexedMetaV2(e.metadata); meta != nil {
+	if meta, _, err := isIndexedMetaV2(e.metadata); meta != nil {
 		return meta.IsLatestDeleteMarker()
+	} else if err != nil {
+		return true
 	}
 	// Fall back...
 	xlMeta, err := e.xlmeta()

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -50,8 +50,8 @@ func getAllFileInfoVersions(xlMetaBuf []byte, volume, path string) (FileInfoVers
 	var versions []FileInfo
 	var err error
 
-	if buf, _, err := isIndexedMetaV2(xlMetaBuf); err != nil {
-		return FileInfoVersions{}, err
+	if buf, _, e := isIndexedMetaV2(xlMetaBuf); e != nil {
+		return FileInfoVersions{}, e
 	} else if buf != nil {
 		versions, err = buf.ListVersions(volume, path)
 	} else {
@@ -89,8 +89,8 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, data bool) (F
 	var fi FileInfo
 	var err error
 	var inData xlMetaInlineData
-	if buf, data, err := isIndexedMetaV2(xlMetaBuf); err != nil {
-		return FileInfo{}, err
+	if buf, data, e := isIndexedMetaV2(xlMetaBuf); e != nil {
+		return FileInfo{}, e
 	} else if buf != nil {
 		inData = data
 		fi, err = buf.ToFileInfo(volume, path, versionID)

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -50,7 +50,9 @@ func getAllFileInfoVersions(xlMetaBuf []byte, volume, path string) (FileInfoVers
 	var versions []FileInfo
 	var err error
 
-	if buf, _ := isIndexedMetaV2(xlMetaBuf); buf != nil {
+	if buf, _, err := isIndexedMetaV2(xlMetaBuf); err != nil {
+		return FileInfoVersions{}, err
+	} else if buf != nil {
 		versions, err = buf.ListVersions(volume, path)
 	} else {
 		var xlMeta xlMetaV2
@@ -87,7 +89,9 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, data bool) (F
 	var fi FileInfo
 	var err error
 	var inData xlMetaInlineData
-	if buf, data := isIndexedMetaV2(xlMetaBuf); buf != nil {
+	if buf, data, err := isIndexedMetaV2(xlMetaBuf); err != nil {
+		return FileInfo{}, err
+	} else if buf != nil {
 		inData = data
 		fi, err = buf.ToFileInfo(volume, path, versionID)
 		if len(buf) != 0 && errors.Is(err, errFileNotFound) {

--- a/cmd/xl-storage-format_test.go
+++ b/cmd/xl-storage-format_test.go
@@ -514,7 +514,7 @@ func BenchmarkXlMetaV2Shallow(b *testing.B) {
 				b.ResetTimer()
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
-					buf, _ := isIndexedMetaV2(enc)
+					buf, _, _ := isIndexedMetaV2(enc)
 					if buf == nil {
 						b.Fatal("buf == nil")
 					}
@@ -529,7 +529,7 @@ func BenchmarkXlMetaV2Shallow(b *testing.B) {
 				b.ResetTimer()
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {
-					buf, _ := isIndexedMetaV2(enc)
+					buf, _, _ := isIndexedMetaV2(enc)
 					if buf == nil {
 						b.Fatal("buf == nil")
 					}


### PR DESCRIPTION
## Description

Indexed streams would be decoded by legacy loader if there was an error loading it.

Return an error when stream is indexed and it cannot be loaded.

Fixes `unknown minor metadata version` on corrupted xl.meta files and returns actual error.

This is reporting only. There should be no functional change.

## How to test this PR?

Truncating or corrupting `xl.meta` with wrong CRC  on disk will trigger it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
