### PR TITLE
Rename inodes metric in grafana dashboards

### DIFF
--- a/docs/metrics/prometheus/grafana/minio-dashboard.json
+++ b/docs/metrics/prometheus/grafana/minio-dashboard.json
@@ -2750,7 +2750,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "minio_cluster_disk_free_inodes{job=\"$scrape_jobs\"}",
+          "expr": "minio_node_disk_free_inodes{job=\"$scrape_jobs\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",

--- a/docs/metrics/prometheus/grafana/minio-replication.json
+++ b/docs/metrics/prometheus/grafana/minio-replication.json
@@ -2392,7 +2392,7 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "minio_cluster_disk_free_inodes{job=\"$scrape_jobs\"}",
+            "expr": "minio_node_disk_free_inodes{job=\"$scrape_jobs\"}",
             "format": "time_series",
             "instant": false,
             "interval": "",
@@ -2834,4 +2834,3 @@
     "uid": "TgmJnqnnk",
     "version": 18
   }
-  


### PR DESCRIPTION
## Description
This PR fix a name of inodes metric in grafana dashboards.

## Motivation and Context
The minio_cluster_disk_free_inodes metric was renamed to minio_node_disk_free_inodes in PR #16155. But grafana dashboards still have the old name.

## How to test this PR?
Check these metrics manually in Grafana.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
