### PR TITLE
fix: expMovingAvg is too small when startTime is zero

### DIFF
--- a/internal/bucket/bandwidth/measurement.go
+++ b/internal/bucket/bandwidth/measurement.go
@@ -57,6 +57,10 @@ func (m *bucketMeasurement) updateExponentialMovingAverage(endTime time.Time) {
 		m.lock.Unlock()
 	}()
 
+	if m.startTime.IsZero() {
+		return
+	}
+
 	if endTime.Before(m.startTime) {
 		return
 	}


### PR DESCRIPTION
## Description

fix:expMovingAvg is too small when startTime is zero
https://github.com/minio/minio/blob/04209082e5083a9c7a585037d0a9ab25a9f1bc4f/internal/bucket/bandwidth/monitor.go#L57-L70
or set it at here?

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
