### PR TITLE
Added missing type declaration

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1855,7 +1855,7 @@ func getServerInfo(ctx context.Context, poolsInfoEnabled bool, r *http.Request) 
 	assignPoolNumbers(servers)
 
 	var poolsInfo map[int]map[int]madmin.ErasureSetInfo
-	var backend interface{}
+	var backend madmin.ErasureBackend
 
 	mode := madmin.ItemInitializing
 


### PR DESCRIPTION
## Description
Adds type declaration to backend variable in admin-handlers.go

## Motivation and Context
MinIO failing to build with this error 

```
Building minio binary to './minio'
# github.com/minio/minio/cmd
cmd/admin-handlers.go:1928:17: cannot use backend (variable of type interface{}) as madmin.ErasureBackend value in struct literal: need type assertion
make: *** [build] Error 1
```

## How to test this PR?
Build minio binary without error using make build

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
