### PR TITLE
fix: return error when requested interface has no stats available

### DIFF
--- a/internal/net/net.go
+++ b/internal/net/net.go
@@ -18,6 +18,8 @@
 package net
 
 import (
+	"fmt"
+
 	"github.com/prometheus/procfs"
 )
 
@@ -31,5 +33,9 @@ func GetInterfaceNetStats(interf string) (procfs.NetDevLine, error) {
 	if err != nil {
 		return procfs.NetDevLine{}, err
 	}
-	return netDev[interf], nil
+	ndl, ok := netDev[interf]
+	if !ok {
+		return procfs.NetDevLine{}, fmt.Errorf("%v interface not found", interf)
+	}
+	return ndl, nil
 }


### PR DESCRIPTION
## Description
The param `interf` comes from `ctx.String("interface")`, the minio server argument --interface. If user set an invalid interface name, we may always got empty metrics and no error message logged.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
