### PR TITLE
Include SuccessorModTime for FileInfo quorum

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -342,6 +342,7 @@ func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.
 		etagOnly := modTime.Equal(timeSentinel) && (etag != "" && etag == meta.Metadata["etag"])
 		mtimeValid := meta.ModTime.Equal(modTime)
 		if mtimeValid || etagOnly {
+			fmt.Fprint(h, meta.SuccessorModTime.Format(http.TimeFormat))
 			fmt.Fprintf(h, "%v", meta.XLV1)
 			if !etagOnly {
 				// Verify dataDir is same only when mtime is valid and etag is not considered.


### PR DESCRIPTION
## Description
findFileInfoInQuorum function picks a valid FileInfo which has several fields that are in quorum but leaves out SuccessorModTime. Leaving this out could lead to picking a FileInfo with invalid values in fields like `IsLatest`, `SuccessorModTime` leading to incorrect ILM policy evaluation.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
