### PR TITLE
support 'admin update' for hotfix versions

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -76,7 +76,7 @@ func releaseTimeToReleaseTag(releaseTime time.Time) string {
 // releaseTagToReleaseTime - reverse of `releaseTimeToReleaseTag()`
 func releaseTagToReleaseTime(releaseTag string) (releaseTime time.Time, err error) {
 	fields := strings.Split(releaseTag, ".")
-	if len(fields) < 2 || len(fields) > 3 {
+	if len(fields) < 2 || len(fields) > 4 {
 		return releaseTime, fmt.Errorf("%s is not a valid release tag", releaseTag)
 	}
 	if fields[0] != "RELEASE" {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -72,6 +72,14 @@ func TestReleaseTagToNFromTimeConversion(t *testing.T) {
 			time.Now().UTC(), "DEVELOPMENT.GOGET",
 			"DEVELOPMENT.GOGET is not a valid release tag",
 		},
+		{
+			time.Date(2017, time.August, 5, 0, 0, 53, 0, utcLoc),
+			"RELEASE.2017-08-05T00-00-53Z.hotfix", "",
+		},
+		{
+			time.Date(2017, time.August, 5, 0, 0, 53, 0, utcLoc),
+			"RELEASE.2017-08-05T00-00-53Z.hotfix.aaaa", "",
+		},
 	}
 	for i, testCase := range testCases {
 		if testCase.errStr != "" {


### PR DESCRIPTION
## Description
support 'admin update' for hotfix versions

## Motivation and Context
hotfixed versions are rejected, support them.

## How to test this PR?
```
mc admin update alias/ https://dl.minio.io/server/minio/hotfixes/linux-amd64/archive/minio.RELEASE.2021-04-22T15-44-28Z.hotfix.c1d7c4c9d.sha256sum
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
