### PR TITLE
fix: tweak read buffer size to reduce over-reading

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1796,15 +1796,9 @@ func (s *xlStorage) ReadFileStream(ctx context.Context, volume, path string, off
 	}
 
 	or := &xioutil.ODirectReader{
-		File:      file,
-		SmallFile: false,
-	}
-
-	if length <= smallFileThreshold {
-		or = &xioutil.ODirectReader{
-			File:      file,
-			SmallFile: true,
-		}
+		File: file,
+		// Select bigger blocks when reading at least 50% of a big block.
+		SmallFile: length <= xioutil.BlockSizeLarge/2,
 	}
 
 	r := struct {

--- a/internal/ioutil/read_file.go
+++ b/internal/ioutil/read_file.go
@@ -81,6 +81,10 @@ func ReadFile(name string) ([]byte, error) {
 	if err != nil {
 		return io.ReadAll(r)
 	}
+
+	// Select bigger blocks when reading at least 50% of a big block.
+	r.SmallFile = st.Size() <= BlockSizeLarge/2
+
 	dst := make([]byte, st.Size())
 	_, err = io.ReadFull(r, dst)
 	return dst, err


### PR DESCRIPTION
## Description

Switch to 2MB read buffers only when file is >1MB to reduce over-reading. Current value is 128KB.

Allow ReadFile to use big buffers with similar metrics.

## How to test this PR?

See https://github.com/minio/minio/discussions/16335

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
