### PR TITLE
Add X-Amz-Request-Id to internode calls

### DIFF
--- a/cmd/http-tracer.go
+++ b/cmd/http-tracer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/handlers"
 	xhttp "github.com/minio/minio/internal/http"
+	"github.com/minio/minio/internal/mcontext"
 )
 
 var ldapPwdRegex = regexp.MustCompile("(^.*?)LDAPPassword=([^&]*?)(&(.*?))?$")
@@ -62,18 +63,6 @@ func getOpName(name string) (op string) {
 	return op
 }
 
-type contextTraceReqType string
-
-const contextTraceReqKey = contextTraceReqType("request-trace-info")
-
-// Hold related tracing data of a http request, any handler
-// can modify this struct to modify the trace information .
-type traceCtxt struct {
-	requestRecorder  *xhttp.RequestRecorder
-	responseRecorder *xhttp.ResponseRecorder
-	funcName         string
-}
-
 // If trace is enabled, execute the request if it is traced by other handlers
 // otherwise, generate a trace event with request information but no response.
 func httpTracer(h http.Handler) http.Handler {
@@ -84,16 +73,19 @@ func httpTracer(h http.Handler) http.Handler {
 		}
 
 		// Create tracing data structure and associate it to the request context
-		tc := traceCtxt{}
-		ctx := context.WithValue(r.Context(), contextTraceReqKey, &tc)
+		tc := mcontext.TraceCtxt{
+			AmzReqID: r.Header.Get(xhttp.AmzRequestID),
+		}
+
+		ctx := context.WithValue(r.Context(), mcontext.ContextTraceKey, &tc)
 		r = r.WithContext(ctx)
 
 		// Setup a http request and response body recorder
 		reqRecorder := &xhttp.RequestRecorder{Reader: r.Body}
 		respRecorder := xhttp.NewResponseRecorder(w)
 
-		tc.requestRecorder = reqRecorder
-		tc.responseRecorder = respRecorder
+		tc.RequestRecorder = reqRecorder
+		tc.ResponseRecorder = respRecorder
 
 		// Execute call.
 		r.Body = reqRecorder
@@ -103,7 +95,7 @@ func httpTracer(h http.Handler) http.Handler {
 		reqEndTime := time.Now().UTC()
 
 		tt := madmin.TraceInternal
-		if strings.HasPrefix(tc.funcName, "s3.") {
+		if strings.HasPrefix(tc.FuncName, "s3.") {
 			tt = madmin.TraceS3
 		}
 		// No need to continue if no subscribers for actual type...
@@ -141,7 +133,7 @@ func httpTracer(h http.Handler) http.Handler {
 		}
 
 		// Calculate function name
-		funcName := tc.funcName
+		funcName := tc.FuncName
 		if funcName == "" {
 			funcName = "<unknown>"
 		}
@@ -185,17 +177,17 @@ func httpTracer(h http.Handler) http.Handler {
 
 func httpTrace(f http.HandlerFunc, logBody bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		tc, ok := r.Context().Value(contextTraceReqKey).(*traceCtxt)
+		tc, ok := r.Context().Value(mcontext.ContextTraceKey).(*mcontext.TraceCtxt)
 		if !ok {
 			// Tracing is not enabled for this request
 			f.ServeHTTP(w, r)
 			return
 		}
 
-		tc.funcName = getOpName(runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name())
-		tc.requestRecorder.LogBody = logBody
-		tc.responseRecorder.LogAllBody = logBody
-		tc.responseRecorder.LogErrBody = true
+		tc.FuncName = getOpName(runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name())
+		tc.RequestRecorder.LogBody = logBody
+		tc.ResponseRecorder.LogAllBody = logBody
+		tc.ResponseRecorder.LogErrBody = true
 
 		f.ServeHTTP(w, r)
 	}

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio/internal/bucket/lifecycle"
 	"github.com/minio/minio/internal/logger"
+	"github.com/minio/minio/internal/mcontext"
 	"github.com/minio/minio/internal/rest"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -2395,10 +2396,10 @@ func metricsServerHandler() http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tc, ok := r.Context().Value(contextTraceReqKey).(*traceCtxt)
+		tc, ok := r.Context().Value(mcontext.ContextTraceKey).(*mcontext.TraceCtxt)
 		if ok {
-			tc.funcName = "handler.MetricsCluster"
-			tc.responseRecorder.LogErrBody = true
+			tc.FuncName = "handler.MetricsCluster"
+			tc.ResponseRecorder.LogErrBody = true
 		}
 
 		mfs, err := gatherers.Gather()
@@ -2442,10 +2443,10 @@ func metricsNodeHandler() http.Handler {
 		registry,
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tc, ok := r.Context().Value(contextTraceReqKey).(*traceCtxt)
+		tc, ok := r.Context().Value(mcontext.ContextTraceKey).(*mcontext.TraceCtxt)
 		if ok {
-			tc.funcName = "handler.MetricsNode"
-			tc.responseRecorder.LogErrBody = true
+			tc.FuncName = "handler.MetricsNode"
+			tc.ResponseRecorder.LogErrBody = true
 		}
 
 		mfs, err := gatherers.Gather()

--- a/internal/mcontext/ctxt.go
+++ b/internal/mcontext/ctxt.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mcontext
+
+// Share a common context information between different
+// packages in github.com/minio/minio
+
+import (
+	xhttp "github.com/minio/minio/internal/http"
+)
+
+// ContextTraceType represents the type of golang Context key
+type ContextTraceType string
+
+// ContextTraceKey is the key of TraceCtxt saved in a Golang context
+const ContextTraceKey = ContextTraceType("ctx-trace-info")
+
+// TraceCtxt holds related tracing data of a http request.
+type TraceCtxt struct {
+	RequestRecorder  *xhttp.RequestRecorder
+	ResponseRecorder *xhttp.ResponseRecorder
+
+	FuncName string
+	AmzReqID string
+}

--- a/internal/rest/client.go
+++ b/internal/rest/client.go
@@ -34,6 +34,7 @@ import (
 
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
+	"github.com/minio/minio/internal/mcontext"
 	xnet "github.com/minio/pkg/net"
 )
 
@@ -192,6 +193,10 @@ func (c *Client) newRequest(ctx context.Context, u *url.URL, body io.Reader) (*h
 	req.Header.Set("X-Minio-Time", time.Now().UTC().Format(time.RFC3339))
 	if body != nil {
 		req.Header.Set("Expect", "100-continue")
+	}
+
+	if tc, ok := ctx.Value(mcontext.ContextTraceKey).(*mcontext.TraceCtxt); ok {
+		req.Header.Set(xhttp.AmzRequestID, tc.AmzReqID)
 	}
 
 	return req, nil


### PR DESCRIPTION
## Description
A S3 request generates a random X-Amz-Request-Id, send the same header
to subsequent internode calls to make it easier to track subsequent
internode calls created by the S3 API call

## Motivation and Context
Add debugging information to internode requests

## How to test this PR?
1. mc admin trace -v -a <alias> 
2. upload an object and check for X-Amz-Request-Id header in mc admin trace

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
