### PR TITLE
add annotations to ServiceMonitor

### DIFF
--- a/helm/minio/templates/servicemonitor.yaml
+++ b/helm/minio/templates/servicemonitor.yaml
@@ -16,6 +16,10 @@ metadata:
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
 {{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
     {{- end }}
+{{- if .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.metrics.serviceMonitor.annotations | trimSuffix "\n" | indent 4 }}
+{{- end }}
 spec:
   endpoints:
     {{- if .Values.tls.enabled }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -38,8 +38,8 @@ additionalLabels: []
 additionalAnnotations: []
 
 ## Typically the deployment/statefulset includes checksums of secrets/config,
-## So that when these change on a subsequent helm install, the deployment/statefulset 
-## is restarted. This can result in unnecessary restarts under GitOps tooling such as 
+## So that when these change on a subsequent helm install, the deployment/statefulset
+## is restarted. This can result in unnecessary restarts under GitOps tooling such as
 ## flux, so set to "true" to disable this behaviour.
 ignoreChartChecksums: false
 
@@ -255,12 +255,12 @@ resources:
 ## In addition to default policies [readonly|readwrite|writeonly|consoleAdmin|diagnostics]
 ## you can define additional policies with custom supported actions and resources
 policies: []
-## writeexamplepolicy policy grants creation or deletion of buckets with name 
+## writeexamplepolicy policy grants creation or deletion of buckets with name
 ## starting with example. In addition, grants objects write permissions on buckets starting with
 ## example.
 # - name: writeexamplepolicy
 #   statements:
-#     - resources: 
+#     - resources:
 #         - 'arn:aws:s3:::example*/*'
 #       actions:
 #         - "s3:AbortMultipartUpload"
@@ -268,7 +268,7 @@ policies: []
 #         - "s3:DeleteObject"
 #         - "s3:PutObject"
 #         - "s3:ListMultipartUploadParts"
-#     - resources: 
+#     - resources:
 #         - 'arn:aws:s3:::example*'
 #       actions:
 #         - "s3:CreateBucket"
@@ -276,15 +276,15 @@ policies: []
 #         - "s3:GetBucketLocation"
 #         - "s3:ListBucket"
 #         - "s3:ListBucketMultipartUploads"
-## readonlyexamplepolicy policy grants access to buckets with name starting with example. 
+## readonlyexamplepolicy policy grants access to buckets with name starting with example.
 ## In addition, grants objects read permissions on buckets starting with example.
 # - name: readonlyexamplepolicy
 #   statements:
-#     - resources: 
+#     - resources:
 #         - 'arn:aws:s3:::example*/*'
 #       actions:
 #         - "s3:GetObject"
-#     - resources: 
+#     - resources:
 #         - 'arn:aws:s3:::example*'
 #       actions:
 #         - "s3:GetBucketLocation"
@@ -432,6 +432,7 @@ metrics:
     enabled: false
     public: true
     additionalLabels: {}
+    annotations: {}
     relabelConfigs: {}
     # namespace: monitoring
     # interval: 30s


### PR DESCRIPTION
## Description

This allows to add annotations to `ServiceMonitor`.

## Motivation and Context

I need to add the following to the `ServiceMonitor`:

```yaml
  annotations:
    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
```

Ref: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
