### PR TITLE
Add generic function to retrieve config value with metadata

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -338,7 +338,7 @@ func validateSubSysConfig(s config.Config, subSys string, objAPI ObjectLayer) er
 			etcdClnt.Close()
 		}
 	case config.IdentityOpenIDSubSys:
-		if _, err := openid.LookupConfig(s[config.IdentityOpenIDSubSys],
+		if _, err := openid.LookupConfig(s,
 			NewGatewayHTTPTransport(), xhttp.DrainBody, globalSite.Region); err != nil {
 			return err
 		}
@@ -560,7 +560,7 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 		logger.LogIf(ctx, fmt.Errorf("CRITICAL: enabling %s is not recommended in a production environment", xtls.EnvIdentityTLSSkipVerify))
 	}
 
-	globalOpenIDConfig, err = openid.LookupConfig(s[config.IdentityOpenIDSubSys],
+	globalOpenIDConfig, err = openid.LookupConfig(s,
 		NewGatewayHTTPTransport(), xhttp.DrainBody, globalSite.Region)
 	if err != nil {
 		logger.LogIf(ctx, fmt.Errorf("Unable to initialize OpenID: %w", err))

--- a/internal/config/identity/openid/jwt_test.go
+++ b/internal/config/identity/openid/jwt_test.go
@@ -243,7 +243,7 @@ func TestKeycloakProviderInitialization(t *testing.T) {
 	testKvs.Set(Vendor, "keycloak")
 	testKvs.Set(KeyCloakRealm, "TestRealm")
 	testKvs.Set(KeyCloakAdminURL, "http://keycloak.test/auth/admin")
-	cfgGet := func(env, param string) string {
+	cfgGet := func(param string) string {
 		return testKvs.Get(param)
 	}
 

--- a/internal/config/identity/openid/providercfg.go
+++ b/internal/config/identity/openid/providercfg.go
@@ -52,17 +52,17 @@ type providerCfg struct {
 	provider provider.Provider
 }
 
-func newProviderCfgFromConfig(getCfgVal func(env, cfgName string) string) providerCfg {
+func newProviderCfgFromConfig(getCfgVal func(cfgName string) string) providerCfg {
 	return providerCfg{
-		DisplayName:        getCfgVal(EnvIdentityOpenIDDisplayName, DisplayName),
-		ClaimName:          getCfgVal(EnvIdentityOpenIDClaimName, ClaimName),
-		ClaimUserinfo:      getCfgVal(EnvIdentityOpenIDClaimUserInfo, ClaimUserinfo) == config.EnableOn,
-		ClaimPrefix:        getCfgVal(EnvIdentityOpenIDClaimPrefix, ClaimPrefix),
-		RedirectURI:        getCfgVal(EnvIdentityOpenIDRedirectURI, RedirectURI),
-		RedirectURIDynamic: getCfgVal(EnvIdentityOpenIDRedirectURIDynamic, RedirectURIDynamic) == config.EnableOn,
-		ClientID:           getCfgVal(EnvIdentityOpenIDClientID, ClientID),
-		ClientSecret:       getCfgVal(EnvIdentityOpenIDClientSecret, ClientSecret),
-		RolePolicy:         getCfgVal(EnvIdentityOpenIDRolePolicy, RolePolicy),
+		DisplayName:        getCfgVal(DisplayName),
+		ClaimName:          getCfgVal(ClaimName),
+		ClaimUserinfo:      getCfgVal(ClaimUserinfo) == config.EnableOn,
+		ClaimPrefix:        getCfgVal(ClaimPrefix),
+		RedirectURI:        getCfgVal(RedirectURI),
+		RedirectURIDynamic: getCfgVal(RedirectURIDynamic) == config.EnableOn,
+		ClientID:           getCfgVal(ClientID),
+		ClientSecret:       getCfgVal(ClientSecret),
+		RolePolicy:         getCfgVal(RolePolicy),
 	}
 }
 
@@ -72,16 +72,16 @@ const (
 
 // initializeProvider initializes if any additional vendor specific information
 // was provided, initialization will return an error initial login fails.
-func (p *providerCfg) initializeProvider(cfgGet func(string, string) string, transport http.RoundTripper) error {
-	vendor := cfgGet(EnvIdentityOpenIDVendor, Vendor)
+func (p *providerCfg) initializeProvider(cfgGet func(string) string, transport http.RoundTripper) error {
+	vendor := cfgGet(Vendor)
 	if vendor == "" {
 		return nil
 	}
 	var err error
 	switch vendor {
 	case keyCloakVendor:
-		adminURL := cfgGet(EnvIdentityOpenIDKeyCloakAdminURL, KeyCloakAdminURL)
-		realm := cfgGet(EnvIdentityOpenIDKeyCloakRealm, KeyCloakRealm)
+		adminURL := cfgGet(KeyCloakAdminURL)
+		realm := cfgGet(KeyCloakRealm)
 		p.provider, err = provider.KeyCloak(
 			provider.WithAdminURL(adminURL),
 			provider.WithOpenIDConfig(provider.DiscoveryDoc(p.DiscoveryDoc)),


### PR DESCRIPTION
## Description
`config.ResolveConfigParam` returns the value of a configuration for any
subsystem based checking env, config store and default value. Also returns info
about which config source returned the value.

This is useful to return info about config params overridden via env in user
APIs. Currently implemented only for OpenID subsystem but will be extended.

## Motivation and Context

Currently, there is no way to return information about env overridden configuration values. This is useful for developing higher level user configuration APIs.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
