### PR TITLE
fix: for FTP server driver allow implicit trust TLS

### DIFF
--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -322,7 +322,7 @@ func (driver *ftpDriver) getMinIOClient(ctx *ftp.Context) (*minio.Client, error)
 		return minio.New(driver.endpoint, &minio.Options{
 			Creds:     credentials.NewStaticV4(cred.AccessKey, cred.SecretKey, cred.SessionToken),
 			Secure:    globalIsTLS,
-			Transport: globalRemoteTargetTransport,
+			Transport: globalRemoteFTPClientTransport,
 		})
 	}
 
@@ -336,7 +336,7 @@ func (driver *ftpDriver) getMinIOClient(ctx *ftp.Context) (*minio.Client, error)
 	return minio.New(driver.endpoint, &minio.Options{
 		Creds:     credentials.NewStaticV4(ui.Credentials.AccessKey, ui.Credentials.SecretKey, ""),
 		Secure:    globalIsTLS,
-		Transport: globalRemoteTargetTransport,
+		Transport: globalRemoteFTPClientTransport,
 	})
 }
 

--- a/cmd/ftp-server.go
+++ b/cmd/ftp-server.go
@@ -34,6 +34,8 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+var globalRemoteFTPClientTransport = NewRemoteTargetHTTPTransport(true)()
+
 // minioLogger use an instance of this to log in a standard format
 type minioLogger struct{}
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -256,7 +256,7 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	globalProxyTransport = NewCustomHTTPProxyTransport()()
 	globalProxyEndpoints = GetProxyEndpoints(globalEndpoints)
 	globalInternodeTransport = NewInternodeHTTPTransport()()
-	globalRemoteTargetTransport = NewRemoteTargetHTTPTransport()()
+	globalRemoteTargetTransport = NewRemoteTargetHTTPTransport(false)()
 
 	globalForwarder = handlers.NewForwarder(&handlers.Forwarder{
 		PassHost:     true,

--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -143,7 +143,7 @@ func (f *sftpDriver) getMinIOClient() (*minio.Client, error) {
 		return minio.New(f.endpoint, &minio.Options{
 			Creds:     credentials.NewStaticV4(cred.AccessKey, cred.SecretKey, cred.SessionToken),
 			Secure:    globalIsTLS,
-			Transport: globalRemoteTargetTransport,
+			Transport: globalRemoteFTPClientTransport,
 		})
 	}
 
@@ -157,7 +157,7 @@ func (f *sftpDriver) getMinIOClient() (*minio.Client, error) {
 	return minio.New(f.endpoint, &minio.Options{
 		Creds:     credentials.NewStaticV4(ui.Credentials.AccessKey, ui.Credentials.SecretKey, ""),
 		Secure:    globalIsTLS,
-		Transport: globalRemoteTargetTransport,
+		Transport: globalRemoteFTPClientTransport,
 	})
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -664,14 +664,14 @@ func newCustomDialContext() dialContext {
 
 // NewRemoteTargetHTTPTransport returns a new http configuration
 // used while communicating with the remote replication targets.
-func NewRemoteTargetHTTPTransport() func() *http.Transport {
+func NewRemoteTargetHTTPTransport(insecure bool) func() *http.Transport {
 	return xhttp.ConnSettings{
 		DialContext: newCustomDialContext(),
 		DNSCache:    globalDNSCache,
 		RootCAs:     globalRootCAs,
 		TCPOptions:  globalTCPOptions,
 		EnableHTTP2: false,
-	}.NewRemoteTargetHTTPTransport()
+	}.NewRemoteTargetHTTPTransport(insecure)
 }
 
 // Load the json (typically from disk file).

--- a/internal/http/transports.go
+++ b/internal/http/transports.go
@@ -78,7 +78,6 @@ func (s ConnSettings) getDefaultTransport() *http.Transport {
 		IdleConnTimeout:       15 * time.Second,
 		ResponseHeaderTimeout: 15 * time.Minute, // Conservative timeout is the default (for MinIO internode)
 		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 10 * time.Second,
 		TLSClientConfig:       &tlsClientConfig,
 		ForceAttemptHTTP2:     s.EnableHTTP2,
 		// Go net/http automatically unzip if content-type is
@@ -117,7 +116,6 @@ func (s ConnSettings) NewInternodeHTTPTransport() func() http.RoundTripper {
 
 	// Settings specific to internode requests.
 	tr.TLSHandshakeTimeout = 15 * time.Second
-	tr.ExpectContinueTimeout = 15 * time.Second
 
 	return func() http.RoundTripper {
 		return tr
@@ -167,12 +165,12 @@ func (s ConnSettings) NewHTTPTransportWithClientCerts(ctx context.Context, clien
 
 // NewRemoteTargetHTTPTransport returns a new http configuration
 // used while communicating with the remote replication targets.
-func (s ConnSettings) NewRemoteTargetHTTPTransport() func() *http.Transport {
+func (s ConnSettings) NewRemoteTargetHTTPTransport(insecure bool) func() *http.Transport {
 	tr := s.getDefaultTransport()
 
-	tr.TLSHandshakeTimeout = 5 * time.Second
-	tr.ExpectContinueTimeout = 5 * time.Second
+	tr.TLSHandshakeTimeout = 10 * time.Second
 	tr.ResponseHeaderTimeout = 0
+	tr.TLSClientConfig.InsecureSkipVerify = insecure
 
 	return func() *http.Transport {
 		return tr


### PR DESCRIPTION
## Description
fix: for FTP server driver allow implicit trust TLS

## Motivation and Context
fixes #17535 

## How to test this PR?
Setup server with TLS certs without using 127.0.0.1 as part
of the TLS certs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
