### PR TITLE
Error creating users, can't find secret

### DIFF
--- a/helm/minio/templates/_helper_create_user.txt
+++ b/helm/minio/templates/_helper_create_user.txt
@@ -93,7 +93,7 @@ connectToMinio $scheme
 {{- range .Values.users }}
 echo {{ tpl .accessKey $global }} > $MINIO_ACCESSKEY_SECRETKEY_TMP
 {{- if .existingSecret }}
-cat /config/secrets/{{ tpl .existingSecret $global }}/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+cat /config/secrets/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
 # Add a new line if it doesn't exist
 sed -i '$a\' $MINIO_ACCESSKEY_SECRETKEY_TMP
 createUser {{ .policy }}


### PR DESCRIPTION

## Motivation and Context

I'm having problems when creating users via the create user job. When it runs i get the following error.
```
Connecting to MinIO server: http://minio:9000
Added `myminio` successfully.
cat: /config/secrets/minio/writeSecretKey: No such file or directory
```

My existing secret is called `minio` and that appears in the path above.

When I look in the pod given the current mounting scheme for secrets, it looks like the secret name is not part of the 
```
sh-4.4# ls config/secrets
lokiSecretKey  writeSecretKey
```


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression https://github.com/minio/minio/pull/15939
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
