### PR TITLE
Protecting the read index is not out of bounds

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -221,16 +221,14 @@ func (s *erasureSets) connectDisks() {
 			if disk.IsLocal() && disk.Healing() != nil {
 				globalBackgroundHealState.pushHealLocalDisks(disk.Endpoint())
 			}
-			s.erasureDisksMu.RLock()
+			s.erasureDisksMu.Lock()
 			setIndex, diskIndex, err := findDiskIndex(s.format, format)
-			s.erasureDisksMu.RUnlock()
 			if err != nil {
 				printEndpointError(endpoint, err, false)
 				disk.Close()
 				return
 			}
 
-			s.erasureDisksMu.Lock()
 			if currentDisk := s.erasureDisks[setIndex][diskIndex]; currentDisk != nil {
 				if !reflect.DeepEqual(currentDisk.Endpoint(), disk.Endpoint()) {
 					err = fmt.Errorf("Detected unexpected drive ordering refusing to use the drive: expecting %s, found %s, refusing to use the drive",

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -226,6 +226,7 @@ func (s *erasureSets) connectDisks() {
 			if err != nil {
 				printEndpointError(endpoint, err, false)
 				disk.Close()
+				s.erasureDisksMu.Unlock()
 				return
 			}
 


### PR DESCRIPTION
## Description

Protecting the read index is not out of bounds
We can see that erasureDisks can be written by other write locks, and if the index we read for the first time is already at risk of going out of bounds after losing the lock, it is necessary to organize this situation.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
