### PR TITLE
optimize double reads by reusing results from checkUploadIDExists()

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -683,10 +683,7 @@ func (er erasureObjects) getObjectInfoAndQuorum(ctx context.Context, bucket, obj
 		return objInfo, er.defaultWQuorum(), toObjectErr(err, bucket, object)
 	}
 
-	wquorum = fi.Erasure.DataBlocks
-	if fi.Erasure.DataBlocks == fi.Erasure.ParityBlocks {
-		wquorum++
-	}
+	wquorum = fi.WriteQuorum(er.defaultWQuorum())
 
 	objInfo = fi.ToObjectInfo(bucket, object, opts.Versioned || opts.VersionSuspended)
 	if !fi.VersionPurgeStatus().Empty() && opts.VersionID != "" {

--- a/cmd/erasure-single-drive.go
+++ b/cmd/erasure-single-drive.go
@@ -795,10 +795,7 @@ func (es *erasureSingle) getObjectInfoAndQuorum(ctx context.Context, bucket, obj
 		return objInfo, 1, toObjectErr(err, bucket, object)
 	}
 
-	wquorum = fi.Erasure.DataBlocks
-	if fi.Erasure.DataBlocks == fi.Erasure.ParityBlocks {
-		wquorum++
-	}
+	wquorum = fi.WriteQuorum(1)
 
 	objInfo = fi.ToObjectInfo(bucket, object, opts.Versioned || opts.VersionSuspended)
 	if !fi.VersionPurgeStatus().Empty() && opts.VersionID != "" {

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -234,6 +234,26 @@ type FileInfo struct {
 	Checksum []byte `msg:"cs,allownil"`
 }
 
+// WriteQuorum returns expected write quorum for this FileInfo
+func (fi FileInfo) WriteQuorum(dquorum int) int {
+	if fi.Deleted {
+		return dquorum
+	}
+	quorum := fi.Erasure.DataBlocks
+	if fi.Erasure.DataBlocks == fi.Erasure.ParityBlocks {
+		quorum++
+	}
+	return quorum
+}
+
+// ReadQuorum returns expected read quorum for this FileInfo
+func (fi FileInfo) ReadQuorum(dquorum int) int {
+	if fi.Deleted {
+		return dquorum
+	}
+	return fi.Erasure.DataBlocks
+}
+
 // Equals checks if fi(FileInfo) matches ofi(FileInfo)
 func (fi FileInfo) Equals(ofi FileInfo) (ok bool) {
 	if !fi.MetadataEquals(ofi) {


### PR DESCRIPTION


## Description
optimize double reads by reusing results from checkUploadIDExists()

## Motivation and Context
Move to using `xl.meta` data structure to keep temporary partInfo, 
this allows for a future change where we move to different parts to 
different drives.

## How to test this PR?
Nothing should change mostly optimization to avoid double reads

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
