### PR TITLE
replication: clone metrics while loading metrics cache

### DIFF
--- a/cmd/bucket-replication-stats.go
+++ b/cmd/bucket-replication-stats.go
@@ -197,7 +197,8 @@ func (r *ReplicationStats) loadInitialReplicationMetrics(ctx context.Context) {
 	m := make(map[string]*BucketReplicationStats)
 	if stats, err := globalReplicationPool.loadStatsFromDisk(); err == nil {
 		for b, st := range stats {
-			m[b] = &st
+			c := st.Clone()
+			m[b] = &c
 		}
 		r.ulock.Lock()
 		r.UsageCache = m


### PR DESCRIPTION
Fixes incorrect metrics reported in `mc replicate status`

## Description

`mc replicate status alias/bucket` reports metrics for incorrect remote targets because the usage cache was holding on to reference of last loaded stats.

In addition to this PR, the contents of .minio.sys/buckets/.replication/replication.stats needs to be removed from all drives across the cluster to set right the metrics. The replication metrics will reset to last reported usage stats 

## Motivation and Context
correctness

## How to test this PR?

set up replication on 2 or more buckets and view `mc replicate status` after some uploads. 
Restart the cluster after stats saved to disk approx 5mins later - with master, on reload the status shows remote target metrics of last bucket in addition to that of correct remote targets. 

After removing the replication.stats saved to  .minio.sys/buckets/.replication/replication.stats path, replication metrics should be accurate across restarts with this PR


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) https://github.com/minio/minio/pull/15594
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
