### PR TITLE
Add deletemarker_total metric

### DIFF
--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -24,6 +24,7 @@ These metrics can be obtained from any MinIO server once per collection.
 | `minio_cluster_usage_object_total`            | Total number of objects in a cluster                                                                            |
 | `minio_cluster_usage_total_bytes`             | Total cluster usage in bytes                                                                                    |
 | `minio_cluster_usage_version_total`           | Total number of versions (includes delete marker) in a cluster                                                  |
+| `minio_cluster_usage_deletemarker_total`      | Total number of delete markers in a cluster                                                                     |
 | `minio_cluster_usage_total_bytes`             | Total cluster usage in bytes                                                                                    |
 | `minio_cluster_buckets_total`                 | Total number of buckets in the cluster                                                                          |
 | `minio_cluster_disk_offline_total`            | Total drives offline.                                                                                           |
@@ -125,6 +126,7 @@ These metrics can be obtained from any MinIO server once per collection.
 | `minio_bucket_traffic_sent_bytes`                 | Total number of S3 bytes sent for this bucket.                                  |
 | `minio_bucket_usage_object_total`                 | Total number of objects.                                                        |
 | `minio_bucket_usage_version_total`                | Total number of versions (includes delete marker)                               |
+| `minio_bucket_usage_deletemarker_total`           | Total number of delete markers.                                                 |
 | `minio_bucket_usage_total_bytes`                  | Total bucket size in bytes.                                                     |
 | `minio_bucket_requests_4xx_errors_total`          | Total number of S3 requests with (4xx) errors on a bucket.                      |
 | `minio_bucket_requests_5xx_errors_total`          | Total number of S3 requests with (5xx) errors on a bucket.                      |


### PR DESCRIPTION
## Description
Add prometheus metrics to monitor total number of delete markers in a bucket and cluster-wide.

```
# HELP minio_cluster_usage_deletemarker_total Total number of delete markers in a cluster
# TYPE minio_cluster_usage_deletemarker_total gauge
minio_cluster_usage_deletemarker_total{server="minio1:9000"} 1
```

```
# HELP minio_bucket_usage_deletemarker_total Total number of delete markers
# TYPE minio_bucket_usage_deletemarker_total gauge
minio_bucket_usage_deletemarker_total{bucket="bucket",server="minio1:9000"} 1
```
## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
