### PR TITLE
fix: remove objects when there are skipped versions due to ILM in decom

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -774,7 +774,7 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 			for _, version := range fivs.Versions {
 				// Apply lifecycle rules on the objects that are expired.
 				if filterLifecycle(bi.Name, version.Name, version) {
-					logger.LogIf(ctx, fmt.Errorf("found %s/%s (%s) expired object based on ILM rules, skipping and scheduled for deletion", bi.Name, version.Name, version.VersionID))
+					decommissionedCount++
 					continue
 				}
 


### PR DESCRIPTION
## Description
Removing versions in the old pool, when there is a skipped version due 
to ILM, is not properly working. The reason is that objects in the old pool
are only removed when all versions of a single object are decommissoned,
however we forgot to count skipped versions due to ILM

This commit fixes the behavior by counting ILM skipped versions

## Motivation and Context
Decomission reports failure sometimes when it is not. Also clean up
some objects in the old pool in some cases.

## How to test this PR?
Run MinIO with two pools, upload some objects, set ILM and change date/time to make sure that ILM is triggerd, then decomission the first pool.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
