### PR TITLE
removed max length check for accesskey and secret key for svc-account

### DIFF
--- a/internal/auth/credentials.go
+++ b/internal/auth/credentials.go
@@ -240,11 +240,11 @@ func GetNewCredentialsWithMetadata(m map[string]interface{}, tokenSecret string)
 // CreateNewCredentialsWithMetadata - creates new credentials using the specified access & secret keys
 // and generate a session token if a secret token is provided.
 func CreateNewCredentialsWithMetadata(accessKey, secretKey string, m map[string]interface{}, tokenSecret string) (cred Credentials, err error) {
-	if len(accessKey) < accessKeyMinLen || len(accessKey) > accessKeyMaxLen {
+	if len(accessKey) < accessKeyMinLen {
 		return Credentials{}, ErrInvalidAccessKeyLength
 	}
 
-	if len(secretKey) < secretKeyMinLen || len(secretKey) > secretKeyMaxLen {
+	if len(secretKey) < secretKeyMinLen {
 		return Credentials{}, ErrInvalidSecretKeyLength
 	}
 


### PR DESCRIPTION

## Description
Fixes #15164

## Motivation and Context


## How to test this PR?
Below command should work fine and create two svc accounts with specified accesskeys
```
mc admin user svcacct add --debug --access-key "e12345678901234567890" --secret-key "testsecret2" minio <existing user>
mc admin user svcacct add --debug --access-key "e123456789012345678901234567890123456789012345678901234567890" --secret-key "testsecret2" minio <existing user>

```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
