### PR TITLE
listing: Expire object versions past expiry

### DIFF
--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -667,8 +667,11 @@ func filterLifeCycle(ctx context.Context, bucket string, lc lifecycle.Lifecycle,
 		action := evalActionFromLifecycle(ctx, lc, lr, objInfo, false)
 		switch action {
 		case lifecycle.DeleteVersionAction, lifecycle.DeleteAction:
-			fallthrough
+			globalExpiryState.enqueueByDays(objInfo, false, action == lifecycle.DeleteVersionAction)
+			// Skip this entry.
+			continue
 		case lifecycle.DeleteRestoredAction, lifecycle.DeleteRestoredVersionAction:
+			globalExpiryState.enqueueByDays(objInfo, true, action == lifecycle.DeleteRestoredVersionAction)
 			// Skip this entry.
 			continue
 		}


### PR DESCRIPTION
## Description
We skip object versions which are past their ILM expiry. This change schedules
them for expiry while at it.

## Motivation and Context
Expire object versions past their expiry when spotted instead of waiting for the scanner to reach it.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
