### PR TITLE
Add LDAP DNS SRV record lookup support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/minio/kes v0.22.0
 	github.com/minio/madmin-go/v2 v2.0.1
 	github.com/minio/minio-go/v7 v7.0.44
-	github.com/minio/pkg v1.5.6
+	github.com/minio/pkg v1.5.8
 	github.com/minio/selfupdate v0.5.0
 	github.com/minio/sha256-simd v1.0.0
 	github.com/minio/simdjson-go v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -774,8 +774,8 @@ github.com/minio/minio-go/v7 v7.0.41/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASM
 github.com/minio/minio-go/v7 v7.0.44 h1:9zUJ7iU7ax2P1jOvTp6nVrgzlZq3AZlFm0XfRFDKstM=
 github.com/minio/minio-go/v7 v7.0.44/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/minio/pkg v1.5.4/go.mod h1:2MOaRFdmFKULD+uOLc3qHLGTQTuxCNPKNPfLBTxC8CA=
-github.com/minio/pkg v1.5.6 h1:4OUvRU1gDWilu/dohkJMVapylXN8q94kU5MgkOJ/x0I=
-github.com/minio/pkg v1.5.6/go.mod h1:EiGlHS2xaooa2VMxhJsxxAZHDObHVUB3HwtuoEXOCVE=
+github.com/minio/pkg v1.5.8 h1:ryx23f28havoidUezmYRNgaZpbyn4y3m2yp/vfasFy0=
+github.com/minio/pkg v1.5.8/go.mod h1:EiGlHS2xaooa2VMxhJsxxAZHDObHVUB3HwtuoEXOCVE=
 github.com/minio/selfupdate v0.5.0 h1:0UH1HlL49+2XByhovKl5FpYTjKfvrQ2sgL1zEXK6mfI=
 github.com/minio/selfupdate v0.5.0/go.mod h1:mcDkzMgq8PRcpCRJo/NlPY7U45O5dfYl2Y0Rg7IustY=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -62,6 +62,7 @@ func (l *Config) Clone() Config {
 // LDAP keys and envs.
 const (
 	ServerAddr         = "server_addr"
+	SRVRecordName      = "srv_record_name"
 	LookupBindDN       = "lookup_bind_dn"
 	LookupBindPassword = "lookup_bind_password"
 	UserDNSearchBaseDN = "user_dn_search_base_dn"
@@ -73,6 +74,7 @@ const (
 	ServerStartTLS     = "server_starttls"
 
 	EnvServerAddr         = "MINIO_IDENTITY_LDAP_SERVER_ADDR"
+	EnvSRVRecordName      = "MINIO_IDENTITY_LDAP_SRV_RECORD_NAME"
 	EnvTLSSkipVerify      = "MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY"
 	EnvServerInsecure     = "MINIO_IDENTITY_LDAP_SERVER_INSECURE"
 	EnvServerStartTLS     = "MINIO_IDENTITY_LDAP_SERVER_STARTTLS"
@@ -98,6 +100,10 @@ var (
 	DefaultKVS = config.KVS{
 		config.KV{
 			Key:   ServerAddr,
+			Value: "",
+		},
+		config.KV{
+			Key:   SRVRecordName,
 			Value: "",
 		},
 		config.KV{
@@ -173,9 +179,10 @@ func Lookup(s config.Config, rootCAs *x509.CertPool) (l Config, err error) {
 		return l, nil
 	}
 	l.LDAP = ldap.Config{
-		Enabled:    true,
-		RootCAs:    rootCAs,
-		ServerAddr: ldapServer,
+		Enabled:       true,
+		RootCAs:       rootCAs,
+		ServerAddr:    ldapServer,
+		SRVRecordName: getCfgVal(SRVRecordName),
 	}
 	l.stsExpiryDuration = defaultLDAPExpiry
 

--- a/internal/config/identity/ldap/help.go
+++ b/internal/config/identity/ldap/help.go
@@ -28,9 +28,16 @@ var (
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         ServerAddr,
-			Description: `AD/LDAP server address e.g. "myldapserver.com:636"` + defaultHelpPostfix(ServerAddr),
+			Description: `AD/LDAP server address e.g. "myldap.com" or "myldapserver.com:636"` + defaultHelpPostfix(ServerAddr),
 			Type:        "address",
 			Sensitive:   true,
+		},
+		config.HelpKV{
+			Key:         SRVRecordName,
+			Description: `DNS SRV record name for LDAP service, if given, must be one of "ldap", "ldaps" or "on"` + defaultHelpPostfix(SRVRecordName),
+			Optional:    true,
+			Type:        "string",
+			Sensitive:   false,
 		},
 		config.HelpKV{
 			Key:         LookupBindDN,


### PR DESCRIPTION
## Description

The main change is in the minio/pkg lib, this change updates docs and adds configuration option.

Needs https://github.com/minio/pkg/pull/52

## Motivation and Context

DNS SRV records are used for LDAP high-availability - https://ldap.com/dns-srv-records-for-ldap/

## How to test this PR?

Test setup would need a configured DNS SRV record - this change is not end to end tested. However, it is possible to ensure that DNS SRV querying is working by picking a public DNS SRV record (e.g. _ldap._tcp.google.com ) - obviously cannot login with that, you can get a credentials invalid error.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
