### PR TITLE
Update endpoint-ellipses.go

### DIFF
--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -207,7 +207,7 @@ func getSetIndexes(args []string, totalSizes []uint64, customSetDriveCount uint6
 }
 
 // Returns all the expanded endpoints, each argument is expanded separately.
-func (s endpointSet) getEndpoints() (endpoints []string) {
+func (s *endpointSet) getEndpoints() (endpoints []string) {
 	if len(s.endpoints) != 0 {
 		return s.endpoints
 	}


### PR DESCRIPTION
This is a strange syntax, does it need to be fixed for this strange usage?
```go
package main

import (
	"fmt"
)

func main() {
	a := A{}
	for i := 0; i < 100; i++ {
		a.Change(i)
	}
	a.Say()
}

type A struct {
	V []int
}

func (a A) Change(v int) {
	a.V = append(a.V, v)
}

func (a A) Say() {
	fmt.Println(a.V)
}
```
output:
```shell
[]
```
```diff
-func (s endpointSet) getEndpoints() (endpoints []string) {
+func (s *endpointSet) getEndpoints() (endpoints []string) {
 	if len(s.endpoints) != 0 {
 		return s.endpoints
 	}
	for _, argPattern := range s.argPatterns {
		for _, lbls := range argPattern.Expand() {
			endpoints = append(endpoints, strings.Join(lbls, ""))
		}
	}
+// this is set ?
	s.endpoints = endpoints
	return endpoints
}
```
## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
