### PR TITLE
fix: simplify passing auditLog eventType

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -649,6 +649,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 			dv := DeletedObjectReplicationInfo{
 				DeletedObject: dobj,
 				Bucket:        bucket,
+				EventType:     ReplicateIncomingDelete,
 			}
 			scheduleReplicationDelete(ctx, dv, objectAPI)
 		}

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -1151,7 +1151,7 @@ func auditLogDecom(ctx context.Context, apiName, bucket, object, versionID strin
 		errStr = err.Error()
 	}
 	auditLogInternal(ctx, bucket, object, AuditLogOptions{
-		Trigger:   "decommissioning",
+		Event:     "decommission",
 		APIName:   apiName,
 		VersionID: versionID,
 		Error:     errStr,

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -262,6 +262,7 @@ func (o ObjectInfo) tierStats() tierStats {
 type ReplicateObjectInfo struct {
 	ObjectInfo
 	OpType            replication.Type
+	EventType         string
 	RetryCount        uint32
 	ResetID           string
 	Dsc               ReplicateDecision

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3567,7 +3567,8 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 				DeleteMarker:          objInfo.DeleteMarker,
 				ReplicationState:      objInfo.getReplicationState(dsc.String(), opts.VersionID, false),
 			},
-			Bucket: bucket,
+			Bucket:    bucket,
+			EventType: ReplicateIncomingDelete,
 		}
 		scheduleReplicationDelete(ctx, dobj, objectAPI)
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1036,7 +1036,7 @@ func totalNodeCount() uint64 {
 
 // AuditLogOptions takes options for audit logging subsystem activity
 type AuditLogOptions struct {
-	Trigger   string
+	Event     string
 	APIName   string
 	Status    string
 	VersionID string
@@ -1046,7 +1046,8 @@ type AuditLogOptions struct {
 // sends audit logs for internal subsystem activity
 func auditLogInternal(ctx context.Context, bucket, object string, opts AuditLogOptions) {
 	entry := audit.NewEntry(globalDeploymentID)
-	entry.Trigger = opts.Trigger
+	entry.Trigger = opts.Event
+	entry.Event = opts.Event
 	entry.Error = opts.Error
 	entry.API.Name = opts.APIName
 	entry.API.Bucket = bucket

--- a/internal/logger/message/audit/entry.go
+++ b/internal/logger/message/audit/entry.go
@@ -40,8 +40,11 @@ type Entry struct {
 	Version      string    `json:"version"`
 	DeploymentID string    `json:"deploymentid,omitempty"`
 	Time         time.Time `json:"time"`
-	Trigger      string    `json:"trigger"`
-	API          struct {
+	Event        string    `json:"event"`
+	// deprecated replaced by 'Event', kept here for some
+	// time for backward compatibility with k8s Operator.
+	Trigger string `json:"trigger"`
+	API     struct {
 		Name            string          `json:"name,omitempty"`
 		Bucket          string          `json:"bucket,omitempty"`
 		Object          string          `json:"object,omitempty"`


### PR DESCRIPTION


## Description
Rename Trigger -> Event to be a more appropriate
name for the audit event.

Bonus: fixes a bug in AddMRFWorker() it did not
cancel the waitgroup, leading to waitgroup leaks.

## Motivation and Context
Cleanup, bringing in more changes to allow for
a generic "worker/task" implementation.

## How to test this PR?
Nothing special should change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
