### PR TITLE
fix: missing http status error in discovery doc parsing function

### DIFF
--- a/docs/sts/web-identity.go
+++ b/docs/sts/web-identity.go
@@ -90,7 +90,7 @@ func parseDiscoveryDoc(ustr string) (DiscoveryDoc, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return d, err
+		return d, errors.New(resp.Status)
 	}
 	dec := json.NewDecoder(resp.Body)
 	if err = dec.Decode(&d); err != nil {

--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -279,7 +279,7 @@ func parseDiscoveryDoc(u *xnet.URL, transport http.RoundTripper, closeRespFn fun
 	}
 	defer closeRespFn(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return d, err
+		return d, errors.New(resp.Status)
 	}
 	dec := json.NewDecoder(resp.Body)
 	if err = dec.Decode(&d); err != nil {


### PR DESCRIPTION
## Description

value of `err` under this condition is `nil`, the return values will be an empty `DiscoveryDoc` and a `nil` error. This will cause outer function skip the err check

## Motivation and Context

I keep seeing this error `Error: Unable to initialize OpenID: no JWKS URI found in your provider's discovery doc` at minio start, but the url is fine. Turns out my web firewall blocks any non-human request with 403 code, but minio's log doesn't mention the status code at all. Thus it's harder to find the root cause of the error

## How to test this PR?

set the openid config url, make it response 4XX code. minio should show error log about the status code instead of missing `jwks_url`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
