### PR TITLE
fix: de-duplicate conflicting object names on namespace

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
@@ -684,7 +685,14 @@ func mergeEntryChannels(ctx context.Context, in []chan metaCacheEntry, out chan<
 				bestIdx = otherIdx
 				continue
 			}
-			if best.name == other.name {
+			// We should make sure to avoid objects and directories
+			// of this fashion such as
+			//  - foo-1
+			//  - foo-1/
+			// we should avoid this situation by making sure that
+			// we compare the `foo-1/` after path.Clean() to
+			// de-dup the entries.
+			if path.Clean(best.name) == path.Clean(other.name) {
 				if compareMeta(best, other) {
 					// Replace "best"
 					if err := selectFrom(bestIdx); err != nil {


### PR DESCRIPTION


## Description
fix: de-duplicate conflicting object names on namespace

## Motivation and Context
In a hypothetical scenario

- foo-1 (object)
- foo-1/ (directory)

`foo-1` must take priority  and `foo-1/` must be
be de-duplicated with the actual object.

This is mainly to avoid cases where we end up listing both `foo-1` and `foo-1/` together. This can happen when

- `foo-1` is an object
- `foo-1/` is just a folder elsewhere on another erasure set.

## How to test this PR?
We need to hand construct this scenario but it is possible to reach this situation
in the wild here is how you do it, have atleast "two" erasure sets

- create an object `foo-1` and let it stay on one erasure set, now you go ahead
- `mkdir foo-1/` on the second erasure set - this will lead to `foo-1/` getting listed
  incorrectly. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
