### PR TITLE
Optionally run a command when completing jobs

### DIFF
--- a/helm/minio/templates/post-install-create-bucket-job.yaml
+++ b/helm/minio/templates/post-install-create-bucket-job.yaml
@@ -69,7 +69,12 @@ spec:
       - name: minio-mc
         image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
         imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+        {{- if .Values.makeBucketJob.exitCommand }}
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sh /config/initialize; x=$(echo $?); {{ .Values.makeBucketJob.exitCommand }} && exit $x" ]
+        {{- else }}
         command: ["/bin/sh", "/config/initialize"]
+        {{- end }}
         env:
           - name: MINIO_ENDPOINT
             value: {{ template "minio.fullname" . }}

--- a/helm/minio/templates/post-install-create-policy-job.yaml
+++ b/helm/minio/templates/post-install-create-policy-job.yaml
@@ -69,7 +69,12 @@ spec:
       - name: minio-mc
         image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
         imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+        {{- if .Values.makePolicyJob.exitCommand }}
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sh /config/add-policy; x=$(echo $?); {{ .Values.makePolicyJob.exitCommand }} && exit $x" ]
+        {{- else }}
         command: ["/bin/sh", "/config/add-policy"]
+        {{- end }}
         env:
           - name: MINIO_ENDPOINT
             value: {{ template "minio.fullname" . }}

--- a/helm/minio/templates/post-install-create-user-job.yaml
+++ b/helm/minio/templates/post-install-create-user-job.yaml
@@ -79,7 +79,12 @@ spec:
       - name: minio-mc
         image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
         imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+        {{- if .Values.makeUserJob.exitCommand }}
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sh /config/add-user; x=$(echo $?); {{ .Values.makeUserJob.exitCommand }} && exit $x" ]
+        {{- else }}
         command: ["/bin/sh", "/config/add-user"]
+        {{- end }}
         env:
           - name: MINIO_ENDPOINT
             value: {{ template "minio.fullname" . }}

--- a/helm/minio/templates/post-install-custom-command.yaml
+++ b/helm/minio/templates/post-install-custom-command.yaml
@@ -69,7 +69,12 @@ spec:
       - name: minio-mc
         image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
         imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+        {{- if .Values.customCommandJob.exitCommand }}
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sh /config/custom-command; x=$(echo $?); {{ .Values.customCommandJob.exitCommand }} && exit $x" ]
+        {{- else }}
         command: ["/bin/sh", "/config/custom-command"]
+        {{- end }}
         env:
           - name: MINIO_ENDPOINT
             value: {{ template "minio.fullname" . }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -305,6 +305,8 @@ makePolicyJob:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Command to run after the main command on exit
+  exitCommand: ""
 
 ## List of users to be created after minio install
 ##
@@ -339,6 +341,8 @@ makeUserJob:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Command to run after the main command on exit
+  exitCommand: ""
 
 ## List of buckets to be created after minio install
 ##
@@ -373,7 +377,9 @@ makeBucketJob:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
+  # Command to run after the main command on exit
+  exitCommand: ""
+  
 ## List of command to run after minio install
 ## NOTE: the mc command TARGET is always "myminio"
 customCommands:
@@ -394,7 +400,9 @@ customCommandJob:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-
+  # Command to run after the main command on exit
+  exitCommand: ""
+  
 ## Use this field to add environment variables relevant to MinIO server. These fields will be passed on to MinIO container(s)
 ## when Chart is deployed
 environment:


### PR DESCRIPTION
## Description

This allows users to run a command before the jobs (e.g. make bucket job) are completed.

## Motivation and Context

In our case we are using istio, a sidecar container is injected and we cannot contact minio without this. The problem is it does not terminate once the main container is completed. This change will allow us to add a curl command to stop the istio container, when the main command is finished so kubernetes can complete the job.

## How to test this PR?

Add in a command to `exitCommand`, view logs and ensure you can see it has run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
