### PR TITLE
fix: allow global leader lock context merge to be canceled

### DIFF
--- a/cmd/shared-lock.go
+++ b/cmd/shared-lock.go
@@ -63,6 +63,8 @@ func mergeContext(ctx1, ctx2 context.Context) (context.Context, context.CancelFu
 		select {
 		case <-ctx1.Done():
 		case <-ctx2.Done():
+		// The lock acquirer decides to cancel, exit this goroutine
+		case <-ctx.Done():
 		}
 
 		cancel()


### PR DESCRIPTION
## Description

Global leader lock was first designated to only acquired once 
until the node is killed. However, currently the code acquires 
it repeatedly during the lifetime of the server, now there is a
 goroutine leak.

Close the goroutine when the lock acquirer cancels the global 
leader lock context.

## Motivation and Context
Fix a possible leak detected by @harshavardhana 

## How to test this PR?
Not trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
