### PR TITLE
fix: make slice cap of right size

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -2380,7 +2380,7 @@ func getWebhookMetrics() *MetricsGroup {
 	}
 	mg.RegisterRead(func(ctx context.Context) []Metric {
 		tgts := append(logger.SystemTargets(), logger.AuditTargets()...)
-		metrics := make([]Metric, 0, len(tgts))
+		metrics := make([]Metric, 0, len(tgts)*4)
 		for _, t := range tgts {
 			isOnline := 0
 			if t.IsOnline(ctx) {


### PR DESCRIPTION
## Description

make slice cap right
It seems should be `len*4` not `len`

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
