### PR TITLE
fix: in disk cache readCacheFileStream should closed upon return

### DIFF
--- a/cmd/format-disk-cache.go
+++ b/cmd/format-disk-cache.go
@@ -354,6 +354,7 @@ func migrateCacheData(ctx context.Context, c *diskCache, bucket, object, oldfile
 	if err != nil {
 		return err
 	}
+	defer readCloser.Close()
 	var reader io.Reader = readCloser
 
 	actualSize := uint64(st.Size())


### PR DESCRIPTION
io.ReadCloser don't call Close()

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
