### PR TITLE
Add minimal setup command to helm chart's readme

### DIFF
--- a/helm/minio/README.md
+++ b/helm/minio/README.md
@@ -32,6 +32,13 @@ helm install --namespace minio --set rootUser=rootuser,rootPassword=rootpass123 
 
 The command deploys MinIO on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
+The default number of replicas is 16 and default setup requests 16Gb of RAM.
+Minimal toy setup for testing purposes can be deployed using:
+
+```bash
+helm install --set resources.requests.memory=512Mi --set replicas=1 --set persistence.enabled=false --set mode=standalone --set rootUser=rootuser,rootPassword=rootpass123 --generate-name minio/minio
+```
+
 ### Upgrading the Chart
 
 You can use Helm to update MinIO version in a live release. Assuming your release is named as `my-release`, get the values using the command:

--- a/helm/minio/README.md
+++ b/helm/minio/README.md
@@ -32,7 +32,8 @@ helm install --namespace minio --set rootUser=rootuser,rootPassword=rootpass123 
 
 The command deploys MinIO on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
-The default number of replicas is 16 and default setup requests 16Gb of RAM.
+### Installing the Chart (toy-setup)
+
 Minimal toy setup for testing purposes can be deployed using:
 
 ```bash


### PR DESCRIPTION
## Description
- add default helm chart's values for `replicas` and `resources.requests.memory` to readme
- add minimal setup command to readme

## Motivation and Context
Help new users to quickly setup a test instance.

#16164 also described here.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
