### PR TITLE
Add env variables to configuration APIs output

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -508,8 +508,7 @@ func parsEnvEntry(envEntry string) (envKV, error) {
 			Skip: true,
 		}, nil
 	}
-	const envSeparator = "="
-	envTokens := strings.SplitN(strings.TrimSpace(strings.TrimPrefix(envEntry, "export")), envSeparator, 2)
+	envTokens := strings.SplitN(strings.TrimSpace(strings.TrimPrefix(envEntry, "export")), config.EnvSeparator, 2)
 	if len(envTokens) != 2 {
 		return envKV{}, fmt.Errorf("envEntry malformed; %s, expected to be of form 'KEY=value'", envEntry)
 	}


### PR DESCRIPTION
## Description

Config export and config get APIs now include environment variables set on the server

## Motivation and Context

Allow admin users to view env vars set on the server through `mc`

## How to test this PR?

See output of `mc admin config export` and `mc admin config get` with some env vars set.

Sample output:

```shell
$ mc admin config get myminio identity_openid
# MINIO_IDENTITY_OPENID_CONFIG_URL=http://localhost:5556/dex/.well-known/openid-configuration
# MINIO_IDENTITY_OPENID_CLIENT_ID=minio-client-app
# MINIO_IDENTITY_OPENID_CLIENT_SECRET=minio-client-app-secret
# MINIO_IDENTITY_OPENID_CLAIM_NAME=groups
# MINIO_IDENTITY_OPENID_REDIRECT_URI=http://127.0.0.1:10000/oauth_callback
# MINIO_IDENTITY_OPENID_SCOPES=openid,groups
identity_openid enable= display_name= config_url= client_id= client_secret= claim_name=policy claim_userinfo= role_policy= claim_prefix= redirect_uri= redirect_uri_dynamic=off scopes= 
identity_openid:dextest display_name="Login via dex2" config_url=http://localhost:5556/dex/.well-known/openid-configuration client_id=minio-client-app client_secret=minio-client-app-secret claim_name=policy claim_userinfo= role_policy=consoleAdmin claim_prefix= redirect_uri=http://127.0.0.1:10000/oauth_callback redirect_uri_dynamic=off scopes=openid,groups 

```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
