### PR TITLE
allow nodes offline in k8s setups when expanding pools

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -409,15 +409,6 @@ func (endpoints Endpoints) GetAllStrings() (all []string) {
 	return
 }
 
-func (endpoints Endpoints) atleastOneEndpointLocal() bool {
-	for _, endpoint := range endpoints {
-		if endpoint.IsLocal {
-			return true
-		}
-	}
-	return false
-}
-
 func hostResolveToLocalhost(endpoint Endpoint) bool {
 	hostIPs, err := getHostIP(endpoint.Hostname())
 	if err != nil {
@@ -440,7 +431,7 @@ func hostResolveToLocalhost(endpoint Endpoint) bool {
 }
 
 // UpdateIsLocal - resolves the host and discovers the local host.
-func (endpoints Endpoints) UpdateIsLocal(foundPrevLocal bool) error {
+func (endpoints Endpoints) UpdateIsLocal() error {
 	orchestrated := IsDocker() || IsKubernetes()
 
 	var epsResolved int
@@ -448,13 +439,14 @@ func (endpoints Endpoints) UpdateIsLocal(foundPrevLocal bool) error {
 	resolvedList := make([]bool, len(endpoints))
 	// Mark the starting time
 	startTime := time.Now()
-	keepAliveTicker := time.NewTicker(10 * time.Millisecond)
+	keepAliveTicker := time.NewTicker(500 * time.Millisecond)
 	defer keepAliveTicker.Stop()
 	for {
 		// Break if the local endpoint is found already Or all the endpoints are resolved.
 		if foundLocal || (epsResolved == len(endpoints)) {
 			break
 		}
+
 		// Retry infinitely on Kubernetes and Docker swarm.
 		// This is needed as the remote hosts are sometime
 		// not available immediately.
@@ -610,8 +602,353 @@ func checkCrossDeviceMounts(endpoints Endpoints) (err error) {
 	return mountinfo.CheckCrossDevice(absPaths)
 }
 
+// PoolEndpointList is a temporary type to holds the list of endpoints
+type PoolEndpointList []Endpoints
+
+// UpdateIsLocal - resolves all hosts and discovers which are local
+func (p PoolEndpointList) UpdateIsLocal() error {
+	orchestrated := IsDocker() || IsKubernetes()
+
+	var epsResolved int
+	var epCount int
+
+	for _, endpoints := range p {
+		epCount += len(endpoints)
+	}
+
+	var foundLocal bool
+	resolvedList := make(map[Endpoint]bool)
+
+	// Mark the starting time
+	startTime := time.Now()
+	keepAliveTicker := time.NewTicker(1 * time.Second)
+	defer keepAliveTicker.Stop()
+	for {
+		// Break if the local endpoint is found already Or all the endpoints are resolved.
+		if foundLocal || (epsResolved == epCount) {
+			break
+		}
+
+		// Retry infinitely on Kubernetes and Docker swarm.
+		// This is needed as the remote hosts are sometime
+		// not available immediately.
+		select {
+		case <-globalOSSignalCh:
+			return fmt.Errorf("The endpoint resolution got interrupted")
+		default:
+			for i, endpoints := range p {
+				for j, endpoint := range endpoints {
+					if resolvedList[endpoint] {
+						// Continue if host is already resolved.
+						continue
+					}
+
+					// Log the message to console about the host resolving
+					reqInfo := (&logger.ReqInfo{}).AppendTags(
+						"host",
+						endpoint.Hostname(),
+					)
+
+					if orchestrated && hostResolveToLocalhost(endpoint) {
+						// time elapsed
+						timeElapsed := time.Since(startTime)
+						// log error only if more than a second has elapsed
+						if timeElapsed > time.Second {
+							reqInfo.AppendTags("elapsedTime",
+								humanize.RelTime(startTime,
+									startTime.Add(timeElapsed),
+									"elapsed",
+									"",
+								))
+							ctx := logger.SetReqInfo(GlobalContext,
+								reqInfo)
+							logger.LogOnceIf(ctx, fmt.Errorf("%s resolves to localhost in a containerized deployment, waiting for it to resolve to a valid IP",
+								endpoint.Hostname()), endpoint.Hostname(), logger.Application)
+						}
+						continue
+					}
+
+					// return err if not Docker or Kubernetes
+					// We use IsDocker() to check for Docker environment
+					// We use IsKubernetes() to check for Kubernetes environment
+					isLocal, err := isLocalHost(endpoint.Hostname(),
+						endpoint.Port(),
+						globalMinioPort,
+					)
+					if err != nil && !orchestrated {
+						return err
+					}
+					if err != nil {
+						// time elapsed
+						timeElapsed := time.Since(startTime)
+						// log error only if more than a second has elapsed
+						if timeElapsed > time.Second {
+							reqInfo.AppendTags("elapsedTime",
+								humanize.RelTime(startTime,
+									startTime.Add(timeElapsed),
+									"elapsed",
+									"",
+								))
+							ctx := logger.SetReqInfo(GlobalContext,
+								reqInfo)
+							logger.LogOnceIf(ctx, err, endpoint.Hostname(), logger.Application)
+						}
+					} else {
+						resolvedList[endpoint] = true
+						endpoint.IsLocal = isLocal
+						epsResolved++
+						if !foundLocal {
+							foundLocal = isLocal
+						}
+						endpoints[j] = endpoint
+					}
+				}
+
+				p[i] = endpoints
+
+				// Wait for the tick, if the there exist a local endpoint in discovery.
+				// Non docker/kubernetes environment we do not need to wait.
+				if !foundLocal && orchestrated {
+					<-keepAliveTicker.C
+				}
+			}
+		}
+	}
+
+	// On Kubernetes/Docker setups DNS resolves inappropriately sometimes
+	// where there are situations same endpoints with multiple disks
+	// come online indicating either one of them is local and some
+	// of them are not local. This situation can never happen and
+	// its only a possibility in orchestrated deployments with dynamic
+	// DNS. Following code ensures that we treat if one of the endpoint
+	// says its local for a given host - it is true for all endpoints
+	// for the same host. Following code ensures that this assumption
+	// is true and it works in all scenarios and it is safe to assume
+	// for a given host.
+	for i, endpoints := range p {
+		endpointLocalMap := make(map[string]bool)
+		for _, ep := range endpoints {
+			if ep.IsLocal {
+				endpointLocalMap[ep.Host] = ep.IsLocal
+			}
+		}
+		for i := range endpoints {
+			endpoints[i].IsLocal = endpointLocalMap[endpoints[i].Host]
+		}
+		p[i] = endpoints
+	}
+
+	return nil
+}
+
+// CreatePoolEndpoints creates a list of endpoints per pool, resolves their relevant hostnames and
+// discovers those are local or remote.
+func CreatePoolEndpoints(serverAddr string, poolArgs ...[][]string) ([]Endpoints, SetupType, error) {
+	var setupType SetupType
+
+	// Check whether serverAddr is valid for this host.
+	if err := CheckLocalServerAddr(serverAddr); err != nil {
+		return nil, setupType, err
+	}
+
+	_, serverAddrPort := mustSplitHostPort(serverAddr)
+
+	poolEndpoints := make(PoolEndpointList, len(poolArgs))
+
+	// For single arg, return single drive EC setup.
+	if len(poolArgs) == 1 && len(poolArgs[0]) == 1 && len(poolArgs[0][0]) == 1 && len(poolArgs[0][0][0]) == 1 {
+		endpoint, err := NewEndpoint(poolArgs[0][0][0])
+		if err != nil {
+			return nil, setupType, err
+		}
+		if err := endpoint.UpdateIsLocal(); err != nil {
+			return nil, setupType, err
+		}
+		if endpoint.Type() != PathEndpointType {
+			return nil, setupType, config.ErrInvalidEndpoint(nil).Msg("use path style endpoint for single node setup")
+		}
+
+		var endpoints Endpoints
+		endpoints = append(endpoints, endpoint)
+		setupType = ErasureSDSetupType
+
+		poolEndpoints[0] = endpoints
+		// Check for cross device mounts if any.
+		if err = checkCrossDeviceMounts(endpoints); err != nil {
+			return nil, setupType, config.ErrInvalidEndpoint(nil).Msg(err.Error())
+		}
+
+		return poolEndpoints, setupType, nil
+	}
+
+	for i, args := range poolArgs {
+		var endpoints Endpoints
+		for _, iargs := range args {
+			// Convert args to endpoints
+			eps, err := NewEndpoints(iargs...)
+			if err != nil {
+				return nil, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(err.Error())
+			}
+
+			// Check for cross device mounts if any.
+			if err = checkCrossDeviceMounts(eps); err != nil {
+				return nil, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(err.Error())
+			}
+
+			endpoints = append(endpoints, eps...)
+		}
+
+		if len(endpoints) == 0 {
+			return nil, setupType, config.ErrInvalidErasureEndpoints(nil).Msg("invalid number of endpoints")
+		}
+
+		poolEndpoints[i] = endpoints
+	}
+
+	for _, endpoints := range poolEndpoints {
+		// Return Erasure setup when all endpoints are path style.
+		if endpoints[0].Type() == PathEndpointType {
+			setupType = ErasureSetupType
+		}
+		if endpoints[0].Type() == URLEndpointType && setupType != DistErasureSetupType {
+			setupType = DistErasureSetupType
+		}
+	}
+
+	if setupType == ErasureSetupType {
+		return poolEndpoints, setupType, nil
+	}
+
+	if err := poolEndpoints.UpdateIsLocal(); err != nil {
+		return nil, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(err.Error())
+	}
+
+	uniqueArgs := set.NewStringSet()
+
+	for i, endpoints := range poolEndpoints {
+		// Here all endpoints are URL style.
+		endpointPathSet := set.NewStringSet()
+		localEndpointCount := 0
+		localServerHostSet := set.NewStringSet()
+		localPortSet := set.NewStringSet()
+
+		for _, endpoint := range endpoints {
+			endpointPathSet.Add(endpoint.Path)
+			if endpoint.IsLocal {
+				localServerHostSet.Add(endpoint.Hostname())
+
+				_, port, err := net.SplitHostPort(endpoint.Host)
+				if err != nil {
+					port = serverAddrPort
+				}
+				localPortSet.Add(port)
+
+				localEndpointCount++
+			}
+		}
+
+		orchestrated := IsKubernetes() || IsDocker()
+		if !orchestrated {
+			// Check whether same path is not used in endpoints of a host on different port.
+			// Only verify this on baremetal setups, DNS is not available in orchestrated
+			// environments so we can't do much here.
+			{
+				pathIPMap := make(map[string]set.StringSet)
+				hostIPCache := make(map[string]set.StringSet)
+				for _, endpoint := range endpoints {
+					host := endpoint.Hostname()
+					hostIPSet, ok := hostIPCache[host]
+					if !ok {
+						var err error
+						hostIPSet, err = getHostIP(host)
+						if err != nil {
+							return nil, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("host '%s' cannot resolve: %s", host, err))
+						}
+						hostIPCache[host] = hostIPSet
+					}
+					if IPSet, ok := pathIPMap[endpoint.Path]; ok {
+						if !IPSet.Intersection(hostIPSet).IsEmpty() {
+							return nil, setupType,
+								config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("same path '%s' can not be served by different port on same address", endpoint.Path))
+						}
+						pathIPMap[endpoint.Path] = IPSet.Union(hostIPSet)
+					} else {
+						pathIPMap[endpoint.Path] = hostIPSet
+					}
+				}
+			}
+		}
+
+		// Check whether same path is used for more than 1 local endpoints.
+		{
+			localPathSet := set.CreateStringSet()
+			for _, endpoint := range endpoints {
+				if !endpoint.IsLocal {
+					continue
+				}
+				if localPathSet.Contains(endpoint.Path) {
+					return nil, setupType,
+						config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("path '%s' cannot be served by different address on same server", endpoint.Path))
+				}
+				localPathSet.Add(endpoint.Path)
+			}
+		}
+
+		// Add missing port in all endpoints.
+		for i := range endpoints {
+			_, port, err := net.SplitHostPort(endpoints[i].Host)
+			if err != nil {
+				endpoints[i].Host = net.JoinHostPort(endpoints[i].Host, serverAddrPort)
+			} else if endpoints[i].IsLocal && serverAddrPort != port {
+				// If endpoint is local, but port is different than serverAddrPort, then make it as remote.
+				endpoints[i].IsLocal = false
+			}
+		}
+
+		// All endpoints are pointing to local host
+		if len(endpoints) == localEndpointCount {
+			// If all endpoints have same port number, Just treat it as local erasure setup
+			// using URL style endpoints.
+			if len(localPortSet) == 1 {
+				if len(localServerHostSet) > 1 {
+					return nil, setupType,
+						config.ErrInvalidErasureEndpoints(nil).Msg("all local endpoints should not have different hostnames/ips")
+				}
+			}
+
+			// Even though all endpoints are local, but those endpoints use different ports.
+			// This means it is DistErasure setup.
+		}
+
+		poolEndpoints[i] = endpoints
+
+		for _, endpoint := range endpoints {
+			uniqueArgs.Add(endpoint.Host)
+		}
+
+		poolEndpoints[i] = endpoints
+	}
+
+	publicIPs := env.Get(config.EnvPublicIPs, "")
+	if len(publicIPs) == 0 {
+		updateDomainIPs(uniqueArgs)
+	}
+
+	for _, endpoints := range poolEndpoints {
+		// Return Erasure setup when all endpoints are path style.
+		if endpoints[0].Type() == PathEndpointType {
+			setupType = ErasureSetupType
+		}
+		if endpoints[0].Type() == URLEndpointType && setupType != DistErasureSetupType {
+			setupType = DistErasureSetupType
+		}
+	}
+
+	return poolEndpoints, setupType, nil
+}
+
 // CreateEndpoints - validates and creates new endpoints for given args.
-func CreateEndpoints(serverAddr string, foundLocal bool, args ...[]string) (Endpoints, SetupType, error) {
+func CreateEndpoints(serverAddr string, args ...[]string) (Endpoints, SetupType, error) {
 	var endpoints Endpoints
 	var setupType SetupType
 	var err error
@@ -672,7 +1009,7 @@ func CreateEndpoints(serverAddr string, foundLocal bool, args ...[]string) (Endp
 		return endpoints, setupType, nil
 	}
 
-	if err = endpoints.UpdateIsLocal(foundLocal); err != nil {
+	if err = endpoints.UpdateIsLocal(); err != nil {
 		return endpoints, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(err.Error())
 	}
 

--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -314,7 +314,7 @@ func TestCreateEndpoints(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run("", func(t *testing.T) {
-			endpoints, setupType, err := CreateEndpoints(testCase.serverAddr, false, testCase.args...)
+			endpoints, setupType, err := CreateEndpoints(testCase.serverAddr, testCase.args...)
 			if err == nil && testCase.expectedErr != nil {
 				t.Errorf("error: expected = %v, got = <nil>", testCase.expectedErr)
 			}
@@ -374,7 +374,7 @@ func TestGetLocalPeer(t *testing.T) {
 	for i, testCase := range testCases {
 		zendpoints := mustGetPoolEndpoints(testCase.endpointArgs...)
 		if !zendpoints[0].Endpoints[0].IsLocal {
-			if err := zendpoints[0].Endpoints.UpdateIsLocal(false); err != nil {
+			if err := zendpoints[0].Endpoints.UpdateIsLocal(); err != nil {
 				t.Fatalf("error: expected = <nil>, got = %v", err)
 			}
 		}
@@ -407,7 +407,7 @@ func TestGetRemotePeers(t *testing.T) {
 	for _, testCase := range testCases {
 		zendpoints := mustGetPoolEndpoints(testCase.endpointArgs...)
 		if !zendpoints[0].Endpoints[0].IsLocal {
-			if err := zendpoints[0].Endpoints.UpdateIsLocal(false); err != nil {
+			if err := zendpoints[0].Endpoints.UpdateIsLocal(); err != nil {
 				t.Errorf("error: expected = <nil>, got = %v", err)
 			}
 		}

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -291,49 +291,46 @@ func waitForFormatErasure(firstDisk bool, endpoints Endpoints, poolCount, setCou
 	tries++ // tried already once
 
 	// Wait on each try for an update.
-	ticker := time.NewTicker(150 * time.Millisecond)
+	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
 	for {
+		// Only log once every 10 iterations, then reset the tries count.
+		verboseLogging = tries >= 10
+		if verboseLogging {
+			tries = 1
+		}
+
+		storageDisks, format, err := connectLoadInitFormats(verboseLogging, firstDisk, endpoints, poolCount, setCount, setDriveCount, deploymentID, distributionAlgo)
+		if err == nil {
+			return storageDisks, format, nil
+		}
+
+		tries++
+		switch err {
+		case errNotFirstDisk:
+			// Fresh setup, wait for first server to be up.
+			logger.Info("Waiting for the first server to format the drives (elapsed %s)\n", getElapsedTime())
+		case errFirstDiskWait:
+			// Fresh setup, wait for other servers to come up.
+			logger.Info("Waiting for all other servers to be online to format the drives (elapses %s)\n", getElapsedTime())
+		case errErasureReadQuorum:
+			// no quorum available continue to wait for minimum number of servers.
+			logger.Info("Waiting for a minimum of %d drives to come online (elapsed %s)\n",
+				len(endpoints)/2, getElapsedTime())
+		case errErasureWriteQuorum:
+			// no quorum available continue to wait for minimum number of servers.
+			logger.Info("Waiting for a minimum of %d drives to come online (elapsed %s)\n",
+				(len(endpoints)/2)+1, getElapsedTime())
+		case errErasureV3ThisEmpty:
+			// need to wait for this error to be healed, so continue.
+		default:
+			// For all other unhandled errors we exit and fail.
+			return nil, nil, err
+		}
+
 		select {
 		case <-ticker.C:
-			// Only log once every 10 iterations, then reset the tries count.
-			verboseLogging = tries >= 10
-			if verboseLogging {
-				tries = 1
-			}
-
-			storageDisks, format, err := connectLoadInitFormats(verboseLogging, firstDisk, endpoints, poolCount, setCount, setDriveCount, deploymentID, distributionAlgo)
-			if err != nil {
-				tries++
-				switch err {
-				case errNotFirstDisk:
-					// Fresh setup, wait for first server to be up.
-					logger.Info("Waiting for the first server to format the drives (elapsed %s)\n", getElapsedTime())
-					continue
-				case errFirstDiskWait:
-					// Fresh setup, wait for other servers to come up.
-					logger.Info("Waiting for all other servers to be online to format the drives (elapses %s)\n", getElapsedTime())
-					continue
-				case errErasureReadQuorum:
-					// no quorum available continue to wait for minimum number of servers.
-					logger.Info("Waiting for a minimum of %d drives to come online (elapsed %s)\n",
-						len(endpoints)/2, getElapsedTime())
-					continue
-				case errErasureWriteQuorum:
-					// no quorum available continue to wait for minimum number of servers.
-					logger.Info("Waiting for a minimum of %d drives to come online (elapsed %s)\n",
-						(len(endpoints)/2)+1, getElapsedTime())
-					continue
-				case errErasureV3ThisEmpty:
-					// need to wait for this error to be healed, so continue.
-					continue
-				default:
-					// For all other unhandled errors we exit and fail.
-					return nil, nil, err
-				}
-			}
-			return storageDisks, format, nil
 		case <-globalOSSignalCh:
 			return nil, nil, fmt.Errorf("Initializing data volumes gracefully stopped")
 		}


### PR DESCRIPTION
## Description
allow nodes offline in k8s setups when expanding pools

## Motivation and Context
expansion of pools did not support offline pods/nodes
during pool expansion, this PR refactors this code
path to ensure that we allow new pool additions, even
the pod/node is offline in k8s/docker environments.

## How to test this PR?
You would need docker-compose and a container built
from this PR. 

Start by initializing first pool with 4 node 1 disk
per node.

```yaml
version: '3.7'

# Settings and configurations that are common for all containers
x-minio-common: &minio-common
  image: minio/minio:dev
  command: server --console-address ":9001" http://minio{1...4}/data1
  expose:
    - "9000"
    - "9001"
  # environment:
    # MINIO_ROOT_USER: minioadmin
    # MINIO_ROOT_PASSWORD: minioadmin
  healthcheck:
    test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
    interval: 30s
    timeout: 20s
    retries: 3

# starts 4 docker containers running minio server instances.
# using nginx reverse proxy, load balancing, you can access
# it through port 9000.
services:
  minio1:
    <<: *minio-common
    hostname: minio1
    volumes:
      - data1-1:/data1

  minio2:
    <<: *minio-common
    hostname: minio2
    volumes:
      - data2-1:/data1

  minio3:
    <<: *minio-common
    hostname: minio3
    volumes:
      - data3-1:/data1

  minio4:
    <<: *minio-common
    hostname: minio4
    volumes:
      - data4-1:/data1
    
  nginx:
    image: nginx:1.19.2-alpine
    hostname: nginx
    volumes:
      - ./nginx.conf:/etc/nginx/nginx.conf:ro
    ports:
      - "9000:9000"
      - "9001:9001"
    depends_on:
      - minio1
      - minio2
      - minio3
      - minio4

## By default this config uses the default local driver,
## For custom volumes replace with volume driver configuration.
volumes:
  data1-1:
  data2-1:
  data3-1:
  data4-1:
```

```
docker-compose -f /tmp/compose.yaml up
```

Now proceed to expand this setup by adding a new pool, this time however
comment out the `minio4` instance, making it offline and also removes
the DNS service for `minio4`. 

```yaml
version: '3.7'

# Settings and configurations that are common for all containers
x-minio-common: &minio-common
  image: minio/minio:dev
  command: server --console-address ":9001" http://minio{1...4}/data1 http://minio{5...8}/data1
  expose:
    - "9000"
    - "9001"
  # environment:
    # MINIO_ROOT_USER: minioadmin
    # MINIO_ROOT_PASSWORD: minioadmin
  healthcheck:
    test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
    interval: 30s
    timeout: 20s
    retries: 3

# starts 4 docker containers running minio server instances.
# using nginx reverse proxy, load balancing, you can access
# it through port 9000.
services:
  minio1:
    <<: *minio-common
    hostname: minio1
    volumes:
      - data1-1:/data1

  minio2:
    <<: *minio-common
    hostname: minio2
    volumes:
      - data2-1:/data1

  minio3:
    <<: *minio-common
    hostname: minio3
    volumes:
      - data3-1:/data1

  # minio4:
  #   <<: *minio-common
  #   hostname: minio4
  #   volumes:
  #     - data4-1:/data1

  minio5:
    <<: *minio-common
    hostname: minio5
    volumes:
      - data5-1:/data1

  minio6:
    <<: *minio-common
    hostname: minio6
    volumes:
      - data6-1:/data1

  minio7:
    <<: *minio-common
    hostname: minio7
    volumes:
      - data7-1:/data1

  minio8:
    <<: *minio-common
    hostname: minio8
    volumes:
      - data8-1:/data1
      
  nginx:
    image: nginx:1.19.2-alpine
    hostname: nginx
    volumes:
      - ./nginx.conf:/etc/nginx/nginx.conf:ro
    ports:
      - "9000:9000"
      - "9001:9001"
    depends_on:
      - minio1
      - minio2
      - minio3
#      - minio4

## By default this config uses default local driver,
## For custom volumes replace with volume driver configuration.
volumes:
  data1-1:
  data2-1:
  data3-1:
  data4-1:
  data5-1:
  data6-1:
  data7-1:
  data8-1:
```

nginx is added for convenience 
```
user  nginx;
worker_processes  auto;

error_log  /var/log/nginx/error.log warn;
pid        /var/run/nginx.pid;

events {
    worker_connections  4096;
}

http {
    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for"';

    access_log  /var/log/nginx/access.log  main;
    sendfile        on;
    keepalive_timeout  65;

    # include /etc/nginx/conf.d/*.conf;

    upstream minio {
        server minio1:9000;
        server minio2:9000;
        server minio3:9000;
    }

    upstream console {
        ip_hash;
        server minio1:9001;
        server minio2:9001;
        server minio3:9001;
    }

    server {
        listen       9000;
        listen  [::]:9000;
        server_name  localhost;

        # To allow special characters in headers
        ignore_invalid_headers off;
        # Allow any size file to be uploaded.
        # Set to a value such as 1000m; to restrict file size to a specific value
        client_max_body_size 0;
        # To disable buffering
        proxy_buffering off;
        proxy_request_buffering off;

        location / {
            proxy_set_header Host $http_host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;

            proxy_connect_timeout 300;
            # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
            proxy_http_version 1.1;
            proxy_set_header Connection "";
            chunked_transfer_encoding off;

            proxy_pass http://minio;
        }
    }

    server {
        listen       9001;
        listen  [::]:9001;
        server_name  localhost;

        # To allow special characters in headers
        ignore_invalid_headers off;
        # Allow any size file to be uploaded.
        # Set to a value such as 1000m; to restrict file size to a specific value
        client_max_body_size 0;
        # To disable buffering
        proxy_buffering off;
        proxy_request_buffering off;

        location / {
            proxy_set_header Host $http_host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header X-NginX-Proxy true;

            # This is necessary to pass the correct IP to be hashed
            real_ip_header X-Real-IP;

            proxy_connect_timeout 300;
            
            # To support websocket
            proxy_http_version 1.1;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection "upgrade";
            
            chunked_transfer_encoding off;

            proxy_pass http://console;
        }
    }
}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
