### PR TITLE
Add HTTP2 config option for policy plugin

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -374,8 +374,7 @@ func validateSubSysConfig(s config.Config, subSys string, objAPI ObjectLayer) er
 		subSys = config.PolicyPluginSubSys
 		fallthrough
 	case config.PolicyPluginSubSys:
-		if ppargs, err := polplugin.LookupConfig(s[config.PolicyPluginSubSys][config.Default],
-			NewHTTPTransport(), xhttp.DrainBody); err != nil {
+		if ppargs, err := polplugin.LookupConfig(s, GetDefaultConnSettings(), xhttp.DrainBody); err != nil {
 			return err
 		} else if ppargs.URL == nil {
 			// Check if legacy opa is configured.

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -233,8 +233,7 @@ func (sys *IAMSys) Init(ctx context.Context, objAPI ObjectLayer, etcdClient *etc
 
 	setGlobalAuthNPlugin(idplugin.New(authNPluginCfg))
 
-	authZPluginCfg, err := polplugin.LookupConfig(s[config.PolicyPluginSubSys][config.Default],
-		NewHTTPTransport(), xhttp.DrainBody)
+	authZPluginCfg, err := polplugin.LookupConfig(s, GetDefaultConnSettings(), xhttp.DrainBody)
 	if err != nil {
 		logger.LogIf(ctx, fmt.Errorf("Unable to initialize AuthZPlugin: %w", err))
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -568,6 +568,15 @@ func ToS3ETag(etag string) string {
 	return etag
 }
 
+// GetDefaultConnSettings returns default HTTP connection settings.
+func GetDefaultConnSettings() xhttp.ConnSettings {
+	return xhttp.ConnSettings{
+		DNSCache:    globalDNSCache,
+		DialTimeout: rest.DefaultTimeout,
+		RootCAs:     globalRootCAs,
+	}
+}
+
 // NewInternodeHTTPTransport returns a transport for internode MinIO
 // connections.
 func NewInternodeHTTPTransport() func() http.RoundTripper {

--- a/docs/iam/access-management-plugin.md
+++ b/docs/iam/access-management-plugin.md
@@ -46,15 +46,18 @@ Only the last operation would fail with a permissions error.
 Access Management Plugin can be configured with environment variables:
 
 ```sh
-$ mc admin config set dminio1 policy_plugin --env
+$ mc admin config set myminio policy_plugin --env
 KEY:
 policy_plugin  enable Access Management Plugin for policy enforcement
 
 ARGS:
-MINIO_POLICY_PLUGIN_URL*        (url)       plugin hook endpoint (HTTP(S)) e.g. "http://localhost:8181/v1/data/httpapi/authz/allow"
-MINIO_POLICY_PLUGIN_AUTH_TOKEN  (string)    authorization token for plugin hook endpoint
-MINIO_POLICY_PLUGIN_COMMENT     (sentence)  optionally add a comment to this setting
+MINIO_POLICY_PLUGIN_URL*          (url)       plugin hook endpoint (HTTP(S)) e.g. "http://localhost:8181/v1/data/httpapi/authz/allow"
+MINIO_POLICY_PLUGIN_AUTH_TOKEN    (string)    authorization header for plugin hook endpoint
+MINIO_POLICY_PLUGIN_ENABLE_HTTP2  (bool)      Enable experimental HTTP2 support to connect to plugin service (default: 'off')
+MINIO_POLICY_PLUGIN_COMMENT       (sentence)  optionally add a comment to this setting
 ```
+
+By default this plugin uses HTTP 1.x. To enable HTTP2 use the `MINIO_POLICY_PLUGIN_ENABLE_HTTP2` environment variable.
 
 ## Request and Response
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1076,7 +1076,7 @@ func getEnvVarName(subSys, target, param string) string {
 		Default, target)
 }
 
-var resolvableSubsystems = set.CreateStringSet(IdentityOpenIDSubSys, IdentityLDAPSubSys)
+var resolvableSubsystems = set.CreateStringSet(IdentityOpenIDSubSys, IdentityLDAPSubSys, PolicyPluginSubSys)
 
 // ValueSource represents the source of a config parameter value.
 type ValueSource uint8

--- a/internal/config/policy/plugin/help.go
+++ b/internal/config/policy/plugin/help.go
@@ -34,10 +34,16 @@ var (
 		},
 		config.HelpKV{
 			Key:         AuthToken,
-			Description: "authorization token for plugin hook endpoint" + defaultHelpPostfix(AuthToken),
+			Description: "authorization header for plugin hook endpoint" + defaultHelpPostfix(AuthToken),
 			Optional:    true,
 			Type:        "string",
 			Sensitive:   true,
+		},
+		config.HelpKV{
+			Key:         EnableHTTP2,
+			Description: "Enable experimental HTTP2 support to connect to plugin service" + defaultHelpPostfix(EnableHTTP2),
+			Optional:    true,
+			Type:        "bool",
 		},
 		config.HelpKV{
 			Key:         config.Comment,


### PR DESCRIPTION
## Description

Also enable HTTP2 in access manager plugin test script for testing.

## Motivation and Context

Based on a customer requirement. Needs https://github.com/minio/minio/pull/16222

## How to test this PR?

Run the policy plugin server demo script with debug options for http2 like so:

```
GODEBUG=http2debug=1 go run docs/iam/access-manager-plugin.go -cert-file /tmp/localhost+1.pem -key-file /tmp/localhost+1-key.pem 
```

Enable policy plugin on minio and see that http2 messages are displayed:

```
2022/12/12 16:57:18 http2: server connection from 127.0.0.1:47952 on 0xc0000fc000
2022/12/12 16:57:18 http2: server: client 127.0.0.1:47952 said hello
2022/12/12 16:57:18 http2: server read frame SETTINGS len=18, settings: ENABLE_PUSH=0, INITIAL_WINDOW_SIZE=4194304, MAX_HEADER_LIST_SIZE=10485760
2022/12/12 16:57:18 http2: server processing setting [ENABLE_PUSH = 0]
2022/12/12 16:57:18 http2: server processing setting [INITIAL_WINDOW_SIZE = 4194304]
2022/12/12 16:57:18 http2: server processing setting [MAX_HEADER_LIST_SIZE = 10485760]
2022/12/12 16:57:18 http2: server read frame WINDOW_UPDATE len=4 (conn) incr=1073741824
2022/12/12 16:57:18 http2: server read frame HEADERS flags=END_STREAM|END_HEADERS stream=1 len=46
2022/12/12 16:57:18 http2: server read frame SETTINGS flags=ACK len=0
2022/12/12 16:57:18 http2: server encoding header ":status" = "400"
2022/12/12 16:57:18 http2: server encoding header "content-type" = "text/plain; charset=utf-8"
2022/12/12 16:57:18 http2: server encoding header "content-length" = "41"
2022/12/12 16:57:18 http2: server encoding header "date" = "Tue, 13 Dec 2022 00:57:18 GMT"
2022/12/12 16:57:24 http2: server read frame HEADERS flags=END_HEADERS stream=3 len=11
2022/12/12 16:57:24 http2: server read frame DATA flags=END_STREAM stream=3 len=965 data="{\"input\":{\"account\":\"minio\",\"groups\":null,\"action\":\"s3:ListAllMyBuckets\",\"bucket\":\"\",\"conditions\":{\"Authorization\":[\"AWS4-HMAC-SHA256 Credential=minio/20221213/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=b667974" (709 bytes omitted)
account: minio | action: s3:ListAllMyBuckets | allowed: true
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
