### PR TITLE
helm: align chart properties with naming convention

### DIFF
--- a/helm/minio/templates/console-ingress.yaml
+++ b/helm/minio/templates/console-ingress.yaml
@@ -36,18 +36,18 @@ spec:
     - http:
         paths:
           - path: {{ $ingressPath }}
-          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             backend:
               service:
                 name: {{ $fullName }}
                 port: 
                   number: {{ $servicePort }}
-          {{- else }}
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $servicePort }}
-          {{- end }}
+            {{- end }}
       {{- if . }}
       host: {{ . | quote }}
       {{- end }}

--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -18,11 +18,11 @@ metadata:
   {{- end }}
 spec:
   strategy:
-    type: {{ .Values.DeploymentUpdate.type }}
-    {{- if eq .Values.DeploymentUpdate.type "RollingUpdate" }}
+    type: {{ .Values.deploymentUpdate.type }}
+    {{- if eq .Values.deploymentUpdate.type "RollingUpdate" }}
     rollingUpdate:
-      maxSurge: {{ .Values.DeploymentUpdate.maxSurge }}
-      maxUnavailable: {{ .Values.DeploymentUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.deploymentUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.deploymentUpdate.maxUnavailable }}
     {{- end }}
   replicas: 1
   selector:

--- a/helm/minio/templates/pvc.yaml
+++ b/helm/minio/templates/pvc.yaml
@@ -25,8 +25,8 @@ spec:
   storageClassName: "{{ .Values.persistence.storageClass }}"
   {{- end }}
   {{- end }}
-  {{- if .Values.persistence.VolumeName }}
-  volumeName: "{{ .Values.persistence.VolumeName }}"
+  {{- if .Values.persistence.volumeName }}
+  volumeName: "{{ .Values.persistence.volumeName }}"
   {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -49,7 +49,7 @@ metadata:
   {{- end }}
 spec:
   updateStrategy:
-    type: {{ .Values.StatefulSetUpdate.updateStrategy }}
+    type: {{ .Values.statefulSetUpdate.updateStrategy }}
   podManagementPolicy: "Parallel"
   serviceName: {{ template "minio.fullname" . }}-svc
   replicas: {{ $replicas }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -64,13 +64,13 @@ minioAPIPort: "9000"
 minioConsolePort: "9001"
 
 ## Update strategy for Deployments
-DeploymentUpdate:
+deploymentUpdate:
   type: RollingUpdate
   maxUnavailable: 0
   maxSurge: 100%
 
 ## Update strategy for StatefulSets
-StatefulSetUpdate:
+statefulSetUpdate:
   updateStrategy: RollingUpdate
 
 ## Pod priority settings
@@ -157,7 +157,7 @@ persistence:
   ## Storage class of PV to bind. By default it looks for standard storage class.
   ## If the PV uses a different storage class, specify that here.
   storageClass: ""
-  VolumeName: ""
+  volumeName: ""
   accessMode: ReadWriteOnce
   size: 500Gi
 


### PR DESCRIPTION
## Description
The PR aligns chart property names with [Helm naming convention](https://helm.sh/docs/chart_best_practices/values/#naming-conventions):
> Variable names should begin with a lowercase letter, and words should be separated with camelcase


It seems to be a breaking change, so it might be a good idea to fail the chart installation/upgrade if old property names are used, for example:
```yaml
  {{- if .Values.persistence.VolumeName }}
  {{- fail "Property 'persistence.VolumeName' is deprecated, use 'persistence.volumeName' instead" }}
  {{- end }}
```

## Motivation and Context
Keep code cleaner by following common naming convention.

## How to test this PR?
Install the chart using new property names.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
