### PR TITLE
fix replication healing on list to consider all versions

### DIFF
--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -377,7 +377,12 @@ func applyBucketActions(ctx context.Context, o listPathOptions, in <-chan metaCa
 		case <-ctx.Done():
 			return
 		case out <- obj:
-			queueReplicationHeal(ctx, o.Bucket, objInfo, o.Replication)
+			if fiv, err := obj.fileInfoVersions(o.Bucket); err == nil {
+				for _, version := range fiv.Versions {
+					objInfo := version.ToObjectInfo(o.Bucket, obj.name, versioned)
+					queueReplicationHeal(ctx, o.Bucket, objInfo, o.Replication)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Currently, only the topmost version was being queued during listing

## Description


## Motivation and Context
speed up re-queuing of replication

## How to test this PR?
set up replication b/w 2 buckets and take down target. All uploads or deletes during the interim should replicate when `mc ls -r --versions alias/bucket` is done on primary (after target back online)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
