### PR TITLE
disable builds for go1.18

### DIFF
--- a/.github/workflows/go-fips.yml
+++ b/.github/workflows/go-fips.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.18.5b7]
+        go-version: [1.19.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
@@ -30,9 +30,10 @@ jobs:
 
       - name: Setup dockerfile for build test
         run: |
-          echo "FROM us-docker.pkg.dev/google.com/api-project-999119582588/go-boringcrypto/golang:${{ matrix.go-version }}" > Dockerfile.fips.test
+          echo "FROM golang:1.19.4" >> Dockerfile.fips.test
           echo "COPY . /minio" >> Dockerfile.fips.test
           echo "WORKDIR /minio" >> Dockerfile.fips.test
+          echo "ENV GOEXPERIMENT=boringcrypto" >> Dockerfile.fips.test
           echo "RUN make" >> Dockerfile.fips.test
 
       - name: Build

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You can also connect using any S3-compatible tool, such as the MinIO Client `mc`
 
 ## Install from Source
 
-Use the following commands to compile and run a standalone MinIO server from source. Source installation is only intended for developers and advanced users. If you do not have a working Golang environment, please follow [How to install Golang](https://golang.org/doc/install). Minimum version required is [go1.18](https://golang.org/dl/#stable)
+Use the following commands to compile and run a standalone MinIO server from source. Source installation is only intended for developers and advanced users. If you do not have a working Golang environment, please follow [How to install Golang](https://golang.org/doc/install). Minimum version required is [go1.19](https://golang.org/dl/#stable)
 
 ```sh
 go install github.com/minio/minio@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/minio
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/storage v1.28.1

--- a/internal/fips/api.go
+++ b/internal/fips/api.go
@@ -139,8 +139,8 @@ func TLSCurveIDs() []tls.CurveID {
 		curves = append(curves, tls.X25519) // Only enable X25519 in non-FIPS mode
 	}
 	curves = append(curves, tls.CurveP256)
-	if go18 {
-		// With go1.18 enable P384, P521 newer constant time implementations.
+	if go19 {
+		// With go1.19 enable P384, P521 newer constant time implementations.
 		curves = append(curves, tls.CurveP384, tls.CurveP521)
 	}
 	return curves

--- a/internal/fips/go19.go
+++ b/internal/fips/go19.go
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build go1.18
-// +build go1.18
+//go:build go1.19
+// +build go1.19
 
 package fips
 
-const go18 = true
+const go19 = true

--- a/internal/fips/no_go19.go
+++ b/internal/fips/no_go19.go
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !go1.18
-// +build !go1.18
+//go:build !go1.19
+// +build !go1.19
 
 package fips
 
-const go18 = false
+const go19 = false


### PR DESCRIPTION
## Description
disable builds for go1.18

## Motivation and Context
go1.20 shall be released in Feb,
make room for future improvements

https://tip.golang.org/doc/go1.20

## How to test this PR?
Nothing should change, the FIPS build has been
updated to use the latest go1.19 native compilation.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
