### PR TITLE
(#16606) add native vrf support

### DIFF
--- a/cmd/net.go
+++ b/cmd/net.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -26,8 +25,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"syscall"
-	"time"
 
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/config"
@@ -216,43 +213,6 @@ func isHostIP(ipAddress string) bool {
 		host = host[:i]
 	}
 	return net.ParseIP(host) != nil
-}
-
-// checkPortAvailability - check if given host and port is already in use.
-// Note: The check method tries to listen on given port and closes it.
-// It is possible to have a disconnected client in this tiny window of time.
-func checkPortAvailability(host, port, vrf string) (err error) {
-	if vrf == "" {
-		l, err := net.Listen("tcp", net.JoinHostPort(host, port))
-		if err != nil {
-			return err
-		}
-		// As we are able to listen on this network, the port is not in use.
-		// Close the listener and continue check other networks.
-		return l.Close()
-	}
-
-	// In case of VRF use: try to open in correct vrf to validate port availability.
-	lc := &net.ListenConfig{
-		Control: func(network, address string, c syscall.RawConn) error {
-			c.Control(func(fdPtr uintptr) {
-				_ = syscall.SetsockoptString(int(fdPtr), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, vrf)
-			})
-
-			return nil
-		},
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	l, err := lc.Listen(ctx, "tcp", net.JoinHostPort(host, port))
-	if err != nil {
-		return err
-	}
-	// As we are able to listen on this network, the port is not in use.
-	// Close the listener and continue check other networks.
-	return l.Close()
 }
 
 // extractHostPort - extracts host/port from many address formats

--- a/cmd/net_linux.go
+++ b/cmd/net_linux.go
@@ -1,5 +1,6 @@
-//go:build (linux && !appengine)
+//go:build linux && !appengine
 // +build linux,!appengine
+
 // Copyright (c) 2015-2021 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack

--- a/cmd/net_linux.go
+++ b/cmd/net_linux.go
@@ -1,0 +1,64 @@
+//go:build (linux && !appengine)
+// +build linux,!appengine
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"net"
+	"syscall"
+	"time"
+)
+
+// checkPortAvailability - check if given host and port is already in use.
+// Note: The check method tries to listen on given port and closes it.
+// It is possible to have a disconnected client in this tiny window of time.
+func checkPortAvailability(host, port, vrf string) (err error) {
+	if vrf == "" {
+		l, err := net.Listen("tcp", net.JoinHostPort(host, port))
+		if err != nil {
+			return err
+		}
+		// As we are able to listen on this network, the port is not in use.
+		// Close the listener and continue check other networks.
+		return l.Close()
+	}
+
+	// In case of VRF use: try to open in correct vrf to validate port availability.
+	lc := &net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			c.Control(func(fdPtr uintptr) {
+				_ = syscall.SetsockoptString(int(fdPtr), syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, vrf)
+			})
+
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	l, err := lc.Listen(ctx, "tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		return err
+	}
+	// As we are able to listen on this network, the port is not in use.
+	// Close the listener and continue check other networks.
+	return l.Close()
+}

--- a/cmd/net_other.go
+++ b/cmd/net_other.go
@@ -1,5 +1,6 @@
 //go:build !linux
 // +build !linux
+
 // Copyright (c) 2015-2021 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack

--- a/cmd/net_other.go
+++ b/cmd/net_other.go
@@ -1,0 +1,37 @@
+//go:build !linux
+// +build !linux
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"net"
+)
+
+// checkPortAvailability - check if given host and port is already in use.
+// Note: The check method tries to listen on given port and closes it.
+// It is possible to have a disconnected client in this tiny window of time.
+func checkPortAvailability(host, port, vrf string) (err error) {
+	l, err := net.Listen("tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		return err
+	}
+	// As we are able to listen on this network, the port is not in use.
+	// Close the listener and continue check other networks.
+	return l.Close()
+}

--- a/cmd/net_test.go
+++ b/cmd/net_test.go
@@ -221,7 +221,7 @@ func TestCheckPortAvailability(t *testing.T) {
 			continue
 		}
 
-		err := checkPortAvailability(testCase.host, testCase.port)
+		err := checkPortAvailability(testCase.host, testCase.port, "")
 		switch {
 		case testCase.expectedErr == nil:
 			if err != nil {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -107,7 +107,7 @@ var ServerFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:   "vrf-device",
-		Usage:  "bind to a specific vrf device name",
+		Usage:  "bind to a specific vrf device name (Linux only)",
 		EnvVar: "MINIO_VRF_DEVICE",
 	},
 }

--- a/internal/http/listener.go
+++ b/internal/http/listener.go
@@ -25,6 +25,8 @@ import (
 	"syscall"
 )
 
+var vrfDeviceName string
+
 type acceptResult struct {
 	conn net.Conn
 	err  error
@@ -37,6 +39,11 @@ type httpListener struct {
 	acceptCh     chan acceptResult  // channel where all TCP listeners write accepted connection.
 	ctx          context.Context
 	ctxCanceler  context.CancelFunc
+}
+
+// SetVRFDeviceName - Defines a Linux VRF to be used by all connections for this package.
+func SetVRFDeviceName(vrf string) {
+	vrfDeviceName = vrf
 }
 
 // start - starts separate goroutine for each TCP listener.  A valid new connection is passed to httpListener.acceptCh.


### PR DESCRIPTION
## Description
This PR implements the suggested solution for #16606 to implement native VRF support for Linux.

## Motivation and Context
See #16606 for details. tldr: s3 api endpoints should run natively in a specified VRF using a new command line flag.

## How to test this PR?
Testing is a bit tricky because it requires a test system with an existing vrf in place. This practically eliminates testing in containers and otherwise requires set up of such vrf using root permissions (which imho shouldn't be done in scripts without testers knowledge). I'm very much open for suggestions on this.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [X] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
