### PR TITLE
tests: Protect globalLocalDrives against races

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -271,6 +271,9 @@ func initAutoHeal(ctx context.Context, objAPI ObjectLayer) {
 }
 
 func getLocalDisksToHeal() (disksToHeal Endpoints) {
+	globalLocalDrivesMu.RLock()
+	globalLocalDrives := globalLocalDrives
+	globalLocalDrivesMu.RUnlock()
 	for _, disk := range globalLocalDrives {
 		_, err := disk.GetDiskID()
 		if errors.Is(err, errUnformattedDisk) {

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -156,7 +156,9 @@ func newErasureServerPools(ctx context.Context, endpointServerPools EndpointServ
 		break
 	}
 
+	globalLocalDrivesMu.Lock()
 	globalLocalDrives = localDrives
+	defer globalLocalDrivesMu.Unlock()
 	return z, nil
 }
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -353,8 +353,10 @@ var (
 	globalServiceFreezeCnt int32
 	globalServiceFreezeMu  sync.Mutex // Updates.
 
-	// List of local drives to this node, this is only set during server startup.
-	globalLocalDrives []StorageAPI
+	// List of local drives to this node, this is only set during server startup,
+	// and should never be mutated. Hold globalLocalDrivesMu to access.
+	globalLocalDrives   []StorageAPI
+	globalLocalDrivesMu sync.RWMutex
 
 	// Is MINIO_CI_CD set?
 	globalIsCICD bool

--- a/cmd/peer-s3-server.go
+++ b/cmd/peer-s3-server.go
@@ -80,6 +80,10 @@ func (s *peerS3Server) HealthHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func listBucketsLocal(ctx context.Context, opts BucketOptions) (buckets []BucketInfo, err error) {
+	globalLocalDrivesMu.RLock()
+	globalLocalDrives := globalLocalDrives
+	globalLocalDrivesMu.RUnlock()
+
 	quorum := (len(globalLocalDrives) / 2)
 
 	buckets = make([]BucketInfo, 0, 32)
@@ -128,6 +132,10 @@ func listBucketsLocal(ctx context.Context, opts BucketOptions) (buckets []Bucket
 }
 
 func getBucketInfoLocal(ctx context.Context, bucket string, opts BucketOptions) (BucketInfo, error) {
+	globalLocalDrivesMu.RLock()
+	globalLocalDrives := globalLocalDrives
+	globalLocalDrivesMu.RUnlock()
+
 	g := errgroup.WithNErrs(len(globalLocalDrives)).WithConcurrency(32)
 	bucketsInfo := make([]BucketInfo, len(globalLocalDrives))
 
@@ -173,6 +181,10 @@ func getBucketInfoLocal(ctx context.Context, bucket string, opts BucketOptions) 
 }
 
 func deleteBucketLocal(ctx context.Context, bucket string, opts DeleteBucketOptions) error {
+	globalLocalDrivesMu.RLock()
+	globalLocalDrives := globalLocalDrives
+	globalLocalDrivesMu.RUnlock()
+
 	g := errgroup.WithNErrs(len(globalLocalDrives)).WithConcurrency(32)
 
 	// Make a volume entry on all underlying storage disks.
@@ -208,6 +220,10 @@ func deleteBucketLocal(ctx context.Context, bucket string, opts DeleteBucketOpti
 }
 
 func makeBucketLocal(ctx context.Context, bucket string, opts MakeBucketOptions) error {
+	globalLocalDrivesMu.RLock()
+	globalLocalDrives := globalLocalDrives
+	globalLocalDrivesMu.RUnlock()
+
 	g := errgroup.WithNErrs(len(globalLocalDrives)).WithConcurrency(32)
 
 	// Make a volume entry on all underlying storage disks.


### PR DESCRIPTION
Add a mutex to globalLocalDrives. Since it is never mutated we just shadow it in functions when read to reduce lock time.

Fixes a race, that should only be seen in tests:

```
2023-03-13T09:15:16.4266293Z WARNING: DATA RACE
2023-03-13T09:15:16.4266564Z Write at 0x000007eaaef0 by goroutine 380270:
2023-03-13T09:15:16.4266913Z   github.com/minio/minio/cmd.newErasureServerPools()
2023-03-13T09:15:16.4267775Z       /home/runner/work/minio/minio/cmd/erasure-server-pool.go:159 +0x1191
2023-03-13T09:15:16.4268171Z   github.com/minio/minio/cmd.newTestObjectLayer()
2023-03-13T09:15:16.4268707Z       /home/runner/work/minio/minio/cmd/test-utils_test.go:1498 +0x67
2023-03-13T09:15:16.4269056Z   github.com/minio/minio/cmd.initObjectLayer()
2023-03-13T09:15:16.4269590Z       /home/runner/work/minio/minio/cmd/test-utils_test.go:1503 +0x76
2023-03-13T09:15:16.4269914Z   github.com/minio/minio/cmd.prepareFS()
2023-03-13T09:15:16.4270435Z       /home/runner/work/minio/minio/cmd/test-utils_test.go:194 +0xb2
2023-03-13T09:15:16.4270812Z   github.com/minio/minio/cmd.ExecObjectLayerAPITest()
2023-03-13T09:15:16.4271354Z       /home/runner/work/minio/minio/cmd/test-utils_test.go:1750 +0xc6
2023-03-13T09:15:16.4271763Z   github.com/minio/minio/cmd.ExecExtendedObjectLayerAPITest.func1()
2023-03-13T09:15:16.4272346Z       /home/runner/work/minio/minio/cmd/test-utils_test.go:1803 +0x64
2023-03-13T09:15:16.4272705Z   github.com/minio/minio/cmd.execExtended.func2()
2023-03-13T09:15:16.4273167Z       /home/runner/work/minio/minio/cmd/object_api_suite_test.go:570 +0x4b
2023-03-13T09:15:16.4273676Z   testing.tRunner()
2023-03-13T09:15:16.4274107Z       /opt/hostedtoolcache/go/1.20.2/x64/src/testing/testing.go:1576 +0x216
2023-03-13T09:15:16.4274413Z   testing.(*T).Run.func1()
2023-03-13T09:15:16.4274851Z       /opt/hostedtoolcache/go/1.20.2/x64/src/testing/testing.go:1629 +0x47
2023-03-13T09:15:16.4275049Z
2023-03-13T09:15:16.4275199Z Previous read at 0x000007eaaef0 by goroutine 380251:
2023-03-13T09:15:16.4275567Z   github.com/minio/minio/cmd.getBucketInfoLocal.func1()
2023-03-13T09:15:16.4276108Z       /home/runner/work/minio/minio/cmd/peer-s3-server.go:138 +0x90
2023-03-13T09:15:16.4276501Z   github.com/minio/minio/internal/sync/errgroup.(*Group).Go.func1()
2023-03-13T09:15:16.4277013Z       /home/runner/work/minio/minio/internal/sync/errgroup/errgroup.go:123 +0x314
```

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
