### PR TITLE
Do not update directory access time

### DIFF
--- a/cmd/os_unix.go
+++ b/cmd/os_unix.go
@@ -232,7 +232,7 @@ func readDirFn(dirPath string, fn func(name string, typ os.FileMode) error) erro
 // Return count entries at the directory dirPath and all entries
 // if count is set to -1
 func readDirWithOpts(dirPath string, opts readDirOpts) (entries []string, err error) {
-	f, err := Open(dirPath)
+	f, err := OpenFile(dirPath, readMode, 0)
 	if err != nil {
 		return nil, osErrToFileErr(err)
 	}


### PR DESCRIPTION
## Description
Most setups will have reltime which only updates access time after a
change in the directory but this can still be beneficial.

## Motivation and Context
Avoid updating dir access time 

## How to test this PR?
1. Run a MinIO distributed setup
2. Create a bucket, upload a file in a prefix, check the prefix access time using stat command, upload a new file in the same prefix, check the access time again

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
