### PR TITLE
Avoid being closed before reading

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -973,7 +973,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		if fileName == "" {
 			// value, store as string in memory
 			n, err := io.CopyN(&b, part, maxMemoryBytes+1)
-			part.Close()
+			defer part.Close()
 			if err != nil && err != io.EOF {
 				apiErr := errorCodes.ToAPIErr(ErrMalformedPOSTRequest)
 				apiErr.Description = fmt.Sprintf("%s (%v)", apiErr.Description, err)


### PR DESCRIPTION
## Description

Avoid being closed before reading

```diff
		if fileName == "" {
			// value, store as string in memory
			n, err := io.CopyN(&b, part, maxMemoryBytes+1)
-			part.Close()
			if err != nil && err != io.EOF {
				apiErr := errorCodes.ToAPIErr(ErrMalformedPOSTRequest)
				apiErr.Description = fmt.Sprintf("%s (%v)", apiErr.Description, err)
				writeErrorResponse(ctx, w, apiErr, r.URL)
				return
			}
			maxMemoryBytes -= n
			if maxMemoryBytes < 0 {
				apiErr := errorCodes.ToAPIErr(ErrMalformedPOSTRequest)
				apiErr.Description = fmt.Sprintf("%s (%v)", apiErr.Description, multipart.ErrMessageTooLarge)
				writeErrorResponse(ctx, w, apiErr, r.URL)
				return
			}
			if n > maxFormFieldSize {
				apiErr := errorCodes.ToAPIErr(ErrMalformedPOSTRequest)
				apiErr.Description = fmt.Sprintf("%s (%v)", apiErr.Description, multipart.ErrMessageTooLarge)
				writeErrorResponse(ctx, w, apiErr, r.URL)
				return
			}
			formValues[http.CanonicalHeaderKey(name)] = append(formValues[http.CanonicalHeaderKey(name)], b.String())
			continue
		}

		// In accordance with https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
		// The file or text content.
		// The file or text content must be the last field in the form.
		// You cannot upload more than one file at a time.
+		fileBody = part // we have found the File part of the request breakout
		defer part.Close()
		break
	}

	if _, ok := formValues["Key"]; !ok {
		apiErr := errorCodes.ToAPIErr(ErrMalformedPOSTRequest)
		apiErr.Description = fmt.Sprintf("%s (%v)", apiErr.Description, errors.New("The name of the uploaded key is missing"))
		writeErrorResponse(ctx, w, apiErr, r.URL)
		return
	}
	if fileName == "" {
		apiErr := errorCodes.ToAPIErr(ErrMalformedPOSTRequest)
		apiErr.Description = fmt.Sprintf("%s (%v)", apiErr.Description, errors.New("The file or text content is missing"))
		writeErrorResponse(ctx, w, apiErr, r.URL)
		return
	}

	formValues.Set("Bucket", bucket)
	if fileName != "" && strings.Contains(formValues.Get("Key"), "${filename}") {
		// S3 feature to replace ${filename} found in Key form field
		// by the filename attribute passed in multipart
		formValues.Set("Key", strings.ReplaceAll(formValues.Get("Key"), "${filename}", fileName))
	}
	object := trimLeadingSlash(formValues.Get("Key"))

	successRedirect := formValues.Get("success_action_redirect")
	successStatus := formValues.Get("success_action_status")
	var redirectURL *url.URL
	if successRedirect != "" {
		redirectURL, err = url.Parse(successRedirect)
		if err != nil {
			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMalformedPOSTRequest), r.URL)
			return
		}
	}

	// Verify policy signature.
	cred, errCode := doesPolicySignatureMatch(formValues)
	if errCode != ErrNone {
		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(errCode), r.URL)
		return
	}

	// Once signature is validated, check if the user has
	// explicit permissions for the user.
	if !globalIAMSys.IsAllowed(iampolicy.Args{
		AccountName:     cred.AccessKey,
		Groups:          cred.Groups,
		Action:          iampolicy.PutObjectAction,
		ConditionValues: getConditionValues(r, "", cred),
		BucketName:      bucket,
		ObjectName:      object,
		IsOwner:         globalActiveCred.AccessKey == cred.AccessKey,
		Claims:          cred.Claims,
	}) {
		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrAccessDenied), r.URL)
		return
	}

	policyBytes, err := base64.StdEncoding.DecodeString(formValues.Get("Policy"))
	if err != nil {
		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMalformedPOSTRequest), r.URL)
		return
	}

+	hashReader, err := hash.NewReader(fileBody, -1, "", "", -1)
	if err != nil {
		logger.LogIf(ctx, err)
		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
		return
	}
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
