### PR TITLE
tar: Avoid storing snowball extraction header in extract objects

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2106,7 +2106,19 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
-	metadata[xhttp.AmzStorageClass] = sc
+
+	// Remove the snowball headers from metadata from objects
+	// since those are actionable headers and not for storage
+	delete(metadata, xhttp.AmzSnowballExtract)
+	delete(metadata, xhttp.AmzSnowballExtract)
+	delete(metadata, xhttp.MinIOSnowballIgnoreDirs)
+	delete(metadata, xhttp.MinIOSnowballIgnoreErrors)
+	delete(metadata, xhttp.MinIOSnowballPrefix)
+
+	// Use the same storage class as the original uploaded tar file
+	if sc != "" {
+		metadata[xhttp.AmzStorageClass] = sc
+	}
 
 	putObjectTar := func(reader io.Reader, info os.FileInfo, object string) error {
 		size := info.Size()

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -89,8 +89,9 @@ const (
 	AmzObjectLockLegalHold        = "X-Amz-Object-Lock-Legal-Hold"
 	AmzObjectLockBypassGovernance = "X-Amz-Bypass-Governance-Retention"
 	AmzBucketReplicationStatus    = "X-Amz-Replication-Status"
-	AmzSnowballExtract            = "X-Amz-Meta-Snowball-Auto-Extract"
 
+	// AmzSnowballExtract will trigger unpacking of an archive content
+	AmzSnowballExtract = "X-Amz-Meta-Snowball-Auto-Extract"
 	// MinIOSnowballIgnoreDirs will skip creating empty directory objects.
 	MinIOSnowballIgnoreDirs = "X-Amz-Meta-Minio-Snowball-Ignore-Dirs"
 	// MinIOSnowballIgnoreErrors will ignore recoverable errors, typically single files failing to upload.


### PR DESCRIPTION
## Description
Extracted objects inside the archive file are not necessarly tar, avoid saving the 
snowball archive header with the extracted objects.

Also avoid storing empty storage class in extarcted objects metadata as well

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
