### PR TITLE
Fix reused field crash

### DIFF
--- a/cmd/xl-storage-format-v2-legacy.go
+++ b/cmd/xl-storage-format-v2-legacy.go
@@ -83,6 +83,10 @@ func (j *xlMetaV2Version) unmarshalV(v uint8, bts []byte) (o []byte, err error) 
 	switch v {
 	// We accept un-set as latest version.
 	case 0, xlMetaVersion:
+		// Clear omitempty fields:
+		if j.ObjectV2 != nil && len(j.ObjectV2.PartIndices) > 0 {
+			j.ObjectV2.PartIndices = j.ObjectV2.PartIndices[:0]
+		}
 		o, err = j.UnmarshalMsg(bts)
 
 		// Clean up PartEtags on v1

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -575,7 +575,7 @@ func (j xlMetaV2Object) ToFileInfo(volume, path string) (FileInfo, error) {
 			fi.Parts[i].ETag = j.PartETags[i]
 		}
 		fi.Parts[i].ActualSize = j.PartActualSizes[i]
-		if len(j.PartIndices) > 0 {
+		if len(j.PartIndices) == len(fi.Parts) {
 			fi.Parts[i].Index = j.PartIndices[i]
 		}
 	}


### PR DESCRIPTION
## Description

`PartIndices` may be set if xlMetaV2Version is reused.

Clear before unmarshal and add sanity check when reading.

## Motivation and Context

Fix crash

## How to test this PR?

Multiple versions of an object is easiest. First one with indices. Second one with more parts, but no indices.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
