### PR TITLE
helm: add extraContainer

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -163,6 +163,13 @@ spec:
             {{- end}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+        {{- with .Values.extraContainers }}
+        {{- if eq (typeOf .) "string" }}
+        {{- tpl . $ | nindent 8 }}
+        {{- else }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -181,6 +181,13 @@ spec:
             {{- end}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+        {{- with .Values.extraContainers }}
+        {{- if eq (typeOf .) "string" }}
+        {{- tpl . $ | nindent 8 }}
+        {{- else }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -52,6 +52,9 @@ extraVolumes: []
 ## Additional volumeMounts to minio container
 extraVolumeMounts: []
 
+## Additional sidecar containers
+extraContainers: []
+
 ## Internal port number for MinIO S3 API container
 ## Change service.port to change external port number
 minioAPIPort: "9000"


### PR DESCRIPTION
## Description
This PR adds the `extraContainer` parameter to the helm chart to allow running additional containers in the minio Pod.

## How to test this PR?
Small extra `values.yaml` definitions like

```
extraContainers: |
  - name: foobar
    image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
```
and 
```
extraContainers:
  - name: foobar
    image: alpine:latest
```
for each `mode` will do the trick.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
