### PR TITLE
helm: specify service account for the jobs

### DIFF
--- a/helm/minio/templates/post-install-create-bucket-job.yaml
+++ b/helm/minio/templates/post-install-create-bucket-job.yaml
@@ -68,6 +68,9 @@ spec:
         {{- if .Values.makeBucketJob.extraVolumes }}
           {{- toYaml .Values.makeBucketJob.extraVolumes | nindent 8 }}
         {{- end }}
+{{ if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- end }}
       containers:
       - name: minio-mc
         image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"

--- a/helm/minio/templates/post-install-create-policy-job.yaml
+++ b/helm/minio/templates/post-install-create-policy-job.yaml
@@ -68,6 +68,9 @@ spec:
         {{- if .Values.makePolicyJob.extraVolumes }}
           {{- toYaml .Values.makePolicyJob.extraVolumes | nindent 8 }}
         {{- end }}
+{{ if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- end }}
       containers:
       - name: minio-mc
         image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"

--- a/helm/minio/templates/post-install-create-user-job.yaml
+++ b/helm/minio/templates/post-install-create-user-job.yaml
@@ -78,6 +78,9 @@ spec:
         {{- if .Values.makeUserJob.extraVolumes }}
           {{- toYaml .Values.makeUserJob.extraVolumes | nindent 8 }}
         {{- end }}
+{{ if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- end }}
       containers:
       - name: minio-mc
         image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"


### PR DESCRIPTION
## Description

If the service account is being created for the deployment it should be also propagated to the job resources.

## Motivation and Context

We use Vault for secrets management and we need to specify the service account for the job to authenticate against the server.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)