### PR TITLE
preserve replicated ETag properly on target

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -350,7 +350,7 @@ func (er erasureObjects) newMultipartUpload(ctx context.Context, bucket string, 
 		rctx := lkctx.Context()
 		obj, err := er.getObjectInfo(rctx, bucket, object, opts)
 		lk.RUnlock(lkctx.Cancel)
-		if err != nil {
+		if err != nil && !isErrVersionNotFound(err) {
 			return nil, err
 		}
 		if opts.CheckPrecondFn(obj) {
@@ -359,7 +359,9 @@ func (er erasureObjects) newMultipartUpload(ctx context.Context, bucket string, 
 	}
 
 	userDefined := cloneMSS(opts.UserDefined)
-
+	if opts.PreserveETag != "" {
+		userDefined["etag"] = opts.PreserveETag
+	}
 	onlineDisks := er.getDisks()
 	parityDrives := globalStorageClass.GetParityForSC(userDefined[xhttp.AmzStorageClass])
 	if parityDrives < 0 {
@@ -1151,9 +1153,13 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 	}
 
 	// Save successfully calculated md5sum.
-	fi.Metadata["etag"] = opts.UserDefined["etag"]
+	// for replica, newMultipartUpload would have already sent the replication ETag
 	if fi.Metadata["etag"] == "" {
-		fi.Metadata["etag"] = getCompleteMultipartMD5(parts)
+		if opts.UserDefined["etag"] != "" {
+			fi.Metadata["etag"] = opts.UserDefined["etag"]
+		} else { // fallback if not already calculated in handler.
+			fi.Metadata["etag"] = getCompleteMultipartMD5(parts)
+		}
 	}
 
 	// Save the consolidated actual size.

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -943,7 +943,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 
 	if opts.CheckPrecondFn != nil {
 		obj, err := er.getObjectInfo(ctx, bucket, object, opts)
-		if err != nil {
+		if err != nil && !isErrVersionNotFound(err) {
 			return objInfo, err
 		}
 		if opts.CheckPrecondFn(obj) {

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -293,6 +293,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 			Err:    fmt.Errorf("invalid/unknown checksum sent: %v", err),
 		}
 	}
+	etag := strings.TrimSpace(r.Header.Get(xhttp.MinIOSourceETag))
 
 	if crypto.S3KMS.IsRequested(r.Header) {
 		keyID, context, err := crypto.S3KMS.ParseHTTP(r.Header)
@@ -311,6 +312,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 			VersionSuspended:     versionSuspended,
 			MTime:                mtime,
 			WantChecksum:         wantCRC,
+			PreserveETag:         etag,
 		}, nil
 	}
 	// default case of passing encryption headers and UserDefined metadata to backend
@@ -325,6 +327,7 @@ func putOpts(ctx context.Context, r *http.Request, bucket, object string, metada
 	opts.ReplicationSourceLegalholdTimestamp = lholdtimestmp
 	opts.ReplicationSourceRetentionTimestamp = retaintimestmp
 	opts.ReplicationSourceTaggingTimestamp = taggingtimestmp
+	opts.PreserveETag = etag
 	opts.WantChecksum = wantCRC
 
 	return opts, nil


### PR DESCRIPTION
Fixes regression from PR's #15674, #15929, #13171 and #15346

## Description


## Motivation and Context
replication ETag passed in x-minio-source-etag header used to be passed into opts.UserDefined as "etag" key for PutObject and NewMultipartUpload. If such an ETag is present in the metadata PutObject and CompleteMultipart should preserve it from the replication source.

 PR's above brought in changes that broke this and could lead to re-replication attempts if ETag is not matching b/w clusters 

## How to test this PR?
Use a replicated setup with encryption enabled.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
