### PR TITLE
feat: add object prefixes as a hint for Listing()

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/bpool"
 	"github.com/minio/minio/internal/dsync"
@@ -69,6 +70,8 @@ type erasureObjects struct {
 	bpOld *bpool.BytePoolCap
 
 	deletedCleanupSleeper *dynamicSleeper
+
+	listQuorumCache *lru.ARCCache
 }
 
 // NewNSLock - initialize a new namespace RWLocker instance.

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -780,7 +780,13 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions, resul
 
 	// get non-healing disks for listing
 	disks, _ := er.getOnlineDisksWithHealing()
-	askDisks := getListQuorum(o.AskDisks, er.setDriveCount)
+	var askDisks int
+	if er.listQuorumCache.Contains(o.BaseDir) {
+		askDisks = getListQuorum("drive", er.setDriveCount)
+	} else {
+		askDisks = getListQuorum(o.AskDisks, er.setDriveCount)
+	}
+
 	var fallbackDisks []StorageAPI
 
 	// Special case: ask all disks if the drive count is 4


### PR DESCRIPTION


## Description
feat: add object prefixes as a hint for Listing()

## Motivation and Context
this new feature optimizes listing at various prefixes
by listing a single disk when we are absolutely sure
that there are no quorum errors

## How to test this PR?
Nothing should change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
