### PR TITLE
Fix site replication status reporting of quota

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -3033,7 +3033,9 @@ func isBktQuotaCfgReplicated(total int, quotaCfgs []*madmin.BucketQuota) bool {
 		}
 		numquotaCfgs++
 	}
-
+	if numquotaCfgs == 0 {
+		return true
+	}
 	if numquotaCfgs > 0 && numquotaCfgs != total {
 		return false
 	}


### PR DESCRIPTION
Regression from #16560

## Description
ignore nil quota configs from quota mismatch comparison

## Motivation and Context
Correctness

## How to test this PR?
`mc admin replicate add minio1 minio2`
`mc mb minio1/bucket`
`mc admin replicate status minio1` will show buckets out of sync 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) #16560
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
