### PR TITLE
Add missing server info fields

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2264,7 +2264,7 @@ func (a adminAPIHandlers) HealthInfoHandler(w http.ResponseWriter, r *http.Reque
 
 		if query.Get("minioinfo") == "true" {
 			infoMessage := getServerInfo(ctx, r)
-			servers := []madmin.ServerInfo{}
+			servers := make([]madmin.ServerInfo, 0, len(infoMessage.Servers))
 			for _, server := range infoMessage.Servers {
 				anonEndpoint := anonAddr(server.Endpoint)
 				servers = append(servers, madmin.ServerInfo{
@@ -2283,6 +2283,11 @@ func (a adminAPIHandlers) HealthInfoHandler(w http.ResponseWriter, r *http.Reque
 						Frees:      server.MemStats.Frees,
 						HeapAlloc:  server.MemStats.HeapAlloc,
 					},
+					GoMaxProcs:     server.GoMaxProcs,
+					NumCPU:         server.NumCPU,
+					RuntimeVersion: server.RuntimeVersion,
+					GCStats:        server.GCStats,
+					MinioEnvVars:   server.MinioEnvVars,
 				})
 			}
 

--- a/cmd/admin-server-info.go
+++ b/cmd/admin-server-info.go
@@ -20,10 +20,14 @@ package cmd
 import (
 	"context"
 	"net/http"
+	"os"
 	"runtime"
+	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/minio/madmin-go"
+	"github.com/minio/minio/internal/config"
 	"github.com/minio/minio/internal/logger"
 )
 
@@ -67,6 +71,22 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 	var memstats runtime.MemStats
 	runtime.ReadMemStats(&memstats)
 
+	gcStats := debug.GCStats{
+		// If stats.PauseQuantiles is non-empty, ReadGCStats fills
+		// it with quantiles summarizing the distribution of pause time.
+		// For example, if len(stats.PauseQuantiles) is 5, it will be
+		// filled with the minimum, 25%, 50%, 75%, and maximum pause times.
+		PauseQuantiles: make([]time.Duration, 5),
+	}
+	debug.ReadGCStats(&gcStats)
+	// Truncate GC stats to max 5 entries.
+	if len(gcStats.PauseEnd) > 5 {
+		gcStats.PauseEnd = gcStats.PauseEnd[len(gcStats.PauseEnd)-5:]
+	}
+	if len(gcStats.Pause) > 5 {
+		gcStats.Pause = gcStats.Pause[len(gcStats.Pause)-5:]
+	}
+
 	props := madmin.ServerProperties{
 		State:    string(madmin.ItemInitializing),
 		Endpoint: addr,
@@ -81,6 +101,44 @@ func getLocalServerProperty(endpointServerPools EndpointServerPools, r *http.Req
 			Frees:      memstats.Frees,
 			HeapAlloc:  memstats.HeapAlloc,
 		},
+		GoMaxProcs:     runtime.GOMAXPROCS(0),
+		NumCPU:         runtime.NumCPU(),
+		RuntimeVersion: runtime.Version(),
+		GCStats: &madmin.GCStats{
+			LastGC:     gcStats.LastGC,
+			NumGC:      gcStats.NumGC,
+			PauseTotal: gcStats.PauseTotal,
+			Pause:      gcStats.Pause,
+			PauseEnd:   gcStats.PauseEnd,
+		},
+		MinioEnvVars: make(map[string]string, 10),
+	}
+
+	sensitive := map[string]struct{}{
+		config.EnvAccessKey:         {},
+		config.EnvSecretKey:         {},
+		config.EnvRootUser:          {},
+		config.EnvRootPassword:      {},
+		config.EnvMinIOSubnetAPIKey: {},
+		config.EnvKMSSecretKey:      {},
+	}
+	for _, v := range os.Environ() {
+		if !strings.HasPrefix(v, "MINIO") && !strings.HasPrefix(v, "_MINIO") {
+			continue
+		}
+		split := strings.SplitN(v, "=", 2)
+		key := split[0]
+		value := ""
+		if len(split) > 1 {
+			value = split[1]
+		}
+
+		// Do not send sensitive creds.
+		if _, ok := sensitive[key]; ok || strings.Contains(strings.ToLower(key), "password") || strings.HasSuffix(strings.ToLower(key), "key") {
+			props.MinioEnvVars[key] = "*** EXISTS, REDACTED ***"
+			continue
+		}
+		props.MinioEnvVars[key] = value
 	}
 
 	objLayer := newObjectLayerFn()

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/minio/dperf v0.4.2
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.21.0
-	github.com/minio/madmin-go v1.5.3
+	github.com/minio/madmin-go v1.6.2
 	github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a
 	github.com/minio/pkg v1.5.0
 	github.com/minio/selfupdate v0.5.0
@@ -226,5 +226,3 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/minio/madmin-go => github.com/klauspost/madmin-go v1.0.15-0.20221010094139-df7a6fe9de79

--- a/go.mod
+++ b/go.mod
@@ -226,3 +226,5 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/minio/madmin-go => github.com/klauspost/madmin-go v1.0.15-0.20221010094139-df7a6fe9de79

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,6 @@ github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.1 h1:t0wUqjowdm8ezddV5k0tLWVklVuvLJpoHeb4WBdydm0=
 github.com/klauspost/cpuid/v2 v2.1.1/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/klauspost/madmin-go v1.0.15-0.20221010094139-df7a6fe9de79 h1:XV2zOItCeKZweOk4kvy2yFIi6Wy1JqGDOByrmpUp1ac=
-github.com/klauspost/madmin-go v1.0.15-0.20221010094139-df7a6fe9de79/go.mod h1:FVl1TS8T79779KZEboPHL5byffHJ6DyrAAavqgsG6UQ=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/readahead v1.4.0 h1:w4hQ3BpdLjBnRQkZyNi+nwdHU7eGP9buTexWK9lU7gY=
@@ -652,6 +650,9 @@ github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/kes v0.21.0 h1:Xe0vNRyBgC35TZkbOnU4hAgJRBEaFcT6KiI9/29BdUo=
 github.com/minio/kes v0.21.0/go.mod h1:3FW1BQkMGQW78yhy+69tUq5bdcf5rnXJizyeKB9a/tc=
+github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
+github.com/minio/madmin-go v1.6.2 h1:Nn9dy287ZqiyJeuDg1V3mlWTVmotwQBlUI9XomhC+Zg=
+github.com/minio/madmin-go v1.6.2/go.mod h1:FVl1TS8T79779KZEboPHL5byffHJ6DyrAAavqgsG6UQ=
 github.com/minio/mc v0.0.0-20221001175248-68ca2bf457e4 h1:DStvFAaRrNCvAa6je41F8WBgziXeF1sZymSQJCWxbKY=
 github.com/minio/mc v0.0.0-20221001175248-68ca2bf457e4/go.mod h1:cqIVmUIAVDVCwR2/XztvlBdZpbI/hPx0ilEOvtG47Tw=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=

--- a/go.sum
+++ b/go.sum
@@ -541,6 +541,8 @@ github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.1 h1:t0wUqjowdm8ezddV5k0tLWVklVuvLJpoHeb4WBdydm0=
 github.com/klauspost/cpuid/v2 v2.1.1/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/klauspost/madmin-go v1.0.15-0.20221010094139-df7a6fe9de79 h1:XV2zOItCeKZweOk4kvy2yFIi6Wy1JqGDOByrmpUp1ac=
+github.com/klauspost/madmin-go v1.0.15-0.20221010094139-df7a6fe9de79/go.mod h1:FVl1TS8T79779KZEboPHL5byffHJ6DyrAAavqgsG6UQ=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/readahead v1.4.0 h1:w4hQ3BpdLjBnRQkZyNi+nwdHU7eGP9buTexWK9lU7gY=
@@ -650,9 +652,6 @@ github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/kes v0.21.0 h1:Xe0vNRyBgC35TZkbOnU4hAgJRBEaFcT6KiI9/29BdUo=
 github.com/minio/kes v0.21.0/go.mod h1:3FW1BQkMGQW78yhy+69tUq5bdcf5rnXJizyeKB9a/tc=
-github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
-github.com/minio/madmin-go v1.5.3 h1:G/xtuOzKuQf2wJhyH2I/wyO6aNzkHQm1sUmpdURbScY=
-github.com/minio/madmin-go v1.5.3/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/mc v0.0.0-20221001175248-68ca2bf457e4 h1:DStvFAaRrNCvAa6je41F8WBgziXeF1sZymSQJCWxbKY=
 github.com/minio/mc v0.0.0-20221001175248-68ca2bf457e4/go.mod h1:cqIVmUIAVDVCwR2/XztvlBdZpbI/hPx0ilEOvtG47Tw=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=


### PR DESCRIPTION
## Description

Returns debug values to previously unpopulated fields.

~Requires https://github.com/minio/madmin-go/pull/134~ Merged.

Information is reported to subnet health checks as well.

## How to test this PR?


Example using (updated) `mc admin info --json myminio`

```
                "go_max_procs": 32,
                "num_cpu": 32,
                "runtime_version": "go1.19.2",
                "gc_stats":
                {
                    "last_gc": "2022-10-10T11:43:49.5013704+02:00",
                    "num_gc": 10,
                    "pause_total": 8024100,
                    "pause":
                    [
                        530700,
                        511700,
                        0,
                        17400,
                        0
                    ],
                    "pause_end":
                    [
                        "2022-10-10T11:43:48.6292458+02:00",
                        "2022-10-10T11:43:48.6103873+02:00",
                        "2022-10-10T11:43:48.553458+02:00",
                        "2022-10-10T11:43:48.5339526+02:00",
                        "2022-10-10T11:43:48.5275452+02:00"
                    ]
                },
                "minio_env_vars":
                {
                    "MINIO_ACCESS_KEY": "*** EXISTS, REDACTED ***",
                    "MINIO_CI_CD": "on",
                    "MINIO_KMS_AUTO_ENCRYPTION": "off",
                    "MINIO_ROOT_PASSWORD": "*** EXISTS, REDACTED ***",
                    "MINIO_ROOT_USER": "*** EXISTS, REDACTED ***",
                    "MINIO_SECRET_KEY": "*** EXISTS, REDACTED ***",
                    "_MINIO_SERVER_DEBUG": "off"
                }
```


## Types of changes
- [x] New feature (non-breaking change which adds functionality)
