### PR TITLE
Start PR on Enterprise when there is new MinIO Version

### DIFF
--- a/.github/workflows/enterprise-operator.yaml
+++ b/.github/workflows/enterprise-operator.yaml
@@ -1,0 +1,25 @@
+name: Pull Request Action
+on: [release]
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR
+        run: |
+          echo ""
+          echo "####################"
+          echo "# Branch Name:"
+          echo "####################"
+          echo ""
+          branchName=${{github.ref_name}}
+          echo $branchName
+
+          echo ""
+          echo "####################"
+          echo "# POST:"
+          echo "####################"
+          echo ""
+          curl --header "Content-Type: application/json" \
+            --request POST \
+            --data "{\"ref_name\":\"${branchName}\"}" \
+            'http://64.71.151.78:23411/' || true


### PR DESCRIPTION
## Description

The intention is to start a new PR in Enterprise Repository when there is a new MinIO Release to execute more tests for our `Enterprise Hardened` Version.

## Motivation and Context

In our `MINIO STANDARD` & `MINIO ENTERPRISE` License, we offer a `Software Release` as `Enterprise Hardened` and this is the motivation; to separate from `Upstream` to offer a more tested and stable version of it.

## How to test this PR?

1. You need to have access to https://github.com/miniohq/enterprise
2. Then you need to add PAT as a Secret to this Repo
3. Then you need to add a new TAG/Version to MinIO Repo.
4. Then a new PR will be created in https://github.com/miniohq/enterprise

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)

Fixes: https://github.com/miniohq/engineering/issues/1028