### PR TITLE
Rename peer S3 prefix to avoid collision in the future

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -306,6 +306,7 @@ func setHTTPStatsHandler(h http.Handler) http.Handler {
 
 		if strings.HasPrefix(r.URL.Path, storageRESTPrefix) ||
 			strings.HasPrefix(r.URL.Path, peerRESTPrefix) ||
+			strings.HasPrefix(r.URL.Path, peerS3Prefix) ||
 			strings.HasPrefix(r.URL.Path, lockRESTPrefix) {
 			globalConnStats.incInputBytes(meteredRequest.BytesRead())
 			globalConnStats.incOutputBytes(meteredResponse.BytesWritten())

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -403,6 +403,12 @@ func errorResponseHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	desc := "Do not upgrade one server at a time - please follow the recommended guidelines mentioned here https://github.com/minio/minio#upgrading-minio for your environment"
 	switch {
+	case strings.HasPrefix(r.URL.Path, peerS3Prefix):
+		writeErrorResponseString(r.Context(), w, APIError{
+			Code:           "XMinioPeerS3VersionMismatch",
+			Description:    desc,
+			HTTPStatusCode: http.StatusUpgradeRequired,
+		}, r.URL)
 	case strings.HasPrefix(r.URL.Path, peerRESTPrefix):
 		writeErrorResponseString(r.Context(), w, APIError{
 			Code:           "XMinioPeerVersionMismatch",

--- a/cmd/peer-s3-server.go
+++ b/cmd/peer-s3-server.go
@@ -33,7 +33,7 @@ const (
 	peerS3Version = "v1" // First implementation
 
 	peerS3VersionPrefix = SlashSeparator + peerS3Version
-	peerS3Prefix        = minioReservedBucketPath + "/peer"
+	peerS3Prefix        = minioReservedBucketPath + "/peer-s3"
 	peerS3Path          = peerS3Prefix + peerS3VersionPrefix
 )
 


### PR DESCRIPTION
## Description
Currently peer REST and peer S3 share the same /minio/peer/ prefix. 
There is a tiny chance that this can lead to a handler collision in the 
future but let's fix it right now.

## Motivation and Context
Rename internal s3 peer url prefix

## How to test this PR?
Test regular bucket listing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
