### PR TITLE
Better error when setting up replication with a service account alias

### DIFF
--- a/cmd/admin-handler-utils.go
+++ b/cmd/admin-handler-utils.go
@@ -154,15 +154,9 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusForbidden,
 			}
-		case errors.Is(err, errIAMServiceAccount):
+		case errors.Is(err, errIAMServiceAccountNotAllowed):
 			apiErr = APIError{
-				Code:           "XMinioIAMServiceAccount",
-				Description:    err.Error(),
-				HTTPStatusCode: http.StatusBadRequest,
-			}
-		case errors.Is(err, errIAMServiceAccountUsed):
-			apiErr = APIError{
-				Code:           "XMinioIAMServiceAccountUsed",
+				Code:           "XMinioIAMServiceAccountNotAllowed",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}

--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -2093,14 +2093,14 @@ func (store *IAMStoreSys) AddServiceAccount(ctx context.Context, cred auth.Crede
 	if su, found := cache.iamUsersMap[accessKey]; found {
 		scred := su.Credentials
 		if scred.ParentUser != parentUser {
-			return updatedAt, errIAMServiceAccountUsed
+			return updatedAt, fmt.Errorf("%w: the service account access key is taken by another user", errIAMServiceAccountNotAllowed)
 		}
-		return updatedAt, errIAMServiceAccount
+		return updatedAt, fmt.Errorf("%w: the service account access key already taken", errIAMServiceAccountNotAllowed)
 	}
 
 	// Parent user must not be a service account.
 	if u, found := cache.iamUsersMap[parentUser]; found && u.Credentials.IsServiceAccount() {
-		return updatedAt, errIAMServiceAccount
+		return updatedAt, fmt.Errorf("%w: unable to create a service account for another service account", errIAMServiceAccountNotAllowed)
 	}
 
 	u := newUserIdentity(cred)

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -102,10 +102,7 @@ var errTooManyPolicies = errors.New("Only a single policy may be specified here.
 var errIAMActionNotAllowed = errors.New("Specified IAM action is not allowed")
 
 // error returned in IAM service account
-var errIAMServiceAccount = errors.New("Specified service account cannot be updated in this API call")
-
-// error returned in IAM service account is already used.
-var errIAMServiceAccountUsed = errors.New("Specified service account is used by another user")
+var errIAMServiceAccountNotAllowed = errors.New("Specified service account action is not allowed")
 
 // error returned in IAM subsystem when IAM sub-system is still being initialized.
 var errIAMNotInitialized = errors.New("IAM sub-system is being initialized, please try again")


### PR DESCRIPTION
## Description
Creating a replicator service account requires having a parent user. 
In this case, the parent user will be the mc alias access-key or 
the console access-key and it cannot be a service account since
 the code does not support creating a sub service account 
for an existing service account.

This commit will just show a better error message in that case.

## Motivation and Context
Better error message

## How to test this PR?
Setup two MinIO clusters, create a regular user, create a service account, set up an alias with the service account and then try to run 'mc admin replicate' using the service account alias for the first site and any other alias for the second site

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
