### PR TITLE
Reduce temporary file clean-up waits

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -206,7 +206,7 @@ func (er erasureObjects) cleanupStaleUploadsOnDisk(ctx context.Context, disk Sto
 				er.deleteAll(ctx, minioMetaMultipartBucket, uploadIDPath)
 				return nil
 			}
-			wait := er.deletedCleanupSleeper.Timer(ctx)
+			wait := deletedCleanupSleeper.Timer(ctx)
 			if now.Sub(fi.ModTime) > expiry {
 				er.deleteAll(ctx, minioMetaMultipartBucket, uploadIDPath)
 			}
@@ -223,7 +223,7 @@ func (er erasureObjects) cleanupStaleUploadsOnDisk(ctx context.Context, disk Sto
 		if err != nil {
 			return nil
 		}
-		wait := er.deletedCleanupSleeper.Timer(ctx)
+		wait := deletedCleanupSleeper.Timer(ctx)
 		if now.Sub(vi.Created) > expiry {
 			er.deleteAll(ctx, minioMetaTmpBucket, tmpDir)
 		}

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -461,17 +461,16 @@ func newErasureSets(ctx context.Context, endpoints PoolEndpoints, storageDisks [
 
 			// Initialize erasure objects for a given set.
 			s.sets[i] = &erasureObjects{
-				setIndex:              i,
-				poolIndex:             poolIdx,
-				setDriveCount:         setDriveCount,
-				defaultParityCount:    defaultParityCount,
-				getDisks:              s.GetDisks(i),
-				getLockers:            s.GetLockers(i),
-				getEndpoints:          s.GetEndpoints(i),
-				deletedCleanupSleeper: newDynamicSleeper(10, 2*time.Second, false),
-				nsMutex:               mutex,
-				bp:                    bp,
-				bpOld:                 bpOld,
+				setIndex:           i,
+				poolIndex:          poolIdx,
+				setDriveCount:      setDriveCount,
+				defaultParityCount: defaultParityCount,
+				getDisks:           s.GetDisks(i),
+				getLockers:         s.GetLockers(i),
+				getEndpoints:       s.GetEndpoints(i),
+				nsMutex:            mutex,
+				bp:                 bp,
+				bpOld:              bpOld,
 			}
 		}(i)
 	}

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -66,8 +66,6 @@ type erasureObjects struct {
 	// Byte pools used for temporary i/o buffers,
 	// legacy objects.
 	bpOld *bpool.BytePoolCap
-
-	deletedCleanupSleeper *dynamicSleeper
 }
 
 // NewNSLock - initialize a new namespace RWLocker instance.
@@ -338,7 +336,7 @@ func (er erasureObjects) cleanupDeletedObjects(ctx context.Context) {
 				defer wg.Done()
 				diskPath := disk.Endpoint().Path
 				readDirFn(pathJoin(diskPath, minioMetaTmpDeletedBucket), func(ddir string, typ os.FileMode) error {
-					wait := er.deletedCleanupSleeper.Timer(ctx)
+					wait := deletedCleanupSleeper.Timer(ctx)
 					removeAll(pathJoin(diskPath, minioMetaTmpDeletedBucket, ddir))
 					wait()
 					return nil

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -381,6 +381,10 @@ var (
 
 	globalConnReadDeadline  time.Duration
 	globalConnWriteDeadline time.Duration
+
+	// Controller for deleted file sweeper.
+	deletedCleanupSleeper = newDynamicSleeper(5, 25*time.Millisecond, false)
+
 	// Add new variable global values here.
 )
 


### PR DESCRIPTION
## Description

Increase base speed by 2x and reduce max wait to 25ms, for a minimum of ~40 items/s (minus delete time) cleanup no matter the system load.

Move sleeper to global var, so it potentially can be updated with custom delay.

## Motivation and Context

If the cleaner is unable to keep up it compounds the problem with more and more items being added to temporary folders.

## How to test this PR?

Observe cleaning.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
