### PR TITLE
fix typo in site replication version healing

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -3712,8 +3712,8 @@ func (c *SiteReplicationSys) healVersioningMetadata(ctx context.Context, objAPI 
 			continue
 		}
 		if dID == globalDeploymentID {
-			if err := globalBucketMetadataSys.Update(ctx, bucket, bucketSSEConfig, latestVersioningConfigBytes); err != nil {
-				logger.LogIf(ctx, fmt.Errorf("Error healing sse metadata from peer site %s : %w", latestPeerName, err))
+			if err := globalBucketMetadataSys.Update(ctx, bucket, bucketVersioningConfig, latestVersioningConfigBytes); err != nil {
+				logger.LogIf(ctx, fmt.Errorf("Error healing versioning metadata from peer site %s : %w", latestPeerName, err))
 			}
 			continue
 		}


### PR DESCRIPTION
## Description


## Motivation and Context
```

API: SYSTEM()
Time: 20:25:51 UTC 06/17/2022
DeploymentID: f49f4812-09e6-41ee-923d-cc7c8aa3f563
Error: Error healing sse metadata from peer site local2 : expected element type <ServerSideEncryptionConfiguration> but have <VersioningConfiguration> (*fmt.wrapError)
       4: internal/logger/logger.go:278:logger.LogIf()
       3: cmd/site-replication.go:3716:cmd.(*SiteReplicationSys).healVersioningMetadata()
       2: cmd/site-replication.go:3446:cmd.(*SiteReplicationSys).healBuckets()
       1: cmd/site-replication.go:3381:cmd.(*SiteReplicationSys).startHealRoutine()
```
## How to test this PR?
Perrform site replication from cluster with existing versioned buckets - site heal will be triggered and should not log above error

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
