### PR TITLE
Do not allow adding root user to IAM subsystem

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -431,7 +431,7 @@ func (a adminAPIHandlers) AddUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Not allowed to add a user with same access key as root credential
-	if owner && accessKey == cred.AccessKey {
+	if accessKey == globalActiveCred.AccessKey {
 		writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrAddUserInvalidArgument), r.URL)
 		return
 	}
@@ -2297,7 +2297,7 @@ func (a adminAPIHandlers) ImportIAM(w http.ResponseWriter, r *http.Request) {
 			}
 			for accessKey, ureq := range userAccts {
 				// Not allowed to add a user with same access key as root credential
-				if owner && accessKey == cred.AccessKey {
+				if accessKey == globalActiveCred.AccessKey {
 					writeErrorResponseJSON(ctx, w, importErrorWithAPIErr(ctx, ErrAddUserInvalidArgument, err, allUsersFile, accessKey), r.URL)
 					return
 				}

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -627,6 +627,11 @@ func (s *TestSuiteIAM) TestSTSForRoot(c *check) {
 	if !gotBuckets.Equals(shouldHaveBuckets) {
 		c.Fatalf("root user should have access to all buckets")
 	}
+
+	// This must fail.
+	if err := userAdmClient.AddUser(ctx, globalActiveCred.AccessKey, globalActiveCred.SecretKey); err == nil {
+		c.Fatal("AddUser() for root credential must fail via root STS creds")
+	}
 }
 
 // SetUpLDAP - expects to setup an LDAP test server using the test LDAP


### PR DESCRIPTION


## Description
Do not allow adding root user to IAM subsystem

## Motivation and Context
A user with sufficient admin-level privileges can 
add the root user into the IAM subsystem, which 
would lead to permanently disabled access to the root
credentials.

The problem exists since RELEASE.2020-12-23T02-24-12Z 
release onwards, a similar change was also introduced
in the IAM import API since RELEASE.2022-06-25T15-50-16Z

This PR fixes both scenarios.

## How to test this PR?
Unit tests are added to cover the scenario.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
