### PR TITLE
[helm] add ability to mount a custom volume to the export directory

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             - name: minio-user
               mountPath: "/tmp/credentials"
               readOnly: true
-            - name: export
+            - name: {{.Values.exportVolumeName | default "export" }}
               mountPath: {{ .Values.mountPath }}
               {{- if and .Values.persistence.enabled .Values.persistence.subPath }}
               subPath: "{{ .Values.persistence.subPath }}"

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -49,6 +49,9 @@ extraArgs: []
 ## Additional volumes to minio container
 extraVolumes: []
 
+## If you add additional volumes and you want to mount one of the those volumes to the export directory then update the exportVolumeName to match the custom volume
+exportVolumeName: export
+
 ## Additional volumeMounts to minio container
 extraVolumeMounts: []
 


### PR DESCRIPTION
## Description
This PR adds 1 parameter to the helm values file allowing the user to choose which volume to mount on the exports folder.

## Motivation and Context
I would like to change where the export folder is mounted in the container using the helm chart

## How to test this PR?
You can add the following to the values.yaml file when you deploy the helm chart:
```yml
exportVolumeName: minio-host-path
extraVolumes:
  - name: minio-host-path
    hostPath:
      # directory location on host
      path: /minio-host-path
      type: Directory
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
