### PR TITLE
docs: fix repetition in wordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ chmod +x minio
 ./minio server /data
 ```
 
-Replace ``/data`` with the path to the drive or directory in which you want MinIO to store data.
-
 The following table lists supported architectures. Replace the `wget` URL with the architecture for your Linux host.
 
 | Architecture                   | URL                                                        |


### PR DESCRIPTION
```txt
## GNU/Linux

Use the following command to run a standalone MinIO server on Linux hosts running 64-bit Intel/AMD architectures. 👉 Replace ``/data`` with the path to the drive or directory in which you want MinIO to store data.

wget https://dl.min.io/server/minio/release/linux-amd64/minio
chmod +x minio
./minio server /data


👉 Replace ``/data`` with the path to the drive or directory in which you want MinIO to store data.
```

## Description

The line is repeated twice for the same context, (see, 👉 )