### PR TITLE
ServerInfo: return per erasure set information

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/minio/dperf v0.4.2
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes v0.22.3
-	github.com/minio/madmin-go/v2 v2.0.9
+	github.com/minio/madmin-go/v2 v2.0.11
 	github.com/minio/minio-go/v7 v7.0.47
 	github.com/minio/mux v1.9.0
 	github.com/minio/pkg v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -775,8 +775,8 @@ github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLT
 github.com/minio/kes v0.22.3 h1:aSPW9uCMVaLax5POxvoQJxCU4MNo/KzMXA7WfmC/lRw=
 github.com/minio/kes v0.22.3/go.mod h1:wnhmdwWX2rpurNPKn3yDFImg2wuc7j3e+IU5rVkR9UY=
 github.com/minio/madmin-go v1.6.6/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
-github.com/minio/madmin-go/v2 v2.0.9 h1:wv1e4ZTH1L1SaHs/jaI3uW2AHYQw77T2hgarfPo1j3U=
-github.com/minio/madmin-go/v2 v2.0.9/go.mod h1:5aFi/VLWBHC2DEFfGIlUmAeJhaF4ZAjuYpEWZFU14Zw=
+github.com/minio/madmin-go/v2 v2.0.11 h1:Ct905UAMJ43EAwKCi8xy5PzWPWyYL5YCQ441E9LYXTA=
+github.com/minio/madmin-go/v2 v2.0.11/go.mod h1:5aFi/VLWBHC2DEFfGIlUmAeJhaF4ZAjuYpEWZFU14Zw=
 github.com/minio/mc v0.0.0-20230203133213-3aebb3362b18 h1:Di71Ums7dD5vA3VK/loOqb/QttQjvCV/1/DF77w1XqA=
 github.com/minio/mc v0.0.0-20230203133213-3aebb3362b18/go.mod h1:j3BgTu1LshBzna9Wf8il7WAyw9IQabMu+EcrDUaNZ2k=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=


### PR DESCRIPTION
## Description
Such as, the number of objects/versions in each erasure set, the usage
and the number of disks healing.

## Motivation and Context
Add per erasure set information to make it easier to parse it

## How to test this PR?
`cd github.com/minio/mc`
`go get github.com/minio/madmin-go/v2@latest` 
`make`
`./mc admin info --json <alias> | jq .info.pools`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
