### PR TITLE
Return remote tier for transitioned objects

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -168,7 +168,9 @@ func (fi FileInfo) ToObjectInfo(bucket, object string, versioned bool) ObjectInf
 	objInfo.Parts = fi.Parts
 
 	// Update storage class
-	if sc, ok := fi.Metadata[xhttp.AmzStorageClass]; ok {
+	if fi.TransitionTier != "" {
+		objInfo.StorageClass = fi.TransitionTier
+	} else if sc, ok := fi.Metadata[xhttp.AmzStorageClass]; ok {
 		objInfo.StorageClass = sc
 	} else {
 		objInfo.StorageClass = globalMinioDefaultStorageClass


### PR DESCRIPTION
## Description
Return remote tier name for storageclass in case of transitioned objects


## Motivation and Context
`mc ls myminio/obj-1` should return the remote tier this object has transitioned into as opposed to `STANDARD`.
`obj-1` has transitioned to `WARM-MINIO-1` in this setup.

Previously,
```
$ mc ls myminio/mybucket/
[2022-11-09 12:20:18 PST]    26B STANDARD obj-1
[2022-11-09 14:16:43 PST]     0B folder1/
```

With this change, 

```
$ mc ls myminio/mybucket/
[2022-11-09 12:20:18 PST]    26B WARM-MINIO-1 obj-1
[2022-11-09 14:16:43 PST]     0B folder1/
```

## How to test this PR?
1. Add a warm tier
2. Configure ILM such that objects under a bucket (say `mybucket`) transitions to this tier
3. `mc ls myminio/mybucket` should display the warm tier name against the storageclass column.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
