### PR TITLE
Use the same lock for the scanner and site replication healing

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -64,11 +64,6 @@ const (
 var (
 	globalHealConfig heal.Config
 
-	dataScannerLeaderLockTimeout = newDynamicTimeoutWithOpts(dynamicTimeoutOpts{
-		timeout:       30 * time.Second,
-		minimum:       10 * time.Second,
-		retryInterval: time.Second,
-	})
 	// Sleeper values are updated when config is loaded.
 	scannerSleeper = newDynamicSleeper(10, 10*time.Second, true)
 	scannerCycle   = uatomic.NewDuration(dataScannerStartDelay)
@@ -157,19 +152,9 @@ func saveBackgroundHealInfo(ctx context.Context, objAPI ObjectLayer, info backgr
 // runDataScanner will start a data scanner.
 // The function will block until the context is canceled.
 // There should only ever be one scanner running per cluster.
-func runDataScanner(pctx context.Context, objAPI ObjectLayer) {
-	// Make sure only 1 scanner is running on the cluster.
-	locker := objAPI.NewNSLock(minioMetaBucket, "scanner/runDataScanner.lock")
-	lkctx, err := locker.GetLock(pctx, dataScannerLeaderLockTimeout)
-	if err != nil {
-		if intDataUpdateTracker.debug {
-			logger.LogIf(pctx, err)
-		}
-		return
-	}
-	ctx := lkctx.Context()
-	defer lkctx.Cancel()
-	// No unlock for "leader" lock.
+func runDataScanner(ctx context.Context, objAPI ObjectLayer) {
+	ctx, cancel := globalLeaderLock.GetLock(ctx)
+	defer cancel()
 
 	// Load current bloom cycle
 	var cycleInfo currentScannerCycle
@@ -181,7 +166,7 @@ func runDataScanner(pctx context.Context, objAPI ObjectLayer) {
 	} else if len(buf) > 8 {
 		cycleInfo.next = binary.LittleEndian.Uint64(buf[:8])
 		buf = buf[8:]
-		_, err = cycleInfo.UnmarshalMsg(buf)
+		_, err := cycleInfo.UnmarshalMsg(buf)
 		logger.LogIf(ctx, err)
 	}
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -291,6 +291,9 @@ var (
 	// GlobalKMS initialized KMS configuration
 	GlobalKMS kms.KMS
 
+	// Common lock for various subsystems performing the leader tasks
+	globalLeaderLock *sharedLock
+
 	// Auto-Encryption, if enabled, turns any non-SSE-C request
 	// into an SSE-S3 request. If enabled a valid, non-empty KMS
 	// configuration must be present.

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -581,6 +581,8 @@ func serverMain(ctx *cli.Context) {
 	xhttp.SetDeploymentID(globalDeploymentID)
 	xhttp.SetMinIOVersion(Version)
 
+	globalLeaderLock = newSharedLock(GlobalContext, newObject, "leader.lock")
+
 	// Enable background operations for erasure coding
 	initAutoHeal(GlobalContext, newObject)
 	initHealMRF(GlobalContext, newObject)

--- a/cmd/shared-lock.go
+++ b/cmd/shared-lock.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"time"
+)
+
+var sharedLockTimeout = newDynamicTimeoutWithOpts(dynamicTimeoutOpts{
+	timeout:       30 * time.Second,
+	minimum:       10 * time.Second,
+	retryInterval: time.Minute,
+})
+
+type sharedLock struct {
+	lockContext chan LockContext
+}
+
+func (ld sharedLock) backgroundRoutine(ctx context.Context, objAPI ObjectLayer, lockName string) {
+	for {
+		locker := objAPI.NewNSLock(minioMetaBucket, lockName)
+		lkctx, err := locker.GetLock(ctx, sharedLockTimeout)
+		if err != nil {
+			continue
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-lkctx.Context().Done():
+				// The context of the lock is canceled, this can happen
+				// if one lock lost quorum due to cluster instability
+				// in that case, try to lock again.
+				break
+			case ld.lockContext <- lkctx:
+				// Send the lock context to anyone asking for it
+			}
+		}
+	}
+}
+
+func mergeContext(ctx1, ctx2 context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-ctx1.Done():
+		case <-ctx2.Done():
+		}
+
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+func (ld sharedLock) GetLock(ctx context.Context) (context.Context, context.CancelFunc) {
+	select {
+	case l := <-ld.lockContext:
+		return mergeContext(l.Context(), ctx)
+	}
+}
+
+func newSharedLock(ctx context.Context, objAPI ObjectLayer, lockName string) *sharedLock {
+	l := &sharedLock{
+		lockContext: make(chan LockContext),
+	}
+	go l.backgroundRoutine(ctx, objAPI, lockName)
+
+	return l
+}


### PR DESCRIPTION
## Description
Reduce locking refresh chattiness by using only one lock called .minio.sys/leader 
that can be used by both data scanner and site replication healing.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
