### PR TITLE
Fix GetObjectRetention to parse in iso8601 time format

### DIFF
--- a/internal/bucket/object/lock/lock.go
+++ b/internal/bucket/object/lock/lock.go
@@ -45,6 +45,10 @@ const (
 
 	// RetCompliance - compliance mode.
 	RetCompliance RetMode = "COMPLIANCE"
+
+	// RFC3339 a subset of the ISO8601 timestamp format. e.g 2014-04-29T18:30:38Z
+	iso8601TimeFormat = "2006-01-02T15:04:05.000Z" // Reply date format with nanosecond precision.
+
 )
 
 // Valid - returns if retention mode is valid
@@ -452,7 +456,7 @@ func GetObjectRetentionMeta(meta map[string]string) ObjectRetention {
 		tillStr, ok = meta[AmzObjectLockRetainUntilDate]
 	}
 	if ok {
-		if t, e := time.Parse(time.RFC3339, tillStr); e == nil {
+		if t, e := time.Parse(iso8601TimeFormat, tillStr); e == nil {
 			retainTill = RetentionDate{t.UTC()}
 		}
 	}

--- a/internal/bucket/object/lock/lock.go
+++ b/internal/bucket/object/lock/lock.go
@@ -47,7 +47,7 @@ const (
 	RetCompliance RetMode = "COMPLIANCE"
 
 	// RFC3339 a subset of the ISO8601 timestamp format. e.g 2014-04-29T18:30:38Z
-	iso8601TimeFormat = "2006-01-02T15:04:05.000Z" // Reply date format with nanosecond precision.
+	iso8601TimeFormat = "2006-01-02T15:04:05.000Z" // Reply date format with millisecond precision.
 
 )
 


### PR DESCRIPTION
## Description


## Motivation and Context
PutObjectRetention and other API calls save retention date in iso8601TimeFormat. 

This may address sporadic failures in mint
```
(9/14) Running minio-java tests ... FAILED in 27 seconds
{
  "name": "minio-java",
  "function": "getObjectRetention()",
  "duration": 45,
  "status": "FAIL",
  "error": "java.time.format.DateTimeParseException: Text '2022-10-09T02:42:14.6Z' could not be parsed at index 19 >>> [io.minio.Xml.unmarshal(Xml.java:55), io.minio.MinioAsyncClient.lambda$getObjectRetention$34(MinioAsyncClient.java:1699), java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642), java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506), java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073), io.minio.S3Base$1.onResponse(S3Base.java:559), okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519), java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128), java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628), java.base/java.lang.Thread.run(Thread.java:829)]"
}
```

## How to test this PR?
Not readily reproducible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
