### PR TITLE
Fix put bucket policy error code

### DIFF
--- a/cmd/bucket-policy-handlers.go
+++ b/cmd/bucket-policy-handlers.go
@@ -87,7 +87,7 @@ func (api objectAPIHandlers) PutBucketPolicyHandler(w http.ResponseWriter, r *ht
 	bucketPolicy, err := policy.ParseConfig(bytes.NewReader(bucketPolicyBytes), bucket)
 	if err != nil {
 		writeErrorResponse(ctx, w, APIError{
-			Code:           "ErrMalformedXML",
+			Code:           "MalformedPolicy",
 			HTTPStatusCode: http.StatusBadRequest,
 			Description:    err.Error(),
 		}, r.URL)


### PR DESCRIPTION

## Description

- Since the policy content is not XML but JSON, the error message should not say "ErrMalformedXML". Instead we are changing it back to it's old value of "MalformedPolicy"

## Motivation and Context

Due to test failure in minio-hs

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
