### PR TITLE
simplify bucketInfo return in GetBucketInfo peer call

### DIFF
--- a/cmd/peer-s3-client.go
+++ b/cmd/peer-s3-client.go
@@ -171,7 +171,9 @@ func (sys *S3PeerSys) GetBucketInfo(ctx context.Context, bucket string, opts Buc
 	}
 
 	for i, err := range errs {
-		if err == nil {
+		// bucketInfos:[local,remote...]
+		// errs:[nil,remote...]
+		if err == nil && i != 0 {
 			bucketInfo = bucketInfos[i]
 			break
 		}

--- a/cmd/peer-s3-client.go
+++ b/cmd/peer-s3-client.go
@@ -169,16 +169,7 @@ func (sys *S3PeerSys) GetBucketInfo(ctx context.Context, bucket string, opts Buc
 	if err = reduceReadQuorumErrs(ctx, errs, bucketOpIgnoredErrs, quorum); err != nil {
 		return BucketInfo{}, toObjectErr(err, bucket)
 	}
-
-	for i, err := range errs {
-		// bucketInfos:[local,remote...]
-		// errs:[nil,remote...]
-		if err == nil && i != 0 {
-			bucketInfo = bucketInfos[i]
-			break
-		}
-	}
-
+	
 	return bucketInfo, nil
 }
 


### PR DESCRIPTION

## Description

		// bucketInfos:[local,remote...]
		// errs:[nil,remote...]
It seems will return local info always.
```go
	errs := []error{nil}
	bucketInfos[0] = bucketInfo
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
