### PR TITLE
grafana: Show one metric for the total data growth

### DIFF
--- a/docs/metrics/prometheus/grafana/minio-dashboard.json
+++ b/docs/metrics/prometheus/grafana/minio-dashboard.json
@@ -500,7 +500,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(minio_bucket_usage_total_bytes{job=\"$scrape_jobs\"}) by (instance)",
+	  "expr": "max(sum(minio_bucket_usage_total_bytes{job=\"$scrape_jobs\"}) by (instance,server))",
           "interval": "",
           "legendFormat": "Usage",
           "refId": "A",


### PR DESCRIPTION
## Description
Currently, having multiple metrics for the total data in the 
cluster is confusing users. Use a metric that shows the maximum
 of the data usage reported by all nodes.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
