### PR TITLE
fix: allow cancel of decom only when its in progress

### DIFF
--- a/docs/bucket/replication/setup_2site_existing_replication.sh
+++ b/docs/bucket/replication/setup_2site_existing_replication.sh
@@ -84,7 +84,7 @@ remote_arn=$(./mc replicate ls sitea/bucket --json | jq -r .rule.Destination.Buc
 sleep 1
 
 ./mc replicate resync start sitea/bucket/ --remote-bucket "${remote_arn}"
-sleep 20s ## sleep for 20s idea is that we give 200ms per object.
+sleep 30s ## sleep for 30s idea is that we give 300ms per object.
 
 count=$(./mc replicate resync status sitea/bucket --remote-bucket "${remote_arn}" --json | jq .resyncInfo.target[].replicationCount)
 
@@ -99,7 +99,7 @@ if [ $ret -ne 0 ]; then
 fi
 
 if [ $count -ne 12 ]; then
-	echo "resync not complete after 10s unexpected failure"
+	echo "resync not complete after 30s - unexpected failure"
 	./mc diff sitea/bucket siteb/bucket
 	exit 1
 fi

--- a/docs/distributed/decom-compressed-sse-s3.sh
+++ b/docs/distributed/decom-compressed-sse-s3.sh
@@ -33,7 +33,7 @@ sleep 2
 ./mc admin policy create myminio/ lake ./docs/distributed/rw.json
 
 ./mc admin policy attach myminio/ rw --user=minio123
-./mc admin policy attach myminio/ lake,rw --user=minio12345
+./mc admin policy attach myminio/ lake --user=minio12345
 
 ./mc mb -l myminio/versioned
 

--- a/docs/distributed/decom-encrypted-sse-s3.sh
+++ b/docs/distributed/decom-encrypted-sse-s3.sh
@@ -28,7 +28,7 @@ sleep 2
 ./mc admin policy create myminio/ lake ./docs/distributed/rw.json
 
 ./mc admin policy attach myminio/ rw --user=minio123
-./mc admin policy attach myminio/ lake,rw --user=minio12345
+./mc admin policy attach myminio/ lake --user=minio12345
 
 ./mc mb -l myminio/versioned
 

--- a/docs/distributed/decom-encrypted.sh
+++ b/docs/distributed/decom-encrypted.sh
@@ -30,7 +30,7 @@ export MC_HOST_myminio="http://minioadmin:minioadmin@localhost:9000/"
 ./mc admin policy create myminio/ lake ./docs/distributed/rw.json
 
 ./mc admin policy attach myminio/ rw --user=minio123
-./mc admin policy attach myminio/ lake,rw --user=minio12345
+./mc admin policy attach myminio/ lake --user=minio12345
 
 ./mc mb -l myminio/versioned
 

--- a/docs/distributed/decom.sh
+++ b/docs/distributed/decom.sh
@@ -15,7 +15,7 @@ fi
 
 export CI=true
 
-(minio server /tmp/xl/{1...10}/disk{0...1} 2>&1 >/dev/null) &
+(minio server /tmp/xl/{1...10}/disk{0...1} 2>&1 >/tmp/decom.log) &
 pid=$!
 
 sleep 2
@@ -29,7 +29,7 @@ export MC_HOST_myminio="http://minioadmin:minioadmin@localhost:9000/"
 ./mc admin policy create myminio/ lake ./docs/distributed/rw.json
 
 ./mc admin policy attach myminio/ rw --user=minio123
-./mc admin policy attach myminio/ lake,rw --user=minio12345
+./mc admin policy attach myminio/ lake --user=minio12345
 
 ./mc mb -l myminio/versioned
 


### PR DESCRIPTION
## Description
fix: allow cancel of decom only when its in progress

## Motivation and Context
canceling a previously not-in-progress pool
but while waiting to be decommed can lead to 
incorrect reporting that it's canceled, while it is 
in progress in the background.

## How to test this PR?
You need a 3 pooled setup, and decommission on two pools
while the first pool is running, cancel the decommission
on the second pool.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
