### PR TITLE
fix: evaluate BypassGov policy action in deletion correctly

### DIFF
--- a/cmd/bucket-object-lock.go
+++ b/cmd/bucket-object-lock.go
@@ -156,11 +156,8 @@ func enforceRetentionBypassForDelete(ctx context.Context, r *http.Request, bucke
 				return ErrNone
 			}
 			// https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes
-			// If you try to delete objects protected by governance mode and have s3:BypassGovernanceRetention
-			// or s3:GetBucketObjectLockConfiguration permissions, the operation will succeed.
-			govBypassPerms1 := checkRequestAuthType(ctx, r, policy.BypassGovernanceRetentionAction, bucket, object.ObjectName)
-			govBypassPerms2 := checkRequestAuthType(ctx, r, policy.GetBucketObjectLockConfigurationAction, bucket, object.ObjectName)
-			if govBypassPerms1 != ErrNone && govBypassPerms2 != ErrNone {
+			// If you try to delete objects protected by governance mode and have s3:BypassGovernanceRetention, the operation will succeed.
+			if checkRequestAuthType(ctx, r, policy.BypassGovernanceRetentionAction, bucket, object.ObjectName) != ErrNone {
 				return ErrAccessDenied
 			}
 		}


### PR DESCRIPTION
## Description

This policy allows bypassing governance for deletion, 
though s3:BypassGovernanceRetention is explicitly denied.
```
{
    "Version": "2012-10-17",
    "Statement": [
      { "Effect": "Deny", "Action": ["s3:BypassGovernanceRetention"],
"Resource": ["arn:aws:s3:::*"] },
      { "Effect": "Allow", "Action": ["s3:*"], "Resource":
["arn:aws:s3:::*"] }
    ]
}
```

Fix the related code and avoid allowing s3:GetBucketObjectLockConfigurationAction 
to remove an object locked with governance.


Found by  @wdinyes

## Motivation and Context
Disallow removal of governance protected with the policy above

## How to test this PR?
1. Create a bucket with lock enabled with default governance locking
2. Create a regular user associated to the policy above
3.  Upload a version and try to remove it

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
