### PR TITLE
ignore VersionNotFound in addition to ObjectNotFound while replicating

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -1068,7 +1068,7 @@ func (ri ReplicateObjectInfo) replicateObject(ctx context.Context, objectAPI Obj
 		VersionSuspended: versionSuspended,
 	})
 	if err != nil {
-		if !isErrObjectNotFound(err) {
+		if !isErrVersionNotFound(err) {
 			sendEvent(eventArgs{
 				EventName:  event.ObjectReplicationNotTracked,
 				BucketName: bucket,
@@ -1216,7 +1216,7 @@ func (ri ReplicateObjectInfo) replicateAll(ctx context.Context, objectAPI Object
 		VersionSuspended: versionSuspended,
 	})
 	if err != nil {
-		if !isErrObjectNotFound(err) {
+		if !isErrVersionNotFound(err) {
 			sendEvent(eventArgs{
 				EventName:  event.ObjectReplicationNotTracked,
 				BucketName: bucket,

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -1068,7 +1068,7 @@ func (ri ReplicateObjectInfo) replicateObject(ctx context.Context, objectAPI Obj
 		VersionSuspended: versionSuspended,
 	})
 	if err != nil {
-		if !isErrVersionNotFound(err) {
+		if !isErrVersionNotFound(err) && !isErrObjectNotFound(err) {
 			sendEvent(eventArgs{
 				EventName:  event.ObjectReplicationNotTracked,
 				BucketName: bucket,
@@ -1216,7 +1216,7 @@ func (ri ReplicateObjectInfo) replicateAll(ctx context.Context, objectAPI Object
 		VersionSuspended: versionSuspended,
 	})
 	if err != nil {
-		if !isErrVersionNotFound(err) {
+		if !isErrVersionNotFound(err) && !isErrObjectNotFound(err) {
 			sendEvent(eventArgs{
 				EventName:  event.ObjectReplicationNotTracked,
 				BucketName: bucket,


### PR DESCRIPTION
## Description
In replication, all objects are versioned, ignore version not found instead of object not found

## Motivation and Context
Fix wrong log reporting

## How to test this PR?
Not easy

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
