### PR TITLE
Fix scanner deadlock on lost global lock

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -689,9 +689,11 @@ func (z *erasureServerPools) NSScanner(ctx context.Context, updates chan<- DataU
 	case updateCloser <- ch:
 		<-ch
 	case <-ctx.Done():
+		mu.Lock()
 		if firstErr == nil {
 			firstErr = ctx.Err()
 		}
+		defer mu.Unlock()
 	}
 	return firstErr
 }

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -485,10 +485,13 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, wa
 				go func(name string) {
 					defer wg.Done()
 					for update := range updates {
-						bucketResults <- dataUsageEntryInfo{
+						select {
+						case <-ctx.Done():
+						case bucketResults <- dataUsageEntryInfo{
 							Name:   name,
 							Parent: dataUsageRoot,
 							Entry:  update,
+						}:
 						}
 					}
 				}(cache.Info.Name)
@@ -516,10 +519,14 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, wa
 					root = cache.flatten(*r)
 				}
 				t := time.Now()
-				bucketResults <- dataUsageEntryInfo{
+				select {
+				case <-ctx.Done():
+					return
+				case bucketResults <- dataUsageEntryInfo{
 					Name:   cache.Info.Name,
 					Parent: dataUsageRoot,
 					Entry:  root,
+				}:
 				}
 				// We want to avoid synchronizing up all writes in case
 				// the results are piled up.

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -412,9 +412,6 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, wa
 
 		for {
 			select {
-			case <-ctx.Done():
-				// Return without saving.
-				return
 			case <-t.C:
 				if cache.Info.LastUpdate.Equal(lastSave) {
 					continue


### PR DESCRIPTION
## Description

Do *not* exit saver on canceled context.

We *must* keep consuming bucketResults even if context is canceled to not risk deadlocking, even if the risk is fairly small of the channel filling up.

Saves will not proceed, but we always drain `bucketResults`.

## How to test this PR?

Requires upstream to cancel the operation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
