### PR TITLE
Fix site replication healing of missing buckets

### DIFF
--- a/docs/site-replication/run-multi-site-ldap.sh
+++ b/docs/site-replication/run-multi-site-ldap.sh
@@ -257,6 +257,9 @@ fi
 kill -9 ${site1_pid}
 # Update tag on minio2/newbucket when minio1 is down
 ./mc tag set minio2/newbucket "key=val2"
+# create a new bucket on minio2. This should replicate to minio1 after it comes online.
+./mc mb minio2/newbucket2
+
 # Restart minio1 instance
 minio server --config-dir /tmp/minio-ldap --address ":9001" /tmp/minio-ldap-idp1/{1...4} >/tmp/minio1_1.log 2>&1 &
 sleep 10
@@ -267,4 +270,10 @@ if [ "${val}" != "val2" ]; then
     exit_1;
 fi
 
+# Test if bucket created when minio1 is down healed
+diff -q <(./mc ls minio1 | awk '{print $3}') <(./mc ls minio2 | awk '{print $3}') 1>/dev/null
+if  [ $? -ne 0 ]; then
+    echo "expected bucket to have replicated, exiting..."
+    exit_1;
+fi
 cleanup

--- a/docs/site-replication/run-multi-site-oidc.sh
+++ b/docs/site-replication/run-multi-site-oidc.sh
@@ -242,6 +242,9 @@ fi
 kill -9 ${site1_pid}
 # Update tag on minio2/newbucket when minio1 is down
 ./mc tag set minio2/newbucket "key=val2"
+# create a new bucket on minio2. This should replicate to minio1 after it comes online.
+./mc mb minio2/newbucket2
+
 # Restart minio1 instance
 minio server --address ":9001" --console-address ":10000" /tmp/minio1/{1...4} >/tmp/minio1_1.log 2>&1 &
 sleep 10
@@ -249,5 +252,12 @@ sleep 10
 val=$(./mc tag list minio1/newbucket --json | jq -r .tagset | jq -r .key )
 if [ "${val}" != "val2" ]; then
     echo "expected bucket tag to have replicated, exiting..."
+    exit_1;
+fi
+
+# Test if bucket created when minio1 is down healed
+diff -q <(./mc ls minio1 | awk '{print $3}') <(./mc ls minio2 | awk '{print $3}') 1>/dev/null
+if  [ $? -ne 0 ]; then
+    echo "expected bucket to have replicated, exiting..."
     exit_1;
 fi


### PR DESCRIPTION
Regression from #15186

- Adding tests to cover healing of buckets.
- Also dereference quota in SiteReplicationStatus only when non-nil

## Description


## Motivation and Context
Buckets created when site is down/failures from initial sync should get healed properly

## How to test this PR?
Set up site replication, then bring down a site and create buckets. This should sync properly once peer comes back online.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) #15186
- [ ] Documentation updated
- [ ] Unit tests added/updated
