### PR TITLE
honor specified target prefix under batch replication

### DIFF
--- a/cmd/batch-handlers.go
+++ b/cmd/batch-handlers.go
@@ -268,6 +268,7 @@ func (r *BatchJobReplicateV1) ReplicateFromSource(ctx context.Context, api Objec
 func (r *BatchJobReplicateV1) ReplicateToTarget(ctx context.Context, api ObjectLayer, c *miniogo.Core, srcObjInfo ObjectInfo, retry bool) error {
 	srcBucket := r.Source.Bucket
 	tgtBucket := r.Target.Bucket
+	tgtPrefix := r.Target.Prefix
 	srcObject := srcObjInfo.Name
 
 	if retry { // when we are retrying avoid copying if necessary.
@@ -299,11 +300,11 @@ func (r *BatchJobReplicateV1) ReplicateToTarget(ctx context.Context, api ObjectL
 	}
 
 	if objInfo.isMultipart() {
-		if err := replicateObjectWithMultipart(ctx, c, tgtBucket, objInfo.Name, rd, objInfo, putOpts); err != nil {
+		if err := replicateObjectWithMultipart(ctx, c, tgtBucket, pathJoin(tgtPrefix, objInfo.Name), rd, objInfo, putOpts); err != nil {
 			return err
 		}
 	} else {
-		if _, err = c.PutObject(ctx, tgtBucket, objInfo.Name, rd, size, "", "", putOpts); err != nil {
+		if _, err = c.PutObject(ctx, tgtBucket, pathJoin(tgtPrefix, objInfo.Name), rd, size, "", "", putOpts); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description
honor specified target prefix under batch replication

## Motivation and Context
user may specify a targetPrefix folder to replicate
the content. we should honor such as configuration.

## How to test this PR?
You would have to test batch jobs following this document
https://github.com/minio/minio/tree/master/docs/batch-jobs

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
