### PR TITLE
read use Rwlock first.

### DIFF
--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -260,16 +260,21 @@ func (config *TierConfigMgr) Bytes() ([]byte, error) {
 
 // getDriver returns a warmBackend interface object initialized with remote tier config matching tierName
 func (config *TierConfigMgr) getDriver(tierName string) (d WarmBackend, err error) {
+	config.RLock()
+	// Lookup in-memory drivercache
+	d, ok := config.drivercache[tierName]
+	if ok {
+		config.Unlock()
+		return d, nil
+	}
+	config.Unlock()
+
 	config.Lock()
 	defer config.Unlock()
-
-	var ok bool
-	// Lookup in-memory drivercache
 	d, ok = config.drivercache[tierName]
 	if ok {
 		return d, nil
 	}
-
 	// Initialize driver from tier config matching tierName
 	t, ok := config.Tiers[tierName]
 	if !ok {

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -264,10 +264,10 @@ func (config *TierConfigMgr) getDriver(tierName string) (d WarmBackend, err erro
 	// Lookup in-memory drivercache
 	d, ok := config.drivercache[tierName]
 	if ok {
-		config.Unlock()
+		config.RUnlock()
 		return d, nil
 	}
-	config.Unlock()
+	config.RUnlock()
 
 	config.Lock()
 	defer config.Unlock()


### PR DESCRIPTION
## Description

It looks like we can use a read/write lock to get the data, and once the data doesn't exist, we can use the write lock to check once if it was written by another thread first, and generate a new one if it wasn't. If we use write lock at the beginning, it feels like it will affect the performance.
Close this pr if on purpose.
## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
