### PR TITLE
Purge the objects immediately when `x-minio-force-delete` header is passed in DeleteObject and DeleteBucket API

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -163,7 +163,9 @@ func (h *healingTracker) save(ctx context.Context) error {
 func (h *healingTracker) delete(ctx context.Context) error {
 	return h.disk.Delete(ctx, minioMetaBucket,
 		pathJoin(bucketMetaPrefix, slashSeparator, healingTrackerFilename),
-		false)
+		false,
+		false,
+	)
 }
 
 func (h *healingTracker) isHealed(bucket string) bool {

--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -163,8 +163,10 @@ func (h *healingTracker) save(ctx context.Context) error {
 func (h *healingTracker) delete(ctx context.Context) error {
 	return h.disk.Delete(ctx, minioMetaBucket,
 		pathJoin(bucketMetaPrefix, slashSeparator, healingTrackerFilename),
-		false,
-		false,
+		DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		},
 	)
 }
 

--- a/cmd/erasure-encode_test.go
+++ b/cmd/erasure-encode_test.go
@@ -196,7 +196,7 @@ func benchmarkErasureEncode(data, parity, dataDown, parityDown int, size int64, 
 			if disk == OfflineDisk {
 				continue
 			}
-			disk.Delete(context.Background(), "testbucket", "object", false)
+			disk.Delete(context.Background(), "testbucket", "object", false, false)
 			writers[i] = newBitrotWriter(disk, "testbucket", "object", erasure.ShardFileSize(size), DefaultBitrotAlgorithm, erasure.ShardSize())
 		}
 		_, err := erasure.Encode(context.Background(), bytes.NewReader(content), writers, buffer, erasure.dataBlocks+1)

--- a/cmd/erasure-encode_test.go
+++ b/cmd/erasure-encode_test.go
@@ -196,7 +196,10 @@ func benchmarkErasureEncode(data, parity, dataDown, parityDown int, size int64, 
 			if disk == OfflineDisk {
 				continue
 			}
-			disk.Delete(context.Background(), "testbucket", "object", false, false)
+			disk.Delete(context.Background(), "testbucket", "object", DeleteOptions{
+				Recursive: false,
+				Force:     false,
+			})
 			writers[i] = newBitrotWriter(disk, "testbucket", "object", erasure.ShardFileSize(size), DefaultBitrotAlgorithm, erasure.ShardSize())
 		}
 		_, err := erasure.Encode(context.Background(), bytes.NewReader(content), writers, buffer, erasure.dataBlocks+1)

--- a/cmd/erasure-healing-common_test.go
+++ b/cmd/erasure-healing-common_test.go
@@ -218,7 +218,10 @@ func TestListOnlineDisks(t *testing.T) {
 					// and check if that disk
 					// appears in outDatedDisks.
 					tamperedIndex = index
-					dErr := erasureDisks[index].Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false, false)
+					dErr := erasureDisks[index].Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), DeleteOptions{
+						Recursive: false,
+						Force:     false,
+					})
 					if dErr != nil {
 						t.Fatalf("Failed to delete %s - %v", filepath.Join(object, "part.1"), dErr)
 					}
@@ -395,7 +398,10 @@ func TestListOnlineDisksSmallObjects(t *testing.T) {
 					// and check if that disk
 					// appears in outDatedDisks.
 					tamperedIndex = index
-					dErr := erasureDisks[index].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
+					dErr := erasureDisks[index].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), DeleteOptions{
+						Recursive: false,
+						Force:     false,
+					})
 					if dErr != nil {
 						t.Fatalf("Failed to delete %s - %v", pathJoin(object, xlStorageFormatFile), dErr)
 					}

--- a/cmd/erasure-healing-common_test.go
+++ b/cmd/erasure-healing-common_test.go
@@ -218,7 +218,7 @@ func TestListOnlineDisks(t *testing.T) {
 					// and check if that disk
 					// appears in outDatedDisks.
 					tamperedIndex = index
-					dErr := erasureDisks[index].Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false)
+					dErr := erasureDisks[index].Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false, false)
 					if dErr != nil {
 						t.Fatalf("Failed to delete %s - %v", filepath.Join(object, "part.1"), dErr)
 					}
