### PR TITLE
tcp: Increase user timeout to 10 minutes

### DIFF
--- a/internal/http/dial_linux.go
+++ b/internal/http/dial_linux.go
@@ -67,8 +67,9 @@ func setTCPParameters(network, address string, c syscall.RawConn) error {
 		// Set tcp user timeout in addition to the keep-alive - tcp-keepalive is not enough to close a socket
 		// with dead end because tcp-keepalive is not fired when there is data in the socket buffer.
 		//    https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/
-		// This is a sensitive configuration, it is better to set it to high values, > 60 secs
-		_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, (15+5*15)*1000)
+		// This is a sensitive configuration, it is better to set it to high values, > 60 secs since it can
+		// affect clients reading data with a very slow pace  (disappropriate with socket buffer sizes)
+		_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, 10*60*1000)
 	})
 	return nil
 }


### PR DESCRIPTION
## Description
TCP_USER_TIMEOUT can be triggered with untransmitted data
in a socket buffer and this can happen when clients read/write 
data with a very low pace.

## Motivation and Context
Some clients read objects by chunks or very slow can get connection
killed

## How to test this PR?
Hard to test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
