### PR TITLE
HELM: Introduction of the secretEnvironment value.

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -161,6 +161,14 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end}}
+            {{- range $secEnv := .Values.secretEnvironment }}
+            - name: {{ $secEnv.name }}
+              valuesFrom:
+                secretKeyRef:
+                  name: {{ $secEnv.secretName }}
+                  key: {{ $secEnv.secretKey }}
+                  optional: false
+            {{- end}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- with .Values.nodeSelector }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -179,6 +179,14 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end}}
+            {{- range $secEnv := .Values.secretEnvironment }}
+            - name: {{ $secEnv.name }}
+              valuesFrom:
+                secretKeyRef:
+                  name: {{ $secEnv.secretName }}
+                  key: {{ $secEnv.secretKey }}
+                  optional: false
+            {{- end}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -443,6 +443,14 @@ environment:
   ## MINIO_SUBNET_LICENSE: "License key obtained from https://subnet.min.io"
   ## MINIO_BROWSER: "off"
 
+## Use this field to supply your own environment variable - from secret keys.
+secretEnvironment:
+  ## Example:
+  #   - name: MINIO_NOTIFY_AMQP_URL_PRIMARY
+  #     secretName: amqpSecret  # The name of the secret
+  #     secretKey: amqpUrlwithPassword # The key within the secret
+
+
 ## The name of a secret in the same kubernetes namespace which contain secret values
 ## This can be useful for LDAP password, etc
 ## The key in the secret must be 'config.env'


### PR DESCRIPTION
## Description

While playing around with minio's helm chart I missed a way to use and provide my very own secrets.

Therefore, I hereby propose the introduction of a
`secretEnvironment` value that can be used to supply our self generated or "shared" secrets to the created statefulset (distributed mode) or deployment (standalone mode).

This new `secretEnvironment` value expects a list that defines the environment variable to create or "mount" and the target secret.

Example:

```yaml
secretEnvironment:
  - name: MINIO_NOTIFY_AMQP_URL_PRIMARY # The name of the env.
    secretName: amqpSecret # The name of the secret.
    secretKey: ampqUrlWithPassword # The key within the secret.
```

## Motivation and Context

Sometime we may want to provide our own secrets.

## How to test this PR?

One can provide a custom value and generate the template (cf: `helm template`) and control if the output are the one expected. That's how I did it.  

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
