### PR TITLE
feat: add idempotent delete marker support

### DIFF
--- a/.github/workflows/go-fips.yml
+++ b/.github/workflows/go-fips.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.17.11b7, 1.18.3b7]
+        go-version: [1.18.5b7]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -452,9 +452,7 @@ func (er erasureObjects) deleteIfDangling(ctx context.Context, bucket, object st
 			VersionID: m.VersionID,
 		}
 		if opts.VersionID != "" {
-			fi = FileInfo{
-				VersionID: opts.VersionID,
-			}
+			fi.VersionID = opts.VersionID
 		}
 
 		disks := er.getDisks()
@@ -1445,7 +1443,6 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 	}
 
 	objInfo = ObjectInfo{VersionID: opts.VersionID} // version id needed in Delete API response.
-	goi := opts.CurrentObjInfo
 	defer NSUpdated(bucket, object)
 
 	storageDisks := er.getDisks()
@@ -1477,13 +1474,10 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 		}
 	}
 
-	versionFound := true
-	if goi.Name == "" && opts.DeleteMarker {
-		versionFound = false
-	}
+	versionFound := !(opts.DeleteMarker && opts.VersionID != "")
 
 	// Determine whether to mark object deleted for replication
-	markDelete := opts.VersionID != ""
+	markDelete := !opts.DeleteMarker && opts.VersionID != ""
 
 	// Default deleteMarker to true if object is under versioning
 	// versioning suspended means we add `null` version as

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1448,15 +1448,6 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 	goi := opts.CurrentObjInfo
 	defer NSUpdated(bucket, object)
 
