### PR TITLE
fix: converting 'server closed idle connection' to errDiskNotFound

### DIFF
--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -46,10 +46,14 @@ func isNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
+
 	if nerr, ok := err.(*rest.NetworkError); ok {
-		return xnet.IsNetworkOrHostDown(nerr.Err, false)
+		if down := xnet.IsNetworkOrHostDown(nerr.Err, false); down {
+			return true
+		}
 	}
 
+	// More corner cases suitable for storage REST API
 	switch {
 	// A peer node can be in shut down phase and proactively
 	// return 503 server closed error,consider it as an offline node


### PR DESCRIPTION
## Description
This commit, ffd57fde900457b1e8df9d948757c84fdf5327da, 
was incomplete to address converting 'server closed idle connection' to errDiskNotFound

This commit fixes it.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
