### PR TITLE
implement support for FTP/SFTP server

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -15022,6 +15022,39 @@ SOFTWARE.
 
 ================================================================
 
+github.com/kr/fs
+https://github.com/kr/fs
+----------------------------------------------------------------
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================
+
 github.com/kr/pretty
 https://github.com/kr/pretty
 ----------------------------------------------------------------
@@ -23931,6 +23964,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================
 
+github.com/pkg/sftp
+https://github.com/pkg/sftp
+----------------------------------------------------------------
+Copyright (c) 2013, Dave Cheney
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================
+
 github.com/pkg/xattr
 https://github.com/pkg/xattr
 ----------------------------------------------------------------
@@ -28532,6 +28580,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+================================================================
+
+goftp.io/server/v2
+https://goftp.io/server/v2
+----------------------------------------------------------------
+Copyright (c) 2018 Goftp Authors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================
 

--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -1,0 +1,505 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/minio/madmin-go/v2"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio/internal/auth"
+	"github.com/minio/minio/internal/logger"
+	ftp "goftp.io/server/v2"
+)
+
+var _ ftp.Driver = &ftpDriver{}
+
+// ftpDriver implements ftpDriver to store files in minio
+type ftpDriver struct {
+	endpoint string
+}
+
+// NewFTPDriver implements ftp.Driver interface
+func NewFTPDriver() ftp.Driver {
+	return &ftpDriver{endpoint: fmt.Sprintf("127.0.0.1:%s", globalMinioPort)}
+}
+
+func buildMinioPath(p string) string {
+	return strings.TrimPrefix(p, SlashSeparator)
+}
+
+func buildMinioDir(p string) string {
+	v := buildMinioPath(p)
+	if !strings.HasSuffix(v, SlashSeparator) {
+		return v + SlashSeparator
+	}
+	return v
+}
+
+type minioFileInfo struct {
+	p     string
+	info  minio.ObjectInfo
+	isDir bool
+}
+
+func (m *minioFileInfo) Name() string {
+	return m.p
+}
+
+func (m *minioFileInfo) Size() int64 {
+	return m.info.Size
+}
+
+func (m *minioFileInfo) Mode() os.FileMode {
+	if m.isDir {
+		return os.ModeDir
+	}
+	return os.ModePerm
+}
+
+func (m *minioFileInfo) ModTime() time.Time {
+	return m.info.LastModified
+}
+
+func (m *minioFileInfo) IsDir() bool {
+	return m.isDir
+}
+
+func (m *minioFileInfo) Sys() interface{} {
+	return nil
+}
+
+//msgp:ignore ftpMetrics
+type ftpMetrics struct{}
+
+var globalFtpMetrics ftpMetrics
+
+func ftpTrace(s *ftp.Context, startTime time.Time, source, path string, err error) madmin.TraceInfo {
+	var errStr string
+	if err != nil {
+		errStr = err.Error()
+	}
+	return madmin.TraceInfo{
+		TraceType: madmin.TraceFTP,
+		Time:      startTime,
+		NodeName:  globalLocalNodeName,
+		FuncName:  fmt.Sprintf("ftp USER=%s COMMAND=%s PARAM=%s ISLOGIN=%t, Source=%s", s.Sess.LoginUser(), s.Cmd, s.Param, s.Sess.IsLogin(), source),
+		Duration:  time.Since(startTime),
+		Path:      path,
+		Error:     errStr,
+	}
+}
+
+func (m *ftpMetrics) log(s *ftp.Context, paths ...string) func(err error) {
+	startTime := time.Now()
+	source := getSource(2)
+	return func(err error) {
+		globalTrace.Publish(ftpTrace(s, startTime, source, strings.Join(paths, " "), err))
+	}
+}
+
+// Stat implements ftpDriver
+func (driver *ftpDriver) Stat(ctx *ftp.Context, path string) (fi os.FileInfo, err error) {
+	stopFn := globalFtpMetrics.log(ctx, path)
+	defer stopFn(err)
+
+	if path == SlashSeparator {
+		return &minioFileInfo{
+			p:     SlashSeparator,
+			isDir: true,
+		}, nil
+	}
+
+	bucket, object := path2BucketObject(path)
+	if bucket == "" {
+		return nil, errors.New("bucket name cannot be empty")
+	}
+
+	clnt, err := driver.getMinIOClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if object == "" {
+		ok, err := clnt.BucketExists(context.Background(), bucket)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+		return &minioFileInfo{
+			p:     pathClean(bucket),
+			info:  minio.ObjectInfo{Key: bucket},
+			isDir: true,
+		}, nil
+	}
+
+	objInfo, err := clnt.StatObject(context.Background(), bucket, object, minio.StatObjectOptions{})
+	if err != nil {
+		if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+			// dummy return to satisfy LIST (stat -> list) behavior.
+			return &minioFileInfo{
+				p:     pathClean(object),
+				info:  minio.ObjectInfo{Key: object},
+				isDir: true,
+			}, nil
+		}
+		return nil, err
+	}
+
+	isDir := strings.HasSuffix(objInfo.Key, SlashSeparator)
+	return &minioFileInfo{
+		p:     pathClean(object),
+		info:  objInfo,
+		isDir: isDir,
+	}, nil
+}
+
+// ListDir implements ftpDriver
+func (driver *ftpDriver) ListDir(ctx *ftp.Context, path string, callback func(os.FileInfo) error) (err error) {
+	stopFn := globalFtpMetrics.log(ctx, path)
+	defer stopFn(err)
+
+	clnt, err := driver.getMinIOClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	cctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bucket, prefix := path2BucketObject(path)
+	if bucket == "" {
+		buckets, err := clnt.ListBuckets(cctx)
+		if err != nil {
+			return err
+		}
+
+		for _, bucket := range buckets {
+			info := minioFileInfo{
+				p:     pathClean(bucket.Name),
+				info:  minio.ObjectInfo{Key: retainSlash(bucket.Name), LastModified: bucket.CreationDate},
+				isDir: true,
+			}
+			if err := callback(&info); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	prefix = retainSlash(prefix)
+
+	for object := range clnt.ListObjects(cctx, bucket, minio.ListObjectsOptions{
+		Prefix:    prefix,
+		Recursive: false,
+	}) {
+		if object.Err != nil {
+			return object.Err
+		}
+
+		if object.Key == prefix {
+			continue
+		}
+
+		isDir := strings.HasSuffix(object.Key, SlashSeparator)
+		info := minioFileInfo{
+			p:     pathClean(strings.TrimPrefix(object.Key, prefix)),
+			info:  object,
+			isDir: isDir,
+		}
+
+		if err := callback(&info); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (driver *ftpDriver) CheckPasswd(c *ftp.Context, username, password string) (ok bool, err error) {
+	stopFn := globalFtpMetrics.log(c, username)
+	defer stopFn(err)
+
+	if globalIAMSys.LDAPConfig.Enabled() {
+		ldapUserDN, groupDistNames, err := globalIAMSys.LDAPConfig.Bind(username, password)
+		if err != nil {
+			return false, err
+		}
+		ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, false, groupDistNames...)
+		if len(ldapPolicies) == 0 {
+			// no policy associated reject it.
+			return false, nil
+		}
+		return true, nil
+	}
+
+	ui, ok := globalIAMSys.GetUser(context.Background(), username)
+	if !ok {
+		return false, nil
+	}
+	return subtle.ConstantTimeCompare([]byte(ui.Credentials.SecretKey), []byte(password)) == 1, nil
+}
+
+func (driver *ftpDriver) getMinIOClient(ctx *ftp.Context) (*minio.Client, error) {
+	ui, ok := globalIAMSys.GetUser(context.Background(), ctx.Sess.LoginUser())
+	if !ok && !globalIAMSys.LDAPConfig.Enabled() {
+		return nil, errNoSuchUser
+	}
+	if !ok && globalIAMSys.LDAPConfig.Enabled() {
+		targetUser, targetGroups, err := globalIAMSys.LDAPConfig.LookupUserDN(ctx.Sess.LoginUser())
+		if err != nil {
+			return nil, err
+		}
+		ldapPolicies, _ := globalIAMSys.PolicyDBGet(targetUser, false, targetGroups...)
+		if len(ldapPolicies) == 0 {
+			return nil, errAuthentication
+		}
+		expiryDur, err := globalIAMSys.LDAPConfig.GetExpiryDuration("")
+		if err != nil {
+			return nil, err
+		}
+		claims := make(map[string]interface{})
+		claims[expClaim] = UTCNow().Add(expiryDur).Unix()
+		claims[ldapUser] = targetUser
+		claims[ldapUserN] = ctx.Sess.LoginUser()
+
+		cred, err := auth.GetNewCredentialsWithMetadata(claims, globalActiveCred.SecretKey)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the parent of the temporary access key, this is useful
+		// in obtaining service accounts by this cred.
+		cred.ParentUser = targetUser
+
+		// Set this value to LDAP groups, LDAP user can be part
+		// of large number of groups
+		cred.Groups = targetGroups
+
+		// Set the newly generated credentials, policyName is empty on purpose
+		// LDAP policies are applied automatically using their ldapUser, ldapGroups
+		// mapping.
+		updatedAt, err := globalIAMSys.SetTempUser(context.Background(), cred.AccessKey, cred, "")
+		if err != nil {
+			return nil, err
+		}
+
+		// Call hook for site replication.
+		logger.LogIf(context.Background(), globalSiteReplicationSys.IAMChangeHook(context.Background(), madmin.SRIAMItem{
+			Type: madmin.SRIAMItemSTSAcc,
+			STSCredential: &madmin.SRSTSCredential{
+				AccessKey:    cred.AccessKey,
+				SecretKey:    cred.SecretKey,
+				SessionToken: cred.SessionToken,
+				ParentUser:   cred.ParentUser,
+			},
+			UpdatedAt: updatedAt,
+		}))
+
+		return minio.New(driver.endpoint, &minio.Options{
+			Creds:     credentials.NewStaticV4(cred.AccessKey, cred.SecretKey, cred.SessionToken),
+			Secure:    globalIsTLS,
+			Transport: globalRemoteTargetTransport,
+		})
+	}
+
+	// ok == true - at this point
+
+	if ui.Credentials.IsTemp() {
+		// Temporary credentials are not allowed.
+		return nil, errAuthentication
+	}
+
+	return minio.New(driver.endpoint, &minio.Options{
+		Creds:     credentials.NewStaticV4(ui.Credentials.AccessKey, ui.Credentials.SecretKey, ""),
+		Secure:    globalIsTLS,
+		Transport: globalRemoteTargetTransport,
+	})
+}
+
+// DeleteDir implements ftpDriver
+func (driver *ftpDriver) DeleteDir(ctx *ftp.Context, path string) (err error) {
+	stopFn := globalFtpMetrics.log(ctx, path)
+	defer stopFn(err)
+
+	bucket, prefix := path2BucketObject(path)
+	if bucket == "" {
+		return errors.New("deleting all buckets not allowed")
+	}
+
+	clnt, err := driver.getMinIOClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	cctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	objectsCh := make(chan minio.ObjectInfo)
+
+	// Send object names that are needed to be removed to objectsCh
+	go func() {
+		defer close(objectsCh)
+		opts := minio.ListObjectsOptions{Prefix: prefix, Recursive: true}
+		for object := range clnt.ListObjects(cctx, bucket, opts) {
+			if object.Err != nil {
+				return
+			}
+			objectsCh <- object
+		}
+	}()
+
+	// Call RemoveObjects API
+	for err := range clnt.RemoveObjects(context.Background(), bucket, objectsCh, minio.RemoveObjectsOptions{}) {
+		if err.Err != nil {
+			return err.Err
+		}
+	}
+
+	return nil
+}
+
+// DeleteFile implements ftpDriver
+func (driver *ftpDriver) DeleteFile(ctx *ftp.Context, path string) (err error) {
+	stopFn := globalFtpMetrics.log(ctx, path)
+	defer stopFn(err)
+
+	bucket, object := path2BucketObject(path)
+	if bucket == "" {
+		return errors.New("bucket name cannot be empty")
+	}
+
+	clnt, err := driver.getMinIOClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	return clnt.RemoveObject(context.Background(), bucket, object, minio.RemoveObjectOptions{})
+}
+
+// Rename implements ftpDriver
+func (driver *ftpDriver) Rename(ctx *ftp.Context, fromPath string, toPath string) (err error) {
+	stopFn := globalFtpMetrics.log(ctx, fromPath, toPath)
+	defer stopFn(err)
+
+	return NotImplemented{}
+}
+
+// MakeDir implements ftpDriver
+func (driver *ftpDriver) MakeDir(ctx *ftp.Context, path string) (err error) {
+	stopFn := globalFtpMetrics.log(ctx, path)
+	defer stopFn(err)
+
+	bucket, prefix := path2BucketObject(path)
+	if bucket == "" {
+		return errors.New("bucket name cannot be empty")
+	}
+
+	clnt, err := driver.getMinIOClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	dirPath := buildMinioDir(prefix)
+
+	_, err = clnt.PutObject(context.Background(), bucket, dirPath, bytes.NewReader([]byte("")), 0,
+		// Always send Content-MD5 to succeed with bucket with
+		// locking enabled. There is no performance hit since
+		// this is always an empty object
+		minio.PutObjectOptions{SendContentMd5: true},
+	)
+	return err
+}
+
+// GetFile implements ftpDriver
+func (driver *ftpDriver) GetFile(ctx *ftp.Context, path string, offset int64) (n int64, rc io.ReadCloser, err error) {
+	stopFn := globalFtpMetrics.log(ctx, path)
+	defer stopFn(err)
+
+	bucket, object := path2BucketObject(path)
+	if bucket == "" {
+		return 0, nil, errors.New("bucket name cannot be empty")
+	}
+
+	clnt, err := driver.getMinIOClient(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	opts := minio.GetObjectOptions{}
+	obj, err := clnt.GetObject(context.Background(), bucket, object, opts)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() {
+		if err != nil && obj != nil {
+			obj.Close()
+		}
+	}()
+
+	_, err = obj.Seek(offset, io.SeekStart)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	info, err := obj.Stat()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return info.Size - offset, obj, nil
+}
+
+// PutFile implements ftpDriver
+func (driver *ftpDriver) PutFile(ctx *ftp.Context, path string, data io.Reader, offset int64) (n int64, err error) {
+	stopFn := globalFtpMetrics.log(ctx, path)
+	defer stopFn(err)
+
+	bucket, object := path2BucketObject(path)
+	if bucket == "" {
+		return 0, errors.New("bucket name cannot be empty")
+	}
+
+	if offset != -1 {
+		// FTP - APPEND not implemented
+		return 0, NotImplemented{}
+	}
+
+	clnt, err := driver.getMinIOClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	info, err := clnt.PutObject(context.Background(), bucket, object, data, -1, minio.PutObjectOptions{
+		ContentType:    "application/octet-stream",
+		SendContentMd5: true,
+	})
+	return info.Size, err
+}

--- a/cmd/ftp-server.go
+++ b/cmd/ftp-server.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/minio/cli"
+	"github.com/minio/minio/internal/ioutil"
+	"github.com/minio/minio/internal/logger"
+	"github.com/pkg/sftp"
+	ftp "goftp.io/server/v2"
+	"golang.org/x/crypto/ssh"
+)
+
+// minioLogger use an instance of this to log in a standard format
+type minioLogger struct{}
+
+// Print implement Logger
+func (log *minioLogger) Print(sessionID string, message interface{}) {
+	if serverDebugLog {
+		logger.Info("%s %s", sessionID, message)
+	}
+}
+
+// Printf implement Logger
+func (log *minioLogger) Printf(sessionID string, format string, v ...interface{}) {
+	if serverDebugLog {
+		if sessionID != "" {
+			logger.Info("%s %s", sessionID, fmt.Sprintf(format, v...))
+		} else {
+			logger.Info(format, v...)
+		}
+	}
+}
+
+// PrintCommand impelment Logger
+func (log *minioLogger) PrintCommand(sessionID string, command string, params string) {
+	if serverDebugLog {
+		if command == "PASS" {
+			logger.Info("%s > PASS ****", sessionID)
+		} else {
+			logger.Info("%s > %s %s", sessionID, command, params)
+		}
+	}
+}
+
+// PrintResponse impelment Logger
+func (log *minioLogger) PrintResponse(sessionID string, code int, message string) {
+	if serverDebugLog {
+		logger.Info("%s < %d %s", sessionID, code, message)
+	}
+}
+
+func startSFTPServer(c *cli.Context) {
+	args := c.StringSlice("sftp")
+
+	var (
+		port          int
+		publicIP      string
+		sshPrivateKey string
+	)
+
+	var err error
+	for _, arg := range args {
+		tokens := strings.SplitN(arg, "=", 2)
+		if len(tokens) != 2 {
+			logger.Fatal(fmt.Errorf("invalid arguments passed to --sftp=%s", arg), "unable to start SFTP server")
+		}
+		switch tokens[0] {
+		case "address":
+			host, portStr, err := net.SplitHostPort(tokens[1])
+			if err != nil {
+				logger.Fatal(fmt.Errorf("invalid arguments passed to --sftp=%s (%v)", arg, err), "unable to start SFTP server")
+			}
+			port, err = strconv.Atoi(portStr)
+			if err != nil {
+				logger.Fatal(fmt.Errorf("invalid arguments passed to --sftp=%s (%v)", arg, err), "unable to start SFTP server")
+			}
+			if port < 1 || port > 65535 {
+				logger.Fatal(fmt.Errorf("invalid arguments passed to --sftp=%s, (port number must be between 1 to 65535)", arg), "unable to start SFTP server")
+			}
+			publicIP = host
+		case "ssh-private-key":
+			sshPrivateKey = tokens[1]
+		}
+	}
+
+	if port == 0 {
+		port = 8022 // Default SFTP port, since no port was given.
+	}
+
+	if sshPrivateKey == "" {
+		logger.Fatal(fmt.Errorf("invalid arguments passed, private key file is mandatory for --sftp='ssh-private-key=path/to/id_ecdsa'"), "unable to start SFTP server")
+	}
+
+	privateBytes, err := ioutil.ReadFile(sshPrivateKey)
+	if err != nil {
+		logger.Fatal(fmt.Errorf("invalid arguments passed, private key file is not accessible: %v", err), "unable to start SFTP server")
+	}
+
+	private, err := ssh.ParsePrivateKey(privateBytes)
+	if err != nil {
+		logger.Fatal(fmt.Errorf("invalid arguments passed, private key file is not parseable: %v", err), "unable to start SFTP server")
+	}
+
+	// An SSH server is represented by a ServerConfig, which holds
+	// certificate details and handles authentication of ServerConns.
+	config := &ssh.ServerConfig{
+		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+			ui, ok := globalIAMSys.GetUser(context.Background(), c.User())
+			if !ok {
+				return nil, errNoSuchUser
+			}
+			if subtle.ConstantTimeCompare([]byte(ui.Credentials.SecretKey), pass) == 1 {
+				return &ssh.Permissions{
+					CriticalOptions: map[string]string{
+						"accessKey": c.User(),
+					},
+					Extensions: make(map[string]string),
+				}, nil
+			}
+			return nil, errAuthentication
+		},
+	}
+
+	config.AddHostKey(private)
+
+	// Once a ServerConfig has been configured, connections can be accepted.
+	listener, err := net.Listen("tcp", net.JoinHostPort(publicIP, strconv.Itoa(port)))
+	if err != nil {
+		logger.Fatal(err, "unable to start listening on --sftp='port=%d'", port)
+	}
+
+	logger.Info(fmt.Sprintf("MinIO SFTP Server listening on %s", net.JoinHostPort(publicIP, strconv.Itoa(port))))
+
+	for {
+		nConn, err := listener.Accept()
+		if err != nil {
+			logger.LogIf(context.Background(), err)
+			continue
+		}
+
+		// Before use, a handshake must be performed on the incoming net.Conn.
+		sconn, chans, reqs, err := ssh.NewServerConn(nConn, config)
+		if err != nil {
+			logger.LogIf(context.Background(), err)
+			continue
+		}
+
+		// The incoming Request channel must be serviced.
+		go ssh.DiscardRequests(reqs)
+
+		// Service the incoming Channel channel.
+		for newChannel := range chans {
+			// Channels have a type, depending on the application level
+			// protocol intended. In the case of an SFTP session, this is "subsystem"
+			// with a payload string of "<length=4>sftp"
+			if newChannel.ChannelType() != "session" {
+				newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
+				continue
+			}
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				logger.Fatal(err, "unable to accept the connection requests channel")
+			}
+
+			// Sessions have out-of-band requests such as "shell",
+			// "pty-req" and "env".  Here we handle only the
+			// "subsystem" request.
+			go func(in <-chan *ssh.Request) {
+				for req := range in {
+					// We only reply to SSH packets that have `sftp` payload.
+					req.Reply(req.Type == "subsystem" && string(req.Payload[4:]) == "sftp", nil)
+				}
+			}(requests)
+
+			server := sftp.NewRequestServer(channel, NewSFTPDriver(sconn.Permissions))
+			if err := server.Serve(); err == io.EOF {
+				server.Close()
+			} else if err != nil {
+				logger.Fatal(err, "unable to start SFTP server")
+			}
+		}
+	}
+}
+
+func startFTPServer(c *cli.Context) {
+	args := c.StringSlice("ftp")
+
+	var (
+		port          int
+		publicIP      string
+		portRange     string
+		tlsPrivateKey string
+		tlsPublicCert string
+	)
+
+	var err error
+	for _, arg := range args {
+		tokens := strings.SplitN(arg, "=", 2)
+		if len(tokens) != 2 {
+			logger.Fatal(fmt.Errorf("invalid arguments passed to --ftp=%s", arg), "unable to start FTP server")
+		}
+		switch tokens[0] {
+		case "address":
+			host, portStr, err := net.SplitHostPort(tokens[1])
+			if err != nil {
+				logger.Fatal(fmt.Errorf("invalid arguments passed to --ftp=%s (%v)", arg, err), "unable to start FTP server")
+			}
+			port, err = strconv.Atoi(portStr)
+			if err != nil {
+				logger.Fatal(fmt.Errorf("invalid arguments passed to --ftp=%s (%v)", arg, err), "unable to start FTP server")
+			}
+			if port < 1 || port > 65535 {
+				logger.Fatal(fmt.Errorf("invalid arguments passed to --ftp=%s, (port number must be between 1 to 65535)", arg), "unable to start FTP server")
+			}
+			publicIP = host
+		case "passive-port-range":
+			portRange = tokens[1]
+		case "tls-private-key":
+			tlsPrivateKey = tokens[1]
+		case "tls-public-cert":
+			tlsPublicCert = tokens[1]
+		}
+	}
+
+	// Verify if only partial inputs are given for FTP(secure)
+	{
+		if tlsPrivateKey == "" && tlsPublicCert != "" {
+			logger.Fatal(fmt.Errorf("invalid TLS arguments provided missing private key --ftp=\"tls-private-key=path/to/private.key\""), "unable to start FTP server")
+		}
+
+		if tlsPrivateKey != "" && tlsPublicCert == "" {
+			logger.Fatal(fmt.Errorf("invalid TLS arguments provided missing public cert --ftp=\"tls-public-cert=path/to/public.crt\""), "unable to start FTP server")
+		}
+		if port == 0 {
+			port = 8021 // Default FTP port, since no port was given.
+		}
+	}
+
+	// If no TLS certs were provided, server is running in TLS for S3 API
+	// we automatically make FTP also run under TLS mode.
+	if globalIsTLS && tlsPrivateKey == "" && tlsPublicCert == "" {
+		tlsPrivateKey = getPrivateKeyFile()
+		tlsPublicCert = getPublicCertFile()
+	}
+
+	tls := tlsPrivateKey != "" && tlsPublicCert != ""
+
+	name := "MinIO FTP Server"
+	if tls {
+		name = "MinIO FTP(Secure) Server"
+	}
+
+	ftpServer, err := ftp.NewServer(&ftp.Options{
+		Name:           name,
+		WelcomeMessage: fmt.Sprintf("Welcome to MinIO FTP Server Version='%s' License='GNU AGPLv3'", Version),
+		Driver:         NewFTPDriver(),
+		Port:           port,
+		Perm:           ftp.NewSimplePerm("nobody", "nobody"),
+		TLS:            tls,
+		KeyFile:        tlsPrivateKey,
+		CertFile:       tlsPublicCert,
+		ExplicitFTPS:   tls,
+		Logger:         &minioLogger{},
+		PassivePorts:   portRange,
+		PublicIP:       publicIP,
+	})
+	if err != nil {
+		logger.Fatal(err, "unable to initialize FTP server")
+	}
+
+	logger.Info(fmt.Sprintf("%s listening on %s", name, net.JoinHostPort(publicIP, strconv.Itoa(port))))
+
+	if err = ftpServer.ListenAndServe(); err != nil {
+		logger.Fatal(err, "unable to start FTP server")
+	}
+}

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1451,6 +1451,11 @@ func (sys *IAMSys) GetUser(ctx context.Context, accessKey string) (u UserIdentit
 		u, ok = sys.store.GetUser(accessKey)
 	}
 
+	if !ok {
+		if accessKey == globalActiveCred.AccessKey {
+			return newUserIdentity(globalActiveCred), true
+		}
+	}
 	return u, ok && u.Credentials.IsValid()
 }
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -105,6 +105,14 @@ var ServerFlags = []cli.Flag{
 		Value:  10 * time.Minute,
 		EnvVar: "MINIO_CONN_WRITE_DEADLINE",
 	},