-	// Acquire a write lock before deleting the object.
-	lk := er.NewNSLock(bucket, object)
-	lkctx, err := lk.GetLock(ctx, globalDeleteOperationTimeout)
-	if err != nil {
-		return ObjectInfo{}, err
-	}
-	ctx = lkctx.Context()
-	defer lk.Unlock(lkctx.Cancel)
-
 	storageDisks := er.getDisks()
 
 	if opts.Expiration.Expire {

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -82,11 +82,6 @@ type ObjectOptions struct {
 	WalkAscending   bool                     // return Walk results in ascending order of versions
 	PrefixEnabledFn func(prefix string) bool // function which returns true if versioning is enabled on prefix
 
-	// CurrentObjInfo carries ObjInfo specific to object on a pool
-	// this is mainly used as an optimization to avoid calling multiple
-	// times xl.meta
-	CurrentObjInfo ObjectInfo
-
 	// IndexCB will return any index created but the compression.
 	// Object must have been read at this point.
 	IndexCB func() []byte

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -82,6 +82,11 @@ type ObjectOptions struct {
 	WalkAscending   bool                     // return Walk results in ascending order of versions
 	PrefixEnabledFn func(prefix string) bool // function which returns true if versioning is enabled on prefix
 
+	// CurrentObjInfo carries ObjInfo specific to object on a pool
+	// this is mainly used as an optimization to avoid calling multiple
+	// times xl.meta
+	CurrentObjInfo ObjectInfo
+
 	// IndexCB will return any index created but the compression.
 	// Object must have been read at this point.
 	IndexCB func() []byte

--- a/docs/bucket/replication/setup_2site_existing_replication.sh
+++ b/docs/bucket/replication/setup_2site_existing_replication.sh
@@ -97,7 +97,7 @@ count=$(./mc replicate resync status sitea/bucket --remote-bucket "${remote_arn}
 out=$(diff -qpruN /tmp/sitea.txt /tmp/siteb.txt)
 ret=$?
 if [ $ret -ne 0 ]; then
-    echo "BUG: expected no missing entries after decommission: $out"
+    echo "BUG: expected no missing entries after replication: $out"
     exit 1
 fi
 

--- a/docs/bucket/replication/setup_2site_existing_replication.sh
+++ b/docs/bucket/replication/setup_2site_existing_replication.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 trap 'catch $LINENO' ERR
 
 # shellcheck disable=SC2120
@@ -37,8 +39,10 @@ unset MINIO_KMS_KES_KEY_FILE
 unset MINIO_KMS_KES_ENDPOINT
 unset MINIO_KMS_KES_KEY_NAME
 
-wget -O mc https://dl.minio.io/client/mc/release/linux-amd64/mc \
-    && chmod +x mc
+if [ ! -f ./mc ]; then
+    wget --quiet -O mc https://dl.minio.io/client/mc/release/linux-amd64/mc && \
+        chmod +x mc
+fi
 
 minio server --address 127.0.0.1:9001 "http://127.0.0.1:9001/tmp/multisitea/data/disterasure/xl{1...4}" \
       "http://127.0.0.1:9002/tmp/multisitea/data/disterasure/xl{5...8}" >/tmp/sitea_1.log 2>&1 &
@@ -66,6 +70,9 @@ done
 ./mc mirror /tmp/data sitea/bucket/
 ./mc version enable sitea/bucket
 
+./mc cp /tmp/data/file_1.txt sitea/bucket/marker
+./mc rm sitea/bucket/marker
+
 ./mc mb siteb/bucket/
 ./mc version enable siteb/bucket/
 
@@ -83,11 +90,49 @@ sleep 1
 sleep 10s ## sleep for 10s idea is that we give 100ms per object.
 
 count=$(./mc replicate resync status sitea/bucket --remote-bucket "${remote_arn}" --json | jq .resyncInfo.target[].replicationCount)
-./mc ls --versions sitea/bucket
-./mc ls --versions siteb/bucket
-if [ $count -ne 10 ]; then
-    echo "resync not complete after 100s unexpected failure"
+
+./mc ls -r --versions sitea/bucket > /tmp/sitea.txt
+./mc ls -r --versions siteb/bucket > /tmp/siteb.txt
+
+out=$(diff -qpruN /tmp/sitea.txt /tmp/siteb.txt)
+ret=$?
+if [ $ret -ne 0 ]; then
+    echo "BUG: expected no missing entries after decommission: $out"
+    exit 1
+fi
+
+if [ $count -ne 12 ]; then
+    echo "resync not complete after 10s unexpected failure"
     ./mc diff sitea/bucket siteb/bucket
+    exit 1
+fi
+
+./mc cp /tmp/data/file_1.txt sitea/bucket/marker_new
+./mc rm sitea/bucket/marker_new
+
+sleep 12s ## sleep for 12s idea is that we give 100ms per object.
+
+./mc ls -r --versions sitea/bucket > /tmp/sitea.txt
+./mc ls -r --versions siteb/bucket > /tmp/siteb.txt
+
+out=$(diff -qpruN /tmp/sitea.txt /tmp/siteb.txt)
+ret=$?
+if [ $ret -ne 0 ]; then
+    echo "BUG: expected no 'diff' after replication: $out"
+    exit 1
+fi
+
+./mc rm -r --force --versions sitea/bucket/marker
+sleep 14s ## sleep for 14s idea is that we give 100ms per object.
+
+./mc ls -r --versions sitea/bucket > /tmp/sitea.txt
+./mc ls -r --versions siteb/bucket > /tmp/siteb.txt
+
+out=$(diff -qpruN /tmp/sitea.txt /tmp/siteb.txt)
+ret=$?
+if [ $ret -ne 0 ]; then
+    echo "BUG: expected no 'diff' after replication: $out"
+    exit 1
 fi
 
 catch

--- a/docs/bucket/replication/setup_3site_replication.sh
+++ b/docs/bucket/replication/setup_3site_replication.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ -n "$TEST_DEBUG" ]; then
+    set -x
+fi
+
 trap 'catch $LINENO' ERR
 
 # shellcheck disable=SC2120


### PR DESCRIPTION
## Description
feat: add idempotent delete marker support

## Motivation and Context
Bottom line is delete markers are a nuisance,
most applications are not version aware and this
has simply complicated the version management.

AWS S3 gave an unnecessary complication overhead
for customers, they need to now manage these
markers by applying ILM settings and to clean
them up on a regular basis.

To make matters worse all these delete markers
get replicated as well in a replicated setup,
requiring two ILM settings on each site.

This PR is an attempt to address this inferior
implementation by deviating MinIO towards an
idempotent delete marker implementation i.e
MinIO will never create no more than single
consecutive delete markers.

This significantly reduces operational overhead
by making versioning more useful for real data.

This is a spec deviation with pragmatic reasons.

## How to test this PR?
Unit tests should cover it

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [x] Unit tests added/updated
