### PR TITLE
fix:wrapped_error_will_not_ignore

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -20,10 +20,8 @@ package logger
 import (
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"go/build"
-	"net/http"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -255,18 +253,9 @@ func LogAlwaysIf(ctx context.Context, err error, errKind ...interface{}) {
 // the execution of the server, if it is not an
 // ignored error.
 func LogIf(ctx context.Context, err error, errKind ...interface{}) {
-	if err == nil {
+	if logIgnoreError(err) {
 		return
 	}
-
-	if errors.Is(err, context.Canceled) {
-		return
-	}
-
-	if err.Error() == http.ErrServerClosed.Error() || err.Error() == "disk not found" {
-		return
-	}
-
 	logIf(ctx, err, errKind...)
 }
 

--- a/internal/logger/logonce.go
+++ b/internal/logger/logonce.go
@@ -19,8 +19,6 @@ package logger
 
 import (
 	"context"
-	"errors"
-	"net/http"
 	"sync"
 	"time"
 )
@@ -98,34 +96,16 @@ var logOnce = newLogOnceType()
 // id is a unique identifier for related log messages, refer to cmd/notification.go
 // on how it is used.
 func LogOnceIf(ctx context.Context, err error, id interface{}, errKind ...interface{}) {
-	if err == nil {
+	if logIgnoreError(err) {
 		return
 	}
-
-	if errors.Is(err, context.Canceled) {
-		return
-	}
-
-	if err.Error() == http.ErrServerClosed.Error() || err.Error() == "disk not found" {
-		return
-	}
-
 	logOnce.logOnceIf(ctx, err, id, errKind...)
 }
 
 // LogOnceConsoleIf - similar to LogOnceIf but exclusively only logs to console target.
 func LogOnceConsoleIf(ctx context.Context, err error, id interface{}, errKind ...interface{}) {
-	if err == nil {
+	if logIgnoreError(err) {
 		return
 	}
-
-	if errors.Is(err, context.Canceled) {
-		return
-	}
-
-	if err.Error() == http.ErrServerClosed.Error() || err.Error() == "disk not found" {
-		return
-	}
-
 	logOnce.logOnceConsoleIf(ctx, err, id, errKind...)
 }

--- a/internal/logger/utils.go
+++ b/internal/logger/utils.go
@@ -18,7 +18,10 @@
 package logger
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"runtime"
 
@@ -58,4 +61,9 @@ func ansiRestoreAttributes() {
 	if color.IsTerminal() {
 		ansiEscape("8")
 	}
+}
+
+// logIgnoreError if true,the error will ignore.
+func logIgnoreError(err error) bool {
+	return err == nil || errors.Is(err, context.Canceled) || errors.Is(err, http.ErrServerClosed) || err.Error() == "disk not found"
 }


### PR DESCRIPTION
## Description
Modify the original judgment method. When err is wrapped, the original way `err.Error() == http.ErrServerClosed.Error()` will fail. This is a bug.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
