### PR TITLE
reduce sha256 CPU usage by turning it off for speedtests

### DIFF
--- a/cmd/perf-tests.go
+++ b/cmd/perf-tests.go
@@ -68,7 +68,7 @@ func selfSpeedtest(ctx context.Context, size, concurrent int, duration time.Dura
 	}
 
 	client, err := minio.New(globalLocalNodeName, &minio.Options{
-		Creds:     credentials.NewStaticV2(globalActiveCred.AccessKey, globalActiveCred.SecretKey, ""),
+		Creds:     credentials.NewStaticV4(globalActiveCred.AccessKey, globalActiveCred.SecretKey, ""),
 		Secure:    globalIsTLS,
 		Transport: globalProxyTransport,
 		Region:    region,
@@ -100,8 +100,9 @@ func selfSpeedtest(ctx context.Context, size, concurrent int, duration time.Dura
 				reader := newRandomReader(size)
 				tmpObjName := fmt.Sprintf("%s%d.%d", objNamePrefix, i, objCountPerThread[i])
 				info, err := client.PutObject(uploadsCtx, globalObjectPerfBucket, tmpObjName, reader, int64(size), minio.PutObjectOptions{
-					UserMetadata:     userMetadata,
-					DisableMultipart: true,
+					UserMetadata:         userMetadata,
+					DisableContentSha256: true,
+					DisableMultipart:     true,
 				}) // Bypass S3 API freeze
 				if err != nil {
 					if !contextCanceled(uploadsCtx) && !errors.Is(err, context.Canceled) {

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.19.2
 	github.com/minio/madmin-go v1.3.14
-	github.com/minio/minio-go/v7 v7.0.29
+	github.com/minio/minio-go/v7 v7.0.30-0.20220623010642-40b13d984ae3
 	github.com/minio/pkg v1.1.26
 	github.com/minio/selfupdate v0.4.0
 	github.com/minio/sha256-simd v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -633,8 +633,8 @@ github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77Z
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.23/go.mod h1:ei5JjmxwHaMrgsMrn4U/+Nmg+d8MKS1U2DAn1ou4+Do=
-github.com/minio/minio-go/v7 v7.0.29 h1:7md6lIq1s6zPzUiDRX1BVLHolA4pDM8RMQqIszaJbY0=
-github.com/minio/minio-go/v7 v7.0.29/go.mod h1:x81+AX5gHSfCSqw7jxRKHvxUXMlE5uKX0Vb75Xk5yYg=
+github.com/minio/minio-go/v7 v7.0.30-0.20220623010642-40b13d984ae3 h1:IKgLWNW7NWtyE7RUfPeaa5PVM4Z7S8xQg1xYrUXyV2c=
+github.com/minio/minio-go/v7 v7.0.30-0.20220623010642-40b13d984ae3/go.mod h1:/sjRKkKIA75CKh1iu8E3qBy7ktBmCCDGII0zbXGwbUk=
 github.com/minio/pkg v1.1.20/go.mod h1:Xo7LQshlxGa9shKwJ7NzQbgW4s8T/Wc1cOStR/eUiMY=
 github.com/minio/pkg v1.1.26 h1:a8x4sHNBxCiHEkxZ/0EBTLqvV3nMtM2G/A6lXNfXN3U=
 github.com/minio/pkg v1.1.26/go.mod h1:z9PfmEI804KFkF6eY4LoGe8IDVvTCsYGVuaf58Dr0WI=


### PR DESCRIPTION
## Description
reduce sha256 CPU usage by turning it off for speedtests

## Motivation and Context
continuation of the PR #15151, keeping signature v4 for
the headers however avoid sha256 for the body.

## How to test this PR?
Nothing special you need hardware to test this.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
