### PR TITLE
Reduce allocations in Walkdir

### DIFF
--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -181,7 +181,7 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 				entries[i] = ""
 				continue
 			}
-			if strings.HasSuffix(entry, slashSeparator) {
+			if hasSuffixByte(entry, SlashSeparatorChar) {
 				if strings.HasSuffix(entry, globalDirSuffixWithSlash) {
 					// Add without extension so it is sorted correctly.
 					entry = strings.TrimSuffix(entry, globalDirSuffixWithSlash) + slashSeparator

--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -126,7 +127,7 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 
 	scanDir = func(current string) error {
 		// Skip forward, if requested...
-		var sb strings.Builder
+		var sb bytes.Buffer
 		forward := ""
 		if len(opts.ForwardTo) > 0 && strings.HasPrefix(opts.ForwardTo, current) {
 			forward = strings.TrimPrefix(opts.ForwardTo, current)
@@ -161,6 +162,9 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 			return nil
 		}
 		dirObjects := make(map[string]struct{})
+
+		// Avoid a bunch of cleanup when joining.
+		current = strings.Trim(current, SlashSeparator)
 		for i, entry := range entries {
 			if opts.Limit > 0 && objsReturned >= opts.Limit {
 				return nil
@@ -318,7 +322,7 @@ func (s *xlStorage) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writ
 				// NOT an object, append to stack (with slash)
 				// If dirObject, but no metadata (which is unexpected) we skip it.
 				if !isDirObj {
-					if !isDirEmpty(pathJoinBuf(&sb, volumeDir, meta.name+slashSeparator)) {
+					if !isDirEmpty(pathJoinBuf(&sb, volumeDir, meta.name)) {
 						dirStack = append(dirStack, meta.name+slashSeparator)
 					}
 				}

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -242,7 +242,7 @@ func pathJoin(elem ...string) string {
 // pathJoinBuf - like path.Join() but retains trailing SlashSeparator of the last element.
 // Provide a string builder to reduce allocation.
 func pathJoinBuf(dst *bytes.Buffer, elem ...string) string {
-	trailingSlash := len(elem) > 0 && hasSuffixByte(elem[len(elem)-1], '/')
+	trailingSlash := len(elem) > 0 && hasSuffixByte(elem[len(elem)-1], SlashSeparatorChar)
 	dst.Reset()
 	added := 0
 	for _, e := range elem {

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -208,6 +208,7 @@ func checkObjectNameForLengthAndSlash(bucket, object string) error {
 
 // SlashSeparator - slash separator.
 const SlashSeparator = "/"
+const SlashSeparatorChar = '/'
 
 // retainSlash - retains slash from a path.
 func retainSlash(s string) string {
@@ -231,7 +232,7 @@ func pathsJoinPrefix(prefix string, elem ...string) (paths []string) {
 func pathJoin(elem ...string) string {
 	trailingSlash := ""
 	if len(elem) > 0 {
-		if HasSuffix(elem[len(elem)-1], SlashSeparator) {
+		if hasSuffixByte(elem[len(elem)-1], SlashSeparatorChar) {
 			trailingSlash = SlashSeparator
 		}
 	}
@@ -241,13 +242,13 @@ func pathJoin(elem ...string) string {
 // pathJoinBuf - like path.Join() but retains trailing SlashSeparator of the last element.
 // Provide a string builder to reduce allocation.
 func pathJoinBuf(dst *bytes.Buffer, elem ...string) string {
-	trailingSlash := len(elem) > 0 && HasSuffix(elem[len(elem)-1], SlashSeparator)
+	trailingSlash := len(elem) > 0 && hasSuffixByte(elem[len(elem)-1], '/')
 	dst.Reset()
 	added := 0
 	for _, e := range elem {
 		if added > 0 || e != "" {
 			if added > 0 {
-				dst.WriteRune('/')
+				dst.WriteRune(SlashSeparatorChar)
 			}
 			dst.WriteString(e)
 			added += len(e)
@@ -262,9 +263,14 @@ func pathJoinBuf(dst *bytes.Buffer, elem ...string) string {
 		return s
 	}
 	if trailingSlash {
-		dst.WriteRune('/')
+		dst.WriteRune(SlashSeparatorChar)
 	}
 	return dst.String()
+}
+
+// hasSuffixByte returns true if the last byte of s is 'suffix'
+func hasSuffixByte(s string, suffix byte) bool {
+	return len(s) > 0 && s[len(s)-1] == suffix
 }
 
 // pathNeedsClean returns whether path.Clean may change the path.

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -238,6 +238,83 @@ func pathJoin(elem ...string) string {
 	return path.Join(elem...) + trailingSlash
 }
 
+// pathJoinBuf - like path.Join() but retains trailing SlashSeparator of the last element.
+// Provide a string builder to reduce allocation.
+func pathJoinBuf(dst *strings.Builder, elem ...string) string {
+	trailingSlash := len(elem) > 0 && HasSuffix(elem[len(elem)-1], SlashSeparator)
+	dst.Reset()
+	added := 0
+	for _, e := range elem {
+		if added > 0 || e != "" {
+			if added > 0 {
+				dst.WriteRune('/')
+			}
+			dst.WriteString(e)
+			added += len(e)
+		}
+	}
+	s := dst.String()
+	if pathNeedsClean(s) {
+		s = path.Clean(s)
+	}
+	if trailingSlash {
+		return s + SlashSeparator
+	}
+	return s
+}
+
+// pathNeedsClean returns whether path.Clean may change the path.
+// Will detect all cases that will be cleaned,
+// but may produce false positives on non-trivial paths.
+func pathNeedsClean(path string) bool {
+	if path == "" {
+		return true
+	}
+
+	rooted := path[0] == '/'
+	n := len(path)
+
+	r, w := 0, 0
+	if rooted {
+		r, w = 1, 1
+	}
+
+	for r < n {
+		switch {
+		case path[r] == '/':
+			// multiple / elements
+			return true
+		case path[r] == '.' && (r+1 == n || path[r+1] == '/'):
+			// . element - assume it has to be cleaned.
+			return true
+		case path[r] == '.' && path[r+1] == '.' && (r+2 == n || path[r+2] == '/'):
+			// .. element: remove to last / - assume it has to be cleaned.
+			return true
+		default:
+			// real path element.
+			// add slash if needed
+			if rooted && w != 1 || !rooted && w != 0 {
+				w++
+			}
+			// copy element
+			for ; r < n && path[r] != '/'; r++ {
+				w++
+			}
+			// allow one slash, not at end
+			if r < n-1 && path[r] == '/' {
+				r++
+			}
+		}
+	}
+
+	// Turn empty string into "."
+	if w == 0 {
+		return true
+	}
+
+	return false
+}
+
 // mustGetUUID - get a random UUID.
 func mustGetUUID() string {
 	u, err := uuid.NewRandom()

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -208,6 +208,8 @@ func checkObjectNameForLengthAndSlash(bucket, object string) error {
 
 // SlashSeparator - slash separator.
 const SlashSeparator = "/"
+
+// SlashSeparatorChar - slash separator.
 const SlashSeparatorChar = '/'
 
 // retainSlash - retains slash from a path.

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -798,7 +798,7 @@ func Test_pathNeedsClean(t *testing.T) {
 	}
 	for _, test := range cleantests {
 		want := test.path != test.result
-		got := pathNeedsClean(test.path)
+		got := pathNeedsClean([]byte(test.path))
 		if !got {
 			t.Logf("no clean: %q", test.path)
 		}

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -740,3 +740,70 @@ func TestS2CompressReader(t *testing.T) {
 		})
 	}
 }
+
+func Test_pathNeedsClean(t *testing.T) {
+	type pathTest struct {
+		path, result string
+	}
+
+	cleantests := []pathTest{
+		// Already clean
+		{"", "."},
+		{"abc", "abc"},
+		{"abc/def", "abc/def"},
+		{"a/b/c", "a/b/c"},
+		{".", "."},
+		{"..", ".."},
+		{"../..", "../.."},
+		{"../../abc", "../../abc"},
+		{"/abc", "/abc"},
+		{"/abc/def", "/abc/def"},
+		{"/", "/"},
+
+		// Remove trailing slash
+		{"abc/", "abc"},
+		{"abc/def/", "abc/def"},
+		{"a/b/c/", "a/b/c"},
+		{"./", "."},
+		{"../", ".."},
+		{"../../", "../.."},
+		{"/abc/", "/abc"},
+
+		// Remove doubled slash
+		{"abc//def//ghi", "abc/def/ghi"},
+		{"//abc", "/abc"},
+		{"///abc", "/abc"},
+		{"//abc//", "/abc"},
+		{"abc//", "abc"},
+
+		// Remove . elements
+		{"abc/./def", "abc/def"},
+		{"/./abc/def", "/abc/def"},
+		{"abc/.", "abc"},
+
+		// Remove .. elements
+		{"abc/def/ghi/../jkl", "abc/def/jkl"},
+		{"abc/def/../ghi/../jkl", "abc/jkl"},
+		{"abc/def/..", "abc"},
+		{"abc/def/../..", "."},
+		{"/abc/def/../..", "/"},
+		{"abc/def/../../..", ".."},
+		{"/abc/def/../../..", "/"},
+		{"abc/def/../../../ghi/jkl/../../../mno", "../../mno"},
+
+		// Combinations
+		{"abc/./../def", "def"},
+		{"abc//./../def", "def"},
+		{"abc/../../././../def", "../../def"},
+	}
+	for _, test := range cleantests {
+		want := test.path != test.result
+		got := pathNeedsClean(test.path)
+		if !got {
+			t.Logf("no clean: %q", test.path)
+		}
+		if want && !got {
+			t.Errorf("input: %q, want %v, got %v", test.path, want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Joining paths is one of the most allocation heavy when listing. Reuse a stringbuffer for listing operations.

Furthermore path cleaning as avoided when not needed, which also reduces allocations.

Use a stringbuilder that can be reused to reduce allocations when listing directories.

## How to test this PR?

Regular tests.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
- [x] Unit tests added/updated
