### PR TITLE
fix: notify systemd as soon as we wait on the OS signal

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -664,10 +664,7 @@ func serverMain(ctx *cli.Context) {
 			setConsoleSrv(srv)
 
 			go func() {
-				server := newConsoleServerFn()
-				logger.FatalIf(server.Listen(), "Unable to initialize console server's sockets")
-				daemon.SdNotify(false, daemon.SdNotifyReady)
-				logger.FatalIf(server.Serve(), "Unable to initialize console server")
+				logger.FatalIf(newConsoleServerFn().Serve(), "Unable to initialize console server")
 			}()
 		}
 
@@ -789,6 +786,8 @@ func serverMain(ctx *cli.Context) {
 		}
 		logger.Info("======")
 	}
+
+	daemon.SdNotify(false, daemon.SdNotifyReady)
 
 	<-globalOSSignalCh
 }


### PR DESCRIPTION

## Description
fix: notify systemd as soon as we wait on the OS signal

## Motivation and Context
fixes #17197 

## How to test this PR?
As per #17197 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
