### PR TITLE
Add missing TLS config to service monitor

### DIFF
--- a/helm/minio/templates/servicemonitor.yaml
+++ b/helm/minio/templates/servicemonitor.yaml
@@ -21,6 +21,12 @@ spec:
     {{- if .Values.tls.enabled }}
     - port: https
       scheme: https
+      tlsConfig:
+        ca:
+          secret:
+            name: {{ .Values.tls.certSecret }}
+            key: {{ .Values.tls.publicCrt }}
+        serverName: {{ template "minio.fullname" . }}
     {{ else }}
     - port: http
       scheme: http


### PR DESCRIPTION
## Description

This PR adds a `tlsConfig` to the service monitor so that Prometheus will be able to successfully scrape the endpoint when TLS is enabled. Without this configuration, it will fail and show errors like:

```
Get "https://xxx.xxx.xxx.xxx:9000/minio/v2/metrics/cluster": x509: cannot validate certificate for xxx.xxx.xxx.xxx because it doesn't contain any IP SANs
```

Technically speaking, the implementation in this PR is a bit dubious because it treats the server certificate as "CA cert", but I've confirmed that Prometheus tolerates this and I don't think there is any other way to make this work correctly without adding additional values that require the user to explicitly specify a CA cert. This would be a breaking change since the chart currently does not require a CA cert when enabling TLS.

In our own clusters we use cert-manager, so the `tls.certSecret` contains `tls.crt`, `tls.key`, and `ca.crt` all in one secret, but I'm guessing that we cannot make this assumption in general. For reference, this is what our `tls` values look like:

```yaml
tls:
  enabled: true
  certSecret: minio-tls
  publicCrt: tls.crt
  privateKey: tls.key
  # caCrt: ca.crt <- hypothetical new value
```

## Motivation and Context

I would like to use the service monitor after enabling TLS.

## How to test this PR?

Deploy Minio with TLS enabled in a cluster with Prometheus (e.g. from the `kube-prometheus-stack` Helm chart) and check if the endpoint is discovered and scraped correctly. It will not work until this `tlsConfig` is added.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated

As far as I can tell this has never worked properly, so not a regression.