### PR TITLE
tiering: UpdateWorkers may be called before Init

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -270,7 +270,9 @@ func (t *transitionState) getDailyAllTierStats() DailyAllTierStats {
 func (t *transitionState) UpdateWorkers(n int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
+	if t.objAPI == nil { // Init hasn't been called yet.
+		return
+	}
 	t.updateWorkers(n)
 }
 


### PR DESCRIPTION
## Description

UpdateWorkers is called when config subsys is initialized. At this time the object layer may not be initialized yet. To avoid nil ObjectLayer being set in transitionState, we wait for the ObjectLayer to be fully initialized before spawning workers.

## Motivation and Context
The side effect of config subsystem being initialized concurrent to the object layer wasn't accounted for in https://github.com/minio/minio/pull/16563

## How to test this PR?
1. Setup ILM tiering on a bucket
2. Upload an object to this bucket
3. MinIO server that is transitioning this object will panic. With this PR, there should be no panic/crash.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
https://github.com/minio/minio/pull/16563
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
