### PR TITLE
Revert "don't error when asked for 0-based range on empty objects (#17708)

### DIFF
--- a/cmd/httprange.go
+++ b/cmd/httprange.go
@@ -59,9 +59,6 @@ func (h *HTTPRangeSpec) GetLength(resourceSize int64) (rangeLength int64, err er
 			rangeLength = resourceSize
 		}
 
-	case h.Start == 0 && resourceSize == 0:
-		rangeLength = resourceSize
-
 	case h.Start >= resourceSize:
 		return 0, errInvalidRange
 


### PR DESCRIPTION
## Description

This reverts commit 7e76d66184ac219f30314d5cffc4d2ef62529fa7.

There is no valid way to specify offsets in a 0-byte file. Blame it on the [RFC](https://datatracker.ietf.org/doc/html/rfc7233#section-4.4)

> The 416 (Range Not Satisfiable) status code indicates that none of the ranges in the request's Range header field (Section 3.1) overlap the current extent of the selected resource...

A request for "bytes=0-" is a request for the first byte of a resource. If the resource is 0-length, the range [0,0] does not overlap the resource content and the server responds with an error.

Unless AWS S3 has this hack, we shouldn't diverge from the spec.

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
