### PR TITLE
Make ReqInfo concurrency safe

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -792,6 +792,8 @@ func likelyUnescapeGeneric(p string, escapeFn func(string) (string, error)) stri
 func updateReqContext(ctx context.Context, objects ...ObjectV) context.Context {
 	req := logger.GetReqInfo(ctx)
 	if req != nil {
+		req.Lock()
+		defer req.Unlock()
 		req.Objects = make([]logger.ObjectVersion, 0, len(objects))
 		for _, ov := range objects {
 			req.Objects = append(req.Objects, logger.ObjectVersion{

--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -149,7 +149,6 @@ func GetAuditEntry(ctx context.Context) *audit.Entry {
 			DeploymentID: xhttp.GlobalDeploymentID,
 			Time:         time.Now().UTC(),
 		}
-		SetAuditEntry(ctx, r)
 		return r
 	}
 	return nil
@@ -168,6 +167,8 @@ func AuditLog(ctx context.Context, w http.ResponseWriter, r *http.Request, reqCl
 		if reqInfo == nil {
 			return
 		}
+		reqInfo.RLock()
+		defer reqInfo.RUnlock()
 
 		entry = audit.ToEntry(w, r, reqClaims, xhttp.GlobalDeploymentID)
 		// indicates all requests for this API call are inbound

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -290,6 +290,8 @@ func errToEntry(ctx context.Context, err error, errKind ...interface{}) log.Entr
 	if req == nil {
 		req = &ReqInfo{API: "SYSTEM"}
 	}
+	req.RLock()
+	defer req.RUnlock()
 
 	API := "SYSTEM"
 	if req.API != "" {

--- a/internal/logger/reqinfo.go
+++ b/internal/logger/reqinfo.go
@@ -41,6 +41,7 @@ type ObjectVersion struct {
 }
 
 // ReqInfo stores the request info.
+// Reading/writing directly to struct requires appropriate R/W lock.
 type ReqInfo struct {
 	RemoteHost   string          // Client Host/IP
 	Host         string          // Node Host/IP
@@ -111,7 +112,7 @@ func (r *ReqInfo) GetTags() []KeyVal {
 	}
 	r.RLock()
 	defer r.RUnlock()
-	return append([]KeyVal(nil), r.tags...)
+	return append(make([]KeyVal, 0, len(r.tags)), r.tags...)
 }
 
 // GetTagsMap - returns the user defined tags in a map structure
@@ -145,7 +146,6 @@ func GetReqInfo(ctx context.Context) *ReqInfo {
 			return r
 		}
 		r = &ReqInfo{}
-		SetReqInfo(ctx, r)
 		return r
 	}
 	return nil

--- a/internal/rest/client.go
+++ b/internal/rest/client.go
@@ -148,7 +148,7 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 				atomic.AddUint64(&networkErrsCounter, 1)
 			}
 			if c.MarkOffline() {
-				logger.LogIf(context.Background(), fmt.Errorf("Marking %s temporary offline; caused by %w", c.url.String(), err))
+				logger.LogIf(ctx, fmt.Errorf("Marking %s temporary offline; caused by %w", c.url.String(), err))
 			}
 		}
 		return nil, &NetworkError{err}
@@ -171,7 +171,7 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 		// fully it should make sure to respond with '412'
 		// instead, see cmd/storage-rest-server.go for ideas.
 		if c.HealthCheckFn != nil && resp.StatusCode == http.StatusPreconditionFailed {
-			logger.LogIf(context.Background(), fmt.Errorf("Marking %s temporary offline; caused by PreconditionFailed with disk ID mismatch", c.url.String()))
+			logger.LogIf(ctx, fmt.Errorf("Marking %s temporary offline; caused by PreconditionFailed with disk ID mismatch", c.url.String()))
 			c.MarkOffline()
 		}
 		defer xhttp.DrainBody(resp.Body)
@@ -183,7 +183,7 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 					atomic.AddUint64(&networkErrsCounter, 1)
 				}
 				if c.MarkOffline() {
-					logger.LogIf(context.Background(), fmt.Errorf("Marking %s temporary offline; caused by %w", c.url.String(), err))
+					logger.LogIf(ctx, fmt.Errorf("Marking %s temporary offline; caused by %w", c.url.String(), err))
 				}
 			}
 			return nil, err


### PR DESCRIPTION
## Description

Some read/writes of ReqInfo did not get appropriate locks, leading to races.

Make sure reading and writing holds appropriate locks.

Reverts #15195

## How to test this PR?

Run minio with -race enabled.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
