### PR TITLE
notify: Return detailed err msg when connecting to target fails

### DIFF
--- a/internal/config/notify/parse.go
+++ b/internal/config/notify/parse.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -59,8 +60,11 @@ func TestSubSysNotificationTargets(ctx context.Context, cfg config.Config, subSy
 
 	for _, target := range targetList {
 		yes, err := target.IsActive()
-		if err != nil || !yes {
-			return ErrTargetsOffline
+		if err == nil && !yes {
+			err = ErrTargetsOffline
+		}
+		if err != nil {
+			return fmt.Errorf("error (%s): %w", target.ID(), err)
 		}
 	}
 


### PR DESCRIPTION
## Description
Currently, when adding a new target notification fails for whatever reason, 
a generic error message is returned, which does not help debugging.

Return a more detailed error in that case.

## Motivation and Context
Better error message

## How to test this PR?
Just run MinIO and run this command:

```
./mc admin config set  myminio notify_postgres connection_string="host=localhost port=5432 dbname=minio_events user=postgres password=password sslmode=disable" table=abcd format=access
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
