### PR TITLE
fix: error in capturing XFS error config in health report

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -136,6 +136,7 @@ func init() {
 
 	gob.Register(StorageErr(""))
 	gob.Register(madmin.TimeInfo{})
+	gob.Register(madmin.XFSErrorConfigs{})
 	gob.Register(map[string]interface{}{})
 
 	defaultAWSCredProvider = []credentials.Provider{

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -178,9 +178,7 @@ func (client *peerRESTClient) GetSysConfig(ctx context.Context) (info madmin.Sys
 	defer xhttp.DrainBody(respBody)
 
 	err = gob.NewDecoder(respBody).Decode(&info)
-	cfg := info.Config["time-info"]
-	if cfg != nil {
-		ti := cfg.(madmin.TimeInfo)
+	if ti, ok := info.Config["time-info"].(madmin.TimeInfo); ok {
 		ti.RoundtripDuration = roundtrip
 		info.Config["time-info"] = ti
 	}


### PR DESCRIPTION
## Description

XFSErrorConfigs was being added as value in map[string]interface{}, but wasn't registered with gob, resulting in error in encoding.

Fixed by registering it. Also fixed on naked assert in related code.

## How to test this PR?

- Generate health report in a multi-node cluster
- Verify that all three sub-nodes (`rlimit-max`, `time-info` and `xfs-error-config`) under `sys -> config` are populated for all nodes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
