### PR TITLE
Use one http response recorder per external http call

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -1004,7 +1004,7 @@ func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI Obje
 			},
 		}
 
-		_, _ = objectAPI.PutObjectMetadata(ctx, bucket, object, popts);
+		_, _ = objectAPI.PutObjectMetadata(ctx, bucket, object, popts)
 		opType := replication.MetadataReplicationType
 		if rinfos.Action() == replicateAll {
 			opType = replication.ObjectReplicationType

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -555,7 +555,7 @@ func addCustomHeaders(h http.Handler) http.Handler {
 		if globalLocalNodeName != "" {
 			w.Header().Set(xhttp.AmzRequestHostID, globalLocalNodeNameHex)
 		}
-		h.ServeHTTP(xhttp.NewResponseRecorder(w), r)
+		h.ServeHTTP(w, r)
 	})
 }
 

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -355,11 +355,11 @@ func collectAPIStats(api string, f http.HandlerFunc) http.HandlerFunc {
 		globalHTTPStats.currentS3Requests.Inc(api)
 		defer globalHTTPStats.currentS3Requests.Dec(api)
 
-		statsWriter := xhttp.NewResponseRecorder(w)
+		f.ServeHTTP(w, r)
 
-		f.ServeHTTP(statsWriter, r)
-
-		globalHTTPStats.updateStats(api, r, statsWriter)
+		if sw, ok := w.(*xhttp.ResponseRecorder); ok {
+			globalHTTPStats.updateStats(api, r, sw)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
internal/http.ResponseRecorder is being created 
and used in multiple handlers for each HTTP call.

This commit will only create the response recoder once 
by the first handler http-tracer.go.

The HTTP response recorder is used for http/s3 stats 
exported by prometheus and by the audit if enabled.

## Motivation and Context
Make the code simpler before the next PR which should audit all requests

## How to test this PR?
Setup a MinIO cluster with Audit endpoint and check if audit is working properly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
