### PR TITLE
wrapped error will not equal

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -539,21 +539,18 @@ func (z *erasureServerPools) Init(ctx context.Context) error {
 					r := rand.New(rand.NewSource(time.Now().UnixNano()))
 					for {
 						if err := z.Decommission(ctx, pool.ID); err != nil {
-							switch {
-							// we already started decommission
-							case errors.Is(err, errDecommissionAlreadyRunning):
+							if errors.Is(err, errDecommissionAlreadyRunning) {
 								// A previous decommission running found restart it.
 								z.doDecommissionInRoutine(ctx, idx)
 								return
-							default:
-								if configRetriableErrors(err) {
-									logger.LogIf(ctx, fmt.Errorf("Unable to resume decommission of pool %v: %w: retrying..", pool, err))
-									time.Sleep(time.Second + time.Duration(r.Float64()*float64(5*time.Second)))
-									continue
-								}
-								logger.LogIf(ctx, fmt.Errorf("Unable to resume decommission of pool %v: %w", pool, err))
-								return
 							}
+							if configRetriableErrors(err) {
+								logger.LogIf(ctx, fmt.Errorf("Unable to resume decommission of pool %v: %w: retrying..", pool, err))
+								time.Sleep(time.Second + time.Duration(r.Float64()*float64(5*time.Second)))
+								continue
+							}
+							logger.LogIf(ctx, fmt.Errorf("Unable to resume decommission of pool %v: %w", pool, err))
+							return
 						}
 						break
 					}

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -539,9 +539,9 @@ func (z *erasureServerPools) Init(ctx context.Context) error {
 					r := rand.New(rand.NewSource(time.Now().UnixNano()))
 					for {
 						if err := z.Decommission(ctx, pool.ID); err != nil {
-							switch err {
+							switch {
 							// we already started decommission
-							case errDecommissionAlreadyRunning:
+							case errors.Is(err, errDecommissionAlreadyRunning):
 								// A previous decommission running found restart it.
 								z.doDecommissionInRoutine(ctx, idx)
 								return


### PR DESCRIPTION
cmd/erasure-server-pool-decom.go:262
```go
			return fmt.Errorf("%w at index: %d", errDecommissionAlreadyRunning, i)
```
to cmd/erasure-server-pool-decom.go:1284
```go
	if err = z.poolMeta.Decommission(idx, pi); err != nil {
		return err
	}
```
to cmd/erasure-server-pool-decom.go:1043
```go
	if err := z.StartDecommission(ctx, idx); err != nil {
		return err
	}
```
cmd/erasure-server-pool-decom.go:541
```go
                                       if err := z.Decommission(ctx, pool.ID); err != nil {
							switch err {
							// we already started decommission
							case errDecommissionAlreadyRunning:
								// A previous decommission running found restart it.
								z.doDecommissionInRoutine(ctx, idx)
								return
							default:
								if configRetriableErrors(err) {
									logger.LogIf(ctx, fmt.Errorf("Unable to resume decommission of pool %v: %w: retrying..", pool, err))
									time.Sleep(time.Second + time.Duration(r.Float64()*float64(5*time.Second)))
									continue
								}
								logger.LogIf(ctx, fmt.Errorf("Unable to resume decommission of pool %v: %w", pool, err))
								return
							}
						}
```

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
