### PR TITLE
Revert "heal: Update object parity with the latest configured SC (#17187)"

### DIFF
--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -296,14 +295,6 @@ func (fi *FileInfo) SetInlineData() {
 		fi.Metadata = make(map[string]string, 1)
 	}
 	fi.Metadata[ReservedMetadataPrefixLower+"inline-data"] = "true"
-}
-
-// SetErasureParityUpdated adds trace information about an object parity update during healing
-func (fi *FileInfo) SetErasureParityUpdated(old, new int) {
-	if fi.Metadata == nil {
-		fi.Metadata = make(map[string]string, 1)
-	}
-	fi.Metadata[ReservedMetadataPrefixLower+"erasure-parity-update"] = fmt.Sprintf("%d->%d", old, new)
 }
 
 // VersionPurgeStatusKey denotes purge status in metadata


### PR DESCRIPTION
## Description
This reverts commit e2b7a08c1024659c8119c4b8819f617bfbb92de2.

Healing while updating the parity can corrupt the object in a unstable system.

Before, healing reverts the old state of an outdated disk and not changing 
anything in the other disks that do not need healing, so it is acceptable that healing
fails to write in some outdated disks already due to any reason, since this will not make
things worse anyway.

However, healing with the parity update enabled will change the state of the object in all 
disks and this can be an issue if the new state is propagated in some disks but not in all
of them.

Hence, reverting the commit. Also it doesn't seem there is any solid solution in an unstable cluster
without making much larger involved changes.

## Motivation and Context
Reverting a commit, this not enabled already.

## How to test this PR?
NA

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
