### PR TITLE
simplify bucket metadata lookups for versioning/object locking

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -705,7 +705,7 @@ func (a adminAPIHandlers) ImportBucketMetadataHandler(w http.ResponseWriter, r *
 			}
 			if _, ok := bucketMap[bucket]; !ok {
 				opts := MakeBucketOptions{
-					LockEnabled: config.ObjectLockEnabled == "Enabled",
+					LockEnabled: config.Enabled(),
 				}
 				err = objectAPI.MakeBucket(ctx, bucket, opts)
 				if err != nil {

--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -119,6 +119,16 @@ func newBucketMetadata(name string) BucketMetadata {
 	}
 }
 
+// Versioning returns true if versioning is enabled
+func (b BucketMetadata) Versioning() bool {
+	return b.LockEnabled || (b.versioningConfig != nil && b.versioningConfig.Enabled()) || (b.objectLockConfig != nil && b.objectLockConfig.Enabled())
+}
+
+// ObjectLocking returns true if object locking is enabled
+func (b BucketMetadata) ObjectLocking() bool {
+	return b.LockEnabled || (b.objectLockConfig != nil && b.objectLockConfig.Enabled())
+}
+
 // SetCreatedAt preserves the CreatedAt time for bucket across sites in site replication. It defaults to
 // creation time of bucket on this cluster in all other cases.
 func (b *BucketMetadata) SetCreatedAt(createdAt time.Time) {

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1627,8 +1627,8 @@ func (z *erasureServerPools) GetBucketInfo(ctx context.Context, bucket string, o
 	meta, err := globalBucketMetadataSys.Get(bucket)
 	if err == nil {
 		bucketInfo.Created = meta.Created
-		bucketInfo.Versioning = meta.LockEnabled || globalBucketVersioningSys.Enabled(bucket)
-		bucketInfo.ObjectLocking = meta.LockEnabled
+		bucketInfo.Versioning = meta.Versioning()
+		bucketInfo.ObjectLocking = meta.ObjectLocking()
 	}
 	return bucketInfo, nil
 }

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -1615,12 +1615,10 @@ func (c *SiteReplicationSys) syncToAllPeers(ctx context.Context) error {
 			return errSRBackendIssue(err)
 		}
 
-		var opts MakeBucketOptions
-		if meta.objectLockConfig != nil {
-			opts.LockEnabled = meta.objectLockConfig.ObjectLockEnabled == "Enabled"
+		opts := MakeBucketOptions{
+			LockEnabled: meta.ObjectLocking(),
+			CreatedAt:   bucketInfo.Created.UTC(),
 		}
-
-		opts.CreatedAt = bucketInfo.Created.UTC()
 
 		// Now call the MakeBucketHook on existing bucket - this will
 		// create buckets and replication rules on peer clusters.

--- a/internal/bucket/object/lock/lock.go
+++ b/internal/bucket/object/lock/lock.go
@@ -229,6 +229,11 @@ type Config struct {
 	} `xml:"Rule,omitempty"`
 }
 
+// Enabled returns true if config.ObjectLockEnabled is set to Enabled
+func (config *Config) Enabled() bool {
+	return config.ObjectLockEnabled == Enabled
+}
+
 // UnmarshalXML - decodes XML data.
 func (config *Config) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	// Make subtype to avoid recursive UnmarshalXML().


### PR DESCRIPTION
## Description
simplify bucket metadata lookups for versioning/object locking

## Motivation and Context
optimize bucket metadata usage and readability improvements

## How to test this PR?
Nothing special to test, just optimal usage of bucket metadata.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
