### PR TITLE
helm: fix pod annotations indentation

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.podAnnotations }}
-          {{- toYaml .Values.podAnnotations | trimSuffix "\n" | indent 8 }}
+          {{- toYaml .Values.podAnnotations | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.priorityClassName }}


### PR DESCRIPTION
## Description

Fix the indentation of pod annotations in the deployment template.

## Motivation and Context

The lack of new line at the start of pod annotations causes helm to return an error.

## How to test this PR?

Run helm template with pod annotations, then verify that there is no error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (18515a4e3b7d185eba81fa5c1e9dd116001c4faf)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
