### PR TITLE
Avoid calling KES Status when peers ping each other

### DIFF
--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -28,7 +28,7 @@ import (
 
 const unavailable = "offline"
 
-func isServerInitialized() bool {
+func isServerNotInitialized() bool {
 	return newObjectLayerFn() == nil
 }
 
@@ -36,7 +36,7 @@ func isServerInitialized() bool {
 func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "ClusterCheckHandler")
 
-	if isServerInitialized() {
+	if isServerNotInitialized() {
 		w.Header().Set(xhttp.MinIOServerStatus, unavailable)
 		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
 		return
@@ -77,7 +77,7 @@ func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 func ClusterReadCheckHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "ClusterReadCheckHandler")
 
-	if isServerInitialized() {
+	if isServerNotInitialized() {
 		w.Header().Set(xhttp.MinIOServerStatus, unavailable)
 		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
 		return
@@ -104,7 +104,13 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 // LivenessCheckHandler - Checks if the process is up. Always returns success.
 func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
-	if isServerInitialized() {
+	peerCall := r.Header.Get("x-minio-from-peer") != ""
+
+	if peerCall {
+		return
+	}
+
+	if isServerNotInitialized() {
 		// Service not initialized yet
 		w.Header().Set(xhttp.MinIOServerStatus, unavailable)
 	}
@@ -121,7 +127,7 @@ func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify if KMS is reachable if its configured
-	if GlobalKMS != nil {
+	if GlobalKMS != nil && !peerCall {
 		ctx, cancel := context.WithTimeout(r.Context(), time.Minute)
 		defer cancel()
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -125,15 +125,16 @@ func isServerResolvable(endpoint Endpoint, timeout time.Duration) error {
 	}
 
 	ctx, cancel := context.WithTimeout(GlobalContext, timeout)
+	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, serverURL.String(), nil)
 	if err != nil {
-		cancel()
 		return err
 	}
 
+	req.Header.Set("x-minio-from-peer", "true")
+
 	resp, err := httpClient.Do(req)
-	cancel()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Currently, peers pinging each other in server startup or in mc admin info 
trigger many KES status call, which is not needed.

Disable it by specifying a peer header in the healtchechk call.


## Motivation and Context
Avoid seeing io.EOF in KES logs during mc admin info

## How to test this PR?
- Set up a cluster with multiple nodes with KES
- Run mc admin info

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
