### PR TITLE
helm: Add an option to put drives in separate pools

### DIFF
--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -3,6 +3,7 @@
 {{ $nodeCount := .Values.replicas | int }}
 {{ $replicas := mul $poolCount $nodeCount }}
 {{ $drivesPerNode := .Values.drivesPerNode | int }}
+{{ $drivesInSeparatePools := .Values.drivesInSeparatePools | not | not }}
 {{ $scheme := "http" }}
 {{- if .Values.tls.enabled }}
 {{ $scheme = "https" }}
@@ -104,12 +105,33 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 
-          command: [ "/bin/sh",
-            "-ce",
-            "/usr/bin/docker-entrypoint.sh minio server {{- range $i := until $poolCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.fullname` $ }}-{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{else}}{{ $bucketRoot }}{{end}}{{- end}} -S {{ .Values.certsPath }} --address :{{ .Values.minioAPIPort }} --console-address :{{ .Values.minioConsolePort }} {{- template `minio.extraArgs` . }}" ]
+          command:
+            - /bin/sh
+            - -ce
+            - /usr/bin/docker-entrypoint.sh minio server
+              {{- $fullname := include `minio.fullname` . }}
+              {{- $serviceDomain := printf "%s-svc.%s.svc.%s" $fullname .Release.Namespace .Values.clusterDomain }}
+              {{- range $i := until $poolCount }}
+                {{- $beginIndex := mul $i $nodeCount }}
+                {{- $endIndex := add $beginIndex $nodeCount -1 }}
+                {{- $bucketUrlPrefix := printf "%s://%s-{%d...%d}.%s%s" $scheme $fullname $beginIndex $endIndex $serviceDomain $bucketRoot }}
+                {{- if $drivesInSeparatePools }}
+                  {{- range $j := until $drivesPerNode }}
+                    {{- printf "%s-%d" $bucketUrlPrefix $j | nindent 14 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if gt $drivesPerNode 1 }}
+                    {{- printf "%s-{0...%d}" $bucketUrlPrefix (sub $drivesPerNode 1) | nindent 14 }}
+                  {{- else }}
+                    {{- $bucketUrlPrefix | nindent 14 }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+              -S {{ .Values.certsPath }} --address :{{ .Values.minioAPIPort }} --console-address :{{ .Values.minioConsolePort }}
+              {{ template `minio.extraArgs` . }}
           volumeMounts:
             {{- if $penabled }}
-            {{- if (gt $drivesPerNode 1) }}
+            {{- if or (gt $drivesPerNode 1) $drivesInSeparatePools }}
             {{- range $i := until $drivesPerNode }}
             - name: export-{{ $i }}
               mountPath: {{ $mountPath }}-{{ $i }}
@@ -222,7 +244,7 @@ spec:
         {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-  {{- if gt $drivesPerNode 1 }}
+  {{- if or (gt $drivesPerNode 1) $drivesInSeparatePools }}
     {{- range $diskId := until $drivesPerNode}}
     - metadata:
         name: export-{{ $diskId }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -116,6 +116,11 @@ bucketRoot: ""
 
 # Number of drives attached to a node
 drivesPerNode: 1
+# Whether each drive on a node should be a member of a separate pool.
+# Setting this to true allows for easy expansion of the MinIO deployment by simply adding additional drives
+# without the need to add additional nodes. Note that when set to true, then the total number of pools is
+# effectively multiplied by drivesPerNode as there is a separate pool for each drive on a node.
+drivesInSeparatePools: false
 # Number of MinIO containers running
 replicas: 16
 # Number of expanded MinIO clusters


### PR DESCRIPTION
## Description
This PR adds an option to the helm chart to put drives on a node to separate pools. In a nutshell it adds the ability to start the nodes in a distributed MinIO deployment with a command line like this:
```sh
/usr/bin/docker-entrypoint.sh \
  minio server \
  http://minio-{0...15}.minio-svc.minio.svc.cluster.local/export-0 \
  http://minio-{0...15}.minio-svc.minio.svc.cluster.local/export-1 \
  -S /etc/minio/certs/ --address :9000 --console-address :9001
```
Notice that the pools reference the same nodes but different drives.

This option can be enabled by setting the newly added helm chart value of `drivesInSeparatePools` to `true`. It is disabled by default, i.e. all drives on a node are put in the same pool just as before.

## Motivation and Context
The option makes it possible to expand a MinIO deployment with additional storage (another pool) without necessarily also having to add nodes, simply by adding a new drive to each existing node and creating a new pool out of those drives.

## How to test this PR?
When the option is disabled, the chart should function just is it did before. When enabled then every drive on a node should be part of a different pool.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
