### PR TITLE
chore: drop go versions in static analysis

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,11 @@
 linters-settings:
   gofumpt:
-    lang-version: '1.20'
+    simplify: true
 
   misspell:
     locale: US
 
   staticcheck:
-    go: '1.20'
     checks: ['all', '-ST1005', '-ST1000', '-SA4000', '-SA9004', '-SA1019', '-SA1008', '-U1000', '-ST1016']
 
 linters:


### PR DESCRIPTION

## Description
Since they are overridden by run go version, which itself defaults to go.mod if missing. That's why no need to duplicate and they do nothing.

## Motivation and Context
Simplification

## How to test this PR?
CI is enough.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
