### PR TITLE
allow bootstrap platform checks to be pool specific

### DIFF
--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -364,6 +365,7 @@ func createServerEndpoints(serverAddr string, args ...string) (
 			DrivesPerSet: len(setArgs[0]),
 			Endpoints:    endpointList,
 			CmdLine:      strings.Join(args, " "),
+			Platform:     fmt.Sprintf("OS: %s | Arch: %s", runtime.GOOS, runtime.GOARCH),
 		})
 		setupType = newSetupType
 		return endpointServerPools, setupType, nil
@@ -389,6 +391,7 @@ func createServerEndpoints(serverAddr string, args ...string) (
 			DrivesPerSet: len(setArgs[0]),
 			Endpoints:    endpointList,
 			CmdLine:      arg,
+			Platform:     fmt.Sprintf("OS: %s | Arch: %s", runtime.GOOS, runtime.GOARCH),
 		}); err != nil {
 			return nil, -1, err
 		}

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -203,6 +203,7 @@ type PoolEndpoints struct {
 	DrivesPerSet int
 	Endpoints    Endpoints
 	CmdLine      string
+	Platform     string
 }
 
 // EndpointServerPools - list of list of endpoints


### PR DESCRIPTION

## Description
allow bootstrap platform checks to be pool-specific

## Motivation and Context
allows for more flexibility when someone wants to
migrate their data using decommissioning from let's say

- Windows -> Linux
- macOS -> Linux
- FreeBSD -> Linux

This PR would allow heterogeneous pools across OS
and processor architectures, however within a pool OS 
and Arch are expected to be homogenous.

## How to test this PR?
Needs a windows box and another a Linux, by setting up
pool1 on windows and pool2 on Linux.

This PR allows this kind of setup, with the intent
that Windows will be decommissioned.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