@@ -395,7 +395,7 @@ func TestListOnlineDisksSmallObjects(t *testing.T) {
 					// and check if that disk
 					// appears in outDatedDisks.
 					tamperedIndex = index
-					dErr := erasureDisks[index].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
+					dErr := erasureDisks[index].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
 					if dErr != nil {
 						t.Fatalf("Failed to delete %s - %v", pathJoin(object, xlStorageFormatFile), dErr)
 					}

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -655,7 +655,10 @@ func (er erasureObjects) healObjectDir(ctx context.Context, bucket, object strin
 				wg.Add(1)
 				go func(index int, disk StorageAPI) {
 					defer wg.Done()
-					_ = disk.Delete(ctx, bucket, object, false, false)
+					_ = disk.Delete(ctx, bucket, object, DeleteOptions{
+						Recursive: false,
+						Force:     false,
+					})
 				}(index, disk)
 			}
 			wg.Wait()

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -655,7 +655,7 @@ func (er erasureObjects) healObjectDir(ctx context.Context, bucket, object strin
 				wg.Add(1)
 				go func(index int, disk StorageAPI) {
 					defer wg.Done()
-					_ = disk.Delete(ctx, bucket, object, false)
+					_ = disk.Delete(ctx, bucket, object, false, false)
 				}(index, disk)
 			}
 			wg.Wait()

--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -610,7 +610,10 @@ func TestHealCorrectQuorum(t *testing.T) {
 		}
 
 		for i := 0; i < nfi.Erasure.ParityBlocks; i++ {
-			erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
+			erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), DeleteOptions{
+				Recursive: false,
+				Force:     false,
+			})
 		}
 
 		// Try healing now, it should heal the content properly.
@@ -634,7 +637,10 @@ func TestHealCorrectQuorum(t *testing.T) {
 		}
 
 		for i := 0; i < nfi.Erasure.ParityBlocks; i++ {
-			erasureDisks[i].Delete(context.Background(), minioMetaBucket, pathJoin(cfgFile, xlStorageFormatFile), false, false)
+			erasureDisks[i].Delete(context.Background(), minioMetaBucket, pathJoin(cfgFile, xlStorageFormatFile), DeleteOptions{
+				Recursive: false,
+				Force:     false,
+			})
 		}
 
 		// Try healing now, it should heal the content properly.
@@ -714,7 +720,10 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 	er := set.sets[0]
 	erasureDisks := er.getDisks()
 	firstDisk := erasureDisks[0]
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	})
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -734,7 +743,10 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 		t.Errorf("Expected xl.meta file to be present but stat failed - %v", err)
 	}
 
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false, false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	})
 	if err != nil {
 		t.Errorf("Failure during deleting part.1 - %v", err)
 	}
@@ -761,7 +773,10 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 		t.Fatalf("FileInfo not equal after healing: %v != %v", fi, nfi)
 	}
 
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false, false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	})
 	if err != nil {
 		t.Errorf("Failure during deleting part.1 - %v", err)
 	}
@@ -792,7 +807,10 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 	// Test 4: checks if HealObject returns an error when xl.meta is not found
 	// in more than read quorum number of disks, to create a corrupted situation.
 	for i := 0; i <= nfi.Erasure.DataBlocks; i++ {
-		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
+		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		})
 	}
 
 	// Try healing now, expect to receive errFileNotFound.
@@ -884,7 +902,10 @@ func TestHealObjectCorruptedXLMeta(t *testing.T) {
 		t.Fatalf("Failed to getLatestFileInfo - %v", err)
 	}
 
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	})
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -936,7 +957,10 @@ func TestHealObjectCorruptedXLMeta(t *testing.T) {
 	// Test 3: checks if HealObject returns an error when xl.meta is not found
 	// in more than read quorum number of disks, to create a corrupted situation.
 	for i := 0; i <= nfi2.Erasure.DataBlocks; i++ {
-		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
+		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		})
 	}
 
 	// Try healing now, expect to receive errFileNotFound.
@@ -1033,7 +1057,10 @@ func TestHealObjectCorruptedParts(t *testing.T) {
 	}
 
 	// Test 1, remove part.1
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false, false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	})
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -1078,7 +1105,10 @@ func TestHealObjectCorruptedParts(t *testing.T) {
 		t.Fatalf("Failed to write a file - %v", err)
 	}
 
-	err = secondDisk.Delete(context.Background(), bucket, object, true, false)
+	err = secondDisk.Delete(context.Background(), bucket, object, DeleteOptions{
+		Recursive: true,
+		Force:     false,
+	})
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -1166,7 +1196,10 @@ func TestHealObjectErasure(t *testing.T) {
 	}
 
 	// Delete the whole object folder
-	err = firstDisk.Delete(context.Background(), bucket, object, true, false)
+	err = firstDisk.Delete(context.Background(), bucket, object, DeleteOptions{
+		Recursive: true,
+		Force:     false,
+	})
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}

--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -610,7 +610,7 @@ func TestHealCorrectQuorum(t *testing.T) {
 		}
 
 		for i := 0; i < nfi.Erasure.ParityBlocks; i++ {
-			erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
+			erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
 		}
 
 		// Try healing now, it should heal the content properly.
@@ -634,7 +634,7 @@ func TestHealCorrectQuorum(t *testing.T) {
 		}
 
 		for i := 0; i < nfi.Erasure.ParityBlocks; i++ {
-			erasureDisks[i].Delete(context.Background(), minioMetaBucket, pathJoin(cfgFile, xlStorageFormatFile), false)
+			erasureDisks[i].Delete(context.Background(), minioMetaBucket, pathJoin(cfgFile, xlStorageFormatFile), false, false)
 		}
 
 		// Try healing now, it should heal the content properly.
