### PR TITLE
Remove Expect 100-continue in internode communications

### DIFF
--- a/internal/rest/client.go
+++ b/internal/rest/client.go
@@ -191,9 +191,6 @@ func (c *Client) newRequest(ctx context.Context, u *url.URL, body io.Reader) (*h
 		req.Header.Set("Authorization", "Bearer "+c.newAuthToken(u.RawQuery))
 	}
 	req.Header.Set("X-Minio-Time", time.Now().UTC().Format(time.RFC3339))
-	if body != nil {
-		req.Header.Set("Expect", "100-continue")
-	}
 
 	if tc, ok := ctx.Value(mcontext.ContextTraceKey).(*mcontext.TraceCtxt); ok {
 		req.Header.Set(xhttp.AmzRequestID, tc.AmzReqID)


### PR DESCRIPTION
## Description
Requests between nodes are always successful, at least, 
in normal environments. Expect 100-continue creates an 
unnecessary additional roundtrip in internode http requests, 
therefore removing it.

It may have some performance improvement but not tested.

## Motivation and Context


## How to test this PR?
Just regular operations

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
