### PR TITLE
fix: allow payload verification error to be returned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ lint: ## runs golangci-lint suite of linters
 check: test
 test: verifiers build ## builds minio, runs linters, tests
 	@echo "Running unit tests"
-	@CGO_ENABLED=0 go test -tags kqueue ./...
+	@MINIO_API_REQUESTS_MAX=10000 CGO_ENABLED=0 go test -tags kqueue ./...
 
 test-decom: install
 	@echo "Running minio decom tests"
@@ -58,9 +58,9 @@ test-race: verifiers build ## builds minio, runs linters, tests (race)
 
 test-iam: build ## verify IAM (external IDP, etcd backends)
 	@echo "Running tests for IAM (external IDP, etcd backends)"
-	@CGO_ENABLED=0 go test -tags kqueue -v -run TestIAM* ./cmd
+	@MINIO_API_REQUESTS_MAX=10000 CGO_ENABLED=0 go test -tags kqueue -v -run TestIAM* ./cmd
 	@echo "Running tests for IAM (external IDP, etcd backends) with -race"
-	@GORACE=history_size=7 CGO_ENABLED=1 go test -race -tags kqueue -v -run TestIAM* ./cmd
+	@MINIO_API_REQUESTS_MAX=10000 GORACE=history_size=7 CGO_ENABLED=1 go test -race -tags kqueue -v -run TestIAM* ./cmd
 
 test-replication: install ## verify multi site replication
 	@echo "Running tests for replicating three sites"

--- a/buildscripts/race.sh
+++ b/buildscripts/race.sh
@@ -3,6 +3,8 @@
 set -e
 
 export GORACE="history_size=7"
+export MINIO_API_REQUESTS_MAX=10000
+
 ## TODO remove `dsync` from race detector once this is merged and released https://go-review.googlesource.com/c/go/+/333529/
 for d in $(go list ./... | grep -v dsync); do
     CGO_ENABLED=1 go test -v -race --timeout 100m "$d"

--- a/internal/bucket/object/lock/lock.go
+++ b/internal/bucket/object/lock/lock.go
@@ -18,6 +18,7 @@
 package lock
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"errors"
@@ -529,8 +530,13 @@ func (l *ObjectLegalHold) IsEmpty() bool {
 
 // ParseObjectLegalHold decodes the XML into ObjectLegalHold
 func ParseObjectLegalHold(reader io.Reader) (hold *ObjectLegalHold, err error) {
+	buf, err := io.ReadAll(io.LimitReader(reader, maxObjectLockConfigSize))
+	if err != nil {
+		return nil, err
+	}
+
 	hold = &ObjectLegalHold{}
-	if err = xml.NewDecoder(reader).Decode(hold); err != nil {
+	if err = xml.NewDecoder(bytes.NewReader(buf)).Decode(hold); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION


## Description
fix: allow payload verification error to be returned

## Motivation and Context
without reading the reader the error is ignored
by the custom unmarshaller written by ObjectLegalHold
data structure.

## How to test this PR?
Send an invalid content-md5 with PutObjectLegalHold API, the payload 
validation will happen but the underlying error will be ignored. 

This PR fixes this behavior. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
