### PR TITLE
Avoid config migration on every startup

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -71,7 +71,7 @@ func (a adminAPIHandlers) DelConfigKVHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	cfg, err := readServerConfig(ctx, objectAPI)
+	cfg, err := readServerConfig(ctx, objectAPI, nil)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
@@ -142,7 +142,7 @@ func (a adminAPIHandlers) SetConfigKVHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	cfg, err := readServerConfig(ctx, objectAPI)
+	cfg, err := readServerConfig(ctx, objectAPI, nil)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
@@ -296,7 +296,7 @@ func (a adminAPIHandlers) RestoreConfigHistoryKVHandler(w http.ResponseWriter, r
 		return
 	}
 
-	cfg, err := readServerConfig(ctx, objectAPI)
+	cfg, err := readServerConfig(ctx, objectAPI, nil)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return

--- a/cmd/admin-handlers-idp-config.go
+++ b/cmd/admin-handlers-idp-config.go
@@ -107,7 +107,7 @@ func (a adminAPIHandlers) addOrUpdateIDPHandler(ctx context.Context, w http.Resp
 		cfgData = subSys + tgtSuffix + config.KvSpaceSeparator + string(reqBytes)
 	}
 
-	cfg, err := readServerConfig(ctx, objectAPI)
+	cfg, err := readServerConfig(ctx, objectAPI, nil)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return
@@ -408,7 +408,7 @@ func (a adminAPIHandlers) DeleteIdentityProviderCfg(w http.ResponseWriter, r *ht
 		return
 	}
 
