### PR TITLE
Remove `checks` target from `docker` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ docker-hotfix: hotfix-push checks ## builds minio docker container with hotfix t
 	@echo "Building minio docker image '$(TAG)'"
 	@docker build -q --no-cache -t $(TAG) --build-arg RELEASE=$(VERSION) . -f Dockerfile.hotfix
 
-docker: build checks ## builds minio docker container
+docker: build ## builds minio docker container
 	@echo "Building minio docker image '$(TAG)'"
 	@docker build -q --no-cache -t $(TAG) . -f Dockerfile
 


### PR DESCRIPTION
the `make docker` target calls upon `build` and `checks` but `build` already calls `checks` so `checks` was being called twice

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>