### PR TITLE
Helm Chart: Use a Prometheus Operator Probe to scrape Cluster metrics

### DIFF
--- a/helm/minio/templates/servicemonitor.yaml
+++ b/helm/minio/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.metrics.serviceMonitor.enabled .Values.metrics.serviceMonitor.includeNode}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -35,7 +35,7 @@ spec:
     - port: http
       scheme: http
     {{- end }}
-      path: /minio/v2/metrics/cluster
+      path: /minio/v2/metrics/node
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}
@@ -58,4 +58,58 @@ spec:
       app: {{ include "minio.name" . }}
       release: {{ .Release.Name }}
       monitoring: "true"
+{{- end }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: {{ template "minio.fullname" . }}-cluster
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{ else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
+  labels:
+    app: {{ template "minio.name" . }}
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  jobName: {{ template "minio.fullname" . }}
+  prober:
+    url: {{ template "minio.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}
+    path: /minio/v2/metrics/cluster
+    {{- if .Values.tls.enabled }}
+    scheme: https
+    tlsConfig:
+      ca:
+        secret:
+          name: {{ .Values.tls.certSecret }}
+          key: {{ .Values.tls.publicCrt }}
+      serverName: {{ template "minio.fullname" . }}
+    {{ else }}
+    scheme: http
+    {{- end }}
+  {{- if .Values.metrics.serviceMonitor.relabelConfigsCluster }}
+{{ toYaml .Values.metrics.serviceMonitor.relabelConfigsCluster | indent 2 }}
+  {{- end }}
+  targets:
+    staticConfig:
+      static:
+      - {{ template "minio.fullname" . }}.{{ .Release.Namespace }}
+      {{- if not .Values.metrics.serviceMonitor.public }}
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      bearerTokenSecret:
+        name: {{ template "minio.fullname" . }}-prometheus
+        key: token
+      {{- end }}
 {{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -476,10 +476,17 @@ serviceAccount:
 metrics:
   serviceMonitor:
     enabled: false
+    # scrape each node/pod individually for additional metrics
+    includeNode: false 
     public: true
     additionalLabels: {}
-    annotations: {}
+    # for node metrics
     relabelConfigs: {}
+    # for cluster metrics
+    relabelConfigsCluster: {}
+      # metricRelabelings:
+      #   - regex: (server|pod)
+      #     action: labeldrop
     # namespace: monitoring
     # interval: 30s
     # scrapeTimeout: 10s


### PR DESCRIPTION
## Description

Scrapes the Cluster metrics from just one pod (via the Service) instead of all of them, avoiding duplicate metrics. Caveat, need to be sure Prometheus Operator is configured to find Probes, and consider whether this is a misusage of Prometheus Operator Probe and if there are any consequences.

Also adds an option to scrape the Node metrics per-pod using a traditional ServiceMonitor.

## Motivation and Context

After deploying a 32 node minio cluster I noticed metrics were very unwieldy and making the Grafana dashboard slow.  The queries in the Dashboard make an attempt to fix this but not sure if they are really successful.

More details here:
https://github.com/minio/minio/issues/15632

## How to test this PR?

Deploy via helm chart with serviceMonitor enabled and you should see a Prometheus Operator Probe object created.

If you are using [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) to deploy Prometheus Operator, finding all Probes in your k8s cluster should be a matter of setting your values.yaml to include:

```
prometheusSpec:
  probeSelectorNilUsesHelmValues: false
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
