### PR TITLE
heal: Do not mark buckets as done when there is no online disks

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -384,7 +384,7 @@ func healFreshDisk(ctx context.Context, z *erasureServerPools, endpoint Endpoint
 	}
 
 	if len(tracker.QueuedBuckets) > 0 {
-		return fmt.Errorf("not all buckets are healed: %v", tracker.QueuedBuckets)
+		return fmt.Errorf("not all buckets were healed: %v", tracker.QueuedBuckets)
 	}
 
 	if serverDebugLog {

--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -383,6 +383,10 @@ func healFreshDisk(ctx context.Context, z *erasureServerPools, endpoint Endpoint
 		logger.Info("Healing drive '%s' complete (healed: %d, failed: %d).", disk, tracker.ItemsHealed, tracker.ItemsFailed)
 	}
 
+	if len(tracker.QueuedBuckets) > 0 {
+		return fmt.Errorf("not all buckets are healed: %v", tracker.QueuedBuckets)
+	}
+
 	if serverDebugLog {
 		tracker.printTo(os.Stdout)
 		logger.Info("\n")

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -214,11 +214,7 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 
 		disks, _ := er.getOnlineDisksWithHealing()
 		if len(disks) == 0 {
-			// all disks are healing in this set, this is allowed
-			// so we simply proceed to next bucket, marking the bucket
-			// as done as there are no objects to heal.
-			tracker.bucketDone(bucket)
-			logger.LogIf(ctx, tracker.update(ctx))
+			logger.LogIf(ctx, fmt.Errorf("no enough online disks found to heal bucket `%s`", bucket))
 			continue
 		}
 

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -214,7 +214,7 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 
 		disks, _ := er.getOnlineDisksWithHealing()
 		if len(disks) == 0 {
-			logger.LogIf(ctx, fmt.Errorf("no enough online disks found to heal bucket `%s`", bucket))
+			logger.LogIf(ctx, fmt.Errorf("no online disks found to heal the bucket `%s`", bucket))
 			continue
 		}
 


### PR DESCRIPTION
## Description
Some old code marks a bucket as healed when it is 
unable to get any non healing disks in the erasure set.

It is not clear what that code point. Remove it - the healing 
will continue healing the remaining data but error out at the 
end, to trigger another healing round.


## Motivation and Context
Error out to retry healing instead of marking a bucket done
when non nil disks are found.

## How to test this PR?
Not trivial

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
