### PR TITLE
fix:panic when globalObjectAPI is not initialized

### DIFF
--- a/cmd/erasure-server-pool-rebalance.go
+++ b/cmd/erasure-server-pool-rebalance.go
@@ -810,6 +810,9 @@ func (z *erasureServerPools) StartRebalance() {
 		}
 
 		go func(idx int) {
+			for newObjectLayerFn() == nil {
+				time.Sleep(time.Second)
+			}
 			stopfn := globalRebalanceMetrics.log(rebalanceMetricRebalanceBuckets, idx)
 			err := z.rebalanceBuckets(ctx, idx)
 			stopfn(err)


### PR DESCRIPTION
## Description

fix when globalObjectAPI is not initialized

## Motivation and Context


## How to test this PR?

Restart minio while minio balance is not completed.

## Types of changes
- [x] Bug fix #17421 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
