### PR TITLE
Updating minio-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.20.0
 	github.com/minio/madmin-go v1.4.3
-	github.com/minio/minio-go/v7 v7.0.30
+	github.com/minio/minio-go/v7 v7.0.31
 	github.com/minio/pkg v1.1.26
 	github.com/minio/selfupdate v0.4.0
 	github.com/minio/sha256-simd v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77Z
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.23/go.mod h1:ei5JjmxwHaMrgsMrn4U/+Nmg+d8MKS1U2DAn1ou4+Do=
-github.com/minio/minio-go/v7 v7.0.30 h1:Re+qlwA+LB3mgFGYbztVPzlEjKtGzRVV5Sk38np858k=
-github.com/minio/minio-go/v7 v7.0.30/go.mod h1:/sjRKkKIA75CKh1iu8E3qBy7ktBmCCDGII0zbXGwbUk=
+github.com/minio/minio-go/v7 v7.0.31 h1:zsJ3qPDeU3bC5UMVi9HJ4ED0lyEzrNd3iQguglZS5FE=
+github.com/minio/minio-go/v7 v7.0.31/go.mod h1:/sjRKkKIA75CKh1iu8E3qBy7ktBmCCDGII0zbXGwbUk=
 github.com/minio/pkg v1.1.20/go.mod h1:Xo7LQshlxGa9shKwJ7NzQbgW4s8T/Wc1cOStR/eUiMY=
 github.com/minio/pkg v1.1.26 h1:a8x4sHNBxCiHEkxZ/0EBTLqvV3nMtM2G/A6lXNfXN3U=
 github.com/minio/pkg v1.1.26/go.mod h1:z9PfmEI804KFkF6eY4LoGe8IDVvTCsYGVuaf58Dr0WI=


### PR DESCRIPTION
## Description

To fix issue on Speed Test:
```sh
mc support perf drive myminio/
```

## Motivation and Context

To get reliable speed testing.

## How to test this PR?

Easy, you need to have MinIO In distributed mode and run this line:

```sh
mc support perf drive myminio/
```

But we should not get `panic` from here.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated

### Related to:

https://github.com/minio/minio-go/pull/1670

Where we want to fix issue on speed test:

```sh
Documentation: https://docs.min.io/
panic: send on closed channel

goroutine 174049 [running]:
github.com/minio/minio-go/v7.(*Object).doGetRequest(_, {{0xc0021a8000, 0x2000, 0x2000}, 0x326000, 0x0, 0x1, 0x0, 0x1, 0x0, ...})
	github.com/minio/minio-go/v7@v7.0.30/api-get-object.go:319 +0xdc
github.com/minio/minio-go/v7.(*Object).Read(0xc018774a80, {0xc0021a8000?, 0x1c0?, 0xc002c6e000?})
	github.com/minio/minio-go/v7@v7.0.30/api-get-object.go:399 +0x248
io.discard.ReadFrom({}, {0x4cfa0a0, 0xc018774a80})
	io/io.go:610 +0x72
io.copyBuffer({0x4d00fc0, 0x604aba0}, {0x4cfa0a0, 0xc018774a80}, {0x0, 0x0, 0x0})
	io/io.go:412 +0x14b
io.Copy(...)
	io/io.go:385
github.com/minio/minio/cmd.selfSpeedTest.func4(0x0)
	github.com/minio/minio/cmd/perf-tests.go:149 +0x3f5
created by github.com/minio/minio/cmd.selfSpeedTest
	github.com/minio/minio/cmd/perf-tests.go:124 +0x8d6
```