### PR TITLE
metrics: Add more logs when unable to read bucket usage

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1802,6 +1802,7 @@ func getBucketUsageMetrics() *MetricsGroup {
 		metrics = make([]Metric, 0, 50)
 		dataUsageInfo, err := loadDataUsageFromBackend(ctx, objLayer)
 		if err != nil {
+			logger.LogIf(ctx, err)
 			return
 		}
 
@@ -1947,8 +1948,9 @@ func getClusterTierMetrics() *MetricsGroup {
 			return
 		}
 
-		dui, err := loadDataUsageFromBackend(GlobalContext, objLayer)
+		dui, err := loadDataUsageFromBackend(ctx, objLayer)
 		if err != nil {
+			logger.LogIf(ctx, err)
 			return
 		}
 		// data usage has not captured any tier stats yet.


### PR DESCRIPTION
## Description
One user reported a fluctuating bucket usage metrics in Prometheus, 
I suspect the cluster is not able to read data from some reasons,
so let's just log the error to make it easier to debug.

## Motivation and Context
Add more logs

## How to test this PR?
Not trivial but trivial change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
