### PR TITLE
Hide objects/delete-markers that are marked to be removed

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -189,6 +189,27 @@ func (e *metaCacheEntry) isLatestDeletemarker() bool {
 	return xlMeta.versions[0].header.Type == DeleteType
 }
 
+// isMarkedAsDeleted returns whether the latest version is marked as deleted
+func (e *metaCacheEntry) isMarkedAsDeleted() bool {
+	if e.cached != nil {
+		return e.cached.versions[0].header.Flags&xlFlagMarkedAsDeleted != 0
+	}
+	if !isXL2V1Format(e.metadata) {
+		return false
+	}
+	if meta, _, err := isIndexedMetaV2(e.metadata); meta != nil {
+		return meta.IsMarkedAsDeleted()
+	} else if err != nil {
+		return false
+	}
+	// Fall back...
+	xlMeta, err := e.xlmeta()
+	if err != nil || len(xlMeta.versions) == 0 {
+		return false
+	}
+	return e.cached.versions[0].header.Flags&xlFlagMarkedAsDeleted != 0
+}
+
 // fileInfo returns the decoded metadata.
 // If entry is a directory it is returned as that.
 // If versioned the latest version will be returned.

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -203,6 +203,10 @@ func (o *listPathOptions) gatherResults(ctx context.Context, in <-chan metaCache
 			if !o.InclDeleted && entry.isObject() && entry.isLatestDeletemarker() && !entry.isObjectDir() {
 				continue
 			}
+			if entry.isMarkedAsDeleted() {
+				continue
+			}
+
 			if o.Limit > 0 && results.len() >= o.Limit {
 				// We have enough and we have more.
 				// Do not return io.EOF
@@ -364,6 +368,9 @@ func (r *metacacheReader) filter(o listPathOptions) (entries metaCacheEntriesSor
 				return true
 			}
 			if !entry.isInDir(o.Prefix, o.Separator) {
+				return true
+			}
+			if entry.isMarkedAsDeleted() {
 				return true
 			}
 			if !o.InclDeleted && entry.isObject() && entry.isLatestDeletemarker() && !entry.isObjectDir() {

--- a/cmd/xl-storage-free-version.go
+++ b/cmd/xl-storage-free-version.go
@@ -73,6 +73,20 @@ func (j xlMetaV2Version) FreeVersion() bool {
 	return false
 }
 
+// MarkedAsDeleted returns true if this version contains
+// version purge meta information
+func (j xlMetaV2Version) MarkedAsDeleted() bool {
+	switch j.Type {
+	case DeleteType:
+		_, ok := j.DeleteMarker.MetaSys[VersionPurgeStatusKey]
+		return ok
+	case ObjectType:
+		_, ok := j.ObjectV2.MetaSys[VersionPurgeStatusKey]
+		return ok
+	}
+	return false
+}
+
 // AddFreeVersion adds a free-version if needed for fi.VersionID version.
 // Free-version will be added if fi.VersionID has transitioned.
 func (x *xlMetaV2) AddFreeVersion(fi FileInfo) error {


### PR DESCRIPTION
## Description
Add a special flag to versions that are marked for deletion 
but not replicated it yet. This flag will be used to hide from listing.

This will only applicable for for new delete replication.
 Current versions that fail to be replicated will still be visible, 
however this should not be an issue a non replicate delete 
will succeed in the future after fixing the underlying issue.


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
