### PR TITLE
fix: avoid printing certain errors under few locations

### DIFF
--- a/cmd/bucket-policy-handlers.go
+++ b/cmd/bucket-policy-handlers.go
@@ -86,7 +86,11 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 
 	bucketPolicy, err := policy.ParseConfig(bytes.NewReader(bucketPolicyBytes), bucket)
 	if err != nil {
-		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
+		writeErrorResponse(ctx, w, APIError{
+			Code:           "ErrMalformedXML",
+			HTTPStatusCode: http.StatusBadRequest,
+			Description:    err.Error(),
+		}, r.URL)
 		return
 	}
 

--- a/cmd/kms-handlers.go
+++ b/cmd/kms-handlers.go
@@ -82,6 +82,11 @@ func (a kmsAPIHandlers) KMSMetricsHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if _, ok := GlobalKMS.(kms.KeyManager); !ok {
+		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrNotImplemented), r.URL)
+		return
+	}
+
 	metrics, err := GlobalKMS.Metrics(ctx)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)

--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -316,11 +316,11 @@ func (z *erasureServerPools) listMerged(ctx context.Context, o listPathOptions, 
 	}
 
 	for _, err := range errs {
-		if err == nil || contextCanceled(ctx) {
-			allAtEOF = false
+		if errors.Is(err, io.EOF) {
 			continue
 		}
-		if err.Error() == io.EOF.Error() {
+		if err == nil || contextCanceled(ctx) || errors.Is(err, context.Canceled) {
+			allAtEOF = false
 			continue
 		}
 		logger.LogIf(ctx, err)

--- a/internal/kms/single-key.go
+++ b/internal/kms/single-key.go
@@ -91,12 +91,15 @@ func (kms secretKey) Stat(context.Context) (Status, error) {
 	}, nil
 }
 
-func (secretKey) Metrics(ctx context.Context) (kes.Metric, error) {
-	return kes.Metric{}, errors.New("kms: metrics are not supported")
+func (secretKey) Metrics(context.Context) (kes.Metric, error) {
+	return kes.Metric{}, errors.New("kms: metrics not supported")
 }
 
-func (secretKey) CreateKey(context.Context, string) error {
-	return errors.New("kms: creating keys is not supported")
+func (kms secretKey) CreateKey(_ context.Context, keyID string) error {
+	if keyID == kms.keyID {
+		return nil
+	}
+	return fmt.Errorf("kms: creating custom key %q is not supported", keyID)
 }
 
 func (kms secretKey) GenerateKey(_ context.Context, keyID string, context Context) (DEK, error) {


### PR DESCRIPTION

## Description
fix: avoid printing certain errors under few locations

## Motivation and Context
- listPathRaw() apparently was printing context.Canceled as error
- kms.Metrics() was printing "unsupported" instead of returning NotImplemented

## How to test this PR?
Not easy to test. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
