### PR TITLE
Mark subnet config keys as sensitive info

### DIFF
--- a/internal/config/subnet/help.go
+++ b/internal/config/subnet/help.go
@@ -31,18 +31,21 @@ var (
 			Type:        "string",
 			Description: "[DEPRECATED use api_key] Subnet license token for the cluster" + defaultHelpPostfix(config.License),
 			Optional:    true,
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.APIKey,
 			Type:        "string",
 			Description: "Subnet api key for the cluster" + defaultHelpPostfix(config.APIKey),
 			Optional:    true,
+			Sensitive:   true,
 		},
 		config.HelpKV{
 			Key:         config.Proxy,
 			Type:        "string",
 			Description: "HTTP(S) proxy URL to use for connecting to SUBNET" + defaultHelpPostfix(config.Proxy),
 			Optional:    true,
+			Sensitive:   true,
 		},
 	}
 )


### PR DESCRIPTION
## Description

Mark subnet config keys as sensitive info
So that they get redacted in the health report

## Motivation and Context

Redact sensitive info in health report

## How to test this PR?

- Register a cluster using `mc license register {alias} --name {account-level-unique-name}`
- Generate health report using `mc support diag {alias} --airgap`
- Extract the report and verify that values of keys under `minio -> config -> config -> subnet` are redacted

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression https://github.com/minio/minio/pull/14788
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
