### PR TITLE
helm: Support adding objectlocking for buckets

### DIFF
--- a/helm/minio/templates/_helper_create_bucket.txt
+++ b/helm/minio/templates/_helper_create_bucket.txt
@@ -50,6 +50,7 @@ createBucket() {
   POLICY=$2
   PURGE=$3
   VERSIONING=$4
+  OBJECTLOCKING=$5
 
   # Purge the bucket, if set & exists
   # Since PURGE is user input, check explicitly for `true`
@@ -64,21 +65,28 @@ createBucket() {
     fi
   fi
 
-  # Create the bucket if it does not exist
+  # Create the bucket if it does not exist and set objectlocking if enabled
   if ! checkBucketExists $BUCKET ; then
+    if [ ! -z $OBJECTLOCKING ] ; then
+      if [ $OBJECTLOCKING = true ] ; then
+          echo "Creating bucket with OBJECTLOCKING '$BUCKET'"
+          ${MC} mb --with-lock myminio/$BUCKET
+      elif [ $OBJECTLOCKING = false ] ; then
     echo "Creating bucket '$BUCKET'"
     ${MC} mb myminio/$BUCKET
+    fi
   else
     echo "Bucket '$BUCKET' already exists."
+  fi
   fi
 
 
   # set versioning for bucket
   if [ ! -z $VERSIONING ] ; then
-    if [ $VERSIONING = true ] ; then
+    if [ $VERSIONING = true ] && [ $OBJECTLOCKING = false ] ; then
         echo "Enabling versioning for '$BUCKET'"
         ${MC} version enable myminio/$BUCKET
-    elif [ $VERSIONING = false ] ; then
+    elif [ $VERSIONING = false ] && [ $OBJECTLOCKING = false ] ; then
         echo "Suspending versioning for '$BUCKET'"
         ${MC} version suspend myminio/$BUCKET
     fi
@@ -104,6 +112,6 @@ connectToMinio $scheme
 {{ $global := . }}
 # Create the buckets
 {{- range .Values.buckets }}
-createBucket {{ tpl .name $global }} {{ .policy }} {{ .purge }} {{ .versioning }}
+createBucket {{ tpl .name $global }} {{ .policy }} {{ .purge }} {{ .versioning }} {{ .objectlocking }}
 {{- end }}
 {{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -362,10 +362,16 @@ buckets:
   #   # set versioning for
   #   # bucket [true|false]
   #   versioning: false
+  #   # set objectlocking for
+  #   # bucket [true|false] NOTE: versioning is enabled by default if you use locking 
+  #   objectlocking: false
   # - name: bucket2
   #   policy: none
   #   purge: false
   #   versioning: true
+  #   # set objectlocking for
+  #   # bucket [true|false] NOTE: versioning is enabled by default if you use locking 
+  #   objectlocking: false
 
 ## Additional Annotations for the Kubernetes Job makeBucketJob
 makeBucketJob:


### PR DESCRIPTION
This PR submits the feature to enable locking during bucket creation.
With object locking enabled, the bucket will also have versioning enabled, which is the default behavior after you enable locking.


## Description
i wanted to have object locking active for buckets, with that you can also configure retention policy and cleanup your buckets from time to time.

## Motivation and Context
with object locking enabled, you can configure retention policy which we wanted in order to clean up buckets automated.


## How to test this PR?
Set in your values.yml the wished parameter, in this case 
```
  #   # set objectlocking for
  #   # bucket [true|false] NOTE: versioning is enabled by default if you use locking 
  #   objectlocking: false
  
  ```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [/] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated