### PR TITLE
grafana-dashboard: Update scrape_jobs variable to be single select

### DIFF
--- a/docs/metrics/prometheus/grafana/minio-replication.json
+++ b/docs/metrics/prometheus/grafana/minio-replication.json
@@ -2784,9 +2784,9 @@
           "description": null,
           "error": null,
           "hide": 0,
-          "includeAll": true,
+          "includeAll": false,
           "label": null,
-          "multi": true,
+          "multi": false,
           "name": "scrape_jobs",
           "options": [],
           "query": {


### PR DESCRIPTION
## Description
Set `includeAll` and `multi` to be false since this dashboard only works with a single value being selected

## Motivation and Context
Removing clicks of selecting a new minIO instance and deselecting another when wanting to swap between minIO you monitor 

## How to test this PR?
Paste dashboard JSON into grafana and see how new variable works

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
