### PR TITLE
Default DeleteReplication rule status if unspecified.

### DIFF
--- a/internal/bucket/replication/replication.go
+++ b/internal/bucket/replication/replication.go
@@ -62,6 +62,12 @@ func ParseConfig(reader io.Reader) (*Config, error) {
 				},
 			}
 		}
+		// Default DeleteReplication to disabled if unset.
+		if len(config.Rules[i].DeleteReplication.Status) == 0 {
+			config.Rules[i].DeleteReplication = DeleteReplication{
+				Status: Disabled,
+			}
+		}
 	}
 	return &config, nil
 }

--- a/internal/bucket/replication/replication_test.go
+++ b/internal/bucket/replication/replication_test.go
@@ -38,13 +38,13 @@ func TestParseAndValidateReplicationConfig(t *testing.T) {
 			expectedParsingErr:    nil,
 			expectedValidationErr: errInvalidDeleteMarkerReplicationStatus,
 		},
-		// 2 Invalid delete replication status in replication config
+		// 2 No delete replication status in replication config
 		{
 			inputConfig:           `<ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Role>arn:aws:iam::AcctID:role/role-name</Role><Rule><Status>Enabled</Status><DeleteMarkerReplication><Status>Disabled</Status></DeleteMarkerReplication><Prefix>key-prefix</Prefix><Destination><Bucket>arn:aws:s3:::destinationbucket</Bucket></Destination></Rule></ReplicationConfiguration>`,
 			destBucket:            "destinationbucket",
 			sameTarget:            false,
 			expectedParsingErr:    nil,
-			expectedValidationErr: errDeleteReplicationMissing,
+			expectedValidationErr: nil,
 		},
 		// 3 valid replication config
 		{


### PR DESCRIPTION
Since this is a MinIO specific extension in the replication config,
default DeleteReplication to Disabled to allow other sdks to be used to configure
replication rules.

## Description


## Motivation and Context
Allows configuring replication rules with non minio sdks

## How to test this PR?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
