### PR TITLE
fix: do not os.Exit(1) while writing goroutines during shutdown

### DIFF
--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -46,21 +46,17 @@ func handleSignals() {
 	}
 
 	stopProcess := func() bool {
-		var err, oerr error
-
 		// send signal to various go-routines that they need to quit.
 		cancelGlobalContext()
 
 		if httpServer := newHTTPServerFn(); httpServer != nil {
-			err = httpServer.Shutdown()
-			if !errors.Is(err, http.ErrServerClosed) {
+			if err := httpServer.Shutdown(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				logger.LogIf(context.Background(), err)
 			}
 		}
 
 		if objAPI := newObjectLayerFn(); objAPI != nil {
-			oerr = objAPI.Shutdown(context.Background())
-			logger.LogIf(context.Background(), oerr)
+			logger.LogIf(context.Background(), objAPI.Shutdown(context.Background()))
 		}
 
 		if srv := newConsoleServerFn(); srv != nil {
@@ -71,7 +67,7 @@ func handleSignals() {
 			globalEventNotifier.RemoveAllBucketTargets()
 		}
 
-		return (err == nil && oerr == nil)
+		return true
 	}
 
 	for {


### PR DESCRIPTION

## Description
fix: do not os.Exit(1) while writing goroutines during shutdown

## Motivation and Context
Also shutdown poll add jitter, to verify if the shutdown
sequence can finish before 500ms, this reduces the overall 
time taken during "restart" of the service.

Provides speedup for `mc admin service restart` during
active I/O, also ensures that systemd doesn't treat the
returned 'error' as a failure, certain configurations
in systemd can cause it to 'auto-restart' the process by-itself 
which can interfere with `mc admin service restart`.

It can be observed how now restarting the service is 
much snappier.

## How to test this PR?
via `mc admin service restart alias/`, via `CTRL-C` while
shutting down the process.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
