### PR TITLE
simplify error responses for KMS

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -38,6 +38,7 @@ import (
 	"github.com/minio/minio/internal/bucket/replication"
 	"github.com/minio/minio/internal/config/dns"
 	"github.com/minio/minio/internal/crypto"
+	"github.com/minio/minio/internal/kms"
 	"github.com/minio/minio/internal/logger"
 
 	objectlock "github.com/minio/minio/internal/bucket/object/lock"
@@ -2311,6 +2312,12 @@ func toAPIError(ctx context.Context, err error) APIError {
 		// any underlying errors if possible depending on
 		// their internal error types.
 		switch e := err.(type) {
+		case kms.Error:
+			apiErr = APIError{
+				Description:    e.Err.Error(),
+				Code:           e.APICode,
+				HTTPStatusCode: e.HTTPStatusCode,
+			}
 		case batchReplicationJobError:
 			apiErr = APIError(e)
 		case InvalidArgument:

--- a/internal/kms/errors.go
+++ b/internal/kms/errors.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package kms
+
+// Error encapsulates S3 API error response fields.
+type Error struct {
+	Err            error
+	APICode        string
+	HTTPStatusCode int
+}
+
+func (e Error) Error() string {
+	return e.Err.Error()
+}

--- a/internal/kms/single-key.go
+++ b/internal/kms/single-key.go
@@ -25,6 +25,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -107,14 +108,22 @@ func (kms secretKey) List() []kes.KeyInfo {
 }
 
 func (secretKey) Metrics(ctx context.Context) (kes.Metric, error) {
-	return kes.Metric{}, errors.New("kms: metrics are not supported")
+	return kes.Metric{}, Error{
+		HTTPStatusCode: http.StatusNotImplemented,
+		APICode:        "KMS.NotImplemented",
+		Err:            errors.New("metrics are not supported"),
+	}
 }
 
 func (kms secretKey) CreateKey(_ context.Context, keyID string) error {
 	if keyID == kms.keyID {
 		return nil
 	}
-	return fmt.Errorf("kms: creating custom key %q is not supported", keyID)
+	return Error{
+		HTTPStatusCode: http.StatusNotImplemented,
+		APICode:        "KMS.NotImplemented",
+		Err:            fmt.Errorf("creating custom key %q is not supported", keyID),
+	}
 }
 
 func (kms secretKey) GenerateKey(_ context.Context, keyID string, context Context) (DEK, error) {
@@ -122,7 +131,11 @@ func (kms secretKey) GenerateKey(_ context.Context, keyID string, context Contex
 		keyID = kms.keyID
 	}
 	if keyID != kms.keyID {
-		return DEK{}, fmt.Errorf("kms: key %q does not exist", keyID)
+		return DEK{}, Error{
+			HTTPStatusCode: http.StatusBadRequest,
+			APICode:        "KMS.NotFoundException",
+			Err:            fmt.Errorf("key %q does not exist", keyID),
+		}
 	}
 	iv, err := sioutil.Random(16)
 	if err != nil {
@@ -163,7 +176,11 @@ func (kms secretKey) GenerateKey(_ context.Context, keyID string, context Contex
 			return DEK{}, err
 		}
 	default:
-		return DEK{}, errors.New("invalid algorithm: " + algorithm)
+		return DEK{}, Error{
+			HTTPStatusCode: http.StatusBadRequest,
+			APICode:        "KMS.InternalException",
+			Err:            errors.New("invalid algorithm: " + algorithm),
+		}
 	}
 
 	nonce, err := sioutil.Random(aead.NonceSize())
@@ -197,17 +214,29 @@ func (kms secretKey) GenerateKey(_ context.Context, keyID string, context Contex
 
 func (kms secretKey) DecryptKey(keyID string, ciphertext []byte, context Context) ([]byte, error) {
 	if keyID != kms.keyID {
-		return nil, fmt.Errorf("kms: key %q does not exist", keyID)
+		return nil, Error{
+			HTTPStatusCode: http.StatusBadRequest,
+			APICode:        "KMS.NotFoundException",
+			Err:            fmt.Errorf("key %q does not exist", keyID),
+		}
 	}
 
 	var encryptedKey encryptedKey
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(ciphertext, &encryptedKey); err != nil {
-		return nil, err
+		return nil, Error{
+			HTTPStatusCode: http.StatusBadRequest,
+			APICode:        "KMS.InternalException",
+			Err:            err,
+		}
 	}
 
 	if n := len(encryptedKey.IV); n != 16 {
-		return nil, fmt.Errorf("kms: invalid iv size")
+		return nil, Error{
+			HTTPStatusCode: http.StatusBadRequest,
+			APICode:        "KMS.InternalException",
+			Err:            fmt.Errorf("invalid iv size: %d", n),
+		}
 	}
 
 	var aead cipher.AEAD
@@ -235,17 +264,29 @@ func (kms secretKey) DecryptKey(keyID string, ciphertext []byte, context Context
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("kms: invalid algorithm: %q", encryptedKey.Algorithm)
+		return nil, Error{
+			HTTPStatusCode: http.StatusBadRequest,
+			APICode:        "KMS.InternalException",
+			Err:            fmt.Errorf("invalid algorithm: %q", encryptedKey.Algorithm),
+		}
 	}
 
 	if n := len(encryptedKey.Nonce); n != aead.NonceSize() {
-		return nil, fmt.Errorf("kms: invalid nonce size %d", n)
+		return nil, Error{
+			HTTPStatusCode: http.StatusBadRequest,
+			APICode:        "KMS.InternalException",
+			Err:            fmt.Errorf("invalid nonce size %d", n),
+		}
 	}
 
 	associatedData, _ := context.MarshalText()
 	plaintext, err := aead.Open(nil, encryptedKey.Nonce, encryptedKey.Bytes, associatedData)
 	if err != nil {
-		return nil, fmt.Errorf("kms: encrypted key is not authentic")
+		return nil, Error{
+			HTTPStatusCode: http.StatusBadRequest,
+			APICode:        "KMS.InternalException",
+			Err:            fmt.Errorf("encrypted key is not authentic"),
+		}
 	}
 	return plaintext, nil
 }


### PR DESCRIPTION

## Description
simplify error responses for KMS

## Motivation and Context
Bonus: remember logger once error counts to
indicate how many times the same code path
was hit, indicating whether the error event
was persistent or indicative of intermittent
losses

## How to test this PR?
Just call various KMS API commands

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
