### PR TITLE
fix: Printf format %w reads arg #2, but call has only 1 args

### DIFF
--- a/docs/debugging/reorder-disks/main.go
+++ b/docs/debugging/reorder-disks/main.go
@@ -97,7 +97,7 @@ type localDisk struct {
 func getMajorMinor(path string) (string, error) {
 	var stat syscall.Stat_t
 	if err := syscall.Stat(path, &stat); err != nil {
-		return "", fmt.Errorf("unable to stat `%s`: %w", err)
+		return "", fmt.Errorf("unable to stat `%s`: %w", path, err)
 	}
 
 	major := (stat.Dev & 0x00000000000fff00) >> 8


### PR DESCRIPTION
## Description
Printf format %w reads arg #2, but call has only 1 args

## Motivation and Context
staticcheck

## How to test this PR?
staticcheck

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
