### PR TITLE
Use hash.NewLimitReader for internal multipart calls

### DIFF
--- a/cmd/batch-handlers.go
+++ b/cmd/batch-handlers.go
@@ -413,7 +413,7 @@ func (r *BatchJobReplicateV1) copyWithMultipartfromSource(ctx context.Context, a
 		}
 		defer rd.Close()
 
-		hr, err = hash.NewReader(rd, objInfo.Size, "", "", objInfo.Size)
+		hr, err = hash.NewLimitReader(rd, objInfo.Size, "", "", objInfo.Size)
 		if err != nil {
 			return err
 		}

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -1485,7 +1485,7 @@ func replicateObjectWithMultipart(ctx context.Context, c *minio.Core, bucket, ob
 	)
 
 	for _, partInfo := range objInfo.Parts {
-		hr, err = hash.NewReader(r, partInfo.ActualSize, "", "", partInfo.ActualSize)
+		hr, err = hash.NewLimitReader(r, partInfo.ActualSize, "", "", partInfo.ActualSize)
 		if err != nil {
 			return err
 		}

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -2088,7 +2088,7 @@ func (er erasureObjects) restoreTransitionedObject(ctx context.Context, bucket s
 
 	// rehydrate the parts back on disk as per the original xl.meta prior to transition
 	for _, partInfo := range oi.Parts {
-		hr, err := hash.NewReader(gr, partInfo.Size, "", "", partInfo.Size)
+		hr, err := hash.NewLimitReader(gr, partInfo.Size, "", "", partInfo.Size)
 		if err != nil {
 			return setRestoreHeaderFn(oi, err)
 		}

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -604,9 +604,9 @@ func (z *erasureServerPools) decommissionObject(ctx context.Context, bucket stri
 		defer z.AbortMultipartUpload(ctx, bucket, objInfo.Name, res.UploadID, ObjectOptions{})
 		parts := make([]CompletePart, len(objInfo.Parts))
 		for i, part := range objInfo.Parts {
-			hr, err := hash.NewReader(gr, part.Size, "", "", part.ActualSize)
+			hr, err := hash.NewLimitReader(gr, part.Size, "", "", part.ActualSize)
 			if err != nil {
-				return fmt.Errorf("decommissionObject: hash.NewReader() %w", err)
+				return fmt.Errorf("decommissionObject: hash.NewLimitReader() %w", err)
 			}
 			pi, err := z.PutObjectPart(ctx, bucket, objInfo.Name, res.UploadID,
 				part.Number,
@@ -638,9 +638,9 @@ func (z *erasureServerPools) decommissionObject(ctx context.Context, bucket stri
 		return err
 	}
 
-	hr, err := hash.NewReader(gr, objInfo.Size, "", "", actualSize)
+	hr, err := hash.NewLimitReader(gr, objInfo.Size, "", "", actualSize)
 	if err != nil {
-		return fmt.Errorf("decommissionObject: hash.NewReader() %w", err)
+		return fmt.Errorf("decommissionObject: hash.NewLimitReader() %w", err)
 	}
 	_, err = z.PutObject(ctx,
 		bucket,

--- a/cmd/erasure-server-pool-rebalance.go
+++ b/cmd/erasure-server-pool-rebalance.go
@@ -721,9 +721,9 @@ func (z *erasureServerPools) rebalanceObject(ctx context.Context, bucket string,
 
 		parts := make([]CompletePart, len(oi.Parts))
 		for i, part := range oi.Parts {
-			hr, err := hash.NewReader(gr, part.Size, "", "", part.ActualSize)
+			hr, err := hash.NewLimitReader(gr, part.Size, "", "", part.ActualSize)
 			if err != nil {
-				return fmt.Errorf("rebalanceObject: hash.NewReader() %w", err)
+				return fmt.Errorf("rebalanceObject: hash.NewLimitReader() %w", err)
 			}
 			pi, err := z.PutObjectPart(ctx, bucket, oi.Name, res.UploadID,
 				part.Number,

--- a/docs/site-replication/run-multi-site-ldap.sh
+++ b/docs/site-replication/run-multi-site-ldap.sh
@@ -149,6 +149,11 @@ if [ $? -eq 0 ]; then
 fi
 
 ./mc mb minio1/newbucket
+# copy large upload to newbucket on minio1
+truncate -s 17M lrgfile
+expected_checksum=$(cat ./lrgfile | md5sum)
+
+./mc cp ./lrgfile minio1/newbucket
 
 # create a bucket bucket2 on minio1.
 ./mc mb minio1/bucket2
@@ -180,6 +185,19 @@ if [ $? -ne 0 ]; then
     echo "expecting object to be present. exiting.."
     exit_1;
 fi
+
+sleep 10
+./mc stat minio3/newbucket/lrgfile
+if [ $? -ne 0 ]; then
+    echo "expected object to be present, exiting.."
+    exit_1;
+fi
+actual_checksum=$(./mc cat minio3/newbucket/lrgfile | md5sum)
+if [ "${expected_checksum}" != "${actual_checksum}" ]; then
+    echo "replication failed on multipart objects expected ${expected_checksum} got ${actual_checksum}"
+    exit
+fi
+rm ./lrgfile
 
 vID=$(./mc stat minio2/newbucket/README.md --json | jq .versionID)
 if [ $? -ne 0 ]; then

--- a/docs/site-replication/run-multi-site-oidc.sh
+++ b/docs/site-replication/run-multi-site-oidc.sh
@@ -168,6 +168,11 @@ fi
 
 ./mc mb minio1/newbucket
 
+# copy large upload to newbucket on minio1
+truncate -s 17M lrgfile
+expected_checksum=$(cat ./lrgfile | md5sum)
+
+./mc cp ./lrgfile minio1/newbucket
 sleep 5
 ./mc stat minio2/newbucket
 if [ $? -ne 0 ]; then
@@ -210,6 +215,19 @@ if [ $? -eq 0 ]; then
     echo "expected file to be deleted, exiting.."
     exit_1;
 fi
+
+sleep 10
+./mc stat minio3/newbucket/lrgfile
+if [ $? -ne 0 ]; then
+    echo "expected object to be present, exiting.."
+    exit_1;
+fi
+actual_checksum=$(./mc cat minio3/newbucket/lrgfile | md5sum)
+if [ "${expected_checksum}" != "${actual_checksum}" ]; then
+    echo "replication failed on multipart objects expected ${expected_checksum} got ${actual_checksum}"
+    exit
+fi
+rm ./lrgfile
 
 ./mc mb --with-lock minio3/newbucket-olock
 sleep 5


### PR DESCRIPTION
Fixes regression from https://github.com/minio/minio/pull/16484 for replication, decommission, tiering etc.

Wrapping hash.NewReader with HardLimitedReader should be done only for enforcing S3 client uploads. Features like replication need to chunk the parts and stop reading once part size is read. Introduce a variant hash.NewLimitReader that wraps io.LimitReader

## Description


## Motivation and Context


## How to test this PR?
set up replication and upload a large object - replication fails with master
```
API: SYSTEM()
Time: 02:22:20 UTC 05/12/2023
DeploymentID: 4c88596b-dbb5-4eea-a27a-c2a0cee391db
Error: unable to replicate for object bucket/test3(e254d13b-691b-4a3c-809e-5cd3f5fa820e): Put "http://localhost:9004/bucket/test3?partNumber=1&uploadId=NDI0MGQ2YTEtMWIyYy00NzI5LWE4OTUtOTU4MjBjOWY2NTBiLjc0ZDliZGNkLWMwOWUtNGE1Ni1iNDZlLWVhMmRmOTQ0ZTg4Yw": input provided more bytes than specified (*errors.errorString)
       3: /Users/kp/code/src/github.com/minio/minio/internal/logger/logger.go:258:logger.LogIf()
       2: /Users/kp/code/src/github.com/minio/minio/cmd/bucket-replication.go:1438:cmd.ReplicateObjectInfo.replicateAll()
       1: /Users/kp/code/src/github.com/minio/minio/cmd/bucket-replication.go:1029:cmd.replicateObject.func2()

AP
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) https://github.com/minio/minio/pull/16484
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
