### PR TITLE
avoid using os.Getenv for internal code, use env.Get() instead

### DIFF
--- a/.github/workflows/iam-integrations.yaml
+++ b/.github/workflows/iam-integrations.yaml
@@ -82,9 +82,9 @@ jobs:
           check-latest: true
       - name: Test LDAP/OpenID/Etcd combo
         env:
-          LDAP_TEST_SERVER: ${{ matrix.ldap }}
-          ETCD_SERVER: ${{ matrix.etcd }}
-          OPENID_TEST_SERVER: ${{ matrix.openid }}
+          _MINIO_LDAP_TEST_SERVER: ${{ matrix.ldap }}
+          _MINIO_ETCD_TEST_SERVER: ${{ matrix.etcd }}
+          _MINIO_OPENID_TEST_SERVER: ${{ matrix.openid }}
         run: |
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0
@@ -92,20 +92,20 @@ jobs:
       - name: Test with multiple OpenID providers
         if: matrix.openid == 'http://127.0.0.1:5556/dex'
         env:
-          LDAP_TEST_SERVER: ${{ matrix.ldap }}
-          ETCD_SERVER: ${{ matrix.etcd }}
-          OPENID_TEST_SERVER: ${{ matrix.openid }}
-          OPENID_TEST_SERVER_2: "http://127.0.0.1:5557/dex"
+          _MINIO_LDAP_TEST_SERVER: ${{ matrix.ldap }}
+          _MINIO_ETCD_TEST_SERVER: ${{ matrix.etcd }}
+          _MINIO_OPENID_TEST_SERVER: ${{ matrix.openid }}
+          _MINIO_OPENID_TEST_SERVER_2: "http://127.0.0.1:5557/dex"
         run: |
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0
           make test-iam
       - name: Test with Access Management Plugin enabled
         env:
-          LDAP_TEST_SERVER: ${{ matrix.ldap }}
-          ETCD_SERVER: ${{ matrix.etcd }}
-          OPENID_TEST_SERVER: ${{ matrix.openid }}
-          POLICY_PLUGIN_ENDPOINT: "http://127.0.0.1:8080"
+          _MINIO_LDAP_TEST_SERVER: ${{ matrix.ldap }}
+          _MINIO_ETCD_TEST_SERVER: ${{ matrix.etcd }}
+          _MINIO_OPENID_TEST_SERVER: ${{ matrix.openid }}
+          _MINIO_POLICY_PLUGIN_TEST_ENDPOINT: "http://127.0.0.1:8080"
         run: |
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0

--- a/cmd/admin-handlers-users_test.go
+++ b/cmd/admin-handlers-users_test.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -40,6 +39,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio-go/v7/pkg/signer"
 	"github.com/minio/minio/internal/auth"
