### PR TITLE
treat 0-byte objects to honor same quorum as delete marker

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -14,9 +14,6 @@ concurrency:
 permissions:
   contents: read
 
-permissions:
-  contents: read
-
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.10
+          go-version: 1.19.11
           check-latest: true
       - name: Get official govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -278,6 +278,11 @@ func (er erasureObjects) GetObjectNInfo(ctx context.Context, bucket, object stri
 		return gr.WithCleanupFuncs(nsUnlocker), nil
 	}
 
+	if objInfo.Size == 0 {
+		// Zero byte objects don't even need to further initialize pipes etc.
+		return NewGetObjectReaderFromReader(bytes.NewReader(nil), objInfo, opts)
+	}
+
 	fn, off, length, err := NewGetObjectReader(rs, objInfo, opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
treat 0-byte objects to honor the same quorum as the delete marker

## Motivation and Context
on unversioned buckets its possible that 0-byte objects
might lose quorum on flaky systems.

## How to test this PR?
You need a zero-byte object that has lost quorum, please ping
me for the inspect file

```
~ mc support inspect myminio/bucket/_SUCCESS/xl.meta --legacy --dev --airgap
Encrypted file data successfully downloaded as inspect-data.283b759f.enc
Decryption key: 283b759fe1c15e26073a28dae0453bfd67215a26f0feaa34d56f2cca4e2cbb0da029b9bf

The decryption key will ONLY be shown here. It cannot be recovered.
The encrypted file can safely be shared without the decryption key.
Even with the decryption key, data stored with encryption cannot be accessed.
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
