### PR TITLE
[test]Add test case

### DIFF
--- a/cmd/server-startup-msg_test.go
+++ b/cmd/server-startup-msg_test.go
@@ -67,6 +67,13 @@ func TestStripStandardPorts(t *testing.T) {
 	if !reflect.DeepEqual(apiEndpoints, newAPIEndpoints) {
 		t.Fatalf("Expected %#v, got %#v", apiEndpoints, newAPIEndpoints)
 	}
+
+	apiEndpoints = []string{"https://127.0.0.1:443"}
+	expectedAPIEndpoints = []string{"https://127.0.0.1:443"}
+	newAPIEndpoints = stripStandardPorts(apiEndpoints, "")
+	if !reflect.DeepEqual(expectedAPIEndpoints, newAPIEndpoints) {
+		t.Fatalf("Expected %#v, got %#v", apiEndpoints, newAPIEndpoints)
+	}
 }
 
 // Test printing server common message.


### PR DESCRIPTION
## Description

As you can see from the comments, this function will cut the correct 80 or 443 address. The available tests do show this as well. But we can see that this function starts with a specific case that is ignored. So I think we need to add test cases to test if this particular scenario is as expected. So I added the use case where the scenario is the correct address and should be processed, but actually will not be processed.

## Motivation and Context

Add test case.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
