### PR TITLE
typo in parameter name

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -47,7 +47,7 @@ Download [`certgen`](https://github.com/minio/certgen/releases/latest) for your 
 `certgen` is a simple *Go* tool to generate self-signed certificates, and provides SAN certificates with DNS and IP entries:
 
 ```sh
-./certgen -ca -host "10.10.0.3,10.10.0.4,10.10.0.5"
+./certgen -host "10.10.0.3,10.10.0.4,10.10.0.5"
 ```
 
 A response similar to this one should be displayed:


### PR DESCRIPTION
## Description
"-ca" is not a valid parameter "-no-ca" however is and it fits the context.

## Motivation and Context
Typo in documentation

## How to test this PR?
Compare with tool source code: https://github.com/minio/certgen/blob/main/certgen.go#L40

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Documentation updated
- [ ] Unit tests added/updated
