### PR TITLE
Indicate RenameData is called by healObject

### DIFF
--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -294,7 +294,7 @@ func shouldHealObjectOnDisk(erErr, dataErr error, meta FileInfo, latestMeta File
 	return false
 }
 
-const xMinIOHealing = "x-minio-healing"
+const xMinIOHealing = ReservedMetadataPrefix + "healing"
 
 // SetHealing marks object (version) as being healed.
 // Note: this is to be used only from healObject

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -296,6 +296,8 @@ func shouldHealObjectOnDisk(erErr, dataErr error, meta FileInfo, latestMeta File
 
 const xMinIOHealing = "x-minio-healing"
 
+// SetHealing marks object (version) as being healed.
+// Note: this is to be used only from healObject
 func (fi *FileInfo) SetHealing() {
 	if fi.Metadata == nil {
 		fi.Metadata = make(map[string]string)
@@ -303,6 +305,8 @@ func (fi *FileInfo) SetHealing() {
 	fi.Metadata[xMinIOHealing] = "true"
 }
 
+// Healing returns true if object is being healed (i.e fi is being passed down
+// from healObject)
 func (fi FileInfo) Healing() bool {
 	if _, ok := fi.Metadata[xMinIOHealing]; ok {
 		return true

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -1583,8 +1583,9 @@ func (x *xlMetaV2) AddVersion(fi FileInfo) error {
 			if len(k) > len(ReservedMetadataPrefixLower) && strings.EqualFold(k[:len(ReservedMetadataPrefixLower)], ReservedMetadataPrefixLower) {
 				// Skip tierFVID, tierFVMarker keys; it's used
 				// only for creating free-version.
+				// Skip xMinIOHealing, it's used only in RenameData
 				switch k {
-				case tierFVIDKey, tierFVMarkerKey:
+				case tierFVIDKey, tierFVMarkerKey, xMinIOHealing:
 					continue
 				}
 

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2357,7 +2357,11 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 	// suspended or disabled on this bucket. RenameData will replace
 	// the 'null' version. We add a free-version to track its tiered
 	// content for asynchronous deletion.
-	if fi.VersionID == "" && !fi.IsRestoreObjReq() {
+	//
+	// Note: RestoreObject and HealObject requests don't end up replacing the
+	// null version and therefore don't require the free-version to track
+	// anything
+	if fi.VersionID == "" && !fi.IsRestoreObjReq() && !fi.Healing() {
 		// Note: Restore object request reuses PutObject/Multipart
 		// upload to copy back its data from the remote tier. This
 		// doesn't replace the existing version, so we don't need to add


### PR DESCRIPTION
## Description
This is to avoid add a free-version in healObject because it doesn't replace an object version.

## How to test this PR?
1. Upload an object
2. Remove a part from one of the drives 
3. `mc cat ALIAS/bucket/object > /dev/null` to trigger object heal.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
