### PR TITLE
feat: allow expiration of all versions via ILM Expiration action

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1187,6 +1187,9 @@ func applyExpiryOnNonTransitionedObjects(ctx context.Context, objLayer ObjectLay
 		opts.Versioned = globalBucketVersioningSys.PrefixEnabled(obj.Bucket, obj.Name)
 		opts.VersionSuspended = globalBucketVersioningSys.PrefixSuspended(obj.Bucket, obj.Name)
 	}
+	if lcEvent.Action.DeleteAll() {
+		opts.DeletePrefix = true
+	}
 
 	obj, err := objLayer.DeleteObject(ctx, obj.Bucket, obj.Name, opts)
 	if err != nil {

--- a/docs/bucket/lifecycle/README.md
+++ b/docs/bucket/lifecycle/README.md
@@ -129,8 +129,30 @@ of objects under the prefix `user-uploads/` as soon as there are more than `N` n
     ]
 }
 ```
-
 Note: This rule has an implicit zero NoncurrentDays, which makes the expiry of those 'extra' noncurrent versions immediate.
+
+#### 3.2.b Automatic removal of all versions (MinIO only extension)
+
+This is available only on MinIO as an extension to the Expiration feature. The following rule makes it possible to remove all versions of an object under 
+the prefix `user-uploads/` as soon as the latest object satisfies the expiration criteria.
+
+```
+{
+    "Rules": [
+        {
+            "ID": "Purge all versions of an expired object",
+            "Status": "Enabled",
+            "Filter": {
+                "Prefix": "users-uploads/"
+            },
+            "Expiration": {
+                "Days": 7,
+                "ExpiredObjectAllVersions": true
+            }
+        }
+    ]
+}
+```
 
 ### 3.3 Automatic removal of delete markers with no other versions
 

--- a/docs/debugging/reorder-disks/main.go
+++ b/docs/debugging/reorder-disks/main.go
@@ -162,7 +162,6 @@ func getDiskLocation(f format) (string, error) {
 }
 
 func main() {
-
 	var node, args string
 
 	flag.StringVar(&node, "local-node-name", "", "the name of the local node")

--- a/internal/bucket/lifecycle/action_string.go
+++ b/internal/bucket/lifecycle/action_string.go
@@ -15,12 +15,13 @@ func _() {
 	_ = x[TransitionVersionAction-4]
 	_ = x[DeleteRestoredAction-5]
 	_ = x[DeleteRestoredVersionAction-6]
-	_ = x[ActionCount-7]
+	_ = x[DeleteAllVersionsAction-7]
+	_ = x[ActionCount-8]
 }
 
-const _Action_name = "NoneActionDeleteActionDeleteVersionActionTransitionActionTransitionVersionActionDeleteRestoredActionDeleteRestoredVersionActionActionCount"
+const _Action_name = "NoneActionDeleteActionDeleteVersionActionTransitionActionTransitionVersionActionDeleteRestoredActionDeleteRestoredVersionActionDeleteAllVersionsActionActionCount"
 
-var _Action_index = [...]uint8{0, 10, 22, 41, 57, 80, 100, 127, 138}
+var _Action_index = [...]uint8{0, 10, 22, 41, 57, 80, 100, 127, 150, 161}
 
 func (i Action) String() string {
 	if i < 0 || i >= Action(len(_Action_index)-1) {

--- a/internal/bucket/lifecycle/expiration.go
+++ b/internal/bucket/lifecycle/expiration.go
@@ -100,6 +100,11 @@ func (eDate ExpirationDate) MarshalXML(e *xml.Encoder, startElement xml.StartEle
 
 // ExpireDeleteMarker represents value of ExpiredObjectDeleteMarker field in Expiration XML element.
 type ExpireDeleteMarker struct {
+	Boolean
+}
+
+// Boolean signifies a boolean XML struct with custom marshaling
+type Boolean struct {
 	val bool
 	set bool
 }
@@ -110,12 +115,16 @@ type Expiration struct {
 	Days         ExpirationDays     `xml:"Days,omitempty"`
 	Date         ExpirationDate     `xml:"Date,omitempty"`
 	DeleteMarker ExpireDeleteMarker `xml:"ExpiredObjectDeleteMarker"`
+	// Indicates whether MinIO will remove all versions. If set to true, all versions will be deleted;
+	// if set to false the policy takes no action. This action uses the Days/Date to expire objects.
+	// This check is verified for latest version of the object.
+	DeleteAll Boolean `xml:"ExpiredObjectAllVersions"`
 
 	set bool
 }
 
 // MarshalXML encodes delete marker boolean into an XML form.
-func (b ExpireDeleteMarker) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
+func (b Boolean) MarshalXML(e *xml.Encoder, startElement xml.StartElement) error {
 	if !b.set {
 		return nil
 	}
@@ -123,7 +132,7 @@ func (b ExpireDeleteMarker) MarshalXML(e *xml.Encoder, startElement xml.StartEle
 }
 
 // UnmarshalXML decodes delete marker boolean from the XML form.
-func (b *ExpireDeleteMarker) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
+func (b *Boolean) UnmarshalXML(d *xml.Decoder, startElement xml.StartElement) error {
 	var exp bool
 	err := d.DecodeElement(&exp, &startElement)
 	if err != nil {

--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -388,6 +388,15 @@ func TestEval(t *testing.T) {
 			isExpiredDelMarker: true,
 			expectedAction:     DeleteVersionAction,
 		},
+		// Should delete expired object right away with 1 day expiration
+		{
+			inputConfig:        `<BucketLifecycleConfiguration><Rule><Expiration><Days>1</Days><ExpiredObjectAllVersions>true</ExpiredObjectAllVersions></Expiration><Filter></Filter><Status>Enabled</Status></Rule></BucketLifecycleConfiguration>`,
+			objectName:         "foodir/fooobject",
+			objectModTime:      time.Now().UTC().Add(-10 * 24 * time.Hour), // Created 10 days ago
+			isExpiredDelMarker: true,
+			expectedAction:     DeleteAllVersionsAction,
+		},
+
 		// Should not delete expired marker if its time has not come yet
 		{
 			inputConfig:        `<BucketLifecycleConfiguration><Rule><Filter></Filter><Status>Enabled</Status><Expiration><Days>1</Days></Expiration></Rule></BucketLifecycleConfiguration>`,


### PR DESCRIPTION


## Description
feat: allow expiration of all versions via ILM Expiration action

## Motivation and Context
The following extension allows users to specify an immediate 
purge all versions as soon as the latest version of an object
has expired.

```xml
<LifecycleConfiguration>
    <Rule>
        <ID>ClassADocRule</ID>
        <Filter>
           <Prefix>classA/</Prefix>
        </Filter>
        <Status>Enabled</Status>
        <Expiration>
             <Days>1</Days>
	     <ExpiredObjectAllVersions>true</ExpiredObjectAllVersions>
        </Expiration>
    </Rule>
    ...
```

## How to test this PR?
Just as per the above ILM rule

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
