### PR TITLE
service accounts are allowed to have no expiration

### DIFF
--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -2343,11 +2343,17 @@ func extractJWTClaims(u UserIdentity) (*jwt.MapClaims, error) {
 }
 
 func validateSvcExpirationInUTC(expirationInUTC time.Time) error {
+	if expirationInUTC.IsZero() || expirationInUTC.Equal(timeSentinel) {
+		// Service accounts might not have expiration in older releases.
+		return nil
+	}
+
 	currentTime := time.Now().UTC()
 	minExpiration := currentTime.Add(minServiceAccountExpiry)
 	maxExpiration := currentTime.Add(maxServiceAccountExpiry)
 	if expirationInUTC.Before(minExpiration) || expirationInUTC.After(maxExpiration) {
 		return errInvalidSvcAcctExpiration
 	}
+
 	return nil
 }


### PR DESCRIPTION

## Description
service accounts are allowed to have no expiration

## Motivation and Context
site-replication fails with service accounts from
older releases that do not have expiration.

## How to test this PR?
Have service accounts created in older releases and then
enable site-replication - service accounts will not
sync anymore.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression not sure when
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
