### PR TITLE
set bucket creation timestamp properly for legacy FS backend

### DIFF
--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -473,6 +473,7 @@ func (fs *FSObjects) MakeBucketWithLocation(ctx context.Context, bucket string, 
 	}
 
 	meta := newBucketMetadata(bucket)
+	meta.SetCreatedAt(opts.CreatedAt)
 	if err := meta.Save(ctx, fs); err != nil {
 		return toObjectErr(err, bucket)
 	}


### PR DESCRIPTION

## Description
set bucket creation timestamp properly for legacy FS backend

## Motivation and Context
fixes #15795

This regression was introduced in PR #15377

## How to test this PR?
Well you need FS backend so you need pre-existing data it is not
reproduced via our CI/CD

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes #15377
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
