### PR TITLE
fix: set modTime to current in snowball if archive shows empty 

### DIFF
--- a/cmd/untar.go
+++ b/cmd/untar.go
@@ -261,6 +261,7 @@ func untar(ctx context.Context, r io.Reader, putObject func(reader io.Reader, in
 		}
 
 		// If zero or earlier modtime, set to current.
+		// Otherwise the resulting objects will be invalid.
 		if header.ModTime.UnixNano() <= 0 {
 			header.ModTime = time.Now()
 		}

--- a/cmd/untar.go
+++ b/cmd/untar.go
@@ -30,6 +30,7 @@ import (
 	"path"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/cosnicolaou/pbzip2"
 	"github.com/klauspost/compress/s2"
@@ -257,6 +258,11 @@ func untar(ctx context.Context, r io.Reader, putObject func(reader io.Reader, in
 				}
 			}(name, header.FileInfo(), b)
 			continue
+		}
+
+		// If zero or earlier modtime, set to current.
+		if header.ModTime.UnixNano() <= 0 {
+			header.ModTime = time.Now()
 		}
 
 		// Sync upload.


### PR DESCRIPTION
## Description

If ModTime in snowball object is prior to or equal to unix epoc, set it to current time.

Fixes #16481

## How to test this PR?

See #16481

## Types of changes
- [x] Bug fix/New feature 
