### PR TITLE
Make pubsub type type safe

### DIFF
--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -22,7 +22,6 @@ import (
 	"runtime"
 
 	"github.com/minio/madmin-go"
-	"github.com/minio/minio/internal/pubsub"
 )
 
 // healTask represents what to heal along with options
@@ -54,7 +53,7 @@ type healRoutine struct {
 func activeListeners() int {
 	// Bucket notification and http trace are not costly, it is okay to ignore them
 	// while counting the number of concurrent connections
-	return int(globalHTTPListen.NumSubscribers(pubsub.MaskAll)) + int(globalTrace.NumSubscribers(pubsub.MaskAll))
+	return int(globalHTTPListen.Subscribers()) + int(globalTrace.Subscribers())
 }
 
 func waitForLowHTTPReq() {

--- a/cmd/event-notification.go
+++ b/cmd/event-notification.go
@@ -29,6 +29,7 @@ import (
 	"github.com/minio/minio/internal/event"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
+	"github.com/minio/minio/internal/pubsub"
 	"github.com/minio/pkg/bucket/policy"
 )
 
@@ -321,7 +322,7 @@ func sendEvent(args eventArgs) {
 	crypto.RemoveSensitiveEntries(args.Object.UserDefined)
 	crypto.RemoveInternalEntries(args.Object.UserDefined)
 
-	if globalHTTPListen.NumSubscribers(args.EventName) > 0 {
+	if globalHTTPListen.NumSubscribers(pubsub.MaskFromMaskable(args.EventName)) > 0 {
 		globalHTTPListen.Publish(args.ToEvent(false))
 	}
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -27,7 +27,8 @@ import (
 	"time"
 
 	"github.com/minio/console/restapi"
-	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/madmin-go"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/bucket/bandwidth"
 	"github.com/minio/minio/internal/config"
@@ -220,11 +221,10 @@ var (
 
 	// global Trace system to send HTTP request/response
 	// and Storage/OS calls info to registered listeners.
-	globalTrace = pubsub.New(8)
+	globalTrace = pubsub.New[madmin.TraceInfo, madmin.TraceType](8)
 
 	// global Listen system to send S3 API events to registered listeners
-	// Objects are expected to be event.Event
-	globalHTTPListen = pubsub.New(0)
+	globalHTTPListen = pubsub.New[event.Event, pubsub.Mask](0)
 
 	// global console system to send console logs to
 	// registered listeners

--- a/internal/event/name.go
+++ b/internal/event/name.go
@@ -67,6 +67,7 @@ const (
 	ObjectReplicationAll
 	ObjectRestorePostAll
 	ObjectTransitionAll
+	Everything
 )
 
 // The number of single names should not exceed 64.
@@ -112,6 +113,12 @@ func (name Name) Expand() []Name {
 			ObjectTransitionFailed,
 			ObjectTransitionComplete,
 		}
+	case Everything:
+		res := make([]Name, objectSingleTypesEnd-1)
+		for i := range res {
+			res[i] = Name(i + 1)
+		}
+		return res
 	default:
 		return []Name{name}
 	}

--- a/internal/pubsub/pubsub_test.go
+++ b/internal/pubsub/pubsub_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestSubscribe(t *testing.T) {
-	ps := New(2)
+	ps := New[Maskable, Mask](2)
 	ch1 := make(chan Maskable, 1)
 	ch2 := make(chan Maskable, 1)
 	doneCh := make(chan struct{})
@@ -38,21 +38,21 @@ func TestSubscribe(t *testing.T) {
 	ps.Lock()
 	defer ps.Unlock()
 
-	if len(ps.subs) != 2 || ps.NumSubscribers(nil) != 2 {
+	if len(ps.subs) != 2 || ps.NumSubscribers(MaskAll) != 2 || ps.Subscribers() != 2 {
 		t.Fatalf("expected 2 subscribers")
 	}
 }
 
 func TestNumSubscribersMask(t *testing.T) {
-	ps := New(2)
+	ps := New[Maskable, Mask](2)
 	ch1 := make(chan Maskable, 1)
 	ch2 := make(chan Maskable, 1)
 	doneCh := make(chan struct{})
 	defer close(doneCh)
-	if err := ps.Subscribe(1, ch1, doneCh, nil); err != nil {
+	if err := ps.Subscribe(Mask(1), ch1, doneCh, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := ps.Subscribe(2, ch2, doneCh, nil); err != nil {
+	if err := ps.Subscribe(Mask(2), ch2, doneCh, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	ps.Lock()
@@ -70,7 +70,7 @@ func TestNumSubscribersMask(t *testing.T) {
 	if want, got := int32(2), ps.NumSubscribers(Mask(1|2)); got != want {
 		t.Fatalf("want %d subscribers, got %d", want, got)
 	}
-	if want, got := int32(2), ps.NumSubscribers(nil); got != want {
+	if want, got := int32(2), ps.NumSubscribers(MaskAll); got != want {
 		t.Fatalf("want %d subscribers, got %d", want, got)
 	}
 	if want, got := int32(0), ps.NumSubscribers(Mask(4)); got != want {
@@ -79,7 +79,7 @@ func TestNumSubscribersMask(t *testing.T) {
 }
 
 func TestSubscribeExceedingLimit(t *testing.T) {
-	ps := New(2)
+	ps := New[Maskable, Maskable](2)
 	ch1 := make(chan Maskable, 1)
 	ch2 := make(chan Maskable, 1)
 	ch3 := make(chan Maskable, 1)
@@ -97,7 +97,7 @@ func TestSubscribeExceedingLimit(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	ps := New(2)
+	ps := New[Maskable, Maskable](2)
 	ch1 := make(chan Maskable, 1)
 	ch2 := make(chan Maskable, 1)
 	doneCh1 := make(chan struct{})
@@ -127,7 +127,7 @@ func (m maskString) Mask() uint64 {
 }
 
 func TestPubSub(t *testing.T) {
-	ps := New(1)
+	ps := New[Maskable, Maskable](1)
 	ch1 := make(chan Maskable, 1)
 	doneCh1 := make(chan struct{})
 	defer close(doneCh1)
@@ -143,7 +143,7 @@ func TestPubSub(t *testing.T) {
 }
 
 func TestMultiPubSub(t *testing.T) {
-	ps := New(2)
+	ps := New[Maskable, Maskable](2)
 	ch1 := make(chan Maskable, 1)
 	ch2 := make(chan Maskable, 1)
 	doneCh := make(chan struct{})
@@ -165,7 +165,7 @@ func TestMultiPubSub(t *testing.T) {
 }
 
 func TestMultiPubSubMask(t *testing.T) {
-	ps := New(3)
+	ps := New[Maskable, Maskable](3)
 	ch1 := make(chan Maskable, 1)
 	ch2 := make(chan Maskable, 1)
 	ch3 := make(chan Maskable, 1)


### PR DESCRIPTION
## Description

Use generics to make pubsub type safe to avoid interface conversions.

`doConsoleLog` was decoding into `madmin.LogInfo`, which should be `log.Info` to be symmetric. This likely fixes a bug for remote logging.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Optimization (provides speedup with no functional changes)
