### PR TITLE
fix: veeam SOS API 'system.xml' strings

### DIFF
--- a/cmd/veeam-sos-api.go
+++ b/cmd/veeam-sos-api.go
@@ -76,6 +76,11 @@ import (
 // - The object should be present in all buckets accessed by Veeam products that want to leverage the SOSAPI functionality.
 //
 // - The current protocol version is 1.0.
+type apiEndpoints struct {
+	IAMEndpoint string `xml:"IAMEndpoint"`
+	STSEndpoint string `xml:"STSEndpoint"`
+}
+
 type systemInfo struct {
 	XMLName              xml.Name `xml:"SystemInfo" json:"-"`
 	ProtocolVersion      string   `xml:"ProtocolVersion"`
@@ -85,14 +90,11 @@ type systemInfo struct {
 		UploadSessions bool `xml:"UploadSessions"`
 		IAMSTS         bool `xml:"IAMSTS"`
 	} `mxl:"ProtocolCapabilities"`
-	APIEndpoints struct {
-		IAMEndpoint string `xml:"IAMEndpoint"`
-		STSEndpoint string `xml:"STSEndpoint"`
-	} `xml:"APIEndpoints"`
+	APIEndpoints          *apiEndpoints `xml:"APIEndpoints,omitempty"`
 	SystemRecommendations struct {
-		S3ConcurrentTaskLimit    int `xml:"S3ConcurrentTaskLimit"`
-		S3MultiObjectDeleteLimit int `xml:"S3MultiObjectDeleteLimit"`
-		StorageCurrentTaskLimit  int `xml:"StorageCurrentTaskLimit"`
+		S3ConcurrentTaskLimit    int `xml:"S3ConcurrentTaskLimit,omitempty"`
+		S3MultiObjectDeleteLimit int `xml:"S3MultiObjectDeleteLimit,omitempty"`
+		StorageCurrentTaskLimit  int `xml:"StorageCurrentTaskLimit,omitempty"`
 		KBBlockSize              int `xml:"KbBlockSize"`
 	} `xml:"SystemRecommendations"`
 }
@@ -118,8 +120,8 @@ func veeamSOSAPIGetObject(ctx context.Context, bucket, object string, rs *HTTPRa
 	switch object {
 	case systemXMLObject:
 		si := systemInfo{
-			ProtocolVersion: "1.0",
-			ModelName:       "MinIO " + ReleaseTag,
+			ProtocolVersion: `"1.0"`,
+			ModelName:       "\"MinIO \"" + ReleaseTag + "\"",
 		}
 		si.ProtocolCapabilities.CapacityInfo = true
 

--- a/cmd/veeam-sos-api.go
+++ b/cmd/veeam-sos-api.go
@@ -121,7 +121,7 @@ func veeamSOSAPIGetObject(ctx context.Context, bucket, object string, rs *HTTPRa
 	case systemXMLObject:
 		si := systemInfo{
 			ProtocolVersion: `"1.0"`,
-			ModelName:       "\"MinIO \"" + ReleaseTag + "\"",
+			ModelName:       "\"MinIO " + ReleaseTag + "\"",
 		}
 		si.ProtocolCapabilities.CapacityInfo = true
 


### PR DESCRIPTION
## Description
fix: veeam SOS API 'system.xml' strings

## Motivation and Context
fixes #17195

The system.xml should look like this:

```
    <?xml version="1.0" encoding="UTF-8"?>
    <SystemInfo>
      <ProtocolVersion>"1.0"</ProtocolVersion>
      <ModelName>"MinIO RELEASE.2023-04-28T18-11-17Z"</ModelName>
    </SystemInfo>
```

Original-Author: Omar Kohl <omarkohl@posteo.net>

We should keep the KBBlockSize value to 4MiB.

## How to test this PR?
Needs Veeam SOS API support

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
