### PR TITLE
Use admin request check for ReplicationDiff handler

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -1083,7 +1083,7 @@ func (a adminAPIHandlers) ImportBucketMetadataHandler(w http.ResponseWriter, r *
 }
 
 // ReplicationDiffHandler - POST returns info on unreplicated versions for a remote target ARN
-// to the connected HTTP client. This is a MinIO only extension
+// to the connected HTTP client.
 func (a adminAPIHandlers) ReplicationDiffHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "ReplicationDiff")
 	defer logger.AuditLog(ctx, w, r, mustGetClaimsFromToken(r))
@@ -1096,15 +1096,8 @@ func (a adminAPIHandlers) ReplicationDiffHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	// Get current object layer instance.
-	objectAPI := newObjectLayerFn()
+	objectAPI, _ := validateAdminReq(ctx, w, r, iampolicy.ReplicationDiff)
 	if objectAPI == nil {
-		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrServerNotInitialized), r.URL)
-		return
-	}
-	// check if user has permissions to perform this operation
-	if s3Error := checkRequestAuthType(ctx, r, policy.ListBucketVersionsAction, bucket, ""); s3Error != ErrNone {
-		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL)
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -225,3 +225,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/minio/pkg => ../pkg

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/minio/kes v0.21.0
 	github.com/minio/madmin-go v1.5.3
 	github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a
-	github.com/minio/pkg v1.4.3
+	github.com/minio/pkg v1.4.4
 	github.com/minio/selfupdate v0.5.0
 	github.com/minio/sha256-simd v1.0.0
 	github.com/minio/simdjson-go v0.4.2
@@ -225,5 +225,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/minio/pkg => ../pkg

--- a/go.sum
+++ b/go.sum
@@ -660,8 +660,8 @@ github.com/minio/minio-go/v7 v7.0.23/go.mod h1:ei5JjmxwHaMrgsMrn4U/+Nmg+d8MKS1U2
 github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a h1:COFh7S3tOKmJNYtKKFAuHQFH7MAaXxg4aAluXC9KQgc=
 github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/minio/pkg v1.1.20/go.mod h1:Xo7LQshlxGa9shKwJ7NzQbgW4s8T/Wc1cOStR/eUiMY=
-github.com/minio/pkg v1.4.3 h1:RJdhFj+5qK/oYuTuLGtTzn6GKniwI57eJ0LxrZ7xpw4=
-github.com/minio/pkg v1.4.3/go.mod h1:mxCLAG+fOGIQr6odQ5Ukqc6qv9Zj6v1d6TD3NP82B7Y=
+github.com/minio/pkg v1.4.4 h1:SASGh5u2qbC40HgVli9Frlkz5glui0i4HMQgX7gmdAQ=
+github.com/minio/pkg v1.4.4/go.mod h1:mxCLAG+fOGIQr6odQ5Ukqc6qv9Zj6v1d6TD3NP82B7Y=
 github.com/minio/selfupdate v0.5.0 h1:0UH1HlL49+2XByhovKl5FpYTjKfvrQ2sgL1zEXK6mfI=
 github.com/minio/selfupdate v0.5.0/go.mod h1:mcDkzMgq8PRcpCRJo/NlPY7U45O5dfYl2Y0Rg7IustY=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=


### PR DESCRIPTION
## Description
Instead of the S3 request validation, use admin check. This is to avoid issues
when validating requests issued mc using madmin library.

## Motivation and Context
Fix mc replicate diff command when the server has an explicite region

## How to test this PR?
1. Start two MinIO servers
2. Enable site replication
3. Create a bucket
4. mc replicate diff <alias>/<bucket>


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
