### PR TITLE
fix: checking for stale STS account under site replication

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -1257,9 +1257,8 @@ func (c *SiteReplicationSys) PeerSTSAccHandler(ctx context.Context, stsCred *mad
 	}
 	// skip overwrite of local update if peer sent stale info
 	if !updatedAt.IsZero() {
-		if u, err := globalIAMSys.GetUserInfo(ctx, stsCred.AccessKey); err == nil {
-			ok, _, _ := globalIAMSys.IsTempUser(stsCred.AccessKey)
-			if ok && u.UpdatedAt.After(updatedAt) {
+		if u, _, err := globalIAMSys.getTempAccount(ctx, stsCred.AccessKey); err == nil {
+			if u.UpdatedAt.After(updatedAt) {
 				return nil
 			}
 		}

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -71,6 +71,12 @@ var errNoSuchUser = errors.New("Specified user does not exist")
 // error returned when service account is not found
 var errNoSuchServiceAccount = errors.New("Specified service account does not exist")
 
+// error returned when temporary account is not found
+var errNoSuchTempAccount = errors.New("Specified temporary account does not exist")
+
+// error returned in IAM subsystem when an account doesn't exist.
+var errNoSuchAccount = errors.New("Specified account does not exist")
+
 // error returned in IAM subsystem when groups doesn't exist.
 var errNoSuchGroup = errors.New("Specified group does not exist")
 


### PR DESCRIPTION
## Description
globalIAMSys.GetUserInfo() does not return valid information for STS accounts. 
It only works with regular users. Fix the code by defining getTempAccount() and use
it instead of GetUserInfo()

## Motivation and Context
Make the code better

## How to test this PR?
Currently, the STS account is immutable, so currently it does not fix any bug.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
