### PR TITLE
listen: Only error out if not able to bind any interface

### DIFF
--- a/internal/http/listener_test.go
+++ b/internal/http/listener_test.go
@@ -136,34 +136,37 @@ func TestNewHTTPListener(t *testing.T) {
 		tcpKeepAliveTimeout time.Duration
 		readTimeout         time.Duration
 		writeTimeout        time.Duration
-		expectedErr         bool
+		expectedListenErrs  []bool
 	}{
-		{[]string{"93.184.216.34:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), true},
-		{[]string{"example.org:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), true},
-		{[]string{"unknown-host"}, time.Duration(0), time.Duration(0), time.Duration(0), true},
-		{[]string{"unknown-host:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), true},
-		{[]string{"localhost:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), false},
-		{[]string{"localhost:65432", "93.184.216.34:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), true},
-		{[]string{"localhost:65432", "unknown-host:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), true},
-		{[]string{"localhost:0"}, time.Duration(0), time.Duration(0), time.Duration(0), false},
-		{[]string{"localhost:0"}, time.Duration(0), time.Duration(0), time.Duration(0), false},
-		{[]string{"[::1]:9090", "localhost:0"}, time.Duration(0), time.Duration(0), time.Duration(0), false},
+		{[]string{"93.184.216.34:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{true}},                           // 1
+		{[]string{"example.org:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{true}},                             // 2
+		{[]string{"unknown-host"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{true}},                                  // 3
+		{[]string{"unknown-host:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{true}},                            // 4
+		{[]string{"localhost:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{false}},                              // 5
+		{[]string{"localhost:65432", "93.184.216.34:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{false, true}}, // 6
+		{[]string{"localhost:65432", "unknown-host:65432"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{false, true}},  // 7
+		{[]string{"[::1:65432", "unknown-host:-1"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{true, true}},           // 7
+		{[]string{"localhost:0"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{false}},                                  // 8
+		{[]string{"localhost:0"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{false}},                                  // 9
+		{[]string{"[::1]:9090", "127.0.0.1:90900"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{false}},                // 10
+		{[]string{"[::1]:9090", "localhost:0"}, time.Duration(0), time.Duration(0), time.Duration(0), []bool{false}},                    // 10
 	}
 
-	for _, testCase := range testCases {
-		listener, err := newHTTPListener(context.Background(),
+	for testIdx, testCase := range testCases {
+		listener, listenErrs := newHTTPListener(context.Background(),
 			testCase.serverAddrs,
 			TCPOptions{},
 		)
-		if !testCase.expectedErr {
-			if err != nil {
-				t.Fatalf("error: expected = <nil>, got = %v", err)
+		for i, expectedListenErr := range testCase.expectedListenErrs {
+			if !expectedListenErr {
+				if listenErrs[i] != nil {
+					t.Fatalf("Test %d:, listenErrs[%d] error: expected = <nil>, got = %v", testIdx+1, i, listenErrs[i])
+				}
+			} else if listenErrs[i] == nil {
+				t.Fatalf("Test %d: listenErrs[%d]: expected = %v, got = <nil>", testIdx+1, i, expectedListenErr)
 			}
-		} else if err == nil {
-			t.Fatalf("error: expected = %v, got = <nil>", testCase.expectedErr)
 		}
-
-		if err == nil {
+		if listener != nil {
 			listener.Close()
 		}
 	}
@@ -187,20 +190,23 @@ func TestHTTPListenerStartClose(t *testing.T) {
 		{[]string{"127.0.0.1:0", nonLoopBackIP + ":0"}},
 	}
 
+nextTest:
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(context.Background(),
+		listener, errs := newHTTPListener(context.Background(),
 			testCase.serverAddrs,
 			TCPOptions{},
 		)
-		if err != nil {
-			if strings.Contains(err.Error(), "The requested address is not valid in its context") {
-				// Ignore if IP is unbindable.
-				continue
+		for _, err := range errs {
+			if err != nil {
+				if strings.Contains(err.Error(), "The requested address is not valid in its context") {
+					// Ignore if IP is unbindable.
+					continue nextTest
+				}
+				if strings.Contains(err.Error(), "bind: address already in use") {
+					continue nextTest
+				}
+				t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 			}
-			if strings.Contains(err.Error(), "bind: address already in use") {
-				continue
-			}
-			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 		}
 
 		for _, serverAddr := range listener.Addrs() {
@@ -238,20 +244,23 @@ func TestHTTPListenerAddr(t *testing.T) {
 		{[]string{"127.0.0.1:" + casePorts[5], nonLoopBackIP + ":" + casePorts[5]}, "0.0.0.0:" + casePorts[5]},
 	}
 
+nextTest:
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(context.Background(),
+		listener, errs := newHTTPListener(context.Background(),
 			testCase.serverAddrs,
 			TCPOptions{},
 		)
-		if err != nil {
-			if strings.Contains(err.Error(), "The requested address is not valid in its context") {
-				// Ignore if IP is unbindable.
-				continue
+		for _, err := range errs {
+			if err != nil {
+				if strings.Contains(err.Error(), "The requested address is not valid in its context") {
+					// Ignore if IP is unbindable.
+					continue nextTest
+				}
+				if strings.Contains(err.Error(), "bind: address already in use") {
+					continue nextTest
+				}
+				t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 			}
-			if strings.Contains(err.Error(), "bind: address already in use") {
-				continue
-			}
-			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 		}
 
 		addr := listener.Addr()
@@ -286,20 +295,23 @@ func TestHTTPListenerAddrs(t *testing.T) {
 		{[]string{"127.0.0.1:" + casePorts[5], nonLoopBackIP + ":" + casePorts[5]}, set.CreateStringSet("127.0.0.1:"+casePorts[5], nonLoopBackIP+":"+casePorts[5])},
 	}
 
+nextTest:
 	for i, testCase := range testCases {
-		listener, err := newHTTPListener(context.Background(),
+		listener, errs := newHTTPListener(context.Background(),
 			testCase.serverAddrs,
 			TCPOptions{},
 		)
-		if err != nil {
-			if strings.Contains(err.Error(), "The requested address is not valid in its context") {
-				// Ignore if IP is unbindable.
-				continue
+		for _, err := range errs {
+			if err != nil {
+				if strings.Contains(err.Error(), "The requested address is not valid in its context") {
+					// Ignore if IP is unbindable.
+					continue nextTest
+				}
+				if strings.Contains(err.Error(), "bind: address already in use") {
+					continue nextTest
+				}
+				t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 			}
-			if strings.Contains(err.Error(), "bind: address already in use") {
-				continue
-			}
-			t.Fatalf("Test %d: error: expected = <nil>, got = %v", i+1, err)
 		}
 
 		addrs := listener.Addrs()


### PR DESCRIPTION
## Description
Quit only when the server does not find any interface to listen on.

Otherwise print logs why it is not able to bind to other interfaces.


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
