### PR TITLE
Add CPU info in the check update user-agent

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -41,6 +41,7 @@ import (
 	"github.com/minio/pkg/env"
 	xnet "github.com/minio/pkg/net"
 	"github.com/minio/selfupdate"
+	gopsutilcpu "github.com/shirou/gopsutil/v3/cpu"
 )
 
 const (
@@ -275,6 +276,18 @@ func getUserAgent(mode string) string {
 		if pcfTileVersion != "" {
 			uaAppend(" MinIO/pcf-tile-", pcfTileVersion)
 		}
+	}
+
+	if cpus, err := gopsutilcpu.Info(); err == nil && len(cpus) > 0 {
+		cpuMap := make(map[string]struct{}, len(cpus))
+		coreMap := make(map[string]struct{}, len(cpus))
+		for i := range cpus {
+			cpuMap[cpus[i].PhysicalID] = struct{}{}
+			coreMap[cpus[i].CoreID] = struct{}{}
+		}
+		cpu := cpus[0]
+		uaAppend(" CPU ", fmt.Sprintf("(total_cpus:%d, total_cores:%d; vendor:%s; family:%s; model:%s; stepping:%d; model_name:%s)",
+			len(cpuMap), len(coreMap), cpu.VendorID, cpu.Family, cpu.Model, cpu.Stepping, cpu.ModelName))
 	}
 
 	return strings.Join(userAgentParts, "")

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -179,7 +179,7 @@ func TestUserAgent(t *testing.T) {
 		if IsDocker() {
 			expectedStr = strings.ReplaceAll(expectedStr, "; source", "; docker; source")
 		}
-		if str != expectedStr {
+		if !strings.Contains(str, expectedStr) {
 			t.Errorf("Test %d: expected: %s, got: %s", i+1, expectedStr, str)
 		}
 		globalIsCICD = sci


### PR DESCRIPTION
## Description
Example, Add this to the existing user-agent header:

```
   CPU (total_cpus:1, total_cores:6; vendor:GenuineIntel; family:6; model:167; stepping:1; model_name:Intel(R) Xeon(R) E-2386G CPU @ 3.50GHz)```

```
## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
