### PR TITLE
add Dial timeout for Kafka broker pings

### DIFF
--- a/internal/event/target/kafka.go
+++ b/internal/event/target/kafka.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/minio/minio/internal/event"
 	"github.com/minio/minio/internal/logger"
@@ -268,9 +269,9 @@ func (target *KafkaTarget) Close() error {
 
 // Check if atleast one broker in cluster is active
 func (k KafkaArgs) pingBrokers() bool {
+	d := net.Dialer{Timeout: 60 * time.Second}
 	for _, broker := range k.Brokers {
-		_, dErr := net.Dial("tcp", broker.String())
-		if dErr == nil {
+		if _, err := d.Dial("tcp", broker.String()); err == nil {
 			return true
 		}
 	}

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/minio/pkg/logger/message/audit"
 
@@ -148,18 +149,16 @@ type Config struct {
 }
 
 // Check if atleast one broker in cluster is active
-func (k Config) pingBrokers() error {
-	var err error
+func (k Config) pingBrokers() (err error) {
+	d := net.Dialer{Timeout: 60 * time.Second}
+
 	for _, broker := range k.Brokers {
-		_, err1 := net.Dial("tcp", broker.String())
-		if err1 != nil {
-			if err == nil {
-				// Set first error
-				err = err1
-			}
+		_, err = d.Dial("tcp", broker.String())
+		if err != nil {
+			return err
 		}
 	}
-	return err
+	return nil
 }
 
 // Stats returns the target statistics.


### PR DESCRIPTION
## Description
add Dial timeout for Kafka broker pings

## Motivation and Context
just don't hang for net.Dial

## How to test this PR?
take down kafka brokers and you can see `pingBroker` 
never responds back. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
