### PR TITLE
helm: default additional labels/annotations to object

### DIFF
--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -32,10 +32,10 @@ mcImage:
 mode: distributed ## other supported values are "standalone", "gateway"
 
 ## Additional labels to include with deployment or statefulset
-additionalLabels: []
+additionalLabels: {}
 
 ## Additional annotations to include with deployment or statefulset
-additionalAnnotations: []
+additionalAnnotations: {}
 
 ## Typically the deployment/statefulset includes checksums of secrets/config,
 ## So that when these change on a subsequent helm install, the deployment/statefulset


### PR DESCRIPTION
## Description
Default the additionLabels and additionalAnnotations key to an object to avoid helm warnings when it is overridden. It is used as an object in the templates and helm complains that the types don't match.

## Motivation and Context
Issue #15694

## How to test this PR?
Add minio as a child chart
Set values for additionalLabels
Run helm lint
Notice the lack of warnings

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
