### PR TITLE
metric: add KMS-related metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/minio/csvparser v1.0.0
 	github.com/minio/dperf v0.4.2
 	github.com/minio/highwayhash v1.0.2
-	github.com/minio/kes v0.19.2
+	github.com/minio/kes v0.20.0
 	github.com/minio/madmin-go v1.4.3
 	github.com/minio/minio-go/v7 v7.0.30
 	github.com/minio/pkg v1.1.26
@@ -65,7 +65,7 @@ require (
 	github.com/philhofer/fwd v1.1.2-0.20210722190033-5c56ac6d0bb9
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.12.1
+	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.34.0
 	github.com/prometheus/procfs v0.7.3

--- a/go.sum
+++ b/go.sum
@@ -618,8 +618,8 @@ github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEX
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
-github.com/minio/kes v0.19.2 h1:0kdMAgLMSkiDA33k8pMHC7d6erDuseuLrZF+N3017SM=
-github.com/minio/kes v0.19.2/go.mod h1:X2fMkDbAkjbSKDGOQZvyPkHxoG7nuzP6R78Jw+TzXtM=
+github.com/minio/kes v0.20.0 h1:1tyC51Rr8zTregTESuT/QN/iebNMX7B9t7d3xLNMEpE=
+github.com/minio/kes v0.20.0/go.mod h1:3FW1BQkMGQW78yhy+69tUq5bdcf5rnXJizyeKB9a/tc=
 github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
 github.com/minio/madmin-go v1.4.3 h1:5/kBHjKTjYOQQHvyznu51weN5hJtFW67LB2VLz+hmzU=
 github.com/minio/madmin-go v1.4.3/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
@@ -745,8 +745,9 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
+github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
+github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/internal/kms/kes.go
+++ b/internal/kms/kes.go
@@ -115,6 +115,10 @@ func (c *kesClient) Stat() (Status, error) {
 	}, nil
 }
 
+func (c *kesClient) Metrics(ctx context.Context) (kes.Metric, error) {
+	return c.client.Metrics(ctx)
+}
+
 // CreateKey tries to create a new key at the KMS with the
 // given key ID.
 //

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/minio/kes"
 )
 
 // KMS is the generic interface that abstracts over
@@ -30,6 +31,9 @@ import (
 type KMS interface {
 	// Stat returns the current KMS status.
 	Stat() (Status, error)
+
+	// Metrics returns a KMS metric snapshot.
+	Metrics(ctx context.Context) (kes.Metric, error)
 
 	// CreateKey creates a new key at the KMS with the given key ID.
 	CreateKey(keyID string) error

--- a/internal/kms/single-key.go
+++ b/internal/kms/single-key.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/crypto/chacha20"
 	"golang.org/x/crypto/chacha20poly1305"
 
+	"github.com/minio/kes"
 	"github.com/minio/minio/internal/hash/sha256"
 )
 
@@ -87,6 +88,10 @@ func (kms secretKey) Stat() (Status, error) {
 		Name:       "SecretKey",
 		DefaultKey: kms.keyID,
 	}, nil
+}
+
+func (secretKey) Metrics(ctx context.Context) (kes.Metric, error) {
+	return kes.Metric{}, errors.New("kms: metrics are not supported")
 }
 
 func (secretKey) CreateKey(string) error {


### PR DESCRIPTION
## Description
This commit adds a minimal set of KMS-related
metrics:
```
 # HELP minio_cluster_kms_online Reports whether the KMS is online (1) or offline (0)
 # TYPE minio_cluster_kms_online gauge
 minio_cluster_kms_online{server="127.0.0.1:9000"} 1
 # HELP minio_cluster_kms_request_error Number of KMS requests that failed with a well-defined error
 # TYPE minio_cluster_kms_request_error counter
 minio_cluster_kms_request_error{server="127.0.0.1:9000"} 16790
 # HELP minio_cluster_kms_request_success Number of KMS requests that succeeded
 # TYPE minio_cluster_kms_request_success counter
 minio_cluster_kms_request_success{server="127.0.0.1:9000"} 348031
```

Currently, we report whether the KMS is available and how many requests
succeeded / failed. However, KES exposes much more metrics which can be
exposed if necessary. See: https://pkg.go.dev/github.com/minio/kes#Metric

## Motivation and Context
KMS, metrics

## How to test this PR?
Setup MinIO with KES - for example:
```
export MINIO_ROOT_USER=minio
export MINIO_ROOT_PASSWORD=minio123
export MINIO_KMS_KES_ENDPOINT=https://play.min.io:7373
export MINIO_KMS_KES_KEY_FILE=/Users/andreas/go/src/github.com/minio/kes/root.key
export MINIO_KMS_KES_CERT_FILE=/Users/andreas/go/src/github.com/minio/kes/root.cert
export MINIO_KMS_KES_KEY_NAME=my-minio-key
export MINIO_PROMETHEUS_AUTH_TYPE=public
```

Fetch metrics:
```
curl -X GET 'http://127.0.0.1:9000/minio/v2/metrics/cluster'
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
