### PR TITLE
Allow users to customize the time zone for trace log printing

### DIFF
--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -263,7 +263,7 @@ func getLogTime() time.Time {
 	timeZone := env.Get(config.EnvMinioTraceLogTimeZone, "")
 	local, err := time.LoadLocation(timeZone)
 	if err != nil {
-		logger.Error("env MINIO_TRACE_LOG_TIME_ZONE is invalid,will use default value.")
+		logger.Error("env MINIO_TRACE_LOG_TIME_ZONE is invalid, will use default value.")
 		local, _ = time.LoadLocation("")
 	}
 	return time.Now().In(local)

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -80,4 +80,7 @@ const (
 	EnvWorm       = "MINIO_WORM"        // legacy
 	EnvRegion     = "MINIO_REGION"      // legacy
 	EnvRegionName = "MINIO_REGION_NAME" // legacy
+	
+	//support users to specify time zone
+	EnvMinioTraceLogTimeZone = "MINIO_TRACE_LOG_TIME_ZONE"	
 )

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -80,7 +80,8 @@ const (
 	EnvWorm       = "MINIO_WORM"        // legacy
 	EnvRegion     = "MINIO_REGION"      // legacy
 	EnvRegionName = "MINIO_REGION_NAME" // legacy
-	
-	//support users to specify time zone
-	EnvMinioTraceLogTimeZone = "MINIO_TRACE_LOG_TIME_ZONE"	
+
+	// support users to specify time zone
+	// Set the value to 'Local' to adapt to the current system time zone
+	EnvMinioTraceLogTimeZone = "MINIO_TRACE_LOG_TIME_ZONE"
 )


### PR DESCRIPTION
## Description

When viewing the trace log of Minio, it is often difficult to determine the time point of the event due to different time zones. I suggest that users can customize the time zone of the trace log.

## Motivation and Context


## How to test this PR?
step1 : export MINIO_TRACE_LOG_TIME_ZONE=Local
step2 : start minio service , and enable admin trace.
mc admin trace myminio

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
