### PR TITLE
Signal stop-rebalance to all rebalancing pools

### DIFF
--- a/cmd/erasure-server-pool-rebalance.go
+++ b/cmd/erasure-server-pool-rebalance.go
@@ -353,6 +353,7 @@ func (z *erasureServerPools) rebalanceBuckets(ctx context.Context, poolIdx int) 
 				z.rebalMu.Lock()
 				z.rebalMeta.PoolStats[poolIdx].Info.Status = rebalStopped
 				z.rebalMeta.PoolStats[poolIdx].Info.EndTime = now
+				z.rebalMeta.cancel = nil // remove the already used context.CancelFunc
 				z.rebalMu.Unlock()
 
 				rebalDone = true

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -649,6 +649,15 @@ func (sys *NotificationSys) StopRebalance(ctx context.Context) {
 			logger.LogIf(logger.SetReqInfo(ctx, reqInfo), nErr.Err)
 		}
 	}
+
+	objAPI := newObjectLayerFn()
+	if objAPI == nil {
+		logger.LogIf(ctx, errServerNotInitialized)
+		return
+	}
+	if pools, ok := objAPI.(*erasureServerPools); ok {
+		pools.StopRebalance()
+	}
 }
 
 // LoadRebalanceMeta notifies all peers to load rebalance.bin from object layer.


### PR DESCRIPTION
## Description
This PR stops rebalance routine if it were running on the node which received `admin-stop-rebalance` request.

## Motivation and Context
Fixes #16434. Since admin-stop-rebalance wouldn't always signal an ongoing rebalance operation to be stopped, it prevented starting of decommissioning as observed in #16434.

## How to test this PR?
Refer #16434 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
