### PR TITLE
with no explicit targetUser assume parentUser for svc/sts

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -647,6 +647,12 @@ func (a adminAPIHandlers) AddServiceAccount(w http.ResponseWriter, r *http.Reque
 	targetUser = createReq.TargetUser
 	if targetUser == "" {
 		targetUser = cred.AccessKey
+		if cred.IsServiceAccount() || cred.IsTemp() {
+			// For temporary credentials or service accounts
+			// without explicit targetUser inherit targetUser
+			// from the parentUser.
+			targetUser = cred.ParentUser
+		}
 	}
 
 	opts := newServiceAccountOpts{


### PR DESCRIPTION
## Description
with no explicit targetUser assume parentUser for svc/sts

## Motivation and Context
without any explicit targetUser specified for
service account request, assume parentUser
to be the targetUser of the incoming credentials.

## How to test this PR?
Configure OIDC and validate via creating service accounts
from `mc` are reflected through Console UI and vice versa.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
