### PR TITLE
Return better error status code in the lock handler

### DIFF
--- a/cmd/lock-rest-server.go
+++ b/cmd/lock-rest-server.go
@@ -43,7 +43,17 @@ type lockRESTServer struct {
 }
 
 func (l *lockRESTServer) writeErrorResponse(w http.ResponseWriter, err error) {
-	w.WriteHeader(http.StatusForbidden)
+	statusCode := http.StatusForbidden
+	switch err {
+	case errLockNotInitialized:
+		// Return 425 instead of 5xx, otherwise this node will be marked offline
+		statusCode = http.StatusTooEarly
+	case errLockConflict:
+		statusCode = http.StatusConflict
+	case errLockNotFound:
+		statusCode = http.StatusNotFound
+	}
+	w.WriteHeader(statusCode)
 	w.Write([]byte(err.Error()))
 }
 


### PR DESCRIPTION
## Description
Currently, the lock handler returns 403 for most calls which can be 
confusing for users tracing all calls.  Use other status codes instead.

This commit does not require any lock API bump and can work seamlessly 
with another node with a different version. No functional change with this.

## Motivation and Context
Better response code

## How to test this PR?
Run minio in a distributed setup

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
