### PR TITLE
fix: decodeDirObject() in single drive DeleteObjects() call

### DIFF
--- a/cmd/erasure-single-drive.go
+++ b/cmd/erasure-single-drive.go
@@ -1310,12 +1310,12 @@ func (es *erasureSingle) DeleteObjects(ctx context.Context, bucket string, objec
 				DeleteMarker:          vr.Deleted,
 				DeleteMarkerVersionID: vr.VersionID,
 				DeleteMarkerMTime:     DeleteMarkerMTime{vr.ModTime},
-				ObjectName:            vr.Name,
+				ObjectName:            decodeDirObject(vr.Name),
 				ReplicationState:      vr.ReplicationState,
 			}
 		} else {
 			dobjects[i] = DeletedObject{
-				ObjectName:       vr.Name,
+				ObjectName:       decodeDirObject(vr.Name),
 				VersionID:        vr.VersionID,
 				ReplicationState: vr.ReplicationState,
 			}


### PR DESCRIPTION
## Description
fix: decodeDirObject() in single drive DeleteObjects() call

## Motivation and Context
Thanks to @bh4t for reproducing this issue.

## How to test this PR?
```
mc mb alias/bucket/folder/
mc rm alias/bucket/folder/
```

Returns `__XLDIR__` without this fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
