### PR TITLE
fix: on windows use FindClose close handler

### DIFF
--- a/cmd/os_windows.go
+++ b/cmd/os_windows.go
@@ -53,7 +53,7 @@ func readDirFn(dirPath string, filter func(name string, typ os.FileMode) error) 
 		}
 		return err
 	}
-	defer syscall.CloseHandle(handle)
+	defer syscall.FindClose(handle)
 
 	for ; ; err = syscall.FindNextFile(handle, data) {
 		if err != nil {
@@ -128,7 +128,7 @@ func readDirWithOpts(dirPath string, opts readDirOpts) (entries []string, err er
 		return nil, syscallErrToFileErr(dirPath, err)
 	}
 
-	defer syscall.CloseHandle(handle)
+	defer syscall.FindClose(handle)
 
 	count := opts.count
 	for ; count != 0; err = syscall.FindNextFile(handle, data) {


### PR DESCRIPTION
## Description

FindClose close findHandler

## Motivation and Context


## How to test this PR?

We can see FindFirstFile will call `FindClose` to close the hander in golang sdk.
We should do the same change.
If not will panic at windows 11.

## Types of changes
- [x] Bug fix #17297 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
