### PR TITLE
Better reporting of total/free usable capacity of the cluster

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1189,7 +1189,7 @@ func deleteObjectPerfBucket(objectAPI ObjectLayer) {
 func validateObjPerfOptions(ctx context.Context, objectAPI ObjectLayer, concurrent int, size int, autotune bool) (sufficientCapacity bool, canAutotune bool, capacityErrMsg string) {
 	storageInfo, _ := objectAPI.StorageInfo(ctx)
 	capacityNeeded := uint64(concurrent * size)
-	capacity := uint64(GetTotalUsableCapacityFree(storageInfo.Disks, storageInfo))
+	capacity := GetTotalUsableCapacityFree(storageInfo.Disks, storageInfo)
 
 	if capacity < capacityNeeded {
 		return false, false, fmt.Sprintf("not enough usable space available to perform speedtest - expected %s, got %s",

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -238,6 +238,7 @@ func (z *erasureServerPools) GetRawData(ctx context.Context, volume, file string
 	return nil
 }
 
+// Return the count of disks in each pool
 func (z *erasureServerPools) SetDriveCounts() []int {
 	setDriveCounts := make([]int, len(z.serverPools))
 	for i := range z.serverPools {

--- a/cmd/erasure-single-drive.go
+++ b/cmd/erasure-single-drive.go
@@ -184,6 +184,10 @@ func (es *erasureSingle) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+func (es *erasureSingle) SetDriveCounts() []int {
+	return []int{1}
+}
+
 func (es *erasureSingle) BackendInfo() (b madmin.BackendInfo) {
 	b.Type = madmin.Erasure
 

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -210,7 +210,13 @@ func (fs *FSObjects) Shutdown(ctx context.Context) error {
 
 // BackendInfo - returns backend information
 func (fs *FSObjects) BackendInfo() madmin.BackendInfo {
-	return madmin.BackendInfo{Type: madmin.FS}
+	return madmin.BackendInfo{
+		Type:             madmin.FS,
+		StandardSCData:   []int{1},
+		StandardSCParity: 0,
+		RRSCData:         []int{1},
+		RRSCParity:       0,
+	}
 }
 
 // LocalStorageInfo - returns underlying storage statistics.
@@ -235,7 +241,7 @@ func (fs *FSObjects) StorageInfo(ctx context.Context) (StorageInfo, []error) {
 			},
 		},
 	}
-	storageInfo.Backend.Type = madmin.FS
+	storageInfo.Backend = fs.BackendInfo()
 	return storageInfo, nil
 }
 

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1904,12 +1904,12 @@ func getClusterStorageMetrics() *MetricsGroup {
 
 		metrics = append(metrics, Metric{
 			Description: getClusterCapacityUsageBytesMD(),
-			Value:       GetTotalUsableCapacity(storageInfo.Disks, storageInfo),
+			Value:       float64(GetTotalUsableCapacity(storageInfo.Disks, storageInfo)),
 		})
 
 		metrics = append(metrics, Metric{
 			Description: getClusterCapacityUsageFreeBytesMD(),
-			Value:       GetTotalUsableCapacityFree(storageInfo.Disks, storageInfo),
+			Value:       float64(GetTotalUsableCapacityFree(storageInfo.Disks, storageInfo)),
 		})
 
 		metrics = append(metrics, Metric{

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -577,7 +577,7 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 			"Total usable capacity online in the cluster",
 			nil, nil),
 		prometheus.GaugeValue,
-		GetTotalUsableCapacity(server.Disks, s),
+		float64(GetTotalUsableCapacity(server.Disks, s)),
 	)
 	// Report total usable capacity free
 	ch <- prometheus.MustNewConstMetric(
@@ -586,7 +586,7 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 			"Total free usable capacity online in the cluster",
 			nil, nil),
 		prometheus.GaugeValue,
-		GetTotalUsableCapacityFree(server.Disks, s),
+		float64(GetTotalUsableCapacityFree(server.Disks, s)),
 	)
 
 	// MinIO Offline Disks per node

--- a/cmd/notification-summary.go
+++ b/cmd/notification-summary.go
@@ -30,17 +30,14 @@ func GetTotalCapacity(diskInfo []madmin.Disk) (capacity uint64) {
 }
 
 // GetTotalUsableCapacity gets the total usable capacity in the cluster.
-// This value is not an accurate representation of total usable in a multi-tenant deployment.
-func GetTotalUsableCapacity(diskInfo []madmin.Disk, s StorageInfo) (capacity float64) {
-	raw := GetTotalCapacity(diskInfo)
-	var approxDataBlocks float64
-	var actualDisks float64
-	for _, scData := range s.Backend.StandardSCData {
-		approxDataBlocks += float64(scData)
-		actualDisks += float64(scData + s.Backend.StandardSCParity)
+func GetTotalUsableCapacity(diskInfo []madmin.Disk, s StorageInfo) (capacity uint64) {
+	for _, disk := range diskInfo {
+		// Ignore parity disks
+		if disk.DiskIndex < s.Backend.StandardSCData[disk.PoolIndex] {
+			capacity += disk.TotalSpace
+		}
 	}
-	ratio := approxDataBlocks / actualDisks
-	return float64(raw) * ratio
+	return
 }
 
 // GetTotalCapacityFree gets the total capacity free in the cluster.
@@ -52,15 +49,12 @@ func GetTotalCapacityFree(diskInfo []madmin.Disk) (capacity uint64) {
 }
 
 // GetTotalUsableCapacityFree gets the total usable capacity free in the cluster.
-// This value is not an accurate representation of total free in a multi-tenant deployment.
-func GetTotalUsableCapacityFree(diskInfo []madmin.Disk, s StorageInfo) (capacity float64) {
-	raw := GetTotalCapacityFree(diskInfo)
-	var approxDataBlocks float64
-	var actualDisks float64
-	for _, scData := range s.Backend.StandardSCData {
-		approxDataBlocks += float64(scData)
-		actualDisks += float64(scData + s.Backend.StandardSCParity)
+func GetTotalUsableCapacityFree(diskInfo []madmin.Disk, s StorageInfo) (capacity uint64) {
+	for _, disk := range diskInfo {
+		// Ignore parity disks
+		if disk.DiskIndex < s.Backend.StandardSCData[disk.PoolIndex] {
+			capacity += disk.AvailableSpace
+		}
 	}
-	ratio := approxDataBlocks / actualDisks
-	return float64(raw) * ratio
+	return
 }

--- a/cmd/notification-summary.go
+++ b/cmd/notification-summary.go
@@ -31,6 +31,9 @@ func GetTotalCapacity(diskInfo []madmin.Disk) (capacity uint64) {
 
 // GetTotalUsableCapacity gets the total usable capacity in the cluster.
 func GetTotalUsableCapacity(diskInfo []madmin.Disk, s StorageInfo) (capacity uint64) {
+	if globalIsGateway {
+		return 0
+	}
 	for _, disk := range diskInfo {
 		// Ignore parity disks
 		if disk.DiskIndex < s.Backend.StandardSCData[disk.PoolIndex] {
@@ -50,6 +53,10 @@ func GetTotalCapacityFree(diskInfo []madmin.Disk) (capacity uint64) {
 
 // GetTotalUsableCapacityFree gets the total usable capacity free in the cluster.
 func GetTotalUsableCapacityFree(diskInfo []madmin.Disk, s StorageInfo) (capacity uint64) {
+	if globalIsGateway {
+		return 0
+	}
+
 	for _, disk := range diskInfo {
 		// Ignore parity disks
 		if disk.DiskIndex < s.Backend.StandardSCData[disk.PoolIndex] {


### PR DESCRIPTION
## Description
The current code uses approximation using a ratio. The approximation can
skew if we have multiple pools with different disk capacity.

Replace the algorithm with a simpler one which counts data disks and
ignore parity disks.

## Motivation and Context
Better reporting for usable/free capacity

## How to test this PR?
Get prometheus data starts with 'minio_cluster_capacity'

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
