### PR TITLE
lock: Use context with timeout for acquiring lock calls

### DIFF
--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -45,7 +45,7 @@ func log(format string, data ...interface{}) {
 
 const (
 	// dRWMutexAcquireTimeout - default tolerance limit to wait for lock acquisition before.
-	drwMutexAcquireTimeout = 1 * time.Second // 1 second.
+	drwMutexAcquireTimeout = 5 * time.Second
 
 	// dRWMutexRefreshTimeout - default timeout for the refresh call
 	drwMutexRefreshCallTimeout = 5 * time.Second
@@ -430,11 +430,11 @@ func lock(ctx context.Context, ds *Dsync, locks *[]string, id, source string, is
 			var locked bool
 			var err error
 			if isReadLock {
-				if locked, err = c.RLock(context.Background(), args); err != nil {
+				if locked, err = c.RLock(ctx, args); err != nil {
 					log("dsync: Unable to call RLock failed with %s for %#v at %s\n", err, args, c)
 				}
 			} else {
-				if locked, err = c.Lock(context.Background(), args); err != nil {
+				if locked, err = c.Lock(ctx, args); err != nil {
 					log("dsync: Unable to call Lock failed with %s for %#v at %s\n", err, args, c)
 				}
 			}


### PR DESCRIPTION
## Description
The code is using context.Background() when doing lock calls, 
it does not timeout.

Also add acquiring lock timeout, probably useful in a hyper 
loaded cluster.

## Motivation and Context
Add timeout to lock acquiring

## How to test this PR?
Not trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
