### PR TITLE
Filter out tiering metadata during CopyObject

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -909,6 +909,11 @@ func getCpObjMetadataFromHeader(ctx context.Context, r *http.Request, userMeta m
 	// to change the original one.
 	defaultMeta := make(map[string]string, len(userMeta))
 	for k, v := range userMeta {
+		// skip tier metadata when copying metadata from source object
+		switch k {
+		case metaTierName, metaTierStatus, metaTierObjName, metaTierVersionID:
+			continue
+		}
 		defaultMeta[k] = v
 	}
 


### PR DESCRIPTION
## Description
Fixes #15906 

## Motivation and Context
CopyObject API copied tiering related internal metadata when `x-amz-metadata-directive` is set to `COPY`. This would result in the source and destination object incorrectly sharing the tiered object content. See #15906 for more details.

## How to test this PR?
See #15906 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
