### PR TITLE
add x-amz-id-2 to indicate the node that received the request

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -550,6 +550,9 @@ func addCustomHeaders(h http.Handler) http.Handler {
 		// part of the log entry, Error response XML and auditing.
 		// Set custom headers such as x-amz-request-id for each request.
 		w.Header().Set(xhttp.AmzRequestID, mustGetRequestID(UTCNow()))
+		if globalLocalNodeName != "" {
+			w.Header().Set(xhttp.AmzRequestNodeID, globalLocalNodeName)
+		}
 		h.ServeHTTP(xhttp.NewResponseRecorder(w), r)
 	})
 }

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -145,7 +145,8 @@ const (
 	AmzAccessKeyID = "AWSAccessKeyId"
 
 	// Response request id.
-	AmzRequestID = "x-amz-request-id"
+	AmzRequestID     = "x-amz-request-id"
+	AmzRequestNodeID = "x-amz-id-2"
 
 	// Deployment id.
 	MinioDeploymentID = "x-minio-deployment-id"


### PR DESCRIPTION
## Description
add x-amz-id-2 to indicate the node that received the request

## Motivation and Context
x-amz-id-2 is used in AWS to designate the host that processed
the request, we can use it for the same reason. 

## How to test this PR?
Nothing special just adds x-amz-id-2 header 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
