### PR TITLE
Properly restart fresh disk healing when failed in some places

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -176,11 +176,12 @@ func (ahs *allHealState) getHealLocalDiskEndpoints() Endpoints {
 	return endpoints
 }
 
-func (ahs *allHealState) markDiskForHealing(ep Endpoint) {
+// Set, in the memory, the state of the disk as currently healing or not
+func (ahs *allHealState) setDiskHealingStatus(ep Endpoint, healing bool) {
 	ahs.Lock()
 	defer ahs.Unlock()
 
-	ahs.healLocalDisks[ep] = true
+	ahs.healLocalDisks[ep] = healing
 }
 
 func (ahs *allHealState) pushHealLocalDisks(healLocalDisks ...Endpoint) {

--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -441,9 +441,10 @@ func monitorLocalDisksAndHeal(ctx context.Context, z *erasureServerPools) {
 
 			for _, disk := range healDisks {
 				go func(disk Endpoint) {
-					globalBackgroundHealState.markDiskForHealing(disk)
+					globalBackgroundHealState.setDiskHealingStatus(disk, true)
 					err := healFreshDisk(ctx, z, disk)
 					if err != nil {
+						globalBackgroundHealState.setDiskHealingStatus(disk, false)
 						printEndpointError(disk, err, false)
 						return
 					}


### PR DESCRIPTION
## Description
globalBackgroundHealState.getHealLocalDiskEndpoints() returns disks 
that need to be healed, but not the disks that are currently in a healing process.

Before starting to heal a disk, this latter is marked in the memory as 
currently healing. However when there is a healing issue, the code 
forgot to mark the disk as non healing anymore, so it never picked 
again in the next healing loop.

The workaround is to restart the node since the state in the memory 
is wrong. However the commit will make it right by removing the healing 
state of the disk when healing fails for any reason.

## Motivation and Context
Healing fresh disks is aborted in some cases, unless the user restarts the node.
This commit addresses this inconvience.

## How to test this PR?
Not trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
