### PR TITLE
fix: avoid audit log race protection deadlocks

### DIFF
--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -124,7 +124,12 @@ func AuditLog(ctx context.Context, w http.ResponseWriter, r *http.Request, reqCl
 		entry.API.HeaderBytes = headerBytes
 		entry.API.TimeToResponse = strconv.FormatInt(timeToResponse.Nanoseconds(), 10) + "ns"
 		entry.API.TimeToResponseInNS = strconv.FormatInt(timeToResponse.Nanoseconds(), 10)
-		entry.Tags = reqInfo.GetTagsMap()
+		// We hold the lock, so we cannot call reqInfo.GetTagsMap().
+		tags := make(map[string]interface{}, len(reqInfo.tags))
+		for _, t := range reqInfo.tags {
+			tags[t.Key] = t.Val
+		}
+		entry.Tags = tags
 		// ignore cases for ttfb when its zero.
 		if timeToFirstByte != 0 {
 			entry.API.TimeToFirstByte = strconv.FormatInt(timeToFirstByte.Nanoseconds(), 10) + "ns"

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -278,9 +278,9 @@ func errToEntry(ctx context.Context, err error, errKind ...interface{}) log.Entr
 		API = req.API
 	}
 
-	kv := req.GetTags()
-	tags := make(map[string]interface{}, len(kv))
-	for _, entry := range kv {
+	// Copy tags. We hold read lock already.
+	tags := make(map[string]interface{}, len(req.tags))
+	for _, entry := range req.tags {
 		tags[entry.Key] = entry.Val
 	}
 


### PR DESCRIPTION
## Description

Since we hold a read lock on reqInfo, if a write lock request comes in before calling `reqInfo.GetTagsMap()` it will deadlock.

A historical bug 9004d69c6f 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
