### PR TITLE
fix:don't close for xml.NewEncoder

### DIFF
--- a/cmd/acl-handlers.go
+++ b/cmd/acl-handlers.go
@@ -158,7 +158,7 @@ func (api objectAPIHandlers) GetBucketACLHandler(w http.ResponseWriter, r *http.
 		Permission: "FULL_CONTROL",
 	})
 
-	if err := xml.NewEncoder(w).Encode(acl); err != nil {
+	if err := xmlMarshalToWriter(w, acl); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
@@ -273,7 +273,7 @@ func (api objectAPIHandlers) GetObjectACLHandler(w http.ResponseWriter, r *http.
 		},
 		Permission: "FULL_CONTROL",
 	})
-	if err := xml.NewEncoder(w).Encode(acl); err != nil {
+	if err := xmlMarshalToWriter(w, acl); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}

--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -67,11 +68,20 @@ func setCommonHeaders(w http.ResponseWriter) {
 func encodeResponse(response interface{}) []byte {
 	var buf bytes.Buffer
 	buf.WriteString(xml.Header)
-	if err := xml.NewEncoder(&buf).Encode(response); err != nil {
+	if err := xmlMarshalToWriter(&buf, response); err != nil {
 		logger.LogIf(GlobalContext, err)
 		return nil
 	}
 	return buf.Bytes()
+}
+
+// xmlMarshalToWriter use like xml.Marshal, use writer instead
+func xmlMarshalToWriter(w io.Writer, response interface{}) error {
+	enc := xml.NewEncoder(w)
+	if err := enc.Encode(response); err != nil {
+		return err
+	}
+	return enc.Close()
 }
 
 // Use this encodeResponseList() to support control characters


### PR DESCRIPTION
## Description

fix:don't close for xml.NewEncoder
Close will call coder.Flush
if not , it will get some not full resp.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
