### PR TITLE
fix: skip free version ID and marker in metadata equality

### DIFF
--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -610,7 +610,19 @@ func (j xlMetaV2Object) ToFileInfo(volume, path string) (FileInfo, error) {
 
 		fi.Metadata[k] = v
 	}
+
+	tierFVIDKey := ReservedMetadataPrefixLower + tierFVID
+	tierFVMarkerKey := ReservedMetadataPrefixLower + tierFVMarker
 	for k, v := range j.MetaSys {
+		// Make sure we skip free-version-id, similar to AddVersion()
+		if len(k) > len(ReservedMetadataPrefixLower) && strings.EqualFold(k[:len(ReservedMetadataPrefixLower)], ReservedMetadataPrefixLower) {
+			// Skip tierFVID, tierFVMarker keys; it's used
+			// only for creating free-version.
+			switch k {
+			case tierFVIDKey, tierFVMarkerKey:
+				continue
+			}
+		}
 		switch {
 		case strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower), equals(k, VersionPurgeStatusKey):
 			fi.Metadata[k] = string(v)


### PR DESCRIPTION

## Description
fix: skip free version ID and marker in metadata equality

## Motivation and Context
It so happens that we previously had a bug where an object 
might be created with free-version-id (incorrectly)

where it is not supposed to since we explicitly reject
such an occurrence, there was an issue in the past
that would end up preserving tier-versionid for a
regular object.

skip checks for metadata equality by skipping these keys 
as they are not supposed to be present via a PUT object.


## How to test this PR?
I have an inspect file that reproduced this issue, please ask
me on how to reproduce this and this PR that fixes this
problem.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
