### PR TITLE
Validate replication target update to avoid duplicate endpoints

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -228,8 +228,10 @@ func (a adminAPIHandlers) SetRemoteTargetHandler(w http.ResponseWriter, r *http.
 		for _, op := range ops {
 			switch op {
 			case madmin.CredentialsUpdateType:
-				tgt.Credentials = target.Credentials
-				tgt.TargetBucket = target.TargetBucket
+				if !globalSiteReplicationSys.isEnabled() {
+					tgt.Credentials = target.Credentials
+					tgt.TargetBucket = target.TargetBucket
+				}
 				tgt.Secure = target.Secure
 				tgt.Endpoint = target.Endpoint
 			case madmin.SyncUpdateType:

--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -256,6 +256,10 @@ func (sys *BucketTargetSys) SetTarget(ctx context.Context, bucket string, tgt *m
 				found = true
 				continue
 			}
+			// fail if endpoint is already present in list of targets and not a matching ARN
+			if t.Endpoint == tgt.Endpoint {
+				return BucketRemoteAlreadyExists{Bucket: t.TargetBucket}
+			}
 		}
 		newtgts[idx] = t
 	}


### PR DESCRIPTION
for the same bucket.

Also adding validation to site replication setup to avoid overwriting the site replicator access key.

## Description


## Motivation and Context
With recent refactor of remote target management into `mc replicate add|update` , user may enter incorrect endpoint while updating the remote target's bandwidth settings etc because the visibility of targets via `mc admin bucket remote ls` has been removed. Tightening the validations will avoid inadvertent changes.

## How to test this PR?
1.  set up site replication b/w 3 sites
2. `mc replicate update --id --remote-bucket "http(s)//ak:sk@<dupl endpoint>" --bandwidth  alias/bucket` should fail with this PR. The administrator ak entered here should not replace the site-replicator service account key
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
