### PR TITLE
simplify MRF, converge it to regular healing

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -869,13 +869,8 @@ func (h *healSequence) healBucket(objAPI ObjectLayer, bucket string, bucketsOnly
 
 	if !h.settings.Recursive {
 		if h.object != "" {
-			// Check if an object named as the objPrefix exists,
-			// and if so heal it.
-			oi, err := objAPI.GetObjectInfo(h.ctx, bucket, h.object, ObjectOptions{})
-			if err == nil {
-				if err = h.healObject(bucket, h.object, oi.VersionID); err != nil {
-					return err
-				}
+			if err := h.healObject(bucket, h.object, ""); err != nil {
+				return err
 			}
 		}
 

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1227,7 +1227,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 		if disk != nil && disk.IsOnline() {
 			continue
 		}
-		er.addPartial(bucket, object, fi.VersionID, fi.Size)
+		er.addPartial(bucket, object, fi.VersionID)
 		break
 	}
 


### PR DESCRIPTION
## Description
simplify MRF, converge it to regular healing

## Motivation and Context
MRF doesn't need to exist as an independent 
healing subsystem, instead it simply should 
be piggybacking existing healing workers 
as well as healing functionality.

## How to test this PR?
MRF functionality is tied to taking nodes down, you 
would have to do that locally by setting up a local cluster
something like this

```
#!/bin/bash

set -x

export MINIO_PROMETHEUS_AUTH_TYPE="public"
export MINIO_API_DELETE_CLEANUP_INTERVAL="5s"
export MINIO_CI_CD=1
export MINIO_SCANNER_CYCLE=10s
killall -9 minio
sudo rm -rf ${HOME}/tmp/dist

scheme="http"
nr_servers=4

addr="localhost"
args=""
for ((i=0;i<$[${nr_servers}];i++)); do
    args="$args $scheme://$addr:$[9100+$i]/${HOME}/tmp/dist/path1/$i"
done

echo $args


for ((i=0;i<$[${nr_servers}];i++)); do
    (minio server --address ":$[9100+$i]" $args 2>&1 > /tmp/log$i.txt) &
done
```

Periodically take down minio pids, and restarting them to see 
object healing catch up on the missing entries.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
