### PR TITLE
Audit dangling object removal

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -372,9 +372,11 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 
 	defer func() {
 		replStatus := string(replicationStatus)
-		auditLogInternal(context.Background(), bucket, dobj.ObjectName, AuditLogOptions{
+		auditLogInternal(context.Background(), AuditLogOptions{
 			Event:     dobj.EventType,
 			APIName:   ReplicateDeleteAPI,
+			Bucket:    bucket,
+			Object:    dobj.ObjectName,
 			VersionID: versionID,
 			Status:    replStatus,
 		})
@@ -903,9 +905,11 @@ func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI Obje
 			// on disk.
 			replicationStatus = ri.ReplicationStatus
 		}
-		auditLogInternal(ctx, ri.Bucket, ri.Name, AuditLogOptions{
+		auditLogInternal(ctx, AuditLogOptions{
 			Event:     ri.EventType,
 			APIName:   ReplicateObjectAPI,
+			Bucket:    ri.Bucket,
+			Object:    ri.Name,
 			VersionID: ri.VersionID,
 			Status:    replicationStatus.String(),
 		})

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1441,9 +1441,11 @@ func auditLogLifecycle(ctx context.Context, oi ObjectInfo, event string) {
 	case ILMTransition:
 		apiName = "ILMTransition"
 	}
-	auditLogInternal(ctx, oi.Bucket, oi.Name, AuditLogOptions{
+	auditLogInternal(ctx, AuditLogOptions{
 		Event:     event,
 		APIName:   apiName,
+		Bucket:    oi.Bucket,
+		Object:    oi.Name,
 		VersionID: oi.VersionID,
 	})
 }

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -440,6 +440,9 @@ func (er erasureObjects) GetObjectInfo(ctx context.Context, bucket, object strin
 }
 
 func auditDanglingObjectDeletion(ctx context.Context, bucket, object, versionID string, pool, set, objectParity int) {
+	if len(logger.AuditTargets()) == 0 {
+		return
+	}
 	tags := make(map[string]interface{})
 	tags["pool"] = pool
 	tags["set"] = set

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -439,10 +439,29 @@ func (er erasureObjects) GetObjectInfo(ctx context.Context, bucket, object strin
 	return er.getObjectInfo(ctx, bucket, object, opts)
 }
 
+func auditDanglingObjectDeletion(ctx context.Context, bucket, object, versionID string, pool, set, objectParity int) {
+	tags := make(map[string]interface{})
+	tags["pool"] = pool
+	tags["set"] = set
+	tags["objectParity"] = objectParity
+
+	opts := AuditLogOptions{
+		Event:     "DeleteDanglingObject",
+		Bucket:    bucket,
+		Object:    object,
+		VersionID: versionID,
+		Tags:      tags,
+	}
+
+	auditLogInternal(ctx, opts)
+}
+
 func (er erasureObjects) deleteIfDangling(ctx context.Context, bucket, object string, metaArr []FileInfo, errs []error, dataErrs []error, opts ObjectOptions) (FileInfo, error) {
 	var err error
 	m, ok := isObjectDangling(metaArr, errs, dataErrs)
 	if ok {
+		defer auditDanglingObjectDeletion(ctx, bucket, object, m.VersionID, er.poolIndex, er.setIndex, m.Erasure.ParityBlocks)
+
 		err = errFileNotFound
 		if opts.VersionID != "" {
 			err = errFileVersionNotFound

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -1274,9 +1274,11 @@ func auditLogDecom(ctx context.Context, apiName, bucket, object, versionID strin
 	if err != nil {
 		errStr = err.Error()
 	}
-	auditLogInternal(ctx, bucket, object, AuditLogOptions{
+	auditLogInternal(ctx, AuditLogOptions{
 		Event:     "decommission",
 		APIName:   apiName,
+		Bucket:    bucket,
+		Object:    object,
 		VersionID: versionID,
 		Error:     errStr,
 	})

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1026,28 +1026,33 @@ type AuditLogOptions struct {
 	Event     string
 	APIName   string
 	Status    string
+	Bucket    string
+	Object    string
 	VersionID string
 	Error     string
+	Tags      map[string]interface{}
 }
 
 // sends audit logs for internal subsystem activity
-func auditLogInternal(ctx context.Context, bucket, object string, opts AuditLogOptions) {
+func auditLogInternal(ctx context.Context, opts AuditLogOptions) {
 	entry := audit.NewEntry(globalDeploymentID)
 	entry.Trigger = opts.Event
 	entry.Event = opts.Event
 	entry.Error = opts.Error
 	entry.API.Name = opts.APIName
-	entry.API.Bucket = bucket
-	entry.API.Object = object
-	if opts.VersionID != "" {
-		entry.ReqQuery = make(map[string]string)
-		entry.ReqQuery[xhttp.VersionID] = opts.VersionID
-	}
+	entry.API.Bucket = opts.Bucket
+	entry.API.Objects = []audit.ObjectVersion{{ObjectName: opts.Object, VersionID: opts.VersionID}}
 	entry.API.Status = opts.Status
+	entry.Tags = opts.Tags
 	// Merge tag information if found - this is currently needed for tags
 	// set during decommissioning.
 	if reqInfo := logger.GetReqInfo(ctx); reqInfo != nil {
-		entry.Tags = reqInfo.GetTagsMap()
+		if entry.Tags == nil {
+			entry.Tags = make(map[string]interface{})
+		}
+		for k, v := range reqInfo.GetTagsMap() {
+			entry.Tags[k] = v
+		}
 	}
 	ctx = logger.SetAuditEntry(ctx, &entry)
 	logger.AuditLog(ctx, nil, nil, nil)


### PR DESCRIPTION
## Description
This is to leave a trace when there is a dangling object.


## Motivation and Context
Keep a logging trace of a dangling object removal

## How to test this PR?
1. Run a webhook audit
2. Start MinIO with 4 disks
3. 
```
mc alias set myminio http://localhost:9000 minioadmin minioadmin
mc admin config set myminio audit_webhook endpoint=http://localhost:8080/ 
mc admin service restart myminio
mc mb myminio/testbucket/
mc cp go.mod myminio/testbucket/go.mod
```

Remove go.mod in 3 disks and run `mc admin heal -r myminio`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
