### PR TITLE
allow restarting of decommissioning if completed, failed or canceld

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -569,7 +569,10 @@ func (z *erasureServerPools) IsDecommissionRunning() bool {
 	defer z.poolMetaMutex.RUnlock()
 	meta := z.poolMeta
 	for _, pool := range meta.Pools {
-		if pool.Decommission != nil {
+		if pool.Decommission != nil &&
+			!pool.Decommission.Complete &&
+			!pool.Decommission.Failed &&
+			!pool.Decommission.Canceled {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description

If a decommission failed or got cancelled the current check for the API `IsDecommissionRunning()` always returns `true` even if the operations is complete, failed or was canceled. This prevents restarting a non-complete decommissioning.

Test is now equal to the check when starting the decommssioning: https://github.com/minio/minio/blob/ca2a1c3f601a8cc6fcff6df6acdf14032777e96f/cmd/erasure-server-pool-decom.go#L253

## Motivation and Context

If a decommissioning failed or got canceled it was not possible to restart the decommissioning at a later time.

## How to test this PR?

Start decommissioning of a pool and cancel it while it is still running. Restart the decommissioning again and wait until it completes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
