### PR TITLE
iam: Generate a descriptive error when loading an IAM entry fails

### DIFF
--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -390,7 +390,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	}
 	listedConfigItems, err := iamOS.listAllIAMConfigItems(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to list IAM data: %w", err)
 	}
 
 	// Loads things in the same order as `LoadIAMCache()`
@@ -401,7 +401,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	for _, item := range policiesList {
 		policyName := path.Dir(item)
 		if err := iamOS.loadPolicyDoc(ctx, policyName, cache.iamPolicyDocsMap); err != nil && !errors.Is(err, errNoSuchPolicy) {
-			return err
+			return fmt.Errorf("unable to load the policy doc `%s`: %w", policyName, err)
 		}
 	}
 	setDefaultCannedPolicies(cache.iamPolicyDocsMap)
@@ -412,7 +412,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 		for _, item := range regUsersList {
 			userName := path.Dir(item)
 			if err := iamOS.loadUser(ctx, userName, regUser, cache.iamUsersMap); err != nil && err != errNoSuchUser {
-				return err
+				return fmt.Errorf("unable to load the user `%s`: %w", userName, err)
 			}
 		}
 
@@ -421,7 +421,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 		for _, item := range groupsList {
 			group := path.Dir(item)
 			if err := iamOS.loadGroup(ctx, group, cache.iamGroupsMap); err != nil && err != errNoSuchGroup {
-				return err
+				return fmt.Errorf("unable to load the group `%s`: %w", group, err)
 			}
 		}
 	}
@@ -431,7 +431,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	for _, item := range userPolicyMappingsList {
 		userName := strings.TrimSuffix(item, ".json")
 		if err := iamOS.loadMappedPolicy(ctx, userName, regUser, false, cache.iamUserPolicyMap); err != nil && !errors.Is(err, errNoSuchPolicy) {
-			return err
+			return fmt.Errorf("unable to load the policy mapping for the user `%s`: %w", userName, err)
 		}
 	}
 
@@ -440,7 +440,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	for _, item := range groupPolicyMappingsList {
 		groupName := strings.TrimSuffix(item, ".json")
 		if err := iamOS.loadMappedPolicy(ctx, groupName, regUser, true, cache.iamGroupPolicyMap); err != nil && !errors.Is(err, errNoSuchPolicy) {
-			return err
+			return fmt.Errorf("unable to load the policy mapping for the group `%s`: %w", groupName, err)
 		}
 	}
 
@@ -449,7 +449,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	for _, item := range svcAccList {
 		userName := path.Dir(item)
 		if err := iamOS.loadUser(ctx, userName, svcUser, cache.iamUsersMap); err != nil && err != errNoSuchUser {
-			return err
+			return fmt.Errorf("unable to load the service account `%s`: %w", userName, err)
 		}
 	}
 
@@ -458,7 +458,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	for _, item := range stsUsersList {
 		userName := path.Dir(item)
 		if err := iamOS.loadUser(ctx, userName, stsUser, cache.iamUsersMap); err != nil && err != errNoSuchUser {
-			return err
+			return fmt.Errorf("unable to load the STS user `%s`: %w", userName, err)
 		}
 	}
 
@@ -467,7 +467,7 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	for _, item := range stsPolicyMappingsList {
 		stsName := strings.TrimSuffix(item, ".json")
 		if err := iamOS.loadMappedPolicy(ctx, stsName, stsUser, false, cache.iamUserPolicyMap); err != nil && !errors.Is(err, errNoSuchPolicy) {
-			return err
+			return fmt.Errorf("unable to load the policy mapping for the STS user `%s`: %w", stsName, err)
 		}
 	}
 


### PR DESCRIPTION
## Description
Sometimes IAM fails to load with not enough information about which 
IAM entry that fails to load, e.g. what user and what service account.

This commit will create a more descriptive error to make it easier to debug.

## Motivation and Context
Better error message

## How to test this PR?
Not easy to reproduce

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
