### PR TITLE
return tags as part of Head/Get calls

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -38,6 +38,7 @@ import (
 const (
 	copyDirective    = "COPY"
 	replaceDirective = "REPLACE"
+	accessDirective  = "ACCESS"
 )
 
 // Parses location constraint from the incoming reader.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -55,6 +55,7 @@ type ObjectOptions struct {
 
 	DeleteMarker            bool // Is only set in DELETE operations for delete marker replication
 	CheckDMReplicationReady bool // Is delete marker ready to be replicated - set only during HEAD
+	Tagging                 bool // Is only in GET/HEAD operations to return tagging metadata along with regular metadata and body.
 
 	UserDefined         map[string]string   // only set in case of POST/PUT operations
 	PartNumber          int                 // only useful in case of GetObject/HeadObject


### PR DESCRIPTION


## Description
return tags as part of Head/Get calls

## Motivation and Context
AWS S3 only returns the number of tag
counts, along with that we must return
the tags as well to avoid another metadata
call to the server.

## How to test this PR?
Verify after attaching new tags on the object
that `mc stat` returns the tags as part
of the Head call.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
