### PR TITLE
Use decrypted object size while computing object size summary

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -546,11 +546,12 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 		for _, oi := range objInfos {
 			done = globalScannerMetrics.time(scannerMetricApplyVersion)
 			sz := item.applyActions(ctx, objAPI, oi, &sizeS)
+			actualSz, _ := oi.GetActualSize()
 			done()
 			if oi.DeleteMarker {
 				sizeS.deleteMarkers++
 			}
-			if oi.VersionID != "" && sz == oi.Size {
+			if oi.VersionID != "" && sz == actualSz {
 				sizeS.versions++
 			}
 			sizeS.totalSize += sz


### PR DESCRIPTION
Corrects an issue with encrypted versioned objects being reported under `unversioned` bin in the object version histogram

## Description


## Motivation and Context
Correctness

## How to test this PR?
on a versioned bucket, turn on default encryption with `mc encrypt set sse-s3..`. 
Upload a version and check prometheus metrics `minio_bucket_objects_version_distribution` - it shows 0 versions with master because of incorrect size accounting

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
