### PR TITLE
heal: Include dir markers when healing a fresh disk

### DIFF
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -269,8 +269,11 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 				return
 			}
 
+			// erasureObjects layer needs object names to be encoded
+			encodedEntryName := encodeDirObject(entry.name)
+
 			for _, version := range fivs.Versions {
-				if _, err := er.HealObject(ctx, bucket, version.Name,
+				if _, err := er.HealObject(ctx, bucket, encodedEntryName,
 					version.VersionID, madmin.HealOpts{
 						ScanMode: scanMode,
 						Remove:   healDeleteDangling,


### PR DESCRIPTION
## Description
Directories markers are not healed when healing a new fresh disk. A
proper fix would be moving object names encoding/decoding to erasure
object level but it is too late now since object to set distribution is
calculated at higher level.

## Motivation and Context
Fix healing directories markers when healing a new fresh disk

## How to test this PR?
1. Create a MinIO cluster with 4 disks
2. Create a bucket and a directory marker
3. Remove one disk content and check if the directory marker is healed in the new disk.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