@@ -714,7 +714,7 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 	er := set.sets[0]
 	erasureDisks := er.getDisks()
 	firstDisk := erasureDisks[0]
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -734,7 +734,7 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 		t.Errorf("Expected xl.meta file to be present but stat failed - %v", err)
 	}
 
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false, false)
 	if err != nil {
 		t.Errorf("Failure during deleting part.1 - %v", err)
 	}
@@ -761,7 +761,7 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 		t.Fatalf("FileInfo not equal after healing: %v != %v", fi, nfi)
 	}
 
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false, false)
 	if err != nil {
 		t.Errorf("Failure during deleting part.1 - %v", err)
 	}
@@ -792,7 +792,7 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 	// Test 4: checks if HealObject returns an error when xl.meta is not found
 	// in more than read quorum number of disks, to create a corrupted situation.
 	for i := 0; i <= nfi.Erasure.DataBlocks; i++ {
-		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
+		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
 	}
 
 	// Try healing now, expect to receive errFileNotFound.
@@ -884,7 +884,7 @@ func TestHealObjectCorruptedXLMeta(t *testing.T) {
 		t.Fatalf("Failed to getLatestFileInfo - %v", err)
 	}
 
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -936,7 +936,7 @@ func TestHealObjectCorruptedXLMeta(t *testing.T) {
 	// Test 3: checks if HealObject returns an error when xl.meta is not found
 	// in more than read quorum number of disks, to create a corrupted situation.
 	for i := 0; i <= nfi2.Erasure.DataBlocks; i++ {
-		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
+		erasureDisks[i].Delete(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false, false)
 	}
 
 	// Try healing now, expect to receive errFileNotFound.
@@ -1033,7 +1033,7 @@ func TestHealObjectCorruptedParts(t *testing.T) {
 	}
 
 	// Test 1, remove part.1
-	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false)
+	err = firstDisk.Delete(context.Background(), bucket, pathJoin(object, fi.DataDir, "part.1"), false, false)
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -1078,7 +1078,7 @@ func TestHealObjectCorruptedParts(t *testing.T) {
 		t.Fatalf("Failed to write a file - %v", err)
 	}
 
-	err = secondDisk.Delete(context.Background(), bucket, object, true)
+	err = secondDisk.Delete(context.Background(), bucket, object, true, false)
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}
@@ -1166,7 +1166,7 @@ func TestHealObjectErasure(t *testing.T) {
 	}
 
 	// Delete the whole object folder
-	err = firstDisk.Delete(context.Background(), bucket, object, true)
+	err = firstDisk.Delete(context.Background(), bucket, object, true, false)
 	if err != nil {
 		t.Fatalf("Failed to delete a file - %v", err)
 	}

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -91,7 +91,7 @@ func (er erasureObjects) removeObjectPart(bucket, object, uploadID, dataDir stri
 			// Ignoring failure to remove parts that weren't present in CompleteMultipartUpload
 			// requests. xl.meta is the authoritative source of truth on which parts constitute
 			// the object. The presence of parts that don't belong in the object doesn't affect correctness.
-			_ = storageDisks[index].Delete(context.TODO(), minioMetaMultipartBucket, curpartPath, false)
+			_ = storageDisks[index].Delete(context.TODO(), minioMetaMultipartBucket, curpartPath, false, false)
 			return nil
 		}, index)
 	}
@@ -138,7 +138,7 @@ func (er erasureObjects) deleteAll(ctx context.Context, bucket, prefix string) {
 		wg.Add(1)
 		go func(disk StorageAPI) {
 			defer wg.Done()
-			disk.Delete(ctx, bucket, prefix, true)
+			disk.Delete(ctx, bucket, prefix, true, false)
 		}(disk)
 	}
 	wg.Wait()

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -91,7 +91,10 @@ func (er erasureObjects) removeObjectPart(bucket, object, uploadID, dataDir stri
 			// Ignoring failure to remove parts that weren't present in CompleteMultipartUpload
 			// requests. xl.meta is the authoritative source of truth on which parts constitute
 			// the object. The presence of parts that don't belong in the object doesn't affect correctness.
-			_ = storageDisks[index].Delete(context.TODO(), minioMetaMultipartBucket, curpartPath, false, false)
+			_ = storageDisks[index].Delete(context.TODO(), minioMetaMultipartBucket, curpartPath, DeleteOptions{
+				Recursive: false,
+				Force:     false,
+			})
 			return nil
 		}, index)
 	}
