### PR TITLE
Ensure safety of transitionState at startup

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -323,6 +323,7 @@ func initAllSubsystems(ctx context.Context) {
 	// Create new ILM tier configuration subsystem
 	globalTierConfigMgr = NewTierConfigMgr()
 
+	globalTransitionState = newTransitionState(GlobalContext)
 	globalSiteResyncMetrics = newSiteResyncMetrics(GlobalContext)
 }
 
@@ -674,8 +675,7 @@ func serverMain(ctx *cli.Context) {
 		// Initialize background replication
 		initBackgroundReplication(GlobalContext, newObject)
 
-		// Initialize background transition
-		initBackgroundTransition(GlobalContext, newObject)
+		globalTransitionState.Init(newObject)
 
 		// Initialize batch job pool.
 		globalBatchJobPool = newBatchJobPool(GlobalContext, newObject, 100)


### PR DESCRIPTION
## Description

By allocating globalTransitionState earlier in MinIO server startup allows tier-stats to become queryable even before complete initialization of tiering subsystem.

## How to test this PR?
Run the following bash snippet, right before starting up a new MinIO cluster. Make sure the get tier-stats call coincide with the start up of a fresh MinIO cluster.

```shell
for i in {1..100};
do
   echo $i;
   mc ilm tier info minio-tier --json > /dev/null; # to trigger a admin API call to fetch tier-stats.
done   
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
