### PR TITLE
fix: intrument os.OpenFile differently for Reads and Writes

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -535,7 +535,7 @@ func parsEnvEntry(envEntry string) (envKV, error) {
 // the environment values from a file, in the form "key, value".
 // in a structured form.
 func minioEnvironFromFile(envConfigFile string) ([]envKV, error) {
-	f, err := os.Open(envConfigFile)
+	f, err := Open(envConfigFile)
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +916,7 @@ func getTLSConfig() (x509Certs []*x509.Certificate, manager *certs.Manager, secu
 	// Therefore, we read all filenames in the cert directory and check
 	// for each directory whether it contains a public.crt and private.key.
 	// If so, we try to add it to certificate manager.
-	root, err := os.Open(globalCertsDir.Get())
+	root, err := Open(globalCertsDir.Get())
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -935,7 +935,7 @@ func getTLSConfig() (x509Certs []*x509.Certificate, manager *certs.Manager, secu
 			continue
 		}
 		if file.Mode()&os.ModeSymlink == os.ModeSymlink {
-			file, err = os.Stat(filepath.Join(root.Name(), file.Name()))
+			file, err = Stat(filepath.Join(root.Name(), file.Name()))
 			if err != nil {
 				// not accessible ignore
 				continue

--- a/cmd/data-update-tracker.go
+++ b/cmd/data-update-tracker.go
@@ -227,7 +227,7 @@ func (d *dataUpdateTracker) load(ctx context.Context, drives ...string) {
 	for _, drive := range drives {
 
 		cacheFormatPath := pathJoin(drive, dataUpdateTrackerFilename)
-		f, err := os.Open(cacheFormatPath)
+		f, err := OpenFile(cacheFormatPath, readMode, 0o666)
 		if err != nil {
 			if osIsNotExist(err) {
 				continue

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -37,7 +37,8 @@ const (
 	osMetricMkdirAll
 	osMetricMkdir
 	osMetricRename
-	osMetricOpenFile
+	osMetricOpenFileW
+	osMetricOpenFileR
 	osMetricOpen
 	osMetricOpenFileDirectIO
 	osMetricLstat
@@ -135,7 +136,12 @@ func Rename(src, dst string) error {
 
 // OpenFile captures time taken to call os.OpenFile
 func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
-	defer updateOSMetrics(osMetricOpenFile, name)()
+	switch flag & writeMode {
+	case writeMode:
+		defer updateOSMetrics(osMetricOpenFileW, name)()
+	default:
+		defer updateOSMetrics(osMetricOpenFileR, name)()
+	}
 	return os.OpenFile(name, flag, perm)
 }
 

--- a/cmd/osmetric_string.go
+++ b/cmd/osmetric_string.go
@@ -12,23 +12,24 @@ func _() {
 	_ = x[osMetricMkdirAll-1]
 	_ = x[osMetricMkdir-2]
 	_ = x[osMetricRename-3]
-	_ = x[osMetricOpenFile-4]
-	_ = x[osMetricOpen-5]
-	_ = x[osMetricOpenFileDirectIO-6]
-	_ = x[osMetricLstat-7]
-	_ = x[osMetricRemove-8]
-	_ = x[osMetricStat-9]
-	_ = x[osMetricAccess-10]
-	_ = x[osMetricCreate-11]
-	_ = x[osMetricReadDirent-12]
-	_ = x[osMetricFdatasync-13]
-	_ = x[osMetricSync-14]
-	_ = x[osMetricLast-15]
+	_ = x[osMetricOpenFileW-4]
+	_ = x[osMetricOpenFileR-5]
+	_ = x[osMetricOpen-6]
+	_ = x[osMetricOpenFileDirectIO-7]
+	_ = x[osMetricLstat-8]
+	_ = x[osMetricRemove-9]
+	_ = x[osMetricStat-10]
+	_ = x[osMetricAccess-11]
+	_ = x[osMetricCreate-12]
+	_ = x[osMetricReadDirent-13]
+	_ = x[osMetricFdatasync-14]
+	_ = x[osMetricSync-15]
+	_ = x[osMetricLast-16]
 }
 
-const _osMetric_name = "RemoveAllMkdirAllMkdirRenameOpenFileOpenOpenFileDirectIOLstatRemoveStatAccessCreateReadDirentFdatasyncSyncLast"
+const _osMetric_name = "RemoveAllMkdirAllMkdirRenameOpenFileWOpenFileROpenOpenFileDirectIOLstatRemoveStatAccessCreateReadDirentFdatasyncSyncLast"
 
-var _osMetric_index = [...]uint8{0, 9, 17, 22, 28, 36, 40, 56, 61, 67, 71, 77, 83, 93, 102, 106, 110}
+var _osMetric_index = [...]uint8{0, 9, 17, 22, 28, 37, 46, 50, 66, 71, 77, 81, 87, 93, 103, 112, 116, 120}
 
 func (i osMetric) String() string {
 	if i >= osMetric(len(_osMetric_index)-1) {

--- a/cmd/tier-journal.go
+++ b/cmd/tier-journal.go
@@ -237,7 +237,7 @@ func (jd *tierDiskJournal) Open() error {
 	}
 
 	var err error
-	jd.file, err = os.OpenFile(jd.JournalPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY|writeMode, 0o666)
+	jd.file, err = OpenFile(jd.JournalPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY|writeMode, 0o666)
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func (jd *tierDiskJournal) Open() error {
 }
 
 func (jd *tierDiskJournal) OpenRO() (io.ReadCloser, error) {
-	file, err := os.Open(jd.ReadOnlyPath())
+	file, err := Open(jd.ReadOnlyPath())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -181,7 +181,7 @@ func IsBOSH() bool {
 // Check if this is Helm package installation and report helm chart version
 func getHelmVersion(helmInfoFilePath string) string {
 	// Read the file exists.
-	helmInfoFile, err := os.Open(helmInfoFilePath)
+	helmInfoFile, err := Open(helmInfoFilePath)
 	if err != nil {
 		// Log errors and return "" as MinIO can be deployed
 		// without Helm charts as well.

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -394,7 +394,7 @@ func (s *xlStorage) readMetadataWithDMTime(ctx context.Context, itemPath string)
 		return nil, time.Time{}, err
 	}
 
-	f, err := OpenFile(itemPath, readMode, 0)
+	f, err := OpenFile(itemPath, readMode, 0o666)
 	if err != nil {
 		return nil, time.Time{}, err
 	}
@@ -1547,7 +1547,7 @@ func (s *xlStorage) ReadFile(ctx context.Context, volume string, path string, of
 	}
 
 	// Open the file for reading.
-	file, err := Open(filePath)
+	file, err := OpenFile(filePath, readMode, 0o666)
 	if err != nil {
 		switch {
 		case osIsNotExist(err):
@@ -2515,7 +2515,7 @@ func (s *xlStorage) RenameFile(ctx context.Context, srcVolume, srcPath, dstVolum
 
 func (s *xlStorage) bitrotVerify(ctx context.Context, partPath string, partSize int64, algo BitrotAlgorithm, sum []byte, shardSize int64) error {
 	// Open the file for reading.
-	file, err := Open(partPath)
+	file, err := OpenFile(partPath, readMode, 0o666)
 	if err != nil {
 		return osErrToFileErr(err)
 	}


### PR DESCRIPTION
## Description
fix: intrument os.OpenFile differently for Reads and Writes

## Motivation and Context
allows us to trace latency for READs or WRITEs

## How to test this PR?
Nothing special just observe `mc admin trace -a alias/` and 
look for Read side calls v/s WRITE side calls for os.OpenFile()

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
