### PR TITLE
Error out clearing SSE config if not set for bucket

### DIFF
--- a/cmd/bucket-metadata-sys.go
+++ b/cmd/bucket-metadata-sys.go
@@ -165,6 +165,16 @@ func (sys *BucketMetadataSys) updateAndParse(ctx context.Context, bucket string,
 // Delete delete the bucket metadata for the specified bucket.
 // must be used by all callers instead of using Update() with nil configData.
 func (sys *BucketMetadataSys) Delete(ctx context.Context, bucket string, configFile string) (updatedAt time.Time, err error) {
+	meta, _, err := sys.GetConfig(GlobalContext, bucket)
+	if err != nil {
+		if errors.Is(err, errConfigNotFound) {
+			return updatedAt, BucketSSEConfigNotFound{Bucket: bucket}
+		}
+		return updatedAt, err
+	}
+	if meta.sseConfig == nil {
+		return updatedAt, BucketSSEConfigNotFound{Bucket: bucket}
+	}
 	return sys.updateAndParse(ctx, bucket, configFile, nil, false)
 }
 


### PR DESCRIPTION
## Description
It doesn't check if SSE config is already set for the bucket and goes ahead to remove it. It also reports a success for configuration removal which actually was never set for the bucket.

## Motivation and Context
It should not succeed for removing a configuration which is not set.

## How to test this PR?
`mc encrypt clear ALIAS/BUCKET`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
