### PR TITLE
choose console port as 9001 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ service iptables restart
 
 MinIO Server comes with an embedded web based object browser. Point your web browser to <http://127.0.0.1:9000> to ensure your server has started successfully.
 
-> NOTE: MinIO runs console on random port by default if you wish choose a specific port use `--console-address` to pick a specific interface and port.
+> NOTE: MinIO runs console on '9001' by default if you wish choose a specific port use `--console-address` to pick a specific interface and port.
 
 ### Things to consider
 

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -421,25 +421,16 @@ func handleCommonCmdArgs(ctx *cli.Context) {
 
 	// Fetch console address option
 	consoleAddr := ctx.GlobalString("console-address")
-	if consoleAddr == "" {
+	if consoleAddr == "" || addr == ":"+GlobalConsoleDefaultPort {
 		consoleAddr = ctx.String("console-address")
-	}
-
-	if consoleAddr == "" {
-		p, err := xnet.GetFreePort()
-		if err != nil {
-			logger.FatalIf(err, "Unable to get free port for console on the host")
-		}
-		globalMinioConsolePortAuto = true
-		consoleAddr = net.JoinHostPort("", p.String())
-	}
-
-	if _, _, err := net.SplitHostPort(consoleAddr); err != nil {
-		logger.FatalIf(err, "Unable to start listening on console port")
 	}
 
 	if consoleAddr == addr {
 		logger.FatalIf(errors.New("--console-address cannot be same as --address"), "Unable to start the server")
+	}
+
+	if _, _, err := net.SplitHostPort(consoleAddr); err != nil {
+		logger.FatalIf(err, "Unable to start listening on console port")
 	}
 
 	globalMinioHost, globalMinioPort = mustSplitHostPort(addr)

--- a/cmd/gateway-startup-msg.go
+++ b/cmd/gateway-startup-msg.go
@@ -48,12 +48,6 @@ func printGatewayStartupMessage(apiEndPoints []string, backendType string) {
 
 	// Prints documentation message.
 	printObjectAPIMsg()
-
-	if globalMinioConsolePortAuto && globalBrowserEnabled {
-		msg := fmt.Sprintf("\nWARNING: Console endpoint is listening on a dynamic port (%s), please use --console-address \":PORT\" to choose a static port.",
-			globalMinioConsolePort)
-		logger.Info(color.RedBold(msg))
-	}
 }
 
 // Prints common server startup message. Prints credential, region and browser access.

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -58,7 +58,8 @@ import (
 
 // minio configuration related constants.
 const (
-	GlobalMinioDefaultPort = "9000"
+	GlobalMinioDefaultPort   = "9000"
+	GlobalConsoleDefaultPort = "9001"
 
 	globalMinioDefaultRegion = ""
 	// This is a sha256 output of ``arn:aws:iam::minio:user/admin``,
@@ -173,9 +174,8 @@ var (
 	globalMinioAddr = ""
 
 	// MinIO default port, can be changed through command line.
-	globalMinioPort            = GlobalMinioDefaultPort
-	globalMinioConsolePort     = "13333"
-	globalMinioConsolePortAuto = false
+	globalMinioPort        = GlobalMinioDefaultPort
+	globalMinioConsolePort = GlobalConsoleDefaultPort
 
 	// Holds the host that was passed using --address
 	globalMinioHost = ""

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -63,6 +63,7 @@ var ServerFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:   "console-address",
+		Value:  ":" + GlobalConsoleDefaultPort,
 		Usage:  "bind to a specific ADDRESS:PORT for embedded Console UI, ADDRESS can be an IP or hostname",
 		EnvVar: "MINIO_CONSOLE_ADDRESS",
 	},

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -142,13 +142,9 @@ func printServerCommonMsg(apiEndpoints []string) {
 	}
 	printEventNotifiers()
 
-	if globalMinioConsolePortAuto && globalBrowserEnabled {
-		logger.Info(color.RedBold("\nWARNING: Console endpoint is listening on a dynamic port (%s), please use --console-address \":PORT\" to choose a static port.",
-			globalMinioConsolePort))
-	}
 	if globalBrowserEnabled {
 		consoleEndpointStr := strings.Join(stripStandardPorts(getConsoleEndpoints(), globalMinioConsoleHost), " ")
-		logger.Info(color.Blue("Console: ") + color.Bold(fmt.Sprintf("%s ", consoleEndpointStr)))
+		logger.Info("\n" + color.Blue("Console: ") + color.Bold(fmt.Sprintf("%s ", consoleEndpointStr)))
 		if color.IsTerminal() && (!globalCLIContext.Anonymous && !globalCLIContext.JSON) {
 			logger.Info(color.Blue("RootUser: ") + color.Bold(fmt.Sprintf("%s ", cred.AccessKey)))
 			logger.Info(color.Blue("RootPass: ") + color.Bold(fmt.Sprintf("%s ", cred.SecretKey)))


### PR DESCRIPTION
## Description
choose console port as 9001 by default

## Motivation and Context
simplifying the	documentation around --console-address
and make sure that MinIO just works out of the box

## How to test this PR?
MinIO should listen on console-address port 9001 by default.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
