### PR TITLE
Include the entirety of vendor folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ site/
 /.idea/
 /Minio.iml
 **/access.log
-vendor/**/*.js
-vendor/**/*.json
+vendor/
 .DS_Store
 *.syso
 coverage.txt


### PR DESCRIPTION
## Description
Include the entirety of "vendor" folder in .gitignore

## Motivation and Context
The 'go mod vendor' command generates a directory called 'vendor' in the
main module's root directory, which includes the required packages to
support builds. Therefore, we can include the 'vendor' directory in
.gitignore completely, regardless of any file extension.

## How to test this PR?
1- Run go mod vendor, or change the "vendor" folder in any way
2- Verify that the changes are not shown on `git status`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
