### PR TITLE
xl-meta: update metadata version

### DIFF
--- a/docs/debugging/xl-meta/main.go
+++ b/docs/debugging/xl-meta/main.go
@@ -465,7 +465,7 @@ func (x xlMetaInlineData) files(fn func(name string, data []byte)) error {
 
 const (
 	xlHeaderVersion = 2
-	xlMetaVersion   = 1
+	xlMetaVersion   = 2
 )
 
 func decodeXLHeaders(buf []byte) (versions int, b []byte, err error) {


### PR DESCRIPTION
## Description


## Motivation and Context
update metadata version since https://github.com/minio/minio/pull/15956 bumped up the version

## How to test this PR?
for newer objects created with master, should be able to decode metadata
```
 xl-meta /tmp/multisitea/data/disterasure/xl1/olock/bin/aax/xl.meta
2022/10/27 14:18:49 decodeXLHeaders: Unknown xl meta version 2
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
