### PR TITLE
config: empty out stale entry in KVS after delete

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,6 +234,11 @@ type KV struct {
 	Value string `json:"value"`
 }
 
+// Empty - return if kv is empty
+func (kv KV) Empty() bool {
+	return kv.Key == "" && kv.Value == ""
+}
+
 // KVS - is a shorthand for some wrapper functions
 // to operate on list of key values.
 type KVS []KV
@@ -277,6 +282,9 @@ func (kvs KVS) Keys() []string {
 func (kvs KVS) String() string {
 	var s strings.Builder
 	for _, kv := range kvs {
+		if kv.Empty() {
+			continue
+		}
 		// Do not need to print if state is on
 		if kv.Key == Enable && kv.Value == EnableOn {
 			continue
@@ -344,6 +352,7 @@ func (kvs *KVS) Delete(key string) {
 	for i, kv := range *kvs {
 		if kv.Key == key {
 			*kvs = append((*kvs)[:i], (*kvs)[i+1:]...)
+			*kvs = append(*kvs, KV{})
 			return
 		}
 	}
@@ -578,7 +587,7 @@ func CheckValidKeys(subSys string, kv KVS, validKVS KVS) error {
 		// Comment is a valid key, its also fully optional
 		// ignore it since it is a valid key for all
 		// sub-systems.
-		if kv.Key == Comment {
+		if kv.Key == Comment || kv.Empty() {
 			continue
 		}
 		if _, ok := validKVS.Lookup(kv.Key); !ok {


### PR DESCRIPTION
config lookup hand outs a pointer to slice - if a deprecated key
is deleted, empty out the last entry in the slice since the slice
is modified in place.

## Description


## Motivation and Context
Allow deprecation of old keys properly.

## How to test this PR?
Was visible when some old keys were deprecated and a new kv being added as a replacement 
e.g. with master deprecating replication_workers, replication_failed_workers and  adding replication_priority as a new key
```
mc admin config get sitea api
api requests_max=0 requests_deadline=10s cluster_deadline=10s cors_allow_origin=* remote_transport_deadline=2h list_quorum=strict transition_workers=100 stale_uploads_cleanup_interval=6h stale_uploads_expiry=24h delete_cleanup_interval=5m disable_odirect=off gzip_objects=off replication_priority=auto replication_priority=auto  replication_priority=auto 

```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
