### PR TITLE
Pass encrypted etag as is for immediate tiering

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1580,6 +1580,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 
+	origETag := objInfo.ETag
 	objInfo.ETag = getDecryptedETag(r.Header, objInfo, false)
 	response := generateCopyObjectResponse(objInfo.ETag, objInfo.ModTime)
 	encodedSuccessResponse := encodeResponse(response)
@@ -1612,6 +1613,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 
 	if !remoteCallRequired && !globalTierConfigMgr.Empty() {
 		// Schedule object for immediate transition if eligible.
+		objInfo.ETag = origETag
 		enqueueTransitionImmediate(objInfo)
 		// Remove the transitioned object whose object version is being overwritten.
 		logger.LogIf(ctx, os.Sweep())
@@ -1942,6 +1944,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 
+	origETag := objInfo.ETag
 	if kind, encrypted := crypto.IsEncrypted(objInfo.UserDefined); encrypted {
 		switch kind {
 		case crypto.S3:
@@ -1988,6 +1991,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	// Remove the transitioned object whose object version is being overwritten.
 	if !globalTierConfigMgr.Empty() {
 		// Schedule object for immediate transition if eligible.
+		objInfo.ETag = origETag
 		enqueueTransitionImmediate(objInfo)
 		logger.LogIf(ctx, os.Sweep())
 	}


### PR DESCRIPTION
## Description
Tiering requires that `objInfo.ETag` matches what's read from the drives. In a PutObject/CopyObject handler the ETag returned in API response is different in the case of objects encrypted using SSE-S3. This directly impacts immediate tiering codepath. This change simply passes the encrypted etag as is before queuing the object for immediate tiering.

## How to test this PR?
1. Stand two MinIO deployments, one for the hot tier and the other for the warm tier
2. Setup immediate tiering ILM policy like so,
`./mc ilm add --tier "WARMTIER-1" --transition-days="0" ALIAS/mybucket`
Note: change `WARMTIER-1` to whatever you named your warm tier at the time of tier-add.
3. Upload an object

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
