### PR TITLE
fix: do not error out if the local bucket is missing

### DIFF
--- a/cmd/peer-s3-client.go
+++ b/cmd/peer-s3-client.go
@@ -137,16 +137,7 @@ func (sys *S3PeerSys) ListBuckets(ctx context.Context, opts BucketOptions) (resu
 func (sys *S3PeerSys) GetBucketInfo(ctx context.Context, bucket string, opts BucketOptions) (binfo BucketInfo, err error) {
 	g := errgroup.WithNErrs(len(sys.peerClients))
 
-	bucketInfos := make([]BucketInfo, len(sys.peerClients)+1)
-
-	bucketInfo, err := getBucketInfoLocal(ctx, bucket, opts)
-	if err != nil {
-		return BucketInfo{}, err
-	}
-
-	errs := []error{nil}
-	bucketInfos[0] = bucketInfo
-
+	bucketInfos := make([]BucketInfo, len(sys.peerClients))
 	for idx, client := range sys.peerClients {
 		idx := idx
 		client := client
@@ -158,19 +149,29 @@ func (sys *S3PeerSys) GetBucketInfo(ctx context.Context, bucket string, opts Buc
 			if err != nil {
 				return err
 			}
-			bucketInfos[idx+1] = bucketInfo
+			bucketInfos[idx] = bucketInfo
 			return nil
 		}, idx)
 	}
 
-	errs = append(errs, g.Wait()...)
+	errs := g.Wait()
+
+	bucketInfo, err := getBucketInfoLocal(ctx, bucket, opts)
+	errs = append(errs, err)
+	bucketInfos = append(bucketInfos, bucketInfo)
 
 	quorum := (len(sys.allPeerClients) / 2)
 	if err = reduceReadQuorumErrs(ctx, errs, bucketOpIgnoredErrs, quorum); err != nil {
 		return BucketInfo{}, toObjectErr(err, bucket)
 	}
 
-	return bucketInfo, nil
+	for i, err := range errs {
+		if err == nil {
+			return bucketInfos[i], nil
+		}
+	}
+
+	return BucketInfo{}, toObjectErr(errVolumeNotFound, bucket)
 }
 
 func (client *peerS3Client) ListBuckets(ctx context.Context, opts BucketOptions) ([]BucketInfo, error) {


### PR DESCRIPTION
## Description
fix: do not error out if the local bucket is missing

## Motivation and Context
do not error out prematurely, verify the quorum
first and then return an error. 

## How to test this PR?
Well create a setup with 4 node setup with 1 disk each and then delete 
the bucket manually from the first disk (first node).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
