### PR TITLE
fix: proxy not set on subnet logger webhook sometimes

### DIFF
--- a/cmd/admin-handlers-config-kv.go
+++ b/cmd/admin-handlers-config-kv.go
@@ -546,7 +546,7 @@ func (a adminAPIHandlers) GetConfigHandler(w http.ResponseWriter, r *http.Reques
 // setLoggerWebhookSubnetProxy - Sets the logger webhook's subnet proxy value to
 // one being set for subnet proxy
 func setLoggerWebhookSubnetProxy(subSys string, cfg config.Config) bool {
-	if subSys == config.SubnetSubSys {
+	if subSys == config.SubnetSubSys || subSys == config.LoggerWebhookSubSys {
 		subnetWebhookCfg := cfg[config.LoggerWebhookSubSys][subnet.LoggerWebhookName]
 		loggerWebhookSubnetProxy := subnetWebhookCfg.Get(logger.Proxy)
 		subnetProxy := cfg[config.SubnetSubSys][config.Default].Get(logger.Proxy)


### PR DESCRIPTION
## Description

Currently the subnet proxy gets copied on to the subnet logger webhook whenever it is set/changed/removed.

However, if it is already set and then callhome logs is enabled, it is not getting set on the newly configured subnet logger webhook. This PR fixes the same.

## Motivation and Context

Ensure that subnet logger webhook picks the proxy correctly

## How to test this PR?

- Set subnet proxy using `mc support proxy set {alias} {proxy-url}`
- Enable callhome logs using `mc support callhome enable {alias} --logs`
- Verify that the proxy has been set on the subnet logger webhook using `mc admin config get {alias} logger_webhook:subnet` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
