### PR TITLE
Prevent the default configuration from being deleted

### DIFF
--- a/cmd/admin-handlers-idp-config.go
+++ b/cmd/admin-handlers-idp-config.go
@@ -354,6 +354,11 @@ func (a adminAPIHandlers) DeleteIdentityProviderCfg(w http.ResponseWriter, r *ht
 	var subSys string
 	switch idpCfgType {
 	case madmin.OpenidIDPCfg:
+		// idpCfgType is OpenidIDPCfg,Can't delete _ (Default)
+		if cfgName == madmin.Default {
+			writeErrorResponseJSON(ctx, w, errorCodes.ToAPIErr(ErrAdminInvalidArgument), r.URL)
+			return
+		}
 		subSys = config.IdentityOpenIDSubSys
 		cfgInfos, err := globalIAMSys.OpenIDConfig.GetConfigInfo(cfgCopy, cfgName)
 		if err != nil {


### PR DESCRIPTION
## Description

Prevent the default configuration from being deleted
When deleting the default, you will find that it can be deleted successfully and minio will be restarted, but the default does not disappear when the page is displayed and the program is actually running, so why don't we just organize the deletion of the default?
Before:
![企业微信截图_4b27a6e6-3fe5-4575-b58f-3e945414d80f](https://github.com/minio/minio/assets/13503801/2db56095-5b7d-4680-b3e2-216183a0bc77)
Do delete:
![企业微信截图_71e156b1-0f69-484a-80c6-7ae93159bf6c](https://github.com/minio/minio/assets/13503801/aa49b4fe-cdb5-42b8-bc28-48230052039d)
After:
![企业微信截图_f303ef56-edf3-4890-bd38-5e6557aa05df](https://github.com/minio/minio/assets/13503801/c3478293-09cc-451a-ba11-c92c580c765c)


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
