### PR TITLE
Tweak objectQuorumFromMeta() to search for parity quorum 

### DIFF
--- a/cmd/erasure-healing-common.go
+++ b/cmd/erasure-healing-common.go
@@ -179,53 +179,6 @@ func listOnlineDisks(disks []StorageAPI, partsMetadata []FileInfo, errs []error)
 	return onlineDisks, modTime
 }
 
-// Returns the latest updated FileInfo files and error in case of failure.
-func getLatestFileInfo(ctx context.Context, partsMetadata []FileInfo, defaultParityCount int, errs []error) (FileInfo, error) {
-	// There should be atleast half correct entries, if not return failure
-	expectedRQuorum := len(partsMetadata) / 2
-	if defaultParityCount == 0 {
-		// if parity count is '0', we expected all entries to be present.
-		expectedRQuorum = len(partsMetadata)
-	}
-
-	reducedErr := reduceReadQuorumErrs(ctx, errs, objectOpIgnoredErrs, expectedRQuorum)
-	if reducedErr != nil {
-		return FileInfo{}, reducedErr
-	}
-
-	// List all the file commit ids from parts metadata.
-	modTimes := listObjectModtimes(partsMetadata, errs)
-
-	// Count all latest updated FileInfo values
-	var count int
-	var latestFileInfo FileInfo
-
-	// Reduce list of UUIDs to a single common value - i.e. the last updated Time
-	modTime := commonTime(modTimes)
-
-	if modTime.IsZero() || modTime.Equal(timeSentinel) {
-		return FileInfo{}, errErasureReadQuorum
-	}
-
-	// Interate through all the modTimes and count the FileInfo(s) with latest time.
-	for index, t := range modTimes {
-		if partsMetadata[index].IsValid() && t.Equal(modTime) {
-			latestFileInfo = partsMetadata[index]
-			count++
-		}
-	}
-
-	if !latestFileInfo.IsValid() {
-		return FileInfo{}, errErasureReadQuorum
-	}
-
-	if count < latestFileInfo.Erasure.DataBlocks {
-		return FileInfo{}, errErasureReadQuorum
-	}
-
-	return latestFileInfo, nil
-}
-
 // disksWithAllParts - This function needs to be called with
 // []StorageAPI returned by listOnlineDisks. Returns,
 //


### PR DESCRIPTION
## Description
In a replication setup, we can have an object REPLICA with the same
modtime in different disks but with different internal information such
as erasure coding information. Currently objectQuorumFromMeta() can pick
a wrong FileInfo{} because modtime was only used as a criteria to pick
the valid FileInfo but that is not always true anymore.

## Motivation and Context
Able to read an object when shards have the same modtime
but not the same erasure config among disks

## How to test this PR?
Hard to test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
