### PR TITLE
only allow decryption of etag for only sse-s3

### DIFF
--- a/.github/workflows/mint/minio-compress-encrypt.yaml
+++ b/.github/workflows/mint/minio-compress-encrypt.yaml
@@ -11,8 +11,9 @@ x-minio-common: &minio-common
     MINIO_CI_CD: "on"
     MINIO_ROOT_USER: "minio"
     MINIO_ROOT_PASSWORD: "minio123"
-    MINIO_COMPRESS: "true"
-    MINIO_COMPRESS_MIMETYPES: "*"
+    MINIO_COMPRESSION_ENABLE: "on"
+    MINIO_COMPRESSION_MIME_TYPES: "*"
+    MINIO_COMPRESSION_ALLOW_ENCRYPTION: "on"
     MINIO_KMS_SECRET_KEY: "my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw="
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]

--- a/.github/workflows/mint/minio-erasure.yaml
+++ b/.github/workflows/mint/minio-erasure.yaml
@@ -11,8 +11,6 @@ x-minio-common: &minio-common
     MINIO_CI_CD: "on"
     MINIO_ROOT_USER: "minio"
     MINIO_ROOT_PASSWORD: "minio123"
-    MINIO_COMPRESS: "true"
-    MINIO_COMPRESS_MIMETYPES: "*"
     MINIO_KMS_SECRET_KEY: "my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw="
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1094,7 +1094,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 
 		// ensure that part ETag is canonicalized to strip off extraneous quotes
 		part.ETag = canonicalizeETag(part.ETag)
-		expETag := tryDecryptETag(objectEncryptionKey, expPart.ETag, kind != crypto.S3)
+		expETag := tryDecryptETag(objectEncryptionKey, expPart.ETag, kind == crypto.S3)
 		if expETag != part.ETag {
 			invp := InvalidPart{
 				PartNumber: part.PartNumber,

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -543,7 +543,7 @@ func (api objectAPIHandlers) CopyObjectPartHandler(w http.ResponseWriter, r *htt
 	}
 
 	if isEncrypted {
-		partInfo.ETag = tryDecryptETag(objectEncryptionKey[:], partInfo.ETag, crypto.SSEC.IsRequested(r.Header))
+		partInfo.ETag = tryDecryptETag(objectEncryptionKey[:], partInfo.ETag, crypto.S3.IsRequested(r.Header))
 	}
 
 	response := generateCopyObjectPartResponse(partInfo.ETag, partInfo.LastModified)
@@ -1165,7 +1165,7 @@ func (api objectAPIHandlers) ListObjectPartsHandler(w http.ResponseWriter, r *ht
 			}
 		}
 		for i, p := range listPartsInfo.Parts {
-			listPartsInfo.Parts[i].ETag = tryDecryptETag(objectEncryptionKey, p.ETag, kind != crypto.S3)
+			listPartsInfo.Parts[i].ETag = tryDecryptETag(objectEncryptionKey, p.ETag, kind == crypto.S3)
 			listPartsInfo.Parts[i].Size = p.ActualSize
 		}
 	}


### PR DESCRIPTION
## Description
only allow decryption of etag for only sse-s3

## Motivation and Context
replaces #17304

## How to test this PR?
minio-go functional tests and `mc` tests. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
