### PR TITLE
Avoid hot loop when lock is cancelled

### DIFF
--- a/cmd/shared-lock.go
+++ b/cmd/shared-lock.go
@@ -40,6 +40,7 @@ func (ld sharedLock) backgroundRoutine(ctx context.Context, objAPI ObjectLayer, 
 			continue
 		}
 
+	keepLock:
 		for {
 			select {
 			case <-ctx.Done():
@@ -48,7 +49,7 @@ func (ld sharedLock) backgroundRoutine(ctx context.Context, objAPI ObjectLayer, 
 				// The context of the lock is canceled, this can happen
 				// if one lock lost quorum due to cluster instability
 				// in that case, try to lock again.
-				break
+				break keepLock
 			case ld.lockContext <- lkctx:
 				// Send the lock context to anyone asking for it
 			}


### PR DESCRIPTION
## Description

If `lkctx.Context().Done()` is triggered we do not exit the loop.

Instead it becomes a hot loop.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Fixes a regression #15985
