### PR TITLE
force all internal MinIO operations to be under UTC

### DIFF
--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -16,3 +16,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package init
+
+import "os"
+
+func init() {
+	// All MinIO operations must be under UTC.
+	os.Setenv("TZ", "UTC")
+}

--- a/internal/init/init_darwin_amd64.go
+++ b/internal/init/init_darwin_amd64.go
@@ -18,10 +18,15 @@
 package init
 
 import (
+	"os"
+
 	"github.com/klauspost/cpuid/v2"
 )
 
 func init() {
+	// All MinIO operations must be under UTC.
+	os.Setenv("TZ", "UTC")
+
 	// Temporary workaround for
 	// https://github.com/golang/go/issues/49233
 	// Keep until upstream has been fixed.


### PR DESCRIPTION
## Description
force all internal MinIO operations to be under UTC

## Motivation and Context
all MinIO operations must be UTC

## How to test this PR?
This is needed to ensure that all servers
run at the same timezone so that we do not
have marshaling problems later on.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
