### PR TITLE
return quorum error instead of insufficient storage error

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -346,6 +346,10 @@ func (z *erasureServerPools) getServerPoolsAvailableSpace(ctx context.Context, b
 	g.Wait()
 
 	for i, zinfo := range storageInfos {
+		if zinfo == nil {
+			serverPools[i] = poolAvailableSpace{Index: i}
+			continue
+		}
 		var available uint64
 		if !isMinioMetaBucketName(bucket) {
 			if avail, err := hasSpaceFor(zinfo, size); err != nil && !avail {

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -1083,7 +1083,7 @@ func hasSpaceFor(di []*DiskInfo, size int64) (bool, error) {
 	}
 
 	if nDisks < len(di)/2 {
-		return false, fmt.Errorf("no enough online disks to calculate the available space")
+		return false, fmt.Errorf("not enough online disks to calculate the available space, expected (%d)/(%d)", (len(di)/2)+1, nDisks)
 	}
 
 	// Check we have enough on each disk, ignoring diskFillFraction.

--- a/internal/disk/directio_darwin.go
+++ b/internal/disk/directio_darwin.go
@@ -37,6 +37,6 @@ func DisableDirectIO(f *os.File) error {
 }
 
 // AlignedBlock - pass through to directio implementation.
-func AlignedBlock(BlockSize int) []byte {
-	return directio.AlignedBlock(BlockSize)
+func AlignedBlock(blockSize int) []byte {
+	return directio.AlignedBlock(blockSize)
 }


### PR DESCRIPTION
## Description
PutObject calculates available disk space from cached disk info. 
However an insufficient storage error (507 status code) can be 
returned when there is no enough good information from those disks.

Return quorum error instead of insufficient storage error and add
 a log to facilitate debugging issues.

## Motivation and Context
Avoid returning 507 insufficient storage error when it should be 503

## How to test this PR?
Not trivial without modifying some code

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
