### PR TITLE
fix: close the notification and lambda targets after testing

### DIFF
--- a/internal/config/notify/parse.go
+++ b/internal/config/notify/parse.go
@@ -44,18 +44,21 @@ const (
 var ErrTargetsOffline = errors.New("one or more targets are offline. Please use `mc admin info --json` to check the offline targets")
 
 // TestSubSysNotificationTargets - tests notification targets of given subsystem
-func TestSubSysNotificationTargets(ctx context.Context, cfg config.Config, subSys string, transport *http.Transport) error {
-	if err := checkValidNotificationKeysForSubSys(subSys, cfg[subSys]); err != nil {
+func TestSubSysNotificationTargets(ctx context.Context, cfg config.Config, subSys string, transport *http.Transport) (err error) {
+	if err = checkValidNotificationKeysForSubSys(subSys, cfg[subSys]); err != nil {
 		return err
 	}
 
-	targetList, err := fetchSubSysTargets(ctx, cfg, subSys, transport)
+	var targetList []event.Target
+	defer func() {
+		for _, target := range targetList {
+			target.Close()
+		}
+	}()
+
+	targetList, err = fetchSubSysTargets(ctx, cfg, subSys, transport)
 	if err != nil {
 		return err
-	}
-
-	for _, target := range targetList {
-		defer target.Close()
 	}
 
 	for _, target := range targetList {


### PR DESCRIPTION
## Description

`fetchSubSysTargets` function may return a non-empty target list even if `err != nil` - this is because we fetch all the targets from a subsystem (say, notify_webhook) and return err even if one target is down. Targets in this non-empty list should be properly closed. Otherwise we will be leaking some go-routines and connections.

## Motivation and Context

Do not leak connections or go-routines and properly close the subsystem targets after testing.

## How to test this PR?

We can't really test this change. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
