### PR TITLE
Add helm chart linting to CI workflow

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,31 @@
+name: Helm Chart Linting
+description: Installs helm tooling and validates helm charts
+
+on:
+  push:
+    branches:
+      - master
+
+# This ensures that previous jobs for the PR are canceled when the PR is
+# updated.
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run helm lint
+        run: |
+          cd helm/minio
+          helm lint .


### PR DESCRIPTION
## Description

Adds helm linting to the CI workflows. This will check for egregious helm errors before they get released.

Related to #17605 and #17600 
Prevents having #17601 in the future

## Motivation and Context

After a few rounds of errors noticing and fixing formatting of the helm chart, it makes sense to add this check to the CI pipeline.

## How to test this PR?

Unsure, exactly. A maintainer probably needs to update something with the repo settings to allow the new workflow to run. Full disclosure, I haven't fully tested this myself (not entirely sure how), but I did copy/paste most of this from working code that I have.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
