### PR TITLE
lifecycle: simplify Eval and HasActiveRules

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -298,7 +298,7 @@ func validateTransitionTier(lc *lifecycle.Lifecycle) error {
 // This is to be called after a successful upload of an object (version).
 func enqueueTransitionImmediate(obj ObjectInfo) {
 	if lc, err := globalLifecycleSys.Get(obj.Bucket); err == nil {
-		event := lc.Eval(obj.ToLifecycleOpts(), time.Now())
+		event := lc.Eval(obj.ToLifecycleOpts())
 		switch event.Action {
 		case lifecycle.TransitionAction, lifecycle.TransitionVersionAction:
 			globalTransitionState.queueTransitionTask(obj, event.StorageClass)

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -420,7 +420,7 @@ func (f *folderScanner) scanFolder(ctx context.Context, folder cachedFolder, int
 		filter := f.withFilter
 		_, prefix := path2BucketObjectWithBasePath(f.root, folder.name)
 		var activeLifeCycle *lifecycle.Lifecycle
-		if f.oldCache.Info.lifeCycle != nil && f.oldCache.Info.lifeCycle.HasActiveRules(prefix, true) {
+		if f.oldCache.Info.lifeCycle != nil && f.oldCache.Info.lifeCycle.HasActiveRules(prefix) {
 			if f.dataUsageScannerDebug {
 				console.Debugf(scannerLogPrefix+" Prefix %q has active rules\n", prefix)
 			}
@@ -1101,7 +1101,7 @@ func (i *scannerItem) applyActions(ctx context.Context, o ObjectLayer, oi Object
 }
 
 func evalActionFromLifecycle(ctx context.Context, lc lifecycle.Lifecycle, lr lock.Retention, obj ObjectInfo) lifecycle.Event {
-	event := lc.Eval(obj.ToLifecycleOpts(), time.Now().UTC())
+	event := lc.Eval(obj.ToLifecycleOpts())
 	if serverDebugLog {
 		console.Debugf(applyActionsLogPrefix+" lifecycle: Secondary scan: %v\n", event.Action)
 	}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -445,7 +445,7 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 	// Check if the current bucket has a configured lifecycle policy
 	if globalLifecycleSys != nil {
 		lc, err = globalLifecycleSys.Get(cache.Info.Name)
-		if err == nil && lc.HasActiveRules("", true) {
+		if err == nil && lc.HasActiveRules("") {
 			cache.Info.lifeCycle = lc
 			if intDataUpdateTracker.debug {
 				console.Debugln(color.Green("scannerDisk:") + " lifecycle: Active rules found")

--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -221,7 +221,7 @@ func TestExpectedExpiryTime(t *testing.T) {
 	}
 }
 
-func TestComputeActions(t *testing.T) {
+func TestEval(t *testing.T) {
 	testCases := []struct {
 		inputConfig            string
 		objectName             string
@@ -538,7 +538,7 @@ func TestComputeActions(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Got unexpected error: %v", err)
 			}
-			if resultAction := lc.ComputeAction(ObjectOpts{
+			if res := lc.Eval(ObjectOpts{
 				Name:             tc.objectName,
 				UserTags:         tc.objectTags,
 				ModTime:          tc.objectModTime,
@@ -547,8 +547,8 @@ func TestComputeActions(t *testing.T) {
 				IsLatest:         !tc.isNoncurrent,
 				SuccessorModTime: tc.objectSuccessorModTime,
 				VersionID:        tc.versionID,
-			}); resultAction != tc.expectedAction {
-				t.Fatalf("Expected action: `%v`, got: `%v`", tc.expectedAction, resultAction)
+			}); res.Action != tc.expectedAction {
+				t.Fatalf("Expected action: `%v`, got: `%v`", tc.expectedAction, res.Action)
 			}
 		})
 	}
@@ -556,50 +556,49 @@ func TestComputeActions(t *testing.T) {
 
 func TestHasActiveRules(t *testing.T) {
 	testCases := []struct {
-		inputConfig    string
-		prefix         string
-		expectedNonRec bool
-		expectedRec    bool
+		inputConfig string
+		prefix      string
+		want        bool
 	}{
 		{
-			inputConfig:    `<LifecycleConfiguration><Rule><Filter><Prefix>foodir/</Prefix></Filter><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
-			prefix:         "foodir/foobject",
-			expectedNonRec: true, expectedRec: true,
+			inputConfig: `<LifecycleConfiguration><Rule><Filter><Prefix>foodir/</Prefix></Filter><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
+			prefix:      "foodir/foobject",
+			want:        true,
 		},
 		{ // empty prefix
-			inputConfig:    `<LifecycleConfiguration><Rule><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
-			prefix:         "foodir/foobject/foo.txt",
-			expectedNonRec: true, expectedRec: true,
+			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
+			prefix:      "foodir/foobject/foo.txt",
+			want:        true,
 		},
 		{
-			inputConfig:    `<LifecycleConfiguration><Rule><Filter><Prefix>foodir/</Prefix></Filter><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
-			prefix:         "zdir/foobject",
-			expectedNonRec: false, expectedRec: false,
+			inputConfig: `<LifecycleConfiguration><Rule><Filter><Prefix>foodir/</Prefix></Filter><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
+			prefix:      "zdir/foobject",
+			want:        false,
 		},
 		{
-			inputConfig:    `<LifecycleConfiguration><Rule><Filter><Prefix>foodir/zdir/</Prefix></Filter><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
-			prefix:         "foodir/",
-			expectedNonRec: false, expectedRec: true,
+			inputConfig: `<LifecycleConfiguration><Rule><Filter><Prefix>foodir/zdir/</Prefix></Filter><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
+			prefix:      "foodir/",
+			want:        true,
 		},
 		{
-			inputConfig:    `<LifecycleConfiguration><Rule><Filter><Prefix></Prefix></Filter><Status>Disabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
-			prefix:         "foodir/",
-			expectedNonRec: false, expectedRec: false,
+			inputConfig: `<LifecycleConfiguration><Rule><Filter><Prefix></Prefix></Filter><Status>Disabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
+			prefix:      "foodir/",
+			want:        false,
 		},
 		{
-			inputConfig:    `<LifecycleConfiguration><Rule><Filter><Prefix>foodir/</Prefix></Filter><Status>Enabled</Status><Expiration><Date>2999-01-01T00:00:00.000Z</Date></Expiration></Rule></LifecycleConfiguration>`,
-			prefix:         "foodir/foobject",
-			expectedNonRec: false, expectedRec: false,
+			inputConfig: `<LifecycleConfiguration><Rule><Filter><Prefix>foodir/</Prefix></Filter><Status>Enabled</Status><Expiration><Date>2999-01-01T00:00:00.000Z</Date></Expiration></Rule></LifecycleConfiguration>`,
+			prefix:      "foodir/foobject",
+			want:        false,
 		},
 		{
-			inputConfig:    `<LifecycleConfiguration><Rule><Status>Enabled</Status><Transition><StorageClass>S3TIER-1</StorageClass></Transition></Rule></LifecycleConfiguration>`,
-			prefix:         "foodir/foobject/foo.txt",
-			expectedNonRec: true, expectedRec: true,
+			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Transition><StorageClass>S3TIER-1</StorageClass></Transition></Rule></LifecycleConfiguration>`,
+			prefix:      "foodir/foobject/foo.txt",
+			want:        true,
 		},
 		{
-			inputConfig:    `<LifecycleConfiguration><Rule><Status>Enabled</Status><NoncurrentVersionTransition><StorageClass>S3TIER-1</StorageClass></NoncurrentVersionTransition></Rule></LifecycleConfiguration>`,
-			prefix:         "foodir/foobject/foo.txt",
-			expectedNonRec: true, expectedRec: true,
+			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><NoncurrentVersionTransition><StorageClass>S3TIER-1</StorageClass></NoncurrentVersionTransition></Rule></LifecycleConfiguration>`,
+			prefix:      "foodir/foobject/foo.txt",
+			want:        true,
 		},
 	}
 
@@ -610,14 +609,10 @@ func TestHasActiveRules(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Got unexpected error: %v", err)
 			}
-			if got := lc.HasActiveRules(tc.prefix, false); got != tc.expectedNonRec {
-				t.Fatalf("Expected result with recursive set to false: `%v`, got: `%v`", tc.expectedNonRec, got)
-			}
-			if got := lc.HasActiveRules(tc.prefix, true); got != tc.expectedRec {
-				t.Fatalf("Expected result with recursive set to true: `%v`, got: `%v`", tc.expectedRec, got)
+			if got := lc.HasActiveRules(tc.prefix); got != tc.want {
+				t.Fatalf("Expected result with recursive set to false: `%v`, got: `%v`", tc.want, got)
 			}
 		})
-
 	}
 }
 
@@ -741,7 +736,7 @@ func TestTransitionTier(t *testing.T) {
 	// Go back seven days in the past
 	now = now.Add(7 * 24 * time.Hour)
 
-	evt := lc.Eval(obj1, now)
+	evt := lc.eval(obj1, now)
 	if evt.Action != TransitionAction {
 		t.Fatalf("Expected action: %s but got %s", TransitionAction, evt.Action)
 	}
@@ -749,7 +744,7 @@ func TestTransitionTier(t *testing.T) {
 		t.Fatalf("Expected TIER-1 but got %s", evt.StorageClass)
 	}
 
-	evt = lc.Eval(obj2, now)
+	evt = lc.eval(obj2, now)
 	if evt.Action != TransitionVersionAction {
 		t.Fatalf("Expected action: %s but got %s", TransitionVersionAction, evt.Action)
 	}
@@ -818,13 +813,13 @@ func TestTransitionTierWithPrefixAndTags(t *testing.T) {
 	now = now.Add(7 * 24 * time.Hour)
 
 	// Eval object 1
-	evt := lc.Eval(obj1, now)
+	evt := lc.eval(obj1, now)
 	if evt.Action != NoneAction {
 		t.Fatalf("Expected action: %s but got %s", NoneAction, evt.Action)
 	}
 
 	// Eval object 2
-	evt = lc.Eval(obj2, now)
+	evt = lc.eval(obj2, now)
 	if evt.Action != TransitionAction {
 		t.Fatalf("Expected action: %s but got %s", TransitionAction, evt.Action)
 	}
@@ -833,7 +828,7 @@ func TestTransitionTierWithPrefixAndTags(t *testing.T) {
 	}
 
 	// Eval object 3
-	evt = lc.Eval(obj3, now)
+	evt = lc.eval(obj3, now)
 	if evt.Action != TransitionAction {
 		t.Fatalf("Expected action: %s but got %s", TransitionAction, evt.Action)
 	}


### PR DESCRIPTION
## Description
- Remove superfluous arguments from exported methods like Eval and HasActiveRules
- Remove unused ComputeAction

## Motivation and Context
- Eval with zero time.Time value is only used within the package by SetPredictiionHeaders method
- HasActiveRules is always called with recursive=`true`
- Eval replaced ComputeAction

## How to test this PR?
Covered by package-level unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
