### PR TITLE
fix(helm): use PodDisruptionBudget v1 for newer k8s versions

### DIFF
--- a/helm/minio/templates/poddisruptionbudget.yaml
+++ b/helm/minio/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodDisruptionBudget") }}
 apiVersion: policy/v1beta1
+{{- else }}
+apiVersion: policy/v1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: minio


### PR DESCRIPTION
## Description

v1 was added in Kubernetes 1.21, v1beta1 is removed from Kubernetes 1.25, see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
