### PR TITLE
fix: allow P-384/P-512 constant time implementation

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -86,8 +86,6 @@ Alternatively, use the following command to generate a private ECDSA key protect
 openssl ecparam -genkey -name prime256v1 | openssl ec -aes256 -out private.key -passout pass:PASSWORD
 ```
 
-**Note:** NIST curves P-384 and P-521 are not currently supported.
-
 #### 3.2.2 Generate a private key with RSA
 
 Use the following command to generate a private key with RSA:

--- a/internal/config/certs.go
+++ b/internal/config/certs.go
@@ -19,8 +19,6 @@ package config
 
 import (
 	"bytes"
-	"crypto"
-	"crypto/ecdsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -102,19 +100,6 @@ func LoadX509KeyPair(certFile, keyFile string) (tls.Certificate, error) {
 	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
 	if err != nil {
 		return tls.Certificate{}, ErrSSLUnexpectedData(nil).Msg(err.Error())
-	}
-	// Ensure that the private key is not a P-384 or P-521 EC key.
-	// The Go TLS stack does not provide constant-time implementations of P-384 and P-521.
-	if priv, ok := cert.PrivateKey.(crypto.Signer); ok {
-		if pub, ok := priv.Public().(*ecdsa.PublicKey); ok {
-			switch pub.Params().Name {
-			case "P-384":
-				fallthrough
-			case "P-521":
-				// unfortunately there is no cleaner way to check
-				return tls.Certificate{}, ErrSSLUnexpectedData(nil).Msg("tls: the ECDSA curve '%s' is not supported", pub.Params().Name)
-			}
-		}
 	}
 	return cert, nil
 }


### PR DESCRIPTION

## Description
fix: allow P-384/P-512 constant time

## Motivation and Context
since go1.18.x P-384/P-512 are now constant time
implementations, enable them.

## How to test this PR?
Nothing special 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
