### PR TITLE
fix: DeleteObject() API with versionId under replication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ test-replication: install ## verify multi site replication
 	@echo "Running tests for replicating three sites"
 	@(env bash $(PWD)/docs/bucket/replication/setup_3site_replication.sh)
 	@(env bash $(PWD)/docs/bucket/replication/setup_2site_existing_replication.sh)
+	@(env bash $(PWD)/docs/bucket/replication/delete-replication.sh)
 
 test-site-replication-ldap: install ## verify automatic site replication
 	@echo "Running tests for automatic site replication of IAM (with LDAP)"

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -309,7 +309,7 @@ func checkReplicateDelete(ctx context.Context, bucket string, dobj ObjectToDelet
 		for _, tgtArn := range tgtArns {
 			opts.TargetArn = tgtArn
 			replicate = rcfg.Replicate(opts)
-			// when incoming delete is removal of a delete marker( a.k.a versioned delete),
+			// when incoming delete is removal of a delete marker(a.k.a versioned delete),
 			// GetObjectInfo returns extra information even though it returns errFileNotFound
 			if gerr != nil {
 				validReplStatus := false

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -147,9 +147,9 @@ func (fi FileInfo) ToObjectInfo(bucket, object string, versioned bool) ObjectInf
 	// Add replication status to the object info
 	objInfo.ReplicationStatusInternal = fi.ReplicationState.ReplicationStatusInternal
 	objInfo.VersionPurgeStatusInternal = fi.ReplicationState.VersionPurgeStatusInternal
-	objInfo.ReplicationStatus = fi.ReplicationState.CompositeReplicationStatus()
+	objInfo.ReplicationStatus = fi.ReplicationStatus()
+	objInfo.VersionPurgeStatus = fi.VersionPurgeStatus()
 
-	objInfo.VersionPurgeStatus = fi.ReplicationState.CompositeVersionPurgeStatus()
 	objInfo.TransitionedObject = TransitionedObject{
 		Name:        fi.TransitionedObjName,
 		VersionID:   fi.TransitionVersionID,
@@ -176,7 +176,6 @@ func (fi FileInfo) ToObjectInfo(bucket, object string, versioned bool) ObjectInf
 		objInfo.StorageClass = globalMinioDefaultStorageClass
 	}
 
-	objInfo.VersionPurgeStatus = fi.VersionPurgeStatus()
 	// set restore status for transitioned object
 	restoreHdr, ok := fi.Metadata[xhttp.AmzRestore]
 	if ok {
@@ -532,6 +531,11 @@ func (fi *FileInfo) IsRestoreObjReq() bool {
 // VersionPurgeStatus returns overall version purge status for this object version across targets
 func (fi *FileInfo) VersionPurgeStatus() VersionPurgeStatusType {
 	return fi.ReplicationState.CompositeVersionPurgeStatus()
+}
+
+// ReplicationStatus returns overall version replication status for this object version across targets
+func (fi *FileInfo) ReplicationStatus() replication.StatusType {
+	return fi.ReplicationState.CompositeReplicationStatus()
 }
 
 // DeleteMarkerReplicationStatus returns overall replication status for this delete marker version across targets

--- a/docs/bucket/replication/delete-replication.sh
+++ b/docs/bucket/replication/delete-replication.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+if [ -n "$TEST_DEBUG" ]; then
+    set -x
+fi
+
+trap 'catch $LINENO' ERR
+
+# shellcheck disable=SC2120
+catch() {
+    if [ $# -ne 0 ]; then
+	echo "error on line $1"
+	echo "dc1 server logs ========="
+	cat /tmp/dc1.log
+	echo "dc2 server logs ========="
+	cat /tmp/dc2.log
+    fi
+
+    echo "Cleaning up instances of MinIO"
+    set +e
+    pkill minio
+    pkill mc
+    rm -rf /tmp/xl/
+}
+
+catch
+
+set -e
+export MINIO_CI_CD=1
+export MINIO_BROWSER=off
+export MINIO_ROOT_USER="minio"
+export MINIO_ROOT_PASSWORD="minio123"
+export MINIO_KMS_AUTO_ENCRYPTION=off
+export MINIO_PROMETHEUS_AUTH_TYPE=public
+export MINIO_KMS_SECRET_KEY=my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw=
+unset MINIO_KMS_KES_CERT_FILE
+unset MINIO_KMS_KES_KEY_FILE
+unset MINIO_KMS_KES_ENDPOINT
+unset MINIO_KMS_KES_KEY_NAME
+
+if [ ! -f ./mc ]; then
+    wget --quiet -O mc https://dl.minio.io/client/mc/release/linux-amd64/mc && \
+        chmod +x mc
+fi
+
+mkdir -p /tmp/xl/1/ /tmp/xl/2/
+
+export MINIO_KMS_SECRET_KEY="my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw="
+export MINIO_ROOT_USER="minioadmin"
+export MINIO_ROOT_PASSWORD="minioadmin"
+
+./minio server --address ":9001" /tmp/xl/1/{1...4}/ 2>&1 > /tmp/dc1.log &
+./minio server --address ":9002" /tmp/xl/2/{1...4}/ 2>&1 > /tmp/dc2.log &
+
+sleep 3
+
+export MC_HOST_myminio1=http://minioadmin:minioadmin@localhost:9001
+export MC_HOST_myminio2=http://minioadmin:minioadmin@localhost:9002
+
+./mc mb myminio1/testbucket/
+./mc version enable myminio1/testbucket/
+./mc mb myminio2/testbucket/
+./mc version enable myminio2/testbucket/
+
+arn=$(mc admin bucket remote add myminio1/testbucket/ http://minioadmin:minioadmin@localhost:9002/testbucket/ --service "replication" --json | jq -r .RemoteARN)
+./mc replicate add myminio1/testbucket --remote-bucket "$arn" --priority 1
+
+./mc cp README.md myminio1/testbucket/dir/file
+./mc cp README.md myminio1/testbucket/dir/file
+
+sleep 1s
+
+echo "=== myminio1"
+./mc ls --versions myminio1/testbucket/dir/file
+
+echo "=== myminio2"
+./mc ls --versions myminio2/testbucket/dir/file
+
+versionId="$(mc ls --json --versions myminio1/testbucket/dir/ | tail -n1 | jq -r .versionId)"
+
+aws s3api --endpoint-url http://localhost:9001 --profile minio delete-object --bucket testbucket --key dir/file --version-id "$versionId"
+
+./mc ls -r --versions myminio1/testbucket > /tmp/myminio1.txt
+./mc ls -r --versions myminio2/testbucket > /tmp/myminio2.txt
+
+out=$(diff -qpruN /tmp/myminio1.txt /tmp/myminio2.txt)
+ret=$?
+if [ $ret -ne 0 ]; then
+    echo "BUG: expected no missing entries after replication: $out"
+    exit 1
+fi
+
+./mc rm myminio1/testbucket/dir/file
+sleep 1s
+
+./mc ls -r --versions myminio1/testbucket > /tmp/myminio1.txt
+./mc ls -r --versions myminio2/testbucket > /tmp/myminio2.txt
+
+out=$(diff -qpruN /tmp/myminio1.txt /tmp/myminio2.txt)
+ret=$?
+if [ $ret -ne 0 ]; then
+    echo "BUG: expected no missing entries after replication: $out"
+    exit 1
+fi
+
+echo "Success"
+catch

--- a/docs/bucket/replication/setup_2site_existing_replication.sh
+++ b/docs/bucket/replication/setup_2site_existing_replication.sh
@@ -41,7 +41,7 @@ unset MINIO_KMS_KES_KEY_NAME
 
 if [ ! -f ./mc ]; then
     wget --quiet -O mc https://dl.minio.io/client/mc/release/linux-amd64/mc && \
-        chmod +x mc
+       chmod +x mc
 fi
 
 minio server --address 127.0.0.1:9001 "http://127.0.0.1:9001/tmp/multisitea/data/disterasure/xl{1...4}" \


### PR DESCRIPTION


This PR adds tests to cover both scenarios.

## Description
fix: DeleteObject() API with versionId under replication

## Motivation and Context
Currently, DeleteObject() of an "exact" versionId leaves a 
delete-marker since (versionPurgeStatus) is non-empty 
is considered a delete-marker, do this special 
interpretation properly as per the original fix in #14555 
and again re-introduced in #15564 to fix another bug.

## How to test this PR?
Tests were added to cover both scenarios under DELETE

- permanent delete
- soft delete

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression from #15564
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
