### PR TITLE
Encrypt checksums

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -704,16 +704,17 @@ func generateInitiateMultipartUploadResponse(bucket, key, uploadID string) Initi
 
 // generates CompleteMultipartUploadResponse for given bucket, key, location and ETag.
 func generateCompleteMultpartUploadResponse(bucket, key, location string, oi ObjectInfo) CompleteMultipartUploadResponse {
+	cs := oi.decryptChecksums()
 	c := CompleteMultipartUploadResponse{
 		Location: location,
 		Bucket:   bucket,
 		Key:      key,
 		// AWS S3 quotes the ETag in XML, make sure we are compatible here.
 		ETag:           "\"" + oi.ETag + "\"",
-		ChecksumSHA1:   oi.Checksum[hash.ChecksumSHA1.String()],
-		ChecksumSHA256: oi.Checksum[hash.ChecksumSHA256.String()],
-		ChecksumCRC32:  oi.Checksum[hash.ChecksumCRC32.String()],
-		ChecksumCRC32C: oi.Checksum[hash.ChecksumCRC32C.String()],
+		ChecksumSHA1:   cs[hash.ChecksumSHA1.String()],
+		ChecksumSHA256: cs[hash.ChecksumSHA256.String()],
+		ChecksumCRC32:  cs[hash.ChecksumCRC32.String()],
+		ChecksumCRC32C: cs[hash.ChecksumCRC32C.String()],
 	}
 	return c
 }

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -962,7 +962,10 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	}
 
 	fi.DataDir = mustGetUUID()
-	fi.Checksum = opts.WantChecksum.AsMap()
+	fi.Checksum = opts.WantChecksum.AppendTo(nil)
+	if opts.EncryptFn != nil {
+		fi.Checksum = opts.EncryptFn("object-checksum", fi.Checksum)
+	}
 	uniqueID := mustGetUUID()
 	tempObj := uniqueID
 

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -179,8 +179,9 @@ type ObjectInfo struct {
 	//  The modtime of the successor object version if any
 	SuccessorModTime time.Time
 
-	// User-Defined object tags
-	Checksum map[string]string
+	// Checksums added on upload.
+	// Encoded, maybe encrypted.
+	Checksum []byte
 }
 
 // ArchiveInfo returns any saved zip archive meta information

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -78,6 +78,9 @@ type ObjectOptions struct {
 	// Use the maximum parity (N/2), used when saving server configuration files
 	MaxParity bool
 
+	// Provides a per object encryption function, allowing metadata encryption.
+	EncryptFn objectMetaEncryptFn
+
 	// SkipDecommissioned set to 'true' if the call requires skipping the pool being decommissioned.
 	// mainly set for certain WRITE operations.
 	SkipDecommissioned bool

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -716,7 +716,7 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, opts ObjectOptions) (
 			}
 			// Decompression reader.
 			var dopts []s2.ReaderOption
-			if off > 0 {
+			if off > 0 || decOff > 0 {
 				// We are not starting at the beginning, so ignore stream identifiers.
 				dopts = append(dopts, s2.ReaderIgnoreStreamIdentifier())
 			}

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -44,15 +43,12 @@ import (
 	"github.com/minio/minio/internal/config/dns"
 	"github.com/minio/minio/internal/config/storageclass"
 	"github.com/minio/minio/internal/crypto"
-	"github.com/minio/minio/internal/fips"
 	"github.com/minio/minio/internal/hash"
-	"github.com/minio/minio/internal/hash/sha256"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/trie"
 	"github.com/minio/pkg/wildcard"
-	"github.com/minio/sio"
 )
 
 const (
@@ -845,6 +841,8 @@ func (g *GetObjectReader) Close() error {
 	return nil
 }
 
+// compressionIndexEncrypter returns a function that will read data from input,
+// encrypt it using the provided key and return the result.
 func compressionIndexEncrypter(key crypto.ObjectKey, input func() []byte) func() []byte {
 	var data []byte
 	var fetched bool
@@ -853,31 +851,13 @@ func compressionIndexEncrypter(key crypto.ObjectKey, input func() []byte) func()
 			data = input()
 			fetched = true
 		}
-		if len(data) == 0 {
-			return data
-		}
-		var buffer bytes.Buffer
-		mac := hmac.New(sha256.New, key[:])
-		mac.Write([]byte("compression-index"))
-		if _, err := sio.Encrypt(&buffer, bytes.NewReader(data), sio.Config{Key: mac.Sum(nil), CipherSuites: fips.DARECiphers()}); err != nil {
-			logger.CriticalIf(context.Background(), errors.New("unable to encrypt compression index using object key"))
-		}
-		return buffer.Bytes()
+		return metadataEncrypter(key)("compression-index", data)
 	}
 }
 
