### PR TITLE
restrict number of disks used for scanning buckets upto GOMAXPROCS

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -438,6 +439,13 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, bf
 	// that objects that are not present in all disks are accounted and ILM applied.
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	r.Shuffle(len(disks), func(i, j int) { disks[i], disks[j] = disks[j], disks[i] })
+
+	// Restrict parallelism for disk usage scanner
+	// upto GOMAXPROCS if GOMAXPROCS is < len(disks)
+	maxProcs := runtime.GOMAXPROCS(0)
+	if maxProcs < len(disks) {
+		disks = disks[:maxProcs]
+	}
 
 	// Start one scanner per disk
 	var wg sync.WaitGroup

--- a/internal/config/scanner/scanner.go
+++ b/internal/config/scanner/scanner.go
@@ -52,11 +52,11 @@ type Config struct {
 var DefaultKVS = config.KVS{
 	config.KV{
 		Key:   Delay,
-		Value: "10",
+		Value: "2",
 	},
 	config.KV{
 		Key:   MaxWait,
-		Value: "15s",
+		Value: "5s",
 	},
 	config.KV{
 		Key:   Cycle,


### PR DESCRIPTION
## Description
restrict number of disks used for scanning buckets upto GOMAXPROCS

## Motivation and Context
control scanner parallelism to avoid higher CPU
usage on nodes that have more drives but an old CPU.

## How to test this PR?
Nothing specific but have 40 drives locally and 40 buckets you
can observe the "CPU" usage by MinIO. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
