### PR TITLE
Do not return an error when version disparity is detected

### DIFF
--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -69,9 +69,6 @@ var errTooManyOpenFiles = StorageErr("too many open files, please increase 'ulim
 // errFileNameTooLong - given file name is too long than supported length.
 var errFileNameTooLong = StorageErr("file name too long")
 
-// errFileNeedsHealing - given file name needs to heal.
-var errFileNeedsHealing = StorageErr("file name needs healing")
-
 // errVolumeExists - cannot create same volume again.
 var errVolumeExists = StorageErr("volume already exists")
 


### PR DESCRIPTION
## Description
This is only for S3 mulipart upload. Currently when a there is high 
level of object's versions disparity, the S3 API returns 503.

The reason is that renameData() returns errFileNeedsHealing
 and it is not ignored in CompleteMultipartUpload.

Fix the issue and modify renameData() to return a boolean 
instead of an error to indicate that an object needs be healed.

## Motivation and Context
S3 wrongly returns 503 in some cases

## How to test this PR?
Not trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
