### PR TITLE
fix: incorrect anonymization of drive endpoint

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -48,6 +48,7 @@ import (
 	"github.com/klauspost/compress/zip"
 	"github.com/minio/madmin-go/v2"
 	"github.com/minio/madmin-go/v2/estream"
+	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/dsync"
 	"github.com/minio/minio/internal/handlers"
 	xhttp "github.com/minio/minio/internal/http"
@@ -2859,10 +2860,16 @@ func createHostAnonymizer() map[string]string {
 	}
 
 	hostAnonymizer := map[string]string{}
+	hosts := set.NewStringSet()
+	srvrIdx := 0
 
 	for poolIdx, pool := range globalEndpoints {
-		for srvrIdx, endpoint := range pool.Endpoints {
-			anonymizeHost(hostAnonymizer, endpoint, poolIdx+1, srvrIdx+1)
+		for _, endpoint := range pool.Endpoints {
+			if !hosts.Contains(endpoint.Host) {
+				hosts.Add(endpoint.Host)
+				srvrIdx++
+			}
+			anonymizeHost(hostAnonymizer, endpoint, poolIdx+1, srvrIdx)
 		}
 	}
 	return hostAnonymizer


### PR DESCRIPTION
## Description

When the endpoints are not provided in ellipses style in the server command line, anonymization of drive endpoints was not happening correctly and was sometimes was adding server indices higher than the number of servers, creating a misleading impression that the health diagnostics is reporting a higher number of servers.

Fixed by ensuring correct server index in the anonymized endpoint.

## Motivation and Context

Bugfix

## How to test this PR?

- Start a cluster by providing endpoints in legacy style (or any other way that doesn't use ellipses e.g. env variable)
- Generate the health report
- Check the `minio -> info -> servers -> {server} -> endpoint` and `minio -> info - servers -> {server} -> drives -> {drive} -> endpoint` values
- Verify that the hostnames in the endpoints (that are of the form `pool1.server1`, `pool1.server2`, etc) never contain a server index that is higher than the number of servers in the cluster.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
