### PR TITLE
honor context cancelation properly to avoid perpetual hangs in WalkDir()

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -966,6 +966,9 @@ func getTLSConfig() (x509Certs []*x509.Certificate, manager *certs.Manager, secu
 
 // contextCanceled returns whether a context is canceled.
 func contextCanceled(ctx context.Context) bool {
+	if ctx == nil {
+		return true
+	}
 	select {
 	case <-ctx.Done():
 		return true

--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -739,7 +739,7 @@ func (er *erasureObjects) saveMetaCacheStream(ctx context.Context, mc *metaCache
 
 	// Keep destination...
 	// Write results to disk.
-	bw := newMetacacheBlockWriter(entries, func(b *metacacheBlock) error {
+	bw := newMetacacheBlockWriter(ctx, entries, func(b *metacacheBlock) error {
 		// if the block is 0 bytes and its a first block skip it.
 		// skip only this for Transient caches.
 		if len(b.data) == 0 && b.n == 0 && o.Transient {

--- a/cmd/metacache-stream_test.go
+++ b/cmd/metacache-stream_test.go
@@ -367,7 +367,7 @@ func Test_metacacheReader_peek(t *testing.T) {
 func Test_newMetacacheStream(t *testing.T) {
 	r := loadMetacacheSample(t)
 	var buf bytes.Buffer
-	w := newMetacacheWriter(&buf, 1<<20)
+	w := newMetacacheWriter(context.Background(), &buf, 1<<20)
 	defer w.Close()
 	err := r.readFn(func(object metaCacheEntry) bool {
 		err := w.write(object)


### PR DESCRIPTION
## Description
honor context cancelation properly to avoid perpetual hangs in WalkDir()

## Motivation and Context
avoid possible hangs via context cancelation

## How to test this PR?
very rare and harder to test

```
goroutine 882 [chan send, 31086 minutes]:
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc0e4b44870, 0x8d})
        github.com/minio/minio/cmd/metacache-walk.go:270 +0x1a72
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc0892053b0, 0x69})
        github.com/minio/minio/cmd/metacache-walk.go:248 +0x2062
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc01742bc00, 0x61})
        github.com/minio/minio/cmd/metacache-walk.go:248 +0x2062
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc03f56ac60, 0x5a})
        github.com/minio/minio/cmd/metacache-walk.go:248 +0x2062
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc045a0f3e0, 0x51})
        github.com/minio/minio/cmd/metacache-walk.go:300 +0x1614
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc05a2a7ae0, 0x49})
        github.com/minio/minio/cmd/metacache-walk.go:300 +0x1614
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc09694b480, 0x38})
        github.com/minio/minio/cmd/metacache-walk.go:300 +0x1614
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc0c638a7e0, 0x1a})
        github.com/minio/minio/cmd/metacache-walk.go:300 +0x1614
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc108a301c8, 0x12})
        github.com/minio/minio/cmd/metacache-walk.go:248 +0x2062
github.com/minio/minio/cmd.(*xlStorage).WalkDir.func1({0xc08fd0a1a9, 0x0})
        github.com/minio/minio/cmd/metacache-walk.go:248 +0x2062
github.com/minio/minio/cmd.(*xlStorage).WalkDir(0xc001a40240, {0x4a9c008, 0xc01e0b9920}, {{0xc08fd0a21d, 0xd}, {0xc08fd0a1a9, 0x0}, 0x1, 0x0, {0xc08fd0a1e9, ...}, ...}, ...)
        github.com/minio/minio/cmd/metacache-walk.go:308 +0x64a
github.com/minio/minio/cmd.(*xlStorageDiskIDCheck).WalkDir(0xc0077dd340, {0x4a9c008, 0xc01e0b9560}, {{0xc08fd0a21d, 0xd}, {0xc08fd0a1a9, 0x0}, 0x1, 0x0, {0xc08fd0a1e9, ...}, ...}, ...)
        github.com/minio/minio/cmd/metacache-walk.go:318 +0x21c
github.com/minio/minio/cmd.(*storageRESTServer).WalkDirHandler(0xc0011f92a8, {0x4a980e0, 0xc007c54640}, 0xc03eccdb00)
        github.com/minio/minio/cmd/metacache-walk.go:371 +0xb65
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
