### PR TITLE
helm: Bump to latest image tag to fix security issues

### DIFF
--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -14,7 +14,7 @@ clusterDomain: cluster.local
 ##
 image:
   repository: quay.io/minio/minio
-  tag: RELEASE.2022-05-08T23-50-31Z
+  tag: RELEASE.2022-07-06T20-29-49Z
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Description

Artifacthub is showing some warning for the minio chart:

![image](https://user-images.githubusercontent.com/2794419/177939892-5d4ab6ca-8c1a-4b00-96ff-3cd8c6e4db44.png)

(find the report here: https://artifacthub.io/packages/helm/epinio/epinio?modal=security-report)

We can override the used image using Epinio's values.yaml (minio is a subchart) but it's better if the upstream chart is using the latest image by default.

I have no idea if the bumped image is compatible with the rest of the chart and I don't know how to test it.

Also, there should be a release of the helm chart after this PR is merged.

## Motivation and Context

Fix security issues and warnings

## How to test this PR?

No idea.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
