### PR TITLE
helm: update bucket policy setting via 'mc anonymous'

### DIFF
--- a/helm/minio/templates/_helper_create_bucket.txt
+++ b/helm/minio/templates/_helper_create_bucket.txt
@@ -103,7 +103,7 @@ if ! checkBucketExists $BUCKET ; then
   # At this point, the bucket should exist, skip checking for existence
   # Set policy on the bucket
   echo "Setting policy of bucket '$BUCKET' to '$POLICY'."
-  ${MC} policy set $POLICY myminio/$BUCKET
+  ${MC} anonymous set $POLICY myminio/$BUCKET
 }
 
 # Try connecting to MinIO instance


### PR DESCRIPTION
## Description
Fix for Issue  #16046

## Motivation and Context
The bucket's policies are not set correctly when the bucket is declared in values.yaml

## How to test this PR?
Create a bucket with policy = **download**  in values.yaml:
```
   - name: bucket001
     policy: download
     purge: false
     versioning: true
     objectlocking: false

```
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
