### PR TITLE
Replicate UserIdentity instead of user/SA/STS cred

### DIFF
--- a/cmd/admin-handlers-site-replication.go
+++ b/cmd/admin-handlers-site-replication.go
@@ -182,16 +182,20 @@ func (a adminAPIHandlers) SRPeerReplicateIAMItem(w http.ResponseWriter, r *http.
 				err = globalSiteReplicationSys.PeerAddPolicyHandler(ctx, item.Name, policy, item.UpdatedAt)
 			}
 		}
-	case madmin.SRIAMItemSvcAcc:
-		err = globalSiteReplicationSys.PeerSvcAccChangeHandler(ctx, item.SvcAccChange, item.UpdatedAt)
 	case madmin.SRIAMItemPolicyMapping:
 		err = globalSiteReplicationSys.PeerPolicyMappingHandler(ctx, item.PolicyMapping, item.UpdatedAt)
+	case madmin.SRIAMItemGroupInfo:
+		err = globalSiteReplicationSys.PeerGroupInfoChangeHandler(ctx, item.GroupInfo, item.UpdatedAt)
+	case madmin.SRIAMItemCredential:
+		err = globalSiteReplicationSys.PeerCredInfoChangeHandler(ctx, item.CredentialInfo, item.UpdatedAt)
+
+	// The following cases would be DEPRECATED by the previous case above.
+	case madmin.SRIAMItemSvcAcc:
+		err = globalSiteReplicationSys.PeerSvcAccChangeHandler(ctx, item.SvcAccChange, item.UpdatedAt)
 	case madmin.SRIAMItemSTSAcc:
 		err = globalSiteReplicationSys.PeerSTSAccHandler(ctx, item.STSCredential, item.UpdatedAt)
 	case madmin.SRIAMItemIAMUser:
 		err = globalSiteReplicationSys.PeerIAMUserChangeHandler(ctx, item.IAMUser, item.UpdatedAt)
-	case madmin.SRIAMItemGroupInfo:
-		err = globalSiteReplicationSys.PeerGroupInfoChangeHandler(ctx, item.GroupInfo, item.UpdatedAt)
 	}
 	if err != nil {
 		logger.LogIf(ctx, err)

--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -76,9 +76,18 @@ func (iamOS *IAMObjectStore) getUsersSysType() UsersSysType {
 	return iamOS.usersSysType
 }
 
-func (iamOS *IAMObjectStore) saveIAMConfig(ctx context.Context, item interface{}, objPath string, opts ...options) error {
+func jsonify(item interface{}) ([]byte, error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	data, err := json.Marshal(item)
+	return json.Marshal(item)
+}
+
+func unjsonify(b []byte, item interface{}) error {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	return json.Unmarshal(b, item)
+}
+
+func (iamOS *IAMObjectStore) saveIAMConfig(ctx context.Context, item interface{}, objPath string, opts ...options) error {
+	data, err := jsonify(item)
 	if err != nil {
 		return err
 	}
@@ -136,8 +145,7 @@ func (iamOS *IAMObjectStore) loadIAMConfig(ctx context.Context, item interface{}
 	if err != nil {
 		return err
 	}
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	return json.Unmarshal(data, item)
+	return unjsonify(data, item)
 }
 
 func (iamOS *IAMObjectStore) deleteIAMConfig(ctx context.Context, path string) error {

--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -123,22 +123,26 @@ func (f *sftpDriver) getMinIOClient() (*minio.Client, error) {
 		// Set the newly generated credentials, policyName is empty on purpose
 		// LDAP policies are applied automatically using their ldapUser, ldapGroups
 		// mapping.
-		updatedAt, err := globalIAMSys.SetTempUser(context.Background(), cred.AccessKey, cred, "")
+		_, err = globalIAMSys.SetTempUser(context.Background(), cred.AccessKey, cred, "")
 		if err != nil {
 			return nil, err
 		}
 
 		// Call hook for site replication.
-		logger.LogIf(context.Background(), globalSiteReplicationSys.IAMChangeHook(context.Background(), madmin.SRIAMItem{
-			Type: madmin.SRIAMItemSTSAcc,
-			STSCredential: &madmin.SRSTSCredential{
-				AccessKey:    cred.AccessKey,
-				SecretKey:    cred.SecretKey,
-				SessionToken: cred.SessionToken,
-				ParentUser:   cred.ParentUser,
-			},
-			UpdatedAt: updatedAt,
-		}))
+		if globalSiteReplicationSys.isEnabled() {
+			ui, _ := globalIAMSys.GetUser(context.Background(), cred.AccessKey)
+			enc, _ := jsonify(ui)
+			logger.LogIf(context.Background(),
+				globalSiteReplicationSys.IAMChangeHook(context.Background(), madmin.SRIAMItem{
+					Type: madmin.SRIAMItemCredential,
+					CredentialInfo: &madmin.SRCredInfo{
+						AccessKey:        cred.AccessKey,
+						IAMUserType:      int(stsUser),
+						UserIdentityJSON: enc,
+					},
+					UpdatedAt: ui.UpdatedAt,
+				}))
+		}
 
 		return minio.New(f.endpoint, &minio.Options{
 			Creds:     credentials.NewStaticV4(cred.AccessKey, cred.SecretKey, cred.SessionToken),

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/minio/dperf v0.5.0
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes-go v0.1.0
-	github.com/minio/madmin-go/v3 v3.0.6
+	github.com/minio/madmin-go/v3 v3.0.7
 	github.com/minio/minio-go/v7 v7.0.59
 	github.com/minio/mux v1.9.0
 	github.com/minio/pkg v1.7.5

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/kes-go v0.1.0 h1:h201DyOYP5sTqajkxFGxmXz/kPbT8HQNX1uh3Yx2PFc=
 github.com/minio/kes-go v0.1.0/go.mod h1:VorHLaIYis9/MxAHAtXN4d8PUMNKhIxTIlvFt0hBOEo=
-github.com/minio/madmin-go/v3 v3.0.6 h1:rlU0UCwRhi/bI5R9Pg5df88ddqFNFA5mpmxScAanQCA=
-github.com/minio/madmin-go/v3 v3.0.6/go.mod h1:lPrMoc1aeiIWmmrxBthkDqzMPQwC/Lu9ByuyM2wenJk=
+github.com/minio/madmin-go/v3 v3.0.7 h1:nuRwrqarFrkzbUiA36H/HKAcuNr8J9TjKlWRlua7lNo=
+github.com/minio/madmin-go/v3 v3.0.7/go.mod h1:lPrMoc1aeiIWmmrxBthkDqzMPQwC/Lu9ByuyM2wenJk=
 github.com/minio/mc v0.0.0-20230706154612-72958227ad65 h1:27INveRWSp7yAEy4szNp15DOA2dyOwnxTGt/p0JuTh4=
 github.com/minio/mc v0.0.0-20230706154612-72958227ad65/go.mod h1:41ndsUBIAA/dRjOQ/0KY4d8vI70gDiKeMo1zusOQRWk=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=


### PR DESCRIPTION
## Description
This simplifies site replication - we can remove the types specific to
IAM user, service account and STS creds as this type would cover all
three. It removes per credential type handling as all the required info
is present in the UserIdentity type.

~- [ ] https://github.com/minio/minio/pull/17483~

## Motivation and Context

This change simplifies site-replication, so we can add move info to the `UserIdentity` type and have it replicated automatically without specific handling for each credential type.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
