### PR TITLE
update '-v' flag behavior to include copyRight and license

### DIFF
--- a/cmd/build-constants.go
+++ b/cmd/build-constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2022 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -37,4 +37,7 @@ var (
 
 	// ShortCommitID - first 12 characters from CommitID.
 	ShortCommitID = "DEVELOPMENT.GOGET"
+
+	// CopyrightYear - dynamic value of the copyright end year
+	CopyrightYear = "0000"
 )

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -73,6 +73,13 @@ var (
 		return fmt.Sprint
 	}()
 
+	Greenf = func() func(format string, a ...interface{}) string {
+		if IsTerminal() {
+			return color.New(color.FgGreen).SprintfFunc()
+		}
+		return fmt.Sprintf
+	}()
+
 	GreenBold = func() func(a ...interface{}) string {
 		if IsTerminal() {
 			return color.New(color.FgGreen, color.Bold).SprintFunc()


### PR DESCRIPTION
## Description
update '-v' flag behavior to include copyRight and license

## Motivation and Context
```
 ~ minio -v
minio version DEVELOPMENT.2022-06-16T20-40-14Z (commit-id=e083228e2a06bfdcd006fee28d449cd2b47c542a)
Runtime: go1.18.3 linux/amd64
Copyright (c) 2015-2022 MinIO, Inc.
Licence AGPLv3 <https://www.gnu.org/licenses/agpl-3.0.html>
```

## How to test this PR?
Nothing just compile and see. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
