### PR TITLE
Fix data race, which caused tests execution to fail

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -590,7 +590,8 @@ func serverMain(ctx *cli.Context) {
 		initBackgroundTransition(GlobalContext, newObject)
 
 		go func() {
-			if err := globalTierConfigMgr.Init(GlobalContext, newObject); err != nil {
+			err := globalTierConfigMgr.Init(GlobalContext, newObject)
+			if err != nil {
 				logger.LogIf(GlobalContext, err)
 			}
 


### PR DESCRIPTION
## Description

Fix data race, which caused test execution to fail (when -race was specified)

## Motivation and Context

related to [Functional Tests](https://github.com/minio/minio/runs/7368103286?check_suite_focus=true)

### console logs:

<img width="947" alt="image" src="https://user-images.githubusercontent.com/48707349/179342170-0d2c5a4a-5f15-4051-9a6b-af6a992315c3.png">

## How to test this PR?

Declare a new variable err instead of using the outer err variable
```go
go func() {
       // here
	var err error
	if err = globalTierConfigMgr.Init(GlobalContext, newObject); err != nil {
		logger.LogIf(GlobalContext, err)
	}

	globalTierJournal, err = initTierDeletionJournal(GlobalContext)
	if err != nil {
		logger.FatalIf(err, "Unable to initialize remote tier pending deletes journal")
	}
}()
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
