### PR TITLE
lambda: negative duration for presigned URL default to 1H

### DIFF
--- a/cmd/object-lambda-handlers.go
+++ b/cmd/object-lambda-handlers.go
@@ -47,7 +47,7 @@ func getLambdaEventData(bucket, object string, cred auth.Credentials, r *http.Re
 	}
 
 	duration := time.Until(cred.Expiration)
-	if cred.Expiration.IsZero() || duration > time.Hour {
+	if duration > time.Hour || duration < time.Hour {
 		// Always limit to 1 hour.
 		duration = time.Hour
 	}


### PR DESCRIPTION
## Description
lambda: negative duration for presigned URL default to 1H

## Motivation and Context
fixes a bug where users created with Expiration as
timeSentinel is not rejected while generating the
presigned URL for lambda processing.

## How to test this PR?
Just use the root user and then
use it via lambda processing documentation.

https://github.com/minio/minio/tree/master/docs/lambda

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
