### PR TITLE
Avoid messages from go test output

### DIFF
--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -99,11 +99,11 @@ func TestMain(m *testing.M) {
 	// Set as non-distributed.
 	globalIsDistErasure = false
 
-	if !testing.Verbose() {
-		// Disable printing console messages during tests.
-		color.Output = ioutil.Discard
-		logger.Disable = true
-	}
+	// Disable printing console messages during tests.
+	color.Output = ioutil.Discard
+	// Minimum is error logs for testing
+	logger.MinimumLogLevel = logger.ErrorLvl
+
 	// Uncomment the following line to see trace logs during unit tests.
 	// logger.AddTarget(console.New())
 

--- a/internal/crypto/key_test.go
+++ b/internal/crypto/key_test.go
@@ -49,8 +49,8 @@ var generateKeyTests = []struct {
 }
 
 func TestGenerateKey(t *testing.T) {
-	defer func(disableLog bool) { logger.Disable = disableLog }(logger.Disable)
-	logger.Disable = true
+	defer func(l logger.LogLevel) { logger.MinimumLogLevel = l }(logger.MinimumLogLevel)
+	logger.MinimumLogLevel = logger.ErrorLvl
 
 	for i, test := range generateKeyTests {
 		i, test := i, test
@@ -75,8 +75,8 @@ var generateIVTests = []struct {
 }
 
 func TestGenerateIV(t *testing.T) {
-	defer func(disableLog bool) { logger.Disable = disableLog }(logger.Disable)
-	logger.Disable = true
+	defer func(l logger.LogLevel) { logger.MinimumLogLevel = l }(logger.MinimumLogLevel)
+	logger.MinimumLogLevel = logger.ErrorLvl
 
 	for i, test := range generateIVTests {
 		i, test := i, test

--- a/internal/crypto/metadata_test.go
+++ b/internal/crypto/metadata_test.go
@@ -313,8 +313,8 @@ var s3CreateMetadataTests = []struct {
 }
 
 func TestS3CreateMetadata(t *testing.T) {
-	defer func(disableLog bool) { logger.Disable = disableLog }(logger.Disable)
-	logger.Disable = true
+	defer func(l logger.LogLevel) { logger.MinimumLogLevel = l }(logger.MinimumLogLevel)
+	logger.MinimumLogLevel = logger.ErrorLvl
 	for i, test := range s3CreateMetadataTests {
 		metadata := S3.CreateMetadata(nil, test.KeyID, test.SealedDataKey, test.SealedKey)
 		keyID, kmsKey, sealedKey, err := S3.ParseMetadata(metadata)
@@ -358,8 +358,8 @@ var ssecCreateMetadataTests = []struct {
 }
 
 func TestSSECCreateMetadata(t *testing.T) {
-	defer func(disableLog bool) { logger.Disable = disableLog }(logger.Disable)
-	logger.Disable = true
+	defer func(l logger.LogLevel) { logger.MinimumLogLevel = l }(logger.MinimumLogLevel)
+	logger.MinimumLogLevel = logger.ErrorLvl
 	for i, test := range ssecCreateMetadataTests {
 		metadata := SSEC.CreateMetadata(nil, test.SealedKey)
 		sealedKey, err := SSEC.ParseMetadata(metadata)

--- a/internal/logger/console.go
+++ b/internal/logger/console.go
@@ -158,7 +158,7 @@ func (i infoMsg) json(msg string, args ...interface{}) {
 		message = fmt.Sprint(args...)
 	}
 	logJSON, err := json.Marshal(&log.Entry{
-		Level:   InformationLvl.String(),
+		Level:   InfoLvl.String(),
 		Message: message,
 		Time:    time.Now().UTC(),
 	})
@@ -214,10 +214,16 @@ func (i errorMsg) pretty(msg string, args ...interface{}) {
 
 // Error :
 func Error(msg string, data ...interface{}) {
+	if MinimumLogLevel > ErrorLvl {
+		return
+	}
 	consoleLog(errorm, msg, data...)
 }
 
 // Info :
 func Info(msg string, data ...interface{}) {
+	if MinimumLogLevel > InfoLvl {
+		return
+	}
 	consoleLog(info, msg, data...)
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -38,15 +38,12 @@ import (
 // HighwayHash key for logging in anonymous mode
 var magicHighwayHash256Key = []byte("\x4b\xe7\x34\xfa\x8e\x23\x8a\xcd\x26\x3e\x83\xe6\xbb\x96\x85\x52\x04\x0f\x93\x5d\xa3\x9f\x44\x14\x97\xe0\x9d\x13\x22\xde\x36\xa0")
 
-// Disable disables all logging, false by default. (used for "go test")
-var Disable = false
-
-// Level type
-type Level int8
+// LogLevel type
+type LogLevel int8
 
 // Enumerated level types
 const (
-	InformationLvl Level = iota + 1
+	InfoLvl LogLevel = iota + 1
 	ErrorLvl
 	FatalLvl
 
@@ -54,6 +51,9 @@ const (
 	Minio       = madmin.LogKindMinio
 	All         = madmin.LogKindAll
 )
+
+// MinimumLogLevel holds the minimum logging level to print - info by default
+var MinimumLogLevel = InfoLvl
 
 var trimStrings []string
 
@@ -67,9 +67,9 @@ var matchingFuncNames = [...]string{
 	// add more here ..
 }
 
-func (level Level) String() string {
+func (level LogLevel) String() string {
 	switch level {
-	case InformationLvl:
+	case InfoLvl:
 		return "INFO"
 	case ErrorLvl:
 		return "ERROR"
@@ -341,7 +341,7 @@ func errToEntry(ctx context.Context, err error, errKind ...interface{}) log.Entr
 // consoleLogIf prints a detailed error message during
 // the execution of the server.
 func consoleLogIf(ctx context.Context, err error, errKind ...interface{}) {
-	if Disable {
+	if MinimumLogLevel > ErrorLvl {
 		return
 	}
 
@@ -354,7 +354,7 @@ func consoleLogIf(ctx context.Context, err error, errKind ...interface{}) {
 // logIf prints a detailed error message during
 // the execution of the server.
 func logIf(ctx context.Context, err error, errKind ...interface{}) {
-	if Disable {
+	if MinimumLogLevel > ErrorLvl {
 		return
 	}
 


### PR DESCRIPTION
## Description
A lot of warning messages are printed in CI/CD failures generated by go
test. Avoid that by requiring at least Error level for logging when
doing go test.


## Motivation and Context
Remove annoying messages in go test verobse output

## How to test this PR?
go test .

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
