### PR TITLE
Fix S3 Select CSV -> JSON with variable field count

### DIFF
--- a/internal/s3select/csv/record.go
+++ b/internal/s3select/csv/record.go
@@ -125,9 +125,11 @@ func (r *Record) WriteCSV(writer io.Writer, opts sql.WriteCSVOpts) error {
 
 // WriteJSON - encodes to JSON data.
 func (r *Record) WriteJSON(writer io.Writer) error {
-	var kvs jstream.KVS = make([]jstream.KV, len(r.columnNames))
-	for i := 0; i < len(r.columnNames); i++ {
-		kvs[i] = jstream.KV{Key: r.columnNames[i], Value: r.csvRecord[i]}
+	var kvs jstream.KVS = make([]jstream.KV, 0, len(r.columnNames))
+	for i, cn := range r.columnNames {
+		if i < len(r.csvRecord) {
+			kvs = append(kvs, jstream.KV{Key: cn, Value: r.csvRecord[i]})
+		}
 	}
 	return json.NewEncoder(writer).Encode(kvs)
 }

--- a/internal/s3select/select_test.go
+++ b/internal/s3select/select_test.go
@@ -1550,6 +1550,36 @@ func TestCSVRanges(t *testing.T) {
 </SelectObjectContentRequest>`),
 		},
 		{
+			name: "var-field-count",
+			input: []byte(`id,time,num,num2,text
+1,2010-01-01T,7867786,4565.908123
+2,2017-01-02T03:04Z,-5, 0.765111,Some some
+`),
+			// Since we are doing offset, no headers are used.
+			wantResult: `{"id":"1","time":"2010-01-01T","num":"7867786","num2":"4565.908123"}
+{"id":"2","time":"2017-01-02T03:04Z","num":"-5","num2":" 0.765111","text":"Some some"}`,
+			wantErr: false,
+			requestXML: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<SelectObjectContentRequest>
+    <Expression>SELECT * from s3object</Expression>
+    <ExpressionType>SQL</ExpressionType>
+    <InputSerialization>
+        <CompressionType>NONE</CompressionType>
+        <CSV>
+        <FileHeaderInfo>USE</FileHeaderInfo>
+	    <QuoteCharacter>"</QuoteCharacter>
+        </CSV>
+    </InputSerialization>
+    <OutputSerialization>
+        <JSON>
+        </JSON>
+    </OutputSerialization>
+    <RequestProgress>
+        <Enabled>FALSE</Enabled>
+    </RequestProgress>
+</SelectObjectContentRequest>`),
+		},
+		{
 			name:  "error-after-eof",
 			input: testInput,
 			// Since we are doing offset, no headers are used.


### PR DESCRIPTION
## Description

When CSV has a variable number of fields JSON output would fail due to out-of-bounds read.

If there are less fields than headers don't output it.

## How to test this PR?

Regression test included.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Unit tests added/updated
