### PR TITLE
fix: calculate scanner metric paths for single drive

### DIFF
--- a/cmd/data-scanner-metric.go
+++ b/cmd/data-scanner-metric.go
@@ -166,7 +166,7 @@ func (p *scannerMetrics) currentPathUpdater(disk, initial string) (update func(p
 // getCurrentPaths returns the paths currently being processed.
 func (p *scannerMetrics) getCurrentPaths() []string {
 	var res []string
-	prefix := globalMinioAddr + "/"
+	prefix := globalLocalNodeName + "/"
 	p.currentPaths.Range(func(key, value interface{}) bool {
 		// We are a bit paranoid, but better miss an entry than crash.
 		name, ok := key.(string)
@@ -179,7 +179,7 @@ func (p *scannerMetrics) getCurrentPaths() []string {
 		}
 		strptr := (*string)(atomic.LoadPointer(obj.name))
 		if strptr != nil {
-			res = append(res, prefix+name+"/"+*strptr)
+			res = append(res, pathJoin(prefix, name, *strptr))
 		}
 		return true
 	})


### PR DESCRIPTION

## Description
fix: calculate scanner metric paths for single drive

Additionally use pathJoin() to avoid double `//`
in path names.

## Motivation and Context
Cosmetic UI issues

## How to test this PR?
just check `mc admin top scanner myminio/` on a single drive setup `minio server ~/test` and upload a bunch of objects. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
