### PR TITLE
Avoid replicating dirs in listing with replication enabled

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -2401,8 +2401,8 @@ func getReplicationDiff(ctx context.Context, objAPI ObjectLayer, bucket string, 
 
 // QueueReplicationHeal is a wrapper for queueReplicationHeal
 func QueueReplicationHeal(ctx context.Context, bucket string, oi ObjectInfo) {
-	// un-versioned case
-	if oi.VersionID == "" {
+	// un-versioned or a prefix
+	if oi.VersionID == "" || oi.ModTime.IsZero() {
 		return
 	}
 	rcfg, _, _ := globalBucketMetadataSys.GetReplicationConfig(ctx, bucket)
@@ -2416,8 +2416,8 @@ func QueueReplicationHeal(ctx context.Context, bucket string, oi ObjectInfo) {
 // queueReplicationHeal enqueues objects that failed replication OR eligible for resyncing through
 // an ongoing resync operation or via existing objects replication configuration setting.
 func queueReplicationHeal(ctx context.Context, bucket string, oi ObjectInfo, rcfg replicationConfig) (roi ReplicateObjectInfo) {
-	// un-versioned case
-	if oi.VersionID == "" {
+	// un-versioned or a prefix
+	if oi.VersionID == "" || oi.ModTime.IsZero() {
 		return roi
 	}
 


### PR DESCRIPTION
## Description
When replication is enabled in a particuler bucket, listing will send
objects to bucket replication, but it is also sending prefixes for non
recursive listing which is useless and showing a lot of error logs.

This commit will ignore prefixes.

## Motivation and Context
Avoid spammy logs

```
API: SYSTEM()
Time: 20:41:28 UTC 09/01/2022
DeploymentID: 517fab08-855b-420b-a4bb-47dd00cbd276
Error: Unable to update replication metadata for testbucket/dir1/(null): Version not found: testbucket/dir1/() (*fmt.wrapError)
       3: internal/logger/logger.go:259:logger.LogIf()
       2: cmd/bucket-replication.go:979:cmd.replicateObject()
       1: cmd/bucket-replication.go:1459:cmd.(*ReplicationPool).AddExistingObjectReplicateWorker()
```

## How to test this PR?
1. Start two clusters, enable site replication
2. Create a bucket, upload an object and do a regular listing

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
