### PR TITLE
trace: Publish storage layer errors

### DIFF
--- a/cmd/storagemetric_string.go
+++ b/cmd/storagemetric_string.go
@@ -35,12 +35,13 @@ func _() {
 	_ = x[storageMetricStatInfoFile-24]
 	_ = x[storageMetricReadMultiple-25]
 	_ = x[storageMetricDeleteAbandonedParts-26]
-	_ = x[storageMetricLast-27]
+	_ = x[storageMetricDiskInfo-27]
+	_ = x[storageMetricLast-28]
 }
 
-const _storageMetric_name = "MakeVolBulkMakeVolListVolsStatVolDeleteVolWalkDirListDirReadFileAppendFileCreateFileReadFileStreamRenameFileRenameDataCheckPartsDeleteDeleteVersionsVerifyFileWriteAllDeleteVersionWriteMetadataUpdateMetadataReadVersionReadXLReadAllStatInfoFileReadMultipleDeleteAbandonedPartsLast"
+const _storageMetric_name = "MakeVolBulkMakeVolListVolsStatVolDeleteVolWalkDirListDirReadFileAppendFileCreateFileReadFileStreamRenameFileRenameDataCheckPartsDeleteDeleteVersionsVerifyFileWriteAllDeleteVersionWriteMetadataUpdateMetadataReadVersionReadXLReadAllStatInfoFileReadMultipleDeleteAbandonedPartsDiskInfoLast"
 
-var _storageMetric_index = [...]uint16{0, 11, 18, 26, 33, 42, 49, 56, 64, 74, 84, 98, 108, 118, 128, 134, 148, 158, 166, 179, 192, 206, 217, 223, 230, 242, 254, 274, 278}
+var _storageMetric_index = [...]uint16{0, 11, 18, 26, 33, 42, 49, 56, 64, 74, 84, 98, 108, 118, 128, 134, 148, 158, 166, 179, 192, 206, 217, 223, 230, 242, 254, 274, 282, 286}
 
 func (i storageMetric) String() string {
 	if i >= storageMetric(len(_storageMetric_index)-1) {

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -577,12 +577,12 @@ func (p *xlStorageDiskIDCheck) updateStorageMetrics(s storageMetric, paths ...st
 		p.apiLatencies[s].add(duration)
 
 		if trace {
-			var err string
+			var errStr string
 			if errp != nil && *errp != nil {
-				err = (*errp).Error()
+				errStr = (*errp).Error()
 			}
 			paths = append([]string{p.String()}, paths...)
-			globalTrace.Publish(storageTrace(s, startTime, duration, strings.Join(paths, " "), err))
+			globalTrace.Publish(storageTrace(s, startTime, duration, strings.Join(paths, " "), errStr))
 		}
 	}
 }

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -66,6 +66,7 @@ const (
 	storageMetricStatInfoFile
 	storageMetricReadMultiple
 	storageMetricDeleteAbandonedParts
+	storageMetricDiskInfo
 
 	// .... add more
 
@@ -225,6 +226,9 @@ func (p *xlStorageDiskIDCheck) DiskInfo(ctx context.Context) (info DiskInfo, err
 	if contextCanceled(ctx) {
 		return DiskInfo{}, ctx.Err()
 	}
+
+	si := p.updateStorageMetrics(storageMetricDiskInfo)
+	defer si(&err)
 
 	info, err = p.storage.DiskInfo(ctx)
 	if err != nil {
@@ -539,7 +543,7 @@ func (p *xlStorageDiskIDCheck) CleanAbandonedData(ctx context.Context, volume st
 	return p.storage.CleanAbandonedData(ctx, volume, path)
 }
 
-func storageTrace(s storageMetric, startTime time.Time, duration time.Duration, path string) madmin.TraceInfo {
+func storageTrace(s storageMetric, startTime time.Time, duration time.Duration, path string, err string) madmin.TraceInfo {
 	return madmin.TraceInfo{
 		TraceType: madmin.TraceStorage,
 		Time:      startTime,
@@ -547,6 +551,7 @@ func storageTrace(s storageMetric, startTime time.Time, duration time.Duration, 
 		FuncName:  "storage." + s.String(),
 		Duration:  duration,
 		Path:      path,
+		Error:     err,
 	}
 }
 
@@ -565,15 +570,19 @@ func scannerTrace(s scannerMetric, startTime time.Time, duration time.Duration, 
 func (p *xlStorageDiskIDCheck) updateStorageMetrics(s storageMetric, paths ...string) func(err *error) {
 	startTime := time.Now()
 	trace := globalTrace.NumSubscribers(madmin.TraceStorage) > 0
-	return func(err *error) {
+	return func(errp *error) {
 		duration := time.Since(startTime)
 
 		atomic.AddUint64(&p.apiCalls[s], 1)
 		p.apiLatencies[s].add(duration)
 
-		paths = append([]string{p.String()}, paths...)
 		if trace {
-			globalTrace.Publish(storageTrace(s, startTime, duration, strings.Join(paths, " ")))
+			var err string
+			if errp != nil && *errp != nil {
+				err = (*errp).Error()
+			}
+			paths = append([]string{p.String()}, paths...)
+			globalTrace.Publish(storageTrace(s, startTime, duration, strings.Join(paths, " "), err))
 		}
 	}
 }


### PR DESCRIPTION
## Description
Add xl-storage errors to trace info, which will be visible with mc admin trace -v

Also add trace for local disk info storage API calls.

## Motivation and Context
Show storage error in mc admin trace

## How to test this PR?
Trivial

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
