### PR TITLE
Supply proper initial values for annotations

### DIFF
--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -297,8 +297,8 @@ policies: []
 #         - "s3:ListBucketMultipartUploads"
 ## Additional Annotations for the Kubernetes Job makePolicyJob
 makePolicyJob:
-  podAnnotations:
-  annotations:
+  podAnnotations: {}
+  annotations: {}
   securityContext:
     enabled: false
     runAsUser: 1000
@@ -333,8 +333,8 @@ users:
 
 ## Additional Annotations for the Kubernetes Job makeUserJob
 makeUserJob:
-  podAnnotations:
-  annotations:
+  podAnnotations: {}
+  annotations: {}
   securityContext:
     enabled: false
     runAsUser: 1000
@@ -375,8 +375,8 @@ buckets:
 
 ## Additional Annotations for the Kubernetes Job makeBucketJob
 makeBucketJob:
-  podAnnotations:
-  annotations:
+  podAnnotations: {}
+  annotations: {}
   securityContext:
     enabled: false
     runAsUser: 1000
@@ -398,8 +398,8 @@ customCommands:
 
 ## Additional Annotations for the Kubernetes Job customCommandJob
 customCommandJob:
-  podAnnotations:
-  annotations:
+  podAnnotations: {}
+  annotations: {}
   securityContext:
     enabled: false
     runAsUser: 1000


### PR DESCRIPTION
## Description

It is found out that using `kustomize` in conjunction with Helm support, the annotations for the hook jobs are cleared because their initial values are not objects. `kustomize` performs its own unification with the values, which leads to annotations get cleared. This 

## Motivation and Context

Deploying the vanilla chart via `kustomize` is partially broken when annotations are needed for the hook jobs.

## How to test this PR?

Use the following `kustomization.yaml` and run `kustomize build . --enable-helm` and note that, with this change, the annotation `abc: def` is properly applied.

```yaml
helmCharts:
  - name: minio
    releaseName: minio
    namespace: pachyderm
    repo: https://charts.min.io/
    valuesInline:
      replicas: 4
      makeBucketJob:
        annotations:
          abc: def
      resources:
        requests:
          memory: 4Gi
      buckets:
        - name: minio
          policy: upload
          purge: false
          versioning: false
      persistence:
        enabled: true
        VolumeName: minio
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
