### PR TITLE
allow DNS cache TTL to be configurable

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -121,6 +121,13 @@ var ServerFlags = []cli.Flag{
 		Hidden: true,
 		EnvVar: "MINIO_INTERFACE",
 	},
+	cli.DurationFlag{
+		Name:   "dns-cache-ttl",
+		Usage:  "custom DNS cache TTL for baremetal setups",
+		Hidden: true,
+		Value:  10 * time.Minute,
+		EnvVar: "MINIO_DNS_CACHE_TTL",
+	},
 	cli.StringSliceFlag{
 		Name:  "ftp",
 		Usage: "enable and configure an FTP(Secure) server",


### PR DESCRIPTION

## Description
allow DNS cache TTL to be configurable

## Motivation and Context
this is added for now as a hidden variable

## How to test this PR?
There is not much to test here, this flag
is useful in rare circumstances where we
want to increase the default DNS cache TTL 
to a higher value on baremetal setups.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
