### PR TITLE
helm: fix correct deployment environment variable

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
               value: {{ .Values.oidc.configUrl }}
             - name: MINIO_IDENTITY_OPENID_CLIENT_ID
               value: {{ .Values.oidc.clientId }}
-            - name: MINIO_IDENTITY_OPENID_CLIENTs_SECRET
+            - name: MINIO_IDENTITY_OPENID_CLIENT_SECRET
               value: {{ .Values.oidc.clientSecret }}
             - name: MINIO_IDENTITY_OPENID_CLAIM_NAME
               value: {{ .Values.oidc.claimName }}


### PR DESCRIPTION
## Description
Deployment manifest contain typo on environment variable.

## Motivation and Context
Environment variable it's `MINIO_IDENTITY_OPENID_CLIENTs_SECRET` instead `MINIO_IDENTITY_OPENID_CLIENT_SECRET`

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #15469
- [ ] Documentation updated
- [ ] Unit tests added/updated
