### PR TITLE
Store multipart checksums

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1180,6 +1180,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 			partsMetadata[index].ModTime = fi.ModTime
 			partsMetadata[index].Metadata = fi.Metadata
 			partsMetadata[index].Parts = fi.Parts
+			partsMetadata[index].Checksum = fi.Checksum
 		}
 	}
 


### PR DESCRIPTION
## Description

Multipart checksums were not returned since fi was replaced by first partsMetadata.

## How to test this PR?

Do multipart upload with checksum. Observe returned values.

Tested with https://github.com/minio/minio-go/pull/1719

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
