### PR TITLE
save deploymentID to avoid mutating request entry in Audit

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -289,8 +289,9 @@ func errToEntry(ctx context.Context, err error, errKind ...interface{}) log.Entr
 
 	// Get the cause for the Error
 	message := fmt.Sprintf("%v (%T)", err, err)
+	DeploymentID := req.DeploymentID
 	if req.DeploymentID == "" {
-		req.DeploymentID = xhttp.GlobalDeploymentID
+		DeploymentID = xhttp.GlobalDeploymentID
 	}
 
 	objects := make([]log.ObjectVersion, 0, len(req.Objects))
@@ -302,7 +303,7 @@ func errToEntry(ctx context.Context, err error, errKind ...interface{}) log.Entr
 	}
 
 	entry := log.Entry{
-		DeploymentID: req.DeploymentID,
+		DeploymentID: DeploymentID,
 		Level:        ErrorLvl.String(),
 		LogKind:      logKind,
 		RemoteHost:   req.RemoteHost,

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -289,9 +289,9 @@ func errToEntry(ctx context.Context, err error, errKind ...interface{}) log.Entr
 
 	// Get the cause for the Error
 	message := fmt.Sprintf("%v (%T)", err, err)
-	DeploymentID := req.DeploymentID
+	deploymentID := req.DeploymentID
 	if req.DeploymentID == "" {
-		DeploymentID = xhttp.GlobalDeploymentID
+		deploymentID = xhttp.GlobalDeploymentID
 	}
 
 	objects := make([]log.ObjectVersion, 0, len(req.Objects))
@@ -303,7 +303,7 @@ func errToEntry(ctx context.Context, err error, errKind ...interface{}) log.Entr
 	}
 
 	entry := log.Entry{
-		DeploymentID: DeploymentID,
+		DeploymentID: deploymentID,
 		Level:        ErrorLvl.String(),
 		LogKind:      logKind,
 		RemoteHost:   req.RemoteHost,


### PR DESCRIPTION
Do set when Use Rlocker

## Description

Do set when Use Rlocker

```go
if req.DeploymentID == "" {
   req.DeploymentID = xhttp.GlobalDeploymentID
}
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
