### PR TITLE
Use async healing in PutObject call

### DIFF
--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -437,7 +437,8 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 	return retErr
 }
 
-// healObject heals given object path in deep to fix bitrot.
+// healObject sends the given object/version to the background healing workers
+// and only returns when healing of the object is done.
 func healObject(bucket, object, versionID string, scan madmin.HealScanMode) {
 	// Get background heal sequence to send elements to heal
 	globalHealStateLK.Lock()


### PR DESCRIPTION
## Description
PutObject can heal up to two versions when 
it finds a disparency between the list of versions, 
however the heal object call is sync and holds 
a lock as well. Call healing in a goroutine instead.

Also, do not account disks returning an error (offline for example) when
trying to detect if there is a versions disparency for an object during
PutObject.

## Motivation and Context
Fix a successful but long 'mc licence update' call seen by a user.

## How to test this PR?
Hard to test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
