### PR TITLE
config: fix duplication of replication priority key

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -602,6 +602,17 @@ var renamedSubsys = map[string]string{
 	// Add future sub-system renames
 }
 
+const ( // deprecated keys
+	apiReplicationWorkers       = "replication_workers"
+	apiReplicationFailedWorkers = "replication_failed_workers"
+)
+
+// map of subsystem to deleted keys
+var deletedSubSysKeys = map[string][]string{
+	APISubSys: {apiReplicationWorkers, apiReplicationFailedWorkers},
+	// Add future sub-system deleted keys
+}
+
 // Merge - merges a new config with all the
 // missing values for default configs,
 // returns a config.
@@ -632,9 +643,16 @@ func (c Config) Merge() Config {
 				}
 				subSys = rnSubSys
 			}
+			// Delete deprecated keys for subsystem if any
+			if keys, ok := deletedSubSysKeys[subSys]; ok {
+				for _, key := range keys {
+					ckvs.Delete(key)
+				}
+			}
 			cp[subSys][tgt] = ckvs
 		}
 	}
+
 	return cp
 }
 


### PR DESCRIPTION
## Description


## Motivation and Context


## How to test this PR?
upgrade from RELEASE.2022-09-22T18-57-27Z to latest - 
`mc admin config get alias api` should show only one entry for replication_priority

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
