### PR TITLE
add user-agent for all minio.Client usage

### DIFF
--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -453,6 +453,8 @@ func (sys *BucketTargetSys) getRemoteTargetClient(tcfg *madmin.BucketTarget) (*T
 	if err != nil {
 		return nil, err
 	}
+	api.SetAppInfo("minio-replication-target", ReleaseTag+" "+tcfg.Arn)
+
 	hcDuration := defaultHealthCheckDuration
 	if tcfg.HealthCheckDuration >= 1 { // require minimum health check duration of 1 sec.
 		hcDuration = tcfg.HealthCheckDuration
@@ -479,7 +481,10 @@ func (sys *BucketTargetSys) getRemoteARN(bucket string, target *madmin.BucketTar
 	}
 	tgts := sys.targetsMap[bucket]
 	for _, tgt := range tgts {
-		if tgt.Type == target.Type && tgt.TargetBucket == target.TargetBucket && target.URL().String() == tgt.URL().String() && tgt.Credentials.AccessKey == target.Credentials.AccessKey {
+		if tgt.Type == target.Type &&
+			tgt.TargetBucket == target.TargetBucket &&
+			target.URL().String() == tgt.URL().String() &&
+			tgt.Credentials.AccessKey == target.Credentials.AccessKey {
 			return tgt.Arn, true
 		}
 	}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -937,11 +937,16 @@ var getRemoteInstanceClient = func(r *http.Request, host string) (*miniogo.Core,
 	cred := getReqAccessCred(r, globalSite.Region)
 	// In a federated deployment, all the instances share config files
 	// and hence expected to have same credentials.
-	return miniogo.NewCore(host, &miniogo.Options{
+	core, err := miniogo.NewCore(host, &miniogo.Options{
 		Creds:     credentials.NewStaticV4(cred.AccessKey, cred.SecretKey, ""),
 		Secure:    globalIsTLS,
 		Transport: getRemoteInstanceTransport,
 	})
+	if err != nil {
+		return nil, err
+	}
+	core.SetAppInfo("minio-federated", ReleaseTag)
+	return core, nil
 }
 
 // Check if the destination bucket is on a remote site, this code only gets executed

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -753,6 +753,9 @@ func serverMain(ctx *cli.Context) {
 	})
 	logger.FatalIf(err, "Unable to initialize MinIO client")
 
+	// Add User-Agent to differentiate the requests.
+	globalMinioClient.SetAppInfo("minio-perf-test", ReleaseTag)
+
 	if serverDebugLog {
 		logger.Info("== DEBUG Mode enabled ==")
 		logger.Info("Currently set environment settings:")

--- a/cmd/warm-backend-minio.go
+++ b/cmd/warm-backend-minio.go
@@ -53,10 +53,9 @@ func newWarmBackendMinIO(conf madmin.TierMinIO) (*warmBackendMinIO, error) {
 	if err != nil {
 		return nil, err
 	}
-	core, err := minio.NewCore(u.Host, opts)
-	if err != nil {
-		return nil, err
-	}
+	client.SetAppInfo("minio-tier-target", ReleaseTag)
+
+	core := &minio.Core{Client: client}
 	return &warmBackendMinIO{
 		warmBackendS3{
 			client: client,

--- a/cmd/warm-backend-s3.go
+++ b/cmd/warm-backend-s3.go
@@ -128,10 +128,9 @@ func newWarmBackendS3(conf madmin.TierS3) (*warmBackendS3, error) {
 	if err != nil {
 		return nil, err
 	}
-	core, err := minio.NewCore(u.Host, opts)
-	if err != nil {
-		return nil, err
-	}
+	client.SetAppInfo("s3-tier-target", ReleaseTag)
+
+	core := &minio.Core{Client: client}
 	return &warmBackendS3{
 		client:       client,
 		core:         core,


### PR DESCRIPTION
## Description
add user-agent for all minio.Client usage

## Motivation and Context
makes it easier to `mc admin trace --request-header "User-Agent: minio-replication-target*"` 

## How to test this PR?
Configure for example replication between buckets and observe the replication
traffic via filtering

```
mc admin trace --request-header "User-Agent: minio-replication-target*"
``` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