+// compressionIndexDecrypt reverses compressionIndexEncrypter.
 func (o *ObjectInfo) compressionIndexDecrypt(input []byte) ([]byte, error) {
-	if len(input) == 0 {
-		return input, nil
-	}
-
-	key, err := decryptObjectInfo(nil, o.Bucket, o.Name, o.UserDefined)
-	if err != nil {
-		return nil, err
-	}
-	mac := hmac.New(sha256.New, key)
-	mac.Write([]byte("compression-index"))
-	return sio.DecryptBuffer(nil, input, sio.Config{Key: mac.Sum(nil), CipherSuites: fips.DARECiphers()})
+	return o.metadataDecrypter()("compression-index", input)
 }
 
 // SealMD5CurrFn seals md5sum with object encryption key and returns sealed

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -267,7 +267,7 @@ func setPutObjHeaders(w http.ResponseWriter, objInfo ObjectInfo, delete bool) {
 			lc.SetPredictionHeaders(w, objInfo.ToLifecycleOpts())
 		}
 	}
-	hash.AddChecksumHeader(w, objInfo.Checksum)
+	hash.AddChecksumHeader(w, objInfo.decryptChecksums())
 }
 
 func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toDel []ObjectToDelete) {

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -520,7 +520,7 @@ func (api objectAPIHandlers) getObjectHandler(ctx context.Context, objectAPI Obj
 	}
 
 	if r.Header.Get(xhttp.AmzChecksumMode) == "ENABLED" {
-		hash.AddChecksumHeader(w, objInfo.Checksum)
+		hash.AddChecksumHeader(w, objInfo.decryptChecksums())
 	}
 
 	if err = setObjectHeaders(w, objInfo, rs, opts); err != nil {
@@ -788,7 +788,7 @@ func (api objectAPIHandlers) headObjectHandler(ctx context.Context, objectAPI Ob
 	}
 
 	if r.Header.Get(xhttp.AmzChecksumMode) == "ENABLED" {
-		hash.AddChecksumHeader(w, objInfo.Checksum)
+		hash.AddChecksumHeader(w, objInfo.decryptChecksums())
 	}
 
 	// Set standard object headers.
@@ -1850,6 +1850,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 			if opts.IndexCB != nil {
 				opts.IndexCB = compressionIndexEncrypter(objectEncryptionKey, opts.IndexCB)
 			}
+			opts.EncryptFn = metadataEncrypter(objectEncryptionKey)
 		}
 	}
 

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -394,10 +394,6 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	_, isEncrypted := crypto.IsEncrypted(mi.UserDefined)
 	var objectEncryptionKey crypto.ObjectKey
 	if objectAPI.IsEncryptionSupported() && isEncrypted {
-		// TODO(klauspost): It seems like compression+encryption indexes are broken.
-		// Check with minio-go functional (mint) tests.
-		// Disable indexes on compressed+encrypted for now.
-		idxCb = nil
 		if !crypto.SSEC.IsRequested(r.Header) && crypto.SSEC.IsEncrypted(mi.UserDefined) {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrSSEMultipartEncrypted), r.URL)
 			return

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -394,6 +394,10 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 	_, isEncrypted := crypto.IsEncrypted(mi.UserDefined)
 	var objectEncryptionKey crypto.ObjectKey
 	if objectAPI.IsEncryptionSupported() && isEncrypted {
+		// TODO(klauspost): It seems like compression+encryption indexes are broken.
+		// Check with minio-go functional (mint) tests.
+		// Disable indexes on compressed+encrypted for now.
+		idxCb = nil
 		if !crypto.SSEC.IsRequested(r.Header) && crypto.SSEC.IsEncrypted(mi.UserDefined) {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrSSEMultipartEncrypted), r.URL)
 			return

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -231,8 +231,7 @@ type FileInfo struct {
 	DiskMTime time.Time `msg:"dmt"`
 
 	// Combined checksum when object was uploaded.
-	// Format is type:base64(checksum).
-	Checksum map[string]string `msg:"cs,allownil"`
+	Checksum []byte `msg:"cs,allownil"`
 }
 
 // Equals checks if fi(FileInfo) matches ofi(FileInfo)

