### PR TITLE
root user is now part of IAM allowing it to be disabled

### DIFF
--- a/.github/workflows/root-disable.yml
+++ b/.github/workflows/root-disable.yml
@@ -1,0 +1,34 @@
+name: Root lockdown tests
+
+on:
+  pull_request:
+    branches:
+    - master
+
+# This ensures that previous jobs for the PR are canceled when the PR is
+# updated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Go ${{ matrix.go-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go-version: [1.20.x]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+      - name: Start root lockdown tests
+        run: |
+          make test-root-disable

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ test: verifiers build ## builds minio, runs linters, tests
 	@echo "Running unit tests"
 	@MINIO_API_REQUESTS_MAX=10000 CGO_ENABLED=0 go test -tags kqueue ./...
 
+test-root-disable: install
+	@echo "Running minio root lockdown tests"
+	@env bash $(PWD)/buildscripts/disable-root.sh
+
 test-decom: install
 	@echo "Running minio decom tests"
 	@env bash $(PWD)/docs/distributed/decom.sh

--- a/buildscripts/disable-root.sh
+++ b/buildscripts/disable-root.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -x
+
+export MINIO_CI_CD=1
+killall -9 minio
+
+rm -rf ${HOME}/tmp/dist
+
+scheme="http"
+nr_servers=4
+
+addr="localhost"
+args=""
+for ((i=0;i<$[${nr_servers}];i++)); do
+    args="$args $scheme://$addr:$[9100+$i]/${HOME}/tmp/dist/path1/$i"
+done
+
+echo $args
+
+for ((i=0;i<$[${nr_servers}];i++)); do
+    (minio server --address ":$[9100+$i]" $args 2>&1 > /tmp/log$i.txt) &
+done
+
+sleep 10s
+
+if [ ! -f ././mc ]; then
+    wget --quiet -O ./mc https://dl.minio.io/client/mc/release/linux-amd64/./mc && \
+       chmod +x mc
+fi
+
+set -e
+
+export MC_HOST_minioadm=http://minioadmin:minioadmin@localhost:9100/
+
+./mc ls minioadm/
+
+./mc admin user add minioadm/ testuser testuser12345
+
+./mc admin policy attach minioadm/ consoleAdmin --user=testuser
+
+sleep 3s # let things settle a little
+
+export MC_HOST_testadm=http://testuser:testuser12345@localhost:9100/
+
+./mc ls testadm/
+
+./mc admin user disable testadm/ minioadmin
+
+sleep 3s # let things settle a little
+
+set +e # do not fail right away, look for exit status.
+
+./mc ls minioadm/
+if [ $? -eq 0 ]; then
+    echo "listing succeeded, 'minioadmin' was not disabled"
+    exit 1
+fi
+
+set -e
+
+./mc admin user enable testadm/ minioadmin # re-enable the root user
+
+set +e
+
+./mc ls minioadm/
+if [ $? -ne 0 ]; then
+    echo "listing must succeed, 'minioadmin' was not enabled"
+    exit 1
+fi
+
+
+

