### PR TITLE
fix: protect ReplicationStats against concurrent map iteration and write crash

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -373,7 +373,7 @@ func (f *folderScanner) sendUpdate() {
 	}
 	if flat := f.updateCache.sizeRecursive(f.newCache.Info.Name); flat != nil {
 		select {
-		case f.updates <- *flat:
+		case f.updates <- flat.clone():
 		default:
 		}
 		f.lastUpdate = time.Now()


### PR DESCRIPTION
## Description

ReplicationStats were only shallow copied for updates, this could result in the following crash:

```
fatal error: concurrent map iteration and map write
goroutine 24306422216 [running]:
github.com/minio/minio/cmd.(*replicationAllStats).EncodeMsg(0xc057871570, 0xc06986f505?)
github.com/minio/minio/cmd/data-usage-cache_gen.go:2753 +0x205
github.com/minio/minio/cmd.(*dataUsageEntry).EncodeMsg(0xc06986f658, 0xc01c33b2d0?)
github.com/minio/minio/cmd/data-usage-cache_gen.go:1687 +0x525
github.com/minio/minio/cmd.(*dataUsageCache).EncodeMsg(0xc05e21a600, 0xc018d9c780?)
github.com/minio/minio/cmd/data-usage-cache_gen.go:478 +0x285
github.com/minio/minio/cmd.(*dataUsageCache).serializeTo(0xc04ac0c600?, {0x4eb1860, 0xc07d32e2d0})
github.com/minio/minio/cmd/data-usage-cache.go:947 +0x10c
```

Implement a dedicated clone function and add a bit of extra safety by explicitly cloning updates before sending.


## How to test this PR?

Rather hard - requires distributed setup with replicating and race detection enabled. Therefore the extra safety.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
