### PR TITLE
Save minio version in xl.meta while healing in outdated disks

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -326,7 +326,6 @@ func (er erasureObjects) newMultipartUpload(ctx context.Context, bucket string, 
 	partsMetadata := make([]FileInfo, len(onlineDisks))
 
 	fi := newFileInfo(pathJoin(bucket, object), dataDrives, parityDrives)
-	fi.WrittenByVersion = globalVersionUnix
 	fi.VersionID = opts.VersionID
 	if opts.Versioned && fi.VersionID == "" {
 		fi.VersionID = mustGetUUID()

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -944,7 +944,6 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	partsMetadata := make([]FileInfo, len(storageDisks))
 
 	fi := newFileInfo(pathJoin(bucket, object), dataDrives, parityDrives)
-	fi.WrittenByVersion = globalVersionUnix
 	fi.VersionID = opts.VersionID
 	if opts.Versioned && fi.VersionID == "" {
 		fi.VersionID = mustGetUUID()

--- a/cmd/erasure-single-drive.go
+++ b/cmd/erasure-single-drive.go
@@ -941,7 +941,6 @@ func (es *erasureSingle) putObject(ctx context.Context, bucket string, object st
 	partsMetadata := make([]FileInfo, len(storageDisks))
 
 	fi := newFileInfo(pathJoin(bucket, object), dataDrives, parityDrives)
-	fi.WrittenByVersion = globalVersionUnix
 	fi.VersionID = opts.VersionID
 	if opts.Versioned && fi.VersionID == "" {
 		fi.VersionID = mustGetUUID()
@@ -2071,7 +2070,6 @@ func (es *erasureSingle) newMultipartUpload(ctx context.Context, bucket string, 
 	partsMetadata := make([]FileInfo, len(onlineDisks))
 
 	fi := newFileInfo(pathJoin(bucket, object), dataDrives, parityDrives)
-	fi.WrittenByVersion = globalVersionUnix
 	fi.VersionID = opts.VersionID
 	if opts.Versioned && fi.VersionID == "" {
 		fi.VersionID = mustGetUUID()

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -1189,6 +1189,7 @@ func (x *xlMetaV2) DeleteVersion(fi FileInfo) (string, error) {
 				ModTime:   fi.ModTime.UnixNano(),
 				MetaSys:   make(map[string][]byte),
 			},
+			WrittenByVersion: globalVersionUnix,
 		}
 		if !ventry.Valid() {
 			return "", errors.New("internal error: invalid version entry generated")
@@ -1432,7 +1433,7 @@ func (x *xlMetaV2) AddVersion(fi FileInfo) error {
 	}
 
 	ventry := xlMetaV2Version{
-		WrittenByVersion: fi.WrittenByVersion,
+		WrittenByVersion: globalVersionUnix,
 	}
 
 	if fi.Deleted {
@@ -1598,7 +1599,7 @@ func (x *xlMetaV2) AddLegacy(m *xlMetaV1Object) error {
 	}
 	m.VersionID = nullVersionID
 
-	return x.addVersion(xlMetaV2Version{ObjectV1: m, Type: LegacyType})
+	return x.addVersion(xlMetaV2Version{ObjectV1: m, Type: LegacyType, WrittenByVersion: globalVersionUnix})
 }
 
 // ToFileInfo converts xlMetaV2 into a common FileInfo datastructure

--- a/cmd/xl-storage-free-version.go
+++ b/cmd/xl-storage-free-version.go
@@ -35,7 +35,7 @@ func (j xlMetaV2Object) InitFreeVersion(fi FileInfo) (xlMetaV2Version, bool) {
 		if err != nil {
 			panic(fmt.Errorf("Invalid Tier Object delete marker versionId %s %v", fi.TierFreeVersionID(), err))
 		}
-		freeEntry := xlMetaV2Version{Type: DeleteType}
+		freeEntry := xlMetaV2Version{Type: DeleteType, WrittenByVersion: globalVersionUnix}
 		freeEntry.DeleteMarker = &xlMetaV2DeleteMarker{
 			VersionID: vID,
 			ModTime:   j.ModTime, // fi.ModTime may be empty


### PR DESCRIPTION
## Description
Also move setting minio version in lower level.


## Motivation and Context
Add minio version in healed disks

## How to test this PR?
1. Run an older version of MinIO with 4 disks
2. Upload an object
3. Compile this PR and run Minio again
4. Remove an object from one disk and heal it. Compare minio version in xl.meta

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
