### PR TITLE
Fix typo in json key for DeploymentID

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2654,7 +2654,7 @@ func checkConnection(endpointStr string, timeout time.Duration) error {
 }
 
 type clusterInfo struct {
-	DeploymentID string `json:"deployement_id"`
+	DeploymentID string `json:"deployment_id"`
 	ClusterName  string `json:"cluster_name"`
 	UsedCapacity uint64 `json:"used_capacity"`
 	Info         struct {


### PR DESCRIPTION
## Description

deployement_id -> deployment_id

## Motivation and Context

Bufgix

## How to test this PR?

- Generate a profile `mc support profile --type mem ALIAS`
- Extract the generated zip file
- Verify that the extracted file `cluster.info` contains the key `deployment_id` and not `deployement_id`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
