### PR TITLE
Fix issue when a Helm create user job returns more than once

### DIFF
--- a/helm/minio/templates/_helper_create_user.txt
+++ b/helm/minio/templates/_helper_create_user.txt
@@ -59,9 +59,9 @@ createUser() {
     rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
     return 1
   fi
+  USER=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
   # Create the user if it does not exist
   if ! checkUserExists ; then
-    USER=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
     echo "Creating user '$USER'"
     cat $MINIO_ACCESSKEY_SECRETKEY_TMP | ${MC} admin user add myminio
   else


### PR DESCRIPTION
## Description

This fix will correct a crash in the Helm Job when a user already exists.


## Motivation and Context

If you re-run the helm chart reinstall (for example from ArgoCD), will fail on a re-sync because the user already exists and the $USER variable is only set the first pass through.


## How to test this PR?

Install the Helm chart more than once

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
