### PR TITLE
Add auto configuration of replication workers

### DIFF
--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -63,16 +63,10 @@ var (
 			Type:        "string",
 		},
 		config.HelpKV{
-			Key:         apiReplicationWorkers,
-			Description: `set the number of replication workers` + defaultHelpPostfix(apiReplicationWorkers),
+			Key:         apiReplicationPriority,
+			Description: `set replication priority` + defaultHelpPostfix(apiReplicationPriority),
 			Optional:    true,
-			Type:        "number",
-		},
-		config.HelpKV{
-			Key:         apiReplicationFailedWorkers,
-			Description: `set the number of replication workers for recently failed replicas` + defaultHelpPostfix(apiReplicationFailedWorkers),
-			Optional:    true,
-			Type:        "number",
+			Type:        "string",
 		},
 		config.HelpKV{
 			Key:         apiTransitionWorkers,


### PR DESCRIPTION
This PR deprecates replication_workers and replication_failed_workers
config variables for api subsystem and adds replication_priority
options of "fast", "slow" or the default "auto"

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
