### PR TITLE
allow single drive mode to run on root disk

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -214,7 +214,7 @@ func newXLStorage(ep Endpoint) (s *xlStorage, err error) {
 	}
 
 	var rootDisk bool
-	if !globalIsCICD {
+	if !globalIsCICD && !globalIsErasureSD {
 		if globalRootDiskThreshold > 0 {
 			// Use MINIO_ROOTDISK_THRESHOLD_SIZE to figure out if
 			// this disk is a root disk.


### PR DESCRIPTION
## Description
allow single drive mode to run on root disk

## Motivation and Context
for practical reasons allow, single drive setups
to run on root disks without any special settings.

## How to test this PR?
Nothing just run the latest release on `/` it shall fail
with some complaints about root disk.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
