### PR TITLE
fix: Delete dir failed when .DS_Store in it

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2077,17 +2077,15 @@ func (s *xlStorage) deleteFile(basePath, deletePath string, recursive, force boo
 			if isObjectDir {
 				return errFileNotFound
 			}
-			// if we have .DS_Store only on macOS
-			if runtime.GOOS == globalMacOSName {
-				storeFilePath := pathJoin(deletePath, ".DS_Store")
-				_, err := Stat(storeFilePath)
-				// .DS_Store exsits
-				if err == nil {
-					// delete first
-					Remove(storeFilePath)
-					// try again
-					Remove(deletePath)
-				}
+			// if we have .DS_Store from macOS, it will copy to any where
+			storeFilePath := pathJoin(deletePath, ".DS_Store")
+			_, err := Stat(storeFilePath)
+			// .DS_Store exsits
+			if err == nil {
+				// delete first
+				Remove(storeFilePath)
+				// try again
+				Remove(deletePath)
 			}
 			// Ignore errors if the directory is not empty. The server relies on
 			// this functionality, and sometimes uses recursion that should not

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2077,6 +2077,21 @@ func (s *xlStorage) deleteFile(basePath, deletePath string, recursive, force boo
 			if isObjectDir {
 				return errFileNotFound
 			}
+			// if we have .DS_Store only on macOS
+			if runtime.GOOS == globalMacOSName {
+				storeFilePath := pathJoin(deletePath, ".DS_Store")
+				_, err := Stat(storeFilePath)
+				//.DS_Store exsits
+				if err == nil {
+					// delete first
+					err := Remove(storeFilePath)
+					if err != nil {
+						return err
+					}
+					// try again
+					Remove(deletePath)
+				}
+			}
 			// Ignore errors if the directory is not empty. The server relies on
 			// this functionality, and sometimes uses recursion that should not
 			// error on parent directories.

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2084,10 +2084,7 @@ func (s *xlStorage) deleteFile(basePath, deletePath string, recursive, force boo
 				//.DS_Store exsits
 				if err == nil {
 					// delete first
-					err := Remove(storeFilePath)
-					if err != nil {
-						return err
-					}
+					Remove(storeFilePath)
 					// try again
 					Remove(deletePath)
 				}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2081,7 +2081,7 @@ func (s *xlStorage) deleteFile(basePath, deletePath string, recursive, force boo
 			if runtime.GOOS == globalMacOSName {
 				storeFilePath := pathJoin(deletePath, ".DS_Store")
 				_, err := Stat(storeFilePath)
-				//.DS_Store exsits
+				// .DS_Store exsits
 				if err == nil {
 					// delete first
 					Remove(storeFilePath)

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2077,15 +2077,17 @@ func (s *xlStorage) deleteFile(basePath, deletePath string, recursive, force boo
 			if isObjectDir {
 				return errFileNotFound
 			}
-			// if we have .DS_Store from macOS, it will copy to any where
-			storeFilePath := pathJoin(deletePath, ".DS_Store")
-			_, err := Stat(storeFilePath)
-			// .DS_Store exsits
-			if err == nil {
-				// delete first
-				Remove(storeFilePath)
-				// try again
-				Remove(deletePath)
+			// if we have .DS_Store only on macOS
+			if runtime.GOOS == globalMacOSName {
+				storeFilePath := pathJoin(deletePath, ".DS_Store")
+				_, err := Stat(storeFilePath)
+				// .DS_Store exsits
+				if err == nil {
+					// delete first
+					Remove(storeFilePath)
+					// try again
+					Remove(deletePath)
+				}
 			}
 			// Ignore errors if the directory is not empty. The server relies on
 			// this functionality, and sometimes uses recursion that should not


### PR DESCRIPTION
## Description

fix: Delete dir failed when .DS_Store in it
This file will create by macOS use Finder to view it.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix ( #16836  )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
