### PR TITLE
Include tier name in MinIO/S3 target user-agent

### DIFF
--- a/cmd/warm-backend-azure.go
+++ b/cmd/warm-backend-azure.go
@@ -108,7 +108,7 @@ func (az *warmBackendAzure) InUse(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func newWarmBackendAzure(conf madmin.TierAzure) (*warmBackendAzure, error) {
+func newWarmBackendAzure(conf madmin.TierAzure, _ string) (*warmBackendAzure, error) {
 	credential, err := azblob.NewSharedKeyCredential(conf.AccountName, conf.AccountKey)
 	if err != nil {
 		if _, ok := err.(base64.CorruptInputError); ok {

--- a/cmd/warm-backend-gcs.go
+++ b/cmd/warm-backend-gcs.go
@@ -101,7 +101,7 @@ func (gcs *warmBackendGCS) InUse(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func newWarmBackendGCS(conf madmin.TierGCS) (*warmBackendGCS, error) {
+func newWarmBackendGCS(conf madmin.TierGCS, _ string) (*warmBackendGCS, error) {
 	credsJSON, err := conf.GetCredentialJSON()
 	if err != nil {
 		return nil, err

--- a/cmd/warm-backend-minio.go
+++ b/cmd/warm-backend-minio.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -33,7 +34,7 @@ type warmBackendMinIO struct {
 
 var _ WarmBackend = (*warmBackendMinIO)(nil)
 
-func newWarmBackendMinIO(conf madmin.TierMinIO) (*warmBackendMinIO, error) {
+func newWarmBackendMinIO(conf madmin.TierMinIO, tier string) (*warmBackendMinIO, error) {
 	u, err := url.Parse(conf.Endpoint)
 	if err != nil {
 		return nil, err
@@ -53,7 +54,7 @@ func newWarmBackendMinIO(conf madmin.TierMinIO) (*warmBackendMinIO, error) {
 	if err != nil {
 		return nil, err
 	}
-	client.SetAppInfo("minio-tier-target", ReleaseTag)
+	client.SetAppInfo(fmt.Sprintf("minio-tier-%s", tier), ReleaseTag)
 
 	core := &minio.Core{Client: client}
 	return &warmBackendMinIO{

--- a/cmd/warm-backend-s3.go
+++ b/cmd/warm-backend-s3.go
@@ -105,7 +105,7 @@ func (s3 *warmBackendS3) InUse(ctx context.Context) (bool, error) {
 	return len(result.CommonPrefixes) > 0 || len(result.Contents) > 0, nil
 }
 
-func newWarmBackendS3(conf madmin.TierS3) (*warmBackendS3, error) {
+func newWarmBackendS3(conf madmin.TierS3, tier string) (*warmBackendS3, error) {
 	u, err := url.Parse(conf.Endpoint)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func newWarmBackendS3(conf madmin.TierS3) (*warmBackendS3, error) {
 	if err != nil {
 		return nil, err
 	}
-	client.SetAppInfo("s3-tier-target", ReleaseTag)
+	client.SetAppInfo(fmt.Sprintf("s3-tier-%s", tier), ReleaseTag)
 
 	core := &minio.Core{Client: client}
 	return &warmBackendS3{

--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -137,13 +137,13 @@ type remoteVersionID string
 func newWarmBackend(ctx context.Context, tier madmin.TierConfig) (d WarmBackend, err error) {
 	switch tier.Type {
 	case madmin.S3:
-		d, err = newWarmBackendS3(*tier.S3)
+		d, err = newWarmBackendS3(*tier.S3, tier.Name)
 	case madmin.Azure:
-		d, err = newWarmBackendAzure(*tier.Azure)
+		d, err = newWarmBackendAzure(*tier.Azure, tier.Name)
 	case madmin.GCS:
-		d, err = newWarmBackendGCS(*tier.GCS)
+		d, err = newWarmBackendGCS(*tier.GCS, tier.Name)
 	case madmin.MinIO:
-		d, err = newWarmBackendMinIO(*tier.MinIO)
+		d, err = newWarmBackendMinIO(*tier.MinIO, tier.Name)
 	default:
 		return nil, errTierTypeUnsupported
 	}


### PR DESCRIPTION
## Description
Adds more information to MinIO SDK client's user-agent connecting to remote tier targets. This will come handy when we filter S3 calls in `admin-trace`.

## Motivation and Context
See https://github.com/minio/minio/pull/16619

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
