### PR TITLE
Fix DeleteObject when only free versions remain

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -997,7 +997,8 @@ func (i *scannerItem) applyTierObjSweep(ctx context.Context, o ObjectLayer, oi O
 
 	// Remove this free version
 	_, err = o.DeleteObject(ctx, oi.Bucket, oi.Name, ObjectOptions{
-		VersionID: oi.VersionID,
+		VersionID:        oi.VersionID,
+		InclFreeVersions: true,
 	})
 	if err == nil {
 		auditLogLifecycle(ctx, oi, ILMFreeVersionDelete)

--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -211,7 +211,7 @@ func (e *metaCacheEntry) fileInfo(bucket string) (FileInfo, error) {
 				ModTime:  timeSentinel1970,
 			}, nil
 		}
-		return e.cached.ToFileInfo(bucket, e.name, "")
+		return e.cached.ToFileInfo(bucket, e.name, "", false)
 	}
 	return getFileInfo(e.metadata, bucket, e.name, "", false)
 }

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -96,6 +96,8 @@ type ObjectOptions struct {
 	// IndexCB will return any index created but the compression.
 	// Object must have been read at this point.
 	IndexCB func() []byte
+
+	InclFreeVersions bool
 }
 
 // ExpirationOptions represents object options for object expiration at objectLayer.

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -122,7 +122,7 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, data bool) (F
 			}, nil
 		}
 		inData = xlMeta.data
-		fi, err = xlMeta.ToFileInfo(volume, path, versionID)
+		fi, err = xlMeta.ToFileInfo(volume, path, versionID, false)
 	}
 	if !data || err != nil {
 		return fi, err

--- a/cmd/xl-storage-format_test.go
+++ b/cmd/xl-storage-format_test.go
@@ -485,7 +485,7 @@ func BenchmarkXlMetaV2Shallow(b *testing.B) {
 						b.Fatal(err)
 					}
 					// List...
-					_, err = xl.ToFileInfo("volume", "path", ids[rng.Intn(size)])
+					_, err = xl.ToFileInfo("volume", "path", ids[rng.Intn(size)], false)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2335,7 +2335,7 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 	}
 
 	// Replace the data of null version or any other existing version-id
-	ofi, err := xlMeta.ToFileInfo(dstVolume, dstPath, reqVID)
+	ofi, err := xlMeta.ToFileInfo(dstVolume, dstPath, reqVID, false)
 	if err == nil && !ofi.Deleted {
 		if xlMeta.SharedDataDirCountStr(reqVID, ofi.DataDir) == 0 {
 			// Purge the destination path as we are not preserving anything


### PR DESCRIPTION
## Description
When only [free-versions](#motivation-and-context) remain for an object, they become invisible to the object layer. This makes it impossible to collect them in these situations. This change allows for scanner (an internal process) to delete free versions by making these free-versions visible only when explicitly requested via a flag (`opts.InclFreeVersions`).

Free-versions of an object become visible only when,
 -  explicitly requested; i.e only scanner will ever use this to collect remote objects
 -  no regular versions (incl. delete markers) are present in this object

## Motivation and Context
MinIO uses free-versions, an internal only version type, to track deletions/replacements of a tiered object version. This free version helps in tracking tiered object content on its tier to handle a possible failure during its deletion. These free versions are dealt with and eventually collected by the scanner. 

## How to test this PR?
1. Make a bucket (without versioning)
2. Set up tiers and configure ILM to tier objects on this bucket to the remote tier setup
3. Upload an object to this bucket, wait for the object to transition.
4. Now, `mc rm ...` this object.
5. After some time, the scanner must have removed the free-version and there must be nothing left behind of this object on the backend drives.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
