### PR TITLE
persist the non-default creds in config

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -543,12 +543,6 @@ func serverMain(ctx *cli.Context) {
 	initHealMRF(GlobalContext, newObject)
 	initBackgroundExpiry(GlobalContext, newObject)
 
-	if globalActiveCred.Equal(auth.DefaultCredentials) {
-		msg := fmt.Sprintf("WARNING: Detected default credentials '%s', we recommend that you change these values with 'MINIO_ROOT_USER' and 'MINIO_ROOT_PASSWORD' environment variables",
-			globalActiveCred)
-		logger.Info(color.RedBold(msg))
-	}
-
 	if !globalCLIContext.StrictS3Compat {
 		logger.Info(color.RedBold("WARNING: Strict AWS S3 compatible incoming PUT, POST content payload validation is turned off, caution is advised do not use in production"))
 	}
@@ -567,6 +561,19 @@ func serverMain(ctx *cli.Context) {
 		}
 
 		logger.LogIf(GlobalContext, err)
+	}
+
+	if globalActiveCred.Equal(auth.DefaultCredentials) {
+		msg := fmt.Sprintf("WARNING: Detected default credentials '%s', we recommend that you change these values with 'MINIO_ROOT_USER' and 'MINIO_ROOT_PASSWORD' environment variables",
+			globalActiveCred)
+		logger.Info(color.RedBold(msg))
+	}
+
+	savedCreds, _ := config.LookupCreds(globalServerConfig[config.CredentialsSubSys][config.Default])
+	if globalActiveCred.Equal(auth.DefaultCredentials) && !globalActiveCred.Equal(savedCreds) {
+		msg := fmt.Sprintf("WARNING: Detected credentials changed to '%s', please set them back to previously set values",
+			globalActiveCred)
+		logger.Info(color.RedBold(msg))
 	}
 
 	// Initialize users credentials and policies in background right after config has initialized.


### PR DESCRIPTION

## Description
persist the non-default creds in config

## Motivation and Context
non-default creds should persist to disk
and we must detect that they are not set
to "default" credentials by mistake.

Print a warning indicating that the
deployment is now using default credentials.

NOTE: we cannot stop the service instead
we can simply warn the users at this point
in time.

## How to test this PR?
Start a fresh setup with

```
#!/bin/bash                                                                                                                                                                                   

set -x

export MINIO_PROMETHEUS_AUTH_TYPE="public"
export MINIO_API_DELETE_CLEANUP_INTERVAL="5s"
export MINIO_CI_CD=1
export MINIO_SCANNER_CYCLE=10s
export GOMAXPROCS=2
export MINIO_ROOT_USER=minio
export MINIO_ROOT_PASSWORD=minio123
export MINIO_SUBNET_PROXY=http://localhost:4389

killall -9 minio
# rm -rf ${HOME}/tmp/dist                                                                                                                                                                     

scheme="http"
nr_servers=4

addr="localhost"
args=""
for ((i=0;i<$[${nr_servers}];i++)); do
    args="$args $scheme://$addr:$[9100+$i]/${HOME}/tmp/dist/path1/$i"
done

echo $args


for ((i=0;i<$[${nr_servers}];i++)); do
    (minio server --address ":$[9100+$i]" $args 2>&1 > /tmp/log$i.txt) &
done
```

```
~ ./run-dist.sh
```


Then change the script by removing the `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` 
```
~ ./run-dist.sh
WARNING: Detected default credentials 'minioadmin:minioadmin', we recommend that you change these values with 'MINIO_ROOT_USER' and 'MINIO_ROOT_PASSWORD' environment variables
WARNING: Detected credentials changed to 'minioadmin:minioadmin', please set them back to previously set values
...
...
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)