+	cli.StringSliceFlag{
+		Name:  "ftp",
+		Usage: "enable and configure an FTP(Secure) server",
+	},
+	cli.StringSliceFlag{
+		Name:  "sftp",
+		Usage: "enable and configure an SFTP server",
+	},
 }
 
 var gatewayCmd = cli.Command{
@@ -145,22 +153,23 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}{{end}}
 EXAMPLES:
-  1. Start minio server on "/home/shared" directory.
+  1. Start MinIO server on "/home/shared" directory.
      {{.Prompt}} {{.HelpName}} /home/shared
 
   2. Start single node server with 64 local drives "/mnt/data1" to "/mnt/data64".
      {{.Prompt}} {{.HelpName}} /mnt/data{1...64}
 
-  3. Start distributed minio server on an 32 node setup with 32 drives each, run following command on all the nodes
-     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ROOT_USER{{.AssignmentOperator}}minio
-     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ROOT_PASSWORD{{.AssignmentOperator}}miniostorage
+  3. Start distributed MinIO server on an 32 node setup with 32 drives each, run following command on all the nodes
      {{.Prompt}} {{.HelpName}} http://node{1...32}.example.com/mnt/export{1...32}
 
-  4. Start distributed minio server in an expanded setup, run the following command on all the nodes
-     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ROOT_USER{{.AssignmentOperator}}minio
-     {{.Prompt}} {{.EnvVarSetCommand}} MINIO_ROOT_PASSWORD{{.AssignmentOperator}}miniostorage
+  4. Start distributed MinIO server in an expanded setup, run the following command on all the nodes
      {{.Prompt}} {{.HelpName}} http://node{1...16}.example.com/mnt/export{1...32} \
             http://node{17...64}.example.com/mnt/export{1...64}
