### PR TITLE
fix: store notification events immediately for persistent queues

### DIFF
--- a/internal/event/target/amqp.go
+++ b/internal/event/target/amqp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -274,12 +274,11 @@ func (target *AMQPTarget) send(eventData event.Event, ch *amqp091.Channel, confi
 
 // Save - saves the events to the store which will be replayed when the amqp connection is active.
 func (target *AMQPTarget) Save(eventData event.Event) error {
-	if err := target.init(); err != nil {
-		return err
-	}
-
 	if target.store != nil {
 		return target.store.Put(eventData)
+	}
+	if err := target.init(); err != nil {
+		return err
 	}
 	ch, confirms, err := target.channel()
 	if err != nil {

--- a/internal/event/target/elasticsearch.go
+++ b/internal/event/target/elasticsearch.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -200,12 +200,11 @@ func (target *ElasticsearchTarget) isActive() (bool, error) {
 
 // Save - saves the events to the store if queuestore is configured, which will be replayed when the elasticsearch connection is active.
 func (target *ElasticsearchTarget) Save(eventData event.Event) error {
-	if err := target.init(); err != nil {
-		return err
-	}
-
 	if target.store != nil {
 		return target.store.Put(eventData)
+	}
+	if err := target.init(); err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/event/target/kafka.go
+++ b/internal/event/target/kafka.go
@@ -168,12 +168,11 @@ func (target *KafkaTarget) isActive() (bool, error) {
 
 // Save - saves the events to the store which will be replayed when the Kafka connection is active.
 func (target *KafkaTarget) Save(eventData event.Event) error {
-	if err := target.init(); err != nil {
-		return err
-	}
-
 	if target.store != nil {
 		return target.store.Put(eventData)
+	}
+	if err := target.init(); err != nil {
+		return err
 	}
 	_, err := target.isActive()
 	if err != nil {

--- a/internal/event/target/kafka_scram_client_contrib.go
+++ b/internal/event/target/kafka_scram_client_contrib.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Object Storage (c) 2021 MinIO, Inc.
+ * MinIO Object Storage (c) 2021-2023 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/event/target/lazyinit.go
+++ b/internal/event/target/lazyinit.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //

--- a/internal/event/target/mqtt.go
+++ b/internal/event/target/mqtt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -200,12 +200,11 @@ func (target *MQTTTarget) Send(eventKey string) error {
 // Save - saves the events to the store if queuestore is configured, which will
 // be replayed when the mqtt connection is active.
 func (target *MQTTTarget) Save(eventData event.Event) error {
-	if err := target.init(); err != nil {
-		return err
-	}
-
 	if target.store != nil {
 		return target.store.Put(eventData)
+	}
+	if err := target.init(); err != nil {
+		return err
 	}
 
 	// Do not send if the connection is not active.

--- a/internal/event/target/mysql.go
+++ b/internal/event/target/mysql.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -196,13 +196,13 @@ func (target *MySQLTarget) isActive() (bool, error) {
 
 // Save - saves the events to the store which will be replayed when the SQL connection is active.
 func (target *MySQLTarget) Save(eventData event.Event) error {
+	if target.store != nil {
+		return target.store.Put(eventData)
+	}
 	if err := target.init(); err != nil {
 		return err
 	}
 
-	if target.store != nil {
-		return target.store.Put(eventData)
-	}
 	_, err := target.isActive()
 	if err != nil {
 		return err

--- a/internal/event/target/mysql_test.go
+++ b/internal/event/target/mysql_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //

--- a/internal/event/target/nats.go
+++ b/internal/event/target/nats.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -289,13 +289,14 @@ func (target *NATSTarget) isActive() (bool, error) {
 
 // Save - saves the events to the store which will be replayed when the Nats connection is active.
 func (target *NATSTarget) Save(eventData event.Event) error {
+	if target.store != nil {
+		return target.store.Put(eventData)
+	}
+
 	if err := target.init(); err != nil {
 		return err
 	}
 
-	if target.store != nil {
-		return target.store.Put(eventData)
-	}
 	_, err := target.isActive()
 	if err != nil {
 		return err

--- a/internal/event/target/nats_contrib_test.go
+++ b/internal/event/target/nats_contrib_test.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Object Storage (c) 2021 MinIO, Inc.
+ * MinIO Object Storage (c) 2021-2023 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/event/target/nats_tls_contrib_test.go
+++ b/internal/event/target/nats_tls_contrib_test.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Object Storage (c) 2021 MinIO, Inc.
+ * MinIO Object Storage (c) 2021-2023 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/event/target/nsq.go
+++ b/internal/event/target/nsq.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -145,13 +145,14 @@ func (target *NSQTarget) isActive() (bool, error) {
 
 // Save - saves the events to the store which will be replayed when the nsq connection is active.
 func (target *NSQTarget) Save(eventData event.Event) error {
+	if target.store != nil {
+		return target.store.Put(eventData)
+	}
+
 	if err := target.init(); err != nil {
 		return err
 	}
 
-	if target.store != nil {
-		return target.store.Put(eventData)
-	}
 	_, err := target.isActive()
 	if err != nil {
 		return err

--- a/internal/event/target/nsq_test.go
+++ b/internal/event/target/nsq_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //

--- a/internal/event/target/postgresql.go
+++ b/internal/event/target/postgresql.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -188,13 +188,14 @@ func (target *PostgreSQLTarget) isActive() (bool, error) {
 
 // Save - saves the events to the store if questore is configured, which will be replayed when the PostgreSQL connection is active.
 func (target *PostgreSQLTarget) Save(eventData event.Event) error {
+	if target.store != nil {
+		return target.store.Put(eventData)
+	}
+
 	if err := target.init(); err != nil {
 		return err
 	}
 
-	if target.store != nil {
-		return target.store.Put(eventData)
-	}
 	_, err := target.isActive()
 	if err != nil {
 		return err

--- a/internal/event/target/postgresql_test.go
+++ b/internal/event/target/postgresql_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //

--- a/internal/event/target/redis.go
+++ b/internal/event/target/redis.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -168,12 +168,11 @@ func (target *RedisTarget) isActive() (bool, error) {
 
 // Save - saves the events to the store if questore is configured, which will be replayed when the redis connection is active.
 func (target *RedisTarget) Save(eventData event.Event) error {
-	if err := target.init(); err != nil {
-		return err
-	}
-
 	if target.store != nil {
 		return target.store.Put(eventData)
+	}
+	if err := target.init(); err != nil {
+		return err
 	}
 	_, err := target.isActive()
 	if err != nil {

--- a/internal/event/target/webhook.go
+++ b/internal/event/target/webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -161,12 +161,11 @@ func (target *WebhookTarget) isActive() (bool, error) {
 // Save - saves the events to the store if queuestore is configured,
 // which will be replayed when the webhook connection is active.
 func (target *WebhookTarget) Save(eventData event.Event) error {
-	if err := target.init(); err != nil {
-		return err
-	}
-
 	if target.store != nil {
 		return target.store.Put(eventData)
+	}
+	if err := target.init(); err != nil {
+		return err
 	}
 	err := target.send(eventData)
 	if err != nil {


### PR DESCRIPTION
## Description

Currently, we initialize the notification targets first and then save the event to the store, this will miss the events if the target is down while starting up.

The commit covers the following changes :-

- Saves the notification event immediately and then initializes the targets lazily.
- Remove the intermediate in-memory queue with a limit. This is not useful and this can lead to queue-overflow and potentially miss the events.

## Motivation and Context

If queue directory is configured, we don't need to care about the target initialization errors during startup. We need immediately persist the events irrespective to the target's conn errors.

No bucket event notifications should be missed.

## How to test this PR?
- Configure bucket notification events with queue dir configured. Eg, 
  ```sh
  mc admin config set myminio notify_webhook enable=on endpoint=http://localhost:8080/ queue_size=100000 queue_dir=/tmp/webhook
  ```
- For example, use the following webhook snippet to listen for the bucket notification events
```go
package main

import (
	"fmt"

	"io/ioutil"
	"log"
	"net/http"
)

func main() {

	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		b, err := ioutil.ReadAll(r.Body)
		defer r.Body.Close()
		if err != nil {
			log.Fatal(err)
			return
		}
		fmt.Println(string(b))
		fmt.Println("*****************")
		w.WriteHeader(200)
	})

	log.Printf("listening on http://%s/", "localhost:8080")
	log.Fatal(http.ListenAndServe("localhost:8080", nil))
}
```
- Shutdown the webhook
- Restart MinIO
- Upload objects to MinIO
- Check the queue dir, you won't see any entries - which is fixed in this PR
- Bring up the webhook, the saved events will be replayed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
