### PR TITLE
Allow create svcaccts

### DIFF
--- a/helm/minio/README.md
+++ b/helm/minio/README.md
@@ -219,6 +219,22 @@ Description of the configuration parameters used above -
 - `users[].existingSecretKey` - data key in existingSecret secret containing the secretKey
 - `users[].policy` - name of the policy to assign to user
 
+### Create service account after install
+
+Install the chart, specifying the service accounts you want to create after install:
+
+```bash
+helm install --set svcaccts[0].accessKey=accessKey,svcaccts[0].secretKey=secretKey,svcaccts[0].user=parentUser,svcaccts[1].accessKey=accessKey2,svcaccts[1].secretRef=existingSecret,svcaccts[1].secretKey=password,svcaccts[1].user=parentUser2 minio/minio
+```
+
+Description of the configuration parameters used above -
+
+- `svcaccts[].accessKey` - accessKey of service account
+- `svcaccts[].secretKey` - secretKey of svcacctsecretRef
+- `svcaccts[].existingSecret` - secret name that contains the secretKey of service account
+- `svcaccts[].existingSecretKey` - data key in existingSecret secret containing the secretKey
+- `svcaccts[].user` - name of the parent user to assign to service account
+
 ## Uninstalling the Chart
 
 Assuming your release is named as `my-release`, delete it using the command:

