### PR TITLE
Fix race when accessing REST tcp dial values

### DIFF
--- a/internal/rest/rpc-stats.go
+++ b/internal/rest/rpc-stats.go
@@ -54,26 +54,26 @@ func GetRPCStats() RPCStats {
 
 // Return a function which update the global stats related to tcp connections
 func setupReqStatsUpdate(req *http.Request) (*http.Request, func()) {
-	var dialStart, dialEnd time.Time
+	var dialStart, dialEnd int64
 
 	trace := &httptrace.ClientTrace{
 		ConnectStart: func(network, addr string) {
-			dialStart = time.Now()
+			atomic.StoreInt64(&dialStart, time.Now().UnixNano())
 		},
 		ConnectDone: func(network, addr string, err error) {
 			if err == nil {
-				dialEnd = time.Now()
+				atomic.StoreInt64(&dialEnd, time.Now().UnixNano())
 			}
 		},
 	}
 
 	return req.WithContext(httptrace.WithClientTrace(req.Context(), trace)), func() {
-		if !dialStart.IsZero() {
-			if dialEnd.IsZero() {
+		if ds := atomic.LoadInt64(&dialStart); ds > 0 {
+			if de := atomic.LoadInt64(&dialEnd); de == 0 {
 				atomic.AddUint64(&globalStats.tcpDialErrs, 1)
 			} else {
 				atomic.AddUint64(&globalStats.tcpDialCount, 1)
-				atomic.AddUint64(&globalStats.tcpDialTotalDur, uint64(dialEnd.Sub(dialStart)))
+				atomic.AddUint64(&globalStats.tcpDialTotalDur, uint64(dialEnd-dialStart))
 			}
 		}
 	}

--- a/internal/rest/rpc-stats.go
+++ b/internal/rest/rpc-stats.go
@@ -71,7 +71,7 @@ func setupReqStatsUpdate(req *http.Request) (*http.Request, func()) {
 		if ds := atomic.LoadInt64(&dialStart); ds > 0 {
 			if de := atomic.LoadInt64(&dialEnd); de == 0 {
 				atomic.AddUint64(&globalStats.tcpDialErrs, 1)
-			} else {
+			} else if de >= ds {
 				atomic.AddUint64(&globalStats.tcpDialCount, 1)
 				atomic.AddUint64(&globalStats.tcpDialTotalDur, uint64(dialEnd-dialStart))
 			}


### PR DESCRIPTION
## Description

Building the binary with -race flag and starts a distributed cluster shows the below warning.

```
WARNING: DATA RACE
Read at 0x00c002172330 by goroutine 1043:
  github.com/minio/minio/internal/rest.setupReqStatsUpdate.func3()
      /Users/vadmeste/code/minio/internal/rest/rpc-stats.go:72 +0xa8
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x30
  github.com/minio/minio/cmd.(*lockRESTClient).callWithContext()
      /Users/vadmeste/code/minio/cmd/lock-rest-client.go:65 +0xc4
  github.com/minio/minio/cmd.(*lockRESTClient).restCall()
      /Users/vadmeste/code/minio/cmd/lock-rest-client.go:97 +0x1a0
  github.com/minio/minio/cmd.(*lockRESTClient).Lock()
      /Users/vadmeste/code/minio/cmd/lock-rest-client.go:116 +0xb8
  github.com/minio/minio/internal/dsync.lock.func1()
      /Users/vadmeste/code/minio/internal/dsync/drwmutex.go:437 +0x3ac
  github.com/minio/minio/internal/dsync.lock.func3()
      /Users/vadmeste/code/minio/internal/dsync/drwmutex.go:445 +0x6c

Previous write at 0x00c002172330 by goroutine 1050:
  github.com/minio/minio/internal/rest.setupReqStatsUpdate.func2()
      /Users/vadmeste/code/minio/internal/rest/rpc-stats.go:65 +0x50
  net.(*sysDialer).dialSingle.func1()
      /usr/local/go/src/net/dial.go:575 +0xc4
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x30
  net.(*sysDialer).dialSerial()
      /usr/local/go/src/net/dial.go:550 +0x378
  net.(*sysDialer).dialParallel()
      /usr/local/go/src/net/dial.go:451 +0x414
  net.(*Dialer).DialContext()
      /usr/local/go/src/net/dial.go:428 +0x864
  github.com/minio/minio/internal/http.NewCustomDialContext.func1()
      /Users/vadmeste/code/minio/internal/http/dial_others.go:48 +0x7c
  github.com/minio/minio/internal/http.DialContextWithDNSCache.func1()
      /Users/vadmeste/code/minio/internal/http/dial_dnscache.go:63 +0x240
  net/http.(*Transport).dial()
      /usr/local/go/src/net/http/transport.go:1170 +0x1bc
  net/http.(*Transport).dialConn()
      /usr/local/go/src/net/http/transport.go:1608 +0xa00
  net/http.(*Transport).dialConnFor()
      /usr/local/go/src/net/http/transport.go:1450 +0xc4
  net/http.(*Transport).queueForDial.func1()
      /usr/local/go/src/net/http/transport.go:1419 +0x40
```

The reason is that golang http/net creates a goroutine which will update tcp connect start/done variables, in parallel, we have other REST calls which can be executed in another goroutine, the rest call will also access the tcp connect start/done variables to update REST stats.

## Motivation and Context
Unit tests fail because if a race detected in internal/rest/rcp-stats.go code

## How to test this PR?
1. go build -race .
2. Run MinIO in a distributed mode

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
