### PR TITLE
fix: ensure metadata update happens after deletemarker replication

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1502,10 +1502,11 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 		modTime = UTCNow()
 	}
 	fvID := mustGetUUID()
+
 	if markDelete && (opts.Versioned || opts.VersionSuspended) {
 		fi := FileInfo{
 			Name:             object,
-			Deleted:          deleteMarker,
+			Deleted:          true,
 			MarkDeleted:      markDelete,
 			ModTime:          modTime,
 			ReplicationState: opts.DeleteReplication,


### PR DESCRIPTION
Fixes regression caused by #15521

## Description


## Motivation and Context
When delete marker is replicated, replication status should reflect completion - otherwise this would be wastefully re-queued for healing

## How to test this PR?
set up replication b/w 2 buckets 
`mc cp` followed by `mc rm`  replicates content but leaves the delete marker replication in `PENDING` state

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) #15521
- [ ] Documentation updated
- [ ] Unit tests added/updated
