### PR TITLE
fix: remove active healing on .minio.sys/ during startup

### DIFF
--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -784,6 +784,11 @@ func (h *healSequence) healDiskMeta(objAPI ObjectLayer) error {
 }
 
 func (h *healSequence) healItems(objAPI ObjectLayer, bucketsOnly bool) error {
+	if h.clientToken == bgHealingUUID {
+		// For background heal do nothing.
+		return nil
+	}
+
 	if err := h.healDiskMeta(objAPI); err != nil {
 		return err
 	}

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -766,6 +766,7 @@ func handleCommonEnvVars() {
 			logger.Info(color.RedBold(msg))
 		}
 		globalActiveCred = cred
+		globalCredViaEnv = true
 	} else {
 		globalActiveCred = auth.DefaultCredentials
 	}

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -2531,6 +2531,12 @@ func readConfigWithoutMigrate(ctx context.Context, objAPI ObjectLayer) (config.C
 		}
 	}
 
+	if !globalCredViaEnv && cfg.Credential.IsValid() {
+		// Preserve older credential if we do not have
+		// root credentials set via environment variable.
+		globalActiveCred = cfg.Credential
+	}
+
 	// Init compression config. For future migration, Compression config needs to be copied over from previous version.
 	switch cfg.Version {
 	case "29":

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -254,6 +254,9 @@ var (
 
 	globalActiveCred auth.Credentials
 
+	// Captures if root credentials are set via ENV.
+	globalCredViaEnv bool
+
 	globalPublicCerts []*x509.Certificate
 
 	globalDomainNames []string      // Root domains for virtual host style requests


### PR DESCRIPTION


## Description
fix: remove active healing on .minio.sys/ during startup

## Motivation and Context
The number of listing calls this can start can easily overwhelm 
the server and add to latencies upon startup on a large setup. 
With the change in PR #17004 - we have no reason to heal or 
migrate old formats.

We can always read and let them be overwritten in time.

## How to test this PR?
Nothing special, this should not affect any functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