@@ -138,7 +141,10 @@ func (er erasureObjects) deleteAll(ctx context.Context, bucket, prefix string) {
 		wg.Add(1)
 		go func(disk StorageAPI) {
 			defer wg.Done()
-			disk.Delete(ctx, bucket, prefix, true, false)
+			disk.Delete(ctx, bucket, prefix, DeleteOptions{
+				Recursive: true,
+				Force:     false,
+			})
 		}(disk)
 	}
 	wg.Wait()

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1367,8 +1367,14 @@ func (er erasureObjects) deletePrefix(ctx context.Context, bucket, prefix string
 			// Deletes
 			// - The prefix and its children
 			// - The prefix__XLDIR__
-			defer disks[index].Delete(ctx, bucket, dirPrefix, true, true)
-			return disks[index].Delete(ctx, bucket, prefix, true, true)
+			defer disks[index].Delete(ctx, bucket, dirPrefix, DeleteOptions{
+				Recursive: true,
+				Force:     true,
+			})
+			return disks[index].Delete(ctx, bucket, prefix, DeleteOptions{
+				Recursive: true,
+				Force:     true,
+			})
 		}, index)
 	}
 	for _, err := range g.Wait() {

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1367,8 +1367,8 @@ func (er erasureObjects) deletePrefix(ctx context.Context, bucket, prefix string
 			// Deletes
 			// - The prefix and its children
 			// - The prefix__XLDIR__
-			defer disks[index].Delete(ctx, bucket, dirPrefix, true)
-			return disks[index].Delete(ctx, bucket, prefix, true)
+			defer disks[index].Delete(ctx, bucket, dirPrefix, true, true)
+			return disks[index].Delete(ctx, bucket, prefix, true, true)
 		}, index)
 	}
 	for _, err := range g.Wait() {

--- a/cmd/erasure-object_test.go
+++ b/cmd/erasure-object_test.go
@@ -528,7 +528,7 @@ func TestGetObjectNoQuorum(t *testing.T) {
 		files, _ := disk.ListDir(ctx, bucket, object, -1)
 		for _, file := range files {
 			if file != "xl.meta" {
-				disk.Delete(ctx, bucket, pathJoin(object, file), true)
+				disk.Delete(ctx, bucket, pathJoin(object, file), true, false)
 			}
 		}
 	}
@@ -629,7 +629,7 @@ func TestHeadObjectNoQuorum(t *testing.T) {
 		files, _ := disk.ListDir(ctx, bucket, object, -1)
 		for _, file := range files {
 			if file != "xl.meta" {
-				disk.Delete(ctx, bucket, pathJoin(object, file), true)
+				disk.Delete(ctx, bucket, pathJoin(object, file), true, false)
 			}
 		}
 	}

--- a/cmd/erasure-object_test.go
+++ b/cmd/erasure-object_test.go
@@ -528,7 +528,10 @@ func TestGetObjectNoQuorum(t *testing.T) {
 		files, _ := disk.ListDir(ctx, bucket, object, -1)
 		for _, file := range files {
 			if file != "xl.meta" {
-				disk.Delete(ctx, bucket, pathJoin(object, file), true, false)
+				disk.Delete(ctx, bucket, pathJoin(object, file), DeleteOptions{
+					Recursive: true,
+					Force:     false,
+				})
 			}
 		}
 	}
@@ -629,7 +632,10 @@ func TestHeadObjectNoQuorum(t *testing.T) {
 		files, _ := disk.ListDir(ctx, bucket, object, -1)
 		for _, file := range files {
 			if file != "xl.meta" {
-				disk.Delete(ctx, bucket, pathJoin(object, file), true, false)
+				disk.Delete(ctx, bucket, pathJoin(object, file), DeleteOptions{
+					Recursive: true,
+					Force:     false,
+				})
 			}
 		}
 	}

--- a/cmd/erasure-single-drive.go
+++ b/cmd/erasure-single-drive.go
@@ -1321,8 +1321,8 @@ func (es *erasureSingle) DeleteObjects(ctx context.Context, bucket string, objec
 
 func (es *erasureSingle) deletePrefix(ctx context.Context, bucket, prefix string) error {
 	dirPrefix := encodeDirObject(prefix)
-	defer es.disk.Delete(ctx, bucket, dirPrefix, true)
-	return es.disk.Delete(ctx, bucket, prefix, true)
+	defer es.disk.Delete(ctx, bucket, dirPrefix, true, true)
+	return es.disk.Delete(ctx, bucket, prefix, true, true)
 }
 
 // DeleteObject - deletes an object, this call doesn't necessary reply
@@ -1916,7 +1916,7 @@ func (es *erasureSingle) removeObjectPart(bucket, object, uploadID, dataDir stri
 			// Ignoring failure to remove parts that weren't present in CompleteMultipartUpload
 			// requests. xl.meta is the authoritative source of truth on which parts constitute
 			// the object. The presence of parts that don't belong in the object doesn't affect correctness.
-			_ = storageDisks[index].Delete(context.TODO(), minioMetaMultipartBucket, curpartPath, false)
+			_ = storageDisks[index].Delete(context.TODO(), minioMetaMultipartBucket, curpartPath, false, false)
 			return nil
 		}, index)
 	}
@@ -1954,7 +1954,7 @@ func (es *erasureSingle) cleanupStaleUploadsOnDisk(ctx context.Context, disk Sto
 		}
 		wait := es.deletedCleanupSleeper.Timer(ctx)
 		if now.Sub(vi.Created) > expiry {
-			disk.Delete(ctx, minioMetaTmpBucket, tmpDir, true)
+			disk.Delete(ctx, minioMetaTmpBucket, tmpDir, true, false)
 		}
 		wait()
 		return nil

