### PR TITLE
helm: shared secrets handling for user and svcacct's

### DIFF
--- a/helm/minio/templates/_helper_create_svcacct.txt
+++ b/helm/minio/templates/_helper_create_svcacct.txt
@@ -91,7 +91,7 @@ connectToMinio $scheme
 {{- range $idx, $svc := .Values.svcaccts }}
 echo {{ tpl .accessKey $global }} > $MINIO_ACCESSKEY_SECRETKEY_TMP
 {{- if .existingSecret }}
-cat /config/secrets/{{ tpl .existingSecret $global }}/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+cat /config/secrets-svc/{{ tpl .existingSecret $global }}/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
 # Add a new line if it doesn't exist
 sed -i '$a\' $MINIO_ACCESSKEY_SECRETKEY_TMP
 {{ else }}

--- a/helm/minio/templates/_helper_create_user.txt
+++ b/helm/minio/templates/_helper_create_user.txt
@@ -93,7 +93,7 @@ connectToMinio $scheme
 {{- range .Values.users }}
 echo {{ tpl .accessKey $global }} > $MINIO_ACCESSKEY_SECRETKEY_TMP
 {{- if .existingSecret }}
-cat /config/secrets/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+cat /config/secrets/{{ tpl .existingSecret $global }}/{{ tpl .existingSecretKey $global }} >> $MINIO_ACCESSKEY_SECRETKEY_TMP
 # Add a new line if it doesn't exist
 sed -i '$a\' $MINIO_ACCESSKEY_SECRETKEY_TMP
 createUser {{ .policy }}

--- a/helm/minio/templates/post-job.yaml
+++ b/helm/minio/templates/post-job.yaml
@@ -63,7 +63,16 @@ spec:
                   name: {{ tpl .existingSecret $ }}
                   items:
                     - key: {{ .existingSecretKey }}
-                      path: secrets/{{ tpl .existingSecretKey $ }}
+                      path: secrets/{{ tpl .existingSecret $ }}/{{ tpl .existingSecretKey $ }}
+              {{- end }}
+              {{- end }}
+              {{- range ( default list .Values.svcaccts ) }}
+              {{- if .existingSecret }}
+              - secret:
+                  name: {{ tpl .existingSecret $ }}
+                  items:
+                    - key: {{ .existingSecretKey }}
+                      path: secrets-svc/{{ tpl .existingSecret $ }}/{{ tpl .existingSecretKey $ }}
               {{- end }}
               {{- end }}
         {{- if .Values.tls.enabled }}


### PR DESCRIPTION
## Description
This PR resolves two issues I had while creating users and service accounts with credentials from shared secrets:
* svcacct creation as documented from shared secrets was not possible as shared secrets have not been mounted
* When creating multiple users from different secrets but with the same key it gave a name clash as only the key name of the secret was used as mount point. Adopted the way it was prepared for the svcacct's.

## Motivation and Context
Motivation: Bringint things to work ;)
Context: good Auto-Provisioning of accounts and service users in context of application deployment during helm installation.

## How to test this PR?

Create a shared secret with two keys in it:
```bash
kubectl create secret generic minio-test-user-secrets \
    --from-literal=accessKeySecret=myAccessKeySecret \
    --from-literal=serviceKeySecret=myServiceKeySecret 
```
Now install the helm with following values.yaml
```yaml
mode: standalone
users:
  - accessKey: testUser
    existingSecret: minio-test-user-secrets
    existingSecretKey: accessKeySecret
svcaccts:
  - accessKey: testPageReader
    existingSecret: minio-test-user-secrets
    existingSecretKey: serviceKeySecret
    user: testUser
```

now we have a user and service account with the credentials from the secret.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
