### PR TITLE
fix: under FanOut API avoid repeated md5sum calculation

### DIFF
--- a/cmd/post-policy-fan-out.go
+++ b/cmd/post-policy-fan-out.go
@@ -36,6 +36,7 @@ type fanOutOptions struct {
 	Key      []byte
 	KmsCtx   kms.Context
 	Checksum *hash.Checksum
+	MD5Hex   string
 }
 
 // fanOutPutObject takes an input source reader and fans out multiple PUT operations
@@ -53,7 +54,14 @@ func fanOutPutObject(ctx context.Context, bucket string, objectAPI ObjectLayer, 
 
 			objInfos[idx] = ObjectInfo{Name: req.Key}
 
-			hr, err := hash.NewReader(bytes.NewReader(fanOutBuf), int64(len(fanOutBuf)), "", "", -1)
+			hopts := hash.Options{
+				Size:       int64(len(fanOutBuf)),
+				MD5Hex:     opts.MD5Hex,
+				SHA256Hex:  "",
+				ActualSize: -1,
+				DisableMD5: true,
+			}
+			hr, err := hash.NewReaderWithOpts(bytes.NewReader(fanOutBuf), hopts)
 			if err != nil {
 				errs[idx] = err
 				return

--- a/internal/hash/reader_test.go
+++ b/internal/hash/reader_test.go
@@ -19,6 +19,7 @@ package hash
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -37,14 +38,15 @@ func TestHashReaderHelperMethods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.MD5HexString() != "e2fc714c4727ee9395f324cd2e7f331f" {
-		t.Errorf("Expected md5hex \"e2fc714c4727ee9395f324cd2e7f331f\", got %s", r.MD5HexString())
+	md5sum := r.MD5Current()
+	if hex.EncodeToString(md5sum) != "e2fc714c4727ee9395f324cd2e7f331f" {
+		t.Errorf("Expected md5hex \"e2fc714c4727ee9395f324cd2e7f331f\", got %s", hex.EncodeToString(md5sum))
 	}
 	if r.SHA256HexString() != "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589" {
 		t.Errorf("Expected sha256hex \"88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589\", got %s", r.SHA256HexString())
 	}
-	if r.MD5Base64String() != "4vxxTEcn7pOV8yTNLn8zHw==" {
-		t.Errorf("Expected md5base64 \"4vxxTEcn7pOV8yTNLn8zHw==\", got \"%s\"", r.MD5Base64String())
+	if base64.StdEncoding.EncodeToString(md5sum) != "4vxxTEcn7pOV8yTNLn8zHw==" {
+		t.Errorf("Expected md5base64 \"4vxxTEcn7pOV8yTNLn8zHw==\", got \"%s\"", base64.StdEncoding.EncodeToString(md5sum))
 	}
 	if r.Size() != 4 {
 		t.Errorf("Expected size 4, got %d", r.Size())
@@ -55,9 +57,6 @@ func TestHashReaderHelperMethods(t *testing.T) {
 	expectedMD5, err := hex.DecodeString("e2fc714c4727ee9395f324cd2e7f331f")
 	if err != nil {
 		t.Fatal(err)
-	}
-	if !bytes.Equal(r.MD5(), expectedMD5) {
-		t.Errorf("Expected md5hex \"e2fc714c4727ee9395f324cd2e7f331f\", got %s", r.MD5HexString())
 	}
 	if !bytes.Equal(r.MD5Current(), expectedMD5) {
 		t.Errorf("Expected md5hex \"e2fc714c4727ee9395f324cd2e7f331f\", got %s", hex.EncodeToString(r.MD5Current()))


### PR DESCRIPTION


## Description
fix: under FanOut API avoid repeated md5sum calculation

## Motivation and Context
md5sum calculation has a high CPU overhead, avoid calculating it 
repeatedly for similar fanOut calls.

To fix the following CPU profiler result
```
(pprof) top10
Showing nodes accounting for 678.68s, 84.67% of 801.54s total
Dropped 1072 nodes (cum <= 4.01s)
Showing top 10 nodes out of 156
      flat  flat%   sum%        cum   cum%
   332.54s 41.49% 41.49%    332.54s 41.49%  runtime/internal/syscall.Syscall6
   228.39s 28.49% 69.98%    228.39s 28.49%  crypto/md5.block
    48.07s  6.00% 75.98%     48.07s  6.00%  runtime.memmove
    28.91s  3.61% 79.59%     28.91s  3.61%  github.com/minio/highwayhash.updateAVX2
     8.25s  1.03% 80.61%      8.25s  1.03%  runtime.futex
     8.25s  1.03% 81.64%     10.81s  1.35%  runtime.step
     6.99s  0.87% 82.52%     22.35s  2.79%  runtime.pcvalue
     6.67s  0.83% 83.35%     38.90s  4.85%  runtime.mallocgc
     5.77s  0.72% 84.07%     32.61s  4.07%  runtime.gentraceback
     4.84s   0.6% 84.67%     10.49s  1.31%  runtime.lock2
```

## How to test this PR?
You would need a setup with multiple disks and run

```
warp fanout --copies=1000 --obj.size=1MiB --concurrent=5 --host=min-io-server.novalocal:9000 --access-key=minioadmin --secret-key=minioadmin --autoterm --serverprof=cpu
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
