### PR TITLE
Attach creds, owner and region to madmin calls

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -154,6 +154,10 @@ func validateAdminSignature(ctx context.Context, r *http.Request, region string)
 		return cred, owner, s3Err
 	}
 
+	logger.GetReqInfo(ctx).Cred = cred
+	logger.GetReqInfo(ctx).Owner = owner
+	logger.GetReqInfo(ctx).Region = region
+
 	return cred, owner, ErrNone
 }
 

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -160,7 +160,7 @@ func validateAdminSignature(ctx context.Context, r *http.Request, region string)
 			ParentUser: cred.ParentUser,
 		}
 		ri.Owner = owner
-		ri.Region = region
+		ri.Region = globalSite.Region
 	}
 
 	return cred, owner, ErrNone
@@ -357,6 +357,7 @@ func authenticateRequest(ctx context.Context, r *http.Request, action policy.Act
 			ParentUser: cred.ParentUser,
 		}
 		ri.Owner = owner
+		ri.Region = globalSite.Region
 	}
 
 	// region is valid only for CreateBucketAction.

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -154,12 +154,14 @@ func validateAdminSignature(ctx context.Context, r *http.Request, region string)
 		return cred, owner, s3Err
 	}
 
-	logger.GetReqInfo(ctx).Cred = auth.Credentials{
-		AccessKey:  cred.AccessKey,
-		ParentUser: cred.ParentUser,
+	if ri := logger.GetReqInfo(ctx); ri != nil {
+		ri.Cred = auth.Credentials{
+			AccessKey:  cred.AccessKey,
+			ParentUser: cred.ParentUser,
+		}
+		ri.Owner = owner
+		ri.Region = region
 	}
-	logger.GetReqInfo(ctx).Owner = owner
-	logger.GetReqInfo(ctx).Region = region
 
 	return cred, owner, ErrNone
 }
@@ -349,11 +351,13 @@ func authenticateRequest(ctx context.Context, r *http.Request, action policy.Act
 		return s3Err
 	}
 
-	logger.GetReqInfo(ctx).Cred = auth.Credentials{
-		AccessKey:  cred.AccessKey,
-		ParentUser: cred.ParentUser,
+	if ri := logger.GetReqInfo(ctx); ri != nil {
+		ri.Cred = auth.Credentials{
+			AccessKey:  cred.AccessKey,
+			ParentUser: cred.ParentUser,
+		}
+		ri.Owner = owner
 	}
-	logger.GetReqInfo(ctx).Owner = owner
 
 	// region is valid only for CreateBucketAction.
 	var region string
@@ -715,12 +719,14 @@ func isPutActionAllowed(ctx context.Context, atype authType, bucketName, objectN
 		return s3Err
 	}
 
-	logger.GetReqInfo(ctx).Cred = auth.Credentials{
-		AccessKey:  cred.AccessKey,
-		ParentUser: cred.ParentUser,
+	if ri := logger.GetReqInfo(ctx); ri != nil {
+		ri.Cred = auth.Credentials{
+			AccessKey:  cred.AccessKey,
+			ParentUser: cred.ParentUser,
+		}
+		ri.Owner = owner
+		ri.Region = region
 	}
-	logger.GetReqInfo(ctx).Owner = owner
-	logger.GetReqInfo(ctx).Region = region
 
 	// Do not check for PutObjectRetentionAction permission,
 	// if mode and retain until date are not set.

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -154,7 +154,10 @@ func validateAdminSignature(ctx context.Context, r *http.Request, region string)
 		return cred, owner, s3Err
 	}
 
-	logger.GetReqInfo(ctx).Cred = cred
+	logger.GetReqInfo(ctx).Cred = auth.Credentials{
+		AccessKey:  cred.AccessKey,
+		ParentUser: cred.ParentUser,
+	}
 	logger.GetReqInfo(ctx).Owner = owner
 	logger.GetReqInfo(ctx).Region = region
 
@@ -346,7 +349,10 @@ func authenticateRequest(ctx context.Context, r *http.Request, action policy.Act
 		return s3Err
 	}
 
-	logger.GetReqInfo(ctx).Cred = cred
+	logger.GetReqInfo(ctx).Cred = auth.Credentials{
+		AccessKey:  cred.AccessKey,
+		ParentUser: cred.ParentUser,
+	}
 	logger.GetReqInfo(ctx).Owner = owner
 
 	// region is valid only for CreateBucketAction.
@@ -709,7 +715,10 @@ func isPutActionAllowed(ctx context.Context, atype authType, bucketName, objectN
 		return s3Err
 	}
 
-	logger.GetReqInfo(ctx).Cred = cred
+	logger.GetReqInfo(ctx).Cred = auth.Credentials{
+		AccessKey:  cred.AccessKey,
+		ParentUser: cred.ParentUser,
+	}
 	logger.GetReqInfo(ctx).Owner = owner
 	logger.GetReqInfo(ctx).Region = region
 

--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -154,14 +154,9 @@ func validateAdminSignature(ctx context.Context, r *http.Request, region string)
 		return cred, owner, s3Err
 	}
 
-	if ri := logger.GetReqInfo(ctx); ri != nil {
-		ri.Cred = auth.Credentials{
-			AccessKey:  cred.AccessKey,
-			ParentUser: cred.ParentUser,
-		}
-		ri.Owner = owner
-		ri.Region = globalSite.Region
-	}
+	logger.GetReqInfo(ctx).Cred = cred
+	logger.GetReqInfo(ctx).Owner = owner
+	logger.GetReqInfo(ctx).Region = globalSite.Region
 
 	return cred, owner, ErrNone
 }
@@ -351,14 +346,9 @@ func authenticateRequest(ctx context.Context, r *http.Request, action policy.Act
 		return s3Err
 	}
 
-	if ri := logger.GetReqInfo(ctx); ri != nil {
-		ri.Cred = auth.Credentials{
-			AccessKey:  cred.AccessKey,
-			ParentUser: cred.ParentUser,
-		}
-		ri.Owner = owner
-		ri.Region = globalSite.Region
-	}
+	logger.GetReqInfo(ctx).Cred = cred
+	logger.GetReqInfo(ctx).Owner = owner
+	logger.GetReqInfo(ctx).Region = globalSite.Region
 
 	// region is valid only for CreateBucketAction.
 	var region string
@@ -720,14 +710,9 @@ func isPutActionAllowed(ctx context.Context, atype authType, bucketName, objectN
 		return s3Err
 	}
 
-	if ri := logger.GetReqInfo(ctx); ri != nil {
-		ri.Cred = auth.Credentials{
-			AccessKey:  cred.AccessKey,
-			ParentUser: cred.ParentUser,
-		}
-		ri.Owner = owner
-		ri.Region = region
-	}
+	logger.GetReqInfo(ctx).Cred = cred
+	logger.GetReqInfo(ctx).Owner = owner
+	logger.GetReqInfo(ctx).Region = region
 
 	// Do not check for PutObjectRetentionAction permission,
 	// if mode and retain until date are not set.


### PR DESCRIPTION
## Description

Right now we don't attach the `creds`, `owner` and `region` values to the request for the subsequent audit logs to contain.

## Motivation and Context

We need to know who is behind a madmin call

## How to test this PR?

Setup audit webhook, perform an admin call, you should see now `parentUset` and `accessKey` in the audit entry

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
