### PR TITLE
Set logger webhook proxy on subnet proxy change

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -209,10 +209,10 @@ func setConfigKV(ctx context.Context, objectAPI ObjectLayer, kvBytes []byte) (re
 	}
 
 	// Check if subnet proxy being set and if so set the same value to proxy of subnet
-	// target of logger webhook configuartion
+	// target of logger webhook configuration
 	if result.SubSys == config.SubnetSubSys {
 		loggerWebhookSubnetProxy := result.Cfg[config.LoggerWebhookSubSys][config.SubnetSubSys].Get(logger.Proxy)
-		subnetProxy := result.Cfg[config.SubnetSubSys]["_"].Get(logger.Proxy)
+		subnetProxy := result.Cfg[config.SubnetSubSys][config.Default].Get(logger.Proxy)
 		if loggerWebhookSubnetProxy != subnetProxy {
 			obj := result.Cfg[config.LoggerWebhookSubSys][subnet.LoggerWebhookName]
 			obj.Set(logger.Proxy, subnetProxy)

--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -29,6 +29,7 @@ import (
 	"github.com/minio/madmin-go/v2"
 	"github.com/minio/minio/internal/config"
 	"github.com/minio/minio/internal/config/cache"
+	"github.com/minio/minio/internal/config/callhome"
 	"github.com/minio/minio/internal/config/etcd"
 	xldap "github.com/minio/minio/internal/config/identity/ldap"
 	"github.com/minio/minio/internal/config/identity/openid"
@@ -209,12 +210,13 @@ func setConfigKV(ctx context.Context, objectAPI ObjectLayer, kvBytes []byte) (re
 
 	// Check if callhome getting enabled, if so set the subnet proxy value to logger_webhook's subnet proxy
 	// Do this only if logger_wenhook's subnet proxy is not yet set
-	if result.SubSys == "callhome" && result.Cfg["callhome"]["_"].Get("enable") == "on" {
-		loggerWebhookSubnetProxy := result.Cfg["logger_webhook"]["subnet"].Get("proxy")
-		subnetProxy := result.Cfg["subnet"]["_"].Get("proxy")
+	callhomeCfg := result.Cfg[config.CallhomeSubSys]["_"]
+	if result.SubSys == config.CallhomeSubSys && callhomeCfg.Get(callhome.Enable) == "on" {
+		loggerWebhookSubnetProxy := result.Cfg[config.LoggerWebhookSubSys][config.SubnetSubSys].Get(logger.Proxy)
+		subnetProxy := result.Cfg[config.SubnetSubSys]["_"].Get(logger.Proxy)
 		if loggerWebhookSubnetProxy == "" && subnetProxy != "" {
-			obj := result.Cfg["logger_webhook"]["subnet"]
-			obj.Set("proxy", subnetProxy)
+			obj := result.Cfg[config.LoggerWebhookSubSys][config.SubnetSubSys]
+			obj.Set(logger.Proxy, subnetProxy)
 			result.LoggerWebhookCfgUpdated = true
 		}
 	}

--- a/internal/config/subnet/subnet.go
+++ b/internal/config/subnet/subnet.go
@@ -33,6 +33,7 @@ import (
 const (
 	respBodyLimit = 1 << 20 // 1 MiB
 
+	// LoggerWebhookName - subnet logger webhook target
 	LoggerWebhookName = "subnet"
 )
 

--- a/internal/config/subnet/subnet.go
+++ b/internal/config/subnet/subnet.go
@@ -32,6 +32,8 @@ import (
 
 const (
 	respBodyLimit = 1 << 20 // 1 MiB
+
+	LoggerWebhookName = "subnet"
 )
 
 // Upload given file content (payload) to specified URL


### PR DESCRIPTION
## Description
While setting subnet proxy using `mc admin config set ALIAS subnet proxy=VALUE`, set the same proxy value to subnet target of logger webhook configuration as well.

## Motivation and Context
If any change in subnet proxy value, the same should be applied to subnet target of logger webhook's proxy as well.

## How to test this PR?
Follow the below steps to verify the PR

Step-1: Start the minio instance
```
✘ ./minio server ./data/1p1host{1...4}/dist{1...4} --address :9010
```
Step-2: Create alias for the deployment
```
✘ ./mc alias set ALIAS http://localhost:9010 minioadmin minioadmin
```
Step-3: Register the cluster with SUBNET
```
✘ ./mc license register --api-key API-KEY ALIAS --name NAME --dev
```
Step-4: Enable support callhome for logging
```
✘ ./mc support callhome enable --logs ALIAS --dev
```
Step-5: Verify the subnet configurations
```
✘ ./mc admin config get ALIAS subnet
subnet license=eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhaWQiOjMsImFwaUtleSI6IjJiZmMyNGE4LTJlMTMtNmI3Mi03YTk5LWUwODFmMzMzNDg4OCIsImNhcCI6MjUsImRpZCI6IjQ5YWIzODQwLWZiYTUtNDI0ZS04YTdjLWMyMmE0ZWIwNGFhMCIsImV4cCI6MS43MDg0Mjg1OTExNTE3NTEyMDJlOSwiaWF0IjoxLjY3Njg5MjU5MTE1MTc1MTIwMmU5LCJpc3MiOiJzdWJuZXRAbWluLmlvIiwibGlkIjoiYzM5NTkwOTgtMmExZC00OTRkLTg2NzEtYjZjZDBkNWUzNmM0Iiwib3JnIjoic2h1YmhlbmR1YzEiLCJwbGFuIjoiU1RBTkRBUkQiLCJzdWIiOiJzdWJuZXRAbWluLmlvIn0.eI0NFRf78duccbnNu__ZbhzvCsyvg4qTilRRYQ7ClHCQD5uvfORoIY8Ggp1ENiv1bNJgtnQWu_TxC-y0t9u6yvOgiCVsRG-wbce8GfsjCdGMulEC8KZobkQQrdzXd1ZS api_key=2bfc24a8-2e13-6b72-7a99-e081f3334888 proxy= 
```
Step-6: Verify the logger webhook configurations
```
✘ ./mc admin config get ALIAS logger_webhook
logger_webhook enable=off endpoint= auth_token= client_cert= client_key= proxy= queue_size=100000 
logger_webhook:subnet endpoint=http://localhost:9000/api/logs auth_token=2bfc24a8-2e13-6b72-7a99-e081f3334888 client_cert= client_key= proxy= queue_size=100000 
```
Step-7: Set the value `proxy` under subnet configuration
```
✘ ./mc admin config set ALIAS subnet proxy=http://test.proxy.com
Successfully applied new settings.
✘ ./mc admin config get ALIAS subnet
subnet license=eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhaWQiOjMsImFwaUtleSI6IjJiZmMyNGE4LTJlMTMtNmI3Mi03YTk5LWUwODFmMzMzNDg4OCIsImNhcCI6MjUsImRpZCI6IjQ5YWIzODQwLWZiYTUtNDI0ZS04YTdjLWMyMmE0ZWIwNGFhMCIsImV4cCI6MS43MDg0Mjg1OTExNTE3NTEyMDJlOSwiaWF0IjoxLjY3Njg5MjU5MTE1MTc1MTIwMmU5LCJpc3MiOiJzdWJuZXRAbWluLmlvIiwibGlkIjoiYzM5NTkwOTgtMmExZC00OTRkLTg2NzEtYjZjZDBkNWUzNmM0Iiwib3JnIjoic2h1YmhlbmR1YzEiLCJwbGFuIjoiU1RBTkRBUkQiLCJzdWIiOiJzdWJuZXRAbWluLmlvIn0.eI0NFRf78duccbnNu__ZbhzvCsyvg4qTilRRYQ7ClHCQD5uvfORoIY8Ggp1ENiv1bNJgtnQWu_TxC-y0t9u6yvOgiCVsRG-wbce8GfsjCdGMulEC8KZobkQQrdzXd1ZS api_key=2bfc24a8-2e13-6b72-7a99-e081f3334888 proxy=http://test.proxy.com 
```
Step-9: Verify the logger webhook configurations now
```
✘ ./mc admin config get ALIAS logger_webhook
logger_webhook enable=off endpoint= auth_token= client_cert= client_key= proxy= queue_size=100000 
logger_webhook:subnet endpoint=http://localhost:9000/api/logs auth_token=2bfc24a8-2e13-6b72-7a99-e081f3334888 client_cert= client_key= proxy=http://test.proxy.com queue_size=100000 
```
Notice that `proxy` value for `logger_webhook:subnet` is set to same value as set for `proxy` under `subnet` configuration.
Step-10: Remove the subnet proxy using below command
```
✘ ./mc support proxy remove ALIAS --dev
```
Step-11: Verify that both subnet proxy nd logger webhook's subnet proxy values are removed
```
✘ ./mc admin config get ALIAS subnet
subnet license=eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhaWQiOjMsImFwaUtleSI6IjJiZmMyNGE4LTJlMTMtNmI3Mi03YTk5LWUwODFmMzMzNDg4OCIsImNhcCI6MjUsImRpZCI6ImU4Y2I1MGZiLTFhM2QtNDllNS1hNjA4LWRjMDQ0ZGQ2YWQ0NiIsImV4cCI6MS43MDg3NzAwMDQ0MjI5ODcxNjllOSwiaWF0IjoxLjY3NzIzNDAwNDQyMjk4NzE2OWU5LCJpc3MiOiJzdWJuZXRAbWluLmlvIiwibGlkIjoiN2U2NDRmZWQtODdiOS00ZTY2LWJlMGUtY2I4MmY5YzNlZTVkIiwib3JnIjoic2h1YmhlbmR1YzEiLCJwbGFuIjoiU1RBTkRBUkQiLCJzdWIiOiJzdWJuZXRAbWluLmlvIn0.2JWAfbtVBnHAsZgu_zKM61nOqWeO-3q7tv2SqOExGLC2n89ULFQCbcot8NbZaIJDxoZ5mhjqCZqLngol3A2z8UibxQ9gPJhKhB_fQl-AoCPTldQD8mUtwQ78lh7K4Od_ api_key=2bfc24a8-2e13-6b72-7a99-e081f3334888 proxy= 
✘ ./mc admin config get ALIAS logger_webhook
logger_webhook enable=off endpoint= auth_token= client_cert= client_key= proxy= queue_size=100000 
logger_webhook:subnet endpoint=http://localhost:9000/api/logs auth_token=2bfc24a8-2e13-6b72-7a99-e081f3334888 client_cert= client_key= proxy= queue_size=100000 
✘ 
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
