### PR TITLE
fix: rebalance to account for object's on-disk size

### DIFF
--- a/cmd/erasure-server-pool-rebalance.go
+++ b/cmd/erasure-server-pool-rebalance.go
@@ -57,15 +57,16 @@ type rebalanceStats struct {
 	Info              rebalanceInfo `json:"info" msg:"inf"`
 }
 
-func (rs *rebalanceStats) update(bucket string, oi ObjectInfo) {
-	if oi.IsLatest {
+func (rs *rebalanceStats) update(bucket string, fi FileInfo) {
+	if fi.IsLatest {
 		rs.NumObjects++
 	}
 
 	rs.NumVersions++
-	rs.Bytes += uint64(oi.Size)
+	onDiskSz := fi.Size * int64(fi.Erasure.DataBlocks+fi.Erasure.ParityBlocks) / int64(fi.Erasure.DataBlocks)
+	rs.Bytes += uint64(onDiskSz)
 	rs.Bucket = bucket
-	rs.Object = oi.Name
+	rs.Object = fi.Name
 }
 
 type rstats []*rebalanceStats
@@ -168,7 +169,7 @@ func (z *erasureServerPools) initRebalanceMeta(ctx context.Context, buckets []st
 	return r.ID, nil
 }
 
-func (z *erasureServerPools) updatePoolStats(poolIdx int, bucket string, oi ObjectInfo) {
+func (z *erasureServerPools) updatePoolStats(poolIdx int, bucket string, fi FileInfo) {
 	z.rebalMu.Lock()
 	defer z.rebalMu.Unlock()
 
@@ -177,7 +178,7 @@ func (z *erasureServerPools) updatePoolStats(poolIdx int, bucket string, oi Obje
 		return
 	}
 
-	r.PoolStats[poolIdx].update(bucket, oi)
+	r.PoolStats[poolIdx].update(bucket, fi)
 }
 
 const (
@@ -534,14 +535,13 @@ func (z *erasureServerPools) rebalanceBucket(ctx context.Context, bucket string,
 					}
 
 					if !failure {
-						z.updatePoolStats(poolIdx, bucket, version.ToObjectInfo(bucket, version.Name, vc.PrefixEnabled(version.Name)))
+						z.updatePoolStats(poolIdx, bucket, version)
 						rebalanced++
 					}
 					continue
 				}
 
 				var failure bool
-				var oi ObjectInfo
 				for try := 0; try < 3; try++ {
 					// GetObjectReader.Close is called by rebalanceObject
 					gr, err := set.GetObjectNInfo(ctx,
@@ -574,14 +574,13 @@ func (z *erasureServerPools) rebalanceBucket(ctx context.Context, bucket string,
 
 					stopFn(nil)
 					failure = false
-					oi = gr.ObjInfo
 					break
 				}
 
 				if failure {
 					break // break out on first error
 				}
-				z.updatePoolStats(poolIdx, bucket, oi)
+				z.updatePoolStats(poolIdx, bucket, version)
 				rebalanced++
 			}
 


### PR DESCRIPTION
## Description
Rebalance routine didn't account for the space occupied by an object on disk (i.e including the space occupied by parity shards) while determining if enough objects were rebalanced. This change addresses this gap in accounting.

## Motivation and Context
See #16212 


## How to test this PR?
See #16212 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
