### PR TITLE
fix: cant parse comment without '=' in environment file

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -490,6 +490,12 @@ func parsEnvEntry(envEntry string) (envKV, error) {
 			Skip: true,
 		}, nil
 	}
+	if strings.HasPrefix(envEntry, "#") {
+		// Skip commented lines
+		return envKV{
+			Skip: true,
+		}, nil
+	}
 	const envSeparator = "="
 	envTokens := strings.SplitN(strings.TrimSpace(strings.TrimPrefix(envEntry, "export")), envSeparator, 2)
 	if len(envTokens) != 2 {
@@ -498,13 +504,6 @@ func parsEnvEntry(envEntry string) (envKV, error) {
 
 	key := envTokens[0]
 	val := envTokens[1]
-
-	if strings.HasPrefix(key, "#") {
-		// Skip commented lines
-		return envKV{
-			Skip: true,
-		}, nil
-	}
 
 	// Remove quotes from the value if found
 	if len(val) >= 2 {

--- a/cmd/common-main_test.go
+++ b/cmd/common-main_test.go
@@ -136,6 +136,7 @@ export MINIO_ROOT_PASSWORD=minio123`,
 		},
 		{
 			`
+# simple comment
 # MINIO_ROOT_USER=minioadmin
 # MINIO_ROOT_PASSWORD=minioadmin
 MINIO_ROOT_USER=minio


### PR DESCRIPTION
## Description
fix: cant parse comment without '=' in environment file

## Motivation and Context
In environment file (= MINIO_CONFIG_ENV_FILE), comments (lines beginning with '#') must contain '=' or the following error will occur.

> envEntry malformed; # simple comment, expected to be of form 'KEY=value'

This error can also happen, for example, with the following configuration file.

https://github.com/minio/minio-service/tree/master/linux-systemd#create-default-configuration

## How to test this PR?

I have updated a test. Therefore `make test` 
Or start MinIO with the following environment file (set file name to 'MINIO_CONFIG_ENV_FILE' env).

```
# simple comment
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
