### PR TITLE
fix: avoid DiskInfo() to fetch metrics for all calls

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -183,7 +183,7 @@ func getDisksInfo(disks []StorageAPI, endpoints []Endpoint) (disksInfo []madmin.
 				}
 				return nil
 			}
-			info, err := disks[index].DiskInfo(context.TODO())
+			info, err := disks[index].DiskInfoMetrics(context.TODO())
 			di := madmin.Disk{
 				Endpoint:       diskEndpoint,
 				DrivePath:      info.MountPath,

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -116,6 +116,13 @@ func (d *naughtyDisk) NSScanner(ctx context.Context, cache dataUsageCache, updat
 	return d.disk.NSScanner(ctx, cache, updates, scanMode)
 }
 
+func (d *naughtyDisk) DiskInfoMetrics(ctx context.Context) (info DiskInfo, err error) {
+	if err := d.calcError(); err != nil {
+		return info, err
+	}
+	return d.disk.DiskInfoMetrics(ctx)
+}
+
 func (d *naughtyDisk) DiskInfo(ctx context.Context) (info DiskInfo, err error) {
 	if err := d.calcError(); err != nil {
 		return info, err

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -65,6 +65,7 @@ type StorageAPI interface {
 	// returns 'nil' once healing is complete or if the disk
 	// has never been replaced.
 	Healing() *healingTracker
+	DiskInfoMetrics(ctx context.Context) (info DiskInfo, err error)
 	DiskInfo(ctx context.Context) (info DiskInfo, err error)
 	NSScanner(ctx context.Context, cache dataUsageCache, updates chan<- dataUsageEntry, scanMode madmin.HealScanMode) (dataUsageCache, error)
 
@@ -167,6 +168,10 @@ func (p *unrecognizedDisk) GetDiskID() (string, error) {
 }
 
 func (p *unrecognizedDisk) SetDiskID(id string) {
+}
+
+func (p *unrecognizedDisk) DiskInfoMetrics(ctx context.Context) (info DiskInfo, err error) {
+	return info, errDiskNotFound
 }
 
 func (p *unrecognizedDisk) DiskInfo(ctx context.Context) (info DiskInfo, err error) {

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -269,6 +269,22 @@ func (client *storageRESTClient) GetDiskID() (string, error) {
 
 func (client *storageRESTClient) SetDiskID(id string) {
 	client.diskID = id
+}
+
+// DiskInfoMetrics - fetch disk information for a remote disk, along with metrics.
+func (client *storageRESTClient) DiskInfoMetrics(ctx context.Context) (info DiskInfo, err error) {
+	respBody, err := client.call(ctx, storageRESTMethodDiskInfoMetrics, nil, nil, -1)
+	if err != nil {
+		return info, err
+	}
+	defer xhttp.DrainBody(respBody)
+	if err = msgp.Decode(respBody, &info); err != nil {
+		return info, err
+	}
+	if info.Error != "" {
+		return info, toStorageErr(errors.New(info.Error))
+	}
+	return info, nil
 }
 
 // DiskInfo - fetch disk information for a remote disk.

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -18,20 +18,21 @@
 package cmd
 
 const (
-	storageRESTVersion       = "v49" // Added RenameData() to return versions
+	storageRESTVersion       = "v50" // Added DiskInfoMetrics API
 	storageRESTVersionPrefix = SlashSeparator + storageRESTVersion
 	storageRESTPrefix        = minioReservedBucketPath + "/storage"
 )
 
 const (
-	storageRESTMethodHealth      = "/health"
-	storageRESTMethodDiskInfo    = "/diskinfo"
-	storageRESTMethodNSScanner   = "/nsscanner"
-	storageRESTMethodMakeVol     = "/makevol"
-	storageRESTMethodMakeVolBulk = "/makevolbulk"
-	storageRESTMethodStatVol     = "/statvol"
-	storageRESTMethodDeleteVol   = "/deletevol"
-	storageRESTMethodListVols    = "/listvols"
+	storageRESTMethodHealth          = "/health"
+	storageRESTMethodDiskInfo        = "/diskinfo"
+	storageRESTMethodDiskInfoMetrics = "/diskinfometrics"
+	storageRESTMethodNSScanner       = "/nsscanner"
+	storageRESTMethodMakeVol         = "/makevol"
+	storageRESTMethodMakeVolBulk     = "/makevolbulk"
+	storageRESTMethodStatVol         = "/statvol"
+	storageRESTMethodDeleteVol       = "/deletevol"
+	storageRESTMethodListVols        = "/listvols"
 
 	storageRESTMethodAppendFile     = "/appendfile"
 	storageRESTMethodCreateFile     = "/createfile"

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -160,6 +160,18 @@ func (s *storageRESTServer) IsValid(w http.ResponseWriter, r *http.Request) bool
 // HealthHandler handler checks if disk is stale
 func (s *storageRESTServer) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	s.IsValid(w, r)
+}
+
+// DiskInfoMetricsHandler - returns disk info.
+func (s *storageRESTServer) DiskInfoMetricsHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.IsAuthValid(w, r) {
+		return
+	}
+	info, err := s.storage.DiskInfoMetrics(r.Context())
+	if err != nil {
+		info.Error = err.Error()
+	}
+	logger.LogIf(r.Context(), msgp.Encode(w, &info))
 }
 
 // DiskInfoHandler - returns disk info.
@@ -1363,6 +1375,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointServerPools Endpoin
 
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodHealth).HandlerFunc(httpTraceHdrs(server.HealthHandler))
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodDiskInfo).HandlerFunc(httpTraceHdrs(server.DiskInfoHandler))
+			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodDiskInfoMetrics).HandlerFunc(httpTraceHdrs(server.DiskInfoMetricsHandler))
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodNSScanner).HandlerFunc(httpTraceHdrs(server.NSScannerHandler))
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodMakeVol).HandlerFunc(httpTraceHdrs(server.MakeVolHandler))
 			subrouter.Methods(http.MethodPost).Path(storageRESTVersionPrefix + storageRESTMethodMakeVolBulk).HandlerFunc(httpTraceHdrs(server.MakeVolBulkHandler))