--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -367,7 +367,10 @@ func saveFormatErasure(disk StorageAPI, format *formatErasureV3, heal bool) erro
 	tmpFormat := mustGetUUID()
 
 	// Purge any existing temporary file, okay to ignore errors here.
-	defer disk.Delete(context.TODO(), minioMetaBucket, tmpFormat, false, false)
+	defer disk.Delete(context.TODO(), minioMetaBucket, tmpFormat, DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	})
 
 	// write to unique file.
 	if err = disk.WriteAll(context.TODO(), minioMetaBucket, tmpFormat, formatBytes); err != nil {

--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -367,7 +367,7 @@ func saveFormatErasure(disk StorageAPI, format *formatErasureV3, heal bool) erro
 	tmpFormat := mustGetUUID()
 
 	// Purge any existing temporary file, okay to ignore errors here.
-	defer disk.Delete(context.TODO(), minioMetaBucket, tmpFormat, false)
+	defer disk.Delete(context.TODO(), minioMetaBucket, tmpFormat, false, false)
 
 	// write to unique file.
 	if err = disk.WriteAll(context.TODO(), minioMetaBucket, tmpFormat, formatBytes); err != nil {

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -221,11 +221,11 @@ func (d *naughtyDisk) CheckParts(ctx context.Context, volume string, path string
 	return d.disk.CheckParts(ctx, volume, path, fi)
 }
 
-func (d *naughtyDisk) Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error) {
+func (d *naughtyDisk) Delete(ctx context.Context, volume string, path string, deleteOpts DeleteOptions) (err error) {
 	if err := d.calcError(); err != nil {
 		return err
 	}
-	return d.disk.Delete(ctx, volume, path, recursive, force)
+	return d.disk.Delete(ctx, volume, path, deleteOpts)
 }
 
 func (d *naughtyDisk) DeleteVersions(ctx context.Context, volume string, versions []FileInfoVersions) []error {

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -221,11 +221,11 @@ func (d *naughtyDisk) CheckParts(ctx context.Context, volume string, path string
 	return d.disk.CheckParts(ctx, volume, path, fi)
 }
 
-func (d *naughtyDisk) Delete(ctx context.Context, volume string, path string, recursive bool) (err error) {
+func (d *naughtyDisk) Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error) {
 	if err := d.calcError(); err != nil {
 		return err
 	}
-	return d.disk.Delete(ctx, volume, path, recursive)
+	return d.disk.Delete(ctx, volume, path, recursive, force)
 }
 
 func (d *naughtyDisk) DeleteVersions(ctx context.Context, volume string, versions []FileInfoVersions) []error {

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -21,6 +21,13 @@ import (
 	"time"
 )
 
+// DeleteOptions represents the disk level delete options available for the APIs
+//msgp:ignore DeleteOptions
+type DeleteOptions struct {
+	Recursive bool
+	Force     bool
+}
+
 //go:generate msgp -file=$GOFILE
 
 // DiskInfo is an extended type which returns current

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -95,7 +95,7 @@ type StorageAPI interface {
 	ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error)
 	RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) error
 	CheckParts(ctx context.Context, volume string, path string, fi FileInfo) error
-	Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error)
+	Delete(ctx context.Context, volume string, path string, deleteOpts DeleteOptions) (err error)
 	VerifyFile(ctx context.Context, volume, path string, fi FileInfo) error
 	StatInfoFile(ctx context.Context, volume, path string, glob bool) (stat []StatInfo, err error)
 
@@ -223,7 +223,7 @@ func (p *unrecognizedDisk) CheckParts(ctx context.Context, volume string, path s
 	return errDiskNotFound
 }
 
-func (p *unrecognizedDisk) Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error) {
+func (p *unrecognizedDisk) Delete(ctx context.Context, volume string, path string, deleteOpts DeleteOptions) (err error) {
 	return errDiskNotFound
 }
 

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -95,7 +95,7 @@ type StorageAPI interface {
 	ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error)
 	RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) error
 	CheckParts(ctx context.Context, volume string, path string, fi FileInfo) error
-	Delete(ctx context.Context, volume string, path string, recursive bool) (err error)
+	Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error)
 	VerifyFile(ctx context.Context, volume, path string, fi FileInfo) error
 	StatInfoFile(ctx context.Context, volume, path string, glob bool) (stat []StatInfo, err error)
 
@@ -223,7 +223,7 @@ func (p *unrecognizedDisk) CheckParts(ctx context.Context, volume string, path s
 	return errDiskNotFound
 }
 
-func (p *unrecognizedDisk) Delete(ctx context.Context, volume string, path string, recursive bool) (err error) {
+func (p *unrecognizedDisk) Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error) {
 	return errDiskNotFound
 }
 

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -581,12 +581,12 @@ func (client *storageRESTClient) ListDir(ctx context.Context, volume, dirPath st
 }
 
 // DeleteFile - deletes a file.
