### PR TITLE
fix: generalize config and also skip healing under single-drive

### DIFF
--- a/internal/config/storageclass/storage-class.go
+++ b/internal/config/storageclass/storage-class.go
@@ -193,12 +193,14 @@ func validateParity(ssParity, rrsParity, setDriveCount int) (err error) {
 		return fmt.Errorf("Reduced redundancy storage class parity %d should be greater than or equal to %d", rrsParity, minParityDisks)
 	}
 
-	if ssParity > setDriveCount/2 {
-		return fmt.Errorf("Standard storage class parity %d should be less than or equal to %d", ssParity, setDriveCount/2)
-	}
+	if setDriveCount > 2 {
+		if ssParity > setDriveCount/2 {
+			return fmt.Errorf("Standard storage class parity %d should be less than or equal to %d", ssParity, setDriveCount/2)
+		}
 
-	if rrsParity > setDriveCount/2 {
-		return fmt.Errorf("Reduced redundancy storage class parity %d should be less than or equal to %d", rrsParity, setDriveCount/2)
+		if rrsParity > setDriveCount/2 {
+			return fmt.Errorf("Reduced redundancy storage class parity %d should be less than or equal to %d", rrsParity, setDriveCount/2)
+		}
 	}
 
 	if ssParity > 0 && rrsParity > 0 {
@@ -283,6 +285,8 @@ func LookupConfig(kvs config.KVS, setDriveCount int) (cfg Config, err error) {
 		if err != nil {
 			return Config{}, err
 		}
+	} else {
+		cfg.Standard.Parity = DefaultParityBlocks(setDriveCount)
 	}
 
 	if rrsc != "" {
@@ -290,14 +294,8 @@ func LookupConfig(kvs config.KVS, setDriveCount int) (cfg Config, err error) {
 		if err != nil {
 			return Config{}, err
 		}
-	}
-
-	if cfg.RRS.Parity == 0 && rrsc == "" {
+	} else {
 		cfg.RRS.Parity = defaultRRSParity
-	}
-
-	if cfg.Standard.Parity == 0 && ssc == "" {
-		cfg.Standard.Parity = DefaultParityBlocks(setDriveCount)
 	}
 
 	// Validation is done after parsing both the storage classes. This is needed because we need one


### PR DESCRIPTION
## Description
fix: generalize config and also skip healing under single-drive

## Motivation and Context
avoid any possibility of setting incorrect parities such as '0'
parity, instead chose it directly based on the 'DriveCounts'
always.

## How to test this PR?
Nothing special this is more of a defensive change to 
avoid any future problems and simplification of 
existing code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
