### PR TITLE
Enabled to send audit log while version deletion

### DIFF
--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -371,6 +371,7 @@ func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toD
 			auditLogLifecycle(
 				ctx,
 				ObjectInfo{
+					Bucket: bucket,
 					Name:      dobj.ObjectName,
 					VersionID: dobj.VersionID,
 				},

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -367,6 +367,15 @@ func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toD
 				continue
 			}
 			dobj := deletedObjs[i]
+			// Send audit for the lifecycle delete operation
+			auditLogLifecycle(
+				ctx,
+				ObjectInfo{
+					Name:      dobj.ObjectName,
+					VersionID: dobj.VersionID,
+				},
+				ILMExpiry)
+
 			sendEvent(eventArgs{
 				EventName:  event.ObjectRemovedDelete,
 				BucketName: bucket,


### PR DESCRIPTION
## Description
During removal of non-current versions older than the most recent when NewerNoncurrentVersions configured, the audit logs were not coming.

## Motivation and Context


## How to test this PR?
Follow the below steps to test the changes

Step-1: Create a minio instance and enable audit webhook for the same
Step-2: Create a bucket and enable versioning on the same
Step-3: Make the bucket public and set the ilm rule as below
```
./mc ilm rule add --noncurrent-expire-newer 1 ALIAS/BUCKET
```
Step-4: Add multiple version of the same object (~10)
Step-5: List and verify the no of version (should show the created no of versions)
Step-6: Wait for few mins and older versions should be removed. List and verify the same
Step-7: Verify the webhook for audit logs of the below format
```
{'version': '1', 'deploymentid': 'a4ab1a04-7d76-4f55-b647-a409a910abe9', 'time': '2023-04-03T13:11:47.924965998Z', 'event': 'ilm:expiry', 'trigger': 'ilm:expiry', 'api': {'name': 'ILMExpiry', 'objects': [{'objectName': 'issue', 'versionId': 'a148ac55-73dc-41b7-a793-0fbf1542133e'}], 'rx': 0, 'tx': 0}}
```
There should be one entry for each version delete

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
