### PR TITLE
Deprecate --listeners flag

### DIFF
--- a/cmd/gateway-main.go
+++ b/cmd/gateway-main.go
@@ -249,16 +249,7 @@ func StartGateway(ctx *cli.Context, gw Gateway) {
 		getCert = globalTLSCerts.GetCertificate
 	}
 
-	listeners := ctx.Int("listeners")
-	if listeners == 0 {
-		listeners = 1
-	}
-	addrs := make([]string, 0, listeners)
-	for i := 0; i < listeners; i++ {
-		addrs = append(addrs, globalMinioAddr)
-	}
-
-	httpServer := xhttp.NewServer(addrs).
+	httpServer := xhttp.NewServer([]string{globalMinioAddr}).
 		UseHandler(setCriticalErrorHandler(corsHandler(router))).
 		UseTLSConfig(newTLSConfig(getCert)).
 		UseShutdownTimeout(ctx.Duration("shutdown-timeout")).

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -57,10 +57,11 @@ var ServerFlags = []cli.Flag{
 		EnvVar: "MINIO_ADDRESS",
 	},
 	cli.IntFlag{
-		Name:   "listeners",
+		Name:   "listeners", // Deprecated Oct 2022
 		Value:  1,
 		Usage:  "bind N number of listeners per ADDRESS:PORT",
 		EnvVar: "MINIO_LISTENERS",
+		Hidden: true,
 	},
 	cli.StringFlag{
 		Name:   "console-address",
@@ -499,16 +500,7 @@ func serverMain(ctx *cli.Context) {
 		getCert = globalTLSCerts.GetCertificate
 	}
 
-	listeners := ctx.Int("listeners")
-	if listeners == 0 {
-		listeners = 1
-	}
-	addrs := make([]string, 0, listeners)
-	for i := 0; i < listeners; i++ {
-		addrs = append(addrs, globalMinioAddr)
-	}
-
-	httpServer := xhttp.NewServer(addrs).
+	httpServer := xhttp.NewServer([]string{globalMinioAddr}).
 		UseHandler(setCriticalErrorHandler(corsHandler(handler))).
 		UseTLSConfig(newTLSConfig(getCert)).
 		UseShutdownTimeout(ctx.Duration("shutdown-timeout")).


### PR DESCRIPTION
## Description
--listeners does not work anywore if it receives a value other than 1. It looks like its meaning is lost over time. Removing it and deprecate the flag.

## Motivation and Context
Remove a flag which seems to be useless

## How to test this PR?
Just running a regular minio command

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
