### PR TITLE
fix: update metacache entry only once

### DIFF
--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -155,9 +155,6 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 						return
 					case <-t.C:
 						meta.lastHandout = time.Now()
-						if rpc == nil {
-							meta, _ = localMetacacheMgr.updateCacheEntry(meta)
-						}
 						meta, _ = rpc.UpdateMetacacheListing(ctx, meta)
 					}
 				}(*c)


### PR DESCRIPTION
## Description
With this change, `localMetacacheMgr.updateCacheEntry` will not be called twice when `rpc == nil`.

## How to test this PR?
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
