### PR TITLE
Freeze before exit when _MINIO_DEBUG_BLOCK_ON_FATAL_CRASH is defined

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,11 +23,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"sort"
 	"strings"
 
 	"github.com/minio/cli"
 	"github.com/minio/minio/internal/color"
+	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/console"
 	"github.com/minio/pkg/trie"
 	"github.com/minio/pkg/words"
@@ -189,8 +191,27 @@ func Main(args []string) {
 	// Set the minio app name.
 	appName := filepath.Base(args[0])
 
+	if os.Getenv("_MINIO_DEBUG_NO_EXIT") != "" {
+		freeze := func(_ int) {
+			// Infinite blocking op
+			<-make(chan struct{})
+		}
+
+		// Override the logger os.Exit()
+		logger.ExitFunc = freeze
+
+		defer func() {
+			if err := recover(); err != nil {
+				fmt.Println("panic:", err)
+				fmt.Println("")
+				fmt.Println(string(debug.Stack()))
+			}
+			freeze(-1)
+		}()
+	}
+
 	// Run the app - exit on error.
 	if err := newApp(appName).Run(args); err != nil {
-		os.Exit(1)
+		os.Exit(1) //nolint:gocritic
 	}
 }

--- a/internal/logger/console.go
+++ b/internal/logger/console.go
@@ -32,6 +32,9 @@ import (
 // ConsoleLoggerTgt is a stringified value to represent console logging
 const ConsoleLoggerTgt = "console+http"
 
+// ExitFunc is called by Fatal() class functions, by default it calls os.Exit()
+var ExitFunc = os.Exit
+
 // Logger interface describes the methods that need to be implemented to satisfy the interface requirements.
 type Logger interface {
 	json(msg string, args ...interface{})
@@ -90,7 +93,7 @@ func (f fatalMsg) json(msg string, args ...interface{}) {
 	}
 	fmt.Println(string(logJSON))
 
-	os.Exit(1)
+	ExitFunc(1)
 }
 
 func (f fatalMsg) quiet(msg string, args ...interface{}) {
@@ -143,7 +146,7 @@ func (f fatalMsg) pretty(msg string, args ...interface{}) {
 	}
 
 	// Exit because this is a fatal error message
-	os.Exit(1)
+	ExitFunc(1)
 }
 
 type infoMsg struct{}


### PR DESCRIPTION
## Description
In some cases, it is a good idea to intercept fatalIf() or a panic crash
and block to make it easier to fix issues.

For example, a k8s pod crashing in a loop for any reason is hard to debug and execute commands in that pod.


## Motivation and Context
Make it easier to debug MinIO crashing pods in k8s for
internal or external reasons

## How to test this PR?
Add a panic("error") in main() of server-main.go
then 
```
export _MINIO_SAFE=1
export CI=1 
./minio server /tmp/fs/
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
