### PR TITLE
fix when set null orgin will return null back

### DIFF
--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/klauspost/compress/gzhttp"
 	"github.com/minio/console/restapi"
-	"github.com/minio/minio/internal/config"
-	"github.com/minio/minio/internal/config/api"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/mux"
@@ -551,6 +549,6 @@ func corsHandler(handler http.Handler) http.Handler {
 		AllowedHeaders:   commonS3Headers,
 		ExposedHeaders:   commonS3Headers,
 		AllowCredentials: true,
-		AllowedOrigins:   api.GetCorsAllowOrigin(config.KVS{}),
+		AllowedOrigins:   globalAPIConfig.getCorsAllowOrigins(),
 	}).Handler(handler)
 }

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/klauspost/compress/gzhttp"
 	"github.com/minio/console/restapi"
+	"github.com/minio/minio/internal/config"
+	"github.com/minio/minio/internal/config/api"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/mux"
@@ -549,5 +551,6 @@ func corsHandler(handler http.Handler) http.Handler {
 		AllowedHeaders:   commonS3Headers,
 		ExposedHeaders:   commonS3Headers,
 		AllowCredentials: true,
+		AllowedOrigins:   api.GetCorsAllowOrigin(config.KVS{}),
 	}).Handler(handler)
 }

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -219,7 +219,7 @@ func (s *TestSuiteCommon) TestBucketSQSNotificationWebHook(c *check) {
 func (s *TestSuiteCommon) TestCors(c *check) {
 	expectedMap := http.Header{}
 	expectedMap.Set("Access-Control-Allow-Credentials", "true")
-	expectedMap.Set("Access-Control-Allow-Origin", "http://foobar.com")
+	expectedMap.Set("Access-Control-Allow-Origin", "*")
 	expectedMap["Access-Control-Expose-Headers"] = []string{
 		"Date",
 		"Etag",

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -194,7 +194,7 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	}
 
 	corsAllowOrigin := strings.Split(env.Get(EnvAPICorsAllowOrigin, kvs.Get(apiCorsAllowOrigin)), ",")
-	if len(corsAllowOrigin) == 0 || len(corsAllowOrigin) == 1 && corsAllowOrigin[0] == "" {
+	if len(corsAllowOrigin) == 1 && corsAllowOrigin[0] == "" {
 		corsAllowOrigin = []string{"*"} // defaults to '*'
 	}
 	cfg.CorsAllowOrigin = corsAllowOrigin

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -193,7 +193,11 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		RootAccess:     rootAccess,
 	}
 
-	cfg.CorsAllowOrigin = GetCorsAllowOrigin(kvs)
+	corsAllowOrigin := strings.Split(env.Get(EnvAPICorsAllowOrigin, kvs.Get(apiCorsAllowOrigin)), ",")
+	if len(corsAllowOrigin) == 0 || len(corsAllowOrigin) == 1 && corsAllowOrigin[0] == "" {
+		corsAllowOrigin = []string{"*"} // defaults to '*'
+	}
+	cfg.CorsAllowOrigin = corsAllowOrigin
 
 	if err = config.CheckValidKeys(config.APISubSys, kvs, DefaultKVS, deprecatedKeys...); err != nil {
 		return cfg, err
@@ -276,12 +280,4 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	cfg.SyncEvents = env.Get(EnvAPISyncEvents, kvs.Get(apiSyncEvents)) == config.EnableOn
 
 	return cfg, nil
-}
-
-func GetCorsAllowOrigin(kvs config.KVS) []string {
-	corsAllowOrigin := strings.Split(env.Get(EnvAPICorsAllowOrigin, kvs.Get(apiCorsAllowOrigin)), ",")
-	if len(corsAllowOrigin) == 0 || len(corsAllowOrigin) == 1 && corsAllowOrigin[0] == "" {
-		corsAllowOrigin = []string{"*"} // defaults to '*'
-	}
-	return corsAllowOrigin
 }

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -193,11 +193,7 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		RootAccess:     rootAccess,
 	}
 
-	corsAllowOrigin := strings.Split(env.Get(EnvAPICorsAllowOrigin, kvs.Get(apiCorsAllowOrigin)), ",")
-	if len(corsAllowOrigin) == 0 {
-		corsAllowOrigin = []string{"*"} // defaults to '*'
-	}
-	cfg.CorsAllowOrigin = corsAllowOrigin
+	cfg.CorsAllowOrigin = GetCorsAllowOrigin(kvs)
 
 	if err = config.CheckValidKeys(config.APISubSys, kvs, DefaultKVS, deprecatedKeys...); err != nil {
 		return cfg, err
@@ -280,4 +276,12 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	cfg.SyncEvents = env.Get(EnvAPISyncEvents, kvs.Get(apiSyncEvents)) == config.EnableOn
 
 	return cfg, nil
+}
+
+func GetCorsAllowOrigin(kvs config.KVS) []string {
+	corsAllowOrigin := strings.Split(env.Get(EnvAPICorsAllowOrigin, kvs.Get(apiCorsAllowOrigin)), ",")
+	if len(corsAllowOrigin) == 0 || len(corsAllowOrigin) == 1 && corsAllowOrigin[0] == "" {
+		corsAllowOrigin = []string{"*"} // defaults to '*'
+	}
+	return corsAllowOrigin
 }

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -193,9 +193,17 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		RootAccess:     rootAccess,
 	}
 
-	corsAllowOrigin := strings.Split(env.Get(EnvAPICorsAllowOrigin, kvs.Get(apiCorsAllowOrigin)), ",")
-	if len(corsAllowOrigin) == 1 && corsAllowOrigin[0] == "" {
+	var corsAllowOrigin []string
+	corsList := env.Get(EnvAPICorsAllowOrigin, kvs.Get(apiCorsAllowOrigin))
+	if corsList == "" {
 		corsAllowOrigin = []string{"*"} // defaults to '*'
+	} else {
+		corsAllowOrigin = strings.Split(corsList, ",")
+		for _, cors := range corsAllowOrigin {
+			if cors == "" {
+				return cfg, errors.New("invalid cors value")
+			}
+		}
 	}
 	cfg.CorsAllowOrigin = corsAllowOrigin
 


### PR DESCRIPTION
## Description

CROS must set  AllowedOrigins work for [*]

## Motivation and Context


## How to test this PR?

`curl -v -XOPTIONS -H "Origin: null" https://host:9000/testing/README.md`
You will see the following header!
before:
`Access-Control-Allow-Origin: null`
after:
`Access-Control-Allow-Origin:  *`
## Types of changes
- [x] Bug fix ( #17409 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
