### PR TITLE
Fix Prometheus Probe tlsConfig, doesn't belong in ProberSpec

### DIFF
--- a/helm/minio/templates/servicemonitor.yaml
+++ b/helm/minio/templates/servicemonitor.yaml
@@ -80,17 +80,19 @@ metadata:
     {{- end }}
 spec:
   jobName: {{ template "minio.fullname" . }}
+  {{- if .Values.tls.enabled }}
+  tlsConfig:
+    ca:
+      secret:
+        name: {{ .Values.tls.certSecret }}
+        key: {{ .Values.tls.publicCrt }}
+    serverName: {{ template "minio.fullname" . }}
+  {{- end }}
   prober:
     url: {{ template "minio.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}
     path: /minio/v2/metrics/cluster
     {{- if .Values.tls.enabled }}
     scheme: https
-    tlsConfig:
-      ca:
-        secret:
-          name: {{ .Values.tls.certSecret }}
-          key: {{ .Values.tls.publicCrt }}
-      serverName: {{ template "minio.fullname" . }}
     {{ else }}
     scheme: http
     {{- end }}


### PR DESCRIPTION
I thought `tlsConfig` was part of `ProberSpec`, but it is part of `ProbeSpec`

Should fix issue reported here:
https://github.com/minio/minio/pull/15659#issuecomment-1254974707

https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ProbeSpec