### PR TITLE
Revert proxying requests with precondition errors

### DIFF
--- a/cmd/gateway-common.go
+++ b/cmd/gateway-common.go
@@ -297,6 +297,10 @@ func ErrorRespToObjectError(err error, params ...string) error {
 	}
 
 	switch minioErr.Code {
+	case "PreconditionFailed":
+		err = PreConditionFailed{}
+	case "InvalidRange":
+		err = InvalidRange{}
 	case "BucketAlreadyOwnedByYou":
 		err = BucketAlreadyOwnedByYou{}
 	case "BucketNotEmpty":


### PR DESCRIPTION
## Description
In a replicated setup, when an object is updated in one cluster but
still waiting to be replicated to the other cluster, GET requests with
if-match, range headers will likley to fail. It is better to proxy
requests instead.

Also, this commit avoids to print verbose logs about precondition &
range erros.

## Motivation and Context
Fixes #15179 

## How to test this PR?
aws s3api get-object --bucket testbucket --key testobject --if-match "random-etag" --endpoint-url http://localhost:9001 --profile local /dev/stdout

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
