### PR TITLE
helm: add policy to svcacct

### DIFF
--- a/helm/minio/templates/_helper_create_svcacct.txt
+++ b/helm/minio/templates/_helper_create_svcacct.txt
@@ -49,6 +49,7 @@ checkSvcacctExists() {
 # createSvcacct ($user)
 createSvcacct () {
   USER=$1
+  FILENAME=$2
   #check accessKey_and_secretKey_tmp file
   if [[ ! -f $MINIO_ACCESSKEY_SECRETKEY_TMP ]];then
     echo "credentials file does not exist"
@@ -63,7 +64,12 @@ createSvcacct () {
   # Create the svcacct if it does not exist
   if ! checkSvcacctExists ; then
     echo "Creating svcacct '$SVCACCT'"
-    ${MC} admin user svcacct add --access-key $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --secret-key $(tail -n1 $MINIO_ACCESSKEY_SECRETKEY_TMP) myminio $USER
+    # Check if policy file is define
+    if [ -z $FILENAME ]; then
+      ${MC} admin user svcacct add --access-key $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --secret-key $(tail -n1 $MINIO_ACCESSKEY_SECRETKEY_TMP) myminio $USER
+    else
+      ${MC} admin user svcacct add --access-key $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --secret-key $(tail -n1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --policy /config/$FILENAME.json myminio $USER
+    fi
   else
     echo "Svcacct '$SVCACCT' already exists."
   fi
@@ -82,15 +88,18 @@ connectToMinio $scheme
 {{ if .Values.svcaccts }}
 {{ $global := . }}
 # Create the svcaccts
-{{- range .Values.svcaccts }}
+{{- range $idx, $svc := .Values.svcaccts }}
 echo {{ tpl .accessKey $global }} > $MINIO_ACCESSKEY_SECRETKEY_TMP
 {{- if .existingSecret }}
 cat /config/secrets/{{ tpl .existingSecret $global }}/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
 # Add a new line if it doesn't exist
 sed -i '$a\' $MINIO_ACCESSKEY_SECRETKEY_TMP
-createSvcacct {{ .user }}
 {{ else }}
 echo {{ .secretKey }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+{{- end }}
+{{- if $svc.policy}}
+createSvcacct {{ .user }} svc_policy_{{ $idx }}
+{{ else }}
 createSvcacct {{ .user }}
 {{- end }}
 {{- end }}

--- a/helm/minio/templates/configmap.yaml
+++ b/helm/minio/templates/configmap.yaml
@@ -16,9 +16,16 @@ data:
   add-policy: |-
 {{ include (print $.Template.BasePath "/_helper_create_policy.txt") . | indent 4 }}
 {{- range $idx, $policy := .Values.policies }}
-  # {{ $policy.name }}
+  # Policy: {{ $policy.name }}
   policy_{{ $idx }}.json: |-
 {{ include (print $.Template.BasePath "/_helper_policy.tpl") . | indent 4 }}
+{{ end }}
+{{- range $idx, $svc := .Values.svcaccts }}
+{{- if $svc.policy }}
+  # SVC: {{ $svc.accessKey }}
+  svc_policy_{{ $idx }}.json: |-
+{{ include (print $.Template.BasePath "/_helper_policy.tpl") .policy | indent 4 }}
+{{- end }}
 {{ end }}
   add-svcacct: |-
 {{ include (print $.Template.BasePath "/_helper_create_svcacct.txt") . | indent 4 }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -370,6 +370,20 @@ makeUserJob:
   #   existingSecret: my-secret
   #   existingSecretKey: password
   #   user: console
+  ## You also can pass custom policy
+  # - accessKey: console-svcacct
+  #   secretKey: console123
+  #   user: console
+  #   policy:
+  #     statements:
+  #       - resources:
+  #           - 'arn:aws:s3:::example*/*'
+  #         actions:
+  #           - "s3:AbortMultipartUpload"
+  #           - "s3:GetObject"
+  #           - "s3:DeleteObject"
+  #           - "s3:PutObject"
+  #           - "s3:ListMultipartUploadParts"
 
 makeServiceAccountJob:
   securityContext:


### PR DESCRIPTION
## Description

Add policy values to `svcacct` for customize it.

## Motivation and Context

Like i have said in my issue #16267, if we want create an service account with policy we need use `customCommands` with something like that :
```sh
admin user svcacct add --access-key accessKey --secret-key secretKey \
  --policy "$(echo '{"Statement":[{"Action":["s3:ListBucket","s3:GetObject","s3:DeleteObject","s3:PutObject"],"Effect":"Allow","Resource":["arn:aws:s3:::tmp/*"]}],"Version":"2012-10-17"}' \
  > policy.json && echo "policy.json")" myminio console
```

## How to test this PR?

Uncomment the service account with `policy` section under `svcaccts` in `values.yaml` and run `helm template . --values values.yaml`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
