### PR TITLE
debug: Close object after check

### DIFF
--- a/docs/debugging/s3-verify/main.go
+++ b/docs/debugging/s3-verify/main.go
@@ -230,6 +230,8 @@ func main() {
 						}()
 						wg.Wait()
 
+						tobj.Close()
+
 						if !sourceFailed && !targetFailed {
 							ssum := srcSha256.Sum(nil)
 							tsum := tgtSha256.Sum(nil)
@@ -240,6 +242,8 @@ func main() {
 							}
 						}
 					}
+
+					sobj.Close()
 				} else {
 					fmt.Printf("unreadable on source: %s (%s)\n", srcCtnt.Key, err)
 				}


### PR DESCRIPTION
## Description
Each minio-go Object reader needs to be closed after reading it,
otherwise a leak will build up.

## Motivation and Context
Avoid leak

## How to test this PR?
Create two clusters with site replication, upload some files and run this tool

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
