### PR TITLE
safely ignore out of band deletions while decommissioning

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -757,6 +757,10 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 						})
 					var failure bool
 					if err != nil {
+						if isErrObjectNotFound(err) || isErrVersionNotFound(err) {
+							// object deleted by the application, nothing to do here we move on.
+							continue
+						}
 						logger.LogIf(ctx, err)
 						failure = true
 					}


### PR DESCRIPTION
## Description
safely ignore out-of-band deletions while decommissioning

## Motivation and Context
it is certainly plausible that the version considered
for decommissioning has been purged already.

## How to test this PR?
Not easy, haven't found a reliable way to reproduce it. 
This PR is mostly an educated guess. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
