### PR TITLE
Fix helm templating syntax in post-job

### DIFF
--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Multi-Cloud Object Storage
 name: minio
-version: 5.0.13
+version: 5.0.12
 appVersion: RELEASE.2023-07-07T07-13-57Z
 keywords:
   - minio

--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Multi-Cloud Object Storage
 name: minio
-version: 5.0.12
+version: 5.0.13
 appVersion: RELEASE.2023-07-07T07-13-57Z
 keywords:
   - minio

--- a/helm/minio/templates/post-job.yaml
+++ b/helm/minio/templates/post-job.yaml
@@ -85,27 +85,27 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
-      { { - if .Values.policies } }
+      {{ - if .Values.policies }}
       initContainers:
         - name: minio-make-policy
           image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
-          { { - if .Values.makePolicyJob.securityContext.enabled } }
+          {{ - if .Values.makePolicyJob.securityContext.enabled }}
           securityContext:
-            runAsUser: { { .Values.makePolicyJob.securityContext.runAsUser } }
-            runAsGroup: { { .Values.makePolicyJob.securityContext.runAsGroup } }
-          { { - end } }
-          imagePullPolicy: { { .Values.mcImage.pullPolicy } }
-          { { - if .Values.makePolicyJob.exitCommand } }
+            runAsUser: {{ .Values.makePolicyJob.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.makePolicyJob.securityContext.runAsGroup }}
+          {{ - end }}
+          imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
+          {{ - if .Values.makePolicyJob.exitCommand }}
           command: [ "/bin/sh", "-c" ]
           args: [ "/bin/sh /config/add-policy; EV=$?; {{ .Values.makePolicyJob.exitCommand }} && exit $EV" ]
-          { { - else } }
+          {{ - else }}
           command: [ "/bin/sh", "/config/add-policy" ]
-          { { - end } }
+          {{ - end }}
           env:
             - name: MINIO_ENDPOINT
-              value: { { template "minio.fullname" . } }
+              value: {{ template "minio.fullname" . }}
             - name: MINIO_PORT
-              value: { { .Values.service.port | quote } }
+              value: {{ .Values.service.port | quote }}
           volumeMounts:
             - name: etc-path
               mountPath: /etc/minio/mc
@@ -113,12 +113,12 @@ spec:
               mountPath: /tmp
             - name: minio-configuration
               mountPath: /config
-            { { - if .Values.tls.enabled } }
+            {{ - if .Values.tls.enabled }}
             - name: cert-secret-volume-mc
-              mountPath: { { .Values.configPathmc } }certs
+              mountPath: {{ .Values.configPathmc }}certs
             {{- end }}
-          resources: { { - toYaml .Values.makePolicyJob.resources | nindent 12 } }
-      { { - end } }
+          resources: {{ - toYaml .Values.makePolicyJob.resources | nindent 12 }}
+      {{ - end }}
       containers:
         {{- if .Values.buckets }}
         - name: minio-make-bucket


### PR DESCRIPTION
## Description

I was getting a parse error when updating my helm deployment using this chart. Not sure if helm actually fails on the brackets with spaces in between, but at a minimum this isn't consistent with the rest of the chart.


## Motivation and Context

Troubleshooting an operational error, I came across this potential issue.

```
Error: parse error at (minio/templates/post-job.yaml:255): unexpected {{end}} Use --debug flag to render out invalid YAML
```

## How to test this PR?

`helm template --debug --dry-run --generate-name .`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #17554 
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