+
+  5. Start distributed MinIO server, with FTP and SFTP servers on all interfaces via port 8021, 8022 respectively
+     {{.Prompt}} {{.HelpName}} http://node{1...4}.example.com/mnt/export{1...4} \
+           --ftp="address=:8021" --ftp="passive-port-range=30000-40000" \
+           --sftp="address=:8022" --sftp="ssh-private-key=${HOME}/.ssh/id_rsa"
 `,
 }
 
@@ -666,6 +675,16 @@ func serverMain(ctx *cli.Context) {
 			go func() {
 				logger.FatalIf(newConsoleServerFn().Serve(), "Unable to initialize console server")
 			}()
+		}
+
+		// if we see FTP args, start FTP if possible
+		if len(ctx.StringSlice("ftp")) > 0 {
+			go startFTPServer(ctx)
+		}
+
+		// If we see SFTP args, start SFTP if possible
+		if len(ctx.StringSlice("sftp")) > 0 {
+			go startSFTPServer(ctx)
 		}
 	}()
 

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -127,16 +127,14 @@ func printServerCommonMsg(apiEndpoints []string) {
 	apiEndpointStr := strings.Join(apiEndpoints, "  ")
 
 	// Colorize the message and print.
-	logger.Info(color.Blue("API: ") + color.Bold(fmt.Sprintf("%s ", apiEndpointStr)))
+	logger.Info(color.Blue("S3-API: ") + color.Bold(fmt.Sprintf("%s ", apiEndpointStr)))
 	if color.IsTerminal() && (!globalCLIContext.Anonymous && !globalCLIContext.JSON) {
 		logger.Info(color.Blue("RootUser: ") + color.Bold(fmt.Sprintf("%s ", cred.AccessKey)))
-		logger.Info(color.Blue("RootPass: ") + color.Bold(fmt.Sprintf("%s ", cred.SecretKey)))
+		logger.Info(color.Blue("RootPass: ") + color.Bold(fmt.Sprintf("%s \n", cred.SecretKey)))
 		if region != "" {
 			logger.Info(color.Blue("Region: ") + color.Bold(fmt.Sprintf(getFormatStr(len(region), 2), region)))
 		}
 	}
-	printEventNotifiers()
-	printLambdaTargets()
 
 	if globalBrowserEnabled {
 		consoleEndpointStr := strings.Join(stripStandardPorts(getConsoleEndpoints(), globalMinioConsoleHost), " ")
@@ -146,6 +144,9 @@ func printServerCommonMsg(apiEndpoints []string) {
 			logger.Info(color.Blue("RootPass: ") + color.Bold(fmt.Sprintf("%s ", cred.SecretKey)))
 		}
 	}
+
+	printEventNotifiers()
+	printLambdaTargets()
 }
 
 // Prints startup message for Object API access, prints link to our SDK documentation.

--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -1,0 +1,442 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/minio/madmin-go/v2"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio/internal/auth"
+	"github.com/minio/minio/internal/logger"
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+type sftpDriver struct {
+	permissions *ssh.Permissions
+	endpoint    string
+}
+
+//msgp:ignore sftpMetrics
+type sftpMetrics struct{}
+
+var globalSftpMetrics sftpMetrics
+
+func sftpTrace(s *sftp.Request, startTime time.Time, source string, user string, err error) madmin.TraceInfo {
+	var errStr string
+	if err != nil {
+		errStr = err.Error()
+	}
+	return madmin.TraceInfo{
+		TraceType: madmin.TraceFTP,
+		Time:      startTime,
+		NodeName:  globalLocalNodeName,
+		FuncName:  fmt.Sprintf("sftp USER=%s COMMAND=%s PARAM=%s, Source=%s", user, s.Method, s.Filepath, source),
+		Duration:  time.Since(startTime),
+		Path:      s.Filepath,
+		Error:     errStr,
+	}
+}
+
+func (m *sftpMetrics) log(s *sftp.Request, user string) func(err error) {
+	startTime := time.Now()
+	source := getSource(2)
+	return func(err error) {
+		globalTrace.Publish(sftpTrace(s, startTime, source, user, err))
+	}
+}
+
+// NewSFTPDriver initializes sftp.Handlers implementation of following interfaces
+//
+// - sftp.Fileread
+// - sftp.Filewrite
+// - sftp.Filelist
+// - sftp.Filecmd
+func NewSFTPDriver(perms *ssh.Permissions) sftp.Handlers {
+	handler := &sftpDriver{endpoint: fmt.Sprintf("127.0.0.1:%s", globalMinioPort), permissions: perms}
+	return sftp.Handlers{
+		FileGet:  handler,
+		FilePut:  handler,
+		FileCmd:  handler,
+		FileList: handler,
+	}
+}
+
+func (f *sftpDriver) getMinIOClient() (*minio.Client, error) {
+	ui, ok := globalIAMSys.GetUser(context.Background(), f.AccessKey())
+	if !ok && !globalIAMSys.LDAPConfig.Enabled() {
+		return nil, errNoSuchUser
+	}
+	if !ok && globalIAMSys.LDAPConfig.Enabled() {
+		targetUser, targetGroups, err := globalIAMSys.LDAPConfig.LookupUserDN(f.AccessKey())
+		if err != nil {
+			return nil, err
+		}
+		ldapPolicies, _ := globalIAMSys.PolicyDBGet(targetUser, false, targetGroups...)
+		if len(ldapPolicies) == 0 {
+			return nil, errAuthentication
+		}
+		expiryDur, err := globalIAMSys.LDAPConfig.GetExpiryDuration("")
+		if err != nil {
+			return nil, err
+		}
+		claims := make(map[string]interface{})
+		claims[expClaim] = UTCNow().Add(expiryDur).Unix()
+		claims[ldapUser] = targetUser
+		claims[ldapUserN] = f.AccessKey()
+
+		cred, err := auth.GetNewCredentialsWithMetadata(claims, globalActiveCred.SecretKey)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the parent of the temporary access key, this is useful
+		// in obtaining service accounts by this cred.
+		cred.ParentUser = targetUser
+
+		// Set this value to LDAP groups, LDAP user can be part
+		// of large number of groups
+		cred.Groups = targetGroups
+
+		// Set the newly generated credentials, policyName is empty on purpose
+		// LDAP policies are applied automatically using their ldapUser, ldapGroups
+		// mapping.
+		updatedAt, err := globalIAMSys.SetTempUser(context.Background(), cred.AccessKey, cred, "")
+		if err != nil {
+			return nil, err
+		}
+
+		// Call hook for site replication.
+		logger.LogIf(context.Background(), globalSiteReplicationSys.IAMChangeHook(context.Background(), madmin.SRIAMItem{
+			Type: madmin.SRIAMItemSTSAcc,
+			STSCredential: &madmin.SRSTSCredential{
+				AccessKey:    cred.AccessKey,
+				SecretKey:    cred.SecretKey,
+				SessionToken: cred.SessionToken,
+				ParentUser:   cred.ParentUser,
+			},
+			UpdatedAt: updatedAt,
+		}))
+
+		return minio.New(f.endpoint, &minio.Options{
+			Creds:     credentials.NewStaticV4(cred.AccessKey, cred.SecretKey, cred.SessionToken),
+			Secure:    globalIsTLS,
+			Transport: globalRemoteTargetTransport,
+		})
+	}
+
+	// ok == true - at this point
+
+	if ui.Credentials.IsTemp() {
+		// Temporary credentials are not allowed.
+		return nil, errAuthentication
+	}
+
+	return minio.New(f.endpoint, &minio.Options{
+		Creds:     credentials.NewStaticV4(ui.Credentials.AccessKey, ui.Credentials.SecretKey, ""),
+		Secure:    globalIsTLS,
+		Transport: globalRemoteTargetTransport,
+	})
+}
+
+func (f *sftpDriver) AccessKey() string {
+	return f.permissions.CriticalOptions["accessKey"]
+}
+
+func (f *sftpDriver) Fileread(r *sftp.Request) (ra io.ReaderAt, err error) {
+	stopFn := globalSftpMetrics.log(r, f.AccessKey())
+	defer stopFn(err)
+
+	flags := r.Pflags()
+	if !flags.Read {
+		// sanity check
+		return nil, os.ErrInvalid
+	}
+
+	bucket, object := path2BucketObject(r.Filepath)
+	if bucket == "" {
+		return nil, errors.New("bucket name cannot be empty")
+	}
+
+	clnt, err := f.getMinIOClient()
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := clnt.GetObject(context.Background(), bucket, object, minio.GetObjectOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = obj.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+type writerAt struct {
+	w  *io.PipeWriter
+	wg *sync.WaitGroup
+}
+
+func (w *writerAt) Close() error {
+	err := w.w.Close()
+	w.wg.Wait()
+	return err
+}
+
+func (w *writerAt) WriteAt(b []byte, offset int64) (n int, err error) {
+	return w.w.Write(b)
+}
+
+func (f *sftpDriver) Filewrite(r *sftp.Request) (w io.WriterAt, err error) {
+	stopFn := globalSftpMetrics.log(r, f.AccessKey())
+	defer stopFn(err)
+
+	flags := r.Pflags()
+	if !flags.Write {
+		// sanity check
+		return nil, os.ErrInvalid
+	}
+
+	bucket, object := path2BucketObject(r.Filepath)
+	if bucket == "" {
+		return nil, errors.New("bucket name cannot be empty")
+	}
+
+	clnt, err := f.getMinIOClient()
+	if err != nil {
+		return nil, err
+	}
+
+	pr, pw := io.Pipe()
+
+	wa := &writerAt{w: pw, wg: &sync.WaitGroup{}}
+	wa.wg.Add(1)
+	go func() {
+		_, err := clnt.PutObject(r.Context(), bucket, object, pr, -1, minio.PutObjectOptions{SendContentMd5: true})
+		pr.CloseWithError(err)
+		wa.wg.Done()
+	}()
+	return wa, nil
+}
+
+func (f *sftpDriver) Filecmd(r *sftp.Request) (err error) {
+	stopFn := globalSftpMetrics.log(r, f.AccessKey())
+	defer stopFn(err)
+
+	clnt, err := f.getMinIOClient()
+	if err != nil {
+		return err
+	}
+
+	switch r.Method {
+	case "Setstat", "Rename", "Link", "Symlink":
+		return NotImplemented{}
+
+	case "Rmdir":
+		bucket, prefix := path2BucketObject(r.Filepath)
+		if bucket == "" {
+			return errors.New("deleting all buckets not allowed")
+		}
+
+		cctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		objectsCh := make(chan minio.ObjectInfo)
+
+		// Send object names that are needed to be removed to objectsCh
+		go func() {
+			defer close(objectsCh)
+			opts := minio.ListObjectsOptions{Prefix: prefix, Recursive: true}
+			for object := range clnt.ListObjects(cctx, bucket, opts) {
+				if object.Err != nil {
+					return
+				}
+				objectsCh <- object
+			}
+		}()
+
+		// Call RemoveObjects API
+		for err := range clnt.RemoveObjects(context.Background(), bucket, objectsCh, minio.RemoveObjectsOptions{}) {
+			if err.Err != nil {
+				return err.Err
+			}
+		}
+
+	case "Remove":
+		bucket, object := path2BucketObject(r.Filepath)
+		if bucket == "" {
+			return errors.New("bucket name cannot be empty")
+		}
+
+		return clnt.RemoveObject(context.Background(), bucket, object, minio.RemoveObjectOptions{})
+
+	case "Mkdir":
+		bucket, prefix := path2BucketObject(r.Filepath)
+		if bucket == "" {
+			return errors.New("bucket name cannot be empty")
+		}
+
+		dirPath := buildMinioDir(prefix)
+
+		_, err = clnt.PutObject(context.Background(), bucket, dirPath, bytes.NewReader([]byte("")), 0,
+			// Always send Content-MD5 to succeed with bucket with
+			// locking enabled. There is no performance hit since
+			// this is always an empty object
+			minio.PutObjectOptions{SendContentMd5: true},
+		)
+		return err
+	}
+
+	return NotImplemented{}
+}
+
+type listerAt []os.FileInfo
+
+// Modeled after strings.Reader's ReadAt() implementation
+func (f listerAt) ListAt(ls []os.FileInfo, offset int64) (int, error) {
+	var n int
+	if offset >= int64(len(f)) {
+		return 0, io.EOF
+	}
+	n = copy(ls, f[offset:])
+	if n < len(ls) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (f *sftpDriver) Filelist(r *sftp.Request) (la sftp.ListerAt, err error) {
+	stopFn := globalSftpMetrics.log(r, f.AccessKey())
+	defer stopFn(err)
+
+	clnt, err := f.getMinIOClient()
+	if err != nil {
+		return nil, err
+	}
+
+	switch r.Method {
+	case "List":
+		var files []os.FileInfo
+
+		bucket, prefix := path2BucketObject(r.Filepath)
+		if bucket == "" {
+			buckets, err := clnt.ListBuckets(r.Context())
+			if err != nil {
+				return nil, err
+			}
+
+			for _, bucket := range buckets {
+				files = append(files, &minioFileInfo{
+					p:     bucket.Name,
+					info:  minio.ObjectInfo{Key: bucket.Name, LastModified: bucket.CreationDate},
+					isDir: true,
+				})
+			}
+
+			return listerAt(files), nil
+		}
+
+		prefix = retainSlash(prefix)
+
+		for object := range clnt.ListObjects(r.Context(), bucket, minio.ListObjectsOptions{
+			Prefix:    prefix,
+			Recursive: false,
+		}) {
+			if object.Err != nil {
+				return nil, object.Err
+			}
+
+			if object.Key == prefix {
+				continue
+			}
+
+			isDir := strings.HasSuffix(object.Key, SlashSeparator)
+			files = append(files, &minioFileInfo{
+				p:     pathClean(strings.TrimPrefix(object.Key, prefix)),
+				info:  object,
+				isDir: isDir,
+			})
+		}
+
+		return listerAt(files), nil
+
+	case "Stat":
+		if r.Filepath == SlashSeparator {
+			return listerAt{&minioFileInfo{
+				p:     r.Filepath,
+				isDir: true,
+			}}, nil
+		}
+
+		bucket, object := path2BucketObject(r.Filepath)
+		if bucket == "" {
+			return nil, errors.New("bucket name cannot be empty")
+		}
+
+		if object == "" {
+			ok, err := clnt.BucketExists(context.Background(), bucket)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, os.ErrNotExist
+			}
+			return listerAt{&minioFileInfo{
+				p:     pathClean(bucket),
+				info:  minio.ObjectInfo{Key: bucket},
+				isDir: true,
+			}}, nil
+		}
+
+		objInfo, err := clnt.StatObject(context.Background(), bucket, object, minio.StatObjectOptions{})
+		if err != nil {
+			if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+				// dummy return to satisfy LIST (stat -> list) behavior.
+				return listerAt{&minioFileInfo{
+					p:     pathClean(object),
+					info:  minio.ObjectInfo{Key: object},
+					isDir: true,
+				}}, nil
+			}
+			return nil, err
+		}
+
+		isDir := strings.HasSuffix(objInfo.Key, SlashSeparator)
+		return listerAt{&minioFileInfo{
+			p:     pathClean(object),
+			info:  objInfo,
+			isDir: isDir,
+		}}, nil
+	}
+
+	return nil, NotImplemented{}
+}

--- a/docs/ftp/README.md
+++ b/docs/ftp/README.md
@@ -1,0 +1,169 @@
+# MinIO FTP/SFTP Server
+
+MinIO natively supports FTP/SFTP protocol, this allows any ftp/sftp client to upload and download files.
+
+Currently supported `FTP/SFTP` operations are as follows:
+
+| ftp-client commands | supported |
+|:-------------------:|:----------|
+| get                 | yes       |
+| put                 | yes       |
+| ls                  | yes       |
+| mkdir               | yes       |
+| rmdir               | yes       |
+| delete              | yes       |
+| append              | no        |
+| rename              | no        |
+
+MinIO supports following FTP/SFTP based protocols to access and manage data.
+
+- Secure File Transfer Protocol (SFTP) – Defined by the Internet Engineering Task Force (IETF) as an
+  extended version of SSH 2.0, allowing file transfer over SSH and for use with Transport Layer
+  Security (TLS) and VPN applications.
+
+- File Transfer Protocol over SSL/TLS (FTPS) – Encrypted FTP communication via TLS certificates.
+
+- File Transfer Protocol (FTP) – Defined by RFC114 originally, and replaced by RFC765 and RFC959
+  unencrypted FTP communication (Not-recommended)
+
+## Scope
+
+- All IAM Credentials are allowed access excluding rotating credentials, rotating credentials
+  are not allowed to login via FTP/SFTP ports, you must use S3 API port for if you are using
+  rotating credentials.
+
+- Access to bucket(s) and object(s) are governed via IAM policies associated with the incoming
+  login credentials.
+
+- Allows authentication and access for all
+  - Built-in IDP users and their respective service accounts
+  - LDAP/AD users and their respective service accounts
+  - OpenID/OIDC service accounts
+
+- On versioned buckets, FTP/SFTP only operates on latest objects, if you need to retrieve
+  an older version you must use an `S3 API client` such as [`mc`](https://github.com/minio/mc).
+
+- All features currently used by your buckets will work as is without any changes
+  - SSE (Server Side Encryption)
+  - Replication (Server Side Replication)
+
+## Prerequisites
+
+- It is assumed you have users created and configured with relevant access policies, to start with
+  use basic "readwrite" canned policy to test all the operations before you finalize on what level
+  of restrictions are needed for a user.
+
+- No "admin:*" operations are needed for FTP/SFTP access to the bucket(s) and object(s), so you may
+  skip them for restrictions.
+
+## Usage
+
+Start MinIO in a distributed setup, with 'ftp/sftp' enabled.
+
+```
+minio server http://server{1...4}/disk{1...4}
+   --ftp="address=:8021" --ftp="passive-port-range=30000-40000" \
+   --sftp="address=:8022" --sftp="ssh-private-key=/home/miniouser/.ssh/id_rsa"
+...
+...
+```
+
+Following example shows connecting via ftp client using `minioadmin` credentials, and list a bucket named `runner`:
+
+```
+ftp localhost -P 8021
+Connected to localhost.
+220 Welcome to MinIO FTP Server
+Name (localhost:user): minioadmin
+331 User name ok, password required
+Password:
+230 Password ok, continue
+Remote system type is UNIX.
+Using binary mode to transfer files.
+ftp> ls runner/
+229 Entering Extended Passive Mode (|||39155|)
+150 Opening ASCII mode data connection for file list
+drwxrwxrwx 1 nobody nobody            0 Jan  1 00:00 chunkdocs/
+drwxrwxrwx 1 nobody nobody            0 Jan  1 00:00 testdir/
+...
+```
+
+Following example shows how to list an object and download it locally via `ftp` client:
+
+```
+ftp> ls runner/chunkdocs/metadata
+229 Entering Extended Passive Mode (|||44269|)
+150 Opening ASCII mode data connection for file list
+-rwxrwxrwx 1 nobody nobody           45 Apr  1 06:13 chunkdocs/metadata
+226 Closing data connection, sent 75 bytes
+ftp> get
+(remote-file) runner/chunkdocs/metadata
+(local-file) test
+local: test remote: runner/chunkdocs/metadata
+229 Entering Extended Passive Mode (|||37785|)
+150 Data transfer starting 45 bytes
+	45        3.58 KiB/s
+226 Closing data connection, sent 45 bytes
+45 bytes received in 00:00 (3.55 KiB/s)
+...
+```
+
+
+Following example shows connecting via sftp client using `minioadmin` credentials, and list a bucket named `runner`:
+
+```
+sftp -P 8022 minioadmin@localhost
+minioadmin@localhost's password:
+Connected to localhost.
+sftp> ls runner/
+chunkdocs  testdir
+```
+
+Following example shows how to download an object locally via `sftp` client:
+
+```
+sftp> get runner/chunkdocs/metadata metadata
+Fetching /runner/chunkdocs/metadata to metadata
+metadata                                                                                                                                                                       100%  226    16.6KB/s   00:00
+sftp>
+```
+
+## Advanced options
+
+### Change default FTP port
+
+Default port '8021' can be changed via
+
+```
+--ftp="address=:3021"
+```
+
+### Change FTP passive port range
+
+By default FTP requests OS to give a free port automatically, however you may want to restrict
+this to specific ports in certain restricted environments via
+
+```
+--ftp="passive-port-range=30000-40000"
+```
+
+### Change default SFTP port
+
+Default port '8022' can be changed via
+
+```
+--sftp="address=:3022"
+```
+
+### TLS (FTP)
+
+Unlike SFTP server, FTP server is insecure by default. To operate under TLS mode, you need to provide certificates via
+
+```
+--ftp="tls-private-key=path/to/private.key" --ftp="tls-public-cert=path/to/public.crt"
+```
+
+> NOTE: if MinIO distributed setup is already configured to run under TLS, FTP will automatically use the relevant
+> certs from the server certificate chain, this is mainly to add simplicity of setup. However if you wish to terminate
+> TLS certificates via a different domain for your FTP servers you may choose the above command line options.
+

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/philhofer/fwd v1.1.2
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/pkg/errors v0.9.1
+	github.com/pkg/sftp v1.10.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.42.0
@@ -84,6 +85,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.7
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.24.0
+	goftp.io/server/v2 v2.0.0
 	golang.org/x/crypto v0.8.0
 	golang.org/x/oauth2 v0.7.0
 	golang.org/x/sys v0.7.0
@@ -157,6 +159,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/juju/ratelimit v1.0.2 // indirect
+	github.com/kr/fs v0.1.0 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -639,6 +639,7 @@ github.com/jedib0t/go-pretty/v6 v6.4.6 h1:v6aG9h6Uby3IusSSEjHaZNXpHFhzqMmjXcPq1R
 github.com/jedib0t/go-pretty/v6 v6.4.6/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jlaffaye/ftp v0.0.0-20190624084859-c1312a7102bf/go.mod h1:lli8NYPQOFy3O++YmYbqVgOcQ1JPCwdOy+5zSjKJ9qY=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -681,6 +682,7 @@ github.com/klauspost/reedsolomon v1.11.7/go.mod h1:4bXRN+cVzMdml6ti7qLouuYi32KHJ
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -782,6 +784,7 @@ github.com/minio/mc v0.0.0-20230411170328-83336dfab325 h1:da5I7G0Va6UnqoxzPHus7z
 github.com/minio/mc v0.0.0-20230411170328-83336dfab325/go.mod h1:v9AeUV4eaMpKCuNz0tk/MSGxvNs3duYvWUIxzpacxtc=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
+github.com/minio/minio-go/v6 v6.0.46/go.mod h1:qD0lajrGW49lKZLtXKtCB4X/qkMf0a5tBvN2PaZg7Gg=
 github.com/minio/minio-go/v7 v7.0.41/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/minio/minio-go/v7 v7.0.52 h1:8XhG36F6oKQUDDSuz6dY3rioMzovKjW40W6ANuN0Dps=
 github.com/minio/minio-go/v7 v7.0.52/go.mod h1:IbbodHyjUAguneyucUaahv+VMNs/EOTV9du7A7/Z3HU=
@@ -792,6 +795,7 @@ github.com/minio/pkg v1.6.6-0.20230330040824-5db111e5f63c h1:Ukw0+d0T/+9lserJfod
 github.com/minio/pkg v1.6.6-0.20230330040824-5db111e5f63c/go.mod h1:0iX1IuJGSCnMvIvrEJauk1GgQSX9JdU6Kh0P3EQRGkI=
 github.com/minio/selfupdate v0.6.0 h1:i76PgT0K5xO9+hjzKcacQtO7+MjJ4JKA8Ak8XQ9DDwU=
 github.com/minio/selfupdate v0.6.0/go.mod h1:bO02GTIPCMQFTEvE5h4DjYB58bCoZ35XLeBf0buTDdM=
+github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/minio/simdjson-go v0.4.5 h1:r4IQwjRGmWCQ2VeMc7fGiilu1z5du0gJ/I/FsKwgo5A=
@@ -893,6 +897,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
+github.com/pkg/sftp v1.10.1 h1:VasscCm72135zRysgrJDKsntdmPN+OuU3+nnHYA9wyc=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/xattr v0.4.9 h1:5883YPCtkSd8LFbs13nXplj9g9tlrwoJRjgpgMu1/fE=
 github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
@@ -994,6 +999,7 @@ github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.1.1/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
+github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -1117,13 +1123,17 @@ go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.23.0/go.mod h1:D+nX8jyLsMHMYrln8A0rJjFt/T/9/bGgIhAqxv5URuY=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
+goftp.io/server/v2 v2.0.0 h1:FF8JKXXKDxAeO1uXEZz7G+IZwCDhl19dpVIlDtp3QAg=
+goftp.io/server/v2 v2.0.0/go.mod h1:7+H/EIq7tXdfo1Muu5p+l3oQ6rYkDZ8lY7IM5d5kVdQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -1195,6 +1205,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1724,6 +1735,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/h2non/filetype.v1 v1.0.5 h1:CC1jjJjoEhNVbMhXYalmGBhOBK2V70Q1N850wt/98/Y=
 gopkg.in/h2non/filetype.v1 v1.0.5/go.mod h1:M0yem4rwSX5lLVrkEuRRp2/NinFMD5vgJ4DlAhZcfNo=
+gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.66.6/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=


### PR DESCRIPTION
## Description
implement support for FTP/SFTP server

## Motivation and Context
(S)FTP server designed to use the handler
layer, the intention is to make sure
that (S)FTP server honors all the S3 
requirements including

- SSE (server-side encryption)
- Replication (bucket/site replication)

Passwords are to be validated again via 
signature v4. Credentials also honor
IAM policies - existing permissions 
automatically apply.

## How to test this PR?
Documentation is available at `docs/ftp/README.md` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
