### PR TITLE
site replication: Avoid returning root svcacct info in sr metadata

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -3322,8 +3322,11 @@ func (c *SiteReplicationSys) SiteReplicationMetaInfo(ctx context.Context, objAPI
 					return info, errSRBackendIssue(err)
 				}
 				for _, svcAcct := range svcAccts {
-					info.UserInfoMap[svcAcct.AccessKey] = madmin.UserInfo{
-						Status: madmin.AccountStatus(svcAcct.Status),
+					// report all non-root user accounts for syncing
+					if svcAcct.ParentUser != "" && svcAcct.ParentUser != globalActiveCred.AccessKey {
+						info.UserInfoMap[svcAcct.AccessKey] = madmin.UserInfo{
+							Status: madmin.AccountStatus(svcAcct.Status),
+						}
 					}
 				}
 				tempAccts, err := globalIAMSys.ListTempAccounts(ctx, user)


### PR DESCRIPTION
Service accounts of root users should not be replicated.

## Description


## Motivation and Context


## How to test this PR?
create a service acct for root user in a site replication setup - should not replicate
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
