### PR TITLE
Avoid listing buckets from a suspended pool

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1652,7 +1652,10 @@ func (z *erasureServerPools) ListBuckets(ctx context.Context) (buckets []BucketI
 	if z.SinglePool() {
 		buckets, err = z.serverPools[0].ListBuckets(ctx)
 	} else {
-		for _, pool := range z.serverPools {
+		for idx, pool := range z.serverPools {
+			if z.IsSuspended(idx) {
+				continue
+			}
 			buckets, err = pool.ListBuckets(ctx)
 			if err != nil {
 				logger.LogIf(ctx, err)


### PR DESCRIPTION
## Description
Make bucket request sent after decommissioning is started are not
created in a suspended pool. Therefore listing buckets should avoid
suspended pools as well.

## Motivation and Context
Fix listing new buckets during decomissioning

## How to test this PR?
1. Run a minio setup with two pools
2.  Start decommissioning 
3. Create a bucket and list all buckets

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
