### PR TITLE
tier: avoid stats infinite loop in forwardTo method

### DIFF
--- a/cmd/tier-last-day-stats.go
+++ b/cmd/tier-last-day-stats.go
@@ -38,6 +38,10 @@ func (l *lastDayTierStats) addStats(ts tierStats) {
 
 // forwardTo moves time to t, clearing entries between last update and t.
 func (l *lastDayTierStats) forwardTo(t time.Time) {
+	if t.IsZero() {
+		t = time.Now()
+	}
+
 	since := t.Sub(l.UpdatedAt).Hours()
 	// within the hour since l.UpdatedAt
 	if since < 1 {
@@ -45,15 +49,17 @@ func (l *lastDayTierStats) forwardTo(t time.Time) {
 	}
 
 	idx, lastIdx := t.Hour(), l.UpdatedAt.Hour()
-	l.UpdatedAt = t
+
+	l.UpdatedAt = t // update to the latest time index
 
 	if since >= 24 {
 		l.Bins = [24]tierStats{}
 		return
 	}
 
-	for ; lastIdx != idx; lastIdx++ {
-		l.Bins[(lastIdx+1)%24] = tierStats{}
+	for lastIdx != idx {
+		lastIdx = (lastIdx + 1) % 24
+		l.Bins[lastIdx] = tierStats{}
 	}
 }
 


### PR DESCRIPTION


## Description
tier: avoid stats infinite loop in forwardTo method

## Motivation and Context
under some sequence of events following
code would reach infinite loop

```
idx1, idx2 := 0, 1
for ; idx2 != idx1; idx2++ {
        fmt.Println(idx2)
}
```

fixes #15639

## How to test this PR?
Just deploy tiered distributed setup and then perform `mc admin tier info` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
