### PR TITLE
info: Report correct pool/set/disk indexes for offline disks

### DIFF
--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -360,7 +360,7 @@ func createServerEndpoints(serverAddr string, args ...string) (
 			return nil, -1, err
 		}
 		for i := range endpointList {
-			endpointList[i].SetPool(0)
+			endpointList[i].SetPoolIndex(0)
 		}
 		endpointServerPools = append(endpointServerPools, PoolEndpoints{
 			Legacy:       true,

--- a/cmd/endpoint_test.go
+++ b/cmd/endpoint_test.go
@@ -37,9 +37,9 @@ func TestNewEndpoint(t *testing.T) {
 		expectedType     EndpointType
 		expectedErr      error
 	}{
-		{"/foo", Endpoint{URL: &url.URL{Path: rootSlashFoo}, IsLocal: true}, PathEndpointType, nil},
-		{"https://example.org/path", Endpoint{URL: u2, IsLocal: false}, URLEndpointType, nil},
-		{"http://192.168.253.200/path", Endpoint{URL: u4, IsLocal: false}, URLEndpointType, nil},
+		{"/foo", Endpoint{&url.URL{Path: rootSlashFoo}, true, -1, -1, -1}, PathEndpointType, nil},
+		{"https://example.org/path", Endpoint{u2, false, -1, -1, -1}, URLEndpointType, nil},
+		{"http://192.168.253.200/path", Endpoint{u4, false, -1, -1, -1}, URLEndpointType, nil},
 		{"", Endpoint{}, -1, fmt.Errorf("empty or root endpoint is not supported")},
 		{SlashSeparator, Endpoint{}, -1, fmt.Errorf("empty or root endpoint is not supported")},
 		{`\`, Endpoint{}, -1, fmt.Errorf("empty or root endpoint is not supported")},

--- a/cmd/erasure-sets_test.go
+++ b/cmd/erasure-sets_test.go
@@ -173,7 +173,7 @@ func TestNewErasureSets(t *testing.T) {
 		defer os.RemoveAll(disk)
 	}
 
-	endpoints := mustGetNewEndpoints(0, erasureDisks...)
+	endpoints := mustGetNewEndpoints(0, 16, erasureDisks...)
 	_, _, err := waitForFormatErasure(true, endpoints, 1, 0, 16, "", "")
 	if err != errInvalidArgument {
 		t.Fatalf("Expecting error, got %s", err)

--- a/cmd/format-erasure_test.go
+++ b/cmd/format-erasure_test.go
@@ -36,7 +36,7 @@ func TestFixFormatV3(t *testing.T) {
 	for _, erasureDir := range erasureDirs {
 		defer os.RemoveAll(erasureDir)
 	}
-	endpoints := mustGetNewEndpoints(0, erasureDirs...)
+	endpoints := mustGetNewEndpoints(0, 8, erasureDirs...)
 
 	storageDisks, errs := initStorageDisksWithErrors(endpoints, false)
 	for _, err := range errs {
@@ -555,7 +555,8 @@ func benchmarkInitStorageDisksN(b *testing.B, nDisks int) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	endpoints := mustGetNewEndpoints(0, fsDirs...)
+
+	endpoints := mustGetNewEndpoints(0, 16, fsDirs...)
 	b.RunParallel(func(pb *testing.PB) {
 		endpoints := endpoints
 		for pb.Next() {

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -2173,13 +2173,13 @@ func generateTLSCertKey(host string) ([]byte, []byte, error) {
 }
 
 func mustGetPoolEndpoints(poolIdx int, args ...string) EndpointServerPools {
-	endpoints := mustGetNewEndpoints(poolIdx, args...)
 	drivesPerSet := len(args)
 	setCount := 1
 	if len(args) >= 16 {
 		drivesPerSet = 16
 		setCount = len(args) / 16
 	}
+	endpoints := mustGetNewEndpoints(poolIdx, drivesPerSet, args...)
 	return []PoolEndpoints{{
 		SetCount:     setCount,
 		DrivesPerSet: drivesPerSet,
@@ -2188,12 +2188,16 @@ func mustGetPoolEndpoints(poolIdx int, args ...string) EndpointServerPools {
 	}}
 }
 
-func mustGetNewEndpoints(poolIdx int, args ...string) (endpoints Endpoints) {
+func mustGetNewEndpoints(poolIdx int, drivesPerSet int, args ...string) (endpoints Endpoints) {
 	endpoints, err := NewEndpoints(args...)
-	for i := range endpoints {
-		endpoints[i].Pool = poolIdx
+	if err != nil {
+		panic(err)
 	}
-	logger.FatalIf(err, "unable to create new endpoint list")
+	for i := range endpoints {
+		endpoints[i].SetPoolIndex(poolIdx)
+		endpoints[i].SetSetIndex(i / drivesPerSet)
+		endpoints[i].SetDiskIndex(i % drivesPerSet)
+	}
 	return endpoints
 }
 


### PR DESCRIPTION
## Description
When a node is offline, MinIO does not correctly report pool/set/disk indexes
for offline disks, which can make mc confused.

Add pool/set/disk information to the Endpoint structure.

The issue is only reproducible when the cluster or a node is restarted, because
in that case, the disk StorageAPI will be nil.

## Motivation and Context
Fix mc reporting wrong node <-> pools information due to offline disks

## How to test this PR?
- Start two nodes, where each node belongs to a one pool
- chmod -R 000 /tmp/path/one/disk/
- Restart the cluster again
- 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
