### PR TITLE
remove serializing WalkDir() across all buckets/prefixes on SSDs

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -247,7 +247,7 @@ func newXLStorage(ep Endpoint, cleanUp bool) (s *xlStorage, err error) {
 	}
 
 	// We stagger listings only on HDDs.
-	if info.Rotational != nil && *info.Rotational {
+	if info.Rotational == nil || *info.Rotational {
 		s.walkMu = &sync.Mutex{}
 		s.walkReadMu = &sync.Mutex{}
 	}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -115,8 +115,8 @@ type xlStorage struct {
 	formatData []byte
 
 	// mutex to prevent concurrent read operations overloading walks.
-	walkMu     sync.Mutex
-	walkReadMu sync.Mutex
+	walkMu     *sync.Mutex
+	walkReadMu *sync.Mutex
 }
 
 // checkPathLength - returns error if given path name length more than 255
@@ -216,18 +216,17 @@ func newXLStorage(ep Endpoint, cleanUp bool) (s *xlStorage, err error) {
 		return nil, err
 	}
 
+	info, err := disk.GetInfo(path)
+	if err != nil {
+		return nil, err
+	}
+
 	var rootDisk bool
 	if !globalIsCICD && !globalIsErasureSD {
 		if globalRootDiskThreshold > 0 {
 			// Use MINIO_ROOTDISK_THRESHOLD_SIZE to figure out if
-			// this disk is a root disk.
-			info, err := disk.GetInfo(path)
-			if err != nil {
-				return nil, err
-			}
-
-			// treat those disks with size less than or equal to the
-			// threshold as rootDisks.
+			// this disk is a root disk. treat those disks with
+			// size less than or equal to the threshold as rootDisks.
 			rootDisk = info.Total <= globalRootDiskThreshold
 		} else {
 			rootDisk, err = disk.IsRootDisk(path, SlashSeparator)
@@ -245,6 +244,12 @@ func newXLStorage(ep Endpoint, cleanUp bool) (s *xlStorage, err error) {
 		poolIndex:  -1,
 		setIndex:   -1,
 		diskIndex:  -1,
+	}
+
+	// We stagger listings only on HDDs.
+	if info.Rotational != nil && *info.Rotational {
+		s.walkMu = &sync.Mutex{}
+		s.walkReadMu = &sync.Mutex{}
 	}
 
 	if cleanUp {

--- a/internal/disk/disk.go
+++ b/internal/disk/disk.go
@@ -23,15 +23,20 @@ package disk
 // Files - total inodes available
 // Ffree - free inodes available
 // FSType - file system type
+// Major - major dev id
+// Minor - minor dev id
+// Devname - device name
 type Info struct {
-	Total  uint64
-	Free   uint64
-	Used   uint64
-	Files  uint64
-	Ffree  uint64
-	FSType string
-	Major  uint32
-	Minor  uint32
+	Total      uint64
+	Free       uint64
+	Used       uint64
+	Files      uint64
+	Ffree      uint64
+	FSType     string
+	Major      uint32
+	Minor      uint32
+	Name       string
+	Rotational *bool
 }
 
 // DevID is the drive major and minor ids

--- a/internal/disk/stat_linux.go
+++ b/internal/disk/stat_linux.go
@@ -1,7 +1,7 @@
 //go:build linux && !s390x && !arm && !386
 // +build linux,!s390x,!arm,!386
 
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/prometheus/procfs/blockdevice"
 	"golang.org/x/sys/unix"
 )
 
@@ -47,14 +48,6 @@ func GetInfo(path string) (info Info, err error) {
 		//nolint:unconvert
 		FSType: getFSType(int64(s.Type)),
 	}
-	// Check for overflows.
-	// https://github.com/minio/minio/issues/8035
-	// XFS can show wrong values at times error out
-	// in such scenarios.
-	if info.Free > info.Total {
-		return info, fmt.Errorf("detected free space (%d) > total drive space (%d), fs corruption at (%s). please run 'fsck'", info.Free, info.Total, path)
-	}
-	info.Used = info.Total - info.Free
 
 	st := syscall.Stat_t{}
 	err = syscall.Stat(path, &st)
@@ -65,6 +58,37 @@ func GetInfo(path string) (info Info, err error) {
 	devID := uint64(st.Dev) // Needed to support multiple GOARCHs
 	info.Major = unix.Major(devID)
 	info.Minor = unix.Minor(devID)
+
+	// Check for overflows.
+	// https://github.com/minio/minio/issues/8035
+	// XFS can show wrong values at times error out
+	// in such scenarios.
+	if info.Free > info.Total {
+		return info, fmt.Errorf("detected free space (%d) > total drive space (%d), fs corruption at (%s). please run 'fsck'", info.Free, info.Total, path)
+	}
+	info.Used = info.Total - info.Free
+
+	bfs, err := blockdevice.NewDefaultFS()
+	if err == nil {
+		diskstats, _ := bfs.ProcDiskstats()
+		for _, dstat := range diskstats {
+			// ignore all loop devices
+			if strings.HasPrefix(dstat.DeviceName, "loop") {
+				continue
+			}
+			qst, err := bfs.SysBlockDeviceQueueStats(dstat.DeviceName)
+			if err != nil {
+				continue
+			}
+			rot := qst.Rotational == 1 // Rotational is '1' if the device is HDD
+			if dstat.MajorNumber == info.Major && dstat.MinorNumber == info.Minor {
+				info.Name = dstat.DeviceName
+				info.Rotational = &rot
+				break
+			}
+		}
+	}
+
 	return info, nil
 }
 


### PR DESCRIPTION


## Description
remove serializing WalkDir() across all buckets/prefixes

## Motivation and Context
slower drives get knocked off they are too slow via active 
monitoring, we do not need to block calls arbitrarily.

Serializing adds latencies for already slow calls, remove 
it and we can revisit this if needed in the future.

Also add selection with context when writing to `out <-` 
channel, to avoid any potential blocks.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
