### PR TITLE
remove double ENABLED help output

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -701,37 +701,42 @@ func GetHelp(subSys, key string, envOnly bool) (Help, error) {
 		h = config.HelpKVS{value}
 	}
 
-	envHelp := config.HelpKVS{}
-	if envOnly {
-		// Only for multiple targets, make sure
-		// to list the ENV, for regular k/v EnableKey is
-		// implicit, for ENVs we cannot make it implicit.
-		if subSysHelp.MultipleTargets {
-			envK := config.EnvPrefix + strings.ToTitle(subSys) + config.EnvWordDelimiter + strings.ToTitle(madmin.EnableKey)
-			envHelp = append(envHelp, config.HelpKV{
-				Key:         envK,
-				Description: fmt.Sprintf("enable %s target, default is 'off'", subSys),
-				Optional:    false,
-				Type:        "on|off",
-			})
+	help := config.HelpKVS{}
+
+	// Only for multiple targets, make sure
+	// to list the ENV, for regular k/v EnableKey is
+	// implicit, for ENVs we cannot make it implicit.
+	if subSysHelp.MultipleTargets {
+		key := madmin.EnableKey
+		if envOnly {
+			key = config.EnvPrefix + strings.ToTitle(subSys) + config.EnvWordDelimiter + strings.ToTitle(madmin.EnableKey)
 		}
-		for _, hkv := range h {
-			envK := config.EnvPrefix + strings.ToTitle(subSys) + config.EnvWordDelimiter + strings.ToTitle(hkv.Key)
-			envHelp = append(envHelp, config.HelpKV{
-				Key:         envK,
-				Description: hkv.Description,
-				Optional:    hkv.Optional,
-				Type:        hkv.Type,
-			})
+		help = append(help, config.HelpKV{
+			Key:         key,
+			Description: fmt.Sprintf("enable %s target, default is 'off'", subSys),
+			Optional:    false,
+			Type:        "on|off",
+		})
+	}
+
+	for _, hkv := range h {
+		key := hkv.Key
+		if envOnly {
+			key = config.EnvPrefix + strings.ToTitle(subSys) + config.EnvWordDelimiter + strings.ToTitle(hkv.Key)
 		}
-		h = envHelp
+		help = append(help, config.HelpKV{
+			Key:         key,
+			Description: hkv.Description,
+			Optional:    hkv.Optional,
+			Type:        hkv.Type,
+		})
 	}
 
 	return Help{
 		SubSys:          subSys,
 		Description:     subSysHelp.Description,
 		MultipleTargets: subSysHelp.MultipleTargets,
-		KeysHelp:        h,
+		KeysHelp:        help,
 	}, nil
 }
 

--- a/internal/config/identity/openid/help.go
+++ b/internal/config/identity/openid/help.go
@@ -27,13 +27,6 @@ var (
 
 	Help = config.HelpKVS{
 		config.HelpKV{
-			Key:         config.Enable,
-			Description: "Enable or disable OpenID",
-			Type:        "on|off",
-			Optional:    true,
-			Sensitive:   false,
-		},
-		config.HelpKV{
 			Key:         DisplayName,
 			Description: "Friendly display name for this Provider/App" + defaultHelpPostfix(DisplayName),
 			Optional:    true,

--- a/internal/config/notify/help.go
+++ b/internal/config/notify/help.go
@@ -28,18 +28,9 @@ const (
 	queueLimitComment = `maximum limit for undelivered messages, defaults to '100000'`
 )
 
-var enableHelp = config.HelpKV{
-	Key:         config.Enable,
-	Description: "Enable or disable notifications",
-	Type:        "on|off",
-	Sensitive:   false,
-	Optional:    true,
-}
-
 // Help template inputs for all notification targets
 var (
 	HelpWebhook = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.WebhookEndpoint,
 			Description: "webhook server endpoint e.g. http://localhost:8080/minio/events",
@@ -88,7 +79,6 @@ var (
 	}
 
 	HelpAMQP = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.AmqpURL,
 			Description: "AMQP server endpoint e.g. `amqp://myuser:mypassword@localhost:5672`",
@@ -177,7 +167,6 @@ var (
 	}
 
 	HelpKafka = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.KafkaBrokers,
 			Description: "comma separated list of Kafka broker addresses",
@@ -274,7 +263,6 @@ var (
 	}
 
 	HelpMQTT = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.MqttBroker,
 			Description: "MQTT server endpoint e.g. `tcp://localhost:1883`",
@@ -339,7 +327,6 @@ var (
 	}
 
 	HelpPostgres = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.PostgresConnectionString,
 			Description: `Postgres server connection-string e.g. "host=localhost port=5432 dbname=minio_events user=postgres password=password sslmode=disable"`,
@@ -383,7 +370,6 @@ var (
 	}
 
 	HelpMySQL = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.MySQLDSNString,
 			Description: `MySQL data-source-name connection string e.g. "<user>:<password>@tcp(<host>:<port>)/<database>"`,
@@ -428,7 +414,6 @@ var (
 	}
 
 	HelpNATS = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.NATSAddress,
 			Description: "NATS server address e.g. '0.0.0.0:4222'",
@@ -551,7 +536,6 @@ var (
 	}
 
 	HelpNSQ = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.NSQAddress,
 			Description: "NSQ server address e.g. '127.0.0.1:4150'",
@@ -596,7 +580,6 @@ var (
 	}
 
 	HelpES = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.ElasticURL,
 			Description: "Elasticsearch server's address, with optional authentication info",
@@ -648,7 +631,6 @@ var (
 	}
 
 	HelpRedis = config.HelpKVS{
-		enableHelp,
 		config.HelpKV{
 			Key:         target.RedisAddress,
 			Description: "Redis server's address. For example: `localhost:6379`",

--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -25,13 +25,6 @@ import (
 var (
 	Help = config.HelpKVS{
 		config.HelpKV{
-			Key:         config.Enable,
-			Description: "set to 'on' to enable the logger webhook",
-			Optional:    true,
-			Type:        "on|off",
-			Sensitive:   false,
-		},
-		config.HelpKV{
 			Key:         Endpoint,
 			Description: `HTTP(s) endpoint e.g. "http://localhost:8080/minio/logs/server"`,
 			Type:        "url",
@@ -74,13 +67,6 @@ var (
 
 	HelpWebhook = config.HelpKVS{
 		config.HelpKV{
-			Key:         config.Enable,
-			Description: "set to 'on' to enable the audit logger",
-			Optional:    true,
-			Type:        "on|off",
-			Sensitive:   false,
-		},
-		config.HelpKV{
 			Key:         Endpoint,
 			Description: `HTTP(s) endpoint e.g. "http://localhost:8080/minio/logs/audit"`,
 			Type:        "url",
@@ -122,13 +108,6 @@ var (
 	}
 
 	HelpKafka = config.HelpKVS{
-		config.HelpKV{
-			Key:         config.Enable,
-			Description: "set to 'on' to enable kafka audit logging",
-			Optional:    true,
-			Type:        "on|off",
-			Sensitive:   false,
-		},
 		config.HelpKV{
 			Key:         KafkaBrokers,
 			Description: "comma separated list of Kafka broker addresses",


### PR DESCRIPTION
## Description
remove double ENABLED help output

## Motivation and Context
double enabled references in all multipletargets

## How to test this PR?
`mc admin config set alias/ logger_webhook` must not show double enabled

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
