### PR TITLE
fix: sync.pool won't Put reader back

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -523,6 +523,7 @@ func (er *erasureObjects) streamMetadataParts(ctx context.Context, o listPathOpt
 			}()
 
 			tmp := newMetacacheReader(pr)
+			defer tmp.Close()
 			e, err := tmp.filter(o)
 			pr.CloseWithError(err)
 			entries.o = append(entries.o, e.o...)
@@ -892,6 +893,11 @@ func listPathRaw(ctx context.Context, opts listPathRawOptions) (err error) {
 	}
 	askDisks := len(disks)
 	readers := make([]*metacacheReader, askDisks)
+	defer func() {
+		for _, r := range readers {
+			r.Close()
+		}
+	}()
 	for i := range disks {
 		r, w := io.Pipe()
 		// Make sure we close the pipe so blocked writes doesn't stay around.


### PR DESCRIPTION
## Description

https://github.com/minio/minio/blob/a7188bc9d0f0a5ae05aaf1b8126bcd3cb3fdc485/cmd/metacache-stream.go#L253-L278
`sync.Pool` will put `*s2.Reader` back when call `Close()`
https://github.com/minio/minio/blob/a7188bc9d0f0a5ae05aaf1b8126bcd3cb3fdc485/cmd/metacache-stream.go#L749-L758
But the place where the `newMetacacheReader` is executed is not closed.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
