### PR TITLE
vrf: Fix testing for loopback coming from the address

### DIFF
--- a/internal/http/dial_linux.go
+++ b/internal/http/dial_linux.go
@@ -73,6 +73,9 @@ func setTCPParametersFn(opts TCPOptions) func(network, address string, c syscall
 			_ = syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, opts.UserTimeout)
 
 			if opts.Interface != "" {
+				if h, _, err := net.SplitHostPort(address); err == nil {
+					address = h
+				}
 				// Create socket on specific vrf device.
 				// To catch all kinds of special cases this filters specifically for loopback networks.
 				if ip := net.ParseIP(address); ip != nil && !ip.IsLoopback() {


### PR DESCRIPTION
## Description

When parsing --address to avoid using loopback as VRF devices, the code
forgot to strip the port

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
