### PR TITLE
config: Deprecated delay/max_wait/scanner and introduce speed

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -225,7 +225,7 @@ func (a adminAPIHandlers) GetConfigKVHandler(w http.ResponseWriter, r *http.Requ
 
 	var s strings.Builder
 	for _, subSysConfig := range subSysConfigs {
-		subSysConfig.AddString(&s, false)
+		subSysConfig.WriteTo(&s, false)
 	}
 
 	password := cred.SecretKey
@@ -454,10 +454,6 @@ func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Reques
 
 	var s strings.Builder
 	hkvs := config.HelpSubSysMap[""]
-	var count int
-	for _, hkv := range hkvs {
-		count += len(cfg[hkv.Key])
-	}
 	for _, hkv := range hkvs {
 		// We ignore the error below, as we cannot get one.
 		cfgSubsysItems, _ := cfg.GetSubsysInfo(hkv.Key, "")
@@ -482,7 +478,7 @@ func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Reques
 			case config.IdentityPluginSubSys:
 				off = !idplugin.Enabled(item.Config)
 			}
-			item.AddString(&s, off)
+			item.WriteTo(&s, off)
 		}
 	}
 

--- a/internal/config/scanner/help.go
+++ b/internal/config/scanner/help.go
@@ -27,22 +27,10 @@ var (
 	// Help provides help for config values
 	Help = config.HelpKVS{
 		config.HelpKV{
-			Key:         Delay,
-			Description: `scanner delay multiplier` + defaultHelpPostfix(Delay),
+			Key:         Speed,
+			Description: `scanner speed` + defaultHelpPostfix(Speed),
 			Optional:    true,
-			Type:        "float",
-		},
-		config.HelpKV{
-			Key:         MaxWait,
-			Description: `maximum wait time between operations` + defaultHelpPostfix(MaxWait),
-			Optional:    true,
-			Type:        "duration",
-		},
-		config.HelpKV{
-			Key:         Cycle,
-			Description: `time duration between scanner cycles` + defaultHelpPostfix(Cycle),
-			Optional:    true,
-			Type:        "duration",
+			Type:        "default|slowest|slow|fast|fastest",
 		},
 	}
 )


### PR DESCRIPTION
## Description
config: Deprecated delay/max_wait/scanner and introduce speed

- Deprecated values will be set to empty in new deployments and will not be visible when empty
- When deprecated values are not empty, they will be prefered over the new 'speed' parameter
- 'mc admin config reset <alias> scanner' will make the deprecated values empty and not visible anymore

However the deprecated values are still working when set, and we may need a mechanism to full discard them
in the future.

## Motivation and Context
Simplify 'mc admin config get <alias> scanner' parameter

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
