### PR TITLE
Download binary once and push it to other servers

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -356,8 +356,8 @@ func (sys *NotificationSys) DownloadProfilingData(ctx context.Context, writer io
 	return
 }
 
-// DownloadBinary - asks remote peers to download a new binary from the URL and to verify the checksum
-func (sys *NotificationSys) DownloadBinary(ctx context.Context, u *url.URL, sha256Sum []byte, releaseInfo string) []NotificationPeerErr {
+// VerifyBinary - asks remote peers to verify the checksum
+func (sys *NotificationSys) VerifyBinary(ctx context.Context, u *url.URL, sha256Sum []byte, releaseInfo string, reader []byte) []NotificationPeerErr {
 	ng := WithNPeers(len(sys.peerClients))
 	for idx, client := range sys.peerClients {
 		if client == nil {
@@ -365,7 +365,7 @@ func (sys *NotificationSys) DownloadBinary(ctx context.Context, u *url.URL, sha2
 		}
 		client := client
 		ng.Go(ctx, func() error {
-			return client.DownloadBinary(ctx, u, sha256Sum, releaseInfo)
+			return client.VerifyBinary(ctx, u, sha256Sum, releaseInfo, reader)
 		}, idx, *client.host)
 	}
 	return ng.Wait()

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -422,16 +422,18 @@ type binaryInfo struct {
 	URL         *url.URL
 	Sha256Sum   []byte
 	ReleaseInfo string
+	BinaryFile  []byte
 }
 
-// DownloadBinary - sends download binary message to remote peers.
-func (client *peerRESTClient) DownloadBinary(ctx context.Context, u *url.URL, sha256Sum []byte, releaseInfo string) error {
+// VerifyBinary - sends verify binary message to remote peers.
+func (client *peerRESTClient) VerifyBinary(ctx context.Context, u *url.URL, sha256Sum []byte, releaseInfo string, readerInput []byte) error {
 	values := make(url.Values)
 	var reader bytes.Buffer
 	if err := gob.NewEncoder(&reader).Encode(binaryInfo{
 		URL:         u,
 		Sha256Sum:   sha256Sum,
 		ReleaseInfo: releaseInfo,
+		BinaryFile:  readerInput,
 	}); err != nil {
 		return err
 	}

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -770,7 +770,7 @@ func (s *peerRESTServer) DownloadBinaryHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if err = downloadBinary(info.URL, info.Sha256Sum, info.ReleaseInfo, getMinioMode()); err != nil {
+	if err = verifyBinary(info.URL, info.Sha256Sum, info.ReleaseInfo, getMinioMode(), info.BinaryFile); err != nil {
 		s.writeErrorResponse(w, err)
 		return
 	}


### PR DESCRIPTION
## Description

To reduce network traffic by downloading binary once and then pushing the downloaded binary to other servers.

## Motivation and Context

To reduce network traffic to https://dl.min.io/server/minio/release/ specially when we have many MinIO Servers running together in a cluster.

## How to test this PR?

Have MinIO Servers in distributed mode, then via mc command update servers:

```sh
mc alias set myminio http://192.168.0.13:9000 minio minio123
mc admin update myminio
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
