### PR TITLE
Add padding to compressed+encrypted files

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -864,7 +864,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		return
 	}
 
-	if _, ok := crypto.IsRequested(r.Header); !objectAPI.IsEncryptionSupported() && ok {
+	if crypto.Requested(r.Header) && !objectAPI.IsEncryptionSupported() {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL)
 		return
 	}
@@ -1040,7 +1040,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		return
 	}
 	if objectAPI.IsEncryptionSupported() {
-		if _, ok := crypto.IsRequested(formValues); ok && !HasSuffix(object, SlashSeparator) { // handle SSE requests
+		if crypto.Requested(formValues) && !HasSuffix(object, SlashSeparator) { // handle SSE requests
 			if crypto.SSECopy.IsRequested(r.Header) {
 				writeErrorResponse(ctx, w, toAPIError(ctx, errInvalidEncryptionParameters), r.URL)
 				return

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -976,14 +976,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	switch size := data.Size(); {
 	case size == 0:
 		buffer = make([]byte, 1) // Allocate atleast a byte to reach EOF
-	case size == -1:
-		if size := data.ActualSize(); size > 0 && size < fi.Erasure.BlockSize {
-			buffer = make([]byte, data.ActualSize()+256, data.ActualSize()*2+512)
-		} else {
-			buffer = er.bp.Get()
-			defer er.bp.Put(buffer)
-		}
-	case size >= fi.Erasure.BlockSize:
+	case size >= fi.Erasure.BlockSize || size == -1:
 		buffer = er.bp.Get()
 		defer er.bp.Put(buffer)
 	case size < fi.Erasure.BlockSize:

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -75,6 +75,10 @@ const (
 	compReadAheadBuffers = 5
 	// Size of each buffer.
 	compReadAheadBufSize = 1 << 20
+	// Pad Encrypted+Compressed files to a multiple of this.
+	compPadEncrypted = 256
+	// Disable compressed file indices below this size
+	compMinIndexSize = 8 << 20
 )
 
 // isMinioBucket returns true if given bucket is a MinIO internal
@@ -437,8 +441,7 @@ func isCompressible(header http.Header, object string) bool {
 	cfg := globalCompressConfig
 	globalCompressConfigMu.Unlock()
 
-	_, ok := crypto.IsRequested(header)
-	if !cfg.Enabled || (ok && !cfg.AllowEncrypted) || excludeForCompression(header, object, cfg) {
+	if !cfg.Enabled || (crypto.Requested(header) && !cfg.AllowEncrypted) || excludeForCompression(header, object, cfg) {
 		return false
 	}
 	return true
@@ -986,10 +989,17 @@ func init() {
 // input 'on' is always recommended such that this function works
 // properly, because we do not wish to create an object even if
 // client closed the stream prematurely.
-func newS2CompressReader(r io.Reader, on int64) (rc io.ReadCloser, idx func() []byte) {
+func newS2CompressReader(r io.Reader, on int64, encrypted bool) (rc io.ReadCloser, idx func() []byte) {
 	pr, pw := io.Pipe()
 	// Copy input to compressor
-	comp := s2.NewWriter(pw, compressOpts...)
+	opts := compressOpts
+	if encrypted {
+		// The values used for padding are not a security concern,
+		// but we choose pseudo-random numbers instead of just zeros.
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		opts = append([]s2.WriterOption{s2.WriterPadding(compPadEncrypted), s2.WriterPaddingSrc(rng)}, compressOpts...)
+	}
+	comp := s2.NewWriter(pw, opts...)
 	indexCh := make(chan []byte, 1)
 	go func() {
 		defer close(indexCh)
@@ -1007,8 +1017,8 @@ func newS2CompressReader(r io.Reader, on int64) (rc io.ReadCloser, idx func() []
 			return
 		}
 		// Close the stream.
-		// If more than 8MB was written, generate index.
-		if cn > 8<<20 {
+		// If more than compMinIndexSize was written, generate index.
+		if cn > compMinIndexSize {
 			idx, err := comp.CloseIndex()
 			idx = removeIndexHeaders(idx)
 			indexCh <- idx
@@ -1049,7 +1059,7 @@ func compressSelfTest() {
 		}
 	}
 	const skip = 2<<20 + 511
-	r, _ := newS2CompressReader(bytes.NewBuffer(data), int64(len(data)))
+	r, _ := newS2CompressReader(bytes.NewBuffer(data), int64(len(data)), true)
 	b, err := io.ReadAll(r)
 	failOnErr(err)
 	failOnErr(r.Close())

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -624,7 +624,7 @@ func TestS2CompressReader(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := make([]byte, 100) // make small buffer to ensure multiple reads are required for large case
 
-			r, idxCB := newS2CompressReader(bytes.NewReader(tt.data), int64(len(tt.data)), true)
+			r, idxCB := newS2CompressReader(bytes.NewReader(tt.data), int64(len(tt.data)), false)
 			defer r.Close()
 
 			var rdrBuf bytes.Buffer

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -624,7 +624,7 @@ func TestS2CompressReader(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := make([]byte, 100) // make small buffer to ensure multiple reads are required for large case
 
-			r, idxCB := newS2CompressReader(bytes.NewReader(tt.data), int64(len(tt.data)))
+			r, idxCB := newS2CompressReader(bytes.NewReader(tt.data), int64(len(tt.data)), true)
 			defer r.Close()
 
 			var rdrBuf bytes.Buffer

--- a/cmd/s3-zip-handlers.go
+++ b/cmd/s3-zip-handlers.go
@@ -66,7 +66,7 @@ func (api objectAPIHandlers) getObjectInArchiveFileHandler(ctx context.Context, 
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrBadRequest), r.URL)
 		return
 	}
-	if _, ok := crypto.IsRequested(r.Header); !objectAPI.IsEncryptionSupported() && ok {
+	if crypto.Requested(r.Header) && !objectAPI.IsEncryptionSupported() {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrBadRequest), r.URL)
 		return
 	}
@@ -357,7 +357,7 @@ func (api objectAPIHandlers) headObjectInArchiveFileHandler(ctx context.Context,
 		writeErrorResponseHeadersOnly(w, errorCodes.ToAPIErr(ErrBadRequest))
 		return
 	}
-	if _, ok := crypto.IsRequested(r.Header); !objectAPI.IsEncryptionSupported() && ok {
+	if crypto.Requested(r.Header) && !objectAPI.IsEncryptionSupported() {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrBadRequest), r.URL)
 		return
 	}

--- a/internal/bucket/encryption/bucket-sse-config.go
+++ b/internal/bucket/encryption/bucket-sse-config.go
@@ -128,7 +128,7 @@ type ApplyOptions struct {
 // set minimal SSE-KMS headers if autoEncrypt is true and the BucketSSEConfig
 // is nil.
 func (b *BucketSSEConfig) Apply(headers http.Header, opts ApplyOptions) {
-	if _, ok := crypto.IsRequested(headers); ok {
+	if crypto.Requested(headers) {
 		return
 	}
 	if b == nil {

--- a/internal/crypto/header_test.go
+++ b/internal/crypto/header_test.go
@@ -29,6 +29,10 @@ import (
 func TestIsRequested(t *testing.T) {
 	for i, test := range kmsIsRequestedTests {
 		_, got := IsRequested(test.Header)
+		if Requested(test.Header) != got {
+			// Test if result matches.
+			t.Errorf("Requested mismatch, want %v, got %v", Requested(test.Header), got)
+		}
 		got = got && S3KMS.IsRequested(test.Header)
 		if got != test.Expected {
 			t.Errorf("SSE-KMS: Test %d: Wanted %v but got %v", i, test.Expected, got)
@@ -36,6 +40,10 @@ func TestIsRequested(t *testing.T) {
 	}
 	for i, test := range s3IsRequestedTests {
 		_, got := IsRequested(test.Header)
+		if Requested(test.Header) != got {
+			// Test if result matches.
+			t.Errorf("Requested mismatch, want %v, got %v", Requested(test.Header), got)
+		}
 		got = got && S3.IsRequested(test.Header)
 		if got != test.Expected {
 			t.Errorf("SSE-S3: Test %d: Wanted %v but got %v", i, test.Expected, got)
@@ -43,6 +51,10 @@ func TestIsRequested(t *testing.T) {
 	}
 	for i, test := range ssecIsRequestedTests {
 		_, got := IsRequested(test.Header)
+		if Requested(test.Header) != got {
+			// Test if result matches.
+			t.Errorf("Requested mismatch, want %v, got %v", Requested(test.Header), got)
+		}
 		got = got && SSEC.IsRequested(test.Header)
 		if got != test.Expected {
 			t.Errorf("SSE-C: Test %d: Wanted %v but got %v", i, test.Expected, got)

--- a/internal/crypto/sse.go
+++ b/internal/crypto/sse.go
@@ -71,6 +71,11 @@ func IsRequested(h http.Header) (Type, bool) {
 	}
 }
 
+// Requested returns whether any type of encryption is requested.
+func Requested(h http.Header) bool {
+	return S3.IsRequested(h) || S3KMS.IsRequested(h) || SSEC.IsRequested(h)
+}
+
 // UnsealObjectKey extracts and decrypts the sealed object key
 // from the metadata using the SSE-Copy client key of the HTTP headers
 // and returns the decrypted object key.


### PR DESCRIPTION
## Description

Add up to 256 bytes of padding for compressed+encrypted files.

This will obscure the obvious cases of extremely compressible content and leave a similar output size for a very wide variety of inputs.

This does *not* mean the compression ratio doesn't leak information about the content, but the outcome space is much smaller, so often *less* information is leaked.

## How to test this PR?

Enable encryption+compression.

Part sizes will be a multiple of 256 plus fixed encryption overhead.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
