### PR TITLE
fix: handle syscall.EROFS also for osIsPermission()

### DIFF
--- a/cmd/xl-storage-errors.go
+++ b/cmd/xl-storage-errors.go
@@ -133,7 +133,7 @@ func osIsNotExist(err error) bool {
 }
 
 func osIsPermission(err error) bool {
-	return errors.Is(err, os.ErrPermission)
+	return errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.EROFS)
 }
 
 func osIsExist(err error) bool {


### PR DESCRIPTION


## Description
fix: handle syscall.EROFS also for osIsPermission()

## Motivation and Context
k8s secrets return EROFS instead of EPERM,
this results in specific code paths fail
unexpectedly

fixes #16746

## How to test this PR?
You need to create k8s secret mounts as described in #16746 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
