### PR TITLE
choose default values upon incorrect storage_class value

### DIFF
--- a/internal/config/storageclass/storage-class.go
+++ b/internal/config/storageclass/storage-class.go
@@ -304,7 +304,12 @@ func LookupConfig(kvs config.KVS, setDriveCount int) (cfg Config, err error) {
 	// Validation is done after parsing both the storage classes. This is needed because we need one
 	// storage class value to deduce the correct value of the other storage class.
 	if err = validateParity(cfg.Standard.Parity, cfg.RRS.Parity, setDriveCount); err != nil {
-		return Config{}, err
+		cfg.RRS.Parity = defaultRRSParity
+		if setDriveCount == 1 {
+			cfg.RRS.Parity = 0
+		}
+		cfg.Standard.Parity = DefaultParityBlocks(setDriveCount)
+		return cfg, err
 	}
 
 	return cfg, nil


### PR DESCRIPTION

## Description
choose default values upon incorrect storage_class value

## Motivation and Context
mistakes can happen, choose safe behavior when such 
mistakes are made and left unnoticed.

## How to test this PR?
Start MinIO freshly with following config

```
MINIO_STORAGE_CLASS_STANDARD=EC:6 minio server /tmp/fs{1...6}
```

You shall see the default parity chosen becomes '0' 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
