### PR TITLE
Add defensive check for one stream message size

### DIFF
--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -1067,9 +1067,12 @@ func waitForHTTPStream(respBody io.ReadCloser, w io.Writer) error {
 				return err
 			}
 			length := binary.LittleEndian.Uint32(tmp[:])
-			_, err = io.CopyBuffer(w, io.LimitReader(respBody, int64(length)), buf)
+			n, err := io.CopyBuffer(w, io.LimitReader(respBody, int64(length)), buf)
 			if err != nil {
 				return err
+			}
+			if n != int64(length) {
+				return io.ErrUnexpectedEOF
 			}
 			continue
 		case 32:


### PR DESCRIPTION
## Description
In a streaming response, the client knowns the size of a streamed
message but never check the received message size. Add the check to error out if
the response message is truncated.

## Motivation and Context
Add more validation. No issue reported associated to this one.

## How to test this PR?
Hard to test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
