### PR TITLE
fix:lcpSuffix(globalDomainNames) use pre instead

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -857,7 +857,7 @@ func restQueries(keys ...string) []string {
 
 // Suffix returns the longest common suffix of the provided strings
 func lcpSuffix(strs []string) string {
-	return lcp(strs, false)
+	return lcp(strs, true)
 }
 
 func lcp(strs []string, pre bool) string {


### PR DESCRIPTION
## Description
It seems test_case use true.
Here is false
test case here:
https://github.com/minio/minio/blob/8a81e317d66bcc596265db76e02defe3d300e297/cmd/utils_test.go#L399-L419
```go
	fmt.Println("output:" + lcp([]string{"127.0.0.1/yyyyy", "127.0.0.1/zzzzz"}, false))
	fmt.Println("output:" + lcp([]string{"127.0.0.1/yyyyy", "127.0.0.1/zzzzz"}, true))
	fmt.Println("output:" + lcp([]string{"127.0.0.1/yyyyy", "127.0.0.2/yyyyy"}, false))
	fmt.Println("output:" + lcp([]string{"127.0.0.1/yyyyy", "127.0.0.2/yyyyy"}, true))
```
```shell
output:
output:127.0.0.1/
output:/yyyyy
output:127.0.0.
```
here 
https://github.com/minio/minio/blob/8a81e317d66bcc596265db76e02defe3d300e297/cmd/common-main.go#L691-L697
It seems should use true instead.
Domain should like `127.0.0.1/xxxx`
## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