--- a/cmd/storage-datatypes_gen.go
+++ b/cmd/storage-datatypes_gen.go
@@ -778,43 +778,10 @@ func (z *FileInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err, "DiskMTime")
 		return
 	}
-	if dc.IsNil() {
-		err = dc.ReadNil()
-		if err != nil {
-			err = msgp.WrapError(err)
-			return
-		}
-		z.Checksum = nil
-	} else {
-		var zb0004 uint32
-		zb0004, err = dc.ReadMapHeader()
-		if err != nil {
-			err = msgp.WrapError(err, "Checksum")
-			return
-		}
-		if z.Checksum == nil {
-			z.Checksum = make(map[string]string, zb0004)
-		} else if len(z.Checksum) > 0 {
-			for key := range z.Checksum {
-				delete(z.Checksum, key)
-			}
-		}
-		for zb0004 > 0 {
-			zb0004--
-			var za0004 string
-			var za0005 string
-			za0004, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, "Checksum")
-				return
-			}
-			za0005, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, "Checksum", za0004)
-				return
-			}
-			z.Checksum[za0004] = za0005
-		}
+	z.Checksum, err = dc.ReadBytes(z.Checksum)
+	if err != nil {
+		err = msgp.WrapError(err, "Checksum")
+		return
 	}
 	return
 }
@@ -980,29 +947,10 @@ func (z *FileInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "DiskMTime")
 		return
 	}
-	if z.Checksum == nil { // allownil: if nil
-		err = en.WriteNil()
-		if err != nil {
-			return
-		}
-	} else {
-		err = en.WriteMapHeader(uint32(len(z.Checksum)))
-		if err != nil {
-			err = msgp.WrapError(err, "Checksum")
-			return
-		}
-		for za0004, za0005 := range z.Checksum {
-			err = en.WriteString(za0004)
-			if err != nil {
-				err = msgp.WrapError(err, "Checksum")
-				return
-			}
-			err = en.WriteString(za0005)
-			if err != nil {
-				err = msgp.WrapError(err, "Checksum", za0004)
-				return
-			}
-		}
+	err = en.WriteBytes(z.Checksum)
+	if err != nil {
+		err = msgp.WrapError(err, "Checksum")
+		return
 	}
 	return
 }
@@ -1058,15 +1006,7 @@ func (z *FileInfo) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendBool(o, z.Fresh)
 	o = msgp.AppendInt(o, z.Idx)
 	o = msgp.AppendTime(o, z.DiskMTime)
-	if z.Checksum == nil { // allownil: if nil
-		o = msgp.AppendNil(o)
-	} else {
-		o = msgp.AppendMapHeader(o, uint32(len(z.Checksum)))
-		for za0004, za0005 := range z.Checksum {
-			o = msgp.AppendString(o, za0004)
-			o = msgp.AppendString(o, za0005)
-		}
-	}
+	o = msgp.AppendBytes(o, z.Checksum)
 	return
 }
 
@@ -1254,39 +1194,10 @@ func (z *FileInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err, "DiskMTime")
 		return
 	}
-	if msgp.IsNil(bts) {
-		bts = bts[1:]
-		z.Checksum = nil
-	} else {
-		var zb0004 uint32
-		zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
-		if err != nil {
-			err = msgp.WrapError(err, "Checksum")
-			return
-		}
-		if z.Checksum == nil {
-			z.Checksum = make(map[string]string, zb0004)
-		} else if len(z.Checksum) > 0 {
-			for key := range z.Checksum {
-				delete(z.Checksum, key)
-			}
-		}
-		for zb0004 > 0 {
-			var za0004 string
-			var za0005 string
-			zb0004--
-			za0004, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Checksum")
-				return
-			}
-			za0005, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Checksum", za0004)
-				return
-			}
-			z.Checksum[za0004] = za0005
-		}
+	z.Checksum, bts, err = msgp.ReadBytesBytes(bts, z.Checksum)
+	if err != nil {
+		err = msgp.WrapError(err, "Checksum")
+		return
 	}
 	o = bts
 	return
