### PR TITLE
Allow querying a single target in config get API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/minio/dperf v0.4.2
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.20.0
-	github.com/minio/madmin-go v1.4.24
+	github.com/minio/madmin-go v1.4.25
 	github.com/minio/minio-go/v7 v7.0.34
 	github.com/minio/pkg v1.3.0
 	github.com/minio/selfupdate v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLT
 github.com/minio/kes v0.20.0 h1:1tyC51Rr8zTregTESuT/QN/iebNMX7B9t7d3xLNMEpE=
 github.com/minio/kes v0.20.0/go.mod h1:3FW1BQkMGQW78yhy+69tUq5bdcf5rnXJizyeKB9a/tc=
 github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
-github.com/minio/madmin-go v1.4.24 h1:AFn8/N/E64RUXV4ztGwQcmsKb2uTlwSwiGyk6B37PWY=
-github.com/minio/madmin-go v1.4.24/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
+github.com/minio/madmin-go v1.4.25 h1:IEJpsTXlHz18/yRI5HxY84KaJdDjUUYdMiC5f8fId4g=
+github.com/minio/madmin-go v1.4.25/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/mc v0.0.0-20220818165341-8c239d16aa37 h1:UE9kHgdza2HB4DDx0nIn0jHRl6YASUomVoKjciMfqjM=
 github.com/minio/mc v0.0.0-20220818165341-8c239d16aa37/go.mod h1:O3pvs5/n57bZ0mpcG/skBuD4pHX6m+wVbW7lw8LO5go=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1221,8 +1221,10 @@ type SubsysInfo struct {
 	EnvMap map[string]EnvPair
 }
 
-// GetSubsysInfo returns `SubsysInfo`s for all targets for the subsystem.
-func (c Config) GetSubsysInfo(subSys string) ([]SubsysInfo, error) {
+// GetSubsysInfo returns `SubsysInfo`s for all targets for the subsystem, when
+// target is empty. Otherwise returns `SubsysInfo` for the desired target only.
+// To request the default target only, target must be set to `Default`.
+func (c Config) GetSubsysInfo(subSys, target string) ([]SubsysInfo, error) {
 	// Check if config param requested is valid.
 	defKVS1, ok := DefaultKVS[subSys]
 	if !ok {
@@ -1232,6 +1234,20 @@ func (c Config) GetSubsysInfo(subSys string) ([]SubsysInfo, error) {
 	targets, err := c.GetAvailableTargets(subSys)
 	if err != nil {
 		return nil, err
+	}
+
+	if target != "" {
+		found := false
+		for _, t := range targets {
+			if t == target {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, Errorf("there is no target `%s` for subsystem `%s`", target, subSys)
+		}
+		targets = []string{target}
 	}
 
 	// The `Comment` configuration variable is optional but is available to be


### PR DESCRIPTION
## Motivation and Context

Restores previous behavior when a single target could be queried. Also allow querying the default target alone with trailing `:`.

No `mc` changes are required.

## How to test this PR?

It should work like this now:

```
$ mc admin config get myminio logger_webhook
logger_webhook enable=off endpoint= auth_token= client_cert= client_key= queue_size=100000 
logger_webhook:1 endpoint=http://localhost:8080/ auth_token= client_cert= client_key= queue_size=100000 
$ mc admin config get myminio logger_webhook:1
logger_webhook:1 endpoint=http://localhost:8080/ auth_token= client_cert= client_key= queue_size=100000 
$ mc admin config get myminio logger_webhook:
logger_webhook enable=off endpoint= auth_token= client_cert= client_key= queue_size=100000 
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (introduced in 21831b3fe29a6ae4d81c4e16132460b879fa872e)
- [ ] Documentation updated
- [ ] Unit tests added/updated
