### PR TITLE
feat:Deadlock caused by unlocking a non-existing lock

### DIFF
--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -60,15 +60,6 @@ func (l *localLocker) String() string {
 	return globalEndpoints.Localhost()
 }
 
-func (l *localLocker) canTakeUnlock(resources ...string) bool {
-	for _, resource := range resources {
-		if !isWriteLock(l.lockMap[resource]) {
-			return false
-		}
-	}
-	return true
-}
-
 func (l *localLocker) canTakeLock(resources ...string) bool {
 	for _, resource := range resources {
 		_, lockTaken := l.lockMap[resource]

--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -127,17 +127,16 @@ func (l *localLocker) Unlock(_ context.Context, args dsync.LockArgs) (reply bool
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	err = nil
+
 	for _, resource := range args.Resources {
-		if lri, ok := l.lockMap[resource]; ok {
-			if !l.canTakeUnlock(resource) {
-				// Unless it is a write lock reject it.
-				err = fmt.Errorf("unlock attempted on a read locked entity: %s", resource)
-				continue
-			}
+		lri, ok := l.lockMap[resource]
+		if ok && !isWriteLock(lri) {
+			// Unless it is a write lock reject it.
+			err = fmt.Errorf("unlock attempted on a read locked entity: %s", resource)
+			continue
+		}
+		if ok {
 			reply = l.removeEntry(resource, args, &lri) || reply
-		} else {
-			// return true if lock not exits.
-			reply = true
 		}
 	}
 	return


### PR DESCRIPTION
## Description
feat:Deadlock caused by unlocking a non-existing lock。
for example， minio-6 locks minio-5 at startup, but minio-5 restarts before minio-6 unlocked,
causing minio-6's lock to be lost, which leads to minio-6 deadlock.
In fixed code, it will return true if lock not exits.

issues :  https://github.com/minio/minio/issues/15519

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
