### PR TITLE
Fixed When the MINIO_BROWSER_REDIRECT_URL parameter contains path, the console cannot be accessed normally.

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -260,6 +260,10 @@ func initConsoleServer() (*restapi.Server, error) {
 		return nil, err
 	}
 
+	subPath := restapi.GetSubPath()
+	swaggerSpec.Spec().BasePath = subPath + swaggerSpec.Spec().BasePath
+	swaggerSpec.OrigSpec().BasePath = subPath + swaggerSpec.OrigSpec().BasePath
+
 	api := operations.NewConsoleAPI(swaggerSpec)
 
 	if !serverDebugLog {


### PR DESCRIPTION
## Description
When the MINIO_BROWSER_REDIRECT_URL parameter contains path, the console cannot be accessed normally.
Related to [https://github.com/minio/console/pull/2725](https://github.com/minio/console/pull/2725) 

## Motivation and Context
When the minio server start, the `basepath ` variable needs to be injected into the swagger spec of the console.

## How to test this PR?
Refer to this PR:
[https://github.com/minio/console/pull/2725](https://github.com/minio/console/pull/2725)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
