### PR TITLE
fix: lambda function expiration when cred.Expiration is set

### DIFF
--- a/cmd/object-lambda-handlers.go
+++ b/cmd/object-lambda-handlers.go
@@ -46,8 +46,9 @@ func getLambdaEventData(bucket, object string, cred auth.Credentials, r *http.Re
 		secure = globalMinioEndpointURL.Scheme == "https"
 	}
 
-	duration := time.Since(cred.Expiration)
-	if cred.Expiration.IsZero() {
+	duration := time.Until(cred.Expiration)
+	if cred.Expiration.IsZero() || duration > time.Hour {
+		// Always limit to 1 hour.
 		duration = time.Hour
 	}
 


### PR DESCRIPTION
## Description

`time.Since` would always give a negative result when `cred.Expiration` is set.

Fix, and limit to 1 hour in all cases, so we don't exceed 7 days limit.

## How to test this PR?

See https://github.com/minio/minio/tree/master/docs/lambda

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
