### PR TITLE
Support systemd notify protocol

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -34,6 +34,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/minio/cli"
 	"github.com/minio/madmin-go/v2"
 	"github.com/minio/minio-go/v7"
@@ -641,7 +642,10 @@ func serverMain(ctx *cli.Context) {
 			setConsoleSrv(srv)
 
 			go func() {
-				logger.FatalIf(newConsoleServerFn().Serve(), "Unable to initialize console server")
+				server := newConsoleServerFn()
+				logger.FatalIf(server.Listen(), "Unable to initialize console server's sockets")
+				daemon.SdNotify(false, daemon.SdNotifyReady)
+				logger.FatalIf(server.Serve(), "Unable to initialize console server")
 			}()
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coredns/coredns v1.10.1
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/cosnicolaou/pbzip2 v1.0.1
 	github.com/dchest/siphash v1.2.3
 	github.com/djherbis/atime v1.1.0
@@ -112,7 +113,6 @@ require (
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
-	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect


### PR DESCRIPTION


## Description

Add support for systemd notification protocol (https://www.freedesktop.org/software/systemd/man/sd_notify.html)

## Motivation and Context

This will allow to set `Type=notify` in systemd service.

Thanks to this, `systemctl start` will actually wait for the ready notification instead of exiting when process has just started.

This will also allow to use `After=minio.service` for proper startup ordering. If some other service depends on MinIO, it will wait until MinIO is actually up and listening on its port.

Unfortunately, `Server.Serve` function has some additional setup going on instead of just launching serving goroutines, so in some cases systemd may report success with MinIO failing shortly after. Thankfully, listening sockets are still bound before, so proper startup ordering will still be achieved.

"Stopping" notification is mostly decorative, and will be reported in `systemctl status`.

If not running under systemd, or running without `Type=notify`, these changes have no effect.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
