### PR TITLE
Fix Kafka initialization crash

### DIFF
--- a/internal/event/target/kafka.go
+++ b/internal/event/target/kafka.go
@@ -321,7 +321,6 @@ func (target *KafkaTarget) initKafka() error {
 		if err != sarama.ErrOutOfBrokers {
 			target.loggerOnce(context.Background(), err, target.ID().String())
 		}
-		target.producer.Close()
 		return err
 	}
 	target.producer = producer


### PR DESCRIPTION
## Description

When we initialize the producer is never set, so closing is never required.

Fixes #16522

## How to test this PR?

See #16522

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
