### PR TITLE
fix: Timestamp not added in diagnostics report

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2253,7 +2253,8 @@ func (a adminAPIHandlers) HealthInfoHandler(w http.ResponseWriter, r *http.Reque
 	enc := json.NewEncoder(w)
 
 	healthInfo := madmin.HealthInfo{
-		Version: madmin.HealthInfoVersion,
+		TimeStamp: time.Now().UTC(),
+		Version:   madmin.HealthInfoVersion,
 		Minio: madmin.MinioHealthInfo{
 			Info: madmin.MinioInfo{
 				DeploymentID: globalDeploymentID,

--- a/cmd/callhome.go
+++ b/cmd/callhome.go
@@ -127,7 +127,8 @@ func performCallhome(ctx context.Context) {
 	}
 
 	healthInfo := madmin.HealthInfo{
-		Version: madmin.HealthInfoVersion,
+		TimeStamp: time.Now().UTC(),
+		Version:   madmin.HealthInfoVersion,
 		Minio: madmin.MinioHealthInfo{
 			Info: madmin.MinioInfo{
 				DeploymentID: globalDeploymentID,


### PR DESCRIPTION
## Description

The `timestamp` field was never getting populated in the health diagnostics info. Fixed by adding the same.

## Motivation and Context

Bugfix

## How to test this PR?

- Generate health diagnostics report (`mc support diag {alias} --airgap`)
- Extract it, open the JSON and verify that the field `timestamp` has a proper value

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
