### PR TITLE
fix: do not pass around sync.Map

### DIFF
--- a/internal/logger/target/console/console.go
+++ b/internal/logger/target/console/console.go
@@ -77,7 +77,7 @@ func (c *Target) Send(e interface{}, logKind string) error {
 			if tagString != "" {
 				tagString += ", "
 			}
-			tagString += fmt.Sprintf("%s=%v", key, value)
+			tagString += fmt.Sprintf("%s=%#v", key, value)
 		}
 	}
 


### PR DESCRIPTION

## Description
fix: do not pass around sync.Map

## Motivation and Context
it is not safe to pass around sync.Map
through pointers, as it may be concurrently
updated by different callers.

this PR simplifies by avoiding sync.Map
altogether, we do not need sync.Map
to keep object->erasureMap association.

This PR fixes a crash when concurrently
using this value when audit logs are
configured.

```
fatal error: concurrent map iteration and map write

goroutine 247651580 [running]:
runtime.throw({0x277a6c1?, 0xc002381400?})
        runtime/panic.go:992 +0x71 fp=0xc004d29b20 sp=0xc004d29af0 pc=0x438671
runtime.mapiternext(0xc0d6e87f18?)
        runtime/map.go:871 +0x4eb fp=0xc004d29b90 sp=0xc004d29b20 pc=0x41002b
```

## How to test this PR?
Perform concurrent I/O and observe that we are directly referencing 
sync.Map that is being edited concurrently as well, instead of that
simply use a `key -> struct` relationship.

This essentially leads to a crash.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
