### PR TITLE
Honor global root CAs for kafka audit tls

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -616,6 +616,9 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 		}
 		for n, l := range loggerCfg.AuditKafka {
 			if l.Enabled {
+				if l.TLS.Enable {
+					l.TLS.RootCAs = globalRootCAs
+				}
 				l.LogOnce = logger.LogOnceIf
 				loggerCfg.AuditKafka[n] = l
 			}


### PR DESCRIPTION
## Description

We need use the global root CAs (~/.minio/certs/CAs) for kafka audit loggers
(the current workaround is to set `tls_skip_verify=on` to skip the SSL verification)

## Motivation and Context

To use the root CAs for connecting to SSL enabled kafka.

## How to test this PR?

Set up kafka+ssl and place the ca.crt in ~/.minio/certs/CAs to connect to the kafka target. (I wasn't able to achieve this - ran into few SSL issues)

Other way to test is to know if  [sconfig.Net.TLS.Config.RootCAs](https://github.com/minio/minio/blob/master/internal/logger/target/kafka/kafka.go#L288) is not nil by printing some logs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
