### PR TITLE
Quick initialized of bucket target notifications

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2556,20 +2556,6 @@ func fetchLambdaInfo() []map[string][]madmin.TargetIDStatus {
 		lambdaMap[targetID.Name] = list
 	}
 
-	for _, tgt := range globalEnvTargetList.Targets() {
-		targetIDStatus := make(map[string]madmin.Status)
-		active, _ := tgt.IsActive()
-		targetID := tgt.ID()
-		if active {
-			targetIDStatus[targetID.ID] = madmin.Status{Status: string(madmin.ItemOnline)}
-		} else {
-			targetIDStatus[targetID.ID] = madmin.Status{Status: string(madmin.ItemOffline)}
-		}
-		list := lambdaMap[targetID.Name]
-		list = append(list, targetIDStatus)
-		lambdaMap[targetID.Name] = list
-	}
-
 	notify := make([]map[string][]madmin.TargetIDStatus, len(lambdaMap))
 	counter := 0
 	for key, value := range lambdaMap {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -396,7 +396,7 @@ func validateSubSysConfig(s config.Config, subSys string, objAPI ObjectLayer) er
 	}
 
 	if config.NotifySubSystems.Contains(subSys) {
-		if err := notify.TestSubSysNotificationTargets(GlobalContext, s, NewGatewayHTTPTransport(), globalEventNotifier.ConfiguredTargetIDs(), subSys); err != nil {
+		if err := notify.TestSubSysNotificationTargets(GlobalContext, s, subSys, NewGatewayHTTPTransport()); err != nil {
 			return err
 		}
 	}
@@ -555,12 +555,7 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 
 	transport := NewGatewayHTTPTransport()
 
-	globalConfigTargetList, err = notify.GetNotificationTargets(GlobalContext, s, transport, false)
-	if err != nil {
-		logger.LogIf(ctx, fmt.Errorf("Unable to initialize notification target(s): %w", err))
-	}
-
-	globalEnvTargetList, err = notify.GetNotificationTargets(GlobalContext, newServerConfig(), transport, true)
+	globalConfigTargetList, err = notify.FetchEnabledTargets(GlobalContext, s, transport)
 	if err != nil {
 		logger.LogIf(ctx, fmt.Errorf("Unable to initialize notification target(s): %w", err))
 	}

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -307,6 +307,9 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	globalObjectAPI = newObject
 	globalObjLayerMutex.Unlock()
 
+	// Initialize the internal state of the event notifier
+	globalEventNotifier.Init(newObject)
+
 	go globalIAMSys.Init(GlobalContext, newObject, globalEtcdClient, globalRefreshIAMInterval)
 
 	if gatewayName == NASBackendGateway {

--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -307,9 +307,6 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 	globalObjectAPI = newObject
 	globalObjLayerMutex.Unlock()
 
-	// Initialize the internal state of the event notifier
-	globalEventNotifier.Init(newObject)
-
 	go globalIAMSys.Init(GlobalContext, newObject, globalEtcdClient, globalRefreshIAMInterval)
 
 	if gatewayName == NASBackendGateway {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -192,8 +192,6 @@ var (
 
 	globalEventNotifier    *EventNotifier
 	globalConfigTargetList *event.TargetList
-	// globalEnvTargetList has list of targets configured via env.
-	globalEnvTargetList *event.TargetList
 
 	globalBucketMetadataSys *BucketMetadataSys
 	globalBucketMonitor     *bandwidth.Monitor

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -544,9 +544,6 @@ func serverMain(ctx *cli.Context) {
 	initHealMRF(GlobalContext, newObject)
 	initBackgroundExpiry(GlobalContext, newObject)
 
-	// Initialize the internal state of the event notifier
-	globalEventNotifier.Init(newObject)
-
 	if globalActiveCred.Equal(auth.DefaultCredentials) {
 		msg := fmt.Sprintf("WARNING: Detected default credentials '%s', we recommend that you change these values with 'MINIO_ROOT_USER' and 'MINIO_ROOT_PASSWORD' environment variables",
 			globalActiveCred)

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -544,6 +544,9 @@ func serverMain(ctx *cli.Context) {
 	initHealMRF(GlobalContext, newObject)
 	initBackgroundExpiry(GlobalContext, newObject)
 
+	// Initialize the internal state of the event notifier
+	globalEventNotifier.Init(newObject)
+
 	if globalActiveCred.Equal(auth.DefaultCredentials) {
 		msg := fmt.Sprintf("WARNING: Detected default credentials '%s', we recommend that you change these values with 'MINIO_ROOT_USER' and 'MINIO_ROOT_PASSWORD' environment variables",
 			globalActiveCred)
@@ -632,8 +635,8 @@ func serverMain(ctx *cli.Context) {
 		// Initialize site replication manager.
 		globalSiteReplicationSys.Init(GlobalContext, newObject)
 
-		// Initialize bucket notification targets.
-		globalEventNotifier.InitBucketTargets(GlobalContext, newObject)
+		// Initialize bucket notification system
+		logger.LogIf(GlobalContext, globalEventNotifier.InitBucketTargets(GlobalContext, newObject))
 
 		// initialize the new disk cache objects.
 		if globalCacheConfig.Enabled {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -373,6 +373,8 @@ func initTestServerWithBackend(ctx context.Context, t TestErrHandler, testServer
 
 	globalIAMSys.Init(ctx, objLayer, globalEtcdClient, 2*time.Second)
 
+	globalEventNotifier.InitBucketTargets(ctx, objLayer)
+
 	return testServer
 }
 

--- a/internal/event/target/kafka.go
+++ b/internal/event/target/kafka.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -122,12 +123,15 @@ func (k KafkaArgs) Validate() error {
 
 // KafkaTarget - Kafka target.
 type KafkaTarget struct {
+	lazyInit lazyInit
+
 	id         event.TargetID
 	args       KafkaArgs
 	producer   sarama.SyncProducer
 	config     *sarama.Config
 	store      Store
 	loggerOnce logger.LogOnce
+	quitCh     chan struct{}
 }
 
 // ID - returns target ID.
@@ -135,13 +139,15 @@ func (target *KafkaTarget) ID() event.TargetID {
 	return target.id
 }
 
-// HasQueueStore - Checks if the queueStore has been configured for the target
-func (target *KafkaTarget) HasQueueStore() bool {
-	return target.store != nil
-}
-
 // IsActive - Return true if target is up and active
 func (target *KafkaTarget) IsActive() (bool, error) {
+	if err := target.init(); err != nil {
+		return false, err
+	}
+	return target.isActive()
+}
+
+func (target *KafkaTarget) isActive() (bool, error) {
 	if !target.args.pingBrokers() {
 		return false, errNotConnected
 	}
@@ -150,10 +156,14 @@ func (target *KafkaTarget) IsActive() (bool, error) {
 
 // Save - saves the events to the store which will be replayed when the Kafka connection is active.
 func (target *KafkaTarget) Save(eventData event.Event) error {
+	if err := target.init(); err != nil {
+		return err
+	}
+
 	if target.store != nil {
 		return target.store.Put(eventData)
 	}
-	_, err := target.IsActive()
+	_, err := target.isActive()
 	if err != nil {
 		return err
 	}
@@ -189,8 +199,12 @@ func (target *KafkaTarget) send(eventData event.Event) error {
 
 // Send - reads an event from store and sends it to Kafka.
 func (target *KafkaTarget) Send(eventKey string) error {
+	if err := target.init(); err != nil {
+		return err
+	}
+
 	var err error
-	_, err = target.IsActive()
+	_, err = target.isActive()
 	if err != nil {
 		return err
 	}
@@ -234,6 +248,7 @@ func (target *KafkaTarget) Send(eventKey string) error {
 
 // Close - closes underneath kafka connection.
 func (target *KafkaTarget) Close() error {
+	close(target.quitCh)
 	if target.producer != nil {
 		return target.producer.Close()
 	}
@@ -251,21 +266,19 @@ func (k KafkaArgs) pingBrokers() bool {
 	return false
 }
 
-// NewKafkaTarget - creates new Kafka target with auth credentials.
-func NewKafkaTarget(id string, args KafkaArgs, doneCh <-chan struct{}, loggerOnce logger.LogOnce, test bool) (*KafkaTarget, error) {
+func (target *KafkaTarget) init() error {
+	return target.lazyInit.Do(target.initKafka)
+}
+
+func (target *KafkaTarget) initKafka() error {
+	args := target.args
+
 	config := sarama.NewConfig()
-
-	target := &KafkaTarget{
-		id:         event.TargetID{ID: id, Name: "kafka"},
-		args:       args,
-		loggerOnce: loggerOnce,
-	}
-
 	if args.Version != "" {
 		kafkaVersion, err := sarama.ParseKafkaVersion(args.Version)
 		if err != nil {
 			target.loggerOnce(context.Background(), err, target.ID().String())
-			return target, err
+			return err
 		}
 		config.Version = kafkaVersion
 	}
@@ -278,7 +291,7 @@ func NewKafkaTarget(id string, args KafkaArgs, doneCh <-chan struct{}, loggerOnc
 	tlsConfig, err := saramatls.NewConfig(args.TLS.ClientTLSCert, args.TLS.ClientTLSKey)
 	if err != nil {
 		target.loggerOnce(context.Background(), err, target.ID().String())
-		return target, err
+		return err
 	}
 
 	config.Net.TLS.Enable = args.TLS.Enable
@@ -298,33 +311,46 @@ func NewKafkaTarget(id string, args KafkaArgs, doneCh <-chan struct{}, loggerOnc
 		brokers = append(brokers, broker.String())
 	}
 
-	var store Store
-
-	if args.QueueDir != "" {
-		queueDir := filepath.Join(args.QueueDir, storePrefix+"-kafka-"+id)
-		store = NewQueueStore(queueDir, args.QueueLimit)
-		if oErr := store.Open(); oErr != nil {
-			target.loggerOnce(context.Background(), oErr, target.ID().String())
-			return target, oErr
-		}
-		target.store = store
-	}
-
 	producer, err := sarama.NewSyncProducer(brokers, config)
 	if err != nil {
-		if store == nil || err != sarama.ErrOutOfBrokers {
+		if err != sarama.ErrOutOfBrokers {
 			target.loggerOnce(context.Background(), err, target.ID().String())
-			return target, err
 		}
+		target.producer.Close()
+		return err
 	}
 	target.producer = producer
 
-	if target.store != nil && !test {
-		// Replays the events from the store.
-		eventKeyCh := replayEvents(target.store, doneCh, target.loggerOnce, target.ID())
-		// Start replaying events from the store.
-		go sendEvents(target, eventKeyCh, doneCh, target.loggerOnce)
+	yes, err := target.isActive()
+	if err != nil {
+		return err
+	}
+	if !yes {
+		return errNotConnected
 	}
 
-	return target, nil
+	if target.store != nil {
+		streamEventsFromStore(target.store, target, target.quitCh, target.loggerOnce)
+	}
+	return nil
+}
+
+// NewKafkaTarget - creates new Kafka target with auth credentials.
+func NewKafkaTarget(id string, args KafkaArgs, loggerOnce logger.LogOnce) (*KafkaTarget, error) {
+	var store Store
+	if args.QueueDir != "" {
+		queueDir := filepath.Join(args.QueueDir, storePrefix+"-kafka-"+id)
+		store = NewQueueStore(queueDir, args.QueueLimit)
+		if err := store.Open(); err != nil {
+			return nil, fmt.Errorf("unable to initialize the queue store of Kafka `%s`: %w", id, err)
+		}
+	}
+
+	return &KafkaTarget{
+		id:         event.TargetID{ID: id, Name: "kafka"},
+		args:       args,
+		store:      store,
+		loggerOnce: loggerOnce,
+		quitCh:     make(chan struct{}),
+	}, nil
 }

--- a/internal/event/target/lazyinit.go
+++ b/internal/event/target/lazyinit.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package target
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Inspired from Golang sync.Once but it is only marked
+// initialized when the provided function returns nil.
+
+type lazyInit struct {
+	done uint32
+	m    sync.Mutex
+}
+
+func (l *lazyInit) Do(f func() error) error {
+	if atomic.LoadUint32(&l.done) == 0 {
+		return l.doSlow(f)
+	}
+	return nil
+}
+
+func (l *lazyInit) doSlow(f func() error) error {
+	l.m.Lock()
+	defer l.m.Unlock()
+	if atomic.LoadUint32(&l.done) == 0 {
+		if f() == nil {
+			// Mark as done only when f() is successful
+			atomic.StoreUint32(&l.done, 1)
+		}
+	}
+	return nil
+}

--- a/internal/event/target/mqtt.go
+++ b/internal/event/target/mqtt.go
@@ -18,7 +18,6 @@
 package target
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -36,7 +35,7 @@ import (
 )
 
 const (
-	reconnectInterval = 5 // In Seconds
+	reconnectInterval = 5 * time.Second
 	storePrefix       = "minio"
 )
 
@@ -107,6 +106,8 @@ func (m MQTTArgs) Validate() error {
 
 // MQTTTarget - MQTT target.
 type MQTTTarget struct {
+	lazyInit lazyInit
+
 	id         event.TargetID
 	args       MQTTArgs
 	client     mqtt.Client
@@ -120,13 +121,15 @@ func (target *MQTTTarget) ID() event.TargetID {
 	return target.id
 }
 
-// HasQueueStore - Checks if the queueStore has been configured for the target
-func (target *MQTTTarget) HasQueueStore() bool {
-	return target.store != nil
-}
-
 // IsActive - Return true if target is up and active
 func (target *MQTTTarget) IsActive() (bool, error) {
+	if err := target.init(); err != nil {
+		return false, err
+	}
+	return target.isActive()
+}
+
+func (target *MQTTTarget) isActive() (bool, error) {
 	if !target.client.IsConnectionOpen() {
 		return false, errNotConnected
 	}
@@ -147,7 +150,7 @@ func (target *MQTTTarget) send(eventData event.Event) error {
 	}
 
 	token := target.client.Publish(target.args.Topic, target.args.QoS, false, string(data))
-	if !token.WaitTimeout(reconnectInterval * time.Second) {
+	if !token.WaitTimeout(reconnectInterval) {
 		return errNotConnected
 	}
 	return token.Error()
@@ -155,8 +158,12 @@ func (target *MQTTTarget) send(eventData event.Event) error {
 
 // Send - reads an event from store and sends it to MQTT.
 func (target *MQTTTarget) Send(eventKey string) error {
+	if err := target.init(); err != nil {
+		return err
+	}
+
 	// Do not send if the connection is not active.
-	_, err := target.IsActive()
+	_, err := target.isActive()
 	if err != nil {
 		return err
 	}
@@ -182,12 +189,16 @@ func (target *MQTTTarget) Send(eventKey string) error {
 // Save - saves the events to the store if queuestore is configured, which will
 // be replayed when the mqtt connection is active.
 func (target *MQTTTarget) Save(eventData event.Event) error {
+	if err := target.init(); err != nil {
+		return err
+	}
+
 	if target.store != nil {
 		return target.store.Put(eventData)
 	}
 
 	// Do not send if the connection is not active.
-	_, err := target.IsActive()
+	_, err := target.isActive()
 	if err != nil {
 		return err
 	}
@@ -202,17 +213,12 @@ func (target *MQTTTarget) Close() error {
 	return nil
 }
 
-// NewMQTTTarget - creates new MQTT target.
-func NewMQTTTarget(id string, args MQTTArgs, doneCh <-chan struct{}, loggerOnce logger.LogOnce, test bool) (*MQTTTarget, error) {
-	if args.MaxReconnectInterval == 0 {
-		// Default interval
-		// https://github.com/eclipse/paho.mqtt.golang/blob/master/options.go#L115
-		args.MaxReconnectInterval = 10 * time.Minute
-	}
+func (target *MQTTTarget) init() error {
+	return target.lazyInit.Do(target.initMQTT)
+}
 
-	if args.KeepAlive == 0 {
-		args.KeepAlive = 10 * time.Second
-	}
+func (target *MQTTTarget) initMQTT() error {
+	args := target.args
 
 	// Using hex here, to make sure we avoid 23
 	// character limit on client_id according to
@@ -229,61 +235,57 @@ func NewMQTTTarget(id string, args MQTTArgs, doneCh <-chan struct{}, loggerOnce 
 		SetTLSConfig(&tls.Config{RootCAs: args.RootCAs}).
 		AddBroker(args.Broker.String())
 
-	client := mqtt.NewClient(options)
+	target.client = mqtt.NewClient(options)
 
-	target := &MQTTTarget{
-		id:         event.TargetID{ID: id, Name: "mqtt"},
-		args:       args,
-		client:     client,
-		quitCh:     make(chan struct{}),
-		loggerOnce: loggerOnce,
+	token := target.client.Connect()
+	ok := token.WaitTimeout(reconnectInterval)
+	if !ok {
+		return errNotConnected
+	}
+	if token.Error() != nil {
+		return token.Error()
 	}
 
-	token := client.Connect()
-	retryRegister := func() {
-		for {
-		retry:
-			select {
-			case <-doneCh:
-				return
-			case <-target.quitCh:
-				return
-			default:
-				ok := token.WaitTimeout(reconnectInterval * time.Second)
-				if ok && token.Error() != nil {
-					target.loggerOnce(context.Background(),
-						fmt.Errorf("Previous connect failed with %w attempting a reconnect",
-							token.Error()),
-						target.ID().String())
-					time.Sleep(reconnectInterval * time.Second)
-					token = client.Connect()
-					goto retry
-				}
-				if ok {
-					// Successfully connected.
-					return
-				}
-			}
-		}
+	yes, err := target.isActive()
+	if err != nil {
+		return err
+	}
+	if !yes {
+		return errNotConnected
 	}
 
+	if target.store != nil {
+		streamEventsFromStore(target.store, target, target.quitCh, target.loggerOnce)
+	}
+	return nil
+}
+
+// NewMQTTTarget - creates new MQTT target.
+func NewMQTTTarget(id string, args MQTTArgs, loggerOnce logger.LogOnce) (*MQTTTarget, error) {
+	if args.MaxReconnectInterval == 0 {
+		// Default interval
+		// https://github.com/eclipse/paho.mqtt.golang/blob/master/options.go#L115
+		args.MaxReconnectInterval = 10 * time.Minute
+	}
+
+	if args.KeepAlive == 0 {
+		args.KeepAlive = 10 * time.Second
+	}
+
+	var store Store
 	if args.QueueDir != "" {
 		queueDir := filepath.Join(args.QueueDir, storePrefix+"-mqtt-"+id)
-		target.store = NewQueueStore(queueDir, args.QueueLimit)
-		if err := target.store.Open(); err != nil {
-			target.loggerOnce(context.Background(), err, target.ID().String())
-			return target, err
+		store = NewQueueStore(queueDir, args.QueueLimit)
+		if err := store.Open(); err != nil {
+			return nil, fmt.Errorf("unable to initialize the queue store of MQTT `%s`: %w", id, err)
 		}
-
-		if !test {
-			go retryRegister()
-			// Replays the events from the store.
-			eventKeyCh := replayEvents(target.store, doneCh, target.loggerOnce, target.ID())
-			// Start replaying events from the store.
-			go sendEvents(target, eventKeyCh, doneCh, target.loggerOnce)
-		}
-	} else if token.Wait() && token.Error() != nil {
-		return target, token.Error()
 	}
-	return target, nil
+
+	return &MQTTTarget{
+		id:         event.TargetID{ID: id, Name: "mqtt"},
+		args:       args,
+		store:      store,
+		quitCh:     make(chan struct{}),
+		loggerOnce: loggerOnce,
+	}, nil
 }

--- a/internal/event/target/redis.go
+++ b/internal/event/target/redis.go
@@ -117,12 +117,15 @@ func (r RedisArgs) validateFormat(c redis.Conn) error {
 
 // RedisTarget - Redis target.
 type RedisTarget struct {
+	lazyInit lazyInit
+
 	id         event.TargetID
 	args       RedisArgs
 	pool       *redis.Pool
 	store      Store
 	firstPing  bool
 	loggerOnce logger.LogOnce
+	quitCh     chan struct{}
 }
 
 // ID - returns target ID.
@@ -130,13 +133,15 @@ func (target *RedisTarget) ID() event.TargetID {
 	return target.id
 }
 
-// HasQueueStore - Checks if the queueStore has been configured for the target
-func (target *RedisTarget) HasQueueStore() bool {
-	return target.store != nil
-}
-
 // IsActive - Return true if target is up and active
 func (target *RedisTarget) IsActive() (bool, error) {
+	if err := target.init(); err != nil {
+		return false, err
+	}
+	return target.isActive()
+}
+
+func (target *RedisTarget) isActive() (bool, error) {
 	conn := target.pool.Get()
 	defer conn.Close()
 
@@ -152,10 +157,14 @@ func (target *RedisTarget) IsActive() (bool, error) {
 
 // Save - saves the events to the store if questore is configured, which will be replayed when the redis connection is active.
 func (target *RedisTarget) Save(eventData event.Event) error {
+	if err := target.init(); err != nil {
+		return err
+	}
+
 	if target.store != nil {
 		return target.store.Put(eventData)
 	}
-	_, err := target.IsActive()
+	_, err := target.isActive()
 	if err != nil {
 		return err
 	}
@@ -204,6 +213,10 @@ func (target *RedisTarget) send(eventData event.Event) error {
 
 // Send - reads an event from store and sends it to redis.
 func (target *RedisTarget) Send(eventKey string) error {
+	if err := target.init(); err != nil {
+		return err
+	}
+
 	conn := target.pool.Get()
 	defer conn.Close()
 
@@ -248,11 +261,58 @@ func (target *RedisTarget) Send(eventKey string) error {
 
 // Close - releases the resources used by the pool.
 func (target *RedisTarget) Close() error {
+	close(target.quitCh)
 	return target.pool.Close()
 }
 
+func (target *RedisTarget) init() error {
+	return target.lazyInit.Do(target.initRedis)
+}
+
+func (target *RedisTarget) initRedis() error {
+	conn := target.pool.Get()
+	defer conn.Close()
+
+	_, pingErr := conn.Do("PING")
+	if pingErr != nil {
+		if !(IsConnRefusedErr(pingErr) || IsConnResetErr(pingErr)) {
+			target.loggerOnce(context.Background(), pingErr, target.ID().String())
+		}
+		return pingErr
+	}
+
+	if err := target.args.validateFormat(conn); err != nil {
+		target.loggerOnce(context.Background(), err, target.ID().String())
+		return err
+	}
+
+	target.firstPing = true
+
+	yes, err := target.isActive()
+	if err != nil {
+		return err
+	}
+	if !yes {
+		return errNotConnected
+	}
+
+	if target.store != nil {
+		streamEventsFromStore(target.store, target, target.quitCh, target.loggerOnce)
+	}
+	return nil
+}
+
 // NewRedisTarget - creates new Redis target.
-func NewRedisTarget(id string, args RedisArgs, doneCh <-chan struct{}, loggerOnce logger.LogOnce, test bool) (*RedisTarget, error) {
+func NewRedisTarget(id string, args RedisArgs, loggerOnce logger.LogOnce) (*RedisTarget, error) {
+	var store Store
+	if args.QueueDir != "" {
+		queueDir := filepath.Join(args.QueueDir, storePrefix+"-redis-"+id)
+		store = NewQueueStore(queueDir, args.QueueLimit)
+		if err := store.Open(); err != nil {
+			return nil, fmt.Errorf("unable to initialize the queue store of Redis `%s`: %w", id, err)
+		}
+	}
+
 	pool := &redis.Pool{
 		MaxIdle:     3,
 		IdleTimeout: 2 * 60 * time.Second,
@@ -283,48 +343,12 @@ func NewRedisTarget(id string, args RedisArgs, doneCh <-chan struct{}, loggerOnc
 		},
 	}
 
-	var store Store
-
-	target := &RedisTarget{
+	return &RedisTarget{
 		id:         event.TargetID{ID: id, Name: "redis"},
 		args:       args,
 		pool:       pool,
+		store:      store,
 		loggerOnce: loggerOnce,
-	}
-
-	if args.QueueDir != "" {
-		queueDir := filepath.Join(args.QueueDir, storePrefix+"-redis-"+id)
-		store = NewQueueStore(queueDir, args.QueueLimit)
-		if oErr := store.Open(); oErr != nil {
-			target.loggerOnce(context.Background(), oErr, target.ID().String())
-			return target, oErr
-		}
-		target.store = store
-	}
-
-	conn := target.pool.Get()
-	defer conn.Close()
-
-	_, pingErr := conn.Do("PING")
-	if pingErr != nil {
-		if target.store == nil || !(IsConnRefusedErr(pingErr) || IsConnResetErr(pingErr)) {
-			target.loggerOnce(context.Background(), pingErr, target.ID().String())
-			return target, pingErr
-		}
-	} else {
-		if err := target.args.validateFormat(conn); err != nil {
-			target.loggerOnce(context.Background(), err, target.ID().String())
-			return target, err
-		}
-		target.firstPing = true
-	}
-
-	if target.store != nil && !test {
-		// Replays the events from the store.
-		eventKeyCh := replayEvents(target.store, doneCh, target.loggerOnce, target.ID())
-		// Start replaying events from the store.
-		go sendEvents(target, eventKeyCh, doneCh, target.loggerOnce)
-	}
-
-	return target, nil
+		quitCh:     make(chan struct{}),
+	}, nil
 }

--- a/internal/event/target/webhook.go
+++ b/internal/event/target/webhook.go
@@ -91,25 +91,31 @@ func (w WebhookArgs) Validate() error {
 
 // WebhookTarget - Webhook target.
 type WebhookTarget struct {
+	lazyInit lazyInit
+
 	id         event.TargetID
 	args       WebhookArgs
+	transport  *http.Transport
 	httpClient *http.Client
 	store      Store
 	loggerOnce logger.LogOnce
+	quitCh     chan struct{}
 }
 
 // ID - returns target ID.
-func (target WebhookTarget) ID() event.TargetID {
+func (target *WebhookTarget) ID() event.TargetID {
 	return target.id
-}
-
-// HasQueueStore - Checks if the queueStore has been configured for the target
-func (target *WebhookTarget) HasQueueStore() bool {
-	return target.store != nil
 }
 
 // IsActive - Return true if target is up and active
 func (target *WebhookTarget) IsActive() (bool, error) {
+	if err := target.init(); err != nil {
+		return false, err
+	}
+	return target.isActive()
+}
+
+func (target *WebhookTarget) isActive() (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -144,6 +150,10 @@ func (target *WebhookTarget) IsActive() (bool, error) {
 // Save - saves the events to the store if queuestore is configured,
 // which will be replayed when the webhook connection is active.
 func (target *WebhookTarget) Save(eventData event.Event) error {
+	if err := target.init(); err != nil {
+		return err
+	}
+
 	if target.store != nil {
 		return target.store.Put(eventData)
 	}
@@ -206,6 +216,10 @@ func (target *WebhookTarget) send(eventData event.Event) error {
 
 // Send - reads an event from store and sends it to webhook.
 func (target *WebhookTarget) Send(eventKey string) error {
+	if err := target.init(); err != nil {
+		return err
+	}
+
 	eventData, eErr := target.store.Get(eventKey)
 	if eErr != nil {
 		// The last event key in a successful batch will be sent in the channel atmost once by the replayEvents()
@@ -229,52 +243,60 @@ func (target *WebhookTarget) Send(eventKey string) error {
 
 // Close - does nothing and available for interface compatibility.
 func (target *WebhookTarget) Close() error {
+	close(target.quitCh)
 	return nil
 }
 
-// NewWebhookTarget - creates new Webhook target.
-func NewWebhookTarget(ctx context.Context, id string, args WebhookArgs, loggerOnce logger.LogOnce, transport *http.Transport, test bool) (*WebhookTarget, error) {
-	var store Store
-	target := &WebhookTarget{
-		id:         event.TargetID{ID: id, Name: "webhook"},
-		args:       args,
-		loggerOnce: loggerOnce,
-	}
+func (target *WebhookTarget) init() error {
+	return target.lazyInit.Do(target.initWebhook)
+}
 
-	if target.args.ClientCert != "" && target.args.ClientKey != "" {
-		manager, err := certs.NewManager(ctx, target.args.ClientCert, target.args.ClientKey, tls.LoadX509KeyPair)
+// Only called from init()
+func (target *WebhookTarget) initWebhook() error {
+	args := target.args
+	transport := target.transport
+
+	if args.ClientCert != "" && args.ClientKey != "" {
+		manager, err := certs.NewManager(context.Background(), args.ClientCert, args.ClientKey, tls.LoadX509KeyPair)
 		if err != nil {
-			return target, err
+			return err
 		}
 		manager.ReloadOnSignal(syscall.SIGHUP) // allow reloads upon SIGHUP
 		transport.TLSClientConfig.GetClientCertificate = manager.GetClientCertificate
 	}
 	target.httpClient = &http.Client{Transport: transport}
 
+	yes, err := target.isActive()
+	if err != nil {
+		return err
+	}
+	if !yes {
+		return errNotConnected
+	}
+
+	if target.store != nil {
+		streamEventsFromStore(target.store, target, target.quitCh, target.loggerOnce)
+	}
+	return nil
+}
+
+// NewWebhookTarget - creates new Webhook target.
+func NewWebhookTarget(ctx context.Context, id string, args WebhookArgs, loggerOnce logger.LogOnce, transport *http.Transport) (*WebhookTarget, error) {
+	var store Store
 	if args.QueueDir != "" {
 		queueDir := filepath.Join(args.QueueDir, storePrefix+"-webhook-"+id)
 		store = NewQueueStore(queueDir, args.QueueLimit)
 		if err := store.Open(); err != nil {
-			target.loggerOnce(context.Background(), err, target.ID().String())
-			return target, err
-		}
-		target.store = store
-	}
-
-	_, err := target.IsActive()
-	if err != nil {
-		if target.store == nil || err != errNotConnected {
-			target.loggerOnce(ctx, err, target.ID().String())
-			return target, err
+			return nil, fmt.Errorf("unable to initialize the queue store of Webhook `%s`: %w", id, err)
 		}
 	}
 
-	if target.store != nil && !test {
-		// Replays the events from the store.
-		eventKeyCh := replayEvents(target.store, ctx.Done(), target.loggerOnce, target.ID())
-		// Start replaying events from the store.
-		go sendEvents(target, eventKeyCh, ctx.Done(), target.loggerOnce)
-	}
-
-	return target, nil
+	return &WebhookTarget{
+		id:         event.TargetID{ID: id, Name: "webhook"},
+		args:       args,
+		loggerOnce: loggerOnce,
+		transport:  transport,
+		store:      store,
+		quitCh:     make(chan struct{}),
+	}, nil
 }

--- a/internal/event/targetlist.go
+++ b/internal/event/targetlist.go
@@ -35,7 +35,6 @@ type Target interface {
 	Save(Event) error
 	Send(string) error
 	Close() error
-	HasQueueStore() bool
 }
 
 // TargetList - holds list of targets indexed by target ID.

--- a/internal/event/targetlist_test.go
+++ b/internal/event/targetlist_test.go
@@ -72,9 +72,9 @@ func (target ExampleTarget) IsActive() (bool, error) {
 	return false, errors.New("not connected to target server/service")
 }
 
-// HasQueueStore - No-Op. Added for interface compatibility
-func (target ExampleTarget) HasQueueStore() bool {
-	return false
+// FlushQueueStore - No-Op. Added for interface compatibility
+func (target ExampleTarget) FlushQueueStore() error {
+	return nil
 }
 
 func TestTargetListAdd(t *testing.T) {


### PR DESCRIPTION
## Description
The initialization of the bucket target notification is lazy now. It is
initialized with FlushQueueStore() called in bucket target loading or
in the first Send().

Loading the configuration of bucket notifications only fails when the
queue store in not properly configured. It doesn't ping the target
notification and checks if it is online or not.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
