### PR TITLE
Draft: Add RISCV64 as supported architecture.

### DIFF
--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -75,11 +75,11 @@ check_minimum_version() {
 
 assert_is_supported_arch() {
     case "${ARCH}" in
-        x86_64 | amd64 | aarch64 | ppc64le | arm* | s390x | loong64 | loongarch64 )
+        x86_64 | amd64 | aarch64 | ppc64le | arm* | s390x | loong64 | loongarch64 | riscv64 )
             return
             ;;
         *)
-            echo "Arch '${ARCH}' is not supported. Supported Arch: [x86_64, amd64, aarch64, ppc64le, arm*, s390x, loong64, loongarch64]"
+            echo "Arch '${ARCH}' is not supported. Supported Arch: [x86_64, amd64, aarch64, ppc64le, arm*, s390x, loong64, loongarch64, riscv64]"
             exit 1
     esac
 }


### PR DESCRIPTION
## Description

Issue [#17162](https://github.com/minio/minio/issues/17162)

## Motivation and Context
Enable RISCV64 architecture in dependencies in order to build minio on RISCV64 CPU.

## How to test this PR?
Compile and run the test suite against a native RISCV64 board. Luckily, I have a board provided by RiscV International for qualification.

## Types of changes
- [X ] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] Run complete Minio Test suite on SiFive Unmatched
- [ ] Create a documentation update request - add RISCV64 as supported if Q/A pass [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
