### PR TITLE
fix: DeleteBucket for peers() must recreate bucket upon errors

### DIFF
--- a/cmd/peer-s3-client.go
+++ b/cmd/peer-s3-client.go
@@ -273,9 +273,24 @@ func (sys *S3PeerSys) DeleteBucket(ctx context.Context, bucket string, opts Dele
 	errs := g.Wait()
 	errs = append(errs, deleteBucketLocal(ctx, bucket, opts))
 
-	quorum := (len(sys.allPeerClients) / 2) + 1
-	err := reduceWriteQuorumErrs(ctx, errs, bucketOpIgnoredErrs, quorum)
-	return toObjectErr(err, bucket)
+	var errReturn error
+	for _, err := range errs {
+		if errReturn == nil && err != nil {
+			// always return first error
+			errReturn = toObjectErr(err, bucket)
+			break
+		}
+	}
+
+	for _, err := range errs {
+		if err == nil && errReturn != nil {
+			// re-create successful deletes, since we are return an error.
+			sys.MakeBucket(ctx, bucket, MakeBucketOptions{})
+			break
+		}
+	}
+
+	return errReturn
 }
 
 // DeleteBucket deletes bucket on a peer


### PR DESCRIPTION

## Description
fix: DeleteBucket for peers() must recreate bucket upon errors

## Motivation and Context
recreate the bucket upon errors if any to avoid leaking 
buckets with content.

fixes #17078

## How to test this PR?
Reproducible as per #17078 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
