### PR TITLE
fix: avoid URL unsafe chars in multipart upload ID

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -43,7 +43,7 @@ import (
 
 func (er erasureObjects) getUploadIDDir(bucket, object, uploadID string) string {
 	uploadUUID := uploadID
-	uploadBytes, err := base64.StdEncoding.DecodeString(uploadID)
+	uploadBytes, err := base64.RawURLEncoding.DecodeString(uploadID)
 	if err == nil {
 		slc := strings.SplitN(string(uploadBytes), ".", 2)
 		if len(slc) == 2 {
@@ -432,7 +432,7 @@ func (er erasureObjects) newMultipartUpload(ctx context.Context, bucket string, 
 		partsMetadata[index].Metadata = userDefined
 	}
 	uploadUUID := mustGetUUID()
-	uploadID := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s.%s", globalDeploymentID, uploadUUID)))
+	uploadID := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%s.%s", globalDeploymentID, uploadUUID)))
 	uploadIDPath := er.getUploadIDDir(bucket, object, uploadUUID)
 
 	// Write updated `xl.meta` to all disks.

--- a/cmd/object-api-input-checks.go
+++ b/cmd/object-api-input-checks.go
@@ -109,7 +109,7 @@ func checkListMultipartArgs(ctx context.Context, bucket, prefix, keyMarker, uplo
 				KeyMarker:      keyMarker,
 			}
 		}
-		_, err := base64.StdEncoding.DecodeString(uploadIDMarker)
+		_, err := base64.RawURLEncoding.DecodeString(uploadIDMarker)
 		if err != nil {
 			logger.LogIf(ctx, err)
 			return MalformedUploadID{

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1051,9 +1051,10 @@ func testListMultipartUploads(obj ObjectLayer, instanceType string, t TestErrHan
 			fmt.Errorf("Invalid combination of uploadID marker '%s' and marker '%s'", "abc", "asia/europe/"), false,
 		},
 		{
-			bucketNames[0], "asia", "asia/europe", "abc", "", 0,
+			// Contains a base64 padding character
+			bucketNames[0], "asia", "asia/europe", "abc=", "", 0,
 			ListMultipartsInfo{},
-			fmt.Errorf("Malformed upload id %s", "abc"), false,
+			fmt.Errorf("Malformed upload id %s", "abc="), false,
 		},
 
 		// Setting up valid case of ListMultiPartUploads.


### PR DESCRIPTION
## Description



## Motivation and Context

Try to avoid issues with clients that don't properly URL encode URL query parameters.

## How to test this PR?

Check with admin trace that during a multipart upload, the upload ID in the URL does not have trailing padding characters (like `==`)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
