### PR TITLE
Fix env var output in config get/export APIs

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -436,24 +436,24 @@ func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Reques
 		cfgSubsysItems, _ := cfg.GetSubsysInfo(hkv.Key)
 
 		for _, item := range cfgSubsysItems {
-			off := item.Params.Get(config.Enable) == config.EnableOff
+			off := item.Config.Get(config.Enable) == config.EnableOff
 			switch hkv.Key {
 			case config.EtcdSubSys:
-				off = !etcd.Enabled(item.Params)
+				off = !etcd.Enabled(item.Config)
 			case config.CacheSubSys:
-				off = !cache.Enabled(item.Params)
+				off = !cache.Enabled(item.Config)
 			case config.StorageClassSubSys:
-				off = !storageclass.Enabled(item.Params)
+				off = !storageclass.Enabled(item.Config)
 			case config.PolicyPluginSubSys:
-				off = !polplugin.Enabled(item.Params)
+				off = !polplugin.Enabled(item.Config)
 			case config.IdentityOpenIDSubSys:
-				off = !openid.Enabled(item.Params)
+				off = !openid.Enabled(item.Config)
 			case config.IdentityLDAPSubSys:
-				off = !xldap.Enabled(item.Params)
+				off = !xldap.Enabled(item.Config)
 			case config.IdentityTLSSubSys:
 				off = !globalSTSTLSConfig.Enabled
 			case config.IdentityPluginSubSys:
-				off = !idplugin.Enabled(item.Params)
+				off = !idplugin.Enabled(item.Config)
 			}
 			item.AddString(&s, off)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1217,7 +1217,8 @@ type EnvPair struct {
 // SubsysInfo holds config info for a subsystem target.
 type SubsysInfo struct {
 	SubSys, Target string
-	Params         KVS
+	Defaults       KVS
+	Config         KVS
 
 	// map of config parameter name to EnvPair.
 	EnvMap map[string]EnvPair
@@ -1248,10 +1249,11 @@ func (c Config) GetSubsysInfo(subSys string) ([]SubsysInfo, error) {
 	for _, target := range targets {
 		kvs := c.getTargetKVS(subSys, target)
 		cs := SubsysInfo{
-			SubSys: subSys,
-			Target: target,
-			Params: kvs,
-			EnvMap: make(map[string]EnvPair),
+			SubSys:   subSys,
+			Target:   target,
+			Defaults: defKVS,
+			Config:   kvs,
+			EnvMap:   make(map[string]EnvPair),
 		}
 
 		// Add all env vars that are set.
@@ -1274,7 +1276,7 @@ func (c Config) GetSubsysInfo(subSys string) ([]SubsysInfo, error) {
 
 // AddEnvString adds env vars to the given string builder.
 func (cs *SubsysInfo) AddEnvString(b *strings.Builder) {
-	for _, v := range cs.Params {
+	for _, v := range cs.Defaults {
 		if ep, ok := cs.EnvMap[v.Key]; ok {
 			b.WriteString(KvComment)
 			b.WriteString(KvSpaceSeparator)
@@ -1301,6 +1303,6 @@ func (cs *SubsysInfo) AddString(b *strings.Builder, off bool) {
 		b.WriteString(cs.Target)
 	}
 	b.WriteString(KvSpaceSeparator)
-	b.WriteString(cs.Params.String())
+	b.WriteString(cs.Config.String())
 	b.WriteString(KvNewline)
 }


### PR DESCRIPTION

## Description

Fix a bug where env vars are not output when the config for the
subsystem is specified solely via env vars.

## How to test this PR?

Configure a subsystem via env vars only and check that they are output.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
