### PR TITLE
s3: Make/Delete buckets to use error quorum per pool

### DIFF
--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -359,6 +359,9 @@ func createServerEndpoints(serverAddr string, args ...string) (
 		if err != nil {
 			return nil, -1, err
 		}
+		for i := range endpointList {
+			endpointList[i].SetPool(0)
+		}
 		endpointServerPools = append(endpointServerPools, PoolEndpoints{
 			Legacy:       true,
 			SetCount:     len(setArgs),

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -224,9 +224,9 @@ var (
 	// registered listeners
 	globalConsoleSys *HTTPConsoleLoggerSys
 
-	// All drives endpoints of this deployment
+	// All unique drives for this deployment
 	globalEndpoints EndpointServerPools
-	// All nodesof this deployment
+	// All unique nodes for this deployment
 	globalNodes []Node
 
 	// The name of this local node, fetched from arguments

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -224,7 +224,10 @@ var (
 	// registered listeners
 	globalConsoleSys *HTTPConsoleLoggerSys
 
+	// All drives endpoints of this deployment
 	globalEndpoints EndpointServerPools
+	// All nodesof this deployment
+	globalNodes []Node
 
 	// The name of this local node, fetched from arguments
 	globalLocalNodeName    string
@@ -236,8 +239,6 @@ var (
 
 	// The global callhome config
 	globalCallhomeConfig callhome.Config
-
-	globalRemoteEndpoints map[string]Endpoint
 
 	// Global server's network statistics
 	globalConnStats = newConnStats()


### PR DESCRIPTION
## Description
Creating and delete buckets should calculate action quorum based on pools
e.g.: it should not error out when few nodes (< quorum are offline

## Motivation and Context
Fix an issue when trying to delete a bucket when one node or less than quorum nodes are offline

## How to test this PR?
Start a MinIO cluster (4 nodes, 1 disk/node)
Kill a node and create a bucket


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
