### PR TITLE
helm fix: add a new line to the end of the credentials file when creating a user

### DIFF
--- a/helm/minio/templates/_helper_create_user.txt
+++ b/helm/minio/templates/_helper_create_user.txt
@@ -94,6 +94,8 @@ connectToMinio $scheme
 echo {{ tpl .accessKey $global }} > $MINIO_ACCESSKEY_SECRETKEY_TMP
 {{- if .existingSecret }}
 cat /config/secrets/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+# Add a new line if it doesn't exist
+sed -i '$a\' $MINIO_ACCESSKEY_SECRETKEY_TMP
 createUser {{ .policy }}
 {{ else }}
 echo {{ .secretKey }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP


### PR DESCRIPTION
## Description
When the access and secret key are appended to `/tmp/accessKey_and_secretKey_tmp` there is no new line at the end of the file. For this reason the following condition failed:

```
if [[ $(cat $MINIO_ACCESSKEY_SECRETKEY_TMP|wc -l) -ne 2 ]]
```

I added a new line using:

```
sed -i '$a\' $MINIO_ACCESSKEY_SECRETKEY_TMP
```

which only appends the line if it does not already exist.

## Motivation and Context
This PR fixes #15480 

## How to test this PR?
Install the helm chart with at least one user defined and watch the create-user job.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
