### PR TITLE
move adding port location so a pool which consist only one host got the port information

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -702,6 +702,17 @@ func CreateEndpoints(serverAddr string, foundLocal bool, args ...[]string) (Endp
 		}
 	}
 
+	// Add missing port in all endpoints.
+	for i := range endpoints {
+		_, port, err := net.SplitHostPort(endpoints[i].Host)
+		if err != nil {
+			endpoints[i].Host = net.JoinHostPort(endpoints[i].Host, serverAddrPort)
+		} else if endpoints[i].IsLocal && serverAddrPort != port {
+			// If endpoint is local, but port is different than serverAddrPort, then make it as remote.
+			endpoints[i].IsLocal = false
+		}
+	}
+
 	// All endpoints are pointing to local host
 	if len(endpoints) == localEndpointCount {
 		// If all endpoints have same port number, Just treat it as local erasure setup
@@ -716,17 +727,6 @@ func CreateEndpoints(serverAddr string, foundLocal bool, args ...[]string) (Endp
 
 		// Even though all endpoints are local, but those endpoints use different ports.
 		// This means it is DistErasure setup.
-	}
-
-	// Add missing port in all endpoints.
-	for i := range endpoints {
-		_, port, err := net.SplitHostPort(endpoints[i].Host)
-		if err != nil {
-			endpoints[i].Host = net.JoinHostPort(endpoints[i].Host, serverAddrPort)
-		} else if endpoints[i].IsLocal && serverAddrPort != port {
-			// If endpoint is local, but port is different than serverAddrPort, then make it as remote.
-			endpoints[i].IsLocal = false
-		}
 	}
 
 	uniqueArgs := set.NewStringSet()

--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -252,10 +252,10 @@ func TestCreateEndpoints(t *testing.T) {
 		},
 		// DistErasure Setup with URLEndpointType
 		{":9000", [][]string{{"http://localhost/d1", "http://localhost/d2", "http://localhost/d3", "http://localhost/d4"}}, ":9000", Endpoints{
-			Endpoint{URL: &url.URL{Scheme: "http", Host: "localhost", Path: "/d1"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Scheme: "http", Host: "localhost", Path: "/d2"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Scheme: "http", Host: "localhost", Path: "/d3"}, IsLocal: true},
-			Endpoint{URL: &url.URL{Scheme: "http", Host: "localhost", Path: "/d4"}, IsLocal: true},
+			Endpoint{URL: &url.URL{Scheme: "http", Host: "localhost:9000", Path: "/d1"}, IsLocal: true},
+			Endpoint{URL: &url.URL{Scheme: "http", Host: "localhost:9000", Path: "/d2"}, IsLocal: true},
+			Endpoint{URL: &url.URL{Scheme: "http", Host: "localhost:9000", Path: "/d3"}, IsLocal: true},
+			Endpoint{URL: &url.URL{Scheme: "http", Host: "localhost:9000", Path: "/d4"}, IsLocal: true},
 		}, ErasureSetupType, nil},
 		// DistErasure Setup with URLEndpointType having mixed naming to local host.
 		{"127.0.0.1:10000", [][]string{{"http://localhost/d1", "http://localhost/d2", "http://127.0.0.1/d3", "http://127.0.0.1/d4"}}, "", Endpoints{}, -1, fmt.Errorf("all local endpoints should not have different hostnames/ips")},


### PR DESCRIPTION
## Description

Move the adding missing port to the top, so all of endpoint configs every pools is same for minio with exactly one host every pool

## Motivation and Context

I setup the minio with helm chart with this configuration
```yaml
drivesPerNode: <some values greater than or equal to 4>
replicas: 1
pools: 3
```

Then got this error:
```
Expected endpoint http://minio-0.minio-svc.<namespace>.svc.cluster.local/export-0, seen http://minio-0.minio-svc.<namespace>.svc.cluster.local:9000/export-0 
```

It turns out that there is a logic error on the minio (if in a pod, the hostname is resolve to it's own pod's IP, the port information will not be included and the endpoint configuration between pods should be same before running minio)

## How to test this PR?

to test it locally run
```bash
go test -v ./cmd -run TestCreateEndpoints
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Unit tests added/updated
