### PR TITLE
fix: honor older scanner settings only if newer has not changed

### DIFF
--- a/internal/config/scanner/scanner.go
+++ b/internal/config/scanner/scanner.go
@@ -85,14 +85,17 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		return cfg, err
 	}
 
-	// Stick to loading deprecated config/env if they are already set
-	if kvs.Get(Delay) != "" && kvs.Get(MaxWait) != "" && kvs.Get(Cycle) != "" {
-		return lookupDeprecatedScannerConfig(kvs)
+	// Stick to loading deprecated config/env if they are already set, and the Speed value
+	// has not been changed from its "default" value, if it has been changed honor new settings.
+	if kvs.GetWithDefault(Speed, DefaultKVS) == "default" {
+		if kvs.Get(Delay) != "" && kvs.Get(MaxWait) != "" {
+			return lookupDeprecatedScannerConfig(kvs)
+		}
 	}
 
 	switch speed := env.Get(EnvSpeed, kvs.GetWithDefault(Speed, DefaultKVS)); speed {
 	case "fastest":
-		cfg.Delay, cfg.MaxWait, cfg.Cycle = 0, 0, 0
+		cfg.Delay, cfg.MaxWait, cfg.Cycle = 0, 0, time.Second
 	case "fast":
 		cfg.Delay, cfg.MaxWait, cfg.Cycle = 1, 100*time.Millisecond, time.Minute
 	case "default":


### PR DESCRIPTION
## Description
fix: honor older scanner settings only if newer has not changed

## Motivation and Context
do the right things

## How to test this PR?
You may have to upgrade from an older release
with some modified settings.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
