### PR TITLE
Add metrics, version and apis handlers

### DIFF
--- a/cmd/kms-router.go
+++ b/cmd/kms-router.go
@@ -52,6 +52,9 @@ func registerKMSRouter(router *mux.Router) {
 	for _, version := range KMSVersions {
 		// KMS Status APIs
 		kmsRouter.Methods(http.MethodGet).Path(version + "/status").HandlerFunc(gz(httpTraceAll(kmsAPI.KMSStatusHandler)))
+		kmsRouter.Methods(http.MethodGet).Path(version + "/metrics").HandlerFunc(gz(httpTraceAll(kmsAPI.KMSMetricsHandler)))
+		kmsRouter.Methods(http.MethodGet).Path(version + "/apis").HandlerFunc(gz(httpTraceAll(kmsAPI.KMSAPIsHandler)))
+		kmsRouter.Methods(http.MethodGet).Path(version + "/version").HandlerFunc(gz(httpTraceAll(kmsAPI.KMSVersionHandler)))
 		// KMS Key APIs
 		kmsRouter.Methods(http.MethodPost).Path(version+"/key/create").HandlerFunc(gz(httpTraceAll(kmsAPI.KMSCreateKeyHandler))).Queries("key-id", "{key-id:.*}")
 		kmsRouter.Methods(http.MethodPost).Path(version+"/key/import").HandlerFunc(gz(httpTraceAll(kmsAPI.KMSImportKeyHandler))).Queries("key-id", "{key-id:.*}")

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/minio/kes v0.21.0
 	github.com/minio/madmin-go v1.5.3
 	github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a
-	github.com/minio/pkg v1.5.0
+	github.com/minio/pkg v1.5.1
 	github.com/minio/selfupdate v0.5.0
 	github.com/minio/sha256-simd v1.0.0
 	github.com/minio/simdjson-go v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ github.com/minio/minio-go/v7 v7.0.23/go.mod h1:ei5JjmxwHaMrgsMrn4U/+Nmg+d8MKS1U2
 github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a h1:COFh7S3tOKmJNYtKKFAuHQFH7MAaXxg4aAluXC9KQgc=
 github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/minio/pkg v1.1.20/go.mod h1:Xo7LQshlxGa9shKwJ7NzQbgW4s8T/Wc1cOStR/eUiMY=
-github.com/minio/pkg v1.5.0 h1:517jxphvCLSNE8vbctMY4avaRDZXiGT7lX+cXPXFb98=
-github.com/minio/pkg v1.5.0/go.mod h1:koF2J2Ep/zpd//k+3UYdh6ySZKjqzy9C6RCZRX7uRY8=
+github.com/minio/pkg v1.5.1 h1:XwuoZMqC+VXYGRFFALO5JGacQxut6iUTJP76UGPzsek=
+github.com/minio/pkg v1.5.1/go.mod h1:koF2J2Ep/zpd//k+3UYdh6ySZKjqzy9C6RCZRX7uRY8=
 github.com/minio/selfupdate v0.5.0 h1:0UH1HlL49+2XByhovKl5FpYTjKfvrQ2sgL1zEXK6mfI=
 github.com/minio/selfupdate v0.5.0/go.mod h1:mcDkzMgq8PRcpCRJo/NlPY7U45O5dfYl2Y0Rg7IustY=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=

--- a/internal/kms/kes.go
+++ b/internal/kms/kes.go
@@ -139,11 +139,28 @@ func (c *kesClient) Stat(ctx context.Context) (Status, error) {
 	}, nil
 }
 
+// Metrics retrieves server metrics in the Prometheus exposition format.
 func (c *kesClient) Metrics(ctx context.Context) (kes.Metric, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
 	return c.client.Metrics(ctx)
+}
+
+// Version retrieves version information
+func (c *kesClient) Version(ctx context.Context) (string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.client.Version(ctx)
+}
+
+// APIs retrieves a list of supported API endpoints
+func (c *kesClient) APIs(ctx context.Context) ([]kes.API, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.client.APIs(ctx)
 }
 
 // CreateKey tries to create a new key at the KMS with the

--- a/internal/kms/status-manager.go
+++ b/internal/kms/status-manager.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package kms
+
+import (
+	"context"
+
+	"github.com/minio/kes"
+)
+
+// StatusManager is the generic interface that handles KMS status operations
+type StatusManager interface {
+	// Version retrieves version information
+	Version(ctx context.Context) (string, error)
+	// APIs retrieves a list of supported API endpoints
+	APIs(ctx context.Context) ([]kes.API, error)
+}


### PR DESCRIPTION
## Description
Adds missing KMS handlers (Version, APIs and Metrics)

## Motivation and Context
We want to show metrics in console and only use the APIs that are actually enable in KES

## How to test this PR?

curl --location --request GET 'http://localhost:5005/api/v1/kms/metrics' \
--header 'Cookie: token={TOKEN}' \
--header 'Content-Type: application/json'

curl --location --request GET 'http://localhost:5005/api/v1/kms/version' \
--header 'Cookie: token={TOKEN}' \
--header 'Content-Type: application/json'

curl --location --request GET 'http://localhost:5005/api/v1/kms/apis' \
--header 'Cookie: token={TOKEN}' \
--header 'Content-Type: application/json'

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
