### PR TITLE
Add minio_bucket_usage_version_total metric to Prometheus

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -2008,7 +2008,7 @@ func getBucketUsageMetrics() *MetricsGroup {
 
 			metrics = append(metrics, Metric{
 				Description:    getBucketUsageVersionsTotalMD(),
-				Value:          float64(usage.VersionssCount),
+				Value:          float64(usage.VersionsCount),
 				VariableLabels: map[string]string{"bucket": bucket},
 			})
 

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -155,6 +155,7 @@ const (
 	waitingTotal   MetricName = "waiting_total"
 	incomingTotal  MetricName = "incoming_total"
 	objectTotal    MetricName = "object_total"
+	versionTotal   MetricName = "version_total"
 	offlineTotal   MetricName = "offline_total"
 	onlineTotal    MetricName = "online_total"
 	openTotal      MetricName = "open_total"
@@ -505,6 +506,16 @@ func getBucketUsageObjectsTotalMD() MetricDescription {
 		Subsystem: usageSubsystem,
 		Name:      objectTotal,
 		Help:      "Total number of objects",
+		Type:      gaugeMetric,
+	}
+}
+
+func getBucketUsageVersionsTotalMD() MetricDescription {
+	return MetricDescription{
+		Namespace: bucketMetricNamespace,
+		Subsystem: usageSubsystem,
+		Name:      versionTotal,
+		Help:      "Total number of versions",
 		Type:      gaugeMetric,
 	}
 }
@@ -1992,6 +2003,12 @@ func getBucketUsageMetrics() *MetricsGroup {
 			metrics = append(metrics, Metric{
 				Description:    getBucketUsageObjectsTotalMD(),
 				Value:          float64(usage.ObjectsCount),
+				VariableLabels: map[string]string{"bucket": bucket},
+			})
+
+			metrics = append(metrics, Metric{
+				Description:    getBucketUsageVersionsTotalMD(),
+				Value:          float64(usage.VersionssCount),
 				VariableLabels: map[string]string{"bucket": bucket},
 			})
 


### PR DESCRIPTION
## Description
Add version count metric to Prometheus

## Motivation and Context
More useful information, ratio object/version in a bucket

## How to test this PR?
Check for minio_bucket_usage_version_total in curl http://localhost:9000/minio/v2/metrics/cluster

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
