### PR TITLE
config: Return XMinioConfigNotFound code for non existing config

### DIFF
--- a/cmd/admin-handler-utils.go
+++ b/cmd/admin-handler-utils.go
@@ -84,7 +84,13 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 			Description:    e.Error(),
 			HTTPStatusCode: http.StatusBadRequest,
 		}
-	case config.Error:
+	case config.ErrConfigNotFound:
+		apiErr = APIError{
+			Code:           "XMinioConfigNotFoundError",
+			Description:    e.Error(),
+			HTTPStatusCode: http.StatusNotFound,
+		}
+	case config.ErrConfigGeneric:
 		apiErr = APIError{
 			Code:           "XMinioConfigError",
 			Description:    e.Error(),


### PR DESCRIPTION
## Description
MinIO operator needs this error to ignore the error of not finding a logsearch webhook config.

## Motivation and Context
Return XMinioConfigNotFoundError instead of XMinioConfigError 
when trying to delete a configuration

## How to test this PR?
```
package main

import (
        "context"
        "fmt"
        "log"
        "reflect"

        "github.com/minio/madmin-go"
)

func main() {
        // Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
        // dummy values, please replace them with original values.

        // API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
        // New returns an MinIO Admin client object.
        madmClnt, err := madmin.New("localhost:9000", "minioadmin", "minioadmin", false)
        if err != nil {
                log.Fatalln(err)
        }   

        _, err := madmClnt.DelConfigKV(context.Background(), "audit_webhook:abcd")
        if err != nil {
                adminErr := madmin.ToErrorResponse(err)
                fmt.Println(adminErr.Code, adminErr.Message)
                fmt.Println(reflect.TypeOf(err))
        }   
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
