### PR TITLE
helm: allow postjob to run without user 1000

### DIFF
--- a/helm/minio/templates/post-job.yaml
+++ b/helm/minio/templates/post-job.yaml
@@ -136,6 +136,8 @@ spec:
             - name: MINIO_PORT
               value: {{ .Values.service.port | quote }}
           volumeMounts:
+            - name: etc-path
+              mountPath: /etc/minio
             - name: minio-configuration
               mountPath: /config
             {{- if .Values.tls.enabled }}
@@ -165,6 +167,8 @@ spec:
             - name: MINIO_PORT
               value: {{ .Values.service.port | quote }}
           volumeMounts:
+            - name: etc-path
+              mountPath: /etc/minio
             - name: minio-configuration
               mountPath: /config
             {{- if .Values.tls.enabled }}
@@ -194,6 +198,8 @@ spec:
             - name: MINIO_PORT
               value: {{ .Values.service.port | quote }}
           volumeMounts:
+            - name: etc-path
+              mountPath: /etc/minio
             - name: minio-configuration
               mountPath: /config
             {{- if .Values.tls.enabled }}
@@ -223,6 +229,8 @@ spec:
             - name: MINIO_PORT
               value: {{ .Values.service.port | quote }}
           volumeMounts:
+            - name: etc-path
+              mountPath: /etc/minio
             - name: minio-configuration
               mountPath: /config
             {{- if .Values.tls.enabled }}


### PR DESCRIPTION
## Description

This changes allow to run the post-job on Openshift. It fixes the problem described in https://github.com/minio/minio/issues/16758.

The changes improve on the previous PR #17148, which only added the the `volumeMounts` to the `minio-make-bucket` container of the post-job.yaml. Now all containers use the proper `volumeMounts` which allows them to run successfully in openshift. 

## How to test this PR?

install the helm chart.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
