### PR TITLE
Allow tls.certSecret in Helm chart to be templated

### DIFF
--- a/helm/minio/templates/_helpers.tpl
+++ b/helm/minio/templates/_helpers.tpl
@@ -166,7 +166,7 @@ Formats volume for MinIO TLS keys and trusted certs
 {{- if .Values.tls.enabled }}
 - name: cert-secret-volume
   secret:
-    secretName: {{ .Values.tls.certSecret }}
+    secretName: {{ tpl .Values.tls.certSecret }}
     items:
     - key: {{ .Values.tls.publicCrt }}
       path: public.crt


### PR DESCRIPTION
## Description

This change allows `tls.certSecret` to contain Helm templating.

## Motivation and Context

The name of the certificate secret may be based on variables like the Helm release name, so it's useful to be able to reference variables like that in `tls.certSecret`.

## How to test this PR?

Deploy the Helm chart using a `values.yaml` like this:

```yaml
minio:
  tls:
    certSecret: '{{ include "my-chart.fullname" . }}-cert'
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
