### PR TITLE
Revert query parameter `src` from diag upload if callhome enabled

### DIFF
--- a/cmd/callhome.go
+++ b/cmd/callhome.go
@@ -168,7 +168,7 @@ func sendHealthInfo(ctx context.Context, healthInfo madmin.HealthInfo) error {
 	}
 
 	filename := fmt.Sprintf("health_%s.json.gz", UTCNow().Format("20060102150405"))
-	url += "?filename=" + filename + "&src=callhome"
+	url += "?filename=" + filename
 
 	_, err := globalSubnetConfig.Upload(url, filename, createHealthJSONGzip(ctx, healthInfo))
 	return err


### PR DESCRIPTION
## Description
This reverts commit 850a945a1873d4c89690c0a4fae3f23dc607bb5c.

## Motivation and Context
Earlier intention was to set a flag in SUBNET if callhome sends diagnostics data for a cluster and the same was achieved using this query parameter.
But we actually want to make diag and callhome synonymous and SUBNET would rather use the information like whether diag had been upadated in last 24h hrs for a cluster or not. This parameters stands of no use in such case and no need to set explicit flag at cluster level just to identify if callhome enabed or not.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
