### PR TITLE
Use os.ReadFile instead of ioutil.ReadFile

### DIFF
--- a/cmd/ftp-server.go
+++ b/cmd/ftp-server.go
@@ -23,11 +23,11 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/minio/cli"
-	"github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
 	"github.com/pkg/sftp"
 	ftp "goftp.io/server/v2"
@@ -117,7 +117,7 @@ func startSFTPServer(c *cli.Context) {
 		logger.Fatal(fmt.Errorf("invalid arguments passed, private key file is mandatory for --sftp='ssh-private-key=path/to/id_ecdsa'"), "unable to start SFTP server")
 	}
 
-	privateBytes, err := ioutil.ReadFile(sshPrivateKey)
+	privateBytes, err := os.ReadFile(sshPrivateKey)
 	if err != nil {
 		logger.Fatal(fmt.Errorf("invalid arguments passed, private key file is not accessible: %v", err), "unable to start SFTP server")
 	}


### PR DESCRIPTION
## Description

When working on supporting sftp in operator based setup, found that minio fails to read the private key mounted from a k8s secret. The private key file is a symlink pointing to `..data/private.key` which is owned by root. Using `os.ReadFile` to read the file fixes this issue.

## How to test this PR?

sftp functionality should continue to work fine

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
