### PR TITLE
fix: parse and save retainUntilDate in correct time format

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -730,9 +730,12 @@ func putReplicationOpts(ctx context.Context, sc string, objInfo ObjectInfo) (put
 		putOpts.Mode = rmode
 	}
 	if retainDateStr, ok := lkMap.Lookup(xhttp.AmzObjectLockRetainUntilDate); ok {
-		rdate, err := time.Parse(time.RFC3339, retainDateStr)
+		rdate, err := time.Parse(iso8601TimeFormat, retainDateStr)
 		if err != nil {
-			return putOpts, err
+			rdate, err = time.Parse(time.RFC3339, retainDateStr)
+			if err != nil {
+				return putOpts, err
+			}
 		}
 		putOpts.RetainUntilDate = rdate
 		// set retention timestamp in opts

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2998,7 +2998,7 @@ func (api objectAPIHandlers) PutObjectRetentionHandler(w http.ResponseWriter, r 
 			}
 			if objRetention.Mode.Valid() {
 				oi.UserDefined[strings.ToLower(xhttp.AmzObjectLockMode)] = string(objRetention.Mode)
-				oi.UserDefined[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)] = objRetention.RetainUntilDate.UTC().Format(time.RFC3339)
+				oi.UserDefined[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)] = objRetention.RetainUntilDate.UTC().Format(iso8601TimeFormat)
 			} else {
 				oi.UserDefined[strings.ToLower(xhttp.AmzObjectLockMode)] = ""
 				oi.UserDefined[strings.ToLower(xhttp.AmzObjectLockRetainUntilDate)] = ""


### PR DESCRIPTION
## Description
fix: parse and save retainUntilDate in correct time format

## Motivation and Context
PutObjectRetention seems to save object metadata retain until
date in time.RFC3339 format, instead it should be iso8601TimeFormat.
    
This also needs to be the parsing logic as well during
replication of metadata.

## How to test this PR?
Nothing special just observe the saved metadata with different APIs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
