### PR TITLE
Bug: fix empty variable $USER

### DIFF
--- a/helm/minio/templates/_helper_create_user.txt
+++ b/helm/minio/templates/_helper_create_user.txt
@@ -59,9 +59,12 @@ createUser() {
     rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
     return 1
   fi
+
+  # Get username
+  USER=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
+
   # Create the user if it does not exist
   if ! checkUserExists ; then
-    USER=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
     echo "Creating user '$USER'"
     cat $MINIO_ACCESSKEY_SECRETKEY_TMP | ${MC} admin user add myminio
   else


### PR DESCRIPTION
## Description
There is a logic error in the script that creates MinIO users.
If the users are already exists, the script will end up in an error (_ and container CrashLoopBackOff_), because the variable `$USER` is empty. This is because the variable `$USER` is defined at the wrong place inside the function `createUser()`.

The else statement (line 67) and the if statement (line 74) fails because the variable `$USER` is defined in the if statement (`checkUserExists`, line 63) and not before.
In the logs you can see that the variable `$USER` is empty:
![image](https://user-images.githubusercontent.com/7498854/179516815-82e5538c-9b51-47c0-8ac8-6c46654bfccf.png)

## Motivation and Context
I am using the MinIO Helm Chart and my pipeline always fails when I run it (except the first time).

## How to test this PR?
- Deploy MinIO with the Helm Chart and create users, example (`<CONSOLE_ADMIN_PW>` & `<READWRITE_PW>` are placeholders):
```
helm upgrade --install minio minio/minio -n minio --set users[0].accessKey=console,users[0].secretKey=<CONSOLE_ADMIN_PW>,users[0].policy=consoleAdmin --set users[1].accessKey=readwrite,users[1].secretKey=<READWRITE_PW>,users[1].policy=readwrite
```
- After MinIO is deployed, run the same again and it should fail because the users already exists.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated


_This is my first pull request, so excuse me if i did something wrong and I know my english is not the best._ 😉
