### PR TITLE
fix: directory listing on Go 1.20 windows

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -20,13 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.20.x, 1.19.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, windows-latest]
-        exclude:
-          - os: ubuntu-latest
-            go-version: 1.19.x
-          - os: windows-latest
-            go-version: 1.20.x
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/cmd/os_windows.go
+++ b/cmd/os_windows.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -40,38 +39,32 @@ func osMkdirAll(dirPath string, perm os.FileMode) error {
 // the directory itself, if the dirPath doesn't exist this function doesn't return
 // an error.
 func readDirFn(dirPath string, filter func(name string, typ os.FileMode) error) error {
-	f, err := Open(dirPath)
+	// Ensure we don't pick up files as directories.
+	globAll := filepath.Clean(dirPath) + `\*`
+	globAllP, err := syscall.UTF16PtrFromString(globAll)
 	if err != nil {
-		if osErrToFileErr(err) == errFileNotFound {
-			return nil
-		}
-		return osErrToFileErr(err)
+		return errInvalidArgument
 	}
-	defer f.Close()
-
-	// Check if file or dir. This is the quickest way.
-	// Do not remove this check, on windows syscall.FindNextFile
-	// would throw an exception if Fd() points to a file
-	// instead of a directory, we need to quickly fail
-	// in such situations - this workadound is expected.
-	if _, err = f.Seek(0, io.SeekStart); err == nil {
+	data := &syscall.Win32finddata{}
+	handle, err := syscall.FindFirstFile(globAllP, data)
+	if err != nil {
+		// Fails on file not found and when not a directory.
 		return errFileNotFound
 	}
+	defer syscall.CloseHandle(handle)
 
-	data := &syscall.Win32finddata{}
-	for {
-		e := syscall.FindNextFile(syscall.Handle(f.Fd()), data)
-		if e != nil {
-			if e == syscall.ERROR_NO_MORE_FILES {
+	for ; ; err = syscall.FindNextFile(handle, data) {
+		if err != nil {
+			if err == syscall.ERROR_NO_MORE_FILES {
 				break
 			} else {
-				if isSysErrPathNotFound(e) {
+				if isSysErrPathNotFound(err) {
 					return nil
 				}
 				err = osErrToFileErr(&os.PathError{
 					Op:   "FindNextFile",
 					Path: dirPath,
-					Err:  e,
+					Err:  err,
 				})
 				if err == errFileNotFound {
 					return nil
@@ -110,7 +103,7 @@ func readDirFn(dirPath string, filter func(name string, typ os.FileMode) error) 
 			typ = os.ModeDir
 		}
 
-		if e = filter(name, typ); e == errDoneForNow {
+		if err = filter(name, typ); err == errDoneForNow {
 			// filtering requested to return by caller.
 			return nil
 		}


### PR DESCRIPTION
## Description

`os.Open` stopped using `FindFirstFile` after [CL 452995](https://go-review.googlesource.com/c/go/+/452995).

`f.Seek(0, io.SeekStart)` could no longer be used to see if we opened a directory.

And `FindNextFile` would crash.

Work around change by opening the directory using `FindFirstFile` ourselves and add `\*` to the path to make sure it is a directory.

See https://github.com/golang/go/issues/59455

## How to test this PR?

Standard tests on Windows, Go 1.20

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
