### PR TITLE
replication: Avoid proxying when precondition failed

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -420,6 +420,11 @@ func (api objectAPIHandlers) getObjectHandler(ctx context.Context, objectAPI Obj
 
 	gr, err := getObjectNInfo(ctx, bucket, object, rs, r.Header, readLock, opts)
 	if err != nil {
+		if isErrPreconditionFailed(err) {
+			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
+			return
+		}
+
 		var (
 			reader *GetObjectReader
 			proxy  proxyResult


### PR DESCRIPTION
Proxying is not required when content is on this cluster and
does not meet pre-conditions specified in the request. Fixes #15124

## Description


## Motivation and Context
Avoid needless proxying

## How to test this PR?
Set up site replication b/w 2 sites - send a `GET` request to any of the sites having the object version with a `if-none-match` header - should see a 304 `Status Not Modified` and no proxying attempt/spurious logs as reported in the issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