-func (client *storageRESTClient) Delete(ctx context.Context, volume string, path string, recursive, force bool) error {
+func (client *storageRESTClient) Delete(ctx context.Context, volume string, path string, deleteOpts DeleteOptions) error {
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)
 	values.Set(storageRESTFilePath, path)
-	values.Set(storageRESTRecursive, strconv.FormatBool(recursive))
-	values.Set(storageRESTForceDelete, strconv.FormatBool(force))
+	values.Set(storageRESTRecursive, strconv.FormatBool(deleteOpts.Recursive))
+	values.Set(storageRESTForceDelete, strconv.FormatBool(deleteOpts.Force))
 
 	respBody, err := client.call(ctx, storageRESTMethodDeleteFile, values, nil, -1)
 	defer xhttp.DrainBody(respBody)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -581,11 +581,12 @@ func (client *storageRESTClient) ListDir(ctx context.Context, volume, dirPath st
 }
 
 // DeleteFile - deletes a file.
-func (client *storageRESTClient) Delete(ctx context.Context, volume string, path string, recursive bool) error {
+func (client *storageRESTClient) Delete(ctx context.Context, volume string, path string, recursive, force bool) error {
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)
 	values.Set(storageRESTFilePath, path)
 	values.Set(storageRESTRecursive, strconv.FormatBool(recursive))
+	values.Set(storageRESTForceDelete, strconv.FormatBool(force))
 
 	respBody, err := client.call(ctx, storageRESTMethodDeleteFile, values, nil, -1)
 	defer xhttp.DrainBody(respBody)

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -657,7 +657,10 @@ func (s *storageRESTServer) DeleteFileHandler(w http.ResponseWriter, r *http.Req
 		s.writeErrorResponse(w, err)
 		return
 	}
-	err = s.storage.Delete(r.Context(), volume, filePath, recursive, force)
+	err = s.storage.Delete(r.Context(), volume, filePath, DeleteOptions{
+		Recursive: recursive,
+		Force:     force,
+	})
 	if err != nil {
 		s.writeErrorResponse(w, err)
 	}

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -652,8 +652,12 @@ func (s *storageRESTServer) DeleteFileHandler(w http.ResponseWriter, r *http.Req
 		s.writeErrorResponse(w, err)
 		return
 	}
-
-	err = s.storage.Delete(r.Context(), volume, filePath, recursive)
+	force, err := strconv.ParseBool(r.Form.Get(storageRESTForceDelete))
+	if err != nil {
+		s.writeErrorResponse(w, err)
+		return
+	}
+	err = s.storage.Delete(r.Context(), volume, filePath, recursive, force)
 	if err != nil {
 		s.writeErrorResponse(w, err)
 	}

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -383,7 +383,10 @@ func testStorageAPIDeleteFile(t *testing.T, storage StorageAPI) {
 	}
 
 	for i, testCase := range testCases {
-		err := storage.Delete(context.Background(), testCase.volumeName, testCase.objectName, false, false)
+		err := storage.Delete(context.Background(), testCase.volumeName, testCase.objectName, DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		})
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -383,7 +383,7 @@ func testStorageAPIDeleteFile(t *testing.T, storage StorageAPI) {
 	}
 
 	for i, testCase := range testCases {
-		err := storage.Delete(context.Background(), testCase.volumeName, testCase.objectName, false)
+		err := storage.Delete(context.Background(), testCase.volumeName, testCase.objectName, false, false)
 		expectErr := (err != nil)
 
 		if expectErr != testCase.expectErr {

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -382,14 +382,14 @@ func (p *xlStorageDiskIDCheck) CheckParts(ctx context.Context, volume string, pa
 	return p.storage.CheckParts(ctx, volume, path, fi)
 }
 
-func (p *xlStorageDiskIDCheck) Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error) {
+func (p *xlStorageDiskIDCheck) Delete(ctx context.Context, volume string, path string, deleteOpts DeleteOptions) (err error) {
 	ctx, done, err := p.TrackDiskHealth(ctx, storageMetricDelete, volume, path)
 	if err != nil {
 		return err
 	}
 	defer done(&err)
 
-	return p.storage.Delete(ctx, volume, path, recursive, force)
+	return p.storage.Delete(ctx, volume, path, deleteOpts)
 }
 
 // DeleteVersions deletes slice of versions, it can be same object
@@ -768,7 +768,10 @@ func (p *xlStorageDiskIDCheck) monitorDiskStatus() {
 		if err != nil || len(b) != 10001 {
 			continue
 		}
-		err = p.storage.Delete(context.Background(), minioMetaTmpBucket, fn, false, false)
+		err = p.storage.Delete(context.Background(), minioMetaTmpBucket, fn, DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		})
 		if err == nil {
 			logger.Info("Able to read+write, bringing disk %s online.", p.storage.String())
 			atomic.StoreInt32(&p.health.status, diskHealthOK)

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -382,14 +382,14 @@ func (p *xlStorageDiskIDCheck) CheckParts(ctx context.Context, volume string, pa
 	return p.storage.CheckParts(ctx, volume, path, fi)
 }
 
-func (p *xlStorageDiskIDCheck) Delete(ctx context.Context, volume string, path string, recursive bool) (err error) {
+func (p *xlStorageDiskIDCheck) Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error) {
 	ctx, done, err := p.TrackDiskHealth(ctx, storageMetricDelete, volume, path)
 	if err != nil {
 		return err
 	}
 	defer done(&err)
 
-	return p.storage.Delete(ctx, volume, path, recursive)
+	return p.storage.Delete(ctx, volume, path, recursive, force)
 }
 
 // DeleteVersions deletes slice of versions, it can be same object
@@ -768,7 +768,7 @@ func (p *xlStorageDiskIDCheck) monitorDiskStatus() {
 		if err != nil || len(b) != 10001 {
 			continue
 		}
-		err = p.storage.Delete(context.Background(), minioMetaTmpBucket, fn, false)
+		err = p.storage.Delete(context.Background(), minioMetaTmpBucket, fn, false, false)
 		if err == nil {
 			logger.Info("Able to read+write, bringing disk %s online.", p.storage.String())
 			atomic.StoreInt32(&p.health.status, diskHealthOK)

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1011,7 +1011,10 @@ func (s *xlStorage) moveToTrash(filePath string, recursive, force bool) error {
 // will force creating a new `xl.meta` to create a new delete marker
 func (s *xlStorage) DeleteVersion(ctx context.Context, volume, path string, fi FileInfo, forceDelMarker bool) error {
 	if HasSuffix(path, SlashSeparator) {
-		return s.Delete(ctx, volume, path, false, false)
+		return s.Delete(ctx, volume, path, DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		})
 	}
 
 	buf, err := s.ReadAll(ctx, volume, pathJoin(path, xlStorageFormatFile))
@@ -2080,7 +2083,7 @@ func (s *xlStorage) deleteFile(basePath, deletePath string, recursive, force boo
 }
 
 // DeleteFile - delete a file at path.
-func (s *xlStorage) Delete(ctx context.Context, volume string, path string, recursive, force bool) (err error) {
+func (s *xlStorage) Delete(ctx context.Context, volume string, path string, deleteOpts DeleteOptions) (err error) {
 	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return err
@@ -2106,7 +2109,7 @@ func (s *xlStorage) Delete(ctx context.Context, volume string, path string, recu
 	}
 
 	// Delete file and delete parent directory as well if it's empty.
-	return s.deleteFile(volumeDir, filePath, recursive, force)
+	return s.deleteFile(volumeDir, filePath, deleteOpts.Recursive, deleteOpts.Force)
 }
 
 func skipAccessChecks(volume string) (ok bool) {

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -933,14 +933,20 @@ func TestXLStorageListDir(t *testing.T) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
-		if err = xlStorageNew.Delete(context.Background(), "mybucket", "myobject", false, false); err != errVolumeAccessDenied {
+		if err = xlStorageNew.Delete(context.Background(), "mybucket", "myobject", DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		}); err != errVolumeAccessDenied {
 			t.Errorf("expected: %s, got: %s", errVolumeAccessDenied, err)
 		}
 	}
 
 	// TestXLStorage for delete on an removed disk.
 	// should fail with disk not found.
-	err = xlStorageDeletedStorage.Delete(context.Background(), "del-vol", "my-file", false, false)
+	err = xlStorageDeletedStorage.Delete(context.Background(), "del-vol", "my-file", DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	})
 	if err != errDiskNotFound {
 		t.Errorf("Expected: \"Disk not found\", got \"%s\"", err)
 	}
@@ -1029,7 +1035,10 @@ func TestXLStorageDeleteFile(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		if err = xlStorage.Delete(context.Background(), testCase.srcVol, testCase.srcPath, false, false); err != testCase.expectedErr {
+		if err = xlStorage.Delete(context.Background(), testCase.srcVol, testCase.srcPath, DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		}); err != testCase.expectedErr {
 			t.Errorf("TestXLStorage case %d: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
 		}
 	}
@@ -1054,7 +1063,10 @@ func TestXLStorageDeleteFile(t *testing.T) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
-		if err = xlStorageNew.Delete(context.Background(), "mybucket", "myobject", false, false); err != errVolumeAccessDenied {
+		if err = xlStorageNew.Delete(context.Background(), "mybucket", "myobject", DeleteOptions{
+			Recursive: false,
+			Force:     false,
+		}); err != errVolumeAccessDenied {
 			t.Errorf("expected: %s, got: %s", errVolumeAccessDenied, err)
 		}
 	}
@@ -1072,7 +1084,10 @@ func TestXLStorageDeleteFile(t *testing.T) {
 
 	// TestXLStorage for delete on an removed disk.
 	// should fail with disk not found.
-	err = xlStorageDeletedStorage.Delete(context.Background(), "del-vol", "my-file", false, false)
+	err = xlStorageDeletedStorage.Delete(context.Background(), "del-vol", "my-file", DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	})
 	if err != errDiskNotFound {
 		t.Errorf("Expected: \"Disk not found\", got \"%s\"", err)
 	}
@@ -1907,7 +1922,10 @@ func TestXLStorageVerifyFile(t *testing.T) {
 		t.Fatal("expected to fail bitrot check")
 	}
 
-	if err := storage.Delete(context.Background(), volName, fileName, false, false); err != nil {
+	if err := storage.Delete(context.Background(), volName, fileName, DeleteOptions{
+		Recursive: false,
+		Force:     false,
+	}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -933,14 +933,14 @@ func TestXLStorageListDir(t *testing.T) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
-		if err = xlStorageNew.Delete(context.Background(), "mybucket", "myobject", false); err != errVolumeAccessDenied {
+		if err = xlStorageNew.Delete(context.Background(), "mybucket", "myobject", false, false); err != errVolumeAccessDenied {
 			t.Errorf("expected: %s, got: %s", errVolumeAccessDenied, err)
 		}
 	}
 
 	// TestXLStorage for delete on an removed disk.
 	// should fail with disk not found.
-	err = xlStorageDeletedStorage.Delete(context.Background(), "del-vol", "my-file", false)
+	err = xlStorageDeletedStorage.Delete(context.Background(), "del-vol", "my-file", false, false)
 	if err != errDiskNotFound {
 		t.Errorf("Expected: \"Disk not found\", got \"%s\"", err)
 	}
@@ -1029,7 +1029,7 @@ func TestXLStorageDeleteFile(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		if err = xlStorage.Delete(context.Background(), testCase.srcVol, testCase.srcPath, false); err != testCase.expectedErr {
+		if err = xlStorage.Delete(context.Background(), testCase.srcVol, testCase.srcPath, false, false); err != testCase.expectedErr {
 			t.Errorf("TestXLStorage case %d: Expected: \"%s\", got: \"%s\"", i+1, testCase.expectedErr, err)
 		}
 	}
@@ -1054,7 +1054,7 @@ func TestXLStorageDeleteFile(t *testing.T) {
 			t.Fatalf("Unable to initialize xlStorage, %s", err)
 		}
 
-		if err = xlStorageNew.Delete(context.Background(), "mybucket", "myobject", false); err != errVolumeAccessDenied {
+		if err = xlStorageNew.Delete(context.Background(), "mybucket", "myobject", false, false); err != errVolumeAccessDenied {
 			t.Errorf("expected: %s, got: %s", errVolumeAccessDenied, err)
 		}
 	}
@@ -1072,7 +1072,7 @@ func TestXLStorageDeleteFile(t *testing.T) {
 
 	// TestXLStorage for delete on an removed disk.
 	// should fail with disk not found.
-	err = xlStorageDeletedStorage.Delete(context.Background(), "del-vol", "my-file", false)
+	err = xlStorageDeletedStorage.Delete(context.Background(), "del-vol", "my-file", false, false)
 	if err != errDiskNotFound {
 		t.Errorf("Expected: \"Disk not found\", got \"%s\"", err)
 	}
@@ -1907,7 +1907,7 @@ func TestXLStorageVerifyFile(t *testing.T) {
 		t.Fatal("expected to fail bitrot check")
 	}
 
-	if err := storage.Delete(context.Background(), volName, fileName, false); err != nil {
+	if err := storage.Delete(context.Background(), volName, fileName, false, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/xl-storage_windows_test.go
+++ b/cmd/xl-storage_windows_test.go
@@ -70,7 +70,7 @@ func TestUNCPaths(t *testing.T) {
 			} else if err == nil && !test.pass {
 				t.Error(err)
 			}
-			fs.Delete(context.Background(), "voldir", test.objName, false)
+			fs.Delete(context.Background(), "voldir", test.objName, false, false)
 		})
 	}
 }

--- a/cmd/xl-storage_windows_test.go
+++ b/cmd/xl-storage_windows_test.go
@@ -70,7 +70,10 @@ func TestUNCPaths(t *testing.T) {
 			} else if err == nil && !test.pass {
 				t.Error(err)
 			}
-			fs.Delete(context.Background(), "voldir", test.objName, false, false)
+			fs.Delete(context.Background(), "voldir", test.objName, DeleteOptions{
+				Recursive: false,
+				Force:     false,
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Description

This PR is a continuation of https://github.com/minio/minio/pull/14818

If  header - `x-minio-force-delete` is passed in the DeleteObject and DeleteBucket API, the objects
will be purged immediately and free up the space

## Motivation and Context

this is a feature to immediately purge the object while deleting and freeing up the space from `.minio.sys/tmp/trash`

## How to test this PR?

Pass `x-minio-force-delete` headers in DeleteObject and DeleteBucket API - This should purge the trash entries immediately

Use the PR https://github.com/minio/minio-go/pull/1667 to test DeleteObject and DeleteBucket APIs with force delete option.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
