### PR TITLE
When listing, do not count delete markers

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -85,6 +85,12 @@ func (e *metaCacheEntry) matches(other *metaCacheEntry, strict bool) (prefer *me
 		return other, false
 	}
 
+	if other.isDir() || e.isDir() {
+		if e.isDir() {
+			return e, other.isDir() == e.isDir()
+		}
+		return other, other.isDir() == e.isDir()
+	}
 	eVers, eErr := e.xlmeta()
 	oVers, oErr := other.xlmeta()
 	if eErr != nil || oErr != nil {

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -768,8 +768,8 @@ func (es *erasureSingle) listPathInner(ctx context.Context, o listPathOptions, r
 
 	var limit int
 	if o.Limit > 0 && o.StopDiskAtLimit {
-		// Over-read by 1 to know if we truncate results.
-		limit = o.Limit + 1
+		// Over-read by 2 to know if we truncate results and not reach false EOF.
+		limit = o.Limit + 2
 	}
 
 	ctxDone := ctx.Done()
@@ -842,9 +842,9 @@ func (er *erasureObjects) listPath(ctx context.Context, o listPathOptions, resul
 	}
 	var limit int
 	if o.Limit > 0 && o.StopDiskAtLimit {
-		// Over-read by 2 + 1 for every 16 in limit to give some space for resolver
-		// And know if we have truncated.
-		limit = o.Limit + 2 + (o.Limit / 16)
+		// Over-read by 4 + 1 for every 16 in limit to give some space for resolver,
+		// allow for truncating the list and know if we have more results.
+		limit = o.Limit + 4 + (o.Limit / 16)
 	}
 	ctxDone := ctx.Done()
 	return listPathRaw(ctx, listPathRawOptions{


### PR DESCRIPTION
## Description

When limiting listing do not count delete marker objects, since they may be discarded.

Extend limit, since we may be discarding the forward-to marker.

Fix directories always being sent to resolve, since they didn't return as match. Makes merging faster.

## How to test this PR?

`go test -test.run=TestListObjectsContinuation -test.count=100`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Optimization (provides speedup with no functional changes)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
