### PR TITLE
allow quota enforcement to rely on older values

### DIFF
--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -151,10 +151,8 @@ func newlockRESTClient(endpoint Endpoint) *lockRESTClient {
 	}
 
 	restClient := rest.NewClient(serverURL, globalInternodeTransport, newCachedAuthToken())
-	restClient.ExpectTimeouts = true
 	// Use a separate client to avoid recursive calls.
 	healthClient := rest.NewClient(serverURL, globalInternodeTransport, newCachedAuthToken())
-	healthClient.ExpectTimeouts = true
 	healthClient.NoMetrics = true
 	restClient.HealthCheckFn = func() bool {
 		ctx, cancel := context.WithTimeout(context.Background(), restClient.HealthCheckTimeout)

--- a/cmd/namespace-lock.go
+++ b/cmd/namespace-lock.go
@@ -200,8 +200,8 @@ func (di *distLockInstance) GetRLock(ctx context.Context, timeout *dynamicTimeou
 	}) {
 		timeout.LogFailure()
 		defer cancel()
-		if err := newCtx.Err(); err == context.Canceled {
-			return LockContext{ctx: ctx, cancel: func() {}}, err
+		if errors.Is(newCtx.Err(), context.Canceled) {
+			return LockContext{ctx: ctx, cancel: func() {}}, newCtx.Err()
 		}
 		return LockContext{ctx: ctx, cancel: func() {}}, OperationTimedOut{}
 	}
@@ -255,8 +255,8 @@ func (li *localLockInstance) GetLock(ctx context.Context, timeout *dynamicTimeou
 					li.ns.unlock(li.volume, li.paths[si], readLock)
 				}
 			}
-			if err := ctx.Err(); err == context.Canceled {
-				return LockContext{}, err
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return LockContext{}, ctx.Err()
 			}
 			return LockContext{}, OperationTimedOut{}
 		}

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -782,7 +782,6 @@ func newPeerRESTClient(peer *xnet.Host) *peerRESTClient {
 	restClient := rest.NewClient(serverURL, globalInternodeTransport, newCachedAuthToken())
 	// Use a separate client to avoid recursive calls.
 	healthClient := rest.NewClient(serverURL, globalInternodeTransport, newCachedAuthToken())
-	healthClient.ExpectTimeouts = true
 	healthClient.NoMetrics = true
 
 	// Construct a new health function.

--- a/cmd/peer-s3-client.go
+++ b/cmd/peer-s3-client.go
@@ -349,7 +349,6 @@ func newPeerS3Client(peer *xnet.Host) *peerS3Client {
 	restClient := rest.NewClient(serverURL, globalInternodeTransport, newCachedAuthToken())
 	// Use a separate client to avoid recursive calls.
 	healthClient := rest.NewClient(serverURL, globalInternodeTransport, newCachedAuthToken())
-	healthClient.ExpectTimeouts = true
 	healthClient.NoMetrics = true
 
 	// Construct a new health function.

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -828,7 +828,6 @@ func newStorageRESTClient(endpoint Endpoint, healthcheck bool) *storageRESTClien
 	if healthcheck {
 		// Use a separate client to avoid recursive calls.
 		healthClient := rest.NewClient(serverURL, globalInternodeTransport, newCachedAuthToken())
-		healthClient.ExpectTimeouts = true
 		healthClient.NoMetrics = true
 		restClient.HealthCheckFn = func() bool {
 			ctx, cancel := context.WithTimeout(context.Background(), restClient.HealthCheckTimeout)


### PR DESCRIPTION
## Description
allow quota enforcement to rely on older values

## Motivation and Context
PUT calls cannot afford to have large latency build-ups due
to contentious `usage.json`, or worse letting them fail with
some unexpected error, this can happen when this file is
concurrently being updated via scanner or it is being
healed during a disk replacement heal.

However, these are fairly quick in theory, stressed clusters
can quickly show visible latency this can add up leading to
invalid errors returned during PUT.

It is perhaps okay for us to relax this error return requirement
instead, make sure that we log that we are proceeding to take in
the requests while the quota is using an older value for the quota
enforcement. These things will reconcile themselves eventually,
via scanner making sure to overwrite the `usage.json`.

Bonus: make sure that storage-rest-client sets ExpectTimeouts to
be 'true', such that DiskInfo() call with contextTimeout does
not prematurely disconnect the servers leading to a longer
healthCheck, back-off routine. This can easily pile up while also
causing active callers to disconnect, leading to quorum loss.

DiskInfo is actively used in the PUT, Multipart call path for
upgrading parity when disks are down, it in-turn shouldn't cause
more disks to go down.

## How to test this PR?
To reproduce the quota error make the following changes in the code
from master branch 

```diff
diff --git a/cmd/data-usage.go b/cmd/data-usage.go
index cecbb25a1..e9959af8b 100644
--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -21,6 +21,7 @@ import (
        "context"
        "errors"
        "strings"
+       "time"
 
        jsoniter "github.com/json-iterator/go"
        "github.com/minio/minio/internal/logger"
@@ -92,6 +93,8 @@ func loadPrefixUsageFromBackend(ctx context.Context, objAPI ObjectLayer, bucket
 }
 
 func loadDataUsageFromBackend(ctx context.Context, objAPI ObjectLayer) (DataUsageInfo, error) {
+       time.Sleep(5100 * time.Millisecond)
+
        buf, err := readConfig(ctx, objAPI, dataUsageObjNamePath)
        if err != nil {
                if errors.Is(err, errConfigNotFound) {
```

Then perform the following commands on SNSD or a distributed setup
```
mc mb alias/mybucket
mc cp /etc/hosts alias/mybucket/ (this succeeds all good)
mc quota set alias/mybucket/ --size 10Gi
mc cp /etc/hosts alias/mybucket (this will never complete and fail)
```

To reproduce the DiskInfo taking nodes offline
```diff
diff --git a/cmd/xl-storage.go b/cmd/xl-storage.go
index af148f8c6..229db81ec 100644
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -613,6 +613,8 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 // DiskInfo provides current information about disk space usage,
 // total free inodes and underlying filesystem.
 func (s *xlStorage) DiskInfo(_ context.Context) (info DiskInfo, err error) {
+       time.Sleep(5100 * time.Millisecond)
+
        s.diskInfoCache.Once.Do(func() {
                s.diskInfoCache.TTL = time.Second
                s.diskInfoCache.Update = func() (interface{}, error) {
```


This will make remote calls for DiskInfo to mark the disk/node as offline, 
failing an on-going PUT operation with write quorum errors.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
