### PR TITLE
fix: Wait 10min to load globalDNS

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -121,12 +121,11 @@ func init() {
 		} else {
 			t = time.NewTicker(10 * time.Minute)
 		}
-		globalDNSCache.RefreshWithOptions(options)
 		defer t.Stop()
 		for {
+			globalDNSCache.RefreshWithOptions(options)
 			select {
 			case <-t.C:
-				globalDNSCache.RefreshWithOptions(options)
 			case <-GlobalContext.Done():
 				return
 			}

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -121,6 +121,7 @@ func init() {
 		} else {
 			t = time.NewTicker(10 * time.Minute)
 		}
+		globalDNSCache.RefreshWithOptions(options)
 		defer t.Stop()
 		for {
 			select {


### PR DESCRIPTION
## Description

If not in containers, It will cost 10min to to refresh globalDNS first.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
