### PR TITLE
mount export volume even if persistence is disabled

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -82,13 +82,11 @@ spec:
             - name: minio-user
               mountPath: "/tmp/credentials"
               readOnly: true
-            {{- if .Values.persistence.enabled }}
             - name: export
               mountPath: {{ .Values.mountPath }}
-              {{- if .Values.persistence.subPath }}
+              {{- if and .Values.persistence.enabled .Values.persistence.subPath }}
               subPath: "{{ .Values.persistence.subPath }}"
               {{- end }}
-            {{- end }}
             {{- if .Values.extraSecret }}
             - name: extra-secret
               mountPath: "/tmp/minio-config-env"


### PR DESCRIPTION
## Description
When the `persistence.enabled` parameter is disabled the `export` volume is actually created as an emptyDir, however, in this context, it is not mounted in the pod.

## Motivation and Context
when I used the chart for a quick test, the pod could not find the volume `/export` (default value)

## How to test this PR?
helm template

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
