### PR TITLE
optimization use small blocks up to 64KB

### DIFF
--- a/internal/disk/directio_darwin.go
+++ b/internal/disk/directio_darwin.go
@@ -24,6 +24,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// ODirectPlatform indicates if the platform supports O_DIRECT
+const ODirectPlatform = true
+
 // OpenFileDirectIO - bypass kernel cache.
 func OpenFileDirectIO(filePath string, flag int, perm os.FileMode) (*os.File, error) {
 	return directio.OpenFile(filePath, flag, perm)

--- a/internal/disk/directio_unix.go
+++ b/internal/disk/directio_unix.go
@@ -28,6 +28,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// ODirectPlatform indicates if the platform supports O_DIRECT
+const ODirectPlatform = true
+
 // OpenFileDirectIO - bypass kernel cache.
 func OpenFileDirectIO(filePath string, flag int, perm os.FileMode) (*os.File, error) {
 	return directio.OpenFile(filePath, flag, perm)

--- a/internal/disk/directio_unsupported.go
+++ b/internal/disk/directio_unsupported.go
@@ -24,6 +24,9 @@ import (
 	"os"
 )
 
+// ODirectPlatform indicates if the platform supports O_DIRECT
+const ODirectPlatform = false
+
 // OpenBSD, Windows, and illumos do not support O_DIRECT.
 // On Windows there is no documentation on disabling O_DIRECT.
 // For these systems we do not attempt to build the 'directio' dependency since

--- a/internal/ioutil/read_file.go
+++ b/internal/ioutil/read_file.go
@@ -66,10 +66,10 @@ func ReadFile(name string) ([]byte, error) {
 		// Don't wrap with un-needed buffer.
 		// Don't use os.ReadFile, since it doesn't pass NO_ATIME when present.
 		f, err := OpenFileDirectIO(name, readMode, 0o666)
-		defer f.Close()
 		if err != nil {
 			return nil, err
 		}
+		defer f.Close()
 		st, err := f.Stat()
 		if err != nil {
 			return io.ReadAll(f)

--- a/internal/ioutil/read_file.go
+++ b/internal/ioutil/read_file.go
@@ -65,7 +65,7 @@ func ReadFile(name string) ([]byte, error) {
 	if !disk.ODirectPlatform {
 		// Don't wrap with un-needed buffer.
 		// Don't use os.ReadFile, since it doesn't pass NO_ATIME when present.
-		f, err := OpenFileDirectIO(name, readMode, 0o666)
+		f, err := OsOpenFile(name, readMode, 0o666)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

From https://github.com/minio/minio/discussions/17103 - files up to 1MB would be read in 32KB blocks. Set that threshold to 64KB, so at most there are 2 reads.

Remove the unneeded wrapper in readAllData when we are not using O_DIRECT - we are reading directly into a single buffer, so there is no need for an intermediate buffer. This will save a memcopy in most cases.

Either way, we now quickly reject on unsupported platforms and avoid the copying there.

Bonus: `ReadFileWithFileInfo` will now also use `NO_ATIME` flag for reads.
 
## How to test this PR?

Picked up by regular tests reliably.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
