### PR TITLE
fix: a crash in KMS cert reload function

### DIFF
--- a/internal/kms/kes.go
+++ b/internal/kms/kes.go
@@ -102,12 +102,12 @@ func NewWithConfig(config Config) (KMS, error) {
 				if !ok {
 					return
 				}
-				sameCert := true
+				sameCert := len(certificate.Certificate) == len(prevCertificate.Certificate)
 				for i, b := range certificate.Certificate {
-					if !bytes.Equal(b, prevCertificate.Certificate[i]) {
-						sameCert = false
+					if !sameCert {
 						break
 					}
+					sameCert = sameCert && bytes.Equal(b, prevCertificate.Certificate[i])
 				}
 				// Do not reload if its the same cert as before.
 				if !sameCert {


### PR DESCRIPTION

## Description
fix: a crash in KMS cert reload function

## Motivation and Context
while skipping the prevCertificate we
should check if the certificate has a
value for comparison.


## How to test this PR?
Change the KES client certs, the server would 
crash reloading the certs. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression in the PR #16135
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
