### PR TITLE
avoid inconsistent versions healing when versions are large

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1261,7 +1261,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 		}
 
 		if len(fivs.Versions) > 2 {
-			return fmt.Errorf("bucket(%s)/object(%s) object needs healing, allowing lazy healing via scanner instead here for versions greater than %d > 2",
+			return fmt.Errorf("bucket(%s)/object(%s) object with %d versions needs healing, allowing lazy healing via scanner instead here for versions greater than 2",
 				bucket, entry.name,
 				len(fivs.Versions))
 		}

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1253,17 +1253,21 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 				return nil
 			}
 		}
+
 		fivs, err := entry.fileInfoVersions(bucket)
 		if err != nil {
-			_, err = er.HealObject(ctx, bucket, entry.name, "", madmin.HealOpts{NoLock: true})
+			healObject(bucket, entry.name, "", madmin.HealNormalScan)
 			return err
 		}
 
+		if len(fivs.Versions) > 2 {
+			return fmt.Errorf("bucket(%s)/object(%s) object needs healing, allowing lazy healing via scanner instead here for versions greater than %d > 2",
+				bucket, entry.name,
+				len(fivs.Versions))
+		}
+
 		for _, version := range fivs.Versions {
-			_, err = er.HealObject(ctx, bucket, version.Name, version.VersionID, madmin.HealOpts{NoLock: true})
-			if err != nil && !isErrObjectNotFound(err) && !isErrVersionNotFound(err) {
-				return err
-			}
+			healObject(bucket, entry.name, version.VersionID, madmin.HealNormalScan)
 		}
 
 		return nil


### PR DESCRIPTION

## Description
avoid inconsistent versions healing when versions are large

## Motivation and Context
PUT() can take a performance hit when there are inconsistent
versions on the disk and the number of versions are large.
    
We error out right away and let the caller run `mc admin heal -r`
if needed without causing incoming I/O to slow down.
    
This PR also makes the heal trigger non-blocking as well.

## How to test this PR?
Nothing special create an object 10,000 versions, perform PUT
on this object making one of the versions inconsistent via some kind 
of a metadata update on the version-id. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