-	cfg, err := readServerConfig(ctx, objectAPI)
+	cfg, err := readServerConfig(ctx, objectAPI, nil)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2135,7 +2135,7 @@ func fetchHealthInfo(healthCtx context.Context, objectAPI ObjectLayer, query *ur
 
 	getAndWriteMinioConfig := func() {
 		if query.Get("minioconfig") == "true" {
-			config, err := readServerConfig(healthCtx, objectAPI)
+			config, err := readServerConfig(healthCtx, objectAPI, nil)
 			if err != nil {
 				healthInfo.Minio.Config = madmin.MinioConfig{
 					Error: err.Error(),

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -782,13 +782,14 @@ func newSrvConfig(objAPI ObjectLayer) error {
 }
 
 func getValidConfig(objAPI ObjectLayer) (config.Config, error) {
-	return readServerConfig(GlobalContext, objAPI)
+	return readServerConfig(GlobalContext, objAPI, nil)
 }
 
 // loadConfig - loads a new config from disk, overrides params
 // from env if found and valid
-func loadConfig(objAPI ObjectLayer) error {
-	srvCfg, err := getValidConfig(objAPI)
+// data is optional. If nil it will be loaded from backend.
+func loadConfig(objAPI ObjectLayer, data []byte) error {
+	srvCfg, err := readServerConfig(GlobalContext, objAPI, data)
 	if err != nil {
 		return err
 	}

--- a/cmd/config-current_test.go
+++ b/cmd/config-current_test.go
@@ -61,7 +61,7 @@ func TestServerConfig(t *testing.T) {
 	}
 
 	// Initialize server config.
-	if err := loadConfig(objLayer); err != nil {
+	if err := loadConfig(objLayer, nil); err != nil {
 		t.Fatalf("Unable to initialize from updated config file %s", err)
 	}
 }

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -2533,6 +2533,21 @@ func checkConfigVersion(objAPI ObjectLayer, configFile string, version string) (
 		}
 	}
 
+	if version == "kvs" {
+		// Check api config values are present.
+		var vcfg struct {
+			API struct {
+				E []struct {
+					Key   string `json:"key"`
+					Value string `json:"value"`
+				} `json:"_"`
+			} `json:"api"`
+		}
+		if err = json.Unmarshal(data, &vcfg); err != nil {
+			return false, nil, nil
+		}
+		return len(vcfg.API.E) > 0, data, nil
+	}
 	var versionConfig struct {
 		Version string `json:"version"`
 	}

--- a/cmd/config-migrate_test.go
+++ b/cmd/config-migrate_test.go
@@ -65,7 +65,7 @@ func TestServerConfigMigrateV1(t *testing.T) {
 	}
 
 	// Initialize server config and check again if everything is fine
-	if err := loadConfig(objLayer); err != nil {
+	if err := loadConfig(objLayer, nil); err != nil {
 		t.Fatalf("Unable to initialize from updated config file %s", err)
 	}
 }
@@ -207,7 +207,7 @@ func TestServerConfigMigrateV2toV33(t *testing.T) {
 	}
 
 	// Initialize server config and check again if everything is fine
-	if err := loadConfig(objLayer); err != nil {
+	if err := loadConfig(objLayer, nil); err != nil {
 		t.Fatalf("Unable to initialize from updated config file %s", err)
 	}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -152,30 +152,34 @@ func saveServerConfig(ctx context.Context, objAPI ObjectLayer, cfg interface{}) 
 	return saveConfig(ctx, objAPI, configFile, data)
 }
 
-func readServerConfig(ctx context.Context, objAPI ObjectLayer) (config.Config, error) {
+// data is optional. If nil it will be loaded from backend.
+func readServerConfig(ctx context.Context, objAPI ObjectLayer, data []byte) (config.Config, error) {
 	srvCfg := config.New()
-	configFile := path.Join(minioConfigPrefix, minioConfigFile)
-	data, err := readConfig(ctx, objAPI, configFile)
-	if err != nil {
-		if errors.Is(err, errConfigNotFound) {
-			lookupConfigs(srvCfg, objAPI)
-			return srvCfg, nil
-		}
-		return nil, err
-	}
-
-	if GlobalKMS != nil && !utf8.Valid(data) {
-		data, err = config.DecryptBytes(GlobalKMS, data, kms.Context{
-			minioMetaBucket: path.Join(minioMetaBucket, configFile),
-		})
+	var err error
+	if len(data) == 0 {
+		configFile := path.Join(minioConfigPrefix, minioConfigFile)
+		data, err = readConfig(ctx, objAPI, configFile)
 		if err != nil {
-			lookupConfigs(srvCfg, objAPI)
+			if errors.Is(err, errConfigNotFound) {
+				lookupConfigs(srvCfg, objAPI)
+				return srvCfg, nil
+			}
 			return nil, err
+		}
+
+		if GlobalKMS != nil && !utf8.Valid(data) {
+			data, err = config.DecryptBytes(GlobalKMS, data, kms.Context{
+				minioMetaBucket: path.Join(minioMetaBucket, configFile),
+			})
+			if err != nil {
+				lookupConfigs(srvCfg, objAPI)
+				return nil, err
+			}
 		}
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err = json.Unmarshal(data, &srvCfg); err != nil {
+	if err := json.Unmarshal(data, &srvCfg); err != nil {
 		return nil, err
 	}
 
@@ -212,6 +216,15 @@ func initConfig(objAPI ObjectLayer) error {
 		}
 	}
 
+	// Check if the config version is latest (kvs), if not migrate.
+	ok, data, err := checkConfigVersion(objAPI, path.Join(minioConfigPrefix, minioConfigFile), "kvs")
+	if err != nil {
+		return err
+	}
+	if ok {
+		return loadConfig(objAPI, data)
+	}
+
 	// Migrates ${HOME}/.minio/config.json or config.json.deprecated
 	// to '<export_path>/.minio.sys/config/config.json'
 	// ignore if the file doesn't exist.
@@ -232,5 +245,5 @@ func initConfig(objAPI ObjectLayer) error {
 		return fmt.Errorf("migrateMinioSysConfigToKV: %w", err)
 	}
 
-	return loadConfig(objAPI)
+	return loadConfig(objAPI, nil)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -218,7 +218,7 @@ func initConfig(objAPI ObjectLayer) error {
 
 	// Check if the config version is latest (kvs), if not migrate.
 	ok, data, err := checkConfigVersion(objAPI, path.Join(minioConfigPrefix, minioConfigFile), "kvs")
-	if err != nil {
+	if err != nil && !errors.Is(err, errConfigNotFound) {
 		return err
 	}
 	if ok {


### PR DESCRIPTION
## Description

Since there is no "Version" field in KVS data it was migrated on every startup on every server with one read per migration check.

Check if data is KVS as the first thing and skip migration if so - and reuse the loaded data from the check.

Before:
```
lockBlocking 42c9d91c-191b-42a6-821e-96a75a1d97a1/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/backend-encrypted"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 42c9d91c-191b-42a6-821e-96a75a1d97a1/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/backend-encrypted"}: granted
lockBlocking 960c3436-4d8f-43ca-9973-928fd12e5957/[erasure-object.go:432:erasureObjects.GetObjectInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 960c3436-4d8f-43ca-9973-928fd12e5957/[erasure-object.go:432:erasureObjects.GetObjectInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking d2c35759-bc17-44eb-ad51-4790f246568d/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking d2c35759-bc17-44eb-ad51-4790f246568d/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking 31312c1b-e8d2-49dd-ab59-d5830f2b355c/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 31312c1b-e8d2-49dd-ab59-d5830f2b355c/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking f22609b7-b9cf-4c31-bc70-de1b7dd9a9fa/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking f22609b7-b9cf-4c31-bc70-de1b7dd9a9fa/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking 665cbe28-395f-424e-a9ce-cfb73933c98e/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 665cbe28-395f-424e-a9ce-cfb73933c98e/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking c4f1d9c7-35d6-47c3-91c2-0742c5976da8/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking c4f1d9c7-35d6-47c3-91c2-0742c5976da8/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking 51792e9e-0c59-47ad-b2b1-5beeaf8a4319/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 51792e9e-0c59-47ad-b2b1-5beeaf8a4319/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking 0f13b720-5b3c-488b-a12d-63259cbfc811/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 0f13b720-5b3c-488b-a12d-63259cbfc811/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking be795906-b91b-482b-863d-034aabc24c4d/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking be795906-b91b-482b-863d-034aabc24c4d/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
lockBlocking 47f97036-d9f3-411a-a3f1-fb63f791a46b/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:300000653437, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 47f97036-d9f3-411a-a3f1-fb63f791a46b/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
```

After:

```
Waiting for all MinIO sub-systems to be initialized.. lock acquired
lockBlocking 266ba312-6713-4037-b4b7-40c0abebfff2/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/backend-encrypted"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 266ba312-6713-4037-b4b7-40c0abebfff2/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/backend-encrypted"}: granted
lockBlocking 549df657-311b-41c3-84a8-84d513418f8b/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: lockType readLock(true), additional opts: dsync.Options{Timeout:600000000000, RetryInterval:0}, quorum: 2, tolerance: 2, lockClients: 4
lockBlocking 549df657-311b-41c3-84a8-84d513418f8b/[erasure-object.go:211:erasureObjects.GetObjectNInfo()] for []string{".minio.sys/config/config.json"}: granted
Automatically configured API requests per node based on available memory on the system: 177
All MinIO sub-systems initialized successfully in 64.4323ms
```


## How to test this PR?

Observe startup with `_MINIO_DSYNC_TRACE=1`.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)

