### PR TITLE
serialize replication stats() only when needed

### DIFF
--- a/cmd/bucket-replication-utils.go
+++ b/cmd/bucket-replication-utils.go
@@ -638,7 +638,7 @@ type replicationResyncer struct {
 }
 
 const (
-	replicationDir      = "replication"
+	replicationDir      = ".replication"
 	resyncFileName      = "resync.bin"
 	resyncMetaFormat    = 1
 	resyncMetaVersionV1 = 1


### PR DESCRIPTION


## Description
serialize replication stats() only when needed

## Motivation and Context
also, rename '.minio.sys/buckets/replication' to
   '.minio.sys/buckets/.replication'

## How to test this PR?
Just test by running on a fresh path, create
buckets and let the usage scanner run once. 

Wait for 5mins and observe if any data is 
written at `.minio.sys/buckets/replication/<hostname>.stats/` 

If replication is not configured we do not need to
serialize anything.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
