### PR TITLE
Implement STS account info API

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -142,6 +142,9 @@ func registerAdminRouter(router *mux.Router, enableConfigOps bool) {
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/list-service-accounts").HandlerFunc(gz(httpTraceHdrs(adminAPI.ListServiceAccounts)))
 		adminRouter.Methods(http.MethodDelete).Path(adminVersion+"/delete-service-account").HandlerFunc(gz(httpTraceHdrs(adminAPI.DeleteServiceAccount))).Queries("accessKey", "{accessKey:.*}")
 
+		// STS accounts ops
+		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/temporary-account-info").HandlerFunc(gz(httpTraceHdrs(adminAPI.TemporaryAccountInfo))).Queries("accessKey", "{accessKey:.*}")
+
 		// Info policy IAM latest
 		adminRouter.Methods(http.MethodGet).Path(adminVersion+"/info-canned-policy").HandlerFunc(gz(httpTraceHdrs(adminAPI.InfoCannedPolicy))).Queries("name", "{name:.*}")
 		// List policies latest

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1034,7 +1034,7 @@ func (sys *IAMSys) GetServiceAccount(ctx context.Context, accessKey string) (aut
 }
 
 func (sys *IAMSys) getServiceAccount(ctx context.Context, accessKey string) (UserIdentity, *iampolicy.Policy, error) {
-	sa, embeddedPolicy, err := sys.getAccountWithEmbeddedPolicy(ctx, accessKey)
+	sa, jwtClaims, err := sys.getAccountWithClaims(ctx, accessKey)
 	if err != nil {
 		if err == errNoSuchAccount {
 			return UserIdentity{}, nil, errNoSuchServiceAccount
@@ -1045,11 +1045,38 @@ func (sys *IAMSys) getServiceAccount(ctx context.Context, accessKey string) (Use
 		return UserIdentity{}, nil, errNoSuchServiceAccount
 	}
 
+	var embeddedPolicy *iampolicy.Policy
+
+	pt, ptok := jwtClaims.Lookup(iamPolicyClaimNameSA())
+	sp, spok := jwtClaims.Lookup(iampolicy.SessionPolicyName)
+	if ptok && spok && pt == embeddedPolicyType {
+		policyBytes, err := base64.StdEncoding.DecodeString(sp)
+		if err != nil {
+			return UserIdentity{}, nil, err
+		}
+		embeddedPolicy, err = iampolicy.ParseConfig(bytes.NewReader(policyBytes))
+		if err != nil {
+			return UserIdentity{}, nil, err
+		}
+	}
+
 	return sa, embeddedPolicy, nil
 }
 
+// GetTemporaryAccount - wrapper method to get information about a temporary account
+func (sys *IAMSys) GetTemporaryAccount(ctx context.Context, accessKey string) (auth.Credentials, *iampolicy.Policy, error) {
+	tmpAcc, embeddedPolicy, err := sys.getTempAccount(ctx, accessKey)
+	if err != nil {
+		return auth.Credentials{}, nil, err
+	}
+	// Hide secret & session keys
+	tmpAcc.Credentials.SecretKey = ""
+	tmpAcc.Credentials.SessionToken = ""
+	return tmpAcc.Credentials, embeddedPolicy, nil
+}
+
 func (sys *IAMSys) getTempAccount(ctx context.Context, accessKey string) (UserIdentity, *iampolicy.Policy, error) {
-	tmpAcc, embeddedPolicy, err := sys.getAccountWithEmbeddedPolicy(ctx, accessKey)
+	tmpAcc, claims, err := sys.getAccountWithClaims(ctx, accessKey)
 	if err != nil {
 		if err == errNoSuchAccount {
 			return UserIdentity{}, nil, errNoSuchTempAccount
@@ -1060,43 +1087,43 @@ func (sys *IAMSys) getTempAccount(ctx context.Context, accessKey string) (UserId
 		return UserIdentity{}, nil, errNoSuchTempAccount
 	}
 
-	return tmpAcc, embeddedPolicy, nil
-}
-
-// getAccountWithEmbeddedPolicy - gets information about an account with its embedded policy if found
-func (sys *IAMSys) getAccountWithEmbeddedPolicy(ctx context.Context, accessKey string) (u UserIdentity, p *iampolicy.Policy, err error) {
-	if !sys.Initialized() {
-		return u, nil, errServerNotInitialized
-	}
-
-	sa, ok := sys.store.GetUser(accessKey)
-	if !ok {
-		return u, nil, errNoSuchAccount
-	}
-
 	var embeddedPolicy *iampolicy.Policy
 
-	jwtClaims, err := auth.ExtractClaims(sa.Credentials.SessionToken, sa.Credentials.SecretKey)
-	if err != nil {
-		jwtClaims, err = auth.ExtractClaims(sa.Credentials.SessionToken, globalActiveCred.SecretKey)
-		if err != nil {
-			return u, nil, err
-		}
-	}
-	pt, ptok := jwtClaims.Lookup(iamPolicyClaimNameSA())
-	sp, spok := jwtClaims.Lookup(iampolicy.SessionPolicyName)
-	if ptok && spok && pt == embeddedPolicyType {
+	sp, spok := claims.Lookup(iampolicy.SessionPolicyName)
+	if spok {
 		policyBytes, err := base64.StdEncoding.DecodeString(sp)
 		if err != nil {
-			return u, nil, err
+			return UserIdentity{}, nil, err
 		}
 		embeddedPolicy, err = iampolicy.ParseConfig(bytes.NewReader(policyBytes))
 		if err != nil {
-			return u, nil, err
+			return UserIdentity{}, nil, err
 		}
 	}
 
-	return sa, embeddedPolicy, nil
+	return tmpAcc, embeddedPolicy, nil
+}
+
+// getAccountWithClaims - gets information about an account with claims
+func (sys *IAMSys) getAccountWithClaims(ctx context.Context, accessKey string) (UserIdentity, *jwt.MapClaims, error) {
+	if !sys.Initialized() {
+		return UserIdentity{}, nil, errServerNotInitialized
+	}
+
+	acc, ok := sys.store.GetUser(accessKey)
+	if !ok {
+		return UserIdentity{}, nil, errNoSuchAccount
+	}
+
+	jwtClaims, err := auth.ExtractClaims(acc.Credentials.SessionToken, acc.Credentials.SecretKey)
+	if err != nil {
+		jwtClaims, err = auth.ExtractClaims(acc.Credentials.SessionToken, globalActiveCred.SecretKey)
+		if err != nil {
+			return UserIdentity{}, nil, err
+		}
+	}
+
+	return acc, jwtClaims, nil
 }
 
 // GetClaimsForSvcAcc - gets the claims associated with the service account.


### PR DESCRIPTION
## Description
Mainly to get the parent of the user of the given STS account access key. 
It also returns the associated policy, similar to the service account.

## Motivation and Context
Retrieve parent user from sts access key

## How to test this PR?
https://github.com/minio/mc/pull/4377

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
