### PR TITLE
fix: Avoid Income globalStats twice upon error

### DIFF
--- a/internal/rest/client.go
+++ b/internal/rest/client.go
@@ -201,23 +201,28 @@ func (c *Client) newRequest(ctx context.Context, u *url.URL, body io.Reader) (*h
 
 type respBodyMonitor struct {
 	io.ReadCloser
-	expectTimeouts bool
+	expectTimeouts  bool
+	errorStatusOnce sync.Once
 }
 
-func (r respBodyMonitor) Read(p []byte) (n int, err error) {
+func (r *respBodyMonitor) Read(p []byte) (n int, err error) {
 	n, err = r.ReadCloser.Read(p)
-	if xnet.IsNetworkOrHostDown(err, r.expectTimeouts) {
-		atomic.AddUint64(&globalStats.errs, 1)
-	}
+	r.errorStatus(err)
 	return
 }
 
-func (r respBodyMonitor) Close() (err error) {
+func (r *respBodyMonitor) Close() (err error) {
 	err = r.ReadCloser.Close()
-	if xnet.IsNetworkOrHostDown(err, r.expectTimeouts) {
-		atomic.AddUint64(&globalStats.errs, 1)
-	}
+	r.errorStatus(err)
 	return
+}
+
+func (r *respBodyMonitor) errorStatus(err error) {
+	if xnet.IsNetworkOrHostDown(err, r.expectTimeouts) {
+		r.errorStatusOnce.Do(func() {
+			atomic.AddUint64(&globalStats.errs, 1)
+		})
+	}
 }
 
 // Call - make a REST call with context.


### PR DESCRIPTION
## Description

Avoid Income globalStats twice where error.
It used for resp.Body
If we not do that.
A error will income twice  For `Read` `Close`.
Because A normal body will must call`Close` for it can call `Read`

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
