### PR TITLE
allow custom speedtest bucket

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -244,8 +244,8 @@ func registerAdminRouter(router *mux.Router, enableConfigOps bool) {
 				Queries("paths", "{paths:.*}").HandlerFunc(gz(httpTraceHdrs(adminAPI.ForceUnlockHandler)))
 		}
 
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest").HandlerFunc(httpTraceHdrs(adminAPI.SpeedtestHandler))
-		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/object").HandlerFunc(httpTraceHdrs(adminAPI.ObjectSpeedtestHandler))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest").HandlerFunc(httpTraceHdrs(adminAPI.SpeedTestHandler))
+		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/object").HandlerFunc(httpTraceHdrs(adminAPI.ObjectSpeedTestHandler))
 		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/drive").HandlerFunc(httpTraceHdrs(adminAPI.DriveSpeedtestHandler))
 		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/speedtest/net").HandlerFunc(httpTraceHdrs(adminAPI.NetperfHandler))
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/minio/console/restapi"
+	minio "github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/bucket/bandwidth"
 	"github.com/minio/minio/internal/config"
@@ -375,6 +376,9 @@ var (
 
 	// MinIO version unix timestamp
 	globalVersionUnix uint64
+
+	// MinIO client
+	globalMinioClient *minio.Client
 
 	// Add new variable global values here.
 )

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1512,17 +1512,15 @@ func (sys *NotificationSys) Netperf(ctx context.Context, duration time.Duration)
 	return results
 }
 
-// Speedtest run GET/PUT tests at input concurrency for requested object size,
+// SpeedTest run GET/PUT tests at input concurrency for requested object size,
 // optionally you can extend the tests longer with time.Duration.
