### PR TITLE
Allow site replication config with multiple IDPs

### DIFF
--- a/internal/config/identity/openid/openid.go
+++ b/internal/config/identity/openid/openid.go
@@ -515,7 +515,7 @@ func (r *Config) GetSettings() madmin.OpenIDSettings {
 			hashedSecret = base64.RawURLEncoding.EncodeToString(bs)
 		}
 		if arn != DummyRoleARN {
-			if res.Roles != nil {
+			if res.Roles == nil {
 				res.Roles = make(map[string]madmin.OpenIDProviderSettings)
 			}
 			res.Roles[arn.String()] = madmin.OpenIDProviderSettings{


### PR DESCRIPTION


## Description

Fixes a bug that did not let site replication be configured when
multiple IDPs are configured.


## How to test this PR?

Setup multiple IDPs for two minio clusters and try to add site replication configuration. This previously results in a failure, but should work now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
