### PR TITLE
site replication: cancel ongoing op properly

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -5169,6 +5169,10 @@ func (c *SiteReplicationSys) cancelResync(ctx context.Context, objAPI ObjectLaye
 	if err := saveSiteResyncMetadata(ctx, rs, objAPI); err != nil {
 		return res, err
 	}
+	select {
+	case globalReplicationPool.resyncer.resyncCancelCh <- struct{}{}:
+	case <-ctx.Done():
+	}
 
 	globalSiteResyncMetrics.updateState(rs)
 


### PR DESCRIPTION
## Description


## Motivation and Context
ongoing bucket resync should stop when site replication op is canceled

## How to test this PR?
`mc admin replicate resync start|cancel|status`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
