### PR TITLE
Add an option to make bucket notifications synchronous

### DIFF
--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -52,6 +52,7 @@ type apiConfig struct {
 	disableODirect              bool
 	gzipObjects                 bool
 	rootAccess                  bool
+	syncEvents                  bool
 }
 
 const cgroupLimitFile = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
@@ -166,6 +167,7 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 	t.disableODirect = cfg.DisableODirect
 	t.gzipObjects = cfg.GzipObjects
 	t.rootAccess = cfg.RootAccess
+	t.syncEvents = cfg.SyncEvents
 }
 
 func (t *apiConfig) isDisableODirect() bool {
@@ -352,4 +354,11 @@ func (t *apiConfig) getTransitionWorkers() int {
 	}
 
 	return t.transitionWorkers
+}
+
+func (t *apiConfig) isSyncEventsEnabled() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.syncEvents
 }

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1032,7 +1032,6 @@ func (sys *NotificationSys) GetPeerOnlineCount() (nodesOnline, nodesOffline int)
 
 // NewNotificationSys - creates new notification system object.
 func NewNotificationSys(endpoints EndpointServerPools) *NotificationSys {
-	// targetList/bucketRulesMap/bucketRemoteTargetRulesMap are populated by NotificationSys.Init()
 	remote, all := newPeerRestClients(endpoints)
 	return &NotificationSys{
 		peerClients:    remote,

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -51,10 +51,6 @@ func handleSignals() {
 		// send signal to various go-routines that they need to quit.
 		cancelGlobalContext()
 
-		if globalEventNotifier != nil {
-			globalEventNotifier.RemoveAllRemoteTargets()
-		}
-
 		if httpServer := newHTTPServerFn(); httpServer != nil {
 			err = httpServer.Shutdown()
 			if !errors.Is(err, http.ErrServerClosed) {
@@ -69,6 +65,10 @@ func handleSignals() {
 
 		if srv := newConsoleServerFn(); srv != nil {
 			logger.LogIf(context.Background(), srv.Shutdown())
+		}
+
+		if globalEventNotifier != nil {
+			globalEventNotifier.RemoveAllBucketTargets()
 		}
 
 		return (err == nil && oerr == nil)

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -45,6 +45,7 @@ const (
 	apiDisableODirect              = "disable_odirect"
 	apiGzipObjects                 = "gzip_objects"
 	apiRootAccess                  = "root_access"
+	apiSyncEvents                  = "sync_events"
 
 	EnvAPIRequestsMax             = "MINIO_API_REQUESTS_MAX"
 	EnvAPIRequestsDeadline        = "MINIO_API_REQUESTS_DEADLINE"
@@ -62,6 +63,7 @@ const (
 	EnvAPIDisableODirect              = "MINIO_API_DISABLE_ODIRECT"
 	EnvAPIGzipObjects                 = "MINIO_API_GZIP_OBJECTS"
 	EnvAPIRootAccess                  = "MINIO_API_ROOT_ACCESS" // default "on"
+	EnvAPISyncEvents                  = "MINIO_API_SYNC_EVENTS" // default "off"
 )
 
 // Deprecated key and ENVs
@@ -135,6 +137,10 @@ var (
 			Key:   apiRootAccess,
 			Value: "on",
 		},
+		config.KV{
+			Key:   apiSyncEvents,
+			Value: "off",
+		},
 	}
 )
 
@@ -154,6 +160,7 @@ type Config struct {
 	DisableODirect              bool          `json:"disable_odirect"`
 	GzipObjects                 bool          `json:"gzip_objects"`
 	RootAccess                  bool          `json:"root_access"`
+	SyncEvents                  bool          `json:"sync_events"`
 }
 
 // UnmarshalJSON - Validate SS and RRS parity when unmarshalling JSON.
@@ -268,6 +275,8 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		return cfg, err
 	}
 	cfg.StaleUploadsExpiry = staleUploadsExpiry
+
+	cfg.SyncEvents = env.Get(EnvAPISyncEvents, kvs.Get(apiSyncEvents)) == config.EnableOn
 
 	return cfg, nil
 }

--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -104,5 +104,11 @@ var (
 			Optional:    true,
 			Type:        "boolean",
 		},
+		config.HelpKV{
+			Key:         apiSyncEvents,
+			Description: "set to enable synchronous bucket notifications" + defaultHelpPostfix(apiSyncEvents),
+			Optional:    true,
+			Type:        "boolean",
+		},
 	}
 )

--- a/internal/event/targetlist.go
+++ b/internal/event/targetlist.go
@@ -157,7 +157,7 @@ func (list *TargetList) TargetMap() map[TargetID]Target {
 }
 
 // Send - sends events to targets identified by target IDs.
-func (list *TargetList) Send(event Event, targetIDset TargetIDSet, resCh chan<- TargetIDResult) {
+func (list *TargetList) Send(event Event, targetIDset TargetIDSet, resCh chan<- TargetIDResult, synchronous bool) {
 	if atomic.LoadInt64(&list.currentSendCalls) > maxConcurrentTargetSendCalls {
 		err := fmt.Errorf("concurrent target notifications exceeded %d", maxConcurrentTargetSendCalls)
 		for id := range targetIDset {
@@ -165,31 +165,38 @@ func (list *TargetList) Send(event Event, targetIDset TargetIDSet, resCh chan<- 
 		}
 		return
 	}
-
+	if synchronous {
+		list.send(event, targetIDset, resCh)
+		return
+	}
 	go func() {
-		var wg sync.WaitGroup
-		for id := range targetIDset {
-			list.RLock()
-			target, ok := list.targets[id]
-			list.RUnlock()
-			if ok {
-				wg.Add(1)
-				go func(id TargetID, target Target) {
-					atomic.AddInt64(&list.currentSendCalls, 1)
-					defer atomic.AddInt64(&list.currentSendCalls, -1)
-					defer wg.Done()
-					tgtRes := TargetIDResult{ID: id}
-					if err := target.Save(event); err != nil {
-						tgtRes.Err = err
-					}
-					resCh <- tgtRes
-				}(id, target)
-			} else {
-				resCh <- TargetIDResult{ID: id}
-			}
-		}
-		wg.Wait()
+		list.send(event, targetIDset, resCh)
 	}()
+}
+
+func (list *TargetList) send(event Event, targetIDset TargetIDSet, resCh chan<- TargetIDResult) {
+	var wg sync.WaitGroup
+	for id := range targetIDset {
+		list.RLock()
+		target, ok := list.targets[id]
+		list.RUnlock()
+		if ok {
+			wg.Add(1)
+			go func(id TargetID, target Target) {
+				atomic.AddInt64(&list.currentSendCalls, 1)
+				defer atomic.AddInt64(&list.currentSendCalls, -1)
+				defer wg.Done()
+				tgtRes := TargetIDResult{ID: id}
+				if err := target.Save(event); err != nil {
+					tgtRes.Err = err
+				}
+				resCh <- tgtRes
+			}(id, target)
+		} else {
+			resCh <- TargetIDResult{ID: id}
+		}
+	}
+	wg.Wait()
 }
 
 // Stats returns stats for targets.

--- a/internal/event/targetlist_test.go
+++ b/internal/event/targetlist_test.go
@@ -249,7 +249,7 @@ func TestTargetListSend(t *testing.T) {
 	for i, testCase := range testCases {
 		testCase.targetList.Send(Event{}, map[TargetID]struct{}{
 			testCase.targetID: {},
-		}, resCh)
+		}, resCh, false)
 		res := <-resCh
 		expectErr := (res.Err != nil)
 


### PR DESCRIPTION
## Description

With the current asynchronous behavior in sending notification events to the targets, we can't provide guaranteed delivery as the systems might go for restarts.

For such event-driven use-cases, we can provide an option to enable synchronous events where the APIs wait until the event is successfully sent or persisted.

This commit adds 'MINIO_ENABLE_SYNC_EVENTS' env which when set to 'true' will enable sending/persisting events to targets synchronously.

This issue can be seen by simulating a slow queue_dir mountpoint with the following diff

```diff
 // Stats returns stats for targets.
diff --git a/internal/store/queuestore.go b/internal/store/queuestore.go
index 60e8a09fd..7fa65f79c 100644
--- a/internal/store/queuestore.go
+++ b/internal/store/queuestore.go
@@ -99,6 +99,7 @@ func (store *QueueStore[_]) Open() error {
 
 // write - writes an item to the directory.
 func (store *QueueStore[I]) write(key string, item I) error {
+       time.Sleep(1 * time.Second)
        // Marshalls the item.
        eventData, err := json.Marshal(item)
        if err != nil {
```

After applying the above diff, enable bucket notifications and restart the server while performing a bulk upload with the notification target down.

ie,

```bash
> mc mb myminio/testb
> mc admin config set myminio notify_webhook:1 enable=on endpoint=http://localhost:8080/ queue_dir=/tmp/webhookevents 
> mc admin service restart myminio
> mc event add myminio/testb arn:minio:sqs::1:webhook
> # Enable trace if needed to check the API trace
> # Now stop the webhook server and start uploading objects in parallel.
> for i in {1..300};do mc cp /home/praveen/Downloads/testobj.img myminio/testb/obj$i.jpg &; done
> # stop the server inbetween and check the queue_dir you will see some events missing.
```

this is because, the `sendEvent` is asynchronous - which will start a goroutine and sends the API response back. TERMINATING/INTERRUPTING the server will cancel all these go-routines which will lead to missing events.

## Motivation and Context

To add an option to make event subsystem synchronous so that we won't be missing any events in a non-resilient systems.

## How to test this PR?

STEP 1: Apply the above diff, set the env `export MINIO_API_SYNC_EVENTS=on` and start MinIO server (or) set the config by `mc admin config set myminio api sync_events=on`

STEP 2: Configure bucket notifications

```bash
> mc mb myminio/testb
> mc admin config set myminio notify_webhook:1 enable=on endpoint=http://localhost:8080/ queue_dir=/tmp/webhookevents 
> mc admin service restart myminio
> mc event add myminio/testb arn:minio:sqs::1:webhook
> # Enable trace if needed to check the API trace
> # Now stop the webhook server and start uploading objects in parallel.
```
STEP 3: Use the following minio-java snippet to upload objects in parallel. Also, enable the trace so that we can see the succeeded PUTs and failed PUTs.

```java
lass PutObjectRunnable implements Runnable {
  MinioClient client;
  String bucketName;
  String filename;
  String objectName;

  public PutObjectRunnable(String objectName) {
    this.client = MinioClient.builder()
    .endpoint("http://localhost:9000")
    .credentials("minio", "minio123")
    .build();
    this.bucketName = "testb";
    this.filename = "/etc/issue";
    this.objectName = objectName;
  }

  public void run() {
    try {
      client.uploadObject(
          UploadObjectArgs.builder()
              .bucket(bucketName)
              .object(objectName)
              .filename(filename)
              .build());
      System.out.println(objectName + " is uploaded successfully");
    } catch (Exception e) {
      System.out.println("error occured while uploading "+objectName+": "+e.toString());
      // e.printStackTrace();
    }
  }
}


public class PutObject {
  /** MinioClient.putObjectProgressBar() example. */
  public static void main(String[] args)
      throws IOException, NoSuchAlgorithmException, InvalidKeyException, MinioException, Exception {
    /* play.min.io for test and development. */
    int count = 300;
    Thread[] threads = new Thread[count];

    for (int i = 0; i < count; i++) {
      threads[i] = new Thread(new PutObjectRunnable("obj-"+i));
    }

    for (int i = 0; i < count; i++) {
      threads[i].start();
    }

    // Waiting for threads to complete.
    for (int i = 0; i < count; i++) {
      threads[i].join();
    }

    // All threads are completed.
    System.out.println("all threads completed");
  }
}
```

STEP 4: Stop the MinIO server inbetween the upload and check the queue dir - `ls -l /tmp/webhookevents/minio-webhook-1/ | wc -l` it should be equal or greater than succeeded responses seen in trace or in java console.

(NOTE: `mc ls` might show more objects as MinIO would've successfully written few objects)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