--- a/helm/minio/templates/_helper_create_svcacct.txt
+++ b/helm/minio/templates/_helper_create_svcacct.txt
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -e ; # Have script exit in the event of a failed command.
+
+{{- if .Values.configPathmc }}
+MC_CONFIG_DIR="{{ .Values.configPathmc }}"
+MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+{{- else }}
+MC="/usr/bin/mc --insecure"
+{{- end }}
+
+# AccessKey and secretkey credentials file are added to prevent shell execution errors caused by special characters.
+# Special characters for example : ',",<,>,{,}
+MINIO_ACCESSKEY_SECRETKEY_TMP="/tmp/accessKey_and_secretKey_srvacct_tmp"
+
+# connectToMinio
+# Use a check-sleep-check loop to wait for MinIO service to be available
+connectToMinio() {
+  SCHEME=$1
+  ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+  set -e ; # fail if we can't read the keys.
+  ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+  set +e ; # The connections to minio are allowed to fail.
+  echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+  MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+  $MC_COMMAND ;
+  STATUS=$? ;
+  until [ $STATUS = 0 ]
+  do
+    ATTEMPTS=`expr $ATTEMPTS + 1` ;
+    echo \"Failed attempts: $ATTEMPTS\" ;
+    if [ $ATTEMPTS -gt $LIMIT ]; then
+      exit 1 ;
+    fi ;
+    sleep 2 ; # 1 second intervals between attempts
+    $MC_COMMAND ;
+    STATUS=$? ;
+  done ;
+  set -e ; # reset `e` as active
+  return 0
+}
+
+# checkSvcacctExists ()
+# Check if the svcacct exists, by using the exit code of `mc admin user svcacct info`
+checkSvcacctExists() {
+  CMD=$(${MC} admin user svcacct info myminio $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) > /dev/null 2>&1)
+  return $?
+}
+
+# createSvcacct ($user)
+createSvcacct () {
+  USER=$1
+  #check accessKey_and_secretKey_tmp file
+  if [[ ! -f $MINIO_ACCESSKEY_SECRETKEY_TMP ]];then
+    echo "credentials file does not exist"
+    return 1
+  fi
+  if [[ $(cat $MINIO_ACCESSKEY_SECRETKEY_TMP|wc -l) -ne 2 ]];then
+    echo "credentials file is invalid"
+    rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+    return 1
+  fi
+  SVCACCT=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
+  # Create the svcacct if it does not exist
+  if ! checkSvcacctExists ; then
+    echo "Creating svcacct '$SVCACCT'"
+    cat $MINIO_ACCESSKEY_SECRETKEY_TMP | ${MC} admin user svcacct add --access-key $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --secret-key $(head -2 $MINIO_ACCESSKEY_SECRETKEY_TMP) myminio $USER
+  else
+    echo "Svcacct '$SVCACCT' already exists."
+  fi
+  #clean up credentials files.
+  rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+}
+
+# Try connecting to MinIO instance
+{{- if .Values.tls.enabled }}
+scheme=https
+{{- else }}
+scheme=http
+{{- end }}
+connectToMinio $scheme
+
+{{ if .Values.svcaccts }}
+{{ $global := . }}
+# Create the svcaccts
+{{- range .Values.svcaccts }}
+echo {{ tpl .accessKey $global }} > $MINIO_ACCESSKEY_SECRETKEY_TMP
+{{- if .existingSecret }}
+cat /config/secrets/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+# Add a new line if it doesn't exist
+sed -i '$a\' $MINIO_ACCESSKEY_SECRETKEY_TMP
+createSvcacct {{ .user }}
+{{ else }}
+echo {{ .secretKey }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+createSvcacct {{ .user }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/minio/templates/configmap.yaml
+++ b/helm/minio/templates/configmap.yaml
@@ -20,5 +20,7 @@ data:
   policy_{{ $idx }}.json: |-
 {{ include (print $.Template.BasePath "/_helper_policy.tpl") . | indent 4 }}
 {{ end }}
+  add-svcacct: |-
+{{ include (print $.Template.BasePath "/_helper_create_svcacct.txt") . | indent 4 }}
   custom-command: |-
 {{ include (print $.Template.BasePath "/_helper_custom_command.txt") . | indent 4 }}

--- a/helm/minio/templates/post-install-create-svcacct-job.yaml
+++ b/helm/minio/templates/post-install-create-svcacct-job.yaml
@@ -1,0 +1,111 @@
+{{- $global := . -}}
+{{- if .Values.svcaccts }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "minio.fullname" . }}-make-user-job
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "minio.name" . }}-make-user-job
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+{{- with .Values.makeUserJob.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "minio.name" . }}-job
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.makeUserJob.podAnnotations }}
+      annotations:
+{{ toYaml .Values.makeUserJob.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      restartPolicy: OnFailure
+{{- include "minio.imagePullSecrets" . | indent 6 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.makeUserJob.nodeSelector | indent 8 }}
+{{- end }}
+{{- with .Values.makeUserJob.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.makeUserJob.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.makeUserJob.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.makeUserJob.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.makeUserJob.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.makeUserJob.securityContext.fsGroup }}
+{{- end }}
+      volumes:
+        - name: minio-configuration
+          projected:
+            sources:
+            - configMap:
+                name: {{ template "minio.fullname" . }}
+            - secret:
+                name: {{ template "minio.secretName" . }}
+            {{- range .Values.svcaccts }}
+            {{- if .existingSecret }}
+            - secret:
+                name: {{ tpl .existingSecret $global }}
+                items:
+                  - key: {{ .existingSecretKey }}
+                    path: secrets/{{ tpl .existingSecretKey $global }}
+            {{- end }}
+            {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: cert-secret-volume-mc
+          secret:
+            secretName: {{ .Values.tls.certSecret }}
+            items:
+            - key: {{ .Values.tls.publicCrt }}
+              path: CAs/public.crt
+        {{ end }}
+        {{- if .Values.makeUserJob.extraVolumes }}
+          {{- toYaml .Values.makeUserJob.extraVolumes | nindent 8 }}
+        {{- end }}
+{{ if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- end }}
+      containers:
+      - name: minio-mc
+        image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
+        imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+        {{- if .Values.makeUserJob.exitCommand }}
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sh /config/add-user; x=$(echo $?); {{ .Values.makeUserJob.exitCommand }} && exit $x" ]
+        {{- else }}
+        command: ["/bin/sh", "/config/add-user"]
+        {{- end }}
+        env:
+          - name: MINIO_ENDPOINT
+            value: {{ template "minio.fullname" . }}
+          - name: MINIO_PORT
+            value: {{ .Values.service.port | quote }}
+        volumeMounts:
+          - name: minio-configuration
+            mountPath: /config
+          {{- if .Values.tls.enabled }}
+          - name: cert-secret-volume-mc
+            mountPath: {{ .Values.configPathmc }}certs
+          {{ end }}
+          {{- if .Values.makeUserJob.extraVolumeMounts }}
+            {{- toYaml .Values.makeUserJob.extraVolumeMounts | nindent 10 }}
+          {{- end }}
+        resources:
+{{ toYaml .Values.makeUserJob.resources | indent 10 }}
+{{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -353,6 +353,21 @@ users:
   #  existingSecretKey: password
   #  policy: readonly
 
+## List of service accounts to be created after minio install
+##
+svcaccts:
+  ## accessKey, secretKey and parent user to be assigned to the service accounts
+  ## Add new service accounts as explained here https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management/minio-user-management.html#service-accounts
+  - accessKey: console
+    secretKey: console123
+    user: console
+  # Or you can refer to specific secret
+  #- accessKey: externalSecret
+  #  existingSecret: my-secret
+  #  existingSecretKey: password
+  #  user: console
+
+
 
 ## Additional Annotations for the Kubernetes Job makeUserJob
 makeUserJob:
@@ -388,14 +403,14 @@ buckets:
   #   # bucket [true|false]
   #   versioning: false
   #   # set objectlocking for
-  #   # bucket [true|false] NOTE: versioning is enabled by default if you use locking 
+  #   # bucket [true|false] NOTE: versioning is enabled by default if you use locking
   #   objectlocking: false
   # - name: bucket2
   #   policy: none
   #   purge: false
   #   versioning: true
   #   # set objectlocking for
-  #   # bucket [true|false] NOTE: versioning is enabled by default if you use locking 
+  #   # bucket [true|false] NOTE: versioning is enabled by default if you use locking
   #   objectlocking: false
 
 ## Additional Annotations for the Kubernetes Job makeBucketJob
@@ -417,7 +432,7 @@ makeBucketJob:
   extraVolumeMounts: []
   # Command to run after the main command on exit
   exitCommand: ""
-  
+
 ## List of command to run after minio install
 ## NOTE: the mc command TARGET is always "myminio"
 customCommands:
@@ -440,7 +455,7 @@ customCommandJob:
   affinity: {}
   # Command to run after the main command on exit
   exitCommand: ""
-  
+
 ## Use this field to add environment variables relevant to MinIO server. These fields will be passed on to MinIO container(s)
 ## when Chart is deployed
 environment:
@@ -492,7 +507,7 @@ metrics:
   serviceMonitor:
     enabled: false
     # scrape each node/pod individually for additional metrics
-    includeNode: false 
+    includeNode: false
     public: true
     additionalLabels: {}
     # for node metrics


### PR DESCRIPTION
## Description
Added new feature to allow create service accounts after installation

## Motivation and Context
When SSO (OpenID) is enabled, internal users are disabled automatically, only service accounts can be used

## How to test this PR?
Service account associated to local user created is created too

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [X] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
