### PR TITLE
do not disable IsKubernetes(), IsDocker() checks with MINIO_CI_CD

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -124,40 +124,31 @@ func GetCurrentReleaseTime() (releaseTime time.Time, err error) {
 //
 //	"/.dockerenv":      "file",
 func IsDocker() bool {
-	if !globalIsCICD {
-		_, err := os.Stat("/.dockerenv")
-		if osIsNotExist(err) {
-			return false
-		}
-
-		// Log error, as we will not propagate it to caller
-		logger.LogIf(GlobalContext, err)
-
-		return err == nil
+	_, err := os.Stat("/.dockerenv")
+	if osIsNotExist(err) {
+		return false
 	}
-	return false
+
+	// Log error, as we will not propagate it to caller
+	logger.LogIf(GlobalContext, err)
+
+	return err == nil
 }
 
 // IsDCOS returns true if minio is running in DCOS.
 func IsDCOS() bool {
-	if !globalIsCICD {
-		// http://mesos.apache.org/documentation/latest/docker-containerizer/
-		// Mesos docker containerizer sets this value
-		return env.Get("MESOS_CONTAINER_NAME", "") != ""
-	}
-	return false
+	// http://mesos.apache.org/documentation/latest/docker-containerizer/
+	// Mesos docker containerizer sets this value
+	return env.Get("MESOS_CONTAINER_NAME", "") != ""
 }
 
 // IsKubernetes returns true if minio is running in kubernetes.
 func IsKubernetes() bool {
-	if !globalIsCICD {
-		// Kubernetes env used to validate if we are
-		// indeed running inside a kubernetes pod
-		// is KUBERNETES_SERVICE_HOST
-		// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_pods.go#L541
-		return env.Get("KUBERNETES_SERVICE_HOST", "") != ""
-	}
-	return false
+	// Kubernetes env used to validate if we are
+	// indeed running inside a kubernetes pod
+	// is KUBERNETES_SERVICE_HOST
+	// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_pods.go#L541
+	return env.Get("KUBERNETES_SERVICE_HOST", "") != ""
 }
 
 // IsBOSH returns true if minio is deployed from a bosh package


### PR DESCRIPTION


## Description
do not disable IsKubernetes(), IsDocker() checks with MINIO_CI_CD

## Motivation and Context
CI/CD MinIO environment has nothing in relation to checking 
if we are running under orchestrated environment, turning this off 
causes specific DNS checks to fail in the Kubernetes environment.

Revert this earlier change.

## How to test this PR?
Try following yaml and observe crash loopbacks

```yaml
## Create service of minio dist erasure StatefulSet.
apiVersion: v1
kind: Service
metadata:
  name: minio-dist-erasure-dev
spec:
  type: NodePort
  ports:
  - port: 9000
  selector:
    app: minio-dist-erasure-app-dev
---
## Create headless service to StatefulSet to work.
apiVersion: v1
kind: Service
metadata:
  name: minio-dist-erasure-headless-dev
  labels:
    app: minio-dist-erasure-headless-dev
spec:
  publishNotReadyAddresses: true
  ports:
  - port: 9000
  clusterIP: None
  selector:
    app: minio-dist-erasure-app-dev
---
## Run minio dist erasure StatefulSet.
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: minio-dist-erasure-dev
spec:
  updateStrategy:
    type: RollingUpdate
  podManagementPolicy: "Parallel"
  serviceName: "minio-dist-erasure-headless-dev"
  replicas: 4
  selector:
    matchLabels:
      app: minio-dist-erasure-app-dev
  template:
    metadata:
      labels:
        app: minio-dist-erasure-app-dev
    spec:
      imagePullSecrets:
      - name: regcred
      containers:
      - name: minio-dist-erasure-dev
        env:
        - name: MINIO_CI_CD
          value: "on"
        - name: MINIO_ROOT_USER
          value: "minio"
        - name: MINIO_ROOT_PASSWORD
          value: "minio123"
        - name: MINIO_KMS_SECRET_KEY
          value: "my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw="
        image: minio/minio:dev
        imagePullPolicy: Always
        args:
        - server
        - http://minio-dist-erasure-dev-{0...3}.minio-dist-erasure-headless-dev.default.svc.cluster.local/data/dist
        ports:
        - containerPort: 9000
        resources:
          requests:
            cpu: 200m
            memory: 256Mi
            ephemeral-storage: 1024Mi
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
