### PR TITLE
fix: regression in resolving the right versions

### DIFF
--- a/buildscripts/resolve-right-versions.sh
+++ b/buildscripts/resolve-right-versions.sh
@@ -39,7 +39,7 @@ function start_minio_5drive() {
     "${MINIO[@]}" --address ":$start_port" "${WORK_DIR}/cicd-corpus/disk{1...5}" > "${WORK_DIR}/server1.log" 2>&1 &
     pid=$!
     disown $pid
-    sleep 30
+    sleep 5
 
     if ! ps -p ${pid} 1>&2 >/dev/null; then
 	echo "server1 log:"


### PR DESCRIPTION


## Description
fix: regression in resolving the right versions

## Motivation and Context
commit d480022711 caused a regression in real
resolver, by picking up incorrect versionID.

## How to test this PR?
Tests already cover this case, however, we need to
fix `mc` so that it can fail when server returns '503'

For that we need a fix https://github.com/minio/mc/pull/4172 this 
is why this regression was missed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
