### PR TITLE
marshal retention XML in expected format

### DIFF
--- a/internal/bucket/object/lock/lock_test.go
+++ b/internal/bucket/object/lock/lock_test.go
@@ -174,17 +174,20 @@ func TestParseObjectLockConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		_, err := ParseObjectLockConfig(strings.NewReader(tt.value))
-		//nolint:gocritic
-		if tt.expectedErr == nil {
-			if err != nil {
-				t.Fatalf("error: expected = <nil>, got = %v", err)
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			_, err := ParseObjectLockConfig(strings.NewReader(tt.value))
+			//nolint:gocritic
+			if tt.expectedErr == nil {
+				if err != nil {
+					t.Fatalf("error: expected = <nil>, got = %v", err)
+				}
+			} else if err == nil {
+				t.Fatalf("error: expected = %v, got = <nil>", tt.expectedErr)
+			} else if tt.expectedErr.Error() != err.Error() {
+				t.Fatalf("error: expected = %v, got = %v", tt.expectedErr, err)
 			}
-		} else if err == nil {
-			t.Fatalf("error: expected = %v, got = <nil>", tt.expectedErr)
-		} else if tt.expectedErr.Error() != err.Error() {
-			t.Fatalf("error: expected = %v, got = %v", tt.expectedErr, err)
-		}
+		})
 	}
 }
 
@@ -209,19 +212,27 @@ func TestParseObjectRetention(t *testing.T) {
 			expectedErr: nil,
 			expectErr:   false,
 		},
+		{
+			value:       `<?xml version="1.0" encoding="UTF-8"?><Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Mode>GOVERNANCE</Mode><RetainUntilDate>2057-01-02T15:04:05.000Z</RetainUntilDate></Retention>`,
+			expectedErr: nil,
+			expectErr:   false,
+		},
 	}
 	for _, tt := range tests {
-		_, err := ParseObjectRetention(strings.NewReader(tt.value))
-		//nolint:gocritic
-		if tt.expectedErr == nil {
-			if err != nil {
-				t.Fatalf("error: expected = <nil>, got = %v", err)
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			_, err := ParseObjectRetention(strings.NewReader(tt.value))
+			//nolint:gocritic
+			if tt.expectedErr == nil {
+				if err != nil {
+					t.Fatalf("error: expected = <nil>, got = %v", err)
+				}
+			} else if err == nil {
+				t.Fatalf("error: expected = %v, got = <nil>", tt.expectedErr)
+			} else if tt.expectedErr.Error() != err.Error() {
+				t.Fatalf("error: expected = %v, got = %v", tt.expectedErr, err)
 			}
-		} else if err == nil {
-			t.Fatalf("error: expected = %v, got = <nil>", tt.expectedErr)
-		} else if tt.expectedErr.Error() != err.Error() {
-			t.Fatalf("error: expected = %v, got = %v", tt.expectedErr, err)
-		}
+		})
 	}
 }
 
@@ -364,6 +375,13 @@ func TestParseObjectLockRetentionHeaders(t *testing.T) {
 			header: http.Header{
 				xhttp.AmzObjectLockMode:            []string{"governance"},
 				xhttp.AmzObjectLockRetainUntilDate: []string{"2087-01-02T15:04:05Z"},
+			},
+			expectedErr: nil,
+		},
+		{
+			header: http.Header{
+				xhttp.AmzObjectLockMode:            []string{"governance"},
+				xhttp.AmzObjectLockRetainUntilDate: []string{"2087-01-02T15:04:05.000Z"},
 			},
 			expectedErr: nil,
 		},


### PR DESCRIPTION


## Description
marshal retention XML in expected format

## Motivation and Context
iso8601TimeFormat must be used for marshalling
as well to be consistent with the output.

## How to test this PR?
Unit tests added to cover the case

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
