### PR TITLE
Set Console global Root CAs early to trust provided certs

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -257,6 +257,9 @@ func initConsoleServer() (*restapi.Server, error) {
 		Path: globalCertsCADir.Get(),
 	}
 
+	// set certs before other console initialization
+	restapi.GlobalRootCAs, restapi.GlobalPublicCerts, restapi.GlobalTLSCertsManager = globalRootCAs, globalPublicCerts, globalTLSCerts
+
 	swaggerSpec, err := loads.Embedded(restapi.SwaggerJSON, restapi.FlatSwaggerJSON)
 	if err != nil {
 		return nil, err
@@ -282,8 +285,6 @@ func initConsoleServer() (*restapi.Server, error) {
 	server := restapi.NewServer(api)
 	// register all APIs
 	server.ConfigureAPI()
-
-	restapi.GlobalRootCAs, restapi.GlobalPublicCerts, restapi.GlobalTLSCertsManager = globalRootCAs, globalPublicCerts, globalTLSCerts
 
 	consolePort, _ := strconv.Atoi(globalMinioConsolePort)
 


### PR DESCRIPTION
## Description

Console caches http.Client with root CAs. That is why root CAs 
in Console should be set early before any console code to be executed.

This commit fixes the console unable to trust an OpenID CA 
through already added to .minio/certs/CAs directory.

## Motivation and Context
Fix Console complaining about not being able to trust OpenID certificate
although already provided in .minio/certs/CAs/

## How to test this PR?
A lot of work to do that, just trust me.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
