### PR TITLE
Validate if replication config being added is self referential

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"path"
 	"reflect"
 	"strings"
@@ -138,6 +139,13 @@ func validateReplicationDestination(ctx context.Context, bucket string, rCfg *re
 		// validate replication ARN against target endpoint
 		c := globalBucketTargetSys.GetRemoteTargetClient(ctx, arnStr)
 		if c != nil {
+			if err := checkRemoteEndpoint(ctx, c.EndpointURL()); err != nil {
+				switch err.(type) {
+				case BucketRemoteIdenticalToSource:
+					return true, errorCodes.ToAPIErrWithErr(ErrBucketRemoteIdenticalToSource, fmt.Errorf("remote target endpoint %s is self referential", c.EndpointURL().String()))
+				default:
+				}
+			}
 			if c.EndpointURL().String() == clnt.EndpointURL().String() {
 				selfTarget, _ := isLocalHost(clnt.EndpointURL().Hostname(), clnt.EndpointURL().Port(), globalMinioPort)
 				if !sameTarget {
@@ -152,6 +160,45 @@ func validateReplicationDestination(ctx context.Context, bucket string, rCfg *re
 		return false, toAPIError(ctx, BucketRemoteTargetNotFound{Bucket: bucket})
 	}
 	return sameTarget, toAPIError(ctx, nil)
+}
+
+// performs a http request to remote endpoint to check if deployment id of remote endpoint is same as
+// local cluster deployment id. This is to prevent replication to self, especially in case of a loadbalancer
+// in front of MinIO.
+func checkRemoteEndpoint(ctx context.Context, epURL *url.URL) error {
+	reqURL := &url.URL{
+		Scheme: epURL.Scheme,
+		Host:   epURL.Host,
+		Path:   healthCheckReadinessPath,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Transport: NewHTTPTransport(),
+		Timeout:   10 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if err == nil {
+		// Drain the connection.
+		xhttp.DrainBody(resp.Body)
+	}
+	if resp != nil {
+		amzid := resp.Header.Get(xhttp.AmzRequestHostID)
+		if _, ok := globalNodeNamesHex[amzid]; ok {
+			return BucketRemoteIdenticalToSource{
+				Endpoint: epURL.String(),
+			}
+		}
+	}
+	return nil
 }
 
 type mustReplicateOptions struct {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -231,6 +231,7 @@ var (
 	// The name of this local node, fetched from arguments
 	globalLocalNodeName    string
 	globalLocalNodeNameHex string
+	globalNodeNamesHex     map[string]struct{}
 
 	// The global subnet config
 	globalSubnetConfig subnet.Config

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -437,6 +437,16 @@ func (e RemoteTargetConnectionErr) Error() string {
 	return fmt.Sprintf("Remote service endpoint %s not available\n\t%s", e.Endpoint, e.Err.Error())
 }
 
+// BucketRemoteIdenticalToSource remote already exists for this target type.
+type BucketRemoteIdenticalToSource struct {
+	GenericError
+	Endpoint string
+}
+
+func (e BucketRemoteIdenticalToSource) Error() string {
+	return fmt.Sprintf("Remote service endpoint %s is self referential to current cluster", e.Endpoint)
+}
+
 // BucketRemoteAlreadyExists remote already exists for this target type.
 type BucketRemoteAlreadyExists GenericError
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -233,9 +233,9 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	logger.FatalIf(err, "Invalid command line arguments")
 
 	globalLocalNodeName = GetLocalPeer(globalEndpoints, globalMinioHost, globalMinioPort)
-	nodeNameSum := sha256.Sum256([]byte(globalLocalNodeNameHex))
+	nodeNameSum := sha256.Sum256([]byte(globalLocalNodeName))
 	globalLocalNodeNameHex = hex.EncodeToString(nodeNameSum[:])
-
+	globalNodeNamesHex = make(map[string]struct{})
 	globalRemoteEndpoints = make(map[string]Endpoint)
 	for _, z := range globalEndpoints {
 		for _, ep := range z.Endpoints {
@@ -244,6 +244,9 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 			} else {
 				globalRemoteEndpoints[ep.Host] = ep
 			}
+			nodeNameSum := sha256.Sum256([]byte(ep.Host))
+			globalNodeNamesHex[hex.EncodeToString(nodeNameSum[:])] = struct{}{}
+
 		}
 	}
 


### PR DESCRIPTION
## Description


## Motivation and Context
Existing checks to compare target endpoint to local cluster endpoint not sufficient to catch issues if a load balancer endpoint configured incorrectly to point to source cluster.

## How to test this PR?
set up sidekick in front of a minio instance - use this endpoint to configure replication. It should throw an error 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
