### PR TITLE
Update api-headers.go

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -171,7 +171,9 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 	if rs == nil && opts.PartNumber > 0 {
 		rs = partNumberToRangeSpec(objInfo, opts.PartNumber)
 	}
-
+	if rs == nil {
+		return fmt.Errorf("Can't get empty RangeSpec. %s", objInfo.Name)
+	}
 	// For providing ranged content
 	start, rangeLen, err = rs.GetOffsetLength(totalObjectSize)
 	if err != nil {


### PR DESCRIPTION


## Description

when rs is nil, will panic
func defined is
```go
func (api objectAPIHandlers) getObjectInArchiveFileHandler(ctx context.Context, objectAPI ObjectLayer, bucket, object string, w http.ResponseWriter, r *http.Request) {
...
}
```
cmd/s3-zip-handlers.go:213
```go
	if err = setObjectHeaders(w, fileObjInfo, nil, opts); err != nil {
		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
		return
	}
```
Despite the logical recopying of rs, it is still possible to have a null. When executed it will panic.
cmd/api-headers.go:178
```go
	start, rangeLen, err = rs.GetOffsetLength(totalObjectSize)
	if err != nil {
		return err
	}
```
## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
