### PR TITLE
Ngenea

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -51,7 +51,7 @@ const (
 	maxHeaderSize = 8 * 1024
 
 	// Maximum size for user-defined metadata - See: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
-	maxUserDataSize = 2 * 1024
+	maxUserDataSize = 8 * 1024
 )
 
 // ReservedMetadataPrefix is the prefix of a metadata key which


### PR DESCRIPTION
## Description
Increased the **maxUserDataSize** value to **8192** (8 * 1024) which will be large enough to hold all the data required in metadata. This has been required as we'll be holding the symlink target in metadata.

Changed the way it moves the finished transfer file to the final destination path. Instead of performing a rename, it now copies the object to the destination then once complete, deletes the temp file. This has been required to copy across devices in Linux. The use case for this is on a GPFS file system, if a bucket is also a fileset, Minio will fail the final rename as it see's the fileset as a separate inode space, thus a different device.
