### PR TITLE
allow JWT parsing on large session policy based tokens

### DIFF
--- a/cmd/admin-handler-utils.go
+++ b/cmd/admin-handler-utils.go
@@ -168,8 +168,14 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 			}
 		case errors.Is(err, errPolicyInUse):
 			apiErr = APIError{
-				Code:           "XMinioAdminPolicyInUse",
+				Code:           "XMinioIAMPolicyInUse",
 				Description:    "The policy cannot be removed, as it is in use",
+				HTTPStatusCode: http.StatusBadRequest,
+			}
+		case errors.Is(err, errSessionPolicyTooLarge):
+			apiErr = APIError{
+				Code:           "XMinioIAMServiceAccountSessionPolicyTooLarge",
+				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}
 		case errors.Is(err, kes.ErrKeyExists):

--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/minio/madmin-go/v2"
 	"github.com/minio/minio-go/v7/pkg/set"
@@ -2221,13 +2220,13 @@ func (store *IAMStoreSys) UpdateServiceAccount(ctx context.Context, accessKey st
 	delete(m, sessionPolicyNameExtracted)
 
 	// sessionPolicy is nil and there is embedded policy attached we remove
-	// rembedded policy at that point.
+	// embedded policy at that point.
 	if _, ok := m[iampolicy.SessionPolicyName]; ok && opts.sessionPolicy == nil {
 		delete(m, iampolicy.SessionPolicyName)
 		m[iamPolicyClaimNameSA()] = inheritedPolicyType
 	}
 
-	if opts.sessionPolicy != nil {
+	if opts.sessionPolicy != nil { // session policies is being updated
 		if err := opts.sessionPolicy.Validate(); err != nil {
 			return updatedAt, err
 		}
@@ -2237,8 +2236,8 @@ func (store *IAMStoreSys) UpdateServiceAccount(ctx context.Context, accessKey st
 			return updatedAt, err
 		}
 
-		if len(policyBuf) > 16*humanize.KiByte {
-			return updatedAt, fmt.Errorf("Session policy should not exceed 16 KiB characters")
+		if len(policyBuf) > 2048 {
+			return updatedAt, errSessionPolicyTooLarge
 		}
 
 		// Overwrite session policy claims.

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -32,7 +32,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
 	"github.com/minio/madmin-go/v2"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio/internal/arn"
@@ -944,8 +943,8 @@ func (sys *IAMSys) NewServiceAccount(ctx context.Context, parentUser string, gro
 		if err != nil {
 			return auth.Credentials{}, time.Time{}, err
 		}
-		if len(policyBuf) > 16*humanize.KiByte {
-			return auth.Credentials{}, time.Time{}, fmt.Errorf("Session policy should not exceed 16 KiB characters")
+		if len(policyBuf) > 2048 {
+			return auth.Credentials{}, time.Time{}, errSessionPolicyTooLarge
 		}
 	}
 

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -238,7 +238,7 @@ func (sts *stsAPIHandlers) AssumeRole(w http.ResponseWriter, r *http.Request) {
 	// The plain text that you use for both inline and managed session
 	// policies shouldn't exceed 2048 characters.
 	if len(sessionPolicyStr) > 2048 {
-		writeSTSErrorResponse(ctx, w, ErrSTSInvalidParameterValue, fmt.Errorf("Session policy shouldn't exceed 2048 characters"))
+		writeSTSErrorResponse(ctx, w, ErrSTSInvalidParameterValue, errSessionPolicyTooLarge)
 		return
 	}
 

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -115,3 +115,6 @@ var errUploadIDNotFound = errors.New("Specified Upload ID is not found")
 
 // error returned when PartNumber is greater than the maximum allowed 10000 parts
 var errInvalidMaxParts = errors.New("Part number is greater than the maximum allowed 10000 parts")
+
+// error returned for session policies > 2048
+var errSessionPolicyTooLarge = errors.New("Session policy should not exceed 2048 characters")

--- a/internal/jwt/parser.go
+++ b/internal/jwt/parser.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/buger/jsonparser"
+	"github.com/dustin/go-humanize"
 	jwtgo "github.com/golang-jwt/jwt/v4"
 	jsoniter "github.com/json-iterator/go"
 )
@@ -53,7 +54,7 @@ var (
 	SigningMethodHS512 *SigningMethodHMAC
 )
 
-const base64BufferSize = 8192
+const base64BufferSize = 64 * humanize.KiByte
 
 var (
 	base64BufPool sync.Pool


### PR DESCRIPTION



## Description
allow JWT parsing on large session policy-based tokens

## Motivation and Context

b64 buffer size of 8192 is not enough to handle larger
session policies of upto 16KiB, this was due to an
incorrect requirement in service accounts where larger
policies were allowed up to 16KiB.
    
This is not correct we should limit this to 2048
characters just like how STS tokens session policy
limits are.
    
This PR would disallow the creation of larger policies
for service accounts beyond 2KiB, however it would
still, support existing service accounts with larger
policies that were allowed.    

fixes #17157

## How to test this PR?
As per #17157 - you may also use the attached large session policy file.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
