### PR TITLE
fix: add correct worker count before startHTTPLogger()

### DIFF
--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -204,6 +204,7 @@ func (h *Target) Init() (err error) {
 		h.workerStartMu.Lock()
 		h.lastStarted = time.Now()
 		h.workerStartMu.Unlock()
+		atomic.AddInt64(&h.workers, 1)
 		go h.startHTTPLogger()
 	}
 	return nil


### PR DESCRIPTION
## Description

`go startHTTPLogger()` will call `defer atomic.AddInt64(&h.workers, -1)` why not add 1 here.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
