### PR TITLE
copy query values before update to preserve the expected keys

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1117,9 +1117,11 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	})
 
 	if redirectURL != nil { // success_action_redirect is valid and set.
-		redirectURL.Query().Add("bucket", objInfo.Bucket)
-		redirectURL.Query().Add("key", objInfo.Name)
-		redirectURL.Query().Add("etag", "\""+objInfo.ETag+"\"")
+		v := redirectURL.Query()
+		v.Add("bucket", objInfo.Bucket)
+		v.Add("key", objInfo.Name)
+		v.Add("etag", "\""+objInfo.ETag+"\"")
+		redirectURL.RawQuery = v.Encode()
 		writeRedirectSeeOther(w, redirectURL.String())
 		return
 	}

--- a/cmd/post-policy_test.go
+++ b/cmd/post-policy_test.go
@@ -499,9 +499,11 @@ func testPostPolicyBucketHandlerRedirect(obj ObjectLayer, instanceType string, t
 		t.Error("Unexpected error: ", err)
 	}
 
-	redirectURL.Query().Add("bucket", info.Bucket)
-	redirectURL.Query().Add("key", info.Name)
-	redirectURL.Query().Add("etag", "\""+info.ETag+"\"")
+	v := redirectURL.Query()
+	v.Add("bucket", info.Bucket)
+	v.Add("key", info.Name)
+	v.Add("etag", "\""+info.ETag+"\"")
+	redirectURL.RawQuery = v.Encode()
 	expectedLocation := redirectURL.String()
 
 	// Check the new location url


### PR DESCRIPTION


## Description
copy query values before update to preserve the expected keys

## Motivation and Context
in success_action_redirect we were missing required
query params as per S3 spec

updated tests as well

## How to test this PR?
Added tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
