### PR TITLE
do not recreate deprecated delete-journal.bin, only read it

### DIFF
--- a/cmd/tier-journal.go
+++ b/cmd/tier-journal.go
@@ -74,10 +74,6 @@ func initTierDeletionJournal(ctx context.Context) (*tierJournal, error) {
 
 	for _, diskPath := range globalEndpoints.LocalDisksPaths() {
 		j.diskPath = diskPath
-		if err := os.MkdirAll(filepath.Dir(j.ReadOnlyPath()), os.FileMode(0o700)); err != nil {
-			logger.LogIf(ctx, err)
-			continue
-		}
 
 		go j.deletePending(ctx)  // for existing journal entries from previous MinIO versions
 		go j.processEntries(ctx) // for newer journal entries circa free-versions


### PR DESCRIPTION
## Description
do not recreate deprecated delete-journal.bin, only read it

## Motivation and Context
simplify deprecated code, re-enable hotswap replace disks

## How to test this PR?
Nothing special just observe that MinIO doesn't keep a
 `delete-journal.bin`  file open in perpetuity. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
