### PR TITLE
add pre-conditions support for PUT calls during replication

### DIFF
--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -283,13 +283,11 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 		}
 	}
 
-	etag := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceETag))
-	if etag != "" {
-		if metadata == nil {
-			metadata = make(map[string]string, 1)
-		}
-		metadata["etag"] = etag
+	if metadata == nil {
+		metadata = make(map[string]string)
 	}
+
+	etag := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceETag))
 
 	wantCRC, err := hash.GetContentChecksum(r)
 	if err != nil {
@@ -310,6 +308,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 			Versioned:            versioned,
 			VersionSuspended:     versionSuspended,
 			MTime:                mtime,
+			PreserveETag:         etag,
 			WantChecksum:         wantCRC,
 		}, nil
 	}


### PR DESCRIPTION

## Description
add pre-conditions support for PUT calls during replication

## Motivation and Context
PUT shall only proceed if pre-conditions are met, the new code uses

- x-minio-source-mtime
- x-minio-source-etag

to verify if the object indeed needs to be replicated or not, allowing us to avoid StatObject() call.

## How to test this PR?
This PR is not finished yet, it is a work-in-progress PR to get some early feedback. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
