### PR TITLE
allow ListObjects() when a prefix is an object

### DIFF
--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"strings"
 
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/minio/internal/sync/errgroup"
@@ -173,10 +172,8 @@ func readAllFileInfo(ctx context.Context, disks []StorageAPI, bucket, object, ve
 		errFileVersionNotFound,
 		errDiskNotFound,
 		errUnformattedDisk,
-	}
-	if strings.HasPrefix(bucket, minioMetaBucket) {
-		// listing object might be truncated, ignore such errors from logging.
-		ignoredErrs = append(ignoredErrs, io.ErrUnexpectedEOF)
+		io.ErrUnexpectedEOF, // some times we would read without locks, ignore these errors
+		io.EOF,              // some times we would read without locks, ignore these errors
 	}
 	errs := g.Wait()
 	for index, err := range errs {

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1307,7 +1307,7 @@ func (z *erasureServerPools) ListObjects(ctx context.Context, bucket, prefix, ma
 	}
 	opts.setBucketMeta(ctx)
 
-	if len(prefix) > 0 && maxKeys == 1 && delimiter == "" && marker == "" {
+	if len(prefix) > 0 && maxKeys == 1 && marker == "" {
 		// Optimization for certain applications like
 		// - Cohesity
 		// - Actifio, Splunk etc.


### PR DESCRIPTION


## Description
allow ListObjects() when a prefix is an object

## Motivation and Context
we do not need to look for the delimiter to be empty,
requests may come in for objects to be listed with 
or without delimiter with max-keys=1

## How to test this PR?
Nothing special, this shouldn't really break anything.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
