### PR TITLE
Added MINIO_BROWSER_LOGIN_ANIMATION env support for WebUI console

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -176,7 +176,7 @@ func minioConfigToConsoleFeatures() {
 		}
 	}
 	// pass the console subpath configuration
-	if value := env.Get(config.EnvMinIOBrowserRedirectURL, ""); value != "" {
+	if value := env.Get(config.EnvBrowserRedirectURL, ""); value != "" {
 		subPath := path.Clean(pathJoin(strings.TrimSpace(globalBrowserRedirectURL.Path), SlashSeparator))
 		if subPath != SlashSeparator {
 			os.Setenv("CONSOLE_SUBPATH", subPath)
@@ -197,6 +197,11 @@ func minioConfigToConsoleFeatures() {
 	if globalIAMSys.LDAPConfig.Enabled() {
 		os.Setenv("CONSOLE_LDAP_ENABLED", config.EnableOn)
 	}
+	// Handle animation in welcome page
+	if value := env.Get(config.EnvBrowserLoginAnimation, "on"); value != "" {
+		os.Setenv("CONSOLE_ANIMATED_LOGIN", value)
+	}
+
 	os.Setenv("CONSOLE_MINIO_REGION", globalSite.Region)
 	os.Setenv("CONSOLE_CERT_PASSWD", env.Get("MINIO_CERT_PASSWD", ""))
 
@@ -621,7 +626,7 @@ func handleCommonEnvVars() {
 		logger.Fatal(config.ErrInvalidBrowserValue(err), "Invalid MINIO_BROWSER value in environment variable")
 	}
 	if globalBrowserEnabled {
-		if redirectURL := env.Get(config.EnvMinIOBrowserRedirectURL, ""); redirectURL != "" {
+		if redirectURL := env.Get(config.EnvBrowserRedirectURL, ""); redirectURL != "" {
 			u, err := xnet.ParseHTTPURL(redirectURL)
 			if err != nil {
 				logger.Fatal(err, "Invalid MINIO_BROWSER_REDIRECT_URL value in environment variable")

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -61,9 +61,10 @@ const (
 	EnvMinIOCallhomeEnable    = "MINIO_CALLHOME_ENABLE"
 	EnvMinIOCallhomeFrequency = "MINIO_CALLHOME_FREQUENCY"
 
-	EnvMinIOServerURL          = "MINIO_SERVER_URL"
-	EnvMinIOBrowserRedirectURL = "MINIO_BROWSER_REDIRECT_URL"
-	EnvRootDiskThresholdSize   = "MINIO_ROOTDISK_THRESHOLD_SIZE"
+	EnvMinIOServerURL        = "MINIO_SERVER_URL"
+	EnvBrowserRedirectURL    = "MINIO_BROWSER_REDIRECT_URL"
+	EnvRootDiskThresholdSize = "MINIO_ROOTDISK_THRESHOLD_SIZE"
+	EnvBrowserLoginAnimation = "MINIO_BROWSER_LOGIN_ANIMATION"
 
 	EnvUpdate = "MINIO_UPDATE"
 


### PR DESCRIPTION
## Description

Added `MINIO_BROWSER_LOGIN_ANIMATION ` env support for embedded WebUI Console

## Motivation and Context

We added an env var in console called `CONSOLE_ANIMATED_LOGIN` to solve a reported issue in k8s with port forward and certain file types (kubernetes/kubectl/issues/1368). 

`MINIO_BROWSER_LOGIN_ANIMATION ` env var was added to MinIO server to allow the use of the env variable from console using embedded WebUI console

> **NOTE:** This PR requires the use of https://github.com/minio/console/pull/2799 to work

## How to test this PR?

1. Set `MINIO_BROWSER_LOGIN_ANIMATION ` env variable, the possible values are `off` and `on` (on is set by default)
2. Start your MinIO server
3. Navigate to Console UI Login Page and observe the background on the left side of the screen, static image must be seen if env variable is set to off, animated background should be seen if env variable is set to on or is not set

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)