### PR TITLE
fix: delete marker discrepancies via DeleteObject() API

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: 1.19
           check-latest: true
       - name: Get official govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
## Description
fix: delete marker discrepancies via DeleteObject() API

## Motivation and Context
This PR fixes potentially 3 different issues perhaps a bit historical

- Make sure to create the correct DEL marker on a versioned 
  bucket when versionId is not specified

- Pass down the correct versionId to delete older DEL markers 
  on a version suspended bucket

## How to test this PR?
Create a versioned bucket and use aws cli to make `delete-object` API calls directly. NOTE: this does not affect multi-object delete API. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression not sure since when
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
