### PR TITLE
kms: add `context.Context` to KMS API calls

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -953,7 +953,7 @@ func (a adminAPIHandlers) ImportBucketMetadataHandler(w http.ResponseWriter, r *
 			kmsKey := encConfig.KeyID()
 			if kmsKey != "" {
 				kmsContext := kms.Context{"MinIO admin API": "ServerInfoHandler"} // Context for a test key operation
-				_, err := GlobalKMS.GenerateKey(kmsKey, kmsContext)
+				_, err := GlobalKMS.GenerateKey(ctx, kmsKey, kmsContext)
 				if err != nil {
 					if errors.Is(err, kes.ErrKeyNotFound) {
 						writeErrorResponse(ctx, w, importError(ctx, errKMSKeyNotFound, file.Name, bucket), r.URL)

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1615,7 +1615,7 @@ func (a adminAPIHandlers) KMSCreateKeyHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if err := GlobalKMS.CreateKey(r.Form.Get("key-id")); err != nil {
+	if err := GlobalKMS.CreateKey(ctx, r.Form.Get("key-id")); err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
 	}
@@ -1637,7 +1637,7 @@ func (a adminAPIHandlers) KMSStatusHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	stat, err := GlobalKMS.Stat()
+	stat, err := GlobalKMS.Stat(ctx)
 	if err != nil {
 		writeCustomErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrInternalError), err.Error(), r.URL)
 		return
@@ -1676,7 +1676,7 @@ func (a adminAPIHandlers) KMSKeyStatusHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	stat, err := GlobalKMS.Stat()
+	stat, err := GlobalKMS.Stat(ctx)
 	if err != nil {
 		writeCustomErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrInternalError), err.Error(), r.URL)
 		return
@@ -1692,7 +1692,7 @@ func (a adminAPIHandlers) KMSKeyStatusHandler(w http.ResponseWriter, r *http.Req
 
 	kmsContext := kms.Context{"MinIO admin API": "KMSKeyStatusHandler"} // Context for a test key operation
 	// 1. Generate a new key using the KMS.
-	key, err := GlobalKMS.GenerateKey(keyID, kmsContext)
+	key, err := GlobalKMS.GenerateKey(ctx, keyID, kmsContext)
 	if err != nil {
 		response.EncryptionErr = err.Error()
 		resp, err := json.Marshal(response)
@@ -2542,7 +2542,7 @@ func fetchKMSStatus() madmin.KMS {
 		return kmsStat
 	}
 
-	stat, err := GlobalKMS.Stat()
+	stat, err := GlobalKMS.Stat(context.Background())
 	if err != nil {
 		kmsStat.Status = string(madmin.ItemOffline)
 		return kmsStat
@@ -2555,7 +2555,7 @@ func fetchKMSStatus() madmin.KMS {
 
 	kmsContext := kms.Context{"MinIO admin API": "ServerInfoHandler"} // Context for a test key operation
 	// 1. Generate a new key using the KMS.
-	key, err := GlobalKMS.GenerateKey("", kmsContext)
+	key, err := GlobalKMS.GenerateKey(context.Background(), "", kmsContext)
 	if err != nil {
 		kmsStat.Encrypt = fmt.Sprintf("Encryption failed: %v", err)
 	} else {

--- a/cmd/bucket-encryption-handlers.go
+++ b/cmd/bucket-encryption-handlers.go
@@ -90,7 +90,7 @@ func (api objectAPIHandlers) PutBucketEncryptionHandler(w http.ResponseWriter, r
 	kmsKey := encConfig.KeyID()
 	if kmsKey != "" {
 		kmsContext := kms.Context{"MinIO admin API": "ServerInfoHandler"} // Context for a test key operation
-		_, err := GlobalKMS.GenerateKey(kmsKey, kmsContext)
+		_, err := GlobalKMS.GenerateKey(ctx, kmsKey, kmsContext)
 		if err != nil {
 			if errors.Is(err, kes.ErrKeyNotFound) {
 				writeErrorResponse(ctx, w, toAPIError(ctx, errKMSKeyNotFound), r.URL)

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1067,7 +1067,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 					return
 				}
 			}
-			reader, objectEncryptionKey, err = newEncryptReader(hashReader, kind, keyID, key, bucket, object, metadata, kmsCtx)
+			reader, objectEncryptionKey, err = newEncryptReader(ctx, hashReader, kind, keyID, key, bucket, object, metadata, kmsCtx)
 			if err != nil {
 				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 				return

--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -136,7 +136,7 @@ func (sys *BucketMetadataSys) Update(ctx context.Context, bucket string, configF
 		meta.ReplicationConfigXML = configData
 		meta.ReplicationConfigUpdatedAt = updatedAt
 	case bucketTargetsFile:
-		meta.BucketTargetsConfigJSON, meta.BucketTargetsConfigMetaJSON, err = encryptBucketMetadata(meta.Name, configData, kms.Context{
+		meta.BucketTargetsConfigJSON, meta.BucketTargetsConfigMetaJSON, err = encryptBucketMetadata(ctx, meta.Name, configData, kms.Context{
 			bucket:            meta.Name,
 			bucketTargetsFile: bucketTargetsFile,
 		})

--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -438,7 +438,7 @@ func (b *BucketMetadata) migrateTargetConfig(ctx context.Context, objectAPI Obje
 		return nil
 	}
 
-	encBytes, metaBytes, err := encryptBucketMetadata(b.Name, b.BucketTargetsConfigJSON, kms.Context{b.Name: b.Name, bucketTargetsFile: bucketTargetsFile})
+	encBytes, metaBytes, err := encryptBucketMetadata(ctx, b.Name, b.BucketTargetsConfigJSON, kms.Context{b.Name: b.Name, bucketTargetsFile: bucketTargetsFile})
 	if err != nil {
 		return err
 	}
@@ -449,14 +449,14 @@ func (b *BucketMetadata) migrateTargetConfig(ctx context.Context, objectAPI Obje
 }
 
 // encrypt bucket metadata if kms is configured.
-func encryptBucketMetadata(bucket string, input []byte, kmsContext kms.Context) (output, metabytes []byte, err error) {
+func encryptBucketMetadata(ctx context.Context, bucket string, input []byte, kmsContext kms.Context) (output, metabytes []byte, err error) {
 	if GlobalKMS == nil {
 		output = input
 		return
 	}
 
 	metadata := make(map[string]string)
-	key, err := GlobalKMS.GenerateKey("", kmsContext)
+	key, err := GlobalKMS.GenerateKey(ctx, "", kmsContext)
 	if err != nil {
 		return
 	}

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -868,7 +868,7 @@ func handleKMSConfig() {
 		// This implicitly checks that we can communicate to KES. We don't treat
 		// a policy error as failure condition since MinIO may not have the permission
 		// to create keys - just to generate/decrypt data encryption keys.
-		if err = KMS.CreateKey(defaultKeyID); err != nil && !errors.Is(err, kes.ErrKeyExists) && !errors.Is(err, kes.ErrNotAllowed) {
+		if err = KMS.CreateKey(context.Background(), defaultKeyID); err != nil && !errors.Is(err, kes.ErrKeyExists) && !errors.Is(err, kes.ErrNotAllowed) {
 			logger.Fatal(err, "Unable to initialize a connection to KES as specified by the shell environment")
 		}
 		GlobalKMS = KMS

--- a/cmd/config-encrypted.go
+++ b/cmd/config-encrypted.go
@@ -70,7 +70,7 @@ func migrateIAMConfigsEtcdToEncrypted(ctx context.Context, client *etcd.Client) 
 	}
 
 	if encrypted && GlobalKMS != nil {
-		stat, err := GlobalKMS.Stat()
+		stat, err := GlobalKMS.Stat(ctx)
 		if err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func migrateConfigPrefixToEncrypted(objAPI ObjectLayer, encrypted bool) error {
 		return nil
 	}
 	if encrypted && GlobalKMS != nil {
-		stat, err := GlobalKMS.Stat()
+		stat, err := GlobalKMS.Stat(context.Background())
 		if err != nil {
 			return err
 		}

--- a/cmd/format-disk-cache.go
+++ b/cmd/format-disk-cache.go
@@ -359,7 +359,7 @@ func migrateCacheData(ctx context.Context, c *diskCache, bucket, object, oldfile
 
 	actualSize := uint64(st.Size())
 	if globalCacheKMS != nil {
-		reader, err = newCacheEncryptReader(readCloser, bucket, object, metadata)
+		reader, err = newCacheEncryptReader(ctx, readCloser, bucket, object, metadata)
 		if err != nil {
 			return err
 		}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1249,7 +1249,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 				}
 			}
 
-			if err = rotateKey(oldKey, newKeyID, newKey, srcBucket, srcObject, encMetadata, kmsCtx); err != nil {
+			if err = rotateKey(ctx, oldKey, newKeyID, newKey, srcBucket, srcObject, encMetadata, kmsCtx); err != nil {
 				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 				return
 			}
@@ -1287,7 +1287,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 			if isTargetEncrypted {
 				var encReader io.Reader
 				kind, _ := crypto.IsRequested(r.Header)
-				encReader, objEncKey, err = newEncryptReader(srcInfo.Reader, kind, newKeyID, newKey, dstBucket, dstObject, encMetadata, kmsCtx)
+				encReader, objEncKey, err = newEncryptReader(ctx, srcInfo.Reader, kind, newKeyID, newKey, dstBucket, dstObject, encMetadata, kmsCtx)
 				if err != nil {
 					writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 					return

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -287,7 +287,7 @@ func (config *TierConfigMgr) configReader() (*PutObjReader, *ObjectOptions, erro
 
 	// Encrypt json encoded tier configurations
 	metadata := make(map[string]string)
-	encBr, oek, err := newEncryptReader(hr, crypto.S3, "", nil, minioMetaBucket, tierConfigPath, metadata, kms.Context{})
+	encBr, oek, err := newEncryptReader(context.Background(), hr, crypto.S3, "", nil, minioMetaBucket, tierConfigPath, metadata, kms.Context{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/config/crypto.go
+++ b/internal/config/crypto.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
@@ -61,13 +62,13 @@ func DecryptBytes(KMS kms.KMS, ciphertext []byte, context kms.Context) ([]byte, 
 //
 // The same context must be provided when decrypting the
 // ciphertext.
-func Encrypt(KMS kms.KMS, plaintext io.Reader, context kms.Context) (io.Reader, error) {
+func Encrypt(KMS kms.KMS, plaintext io.Reader, ctx kms.Context) (io.Reader, error) {
 	algorithm := sio.AES_256_GCM
 	if !fips.Enabled && !sioutil.NativeAES() {
 		algorithm = sio.ChaCha20Poly1305
 	}
 
-	key, err := KMS.GenerateKey("", context)
+	key, err := KMS.GenerateKey(context.Background(), "", ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -30,13 +30,13 @@ import (
 // different KMS implementations.
 type KMS interface {
 	// Stat returns the current KMS status.
-	Stat() (Status, error)
+	Stat(cxt context.Context) (Status, error)
 
 	// Metrics returns a KMS metric snapshot.
 	Metrics(ctx context.Context) (kes.Metric, error)
 
 	// CreateKey creates a new key at the KMS with the given key ID.
-	CreateKey(keyID string) error
+	CreateKey(ctx context.Context, keyID string) error
 
 	// GenerateKey generates a new data encryption key using the
 	// key referenced by the key ID.
@@ -50,7 +50,7 @@ type KMS interface {
 	// should be decrypted. Therefore, it is the callers
 	// responsibility to remember the corresponding context for
 	// a particular DEK. The context may be nil.
-	GenerateKey(keyID string, context Context) (DEK, error)
+	GenerateKey(ctx context.Context, keyID string, context Context) (DEK, error)
 
 	// DecryptKey decrypts the ciphertext with the key referenced
 	// by the key ID. The context must match the context value

--- a/internal/kms/single-key.go
+++ b/internal/kms/single-key.go
@@ -83,7 +83,7 @@ const ( // algorithms used to derive and encrypt DEKs
 	algorithmChaCha20Poly1305 = "ChaCha20Poly1305"
 )
 
-func (kms secretKey) Stat() (Status, error) {
+func (kms secretKey) Stat(context.Context) (Status, error) {
 	return Status{
 		Name:       "SecretKey",
 		DefaultKey: kms.keyID,
@@ -94,11 +94,11 @@ func (secretKey) Metrics(ctx context.Context) (kes.Metric, error) {
 	return kes.Metric{}, errors.New("kms: metrics are not supported")
 }
 
-func (secretKey) CreateKey(string) error {
+func (secretKey) CreateKey(context.Context, string) error {
 	return errors.New("kms: creating keys is not supported")
 }
 
-func (kms secretKey) GenerateKey(keyID string, context Context) (DEK, error) {
+func (kms secretKey) GenerateKey(_ context.Context, keyID string, context Context) (DEK, error) {
 	if keyID == "" {
 		keyID = kms.keyID
 	}

--- a/internal/kms/single-key_test.go
+++ b/internal/kms/single-key_test.go
@@ -19,6 +19,7 @@ package kms
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"testing"
 )
@@ -29,7 +30,7 @@ func TestSingleKeyRoundtrip(t *testing.T) {
 		t.Fatalf("Failed to initialize KMS: %v", err)
 	}
 
-	key, err := KMS.GenerateKey("my-key", Context{})
+	key, err := KMS.GenerateKey(context.Background(), "my-key", Context{})
 	if err != nil {
 		t.Fatalf("Failed to generate key: %v", err)
 	}


### PR DESCRIPTION
## Description
This commit adds a `context.Context` to the
the KMS `{Stat, CreateKey, GenerateKey}` API
calls.

The context will be used to terminate external calls
as soon as the client requests gets canceled.

A follow-up PR will add a `context.Context` to
the remaining `DecryptKey` API call.

## Motivation and Context
KMS

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
