### PR TITLE
pick internode interface properly via globalLocalNodeName

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -248,12 +248,12 @@ func serverHandleCmdArgs(ctx *cli.Context) {
 	logger.FatalIf(err, "Invalid command line arguments")
 	globalNodes = globalEndpoints.GetNodes()
 
-	// Initialize, see which NIC the service is running on, and save it as global
-	_ = getGlobalInternodeInterface(ctx.String("interface"))
-
 	globalLocalNodeName = GetLocalPeer(globalEndpoints, globalMinioHost, globalMinioPort)
 	nodeNameSum := sha256.Sum256([]byte(globalLocalNodeName))
 	globalLocalNodeNameHex = hex.EncodeToString(nodeNameSum[:])
+
+	// Initialize, see which NIC the service is running on, and save it as global value
+	setGlobalInternodeInterface(ctx.String("interface"))
 
 	// allow transport to be HTTP/1.1 for proxying.
 	globalProxyTransport = NewCustomHTTPProxyTransport()()
@@ -464,18 +464,27 @@ func initConfigSubsystem(ctx context.Context, newObject ObjectLayer) error {
 	return nil
 }
 
-func getGlobalInternodeInterface(interfs ...string) string {
+func setGlobalInternodeInterface(interfaceName string) {
 	globalInternodeInterfaceOnce.Do(func() {
-		if len(interfs) != 0 && strings.TrimSpace(interfs[0]) != "" {
-			globalInternodeInterface = interfs[0]
+		if interfaceName != "" {
+			globalInternodeInterface = interfaceName
 			return
 		}
 		ip := "127.0.0.1"
-		host, _ := mustSplitHostPort(globalMinioAddr)
+		host, _ := mustSplitHostPort(globalLocalNodeName)
 		if host != "" {
-			ip = host
+			if net.ParseIP(host) != nil {
+				ip = host
+			} else {
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+
+				haddrs, err := globalDNSCache.LookupHost(ctx, host)
+				if err == nil {
+					ip = haddrs[0]
+				}
+			}
 		}
-		globalInternodeInterface = ip
 		ifs, _ := net.Interfaces()
 		for _, interf := range ifs {
 			addrs, err := interf.Addrs()
@@ -488,7 +497,6 @@ func getGlobalInternodeInterface(interfs ...string) string {
 			}
 		}
 	})
-	return globalInternodeInterface
 }
 
 // Return the list of address that MinIO server needs to listen on:


### PR DESCRIPTION


## Description
pick internode interface properly via globalLocalNodeName

## Motivation and Context
current code will not pick the right interface name
if --address or --interface is not provided.

## How to test this PR?
`mc support top net` in a k8s environment would not
provide the correct results. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
