### PR TITLE
Adding error check for jetstream connection

### DIFF
--- a/internal/event/target/nats.go
+++ b/internal/event/target/nats.go
@@ -256,10 +256,12 @@ func (target *NATSTarget) IsActive() (bool, error) {
 
 	if target.natsConn != nil && target.args.JetStream.Enable {
 		target.jstream, connErr = target.natsConn.JetStream()
-		if connErr.Error() == nats.ErrNoServers.Error() {
-			return false, errNotConnected
+		if connErr != nil {
+			if connErr.Error() == nats.ErrNoServers.Error() {
+				return false, errNotConnected
+			}
+			return false, connErr
 		}
-		return false, connErr
 	}
 
 	return true, nil


### PR DESCRIPTION
## Description

I got my jetstream server online today and I found a missing error check in the new jetstream implementation.

## Motivation and Context

When I startup with `MINIO_NOTIFY_NATS_JETSTREAM=on` I get this error.

```rust
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1b42194]

goroutine 101 [running]:
github.com/minio/minio/internal/event/target.(*NATSTarget).IsActive(0xc003a986e0)
	github.com/minio/minio/internal/event/target/nats.go:259 +0x2b4
github.com/minio/minio/cmd.(*NotificationSys).GetARNList(0xc00266fb68?, 0x1)
	github.com/minio/minio/cmd/notification.go:72 +0x249
github.com/minio/minio/cmd.printEventNotifiers()
	github.com/minio/minio/cmd/server-startup-msg.go:170 +0x2f
github.com/minio/minio/cmd.printServerCommonMsg({0xc0014d0ba0?, 0x1?, 0x1?})
	github.com/minio/minio/cmd/server-startup-msg.go:143 +0x4c5
github.com/minio/minio/cmd.printStartupMessage({0xc0014d0b60, 0x2, 0x2}, {0x0, 0x0})
	github.com/minio/minio/cmd/server-startup-msg.go:74 +0x325
github.com/minio/minio/cmd.serverMain.func4()
	github.com/minio/minio/cmd/server-main.go:640 +0x56c
created by github.com/minio/minio/cmd.serverMain
	github.com/minio/minio/cmd/server-main.go:585 +0x135b
```

nats.go line 259 is this line which just wasn't checking `connErr` for `nil` first, easy fix.

```golang
if connErr.Error() == nats.ErrNoServers.Error() {
	return false, errNotConnected
}
return false, connErr
```

Seems like it is working now after the patch.

Thanks again @harshavardhana 

## How to test this PR?

```
helm upgrade --install \
  --namespace minio \
  --set mode=standalone \
  --set replicas=1 \
  --set environment.MINIO_NOTIFY_NATS_ENABLE=on \
  --set environment.MINIO_NOTIFY_NATS_TLS=on \
  --set environment.MINIO_NOTIFY_NATS_TLS_SKIP_VERIFY=off \
  --set environment.MINIO_NOTIFY_NATS_ADDRESS="nats.nats.svc.cluster.local:4222" \
  --set environment.MINIO_NOTIFY_NATS_SUBJECT=minioevents \
  --set environment.MINIO_NOTIFY_NATS_JETSTREAM=on \
  minio minio/minio
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
