### PR TITLE
Check for s3zip content offset

### DIFF
--- a/cmd/s3-zip-handlers.go
+++ b/cmd/s3-zip-handlers.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/minio/minio/internal/crypto"
+	xhttp "github.com/minio/minio/internal/http"
 	xioutil "github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/bucket/policy"
@@ -122,6 +123,16 @@ func (api objectAPIHandlers) getObjectInArchiveFileHandler(ctx context.Context, 
 		return
 	}
 
+	// We do not allow offsetting into extracted files.
+	if opts.PartNumber != 0 {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidPartNumber), r.URL)
+		return
+	}
+
+	if r.Header.Get(xhttp.Range) != "" {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidRange), r.URL)
+	}
+
 	// Validate pre-conditions if any.
 	opts.CheckPrecondFn = func(oi ObjectInfo) bool {
 		if objectAPI.IsEncryptionSupported() {
@@ -192,6 +203,8 @@ func (api objectAPIHandlers) getObjectInArchiveFileHandler(ctx context.Context, 
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
+	// s3zip does not allow ranges
+	w.Header().Del(xhttp.AcceptRanges)
 
 	setHeadGetRespHeaders(w, r.Form)
 
@@ -410,11 +423,19 @@ func (api objectAPIHandlers) headObjectInArchiveFileHandler(ctx context.Context,
 		return
 	}
 
-	var rs *HTTPRangeSpec
-
 	// Validate pre-conditions if any.
 	opts.CheckPrecondFn = func(oi ObjectInfo) bool {
 		return checkPreconditions(ctx, w, r, oi, opts)
+	}
+
+	// We do not allow offsetting into extracted files.
+	if opts.PartNumber != 0 {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidPartNumber), r.URL)
+		return
+	}
+
+	if r.Header.Get(xhttp.Range) != "" {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidRange), r.URL)
 	}
 
 	zipObjInfo, err := getObjectInfo(ctx, bucket, zipPath, opts)
@@ -455,15 +476,14 @@ func (api objectAPIHandlers) headObjectInArchiveFileHandler(ctx context.Context,
 		return
 	}
 
+	// s3zip does not allow ranges.
+	w.Header().Del(xhttp.AcceptRanges)
+
 	// Set any additional requested response headers.
 	setHeadGetRespHeaders(w, r.Form)
 
 	// Successful response.
-	if rs != nil {
-		w.WriteHeader(http.StatusPartialContent)
-	} else {
-		w.WriteHeader(http.StatusOK)
-	}
+	w.WriteHeader(http.StatusOK)
 }
 
 // Update the passed zip object metadata with the zip contents info, file name, modtime, size, etc..

--- a/cmd/s3-zip-handlers.go
+++ b/cmd/s3-zip-handlers.go
@@ -131,6 +131,7 @@ func (api objectAPIHandlers) getObjectInArchiveFileHandler(ctx context.Context, 
 
 	if r.Header.Get(xhttp.Range) != "" {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidRange), r.URL)
+		return
 	}
 
 	// Validate pre-conditions if any.
@@ -436,6 +437,7 @@ func (api objectAPIHandlers) headObjectInArchiveFileHandler(ctx context.Context,
 
 	if r.Header.Get(xhttp.Range) != "" {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidRange), r.URL)
+		return
 	}
 
 	zipObjInfo, err := getObjectInfo(ctx, bucket, zipPath, opts)

--- a/docs/extensions/s3zip/README.md
+++ b/docs/extensions/s3zip/README.md
@@ -31,10 +31,11 @@ All properties except the file size are tied to the zip file. This means that mo
 
 - ListObjectsV2 can only list the most recent ZIP archive version of your object, applicable only for versioned buckets.
 - ListObjectsV2 API calls must be used to list zip file content.
+- Range requests for GetObject/HeadObject for individual files from zip is not supported.
 - Names inside ZIP files are kept unmodified, but some may lead to invalid paths. See [Object key naming guidelines](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html) on safe names.
 - This API behavior is limited for following **read** operations on files inside a zip archive:
   - `HeadObject`
   - `GetObject`
   - `ListObjectsV2`
-- A maximum of 100,000 files inside a single ZIP archive is recommended for best performance and memory usage trade-off.
 - If the ZIP file directory isn't located within the last 100MB the file will not be parsed.
+- A maximum of 100M inside a single zip is allowed. However, a reasonable limit of 100,000 files inside a single ZIP archive is recommended for best performance and memory usage trade-off.


### PR DESCRIPTION
## Description

Removes `Accept-Ranges: bytes` from Head/Get request to indicate we do not support ranges.

Return errors if ranges are requested.

## How to test this PR?

Works with mc.

Not sure if minio-go (and others) check "Accept-Ranges". They should but they could just assume that S3 always support it.

We could support `0-(something)` ranges, but to be honest we can cross that bridge when we come to it.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
