### PR TITLE
Reduce allocations

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -153,7 +153,7 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 			continue
 		}
 
-		if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+		if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 			// Do not need to send any internal metadata
 			// values to client.
 			continue
@@ -166,7 +166,7 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 
 		var isSet bool
 		for _, userMetadataPrefix := range userMetadataKeyPrefixes {
-			if !strings.HasPrefix(strings.ToLower(k), strings.ToLower(userMetadataPrefix)) {
+			if !stringsHasPrefixFold(k, userMetadataPrefix) {
 				continue
 			}
 			w.Header()[strings.ToLower(k)] = []string{v}

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -550,7 +550,7 @@ func generateListVersionsResponse(bucket, prefix, marker, versionIDMarker, delim
 				content.UserMetadata.Set(xhttp.AmzServerSideEncryptionCustomerAlgorithm, xhttp.AmzEncryptionAES)
 			}
 			for k, v := range cleanMinioInternalMetadataKeys(object.UserDefined) {
-				if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+				if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 					// Do not need to send any internal metadata
 					// values to client.
 					continue
@@ -693,7 +693,7 @@ func generateListObjectsV2Response(bucket, prefix, token, nextToken, startAfter,
 					content.UserMetadata.Set(xhttp.AmzServerSideEncryptionCustomerAlgorithm, xhttp.AmzEncryptionAES)
 				}
 				for k, v := range cleanMinioInternalMetadataKeys(object.UserDefined) {
-					if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+					if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 						// Do not need to send any internal metadata
 						// values to client.
 						continue

--- a/cmd/batch-handlers.go
+++ b/cmd/batch-handlers.go
@@ -520,7 +520,7 @@ func (r *BatchJobReplicateV1) StartFromSource(ctx context.Context, api ObjectLay
 		if len(r.Flags.Filter.Metadata) > 0 {
 			for _, kv := range r.Flags.Filter.Metadata {
 				for k, v := range oi.UserDefined {
-					if !strings.HasPrefix(strings.ToLower(k), "x-amz-meta-") && !isStandardHeader(k) {
+					if !stringsHasPrefixFold(k, "x-amz-meta-") && !isStandardHeader(k) {
 						continue
 					}
 					// We only need to match x-amz-meta or standardHeaders
@@ -1075,7 +1075,7 @@ func (r *BatchJobReplicateV1) Start(ctx context.Context, api ObjectLayer, job Ba
 		if len(r.Flags.Filter.Metadata) > 0 {
 			for _, kv := range r.Flags.Filter.Metadata {
 				for k, v := range info.Metadata {
-					if !strings.HasPrefix(strings.ToLower(k), "x-amz-meta-") && !isStandardHeader(k) {
+					if !stringsHasPrefixFold(k, "x-amz-meta-") && !isStandardHeader(k) {
 						continue
 					}
 					// We only need to match x-amz-meta or standardHeaders

--- a/cmd/batch-rotate.go
+++ b/cmd/batch-rotate.go
@@ -289,7 +289,7 @@ func (r *BatchJobKeyRotateV1) KeyRotate(ctx context.Context, api ObjectLayer, ob
 	)
 	encMetadata := make(map[string]string)
 	for k, v := range oi.UserDefined {
-		if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+		if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 			encMetadata[k] = v
 		}
 	}
@@ -401,7 +401,7 @@ func (r *BatchJobKeyRotateV1) Start(ctx context.Context, api ObjectLayer, job Ba
 		if len(r.Flags.Filter.Metadata) > 0 {
 			for _, kv := range r.Flags.Filter.Metadata {
 				for k, v := range info.Metadata {
-					if !strings.HasPrefix(strings.ToLower(k), "x-amz-meta-") && !isStandardHeader(k) {
+					if !stringsHasPrefixFold(k, "x-amz-meta-") && !isStandardHeader(k) {
 						continue
 					}
 					// We only need to match x-amz-meta or standardHeaders

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -691,7 +691,7 @@ func putRestoreOpts(bucket, object string, rreq *RestoreObjectRequest, objInfo O
 
 	if rreq.Type == SelectRestoreRequest {
 		for _, v := range rreq.OutputLocation.S3.UserMetadata {
-			if !strings.HasPrefix(strings.ToLower(v.Name), "x-amz-meta") {
+			if !stringsHasPrefixFold(v.Name, "x-amz-meta") {
 				meta["x-amz-meta-"+v.Name] = v.Value
 				continue
 			}

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -679,7 +679,7 @@ func replicateDeleteToTarget(ctx context.Context, dobj DeletedObjectReplicationI
 func getCopyObjMetadata(oi ObjectInfo, sc string) map[string]string {
 	meta := make(map[string]string, len(oi.UserDefined))
 	for k, v := range oi.UserDefined {
-		if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+		if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 			continue
 		}
 
@@ -744,7 +744,7 @@ func (m caseInsensitiveMap) Lookup(key string) (string, bool) {
 func putReplicationOpts(ctx context.Context, sc string, objInfo ObjectInfo) (putOpts minio.PutObjectOptions, err error) {
 	meta := make(map[string]string)
 	for k, v := range objInfo.UserDefined {
-		if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+		if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 			continue
 		}
 		if isStandardHeader(k) {
@@ -909,7 +909,7 @@ func getReplicationAction(oi1 ObjectInfo, oi2 minio.ObjectInfo, opType replicati
 	for k, v := range oi1.UserDefined {
 		var found bool
 		for _, prefix := range compareKeys {
-			if !strings.HasPrefix(strings.ToLower(k), strings.ToLower(prefix)) {
+			if !stringsHasPrefixFold(k, prefix) {
 				continue
 			}
 			found = true
@@ -924,7 +924,7 @@ func getReplicationAction(oi1 ObjectInfo, oi2 minio.ObjectInfo, opType replicati
 	for k, v := range oi2.Metadata {
 		var found bool
 		for _, prefix := range compareKeys {
-			if !strings.HasPrefix(strings.ToLower(k), strings.ToLower(prefix)) {
+			if !stringsHasPrefixFold(k, prefix) {
 				continue
 			}
 			found = true

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -139,14 +139,14 @@ func (c *cacheObjects) updateMetadataIfChanged(ctx context.Context, dcache *disk
 	bkMeta := make(map[string]string, len(bkObjectInfo.UserDefined))
 	cacheMeta := make(map[string]string, len(cacheObjInfo.UserDefined))
 	for k, v := range bkObjectInfo.UserDefined {
-		if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+		if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 			// Do not need to send any internal metadata
 			continue
 		}
 		bkMeta[http.CanonicalHeaderKey(k)] = v
 	}
 	for k, v := range cacheObjInfo.UserDefined {
-		if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+		if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 			// Do not need to send any internal metadata
 			continue
 		}

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -632,7 +632,7 @@ func readAllXL(ctx context.Context, disks []StorageAPI, bucket, object string, r
 		metaFileInfos[index].DiskMTime = diskMTime
 	}
 	if !readData {
-		for i := range v2bufs[:] {
+		for i := range v2bufs {
 			metaDataPoolPut(v2bufs[i])
 		}
 	}

--- a/cmd/event-notification.go
+++ b/cmd/event-notification.go
@@ -268,7 +268,7 @@ func (args eventArgs) ToEvent(escape bool) event.Event {
 		newEvent.S3.Object.ContentType = args.Object.ContentType
 		newEvent.S3.Object.UserMetadata = make(map[string]string, len(args.Object.UserDefined))
 		for k, v := range args.Object.UserDefined {
-			if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+			if stringsHasPrefixFold(strings.ToLower(k), ReservedMetadataPrefixLower) {
 				continue
 			}
 			newEvent.S3.Object.UserMetadata[k] = v

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -71,7 +71,7 @@ const (
 // and must not set by clients
 func containsReservedMetadata(header http.Header) bool {
 	for key := range header {
-		if strings.HasPrefix(strings.ToLower(key), ReservedMetadataPrefixLower) {
+		if stringsHasPrefixFold(key, ReservedMetadataPrefix) {
 			return true
 		}
 	}
@@ -87,7 +87,7 @@ func isHTTPHeaderSizeTooLarge(header http.Header) bool {
 		length := len(key) + len(header.Get(key))
 		size += length
 		for _, prefix := range userMetadataKeyPrefixes {
-			if strings.HasPrefix(strings.ToLower(key), prefix) {
+			if stringsHasPrefixFold(key, prefix) {
 				usersize += length
 				break
 			}

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -184,7 +184,7 @@ func extractMetadataFromMime(ctx context.Context, v textproto.MIMEHeader, m map[
 
 	for key := range v {
 		for _, prefix := range userMetadataKeyPrefixes {
-			if !strings.HasPrefix(strings.ToLower(key), strings.ToLower(prefix)) {
+			if !stringsHasPrefixFold(key, prefix) {
 				continue
 			}
 			value, ok := nv[http.CanonicalHeaderKey(key)]

--- a/cmd/lock-rest-server.go
+++ b/cmd/lock-rest-server.go
@@ -73,7 +73,7 @@ func (l *lockRESTServer) IsValid(w http.ResponseWriter, r *http.Request) bool {
 
 func getLockArgs(r *http.Request) (args dsync.LockArgs, err error) {
 	dec := msgpNewReader(io.LimitReader(r.Body, 1000*humanize.KiByte))
-	defer readMsgpReaderPool.Put(dec)
+	defer readMsgpReaderPoolPut(dec)
 	err = args.DecodeMsg(dec)
 	return args, err
 }

--- a/cmd/metacache-stream.go
+++ b/cmd/metacache-stream.go
@@ -261,7 +261,7 @@ func newMetacacheReader(r io.Reader) *metacacheReader {
 		closer: func() {
 			dec.Reset(nil)
 			s2DecPool.Put(dec)
-			readMsgpReaderPool.Put(mr)
+			readMsgpReaderPoolPut(mr)
 		},
 		creator: func() error {
 			v, err := mr.ReadByte()

--- a/cmd/metacache-stream.go
+++ b/cmd/metacache-stream.go
@@ -255,12 +255,13 @@ type metacacheReader struct {
 func newMetacacheReader(r io.Reader) *metacacheReader {
 	dec := s2DecPool.Get().(*s2.Reader)
 	dec.Reset(r)
-	mr := msgp.NewReader(dec)
+	mr := msgpNewReader(dec)
 	return &metacacheReader{
 		mr: mr,
 		closer: func() {
 			dec.Reset(nil)
 			s2DecPool.Put(dec)
+			readMsgpReaderPool.Put(mr)
 		},
 		creator: func() error {
 			v, err := mr.ReadByte()

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -402,7 +402,7 @@ func extractETag(metadata map[string]string) string {
 // to do case insensitive checks.
 func HasPrefix(s string, prefix string) bool {
 	if runtime.GOOS == globalWindowsOSName {
-		return strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix))
+		return stringsHasPrefixFold(s, prefix)
 	}
 	return strings.HasPrefix(s, prefix)
 }

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1261,7 +1261,7 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 		}
 
 		for k, v := range srcInfo.UserDefined {
-			if strings.HasPrefix(strings.ToLower(k), ReservedMetadataPrefixLower) {
+			if stringsHasPrefixFold(k, ReservedMetadataPrefixLower) {
 				encMetadata[k] = v
 			}
 		}

--- a/cmd/object-lambda-handlers.go
+++ b/cmd/object-lambda-handlers.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/klauspost/compress/gzhttp"
@@ -182,7 +181,7 @@ func StatusCode(text string) int {
 func fwdHeadersToS3(h http.Header, w http.ResponseWriter) {
 	const trim = "x-amz-fwd-header-"
 	for k, v := range h {
-		if strings.HasPrefix(strings.ToLower(k), trim) {
+		if stringsHasPrefixFold(k, trim) {
 			w.Header()[k[len(trim):]] = v
 		}
 	}

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -62,8 +62,9 @@ func getCanonicalHeaders(signedHeaders http.Header) string {
 	var headers []string
 	vals := make(http.Header)
 	for k, vv := range signedHeaders {
-		headers = append(headers, strings.ToLower(k))
-		vals[strings.ToLower(k)] = vv
+		k = strings.ToLower(k)
+		headers = append(headers, k)
+		vals[k] = vv
 	}
 	sort.Strings(headers)
 

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -227,7 +227,8 @@ func (client *storageRESTClient) NSScanner(ctx context.Context, cache dataUsageC
 		rw.CloseWithError(waitForHTTPStream(respBody, rw))
 	}()
 
-	ms := msgp.NewReader(rr)
+	ms := msgpNewReader(rr)
+	defer readMsgpReaderPool.Put(rr)
 	for {
 		// Read whether it is an update.
 		upd, err := ms.ReadBool()
@@ -774,6 +775,7 @@ func (client *storageRESTClient) ReadMultiple(ctx context.Context, req ReadMulti
 		pw.CloseWithError(waitForHTTPStream(respBody, pw))
 	}()
 	mr := msgp.NewReader(pr)
+	defer readMsgpReaderPool.Put(mr)
 	for {
 		var file ReadMultipleResp
 		if err := file.DecodeMsg(mr); err != nil {

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -686,7 +686,7 @@ func (s *storageRESTServer) DeleteVersionsHandler(w http.ResponseWriter, r *http
 
 	versions := make([]FileInfoVersions, totalVersions)
 	decoder := msgpNewReader(r.Body)
-	defer readMsgpReaderPool.Put(decoder)
+	defer readMsgpReaderPoolPut(decoder)
 	for i := 0; i < totalVersions; i++ {
 		dst := &versions[i]
 		if err := dst.DecodeMsg(decoder); err != nil {
@@ -1295,7 +1295,7 @@ func (s *storageRESTServer) ReadMultiple(w http.ResponseWriter, r *http.Request)
 
 	var req ReadMultipleReq
 	mr := msgpNewReader(r.Body)
-	defer readMsgpReaderPool.Put(mr)
+	defer readMsgpReaderPoolPut(mr)
 	err := req.DecodeMsg(mr)
 	if err != nil {
 		rw.CloseWithError(err)

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -685,7 +685,8 @@ func (s *storageRESTServer) DeleteVersionsHandler(w http.ResponseWriter, r *http
 	}
 
 	versions := make([]FileInfoVersions, totalVersions)
-	decoder := msgp.NewReader(r.Body)
+	decoder := msgpNewReader(r.Body)
+	defer readMsgpReaderPool.Put(decoder)
 	for i := 0; i < totalVersions; i++ {
 		dst := &versions[i]
 		if err := dst.DecodeMsg(decoder); err != nil {

--- a/cmd/tier-journal.go
+++ b/cmd/tier-journal.go
@@ -120,7 +120,7 @@ func (jd *tierDiskJournal) WalkEntries(ctx context.Context, fn walkFn) {
 	}
 	defer ro.Close()
 	mr := msgpNewReader(ro)
-	defer readMsgpReaderPool.Put(mr)
+	defer readMsgpReaderPoolPut(mr)
 
 	done := false
 	for {

--- a/cmd/tier-journal.go
+++ b/cmd/tier-journal.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/minio/minio/internal/logger"
-	"github.com/tinylib/msgp/msgp"
 )
 
 //go:generate msgp -file $GOFILE -unexported
@@ -120,7 +119,8 @@ func (jd *tierDiskJournal) WalkEntries(ctx context.Context, fn walkFn) {
 		return
 	}
 	defer ro.Close()
-	mr := msgp.NewReader(ro)
+	mr := msgpNewReader(ro)
+	defer readMsgpReaderPool.Put(mr)
 
 	done := false
 	for {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1286,3 +1286,9 @@ func unwrapAll(err error) error {
 		err = werr
 	}
 }
+
+// stringsHasPrefixFold tests whether the string s begins with prefix ignoring case.
+func stringsHasPrefixFold(s, prefix string) bool {
+	// Test match with case first.
+	return len(s) >= len(prefix) && (s[0:len(prefix)] == prefix || strings.EqualFold(s[0:len(prefix)], prefix))
+}


### PR DESCRIPTION
## Description

* Add `stringsHasPrefixFold` which can compare string prefixes, while ignoring case and not allocating with `strings.ToLower`.
* Reuse all msgp.Readers
* Reuse metadata buffers when not reading data.

## How to test this PR?

Regular tests should cover functionality.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
