### PR TITLE
Add compression scheme to header

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -199,5 +199,12 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 		lc.SetPredictionHeaders(w, objInfo.ToLifecycleOpts())
 	}
 
+	if v, ok := objInfo.UserDefined[ReservedMetadataPrefix+"compression"]; ok {
+		if i := strings.LastIndexByte(v, '/'); i >= 0 {
+			v = v[i+1:]
+		}
+		w.Header()[xhttp.MinIOCompressed] = []string{v}
+	}
+
 	return nil
 }

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -187,6 +187,9 @@ const (
 	MinIOSourceObjectLegalHoldTimestamp = "X-Minio-Source-Replication-LegalHold-Timestamp"
 	// predicted date/time of transition
 	MinIOTransition = "X-Minio-Transition"
+
+	// MinIOCompressed is returned when object is compressed
+	MinIOCompressed = "X-Minio-Compressed"
 )
 
 // Common http query params S3 API


### PR DESCRIPTION
## Description

For easier debugging. We still do not return compressed size for security reasons.

## How to test this PR?

Look at returned headers.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
