### PR TITLE
fix: ListObjectV2 return an empty dir prefix

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -564,6 +564,19 @@ func (m *metaCacheEntriesSorted) fileInfos(bucket, prefix, delimiter string) (ob
 
 	vcfg, _ := globalBucketVersioningSys.Get(bucket)
 
+	entryMap := make(map[string]int, 0)
+	for _, entry := range m.o {
+		name := strings.TrimPrefix(entry.name, prefix)
+		if name == "" {
+			continue
+		}
+		s := strings.Split(name, delimiter)
+		if len(s) == 0 {
+			continue
+		}
+		entryMap[s[0]] = entryMap[s[0]] + 1
+	}
+
 	for _, entry := range m.o {
 		if entry.isObject() {
 			if delimiter != "" {
@@ -602,6 +615,14 @@ func (m *metaCacheEntriesSorted) fileInfos(bucket, prefix, delimiter string) (ob
 			idx = len(prefix) + idx + len(delimiter)
 			currPrefix := entry.name[:idx]
 			if currPrefix == prevPrefix {
+				continue
+			}
+			// if prefix is empty dir, should not return this prefix
+			s := strings.Split(currPrefix, delimiter)
+			if len(s) == 0 {
+				continue
+			}
+			if subs := entryMap[s[0]]; subs > 0 {
 				continue
 			}
 			prevPrefix = currPrefix


### PR DESCRIPTION
## Description

The CommonPrefix returned by ListObjectV2 is an empty folder


## Motivation and Context


## How to test this PR?
Steps to reproduce:
- Create a multi-version bucket
- Create a dir/ object through the S3 API
- Upload an object dir/test.png via S3 API
- Delete the dir/test.png object through the S3 API
- Delete dir/ object via S3 API
- ListObjectV2 still returns dir/ this CommonPrefix

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
