### PR TITLE
allow lookup()/head() operations on Veeam SOS objects

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -442,6 +442,14 @@ func (er erasureObjects) getObjectWithFileInfo(ctx context.Context, bucket, obje
 func (er erasureObjects) GetObjectInfo(ctx context.Context, bucket, object string, opts ObjectOptions) (info ObjectInfo, err error) {
 	auditObjectErasureSet(ctx, object, &er)
 
+	// This is a special call attempted first to check for SOS-API calls.
+	info, err = veeamSOSAPIHeadObject(ctx, bucket, object, opts)
+	if err == nil {
+		return info, nil
+	}
+	// reset any error to 'nil'
+	err = nil
+
 	if !opts.NoLock {
 		// Lock the object before reading.
 		lk := er.NewNSLock(bucket, object)

--- a/cmd/veeam-sos-api.go
+++ b/cmd/veeam-sos-api.go
@@ -115,6 +115,15 @@ const (
 	capacityXMLObject = ".system-d26a9498-cb7c-4a87-a44a-8ae204f5ba6c/capacity.xml"
 )
 
+func veeamSOSAPIHeadObject(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error) {
+	gr, err := veeamSOSAPIGetObject(ctx, bucket, object, nil, opts)
+	if gr != nil {
+		gr.Close()
+		return gr.ObjInfo, nil
+	}
+	return ObjectInfo{}, err
+}
+
 func veeamSOSAPIGetObject(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, opts ObjectOptions) (gr *GetObjectReader, err error) {
 	var buf []byte
 	switch object {


### PR DESCRIPTION


## Description
allow lookup()/head() operations on Veeam SOS objects

## Motivation and Context
without this Veeam SOS API support won't work
on multiple-pool setups.

## How to test this PR?
Run multiple pool setups and try to access via `mc cat alias/bucket/.system-d26a9498-cb7c-4a87-a44a-8ae204f5ba6c/system.xml`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
