### PR TITLE
Add more bootstrap info in debug mode

### DIFF
--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -267,7 +267,9 @@ func newBootstrapRESTClients(endpointServerPools EndpointServerPools) []*bootstr
 			// Only proceed for remote endpoints.
 			if !endpoint.IsLocal {
 				cl := newBootstrapRESTClient(endpoint)
-				cl.restClient.TraceOutput = os.Stderr
+				if serverDebugLog {
+					cl.restClient.TraceOutput = os.Stdout
+				}
 				clnts = append(clnts, cl)
 			}
 		}

--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"time"
 
@@ -265,7 +266,9 @@ func newBootstrapRESTClients(endpointServerPools EndpointServerPools) []*bootstr
 
 			// Only proceed for remote endpoints.
 			if !endpoint.IsLocal {
-				clnts = append(clnts, newBootstrapRESTClient(endpoint))
+				cl := newBootstrapRESTClient(endpoint)
+				cl.restClient.TraceOutput = os.Stderr
+				clnts = append(clnts, cl)
 			}
 		}
 	}

--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -216,6 +216,7 @@ func verifyServerSystemConfig(ctx context.Context, endpointServerPools EndpointS
 	for onlineServers < len(clnts)/2 {
 		for _, clnt := range clnts {
 			if err := clnt.Verify(ctx, srcCfg); err != nil {
+				bootstrapTrace(fmt.Sprintf("clnt.Verify: %v, endpoint: %v", err, clnt.endpoint))
 				if !isNetworkError(err) {
 					logger.LogOnceIf(ctx, fmt.Errorf("%s has incorrect configuration: %w", clnt.String(), err), clnt.String())
 					incorrectConfigs = append(incorrectConfigs, fmt.Errorf("%s has incorrect configuration: %w", clnt.String(), err))

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -395,6 +395,7 @@ func configRetriableErrors(err error) bool {
 
 func bootstrapTrace(msg string) {
 	globalBootstrapTracer.Record(msg, 2)
+	fmt.Fprintln(os.Stderr, time.Now().Round(time.Millisecond).Format(time.RFC3339), "bootstrap:", msg)
 
 	if globalTrace.NumSubscribers(madmin.TraceBootstrap) == 0 {
 		return
@@ -598,6 +599,7 @@ func serverMain(ctx *cli.Context) {
 		globalHTTPServerErrorCh <- httpServer.Start(GlobalContext)
 	}()
 
+	fmt.Fprintln(os.Stderr, time.Now().Round(time.Millisecond).Format(time.RFC3339), "setHTTPServer")
 	setHTTPServer(httpServer)
 
 	if globalIsDistErasure {
@@ -608,6 +610,7 @@ func serverMain(ctx *cli.Context) {
 		}
 	}
 
+	bootstrapTrace("newObjectLayer")
 	newObject, err := newObjectLayer(GlobalContext, globalEndpoints)
 	if err != nil {
 		logFatalErrs(err, Endpoint{}, true)
@@ -616,11 +619,15 @@ func serverMain(ctx *cli.Context) {
 	xhttp.SetDeploymentID(globalDeploymentID)
 	xhttp.SetMinIOVersion(Version)
 
+	bootstrapTrace("newSharedLock")
 	globalLeaderLock = newSharedLock(GlobalContext, newObject, "leader.lock")
 
 	// Enable background operations for erasure coding
+	bootstrapTrace("initAutoHeal")
 	initAutoHeal(GlobalContext, newObject)
+	bootstrapTrace("initHealMRF")
 	initHealMRF(GlobalContext, newObject)
+	bootstrapTrace("initBackgroundExpiry")
 	initBackgroundExpiry(GlobalContext, newObject)
 
 	if !globalCLIContext.StrictS3Compat {
@@ -657,15 +664,18 @@ func serverMain(ctx *cli.Context) {
 
 	// Initialize users credentials and policies in background right after config has initialized.
 	go func() {
+		bootstrapTrace("globalIAMSys.Init")
 		globalIAMSys.Init(GlobalContext, newObject, globalEtcdClient, globalRefreshIAMInterval)
 
 		// Initialize
 		if globalBrowserEnabled {
+			bootstrapTrace("initConsoleServer")
 			srv, err := initConsoleServer()
 			if err != nil {
 				logger.FatalIf(err, "Unable to initialize console service")
 			}
 
+			bootstrapTrace("setConsoleSrv")
 			setConsoleSrv(srv)
 
 			go func() {
@@ -675,11 +685,13 @@ func serverMain(ctx *cli.Context) {
 
 		// if we see FTP args, start FTP if possible
 		if len(ctx.StringSlice("ftp")) > 0 {
+			bootstrapTrace("startFTPServer")
 			go startFTPServer(ctx)
 		}
 
 		// If we see SFTP args, start SFTP if possible
 		if len(ctx.StringSlice("sftp")) > 0 {
+			bootstrapTrace("startFTPServer")
 			go startSFTPServer(ctx)
 		}
 	}()
@@ -694,17 +706,22 @@ func serverMain(ctx *cli.Context) {
 		}
 
 		// Initialize data scanner.
+		bootstrapTrace("initDataScanner")
 		initDataScanner(GlobalContext, newObject)
 
 		// Initialize background replication
+		bootstrapTrace("initBackgroundReplication")
 		initBackgroundReplication(GlobalContext, newObject)
 
+		bootstrapTrace("globalTransitionState.Init")
 		globalTransitionState.Init(newObject)
 
 		// Initialize batch job pool.
+		bootstrapTrace("newBatchJobPool")
 		globalBatchJobPool = newBatchJobPool(GlobalContext, newObject, 100)
 
 		// Initialize the license update job
+		bootstrapTrace("initLicenseUpdateJob")
 		initLicenseUpdateJob(GlobalContext, newObject)
 
 		go func() {
@@ -734,26 +751,31 @@ func serverMain(ctx *cli.Context) {
 		logger.LogIf(GlobalContext, globalEventNotifier.InitBucketTargets(GlobalContext, newObject))
 
 		// List buckets to initialize bucket metadata sub-sys.
+		bootstrapTrace("ListBuckets")
 		buckets, err := newObject.ListBuckets(GlobalContext, BucketOptions{})
 		if err != nil {
 			logger.LogIf(GlobalContext, fmt.Errorf("Unable to list buckets to initialize bucket metadata sub-system: %w", err))
 		}
 
 		// Initialize bucket metadata sub-system.
+		bootstrapTrace("globalBucketMetadataSys.Init")
 		globalBucketMetadataSys.Init(GlobalContext, buckets, newObject)
 
 		// initialize replication resync state.
 		go globalReplicationPool.initResync(GlobalContext, buckets, newObject)
 
 		// Initialize site replication manager after bucket metadata
+		bootstrapTrace("globalSiteReplicationSys.Init")
 		globalSiteReplicationSys.Init(GlobalContext, newObject)
 
 		// Initialize quota manager.
+		bootstrapTrace("globalBucketQuotaSys.Init")
 		globalBucketQuotaSys.Init(newObject)
 
 		// Populate existing buckets to the etcd backend
 		if globalDNSConfig != nil {
 			// Background this operation.
+			bootstrapTrace("initFederatorBackend")
 			go initFederatorBackend(buckets, newObject)
 		}
 
@@ -770,6 +792,7 @@ func serverMain(ctx *cli.Context) {
 	if region == "" {
 		region = "us-east-1"
 	}
+	bootstrapTrace("globalMinioClient")
 	globalMinioClient, err = minio.New(globalLocalNodeName, &minio.Options{
 		Creds:     credentials.NewStaticV4(globalActiveCred.AccessKey, globalActiveCred.SecretKey, ""),
 		Secure:    globalIsTLS,

--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -41,7 +41,7 @@ var lockRetryBackOff func(*rand.Rand, uint) time.Duration
 
 func init() {
 	// Check for MINIO_DSYNC_TRACE env variable, if set logging will be enabled for failed REST operations.
-	dsyncLog = os.Getenv("_MINIO_DSYNC_TRACE") == "1"
+	dsyncLog = true || os.Getenv("_MINIO_DSYNC_TRACE") == "1"
 
 	lockRetryMinInterval = 250 * time.Millisecond
 	if lri := os.Getenv("_MINIO_LOCK_RETRY_INTERVAL"); lri != "" {

--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -41,7 +41,7 @@ var lockRetryBackOff func(*rand.Rand, uint) time.Duration
 
 func init() {
 	// Check for MINIO_DSYNC_TRACE env variable, if set logging will be enabled for failed REST operations.
-	dsyncLog = true || os.Getenv("_MINIO_DSYNC_TRACE") == "1"
+	dsyncLog = os.Getenv("_MINIO_DSYNC_TRACE") == "1"
 
 	lockRetryMinInterval = 250 * time.Millisecond
 	if lri := os.Getenv("_MINIO_LOCK_RETRY_INTERVAL"); lri != "" {

--- a/internal/rest/client.go
+++ b/internal/rest/client.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"path"
 	"strings"
@@ -88,6 +89,9 @@ type Client struct {
 
 	// Avoid metrics update if set to true
 	NoMetrics bool
+
+	// TraceOutput will print debug information on non-200 calls if set.
+	TraceOutput io.Writer // Debug trace output
 
 	httpClient   *http.Client
 	url          *url.URL
@@ -222,6 +226,66 @@ func (r *respBodyMonitor) errorStatus(err error) {
 	}
 }
 
+// dumpHTTP - dump HTTP request and response.
+func (c *Client) dumpHTTP(req *http.Request, resp *http.Response) {
+	// Starts http dump.
+	_, err := fmt.Fprintln(c.TraceOutput, "---------START-HTTP---------")
+	if err != nil {
+		return
+	}
+
+	// Filter out Signature field from Authorization header.
+	origAuth := req.Header.Get("Authorization")
+	if origAuth != "" {
+		req.Header.Set("Authorization", "**REDACTED**")
+	}
+
+	// Only display request header.
+	reqTrace, err := httputil.DumpRequestOut(req, false)
+	if err != nil {
+		return
+	}
+
+	// Write request to trace output.
+	_, err = fmt.Fprint(c.TraceOutput, string(reqTrace))
+	if err != nil {
+		return
+	}
+
+	// Only display response header.
+	var respTrace []byte
+
+	// For errors we make sure to dump response body as well.
+	if resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusPartialContent &&
+		resp.StatusCode != http.StatusNoContent {
+		respTrace, err = httputil.DumpResponse(resp, true)
+		if err != nil {
+			return
+		}
+	} else {
+		respTrace, err = httputil.DumpResponse(resp, false)
+		if err != nil {
+			return
+		}
+	}
+
+	// Write response to trace output.
+	_, err = fmt.Fprint(c.TraceOutput, strings.TrimSuffix(string(respTrace), "\r\n"))
+	if err != nil {
+		return
+	}
+
+	// Ends the http dump.
+	_, err = fmt.Fprintln(c.TraceOutput, "---------END-HTTP---------")
+	if err != nil {
+		return
+	}
+
+	// Returns success.
+	return
+}
+
 // Call - make a REST call with context.
 func (c *Client) Call(ctx context.Context, method string, values url.Values, body io.Reader, length int64) (reply io.ReadCloser, err error) {
 	urlStr := c.url.String()
@@ -261,6 +325,12 @@ func (c *Client) Call(ctx context.Context, method string, values url.Values, bod
 			}
 		}
 		return nil, &NetworkError{err}
+	}
+
+	// If trace is enabled, dump http request and response,
+	// except when the traceErrorsOnly enabled and the response's status code is ok
+	if c.TraceOutput != nil && resp.StatusCode != http.StatusOK {
+		c.dumpHTTP(req, resp)
 	}
 
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
## Description

Add more bootstrap info, basically printing progress at every step.

This will now be printed when `_MINIO_SERVER_DEBUG=on`.

## Motivation and Context

Allow debugging of startup issues, that occur before mc can connect and receive bootstrap info.

## How to test this PR?

Enable env var above.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
