### PR TITLE
avoid logging gzipped body in trace output

### DIFF
--- a/internal/http/request-recorder.go
+++ b/internal/http/request-recorder.go
@@ -67,6 +67,6 @@ func (r *RequestRecorder) Data() []byte {
 	if r.LogBody {
 		return r.buf.Bytes()
 	}
-	// ... otherwise we return <BODY> placeholder
-	return BodyPlaceHolder
+	// ... otherwise we return <BLOB> placeholder
+	return blobBody
 }


### PR DESCRIPTION
## Description
avoid logging gzipped body in trace output

## Motivation and Context
gzipped response is encoded is not
humanly readable instead add a place
holder.

## How to test this PR?
Test with `mc admin trace -v` output for List()
response beyond 1kib sized XML responses.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
