### PR TITLE
fix: keep decommission in a go-routine

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -1114,11 +1114,13 @@ func (z *erasureServerPools) Decommission(ctx context.Context, indices ...int) e
 		return err
 	}
 
-	for _, idx := range indices {
-		// decommission all pools serially one after
-		// the other.
-		z.doDecommissionInRoutine(ctx, idx)
-	}
+	go func() {
+		for _, idx := range indices {
+			// decommission all pools serially one after
+			// the other.
+			z.doDecommissionInRoutine(ctx, idx)
+		}
+	}()
 
 	// Successfully started decommissioning.
 	return nil


### PR DESCRIPTION

## Description
fix: keep decommission in a go-routine

## Motivation and Context
This was removed by mistake in #17491

## How to test this PR?
Just see that Decom doesn't block the server startup while draining.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
