### PR TITLE
log: Do not interpret verbs in object names in console output

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -541,7 +541,7 @@ func serverMain(ctx *cli.Context) {
 	maxProcs := runtime.GOMAXPROCS(0)
 	cpuProcs := runtime.NumCPU()
 	if maxProcs < cpuProcs {
-		logger.Info(color.RedBold("WARNING: Detected GOMAXPROCS(%d) < NumCPU(%d), please make sure to provide all PROCS to MinIO for optimal performance", maxProcs, cpuProcs))
+		logger.Info(color.RedBoldf("WARNING: Detected GOMAXPROCS(%d) < NumCPU(%d), please make sure to provide all PROCS to MinIO for optimal performance", maxProcs, cpuProcs))
 	}
 
 	// Configure server.

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -38,7 +38,14 @@ var (
 		return fmt.Sprintf
 	}()
 
-	RedBold = func() func(format string, a ...interface{}) string {
+	RedBold = func() func(a ...interface{}) string {
+		if IsTerminal() {
+			return color.New(color.FgRed, color.Bold).SprintFunc()
+		}
+		return fmt.Sprint
+	}()
+
+	RedBoldf = func() func(format string, a ...interface{}) string {
 		if IsTerminal() {
 			return color.New(color.FgRed, color.Bold).SprintfFunc()
 		}

--- a/internal/logger/target/console/console.go
+++ b/internal/logger/target/console/console.go
@@ -133,7 +133,7 @@ func (c *Target) Send(e interface{}, logKind string) error {
 		tagString = "\n       " + tagString
 	}
 
-	msg := color.FgRed(color.Bold(entry.Trace.Message))
+	msg := color.RedBold(entry.Trace.Message)
 	output := fmt.Sprintf("\n%s\n%s%s%s%s%s%s\nError: %s%s\n%s",
 		apiString, timeString, deploymentID, requestID, remoteHost, host, userAgent,
 		msg, tagString, strings.Join(trace, "\n"))


### PR DESCRIPTION
Logs related to object names containing % character is interpreted. 

e.g:
```
API: GetObject(bucket=testbucket, object=a%db)
Time: 10:38:48 UTC 12/13/2022
DeploymentID: 677b87c0-b7e8-4aec-87b6-52dcc94792d9
RequestID: 17305418E7610AF8
RemoteHost: [::1]
Host: localhost:9001
UserAgent: MinIO (darwin; arm64) minio-go/v7.0.43 mc/DEVELOPMENT.2022-11-23T00-07-43Z
Error: Unable to write all the data to client Storage resources are insufficient for the read operation testbucket/a%!d(MISSING)b (*fmt.wrapError)
       4: internal/logger/logger.go:258:logger.LogIf()
       3: cmd/object-handlers.go:569:cmd.objectAPIHandlers.getObjectHandler()
       2: cmd/object-handlers.go:626:cmd.objectAPIHandlers.GetObjectHandler()
       1: net/http/server.go:2109:http.HandlerFunc.ServeHTTP()
```


The reason is that color package uses fmt.Sprintf() unnecessarly.

This commit fixes the behavior by differenting when it wants to interpret verbs in the error message.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
