### PR TITLE
remove io/util for advanced golang

### DIFF
--- a/docs/debugging/inspect/export.go
+++ b/docs/debugging/inspect/export.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -37,7 +36,7 @@ import (
 
 func inspectToExportType(downloadPath string, datajson bool) error {
 	decode := func(r io.Reader, file string) ([]byte, error) {
-		b, e := ioutil.ReadAll(r)
+		b, e := io.ReadAll(r)
 		if e != nil {
 			return nil, e
 		}


### PR DESCRIPTION
## Description
We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [✔️](https://tw.piliapp.com/emojis/check-mark/) ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)