### PR TITLE
fips: fix order of elliptic curves

### DIFF
--- a/internal/fips/api.go
+++ b/internal/fips/api.go
@@ -134,14 +134,14 @@ func TLSCiphersBackwardCompatible() []uint16 {
 // TLSCurveIDs returns a list of supported elliptic curve IDs
 // in preference order.
 func TLSCurveIDs() []tls.CurveID {
-	curves := []tls.CurveID{tls.CurveP256}
+	var curves []tls.CurveID
+	if !Enabled {
+		curves = append(curves, tls.X25519) // Only enable X25519 in non-FIPS mode
+	}
+	curves = append(curves, tls.CurveP256)
 	if go18 {
 		// With go1.18 enable P384, P521 newer constant time implementations.
-		curves = append(curves, []tls.CurveID{tls.CurveP384, tls.CurveP521}...)
-	}
-	if !Enabled {
-		// No-FIPS we enable x25519 as well.
-		curves = append(curves, tls.X25519)
+		curves = append(curves, tls.CurveP384, tls.CurveP521)
 	}
 	return curves
 }


### PR DESCRIPTION
## Description
This commit fixes the order of elliptic curves.
As documented by https://pkg.go.dev/crypto/tls#Config
```
// CurvePreferences contains the elliptic curves that will be used in
// an ECDHE handshake, in preference order. If empty, the default will
// be used. The client will use the first preference as the type for
// its key share in TLS 1.3. This may change in the future.
```

In general, we should prefer `X25519` over the NIST curves.

## Motivation and Context
FIPS, TLS

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
