### PR TITLE
Remove ~ from Object Lambda curl example

### DIFF
--- a/docs/lambda/README.md
+++ b/docs/lambda/README.md
@@ -173,7 +173,7 @@ func main() {
 
 Use the Presigned URL via `curl` to receive the transformed object.
 ```
-~ curl -v $(go run presigned.go)
+curl -v $(go run presigned.go)
 ...
 ...
 > GET /functionbucket/testobject?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minioadmin%2F20230205%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230205T173023Z&X-Amz-Expires=1000&X-Amz-SignedHeaders=host&lambdaArn=arn%3Aminio%3As3-object-lambda%3A%3Atoupper%3Awebhook&X-Amz-Signature=d7e343f0da9d4fa2bc822c12ad2f54300ff16796a1edaa6d31f1313c8e94d5b2 HTTP/1.1


### PR DESCRIPTION
## Description

The tilde at the beginning shouldn't be included when running the example curl command. Remove it to reduce the chance for confusion.

## Motivation and Context

As a new MinIO user, I was confused about the command in this example.

## How to test this PR?

Docs only change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
