### PR TITLE
mint: Ignore teardown errors

### DIFF
--- a/.github/workflows/run-mint.sh
+++ b/.github/workflows/run-mint.sh
@@ -40,11 +40,11 @@ docker run --rm --net=host \
 	 s3select     \
 	 versioning
 
-docker-compose -f minio-${MODE}.yaml down
+docker-compose -f minio-${MODE}.yaml down || true
 sleep 10s
 
-docker system prune -f
-docker volume prune -f
+docker system prune -f || true
+docker volume prune -f || true
 
 ## change working directory
 cd ../../../


### PR DESCRIPTION
## Motivation and Context

More reliable tests.

```
Removing mint_nginx_1  ... 
Removing mint_minio4_1 ... 
Removing mint_minio2_1 ... 
Removing mint_minio1_1 ... 
Removing mint_minio3_1 ... 

Removing mint_minio3_1 ... done

Removing mint_minio2_1 ... done

Removing mint_nginx_1  ... done

Removing mint_minio1_1 ... done

Removing mint_minio4_1 ... done
Removing network mint_default
error while removing network: network mint_default id abf3c8fd5fd81b5dfa26a8acd9f67a84faae353b6[99](https://github.com/minio/minio/actions/runs/4618999194/jobs/8167152781?pr=16977#step:7:100)09a1850807d485f1df91e has active endpoints
```

## How to test this PR?

Self-testing. Add time.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

