### PR TITLE
ignore io.EOF, io.ErrUnexpectedEOF on xl.meta reads in WalkDir()

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -2186,7 +2186,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 		apiErr = ErrTransitionStorageClassNotFoundError
 	case InvalidObjectState:
 		apiErr = ErrInvalidObjectState
-
+	case PreConditionFailed:
+		apiErr = ErrPreconditionFailed
 	case BucketQuotaExceeded:
 		apiErr = ErrAdminBucketQuotaExceeded
 	case *event.ErrInvalidEventName:

--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -324,7 +324,12 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			case isSysErrNotDir(err):
 				// skip
 			default:
-				logger.LogIf(ctx, err)
+				// It is totally possible that xl.meta was overwritten
+				// while being concurrently listed at the same time in
+				// such scenarios the 'xl.meta' might get truncated
+				if !IsErrIgnored(err, io.EOF, io.ErrUnexpectedEOF) {
+					logger.LogIf(ctx, err)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description
ignore io.EOF, io.ErrUnexpectedEOF on xl.meta reads in WalkDir()

## Motivation and Context
Similar to #15100 this was missed

## How to test this PR?
Not easy, needs a heavily concurrent system such as 
site-replication running with many buckets.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
