### PR TITLE
Helm conditions

### DIFF
--- a/helm/minio/templates/_helper_policy.tpl
+++ b/helm/minio/templates/_helper_policy.tpl
@@ -12,6 +12,16 @@
       "Resource": [
 "{{ $statement.resources | join "\",\n\"" }}"
       ]{{ end }}
+{{- if $statement.conditions }}
+{{- $condition_len := len $statement.conditions }}
+{{- $condition_len := sub $condition_len 1 }}
+      ,
+      "Condition": {
+ {{- range $k,$v := $statement.conditions }}
+ {{- range $operator,$object := $v }}
+        "{{ $operator }}": { {{ $object }} }{{- if lt $k $condition_len }},{{- end }}
+ {{- end }}{{- end }}
+      }{{- end }} 
     }{{ if lt $i $statements_length }},{{end }}
 {{- end }}
   ]

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -301,6 +301,21 @@ policies: []
 #         - "s3:GetBucketLocation"
 #         - "s3:ListBucket"
 #         - "s3:ListBucketMultipartUploads"
+## conditionsexample policy creates all access to example bucket with aws:username="johndoe" and source ip range 10.0.0.0/8 and 192.168.0.0/24 only
+# - name: conditionsexample
+#   statements:
+#     - resources:
+#       - 'arn:aws:s3:::example/*'
+#       actions:
+#       - 's3:*'
+#       conditions:
+#         - StringEquals: '"aws:username": "johndoe"'
+#         - IpAddress: |
+#             "aws:SourceIp": [
+#               "10.0.0.0/8",
+#               "192.168.0.0/24"
+#             ]
+#
 ## Additional Annotations for the Kubernetes Job makePolicyJob
 makePolicyJob:
   podAnnotations: {}


### PR DESCRIPTION
## Description
This adds support for policy condition to the helm chart

## Motivation and Context
Github Issue [15582](https://github.com/minio/minio/issues/15582) - missing feature

## How to test this PR?

- create values.yaml as in the example and have policy creation enabled
- have also conditions setup for the policy 
- run the helm chart with those values (and eventually --dry-run)
- the existing configMap generator will produce policies as before
- those having conditions configured will incl. the conditions and will run on the post activitied


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
