### PR TITLE
add audit webhook/kafka logger filters on API

### DIFF
--- a/cmd/consolelogger.go
+++ b/cmd/consolelogger.go
@@ -161,6 +161,11 @@ func (sys *HTTPConsoleLoggerSys) Type() types.TargetType {
 	return types.TargetConsole
 }
 
+// Filters is dummy function for console target.
+func (sys *HTTPConsoleLoggerSys) Filters() []string {
+	return []string{}
+}
+
 // Send log message 'e' to console and publish to console
 // log pubsub system
 func (sys *HTTPConsoleLoggerSys) Send(e interface{}, logKind string) error {

--- a/cmd/data-update-tracker_test.go
+++ b/cmd/data-update-tracker_test.go
@@ -63,6 +63,10 @@ func (t *testingLogger) Type() types.TargetType {
 	return types.TargetHTTP
 }
 
+func (t *testingLogger) Filters() []string {
+	return []string{}
+}
+
 func (t *testingLogger) Send(entry interface{}, errKind string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -114,6 +114,12 @@ var (
 			Type:        "number",
 		},
 		config.HelpKV{
+			Key:         Filter,
+			Description: "filter only relevant audit events to Audit Webhook targets, eg: 'Decom*,Replicate*'",
+			Optional:    true,
+			Type:        "csv",
+		},
+		config.HelpKV{
 			Key:         config.Comment,
 			Description: config.DefaultComment,
 			Optional:    true,
@@ -203,6 +209,12 @@ var (
 			Description: "specify the version of the Kafka cluster",
 			Optional:    true,
 			Type:        "string",
+		},
+		config.HelpKV{
+			Key:         Filter,
+			Description: "filter only relevant audit events to Audit Webhook targets, eg: 'Decom*,Replicate*'",
+			Optional:    true,
+			Type:        "csv",
 		},
 		config.HelpKV{
 			Key:         config.Comment,

--- a/internal/logger/target/console/console.go
+++ b/internal/logger/target/console/console.go
@@ -47,6 +47,11 @@ func (c *Target) String() string {
 	return "console"
 }
 
+// Filters is a dummy function for console target
+func (c *Target) Filters() []string {
+	return []string{}
+}
+
 // Send log message 'e' to console
 func (c *Target) Send(e interface{}, logKind string) error {
 	entry, ok := e.(log.Entry)

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -45,6 +45,7 @@ type Config struct {
 	ClientCert string            `json:"clientCert"`
 	ClientKey  string            `json:"clientKey"`
 	QueueSize  int               `json:"queueSize"`
+	Filters    []string          `json:"filters"`
 	Transport  http.RoundTripper `json:"-"`
 
 	// Custom logger
@@ -200,6 +201,11 @@ func New(config Config) *Target {
 	}
 
 	return h
+}
+
+// Filters - Returns configured filters if any.
+func (h *Target) Filters() []string {
+	return h.config.Filters
 }
 
 // Send log message 'e' to http target.

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -47,6 +47,11 @@ type Target struct {
 	config   *sarama.Config
 }
 
+// Filters - Returns configured filters if any.
+func (h *Target) Filters() []string {
+	return h.kconfig.Filters
+}
+
 // Send log message 'e' to kafka target.
 func (h *Target) Send(entry interface{}, errKind string) error {
 	select {
@@ -127,6 +132,7 @@ type Config struct {
 		Password  string `json:"password"`
 		Mechanism string `json:"mechanism"`
 	} `json:"sasl"`
+	Filters []string `json:"filters"`
 
 	// Custom logger
 	LogOnce func(ctx context.Context, err error, id interface{}, errKind ...interface{}) `json:"-"`

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -32,6 +32,7 @@ type Target interface {
 	String() string
 	Endpoint() string
 	Init() error
+	Filters() []string
 	Cancel()
 	Send(entry interface{}, errKind string) error
 	Type() types.TargetType


### PR DESCRIPTION

## Description
add audit webhook/kafka logger filters on API

## Motivation and Context
This PR allows applying wildcard filters optionally
for audit targets, to filter only relevant audit
events for the concerned target.

## How to test this PR?
Nothing special just observe that

```
MINIO_AUDIT_WEBHOOK_FILTER_target1="Decom*"
```

Would only send "Decommission" related internal audit
events to `target1`, the FILTER also supports multiple
wildcards to allow for multiple such filters.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
