### PR TITLE
Add RPC tcp timeout/errs and avg duration to prometheus

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/bucket/lifecycle"
 	"github.com/minio/minio/internal/logger"
+	"github.com/minio/minio/internal/rest"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -167,7 +168,8 @@ const (
 	writeBytes      MetricName = "write_bytes"
 	wcharBytes      MetricName = "wchar_bytes"
 
-	apiLatencyMicroSec MetricName = "latency_us"
+	latencyMicroSec MetricName = "latency_us"
+	latencyNanoSec  MetricName = "latency_ns"
 
 	usagePercent MetricName = "update_percent"
 
@@ -331,7 +333,7 @@ func getNodeDiskAPILatencyMD() MetricDescription {
 	return MetricDescription{
 		Namespace: nodeMetricNamespace,
 		Subsystem: diskSubsystem,
-		Name:      apiLatencyMicroSec,
+		Name:      latencyMicroSec,
 		Help:      "Average last minute latency in µs for drive API storage operations",
 		Type:      gaugeMetric,
 	}
@@ -534,6 +536,26 @@ func getInternodeFailedRequests() MetricDescription {
 		Name:      errorsTotal,
 		Help:      "Total number of failed internode calls",
 		Type:      counterMetric,
+	}
+}
+
+func getInternodeTCPDialTimeout() MetricDescription {
+	return MetricDescription{
+		Namespace: interNodeMetricNamespace,
+		Subsystem: trafficSubsystem,
+		Name:      "dial_errors",
+		Help:      "Total number of internode TCP dial timeouts and errors",
+		Type:      counterMetric,
+	}
+}
+
+func getInternodeTCPAvgDuration() MetricDescription {
+	return MetricDescription{
+		Namespace: interNodeMetricNamespace,
+		Subsystem: trafficSubsystem,
+		Name:      "dial_avg_time",
+		Help:      "Average time of internodes TCP dial calls",
+		Type:      gaugeMetric,
 	}
 }
 
@@ -1607,10 +1629,19 @@ func getNetworkMetrics() *MetricsGroup {
 	mg.RegisterRead(func(ctx context.Context) (metrics []Metric) {
 		metrics = make([]Metric, 0, 10)
 		connStats := globalConnStats.toServerConnStats()
+		rpcStats := rest.GetRPCStats()
 		if globalIsDistErasure {
 			metrics = append(metrics, Metric{
 				Description: getInternodeFailedRequests(),
-				Value:       float64(loadAndResetRPCNetworkErrsCounter()),
+				Value:       float64(rpcStats.Errs),
+			})
+			metrics = append(metrics, Metric{
+				Description: getInternodeTCPDialTimeout(),
+				Value:       float64(rpcStats.DialErrs),
+			})
+			metrics = append(metrics, Metric{
+				Description: getInternodeTCPAvgDuration(),
+				Value:       float64(rpcStats.DialAvgDuration),
 			})
 			metrics = append(metrics, Metric{
 				Description: getInterNodeSentBytesMD(),

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -56,7 +56,6 @@ import (
 	ioutilx "github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/minio/internal/logger/message/audit"
-	"github.com/minio/minio/internal/rest"
 	"github.com/minio/pkg/certs"
 	"github.com/minio/pkg/env"
 	"golang.org/x/oauth2"
@@ -1014,13 +1013,6 @@ func decodeDirObject(object string) string {
 		return strings.TrimSuffix(object, globalDirSuffix) + slashSeparator
 	}
 	return object
-}
-
-// This is used by metrics to show the number of failed RPC calls
-// between internodes
-func loadAndResetRPCNetworkErrsCounter() uint64 {
-	defer rest.ResetNetworkErrsCounter()
-	return rest.GetNetworkErrsCounter()
 }
 
 // Helper method to return total number of nodes in cluster

--- a/internal/rest/rpc-stats.go
+++ b/internal/rest/rpc-stats.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package rest
+
+import (
+	"net/http"
+	"net/http/httptrace"
+	"sync/atomic"
+	"time"
+)
+
+var globalStats = struct {
+	errs uint64
+
+	tcpDialErrs     uint64
+	tcpDialCount    uint64
+	tcpDialTotalDur uint64
+}{}
+
+// RPCStats holds information about the DHCP/TCP metrics and errors
+type RPCStats struct {
+	Errs uint64
+
+	DialAvgDuration uint64
+	DialErrs        uint64
+}
+
+// GetRPCStats returns RPC stats, include calls errors and dhcp/tcp metrics
+func GetRPCStats() RPCStats {
+	s := RPCStats{
+		Errs:     atomic.LoadUint64(&globalStats.errs),
+		DialErrs: atomic.LoadUint64(&globalStats.tcpDialErrs),
+	}
+	if v := atomic.LoadUint64(&globalStats.tcpDialCount); v > 0 {
+		s.DialAvgDuration = atomic.LoadUint64(&globalStats.tcpDialTotalDur) / v
+	}
+	return s
+}
+
+// Return a function which update the global stats related to tcp connections
+func setupReqStatsUpdate(req *http.Request) (*http.Request, func()) {
+	var dialStart, dialEnd time.Time
+
+	trace := &httptrace.ClientTrace{
+		ConnectStart: func(network, addr string) {
+			dialStart = time.Now()
+		},
+		ConnectDone: func(network, addr string, err error) {
+			if err == nil {
+				dialEnd = time.Now()
+			}
+		},
+	}
+
+	return req.WithContext(httptrace.WithClientTrace(req.Context(), trace)), func() {
+		if !dialStart.IsZero() {
+			if dialEnd.IsZero() {
+				atomic.AddUint64(&globalStats.tcpDialErrs, 1)
+			} else {
+				atomic.AddUint64(&globalStats.tcpDialCount, 1)
+				atomic.AddUint64(&globalStats.tcpDialTotalDur, uint64(dialEnd.Sub(dialStart)))
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description
Add prometheus entries for RPC calls:

- TCP dial connect errors + timeout counter
- TCP dial average time

The stats are reset for each prometheus scrape so it is easier to
detect intermittent issues.

Also do not reset counters anymore, prometheus can have a query that
show the increase of the errors.

## Motivation and Context
More visibility of the networking performance

## How to test this PR?
Run a cluster of 4 nodes and then:
curl http://localhost:9001/minio/v2/metrics/cluster | grep inter_node | grep dial

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
