### PR TITLE
remove delete dangling code not useful anymore

### DIFF
--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -345,23 +345,7 @@ func (er *erasureObjects) healObject(ctx context.Context, bucket string, object 
 
 	readQuorum, _, err := objectQuorumFromMeta(ctx, partsMetadata, errs, er.defaultParityCount)
 	if err != nil {
-		m, err := er.deleteIfDangling(ctx, bucket, object, partsMetadata, errs, nil, ObjectOptions{
-			VersionID: versionID,
-		})
-		errs = make([]error, len(errs))
-		for i := range errs {
-			errs[i] = err
-		}
-		if err == nil {
-			// Dangling object successfully purged, size is '0'
-			m.Size = 0
-		}
-		// Generate file/version not found with default heal result
-		err = errFileNotFound
-		if versionID != "" {
-			err = errFileVersionNotFound
-		}
-		return er.defaultHealResult(m, storageDisks, storageEndpoints,
+		return er.defaultHealResult(FileInfo{}, storageDisks, storageEndpoints,
 			errs, bucket, object, versionID), err
 	}
 


### PR DESCRIPTION

## Description
remove delete dangling code not useful anymore

## Motivation and Context
delete dangling code is broken and has been broken
perhaps from Day 1 when it was implemented, there
are no well defined errors here that we can rely
on to make decisions to safely purge content.
    
we shall never delete() during xl.meta READs

## How to test this PR?
As per @poornas with the new confess tool 
and replicated setup leads to multiple 
situations where deleteIfDangling is called.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
