### PR TITLE
enable using different ports for minioAPIPort/service.port and minioConsolePort/consoleService.port

### DIFF
--- a/helm/minio/templates/console-service.yaml
+++ b/helm/minio/templates/console-service.yaml
@@ -35,7 +35,7 @@ spec:
 {{- if (and (eq .Values.consoleService.type "NodePort") ( .Values.consoleService.nodePort)) }}
       nodePort: {{ .Values.consoleService.nodePort }}
 {{- else }}
-      targetPort: {{ .Values.consoleService.port }}
+      targetPort: {{ .Values.minioConsolePort }}
 {{- end}}
 {{- if .Values.consoleService.externalIPs }}
   externalIPs:

--- a/helm/minio/templates/networkpolicy.yaml
+++ b/helm/minio/templates/networkpolicy.yaml
@@ -16,8 +16,8 @@ spec:
       release: {{ .Release.Name }}
   ingress:
     - ports:
-        - port: {{ .Values.service.port }}
-        - port: {{ .Values.consoleService.port }}
+        - port: {{ .Values.minioAPIPort }}
+        - port: {{ .Values.minioConsolePort }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:

--- a/helm/minio/templates/service.yaml
+++ b/helm/minio/templates/service.yaml
@@ -36,7 +36,7 @@ spec:
 {{- if (and (eq .Values.service.type "NodePort") ( .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
 {{- else }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: {{ .Values.minioAPIPort }}
 {{- end}}
 {{- if .Values.service.externalIPs }}
   externalIPs:

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -30,6 +30,7 @@ spec:
     - name: {{ $scheme }}
       port: {{ .Values.service.port }}
       protocol: TCP
+      targetPort: {{ .Values.minioAPIPort }}
   selector:
     app: {{ template "minio.name" . }}
     release: {{ .Release.Name }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -162,7 +162,6 @@ persistence:
 service:
   type: ClusterIP
   clusterIP: ~
-  ## Make sure to match it to minioAPIPort
   port: "9000"
   nodePort: 32000
 
@@ -194,7 +193,6 @@ ingress:
 consoleService:
   type: ClusterIP
   clusterIP: ~
-  ## Make sure to match it to minioConsolePort
   port: "9001"
   nodePort: 32001
 

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -46,10 +46,12 @@ ignoreChartChecksums: false
 ## Additional arguments to pass to minio binary
 extraArgs: []
 
-## Port number for MinIO S3 API Access
+## Internal port number for MinIO S3 API container
+## Change service.port to change external port number
 minioAPIPort: "9000"
 
-## Port number for MinIO Browser COnsole Access
+## Internal port number for MinIO Browser Console container
+## Change consoleService.port to change external port number
 minioConsolePort: "9001"
 
 ## Update strategy for Deployments


### PR DESCRIPTION

## Description
Improves [#15223] to fix [#15175]
[#15223] was breaking configuration where service port was different from 9000.
minioAPIPort and minioConsolePort can now be independent from respective services ports.

## Motivation and Context
Enable exposing services to common ports (for example http/80) while keeping 9000 for internal minioAPIPort.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
