### PR TITLE
Add active disk health checks

### DIFF
--- a/cmd/format-erasure_test.go
+++ b/cmd/format-erasure_test.go
@@ -38,7 +38,7 @@ func TestFixFormatV3(t *testing.T) {
 	}
 	endpoints := mustGetNewEndpoints(erasureDirs...)
 
-	storageDisks, errs := initStorageDisksWithErrors(endpoints, true)
+	storageDisks, errs := initStorageDisksWithErrors(endpoints, false)
 	for _, err := range errs {
 		if err != nil && err != errDiskNotFound {
 			t.Fatal(err)
@@ -559,7 +559,7 @@ func benchmarkInitStorageDisksN(b *testing.B, nDisks int) {
 	b.RunParallel(func(pb *testing.PB) {
 		endpoints := endpoints
 		for pb.Next() {
-			initStorageDisksWithErrors(endpoints, true)
+			initStorageDisksWithErrors(endpoints, false)
 		}
 	})
 }

--- a/cmd/object-api-common.go
+++ b/cmd/object-api-common.go
@@ -62,7 +62,7 @@ func newStorageAPI(endpoint Endpoint, healthCheck bool) (storage StorageAPI, err
 		if err != nil {
 			return nil, err
 		}
-		return newXLStorageDiskIDCheck(storage), nil
+		return newXLStorageDiskIDCheck(storage, healthCheck), nil
 	}
 
 	return newStorageRESTClient(endpoint, healthCheck), nil

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -1356,7 +1356,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointServerPools Endpoin
 
 			endpoint := storage.Endpoint()
 
-			server := &storageRESTServer{storage: newXLStorageDiskIDCheck(storage)}
+			server := &storageRESTServer{storage: newXLStorageDiskIDCheck(storage, true)}
 			server.storage.SetDiskID(storage.diskID)
 
 			subrouter := router.PathPrefix(path.Join(storageRESTPrefix, endpoint.Path)).Subrouter()

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -840,6 +840,10 @@ func (p *xlStorageDiskIDCheck) monitorDiskWritable() {
 		if atomic.LoadInt32(&p.health.status) != diskHealthOK {
 			continue
 		}
+		if time.Since(time.Unix(0, atomic.LoadInt64(&p.health.lastSuccess))) < 5*time.Second {
+			// We recently saw a success - no need to check.
+			continue
+		}
 		goOffline := func(err error) {
 			if atomic.CompareAndSwapInt32(&p.health.status, diskHealthOK, diskHealthFaulty) {
 				logger.LogAlwaysIf(context.Background(), fmt.Errorf("node(%s): taking drive %s offline: %v", globalLocalNodeName, p.storage.String(), err))

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -875,8 +875,6 @@ func (p *xlStorageDiskIDCheck) monitorDiskWritable(ctx context.Context) {
 		go func() {
 			timeout := time.NewTimer(timeoutOperation)
 			select {
-			// Reuse the same trigger
-			// If it triggers again, it took too long.
 			case <-timeout.C:
 				spent := time.Since(started)
 				goOffline(fmt.Errorf("unable to write+read for %v", spent.Round(time.Millisecond)))

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -130,7 +130,7 @@ func newXLStorageTestSetup(tb testing.TB) (*xlStorageDiskIDCheck, string, error)
 		return nil, "", err
 	}
 
-	disk := newXLStorageDiskIDCheck(storage)
+	disk := newXLStorageDiskIDCheck(storage, false)
 	disk.SetDiskID("da017d62-70e3-45f1-8a1a-587707e69ad1")
 	return disk, diskPath, nil
 }


### PR DESCRIPTION
## Description

Add check every 2 minutes to see if a write+read operation can complete.

If disk doesn't complete a read+write within 2 minutes or returns errFaultyDisk, take it offline.

## Motivation and Context

Disks are not taken offline until all 512 slots have been exhausted. For a low-traffic site this may not trigger for quite a while.

This should be conservative enough that it shouldn't be triggered unless drive is either faulty or extremely overloaded - in both cases taking the drive offline makes sense.

## How to test this PR?

Requires flaky drives or similar.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
