### PR TITLE
fix: a possible closer leak in SelectObjectHandler

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -242,7 +242,7 @@ func (api objectAPIHandlers) SelectObjectContentHandler(w http.ResponseWriter, r
 		},
 		actualSize,
 	)
-
+	defer objectRSC.Close()
 	s3Select, err := s3select.NewS3Select(r.Body)
 	if err != nil {
 		if serr, ok := err.(s3select.SelectError); ok {
@@ -3124,7 +3124,7 @@ func (api objectAPIHandlers) PostRestoreObjectHandler(w http.ResponseWriter, r *
 				},
 				actualSize,
 			)
-
+			defer objectRSC.Close()
 			if err = rreq.SelectParameters.Open(objectRSC); err != nil {
 				if serr, ok := err.(s3select.SelectError); ok {
 					encodedErrorResponse := encodeResponse(APIErrorResponse{

--- a/internal/s3select/select.go
+++ b/internal/s3select/select.go
@@ -286,10 +286,9 @@ type S3Select struct {
 	Progress       RequestProgress     `xml:"RequestProgress"`
 	ScanRange      *ScanRange          `xml:"ScanRange"`
 
-	statement        *sql.SelectStatement
-	progressReader   *progressReader
-	recordReader     recordReader
-	openReaderCloser []io.Closer
+	statement      *sql.SelectStatement
+	progressReader *progressReader
+	recordReader   recordReader
 }
 
 var legacyXMLName = "SelectObjectContentRequest"
@@ -363,12 +362,6 @@ func (s3Select *S3Select) getProgress() (bytesScanned, bytesProcessed int64) {
 // Open - opens S3 object by using callback for SQL selection query.
 // Currently CSV, JSON and Apache Parquet formats are supported.
 func (s3Select *S3Select) Open(rsc io.ReadSeekCloser) error {
-	if rsc != nil {
-		if s3Select.openReaderCloser == nil {
-			s3Select.openReaderCloser = []io.Closer{}
-		}
-		s3Select.openReaderCloser = append(s3Select.openReaderCloser, rsc.(io.Closer))
-	}
 	offset, length, err := s3Select.ScanRange.StartLen()
 	if err != nil {
 		return err
@@ -660,11 +653,6 @@ OuterLoop:
 
 // Close - closes opened S3 object.
 func (s3Select *S3Select) Close() error {
-	for _, closer := range s3Select.openReaderCloser {
-		if closer != nil {
-			closer.Close()
-		}
-	}
 	if s3Select.recordReader == nil {
 		return nil
 	}
@@ -689,6 +677,18 @@ func NewS3Select(r io.Reader) (*S3Select, error) {
 type limitedReadCloser struct {
 	io.LimitedReader
 	io.Closer
+	// for io.Closer
+	sync.Once
+}
+
+func (l *limitedReadCloser) Close() error {
+	var err error
+	l.Once.Do(func() {
+		if l.Closer != nil {
+			err = l.Closer.Close()
+		}
+	})
+	return err
 }
 
 func newLimitedReadCloser(r io.ReadCloser, n int64) *limitedReadCloser {

--- a/internal/s3select/select.go
+++ b/internal/s3select/select.go
@@ -683,7 +683,7 @@ type limitedReadCloser struct {
 
 func (l *limitedReadCloser) Close() error {
 	var err error
-	l.Once.Do(func() {
+	l.once.Do(func() {
 		if l.Closer != nil {
 			err = l.Closer.Close()
 		}

--- a/internal/s3select/select.go
+++ b/internal/s3select/select.go
@@ -678,7 +678,7 @@ type limitedReadCloser struct {
 	io.LimitedReader
 	io.Closer
 	// for io.Closer
-	sync.Once
+	once sync.Once
 }
 
 func (l *limitedReadCloser) Close() error {


### PR DESCRIPTION
## Description

https://github.com/minio/minio/blob/689179bf18751d214ea4cce60ee164dbfbb68e8f/internal/s3select/select.go#L362-L455 `Close()` will close `s3Select.recordReader`,see 
https://github.com/minio/minio/blob/689179bf18751d214ea4cce60ee164dbfbb68e8f/internal/s3select/select.go#L654-L660

In fact, it is possible that Close's Reader was not written to it in the first place, causing the Reader to leak. There is `defer Close`.If an error occurs in Open, Close will be executed as well. https://github.com/minio/minio/blob/689179bf18751d214ea4cce60ee164dbfbb68e8f/cmd/object-handlers.go#L259-L281


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