+	"github.com/minio/pkg/env"
 )
 
 const (
@@ -121,7 +121,7 @@ var iamTestSuites = func() []*TestSuiteIAM {
 }()
 
 const (
-	EnvTestEtcdBackend = "ETCD_SERVER"
+	EnvTestEtcdBackend = "_MINIO_ETCD_TEST_SERVER"
 )
 
 func (s *TestSuiteIAM) setUpEtcd(c *check, etcdServer string) {
@@ -144,7 +144,7 @@ func (s *TestSuiteIAM) setUpEtcd(c *check, etcdServer string) {
 func (s *TestSuiteIAM) SetUpSuite(c *check) {
 	// If etcd backend is specified and etcd server is not present, the test
 	// is skipped.
-	etcdServer := os.Getenv(EnvTestEtcdBackend)
+	etcdServer := env.Get(EnvTestEtcdBackend, "")
 	if s.withEtcdBackend && etcdServer == "" {
 		c.Skip("Skipping etcd backend IAM test as no etcd server is configured.")
 	}
@@ -983,9 +983,9 @@ func (s *TestSuiteIAM) SetUpAccMgmtPlugin(c *check) {
 	ctx, cancel := context.WithTimeout(context.Background(), testDefaultTimeout)
 	defer cancel()
 
-	pluginEndpoint := os.Getenv("POLICY_PLUGIN_ENDPOINT")
+	pluginEndpoint := env.Get("_MINIO_POLICY_PLUGIN_ENDPOINT", "")
 	if pluginEndpoint == "" {
-		c.Skip("POLICY_PLUGIN_ENDPOINT not given - skipping.")
+		c.Skip("_MINIO_POLICY_PLUGIN_ENDPOINT not given - skipping.")
 	}
 
 	configCmds := []string{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minio/minio/internal/color"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/console"
+	"github.com/minio/pkg/env"
 	"github.com/minio/pkg/trie"
 	"github.com/minio/pkg/words"
 )
@@ -191,7 +192,7 @@ func Main(args []string) {
 	// Set the minio app name.
 	appName := filepath.Base(args[0])
 
-	if os.Getenv("_MINIO_DEBUG_NO_EXIT") != "" {
+	if env.Get("_MINIO_DEBUG_NO_EXIT", "") != "" {
 		freeze := func(_ int) {
 			// Infinite blocking op
 			<-make(chan struct{})

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -660,7 +660,7 @@ func (s *TestSuiteIAM) SetUpLDAP(c *check, serverAddr string) {
 }
 
 const (
-	EnvTestLDAPServer = "LDAP_TEST_SERVER"
+	EnvTestLDAPServer = "_MINIO_LDAP_TEST_SERVER"
 )
 
 func TestIAMWithLDAPServerSuite(t *testing.T) {
@@ -1379,8 +1379,8 @@ var testAppParams = OpenIDClientAppParams{
 }
 
 const (
-	EnvTestOpenIDServer  = "OPENID_TEST_SERVER"
-	EnvTestOpenIDServer2 = "OPENID_TEST_SERVER_2"
+	EnvTestOpenIDServer  = "_MINIO_OPENID_TEST_SERVER"
+	EnvTestOpenIDServer2 = "_MINIO_OPENID_TEST_SERVER_2"
 )
 
 // SetUpOpenIDs - sets up one or more OpenID test servers using the test OpenID

--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"math/rand"
-	"os"
 	"sort"
 	"strconv"
 	"sync"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/minio/minio/internal/mcontext"
 	"github.com/minio/pkg/console"
+	"github.com/minio/pkg/env"
 )
 
 // Indicator if logging is enabled.
@@ -41,10 +41,10 @@ var lockRetryBackOff func(*rand.Rand, uint) time.Duration
 
 func init() {
 	// Check for MINIO_DSYNC_TRACE env variable, if set logging will be enabled for failed REST operations.
-	dsyncLog = os.Getenv("_MINIO_DSYNC_TRACE") == "1"
+	dsyncLog = env.Get("_MINIO_DSYNC_TRACE", "0") == "1"
 
 	lockRetryMinInterval = 250 * time.Millisecond
-	if lri := os.Getenv("_MINIO_LOCK_RETRY_INTERVAL"); lri != "" {
+	if lri := env.Get("_MINIO_LOCK_RETRY_INTERVAL", ""); lri != "" {
 		v, err := strconv.Atoi(lri)
 		if err != nil {
 			panic(err)

--- a/internal/s3select/select_test.go
+++ b/internal/s3select/select_test.go
@@ -1684,7 +1684,11 @@ func TestCSVRanges(t *testing.T) {
 }
 
 func TestParquetInput(t *testing.T) {
-	t.Setenv("MINIO_API_SELECT_PARQUET", "on")
+	saved := parquetSupport
+	defer func() {
+		parquetSupport = saved
+	}()
+	parquetSupport = true
 
 	testTable := []struct {
 		requestXML     []byte
@@ -1785,7 +1789,11 @@ func TestParquetInput(t *testing.T) {
 }
 
 func TestParquetInputSchema(t *testing.T) {
-	t.Setenv("MINIO_API_SELECT_PARQUET", "on")
+	saved := parquetSupport
+	defer func() {
+		parquetSupport = saved
+	}()
+	parquetSupport = true
 
 	testTable := []struct {
 		requestXML []byte
@@ -1887,7 +1895,11 @@ func TestParquetInputSchema(t *testing.T) {
 }
 
 func TestParquetInputSchemaCSV(t *testing.T) {
-	t.Setenv("MINIO_API_SELECT_PARQUET", "on")
+	saved := parquetSupport
+	defer func() {
+		parquetSupport = saved
+	}()
+	parquetSupport = true
 
 	testTable := []struct {
 		requestXML []byte


### PR DESCRIPTION
## Description
avoid using os.Getenv for internal code, use env.Get() instead

## Motivation and Context
several places were using os.Getenv(), replace them
with env.Get() wherever its applicable.

## How to test this PR?
Nothing should change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