-func (sys *NotificationSys) Speedtest(ctx context.Context, size int,
-	concurrent int, duration time.Duration, storageClass string,
-) []SpeedtestResult {
+func (sys *NotificationSys) SpeedTest(ctx context.Context, sopts speedTestOpts) []SpeedTestResult {
 	length := len(sys.allPeerClients)
 	if length == 0 {
 		// For single node erasure setup.
 		length = 1
 	}
-	results := make([]SpeedtestResult, length)
+	results := make([]SpeedTestResult, length)
 
 	scheme := "http"
 	if globalIsTLS {
@@ -1537,8 +1535,7 @@ func (sys *NotificationSys) Speedtest(ctx context.Context, size int,
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
-			r, err := sys.peerClients[index].Speedtest(ctx, size,
-				concurrent, duration, storageClass)
+			r, err := sys.peerClients[index].SpeedTest(ctx, sopts)
 			u := &url.URL{
 				Scheme: scheme,
 				Host:   sys.peerClients[index].host.String(),
@@ -1555,7 +1552,7 @@ func (sys *NotificationSys) Speedtest(ctx context.Context, size int,
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		r, err := selfSpeedtest(ctx, size, concurrent, duration, storageClass)
+		r, err := selfSpeedTest(ctx, sopts)
 		u := &url.URL{
 			Scheme: scheme,
 			Host:   globalLocalNodeName,

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -803,26 +803,25 @@ func (client *peerRESTClient) GetPeerMetrics(ctx context.Context) (<-chan Metric
 	return ch, nil
 }
 
-func (client *peerRESTClient) Speedtest(ctx context.Context, size,
-	concurrent int, duration time.Duration, storageClass string,
-) (SpeedtestResult, error) {
+func (client *peerRESTClient) SpeedTest(ctx context.Context, opts speedTestOpts) (SpeedTestResult, error) {
 	values := make(url.Values)
-	values.Set(peerRESTSize, strconv.Itoa(size))
-	values.Set(peerRESTConcurrent, strconv.Itoa(concurrent))
-	values.Set(peerRESTDuration, duration.String())
-	values.Set(peerRESTStorageClass, storageClass)
+	values.Set(peerRESTSize, strconv.Itoa(opts.objectSize))
+	values.Set(peerRESTConcurrent, strconv.Itoa(opts.concurrency))
+	values.Set(peerRESTDuration, opts.duration.String())
+	values.Set(peerRESTStorageClass, opts.storageClass)
+	values.Set(peerRESTBucket, opts.bucketName)
 
-	respBody, err := client.callWithContext(context.Background(), peerRESTMethodSpeedtest, values, nil, -1)
+	respBody, err := client.callWithContext(context.Background(), peerRESTMethodSpeedTest, values, nil, -1)
 	if err != nil {
-		return SpeedtestResult{}, err
+		return SpeedTestResult{}, err
 	}
 	defer http.DrainBody(respBody)
 	waitReader, err := waitForHTTPResponse(respBody)
 	if err != nil {
-		return SpeedtestResult{}, err
+		return SpeedTestResult{}, err
 	}
 
-	var result SpeedtestResult
+	var result SpeedTestResult
 	err = gob.NewDecoder(waitReader).Decode(&result)
 	if err != nil {
 		return result, err

--- a/cmd/peer-rest-common.go
+++ b/cmd/peer-rest-common.go
@@ -63,7 +63,7 @@ const (
 	peerRESTMethodUpdateMetacacheListing      = "/updatemetacache"
 	peerRESTMethodGetPeerMetrics              = "/peermetrics"
 	peerRESTMethodLoadTransitionTierConfig    = "/loadtransitiontierconfig"
-	peerRESTMethodSpeedtest                   = "/speedtest"
+	peerRESTMethodSpeedTest                   = "/speedtest"
 	peerRESTMethodDriveSpeedTest              = "/drivespeedtest"
 	peerRESTMethodReloadSiteReplicationConfig = "/reloadsitereplicationconfig"
 	peerRESTMethodReloadPoolMeta              = "/reloadpoolmeta"

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -1125,7 +1125,7 @@ func (s *peerRESTServer) GetPeerMetrics(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func (s *peerRESTServer) SpeedtestHandler(w http.ResponseWriter, r *http.Request) {
+func (s *peerRESTServer) SpeedTestHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.IsValid(w, r) {
 		s.writeErrorResponse(w, errors.New("invalid request"))
 		return
@@ -1141,6 +1141,7 @@ func (s *peerRESTServer) SpeedtestHandler(w http.ResponseWriter, r *http.Request
 	durationStr := r.Form.Get(peerRESTDuration)
 	concurrentStr := r.Form.Get(peerRESTConcurrent)
 	storageClass := r.Form.Get(peerRESTStorageClass)
+	bucketName := r.Form.Get(peerRESTBucket)
 
 	size, err := strconv.Atoi(sizeStr)
 	if err != nil {
@@ -1159,7 +1160,13 @@ func (s *peerRESTServer) SpeedtestHandler(w http.ResponseWriter, r *http.Request
 
 	done := keepHTTPResponseAlive(w)
 
-	result, err := selfSpeedtest(r.Context(), size, concurrent, duration, storageClass)
+	result, err := selfSpeedTest(r.Context(), speedTestOpts{
+		objectSize:   size,
+		concurrency:  concurrent,
+		duration:     duration,
+		storageClass: storageClass,
+		bucketName:   bucketName,
+	})
 	if err != nil {
 		result.Error = err.Error()
 	}
@@ -1312,7 +1319,7 @@ func registerPeerRESTHandlers(router *mux.Router) {
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodUpdateMetacacheListing).HandlerFunc(httpTraceHdrs(server.UpdateMetacacheListingHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodGetPeerMetrics).HandlerFunc(httpTraceHdrs(server.GetPeerMetrics))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodLoadTransitionTierConfig).HandlerFunc(httpTraceHdrs(server.LoadTransitionTierConfigHandler))
-	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodSpeedtest).HandlerFunc(httpTraceHdrs(server.SpeedtestHandler))
+	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodSpeedTest).HandlerFunc(httpTraceHdrs(server.SpeedTestHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodDriveSpeedTest).HandlerFunc(httpTraceHdrs(server.DriveSpeedTestHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodNetperf).HandlerFunc(httpTraceHdrs(server.NetSpeedTestHandler))
 	subrouter.Methods(http.MethodPost).Path(peerRESTVersionPrefix + peerRESTMethodDevNull).HandlerFunc(httpTraceHdrs(server.DevNull))

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -35,6 +35,8 @@ import (
 	"time"
 
 	"github.com/minio/cli"
+	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/bucket/bandwidth"
 	"github.com/minio/minio/internal/color"
@@ -639,6 +641,18 @@ func serverMain(ctx *cli.Context) {
 		// Prints the formatted startup message, if err is not nil then it prints additional information as well.
 		printStartupMessage(getAPIEndpoints(), err)
 	}()
+
+	region := globalSite.Region
+	if region == "" {
+		region = "us-east-1"
+	}
+	globalMinioClient, err = minio.New(globalLocalNodeName, &minio.Options{
+		Creds:     credentials.NewStaticV4(globalActiveCred.AccessKey, globalActiveCred.SecretKey, ""),
+		Secure:    globalIsTLS,
+		Transport: globalProxyTransport,
+		Region:    region,
+	})
+	logger.FatalIf(err, "Unable to initialize MinIO client")
 
 	if serverDebugLog {
 		logger.Info("== DEBUG Mode enabled ==")


### PR DESCRIPTION
## Description
allow custom speedtest bucket

## Motivation and Context
this allows for specifying existing buckets with

- object replication enabled
- object encryption enabled
- object versioning enabled
- object locking enabled

## How to test this PR?
https://github.com/minio/madmin-go/pull/97 allows for specifying customer bucket names.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
