### PR TITLE
fix(helm): fsGroup is only on podSecurityContext

### DIFF
--- a/helm/minio/templates/post-job.yaml
+++ b/helm/minio/templates/post-job.yaml
@@ -82,7 +82,6 @@ spec:
           securityContext:
             runAsUser: {{ .Values.makeBucketJob.securityContext.runAsUser }}
             runAsGroup: {{ .Values.makeBucketJob.securityContext.runAsGroup }}
-            fsGroup: {{ .Values.makeBucketJob.securityContext.fsGroup }}
           {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.makeBucketJob.exitCommand }}
@@ -113,7 +112,6 @@ spec:
           securityContext:
             runAsUser: {{ .Values.makeUserJob.securityContext.runAsUser }}
             runAsGroup: {{ .Values.makeUserJob.securityContext.runAsGroup }}
-            fsGroup: {{ .Values.makeUserJob.securityContext.fsGroup }}
           {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.makeUserJob.exitCommand }}
@@ -144,7 +142,6 @@ spec:
           securityContext:
             runAsUser: {{ .Values.makePolicyJob.securityContext.runAsUser }}
             runAsGroup: {{ .Values.makePolicyJob.securityContext.runAsGroup }}
-            fsGroup: {{ .Values.makePolicyJob.securityContext.fsGroup }}
           {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.makePolicyJob.exitCommand }}
@@ -175,7 +172,6 @@ spec:
           securityContext:
             runAsUser: {{ .Values.customCommandJob.securityContext.runAsUser }}
             runAsGroup: {{ .Values.customCommandJob.securityContext.runAsGroup }}
-            fsGroup: {{ .Values.customCommandJob.securityContext.fsGroup }}
           {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.customCommandJob.exitCommand }}
@@ -206,7 +202,6 @@ spec:
           securityContext:
             runAsUser: {{ .Values.makeServiceAccountJob.securityContext.runAsUser }}
             runAsGroup: {{ .Values.makeServiceAccountJob.securityContext.runAsGroup }}
-            fsGroup: {{ .Values.makeServiceAccountJob.securityContext.fsGroup }}
           {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.makeServiceAccountJob.exitCommand }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -320,7 +320,6 @@ makePolicyJob:
     enabled: false
     runAsUser: 1000
     runAsGroup: 1000
-    fsGroup: 1000
   resources:
     requests:
       memory: 128Mi
@@ -350,7 +349,6 @@ makeUserJob:
     enabled: false
     runAsUser: 1000
     runAsGroup: 1000
-    fsGroup: 1000
   resources:
     requests:
       memory: 128Mi
@@ -390,7 +388,6 @@ makeServiceAccountJob:
     enabled: false
     runAsUser: 1000
     runAsGroup: 1000
-    fsGroup: 1000
   resources:
     requests:
       memory: 128Mi
@@ -427,7 +424,6 @@ makeBucketJob:
     enabled: false
     runAsUser: 1000
     runAsGroup: 1000
-    fsGroup: 1000
   resources:
     requests:
       memory: 128Mi
@@ -445,7 +441,6 @@ customCommandJob:
     enabled: false
     runAsUser: 1000
     runAsGroup: 1000
-    fsGroup: 1000
   resources:
     requests:
       memory: 128Mi


### PR DESCRIPTION
## Description

[Pod's `securityContext`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) has `fsGroup` while [container's `securityContext`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) hasn't.

Related note: I'm tempted to rename `postJob.securityContext` to `postJob.podSecurityContext` (and `securityContext` to `podSecurityContext`) ; but this would be a breaking change.

## Motivation and Context

Without this fix it's not possible to set `makePolicyJob.securityContext.enabled=true`, `makeUserJob.securityContext.enabled=true`, `makeServiceAccountJob.securityContext.enabled=true`, `makeBucketJob.securityContext.enabled=true` or `customCommandJob.securityContext.enabled=true`.

## How to test this PR?

Install using Helm with one of the `--set` above.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression of https://github.com/minio/minio/commit/1ef1b2ba50a2f668a2394b2f48abfac3b598f423
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
