### PR TITLE
Remove unnecessary code in WalkDir()

### DIFF
--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -248,11 +248,6 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 				out <- metaCacheEntry{name: pop}
 				if opts.Recursive {
 					// Scan folder we found. Should be in correct sort order where we are.
-					forward = ""
-					if len(opts.ForwardTo) > 0 && strings.HasPrefix(opts.ForwardTo, pop) {
-						forward = strings.TrimPrefix(opts.ForwardTo, pop)
-					}
-
 					err := scanDir(pop)
 					if err != nil && !IsErrIgnored(err, context.Canceled) {
 						logger.LogIf(ctx, err)


### PR DESCRIPTION
## Description
Recalculating forward is useless. It is never used and it will be
computed again when calling scanDir() again.

## Motivation and Context
Remove unneeded code

## How to test this PR?
No testing

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
