### PR TITLE
tier verification leaks fd, that must be closed

### DIFF
--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	xhttp "github.com/minio/minio/internal/http"
 	"io"
 
 	"github.com/minio/madmin-go/v2"
@@ -60,7 +61,7 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 		}
 	}
 
-	_, err = w.Get(ctx, probeObject, rv, WarmBackendGetOpts{})
+	r, err := w.Get(ctx, probeObject, rv, WarmBackendGetOpts{})
 	if err != nil {
 		switch err.(type) {
 		case BackendDown:
@@ -78,7 +79,7 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 			}
 		}
 	}
-
+	xhttp.DrainBody(r)
 	if err = w.Remove(ctx, probeObject, rv); err != nil {
 		switch err.(type) {
 		case BackendDown:

--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -22,10 +22,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	xhttp "github.com/minio/minio/internal/http"
 	"io"
 
 	"github.com/minio/madmin-go/v2"
+	xhttp "github.com/minio/minio/internal/http"
 )
 
 // WarmBackendGetOpts is used to express byte ranges within an object. The zero
@@ -62,6 +62,7 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 	}
 
 	r, err := w.Get(ctx, probeObject, rv, WarmBackendGetOpts{})
+	xhttp.DrainBody(r)
 	if err != nil {
 		switch err.(type) {
 		case BackendDown:
@@ -79,7 +80,6 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 			}
 		}
 	}
-	xhttp.DrainBody(r)
 	if err = w.Remove(ctx, probeObject, rv); err != nil {
 		switch err.(type) {
 		case BackendDown:


### PR DESCRIPTION
## Description
when check checkWarmBackend.  http.Body will be ignore.It Should close.
```go
func (s3 *warmBackendS3) Get(ctx context.Context, object string, rv remoteVersionID, opts WarmBackendGetOpts) (io.ReadCloser, error) {
	gopts := minio.GetObjectOptions{}

	if rv != "" {
		gopts.VersionID = string(rv)
	}
	if opts.startOffset >= 0 && opts.length > 0 {
		if err := gopts.SetRange(opts.startOffset, opts.startOffset+opts.length-1); err != nil {
			return nil, s3.ToObjectError(err, object)
		}
	}
	c := &minio.Core{Client: s3.client}
	// Important to use core primitives here to pass range get options as is.
	r, _, _, err := c.GetObject(ctx, s3.Bucket, s3.getDest(object), gopts)
	if err != nil {
		return nil, s3.ToObjectError(err, object)
	}
	return r, nil
}
```
```go
// go to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35.
func (c *Client) getObject(ctx context.Context, bucketName, objectName string, opts GetObjectOptions) (io.ReadCloser, ObjectInfo, http.Header, error) {
	// Validate input arguments.
	if err := s3utils.CheckValidBucketName(bucketName); err != nil {
		return nil, ObjectInfo{}, nil, err
	}
	if err := s3utils.CheckValidObjectName(objectName); err != nil {
		return nil, ObjectInfo{}, nil, err
	}

	urlValues := make(url.Values)
	if opts.VersionID != "" {
		urlValues.Set("versionId", opts.VersionID)
	}
	if opts.PartNumber > 0 {
		urlValues.Set("partNumber", strconv.Itoa(opts.PartNumber))
	}

	// Execute GET on objectName.
	resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{
		bucketName:       bucketName,
		objectName:       objectName,
		queryValues:      urlValues,
		customHeader:     opts.Header(),
		contentSHA256Hex: emptySHA256Hex,
	})
	if err != nil {
		return nil, ObjectInfo{}, nil, err
	}
	if resp != nil {
		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
			return nil, ObjectInfo{}, nil, httpRespToErrorResponse(resp, bucketName, objectName)
		}
	}

	objectStat, err := ToObjectInfo(bucketName, objectName, resp.Header)
	if err != nil {
		closeResponse(resp)
		return nil, ObjectInfo{}, nil, err
	}

	// do not close body here, caller will close
	return resp.Body, objectStat, resp.Header, nil
}
```
## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
