### PR TITLE
helm: fix regression of #15243

### DIFF
--- a/helm/minio/templates/_helper_create_user.txt
+++ b/helm/minio/templates/_helper_create_user.txt
@@ -93,7 +93,7 @@ connectToMinio $scheme
 {{- range .Values.users }}
 echo {{ tpl .accessKey $global }} > $MINIO_ACCESSKEY_SECRETKEY_TMP
 {{- if .existingSecret }}
-cat /config/secrets/{{ tpl .secretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+cat /config/secrets/{{ tpl .accessKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
 createUser {{ .policy }}
 {{ else }}
 echo {{ .secretKey }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP

--- a/helm/minio/templates/_helper_create_user.txt
+++ b/helm/minio/templates/_helper_create_user.txt
@@ -93,7 +93,7 @@ connectToMinio $scheme
 {{- range .Values.users }}
 echo {{ tpl .accessKey $global }} > $MINIO_ACCESSKEY_SECRETKEY_TMP
 {{- if .existingSecret }}
-cat /config/secrets/{{ tpl .accessKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+cat /config/secrets/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
 createUser {{ .policy }}
 {{ else }}
 echo {{ .secretKey }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP


### PR DESCRIPTION
The previous behavior was to use accessKey as secret key.

## Description


## Motivation and Context

#15243 broke my install with an error.

## How to test this PR?

```
  users:
  - accessKey: "foobar"
    existingSecret: minio-secretkeys-gitops
    existingSecretKey: "foobar"  # actually ignored
    policy: "readwrite_test"
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #15243 ab9544c0d34a825a31cdd9eb9e251ef7faa1f1a3
- [ ] Documentation updated
- [ ] Unit tests added/updated
