### PR TITLE
Add endpoint option for FTP mode

### DIFF
--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -44,8 +44,12 @@ type ftpDriver struct {
 }
 
 // NewFTPDriver implements ftp.Driver interface
-func NewFTPDriver() ftp.Driver {
-	return &ftpDriver{endpoint: fmt.Sprintf("127.0.0.1:%s", globalMinioPort)}
+func NewFTPDriver(endpoint string) ftp.Driver {
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("127.0.0.1:%s", globalMinioPort)
+	}
+
+	return &ftpDriver{endpoint: endpoint}
 }
 
 func buildMinioPath(p string) string {

--- a/cmd/ftp-server.go
+++ b/cmd/ftp-server.go
@@ -215,6 +215,7 @@ func startFTPServer(c *cli.Context) {
 		portRange     string
 		tlsPrivateKey string
 		tlsPublicCert string
+		endpoint      string
 	)
 
 	var err error
@@ -243,6 +244,8 @@ func startFTPServer(c *cli.Context) {
 			tlsPrivateKey = tokens[1]
 		case "tls-public-cert":
 			tlsPublicCert = tokens[1]
+		case "endpoint":
+			endpoint = tokens[1]
 		}
 	}
 
@@ -277,7 +280,7 @@ func startFTPServer(c *cli.Context) {
 	ftpServer, err := ftp.NewServer(&ftp.Options{
 		Name:           name,
 		WelcomeMessage: fmt.Sprintf("Welcome to MinIO FTP Server Version='%s' License='GNU AGPLv3'", Version),
-		Driver:         NewFTPDriver(),
+		Driver:         NewFTPDriver(endpoint),
 		Port:           port,
 		Perm:           ftp.NewSimplePerm("nobody", "nobody"),
 		TLS:            tls,


### PR DESCRIPTION
## Description

This PR add an option to configure the endpoint used to call Minio when using FTP/SFTP mode.

```
minio server http://server{1...4}/disk{1...4} \
--ftp="address=:8021" \
--ftp="passive-port-range=30000-40000" \
--ftp="endpoint=minio.mycorp.org:9000"
```

## Motivation and Context

PR #16952 added support of FTP/SFTP protocols, but the endpoint used to do Minio HTTP call is hardcoded to 127.0.0.1 [code](https://github.com/minio/minio/blob/dd9ed85e22b6f0668c2c079eb0b56ef12e47f941/cmd/ftp-server-driver.go#L48). It can cause an issue when using Minio over HTTPS if the TLS certificate doesn't have an IP SAN for the localhost IP (this is the case when using a certificate from a public CA).

```
Command:	MLSD
Response:	550 Get "https://127.0.0.1:9000/": tls: failed to verify certificate: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs
```

So using this endpoint option, we can use the public name of the Minio instance and the certificate can be validated.

## How to test this PR?


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
