### PR TITLE
feat: allow offline disks on a fresh start

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -304,11 +304,6 @@ func countErrs(errs []error, err error) int {
 	return i
 }
 
-// Does all errors indicate we need to initialize all disks?.
-func shouldInitErasureDisks(errs []error) bool {
-	return countErrs(errs, errUnformattedDisk) == len(errs)
-}
-
 // Check if unformatted disks are equal to write quorum.
 func quorumUnformattedDisks(errs []error) bool {
 	return countErrs(errs, errUnformattedDisk) >= (len(errs)/2)+1
@@ -750,6 +745,9 @@ func initFormatErasure(ctx context.Context, storageDisks []StorageAPI, setCount,
 		hostCount := make(map[string]int, setDriveCount)
 		for j := 0; j < setDriveCount; j++ {
 			disk := storageDisks[i*setDriveCount+j]
+			if disk == nil {
+				continue
+			}
 			newFormat := format.Clone()
 			newFormat.Erasure.This = format.Erasure.Sets[i][j]
 			if distributionAlgo != "" {
@@ -761,26 +759,24 @@ func initFormatErasure(ctx context.Context, storageDisks []StorageAPI, setCount,
 			hostCount[disk.Hostname()]++
 			formats[i*setDriveCount+j] = newFormat
 		}
-		if len(hostCount) > 0 {
-			var once sync.Once
-			for host, count := range hostCount {
-				if count > wantAtMost {
-					if host == "" {
-						host = "local"
-					}
-					once.Do(func() {
-						if len(hostCount) == 1 {
-							return
-						}
-						logger.Info(" * Set %v:", i+1)
-						for j := 0; j < setDriveCount; j++ {
-							disk := storageDisks[i*setDriveCount+j]
-							logger.Info("   - Drive: %s", disk.String())
-						}
-					})
-					logger.Info(color.Yellow("WARNING:")+" Host %v has more than %v drives of set. "+
-						"A host failure will result in data becoming unavailable.", host, wantAtMost)
+		var once sync.Once
+		for host, count := range hostCount {
+			if count > wantAtMost {
+				if host == "" {
+					host = "local"
 				}
+				once.Do(func() {
+					if len(hostCount) == 1 {
+						return
+					}
+					logger.Info(" * Set %v:", i+1)
+					for j := 0; j < setDriveCount; j++ {
+						disk := storageDisks[i*setDriveCount+j]
+						logger.Info("   - Drive: %s", disk.String())
+					}
+				})
+				logger.Info(color.Yellow("WARNING:")+" Host %v has more than %v drives of set. "+
+					"A host failure will result in data becoming unavailable.", host, wantAtMost)
 			}
 		}
 	}

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -198,8 +198,15 @@ func connectLoadInitFormats(verboseLogging bool, firstDisk bool, endpoints Endpo
 		return nil, nil, err
 	}
 
+	// Return error when quorum unformatted disks - indicating we are
+	// waiting for first server to be online.
+	unformattedDisks := quorumUnformattedDisks(sErrs)
+	if unformattedDisks && !firstDisk {
+		return nil, nil, errNotFirstDisk
+	}
+
 	// All disks report unformatted we should initialized everyone.
-	if shouldInitErasureDisks(sErrs) && firstDisk {
+	if unformattedDisks && firstDisk {
 		logger.Info("Formatting %s pool, %v set(s), %v drives per set.",
 			humanize.Ordinal(poolCount), setCount, setDriveCount)
 
@@ -213,19 +220,6 @@ func connectLoadInitFormats(verboseLogging bool, firstDisk bool, endpoints Endpo
 		// minio server managing the first disk
 		globalDeploymentID = format.ID
 		return storageDisks, format, nil
-	}
-
-	// Return error when quorum unformatted disks - indicating we are
-	// waiting for first server to be online.
-	unformattedDisks := quorumUnformattedDisks(sErrs)
-	if unformattedDisks && !firstDisk {
-		return nil, nil, errNotFirstDisk
-	}
-
-	// Return error when quorum unformatted disks but waiting for rest
-	// of the servers to be online.
-	if unformattedDisks && firstDisk {
-		return nil, nil, errFirstDiskWait
 	}
 
 	// Mark all root disks down

--- a/internal/config/identity/openid/provider/provider.go
+++ b/internal/config/identity/openid/provider/provider.go
@@ -21,6 +21,8 @@ import "errors"
 
 // DiscoveryDoc - parses the output from openid-configuration
 // for example https://accounts.google.com/.well-known/openid-configuration
+//
+//nolint:unused
 type DiscoveryDoc struct {
 	Issuer                           string   `json:"issuer,omitempty"`
 	AuthEndpoint                     string   `json:"authorization_endpoint,omitempty"`


### PR DESCRIPTION


## Description
feat: allow offline disks on a fresh start

## Motivation and Context
We never used to allow offline disks during fresh
setup, but that is not necessary anymore. The reason 
being we expect the order of disks to be exactly the 
same once started.

This new change simply allows starting MinIO with
some offline disks, it still refuses to start if we 
do not have enough disks online, i.e

quorum=(len(disks)/2+1)

## How to test this PR?
Nothing special start with a setup like this

```
~ mkdir -p /tmp/xl{1..4}
~ sudo chown -R root. /tmp/xl2
~ CI=true minio server /tmp/xl{1...4}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
