### PR TITLE
helm: Make bucket existence check faster

### DIFF
--- a/helm/minio/templates/_helper_create_bucket.txt
+++ b/helm/minio/templates/_helper_create_bucket.txt
@@ -39,7 +39,7 @@ connectToMinio() {
 # Check if the bucket exists, by using the exit code of `mc ls`
 checkBucketExists() {
   BUCKET=$1
-  CMD=$(${MC} ls myminio/$BUCKET > /dev/null 2>&1)
+  CMD=$(${MC} stat myminio/$BUCKET > /dev/null 2>&1)
   return $?
 }
 


### PR DESCRIPTION
## Description
`stat` is much faster than `ls` on large buckets.

## Motivation and Context
It takes a lot of time to deploy minio on large deployments.

## How to test this PR?
I don't know, tested manually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
