### PR TITLE
replication: Attempt delete marker replication after object is replic…

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -740,6 +740,15 @@ func (api objectAPIHandlers) headObjectHandler(ctx context.Context, objectAPI Ob
 			}
 			QueueReplicationHeal(ctx, bucket, objInfo)
 		}
+		// do an additional verification whether object exists when opts.DeleteMarker is set by source
+		// cluster as part of delete marker replication
+		if opts.DeleteMarker && opts.ProxyHeaderSet {
+			opts.VersionID = ""
+			goi, gerr := getObjectInfo(ctx, bucket, object, opts)
+			if gerr == nil || goi.VersionID != "" { // object layer returned more info because object is deleted
+				w.Header().Set(xhttp.MinIOTargetReplicationReady, "true")
+			}
+		}
 		writeErrorResponseHeadersOnly(w, toAPIError(ctx, err))
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.21.0
 	github.com/minio/madmin-go v1.6.2
-	github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a
+	github.com/minio/minio-go/v7 v7.0.41-0.20221013203648-8257e7003b5e
 	github.com/minio/pkg v1.5.2
 	github.com/minio/selfupdate v0.5.0
 	github.com/minio/sha256-simd v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -661,6 +661,8 @@ github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEp
 github.com/minio/minio-go/v7 v7.0.23/go.mod h1:ei5JjmxwHaMrgsMrn4U/+Nmg+d8MKS1U2DAn1ou4+Do=
 github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a h1:COFh7S3tOKmJNYtKKFAuHQFH7MAaXxg4aAluXC9KQgc=
 github.com/minio/minio-go/v7 v7.0.40-0.20220928095841-8848d8affe8a/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
+github.com/minio/minio-go/v7 v7.0.41-0.20221013203648-8257e7003b5e h1:Sq8FAHvwrz9x+Nwb1dt9f/BSmje07a6Q5LXdmprff/A=
+github.com/minio/minio-go/v7 v7.0.41-0.20221013203648-8257e7003b5e/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/minio/pkg v1.1.20/go.mod h1:Xo7LQshlxGa9shKwJ7NzQbgW4s8T/Wc1cOStR/eUiMY=
 github.com/minio/pkg v1.5.2 h1:vyEZ3TroiRGS/qb1XgP9RpK2zhjSWpBPjhNEbIo0pY8=
 github.com/minio/pkg v1.5.2/go.mod h1:koF2J2Ep/zpd//k+3UYdh6ySZKjqzy9C6RCZRX7uRY8=

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -187,7 +187,8 @@ const (
 	MinIOSourceReplicationRequest = "X-Minio-Source-Replication-Request"
 	// Header indicates replication reset status.
 	MinIOReplicationResetStatus = "X-Minio-Replication-Reset-Status"
-
+	// Header indicating target cluster can receive delete marker replication requests because object has been replicated
+	MinIOTargetReplicationReady = "X-Minio-Replication-Ready"
 	// Header indiicates last tag update time on source
 	MinIOSourceTaggingTimestamp = "X-Minio-Source-Replication-Tagging-Timestamp"
 	// Header indiicates last rtention update time on source


### PR DESCRIPTION
…ated

This is to avoid possibility of delete marker replication being marked completed prematurely.

## Description


## Motivation and Context
Ensure delete marker replication success, especially since the recent optimizations to heal on HEAD, LIST and GET can force replication attempts on delete marker before underlying object version could be synced

## How to test this PR?
Set up replication and upload one or more objects and set delete marker when target is down. after target comes up, `mc stat alias/bucket/obj`.
 if delete marker is top most, it is marked completed because it is attempted to replicate out of order (with master). 

With this PR both clusters should get in sync

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
