### PR TITLE
fix: for delete marked objects choose appropriate parity

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -448,7 +448,7 @@ func commonParity(parities []int, defaultParityCount int) int {
 		occMap[p]++
 	}
 
-	var maxOcc, commonParity int
+	var maxOcc, cparity int
 	for parity, occ := range occMap {
 		if parity == -1 {
 			// Ignore non defined parity
@@ -468,7 +468,7 @@ func commonParity(parities []int, defaultParityCount int) int {
 
 		if occ > maxOcc {
 			maxOcc = occ
-			commonParity = parity
+			cparity = parity
 		}
 	}
 
@@ -476,7 +476,7 @@ func commonParity(parities []int, defaultParityCount int) int {
 		// Did not found anything useful
 		return -1
 	}
-	return commonParity
+	return cparity
 }
 
 func listObjectParities(partsMetadata []FileInfo, errs []error) (parities []int) {
@@ -490,7 +490,9 @@ func listObjectParities(partsMetadata []FileInfo, errs []error) (parities []int)
 			parities[index] = -1
 			continue
 		}
-		if !metadata.Deleted {
+		if metadata.Deleted {
+			parities[index] = len(partsMetadata) / 2
+		} else {
 			parities[index] = metadata.Erasure.ParityBlocks
 		}
 	}


### PR DESCRIPTION

## Description
fix: for delete marked objects choose the appropriate parity

## Motivation and Context
deleted marked objects only need to have N/2 consistent 
copies to be called a good copy.

## How to test this PR?
Needs a specific scenario to be handled here where out of 16 striped deployments, if you have 8 inconsistent DEL markers we should still allow it. Del markers honor n/2 quorum not the same quorum as regular objects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
