### PR TITLE
Fix resetting a config with a non default target name

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -836,10 +836,6 @@ func GetSubSys(s string) (subSys string, inputs []string, tgt string, e error) {
 		return subSys, inputs, tgt, Errorf("unknown sub-system %s", s)
 	}
 
-	if len(inputs) == 1 {
-		return subSys, inputs, tgt, nil
-	}
-
 	if SubSystemsSingleTargets.Contains(subSystemValue[0]) && len(subSystemValue) == 2 {
 		return subSys, inputs, tgt, Errorf("sub-system '%s' only supports single target", subSystemValue[0])
 	}


### PR DESCRIPTION
## Description
mc admin config reset <alias> notify_webhook:something was not working
properly.

The reason is that GetSubSys() was not calculating the target
name properly because it is quitting early when the number of config
inputs ('notify_webhook:something' in this case) is equal to 1.

This commit will make the code calculates always calculate the target
name if found.

## Motivation and Context
Fix resetting a target with a name

## How to test this PR?
```
mc admin config set myminio notify_webhook:abcd endpoint=http://localhost:8080
mc admin config reset myminio notify_webhook:abcd
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