--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -422,17 +422,19 @@ func (a adminAPIHandlers) SetUserStatus(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	logger.LogIf(ctx, globalSiteReplicationSys.IAMChangeHook(ctx, madmin.SRIAMItem{
-		Type: madmin.SRIAMItemIAMUser,
-		IAMUser: &madmin.SRIAMUser{
-			AccessKey:   accessKey,
-			IsDeleteReq: false,
-			UserReq: &madmin.AddOrUpdateUserReq{
-				Status: madmin.AccountStatus(status),
+	if accessKey != globalActiveCred.AccessKey {
+		logger.LogIf(ctx, globalSiteReplicationSys.IAMChangeHook(ctx, madmin.SRIAMItem{
+			Type: madmin.SRIAMItemIAMUser,
+			IAMUser: &madmin.SRIAMUser{
+				AccessKey:   accessKey,
+				IsDeleteReq: false,
+				UserReq: &madmin.AddOrUpdateUserReq{
+					Status: madmin.AccountStatus(status),
+				},
 			},
-		},
-		UpdatedAt: updatedAt,
-	}))
+			UpdatedAt: updatedAt,
+		}))
+	}
 }
 
 // AddUser - PUT /minio/admin/v3/add-user?accessKey=<access_key>

--- a/cmd/auth-handler_test.go
+++ b/cmd/auth-handler_test.go
@@ -375,14 +375,14 @@ func TestIsReqAuthenticated(t *testing.T) {
 
 	initConfigSubsystem(ctx, objLayer)
 
-	globalIAMSys.Init(ctx, objLayer, globalEtcdClient, 2*time.Second)
-
 	creds, err := auth.CreateCredentials("myuser", "mypassword")
 	if err != nil {
 		t.Fatalf("unable create credential, %s", err)
 	}
 
 	globalActiveCred = creds
+
+	globalIAMSys.Init(ctx, objLayer, globalEtcdClient, 2*time.Second)
 
 	// List of test cases for validating http request authentication.
 	testCases := []struct {
@@ -464,15 +464,16 @@ func TestValidateAdminSignature(t *testing.T) {
 	}
 
 	initAllSubsystems(ctx)
-	initConfigSubsystem(ctx, objLayer)
 
-	globalIAMSys.Init(ctx, objLayer, globalEtcdClient, 2*time.Second)
+	initConfigSubsystem(ctx, objLayer)
 
 	creds, err := auth.CreateCredentials("admin", "mypassword")
 	if err != nil {
 		t.Fatalf("unable create credential, %s", err)
 	}
 	globalActiveCred = creds
+
+	globalIAMSys.Init(ctx, objLayer, globalEtcdClient, 2*time.Second)
 
 	testCases := []struct {
 		AccessKey string

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1435,12 +1435,6 @@ func (sys *IAMSys) GetUser(ctx context.Context, accessKey string) (u UserIdentit
 		sys.store.LoadUser(ctx, accessKey)
 		u, ok = sys.store.GetUser(accessKey)
 	}
-
-	if !ok {
-		if accessKey == globalActiveCred.AccessKey {
-			return newUserIdentity(globalActiveCred), true
-		}
-	}
 	return u, ok && u.Credentials.IsValid()
 }
 

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -40,47 +39,14 @@ const (
 
 	// Inter-node JWT token expiry is 15 minutes.
 	defaultInterNodeJWTExpiry = 15 * time.Minute
-
-	// URL JWT token expiry is one minute (might be exposed).
-	defaultURLJWTExpiry = time.Minute
 )
 
 var (
-	errInvalidAccessKeyID = errors.New("The access key ID you provided does not exist in our records")
-	errAuthentication     = errors.New("Authentication failed, check your access credentials")
-	errNoAuthToken        = errors.New("JWT token missing")
+	errInvalidAccessKey  = errors.New("The access key you provided does not exist in our records")
+	errAccessKeyDisabled = errors.New("The access key you provided is disabled")
+	errAuthentication    = errors.New("Authentication failed, check your access credentials")
+	errNoAuthToken       = errors.New("JWT token missing")
 )
-
-func authenticateJWTUsers(accessKey, secretKey string, expiry time.Duration) (string, error) {
-	passedCredential, err := auth.CreateCredentials(accessKey, secretKey)
-	if err != nil {
-		return "", err
-	}
-	expiresAt := UTCNow().Add(expiry)
-	return authenticateJWTUsersWithCredentials(passedCredential, expiresAt)
-}
-
-func authenticateJWTUsersWithCredentials(credentials auth.Credentials, expiresAt time.Time) (string, error) {
-	serverCred := globalActiveCred
-	if serverCred.AccessKey != credentials.AccessKey {
-		u, ok := globalIAMSys.GetUser(context.TODO(), credentials.AccessKey)
-		if !ok {
-			return "", errInvalidAccessKeyID
-		}
-		serverCred = u.Credentials
-	}
-
-	if !serverCred.Equal(credentials) {
-		return "", errAuthentication
-	}
-
-	claims := xjwt.NewMapClaims()
-	claims.SetExpiry(expiresAt)
-	claims.SetAccessKey(credentials.AccessKey)
-
-	jwt := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, claims)
-	return jwt.SignedString([]byte(serverCred.SecretKey))
-}
 
 // cachedAuthenticateNode will cache authenticateNode results for given values up to ttl.
 func cachedAuthenticateNode(ttl time.Duration) func(accessKey, secretKey, audience string) (string, error) {
@@ -121,14 +87,6 @@ func authenticateNode(accessKey, secretKey, audience string) (string, error) {
 	return jwt.SignedString([]byte(secretKey))
 }
 
-func authenticateWeb(accessKey, secretKey string) (string, error) {
-	return authenticateJWTUsers(accessKey, secretKey, defaultJWTExpiry)
-}
-
-func authenticateURL(accessKey, secretKey string) (string, error) {
-	return authenticateJWTUsers(accessKey, secretKey, defaultURLJWTExpiry)
-}
-
 // Check if the request is authenticated.
 // Returns nil if the request is authenticated. errNoAuthToken if token missing.
 // Returns errAuthentication for all other errors.
@@ -141,48 +99,40 @@ func metricsRequestAuthenticate(req *http.Request) (*xjwt.MapClaims, []string, b
 		return nil, nil, false, err
 	}
 	claims := xjwt.NewMapClaims()
+	var cred auth.Credentials
 	if err := xjwt.ParseWithClaims(token, claims, func(claims *xjwt.MapClaims) ([]byte, error) {
-		if claims.AccessKey == globalActiveCred.AccessKey {
-			return []byte(globalActiveCred.SecretKey), nil
-		}
 		u, ok := globalIAMSys.GetUser(req.Context(), claims.AccessKey)
 		if !ok {
-			return nil, errInvalidAccessKeyID
+			// Credentials will be invalid but for disabled
+			// return a different error in such a scenario.
+			if u.Credentials.Status == auth.AccountOff {
+				return nil, errAccessKeyDisabled
+			}
+			return nil, errInvalidAccessKey
 		}
-		cred := u.Credentials
+		cred = u.Credentials
 		return []byte(cred.SecretKey), nil
 	}); err != nil {
 		return claims, nil, false, errAuthentication
 	}
-	owner := true
-	var groups []string
-	if globalActiveCred.AccessKey != claims.AccessKey {
-		// Check if the access key is part of users credentials.
-		u, ok := globalIAMSys.GetUser(req.Context(), claims.AccessKey)
-		if !ok {
-			return nil, nil, false, errInvalidAccessKeyID
-		}
-		ucred := u.Credentials
-		// get embedded claims
-		eclaims, s3Err := checkClaimsFromToken(req, ucred)
-		if s3Err != ErrNone {
-			return nil, nil, false, errAuthentication
-		}
 
-		for k, v := range eclaims {
-			claims.MapClaims[k] = v
-		}
-
-		// Now check if we have a sessionPolicy.
-		if _, ok = eclaims[iampolicy.SessionPolicyName]; ok {
-			owner = false
-		} else {
-			owner = globalActiveCred.AccessKey == ucred.ParentUser
-		}
-
-		groups = ucred.Groups
+	// get embedded claims
+	eclaims, s3Err := checkClaimsFromToken(req, cred)
+	if s3Err != ErrNone {
+		return nil, nil, false, errAuthentication
 	}
 
+	for k, v := range eclaims {
+		claims.MapClaims[k] = v
+	}
+
+	owner := cred.AccessKey == globalActiveCred.AccessKey || cred.ParentUser == globalActiveCred.AccessKey
+	// Now check if we have a sessionPolicy.
+	if _, ok := eclaims[iampolicy.SessionPolicyName]; ok {
+		owner = false
+	}
+
+	groups := cred.Groups
 	return claims, groups, owner, nil
 }
 

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -3360,6 +3360,10 @@ func (c *SiteReplicationSys) SiteReplicationMetaInfo(ctx context.Context, objAPI
 					continue
 				}
 
+				if v.Credentials.AccessKey == globalActiveCred.AccessKey {
+					// skip root users.
+					continue
+				}
 				if v.Credentials.ParentUser != "" && v.Credentials.ParentUser == globalActiveCred.AccessKey {
 					// skip all root user service accounts.
 					continue

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -109,8 +109,8 @@ func toStorageErr(err error) error {
 		return errCorruptedFormat
 	case errUnformattedDisk.Error():
 		return errUnformattedDisk
-	case errInvalidAccessKeyID.Error():
-		return errInvalidAccessKeyID
+	case errInvalidAccessKey.Error():
+		return errInvalidAccessKey
 	case errAuthentication.Error():
 		return errAuthentication
 	case errRPCAPIVersionUnsupported.Error():

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -764,7 +764,7 @@ func (s *TestSuiteIAM) TestLDAPSTS(c *check) {
 	if err != nil {
 		c.Fatalf("list users should not fail: %v", err)
 	}
-	if len(usersList) != 1 {
+	if len(usersList) != 2 {
 		c.Fatalf("expected user listing output: %v", usersList)
 	}
 	uinfo := usersList[userDN]


### PR DESCRIPTION
## Description
root user is now part of IAM allowing it to be disabled

## Motivation and Context
root user exists now as a special user that does not
carry any policy associated with it, however allows
it to be disabled via another admin.
    
This admin can also enable root if needed in the future,
this allows for completely disabled root credentials.

## How to test this PR?
```
minio server ~/test

mc alias set myminio/ http://localhost:9000 minioadmin minioadmin
mc admin user add myminio/ testuser testuser123

mc admin policy attach myminio/ consoleAdmin --user=testuser

mc alias set testuser-adm/ http://localhost:9000 testuser testuser123
mc admin user disable testuser-adm/ minioadmin

mc ls myminio/
mc: <ERROR> Unable to list folder. Your account is disabled; please contact your administrator.
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
