### PR TITLE
fix: use readLocks() when reporting() latency metrics

### DIFF
--- a/cmd/last-minute.go
+++ b/cmd/last-minute.go
@@ -90,7 +90,7 @@ func (a *AccElem) add(dur time.Duration) {
 	a.N++
 }
 
-// Add a duration to a single element.
+// Add a duration with size to a single element.
 func (a *AccElem) addSize(dur time.Duration, sz int64) {
 	if dur < 0 {
 		dur = 0
@@ -146,7 +146,7 @@ func (l lastMinuteLatency) merge(o lastMinuteLatency) (merged lastMinuteLatency)
 	return merged
 }
 
-// Add  a new duration data
+// Add a new duration data
 func (l *lastMinuteLatency) add(t time.Duration) {
 	sec := time.Now().Unix()
 	l.forwardTo(sec)
@@ -155,7 +155,7 @@ func (l *lastMinuteLatency) add(t time.Duration) {
 	l.LastSec = sec
 }
 
-// Add  a new duration data
+// Add a new duration data by size
 func (l *lastMinuteLatency) addSize(t time.Duration, sz int64) {
 	sec := time.Now().Unix()
 	l.forwardTo(sec)

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -106,7 +106,7 @@ func (p *xlStorageDiskIDCheck) getMetrics() DiskMetrics {
 }
 
 type lockedLastMinuteLatency struct {
-	sync.Mutex
+	sync.RWMutex
 	lastMinuteLatency
 }
 
@@ -125,8 +125,8 @@ func (e *lockedLastMinuteLatency) addSize(value time.Duration, sz int64) {
 
 // total returns the total call count and latency for the last minute.
 func (e *lockedLastMinuteLatency) total() AccElem {
-	e.Lock()
-	defer e.Unlock()
+	e.RLock()
+	defer e.RUnlock()
 	return e.lastMinuteLatency.getTotal()
 }
 


### PR DESCRIPTION
## Description
fix: use readLocks() when reporting() latency metrics

## Motivation and Context
use read lock() to allow for some independent calls

## How to test this PR?
hard to test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
