### PR TITLE
Crash: Hold lock while serializing replication stats

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -2934,17 +2934,9 @@ func (p *ReplicationPool) saveStats(ctx context.Context) error {
 	if !p.initialized() {
 		return nil
 	}
-	bsm := globalReplicationStats.getAllCachedLatest()
-	if len(bsm.Stats) == 0 {
-		return nil
-	}
-	data := make([]byte, 4, 4+bsm.Msgsize())
-	// Add the replication stats meta header.
-	binary.LittleEndian.PutUint16(data[0:2], replStatsMetaFormat)
-	binary.LittleEndian.PutUint16(data[2:4], replStatsVersion)
-	// Add data
-	data, err := bsm.MarshalMsg(data)
-	if err != nil {
+
+	data, err := globalReplicationStats.serializeStats()
+	if data == nil {
 		return err
 	}
 	return saveConfig(ctx, p.objLayer, getReplicationStatsPath(globalLocalNodeName), data)


### PR DESCRIPTION
## Description

Stats map was updated after `getAllCachedLatest` had returned.

Hold a lock while the data is being read.

Since there is only ever one reader, make it a regular mutex.

Fixes crash:

```
fatal error: concurrent map iteration and map write

goroutine 18704 [running]:
runtime.throw({0x29490b2?, 0x0?})
	runtime/panic.go:992 +0x71 fp=0xc0338bdbb0 sp=0xc0338bdb80 pc=0x4385f1
runtime.mapiternext(0xc0338bdce8?)
	runtime/map.go:871 +0x4eb fp=0xc0338bdc20 sp=0xc0338bdbb0 pc=0x40ffcb
github.com/minio/minio/cmd.(*BucketStatsMap).MarshalMsg(0xc0338bde08, {0xc056518000, 0x4, 0x65944})
	github.com/minio/minio/cmd/bucket-stats_gen.go:934 +0x1ef fp=0xc0338bdd90 sp=0xc0338bdc20 pc=0x1eb046f
github.com/minio/minio/cmd.(*ReplicationPool).saveStats(0xc00368b450, {0x512bf58, 0xc001296dc0})
	github.com/minio/minio/cmd/bucket-replication.go:2807 +0xe6 fp=0xc0338bde38 sp=0xc0338bdd90 pc=0x1eaa1e6
github.com/minio/minio/cmd.(*ReplicationPool).saveStatsToDisk(0xc00368b450)
	github.com/minio/minio/cmd/bucket-replication.go:2788 +0xc9 fp=0xc0338bdfc8 sp=0xc0338bde38 pc=0x1ea9e49
```

## How to test this PR?

Set up active replication with race detection.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] Fixes a regression(#15594
