### PR TITLE
fix:Use Locker instead of Rlocker

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -270,8 +270,8 @@ func errToEntry(ctx context.Context, err error, errKind ...interface{}) log.Entr
 	if req == nil {
 		req = &ReqInfo{API: "SYSTEM"}
 	}
-	req.RLock()
-	defer req.RUnlock()
+	req.Lock()
+	defer req.Unlock()
 
 	API := "SYSTEM"
 	if req.API != "" {


### PR DESCRIPTION
Use Locker instead of Rlocker

## Description

Use Locker instead of Rlocker
When Use Rlocker ,set `req.DeploymentID`

```go
	if req.DeploymentID == "" {
		req.DeploymentID = xhttp.GlobalDeploymentID
	}
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
