### PR TITLE
fix: DeleteBucketThrottle must delete ARN

### DIFF
--- a/internal/bucket/bandwidth/monitor.go
+++ b/internal/bucket/bandwidth/monitor.go
@@ -186,10 +186,14 @@ func (m *Monitor) DeleteBucket(bucket string) {
 // DeleteBucketThrottle deletes monitoring for a bucket's target
 func (m *Monitor) DeleteBucketThrottle(bucket, arn string) {
 	m.tlock.Lock()
-	delete(m.bucketThrottle, bucket)
+	if _, ok := m.bucketThrottle[bucket]; ok {
+		delete(m.bucketThrottle[bucket], arn)
+	}
 	m.tlock.Unlock()
 	m.mlock.Lock()
-	delete(m.activeBuckets, bucket)
+	if _, ok := m.activeBuckets[bucket]; ok {
+		delete(m.activeBuckets[bucket], arn)
+	}
 	m.mlock.Unlock()
 }
 


### PR DESCRIPTION
## Description

https://github.com/minio/minio/blob/a9269cee2937ad4c07b0121940ba7c0ed04e0c29/internal/bucket/bandwidth/monitor.go#L176-L194
it seems the same func.
Based on the comments and the entries, it looks like this is how it needs to be removed. 
Close it if on purpose.


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
