### PR TITLE
kms: add support for KES enclaves

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -854,6 +854,7 @@ func handleKMSConfig() {
 		defaultKeyID := env.Get(config.EnvKESKeyName, "")
 		KMS, err := kms.NewWithConfig(kms.Config{
 			Endpoints:        endpoints,
+			Enclave:          env.Get(config.EnvKESEnclave, ""),
 			DefaultKeyID:     defaultKeyID,
 			Certificate:      certificate,
 			ReloadCertEvents: reloadCertEvents,

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -70,6 +70,7 @@ const (
 	EnvKMSSecretKey      = "MINIO_KMS_SECRET_KEY"
 	EnvKMSSecretKeyFile  = "MINIO_KMS_SECRET_KEY_FILE"
 	EnvKESEndpoint       = "MINIO_KMS_KES_ENDPOINT"
+	EnvKESEnclave        = "MINIO_KMS_KES_ENCLAVE"
 	EnvKESKeyName        = "MINIO_KMS_KES_KEY_NAME"
 	EnvKESClientKey      = "MINIO_KMS_KES_KEY_FILE"
 	EnvKESClientPassword = "MINIO_KMS_KES_KEY_PASSWORD"


### PR DESCRIPTION
## Description
This commit adds support for KES enclaves.
An enclave is an isolated space within the
KES server that allows tenant separation.

This commit introduces an optional new env. variable:
```
MINIO_KMS_KES_ENCLAVE=<name>
```
If not set, the KES client will not send any enclave information. On a stateless KES server, this will
result in the default enclave.

## Motivation and Context
KMS, KES

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
