### PR TITLE
do not save plain-text ETag when encryption is requested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ test-iam: build ## verify IAM (external IDP, etcd backends)
 	@echo "Running tests for IAM (external IDP, etcd backends) with -race"
 	@MINIO_API_REQUESTS_MAX=10000 GORACE=history_size=7 CGO_ENABLED=1 go test -race -tags kqueue -v -run TestIAM* ./cmd
 
+test-sio-error:
+	@(env bash $(PWD)/docs/bucket/replication/sio-error.sh)
+
 test-replication-2site:
 	@(env bash $(PWD)/docs/bucket/replication/setup_2site_existing_replication.sh)
 
@@ -83,7 +86,7 @@ test-replication-3site:
 test-delete-replication:
 	@(env bash $(PWD)/docs/bucket/replication/delete-replication.sh)
 
-test-replication: install test-replication-2site test-replication-3site test-delete-replication ## verify multi site replication
+test-replication: install test-replication-2site test-replication-3site test-delete-replication test-sio-error ## verify multi site replication
 	@echo "Running tests for replicating three sites"
 
 test-site-replication-ldap: install ## verify automatic site replication

--- a/docs/bucket/replication/sio-error.sh
+++ b/docs/bucket/replication/sio-error.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -x
+
+export CI=1
+
+make || exit -1
+
+killall -9 minio
+
+rm -rf /tmp/xl/
+mkdir -p /tmp/xl/1/ /tmp/xl/2/
+
+export MINIO_KMS_SECRET_KEY="my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw="
+
+NODES=4
+
+args1=()
+args2=()
+for i in $(seq 1 $NODES); do
+	args1+=("http://localhost:$((9000 + i))/tmp/xl/1/$i ")
+	args2+=("http://localhost:$((9100 + i))/tmp/xl/2/$i ")
+done
+
+for i in $(seq 1 $NODES); do
+	./minio server --address "127.0.0.1:$((9000 + i))" ${args1[@]} & # | tee /tmp/minio/node.$i &
+	./minio server --address "127.0.0.1:$((9100 + i))" ${args2[@]} & # | tee /tmp/minio/node.$i &
+done
+
+sleep 10
+
+./mc alias set myminio1 http://localhost:9001 minioadmin minioadmin
+./mc alias set myminio2 http://localhost:9101 minioadmin minioadmin
+
+sleep 1
+
+./mc mb myminio1/testbucket/ --with-lock
+./mc mb myminio2/testbucket/ --with-lock
+
+./mc encrypt set sse-s3 my-minio-key myminio1/testbucket/
+./mc encrypt set sse-s3 my-minio-key myminio2/testbucket/
+
+./mc replicate add myminio1/testbucket --remote-bucket http://minioadmin:minioadmin@localhost:9101/testbucket --priority 1
+./mc replicate add myminio2/testbucket --remote-bucket http://minioadmin:minioadmin@localhost:9001/testbucket --priority 1
+
+sleep 1
+
+./mc cp internal.tar myminio1/testbucket/dir/1.tar
+./mc cp internal.tar myminio2/testbucket/dir/2.tar
+
+sleep 1
+
+./mc ls -r --versions myminio1/testbucket/dir/ >/tmp/dir_1.txt
+./mc ls -r --versions myminio2/testbucket/dir/ >/tmp/dir_2.txt
+
+out=$(diff -qpruN /tmp/dir_1.txt /tmp/dir_2.txt)
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "BUG: expected no 'diff' after replication: $out"
+	exit 1
+fi


### PR DESCRIPTION

## Description
do not save plain-text ETag when encryption is requested

## Motivation and Context
fixes an issue under bucket replication could cause
ETags for replicated SSE-S3 single-part PUT objects,
to fail as we would attempt a decryption while listing,
or stat() operation.

## How to test this PR?
```bash
set -x

export CI=1

make || exit -1

killall -9 minio

rm -rf /tmp/xl/
mkdir -p /tmp/xl/1/ /tmp/xl/2/

export MINIO_KMS_SECRET_KEY="my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw="

NODES=4

args1=()
args2=()
for i in $(seq 1 $NODES); do
        args1+=("http://localhost:$((9000 + $i))/tmp/xl/1/$i ")
        args2+=("http://localhost:$((9100 + $i))/tmp/xl/2/$i ")
done

for i in $(seq 1 $NODES); do
        ./minio server --address "127.0.0.1:$((9000 + $i))" ${args1[@]} & # | tee /tmp/minio/node.$i &
        ./minio server --address "127.0.0.1:$((9100 + $i))" ${args2[@]} & # | tee /tmp/minio/node.$i &
done

sleep 10

./mc alias set myminio1 http://localhost:9001 minioadmin minioadmin
./mc alias set myminio2 http://localhost:9101 minioadmin minioadmin

sleep 1

./mc mb myminio1/testbucket/ --with-lock
./mc mb myminio2/testbucket/ --with-lock
./mc encrypt set sse-s3 my-minio-key myminio1/testbucket/
./mc encrypt set sse-s3 my-minio-key myminio2/testbucket/

./mc replicate add myminio1/testbucket --remote-bucket http://minioadmin:minioadmin@localhost:9101/testbucket --priority 1

sleep 1

./mc cp internal.tar myminio1/testbucket/dir/1.tar
./mc cp internal.tar myminio2/testbucket/dir/2.tar

sleep 1

./mc ls myminio1/testbucket/dir/

./mc ls myminio2/testbucket/dir/
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