@@ -1305,13 +1216,7 @@ func (z *FileInfo) Msgsize() (s int) {
 	for za0003 := range z.Parts {
 		s += z.Parts[za0003].Msgsize()
 	}
-	s += z.Erasure.Msgsize() + msgp.BoolSize + z.ReplicationState.Msgsize() + msgp.BytesPrefixSize + len(z.Data) + msgp.IntSize + msgp.TimeSize + msgp.BoolSize + msgp.IntSize + msgp.TimeSize + msgp.MapHeaderSize
-	if z.Checksum != nil {
-		for za0004, za0005 := range z.Checksum {
-			_ = za0005
-			s += msgp.StringPrefixSize + len(za0004) + msgp.StringPrefixSize + len(za0005)
-		}
-	}
+	s += z.Erasure.Msgsize() + msgp.BoolSize + z.ReplicationState.Msgsize() + msgp.BytesPrefixSize + len(z.Data) + msgp.IntSize + msgp.TimeSize + msgp.BoolSize + msgp.IntSize + msgp.TimeSize + msgp.BytesPrefixSize + len(z.Checksum)
 	return
 }
 

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -36,7 +36,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/minio/minio/internal/bucket/lifecycle"
 	"github.com/minio/minio/internal/bucket/replication"
-	"github.com/minio/minio/internal/hash"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/tinylib/msgp/msgp"
@@ -640,7 +639,7 @@ func (j xlMetaV2Object) ToFileInfo(volume, path string) (FileInfo, error) {
 		fi.TransitionTier = string(sc)
 	}
 	if crcs := j.MetaSys[ReservedMetadataPrefixLower+"crc"]; len(crcs) > 0 {
-		fi.Checksum = hash.ReadCheckSums(crcs)
+		fi.Checksum = crcs
 	}
 	return fi, nil
 }
@@ -1541,14 +1540,7 @@ func (x *xlMetaV2) AddVersion(fi FileInfo) error {
 			ventry.ObjectV2.MetaSys[ReservedMetadataPrefixLower+TransitionTier] = []byte(fi.TransitionTier)
 		}
 		if len(fi.Checksum) > 0 {
-			res := make([]byte, 0, len(fi.Checksum)*40)
-			for k, v := range fi.Checksum {
-				crc := hash.NewChecksumString(k, v)
-				if crc.Valid() {
-					res = crc.AppendTo(res)
-				}
-			}
-			ventry.ObjectV2.MetaSys[ReservedMetadataPrefixLower+"crc"] = res
+			ventry.ObjectV2.MetaSys[ReservedMetadataPrefixLower+"crc"] = fi.Checksum
 		}
 	}
 

--- a/internal/hash/checksum.go
+++ b/internal/hash/checksum.go
@@ -136,7 +136,7 @@ func (c ChecksumType) String() string {
 	case c.Is(ChecksumSHA256):
 		return "SHA256"
 	case c.Is(ChecksumNone):
-		return "<none>"
+		return ""
 	}
 	return "invalid"
 }

--- a/internal/hash/checksum.go
+++ b/internal/hash/checksum.go
@@ -136,7 +136,7 @@ func (c ChecksumType) String() string {
 	case c.Is(ChecksumSHA256):
 		return "SHA256"
 	case c.Is(ChecksumNone):
-		return ""
+		return "<none>"
 	}
 	return "invalid"
 }
@@ -215,7 +215,10 @@ func NewChecksumString(alg, value string) *Checksum {
 
 // AppendTo will append the checksum to b.
 // ReadCheckSums reads the values back.
-func (c Checksum) AppendTo(b []byte) []byte {
+func (c *Checksum) AppendTo(b []byte) []byte {
+	if c == nil {
+		return nil
+	}
 	var tmp [binary.MaxVarintLen32]byte
 	n := binary.PutUvarint(tmp[:], uint64(c.Type))
 	crc := c.Raw()


### PR DESCRIPTION
## Description

When object data is encrypted, also encrypt checksums.

`x-minio-internal-crc": "IAAgANKe+IDKIfhm7uMtu9V4syPulWlWpmL5kKOPeUKxwPSN6CAd7/9ZrhpwGR839NcZmGg5LtCJgGZO2gRKK+8="` when encrypted.

## How to test this PR?

Mint check in: https://github.com/minio/minio-go/pull/1690


## Types of changes
- [x] New feature (non-breaking change which adds functionality)
