### PR TITLE
Upgrade madmin-go to 2.0.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/minio/dperf v0.4.2
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes-go v0.1.0
-	github.com/minio/madmin-go/v2 v2.0.19
+	github.com/minio/madmin-go/v2 v2.0.20
 	github.com/minio/minio-go/v7 v7.0.52
 	github.com/minio/mux v1.9.0
 	github.com/minio/pkg v1.6.6-0.20230330040824-5db111e5f63c

--- a/go.sum
+++ b/go.sum
@@ -780,6 +780,8 @@ github.com/minio/kes-go v0.1.0/go.mod h1:VorHLaIYis9/MxAHAtXN4d8PUMNKhIxTIlvFt0h
 github.com/minio/madmin-go v1.6.6/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
 github.com/minio/madmin-go/v2 v2.0.19 h1:XznxdMVCTyr0A88JrZFhdxWY8KLfJcrs0TTmFiE9cc8=
 github.com/minio/madmin-go/v2 v2.0.19/go.mod h1:8bL1RMNkblIENFSgGYjeHrzUx9PxROb7OqfNuMU9ivE=
+github.com/minio/madmin-go/v2 v2.0.20 h1:EO2IIQsnaVM3ki/ONcW0Ry4UpDn5aa+/S1kLkHuDBs8=
+github.com/minio/madmin-go/v2 v2.0.20/go.mod h1:8bL1RMNkblIENFSgGYjeHrzUx9PxROb7OqfNuMU9ivE=
 github.com/minio/mc v0.0.0-20230411170328-83336dfab325 h1:da5I7G0Va6UnqoxzPHus7zmqo2pEQnltI09/XKNvHP4=
 github.com/minio/mc v0.0.0-20230411170328-83336dfab325/go.mod h1:v9AeUV4eaMpKCuNz0tk/MSGxvNs3duYvWUIxzpacxtc=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=


### PR DESCRIPTION
## Description

This will ensure that the health report starts capturing XFS error configuration details.

## Motivation and Context

Add a health check related to XFS error configuration

## How to test this PR?

- Generate health report on a server having XFS file system (`mc support diag --airgap`)
- Extract it and verify that it contains a node `config -> xfs-error-config` that looks like:
```json
"xfs-error-config": {
  "configs": [
    {
      "config_file": "/sys/fs/xfs/vda2/error/metadata/EIO/max_retries",
      "max_retries": -1    
    },
    {
      "config_file": "/sys/fs/xfs/vda2/error/metadata/ENODEV/max_retries",
      "max_retries": 0
    },
    {
      "config_file": "/sys/fs/xfs/vda2/error/metadata/ENOSPC/max_retries",
      "max_retries": -1
    },             
    {  
      "config_file": "/sys/fs/xfs/vda2/error/metadata/default/max_retries",
      "max_retries": -1
    }
  ],
  "error": "" 
}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
