### PR TITLE
fix: support LDAP settings properly in ftp/sftp

### DIFF
--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -253,11 +253,7 @@ func (driver *ftpDriver) CheckPasswd(c *ftp.Context, username, password string) 
 			return false, err
 		}
 		ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, false, groupDistNames...)
-		if len(ldapPolicies) == 0 {
-			// no policy associated reject it.
-			return false, nil
-		}
-		return true, nil
+		return len(ldapPolicies) > 0, nil
 	}
 
 	ui, ok := globalIAMSys.GetUser(context.Background(), username)
@@ -362,12 +358,20 @@ func (driver *ftpDriver) DeleteDir(ctx *ftp.Context, path string) (err error) {
 	cctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if prefix == "" {
+		// if all objects are not deleted yet this call may fail.
+		return clnt.RemoveBucket(cctx, bucket)
+	}
+
 	objectsCh := make(chan minio.ObjectInfo)
 
 	// Send object names that are needed to be removed to objectsCh
 	go func() {
 		defer close(objectsCh)
-		opts := minio.ListObjectsOptions{Prefix: prefix, Recursive: true}
+		opts := minio.ListObjectsOptions{
+			Prefix:    prefix,
+			Recursive: true,
+		}
 		for object := range clnt.ListObjects(cctx, bucket, opts) {
 			if object.Err != nil {
 				return
@@ -425,6 +429,10 @@ func (driver *ftpDriver) MakeDir(ctx *ftp.Context, path string) (err error) {
 	clnt, err := driver.getMinIOClient(ctx)
 	if err != nil {
 		return err
+	}
+
+	if prefix == "" {
+		return clnt.MakeBucket(context.Background(), bucket, minio.MakeBucketOptions{Region: globalSite.Region})
 	}
 
 	dirPath := buildMinioDir(prefix)

--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -97,18 +97,15 @@ func (f *sftpDriver) getMinIOClient() (*minio.Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		ldapPolicies, _ := globalIAMSys.PolicyDBGet(targetUser, false, targetGroups...)
-		if len(ldapPolicies) == 0 {
-			return nil, errAuthentication
-		}
 		expiryDur, err := globalIAMSys.LDAPConfig.GetExpiryDuration("")
 		if err != nil {
 			return nil, err
 		}
 		claims := make(map[string]interface{})
 		claims[expClaim] = UTCNow().Add(expiryDur).Unix()
-		claims[ldapUser] = targetUser
-		claims[ldapUserN] = f.AccessKey()
+		for k, v := range f.permissions.CriticalOptions {
+			claims[k] = v
+		}
 
 		cred, err := auth.GetNewCredentialsWithMetadata(claims, globalActiveCred.SecretKey)
 		if err != nil {
@@ -165,6 +162,9 @@ func (f *sftpDriver) getMinIOClient() (*minio.Client, error) {
 }
 
 func (f *sftpDriver) AccessKey() string {
+	if _, ok := f.permissions.CriticalOptions["accessKey"]; !ok {
+		return f.permissions.CriticalOptions[ldapUserN]
+	}
 	return f.permissions.CriticalOptions["accessKey"]
 }
 
@@ -270,12 +270,20 @@ func (f *sftpDriver) Filecmd(r *sftp.Request) (err error) {
 		cctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		if prefix == "" {
+			// if all objects are not deleted yet this call may fail.
+			return clnt.RemoveBucket(cctx, bucket)
+		}
+
 		objectsCh := make(chan minio.ObjectInfo)
 
 		// Send object names that are needed to be removed to objectsCh
 		go func() {
 			defer close(objectsCh)
-			opts := minio.ListObjectsOptions{Prefix: prefix, Recursive: true}
+			opts := minio.ListObjectsOptions{
+				Prefix:    prefix,
+				Recursive: true,
+			}
 			for object := range clnt.ListObjects(cctx, bucket, opts) {
 				if object.Err != nil {
 					return
@@ -303,6 +311,10 @@ func (f *sftpDriver) Filecmd(r *sftp.Request) (err error) {
 		bucket, prefix := path2BucketObject(r.Filepath)
 		if bucket == "" {
 			return errors.New("bucket name cannot be empty")
+		}
+
+		if prefix == "" {
+			return clnt.MakeBucket(context.Background(), bucket, minio.MakeBucketOptions{Region: globalSite.Region})
 		}
 
 		dirPath := buildMinioDir(prefix)


### PR DESCRIPTION
## Description
fix: support LDAP settings properly in ftp/sftp

## Motivation and Context
Bonus this PR enhances and supports creating
buckets via ftp `mkdir`

fixes #17526

## How to test this PR?
As per #17526 

```
minio server /tmp/disk{1...4} --ftp="address=:8021" --ftp="passive-port-range=30000-40000" --sftp="address=:8022" --sftp="ssh-private-key=/home/harsha/.ssh/id_rsa" &
```

and then setup LDAP as per https://github.com/minio/minio-iam-testing/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
