### PR TITLE
Do not save credentials in config.json

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -773,6 +773,8 @@ func handleCommonEnvVars() {
 			logger.Info(color.RedBold(msg))
 		}
 		globalActiveCred = cred
+	} else {
+		globalActiveCred = auth.DefaultCredentials
 	}
 }
 

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -2740,9 +2740,7 @@ func migrateMinioSysConfigToKV(objAPI ObjectLayer) error {
 
 	newCfg := newServerConfig()
 
-	config.SetCredentials(newCfg, cfg.Credential)
 	config.SetRegion(newCfg, cfg.Region)
-
 	storageclass.SetStorageClass(newCfg, cfg.StorageClass)
 
 	for k, loggerArgs := range cfg.Logger.HTTP {

--- a/cmd/config-migrate_test.go
+++ b/cmd/config-migrate_test.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-
-	"github.com/minio/minio/internal/config"
 )
 
 // Test if config v1 is purged
@@ -209,17 +207,6 @@ func TestServerConfigMigrateV2toV33(t *testing.T) {
 	// Initialize server config and check again if everything is fine
 	if err := loadConfig(objLayer); err != nil {
 		t.Fatalf("Unable to initialize from updated config file %s", err)
-	}
-
-	// Check if accessKey and secretKey are not altered during migration
-	caccessKey := globalServerConfig[config.CredentialsSubSys][config.Default].Get(config.AccessKey)
-	if caccessKey != accessKey {
-		t.Fatalf("Access key lost during migration, expected: %v, found:%v", accessKey, caccessKey)
-	}
-
-	csecretKey := globalServerConfig[config.CredentialsSubSys][config.Default].Get(config.SecretKey)
-	if csecretKey != secretKey {
-		t.Fatalf("Secret key lost during migration, expected: %v, found: %v", secretKey, csecretKey)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,7 +96,6 @@ const (
 
 // Top level config constants.
 const (
-	CredentialsSubSys    = madmin.CredentialsSubSys
 	PolicyOPASubSys      = madmin.PolicyOPASubSys
 	PolicyPluginSubSys   = madmin.PolicyPluginSubSys
 	IdentityOpenIDSubSys = madmin.IdentityOpenIDSubSys
@@ -178,7 +177,6 @@ var SubSystemsDynamic = set.CreateStringSet(
 
 // SubSystemsSingleTargets - subsystems which only support single target.
 var SubSystemsSingleTargets = set.CreateStringSet(
-	CredentialsSubSys,
 	SiteSubSys,
 	RegionSubSys,
 	EtcdSubSys,
@@ -463,9 +461,6 @@ func (c Config) RedactSensitiveInfo() Config {
 		}
 	}
 
-	// Remove the server credentials altogether
-	nc.DelKVS(CredentialsSubSys)
-
 	return nc
 }
 
@@ -500,20 +495,6 @@ var (
 		},
 	}
 )
-
-// LookupCreds - lookup credentials from config.
-func LookupCreds(kv KVS) (auth.Credentials, error) {
-	if err := CheckValidKeys(CredentialsSubSys, kv, DefaultCredentialKVS); err != nil {
-		return auth.Credentials{}, err
-	}
-	accessKey := kv.Get(AccessKey)
-	secretKey := kv.Get(SecretKey)
-	if accessKey == "" || secretKey == "" {
-		accessKey = auth.DefaultAccessKey
-		secretKey = auth.DefaultSecretKey
-	}
-	return auth.CreateCredentials(accessKey, secretKey)
-}
 
 // Site - holds site info - name and region.
 type Site struct {

--- a/internal/config/legacy.go
+++ b/internal/config/legacy.go
@@ -17,30 +17,7 @@
 
 package config
 
-import "github.com/minio/minio/internal/auth"
-
 // One time migration code section
-
-// SetCredentials - One time migration code needed, for migrating from older config to new for server credentials.
-func SetCredentials(c Config, cred auth.Credentials) {
-	creds, err := auth.CreateCredentials(cred.AccessKey, cred.SecretKey)
-	if err != nil {
-		return
-	}
-	if !creds.IsValid() {
-		return
-	}
-	c[CredentialsSubSys][Default] = KVS{
-		KV{
-			Key:   AccessKey,
-			Value: cred.AccessKey,
-		},
-		KV{
-			Key:   SecretKey,
-			Value: cred.SecretKey,
-		},
-	}
-}
 
 // SetRegion - One time migration code needed, for migrating from older config to new for server Region.
 func SetRegion(c Config, name string) {


### PR DESCRIPTION
## Description

Currently, credentials are stored in .minio.sys/config/config.json for 
historical reasons, but it is not documented it is the case, neither it 
is possible to modify the access/secret keys in config.json

Also it is documented that users need to define MINIO_ROOT_USER 
and MINIO_ROOT_PASSWORD in the MinIO environment.

This change can break users who did never define MINIO_ROOT_USER 
and MINIO_ROOT_PASSWORD. In that case, the credentials will be 
minioadmin:minioadmin, which means this is not a serious deployment.

This can also break users that set MINIO_ROOT_USER and MINIO_ROOT_PASSWORD 
with a custom access and secret keys temporarly and then removed those env variables. 
But again, this is not a supported use case since a long time.

Therefore removing credentials subsystem from MinIO configuration.

## Motivation and Context
Removing deprecated code and prepare for the next PR

## How to test this PR?
Tests related to check if credentials are loaded properly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
