### PR TITLE
Add root certs for nats streaming (stan) client

### DIFF
--- a/internal/event/target/nats.go
+++ b/internal/event/target/nats.go
@@ -187,6 +187,11 @@ func (n NATSArgs) connectStan() (stan.Conn, error) {
 	}
 
 	connOpts := []stan.Option{stan.NatsURL(addressURL)}
+
+	if n.TLS && !n.TLSSkipVerify {
+		connOpts = append(connOpts, stan.NatsOptions(nats.Secure(&tls.Config{RootCAs: n.RootCAs})))
+	}
+
 	if n.Streaming.MaxPubAcksInflight > 0 {
 		connOpts = append(connOpts, stan.MaxPubAcksInflight(n.Streaming.MaxPubAcksInflight))
 	}


### PR DESCRIPTION
## Description

Add Root CAs from minio flag `--certs-dir` for nats streaming (stan) client.

## Motivation and Context

Minio is able to notify nats by supplying the self-signed root CA using:

Minio settings
```shell
MINIO_NOTIFY_NATS_TLS=on
MINIO_NOTIFY_NATS_TLS_SKIP_VERIFY=off
```

Helm settings
```shell
--set trustedCertsSecret=minio-trusted-certs
```

But as soon as I turn on nats streaming in minio configuration like this:
```
MINIO_NOTIFY_NATS_STREAMING=on
MINIO_NOTIFY_NATS_STREAMING_CLUSTER_ID=test
``` 

It fails with `Error: x509: certificate signed by unknown authority (x509.UnknownAuthorityError)`

I found that the `stan` client wasn't being supplied the `RootCAs` at all so I added it in the same way the regular `nats` client is configured in the lines above. Here are those lines from the `nats` client implementation: https://github.com/minio/minio/blob/master/internal/event/target/nats.go#L168-L172

## How to test this PR?

(this is a long one)

Setup nats with self-signed cert

https://github.com/nats-io/k8s/tree/main/helm/charts/nats

https://docs.nats.io/running-a-nats-service/configuration/securing_nats/tls#self-signed-certificates-for-testing

```yaml
auth:
  enabled: false
cluster:
  enabled: true
  replicas: 3
  tls:
    ca: ca.crt
    cert: tls.crt
    key: tls.key
    secret:
      name: nats-server-tls
fileStorage:
  storageClassName: nats-nats
k8sClusterDomain: cluster.local
nats:
  image: nats:2.8.4-alpine
  logging:
    debug: true
    trace: true
  resources:
    requests:
      cpu: "0.25"
      memory: 500Mi
  tls:
    ca: ca.crt
    cert: tls.crt
    key: tls.key
    secret:
      name: nats-server-tls
    verify: false
```

Setup nats-streaming with self-signed cert

https://github.com/nats-io/k8s/tree/main/helm/charts/stan

```yaml
nats:
  tls:
    ca: ca.crt
    cert: tls.crt
    key: tls.key
    secret:
      name: nats-server-tls
stan:
  clusterID: test
  logging:
    adsf: false
    debug: true
    trace: true
  nats:
    url: nats://nats.nats.svc.cluster.local:4222
  replicas: 1
  tls:
    enabled: true
    secretName: nats-streaming-server-tls
    settings:
      insecure: true
```

Add `trustedCertsSecret` with CA file (from nats) in a secret via Helm 

https://github.com/minio/minio/tree/master/helm/minio#installing-certificates-from-third-party-cas

```shell
helm upgrade --install \
  --namespace minio \
  --set mode=standalone \
  --set replicas=1 \
  --set persistence.size=5Gi \
  --set resources.requests.memory=1Gi \
  --set trustedCertsSecret=minio-trusted-certs \
  --set environment.MINIO_NOTIFY_NATS_ENABLE=on \
  --set environment.MINIO_NOTIFY_NATS_TLS=on \
  --set environment.MINIO_NOTIFY_NATS_TLS_SKIP_VERIFY=off \
  --set environment.MINIO_NOTIFY_NATS_ADDRESS="nats.nats.svc.cluster.local:4222" \
  --set environment.MINIO_NOTIFY_NATS_SUBJECT=minioevents \
  --set environment.MINIO_NOTIFY_NATS_STREAMING=on \
  --set environment.MINIO_NOTIFY_NATS_STREAMING_CLUSTER_ID=test \
  minio \
  minio/minio
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
