### PR TITLE
fix: objects matching prefixes should not leave delete markers

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -197,7 +197,7 @@ func mustReplicate(ctx context.Context, bucket, object string, mopts mustReplica
 
 	// Disable server-side replication on object prefixes which are excluded
 	// from versioning via the MinIO bucket versioning extension.
-	if globalBucketVersioningSys.PrefixSuspended(bucket, object) {
+	if !globalBucketVersioningSys.PrefixEnabled(bucket, object) {
 		return
 	}
 
@@ -490,7 +490,11 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 		MTime:             dobj.DeleteMarkerMTime.Time,
 		DeleteReplication: drs,
 		Versioned:         globalBucketVersioningSys.PrefixEnabled(bucket, dobj.ObjectName),
-		VersionSuspended:  globalBucketVersioningSys.PrefixSuspended(bucket, dobj.ObjectName),
+		// Objects matching prefixes should not leave delete markers,
+		// dramatically reduces namespace pollution while keeping the
+		// benefits of replication, make sure to apply version suspension
+		// only at bucket level instead.
+		VersionSuspended: globalBucketVersioningSys.Suspended(bucket),
 	})
 	if err != nil && !isErrVersionNotFound(err) { // VersionNotFound would be reported by pool that object version is missing on.
 		logger.LogIf(ctx, fmt.Errorf("Unable to update replication metadata for %s/%s(%s): %s", bucket, dobj.ObjectName, versionID, err))

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -169,7 +169,11 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 		return opts, err
 	}
 	opts.Versioned = globalBucketVersioningSys.PrefixEnabled(bucket, object)
-	opts.VersionSuspended = globalBucketVersioningSys.PrefixSuspended(bucket, object)
+	// Objects matching prefixes should not leave delete markers,
+	// dramatically reduces namespace pollution while keeping the
+	// benefits of replication, make sure to apply version suspension
+	// only at bucket level instead.
+	opts.VersionSuspended = globalBucketVersioningSys.Suspended(bucket)
 	delMarker := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceDeleteMarker))
 	if delMarker != "" {
 		switch delMarker {


### PR DESCRIPTION

## Description
fix: objects matching prefixes should not leave delete markers

## Motivation and Context
This is needed to ensure that we do not leave prefixes where
version is suspended, instead we never leave versions on
these paths.

## How to test this PR?
```scala
import org.apache.spark.sql._
import org.apache.spark.sql.types._

object app {
  def main() {

    val spark: SparkSession = SparkSession.builder()
      .master("local[1]")
      .appName("SparkByExamples.com")
      .getOrCreate()

    // Replace Key with your AWS account key (You can find this on IAM
    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.access.key", "minioadmin")

    // Replace Key with your AWS secret key (You can find this on IAM
    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.secret.key", "minioadmin")

    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.endpoint", "http://localhost:9001")

    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")

    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")

    spark.sparkContext
      .hadoopConfiguration.set("fs.s3a.path.style.access", "true")
    
    val data = Seq(
      ("James ","","Smith","36636","M",3000),
      ("Michael ","Rose","","40288","M",4000),
      ("Robert ","","Williams","42114","M",4000),
      ("Maria ","Anne","Jones","39192","F",4000),
      ("Jen","Mary","Brown","","F",-1)
    )

    val columns = Seq("firstname","middlename","lastname","dob","gender","salary")
    import spark.sqlContext.implicits._
    val df = data.toDF(columns:_*)

    // Step 1 - first create bunch of parquet files by partition.
    df.write.partitionBy("gender").csv("s3a://spark-bucket/spark-job/newdata/")

    // Step 2 - second attempt overwrite the parquet files by partition.
    df.write.partitionBy("gender").mode("overwrite").csv("s3a://spark-bucket/spark-job/newdata/")

    // Step 3 - attempt to read this folder.
    val df_read = spark.read.schema(df.schema).csv("s3a://spark-bucket/spark-job/newdata/")
    df_read.registerTempTable("mytable")

    val sql_df = spark.sql("select * from mytable")
    sql_df.show()
  }
}
```

```
./bin/spark-shell --packages com.amazonaws:aws-java-sdk:1.11.375,org.apache.hadoop:hadoop-aws:3.2.2 -i min.scala
```

```
app.main()
```

Should run fine without issues.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression introduced in #15043
- [ ] Documentation updated
- [ ] Unit tests added/updated
