### PR TITLE
Make cluster.info unencrypted

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2740,7 +2740,7 @@ func (a adminAPIHandlers) InspectDataHandler(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		if b := getClusterMetaInfo(ctx); len(b) > 0 {
-			w, err := stream.AddEncryptedStream("cluster.info", nil)
+			w, err := stream.AddUnencryptedStream("cluster.info", nil)
 			if err != nil {
 				logger.LogIf(ctx, err)
 				return


### PR DESCRIPTION
## Description

So that it can be read by SUBNET for auto-registration.

## Motivation and Context

SUBNET needs to read cluster.info to perform auto-registration where possible.
So it should be unencrypted.

## How to test this PR?

- Run `mc support inspect {alias}/{path}` to generate output file (`inspect-data.enc`)
- Use following code to read `cluster.info` from the generated file and print to stdout:
```go
        data, err := os.ReadFile("inspect-data.enc")
	if err != nil {
		return err
	}

	r, err := estream.NewReader(bytes.NewReader(data))
	if err != nil {
		return err
	}

	r.SkipEncrypted(true)

        for {
		stream, err := r.NextStream()
		if err == io.EOF {
			// All streams read
			break
		}
		if err != nil {
			return err
		}

		if stream.Name == "cluster.info" {
			io.Copy(os.Stdout, stream)
		}
	}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
