### PR TITLE
don't error when asked for 0-based range on empty objects

### DIFF
--- a/cmd/httprange.go
+++ b/cmd/httprange.go
@@ -59,6 +59,9 @@ func (h *HTTPRangeSpec) GetLength(resourceSize int64) (rangeLength int64, err er
 			rangeLength = resourceSize
 		}
 
+	case h.Start == 0 && resourceSize == 0:
+		rangeLength = resourceSize
+
 	case h.Start >= resourceSize:
 		return 0, errInvalidRange
 


### PR DESCRIPTION
In a reverse proxying setup, a proxy in front of minio may attempt to request objects in slices for enhanced cache efficiency. Since such a proxy cannot have prior knowledge of how large a requested resource is, it usually sends a header of the form:

        Range: 0-$slice_size

... and, depending on the size of the resource, expects either:

- an empty response, if $resource_size == 0
- a full response, if $resource_size <= $slice_size
- a partial response, if $resource_size > $slice_size

Prior to this change, minio would respond `416 Range Not Satisfiable` if a client tried to request a range on an empty resource. This behavior is technically consistent with [RFC9110][1] – however, it renders sliced reverse proxying, such as implemented in nginx, broken in the case of empty files. Nginx itself seems to break this convention to enable "useful" responses in these cases, and minio should probably do that too.

[1]: https://www.rfc-editor.org/rfc/rfc9110#byte.ranges



## How to test this PR?

Using e.g. curl, request ranges on objects served by a minio instance:

```
$ curl -v --range 0-1 http://localhost:12345/testbucket/empty
```

Without the patch applied, the above run against an empty (0-byte) object should fail with `416 Range Not Satisfiable`.

With the patch applied, an empty response should be returned.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
