### PR TITLE
audit: account for response headers separately

### DIFF
--- a/internal/logger/message/audit/entry.go
+++ b/internal/logger/message/audit/entry.go
@@ -53,6 +53,7 @@ type Entry struct {
 		StatusCode      int             `json:"statusCode,omitempty"`
 		InputBytes      int64           `json:"rx"`
 		OutputBytes     int64           `json:"tx"`
+		HeaderBytes     int64           `json:"txHeaders,omitempty"`
 		TimeToFirstByte string          `json:"timeToFirstByte,omitempty"`
 		TimeToResponse  string          `json:"timeToResponse,omitempty"`
 	} `json:"api"`


### PR DESCRIPTION
## Description
Today, audit-log entries account for response headers along with the response body towards `OutputBytes` (seen as `api.tx` in json). With this change, audit logs would account for response header bytes in `HeaderBytes` (seen as `api.txHeaders` in json). 

## How to test this PR?
Requires setting up an audit-log target, like a simple webhook server (https://github.com/krishnasrinivas/minio-webhook)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