--- a/cmd/storagemetric_string.go
+++ b/cmd/storagemetric_string.go
@@ -36,12 +36,13 @@ func _() {
 	_ = x[storageMetricReadMultiple-25]
 	_ = x[storageMetricDeleteAbandonedParts-26]
 	_ = x[storageMetricDiskInfo-27]
-	_ = x[storageMetricLast-28]
+	_ = x[storageMetricDiskInfoMetrics-28]
+	_ = x[storageMetricLast-29]
 }
 
-const _storageMetric_name = "MakeVolBulkMakeVolListVolsStatVolDeleteVolWalkDirListDirReadFileAppendFileCreateFileReadFileStreamRenameFileRenameDataCheckPartsDeleteDeleteVersionsVerifyFileWriteAllDeleteVersionWriteMetadataUpdateMetadataReadVersionReadXLReadAllStatInfoFileReadMultipleDeleteAbandonedPartsDiskInfoLast"
+const _storageMetric_name = "MakeVolBulkMakeVolListVolsStatVolDeleteVolWalkDirListDirReadFileAppendFileCreateFileReadFileStreamRenameFileRenameDataCheckPartsDeleteDeleteVersionsVerifyFileWriteAllDeleteVersionWriteMetadataUpdateMetadataReadVersionReadXLReadAllStatInfoFileReadMultipleDeleteAbandonedPartsDiskInfoDiskInfoMetricsLast"
 
-var _storageMetric_index = [...]uint16{0, 11, 18, 26, 33, 42, 49, 56, 64, 74, 84, 98, 108, 118, 128, 134, 148, 158, 166, 179, 192, 206, 217, 223, 230, 242, 254, 274, 282, 286}
+var _storageMetric_index = [...]uint16{0, 11, 18, 26, 33, 42, 49, 56, 64, 74, 84, 98, 108, 118, 128, 134, 148, 158, 166, 179, 192, 206, 217, 223, 230, 242, 254, 274, 282, 297, 301}
 
 func (i storageMetric) String() string {
 	if i >= storageMetric(len(_storageMetric_index)-1) {

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -610,6 +610,12 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 	return dataUsageInfo, nil
 }
 
+// DiskInfoMetrics is a stub that returns DiskInfo() this API must never be directly
+// called, caller always calls *xlStorageDiskIDCheck.DiskInfoMetrics(...)
+func (s *xlStorage) DiskInfoMetrics(_ context.Context) (info DiskInfo, err error) {
+	return s.DiskInfo(context.TODO())
+}
+
 // DiskInfo provides current information about disk space usage,
 // total free inodes and underlying filesystem.
 func (s *xlStorage) DiskInfo(_ context.Context) (info DiskInfo, err error) {


### PR DESCRIPTION


## Description
fix: avoid DiskInfo() to fetch metrics for all calls

## Motivation and Context
introduce a new DiskInfoMetrics() API to fetch metrics
for specific Metrics() interested callers.

DiskInfo() is commonly used in PUT, Multipart phase avoids
calling for metrics which is not useful during these calls.

## How to test this PR?
There nothing much to test here, but there is a possible
improvements here in terms of latency per DiskInfo() call.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
