### PR TITLE
fix: unrecognized openid config parameters

### DIFF
--- a/internal/config/identity/openid/openid.go
+++ b/internal/config/identity/openid/openid.go
@@ -116,6 +116,18 @@ var (
 			Key:   Scopes,
 			Value: "",
 		},
+		config.KV{
+			Key:   Vendor,
+			Value: "",
+		},
+		config.KV{
+			Key:   KeyCloakRealm,
+			Value: "",
+		},
+		config.KV{
+			Key:   KeyCloakAdminURL,
+			Value: "",
+		},
 	}
 )
 


### PR DESCRIPTION
## Description
The openid config KVS did not contain all available config options which is why it was not possible to configure the following options:
* `vendor` - `MINIO_IDENTITY_OPENID_VENDOR`
* `keycloak_realm` - `MINIO_IDENTITY_OPENID_KEYCLOAK_REALM`
* `keycloak_admin_url` - `MINIO_IDENTITY_OPENID_KEYCLOAK_ADMIN_URL`

## Motivation and Context
Without this fix, it is no longer possible to configure OIDC creds auto expiration for keycloak servers.

## How to test this PR?
Start the `minio` binary with `MINIO_IDENTITY_OPENID_VENDOR` environment variable set to some random value. Before this PR `initConfig` printed an error message:
```
Error: Unable to initialize OpenID: The following environment variables are unknown: MINIO_IDENTITY_OPENID_VENDOR (*fmt.wrapError)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression: 7f629df4d56b96adcb64673cf6a19ce2c4426d66, #15083
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here]
