### PR TITLE
logger-http: Don't retry after a succesful send

### DIFF
--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -283,6 +283,8 @@ func (h *Target) logEntry(ctx context.Context, entry interface{}) {
 		if err := h.send(ctx, logJSON, webhookCallTimeout); err != nil {
 			h.config.LogOnce(ctx, err, h.config.Endpoint)
 			atomic.AddInt64(&h.failedMessages, 1)
+		} else {
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Description
Fixes the retry logic in http log target. With this fix, we only send a log entry to a configured target at most once.

## Motivation and Context
N/A

## How to test this PR?
1. Configure a webhook target for audit logs
2. Run `mc admin config get ALIAS api`
3. Without this fix, you will see the audit log corresponding to the Step 2 repeated 10 times. After applying this PR, you should only see the audit log once.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
minio/minio#17121
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
