### PR TITLE
Corrected the API name for audit logging purpose

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -1772,7 +1772,7 @@ func (a adminAPIHandlers) ListPolicyMappingEntities(w http.ResponseWriter, r *ht
 
 // AttachDetachPolicyBuiltin - POST /minio/admin/v3/idp/builtin/policy/{operation}
 func (a adminAPIHandlers) AttachDetachPolicyBuiltin(w http.ResponseWriter, r *http.Request) {
-	ctx := newContext(r, w, "AttachPolicyBuiltin")
+	ctx := newContext(r, w, "AttachDetachPolicyBuiltin")
 
 	defer logger.AuditLog(ctx, w, r, mustGetClaimsFromToken(r))
 


### PR DESCRIPTION
## Description
This would better to record the correct API name so that any verification around audit logs to figure out if required APIs are called required no of times, would be correct. Here in this case of policy attached, API `AttachDetachPolicyBuiltin` would be called with `requestPath` as `/minio/admin/v3/idp/builtin/policy/attach` and in case of detach policy the value would be `/minio/admin/v3/idp/builtin/policy/detach`

## Motivation and Context


## How to test this PR?
1. Start a custom webhook endpoint
2. Set `audit_webhook` config for instance `mc admin config set ALIAS audit_webhook enable=on endpoint=WEBHOOK-ENDPOINT`
3. `mc admin policy attach ALIAS POLICY --user USER`
4. `mc admin policy detach ALIAS POLICY --user USER`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
