### PR TITLE
make subnet subsys dynamic and simplify callhome

### DIFF
--- a/cmd/callhome.go
+++ b/cmd/callhome.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/logger"
-	uatomic "go.uber.org/atomic"
 )
 
 const (
@@ -34,9 +33,6 @@ const (
 
 	// callhomeSchemaVersion is current callhome schema version.
 	callhomeSchemaVersion = callhomeSchemaVersion1
-
-	// callhomeCycleDefault is the default interval between two callhome cycles (24hrs)
-	callhomeCycleDefault = 24 * time.Hour
 )
 
 // CallhomeInfo - Contains callhome information
@@ -45,26 +41,14 @@ type CallhomeInfo struct {
 	AdminInfo     madmin.InfoMessage `json:"admin_info"`
 }
 
-var (
-	enableCallhome            = uatomic.NewBool(false)
-	callhomeLeaderLockTimeout = newDynamicTimeout(30*time.Second, 10*time.Second)
-	callhomeFreq              = uatomic.NewDuration(callhomeCycleDefault)
-)
-
-func updateCallhomeParams(ctx context.Context, objAPI ObjectLayer) {
-	alreadyEnabled := enableCallhome.Load()
-	enableCallhome.Store(globalCallhomeConfig.Enable)
-	callhomeFreq.Store(globalCallhomeConfig.Frequency)
-
-	// If callhome was disabled earlier and has now been enabled,
-	// initialize the callhome process again.
-	if !alreadyEnabled && enableCallhome.Load() {
-		initCallhome(ctx, objAPI)
-	}
-}
+var callhomeLeaderLockTimeout = newDynamicTimeout(30*time.Second, 10*time.Second)
 
 // initCallhome will start the callhome task in the background.
 func initCallhome(ctx context.Context, objAPI ObjectLayer) {
+	if !globalCallhomeConfig.Enabled() {
+		return
+	}
+
 	go func() {
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		// Leader node (that successfully acquires the lock inside runCallhome)
@@ -72,54 +56,63 @@ func initCallhome(ctx context.Context, objAPI ObjectLayer) {
 		// the lock will be released and another node will acquire it and take over
 		// because of this loop.
 		for {
-			runCallhome(ctx, objAPI)
-			if !enableCallhome.Load() {
+			if !globalCallhomeConfig.Enabled() {
+				return
+			}
+
+			if !runCallhome(ctx, objAPI) {
+				// callhome was disabled or context was canceled
 				return
 			}
 
 			// callhome running on a different node.
 			// sleep for some time and try again.
-			duration := time.Duration(r.Float64() * float64(callhomeFreq.Load()))
+			duration := time.Duration(r.Float64() * float64(globalCallhomeConfig.FrequencyDur()))
 			if duration < time.Second {
 				// Make sure to sleep atleast a second to avoid high CPU ticks.
 				duration = time.Second
 			}
 			time.Sleep(duration)
-
-			if !enableCallhome.Load() {
-				return
-			}
 		}
 	}()
 }
 
-func runCallhome(ctx context.Context, objAPI ObjectLayer) {
+func runCallhome(ctx context.Context, objAPI ObjectLayer) bool {
 	// Make sure only 1 callhome is running on the cluster.
 	locker := objAPI.NewNSLock(minioMetaBucket, "callhome/runCallhome.lock")
 	lkctx, err := locker.GetLock(ctx, callhomeLeaderLockTimeout)
 	if err != nil {
-		return
+		// lock timedout means some other node is the leader,
+		// cycle back return 'true'
+		return true
 	}
 
 	ctx = lkctx.Context()
 	defer locker.Unlock(lkctx.Cancel)
 
-	callhomeTimer := time.NewTimer(callhomeFreq.Load())
+	callhomeTimer := time.NewTimer(globalCallhomeConfig.FrequencyDur())
 	defer callhomeTimer.Stop()
 
 	for {
+		if !globalCallhomeConfig.Enabled() {
+			// Stop the processing as callhome got disabled
+			return false
+		}
+
 		select {
 		case <-ctx.Done():
-			return
+			// indicates that we do not need to run callhome anymore
+			return false
 		case <-callhomeTimer.C:
-			if !enableCallhome.Load() {
+			if !globalCallhomeConfig.Enabled() {
 				// Stop the processing as callhome got disabled
-				return
+				return false
 			}
+
 			performCallhome(ctx)
 
 			// Reset the timer for next cycle.
-			callhomeTimer.Reset(callhomeFreq.Load())
+			callhomeTimer.Reset(globalCallhomeConfig.FrequencyDur())
 		}
 	}
 }

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -209,15 +209,8 @@ func minioConfigToConsoleFeatures() {
 	}
 	os.Setenv("CONSOLE_MINIO_REGION", globalSite.Region)
 	os.Setenv("CONSOLE_CERT_PASSWD", env.Get("MINIO_CERT_PASSWD", ""))
-	if globalSubnetConfig.License != "" {
-		os.Setenv("CONSOLE_SUBNET_LICENSE", globalSubnetConfig.License)
-	}
-	if globalSubnetConfig.APIKey != "" {
-		os.Setenv("CONSOLE_SUBNET_API_KEY", globalSubnetConfig.APIKey)
-	}
-	if globalSubnetConfig.ProxyURL != nil {
-		os.Setenv("CONSOLE_SUBNET_PROXY", globalSubnetConfig.ProxyURL.String())
-	}
+
+	globalSubnetConfig.ApplyEnv()
 }
 
 func buildOpenIDConsoleConfig() consoleoauth2.OpenIDPCfg {

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -51,7 +51,7 @@ func printStartupMessage(apiEndpoints []string, err error) {
 		}
 	}
 
-	if len(globalSubnetConfig.APIKey) == 0 && err == nil {
+	if !globalSubnetConfig.Registered() {
 		var builder strings.Builder
 		startupBanner(&builder)
 		logger.Info(builder.String())

--- a/internal/config/subnet/subnet.go
+++ b/internal/config/subnet/subnet.go
@@ -35,8 +35,8 @@ const (
 
 // Post submit 'payload' to specified URL
 func (c Config) Post(reqURL string, payload interface{}) (string, error) {
-	if len(c.APIKey) == 0 {
-		return "", errors.New("Deployment is not registered with SUBNET. Please register the deployment via 'mc support register ALIAS'")
+	if !c.Registered() {
+		return "", errors.New("Deployment is not registered with SUBNET. Please register the deployment via 'mc license register ALIAS'")
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -47,7 +47,10 @@ func (c Config) Post(reqURL string, payload interface{}) (string, error) {
 		return "", err
 	}
 
+	configLock.RLock()
 	r.Header.Set("Authorization", c.APIKey)
+	configLock.RUnlock()
+
 	r.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{


### PR DESCRIPTION


## Description
make subnet subsys dynamic and simplify callhome

## Motivation and Context
return error if callhome is getting set without
registering with subnet.

## How to test this PR?
Nothing should change but this mostly makes
the reflection of newly applied license or 
registration in Console UI automatic. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
