### PR TITLE
fix: initialize reverse proxy forwarder with right public certs

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -59,7 +59,6 @@ import (
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/color"
 	"github.com/minio/minio/internal/config"
-	"github.com/minio/minio/internal/handlers"
 	"github.com/minio/minio/internal/kms"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/certs"
@@ -132,16 +131,6 @@ func init() {
 			}
 		}
 	}()
-
-	globalForwarder = handlers.NewForwarder(&handlers.Forwarder{
-		PassHost:     true,
-		RoundTripper: NewHTTPTransportWithTimeout(1 * time.Hour),
-		Logger: func(err error) {
-			if err != nil && !errors.Is(err, context.Canceled) {
-				logger.LogIf(GlobalContext, err)
-			}
-		},
-	})
 
 	console.SetColor("Debug", fcolor.New())
 


### PR DESCRIPTION


## Description
fix: initialize reverse proxy forwarder with right public certs

## Motivation and Context
public certs were missing for reverse proxy forwarder 
due to the fact that it was initialized very early on 
even before certs were loaded, move the code such that 
we only initialize the forwarder after TLS has been
successfully loaded.

## How to test this PR?
Configure two sites with self-signed TLS and then
upload one part to site1, second part goes to site2
would succeed (instead of how it fails on the master)
after this PR.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
