### PR TITLE
site replication: Ignore missing targets/replication config during re…

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -2165,6 +2165,9 @@ func (c *SiteReplicationSys) RemoveRemoteTargetsForEndpoint(ctx context.Context,
 	for _, b := range buckets {
 		config, _, err := globalBucketMetadataSys.GetReplicationConfig(ctx, b.Name)
 		if err != nil {
+			if errors.Is(err, BucketReplicationConfigNotFound{Bucket: b.Name}) {
+				continue
+			}
 			return err
 		}
 		var nRules []sreplication.Rule
@@ -2190,6 +2193,9 @@ func (c *SiteReplicationSys) RemoveRemoteTargetsForEndpoint(ctx context.Context,
 	}
 	for arn, t := range m {
 		if err := globalBucketTargetSys.RemoveTarget(ctx, t.SourceBucket, arn); err != nil {
+			if errors.Is(err, BucketRemoteTargetNotFound{Bucket: t.SourceBucket}) {
+				continue
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
…moval of site replication.

## Description


## Motivation and Context
Site replication sync may have succeeded partially during linking of the 2 clusters and may be missing replication config/target.Allow graceful cleanup

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
