### PR TITLE
Fix CopyPart etag mismatch

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1093,7 +1093,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 
 		// ensure that part ETag is canonicalized to strip off extraneous quotes
 		part.ETag = canonicalizeETag(part.ETag)
-		expETag := tryDecryptETag(objectEncryptionKey, expPart.ETag, kind != crypto.S3)
+		expETag := tryDecryptETag(objectEncryptionKey, expPart.ETag, kind == crypto.SSEC)
 		if expETag != part.ETag {
 			invp := InvalidPart{
 				PartNumber: part.PartNumber,

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -1165,7 +1165,7 @@ func (api objectAPIHandlers) ListObjectPartsHandler(w http.ResponseWriter, r *ht
 			}
 		}
 		for i, p := range listPartsInfo.Parts {
-			listPartsInfo.Parts[i].ETag = tryDecryptETag(objectEncryptionKey, p.ETag, kind != crypto.S3)
+			listPartsInfo.Parts[i].ETag = tryDecryptETag(objectEncryptionKey, p.ETag, kind == crypto.SSEC)
 			listPartsInfo.Parts[i].Size = p.ActualSize
 		}
 	}


### PR DESCRIPTION
## Description

Fix etag mismatches on CopyPart for SSE-KMS.

Checks for SSEC were `kind != crypto.S3`, which also triggered on KMS type crypto.

[CopyPart](https://github.com/minio/minio/blob/66156b82305a69471545158186aa5e050de2395c/cmd/object-multipart-handlers.go#L546) would return decrypted etags based on SSEC headers, while CompleteMultipart would base this on whether `kind != crypto.S3`. Therefore etags would mismatch.

@aead Please verify which is the intended way, so we don't accidentally leak something.

## How to test this PR?

Mint test `testComposeMultipleSources` will catch this.

MinIO Env vars:

```
SET MINIO_KMS_SECRET_KEY=my-minio-key:oyArl7zlPECEduNbB1KXgdzDn2Bdpvvw0l8VO51HQnY=
SET MINIO_KMS_AUTO_ENCRYPTION=on
SET MINIO_API_SELECT_PARQUET=on
SET _MINIO_SERVER_DEBUG=off
SET MINIO_COMPRESSION_ENABLE=on
SET MINIO_COMPRESSION_MIME_TYPES=*
SET MINIO_COMPRESSION_ALLOW_ENCRYPTION=on
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
