### PR TITLE
add deadlineConnections on remoteTransport

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -373,6 +373,8 @@ var (
 	// Public key for subnet confidential information
 	subnetAdminPublicKey = []byte("-----BEGIN PUBLIC KEY-----\nMIIBCgKCAQEAyC+ol5v0FP+QcsR6d1KypR/063FInmNEFsFzbEwlHQyEQN3O7kNI\nwVDN1vqp1wDmJYmv4VZGRGzfFw1q+QV7K1TnysrEjrqpVxfxzDQCoUadAp8IxLLc\ns2fjyDNxnZjoC6fTID9C0khKnEa5fPZZc3Ihci9SiCGkPmyUyCGVSxWXIKqL2Lrj\nyDc0pGeEhWeEPqw6q8X2jvTC246tlzqpDeNsPbcv2KblXRcKniQNbBrizT37CKHQ\nM6hc9kugrZbFuo8U5/4RQvZPJnx/DVjLDyoKo2uzuVQs4s+iBrA5sSSLp8rPED/3\n6DgWw3e244Dxtrg972dIT1IOqgn7KUJzVQIDAQAB\n-----END PUBLIC KEY-----")
 
+	globalConnReadDeadline  time.Duration
+	globalConnWriteDeadline time.Duration
 	// Add new variable global values here.
 )
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -91,6 +91,20 @@ var ServerFlags = []cli.Flag{
 		EnvVar: "MINIO_READ_HEADER_TIMEOUT",
 		Hidden: true,
 	},
+	cli.DurationFlag{
+		Name:   "conn-read-deadline",
+		Usage:  "custom connection READ deadline",
+		Hidden: true,
+		Value:  10 * time.Minute,
+		EnvVar: "MINIO_CONN_READ_DEADLINE",
+	},
+	cli.DurationFlag{
+		Name:   "conn-write-deadline",
+		Usage:  "custom connection WRITE deadline",
+		Hidden: true,
+		Value:  10 * time.Minute,
+		EnvVar: "MINIO_CONN_WRITE_DEADLINE",
+	},
 }
 
 var gatewayCmd = cli.Command{
@@ -249,6 +263,9 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 		globalIsErasure = true
 	}
 	globalIsErasureSD = (setupType == ErasureSDSetupType)
+
+	globalConnReadDeadline = ctx.Duration("conn-read-deadline")
+	globalConnWriteDeadline = ctx.Duration("conn-write-deadline")
 }
 
 func serverHandleEnvVars() {

--- a/internal/deadlineconn/deadlineconn.go
+++ b/internal/deadlineconn/deadlineconn.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package deadlineconn implements net.Conn wrapper with configured deadlines.
+package deadlineconn
+
+import (
+	"net"
+	"time"
+)
+
+// DeadlineConn - is a generic stream-oriented network connection supporting buffered reader and read/write timeout.
+type DeadlineConn struct {
+	net.Conn
+	readDeadline  time.Duration // sets the read deadline on a connection.
+	writeDeadline time.Duration // sets the write deadline on a connection.
+}
+
+// Sets read deadline
+func (c *DeadlineConn) setReadDeadline() {
+	if c.readDeadline > 0 {
+		c.SetReadDeadline(time.Now().UTC().Add(c.readDeadline))
+	}
+}
+
+func (c *DeadlineConn) setWriteDeadline() {
+	if c.writeDeadline > 0 {
+		c.SetWriteDeadline(time.Now().UTC().Add(c.writeDeadline))
+	}
+}
+
+// Read - reads data from the connection using wrapped buffered reader.
+func (c *DeadlineConn) Read(b []byte) (n int, err error) {
+	c.setReadDeadline()
+	n, err = c.Conn.Read(b)
+	return n, err
+}
+
+// Write - writes data to the connection.
+func (c *DeadlineConn) Write(b []byte) (n int, err error) {
+	c.setWriteDeadline()
+	n, err = c.Conn.Write(b)
+	return n, err
+}
+
+// WithReadDeadline sets a new read side net.Conn deadline.
+func (c *DeadlineConn) WithReadDeadline(d time.Duration) *DeadlineConn {
+	c.readDeadline = d
+	return c
+}
+
+// WithWriteDeadline sets a new write side net.Conn deadline.
+func (c *DeadlineConn) WithWriteDeadline(d time.Duration) *DeadlineConn {
+	c.writeDeadline = d
+	return c
+}
+
+// New - creates a new connection object wrapping net.Conn with deadlines.
+func New(c net.Conn) *DeadlineConn {
+	return &DeadlineConn{
+		Conn: c,
+	}
+}

--- a/internal/deadlineconn/deadlineconn_test.go
+++ b/internal/deadlineconn/deadlineconn_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package deadlineconn
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Test deadlineconn handles read timeout properly by reading two messages beyond deadline.
+func TestBuffConnReadTimeout(t *testing.T) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("unable to create listener. %v", err)
+	}
+	defer l.Close()
+	serverAddr := l.Addr().String()
+
+	tcpListener, ok := l.(*net.TCPListener)
+	if !ok {
+		t.Fatalf("failed to assert to net.TCPListener")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		tcpConn, terr := tcpListener.AcceptTCP()
+		if terr != nil {
+			t.Errorf("failed to accept new connection. %v", terr)
+			return
+		}
+		deadlineconn := New(tcpConn)
+		deadlineconn.WithReadDeadline(time.Second)
+		deadlineconn.WithWriteDeadline(time.Second)
+		defer deadlineconn.Close()
+
+		// Read a line
+		b := make([]byte, 12)
+		_, terr = deadlineconn.Read(b)
+		if terr != nil {
+			t.Errorf("failed to read from client. %v", terr)
+			return
+		}
+		received := string(b)
+		if received != "message one\n" {
+			t.Errorf(`server: expected: "message one\n", got: %v`, received)
+			return
+		}
+
+		// Wait for more than read timeout to simulate processing.
+		time.Sleep(3 * time.Second)
+
+		_, terr = deadlineconn.Read(b)
+		if terr != nil {
+			t.Errorf("failed to read from client. %v", terr)
+			return
+		}
+		received = string(b)
+		if received != "message two\n" {
+			t.Errorf(`server: expected: "message two\n", got: %v`, received)
+			return
+		}
+
+		// Send a response.
+		_, terr = io.WriteString(deadlineconn, "messages received\n")
+		if terr != nil {
+			t.Errorf("failed to write to client. %v", terr)
+			return
+		}
+	}()
+
+	c, err := net.Dial("tcp", serverAddr)
+	if err != nil {
+		t.Fatalf("unable to connect to server. %v", err)
+	}
+	defer c.Close()
+
+	_, err = io.WriteString(c, "message one\n")
+	if err != nil {
+		t.Fatalf("failed to write to server. %v", err)
+	}
+	_, err = io.WriteString(c, "message two\n")
+	if err != nil {
+		t.Fatalf("failed to write to server. %v", err)
+	}
+
+	received, err := bufio.NewReader(c).ReadString('\n')
+	if err != nil {
+		t.Fatalf("failed to read from server. %v", err)
+	}
+	if received != "messages received\n" {
+		t.Fatalf(`client: expected: "messages received\n", got: %v`, received)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Description
add deadlineConnections on remoteTransport

## Motivation and Context
allow for disconnecting hung net/http clients

## How to test this PR?
Generally, an unreachable target would be 
necessary for this to be reproducible. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
