### PR TITLE
replication: Ensure metadata updates go to same pool where version ex…

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -411,7 +411,9 @@ func (z *erasureServerPools) getPoolInfoExistingWithOpts(ctx context.Context, bu
 			}
 			// do not remove this check as it can lead to inconsistencies
 			// for all callers of bucket replication.
-			opts.VersionID = ""
+			if !opts.MetadataChg {
+				opts.VersionID = ""
+			}
 			pinfo.ObjInfo, pinfo.Err = pool.GetObjectInfo(ctx, bucket, object, opts)
 			poolObjInfos[i] = pinfo
 		}(i, pool, poolOpts[i])
@@ -443,7 +445,7 @@ func (z *erasureServerPools) getPoolInfoExistingWithOpts(ctx context.Context, bu
 			// found a pool
 			return pinfo, nil
 		}
-		if isErrReadQuorum(pinfo.Err) {
+		if isErrReadQuorum(pinfo.Err) && !opts.MetadataChg {
 			// read quorum is returned when the object is visibly
 			// present but its unreadable, we simply ask the writes to
 			// schedule to this pool instead. If there is no quorum
@@ -2268,6 +2270,7 @@ func (z *erasureServerPools) PutObjectMetadata(ctx context.Context, bucket, obje
 		return z.serverPools[0].PutObjectMetadata(ctx, bucket, object, opts)
 	}
 
+	opts.MetadataChg = true
 	// We don't know the size here set 1GiB atleast.
 	idx, err := z.getPoolIdxExistingWithOpts(ctx, bucket, object, opts)
 	if err != nil {
@@ -2284,6 +2287,8 @@ func (z *erasureServerPools) PutObjectTags(ctx context.Context, bucket, object s
 		return z.serverPools[0].PutObjectTags(ctx, bucket, object, tags, opts)
 	}
 
+	opts.MetadataChg = true
+
 	// We don't know the size here set 1GiB atleast.
 	idx, err := z.getPoolIdxExistingWithOpts(ctx, bucket, object, opts)
 	if err != nil {
@@ -2299,6 +2304,8 @@ func (z *erasureServerPools) DeleteObjectTags(ctx context.Context, bucket, objec
 	if z.SinglePool() {
 		return z.serverPools[0].DeleteObjectTags(ctx, bucket, object, opts)
 	}
+
+	opts.MetadataChg = true
 
 	idx, err := z.getPoolIdxExistingWithOpts(ctx, bucket, object, opts)
 	if err != nil {

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -99,6 +99,8 @@ type ObjectOptions struct {
 	IndexCB func() []byte
 
 	InclFreeVersions bool
+
+	MetadataChg bool // is true if it is a metadata update operation.
 }
 
 // ExpirationOptions represents object options for object expiration at objectLayer.


### PR DESCRIPTION
## Description


## Motivation and Context
when there is no read quorum on one pool for objectversion, there is potential for metadata updates to go to pool that the version does not exist on. This affects replication metadata updates and potentially leaves the same version written to xl.meta on both pools.

Also fixing replication status when proxying from peer - proxied HEAD was not showing repl.status and deferring replication attempt if target returned error other than NoSuchKey or NoSuchVersion

## How to test this PR?
run site replication on multipool setups with below code 
synthetically create quorum error on GetObjectInfo at random
```
func (er erasureObjects) getObjectInfo(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error) {
n := rand.Int31n(3)
	if strconv.Itoa(int(n)) == object {
		return objInfo, InsufficientReadQuorum{}
	}
...
```

```
mc admin replicate add sitea siteb 
mc mb sitea/bucket
mc cp go.mod sitea/bucket/1
mc cp go.mod sitea/bucket/1
```
With master, 503's will drop the metadata update and leave replication in FAILED state, subsequent stat will cause re-replication and proper setting of replication status if correct pool is found. Alternatively, this can also manifest as duplicate versions seen in the pools xl.meta 

```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) 
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
