### PR TITLE
fix: a cosmetic error reporting with a lock timeout

### DIFF
--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -170,7 +170,7 @@ func (di *distLockInstance) GetLock(ctx context.Context, timeout *dynamicTimeout
 		RetryInterval: timeout.RetryInterval(),
 	}) {
 		timeout.LogFailure()
-		cancel()
+		defer cancel()
 		if err := newCtx.Err(); err == context.Canceled {
 			return LockContext{ctx: ctx, cancel: func() {}}, err
 		}
@@ -199,7 +199,7 @@ func (di *distLockInstance) GetRLock(ctx context.Context, timeout *dynamicTimeou
 		RetryInterval: timeout.RetryInterval(),
 	}) {
 		timeout.LogFailure()
-		cancel()
+		defer cancel()
 		if err := newCtx.Err(); err == context.Canceled {
 			return LockContext{ctx: ctx, cancel: func() {}}, err
 		}


### PR DESCRIPTION
## Description
This does not address a known issue, but the code should not 
cancel the context and immediately test for a context.Canceled error.

Tracing will show operation timed out instead of context canceled error.

## Motivation and Context
Cosmetic fix

## How to test this PR?
Run many servers then 'mc admin trace --call=bootstrap <alias>'

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
